### PR TITLE
fix(BA-5988): raise IncompleteModelDefinitionError for missing model definition fields

### DIFF
--- a/changes/11539.fix.md
+++ b/changes/11539.fix.md
@@ -1,0 +1,1 @@
+Raise `IncompleteModelDefinitionError` (HTTP 400) instead of a generic `ValueError` when a required model-definition field is missing after the deployment revision merge chain, naming the field and the layers (request, preset, runtime variant, vfolder yaml, model mount destination) that could have supplied it.

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -539,7 +539,7 @@ class ModelHealthCheckDraft(BaseConfigModel):
                     "request input",
                     "revision preset",
                     "runtime variant's default model definition",
-                    "model-definition.yaml on the model vfolder",
+                    "model definition file on the model vfolder",
                 ),
             )
         # Drop unset (None) fields so the strict type's ``Field(default=...)``
@@ -567,7 +567,7 @@ class ModelServiceConfigDraft(BaseConfigModel):
                     "request input",
                     "revision preset",
                     "runtime variant's default model definition",
-                    "model-definition.yaml on the model vfolder",
+                    "model definition file on the model vfolder",
                 ),
             )
         # Drop unset (None) scalars so the strict type's ``Field(default=...)``
@@ -594,7 +594,7 @@ class ModelConfigDraft(BaseConfigModel):
                     "request input",
                     "revision preset",
                     "runtime variant's default model definition",
-                    "model-definition.yaml on the model vfolder",
+                    "model definition file on the model vfolder",
                 ),
             )
         if self.model_path is None:
@@ -604,7 +604,7 @@ class ModelConfigDraft(BaseConfigModel):
                     "request input",
                     "revision preset",
                     "runtime variant's default model definition",
-                    "model-definition.yaml on the model vfolder",
+                    "model definition file on the model vfolder",
                     "model mount destination",
                 ),
             )

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -20,7 +20,7 @@ from pydantic import (
 
 from . import validators as tx
 from .etcd import AsyncEtcd, ConfigScopes
-from .exception import ConfigurationError
+from .exception import ConfigurationError, IncompleteModelDefinitionError
 from .types import RedisHelperConfig
 
 __all__ = (
@@ -533,7 +533,15 @@ class ModelHealthCheckDraft(BaseConfigModel):
 
     def to_resolved(self) -> ModelHealthCheck:
         if self.path is None:
-            raise ValueError("ModelHealthCheck.path is required")
+            raise IncompleteModelDefinitionError(
+                field="ModelHealthCheck.path",
+                sources=(
+                    "request input",
+                    "revision preset",
+                    "runtime variant's default model definition",
+                    "model-definition.yaml on the model vfolder",
+                ),
+            )
         # Drop unset (None) fields so the strict type's ``Field(default=...)``
         # declarations remain the single source of truth for default values.
         return ModelHealthCheck.model_validate(self.model_dump(exclude_none=True))
@@ -553,7 +561,15 @@ class ModelServiceConfigDraft(BaseConfigModel):
 
     def to_resolved(self) -> ModelServiceConfig:
         if self.port is None:
-            raise ValueError("ModelServiceConfig.port is required")
+            raise IncompleteModelDefinitionError(
+                field="ModelServiceConfig.port",
+                sources=(
+                    "request input",
+                    "revision preset",
+                    "runtime variant's default model definition",
+                    "model-definition.yaml on the model vfolder",
+                ),
+            )
         # Drop unset (None) scalars so the strict type's ``Field(default=...)``
         # declarations remain the single source of truth for default values;
         # resolve the nested ``health_check`` draft explicitly so its own
@@ -572,9 +588,26 @@ class ModelConfigDraft(BaseConfigModel):
 
     def to_resolved(self) -> ModelConfig:
         if self.name is None:
-            raise ValueError("ModelConfig.name is required")
+            raise IncompleteModelDefinitionError(
+                field="ModelConfig.name",
+                sources=(
+                    "request input",
+                    "revision preset",
+                    "runtime variant's default model definition",
+                    "model-definition.yaml on the model vfolder",
+                ),
+            )
         if self.model_path is None:
-            raise ValueError("ModelConfig.model_path is required")
+            raise IncompleteModelDefinitionError(
+                field="ModelConfig.model_path",
+                sources=(
+                    "request input",
+                    "revision preset",
+                    "runtime variant's default model definition",
+                    "model-definition.yaml on the model vfolder",
+                    "model mount destination",
+                ),
+            )
         service = self.service.to_resolved() if self.service else None
         if service is not None and service.start_command:
             # ``{model_path}`` placeholders in the variant baseline's

--- a/src/ai/backend/common/exception.py
+++ b/src/ai/backend/common/exception.py
@@ -1264,3 +1264,29 @@ class CloudDetectionError(BackendAIError, web.HTTPInternalServerError):
             operation=ErrorOperation.READ,
             error_detail=ErrorDetail.BAD_REQUEST,
         )
+
+
+class IncompleteModelDefinitionError(BackendAIError, web.HTTPBadRequest):
+    """Raised when a required model-definition field is missing after the
+    revision merge chain. ``sources`` lists every layer that could have
+    supplied the value so the caller can tell exactly where to set it."""
+
+    error_type = "https://api.backend.ai/probs/incomplete-model-definition"
+    error_title = "Incomplete Model Definition"
+
+    def __init__(self, field: str, sources: tuple[str, ...]) -> None:
+        sources_str = ", ".join(sources)
+        super().__init__(
+            extra_msg=(
+                f"`{field}` was not provided by any source ({sources_str}). "
+                f"Set `{field}` in one of these sources."
+            ),
+            extra_data={"field": field, "sources": list(sources)},
+        )
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.MODEL_DEPLOYMENT,
+            operation=ErrorOperation.REQUEST,
+            error_detail=ErrorDetail.INVALID_PARAMETERS,
+        )

