### PR TITLE
feat(BA-5989): add node-exporter to halfstack observability profile

### DIFF
--- a/changes/11541.feature.md
+++ b/changes/11541.feature.md
@@ -1,0 +1,3 @@
+Add `node-exporter` to the halfstack `observability` profile so Prometheus
+automatically scrapes host-level metrics (CPU, memory, disk, network) in local
+dev environments.

--- a/configs/prometheus/prometheus-ha.yaml
+++ b/configs/prometheus/prometheus-ha.yaml
@@ -40,3 +40,7 @@ scrape_configs:
     static_configs:
       - targets:
           - backendai-half-db-exporter:9187
+  - job_name: 'node-exporter'
+    static_configs:
+      - targets:
+          - backendai-half-node-exporter:9100

--- a/configs/prometheus/prometheus.yaml
+++ b/configs/prometheus/prometheus.yaml
@@ -38,3 +38,7 @@ scrape_configs:
     static_configs:
       - targets:
           - backendai-half-db-exporter:9187
+  - job_name: 'node-exporter'
+    static_configs:
+      - targets:
+          - backendai-half-node-exporter:9100

--- a/docker-compose.halfstack-ha.yml
+++ b/docker-compose.halfstack-ha.yml
@@ -76,6 +76,25 @@ services:
     depends_on:
       - backendai-half-redis-node03
 
+  backendai-half-node-exporter:
+    image: prom/node-exporter:v1.9.1
+    profiles: ["observability"]
+    restart: unless-stopped
+    networks:
+      - half
+    pid: host
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+      - '--path.rootfs=/host/root'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/host/root:ro,rslave
+    ports:
+      - "9100:9100"
+
   # Initial master is redis-node01.
   backendai-half-redis-node01:
     image: redis:7.2.11-alpine

--- a/docker-compose.halfstack-main.yml
+++ b/docker-compose.halfstack-main.yml
@@ -78,6 +78,25 @@ services:
     ports:
       - "9121:9121"
 
+  backendai-half-node-exporter:
+    image: prom/node-exporter:v1.9.1
+    profiles: ["observability"]
+    restart: unless-stopped
+    networks:
+      - half
+    pid: host
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+      - '--path.rootfs=/host/root'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/host/root:ro,rslave
+    ports:
+      - "9100:9100"
+
   backendai-half-etcd:
     image: quay.io/coreos/etcd:v3.5.14
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- Adds `backendai-half-node-exporter` (prom/node-exporter:v1.9.1) to the `observability` profile in `docker-compose.halfstack-main.yml` and `docker-compose.halfstack-ha.yml`.
- Adds a `node-exporter` scrape target to `configs/prometheus/prometheus.yaml` and `configs/prometheus/prometheus-ha.yaml` so Prometheus picks up host metrics automatically.
- Exporter runs with `pid: host` and read-only mounts of `/proc`, `/sys`, `/` to expose real host CPU/memory/disk/network metrics rather than container-internal ones.

## Why `observability` and not `telemetry`?

The recent profile split (BA-5867, BA-5870) intentionally keeps `telemetry` minimal because it's on by default in dev installs. Host metrics are debugging-oriented and pair naturally with the existing exporters/Grafana/Pyroscope in `observability`, so they live there.

## Test plan

- [x] `docker compose -f docker-compose.halfstack.current.yml --profile observability up -d backendai-half-node-exporter` brings the container up cleanly
- [x] `curl http://localhost:9100/metrics` returns 1662 `node_*` metrics
- [x] Prometheus targets page shows `node-exporter` job as `up` after restart
- [x] `docker compose config --profiles` confirms membership in the `observability` profile only (no leak into default/telemetry/storage)

Jira: [BA-5989](https://lablup.atlassian.net/browse/BA-5989)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BA-5989]: https://lablup.atlassian.net/browse/BA-5989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