### PR TITLE
feat(health-checker): add informational tier and surface probe failures via HTTP 503

### DIFF
--- a/changes/11544.feature.md
+++ b/changes/11544.feature.md
@@ -1,0 +1,1 @@
+Split health probe into liveness, readiness, and informational tiers, and surface gating failures via HTTP 503 from `/livez` and `/readyz` so Kubernetes probes react automatically; `/health` detail stays at 200 with `DEGRADED` status for informational failures.

--- a/src/ai/backend/agent/cli/health.py
+++ b/src/ai/backend/agent/cli/health.py
@@ -101,13 +101,14 @@ def check(
             agent_input = AgentDependencyInput(config_path=config_path, log_level=log_level)
             await dependency_stack.enter_composer(agent_composer, agent_input)
 
-            # Get collected health checkers and register them
-            health_checkers = dependency_stack.get_health_checkers()
-            for key, checker in health_checkers.items():
-                await probe.register(checker)
+            liveness_checkers = dependency_stack.get_liveness_checkers()
+            readiness_checkers = dependency_stack.get_readiness_checkers()
+            for checker in liveness_checkers.values():
+                await probe.register_liveness(checker)
+            for checker in readiness_checkers.values():
+                await probe.register_readiness(checker)
 
-            # Perform health checks on successfully initialized components
-            if health_checkers:
+            if liveness_checkers or readiness_checkers:
                 await probe.check_all()
 
             yield

--- a/src/ai/backend/agent/dependencies/bootstrap/etcd.py
+++ b/src/ai/backend/agent/dependencies/bootstrap/etcd.py
@@ -60,14 +60,6 @@ class AgentEtcdDependency(DependencyProvider[AgentUnifiedConfig, AsyncEtcd]):
         ) as etcd:
             yield etcd
 
-    def gen_health_checkers(self, resource: AsyncEtcd) -> ServiceHealthChecker:
-        """
-        Return health checker for etcd.
-
-        Args:
-            resource: The initialized etcd client
-
-        Returns:
-            Health checker for etcd
-        """
+    def gen_liveness_checker(self, resource: AsyncEtcd) -> ServiceHealthChecker:
+        """Liveness — stuck etcd connection observed; restart is the recovery path."""
         return EtcdHealthChecker(etcd=resource)

--- a/src/ai/backend/agent/dependencies/infrastructure/docker.py
+++ b/src/ai/backend/agent/dependencies/infrastructure/docker.py
@@ -38,17 +38,9 @@ class DockerDependency(DependencyProvider[AgentUnifiedConfig, Docker]):
         finally:
             await docker.close()
 