--- a/tests/unit/common/test_config.py
+++ b/tests/unit/common/test_config.py
@@ -302,7 +302,7 @@ class TestModelConfigs:
                 "request input",
                 "revision preset",
                 "runtime variant's default model definition",
-                "model-definition.yaml on the model vfolder",
+                "model definition file on the model vfolder",
             ],
         }
         assert exc_info.value.status_code == 400

--- a/tests/unit/common/test_config.py
+++ b/tests/unit/common/test_config.py
@@ -18,6 +18,7 @@ from ai.backend.common.config import (
     merge,
     override_key,
 )
+from ai.backend.common.exception import IncompleteModelDefinitionError
 
 
 def test_override_key() -> None:
@@ -283,6 +284,28 @@ class TestModelConfigs:
             "--model-path",
             "/data",
         ]
+
+    def test_to_resolved_raises_incomplete_error_when_name_missing(self) -> None:
+        # After the merge chain collapses, ``name`` is still ``None``;
+        # the error must name the missing field and the source layers
+        # so callers know exactly which layer should have supplied it.
+        draft = ModelDefinitionDraft.model_validate({
+            "models": [{"model_path": "/models/demo"}],
+        })
+
+        with pytest.raises(IncompleteModelDefinitionError) as exc_info:
+            draft.to_resolved()
+
+        assert exc_info.value.extra_data == {
+            "field": "ModelConfig.name",
+            "sources": [
+                "request input",
+                "revision preset",
+                "runtime variant's default model definition",
+                "model-definition.yaml on the model vfolder",
+            ],
+        }
+        assert exc_info.value.status_code == 400
 
     def test_to_resolved_leaves_start_command_with_no_placeholder_unchanged(self) -> None:
         draft = ModelDefinitionDraft.model_validate({


### PR DESCRIPTION
Resolves BA-5988.

## Summary
- Replace four `ValueError` raises in `ModelHealthCheckDraft`, `ModelServiceConfigDraft`, and `ModelConfigDraft`'s `to_resolved()` with a new `IncompleteModelDefinitionError` (subclass of `BackendAIError` + `web.HTTPBadRequest`) that returns `MODEL_DEPLOYMENT / REQUEST / INVALID_PARAMETERS`.
- New error message names the missing field and enumerates every merge-chain source that could have supplied the value (request input, revision preset, runtime variant baseline, model-definition.yaml on the vfolder, model mount destination). `extra_data={"field", "sources"}` makes it programmatically actionable.
- Motivation: callers hitting `"ModelConfig.name is required"` had no way to tell whether the request omitted the field or whether the DB-side defaults (preset, runtime variant) were empty.

Jira: https://lablup.atlassian.net/browse/BA-5988

## Test plan
- [x] `pants fix lint check src/ai/backend/common/config.py src/ai/backend/common/exception.py`
- [x] `pants test tests/unit/common/test_config.py`
- [x] Pre-push hook (full lint + check + relevant test suite on origin/main..HEAD)
- [ ] Verify the API error response shape against a deployment revision request that omits a required field

🤖 Generated with [Claude Code](https://claude.com/claude-code)