-    def gen_health_checkers(
+    def gen_liveness_checker(
         self,
         resource: Docker,
     ) -> ServiceHealthChecker:
-        """
-        Return Docker health checker.
-
-        Args:
-            resource: The initialized Docker client
-
-        Returns:
-            DockerHealthChecker for Docker
-        """
+        """Liveness — Docker daemon connection-stuck observed; restart recovers."""
         return DockerHealthChecker(docker=resource)

--- a/src/ai/backend/agent/dependencies/infrastructure/redis.py
+++ b/src/ai/backend/agent/dependencies/infrastructure/redis.py
@@ -97,16 +97,8 @@ class AgentValkeyDependency(DependencyProvider[RedisConfig, AgentValkeyClients])
         finally:
             await clients.close()
 
-    def gen_health_checkers(self, resource: AgentValkeyClients) -> ServiceHealthChecker:
-        """
-        Return health checkers for all 4 agent Valkey clients.
-
-        Args:
-            resource: The initialized Valkey clients
-
-        Returns:
-            Health checker for all 4 Valkey clients
-        """
+    def gen_liveness_checker(self, resource: AgentValkeyClients) -> ServiceHealthChecker:
+        """Liveness — Valkey connection-stuck observed; restart recovers."""
         return ValkeyHealthChecker(
             clients={
                 CID_REDIS_STAT: resource.stat,

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -72,7 +72,11 @@ from ai.backend.common.dto.agent.response import (
     CodeCompletionResp,
     PurgeImagesResp,
 )
-from ai.backend.common.dto.internal.health import HealthResponse, HealthStatus
+from ai.backend.common.dto.internal.health import (
+    ConnectivityCheckResponse,
+    HealthResponse,
+    HealthStatus,
+)
 from ai.backend.common.dto.manager.rpc_request import PurgeImagesReq
 from ai.backend.common.etcd import AsyncEtcd, ConfigScopes
 from ai.backend.common.events.event_types.kernel.anycast import (
@@ -412,21 +416,22 @@ class AgentRPCServer(aobject):
         # Initialize health probe
         self.health_probe = HealthProbe(options=HealthProbeOptions(check_interval=60))
 
-        # Register health checkers
-        await self.health_probe.register(EtcdHealthChecker(etcd=self.etcd))
+        # Liveness-registered: also surfaced in readiness — connection-stuck
+        # issues observed where restart is the actual recovery path.
+        await self.health_probe.register_liveness(EtcdHealthChecker(etcd=self.etcd))
 
         # Get default agent for health checking
         default_agent = self.runtime.get_agent(None)
 
-        # Register Docker health checker based on config
         if self.local_config.agent_common.backend == AgentBackend.DOCKER:
             from ai.backend.agent.docker.agent import DockerAgent
 
             docker_agent = cast(DockerAgent, default_agent)
-            await self.health_probe.register(DockerHealthChecker(docker=docker_agent.docker))
+            await self.health_probe.register_liveness(
+                DockerHealthChecker(docker=docker_agent.docker)
+            )
 
-        # Register Valkey health checker with all 4 agent valkey clients
-        await self.health_probe.register(
+        await self.health_probe.register_liveness(
             ValkeyHealthChecker(
                 clients={
                     ComponentId("stat"): default_agent.valkey_stat_client,
@@ -1299,15 +1304,9 @@ async def server_main_logwrapper(
         traceback.print_exc(file=sys.stderr)
 
 
-async def check_health(request: web.Request) -> web.Response:
-    """Health check endpoint with dependency connectivity status"""
-
+def _build_agent_health_response(connectivity: ConnectivityCheckResponse) -> web.Response:
     from . import __version__
 
-    request["do_not_print_access_log"] = True
-
-    health_probe: HealthProbe = request.app["health_probe"]
-    connectivity = await health_probe.get_connectivity_status()
     response = HealthResponse(
         status=HealthStatus.OK if connectivity.overall_healthy else HealthStatus.DEGRADED,
         version=__version__,
@@ -1315,6 +1314,30 @@ async def check_health(request: web.Request) -> web.Response:
         connectivity=connectivity,
     )
     return web.json_response(response.model_dump(mode="json"))
+
+
+async def check_health(request: web.Request) -> web.Response:
+    """Aggregated health (union of liveness and readiness)."""
+    request["do_not_print_access_log"] = True
+    health_probe: HealthProbe = request.app["health_probe"]
+    connectivity = await health_probe.get_connectivity_status()
+    return _build_agent_health_response(connectivity)
+
+
+async def check_livez(request: web.Request) -> web.Response:
+    """Liveness probe — only liveness-registered checkers."""
+    request["do_not_print_access_log"] = True
+    health_probe: HealthProbe = request.app["health_probe"]
+    connectivity = await health_probe.get_liveness_status()
+    return _build_agent_health_response(connectivity)
+
+
+async def check_readyz(request: web.Request) -> web.Response:
+    """Readiness probe — only readiness-registered checkers."""
+    request["do_not_print_access_log"] = True
+    health_probe: HealthProbe = request.app["health_probe"]
+    connectivity = await health_probe.get_readiness_status()
+    return _build_agent_health_response(connectivity)
 
 
 def build_root_server() -> web.Application:
@@ -1333,6 +1356,8 @@ def build_root_server() -> web.Application:
         },
     )
     cors.add(app.router.add_route("GET", r"/health", check_health))
+    cors.add(app.router.add_route("GET", r"/livez", check_livez))
+    cors.add(app.router.add_route("GET", r"/readyz", check_readyz))
     cors.add(
         app.router.add_route("GET", r"/metrics", build_prometheus_metrics_handler(metric_registry))
     )

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -21,6 +21,7 @@ from collections.abc import (
     Sequence,
 )
 from contextlib import AsyncExitStack, asynccontextmanager
+from http import HTTPStatus
 from ipaddress import ip_network
 from pathlib import Path
 from pprint import pformat, pprint
@@ -1305,6 +1306,8 @@ async def server_main_logwrapper(
 
 
 def _build_agent_health_response(connectivity: ConnectivityCheckResponse) -> web.Response:
+    """Detail /health — always 200; informational tier failures reported as
+    DEGRADED in the body but not surfaced via HTTP status."""
     from . import __version__
 
     response = HealthResponse(
@@ -1314,6 +1317,23 @@ def _build_agent_health_response(connectivity: ConnectivityCheckResponse) -> web
         connectivity=connectivity,
     )
     return web.json_response(response.model_dump(mode="json"))
+
+
+def _build_agent_probe_response(connectivity: ConnectivityCheckResponse) -> web.Response:
+    """/livez, /readyz — 503 when any gating check fails so K8s probes trip."""
+    from . import __version__
+
+    is_healthy = connectivity.overall_healthy
+    response = HealthResponse(
+        status=HealthStatus.OK if is_healthy else HealthStatus.ERROR,
+        version=__version__,
+        component="agent",
+        connectivity=connectivity,
+    )
+    return web.json_response(
+        response.model_dump(mode="json"),
+        status=HTTPStatus.OK if is_healthy else HTTPStatus.SERVICE_UNAVAILABLE,
+    )
 
 
 async def check_health(request: web.Request) -> web.Response:
@@ -1329,7 +1349,7 @@ async def check_livez(request: web.Request) -> web.Response:
     request["do_not_print_access_log"] = True
     health_probe: HealthProbe = request.app["health_probe"]
     connectivity = await health_probe.get_liveness_status()
-    return _build_agent_health_response(connectivity)
+    return _build_agent_probe_response(connectivity)
 
 
 async def check_readyz(request: web.Request) -> web.Response:
@@ -1337,7 +1357,7 @@ async def check_readyz(request: web.Request) -> web.Response:
     request["do_not_print_access_log"] = True
     health_probe: HealthProbe = request.app["health_probe"]
     connectivity = await health_probe.get_readiness_status()
-    return _build_agent_health_response(connectivity)
+    return _build_agent_probe_response(connectivity)
 
 
 def build_root_server() -> web.Application:

--- a/src/ai/backend/appproxy/coordinator/api/health.py
+++ b/src/ai/backend/appproxy/coordinator/api/health.py
@@ -21,7 +21,11 @@ from ai.backend.appproxy.common.utils import pydantic_api_response_handler
 from ai.backend.appproxy.coordinator import __version__
 from ai.backend.appproxy.coordinator.models import Circuit, Endpoint, Worker
 from ai.backend.appproxy.coordinator.types import RootContext
-from ai.backend.common.dto.internal.health import HealthResponse, HealthStatus
+from ai.backend.common.dto.internal.health import (
+    ConnectivityCheckResponse,
+    HealthResponse,
+    HealthStatus,
+)
 from ai.backend.common.types import ModelServiceStatus
 from ai.backend.logging import BraceStyleAdapter
 
@@ -287,11 +291,7 @@ async def get_circuit_health(
     return PydanticResponse(HealthStatusResponseModel(success=True, circuits=[circuit_status]))
 
 
-async def hello(request: web.Request) -> web.Response:
-    """Health check endpoint with dependency connectivity status"""
-    request["do_not_print_access_log"] = True
-    root_ctx: RootContext = request.app["_root.context"]
-    connectivity = await root_ctx.health_probe.get_connectivity_status()
+def _build_coordinator_health_response(connectivity: ConnectivityCheckResponse) -> web.Response:
     response = HealthResponse(
         status=HealthStatus.OK if connectivity.overall_healthy else HealthStatus.DEGRADED,
         version=__version__,
@@ -299,6 +299,30 @@ async def hello(request: web.Request) -> web.Response:
         connectivity=connectivity,
     )
     return web.json_response(response.model_dump(mode="json"))
+
+
+async def hello(request: web.Request) -> web.Response:
+    """Aggregated health (union of liveness and readiness)."""
+    request["do_not_print_access_log"] = True
+    root_ctx: RootContext = request.app["_root.context"]
+    connectivity = await root_ctx.health_probe.get_connectivity_status()
+    return _build_coordinator_health_response(connectivity)
+
+
+async def livez(request: web.Request) -> web.Response:
+    """Liveness probe — only liveness-registered checkers."""
+    request["do_not_print_access_log"] = True
+    root_ctx: RootContext = request.app["_root.context"]
+    connectivity = await root_ctx.health_probe.get_liveness_status()
+    return _build_coordinator_health_response(connectivity)
+
+
+async def readyz(request: web.Request) -> web.Response:
+    """Readiness probe — only readiness-registered checkers."""
+    request["do_not_print_access_log"] = True
+    root_ctx: RootContext = request.app["_root.context"]
+    connectivity = await root_ctx.health_probe.get_readiness_status()
+    return _build_coordinator_health_response(connectivity)
 
 
 @auth_required("manager")
@@ -349,6 +373,8 @@ def create_app(
     add_route = app.router.add_route
     root_resource = cors.add(app.router.add_resource(r""))
     cors.add(root_resource.add_route("GET", hello))
+    cors.add(add_route("GET", "/livez", livez))
+    cors.add(add_route("GET", "/readyz", readyz))
     cors.add(add_route("GET", "/status", status))
     cors.add(add_route("GET", "/summary", get_health_summary))
     cors.add(add_route("GET", "/endpoints", get_endpoints_health))

--- a/src/ai/backend/appproxy/coordinator/api/health.py
+++ b/src/ai/backend/appproxy/coordinator/api/health.py
@@ -3,6 +3,7 @@
 import logging
 from collections.abc import Iterable
 from datetime import UTC, datetime
+from http import HTTPStatus
 from typing import Literal
 from uuid import UUID
 
@@ -292,6 +293,8 @@ async def get_circuit_health(
 
 
 def _build_coordinator_health_response(connectivity: ConnectivityCheckResponse) -> web.Response:
+    """Detail /health — always 200; informational tier failures reported as
+    DEGRADED in the body but not surfaced via HTTP status."""
     response = HealthResponse(
         status=HealthStatus.OK if connectivity.overall_healthy else HealthStatus.DEGRADED,
         version=__version__,
@@ -299,6 +302,21 @@ def _build_coordinator_health_response(connectivity: ConnectivityCheckResponse) 
         connectivity=connectivity,
     )
     return web.json_response(response.model_dump(mode="json"))
+
+
+def _build_coordinator_probe_response(connectivity: ConnectivityCheckResponse) -> web.Response:
+    """/livez, /readyz — 503 when any gating check fails so K8s probes trip."""
+    is_healthy = connectivity.overall_healthy
+    response = HealthResponse(
+        status=HealthStatus.OK if is_healthy else HealthStatus.ERROR,
+        version=__version__,
+        component="appproxy-coordinator",
+        connectivity=connectivity,
+    )
+    return web.json_response(
+        response.model_dump(mode="json"),
+        status=HTTPStatus.OK if is_healthy else HTTPStatus.SERVICE_UNAVAILABLE,
+    )
 
 
 async def hello(request: web.Request) -> web.Response:
@@ -314,7 +332,7 @@ async def livez(request: web.Request) -> web.Response:
     request["do_not_print_access_log"] = True
     root_ctx: RootContext = request.app["_root.context"]
     connectivity = await root_ctx.health_probe.get_liveness_status()
-    return _build_coordinator_health_response(connectivity)
+    return _build_coordinator_probe_response(connectivity)
 
 
 async def readyz(request: web.Request) -> web.Response:
@@ -322,7 +340,7 @@ async def readyz(request: web.Request) -> web.Response:
     request["do_not_print_access_log"] = True
     root_ctx: RootContext = request.app["_root.context"]
     connectivity = await root_ctx.health_probe.get_readiness_status()
-    return _build_coordinator_health_response(connectivity)
+    return _build_coordinator_probe_response(connectivity)
 
 
 @auth_required("manager")

--- a/src/ai/backend/appproxy/coordinator/cli/health.py
+++ b/src/ai/backend/appproxy/coordinator/cli/health.py
@@ -99,13 +99,14 @@ def check(
             coordinator_input = DependencyInput(config_path=config_path)
             await dependency_stack.enter_composer(coordinator_composer, coordinator_input)
 
-            # Get collected health checkers and register them
-            health_checkers = dependency_stack.get_health_checkers()
-            for key, checker in health_checkers.items():
-                await probe.register(checker)
+            liveness_checkers = dependency_stack.get_liveness_checkers()
+            readiness_checkers = dependency_stack.get_readiness_checkers()
+            for checker in liveness_checkers.values():
+                await probe.register_liveness(checker)
+            for checker in readiness_checkers.values():
+                await probe.register_readiness(checker)
 
-            # Perform health checks on successfully initialized components
-            if health_checkers:
+            if liveness_checkers or readiness_checkers:
                 await probe.check_all()
 
             yield

--- a/src/ai/backend/appproxy/coordinator/dependencies/infrastructure/database.py
+++ b/src/ai/backend/appproxy/coordinator/dependencies/infrastructure/database.py
@@ -23,14 +23,6 @@ class DatabaseProvider(DependencyProvider[ServerConfig, ExtendedAsyncSAEngine]):
         async with connect_database(setup_input.db) as db:
             yield db
 
-    def gen_health_checkers(self, resource: ExtendedAsyncSAEngine) -> ServiceHealthChecker:
-        """
-        Return database health checker.
-
-        Args:
-            resource: The initialized database engine
-
-        Returns:
-            Health checker for PostgreSQL database
-        """
+    def gen_readiness_checker(self, resource: ExtendedAsyncSAEngine) -> ServiceHealthChecker:
+        """Readiness only — DB unreachable should drain traffic, not trigger restart."""
         return DatabaseHealthChecker(db=resource)

--- a/src/ai/backend/appproxy/coordinator/dependencies/infrastructure/etcd.py
+++ b/src/ai/backend/appproxy/coordinator/dependencies/infrastructure/etcd.py
@@ -52,16 +52,8 @@ class EtcdProvider(DependencyProvider[ServerConfig, TraefikEtcd | None]):
         else:
             yield None
 
-    def gen_health_checkers(self, resource: TraefikEtcd | None) -> ServiceHealthChecker | None:
-        """
-        Return health checker for etcd if enabled.
-
-        Args:
-            resource: The initialized etcd client or None if not enabled
-
-        Returns:
-            Health checker for etcd if enabled, None otherwise
-        """
+    def gen_liveness_checker(self, resource: TraefikEtcd | None) -> ServiceHealthChecker | None:
+        """Liveness — stuck etcd connection observed; restart is the recovery path."""
         if resource is None:
             return None
         return EtcdHealthChecker(etcd=resource)

--- a/src/ai/backend/appproxy/coordinator/dependencies/infrastructure/redis.py
+++ b/src/ai/backend/appproxy/coordinator/dependencies/infrastructure/redis.py
@@ -91,16 +91,8 @@ class RedisProvider(DependencyProvider[ServerConfig, CoordinatorValkeyClients]):
             await valkey_schedule.close()
             await redis_lock.close()
 
-    def gen_health_checkers(self, resource: CoordinatorValkeyClients) -> ServiceHealthChecker:
-        """
-        Return health checkers for coordinator Valkey clients.
-
-        Args:
-            resource: The initialized Valkey clients
-
-        Returns:
-            Health checker for Valkey clients
-        """
+    def gen_liveness_checker(self, resource: CoordinatorValkeyClients) -> ServiceHealthChecker:
+        """Liveness — Valkey connection-stuck observed; restart recovers."""
         return ValkeyHealthChecker(
             clients={
                 CID_REDIS_LIVE: resource.valkey_live,

--- a/src/ai/backend/appproxy/coordinator/server.py
+++ b/src/ai/backend/appproxy/coordinator/server.py
@@ -806,9 +806,11 @@ async def health_probe_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
     probe = HealthProbe(options=HealthProbeOptions(check_interval=60))
     root_ctx.health_probe = probe
 
-    # Register health checkers using already-initialized resources
-    await probe.register(DatabaseHealthChecker(db=root_ctx.db))
-    await probe.register(
+    # Database: readiness only — no connection-stuck restart pattern needed.
+    await probe.register_readiness(DatabaseHealthChecker(db=root_ctx.db))
+
+    # Valkey: liveness — also surfaced in readiness.
+    await probe.register_liveness(
         ValkeyHealthChecker(
             clients={
                 ComponentId("live"): root_ctx.valkey_live,

--- a/src/ai/backend/appproxy/worker/api/health.py
+++ b/src/ai/backend/appproxy/worker/api/health.py
@@ -7,15 +7,14 @@ from ai.backend.appproxy.common.types import CORSOptions, FrontendServerMode, We
 from ai.backend.appproxy.worker import __version__
 from ai.backend.appproxy.worker.errors import MissingPortProxyConfigError
 from ai.backend.appproxy.worker.types import RootContext
-from ai.backend.common.dto.internal.health import HealthResponse, HealthStatus
+from ai.backend.common.dto.internal.health import (
+    ConnectivityCheckResponse,
+    HealthResponse,
+    HealthStatus,
+)
 
 
-async def hello(request: web.Request) -> web.Response:
-    """Health check endpoint with dependency connectivity status"""
-    request["do_not_print_access_log"] = True
-
-    root_ctx: RootContext = request.app["_root.context"]
-    connectivity = await root_ctx.health_probe.get_connectivity_status()
+def _build_worker_health_response(connectivity: ConnectivityCheckResponse) -> web.Response:
     response = HealthResponse(
         status=HealthStatus.OK if connectivity.overall_healthy else HealthStatus.DEGRADED,
         version=__version__,
@@ -23,6 +22,30 @@ async def hello(request: web.Request) -> web.Response:
         connectivity=connectivity,
     )
     return web.json_response(response.model_dump_json())
+
+
+async def hello(request: web.Request) -> web.Response:
+    """Aggregated health (union of liveness and readiness)."""
+    request["do_not_print_access_log"] = True
+    root_ctx: RootContext = request.app["_root.context"]
+    connectivity = await root_ctx.health_probe.get_connectivity_status()
+    return _build_worker_health_response(connectivity)
+
+
+async def livez(request: web.Request) -> web.Response:
+    """Liveness probe — only liveness-registered checkers."""
+    request["do_not_print_access_log"] = True
+    root_ctx: RootContext = request.app["_root.context"]
+    connectivity = await root_ctx.health_probe.get_liveness_status()
+    return _build_worker_health_response(connectivity)
+
+
+async def readyz(request: web.Request) -> web.Response:
+    """Readiness probe — only readiness-registered checkers."""
+    request["do_not_print_access_log"] = True
+    root_ctx: RootContext = request.app["_root.context"]
+    connectivity = await root_ctx.health_probe.get_readiness_status()
+    return _build_worker_health_response(connectivity)
 
 
 async def status(request: web.Request) -> web.Response:
@@ -72,5 +95,7 @@ def create_app(
     add_route = app.router.add_route
     root_resource = cors.add(app.router.add_resource(r""))
     cors.add(root_resource.add_route("GET", hello))
+    cors.add(add_route("GET", "/livez", livez))
+    cors.add(add_route("GET", "/readyz", readyz))
     cors.add(add_route("GET", "/status", status))
     return app, []

--- a/src/ai/backend/appproxy/worker/api/health.py
+++ b/src/ai/backend/appproxy/worker/api/health.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable
+from http import HTTPStatus
 
 import aiohttp_cors
 from aiohttp import web
@@ -15,6 +16,8 @@ from ai.backend.common.dto.internal.health import (
 
 
 def _build_worker_health_response(connectivity: ConnectivityCheckResponse) -> web.Response:
+    """Detail /health — always 200; informational tier failures reported as
+    DEGRADED in the body but not surfaced via HTTP status."""
     response = HealthResponse(
         status=HealthStatus.OK if connectivity.overall_healthy else HealthStatus.DEGRADED,
         version=__version__,
@@ -22,6 +25,21 @@ def _build_worker_health_response(connectivity: ConnectivityCheckResponse) -> we
         connectivity=connectivity,
     )
     return web.json_response(response.model_dump_json())
+
+
+def _build_worker_probe_response(connectivity: ConnectivityCheckResponse) -> web.Response:
+    """/livez, /readyz — 503 when any gating check fails so K8s probes trip."""
+    is_healthy = connectivity.overall_healthy
+    response = HealthResponse(
+        status=HealthStatus.OK if is_healthy else HealthStatus.ERROR,
+        version=__version__,
+        component="appproxy-worker",
+        connectivity=connectivity,
+    )
+    return web.json_response(
+        response.model_dump(mode="json"),
+        status=HTTPStatus.OK if is_healthy else HTTPStatus.SERVICE_UNAVAILABLE,
+    )
 
 
 async def hello(request: web.Request) -> web.Response:
@@ -37,7 +55,7 @@ async def livez(request: web.Request) -> web.Response:
     request["do_not_print_access_log"] = True
     root_ctx: RootContext = request.app["_root.context"]
     connectivity = await root_ctx.health_probe.get_liveness_status()
-    return _build_worker_health_response(connectivity)
+    return _build_worker_probe_response(connectivity)
 
 
 async def readyz(request: web.Request) -> web.Response:
@@ -45,7 +63,7 @@ async def readyz(request: web.Request) -> web.Response:
     request["do_not_print_access_log"] = True
     root_ctx: RootContext = request.app["_root.context"]
     connectivity = await root_ctx.health_probe.get_readiness_status()
-    return _build_worker_health_response(connectivity)
+    return _build_worker_probe_response(connectivity)
 
 
 async def status(request: web.Request) -> web.Response:

--- a/src/ai/backend/appproxy/worker/cli/health.py
+++ b/src/ai/backend/appproxy/worker/cli/health.py
@@ -99,13 +99,14 @@ def check(
             worker_input = DependencyInput(config_path=config_path)
             await dependency_stack.enter_composer(worker_composer, worker_input)
 
-            # Get collected health checkers and register them
-            health_checkers = dependency_stack.get_health_checkers()
-            for key, checker in health_checkers.items():
-                await probe.register(checker)
+            liveness_checkers = dependency_stack.get_liveness_checkers()
+            readiness_checkers = dependency_stack.get_readiness_checkers()
+            for checker in liveness_checkers.values():
+                await probe.register_liveness(checker)
+            for checker in readiness_checkers.values():
+                await probe.register_readiness(checker)
 
-            # Perform health checks on successfully initialized components
-            if health_checkers:
+            if liveness_checkers or readiness_checkers:
                 await probe.check_all()
 
             yield

--- a/src/ai/backend/appproxy/worker/dependencies/infrastructure/redis.py
+++ b/src/ai/backend/appproxy/worker/dependencies/infrastructure/redis.py
@@ -56,16 +56,8 @@ class RedisProvider(DependencyProvider[ServerConfig, WorkerValkeyClients]):
             await valkey_live.close()
             await valkey_stat.close()
 
-    def gen_health_checkers(self, resource: WorkerValkeyClients) -> ServiceHealthChecker:
-        """
-        Return health checkers for worker Valkey clients.
-
-        Args:
-            resource: The initialized Valkey clients
-
-        Returns:
-            Health checker for Valkey clients
-        """
+    def gen_liveness_checker(self, resource: WorkerValkeyClients) -> ServiceHealthChecker:
+        """Liveness — Valkey connection-stuck observed; restart recovers."""
         return ValkeyHealthChecker(
             clients={
                 CID_REDIS_LIVE: resource.valkey_live,

--- a/src/ai/backend/appproxy/worker/server.py
+++ b/src/ai/backend/appproxy/worker/server.py
@@ -18,6 +18,7 @@ from collections.abc import AsyncGenerator, AsyncIterator, Callable, Iterable, M
 from contextlib import AsyncExitStack, asynccontextmanager
 from datetime import UTC, datetime
 from functools import partial
+from http import HTTPStatus
 from pathlib import Path
 from typing import Any, Final, cast
 
@@ -615,6 +616,8 @@ async def metrics(request: web.Request) -> web.Response:
 
 
 def _build_worker_health_response(connectivity: ConnectivityCheckResponse) -> web.Response:
+    """Detail /health — always 200; informational tier failures reported as
+    DEGRADED in the body but not surfaced via HTTP status."""
     response = HealthResponse(
         status=HealthStatus.OK if connectivity.overall_healthy else HealthStatus.DEGRADED,
         version=__version__,
@@ -622,6 +625,21 @@ def _build_worker_health_response(connectivity: ConnectivityCheckResponse) -> we
         connectivity=connectivity,
     )
     return web.json_response(response.model_dump(mode="json"))
+
+
+def _build_worker_probe_response(connectivity: ConnectivityCheckResponse) -> web.Response:
+    """/livez, /readyz — 503 when any gating check fails so K8s probes trip."""
+    is_healthy = connectivity.overall_healthy
+    response = HealthResponse(
+        status=HealthStatus.OK if is_healthy else HealthStatus.ERROR,
+        version=__version__,
+        component="appproxy-worker",
+        connectivity=connectivity,
+    )
+    return web.json_response(
+        response.model_dump(mode="json"),
+        status=HTTPStatus.OK if is_healthy else HTTPStatus.SERVICE_UNAVAILABLE,
+    )
 
 
 async def hello(request: web.Request) -> web.Response:
@@ -637,7 +655,7 @@ async def livez(request: web.Request) -> web.Response:
     request["do_not_print_access_log"] = True
     root_ctx: RootContext = request.app["_root.context"]
     connectivity = await root_ctx.health_probe.get_liveness_status()
-    return _build_worker_health_response(connectivity)
+    return _build_worker_probe_response(connectivity)
 
 
 async def readyz(request: web.Request) -> web.Response:
@@ -645,7 +663,7 @@ async def readyz(request: web.Request) -> web.Response:
     request["do_not_print_access_log"] = True
     root_ctx: RootContext = request.app["_root.context"]
     connectivity = await root_ctx.health_probe.get_readiness_status()
-    return _build_worker_health_response(connectivity)
+    return _build_worker_probe_response(connectivity)
 
 
 async def status(request: web.Request) -> web.Response:

--- a/src/ai/backend/appproxy/worker/server.py
+++ b/src/ai/backend/appproxy/worker/server.py
@@ -82,7 +82,11 @@ from ai.backend.common.defs import (
     REDIS_STREAM_DB,
     RedisRole,
 )
-from ai.backend.common.dto.internal.health import HealthResponse, HealthStatus
+from ai.backend.common.dto.internal.health import (
+    ConnectivityCheckResponse,
+    HealthResponse,
+    HealthStatus,
+)
 from ai.backend.common.events.dispatcher import EventDispatcher, EventHandler, EventProducer
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.health_checker.checkers.valkey import ValkeyHealthChecker
@@ -500,8 +504,8 @@ async def health_probe_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
     probe = HealthProbe(options=HealthProbeOptions(check_interval=60))
     root_ctx.health_probe = probe
 
-    # Register health checkers using already-initialized resources
-    await probe.register(
+    # Valkey: liveness — also surfaced in readiness.
+    await probe.register_liveness(
         ValkeyHealthChecker(
             clients={
                 ComponentId("live"): root_ctx.valkey_live,
@@ -610,11 +614,7 @@ async def metrics(request: web.Request) -> web.Response:
     )
 
 
-async def hello(request: web.Request) -> web.Response:
-    """Health check endpoint with dependency connectivity status"""
-    request["do_not_print_access_log"] = True
-    root_ctx: RootContext = request.app["_root.context"]
-    connectivity = await root_ctx.health_probe.get_connectivity_status()
+def _build_worker_health_response(connectivity: ConnectivityCheckResponse) -> web.Response:
     response = HealthResponse(
         status=HealthStatus.OK if connectivity.overall_healthy else HealthStatus.DEGRADED,
         version=__version__,
@@ -622,6 +622,30 @@ async def hello(request: web.Request) -> web.Response:
         connectivity=connectivity,
     )
     return web.json_response(response.model_dump(mode="json"))
+
+
+async def hello(request: web.Request) -> web.Response:
+    """Aggregated health (union of liveness and readiness)."""
+    request["do_not_print_access_log"] = True
+    root_ctx: RootContext = request.app["_root.context"]
+    connectivity = await root_ctx.health_probe.get_connectivity_status()
+    return _build_worker_health_response(connectivity)
+
+
+async def livez(request: web.Request) -> web.Response:
+    """Liveness probe — only liveness-registered checkers."""
+    request["do_not_print_access_log"] = True
+    root_ctx: RootContext = request.app["_root.context"]
+    connectivity = await root_ctx.health_probe.get_liveness_status()
+    return _build_worker_health_response(connectivity)
+
+
+async def readyz(request: web.Request) -> web.Response:
+    """Readiness probe — only readiness-registered checkers."""
+    request["do_not_print_access_log"] = True
+    root_ctx: RootContext = request.app["_root.context"]
+    connectivity = await root_ctx.health_probe.get_readiness_status()
+    return _build_worker_health_response(connectivity)
 
 
 async def status(request: web.Request) -> web.Response:
@@ -811,6 +835,8 @@ def build_root_app(
     # should be done in create_app() in other modules.
     cors.add(app.router.add_route("GET", r"", hello))
     cors.add(app.router.add_route("GET", r"/", hello))
+    cors.add(app.router.add_route("GET", "/livez", livez))
+    cors.add(app.router.add_route("GET", "/readyz", readyz))
     cors.add(app.router.add_route("GET", "/status", status))
     cors.add(app.router.add_route("GET", "/metrics", metrics))
     for pkg_name in subapp_pkgs:

--- a/src/ai/backend/common/dependencies/base.py
+++ b/src/ai/backend/common/dependencies/base.py
@@ -45,44 +45,55 @@ class DependencyProvider[SetupInputT, ResourceT](ABC):
         """
         raise NotImplementedError
 
-    @abstractmethod
-    def gen_health_checkers(self, resource: ResourceT) -> ServiceHealthChecker | None:
+    def gen_liveness_checker(self, resource: ResourceT) -> ServiceHealthChecker | None:
         """
-        Return a health checker for the provided resource.
+        Return a liveness health checker for the provided resource.
 
-        Override this method to provide health checking capability for this dependency.
-        The health checker will be automatically collected by DependencyBuilderStack
-        and registered using checker.target_service_group as the key.
+        Override this method when the dependency should contribute to the liveness
+        probe — typically connection-stuck issues where a process restart is the
+        actual recovery path (e.g., Etcd, Valkey, Docker daemon).
 
         Args:
             resource: The initialized resource from provide()
 
         Returns:
-            ServiceHealthChecker instance or None if no health checking is needed
+            ServiceHealthChecker instance or None if this dependency does not
+            contribute to liveness checks.
         """
-        raise NotImplementedError
+        return None
+
+    def gen_readiness_checker(self, resource: ResourceT) -> ServiceHealthChecker | None:
+        """
+        Return a readiness health checker for the provided resource.
+
+        Override this method when the dependency should contribute to the readiness
+        probe only — failure should drain traffic but no process restart is needed
+        (e.g., database connections).
+
+        Args:
+            resource: The initialized resource from provide()
+
+        Returns:
+            ServiceHealthChecker instance or None if this dependency does not
+            contribute to readiness checks.
+        """
+        return None
 
 
 class NonMonitorableDependencyProvider(DependencyProvider[SetupInputT, ResourceT]):
     """
     Base class for dependency providers that do not require health monitoring.
 
-    This class provides a default implementation of gen_health_checkers()
-    that returns None, indicating no health checks are needed.
+    Both liveness and readiness checkers are pinned to None.
     """
 
     @final
-    def gen_health_checkers(self, resource: ResourceT) -> None:
-        """
-        Return None as this dependency does not require health monitoring.
+    def gen_liveness_checker(self, resource: ResourceT) -> None:
+        return None
 
-        Args:
-            resource: The initialized resource from provide()
-
-        Returns:
-            None indicating no health checks
-        """
-        return
+    @final
+    def gen_readiness_checker(self, resource: ResourceT) -> None:
+        return None
 
 
 class DependencyComposer[SetupInputT, ResourcesT](ABC):

--- a/src/ai/backend/common/dependencies/stacks/builder.py
+++ b/src/ai/backend/common/dependencies/stacks/builder.py
@@ -21,23 +21,19 @@ class DependencyBuilderStack(DependencyStack):
     """
     DependencyStack that collects health checkers from providers.
 
-    Uses AsyncExitStack internally for lifecycle management while automatically
-    collecting health checkers from providers that implement gen_health_checkers() method.
-
-    Health checkers are registered by their ServiceGroup (e.g., REDIS, DATABASE, ETCD).
-    Each ServiceGroup can have only one health checker, which checks multiple components
-    within that service group.
-
-    Health checkers can be retrieved after dependency initialization
-    to register them with a HealthProbe for health monitoring.
+    Uses AsyncExitStack internally for lifecycle management while collecting
+    liveness/readiness health checkers from each provider. Each ServiceGroup
+    can have only one checker per kind.
     """
 
     _stack: AsyncExitStack
-    _health_checkers: dict[ServiceGroup, ServiceHealthChecker]
+    _liveness_checkers: dict[ServiceGroup, ServiceHealthChecker]
+    _readiness_checkers: dict[ServiceGroup, ServiceHealthChecker]
 
     def __init__(self) -> None:
         self._stack = AsyncExitStack()
-        self._health_checkers = {}
+        self._liveness_checkers = {}
+        self._readiness_checkers = {}
 
     async def enter_dependency(
         self,
@@ -45,17 +41,17 @@ class DependencyBuilderStack(DependencyStack):
         setup_input: SetupInputT,
     ) -> ResourceT:
         """
-        Execute a dependency provider and collect health checker.
-
-        If the provider returns a health checker, it will be registered using
-        checker.target_service_group as the key.
+        Execute a dependency provider and collect its liveness/readiness checkers.
         """
         resource = await self._stack.enter_async_context(provider.provide(setup_input))
 
-        # Collect health checker from provider
-        checker = provider.gen_health_checkers(resource)
-        if checker is not None:
-            self._health_checkers[checker.target_service_group] = checker
+        liveness = provider.gen_liveness_checker(resource)
+        if liveness is not None:
+            self._liveness_checkers[liveness.target_service_group] = liveness
+
+        readiness = provider.gen_readiness_checker(resource)
+        if readiness is not None:
+            self._readiness_checkers[readiness.target_service_group] = readiness
 
         return resource
 
@@ -65,47 +61,35 @@ class DependencyBuilderStack(DependencyStack):
         setup_input: SetupInputT,
     ) -> ResourcesT:
         """
-        Execute a dependency composer and collect health checkers from nested dependencies.
-
-        Creates a nested DependencyBuilderStack to track dependencies
-        within the composer, then merges collected health checkers.
+        Execute a dependency composer and merge collected checkers from nested deps.
         """
-        # Create nested builder stack
         nested_stack = DependencyBuilderStack()
         await self._stack.enter_async_context(nested_stack)
 
-        # Compose and get resources
         resources = await nested_stack._stack.enter_async_context(
             composer.compose(nested_stack, setup_input)
         )
 
-        # Collect health checkers from nested stack
-        for service_group, checker in nested_stack._health_checkers.items():
-            self._health_checkers[service_group] = checker
+        for service_group, checker in nested_stack._liveness_checkers.items():
+            self._liveness_checkers[service_group] = checker
+        for service_group, checker in nested_stack._readiness_checkers.items():
+            self._readiness_checkers[service_group] = checker
 
         return resources
 
-    def get_health_checkers(self) -> dict[ServiceGroup, ServiceHealthChecker]:
-        """
-        Return collected health checkers.
+    def get_liveness_checkers(self) -> dict[ServiceGroup, ServiceHealthChecker]:
+        """Return collected liveness checkers."""
+        return self._liveness_checkers.copy()
 
-        Returns:
-            Dictionary mapping ServiceGroup to ServiceHealthChecker instances
-            collected from all initialized dependencies.
-        """
-        return self._health_checkers.copy()
+    def get_readiness_checkers(self) -> dict[ServiceGroup, ServiceHealthChecker]:
+        """Return collected readiness checkers."""
+        return self._readiness_checkers.copy()
 
     async def __aenter__(self) -> DependencyBuilderStack:
-        """
-        Enter the async context.
-        """
         await self._stack.__aenter__()
         return self
 
     async def __aexit__(
         self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: Any
     ) -> bool | None:
-        """
-        Exit the async context and cleanup resources in LIFO order.
-        """
         return await self._stack.__aexit__(exc_type, exc_val, exc_tb)

--- a/src/ai/backend/common/health_checker/__init__.py
+++ b/src/ai/backend/common/health_checker/__init__.py
@@ -17,7 +17,7 @@ from .exceptions import (
     HealthCheckerNotFound,
     HealthCheckError,
 )
-from .probe import HealthProbe, HealthProbeOptions, RegisteredChecker
+from .probe import HealthProbe, HealthProbeOptions
 from .types import (
     AGENT,
     APPPROXY,
@@ -44,6 +44,7 @@ from .types import (
     AllServicesHealth,
     ComponentHealthStatus,
     ComponentId,
+    ProbeKind,
     ServiceGroup,
     ServiceHealth,
 )
@@ -69,6 +70,7 @@ __all__ = [
     "ComponentHealthStatus",
     "ServiceHealth",
     "AllServicesHealth",
+    "ProbeKind",
     # Built-in ServiceGroups
     "MANAGER",
     "AGENT",
@@ -96,5 +98,4 @@ __all__ = [
     # Probe
     "HealthProbe",
     "HealthProbeOptions",
-    "RegisteredChecker",
 ]

--- a/src/ai/backend/common/health_checker/probe.py
+++ b/src/ai/backend/common/health_checker/probe.py
@@ -15,239 +15,137 @@ from ai.backend.common.dto.internal.health import (
 from ai.backend.logging.utils import BraceStyleAdapter
 
 from .abc import ServiceHealthChecker
-from .exceptions import HealthCheckerAlreadyRegistered, HealthCheckerNotFound
-from .types import AllServicesHealth, ServiceGroup, ServiceHealth
+from .exceptions import HealthCheckerAlreadyRegistered
+from .types import AllServicesHealth, ProbeKind, ServiceGroup, ServiceHealth
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @dataclass
 class HealthProbeOptions:
-    """
-    Configuration options for the health probe.
-    """
-
     check_interval: float = 60.0
-
-
-@dataclass
-class RegisteredChecker:
-    """
-    Container for a registered health checker with its latest result.
-
-    This is stored internally in the probe for each registered ServiceGroup.
-    Combines the checker instance with runtime status containing results
-    for multiple components within that service group.
-    """
-
-    checker: ServiceHealthChecker
-    result: ServiceHealth | None = None
-
-    @property
-    def current_result(self) -> ServiceHealth | None:
-        """
-        Get the current health check result.
-
-        Returns:
-            The current health check result, or None if no check has been performed yet
-        """
-        return self.result
 
 
 class HealthProbe:
     """
     Probe for running periodic health checks on registered service groups.
 
-    This class manages health checker registration and runs periodic checks
-    on all registered service groups. Each service group (e.g., REDIS, DATABASE, ETCD)
-    has one health checker that checks multiple components within that group.
+    Checkers are tagged at registration time as liveness, readiness, or
+    informational. The probe exposes a per-kind connectivity view to mirror
+    Kubernetes liveness/readiness probes:
+
+    - Liveness view: only liveness checkers gate `overall_healthy`.
+    - Readiness view: liveness + readiness checkers gate (a process that is
+      not alive cannot be ready).
+    - Detail view (`get_connectivity_status`): every registered checker
+      appears, including informational ones. `overall_healthy` here reflects
+      the full surface — informational failures degrade the detail view
+      without affecting the liveness or readiness probes.
     """
 
-    _checkers: dict[ServiceGroup, RegisteredChecker]
-    _lock: asyncio.Lock
+    _liveness: set[ServiceHealthChecker]
+    _readiness: set[ServiceHealthChecker]
+    _informational: set[ServiceHealthChecker]
+    _results: dict[ServiceGroup, ServiceHealth]
     _loop_task: asyncio.Task[Any] | None
     _running: bool
     _options: HealthProbeOptions
 
     def __init__(self, options: HealthProbeOptions) -> None:
-        """
-        Initialize the health probe.
-
-        Args:
-            options: Configuration options for the probe
-        """
-        self._checkers = {}
-        self._lock = asyncio.Lock()
+        self._liveness = set()
+        self._readiness = set()
+        self._informational = set()
+        self._results = {}
         self._loop_task = None
         self._running = False
         self._options = options
 
     async def start(self) -> None:
-        """
-        Start the periodic health check loop.
-
-        Creates a single background task that periodically checks all
-        registered checkers and runs those whose interval has elapsed.
-        Supports dynamic registration and unregistration of checkers.
-        """
         if self._running:
             log.warning("Health probe is already running")
             return
-
         self._running = True
         self._loop_task = asyncio.create_task(self._run_loop())
         log.info("Started health probe")
 
     async def stop(self) -> None:
-        """
-        Stop the periodic health check loop.
-
-        Cancels the background task and waits for it to complete.
-        """
         if not self._running:
             log.warning("Health probe is not running")
             return
-
         self._running = False
-
-        # Cancel the loop task
         if self._loop_task:
             await cancel_and_wait(self._loop_task)
             self._loop_task = None
-
         log.info("Stopped health probe")
 
+    async def register_liveness(self, checker: ServiceHealthChecker) -> None:
+        self._register(checker, ProbeKind.LIVENESS)
+
+    async def register_readiness(self, checker: ServiceHealthChecker) -> None:
+        self._register(checker, ProbeKind.READINESS)
+
+    async def register_informational(self, checker: ServiceHealthChecker) -> None:
+        """Register a checker whose result is surfaced in detail `/health` but
+        never gates liveness or readiness. Use for observability dependencies
+        (e.g. metrics backends) whose outage should not cut traffic or restart
+        the process.
+        """
+        self._register(checker, ProbeKind.INFORMATIONAL)
+
+    def _register(self, checker: ServiceHealthChecker, kind: ProbeKind) -> None:
+        service_group = checker.target_service_group
+        target = self._target_set(kind)
+
+        if checker in target:
+            raise HealthCheckerAlreadyRegistered(
+                f"Health checker already registered for {service_group} on {kind.value} probe"
+            )
+        for existing in self._all_checkers():
+            if existing.target_service_group == service_group and existing is not checker:
+                raise HealthCheckerAlreadyRegistered(
+                    f"A different checker instance is already registered for {service_group}"
+                )
+        target.add(checker)
+
+    def _target_set(self, kind: ProbeKind) -> set[ServiceHealthChecker]:
+        match kind:
+            case ProbeKind.LIVENESS:
+                return self._liveness
+            case ProbeKind.READINESS:
+                return self._readiness
+            case ProbeKind.INFORMATIONAL:
+                return self._informational
+
+    def _all_checkers(self) -> set[ServiceHealthChecker]:
+        return self._liveness | self._readiness | self._informational
+
     async def check_all(self) -> AllServicesHealth:
-        """
-        Check all registered health checkers immediately and return their results.
-
-        This is useful for CLI tools or manual health checks.
-        Updates the internal result registry with the results.
-
-        Returns:
-            AllServicesHealth containing results from all registered checkers
-        """
-        registered = await self._get_all_registered()
+        """Run every registered checker once and store the latest results."""
+        snapshot: list[ServiceHealthChecker] = list(self._all_checkers())
         now = datetime.now(UTC)
 
-        # Run all checks in parallel
-        check_tasks = [
-            self._check_single(service_group, reg.checker, now)
-            for service_group, reg in registered.items()
-        ]
-        results_or_exc = await asyncio.gather(*check_tasks, return_exceptions=True)
+        tasks = [self._check_single(c.target_service_group, c, now) for c in snapshot]
+        results_or_exc = await asyncio.gather(*tasks, return_exceptions=True)
 
         results: dict[ServiceGroup, ServiceHealth] = {}
-        for (service_group, _), result_or_exc in zip(
-            registered.items(), results_or_exc, strict=True
-        ):
+        for checker, result_or_exc in zip(snapshot, results_or_exc, strict=True):
+            service_group = checker.target_service_group
             if isinstance(result_or_exc, BaseException):
                 log.error(f"Unexpected error checking {service_group}: {result_or_exc}")
                 continue
-
             results[service_group] = result_or_exc
-            # Update the result in registry
-            try:
-                await self._update_result(service_group, result_or_exc)
-            except HealthCheckerNotFound:
-                # Checker was unregistered while we were checking
-                log.debug(f"Checker unregistered during check: {service_group}")
 
+        self._results.update(results)
         return AllServicesHealth(results=results)
 
-    async def register(
-        self,
-        checker: ServiceHealthChecker,
-    ) -> None:
-        """
-        Register a health checker for a specific service group.
-
-        The service group is automatically obtained from checker.target_service_group.
-
-        Args:
-            checker: The health checker instance that checks all components in this service group
-
-        Raises:
-            HealthCheckerAlreadyRegistered: If a checker is already registered for this service group
-        """
-        service_group = checker.target_service_group
-        async with self._lock:
-            if service_group in self._checkers:
-                raise HealthCheckerAlreadyRegistered(
-                    f"Health checker already registered for {service_group}"
-                )
-            self._checkers[service_group] = RegisteredChecker(
-                checker=checker,
-                result=None,
-            )
-
-    async def unregister(
-        self,
-        service_group: ServiceGroup,
-    ) -> None:
-        """
-        Unregister a health checker for a specific service group.
-
-        Args:
-            service_group: The service group to unregister
-
-        Raises:
-            HealthCheckerNotFound: If no checker is registered for this service group
-        """
-        async with self._lock:
-            if service_group not in self._checkers:
-                raise HealthCheckerNotFound(f"No health checker registered for {service_group}")
-            del self._checkers[service_group]
-
-    async def _get_all_registered(
-        self,
-    ) -> dict[ServiceGroup, RegisteredChecker]:
-        """
-        Get all registered checkers with their configurations and results.
-
-        Returns:
-            A mapping from ServiceGroup to RegisteredChecker
-        """
-        async with self._lock:
-            return dict(self._checkers)
-
-    async def _update_result(
-        self,
-        service_group: ServiceGroup,
-        result: ServiceHealth,
-    ) -> None:
-        """
-        Update the health check result for a specific service group.
-
-        Args:
-            service_group: The service group to update
-            result: The new health check result containing statuses for all components
-
-        Raises:
-            HealthCheckerNotFound: If no checker is registered for this service group
-        """
-        async with self._lock:
-            if service_group not in self._checkers:
-                raise HealthCheckerNotFound(f"No health checker registered for {service_group}")
-            self._checkers[service_group].result = result
-
     async def _run_loop(self) -> None:
-        """
-        Main loop that periodically checks all registered checkers.
-
-        This loop runs continuously, checking all registered checkers
-        at the configured interval.
-        Supports dynamic registration and unregistration.
-        """
         log.debug(f"Health probe loop started (check interval: {self._options.check_interval}s)")
-
         try:
             while self._running:
                 try:
                     await self.check_all()
                 except Exception as e:
                     log.error(f"Error in health probe loop: {e}", exc_info=True)
-                    # Continue running despite errors
                 finally:
                     await asyncio.sleep(self._options.check_interval)
         except asyncio.CancelledError:
@@ -262,53 +160,54 @@ class HealthProbe:
         checker: ServiceHealthChecker,
         check_time: datetime,
     ) -> ServiceHealth:
-        """
-        Execute a single health check for a service group.
-
-        Args:
-            service_group: The service group being checked
-            checker: The health checker to execute
-            check_time: The current time to record as check time
-
-        Returns:
-            The health check result containing statuses for all components in this service group
-        """
         try:
-            # Run the health check with timeout
             result = await asyncio.wait_for(checker.check_service(), timeout=checker.timeout)
             log.debug(f"Health check succeeded for {service_group}")
             return result
-
         except TimeoutError:
-            # Health check timed out - return empty result
             log.warning(f"Health check timed out for {service_group} after {checker.timeout}s")
             return ServiceHealth(results={})
-
         except Exception as e:
-            # Health check failed with exception
             log.error(f"Health check failed for {service_group}: {e}", exc_info=True)
             return ServiceHealth(results={})
 
     async def get_connectivity_status(self) -> ConnectivityCheckResponse:
+        """Return connectivity status across every registered checker, including
+        informational ones. Used by the detail `/health` endpoint."""
+        return self._build_connectivity_response(self._service_groups(self._all_checkers()))
+
+    async def get_liveness_status(self) -> ConnectivityCheckResponse:
+        """Return connectivity status for liveness-registered checkers only.
+
+        Informational and readiness-only checkers are excluded — only failures
+        that warrant a process restart contribute to `overall_healthy`.
         """
-        Get the current connectivity status for all registered components.
+        return self._build_connectivity_response(self._service_groups(self._liveness))
 
-        Converts internal health check results into a structured
-        connectivity check response suitable for external consumption.
-        Flattens component statuses from all service groups into a single list.
+    async def get_readiness_status(self) -> ConnectivityCheckResponse:
+        """Return connectivity status for readiness.
 
-        Returns:
-            ConnectivityCheckResponse containing overall connectivity health and individual component statuses
+        Liveness-registered checkers are included as well — a process that is
+        not alive cannot be ready. Informational checkers are excluded.
         """
-        registered = await self._get_all_registered()
+        return self._build_connectivity_response(
+            self._service_groups(self._liveness | self._readiness)
+        )
 
+    @staticmethod
+    def _service_groups(checkers: set[ServiceHealthChecker]) -> set[ServiceGroup]:
+        return {c.target_service_group for c in checkers}
+
+    def _build_connectivity_response(
+        self,
+        service_groups: set[ServiceGroup],
+    ) -> ConnectivityCheckResponse:
         components: list[ComponentConnectivityStatus] = []
-        for service_group, reg in registered.items():
-            if reg.result is None:
+        for service_group in service_groups:
+            result = self._results.get(service_group)
+            if result is None:
                 continue
-
-            # Flatten component statuses from the result
-            for component_id, status in reg.result.results.items():
+            for component_id, status in result.results.items():
                 components.append(
                     ComponentConnectivityStatus(
                         service_group=service_group,

--- a/src/ai/backend/common/health_checker/types.py
+++ b/src/ai/backend/common/health_checker/types.py
@@ -1,8 +1,32 @@
 from __future__ import annotations
 
+import enum
 from dataclasses import dataclass
 from datetime import datetime
 from typing import NewType
+
+
+class ProbeKind(enum.Enum):
+    """
+    Kind of health probe a checker contributes to.
+
+    Mirrors Kubernetes liveness vs readiness probes, plus an informational
+    lane for dependencies whose state is worth surfacing but not worth gating:
+
+    - LIVENESS: "Is the process alive and not deadlocked?" — failure triggers restart.
+    - READINESS: "Can this instance serve traffic?" — failure removes it from
+      the load balancer. Liveness-registered checkers also count toward
+      readiness (a process that is not alive cannot be ready).
+    - INFORMATIONAL: "Surface this dependency's state to operators but never
+      let it gate liveness or readiness." Use for observability/auxiliary
+      services (e.g. Prometheus) whose outage should not cut traffic or
+      cause restarts.
+    """
+
+    LIVENESS = "liveness"
+    READINESS = "readiness"
+    INFORMATIONAL = "informational"
+
 
 # Service group is a string identifier with type safety
 # Allows components to define their own service groups while maintaining type safety

--- a/src/ai/backend/manager/api/rest/internal/health/handler.py
+++ b/src/ai/backend/manager/api/rest/internal/health/handler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from http import HTTPStatus
 from typing import TYPE_CHECKING
 
 from aiohttp import web
@@ -21,7 +22,9 @@ if TYPE_CHECKING:
 _COMPONENT_NAME = "manager"
 
 
-def _build_response(connectivity: ConnectivityCheckResponse) -> web.Response:
+def _build_detail_response(connectivity: ConnectivityCheckResponse) -> web.Response:
+    """Detail /health — always 200; informational tier failures reported as
+    DEGRADED in the body but not surfaced via HTTP status."""
     response = HealthResponse(
         status=HealthStatus.OK if connectivity.overall_healthy else HealthStatus.DEGRADED,
         version=__version__,
@@ -29,6 +32,21 @@ def _build_response(connectivity: ConnectivityCheckResponse) -> web.Response:
         connectivity=connectivity,
     )
     return web.json_response(response.model_dump(mode="json"))
+
+
+def _build_probe_response(connectivity: ConnectivityCheckResponse) -> web.Response:
+    """/livez, /readyz — 503 when any gating check fails so K8s probes trip."""
+    is_healthy = connectivity.overall_healthy
+    response = HealthResponse(
+        status=HealthStatus.OK if is_healthy else HealthStatus.ERROR,
+        version=__version__,
+        component=_COMPONENT_NAME,
+        connectivity=connectivity,
+    )
+    return web.json_response(
+        response.model_dump(mode="json"),
+        status=HTTPStatus.OK if is_healthy else HTTPStatus.SERVICE_UNAVAILABLE,
+    )
 
 
 class InternalHealthHandler:
@@ -41,16 +59,16 @@ class InternalHealthHandler:
         """Aggregated health (union of liveness and readiness)."""
         request_ctx.request["do_not_print_access_log"] = True
         connectivity = await self._health_probe.get_connectivity_status()
-        return _build_response(connectivity)
+        return _build_detail_response(connectivity)
 
     async def livez(self, request_ctx: RequestCtx) -> web.Response:
         """Liveness probe — reports only liveness-registered checkers."""
         request_ctx.request["do_not_print_access_log"] = True
         connectivity = await self._health_probe.get_liveness_status()
-        return _build_response(connectivity)
+        return _build_probe_response(connectivity)
 
     async def readyz(self, request_ctx: RequestCtx) -> web.Response:
         """Readiness probe — reports only readiness-registered checkers."""
         request_ctx.request["do_not_print_access_log"] = True
         connectivity = await self._health_probe.get_readiness_status()
-        return _build_response(connectivity)
+        return _build_probe_response(connectivity)

--- a/src/ai/backend/manager/api/rest/internal/health/handler.py
+++ b/src/ai/backend/manager/api/rest/internal/health/handler.py
@@ -6,12 +6,29 @@ from typing import TYPE_CHECKING
 
 from aiohttp import web
 
-from ai.backend.common.dto.internal.health import HealthResponse, HealthStatus
+from ai.backend.common.dto.internal.health import (
+    ConnectivityCheckResponse,
+    HealthResponse,
+    HealthStatus,
+)
 from ai.backend.manager import __version__
 from ai.backend.manager.dto.context import RequestCtx
 
 if TYPE_CHECKING:
     from ai.backend.common.health_checker.probe import HealthProbe
+
+
+_COMPONENT_NAME = "manager"
+
+
+def _build_response(connectivity: ConnectivityCheckResponse) -> web.Response:
+    response = HealthResponse(
+        status=HealthStatus.OK if connectivity.overall_healthy else HealthStatus.DEGRADED,
+        version=__version__,
+        component=_COMPONENT_NAME,
+        connectivity=connectivity,
+    )
+    return web.json_response(response.model_dump(mode="json"))
 
 
 class InternalHealthHandler:
@@ -21,13 +38,19 @@ class InternalHealthHandler:
         self._health_probe = health_probe
 
     async def hello(self, request_ctx: RequestCtx) -> web.Response:
-        """Internal health check endpoint with full dependency connectivity status."""
+        """Aggregated health (union of liveness and readiness)."""
         request_ctx.request["do_not_print_access_log"] = True
         connectivity = await self._health_probe.get_connectivity_status()
-        response = HealthResponse(
-            status=HealthStatus.OK if connectivity.overall_healthy else HealthStatus.DEGRADED,
-            version=__version__,
-            component="manager",
-            connectivity=connectivity,
-        )
-        return web.json_response(response.model_dump(mode="json"))
+        return _build_response(connectivity)
+
+    async def livez(self, request_ctx: RequestCtx) -> web.Response:
+        """Liveness probe — reports only liveness-registered checkers."""
+        request_ctx.request["do_not_print_access_log"] = True
+        connectivity = await self._health_probe.get_liveness_status()
+        return _build_response(connectivity)
+
+    async def readyz(self, request_ctx: RequestCtx) -> web.Response:
+        """Readiness probe — reports only readiness-registered checkers."""
+        request_ctx.request["do_not_print_access_log"] = True
+        connectivity = await self._health_probe.get_readiness_status()
+        return _build_response(connectivity)

--- a/src/ai/backend/manager/api/rest/internal/health/registry.py
+++ b/src/ai/backend/manager/api/rest/internal/health/registry.py
@@ -12,5 +12,7 @@ def register_internal_health_routes(handler: InternalHealthHandler) -> RouteRegi
 
     # Internal endpoint — no CORS required
     reg.add("GET", "", handler.hello)
+    reg.add("GET", "/livez", handler.livez)
+    reg.add("GET", "/readyz", handler.readyz)
 
     return reg

--- a/src/ai/backend/manager/cli/health.py
+++ b/src/ai/backend/manager/cli/health.py
@@ -101,13 +101,14 @@ def check(
             manager_input = DependencyInput(config_path=config_path, log_level=log_level)
             await dependency_stack.enter_composer(manager_composer, manager_input)
 
-            # Get collected health checkers and register them
-            health_checkers = dependency_stack.get_health_checkers()
-            for key, checker in health_checkers.items():
-                await probe.register(checker)
+            liveness_checkers = dependency_stack.get_liveness_checkers()
+            readiness_checkers = dependency_stack.get_readiness_checkers()
+            for checker in liveness_checkers.values():
+                await probe.register_liveness(checker)
+            for checker in readiness_checkers.values():
+                await probe.register_readiness(checker)
 
-            # Perform health checks on successfully initialized components
-            if health_checkers:
+            if liveness_checkers or readiness_checkers:
                 await probe.check_all()
 
             yield

--- a/src/ai/backend/manager/dependencies/bootstrap/etcd.py
+++ b/src/ai/backend/manager/dependencies/bootstrap/etcd.py
@@ -31,14 +31,6 @@ class EtcdDependency(BootstrapDependency[AsyncEtcd]):
         async with AsyncEtcd.create_from_config(setup_input.etcd.to_dataclass()) as etcd:
             yield etcd
 
-    def gen_health_checkers(self, resource: AsyncEtcd) -> ServiceHealthChecker:
-        """
-        Return health checker for etcd.
-
-        Args:
-            resource: The initialized etcd client
-
-        Returns:
-            EtcdHealthChecker for etcd
-        """
+    def gen_liveness_checker(self, resource: AsyncEtcd) -> ServiceHealthChecker:
+        """Liveness — stuck etcd connection observed; restart is the recovery path."""
         return EtcdHealthChecker(etcd=resource)

--- a/src/ai/backend/manager/dependencies/components/storage.py
+++ b/src/ai/backend/manager/dependencies/components/storage.py
@@ -33,17 +33,3 @@ class StorageManagerDependency(ComponentDependency[StorageSessionManager]):
             yield storage_manager
         finally:
             await storage_manager.aclose()
-
-    def gen_health_checkers(self, resource: StorageSessionManager) -> None:
-        """
-        Return health checkers for storage manager.
-
-        Currently no health checks are implemented for storage manager.
-
-        Args:
-            resource: The initialized storage session manager
-
-        Returns:
-            None (no health checks)
-        """
-        return

--- a/src/ai/backend/manager/dependencies/infrastructure/database.py
+++ b/src/ai/backend/manager/dependencies/infrastructure/database.py
@@ -33,17 +33,9 @@ class DatabaseDependency(InfrastructureDependency[ExtendedAsyncSAEngine]):
         async with connect_database(setup_input.db) as db:
             yield db
 
-    def gen_health_checkers(
+    def gen_readiness_checker(
         self,
         resource: ExtendedAsyncSAEngine,
     ) -> ServiceHealthChecker:
-        """
-        Return database health checker.
-
-        Args:
-            resource: The initialized database engine
-
-        Returns:
-            DatabaseHealthChecker for PostgreSQL database
-        """
+        """Readiness only — DB unreachable should drain traffic, not trigger restart."""
         return DatabaseHealthChecker(db=resource)

--- a/src/ai/backend/manager/dependencies/infrastructure/redis.py
+++ b/src/ai/backend/manager/dependencies/infrastructure/redis.py
@@ -156,19 +156,11 @@ class ValkeyDependency(InfrastructureDependency[ValkeyClients]):
         finally:
             await clients.close()
 
-    def gen_health_checkers(
+    def gen_liveness_checker(
         self,
         resource: ValkeyClients,
     ) -> ServiceHealthChecker:
-        """
-        Return a single health checker for all 8 Valkey clients.
-
-        Args:
-            resource: The initialized Valkey clients
-
-        Returns:
-            ValkeyHealthChecker that checks all 8 Valkey clients
-        """
+        """Liveness — Valkey connection-stuck observed; restart recovers."""
         return ValkeyHealthChecker(
             clients={
                 CID_REDIS_ARTIFACT: resource.artifact,

--- a/src/ai/backend/manager/dependencies/system/health_probe.py
+++ b/src/ai/backend/manager/dependencies/system/health_probe.py
@@ -19,7 +19,6 @@ from ai.backend.common.health_checker import (
     HealthProbe,
     HealthProbeOptions,
     PrometheusHealthChecker,
-    ServiceHealthChecker,
     ValkeyHealthChecker,
 )
 from ai.backend.manager.dependencies.infrastructure.redis import ValkeyClients
@@ -47,10 +46,18 @@ class HealthProbeDependency(DependencyProvider[HealthProbeInput, HealthProbe]):
     async def provide(self, setup_input: HealthProbeInput) -> AsyncIterator[HealthProbe]:
         probe = HealthProbe(options=HealthProbeOptions(check_interval=60))
 
-        await probe.register(DatabaseHealthChecker(db=setup_input.db))
-        await probe.register(EtcdHealthChecker(etcd=setup_input.etcd))
-        await probe.register(PrometheusHealthChecker())
-        await probe.register(
+        # Readiness-only: failure should drain traffic, but no restart is warranted.
+        await probe.register_readiness(DatabaseHealthChecker(db=setup_input.db))
+
+        # Informational: surfaced in detail /health but does not gate either
+        # probe. Prometheus is an observability dependency — its outage
+        # should neither restart the manager nor cut user traffic.
+        await probe.register_informational(PrometheusHealthChecker())
+
+        # Liveness-registered: also surfaced in readiness — connection-stuck
+        # issues observed where restart is the actual recovery path.
+        await probe.register_liveness(EtcdHealthChecker(etcd=setup_input.etcd))
+        await probe.register_liveness(
             ValkeyHealthChecker(
                 clients={
                     CID_REDIS_ARTIFACT: setup_input.valkey.artifact,
@@ -70,6 +77,3 @@ class HealthProbeDependency(DependencyProvider[HealthProbeInput, HealthProbe]):
             yield probe
         finally:
             await probe.stop()
-
-    def gen_health_checkers(self, resource: HealthProbe) -> ServiceHealthChecker | None:
-        return None

--- a/src/ai/backend/storage/api/manager.py
+++ b/src/ai/backend/storage/api/manager.py
@@ -33,7 +33,11 @@ from ai.backend.common.api_handlers import (
     api_handler,
 )
 from ai.backend.common.defs import DEFAULT_VFOLDER_PERMISSION_MODE
-from ai.backend.common.dto.internal.health import HealthResponse, HealthStatus
+from ai.backend.common.dto.internal.health import (
+    ConnectivityCheckResponse,
+    HealthResponse,
+    HealthStatus,
+)
 from ai.backend.common.dto.storage.request import (
     ArchiveDownloadTokenData,
     CreateArchiveDownloadSessionRequest,
@@ -141,22 +145,41 @@ def skip_token_auth(
     return handler
 
 
-@skip_token_auth
-async def check_health(request: web.Request) -> web.Response:
-    """Health check endpoint with dependency connectivity status"""
-
-    request["do_not_print_access_log"] = True
-
-    ctx: RootContext = request.app["ctx"]
-    connectivity = await ctx.health_probe.get_connectivity_status()
+def _build_storage_health_response(connectivity: ConnectivityCheckResponse) -> web.Response:
     response = HealthResponse(
         status=HealthStatus.OK if connectivity.overall_healthy else HealthStatus.DEGRADED,
         version=__version__,
         component="storage-proxy",
         connectivity=connectivity,
     )
-
     return web.json_response(response.model_dump(mode="json"))
+
+
+@skip_token_auth
+async def check_health(request: web.Request) -> web.Response:
+    """Aggregated health (union of liveness and readiness)."""
+    request["do_not_print_access_log"] = True
+    ctx: RootContext = request.app["ctx"]
+    connectivity = await ctx.health_probe.get_connectivity_status()
+    return _build_storage_health_response(connectivity)
+
+
+@skip_token_auth
+async def check_livez(request: web.Request) -> web.Response:
+    """Liveness probe — only liveness-registered checkers."""
+    request["do_not_print_access_log"] = True
+    ctx: RootContext = request.app["ctx"]
+    connectivity = await ctx.health_probe.get_liveness_status()
+    return _build_storage_health_response(connectivity)
+
+
+@skip_token_auth
+async def check_readyz(request: web.Request) -> web.Response:
+    """Readiness probe — only readiness-registered checkers."""
+    request["do_not_print_access_log"] = True
+    ctx: RootContext = request.app["ctx"]
+    connectivity = await ctx.health_probe.get_readiness_status()
+    return _build_storage_health_response(connectivity)
 
 
 @skip_token_auth
@@ -1308,6 +1331,8 @@ async def init_manager_app(ctx: RootContext) -> web.Application:
 
     app.router.add_route("GET", "/", check_status)
     app.router.add_route("GET", "/health", check_health)
+    app.router.add_route("GET", "/livez", check_livez)
+    app.router.add_route("GET", "/readyz", check_readyz)
     app.router.add_route("GET", "/status", check_status)
     app.router.add_route("GET", "/volumes", get_volumes)
     app.router.add_route("GET", "/volume/hwinfo", get_hwinfo)
@@ -1359,6 +1384,8 @@ def init_internal_app(ctx: RootContext) -> web.Application:
     app["ctx"] = ctx
     metric_registry = CommonMetricRegistry.instance()
     app.router.add_route("GET", "/health", check_health)
+    app.router.add_route("GET", "/livez", check_livez)
+    app.router.add_route("GET", "/readyz", check_readyz)
     app.router.add_route("GET", "/metrics", build_prometheus_metrics_handler(metric_registry))
     return app
 

--- a/src/ai/backend/storage/api/manager.py
+++ b/src/ai/backend/storage/api/manager.py
@@ -146,6 +146,8 @@ def skip_token_auth(
 
 
 def _build_storage_health_response(connectivity: ConnectivityCheckResponse) -> web.Response:
+    """Detail /health — always 200; informational tier failures reported as
+    DEGRADED in the body but not surfaced via HTTP status."""
     response = HealthResponse(
         status=HealthStatus.OK if connectivity.overall_healthy else HealthStatus.DEGRADED,
         version=__version__,
@@ -153,6 +155,21 @@ def _build_storage_health_response(connectivity: ConnectivityCheckResponse) -> w
         connectivity=connectivity,
     )
     return web.json_response(response.model_dump(mode="json"))
+
+
+def _build_storage_probe_response(connectivity: ConnectivityCheckResponse) -> web.Response:
+    """/livez, /readyz — 503 when any gating check fails so K8s probes trip."""
+    is_healthy = connectivity.overall_healthy
+    response = HealthResponse(
+        status=HealthStatus.OK if is_healthy else HealthStatus.ERROR,
+        version=__version__,
+        component="storage-proxy",
+        connectivity=connectivity,
+    )
+    return web.json_response(
+        response.model_dump(mode="json"),
+        status=HTTPStatus.OK if is_healthy else HTTPStatus.SERVICE_UNAVAILABLE,
+    )
 
 
 @skip_token_auth
@@ -170,7 +187,7 @@ async def check_livez(request: web.Request) -> web.Response:
     request["do_not_print_access_log"] = True
     ctx: RootContext = request.app["ctx"]
     connectivity = await ctx.health_probe.get_liveness_status()
-    return _build_storage_health_response(connectivity)
+    return _build_storage_probe_response(connectivity)
 
 
 @skip_token_auth
@@ -179,7 +196,7 @@ async def check_readyz(request: web.Request) -> web.Response:
     request["do_not_print_access_log"] = True
     ctx: RootContext = request.app["ctx"]
     connectivity = await ctx.health_probe.get_readiness_status()
-    return _build_storage_health_response(connectivity)
+    return _build_storage_probe_response(connectivity)
 
 
 @skip_token_auth

--- a/src/ai/backend/storage/cli/health.py
+++ b/src/ai/backend/storage/cli/health.py
@@ -99,13 +99,14 @@ def check(
             storage_input = DependencyInput(config_path=config_path)
             await dependency_stack.enter_composer(storage_composer, storage_input)
 
-            # Get collected health checkers and register them
-            health_checkers = dependency_stack.get_health_checkers()
-            for key, checker in health_checkers.items():
-                await probe.register(checker)
+            liveness_checkers = dependency_stack.get_liveness_checkers()
+            readiness_checkers = dependency_stack.get_readiness_checkers()
+            for checker in liveness_checkers.values():
+                await probe.register_liveness(checker)
+            for checker in readiness_checkers.values():
+                await probe.register_readiness(checker)
 
-            # Perform health checks on successfully initialized components
-            if health_checkers:
+            if liveness_checkers or readiness_checkers:
                 await probe.check_all()
 
             yield

--- a/src/ai/backend/storage/dependencies/infrastructure/etcd.py
+++ b/src/ai/backend/storage/dependencies/infrastructure/etcd.py
@@ -24,14 +24,6 @@ class EtcdProvider(DependencyProvider[StorageProxyUnifiedConfig, AsyncEtcd]):
         async with make_etcd(setup_input) as etcd:
             yield etcd
 
-    def gen_health_checkers(self, resource: AsyncEtcd) -> ServiceHealthChecker:
-        """
-        Return health checker for etcd.
-
-        Args:
-            resource: The initialized etcd client
-
-        Returns:
-            Health checker for etcd
-        """
+    def gen_liveness_checker(self, resource: AsyncEtcd) -> ServiceHealthChecker:
+        """Liveness — stuck etcd connection observed; restart is the recovery path."""
         return EtcdHealthChecker(etcd=resource)

--- a/src/ai/backend/storage/dependencies/infrastructure/redis.py
+++ b/src/ai/backend/storage/dependencies/infrastructure/redis.py
@@ -70,16 +70,8 @@ class RedisProvider(DependencyProvider[AsyncEtcd, StorageProxyValkeyClients]):
             await bgtask_client.close()
             await artifact_client.close()
 
-    def gen_health_checkers(self, resource: StorageProxyValkeyClients) -> ServiceHealthChecker:
-        """
-        Return health checkers for storage proxy Valkey clients.
-
-        Args:
-            resource: The initialized Valkey clients
-
-        Returns:
-            Health checker for bgtask and artifact clients
-        """
+    def gen_liveness_checker(self, resource: StorageProxyValkeyClients) -> ServiceHealthChecker:
+        """Liveness — Valkey connection-stuck observed; restart recovers."""
         return ValkeyHealthChecker(
             clients={
                 CID_REDIS_BGTASK: resource.bgtask,

--- a/src/ai/backend/storage/server.py
+++ b/src/ai/backend/storage/server.py
@@ -646,8 +646,10 @@ async def server_main(
 
         # Initialize health probe
         health_probe = HealthProbe(options=HealthProbeOptions(check_interval=60))
-        await health_probe.register(EtcdHealthChecker(etcd=etcd))
-        await health_probe.register(
+        # Liveness-registered: also surfaced in readiness — connection-stuck
+        # issues observed where restart is the actual recovery path.
+        await health_probe.register_liveness(EtcdHealthChecker(etcd=etcd))
+        await health_probe.register_liveness(
             ValkeyHealthChecker(
                 clients={
                     ComponentId("bgtask"): bgtask_mgr._valkey_client,

--- a/src/ai/backend/web/cli/health.py
+++ b/src/ai/backend/web/cli/health.py
@@ -101,13 +101,14 @@ def check(
             web_input = DependencyInput(config_path=config_path, log_level=log_level)
             await dependency_stack.enter_composer(web_composer, web_input)
 
-            # Get collected health checkers and register them
-            health_checkers = dependency_stack.get_health_checkers()
-            for key, checker in health_checkers.items():
-                await probe.register(checker)
+            liveness_checkers = dependency_stack.get_liveness_checkers()
+            readiness_checkers = dependency_stack.get_readiness_checkers()
+            for checker in liveness_checkers.values():
+                await probe.register_liveness(checker)
+            for checker in readiness_checkers.values():
+                await probe.register_readiness(checker)
 
-            # Perform health checks on successfully initialized components
-            if health_checkers:
+            if liveness_checkers or readiness_checkers:
                 await probe.check_all()
 
             yield

--- a/src/ai/backend/web/dependencies/infrastructure/redis.py
+++ b/src/ai/backend/web/dependencies/infrastructure/redis.py
@@ -42,14 +42,6 @@ class RedisProvider(DependencyProvider[WebServerUnifiedConfig, ValkeySessionClie
         finally:
             await valkey_session_client.close()
 
-    def gen_health_checkers(self, resource: ValkeySessionClient) -> ServiceHealthChecker:
-        """
-        Return health checker for session Valkey client.
-
-        Args:
-            resource: The initialized Valkey session client
-
-        Returns:
-            Health checker for session storage
-        """
+    def gen_liveness_checker(self, resource: ValkeySessionClient) -> ServiceHealthChecker:
+        """Liveness — Valkey connection-stuck observed; restart recovers."""
         return ValkeyHealthChecker(clients={CID_REDIS_SESSION: resource})

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -48,7 +48,11 @@ from ai.backend.common import config
 from ai.backend.common.clients.http_client.client_pool import ClientPool
 from ai.backend.common.clients.valkey_client.valkey_session.client import ValkeySessionClient
 from ai.backend.common.defs import REDIS_STATISTICS_DB, RedisRole
-from ai.backend.common.dto.internal.health import HealthResponse, HealthStatus
+from ai.backend.common.dto.internal.health import (
+    ConnectivityCheckResponse,
+    HealthResponse,
+    HealthStatus,
+)
 from ai.backend.common.dto.manager.auth.request import UpdatePasswordNoAuthRequest
 from ai.backend.common.dto.manager.auth.types import (
     AuthSuccessResponse,
@@ -547,20 +551,38 @@ async def extend_login_session(request: web.Request) -> web.Response:
     return web.json_response(result)
 
 
-async def check_health(request: web.Request) -> web.Response:
-    """Health check endpoint with dependency connectivity status"""
-    request["do_not_print_access_log"] = True
-
-    health_probe: HealthProbe = request.app["health_probe"]
-    connectivity = await health_probe.get_connectivity_status()
+def _build_web_health_response(connectivity: ConnectivityCheckResponse) -> web.Response:
     response = HealthResponse(
         status=HealthStatus.OK if connectivity.overall_healthy else HealthStatus.DEGRADED,
         version=__version__,
         component="webserver",
         connectivity=connectivity,
     )
-
     return web.json_response(response.model_dump(mode="json"))
+
+
+async def check_health(request: web.Request) -> web.Response:
+    """Aggregated health (union of liveness and readiness)."""
+    request["do_not_print_access_log"] = True
+    health_probe: HealthProbe = request.app["health_probe"]
+    connectivity = await health_probe.get_connectivity_status()
+    return _build_web_health_response(connectivity)
+
+
+async def check_livez(request: web.Request) -> web.Response:
+    """Liveness probe — only liveness-registered checkers."""
+    request["do_not_print_access_log"] = True
+    health_probe: HealthProbe = request.app["health_probe"]
+    connectivity = await health_probe.get_liveness_status()
+    return _build_web_health_response(connectivity)
+
+
+async def check_readyz(request: web.Request) -> web.Response:
+    """Readiness probe — only readiness-registered checkers."""
+    request["do_not_print_access_log"] = True
+    health_probe: HealthProbe = request.app["health_probe"]
+    connectivity = await health_probe.get_readiness_status()
+    return _build_web_health_response(connectivity)
 
 
 async def webserver_healthcheck(request: web.Request) -> web.Response:
@@ -882,6 +904,8 @@ async def webapp_ctx(
     cors.add(app.router.add_route("POST", "/server/extend-login-session", extend_login_session))
     cors.add(app.router.add_route("GET", "/stats", view_stats))
     cors.add(app.router.add_route("GET", "/health", check_health))
+    cors.add(app.router.add_route("GET", "/livez", check_livez))
+    cors.add(app.router.add_route("GET", "/readyz", check_readyz))
     cors.add(app.router.add_route("GET", "/func/ping", webserver_healthcheck))
     cors.add(app.router.add_route("GET", "/func/{path:cloud/.*$}", anon_web_plugin_handler))
     cors.add(app.router.add_route("POST", "/func/{path:cloud/.*$}", anon_web_plugin_handler))
@@ -1000,7 +1024,8 @@ async def server_main(
 
         # Initialize health probe
         health_probe = HealthProbe(options=HealthProbeOptions(check_interval=60))
-        await health_probe.register(
+        # Valkey: liveness — also surfaced in readiness.
+        await health_probe.register_liveness(
             ValkeyHealthChecker(
                 clients={
                     ComponentId("session"): app["redis"],

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -23,6 +23,7 @@ from collections.abc import (
 from contextlib import AsyncExitStack, asynccontextmanager
 from datetime import UTC, datetime
 from functools import partial
+from http import HTTPStatus
 from pathlib import Path
 from pprint import pprint
 from typing import Any, cast
@@ -552,6 +553,8 @@ async def extend_login_session(request: web.Request) -> web.Response:
 
 
 def _build_web_health_response(connectivity: ConnectivityCheckResponse) -> web.Response:
+    """Detail /health — always 200; informational tier failures reported as
+    DEGRADED in the body but not surfaced via HTTP status."""
     response = HealthResponse(
         status=HealthStatus.OK if connectivity.overall_healthy else HealthStatus.DEGRADED,
         version=__version__,
@@ -559,6 +562,21 @@ def _build_web_health_response(connectivity: ConnectivityCheckResponse) -> web.R
         connectivity=connectivity,
     )
     return web.json_response(response.model_dump(mode="json"))
+
+
+def _build_web_probe_response(connectivity: ConnectivityCheckResponse) -> web.Response:
+    """/livez, /readyz — 503 when any gating check fails so K8s probes trip."""
+    is_healthy = connectivity.overall_healthy
+    response = HealthResponse(
+        status=HealthStatus.OK if is_healthy else HealthStatus.ERROR,
+        version=__version__,
+        component="webserver",
+        connectivity=connectivity,
+    )
+    return web.json_response(
+        response.model_dump(mode="json"),
+        status=HTTPStatus.OK if is_healthy else HTTPStatus.SERVICE_UNAVAILABLE,
+    )
 
 
 async def check_health(request: web.Request) -> web.Response:
@@ -574,7 +592,7 @@ async def check_livez(request: web.Request) -> web.Response:
     request["do_not_print_access_log"] = True
     health_probe: HealthProbe = request.app["health_probe"]
     connectivity = await health_probe.get_liveness_status()
-    return _build_web_health_response(connectivity)
+    return _build_web_probe_response(connectivity)
 
 
 async def check_readyz(request: web.Request) -> web.Response:
@@ -582,7 +600,7 @@ async def check_readyz(request: web.Request) -> web.Response:
     request["do_not_print_access_log"] = True
     health_probe: HealthProbe = request.app["health_probe"]
     connectivity = await health_probe.get_readiness_status()
-    return _build_web_health_response(connectivity)
+    return _build_web_probe_response(connectivity)
 
 
 async def webserver_healthcheck(request: web.Request) -> web.Response:

--- a/tests/unit/common/health_checker/test_probe.py
+++ b/tests/unit/common/health_checker/test_probe.py
@@ -14,7 +14,6 @@ from ai.backend.common.health_checker import (
     ComponentHealthStatus,
     ComponentId,
     HealthCheckerAlreadyRegistered,
-    HealthCheckerNotFound,
     HealthProbe,
     ServiceGroup,
     ServiceHealth,
@@ -22,310 +21,170 @@ from ai.backend.common.health_checker import (
 )
 
 
-async def test_probe_register_checker(
-    health_probe: HealthProbe,
-    sample_service_group: ServiceGroup,
-    mock_healthy_checker: ServiceHealthChecker,
-) -> None:
-    """Test registering a health checker."""
-    await health_probe.register(mock_healthy_checker)
-
-    # Verify registration by getting all registered checkers
-    registered = await health_probe._get_all_registered()
-    assert sample_service_group in registered
-    assert registered[sample_service_group].checker == mock_healthy_checker
-    assert registered[sample_service_group].result is None  # Not checked yet
-
-
-async def test_probe_register_duplicate_checker_raises_error(
-    health_probe: HealthProbe,
-    sample_service_group: ServiceGroup,
-    mock_healthy_checker: ServiceHealthChecker,
-) -> None:
-    """Test that registering a duplicate checker raises HealthCheckerAlreadyRegistered."""
-    await health_probe.register(mock_healthy_checker)
-
-    # Try to register again with the same key
-    with pytest.raises(HealthCheckerAlreadyRegistered) as exc_info:
-        await health_probe.register(mock_healthy_checker)
-
-    # Verify the exception contains service_group
-    assert str(sample_service_group) in str(exc_info.value)
-
-
-async def test_probe_unregister_checker(
-    health_probe: HealthProbe,
-    sample_service_group: ServiceGroup,
-    mock_healthy_checker: ServiceHealthChecker,
-) -> None:
-    """Test unregistering a health checker."""
-    await health_probe.register(mock_healthy_checker)
-    await health_probe.unregister(sample_service_group)
-
-    # Verify unregistration
-    registered = await health_probe._get_all_registered()
-    assert sample_service_group not in registered
-
-
-async def test_probe_unregister_nonexistent_checker_raises_error(
-    health_probe: HealthProbe,
-    sample_service_group: ServiceGroup,
-) -> None:
-    """Test that unregistering a non-existent checker raises HealthCheckerNotFound."""
-    with pytest.raises(HealthCheckerNotFound) as exc_info:
-        await health_probe.unregister(sample_service_group)
-
-    # Verify the exception contains service_group
-    assert str(sample_service_group) in str(exc_info.value)
-
-
-async def test_probe_register_multiple_checkers(
-    health_probe: HealthProbe,
-    mock_healthy_checker: ServiceHealthChecker,
-) -> None:
-    """Test registering multiple health checkers."""
-    # Create separate mock checkers with different service groups
+def _make_checker(
+    service_group: ServiceGroup,
+    *,
+    is_healthy: bool = True,
+    error_message: str | None = None,
+    component_id: str = "test-component",
+    timeout: float = 1.0,
+) -> ServiceHealthChecker:
     check_time = datetime.now(UTC)
-    healthy_result = ServiceHealth(
+    result = ServiceHealth(
         results={
-            ComponentId("test-component"): ComponentHealthStatus(
-                is_healthy=True,
+            ComponentId(component_id): ComponentHealthStatus(
+                is_healthy=is_healthy,
                 last_checked_at=check_time,
-                error_message=None,
+                error_message=error_message,
             )
         }
     )
-
-    manager_checker = AsyncMock(spec=ServiceHealthChecker)
-    manager_checker.check_service = AsyncMock(return_value=healthy_result)
-    manager_checker.timeout = 1.0
-    manager_checker.target_service_group = MANAGER
-
-    database_checker = AsyncMock(spec=ServiceHealthChecker)
-    database_checker.check_service = AsyncMock(return_value=healthy_result)
-    database_checker.timeout = 1.0
-    database_checker.target_service_group = DATABASE
-
-    agent_checker = AsyncMock(spec=ServiceHealthChecker)
-    agent_checker.check_service = AsyncMock(return_value=healthy_result)
-    agent_checker.timeout = 1.0
-    agent_checker.target_service_group = AGENT
-
-    await health_probe.register(manager_checker)
-    await health_probe.register(database_checker)
-    await health_probe.register(agent_checker)
-
-    registered = await health_probe._get_all_registered()
-    assert len(registered) == 3
-    assert MANAGER in registered
-    assert DATABASE in registered
-    assert AGENT in registered
+    checker = AsyncMock(spec=ServiceHealthChecker)
+    checker.check_service = AsyncMock(return_value=result)
+    checker.timeout = timeout
+    checker.target_service_group = service_group
+    return checker
 
 
-async def test_probe_check_healthy_checker(
+async def test_register_readiness_appears_in_readyz(
     health_probe: HealthProbe,
     sample_service_group: ServiceGroup,
     mock_healthy_checker: ServiceHealthChecker,
 ) -> None:
-    """Test checking a healthy checker returns success result."""
-    await health_probe.register(mock_healthy_checker)
+    await health_probe.register_readiness(mock_healthy_checker)
+    await health_probe.check_all()
+
+    readiness = await health_probe.get_readiness_status()
+    liveness = await health_probe.get_liveness_status()
+
+    assert {c.service_group for c in readiness.connectivity_checks} == {sample_service_group}
+    assert liveness.connectivity_checks == []
+
+
+async def test_register_liveness_appears_in_both_livez_and_readyz(
+    health_probe: HealthProbe,
+    sample_service_group: ServiceGroup,
+    mock_healthy_checker: ServiceHealthChecker,
+) -> None:
+    await health_probe.register_liveness(mock_healthy_checker)
+    await health_probe.check_all()
+
+    liveness = await health_probe.get_liveness_status()
+    readiness = await health_probe.get_readiness_status()
+
+    assert {c.service_group for c in liveness.connectivity_checks} == {sample_service_group}
+    assert {c.service_group for c in readiness.connectivity_checks} == {sample_service_group}
+
+
+async def test_register_same_checker_to_both_runs_check_once(
+    health_probe: HealthProbe,
+    mock_healthy_checker: ServiceHealthChecker,
+) -> None:
+    await health_probe.register_readiness(mock_healthy_checker)
+    await health_probe.register_liveness(mock_healthy_checker)
+
+    await health_probe.check_all()
+
+    mock = mock_healthy_checker.check_service
+    assert isinstance(mock, AsyncMock)
+    assert mock.call_count == 1
+
+
+async def test_register_duplicate_in_same_kind_raises(
+    health_probe: HealthProbe,
+    sample_service_group: ServiceGroup,
+    mock_healthy_checker: ServiceHealthChecker,
+) -> None:
+    await health_probe.register_readiness(mock_healthy_checker)
+
+    with pytest.raises(HealthCheckerAlreadyRegistered) as exc_info:
+        await health_probe.register_readiness(mock_healthy_checker)
+
+    assert str(sample_service_group) in str(exc_info.value)
+
+
+async def test_register_different_instance_for_same_group_raises(
+    health_probe: HealthProbe,
+    sample_service_group: ServiceGroup,
+    mock_healthy_checker: ServiceHealthChecker,
+) -> None:
+    await health_probe.register_readiness(mock_healthy_checker)
+
+    other = _make_checker(sample_service_group)
+
+    with pytest.raises(HealthCheckerAlreadyRegistered):
+        await health_probe.register_liveness(other)
+
+
+async def test_check_all_with_healthy_checker(
+    health_probe: HealthProbe,
+    sample_service_group: ServiceGroup,
+    mock_healthy_checker: ServiceHealthChecker,
+) -> None:
+    await health_probe.register_readiness(mock_healthy_checker)
 
     all_results = await health_probe.check_all()
 
     assert isinstance(all_results, AllServicesHealth)
     assert sample_service_group in all_results.results
-    result = all_results.results[sample_service_group]
-    # Result contains component statuses
-    assert len(result.results) > 0
-    for component_status in result.results.values():
-        assert component_status.is_healthy is True
-        assert component_status.error_message is None
-        assert isinstance(component_status.last_checked_at, datetime)
+    for status in all_results.results[sample_service_group].results.values():
+        assert status.is_healthy is True
+        assert status.error_message is None
 
 
-async def test_probe_check_unhealthy_checker(
+async def test_check_all_with_unhealthy_checker(
     health_probe: HealthProbe,
     sample_service_group: ServiceGroup,
     mock_unhealthy_checker: ServiceHealthChecker,
 ) -> None:
-    """Test checking an unhealthy checker returns failure result."""
-    await health_probe.register(mock_unhealthy_checker)
+    await health_probe.register_readiness(mock_unhealthy_checker)
 
     all_results = await health_probe.check_all()
 
-    assert isinstance(all_results, AllServicesHealth)
-    assert sample_service_group in all_results.results
-    result = all_results.results[sample_service_group]
-    assert len(result.results) > 0
-    for component_status in result.results.values():
-        assert component_status.is_healthy is False
-        assert "Service unavailable" in component_status.error_message  # type: ignore
-        assert isinstance(component_status.last_checked_at, datetime)
+    for status in all_results.results[sample_service_group].results.values():
+        assert status.is_healthy is False
+        assert status.error_message is not None
+        assert "Service unavailable" in status.error_message
 
 
-async def test_probe_check_timeout_checker(
+async def test_check_all_timeout_returns_empty(
     health_probe: HealthProbe,
     sample_service_group: ServiceGroup,
     mock_timeout_checker: ServiceHealthChecker,
 ) -> None:
-    """Test checking a timeout checker returns empty result."""
-    await health_probe.register(mock_timeout_checker)
+    await health_probe.register_readiness(mock_timeout_checker)
 
     all_results = await health_probe.check_all()
 
-    assert isinstance(all_results, AllServicesHealth)
-    assert sample_service_group in all_results.results
-    result = all_results.results[sample_service_group]
-    # Timeout returns empty results
-    assert len(result.results) == 0
+    assert all_results.results[sample_service_group].results == {}
 
 
-async def test_probe_check_all_updates_internal_status(
+async def test_check_all_mixed_kinds(
     health_probe: HealthProbe,
-    sample_service_group: ServiceGroup,
-    mock_healthy_checker: ServiceHealthChecker,
 ) -> None:
-    """Test that check_all() updates the internal result registry."""
-    await health_probe.register(mock_healthy_checker)
+    manager_checker = _make_checker(MANAGER, is_healthy=True)
+    database_checker = _make_checker(DATABASE, is_healthy=False, error_message="db down")
+    agent_checker = _make_checker(AGENT, is_healthy=True)
 
-    # Initially, result should be None
-    registered = await health_probe._get_all_registered()
-    assert registered[sample_service_group].result is None
-
-    # After check_all(), result should be updated
-    await health_probe.check_all()
-
-    registered = await health_probe._get_all_registered()
-    assert registered[sample_service_group].result is not None
-
-
-async def test_probe_check_all_mixed_results(
-    health_probe: HealthProbe,
-    mock_healthy_checker: ServiceHealthChecker,
-    mock_unhealthy_checker: ServiceHealthChecker,
-) -> None:
-    """Test check_all() with a mix of healthy and unhealthy checkers."""
-    # Create separate checkers with different service groups
-    check_time = datetime.now(UTC)
-
-    # Healthy checker for MANAGER
-    healthy_result = ServiceHealth(
-        results={
-            ComponentId("test-component"): ComponentHealthStatus(
-                is_healthy=True,
-                last_checked_at=check_time,
-                error_message=None,
-            )
-        }
-    )
-    manager_checker = AsyncMock(spec=ServiceHealthChecker)
-    manager_checker.check_service = AsyncMock(return_value=healthy_result)
-    manager_checker.timeout = 1.0
-    manager_checker.target_service_group = MANAGER
-
-    # Unhealthy checker for DATABASE
-    unhealthy_result = ServiceHealth(
-        results={
-            ComponentId("test-component"): ComponentHealthStatus(
-                is_healthy=False,
-                last_checked_at=check_time,
-                error_message="Service unavailable",
-            )
-        }
-    )
-    database_checker = AsyncMock(spec=ServiceHealthChecker)
-    database_checker.check_service = AsyncMock(return_value=unhealthy_result)
-    database_checker.timeout = 1.0
-    database_checker.target_service_group = DATABASE
-
-    await health_probe.register(manager_checker)
-    await health_probe.register(database_checker)
+    await health_probe.register_liveness(manager_checker)
+    await health_probe.register_readiness(database_checker)
+    await health_probe.register_readiness(agent_checker)
 
     all_results = await health_probe.check_all()
 
-    assert isinstance(all_results, AllServicesHealth)
-    assert len(all_results.results) == 2
-    # Check healthy result
-    manager_result = all_results.results[MANAGER]
-    assert all(s.is_healthy for s in manager_result.results.values())
-    # Check unhealthy result
-    database_result = all_results.results[DATABASE]
-    assert all(not s.is_healthy for s in database_result.results.values())
+    assert set(all_results.results.keys()) == {MANAGER, DATABASE, AGENT}
 
 
-async def test_probe_check_all_continues_on_exception(
-    health_probe: HealthProbe,
-    mock_healthy_checker: ServiceHealthChecker,
-    mock_unhealthy_checker: ServiceHealthChecker,
-) -> None:
-    """Test that check_all() continues checking even if some checkers fail."""
-    # Create separate checkers with different service groups
-    check_time = datetime.now(UTC)
-
-    # Healthy result
-    healthy_result = ServiceHealth(
-        results={
-            ComponentId("test-component"): ComponentHealthStatus(
-                is_healthy=True,
-                last_checked_at=check_time,
-                error_message=None,
-            )
-        }
-    )
-
-    # Unhealthy result
-    unhealthy_result = ServiceHealth(
-        results={
-            ComponentId("test-component"): ComponentHealthStatus(
-                is_healthy=False,
-                last_checked_at=check_time,
-                error_message="Service unavailable",
-            )
-        }
-    )
-
-    manager_checker = AsyncMock(spec=ServiceHealthChecker)
-    manager_checker.check_service = AsyncMock(return_value=healthy_result)
-    manager_checker.timeout = 1.0
-    manager_checker.target_service_group = MANAGER
-
-    database_checker = AsyncMock(spec=ServiceHealthChecker)
-    database_checker.check_service = AsyncMock(return_value=unhealthy_result)
-    database_checker.timeout = 1.0
-    database_checker.target_service_group = DATABASE
-
-    agent_checker = AsyncMock(spec=ServiceHealthChecker)
-    agent_checker.check_service = AsyncMock(return_value=healthy_result)
-    agent_checker.timeout = 1.0
-    agent_checker.target_service_group = AGENT
-
-    await health_probe.register(manager_checker)
-    await health_probe.register(database_checker)
-    await health_probe.register(agent_checker)
-
-    all_results = await health_probe.check_all()
-
-    # All three should be checked
-    assert isinstance(all_results, AllServicesHealth)
-    assert len(all_results.results) == 3
-    assert MANAGER in all_results.results
-    assert DATABASE in all_results.results
-    assert AGENT in all_results.results
-
-
-async def test_probe_check_all_empty_registry(
+async def test_check_all_empty_returns_empty(
     health_probe: HealthProbe,
 ) -> None:
-    """Test check_all() with no registered checkers returns empty results."""
     all_results = await health_probe.check_all()
-    assert isinstance(all_results, AllServicesHealth)
     assert all_results.results == {}
 
 
-async def test_probe_start_and_stop(
+async def test_start_and_stop(
     health_probe: HealthProbe,
 ) -> None:
-    """Test starting and stopping the health probe loop."""
     assert health_probe._running is False
     assert health_probe._loop_task is None
 
@@ -338,245 +197,128 @@ async def test_probe_start_and_stop(
     assert health_probe._loop_task is None
 
 
-async def test_probe_start_already_running(
-    health_probe: HealthProbe,
-) -> None:
-    """Test that starting an already running probe logs a warning."""
-    await health_probe.start()
-
-    # Start again - should log warning but not crash
-    await health_probe.start()
-
-    # Should still be running
-    assert health_probe._running is True
-
-    await health_probe.stop()
-
-
-async def test_probe_stop_not_running(
-    health_probe: HealthProbe,
-) -> None:
-    """Test that stopping a non-running probe logs a warning."""
-    assert health_probe._running is False
-
-    # Stop without starting - should log warning but not crash
-    await health_probe.stop()
-
-    # Should still be not running
-    assert health_probe._running is False
-
-
-async def test_probe_periodic_check(
+async def test_periodic_check_invokes_checker(
     health_probe: HealthProbe,
     mock_healthy_checker: ServiceHealthChecker,
 ) -> None:
-    """Test that the probe periodically checks registered checkers."""
-    await health_probe.register(mock_healthy_checker)
-
+    await health_probe.register_readiness(mock_healthy_checker)
     await health_probe.start()
-
-    # Wait for at least 2-3 check intervals
     await asyncio.sleep(0.35)
-
     await health_probe.stop()
 
-    # Verify that check_service was called multiple times
     mock = mock_healthy_checker.check_service
     assert isinstance(mock, AsyncMock)
     assert mock.call_count >= 2
 
 
-async def test_probe_dynamic_registration_during_loop(
+async def test_dynamic_registration_during_loop(
     health_probe: HealthProbe,
-    mock_healthy_checker: ServiceHealthChecker,
 ) -> None:
-    """Test that checkers can be registered/unregistered while the loop is running."""
-    # Create separate checkers with different service groups
-    check_time = datetime.now(UTC)
-    healthy_result = ServiceHealth(
-        results={
-            ComponentId("test-component"): ComponentHealthStatus(
-                is_healthy=True,
-                last_checked_at=check_time,
-                error_message=None,
-            )
-        }
-    )
+    manager_checker = _make_checker(MANAGER)
+    database_checker = _make_checker(DATABASE)
 
-    manager_checker = AsyncMock(spec=ServiceHealthChecker)
-    manager_checker.check_service = AsyncMock(return_value=healthy_result)
-    manager_checker.timeout = 1.0
-    manager_checker.target_service_group = MANAGER
-
-    database_checker = AsyncMock(spec=ServiceHealthChecker)
-    database_checker.check_service = AsyncMock(return_value=healthy_result)
-    database_checker.timeout = 1.0
-    database_checker.target_service_group = DATABASE
-
-    # Start with one checker
-    await health_probe.register(manager_checker)
+    await health_probe.register_readiness(manager_checker)
     await health_probe.start()
-
-    # Wait for first check
     await asyncio.sleep(0.15)
 
-    # Add another checker while running
-    await health_probe.register(database_checker)
-
-    # Wait for next check
-    await asyncio.sleep(0.15)
-
-    # Unregister first checker
-    await health_probe.unregister(MANAGER)
-
-    # Wait for final check
-    await asyncio.sleep(0.15)
+    await health_probe.register_readiness(database_checker)
+    await asyncio.sleep(0.25)
 
     await health_probe.stop()
 
-    # Verify final state
-    registered = await health_probe._get_all_registered()
-    assert MANAGER not in registered
-    assert DATABASE in registered
+    readiness = await health_probe.get_readiness_status()
+    assert {c.service_group for c in readiness.connectivity_checks} == {MANAGER, DATABASE}
 
 
-async def test_probe_get_connectivity_status_all_healthy(
+async def test_readiness_includes_liveness_registered(
     health_probe: HealthProbe,
-    mock_healthy_checker: ServiceHealthChecker,
 ) -> None:
-    """Test get_connectivity_status() when all components are healthy."""
-    # Create separate checkers with different service groups
-    check_time = datetime.now(UTC)
-    healthy_result = ServiceHealth(
-        results={
-            ComponentId("test-component"): ComponentHealthStatus(
-                is_healthy=True,
-                last_checked_at=check_time,
-                error_message=None,
-            )
-        }
-    )
+    """Readiness response is a superset of liveness — if not alive, not ready."""
+    readiness_checker = _make_checker(DATABASE)
+    liveness_checker = _make_checker(MANAGER)
 
-    manager_checker = AsyncMock(spec=ServiceHealthChecker)
-    manager_checker.check_service = AsyncMock(return_value=healthy_result)
-    manager_checker.timeout = 1.0
-    manager_checker.target_service_group = MANAGER
-
-    database_checker = AsyncMock(spec=ServiceHealthChecker)
-    database_checker.check_service = AsyncMock(return_value=healthy_result)
-    database_checker.timeout = 1.0
-    database_checker.target_service_group = DATABASE
-
-    await health_probe.register(manager_checker)
-    await health_probe.register(database_checker)
-
-    # Run checks first
+    await health_probe.register_readiness(readiness_checker)
+    await health_probe.register_liveness(liveness_checker)
     await health_probe.check_all()
 
-    response = await health_probe.get_connectivity_status()
+    readiness = await health_probe.get_readiness_status()
+    liveness = await health_probe.get_liveness_status()
 
-    assert response.overall_healthy is True
-    # Should have 2 components (one from each service group's checker)
-    assert len(response.connectivity_checks) == 2
-    assert isinstance(response.timestamp, datetime)
+    assert {c.service_group for c in readiness.connectivity_checks} == {DATABASE, MANAGER}
+    assert {c.service_group for c in liveness.connectivity_checks} == {MANAGER}
 
 
-async def test_probe_get_connectivity_status_some_unhealthy(
+async def test_get_readiness_status_reflects_unhealthy(
     health_probe: HealthProbe,
-    mock_healthy_checker: ServiceHealthChecker,
-    mock_unhealthy_checker: ServiceHealthChecker,
 ) -> None:
-    """Test get_connectivity_status() when some components are unhealthy."""
-    # Create separate checkers with different service groups
-    check_time = datetime.now(UTC)
+    healthy = _make_checker(MANAGER, is_healthy=True)
+    unhealthy = _make_checker(DATABASE, is_healthy=False, error_message="db down")
 
-    # Healthy result
-    healthy_result = ServiceHealth(
-        results={
-            ComponentId("test-component"): ComponentHealthStatus(
-                is_healthy=True,
-                last_checked_at=check_time,
-                error_message=None,
-            )
-        }
-    )
-
-    # Unhealthy result
-    unhealthy_result = ServiceHealth(
-        results={
-            ComponentId("test-component"): ComponentHealthStatus(
-                is_healthy=False,
-                last_checked_at=check_time,
-                error_message="Service unavailable",
-            )
-        }
-    )
-
-    manager_checker = AsyncMock(spec=ServiceHealthChecker)
-    manager_checker.check_service = AsyncMock(return_value=healthy_result)
-    manager_checker.timeout = 1.0
-    manager_checker.target_service_group = MANAGER
-
-    database_checker = AsyncMock(spec=ServiceHealthChecker)
-    database_checker.check_service = AsyncMock(return_value=unhealthy_result)
-    database_checker.timeout = 1.0
-    database_checker.target_service_group = DATABASE
-
-    await health_probe.register(manager_checker)
-    await health_probe.register(database_checker)
-
-    # Run checks first
+    await health_probe.register_readiness(healthy)
+    await health_probe.register_readiness(unhealthy)
     await health_probe.check_all()
 
-    response = await health_probe.get_connectivity_status()
-
+    response = await health_probe.get_readiness_status()
     assert response.overall_healthy is False
     assert len(response.connectivity_checks) == 2
 
 
-async def test_probe_get_connectivity_status_empty_registry(
-    health_probe: HealthProbe,
-) -> None:
-    """Test get_connectivity_status() with no registered checkers."""
-    response = await health_probe.get_connectivity_status()
-
-    assert response.overall_healthy is True  # Default to True when empty
-    assert len(response.connectivity_checks) == 0
-    assert isinstance(response.timestamp, datetime)
-
-
-async def test_probe_get_connectivity_status_excludes_unchecked(
+async def test_liveness_excludes_readiness_only(
     health_probe: HealthProbe,
     mock_healthy_checker: ServiceHealthChecker,
 ) -> None:
-    """Test that get_connectivity_status() excludes checkers that haven't been checked yet."""
-    await health_probe.register(mock_healthy_checker)
+    """A readiness-only checker must NOT appear in liveness."""
+    await health_probe.register_readiness(mock_healthy_checker)
+    await health_probe.check_all()
 
-    # Don't run check_all() - result should be None
+    liveness = await health_probe.get_liveness_status()
+
+    assert liveness.overall_healthy is True
+    assert liveness.connectivity_checks == []
+
+
+async def test_get_connectivity_status_returns_union(
+    health_probe: HealthProbe,
+) -> None:
+    readiness_checker = _make_checker(DATABASE)
+    liveness_checker = _make_checker(MANAGER)
+
+    await health_probe.register_readiness(readiness_checker)
+    await health_probe.register_liveness(liveness_checker)
+    await health_probe.check_all()
 
     response = await health_probe.get_connectivity_status()
 
-    # Should not include the unchecked component
-    assert len(response.connectivity_checks) == 0
-    assert response.overall_healthy is True  # Default when no checked components
+    assert {c.service_group for c in response.connectivity_checks} == {DATABASE, MANAGER}
+    assert response.overall_healthy is True
 
 
-async def test_probe_get_connectivity_status_component_fields(
+async def test_get_connectivity_status_excludes_unchecked(
+    health_probe: HealthProbe,
+    mock_healthy_checker: ServiceHealthChecker,
+) -> None:
+    await health_probe.register_readiness(mock_healthy_checker)
+
+    response = await health_probe.get_connectivity_status()
+
+    assert response.connectivity_checks == []
+    assert response.overall_healthy is True
+
+
+async def test_get_connectivity_status_component_fields(
     health_probe: HealthProbe,
     sample_service_group: ServiceGroup,
     mock_unhealthy_checker: ServiceHealthChecker,
 ) -> None:
-    """Test that ComponentConnectivityStatus in response has correct fields."""
-    await health_probe.register(mock_unhealthy_checker)
-
+    await health_probe.register_readiness(mock_unhealthy_checker)
     await health_probe.check_all()
+
     response = await health_probe.get_connectivity_status()
 
     assert len(response.connectivity_checks) == 1
     component = response.connectivity_checks[0]
-
-    assert component.service_group == "test"  # From mock fixture (TEST_SERVICE_GROUP)
-    assert component.component_id == "test-component"  # From mock fixture
+    assert component.service_group == "test"
+    assert component.component_id == "test-component"
     assert component.is_healthy is False
     assert component.error_message is not None
     assert "Service unavailable" in component.error_message

--- a/tests/unit/manager/dependencies/domain/test_notification.py
+++ b/tests/unit/manager/dependencies/domain/test_notification.py
@@ -49,4 +49,6 @@ class TestNotificationCenterDependency:
     def test_gen_health_checkers_returns_none(self) -> None:
         """NonMonitorable dependency should return None for health checkers."""
         dependency = NotificationCenterDependency()
-        assert dependency.gen_health_checkers(MagicMock()) is None
+        resource = MagicMock()
+        assert dependency.gen_liveness_checker(resource) is None
+        assert dependency.gen_readiness_checker(resource) is None

--- a/tests/unit/manager/dependencies/orchestration/test_composer.py
+++ b/tests/unit/manager/dependencies/orchestration/test_composer.py
@@ -90,9 +90,9 @@ class TestOrchestrationComposer:
         mock_sokovan_dep.stage_name = "sokovan-orchestrator"
         mock_leader_dep.stage_name = "leader-election"
 
-        mock_idle_checker_dep.gen_health_checkers.return_value = None
-        mock_sokovan_dep.gen_health_checkers.return_value = None
-        mock_leader_dep.gen_health_checkers.return_value = None
+        for dep in (mock_idle_checker_dep, mock_sokovan_dep, mock_leader_dep):
+            dep.gen_liveness_checker.return_value = None
+            dep.gen_readiness_checker.return_value = None
 
         def make_provide(name: str, result: MagicMock) -> object:
             @asynccontextmanager

--- a/tests/unit/manager/dependencies/system/test_composer.py
+++ b/tests/unit/manager/dependencies/system/test_composer.py
@@ -127,7 +127,9 @@ class TestSystemComposer:
 
         # Setup mock health probe
         mock_probe = MagicMock()
-        mock_probe.register = AsyncMock()
+        mock_probe.register_liveness = AsyncMock()
+        mock_probe.register_readiness = AsyncMock()
+        mock_probe.register_informational = AsyncMock()
         mock_probe.start = AsyncMock()
         mock_probe.stop = AsyncMock()
         mock_health_probe_class.return_value = mock_probe


### PR DESCRIPTION
## Summary

- Adds a third probe tier (`ProbeKind.INFORMATIONAL`) so observability dependencies (e.g. Prometheus) can surface in `/health` detail without gating `/livez` or `/readyz`. Manager's `PrometheusHealthChecker` moves to this tier.
- `/livez` and `/readyz` now return `HTTPStatus.SERVICE_UNAVAILABLE` (503) with `status=ERROR` in the body when their gating tier reports unhealthy, letting Kubernetes livenessProbe / readinessProbe react automatically.
- `/health` detail keeps `HTTPStatus.OK` (200) with `status=DEGRADED` so monitoring tools watching the detail endpoint do not get noisy on informational failures.

## Test plan

- [x] Local probe via curl with all dependencies up returns 200 / status=ok across manager (internal), webserver, agent, storage-proxy (both ports), appproxy coordinator and worker.
- [x] `docker compose stop backendai-half-redis` → all components' `/livez` and `/readyz` return 503 / status=error within one probe cycle; recover to 200 after restart.
- [x] `docker compose stop backendai-half-db` → manager and appproxy coordinator `/readyz` return 503 while `/livez` stays 200; other components unaffected. Recovers after DB restart.
- [x] Prometheus is omitted from manager `/livez` and `/readyz` connectivity payloads and only appears in detail `/health`.
- [x] `pants fmt`, `pants fix`, `pants lint` clean on changed files.
- [x] `tests/unit/manager/dependencies/system/test_composer.py` updated for the new tier API and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)