### PR TITLE
refactor(BA-6003): bulk-migrate all pydantic BaseModel subclasses to BackendAISchema

### DIFF
--- a/changes/11554.enhance.md
+++ b/changes/11554.enhance.md
@@ -1,0 +1,1 @@
+Migrate every remaining pydantic `BaseModel` subclass across `src/ai/backend/` to `BackendAISchema`, so any `model_validate()` failure auto-converts to a `BackendAISchemaValidationFailed` (HTTP 400) instead of leaking as raw `pydantic.ValidationError`.

--- a/src/ai/backend/account_manager/api/utils.py
+++ b/src/ai/backend/account_manager/api/utils.py
@@ -13,6 +13,8 @@ from aiohttp.typedefs import Handler
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 from ai.backend.account_manager.exceptions import AuthorizationFailed, InvalidAPIParameters
+from ai.backend.common.exception import BackendAISchemaValidationFailed
+from ai.backend.common.types import BackendAISchema
 from ai.backend.logging import BraceStyleAdapter
 
 
@@ -69,7 +71,7 @@ def mask_sensitive_keys(data: Mapping[str, Any]) -> Mapping[str, Any]:
 TBaseModel = TypeVar("TBaseModel", bound=BaseModel)
 
 
-class RequestData(BaseModel):
+class RequestData(BackendAISchema):
     model_config = ConfigDict(
         extra="allow",
     )
@@ -173,8 +175,13 @@ def pydantic_api_handler[TParamModel: BaseModel, TQueryModel: BaseModel](
                     kwargs["query"] = query_params
             except (json.decoder.JSONDecodeError, yaml.YAMLError, yaml.MarkedYAMLError) as e:
                 raise InvalidAPIParameters("Malformed body") from e
-            except ValidationError as e:
-                raise InvalidAPIParameters("Input validation error", extra_data=e.errors()) from e
+            except (BackendAISchemaValidationFailed, ValidationError) as e:
+                # ``ValidationError`` covers plain ``BaseModel`` subclasses that
+                # skip the ``BackendAISchema`` auto-conversion override.
+                raise InvalidAPIParameters(
+                    "Input validation error",
+                    extra_data={"errors": e.errors()},
+                ) from e
             result = await handler(request, checked_params, *args, **kwargs)
             return ensure_stream_response_type(result)
 

--- a/src/ai/backend/account_manager/config.py
+++ b/src/ai/backend/account_manager/config.py
@@ -12,7 +12,6 @@ from typing import Annotated, Any
 
 import click
 from pydantic import (
-    BaseModel,
     ConfigDict,
     Field,
     GetCoreSchemaHandler,
@@ -23,6 +22,7 @@ from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticUndefined, core_schema
 
 from ai.backend.common import config
+from ai.backend.common.types import BackendAISchema
 from ai.backend.logging import LogLevel
 
 from .types import EventLoopType
@@ -46,7 +46,7 @@ class TransactionIsolationLevel(enum.StrEnum):
     SERIALIZABLE = "SERIALIZABLE"
 
 
-class BaseSchema(BaseModel):
+class BaseSchema(BackendAISchema):
     model_config = ConfigDict(
         validate_by_name=True,
         from_attributes=True,

--- a/src/ai/backend/agent/kernel_registry/types.py
+++ b/src/ai/backend/agent/kernel_registry/types.py
@@ -3,19 +3,19 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Self
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.agent.kernel import KernelOwnershipData
 from ai.backend.agent.proxy import DomainSocketPathPair
 from ai.backend.agent.resources import KernelResourceSpec
 from ai.backend.common.docker import ImageRef
-from ai.backend.common.types import AgentId, KernelId, ServicePort, SessionTypes
+from ai.backend.common.types import AgentId, BackendAISchema, KernelId, ServicePort, SessionTypes
 
 if TYPE_CHECKING:
     from ai.backend.agent.docker.kernel import DockerKernel
 
 
-class KernelRecoveryData(BaseModel):
+class KernelRecoveryData(BackendAISchema):
     """
     Data required for recovering a Kernel.
     Agent should load and write Kernel data using this structure

--- a/src/ai/backend/agent/proxy.py
+++ b/src/ai/backend/agent/proxy.py
@@ -4,9 +4,9 @@ from pathlib import Path
 from typing import Any
 
 import attrs
-from pydantic import BaseModel
 
 from ai.backend.common.asyncio import current_loop
+from ai.backend.common.types import BackendAISchema
 
 
 @attrs.define(auto_attribs=True, slots=True)
@@ -16,7 +16,7 @@ class DomainSocketProxy:
     proxy_server: asyncio.AbstractServer
 
 
-class DomainSocketPathPair(BaseModel):
+class DomainSocketPathPair(BackendAISchema):
     host_sock_path: Path
     host_proxy_path: Path
 

--- a/src/ai/backend/agent/scratch/types.py
+++ b/src/ai/backend/agent/scratch/types.py
@@ -1,17 +1,15 @@
 from collections.abc import Mapping
 from typing import Self
 
-from pydantic import BaseModel
-
 from ai.backend.agent.kernel import KernelOwnershipData
 from ai.backend.agent.kernel_registry.types import KernelRecoveryData
 from ai.backend.agent.proxy import DomainSocketPathPair
 from ai.backend.agent.resources import KernelResourceSpec
 from ai.backend.common.docker import ImageRef
-from ai.backend.common.types import AgentId, KernelId, ServicePort, SessionTypes
+from ai.backend.common.types import AgentId, BackendAISchema, KernelId, ServicePort, SessionTypes
 
 
-class KernelRecoveryScratchData(BaseModel):
+class KernelRecoveryScratchData(BackendAISchema):
     """
     Serializable subset of KernelRecoveryData for scratch storage.
     Excludes `resource_spec` and `environ` which are loaded separately.

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -44,7 +44,6 @@ from callosum.lower.zeromq import ZeroMQAddress, ZeroMQRPCTransport
 from callosum.ordering import ExitOrderedAsyncScheduler
 from callosum.rpc import Peer, RPCMessage
 from etcd_client import WatchEventType
-from pydantic import ValidationError
 from setproctitle import setproctitle
 from zmq.auth.certs import load_certificate
 
@@ -87,7 +86,7 @@ from ai.backend.common.events.event_types.kernel.broadcast import (
     KernelTerminatedBroadcastEvent,
 )
 from ai.backend.common.events.event_types.kernel.types import KernelLifecycleEventReason
-from ai.backend.common.exception import ConfigurationError
+from ai.backend.common.exception import BackendAISchemaValidationFailed, ConfigurationError
 from ai.backend.common.health_checker.checkers.etcd import EtcdHealthChecker
 from ai.backend.common.health_checker.checkers.valkey import ValkeyHealthChecker
 from ai.backend.common.health_checker.probe import HealthProbe, HealthProbeOptions
@@ -1740,7 +1739,7 @@ def main(
         if server_config.debug.enabled:
             print("== Agent configuration ==")
             pprint(server_config.model_dump(by_alias=True))
-    except ValidationError as e:
+    except BackendAISchemaValidationFailed as e:
         print(
             "ConfigurationError: Agent local config failed validation checks:",
             file=sys.stderr,

--- a/src/ai/backend/appproxy/common/config.py
+++ b/src/ai/backend/appproxy/common/config.py
@@ -17,6 +17,7 @@ from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticUndefined, core_schema
 
 from ai.backend.common.meta import BackendAIConfigMeta, CompositeType, ConfigExample
+from ai.backend.common.types import BackendAISchema
 
 from .errors import (
     GroupNotFoundError,
@@ -30,7 +31,7 @@ from .types import DigestModType
 # FIXME: merge majority of common definitions to ai.backend.common when ready
 
 
-class BaseSchema(BaseModel):
+class BaseSchema(BackendAISchema):
     model_config = ConfigDict(
         populate_by_name=True,
         from_attributes=True,
@@ -723,7 +724,7 @@ class UnsupportedTypeError(RuntimeError):
 
 
 def generate_example_json(
-    schema: type[BaseModel] | types.GenericAlias | types.UnionType,
+    schema: type[BackendAISchema] | types.GenericAlias | types.UnionType,
     parent: list[str] | None = None,
 ) -> dict[str, Any] | list[Any]:
     if parent is None:

--- a/src/ai/backend/appproxy/common/openapi.py
+++ b/src/ai/backend/appproxy/common/openapi.py
@@ -8,6 +8,7 @@ from aiohttp.web_urldispatcher import AbstractResource, DynamicResource
 from pydantic import BaseModel
 
 from ai.backend.appproxy.common.types import PydanticResponse
+from ai.backend.common.types import BackendAISchema
 
 from . import __version__
 
@@ -131,7 +132,7 @@ def generate_openapi(
             route_def["description"] = "\n".join(description)
             type_hints = get_type_hints(route.handler)
 
-            def _parse_schema(model_cls: type[BaseModel]) -> dict[str, Any]:
+            def _parse_schema(model_cls: type[BackendAISchema]) -> dict[str, Any]:
                 if not issubclass(model_cls, BaseModel):
                     raise RuntimeError(f"{model_cls} not considered as a valid response type")
 

--- a/src/ai/backend/appproxy/common/types.py
+++ b/src/ai/backend/appproxy/common/types.py
@@ -16,7 +16,7 @@ import aiohttp_cors
 from aiohttp import web
 from pydantic import AliasChoices, AnyUrl, BaseModel, ConfigDict, Field
 
-from ai.backend.common.types import ModelServiceStatus, RuntimeVariant
+from ai.backend.common.types import BackendAISchema, ModelServiceStatus, RuntimeVariant
 
 # FIXME: merge majority of common definitions to ai.backend.common when ready
 
@@ -84,7 +84,7 @@ type AppCreator = Callable[
 ]
 
 
-class RouteInfo(BaseModel):
+class RouteInfo(BackendAISchema):
     """Information about a route within a circuit.
 
     Routes describe a kernel endpoint (``kernel_host`` + ``kernel_port``)
@@ -157,7 +157,7 @@ class RouteInfo(BaseModel):
         return self.kernel_host or "localhost"
 
 
-class SerializableCircuit(BaseModel):
+class SerializableCircuit(BackendAISchema):
     """
     Serializable representation of `ai.backend.appproxy.coordinator.models.Circuit`
     """
@@ -241,7 +241,7 @@ class SerializableCircuit(BaseModel):
         return f"bai_router_{self.id}@etcd"
 
 
-class SerializableToken(BaseModel):
+class SerializableToken(BackendAISchema):
     login_session_token: str | None
     kernel_host: str
     kernel_port: int
@@ -252,7 +252,7 @@ class SerializableToken(BaseModel):
     domain_name: str
 
 
-class SessionConfig(BaseModel):
+class SessionConfig(BackendAISchema):
     model_config = ConfigDict(populate_by_name=True)
 
     id: Annotated[UUID | None, Field(default=None)]
@@ -265,13 +265,13 @@ class SessionConfig(BaseModel):
     domain_name: str
 
 
-class EndpointConfig(BaseModel):
+class EndpointConfig(BackendAISchema):
     id: UUID
     runtime_variant: Annotated[RuntimeVariant | None, Field(default=None)]
     existing_url: AnyUrl | None
 
 
-class HealthCheckState(BaseModel):
+class HealthCheckState(BackendAISchema):
     """
     Runtime health check state
     """

--- a/src/ai/backend/appproxy/common/utils.py
+++ b/src/ai/backend/appproxy/common/utils.py
@@ -28,6 +28,7 @@ from pydantic import BaseModel, ValidationError
 
 from ai.backend.appproxy.common.types import PydanticResponse
 from ai.backend.common import redis_helper
+from ai.backend.common.exception import BackendAISchemaValidationFailed
 from ai.backend.common.types import RedisConnectionInfo
 from ai.backend.logging import BraceStyleAdapter
 
@@ -232,8 +233,13 @@ def pydantic_api_handler[TParamModel: BaseModel, TQueryModel: BaseModel](
                     kwargs["query"] = query_params
             except (json.decoder.JSONDecodeError, yaml.YAMLError, yaml.MarkedYAMLError) as e:
                 raise InvalidAPIParameters("Malformed body") from e
-            except ValidationError as e:
-                raise InvalidAPIParameters("Input validation error", extra_data=e.errors()) from e
+            except (BackendAISchemaValidationFailed, ValidationError) as e:
+                # ``ValidationError`` covers plain ``BaseModel`` subclasses that
+                # skip the ``BackendAISchema`` auto-conversion override.
+                raise InvalidAPIParameters(
+                    "Input validation error",
+                    extra_data={"errors": e.errors()},
+                ) from e
             result = await handler(request, checked_params, *args, **kwargs)
             return ensure_stream_response_type(result)
 

--- a/src/ai/backend/appproxy/coordinator/api/circuit_v2.py
+++ b/src/ai/backend/appproxy/coordinator/api/circuit_v2.py
@@ -8,7 +8,7 @@ from uuid import UUID
 import aiohttp_cors
 import sqlalchemy as sa
 from aiohttp import web
-from pydantic import BaseModel, Field, validator
+from pydantic import Field, validator
 from sqlalchemy.orm import selectinload
 
 from ai.backend.appproxy.common.types import (
@@ -22,6 +22,7 @@ from ai.backend.appproxy.common.utils import pydantic_api_handler, pydantic_api_
 from ai.backend.appproxy.coordinator.models import Circuit
 from ai.backend.appproxy.coordinator.models.utils import execute_with_txn_retry
 from ai.backend.appproxy.coordinator.types import RootContext
+from ai.backend.common.types import BackendAISchema
 
 from .types import StubResponseModel
 from .utils import auth_required
@@ -30,7 +31,7 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
 
-class BulkRemoveCircuitsRequestModel(BaseModel):
+class BulkRemoveCircuitsRequestModel(BackendAISchema):
     circuit_ids: Annotated[list[UUID], Field(description="Comma separated list of Circuit UUIDs.")]
 
     @validator("circuit_ids", pre=True)

--- a/src/ai/backend/appproxy/coordinator/api/conf.py
+++ b/src/ai/backend/appproxy/coordinator/api/conf.py
@@ -4,7 +4,6 @@ from collections.abc import Iterable
 
 import aiohttp_cors
 from aiohttp import web
-from pydantic import BaseModel
 
 from ai.backend.appproxy.common.errors import AuthorizationFailed
 from ai.backend.appproxy.common.types import CORSOptions, PydanticResponse, WebMiddleware
@@ -13,12 +12,13 @@ from ai.backend.appproxy.coordinator.api.types import ConfRequestModel
 from ai.backend.appproxy.coordinator.errors import InvalidSessionParameterError
 from ai.backend.appproxy.coordinator.models import Token
 from ai.backend.appproxy.coordinator.types import RootContext
+from ai.backend.common.types import BackendAISchema
 from ai.backend.logging import BraceStyleAdapter
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
-class TokenResponseModel(BaseModel):
+class TokenResponseModel(BackendAISchema):
     token: str
 
 

--- a/src/ai/backend/appproxy/coordinator/api/endpoint.py
+++ b/src/ai/backend/appproxy/coordinator/api/endpoint.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 import aiohttp_cors
 from aiohttp import web
-from pydantic import AnyUrl, BaseModel, Field
+from pydantic import AnyUrl, Field
 
 from ai.backend.appproxy.common.errors import ObjectNotFound
 from ai.backend.appproxy.common.types import (
@@ -48,17 +48,18 @@ from ai.backend.common.dto.appproxy_coordinator.v2.endpoint.types import (
     TagsModel,
 )
 from ai.backend.common.identifier.deployment import DeploymentID
+from ai.backend.common.types import BackendAISchema
 
 from .types import StubResponseModel
 from .utils import auth_required
 
 
-class EndpointTagConfig(BaseModel):
+class EndpointTagConfig(BackendAISchema):
     session: SessionConfig
     endpoint: EndpointConfig
 
 
-class EndpointCreationRequestModel(BaseModel):
+class EndpointCreationRequestModel(BackendAISchema):
     version: Annotated[str, Field(description="Creation API version")]
     service_name: Annotated[str, Field(description="Name of the model service.")]
     tags: Annotated[
@@ -101,7 +102,7 @@ class EndpointCreationRequestModel(BaseModel):
     ] = None
 
 
-class EndpointCreationResponseModel(BaseModel):
+class EndpointCreationResponseModel(BackendAISchema):
     success: bool
     endpoint: AnyUrl
     health_check_enabled: bool
@@ -211,7 +212,7 @@ async def bulk_unregister_routes(
     return PydanticResponse(BulkUnregisterRoutesResponse(endpoints=items))
 
 
-class UpdateModelHealthCheckRequestModel(BaseModel):
+class UpdateModelHealthCheckRequestModel(BackendAISchema):
     health_check: ModelHealthCheck | None
 
 
@@ -238,7 +239,7 @@ async def inject_health_check_information(
     return PydanticResponse(StubResponseModel(success=True))
 
 
-class EndpointAPITokenGenerationRequestModel(BaseModel):
+class EndpointAPITokenGenerationRequestModel(BackendAISchema):
     user_uuid: UUID
     """
     Token requester's user UUID.
@@ -249,7 +250,7 @@ class EndpointAPITokenGenerationRequestModel(BaseModel):
     """
 
 
-class EndpointAPITokenResponseModel(BaseModel):
+class EndpointAPITokenResponseModel(BackendAISchema):
     token: str
 
 

--- a/src/ai/backend/appproxy/coordinator/api/health.py
+++ b/src/ai/backend/appproxy/coordinator/api/health.py
@@ -10,7 +10,6 @@ from uuid import UUID
 import aiohttp_cors
 import sqlalchemy as sa
 from aiohttp import web
-from pydantic import BaseModel
 
 from ai.backend.appproxy.common.types import (
     AppMode,
@@ -27,7 +26,7 @@ from ai.backend.common.dto.internal.health import (
     HealthResponse,
     HealthStatus,
 )
-from ai.backend.common.types import ModelServiceStatus
+from ai.backend.common.types import BackendAISchema, ModelServiceStatus
 from ai.backend.logging import BraceStyleAdapter
 
 from .utils import auth_required
@@ -40,7 +39,7 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 # compatibility with external consumers but report routes as `unknown`.
 
 
-class RouteHealthStatusModel(BaseModel):
+class RouteHealthStatusModel(BackendAISchema):
     """Model for individual route health status"""
 
     route_id: UUID
@@ -55,7 +54,7 @@ class RouteHealthStatusModel(BaseModel):
     updated_at: datetime | None
 
 
-class EndpointHealthStatusModel(BaseModel):
+class EndpointHealthStatusModel(BackendAISchema):
     """Model for endpoint health status summary"""
 
     endpoint_id: UUID
@@ -67,7 +66,7 @@ class EndpointHealthStatusModel(BaseModel):
     routes: list[RouteHealthStatusModel]
 
 
-class CircuitHealthStatusModel(BaseModel):
+class CircuitHealthStatusModel(BackendAISchema):
     """Model for circuit health status with route details"""
 
     circuit_id: UUID
@@ -77,7 +76,7 @@ class CircuitHealthStatusModel(BaseModel):
     all_routes: list[RouteHealthStatusModel]
 
 
-class HealthSummaryModel(BaseModel):
+class HealthSummaryModel(BackendAISchema):
     """Model for overall health summary"""
 
     total_endpoints: int
@@ -88,7 +87,7 @@ class HealthSummaryModel(BaseModel):
     unknown_routes: int
 
 
-class HealthStatusResponseModel(BaseModel):
+class HealthStatusResponseModel(BackendAISchema):
     """Response model for health status APIs"""
 
     success: bool
@@ -97,14 +96,14 @@ class HealthStatusResponseModel(BaseModel):
     circuits: list[CircuitHealthStatusModel] | None = None
 
 
-class WorkerInfoModel(BaseModel):
+class WorkerInfoModel(BackendAISchema):
     authority: str
     available_slots: int
     occupied_slots: int
     ha_setup: bool
 
 
-class StatusResponseModel(BaseModel):
+class StatusResponseModel(BackendAISchema):
     coordinator_version: str
     appproxy_api_version: Literal["v2"]
     workers: list[WorkerInfoModel]

--- a/src/ai/backend/appproxy/coordinator/api/proxy.py
+++ b/src/ai/backend/appproxy/coordinator/api/proxy.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 import jwt
 from aiohttp import web
-from pydantic import AnyUrl, BaseModel, Field
+from pydantic import AnyUrl, Field
 
 from ai.backend.appproxy.common.errors import (
     InvalidCredentials,
@@ -29,6 +29,7 @@ from ai.backend.appproxy.coordinator.errors import CircuitCreationError
 from ai.backend.appproxy.coordinator.models import Circuit, Token, Worker, add_circuit
 from ai.backend.appproxy.coordinator.models.utils import execute_with_txn_retry
 from ai.backend.appproxy.coordinator.types import RootContext
+from ai.backend.common.types import BackendAISchema
 from ai.backend.logging import BraceStyleAdapter
 
 if TYPE_CHECKING:
@@ -37,7 +38,7 @@ if TYPE_CHECKING:
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
-class AddRequestModel(BaseModel):
+class AddRequestModel(BackendAISchema):
     app: str
     protocol: ProxyProtocol
     envs: Annotated[dict[str, str | int | None], Field(default={})]
@@ -56,12 +57,12 @@ class ProxyRequestModel(AddRequestModel):
     session_id: UUID
 
 
-class AddResponseModel(BaseModel):
+class AddResponseModel(BackendAISchema):
     code: int
     url: AnyUrl
 
 
-class ProxyResponseModel(BaseModel):
+class ProxyResponseModel(BackendAISchema):
     redirect_url: AnyUrl
     reuse: bool
 

--- a/src/ai/backend/appproxy/coordinator/api/slot_v1.py
+++ b/src/ai/backend/appproxy/coordinator/api/slot_v1.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 import aiohttp_cors
 from aiohttp import web
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.appproxy.common.types import (
     CORSOptions,
@@ -19,6 +19,7 @@ from ai.backend.appproxy.common.utils import (
 )
 from ai.backend.appproxy.coordinator.models import Circuit
 from ai.backend.appproxy.coordinator.types import RootContext
+from ai.backend.common.types import BackendAISchema
 from ai.backend.logging import BraceStyleAdapter
 
 from .utils import auth_required
@@ -26,7 +27,7 @@ from .utils import auth_required
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
-class SlotResponseModel(BaseModel):
+class SlotResponseModel(BackendAISchema):
     rel: Annotated[UUID, Field(description="Circuit ID.")]
     port: Annotated[int | None, Field(description="Port number.")]
     subdomain: Annotated[str | None, Field(default=None, description="Subdomain for the circuit.")]

--- a/src/ai/backend/appproxy/coordinator/api/slot_v2.py
+++ b/src/ai/backend/appproxy/coordinator/api/slot_v2.py
@@ -4,18 +4,19 @@ from typing import Annotated
 
 import aiohttp_cors
 from aiohttp import web
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.appproxy.common.types import CORSOptions, PydanticResponse, WebMiddleware
 from ai.backend.appproxy.common.utils import pydantic_api_handler
 from ai.backend.appproxy.coordinator.models.worker import Worker
 from ai.backend.appproxy.coordinator.types import RootContext
+from ai.backend.common.types import BackendAISchema
 
 from .types import SlotModel
 from .utils import auth_required
 
 
-class ListSlotsRequestModel(BaseModel):
+class ListSlotsRequestModel(BackendAISchema):
     wsproxy_host: Annotated[
         str | None,
         Field(
@@ -29,7 +30,7 @@ class ListSlotsRequestModel(BaseModel):
     ]
 
 
-class ListSlotsResponseModel(BaseModel):
+class ListSlotsResponseModel(BackendAISchema):
     slots: list[SlotModel]
 
 

--- a/src/ai/backend/appproxy/coordinator/api/types.py
+++ b/src/ai/backend/appproxy/coordinator/api/types.py
@@ -1,16 +1,17 @@
 from typing import Annotated
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.appproxy.common.types import (
     FrontendMode,
     SerializableCircuit,
     SessionConfig,
 )
+from ai.backend.common.types import BackendAISchema
 
 
-class SlotModel(BaseModel):
+class SlotModel(BackendAISchema):
     frontend_mode: FrontendMode
     in_use: bool
     port: Annotated[int | None, Field(default=None)]
@@ -21,11 +22,11 @@ class SlotModel(BaseModel):
     """
 
 
-class StubResponseModel(BaseModel):
+class StubResponseModel(BackendAISchema):
     success: Annotated[bool, Field(default=True)]
 
 
-class AppProxyStatusResponse(BaseModel):
+class AppProxyStatusResponse(BackendAISchema):
     """Response from AppProxy /status endpoint."""
 
     api_version: str = Field(description="AppProxy API version (e.g., 'v1', 'v2')")
@@ -34,11 +35,11 @@ class AppProxyStatusResponse(BaseModel):
     )
 
 
-class CircuitListResponseModel(BaseModel):
+class CircuitListResponseModel(BackendAISchema):
     circuits: list[SerializableCircuit]
 
 
-class ConfRequestModel(BaseModel):
+class ConfRequestModel(BackendAISchema):
     login_session_token: str | None
     kernel_host: str
     kernel_port: int

--- a/src/ai/backend/appproxy/coordinator/api/worker_v1.py
+++ b/src/ai/backend/appproxy/coordinator/api/worker_v1.py
@@ -5,7 +5,7 @@ from typing import Annotated
 
 import aiohttp_cors
 from aiohttp import web
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.appproxy.common.types import (
     CORSOptions,
@@ -17,6 +17,7 @@ from ai.backend.appproxy.common.utils import (
 )
 from ai.backend.appproxy.coordinator.models import Worker
 from ai.backend.appproxy.coordinator.types import RootContext
+from ai.backend.common.types import BackendAISchema
 from ai.backend.logging import BraceStyleAdapter
 
 from .utils import auth_required
@@ -24,7 +25,7 @@ from .utils import auth_required
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
-class WorkerResponseModel(BaseModel):
+class WorkerResponseModel(BackendAISchema):
     authority: Annotated[str, Field(description="authority name of worker.")]
     endpoint: Annotated[str, Field(description="API Endpoint of the worker.")]
 

--- a/src/ai/backend/appproxy/coordinator/api/worker_v2.py
+++ b/src/ai/backend/appproxy/coordinator/api/worker_v2.py
@@ -13,7 +13,7 @@ import aiohttp_cors
 import attrs
 from aiohttp import web
 from dateutil.tz import tzutc
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.appproxy.common.config import get_default_redis_key_ttl
 from ai.backend.appproxy.common.errors import ObjectNotFound
@@ -35,7 +35,7 @@ from ai.backend.appproxy.coordinator.models import Token, Worker, WorkerAppFilte
 from ai.backend.appproxy.coordinator.models.utils import execute_with_txn_retry
 from ai.backend.appproxy.coordinator.types import RootContext
 from ai.backend.common.events.dispatcher import EventHandler
-from ai.backend.common.types import AgentId
+from ai.backend.common.types import AgentId, BackendAISchema
 from ai.backend.logging import BraceStyleAdapter
 
 from .types import CircuitListResponseModel, SlotModel, StubResponseModel
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
-class WorkerModel(BaseModel):
+class WorkerModel(BackendAISchema):
     authority: Annotated[
         str,
         Field(
@@ -73,7 +73,7 @@ class WorkerModel(BaseModel):
     accepted_traffics: list[AppMode]
 
 
-class AppFilter(BaseModel):
+class AppFilter(BackendAISchema):
     key: str
     value: str
 
@@ -112,11 +112,11 @@ class WorkerResponseModel(WorkerModel):
     slots: list[SlotModel]
 
 
-class WorkerListResponseModel(BaseModel):
+class WorkerListResponseModel(BackendAISchema):
     workers: list[WorkerResponseModel]
 
 
-class TokenResponseModel(BaseModel):
+class TokenResponseModel(BackendAISchema):
     login_session_token: str | None
     kernel_host: str
     kernel_port: int

--- a/src/ai/backend/appproxy/coordinator/models/base.py
+++ b/src/ai/backend/appproxy/coordinator/models/base.py
@@ -25,7 +25,7 @@ from ai.backend.appproxy.common.errors import InvalidAPIParameters
 from ai.backend.appproxy.common.utils import ensure_json_serializable
 from ai.backend.appproxy.coordinator.errors import InvalidEnumTypeError
 from ai.backend.common.exception import InvalidIpAddressValue
-from ai.backend.common.types import ReadableCIDR
+from ai.backend.common.types import BackendAISchema, ReadableCIDR
 from ai.backend.logging import BraceStyleAdapter
 
 SAFE_MIN_INT = -9007199254740991
@@ -174,9 +174,9 @@ class StructuredJSONColumn(TypeDecorator[BaseModel]):
 
     impl = JSONB
     cache_ok = True
-    _schema: type[BaseModel]
+    _schema: type[BackendAISchema]
 
-    def __init__(self, schema: type[BaseModel]) -> None:
+    def __init__(self, schema: type[BackendAISchema]) -> None:
         super().__init__()
         self._schema = schema
 
@@ -215,7 +215,7 @@ class StructuredJSONObjectColumn(TypeDecorator[BaseModel]):
     impl = JSONB
     cache_ok = True
 
-    def __init__(self, schema: type[BaseModel]) -> None:
+    def __init__(self, schema: type[BackendAISchema]) -> None:
         super().__init__()
         self._schema = schema
 

--- a/src/ai/backend/appproxy/coordinator/server.py
+++ b/src/ai/backend/appproxy/coordinator/server.py
@@ -6,6 +6,7 @@ import grp
 import importlib
 import importlib.resources
 import ipaddress
+import json
 import logging
 import os
 import pwd
@@ -80,7 +81,7 @@ from ai.backend.common.clients.valkey_client.valkey_schedule import ValkeySchedu
 from ai.backend.common.defs import REDIS_LIVE_DB, REDIS_STREAM_DB, REDIS_STREAM_LOCK, RedisRole
 from ai.backend.common.etcd import ConfigScopes
 from ai.backend.common.events.dispatcher import EventDispatcher, EventProducer
-from ai.backend.common.exception import BackendAIError
+from ai.backend.common.exception import BackendAIError, BackendAISchemaValidationFailed
 from ai.backend.common.health_checker.checkers.valkey import ValkeyHealthChecker
 from ai.backend.common.health_checker.probe import HealthProbe, HealthProbeOptions
 from ai.backend.common.health_checker.types import ComponentId
@@ -197,8 +198,13 @@ async def exception_middleware(
     root_ctx: RootContext = request.app["_root.context"]
     try:
         resp = await handler(request)
-    except ValidationError as ex:
-        log.exception("Failed to create response model: {}", ex.json(indent=2))
+    except (BackendAISchemaValidationFailed, ValidationError) as ex:
+        # ``ValidationError`` covers plain ``BaseModel`` subclasses that
+        # skip the ``BackendAISchema`` auto-conversion override.
+        log.exception(
+            "Failed to create response model: {}",
+            json.dumps(ex.errors(), indent=2, default=str),
+        )
         raise InternalServerError() from ex
     except BackendAIError as ex:
         if ex.status_code == 500:

--- a/src/ai/backend/appproxy/coordinator/types.py
+++ b/src/ai/backend/appproxy/coordinator/types.py
@@ -19,7 +19,7 @@ from uuid import UUID
 
 import aiohttp_cors
 import attrs
-from pydantic import AliasChoices, BaseModel, Field, TypeAdapter
+from pydantic import AliasChoices, Field, TypeAdapter
 
 from ai.backend.appproxy.common.errors import ServerMisconfiguredError, ServiceUnavailable
 from ai.backend.appproxy.common.etcd import TraefikEtcd, convert_to_etcd_dict
@@ -42,7 +42,7 @@ from ai.backend.common.metrics.metric import (
     SystemMetricObserver,
 )
 from ai.backend.common.metrics.multiprocess import generate_latest_multiprocess
-from ai.backend.common.types import AgentId, RedisConnectionInfo
+from ai.backend.common.types import AgentId, BackendAISchema, RedisConnectionInfo
 from ai.backend.logging import BraceStyleAdapter
 
 from .config import ServerConfig
@@ -426,7 +426,7 @@ class RootContext:
 type CleanupContext = Callable[["RootContext"], AbstractAsyncContextManager[None]]
 
 
-class InferenceAppConfig(BaseModel):
+class InferenceAppConfig(BackendAISchema):
     session_id: Annotated[
         UUID,
         Field(

--- a/src/ai/backend/appproxy/worker/api/setup.py
+++ b/src/ai/backend/appproxy/worker/api/setup.py
@@ -6,7 +6,7 @@ import aiohttp
 import jwt
 import yarl
 from aiohttp import web
-from pydantic import AnyUrl, BaseModel
+from pydantic import AnyUrl
 from tenacity import AsyncRetrying, TryAgain, retry_if_exception_type, wait_exponential
 from tenacity.stop import stop_after_attempt
 
@@ -33,6 +33,7 @@ from ai.backend.appproxy.worker.config import (
 )
 from ai.backend.appproxy.worker.coordinator_client import get_circuit_info
 from ai.backend.appproxy.worker.types import InteractiveAppInfo, RootContext
+from ai.backend.common.types import BackendAISchema
 
 
 def generate_proxy_url(
@@ -87,11 +88,11 @@ async def ensure_traefik_route_set_up(traefik_api_port: int, circuit: Circuit) -
                         raise TryAgain
 
 
-class ProxySetupRequestModel(BaseModel):
+class ProxySetupRequestModel(BackendAISchema):
     token: str
 
 
-class ProxySetupResponseModel(BaseModel):
+class ProxySetupResponseModel(BackendAISchema):
     redirect: AnyUrl
     redirectURI: AnyUrl
 

--- a/src/ai/backend/appproxy/worker/config.py
+++ b/src/ai/backend/appproxy/worker/config.py
@@ -38,6 +38,7 @@ from ai.backend.common.configs import (
     PyroscopeConfig,
     ServiceDiscoveryConfig,
 )
+from ai.backend.common.exception import BackendAISchemaValidationFailed
 from ai.backend.common.meta import BackendAIConfigMeta, CompositeType, ConfigExample
 from ai.backend.common.typed_validators import AutoDirectoryPath
 from ai.backend.common.types import ServiceDiscoveryType
@@ -1002,12 +1003,14 @@ def load(config_path: Path | None = None, log_level: LogLevel = LogLevel.NOTSET)
                 raise ConfigValidationError("Pyroscope enabled but config is not populated")
             if server_config.profiling.pyroscope_config.application_name is None:
                 server_config.profiling.pyroscope_config.application_name = f"proxy-worker-{server_config.proxy_worker.authority}-{server_config.proxy_worker.api_bind_addr.port}"
-    except (ValidationError, ConfigValidationError) as e:
+    except (BackendAISchemaValidationFailed, ValidationError, ConfigValidationError) as e:
+        # ``ValidationError`` covers plain ``BaseModel`` subclasses that
+        # skip the ``BackendAISchema`` auto-conversion override.
         print(
             "ConfigurationError: Could not read or validate the manager local config:",
             file=sys.stderr,
         )
-        if isinstance(e, ValidationError):
+        if isinstance(e, (BackendAISchemaValidationFailed, ValidationError)):
             detail = str(e)
         else:
             detail = pformat(e)

--- a/src/ai/backend/client/cli/v2/admin/deployment_revision_preset.py
+++ b/src/ai/backend/client/cli/v2/admin/deployment_revision_preset.py
@@ -19,11 +19,11 @@ from ai.backend.client.cli.v2.helpers import (
 
 
 def _build_dto(dto_cls: type, data: dict[str, Any]) -> Any:
-    from pydantic import ValidationError
+    from ai.backend.common.exception import BackendAISchemaValidationFailed
 
     try:
-        return dto_cls(**data)
-    except ValidationError as e:
+        return dto_cls.model_validate(data)
+    except BackendAISchemaValidationFailed as e:
         click.echo("Validation error:", err=True)
         for err in e.errors():
             field = ".".join(str(loc) for loc in err["loc"])

--- a/src/ai/backend/client/cli/v2/admin/model_card.py
+++ b/src/ai/backend/client/cli/v2/admin/model_card.py
@@ -19,11 +19,11 @@ from ai.backend.client.cli.v2.helpers import (
 
 
 def _build_dto(dto_cls: type, data: dict[str, Any]) -> Any:
-    from pydantic import ValidationError
+    from ai.backend.common.exception import BackendAISchemaValidationFailed
 
     try:
-        return dto_cls(**data)
-    except ValidationError as e:
+        return dto_cls.model_validate(data)
+    except BackendAISchemaValidationFailed as e:
         click.echo("Validation error:", err=True)
         for err in e.errors():
             field = ".".join(str(loc) for loc in err["loc"])

--- a/src/ai/backend/client/cli/v2/admin/resource_policy.py
+++ b/src/ai/backend/client/cli/v2/admin/resource_policy.py
@@ -48,11 +48,11 @@ def _load_input(
 
 def _build_dto(dto_cls: type, data: dict[str, Any]) -> Any:
     """Build a Pydantic DTO from a dict, catching validation errors."""
-    from pydantic import ValidationError
+    from ai.backend.common.exception import BackendAISchemaValidationFailed
 
     try:
-        return dto_cls(**data)
-    except ValidationError as e:
+        return dto_cls.model_validate(data)
+    except BackendAISchemaValidationFailed as e:
         click.echo("Validation error:", err=True)
         for err in e.errors():
             field = ".".join(str(loc) for loc in err["loc"])

--- a/src/ai/backend/client/cli/v2/admin/resource_preset.py
+++ b/src/ai/backend/client/cli/v2/admin/resource_preset.py
@@ -20,11 +20,11 @@ from ai.backend.client.cli.v2.helpers import (
 
 def _build_dto(dto_cls: type, data: dict[str, Any]) -> Any:
     """Build a Pydantic DTO from a dict, catching validation errors."""
-    from pydantic import ValidationError
+    from ai.backend.common.exception import BackendAISchemaValidationFailed
 
     try:
-        return dto_cls(**data)
-    except ValidationError as e:
+        return dto_cls.model_validate(data)
+    except BackendAISchemaValidationFailed as e:
         click.echo("Validation error:", err=True)
         for err in e.errors():
             field = ".".join(str(loc) for loc in err["loc"])

--- a/src/ai/backend/client/cli/v2/admin/runtime_variant.py
+++ b/src/ai/backend/client/cli/v2/admin/runtime_variant.py
@@ -19,11 +19,11 @@ from ai.backend.client.cli.v2.helpers import (
 
 
 def _build_dto(dto_cls: type, data: dict[str, Any]) -> Any:
-    from pydantic import ValidationError
+    from ai.backend.common.exception import BackendAISchemaValidationFailed
 
     try:
-        return dto_cls(**data)
-    except ValidationError as e:
+        return dto_cls.model_validate(data)
+    except BackendAISchemaValidationFailed as e:
         click.echo("Validation error:", err=True)
         for err in e.errors():
             field = ".".join(str(loc) for loc in err["loc"])

--- a/src/ai/backend/client/cli/v2/admin/runtime_variant_preset.py
+++ b/src/ai/backend/client/cli/v2/admin/runtime_variant_preset.py
@@ -19,11 +19,11 @@ from ai.backend.client.cli.v2.helpers import (
 
 
 def _build_dto(dto_cls: type, data: dict[str, Any]) -> Any:
-    from pydantic import ValidationError
+    from ai.backend.common.exception import BackendAISchemaValidationFailed
 
     try:
-        return dto_cls(**data)
-    except ValidationError as e:
+        return dto_cls.model_validate(data)
+    except BackendAISchemaValidationFailed as e:
         click.echo("Validation error:", err=True)
         for err in e.errors():
             field = ".".join(str(loc) for loc in err["loc"])

--- a/src/ai/backend/client/cli/v2/deployment/chat/types.py
+++ b/src/ai/backend/client/cli/v2/deployment/chat/types.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import Annotated, Self
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import Field
 
 from ai.backend.client.cli.v2.deployment.chat.utils import (
     CHAT_CACHE_FILE,
@@ -16,7 +16,9 @@ from ai.backend.client.cli.v2.deployment.chat.utils import (
     read_json_file,
     write_json_file,
 )
+from ai.backend.common.exception import BackendAISchemaValidationFailed
 from ai.backend.common.identifier.deployment import DeploymentID
+from ai.backend.common.types import BackendAISchema
 
 CACHE_ENTRY_TTL = timedelta(hours=24)
 """Endpoint cache entries older than this are treated as a cache miss."""
@@ -36,7 +38,7 @@ user never runs ``chat-history clear``. Older messages are dropped FIFO.
 """
 
 
-class DeploymentChatCacheEntry(BaseModel):
+class DeploymentChatCacheEntry(BackendAISchema):
     """One deployment's auto-managed endpoint metadata."""
 
     endpoint_url: str
@@ -48,7 +50,7 @@ class DeploymentChatCacheEntry(BaseModel):
         return now - self.last_synced_at >= ttl
 
 
-class DeploymentChatCache(BaseModel):
+class DeploymentChatCache(BackendAISchema):
     """In-memory representation of the chat cache file."""
 
     deployments: dict[DeploymentID, DeploymentChatCacheEntry] = Field(default_factory=dict)
@@ -71,7 +73,7 @@ class DeploymentChatCache(BaseModel):
             return cls()
         try:
             return cls.model_validate(raw)
-        except ValidationError:
+        except BackendAISchemaValidationFailed:
             print(
                 f"WARNING: {CHAT_CACHE_FILE} is in an invalid format and was ignored.",
                 file=sys.stderr,
@@ -85,7 +87,7 @@ class DeploymentChatCache(BaseModel):
         write_json_file(CHAT_CACHE_FILE, self.model_dump_json(indent=2))
 
 
-class DeploymentChatConfigEntry(BaseModel):
+class DeploymentChatConfigEntry(BackendAISchema):
     """One deployment's user-managed state.
 
     ``model`` holds the user's explicit ``--model`` choice for a deployment;
@@ -100,7 +102,7 @@ class DeploymentChatConfigEntry(BaseModel):
         return self.token is None and self.model is None
 
 
-class DeploymentChatConfig(BaseModel):
+class DeploymentChatConfig(BackendAISchema):
     """Per-deployment user-managed registry (tokens + chosen model name)."""
 
     deployments: defaultdict[
@@ -163,7 +165,7 @@ class DeploymentChatConfig(BaseModel):
             return cls()
         try:
             return cls.model_validate(raw)
-        except ValidationError:
+        except BackendAISchemaValidationFailed:
             print(
                 f"WARNING: {CHAT_CONFIG_FILE} is in an invalid format and was ignored. "
                 "Re-register tokens with `./bai deployment chat-config set`.",
@@ -178,7 +180,7 @@ class DeploymentChatConfig(BaseModel):
         write_json_file(CHAT_CONFIG_FILE, self.model_dump_json(indent=2))
 
 
-class ChatMessage(BaseModel):
+class ChatMessage(BackendAISchema):
     """One persisted user/assistant turn.
 
     ``created_at`` is local-only metadata for ``chat-history show``; it is
@@ -191,7 +193,7 @@ class ChatMessage(BaseModel):
     created_at: datetime
 
 
-class DeploymentChatHistory(BaseModel):
+class DeploymentChatHistory(BackendAISchema):
     """Per-deployment rolling chat transcripts.
 
     Stored separately from the cache (auto-managed endpoint metadata) and
@@ -241,7 +243,7 @@ class DeploymentChatHistory(BaseModel):
             return cls()
         try:
             return cls.model_validate(raw)
-        except ValidationError:
+        except BackendAISchemaValidationFailed:
             print(
                 f"WARNING: {CHAT_HISTORY_FILE} is in an invalid format and was ignored.",
                 file=sys.stderr,

--- a/src/ai/backend/client/cli/v2/model_card/commands.py
+++ b/src/ai/backend/client/cli/v2/model_card/commands.py
@@ -19,11 +19,11 @@ from ai.backend.client.cli.v2.helpers import (
 
 
 def _build_dto(dto_cls: type, data: dict[str, Any]) -> Any:
-    from pydantic import ValidationError
+    from ai.backend.common.exception import BackendAISchemaValidationFailed
 
     try:
-        return dto_cls(**data)
-    except ValidationError as e:
+        return dto_cls.model_validate(data)
+    except BackendAISchemaValidationFailed as e:
         click.echo("Validation error:", err=True)
         for err in e.errors():
             field = ".".join(str(loc) for loc in err["loc"])

--- a/src/ai/backend/common/api_handlers.py
+++ b/src/ai/backend/common/api_handlers.py
@@ -19,20 +19,20 @@ from typing import (
 from aiohttp import web
 from aiohttp.web_urldispatcher import UrlMappingMatchInfo
 from multidict import CIMultiDictProxy, MultiMapping
-from pydantic import BaseModel, ConfigDict, RootModel
+from pydantic import ConfigDict, RootModel
 from pydantic_core._pydantic_core import ValidationError
 
-from ai.backend.common.types import StreamReader
+from ai.backend.common.types import BackendAISchema, StreamReader
 from ai.backend.logging import BraceStyleAdapter
 
 from .exception import (
+    BackendAISchemaValidationFailed,
     InvalidAPIHandlerDefinition,
     InvalidAPIParameters,
     MalformedRequestBody,
     MiddlewareParamParsingFailed,
     ParameterNotParsedError,
 )
-from .types import BackendAISchema
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -84,7 +84,9 @@ def convert_validation_error[T](func: Callable[..., T]) -> Callable[..., T]:
     def wrapped(*args: Any, **kwargs: Any) -> T:
         try:
             return func(*args, **kwargs)
-        except ValidationError as e:
+        except (BackendAISchemaValidationFailed, ValidationError) as e:
+            # ``ValidationError`` covers plain ``BaseModel`` subclasses that
+            # skip the ``BackendAISchema`` auto-conversion override.
             raise InvalidAPIParameters(repr(e)) from e
 
     return wrapped
@@ -178,7 +180,7 @@ class PathParam[TRequestModel: BaseRequestModel]:
         return self
 
 
-class MiddlewareParam(ABC, BaseModel):
+class MiddlewareParam(ABC, BackendAISchema):
     @classmethod
     @abstractmethod
     async def from_request(cls, request: web.Request) -> Self:
@@ -269,7 +271,9 @@ async def extract_param_value(request: web.Request, input_param_type: Any) -> _P
             f"Parameter '{input_param_type}' must use one of QueryParam, PathParam, HeaderParam, MiddlewareParam, BodyParam"
         )
 
-    except ValidationError as e:
+    except (BackendAISchemaValidationFailed, ValidationError) as e:
+        # ``ValidationError`` covers plain ``BaseModel`` subclasses that
+        # skip the ``BackendAISchema`` auto-conversion override.
         raise InvalidAPIParameters(str(e)) from e
 
 

--- a/src/ai/backend/common/bgtask/task/base.py
+++ b/src/ai/backend/common/bgtask/task/base.py
@@ -1,11 +1,12 @@
 from abc import ABC, abstractmethod
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
 
 from ai.backend.common.bgtask.types import BgtaskNameBase
+from ai.backend.common.types import BackendAISchema
 
 
-class BaseBackgroundTaskManifest(BaseModel):
+class BaseBackgroundTaskManifest(BackendAISchema):
     """
     Base class for background task manifests using Pydantic.
     Provides automatic serialization/deserialization via model_dump() and model_validate().
@@ -19,7 +20,7 @@ class BaseBackgroundTaskManifest(BaseModel):
     )
 
 
-class BaseBackgroundTaskResult(BaseModel):
+class BaseBackgroundTaskResult(BackendAISchema):
     """
     Base class for background task results using Pydantic.
     Provides automatic serialization/deserialization via model_dump() and model_validate().

--- a/src/ai/backend/common/bgtask/types.py
+++ b/src/ai/backend/common/bgtask/types.py
@@ -6,10 +6,11 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, NewType, Protocol, Self
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 from pydantic_core import ValidationError
 
 from ai.backend.common.json import dump_json, load_json
+from ai.backend.common.types import BackendAISchema
 
 from .exception import InvalidTaskMetadataError
 
@@ -109,7 +110,7 @@ class TaskStatus(enum.StrEnum):
     FAILURE = "failure"
 
 
-class TaskSubKeyInfo(BaseModel):
+class TaskSubKeyInfo(BackendAISchema):
     """
     Status information for a specific task key.
     """

--- a/src/ai/backend/common/clients/valkey_client/valkey_artifact/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_artifact/client.py
@@ -6,7 +6,6 @@ import time
 from typing import Final, Self, cast
 
 from glide import Batch, ExpirySet, ExpiryType
-from pydantic import ValidationError
 
 from ai.backend.common.clients.valkey_client.client import (
     AbstractValkeyClient,
@@ -17,7 +16,7 @@ from ai.backend.common.data.artifact.types import (
     DownloadProgressData,
     FileDownloadProgressData,
 )
-from ai.backend.common.exception import BackendAIError
+from ai.backend.common.exception import BackendAIError, BackendAISchemaValidationFailed
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience import (
     BackoffStrategy,
@@ -254,7 +253,7 @@ class ValkeyArtifactDownloadTrackingClient:
                         previous_data_bytes
                     )
                     previous_current_bytes = previous_data.current_bytes
-                except (ValidationError, UnicodeDecodeError):
+                except (BackendAISchemaValidationFailed, UnicodeDecodeError):
                     log.warning("Failed to parse previous file data for progress update")
 
             # Calculate bytes delta for artifact aggregation
@@ -361,7 +360,7 @@ class ValkeyArtifactDownloadTrackingClient:
 
         try:
             return FileDownloadProgressData.model_validate_json(data_bytes)
-        except (ValidationError, UnicodeDecodeError):
+        except (BackendAISchemaValidationFailed, UnicodeDecodeError):
             log.warning("Failed to parse file progress data")
             return None
 
@@ -398,7 +397,7 @@ class ValkeyArtifactDownloadTrackingClient:
                                     value_bytes
                                 )
                                 file_progress_list.append(file_progress)
-                            except (ValidationError, UnicodeDecodeError):
+                            except (BackendAISchemaValidationFailed, UnicodeDecodeError):
                                 log.warning(
                                     "Failed to parse file progress data for key: {}", key_bytes
                                 )

--- a/src/ai/backend/common/clients/valkey_client/valkey_session/types.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_session/types.py
@@ -1,7 +1,7 @@
-from pydantic import BaseModel
+from ai.backend.common.types import BackendAISchema
 
 
-class LoginSessionTokenData(BaseModel):
+class LoginSessionTokenData(BackendAISchema):
     type: str
     access_key: str
     secret_key: str
@@ -9,12 +9,12 @@ class LoginSessionTokenData(BaseModel):
     status: str
 
 
-class LoginSessionInner(BaseModel):
+class LoginSessionInner(BackendAISchema):
     authenticated: bool
     token: LoginSessionTokenData
 
 
-class LoginSessionData(BaseModel):
+class LoginSessionData(BackendAISchema):
     created: int
     expiration_dt: int
     session: LoginSessionInner

--- a/src/ai/backend/common/configs/generator/toml.py
+++ b/src/ai/backend/common/configs/generator/toml.py
@@ -6,10 +6,9 @@ from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel
-
 from ai.backend.common.configs.inspector import ConfigInspector, FieldSchema
 from ai.backend.common.meta import CompositeType, ConfigEnvironment, ConfigExample
+from ai.backend.common.types import BackendAISchema
 
 from .formatter import CompositeFormatter, create_default_formatter
 from .types import FieldVisibility, GeneratorConfig
@@ -62,7 +61,7 @@ class TOMLGenerator:
         """The target environment for example values."""
         return self._inspector.env
 
-    def generate(self, model: type[BaseModel]) -> str:
+    def generate(self, model: type[BackendAISchema]) -> str:
         """Generate TOML configuration string from a Pydantic model.
 
         Args:
@@ -77,7 +76,7 @@ class TOMLGenerator:
 
     def generate_to_file(
         self,
-        model: type[BaseModel],
+        model: type[BackendAISchema],
         output_path: str | Path,
         header: str | None = None,
     ) -> None:
@@ -569,7 +568,7 @@ class TOMLGenerator:
 
 
 def generate_sample_toml(
-    model: type[BaseModel],
+    model: type[BackendAISchema],
     output_path: str | Path | None = None,
     header: str | None = None,
 ) -> str:
@@ -595,7 +594,7 @@ def generate_sample_toml(
 
 
 def generate_halfstack_toml(
-    model: type[BaseModel],
+    model: type[BackendAISchema],
     output_path: str | Path | None = None,
     header: str | None = None,
 ) -> str:

--- a/src/ai/backend/common/configs/inspector/extractor.py
+++ b/src/ai/backend/common/configs/inspector/extractor.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import types
 from typing import TYPE_CHECKING, Any, cast
 
-from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
 
@@ -15,6 +14,7 @@ from ai.backend.common.meta import (
     ConfigExample,
     get_field_meta,
 )
+from ai.backend.common.types import BackendAISchema
 
 from .types import FieldDocumentation, FieldSchema, FieldTypeInfo
 
@@ -53,7 +53,7 @@ class ConfigInspector:
         """The current environment for example extraction."""
         return self._env
 
-    def extract(self, model: type[BaseModel]) -> Mapping[str, FieldSchema]:
+    def extract(self, model: type[BackendAISchema]) -> Mapping[str, FieldSchema]:
         """Extract complete schema from a Pydantic model.
 
         Args:
@@ -73,7 +73,7 @@ class ConfigInspector:
 
     def _extract_field(
         self,
-        model: type[BaseModel],
+        model: type[BackendAISchema],
         field_name: str,
         field_info: FieldInfo,
     ) -> FieldSchema | None:
@@ -298,8 +298,8 @@ class ConfigInspector:
         if target_type is None:
             return None
 
-        # Extract children from the target BaseModel
-        if isinstance(target_type, type) and issubclass(target_type, BaseModel):
+        # Extract children from the target BackendAISchema
+        if isinstance(target_type, type) and issubclass(target_type, BackendAISchema):
             return self.extract(target_type)
 
         return None

--- a/src/ai/backend/common/configs/redis.py
+++ b/src/ai/backend/common/configs/redis.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from pydantic import AliasChoices, BaseModel, Field, field_serializer, field_validator
+from pydantic import AliasChoices, Field, field_serializer, field_validator
 
 from ai.backend.common.meta import (
     BackendAIConfigMeta,
@@ -10,12 +10,17 @@ from ai.backend.common.meta import (
     ConfigExample,
 )
 from ai.backend.common.typed_validators import HostPortPair as HostPortPairModel
+from ai.backend.common.types import (
+    BackendAISchema,
+    RedisProfileTarget,
+    ValkeyProfileTarget,
+    ValkeyTarget,
+)
 from ai.backend.common.types import RedisHelperConfig as RedisHelperConfigDict
-from ai.backend.common.types import RedisProfileTarget, ValkeyProfileTarget, ValkeyTarget
 from ai.backend.common.types import RedisTarget as _RedisTarget
 
 
-class RedisHelperConfig(BaseModel):
+class RedisHelperConfig(BackendAISchema):
     socket_timeout: Annotated[
         float,
         Field(
@@ -94,7 +99,7 @@ class RedisHelperConfig(BaseModel):
         )
 
 
-class SingleRedisConfig(BaseModel):
+class SingleRedisConfig(BackendAISchema):
     addr: Annotated[
         HostPortPairModel | None,
         Field(default=None),

--- a/src/ai/backend/common/container_registry.py
+++ b/src/ai/backend/common/container_registry.py
@@ -2,7 +2,9 @@ import enum
 import uuid
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from ai.backend.common.types import BackendAISchema
 
 from .api_handlers import BaseFieldModel, BaseRequestModel, BaseResponseModel
 
@@ -24,7 +26,7 @@ class AllowedGroupsModel(BaseFieldModel):
     remove: list[str] = []
 
 
-class ContainerRegistryModel(BaseModel):
+class ContainerRegistryModel(BackendAISchema):
     model_config = ConfigDict(from_attributes=True)
 
     id: uuid.UUID | None = None

--- a/src/ai/backend/common/data/agent/types.py
+++ b/src/ai/backend/common/data/agent/types.py
@@ -2,17 +2,17 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
+from pydantic import AliasChoices, ConfigDict, Field, field_validator
 
 from ai.backend.common.auth import PublicKey
-from ai.backend.common.types import DeviceName, ResourceSlot, SlotName, SlotTypes
+from ai.backend.common.types import BackendAISchema, DeviceName, ResourceSlot, SlotName, SlotTypes
 
 
-class ImageOpts(BaseModel):
+class ImageOpts(BackendAISchema):
     compression: str
 
 
-class AgentInfo(BaseModel):
+class AgentInfo(BackendAISchema):
     ip: str
     region: str | None
     scaling_group: str

--- a/src/ai/backend/common/data/artifact/types.py
+++ b/src/ai/backend/common/data/artifact/types.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import enum
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from ai.backend.common.types import BackendAISchema
 
 
-class VerifierResult(BaseModel):
+class VerifierResult(BackendAISchema):
     """Result from a single verifier"""
 
     success: bool
@@ -18,7 +20,7 @@ class VerifierResult(BaseModel):
     error: str | None = None  # For when verifier fails with exception
 
 
-class VerificationStepResult(BaseModel):
+class VerificationStepResult(BackendAISchema):
     """Verification result containing results from all verifiers"""
 
     verifiers: dict[str, VerifierResult]
@@ -29,7 +31,7 @@ class ArtifactRegistryType(enum.StrEnum):
     RESERVOIR = "reservoir"
 
 
-class ArtifactDownloadTrackingData(BaseModel):
+class ArtifactDownloadTrackingData(BackendAISchema):
     """
     Artifact-level download tracking data stored in Redis.
     """
@@ -60,7 +62,7 @@ class ArtifactDownloadTrackingData(BaseModel):
     )
 
 
-class FileDownloadProgressData(BaseModel):
+class FileDownloadProgressData(BackendAISchema):
     """
     File-level download progress data stored in Redis.
     """
@@ -91,7 +93,7 @@ class FileDownloadProgressData(BaseModel):
     )
 
 
-class DownloadProgressData(BaseModel):
+class DownloadProgressData(BackendAISchema):
     """
     Download progress data including artifact-level and all file-level information.
     """
@@ -104,7 +106,7 @@ class DownloadProgressData(BaseModel):
     )
 
 
-class ArtifactRevisionDownloadProgress(BaseModel):
+class ArtifactRevisionDownloadProgress(BackendAISchema):
     """
     Download progress with artifact revision status.
     Used for both local and remote download progress.
@@ -130,7 +132,7 @@ class ArtifactRevisionDownloadProgress(BaseModel):
     )
 
 
-class CombinedDownloadProgress(BaseModel):
+class CombinedDownloadProgress(BackendAISchema):
     """
     Combined local and remote download progress.
     """

--- a/src/ai/backend/common/data/artifact_registry/types.py
+++ b/src/ai/backend/common/data/artifact_registry/types.py
@@ -4,12 +4,13 @@ import uuid
 from collections.abc import Mapping
 from typing import Any, Self
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.data.artifact.types import ArtifactRegistryType
+from ai.backend.common.types import BackendAISchema
 
 
-class ArtifactRegistryStatefulData(BaseModel):
+class ArtifactRegistryStatefulData(BackendAISchema):
     """Base class for artifact registry stateful data."""
 
     @classmethod

--- a/src/ai/backend/common/data/bgtask/types.py
+++ b/src/ai/backend/common/data/bgtask/types.py
@@ -1,7 +1,9 @@
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from ai.backend.common.types import BackendAISchema
 
 
-class BgTaskProgressData(BaseModel):
+class BgTaskProgressData(BackendAISchema):
     current: int = Field(
         default=0,
         description="Current progress of the scan operation, expressed as a percentage.",

--- a/src/ai/backend/common/data/image/types.py
+++ b/src/ai/backend/common/data/image/types.py
@@ -1,12 +1,11 @@
 from dataclasses import dataclass
 from typing import Self
 
-from pydantic import BaseModel
-
 from ai.backend.common.arch import arch_name_aliases
+from ai.backend.common.types import BackendAISchema
 
 
-class InstalledImageInfo(BaseModel):
+class InstalledImageInfo(BackendAISchema):
     """ "
     Information about an installed image on an agent.
     Attributes:

--- a/src/ai/backend/common/data/notification/messages.py
+++ b/src/ai/backend/common/data/notification/messages.py
@@ -6,7 +6,9 @@ from abc import abstractmethod
 from collections.abc import Mapping
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from ai.backend.common.types import BackendAISchema
 
 from .types import NotificationRuleType
 
@@ -22,7 +24,7 @@ __all__ = (
 _MESSAGE_TYPE_REGISTRY: dict[NotificationRuleType, type[NotifiableMessage]] = {}
 
 
-class NotifiableMessage(BaseModel):
+class NotifiableMessage(BackendAISchema):
     """Base class for all notification messages.
 
     All notification messages must inherit from this class and define

--- a/src/ai/backend/common/data/notification/types.py
+++ b/src/ai/backend/common/data/notification/types.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
-from ai.backend.common.types import CIStrEnum
+from ai.backend.common.types import BackendAISchema, CIStrEnum
 
 
 class NotificationChannelType(CIStrEnum):
@@ -21,7 +21,7 @@ class NotificationRuleType(CIStrEnum):
     ENDPOINT_LIFECYCLE_CHANGED = "endpoint.lifecycle.changed"
 
 
-class WebhookSpec(BaseModel):
+class WebhookSpec(BackendAISchema):
     """Configuration for webhook notification channel."""
 
     url: str = Field(description="Webhook endpoint URL")
@@ -39,7 +39,7 @@ class WebhookSpec(BaseModel):
     )
 
 
-class SMTPAuth(BaseModel):
+class SMTPAuth(BackendAISchema):
     """SMTP authentication credentials."""
 
     username: str | None = Field(default=None, description="SMTP username for authentication")
@@ -49,7 +49,7 @@ class SMTPAuth(BaseModel):
     )
 
 
-class SMTPConnection(BaseModel):
+class SMTPConnection(BackendAISchema):
     """SMTP server connection settings."""
 
     host: str = Field(description="SMTP server host")
@@ -58,7 +58,7 @@ class SMTPConnection(BaseModel):
     timeout: int = Field(default=30, gt=0, description="SMTP connection timeout in seconds")
 
 
-class EmailMessage(BaseModel):
+class EmailMessage(BackendAISchema):
     """Email message settings."""
 
     from_email: str = Field(description="Sender email address")
@@ -69,7 +69,7 @@ class EmailMessage(BaseModel):
     )
 
 
-class EmailSpec(BaseModel):
+class EmailSpec(BackendAISchema):
     """Configuration for email notification channel."""
 
     smtp: SMTPConnection = Field(description="SMTP server connection settings")

--- a/src/ai/backend/common/data/storage/registries/types.py
+++ b/src/ai/backend/common/data/storage/registries/types.py
@@ -2,10 +2,11 @@ import enum
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.data.artifact.types import ArtifactRegistryType
 from ai.backend.common.exception import ArtifactDefaultRevisionResolveError
+from ai.backend.common.types import BackendAISchema
 
 
 class ModelSortKey(enum.StrEnum):
@@ -17,7 +18,7 @@ class ModelSortKey(enum.StrEnum):
 
 
 # TODO: Separate of the ModelTarget type used in the storage proxy and the one used in the manager
-class ModelTarget(BaseModel):
+class ModelTarget(BackendAISchema):
     model_id: str = Field(
         description="""
         HuggingFace model ID to import.
@@ -47,7 +48,7 @@ class ModelTarget(BaseModel):
                 )
 
 
-class FileObjectData(BaseModel):
+class FileObjectData(BackendAISchema):
     """
     Model file information.
     """
@@ -82,7 +83,7 @@ class FileObjectData(BaseModel):
     )
 
 
-class ModelData(BaseModel):
+class ModelData(BackendAISchema):
     """
     Model Artifact information.
     """

--- a/src/ai/backend/common/data/storage/types.py
+++ b/src/ai/backend/common/data/storage/types.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import enum
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
 
 from ai.backend.common.type_adapters import VFolderIDField
+from ai.backend.common.types import BackendAISchema
 
 
-class VFolderStorageTarget(BaseModel):
+class VFolderStorageTarget(BackendAISchema):
     """Target for direct import to a specific virtual folder."""
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -16,7 +17,7 @@ class VFolderStorageTarget(BaseModel):
     volume_name: str
 
 
-class NamedStorageTarget(BaseModel):
+class NamedStorageTarget(BackendAISchema):
     """Target for named storage lookup via storage pool."""
 
     storage_name: str

--- a/src/ai/backend/common/dto/agent/response.py
+++ b/src/ai/backend/common/dto/agent/response.py
@@ -3,7 +3,7 @@ from dataclasses import asdict, dataclass
 from enum import StrEnum
 from typing import Any, Self, TypeVar, override
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
 
 from ai.backend.common.dto.internal.health import ConnectivityCheckResponse, HealthStatus
 from ai.backend.common.types import BackendAISchema
@@ -60,7 +60,7 @@ class DeviceHwStatus(StrEnum):
     UNAVAILABLE = "unavailable"
 
 
-class DeviceHardwareInfo(BaseModel):
+class DeviceHardwareInfo(BackendAISchema):
     """Per-device hardware info entry for ``GatherHwinfoResp``.
 
     The ``metadata`` field is a plugin-defined free-form string map — the

--- a/src/ai/backend/common/dto/clients/openai_compat/request.py
+++ b/src/ai/backend/common/dto/clients/openai_compat/request.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from ai.backend.common.types import BackendAISchema
 
 
-class ChatCompletionMessage(BaseModel):
+class ChatCompletionMessage(BackendAISchema):
     """One message inside a chat-completions request."""
 
     role: str
     content: str
 
 
-class ChatCompletionRequest(BaseModel):
+class ChatCompletionRequest(BackendAISchema):
     """Body for ``POST /v1/chat/completions`` (OpenAI-compatible).
 
     Extra fields are forwarded so callers can pass runtime-variant-specific

--- a/src/ai/backend/common/dto/clients/openai_compat/response.py
+++ b/src/ai/backend/common/dto/clients/openai_compat/response.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from ai.backend.common.types import BackendAISchema
 
 
-class _OpenAICompatModel(BaseModel):
+class _OpenAICompatModel(BackendAISchema):
     """Base for OpenAI-compat response DTOs.
 
     Runtimes (vLLM, SGLang, NIM, TGI) ship runtime-specific extras

--- a/src/ai/backend/common/dto/clients/prometheus/request.py
+++ b/src/ai/backend/common/dto/clients/prometheus/request.py
@@ -1,7 +1,9 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from ai.backend.common.types import BackendAISchema
 
 
-class QueryTimeRange(BaseModel):
+class QueryTimeRange(BackendAISchema):
     """Time range parameters for a Prometheus query."""
 
     start: str

--- a/src/ai/backend/common/dto/clients/prometheus/response.py
+++ b/src/ai/backend/common/dto/clients/prometheus/response.py
@@ -1,9 +1,11 @@
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import ConfigDict, Field, model_validator
+
+from ai.backend.common.types import BackendAISchema
 
 
-class MetricResponseInfo(BaseModel):
+class MetricResponseInfo(BackendAISchema):
     """Metric information from Prometheus response."""
 
     value_type: str | None = Field(default=None)
@@ -32,7 +34,7 @@ class MetricResponseInfo(BaseModel):
 type MetricResponseValue = tuple[float, str]  # (timestamp, value)
 
 
-class MetricResponse(BaseModel):
+class MetricResponse(BackendAISchema):
     """Single metric result from a Prometheus query.
 
     Handles both instant queries (single ``value``) and range queries
@@ -50,7 +52,7 @@ class MetricResponse(BaseModel):
         return data
 
 
-class PrometheusQueryData(BaseModel):
+class PrometheusQueryData(BackendAISchema):
     """Data field from a Prometheus query response."""
 
     result_type: str = Field(validation_alias="resultType")
@@ -59,14 +61,14 @@ class PrometheusQueryData(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
-class PrometheusResponse(BaseModel):
+class PrometheusResponse(BackendAISchema):
     """Response from Prometheus query API (instant or range)."""
 
     status: str
     data: PrometheusQueryData
 
 
-class LabelValueResponse(BaseModel):
+class LabelValueResponse(BackendAISchema):
     """Response from Prometheus label values API."""
 
     status: str

--- a/src/ai/backend/common/dto/internal/health.py
+++ b/src/ai/backend/common/dto/internal/health.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from enum import StrEnum
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from ai.backend.common.types import BackendAISchema
 
 
 class HealthStatus(StrEnum):
@@ -14,7 +16,7 @@ class HealthStatus(StrEnum):
     ERROR = "error"
 
 
-class ComponentConnectivityStatus(BaseModel):
+class ComponentConnectivityStatus(BackendAISchema):
     """
     Connectivity status of a single component (for API response).
 
@@ -32,7 +34,7 @@ class ComponentConnectivityStatus(BaseModel):
     )
 
 
-class ConnectivityCheckResponse(BaseModel):
+class ConnectivityCheckResponse(BackendAISchema):
     """
     Connectivity check response containing status of all registered components.
 
@@ -46,7 +48,7 @@ class ConnectivityCheckResponse(BaseModel):
     timestamp: datetime = Field(description="Timestamp when this response was generated")
 
 
-class HealthResponse(BaseModel):
+class HealthResponse(BackendAISchema):
     """
     Standard health check response for all Backend.AI components.
 

--- a/src/ai/backend/common/dto/manager/agent/response.py
+++ b/src/ai/backend/common/dto/manager/agent/response.py
@@ -5,10 +5,11 @@ Shared between Client SDK and Manager API.
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.pagination import PaginationInfo
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     "AgentDTO",
@@ -19,7 +20,7 @@ __all__ = (
 )
 
 
-class AgentDTO(BaseModel):
+class AgentDTO(BackendAISchema):
     """DTO for agent data."""
 
     id: str = Field(description="Agent ID")

--- a/src/ai/backend/common/dto/manager/artifact/response.py
+++ b/src/ai/backend/common/dto/manager/artifact/response.py
@@ -9,13 +9,14 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.data.artifact.types import (
     CombinedDownloadProgress,
     VerificationStepResult,
 )
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     # DTOs
@@ -35,7 +36,7 @@ __all__ = (
 )
 
 
-class ArtifactRevisionDTO(BaseModel):
+class ArtifactRevisionDTO(BackendAISchema):
     """DTO for artifact revision data."""
 
     id: UUID = Field(description="Artifact revision ID")
@@ -52,7 +53,7 @@ class ArtifactRevisionDTO(BaseModel):
     )
 
 
-class ArtifactDTO(BaseModel):
+class ArtifactDTO(BackendAISchema):
     """DTO for artifact data."""
 
     id: UUID = Field(description="Artifact ID")
@@ -70,7 +71,7 @@ class ArtifactDTO(BaseModel):
     extra: dict[str, Any] | None = Field(default=None, description="Extra metadata")
 
 
-class ArtifactRevisionImportTaskDTO(BaseModel):
+class ArtifactRevisionImportTaskDTO(BackendAISchema):
     """DTO for an artifact revision import task."""
 
     task_id: str | None = Field(default=None, description="Background task ID")

--- a/src/ai/backend/common/dto/manager/artifact_registry/request.py
+++ b/src/ai/backend/common/dto/manager/artifact_registry/request.py
@@ -7,12 +7,13 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseRequestModel
 from ai.backend.common.data.artifact.types import ArtifactRegistryType
 from ai.backend.common.data.storage.registries.types import ModelTarget
 from ai.backend.common.dto.manager.query import StringFilter
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     # Nested types
@@ -38,7 +39,7 @@ __all__ = (
 # ---------------------------------------------------------------------------
 
 
-class DelegateeTargetInput(BaseModel):
+class DelegateeTargetInput(BackendAISchema):
     """Target reservoir for delegation operations."""
 
     delegatee_reservoir_id: UUID = Field(description="ID of the delegatee reservoir")

--- a/src/ai/backend/common/dto/manager/artifact_registry/response.py
+++ b/src/ai/backend/common/dto/manager/artifact_registry/response.py
@@ -9,13 +9,14 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.data.artifact.types import (
     ArtifactRegistryType,
     VerificationStepResult,
 )
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     # DTOs
@@ -39,7 +40,7 @@ __all__ = (
 # ---------------------------------------------------------------------------
 
 
-class ArtifactRevisionDTO(BaseModel):
+class ArtifactRevisionDTO(BackendAISchema):
     """Artifact revision data (without readme) for API responses."""
 
     id: UUID = Field(description="Revision ID")
@@ -56,7 +57,7 @@ class ArtifactRevisionDTO(BaseModel):
     )
 
 
-class ArtifactDTO(BaseModel):
+class ArtifactDTO(BackendAISchema):
     """Artifact data with revisions (without readme in revisions) for API responses."""
 
     id: UUID = Field(description="Artifact ID")
@@ -77,7 +78,7 @@ class ArtifactDTO(BaseModel):
     )
 
 
-class ArtifactRevisionDataDTO(BaseModel):
+class ArtifactRevisionDataDTO(BackendAISchema):
     """Full artifact revision data including readme."""
 
     id: UUID = Field(description="Revision ID")
@@ -95,7 +96,7 @@ class ArtifactRevisionDataDTO(BaseModel):
     )
 
 
-class ArtifactWithRevisionsDTO(BaseModel):
+class ArtifactWithRevisionsDTO(BackendAISchema):
     """Artifact data with full revisions (including readme) for single-model responses."""
 
     id: UUID = Field(description="Artifact ID")
@@ -116,14 +117,14 @@ class ArtifactWithRevisionsDTO(BaseModel):
     )
 
 
-class ArtifactRevisionImportTaskDTO(BaseModel):
+class ArtifactRevisionImportTaskDTO(BackendAISchema):
     """Import task for an artifact revision."""
 
     task_id: str | None = Field(default=None, description="Background task ID")
     artifact_revision: ArtifactRevisionDTO = Field(description="The artifact revision")
 
 
-class ArtifactRevisionReadmeDTO(BaseModel):
+class ArtifactRevisionReadmeDTO(BackendAISchema):
     """Readme data for an artifact revision."""
 
     readme: str | None = Field(default=None, description="Readme content")

--- a/src/ai/backend/common/dto/manager/auth/types.py
+++ b/src/ai/backend/common/dto/manager/auth/types.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Any, Self
 
-from pydantic import BaseModel
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     "AuthTokenType",
@@ -36,7 +36,7 @@ class TwoFactorType(StrEnum):
     TOTP = "TOTP"
 
 
-class AuthResponse(BaseModel):
+class AuthResponse(BackendAISchema):
     """Base class for all authorization responses. The response_type discriminator
     determines which subclass the response should be deserialized into."""
 

--- a/src/ai/backend/common/dto/manager/auto_scaling_rule/response.py
+++ b/src/ai/backend/common/dto/manager/auto_scaling_rule/response.py
@@ -9,11 +9,11 @@ from datetime import datetime
 from decimal import Decimal
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.pagination import PaginationInfo
-from ai.backend.common.types import AutoScalingMetricSource
+from ai.backend.common.types import AutoScalingMetricSource, BackendAISchema
 
 __all__ = (
     "AutoScalingRuleDTO",
@@ -26,7 +26,7 @@ __all__ = (
 )
 
 
-class AutoScalingRuleDTO(BaseModel):
+class AutoScalingRuleDTO(BackendAISchema):
     """DTO for auto-scaling rule data."""
 
     id: UUID = Field(description="Auto-scaling rule ID")

--- a/src/ai/backend/common/dto/manager/config/response.py
+++ b/src/ai/backend/common/dto/manager/config/response.py
@@ -5,9 +5,10 @@ Shared between Client SDK and Manager API.
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel, BaseRootResponseModel
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     "DotfileItem",
@@ -22,7 +23,7 @@ __all__ = (
 )
 
 
-class DotfileItem(BaseModel):
+class DotfileItem(BackendAISchema):
     """A single dotfile entry."""
 
     path: str = Field(description="Dotfile path")
@@ -30,7 +31,7 @@ class DotfileItem(BaseModel):
     data: str = Field(description="Dotfile content")
 
 
-class DotfileListItem(BaseModel):
+class DotfileListItem(BackendAISchema):
     """A dotfile entry for list responses (backward compatible field names)."""
 
     path: str = Field(description="Dotfile path")

--- a/src/ai/backend/common/dto/manager/deployment/response.py
+++ b/src/ai/backend/common/dto/manager/deployment/response.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.data.model_deployment.types import (
@@ -21,7 +21,7 @@ from ai.backend.common.data.model_deployment.types import (
 from ai.backend.common.dto.manager.pagination import PaginationInfo
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.vfolder import VFolderUUID
-from ai.backend.common.types import ClusterMode, RuntimeVariant
+from ai.backend.common.types import BackendAISchema, ClusterMode, RuntimeVariant
 
 __all__ = (
     # DTOs
@@ -57,7 +57,7 @@ __all__ = (
 )
 
 
-class NetworkConfigDTO(BaseModel):
+class NetworkConfigDTO(BackendAISchema):
     """Network configuration for deployment."""
 
     open_to_public: bool = Field(description="Whether the deployment is public")
@@ -65,27 +65,27 @@ class NetworkConfigDTO(BaseModel):
     preferred_domain_name: str | None = Field(default=None, description="Preferred domain name")
 
 
-class ClusterConfigDTO(BaseModel):
+class ClusterConfigDTO(BackendAISchema):
     """Cluster configuration for revision."""
 
     mode: ClusterMode = Field(description="Cluster mode")
     size: int = Field(description="Cluster size")
 
 
-class ResourceConfigDTO(BaseModel):
+class ResourceConfigDTO(BackendAISchema):
     """Resource configuration for revision."""
 
     resource_group_name: str = Field(description="Resource group name")
     resource_slot: dict[str, Any] = Field(description="Resource slot allocation")
 
 
-class ModelRuntimeConfigDTO(BaseModel):
+class ModelRuntimeConfigDTO(BackendAISchema):
     """Model runtime configuration for revision."""
 
     runtime_variant: RuntimeVariant = Field(description="Runtime variant")
 
 
-class ModelMountConfigDTO(BaseModel):
+class ModelMountConfigDTO(BackendAISchema):
     """Model mount configuration for revision."""
 
     # ``vfolder_id`` is null when the referenced vfolder has been deleted
@@ -96,14 +96,14 @@ class ModelMountConfigDTO(BaseModel):
     definition_path: str = Field(description="Model definition path")
 
 
-class ReplicaStateDTO(BaseModel):
+class ReplicaStateDTO(BackendAISchema):
     """Replica state information."""
 
     desired_replica_count: int = Field(description="Desired number of replicas")
     replica_ids: list[UUID] = Field(description="IDs of current replicas")
 
 
-class RevisionDTO(BaseModel):
+class RevisionDTO(BackendAISchema):
     """DTO for model revision data."""
 
     id: UUID = Field(description="Revision ID")
@@ -118,7 +118,7 @@ class RevisionDTO(BaseModel):
     image_id: ImageID | None = Field(description="Image ID")
 
 
-class DeploymentDTO(BaseModel):
+class DeploymentDTO(BackendAISchema):
     """DTO for deployment data."""
 
     id: UUID = Field(description="Deployment ID")
@@ -208,7 +208,7 @@ class DeactivateRevisionResponse(BaseResponseModel):
     success: bool = Field(description="Whether the revision was deactivated")
 
 
-class RouteDTO(BaseModel):
+class RouteDTO(BackendAISchema):
     """DTO for route data."""
 
     id: UUID = Field(description="Route ID")
@@ -222,7 +222,7 @@ class RouteDTO(BaseModel):
     error_data: dict[str, Any] = Field(default_factory=dict, description="Error data if any")
 
 
-class CursorPaginationInfo(BaseModel):
+class CursorPaginationInfo(BackendAISchema):
     """Cursor-based pagination information."""
 
     total_count: int = Field(description="Total number of items")
@@ -246,7 +246,7 @@ class UpdateRouteTrafficStatusResponse(BaseResponseModel):
 # ========== Deployment Policy DTOs ==========
 
 
-class DeploymentPolicyDTO(BaseModel):
+class DeploymentPolicyDTO(BackendAISchema):
     """DTO representing the rollout policy for a deployment.
 
     Controls how new revisions are promoted to production traffic,

--- a/src/ai/backend/common/dto/manager/domain/response.py
+++ b/src/ai/backend/common/dto/manager/domain/response.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.pagination import PaginationInfo
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     "CreateDomainResponse",
@@ -25,7 +26,7 @@ __all__ = (
 )
 
 
-class DomainDTO(BaseModel):
+class DomainDTO(BackendAISchema):
     """DTO for domain data."""
 
     name: str = Field(description="Domain name (primary key)")

--- a/src/ai/backend/common/dto/manager/error_log/response.py
+++ b/src/ai/backend/common/dto/manager/error_log/response.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     "ErrorLogDTO",
@@ -19,7 +20,7 @@ __all__ = (
 )
 
 
-class ErrorLogDTO(BaseModel):
+class ErrorLogDTO(BackendAISchema):
     """DTO representing a single error log entry."""
 
     log_id: str = Field(description="Error log ID")

--- a/src/ai/backend/common/dto/manager/event_stream/response.py
+++ b/src/ai/backend/common/dto/manager/event_stream/response.py
@@ -7,7 +7,9 @@ of Server-Sent Events produced by the ``/events/session`` endpoint.
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     "SessionEventPayload",
@@ -15,7 +17,7 @@ __all__ = (
 )
 
 
-class SessionEventPayload(BaseModel):
+class SessionEventPayload(BackendAISchema):
     """Payload for session lifecycle SSE events.
 
     Emitted for events such as ``session_enqueued``, ``session_success``,

--- a/src/ai/backend/common/dto/manager/fair_share/request.py
+++ b/src/ai/backend/common/dto/manager/fair_share/request.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from decimal import Decimal
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseRequestModel
+from ai.backend.common.types import BackendAISchema
 
 from .types import (
     DomainFairShareFilter,
@@ -351,7 +352,7 @@ class UpsertUserFairShareWeightRequest(BaseRequestModel):
 # Update Resource Group Fair Share Spec
 
 
-class ResourceWeightEntryInput(BaseModel):
+class ResourceWeightEntryInput(BackendAISchema):
     """A single resource weight entry for fair share calculation.
 
     Set weight to null to remove the resource type weight (revert to default).

--- a/src/ai/backend/common/dto/manager/fair_share/response.py
+++ b/src/ai/backend/common/dto/manager/fair_share/response.py
@@ -6,10 +6,11 @@ from datetime import date, datetime
 from decimal import Decimal
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.pagination import PaginationInfo
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     # Common
@@ -52,20 +53,20 @@ __all__ = (
 )
 
 
-class ResourceSlotEntryDTO(BaseModel):
+class ResourceSlotEntryDTO(BackendAISchema):
     """A single resource slot entry with resource type and quantity."""
 
     resource_type: str = Field(description="Resource type identifier (e.g., cpu, mem, cuda.shares)")
     quantity: str = Field(description="Quantity as a decimal string to preserve precision")
 
 
-class ResourceSlotDTO(BaseModel):
+class ResourceSlotDTO(BackendAISchema):
     """Collection of compute resource allocations."""
 
     entries: list[ResourceSlotEntryDTO] = Field(description="List of resource allocations")
 
 
-class FairShareSpecDTO(BaseModel):
+class FairShareSpecDTO(BackendAISchema):
     """Fair share specification parameters."""
 
     weight: Decimal | None = Field(
@@ -78,7 +79,7 @@ class FairShareSpecDTO(BaseModel):
     resource_weights: ResourceSlotDTO = Field(description="Weights for each resource type")
 
 
-class FairShareCalculationSnapshotDTO(BaseModel):
+class FairShareCalculationSnapshotDTO(BackendAISchema):
     """Snapshot of the most recent fair share calculation."""
 
     fair_share_factor: Decimal = Field(description="Computed fair share factor (0-1 range)")
@@ -207,7 +208,7 @@ class SearchUserFairSharesResponse(BaseResponseModel):
 # Usage Bucket Common
 
 
-class UsageBucketMetadataDTO(BaseModel):
+class UsageBucketMetadataDTO(BackendAISchema):
     """Common metadata for usage bucket records."""
 
     period_start: date = Field(description="Start date of the usage measurement period (inclusive)")
@@ -370,7 +371,7 @@ class BulkUpsertUserFairShareWeightResponse(BaseResponseModel):
 # Resource Group Fair Share Spec
 
 
-class ResourceGroupFairShareSpecDTO(BaseModel):
+class ResourceGroupFairShareSpecDTO(BackendAISchema):
     """Fair share specification for a resource group."""
 
     half_life_days: int = Field(description="Half-life for exponential decay in days")
@@ -396,7 +397,7 @@ class GetResourceGroupFairShareSpecResponse(BaseResponseModel):
     fair_share_spec: ResourceGroupFairShareSpecDTO = Field(description="Fair share specification")
 
 
-class ResourceGroupFairShareSpecItemDTO(BaseModel):
+class ResourceGroupFairShareSpecItemDTO(BackendAISchema):
     """Resource group with its fair share specification."""
 
     resource_group: str = Field(description="Name of the resource group")

--- a/src/ai/backend/common/dto/manager/group/response.py
+++ b/src/ai/backend/common/dto/manager/group/response.py
@@ -9,10 +9,11 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.pagination import PaginationInfo
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     # DTOs
@@ -35,7 +36,7 @@ __all__ = (
 )
 
 
-class GroupDTO(BaseModel):
+class GroupDTO(BackendAISchema):
     """DTO for group/project data."""
 
     id: UUID = Field(description="Group ID")
@@ -58,7 +59,7 @@ class GroupDTO(BaseModel):
     )
 
 
-class GroupMemberDTO(BaseModel):
+class GroupMemberDTO(BackendAISchema):
     """DTO for group membership data."""
 
     user_id: UUID = Field(description="User ID")

--- a/src/ai/backend/common/dto/manager/image/response.py
+++ b/src/ai/backend/common/dto/manager/image/response.py
@@ -9,10 +9,11 @@ from datetime import datetime
 from decimal import Decimal
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.pagination import PaginationInfo
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     "AliasImageResponse",
@@ -26,21 +27,21 @@ __all__ = (
 )
 
 
-class ImageTagEntryDTO(BaseModel):
+class ImageTagEntryDTO(BackendAISchema):
     """A single parsed tag component from the image reference."""
 
     key: str = Field(description="Tag key")
     value: str = Field(description="Tag value")
 
 
-class ImageLabelEntryDTO(BaseModel):
+class ImageLabelEntryDTO(BackendAISchema):
     """A single label from the image metadata."""
 
     key: str = Field(description="Label key")
     value: str = Field(description="Label value")
 
 
-class ImageResourceLimitDTO(BaseModel):
+class ImageResourceLimitDTO(BackendAISchema):
     """Resource limit for an image."""
 
     key: str = Field(description="Resource slot name")
@@ -48,7 +49,7 @@ class ImageResourceLimitDTO(BaseModel):
     max: Decimal | None = Field(default=None, description="Maximum limit (None means unlimited)")
 
 
-class ImageDTO(BaseModel):
+class ImageDTO(BackendAISchema):
     """DTO for image data."""
 
     id: UUID = Field(description="Image ID")

--- a/src/ai/backend/common/dto/manager/infra/response.py
+++ b/src/ai/backend/common/dto/manager/infra/response.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel, BaseRootResponseModel
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     # Nested DTOs
@@ -43,14 +44,14 @@ __all__ = (
 # --- Nested DTOs ---
 
 
-class NumberFormatDTO(BaseModel):
+class NumberFormatDTO(BackendAISchema):
     """Number formatting configuration for resource slot display."""
 
     binary: bool = Field(description="Whether to use binary (base-2) formatting.")
     round_length: int = Field(description="Number of decimal places to round to.")
 
 
-class AcceleratorMetadataDTO(BaseModel):
+class AcceleratorMetadataDTO(BackendAISchema):
     """Metadata for an accelerator resource slot."""
 
     slot_name: str = Field(description="Internal slot name identifier.")
@@ -61,13 +62,13 @@ class AcceleratorMetadataDTO(BaseModel):
     display_icon: str = Field(description="Icon identifier for UI rendering.")
 
 
-class ScalingGroupDTO(BaseModel):
+class ScalingGroupDTO(BackendAISchema):
     """Minimal scaling group information."""
 
     name: str = Field(description="Name of the scaling group.")
 
 
-class ResourcePresetDTO(BaseModel):
+class ResourcePresetDTO(BackendAISchema):
     """Resource preset configuration."""
 
     name: str = Field(description="Name of the resource preset.")

--- a/src/ai/backend/common/dto/manager/model_serving/response.py
+++ b/src/ai/backend/common/dto/manager/model_serving/response.py
@@ -9,11 +9,11 @@ import uuid
 from collections.abc import Sequence
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, HttpUrl, NonNegativeFloat, NonNegativeInt
+from pydantic import ConfigDict, Field, HttpUrl, NonNegativeFloat, NonNegativeInt
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.identifier.vfolder import VFolderUUID
-from ai.backend.common.types import RuntimeVariant
+from ai.backend.common.types import BackendAISchema, RuntimeVariant
 
 __all__ = (
     # Response models
@@ -64,7 +64,7 @@ class CompactServeInfoModel(BaseResponseModel):
     )
 
 
-class RouteInfoModel(BaseModel):
+class RouteInfoModel(BackendAISchema):
     route_id: uuid.UUID = Field(
         description=(
             "Unique ID referencing endpoint route. Each endpoint route has a one-to-one"
@@ -157,7 +157,7 @@ class TokenResponseModel(BaseResponseModel):
     token: str
 
 
-class ErrorInfoModel(BaseModel):
+class ErrorInfoModel(BackendAISchema):
     session_id: uuid.UUID | None
     error: dict[str, Any]
 
@@ -167,7 +167,7 @@ class ErrorListResponseModel(BaseResponseModel):
     retries: int
 
 
-class RuntimeInfo(BaseModel):
+class RuntimeInfo(BackendAISchema):
     name: str = Field(description="Identifier to be passed later inside request body")
     human_readable_name: str = Field(description="Use this value as displayed label to user")
 

--- a/src/ai/backend/common/dto/manager/notification/response.py
+++ b/src/ai/backend/common/dto/manager/notification/response.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.data.notification.types import (
@@ -20,6 +20,7 @@ from ai.backend.common.data.notification.types import (
     SMTPConnection,
 )
 from ai.backend.common.dto.manager.pagination import PaginationInfo
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     "CreateNotificationChannelResponse",
@@ -57,7 +58,7 @@ class EmailSpecResponse(BaseResponseModel):
     auth: SMTPAuth | None = Field(default=None, description="SMTP authentication credentials")
 
 
-class NotificationChannelDTO(BaseModel):
+class NotificationChannelDTO(BackendAISchema):
     """DTO for notification channel data."""
 
     id: UUID = Field(description="Channel ID")
@@ -71,7 +72,7 @@ class NotificationChannelDTO(BaseModel):
     updated_at: datetime = Field(description="Last update timestamp")
 
 
-class NotificationRuleDTO(BaseModel):
+class NotificationRuleDTO(BackendAISchema):
     """DTO for notification rule data."""
 
     id: UUID = Field(description="Rule ID")

--- a/src/ai/backend/common/dto/manager/pagination.py
+++ b/src/ai/backend/common/dto/manager/pagination.py
@@ -4,12 +4,14 @@ Shared pagination DTOs for manager API responses.
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from ai.backend.common.types import BackendAISchema
 
 __all__ = ("PaginationInfo",)
 
 
-class PaginationInfo(BaseModel):
+class PaginationInfo(BackendAISchema):
     """Pagination information for list responses."""
 
     total: int = Field(description="Total number of items", ge=0)

--- a/src/ai/backend/common/dto/manager/prometheus_query_preset/response.py
+++ b/src/ai/backend/common/dto/manager/prometheus_query_preset/response.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.pagination import PaginationInfo
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     "CreateQueryDefinitionResponse",
@@ -30,14 +31,14 @@ __all__ = (
 )
 
 
-class QueryDefinitionOptionsDTO(BaseModel):
+class QueryDefinitionOptionsDTO(BackendAISchema):
     """Options DTO for a prometheus query definition."""
 
     filter_labels: list[str] = Field(description="Allowed filter label keys")
     group_labels: list[str] = Field(description="Allowed group-by label keys")
 
 
-class QueryDefinitionDTO(BaseModel):
+class QueryDefinitionDTO(BackendAISchema):
     """DTO for prometheus query definition data."""
 
     id: UUID = Field(description="Query definition ID")
@@ -81,28 +82,28 @@ class DeleteQueryDefinitionResponse(BaseResponseModel):
     id: UUID = Field(description="Deleted query definition ID")
 
 
-class MetricLabelEntryDTO(BaseModel):
+class MetricLabelEntryDTO(BackendAISchema):
     """A key-value label entry in the execute response."""
 
     key: str
     value: str
 
 
-class MetricValueDTO(BaseModel):
+class MetricValueDTO(BackendAISchema):
     """A single (timestamp, value) data point from Prometheus."""
 
     timestamp: float
     value: str
 
 
-class QueryDefinitionMetricResult(BaseModel):
+class QueryDefinitionMetricResult(BackendAISchema):
     """A single metric result from query definition execution."""
 
     metric: list[MetricLabelEntryDTO]
     values: list[MetricValueDTO]
 
 
-class QueryDefinitionExecuteData(BaseModel):
+class QueryDefinitionExecuteData(BackendAISchema):
     """Data field of the execute response."""
 
     result_type: str

--- a/src/ai/backend/common/dto/manager/quota_scope/response.py
+++ b/src/ai/backend/common/dto/manager/quota_scope/response.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.pagination import PaginationInfo
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     "GetQuotaScopeResponse",
@@ -15,7 +16,7 @@ __all__ = (
 )
 
 
-class QuotaScopeDTO(BaseModel):
+class QuotaScopeDTO(BackendAISchema):
     quota_scope_id: str = Field(description="Quota scope ID")
     storage_host_name: str = Field(description="Storage host name")
     usage_bytes: int | None = Field(default=None, description="Current usage in bytes")

--- a/src/ai/backend/common/dto/manager/rbac/response.py
+++ b/src/ai/backend/common/dto/manager/rbac/response.py
@@ -8,11 +8,12 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.data.permission.types import ScopeType
 from ai.backend.common.dto.manager.pagination import PaginationInfo
+from ai.backend.common.types import BackendAISchema
 
 from .types import EntityType, OperationType, RoleSource, RoleStatus
 
@@ -43,7 +44,7 @@ __all__ = (
 )
 
 
-class RoleDTO(BaseModel):
+class RoleDTO(BackendAISchema):
     """DTO for role data."""
 
     id: UUID = Field(description="Role ID")
@@ -56,7 +57,7 @@ class RoleDTO(BaseModel):
     description: str | None = Field(default=None, description="Role description")
 
 
-class AssignedUserDTO(BaseModel):
+class AssignedUserDTO(BackendAISchema):
     """DTO for user assigned to a role."""
 
     user_id: UUID = Field(description="User ID")
@@ -117,7 +118,7 @@ class SearchUsersAssignedToRoleResponse(BaseResponseModel):
     pagination: PaginationInfo = Field(description="Pagination information")
 
 
-class PermissionDTO(BaseModel):
+class PermissionDTO(BackendAISchema):
     """DTO for permission data."""
 
     id: UUID = Field(description="Permission ID")
@@ -125,7 +126,7 @@ class PermissionDTO(BaseModel):
     operation: OperationType = Field(description="Operation type")
 
 
-class ObjectPermissionDTO(BaseModel):
+class ObjectPermissionDTO(BackendAISchema):
     """DTO for object permission data."""
 
     id: UUID = Field(description="Object permission ID")
@@ -165,7 +166,7 @@ class GetScopeTypesResponse(BaseResponseModel):
     items: list[ScopeType] = Field(description="List of available scope types")
 
 
-class ScopeDTO(BaseModel):
+class ScopeDTO(BackendAISchema):
     """DTO for scope data."""
 
     scope_type: ScopeType = Field(description="Scope type")
@@ -186,7 +187,7 @@ class GetEntityTypesResponse(BaseResponseModel):
     items: list[EntityType] = Field(description="List of available entity types")
 
 
-class EntityDTO(BaseModel):
+class EntityDTO(BackendAISchema):
     """DTO for entity data."""
 
     entity_type: EntityType = Field(description="Entity type")

--- a/src/ai/backend/common/dto/manager/resource_policy/response.py
+++ b/src/ai/backend/common/dto/manager/resource_policy/response.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.pagination import PaginationInfo
-from ai.backend.common.types import DefaultForUnspecified
+from ai.backend.common.types import BackendAISchema, DefaultForUnspecified
 
 __all__ = (
     # Keypair
@@ -44,7 +44,7 @@ __all__ = (
 # ---- Keypair Resource Policy ----
 
 
-class KeypairResourcePolicyDTO(BaseModel):
+class KeypairResourcePolicyDTO(BackendAISchema):
     """DTO for keypair resource policy data."""
 
     name: str = Field(description="Policy name")
@@ -101,7 +101,7 @@ class SearchKeypairResourcePoliciesResponse(BaseResponseModel):
 # ---- User Resource Policy ----
 
 
-class UserResourcePolicyDTO(BaseModel):
+class UserResourcePolicyDTO(BackendAISchema):
     """DTO for user resource policy data."""
 
     name: str = Field(description="Policy name")
@@ -148,7 +148,7 @@ class SearchUserResourcePoliciesResponse(BaseResponseModel):
 # ---- Project Resource Policy ----
 
 
-class ProjectResourcePolicyDTO(BaseModel):
+class ProjectResourcePolicyDTO(BackendAISchema):
     """DTO for project resource policy data."""
 
     name: str = Field(description="Policy name")

--- a/src/ai/backend/common/dto/manager/resource_slot/response.py
+++ b/src/ai/backend/common/dto/manager/resource_slot/response.py
@@ -5,10 +5,11 @@ Shared between Client SDK and Manager API.
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.pagination import PaginationInfo
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     "NumberFormatDTO",
@@ -19,14 +20,14 @@ __all__ = (
 )
 
 
-class NumberFormatDTO(BaseModel):
+class NumberFormatDTO(BackendAISchema):
     """DTO for number format data."""
 
     binary: bool = Field(description="Whether to use binary (1024-based) units")
     round_length: int = Field(description="Number of decimal places to round to")
 
 
-class ResourceSlotTypeDTO(BaseModel):
+class ResourceSlotTypeDTO(BackendAISchema):
     """DTO for resource slot type data."""
 
     slot_name: str = Field(description="Unique slot name identifier")

--- a/src/ai/backend/common/dto/manager/scaling_group/response.py
+++ b/src/ai/backend/common/dto/manager/scaling_group/response.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     "ScalingGroupItem",
@@ -13,7 +14,7 @@ __all__ = (
 )
 
 
-class ScalingGroupItem(BaseModel):
+class ScalingGroupItem(BackendAISchema):
     """A single scaling group entry."""
 
     name: str = Field(description="Scaling group name")

--- a/src/ai/backend/common/dto/manager/storage/response.py
+++ b/src/ai/backend/common/dto/manager/storage/response.py
@@ -12,8 +12,6 @@ location, because ``common`` cannot import from ``manager``.
 ``manager.dto.response`` re-exports these models for backward compatibility.
 """
 
-from pydantic import BaseModel
-
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.response import (
     GetPresignedDownloadURLResponse,
@@ -23,6 +21,7 @@ from ai.backend.common.dto.manager.response import (
     ObjectStorageListResponse,
     ObjectStorageResponse,
 )
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     # Object storage models (re-exported from common.dto.manager.response)
@@ -51,7 +50,7 @@ __all__ = (
 # ---------------------------------------------------------------------------
 
 
-class VFSStorage(BaseModel):
+class VFSStorage(BackendAISchema):
     name: str
     base_path: str
     host: str

--- a/src/ai/backend/common/dto/manager/streaming/types.py
+++ b/src/ai/backend/common/dto/manager/streaming/types.py
@@ -11,7 +11,9 @@ from enum import StrEnum
 from typing import Annotated, Any, Literal
 from uuid import UUID
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, ConfigDict, Field
+
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     # Enums
@@ -114,7 +116,7 @@ class BgtaskSSEEventName(StrEnum):
 # ============================
 
 
-class PtyStdinMessage(BaseModel):
+class PtyStdinMessage(BackendAISchema):
     """Client→server: terminal input data (base64-encoded)."""
 
     model_config = ConfigDict(extra="forbid")
@@ -123,7 +125,7 @@ class PtyStdinMessage(BaseModel):
     chars: str
 
 
-class PtyResizeMessage(BaseModel):
+class PtyResizeMessage(BackendAISchema):
     """Client→server: terminal resize event."""
 
     model_config = ConfigDict(extra="forbid")
@@ -133,7 +135,7 @@ class PtyResizeMessage(BaseModel):
     cols: int
 
 
-class PtyPingMessage(BaseModel):
+class PtyPingMessage(BackendAISchema):
     """Client→server: keepalive ping."""
 
     model_config = ConfigDict(extra="forbid")
@@ -141,7 +143,7 @@ class PtyPingMessage(BaseModel):
     type: Literal[PtyInputMessageType.PING]
 
 
-class PtyRestartMessage(BaseModel):
+class PtyRestartMessage(BackendAISchema):
     """Client→server: kernel restart request."""
 
     model_config = ConfigDict(extra="forbid")
@@ -156,7 +158,7 @@ PtyClientMessage = Annotated[
 """Discriminated union of all client-to-server PTY WebSocket messages."""
 
 
-class PtyOutputMessage(BaseModel):
+class PtyOutputMessage(BackendAISchema):
     """Server→client: terminal output data (base64-encoded)."""
 
     model_config = ConfigDict(extra="forbid")
@@ -170,7 +172,7 @@ class PtyOutputMessage(BaseModel):
 # ============================
 
 
-class ExecuteRequest(BaseModel):
+class ExecuteRequest(BackendAISchema):
     """Client→server: first message to start code execution."""
 
     model_config = ConfigDict(extra="forbid")
@@ -180,7 +182,7 @@ class ExecuteRequest(BaseModel):
     options: dict[str, Any] = Field(default_factory=dict)
 
 
-class ExecuteResult(BaseModel):
+class ExecuteResult(BackendAISchema):
     """Server→client: code execution result message."""
 
     model_config = ConfigDict(extra="forbid")
@@ -198,7 +200,7 @@ class ExecuteResult(BaseModel):
 # ============================
 
 
-class StreamProxyParams(BaseModel):
+class StreamProxyParams(BackendAISchema):
     """Parameters for stream_proxy / tcpproxy WebSocket endpoints."""
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
@@ -212,7 +214,7 @@ class StreamProxyParams(BaseModel):
     arguments: str | None = Field(default=None, description="Stringified JSON arguments")
 
 
-class StreamAppInfo(BaseModel):
+class StreamAppInfo(BackendAISchema):
     """Information about an available streaming app/service."""
 
     model_config = ConfigDict(extra="forbid")
@@ -230,7 +232,7 @@ class StreamAppInfo(BaseModel):
 # ============================
 
 
-class SessionEventParams(BaseModel):
+class SessionEventParams(BackendAISchema):
     """Parameters for push_session_events SSE endpoint."""
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
@@ -254,7 +256,7 @@ class SessionEventParams(BaseModel):
     scope: str = Field(default="*")
 
 
-class BackgroundTaskEventParams(BaseModel):
+class BackgroundTaskEventParams(BackendAISchema):
     """Parameters for push_background_task_events SSE endpoint."""
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
@@ -269,7 +271,7 @@ class BackgroundTaskEventParams(BaseModel):
 # ============================
 
 
-class BgtaskUpdatedPayload(BaseModel):
+class BgtaskUpdatedPayload(BackendAISchema):
     """Payload for bgtask_updated SSE event."""
 
     model_config = ConfigDict(extra="forbid")
@@ -280,7 +282,7 @@ class BgtaskUpdatedPayload(BaseModel):
     total_progress: float
 
 
-class BgtaskDonePayload(BaseModel):
+class BgtaskDonePayload(BackendAISchema):
     """Payload for bgtask_done SSE event."""
 
     model_config = ConfigDict(extra="forbid")
@@ -289,7 +291,7 @@ class BgtaskDonePayload(BaseModel):
     message: str
 
 
-class BgtaskPartialSuccessPayload(BaseModel):
+class BgtaskPartialSuccessPayload(BackendAISchema):
     """Payload for bgtask_done SSE event with partial success (includes errors)."""
 
     model_config = ConfigDict(extra="forbid")
@@ -299,7 +301,7 @@ class BgtaskPartialSuccessPayload(BaseModel):
     errors: list[str]
 
 
-class BgtaskCancelledPayload(BaseModel):
+class BgtaskCancelledPayload(BackendAISchema):
     """Payload for bgtask_cancelled SSE event."""
 
     model_config = ConfigDict(extra="forbid")
@@ -308,7 +310,7 @@ class BgtaskCancelledPayload(BaseModel):
     message: str
 
 
-class BgtaskFailedPayload(BaseModel):
+class BgtaskFailedPayload(BackendAISchema):
     """Payload for bgtask_failed SSE event."""
 
     model_config = ConfigDict(extra="forbid")

--- a/src/ai/backend/common/dto/manager/template/response.py
+++ b/src/ai/backend/common/dto/manager/template/response.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel, BaseRootResponseModel
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     # Shared DTOs
@@ -36,7 +37,7 @@ __all__ = (
 # --- Shared DTOs ---
 
 
-class SessionTemplateItemDTO(BaseModel):
+class SessionTemplateItemDTO(BackendAISchema):
     """Base DTO for a template item in list responses."""
 
     name: str = Field(description="Template name")
@@ -63,7 +64,7 @@ class ClusterTemplateListItemDTO(SessionTemplateItemDTO):
     type: Literal["user", "group"] = Field(description='Template type ("user" or "group")')
 
 
-class CreateSessionTemplateItemDTO(BaseModel):
+class CreateSessionTemplateItemDTO(BackendAISchema):
     """DTO for a single created session template entry."""
 
     id: str = Field(description="Created template ID")

--- a/src/ai/backend/common/dto/manager/user/response.py
+++ b/src/ai/backend/common/dto/manager/user/response.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.pagination import PaginationInfo
+from ai.backend.common.types import BackendAISchema
 
 from .types import UserRole, UserStatus
 
@@ -27,7 +28,7 @@ __all__ = (
 )
 
 
-class UserDTO(BaseModel):
+class UserDTO(BackendAISchema):
     """DTO for user data in REST API responses."""
 
     id: UUID = Field(description="User UUID")

--- a/src/ai/backend/common/dto/manager/v2/deployment/types.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/types.py
@@ -9,7 +9,7 @@ from enum import StrEnum
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import Field, model_validator
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
@@ -24,6 +24,7 @@ from ai.backend.common.dto.manager.v2.common import OrderDirection, ResourceSlot
 from ai.backend.common.dto.manager.v2.resource_slot.types import ResourceOptsInfoDTO
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.common.types import (
+    BackendAISchema,
     ClusterMode,
     MountPermission,
     RuntimeVariant,
@@ -75,7 +76,7 @@ __all__ = (
 )
 
 
-class ProjectDeploymentScope(BaseModel):
+class ProjectDeploymentScope(BackendAISchema):
     """Scope for project-level deployment operations."""
 
     project_id: UUID = Field(description="Project UUID to scope the deployment operation.")
@@ -111,7 +112,7 @@ class RouteOrderField(StrEnum):
     TRAFFIC_RATIO = "traffic_ratio"
 
 
-class IntOrPercent(BaseModel):
+class IntOrPercent(BackendAISchema):
     """A rolling-update budget value: either an absolute count or a percentage.
 
     Exactly one of ``count`` or ``percent`` must be provided (oneOf semantics).

--- a/src/ai/backend/common/dto/manager/v2/domain/response.py
+++ b/src/ai/backend/common/dto/manager/v2/domain/response.py
@@ -7,10 +7,11 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.pagination import PaginationInfo
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     "AdminSearchDomainsPayload",
@@ -25,7 +26,7 @@ __all__ = (
 )
 
 
-class DomainBasicInfo(BaseModel):
+class DomainBasicInfo(BackendAISchema):
     """Basic domain information."""
 
     name: str = Field(
@@ -41,7 +42,7 @@ class DomainBasicInfo(BaseModel):
     )
 
 
-class DomainRegistryInfo(BaseModel):
+class DomainRegistryInfo(BackendAISchema):
     """Domain container registry configuration."""
 
     allowed_docker_registries: list[str] = Field(
@@ -52,7 +53,7 @@ class DomainRegistryInfo(BaseModel):
     )
 
 
-class DomainLifecycleInfo(BaseModel):
+class DomainLifecycleInfo(BackendAISchema):
     """Domain lifecycle information."""
 
     is_active: bool = Field(

--- a/src/ai/backend/common/dto/manager/v2/group/response.py
+++ b/src/ai/backend/common/dto/manager/v2/group/response.py
@@ -8,12 +8,13 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.pagination import PaginationInfo
 from ai.backend.common.dto.manager.v2.group.types import ProjectType
 from ai.backend.common.dto.manager.v2.user.response import UserNode
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     "AdminSearchGroupsPayload",
@@ -33,7 +34,7 @@ __all__ = (
 )
 
 
-class ProjectBasicInfo(BaseModel):
+class ProjectBasicInfo(BackendAISchema):
     """Basic project information."""
 
     name: str = Field(
@@ -52,7 +53,7 @@ class ProjectBasicInfo(BaseModel):
     )
 
 
-class ProjectOrganizationInfo(BaseModel):
+class ProjectOrganizationInfo(BackendAISchema):
     """Project's organizational context."""
 
     domain_name: str = Field(
@@ -63,7 +64,7 @@ class ProjectOrganizationInfo(BaseModel):
     )
 
 
-class VFolderHostPermissionEntry(BaseModel):
+class VFolderHostPermissionEntry(BackendAISchema):
     """Storage host permission entry."""
 
     host: str = Field(
@@ -77,7 +78,7 @@ class VFolderHostPermissionEntry(BaseModel):
     )
 
 
-class ProjectStorageInfo(BaseModel):
+class ProjectStorageInfo(BackendAISchema):
     """Project storage configuration."""
 
     allowed_vfolder_hosts: list[VFolderHostPermissionEntry] = Field(
@@ -89,7 +90,7 @@ class ProjectStorageInfo(BaseModel):
     )
 
 
-class ProjectLifecycleInfo(BaseModel):
+class ProjectLifecycleInfo(BackendAISchema):
     """Project lifecycle information."""
 
     is_active: bool | None = Field(

--- a/src/ai/backend/common/dto/manager/v2/runtime_variant_preset/types.py
+++ b/src/ai/backend/common/dto/manager/v2/runtime_variant_preset/types.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Self
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import Field, model_validator
+
+from ai.backend.common.types import BackendAISchema
 
 
 class RuntimeVariantPresetOrderField(StrEnum):
@@ -33,31 +35,31 @@ class UIType(StrEnum):
     TEXT_INPUT = "text_input"
 
 
-class SliderOption(BaseModel):
+class SliderOption(BackendAISchema):
     min: float = Field(description="Minimum value.")
     max: float = Field(description="Maximum value.")
     step: float = Field(default=1, description="Increment step.")
 
 
-class NumberOption(BaseModel):
+class NumberOption(BackendAISchema):
     min: float | None = Field(default=None, description="Minimum value.")
     max: float | None = Field(default=None, description="Maximum value.")
 
 
-class ChoiceItem(BaseModel):
+class ChoiceItem(BackendAISchema):
     value: str = Field(description="Option value.")
     label: str = Field(description="Display label.")
 
 
-class ChoiceOption(BaseModel):
+class ChoiceOption(BackendAISchema):
     items: list[ChoiceItem] = Field(description="List of choices.")
 
 
-class TextOption(BaseModel):
+class TextOption(BackendAISchema):
     placeholder: str | None = Field(default=None, description="Placeholder text.")
 
 
-class UIOption(BaseModel):
+class UIOption(BackendAISchema):
     """UI rendering options. ui_type determines which option field is valid."""
 
     ui_type: UIType = Field(description="UI render type.")

--- a/src/ai/backend/common/dto/manager/v2/user/response.py
+++ b/src/ai/backend/common/dto/manager/v2/user/response.py
@@ -8,11 +8,12 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.pagination import PaginationInfo
 from ai.backend.common.dto.manager.v2.user.types import UserRole, UserStatus
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     "AdminSearchUsersPayload",
@@ -41,7 +42,7 @@ __all__ = (
 )
 
 
-class UserBasicInfo(BaseModel):
+class UserBasicInfo(BackendAISchema):
     """Basic user profile information."""
 
     username: str | None = Field(
@@ -65,7 +66,7 @@ class UserBasicInfo(BaseModel):
     )
 
 
-class UserStatusInfo(BaseModel):
+class UserStatusInfo(BackendAISchema):
     """User account status information."""
 
     status: UserStatus = Field(
@@ -84,7 +85,7 @@ class UserStatusInfo(BaseModel):
     )
 
 
-class UserOrganizationInfo(BaseModel):
+class UserOrganizationInfo(BackendAISchema):
     """User's organizational context and permissions."""
 
     domain_name: str | None = Field(
@@ -104,7 +105,7 @@ class UserOrganizationInfo(BaseModel):
     )
 
 
-class UserSecurityInfo(BaseModel):
+class UserSecurityInfo(BackendAISchema):
     """User security settings and authentication configuration."""
 
     allowed_client_ip: list[str] | None = Field(
@@ -128,7 +129,7 @@ class UserSecurityInfo(BaseModel):
     )
 
 
-class UserContainerSettings(BaseModel):
+class UserContainerSettings(BackendAISchema):
     """Container execution settings for the user."""
 
     container_uid: int | None = Field(
@@ -145,7 +146,7 @@ class UserContainerSettings(BaseModel):
     )
 
 
-class EntityTimestamps(BaseModel):
+class EntityTimestamps(BackendAISchema):
     """Common timestamp fields for entity lifecycle tracking."""
 
     created_at: datetime | None = Field(

--- a/src/ai/backend/common/dto/manager/vfolder/response.py
+++ b/src/ai/backend/common/dto/manager/vfolder/response.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import uuid
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel, BaseRootResponseModel
 from ai.backend.common.bgtask.types import TaskID
@@ -17,7 +17,7 @@ from ai.backend.common.dto.manager.field import (
     VFolderOwnershipTypeField,
     VFolderPermissionField,
 )
-from ai.backend.common.types import ResultSet, VFolderUsageMode
+from ai.backend.common.types import BackendAISchema, ResultSet, VFolderUsageMode
 
 __all__ = (
     # DTOs (data transfer objects)
@@ -68,7 +68,7 @@ __all__ = (
 # ============================================================
 
 
-class VFolderCreatedDTO(BaseModel):
+class VFolderCreatedDTO(BackendAISchema):
     """DTO for a newly created vfolder."""
 
     id: str = Field(description="VFolder ID (hex UUID)")
@@ -87,7 +87,7 @@ class VFolderCreatedDTO(BaseModel):
     unmanaged_path: str | None = Field(default=None, description="Unmanaged path if any")
 
 
-class VFolderInfoDTO(BaseModel):
+class VFolderInfoDTO(BackendAISchema):
     """DTO for detailed vfolder information."""
 
     name: str = Field(description="VFolder name")
@@ -108,14 +108,14 @@ class VFolderInfoDTO(BaseModel):
     cloneable: bool = Field(description="Whether the vfolder is cloneable")
 
 
-class CompactVFolderInfoDTO(BaseModel):
+class CompactVFolderInfoDTO(BackendAISchema):
     """DTO for compact vfolder information (ID + name only)."""
 
     id: uuid.UUID = Field(description="VFolder ID")
     name: str = Field(description="VFolder name")
 
 
-class VFolderInvitationDTO(BaseModel):
+class VFolderInvitationDTO(BackendAISchema):
     """DTO for vfolder invitation data."""
 
     id: str = Field(description="Invitation ID")
@@ -129,7 +129,7 @@ class VFolderInvitationDTO(BaseModel):
     vfolder_name: str = Field(description="VFolder name")
 
 
-class VFolderSharedInfoDTO(BaseModel):
+class VFolderSharedInfoDTO(BackendAISchema):
     """DTO for shared vfolder information."""
 
     vfolder_id: str = Field(description="VFolder ID")
@@ -141,7 +141,7 @@ class VFolderSharedInfoDTO(BaseModel):
     perm: VFolderPermissionField = Field(description="Permission level")
 
 
-class VFolderCloneInfoDTO(BaseModel):
+class VFolderCloneInfoDTO(BackendAISchema):
     """DTO for cloned vfolder information."""
 
     id: str = Field(description="Cloned VFolder ID (hex UUID)")
@@ -157,7 +157,7 @@ class VFolderCloneInfoDTO(BaseModel):
     bgtask_id: str = Field(description="Background task ID for the clone operation")
 
 
-class VolumeInfoDTO(BaseModel):
+class VolumeInfoDTO(BackendAISchema):
     """DTO for volume host information."""
 
     backend: str = Field(description="Storage backend type")
@@ -166,7 +166,7 @@ class VolumeInfoDTO(BaseModel):
     sftp_scaling_groups: list[str] | None = Field(default=None, description="SFTP scaling groups")
 
 
-class MountResultDTO(BaseModel):
+class MountResultDTO(BackendAISchema):
     """DTO for mount/umount operation result per node."""
 
     success: bool = Field(description="Whether the operation succeeded")

--- a/src/ai/backend/common/dto/storage/request.py
+++ b/src/ai/backend/common/dto/storage/request.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from enum import StrEnum
 from pathlib import PurePosixPath
 
-from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
+from pydantic import ConfigDict, Field, field_serializer, field_validator
 
 from ai.backend.common.api_handlers import BaseRequestModel
 from ai.backend.common.data.storage.registries.types import ModelSortKey, ModelTarget
@@ -14,7 +14,7 @@ from ai.backend.common.data.storage.types import (
     ArtifactStorageTarget,
 )
 from ai.backend.common.type_adapters import VFolderIDField
-from ai.backend.common.types import QuotaConfig
+from ai.backend.common.types import BackendAISchema, QuotaConfig
 
 
 class QuotaScopeReq(BaseRequestModel):
@@ -550,7 +550,7 @@ _UNSAFE_FILENAME_RE = re.compile(r"[\x00-\x1f\x7f/\\]")
 
 
 # Client-facing API request models for download archive endpoint
-class ArchiveDownloadTokenData(BaseModel):
+class ArchiveDownloadTokenData(BackendAISchema):
     """Pydantic model for validating the JWT payload of archive download tokens."""
 
     operation: TokenOperationType = Field(

--- a/src/ai/backend/common/events/event_types/notification/anycast.py
+++ b/src/ai/backend/common/events/event_types/notification/anycast.py
@@ -4,16 +4,17 @@ from collections.abc import Mapping
 from datetime import datetime
 from typing import Any, override
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.events.types import AbstractAnycastEvent, EventDomain
 from ai.backend.common.events.user_event.user_event import UserEvent
 from ai.backend.common.json import dump_json_str, load_json
+from ai.backend.common.types import BackendAISchema
 
 __all__ = ("NotificationTriggeredEvent",)
 
 
-class NotificationTriggeredEvent(AbstractAnycastEvent, BaseModel):
+class NotificationTriggeredEvent(AbstractAnycastEvent, BackendAISchema):
     """
     Event triggered when a notification needs to be processed.
     This is an anycast event ensuring only one handler processes each notification.

--- a/src/ai/backend/common/events/event_types/service_discovery/anycast.py
+++ b/src/ai/backend/common/events/event_types/service_discovery/anycast.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, override
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.events.types import AbstractAnycastEvent, EventDomain
 from ai.backend.common.events.user_event.user_event import UserEvent
 from ai.backend.common.json import dump_json_str, load_json
+from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     "DoSweepStaleServicesEvent",
@@ -17,7 +18,7 @@ __all__ = (
 )
 
 
-class ServiceEndpointInfo(BaseModel):
+class ServiceEndpointInfo(BackendAISchema):
     """Data model for a service endpoint."""
 
     role: str = Field(description="Role of this endpoint (e.g., 'main', 'health', 'internal').")
@@ -52,7 +53,7 @@ class BaseServiceDiscoveryEvent(AbstractAnycastEvent):
         return None
 
 
-class ServiceRegisteredEvent(BaseServiceDiscoveryEvent, BaseModel):
+class ServiceRegisteredEvent(BaseServiceDiscoveryEvent, BackendAISchema):
     """Event emitted when a service instance registers or sends a heartbeat.
 
     Contains full service metadata and endpoint information.
@@ -130,7 +131,7 @@ class DoSweepStaleServicesEvent(BaseServiceDiscoveryEvent):
         return cls()
 
 
-class ServiceDeregisteredEvent(BaseServiceDiscoveryEvent, BaseModel):
+class ServiceDeregisteredEvent(BaseServiceDiscoveryEvent, BackendAISchema):
     """Event emitted when a service instance is deregistered."""
 
     instance_id: str = Field(description="Unique instance identifier.")

--- a/src/ai/backend/common/meta/meta.py
+++ b/src/ai/backend/common/meta/meta.py
@@ -2,12 +2,9 @@ from __future__ import annotations
 
 import enum
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from pydantic import BaseModel as PydanticBaseModel
-
-if TYPE_CHECKING:
-    from pydantic import BaseModel
+from ai.backend.common.types import BackendAISchema
 
 NEXT_RELEASE_VERSION = "UNRELEASED"
 """Placeholder for the next release version.
@@ -166,7 +163,7 @@ class BackendAIGQLMeta(BackendAIFieldMeta):
 
 
 def get_field_meta(
-    model: type[BaseModel],
+    model: type[BackendAISchema],
     field_name: str,
 ) -> BackendAIFieldMeta | None:
     """Retrieve BackendAI metadata for a field.
@@ -183,7 +180,7 @@ def get_field_meta(
         The BackendAIFieldMeta instance if found, None otherwise.
 
     Example:
-        >>> class MyConfig(BaseModel):
+        >>> class MyConfig(BackendAISchema):
         ...     name: Annotated[str, Field(), BackendAIConfigMeta(
         ...         description="Config name",
         ...         added_version="25.1.0",
@@ -203,7 +200,7 @@ def get_field_meta(
     return None
 
 
-def get_field_type(model: type[BaseModel], field_name: str) -> type | None:
+def get_field_type(model: type[BackendAISchema], field_name: str) -> type | None:
     """Get the actual type of a field.
 
     In Pydantic v2, Annotated types are already unwrapped by the time they're
@@ -217,7 +214,7 @@ def get_field_type(model: type[BaseModel], field_name: str) -> type | None:
         The underlying type of the field, or None if field doesn't exist.
 
     Example:
-        >>> class MyConfig(BaseModel):
+        >>> class MyConfig(BackendAISchema):
         ...     name: Annotated[str, Field()]
         >>> get_field_type(MyConfig, "name")
         <class 'str'>
@@ -231,7 +228,7 @@ def get_field_type(model: type[BaseModel], field_name: str) -> type | None:
 
 
 def generate_example(
-    model: type[BaseModel],
+    model: type[BackendAISchema],
     field_name: str,
     env: ConfigEnvironment = ConfigEnvironment.LOCAL,
 ) -> str:
@@ -272,7 +269,7 @@ def generate_example(
 
 
 def generate_composite_example(
-    model: type[BaseModel],
+    model: type[BackendAISchema],
     env: ConfigEnvironment = ConfigEnvironment.LOCAL,
 ) -> dict[str, Any]:
     """Recursively generate example for composite types from child fields.
@@ -288,7 +285,7 @@ def generate_composite_example(
         A dictionary mapping field names to their example values.
 
     Example:
-        >>> class SessionConfig(BaseModel):
+        >>> class SessionConfig(BackendAISchema):
         ...     cpu: Annotated[int, BackendAIConfigMeta(
         ...         description="CPU cores", added_version="25.1.0",
         ...         example=ConfigExample(local="2", prod="8")
@@ -313,7 +310,7 @@ def generate_composite_example(
             if (
                 child_type is not None
                 and isinstance(child_type, type)
-                and issubclass(child_type, PydanticBaseModel)
+                and issubclass(child_type, BackendAISchema)
             ):
                 result[name] = generate_composite_example(child_type, env)
         else:
@@ -325,7 +322,7 @@ def generate_composite_example(
 
 
 def generate_model_example(
-    model: type[BaseModel],
+    model: type[BackendAISchema],
     env: ConfigEnvironment = ConfigEnvironment.LOCAL,
 ) -> dict[str, Any]:
     """Generate example for entire model by collecting all field examples.
@@ -340,7 +337,7 @@ def generate_model_example(
         A dictionary mapping field names to their example values.
 
     Example:
-        >>> class CreateSessionRequest(BaseModel):
+        >>> class CreateSessionRequest(BackendAISchema):
         ...     name: Annotated[str, BackendAIConfigMeta(
         ...         description="Session name", added_version="25.1.0",
         ...         example=ConfigExample(local="dev-session", prod="prod-session")

--- a/src/ai/backend/common/service_discovery/service_discovery.py
+++ b/src/ai/backend/common/service_discovery/service_discovery.py
@@ -7,9 +7,9 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import Any, Final, Self
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
-from ai.backend.common.types import ServiceDiscoveryType
+from ai.backend.common.types import BackendAISchema, ServiceDiscoveryType
 from ai.backend.logging.utils import BraceStyleAdapter
 
 _DEFAULT_HEARTBEAT_TIMEOUT = 60 * 5  # 5 minutes
@@ -22,7 +22,7 @@ MODEL_SERVICE_GROUP: Final[str] = "model-services"
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
-class ServiceEndpoint(BaseModel):
+class ServiceEndpoint(BackendAISchema):
     """
     Service endpoint.
     """
@@ -33,7 +33,7 @@ class ServiceEndpoint(BaseModel):
     prometheus_address: str
 
 
-class ModelServiceMetadata(BaseModel):
+class ModelServiceMetadata(BackendAISchema):
     """
     Simplified metadata for model service routes.
     Used for Prometheus service discovery registration.
@@ -80,7 +80,7 @@ class ModelServiceMetadata(BaseModel):
         )
 
 
-class HealthStatus(BaseModel):
+class HealthStatus(BackendAISchema):
     """
     Health status of a service.
     """
@@ -109,7 +109,7 @@ class HealthStatus(BaseModel):
         return self.registration_time == value.registration_time
 
 
-class ServiceMetadata(BaseModel):
+class ServiceMetadata(BackendAISchema):
     """
     Metadata for a service.
     """

--- a/src/ai/backend/common/typed_validators.py
+++ b/src/ai/backend/common/typed_validators.py
@@ -28,11 +28,13 @@ from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import core_schema
 
 from ai.backend.common.exception import (
+    BackendAISchemaValidationFailed,
     JWTDecodeError,
     JWTExpiredError,
     JWTInvalidSignatureError,
     JWTPayloadValidationError,
 )
+from ai.backend.common.types import BackendAISchema
 from ai.backend.common.types import HostPortPair as LegacyHostPortPair
 
 from .defs import (
@@ -206,7 +208,7 @@ def _vfolder_name_validator(name: str) -> str:
 VFolderName = Annotated[str, AfterValidator(_vfolder_name_validator)]
 
 
-class HostPortPair(BaseModel):
+class HostPortPair(BackendAISchema):
     host: Annotated[
         str,
         Field(),
@@ -579,5 +581,7 @@ class PydanticJWTValidator:
 
         try:
             return model.model_validate(payload)
-        except ValidationError as e:
+        except (BackendAISchemaValidationFailed, ValidationError) as e:
+            # ``ValidationError`` covers plain ``BaseModel`` subclasses that
+            # skip the ``BackendAISchema`` auto-conversion override.
             raise JWTPayloadValidationError(extra_msg=str(e)) from e

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -729,7 +729,7 @@ _MOUNT_PERMISSION_ORDER: dict[MountPermission, int] = {
 MountPermissionLiteral = Literal["ro", "rw", "wd"]
 
 
-class MountInfoEntry(BaseModel):
+class MountInfoEntry(BackendAISchema):
     """Revision-stored form of a user-supplied extra mount.
 
     The row column persists only these three fields; everything else
@@ -785,7 +785,7 @@ class VFolderMountRequest:
     options: VFolderMountOptions = attrs.Factory(VFolderMountOptions)
 
 
-class MountPoint(BaseModel):
+class MountPoint(BackendAISchema):
     model_config = ConfigDict(
         validate_by_name=True,
         protected_namespaces=(),
@@ -1333,7 +1333,7 @@ class SlotQuantity:
     quantity: Decimal
 
 
-class ResourceSlotEntry(BaseModel):
+class ResourceSlotEntry(BackendAISchema):
     """List-friendly shared form of a single resource slot allocation.
 
     The preferred replacement for the ``ResourceSlot`` ``UserDict`` in new

--- a/src/ai/backend/install/types.py
+++ b/src/ai/backend/install/types.py
@@ -5,11 +5,11 @@ import enum
 from datetime import datetime
 from pathlib import Path
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 from rich.console import ConsoleRenderable, RichCast
 from rich.text import Text
 
-from ai.backend.common.types import HostPortPair
+from ai.backend.common.types import BackendAISchema, HostPortPair
 
 from . import __version__
 
@@ -89,12 +89,12 @@ class PrerequisiteError(RichCast, Exception):
         return Text.from_markup(text)
 
 
-class LocalImageSource(BaseModel):
+class LocalImageSource(BackendAISchema):
     ref: str
     file: Path
 
 
-class DistInfo(BaseModel):
+class DistInfo(BackendAISchema):
     version: str = __version__
     package_source: PackageSource = PackageSource.GITHUB_RELEASE
     package_dir: Path = Field(default_factory=Path.cwd)
@@ -112,7 +112,7 @@ class Accelerator(enum.StrEnum):
     ROCM_MOCK = "rocm_mock"
 
 
-class InstallInfo(BaseModel):
+class InstallInfo(BackendAISchema):
     version: str
     type: InstallType
     last_updated: datetime

--- a/src/ai/backend/logging/config.py
+++ b/src/ai/backend/logging/config.py
@@ -5,7 +5,6 @@ from typing import Annotated, Any, Self
 
 from pydantic import (
     AliasChoices,
-    BaseModel,
     ByteSize,
     ConfigDict,
     Field,
@@ -17,6 +16,7 @@ from pydantic import (
 
 from ai.backend.common.meta import BackendAIConfigMeta, CompositeType, ConfigExample
 from ai.backend.common.typed_validators import AutoDirectoryPath
+from ai.backend.common.types import BackendAISchema
 
 from .exceptions import ConfigurationError
 from .types import LogFormat, LogLevel, MsgpackOptions
@@ -43,7 +43,7 @@ class LogstashProtocol(StrEnum):
     UDP = "udp"
 
 
-class BaseConfigModel(BaseModel):
+class BaseConfigModel(BackendAISchema):
     @staticmethod
     def snake_to_kebab_case(string: str) -> str:
         if string == "class_":

--- a/src/ai/backend/logging/validation_context.py
+++ b/src/ai/backend/logging/validation_context.py
@@ -1,12 +1,14 @@
 from abc import ABC
 from typing import Self
 
-from pydantic import BaseModel, ConfigDict, ValidationInfo
+from pydantic import ConfigDict, ValidationInfo
+
+from ai.backend.common.types import BackendAISchema
 
 from .types import LogLevel
 
 
-class BaseConfigValidationContext(BaseModel, ABC):
+class BaseConfigValidationContext(BackendAISchema, ABC):
     debug: bool
     log_level: LogLevel
 

--- a/src/ai/backend/manager/api/gql/graphql_ws/types.py
+++ b/src/ai/backend/manager/api/gql/graphql_ws/types.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 import enum
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from ai.backend.common.types import BackendAISchema
 
 
 class GQLWSMessageType(enum.StrEnum):
@@ -30,34 +32,34 @@ class GQLWSMessageType(enum.StrEnum):
 # --- Client → Server ---
 
 
-class ConnectionInitMessage(BaseModel, frozen=True):
+class ConnectionInitMessage(BackendAISchema, frozen=True):
     type: Literal[GQLWSMessageType.CONNECTION_INIT]
     payload: dict[str, Any] | None = None
 
 
-class SubscribePayload(BaseModel, frozen=True):
+class SubscribePayload(BackendAISchema, frozen=True):
     query: str
     variables: dict[str, Any] | None = None
     operationName: str | None = None
 
 
-class SubscribeMessage(BaseModel, frozen=True):
+class SubscribeMessage(BackendAISchema, frozen=True):
     type: Literal[GQLWSMessageType.SUBSCRIBE]
     id: str
     payload: SubscribePayload
 
 
-class ClientCompleteMessage(BaseModel, frozen=True):
+class ClientCompleteMessage(BackendAISchema, frozen=True):
     type: Literal[GQLWSMessageType.COMPLETE]
     id: str
 
 
-class PingMessage(BaseModel, frozen=True):
+class PingMessage(BackendAISchema, frozen=True):
     type: Literal[GQLWSMessageType.PING] = GQLWSMessageType.PING
     payload: dict[str, Any] | None = None
 
 
-class PongMessage(BaseModel, frozen=True):
+class PongMessage(BackendAISchema, frozen=True):
     type: Literal[GQLWSMessageType.PONG] = GQLWSMessageType.PONG
     payload: dict[str, Any] | None = None
 
@@ -65,29 +67,29 @@ class PongMessage(BaseModel, frozen=True):
 # --- Server → Client ---
 
 
-class ConnectionAckMessage(BaseModel, frozen=True):
+class ConnectionAckMessage(BackendAISchema, frozen=True):
     type: Literal[GQLWSMessageType.CONNECTION_ACK] = GQLWSMessageType.CONNECTION_ACK
     payload: dict[str, Any] | None = None
 
 
-class NextPayload(BaseModel, frozen=True):
+class NextPayload(BackendAISchema, frozen=True):
     data: dict[str, Any] | None = None
     errors: list[dict[str, Any]] | None = None
 
 
-class NextMessage(BaseModel, frozen=True):
+class NextMessage(BackendAISchema, frozen=True):
     type: Literal[GQLWSMessageType.NEXT] = GQLWSMessageType.NEXT
     id: str
     payload: NextPayload
 
 
-class ErrorMessage(BaseModel, frozen=True):
+class ErrorMessage(BackendAISchema, frozen=True):
     type: Literal[GQLWSMessageType.ERROR] = GQLWSMessageType.ERROR
     id: str
     payload: list[dict[str, Any]]
 
 
-class ServerCompleteMessage(BaseModel, frozen=True):
+class ServerCompleteMessage(BackendAISchema, frozen=True):
     type: Literal[GQLWSMessageType.COMPLETE] = GQLWSMessageType.COMPLETE
     id: str
 

--- a/src/ai/backend/manager/api/utils.py
+++ b/src/ai/backend/manager/api/utils.py
@@ -39,8 +39,7 @@ from aiohttp.typedefs import Handler
 from pydantic import Field, TypeAdapter, ValidationError
 
 from ai.backend.common.api_handlers import BaseRequestModel, BaseResponseModel
-from ai.backend.common.exception import DeprecatedAPI
-from ai.backend.common.json import load_json
+from ai.backend.common.exception import BackendAISchemaValidationFailed, DeprecatedAPI
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.errors.api import (
     InvalidAPIParameters,
@@ -223,13 +222,15 @@ def pydantic_params_api_handler[
                     kwargs["query"] = query_params
             except (json.decoder.JSONDecodeError, yaml.YAMLError, yaml.MarkedYAMLError) as e:
                 raise InvalidAPIParameters("Malformed body") from e
-            except ValidationError as ex:
+            except (BackendAISchemaValidationFailed, ValidationError) as ex:
+                # ``ValidationError`` covers plain ``BaseModel`` subclasses that
+                # skip the ``BackendAISchema`` auto-conversion override.
+                # Format the first validation error as the message; the client
+                # may refer to ``extra_data["errors"]`` for the full list.
                 first_error = ex.errors()[0]
-                # Format the first validation error as the message
-                # The client may refer extra_data to access the full validation errors.
-                metadata = {
-                    "input": first_error["input"],
-                }
+                metadata: dict[str, Any] = {}
+                if (input_val := first_error.get("input")) is not None:
+                    metadata["input"] = input_val
                 if loc := first_error["loc"]:
                     metadata["loc"] = loc[0]
                 metadata_formatted_items = [
@@ -237,8 +238,7 @@ def pydantic_params_api_handler[
                     *(f"{k}={v!r}" for k, v in metadata.items()),
                 ]
                 msg = f"{first_error['msg']} [{', '.join(metadata_formatted_items)}]"
-                # To reuse the json serialization provided by pydantic, we call ex.json() and re-parse it.
-                raise InvalidAPIParameters(msg, extra_data=load_json(ex.json())) from ex
+                raise InvalidAPIParameters(msg, extra_data={"errors": ex.errors()}) from ex
             result = await handler(request, checked_params, *args, **kwargs)
             return ensure_stream_response_type(result)
 

--- a/src/ai/backend/manager/bgtask/tasks/purge_images.py
+++ b/src/ai/backend/manager/bgtask/tasks/purge_images.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, override
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.bgtask.task.base import (
     BaseBackgroundTaskHandler,
     BaseBackgroundTaskManifest,
     BaseBackgroundTaskResult,
 )
-from ai.backend.common.types import AgentId
+from ai.backend.common.types import AgentId, BackendAISchema
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.bgtask.types import ManagerBgtaskName
 from ai.backend.manager.services.image.actions.purge_images import PurgeImageAction
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
-class PurgedImageData(BaseModel):
+class PurgedImageData(BackendAISchema):
     """Data about a purged image."""
 
     agent_id: str = Field(description="Agent ID where the image was purged")
@@ -41,7 +41,7 @@ class PurgeImagesTaskResult(BaseBackgroundTaskResult):
     errors: list[str] = Field(description="List of errors encountered during the purge operation")
 
 
-class PurgeImageSpec(BaseModel):
+class PurgeImageSpec(BackendAISchema):
     """Specification of a container image to purge."""
 
     name: str = Field(description="Image name")
@@ -49,7 +49,7 @@ class PurgeImageSpec(BaseModel):
     architecture: str = Field(description="Image architecture (e.g., x86_64, aarch64)")
 
 
-class PurgeAgentSpec(BaseModel):
+class PurgeAgentSpec(BackendAISchema):
     """Specification for purging images on a specific agent."""
 
     agent_id: AgentId = Field(description="Agent ID where images will be purged")

--- a/src/ai/backend/manager/clients/agent/client.py
+++ b/src/ai/backend/manager/clients/agent/client.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
 
 from ai.backend.common.docker import ImageRef
 from ai.backend.common.dto.agent.request import BaseAgentRequestModel, GatherHwinfoReq, HealthReq
@@ -18,6 +18,7 @@ from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPoli
 from ai.backend.common.resilience.resilience import Resilience
 from ai.backend.common.types import (
     AgentId,
+    BackendAISchema,
     ClusterInfo,
     ImageConfig,
     KernelCreationConfig,
@@ -43,7 +44,7 @@ agent_client_resilience = Resilience(
 TResp = TypeVar("TResp", bound=BaseAgentResponseModel)
 
 
-class AgentRPCCall(BaseModel):
+class AgentRPCCall(BackendAISchema):
     """Manager-side envelope describing a single v3 agent RPC invocation.
 
     Grouping ``method`` / ``agent_id`` / ``payload`` into one pydantic

--- a/src/ai/backend/manager/config/bootstrap.py
+++ b/src/ai/backend/manager/config/bootstrap.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from pprint import pformat
 from typing import Any, Self
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.configs.etcd import EtcdConfig
 from ai.backend.common.configs.loader import (
@@ -12,6 +12,7 @@ from ai.backend.common.configs.loader import (
     TomlConfigLoader,
 )
 from ai.backend.common.configs.pyroscope import PyroscopeConfig
+from ai.backend.common.types import BackendAISchema
 from ai.backend.logging.config import LoggingConfig
 from ai.backend.logging.types import LogLevel
 from ai.backend.manager.config.unified import (
@@ -24,7 +25,7 @@ from .constant import MANAGER_LOCAL_CFG_OVERRIDE_ENVS
 
 
 # TODO: Remove useless config fields from this
-class BootstrapConfig(BaseModel):
+class BootstrapConfig(BackendAISchema):
     db: DatabaseConfig = Field(
         default_factory=DatabaseConfig,  # type: ignore[arg-type]
         description="""

--- a/src/ai/backend/manager/data/deployment/inference_runtime_config.py
+++ b/src/ai/backend/manager/data/deployment/inference_runtime_config.py
@@ -1,11 +1,13 @@
 from decimal import Decimal
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
+from ai.backend.common.types import BackendAISchema
 
-class BaseInferenceRuntimeConfig(BaseModel):
+
+class BaseInferenceRuntimeConfig(BackendAISchema):
     model_config = ConfigDict(alias_generator=to_camel)
 
     @classmethod

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 import yarl
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
 
 from ai.backend.common.config import ModelDefinition, ModelDefinitionDraft
 from ai.backend.common.data.endpoint.types import EndpointLifecycle, ScalingState
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 
 from ai.backend.common.types import (
     AutoScalingMetricSource,
+    BackendAISchema,
     ClusterMode,
     MountInfoEntry,
     MountPermission,
@@ -52,7 +53,7 @@ from ai.backend.manager.data.deployment_revision_preset.types import (
 from ai.backend.manager.data.runtime_variant.types import RuntimeVariantData
 
 
-class DeploymentConfig(BaseModel):
+class DeploymentConfig(BackendAISchema):
     """``deployment-config.yaml`` payload after repository-side resolution.
 
     The raw yaml carries ``image`` + ``architecture`` strings; the repository
@@ -370,7 +371,7 @@ class ReplicaData:
         return self.replica_count
 
 
-class ConfiguredModel(BaseModel):
+class ConfiguredModel(BackendAISchema):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 

--- a/src/ai/backend/manager/data/session/types.py
+++ b/src/ai/backend/manager/data/session/types.py
@@ -8,11 +8,10 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
-from pydantic import BaseModel
-
 from ai.backend.common.data.vfolder.types import VFolderMountData
 from ai.backend.common.types import (
     AccessKey,
+    BackendAISchema,
     CIStrEnum,
     ClusterMode,
     ResourceSlot,
@@ -354,7 +353,7 @@ class PromotionStatusTransitions:
     success: SessionStatus | None = None
 
 
-class SubStepResult(BaseModel):
+class SubStepResult(BackendAISchema):
     """Sub-step result for scheduling history."""
 
     step: str

--- a/src/ai/backend/manager/idle.py
+++ b/src/ai/backend/manager/idle.py
@@ -31,7 +31,6 @@ import trafaret as t
 from aiotools import TaskGroupError
 from dateutil.relativedelta import relativedelta
 from pydantic import (
-    BaseModel,
     Field,
     GetCoreSchemaHandler,
 )
@@ -60,6 +59,7 @@ from ai.backend.common.events.event_types.session.anycast import (
 from ai.backend.common.events.types import AbstractEvent
 from ai.backend.common.types import (
     AccessKey,
+    BackendAISchema,
     BinarySize,
     ResourceSlot,
     SessionExecutionStatus,
@@ -874,7 +874,7 @@ def _get_resource_name_from_metric_key(name: str) -> str:
     return name
 
 
-class ResourceThresholdValue(BaseModel):
+class ResourceThresholdValue(BackendAISchema):
     average: Annotated[
         int | float | Decimal | None,
         Field(

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -39,6 +39,7 @@ from ai.backend.common.exception import InvalidIpAddressValue
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.types import (
     AbstractPermission,
+    BackendAISchema,
     JSONSerializableMixin,
     KernelId,
     QuotaScopeID,
@@ -837,14 +838,14 @@ class KernelIDColumnType(GUID[KernelId]):
     cache_ok = True
 
 
-class ResourceSlotEntry(BaseModel):
+class ResourceSlotEntry(BackendAISchema):
     """A single resource slot entry for PydanticListColumn storage."""
 
     resource_type: str
     quantity: str
 
 
-class ResourceOptsEntry(BaseModel):
+class ResourceOptsEntry(BackendAISchema):
     """A single resource option entry for PydanticListColumn storage."""
 
     name: str

--- a/src/ai/backend/manager/models/deployment_policy/row.py
+++ b/src/ai/backend/manager/models/deployment_policy/row.py
@@ -7,13 +7,14 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
-from pydantic import BaseModel, Field, model_validator
+from pydantic import Field, model_validator
 from sqlalchemy.dialects import postgresql as pgsql
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.dto.manager.v2.deployment.types import IntOrPercent
 from ai.backend.common.identifier.deployment import DeploymentID
+from ai.backend.common.types import BackendAISchema
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.deployment.types import DeploymentPolicyData
 from ai.backend.manager.errors.deployment import InvalidDeploymentStrategy
@@ -36,7 +37,7 @@ __all__ = (
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
-class RollingUpdateSpec(BaseModel):
+class RollingUpdateSpec(BackendAISchema):
     """Specification for rolling update deployment strategy.
 
     ``max_surge`` and ``max_unavailable`` are :class:`IntOrPercent` objects.
@@ -84,7 +85,7 @@ class RollingUpdateSpec(BaseModel):
         return math.ceil(result) if round_up else math.floor(result)
 
 
-class BlueGreenSpec(BaseModel):
+class BlueGreenSpec(BackendAISchema):
     """Specification for blue-green deployment strategy."""
 
     auto_promote: bool = False

--- a/src/ai/backend/manager/models/deployment_revision_preset/types.py
+++ b/src/ai/backend/manager/models/deployment_revision_preset/types.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ai.backend.common.identifier.deployment_preset import DeploymentPresetID
+from ai.backend.common.types import BackendAISchema
 
 
-class PresetValueEntry(BaseModel):
+class PresetValueEntry(BackendAISchema):
     preset_id: DeploymentPresetID = Field(description="Deployment preset ID.")
     value: str = Field(description="Value for this preset.")

--- a/src/ai/backend/manager/models/health.py
+++ b/src/ai/backend/manager/models/health.py
@@ -7,11 +7,11 @@ from typing import TYPE_CHECKING, cast
 
 import glide
 from pydantic import (
-    BaseModel,
     Field,
 )
 
 from ai.backend.common import msgpack
+from ai.backend.common.types import BackendAISchema
 from ai.backend.logging import BraceStyleAdapter
 
 if TYPE_CHECKING:
@@ -46,7 +46,7 @@ def _get_connection_status_key(node_id: str, pid: int) -> str:
     return f"{MANAGER_STATUS_KEY}.{node_id}:{pid}"
 
 
-class SQLAlchemyConnectionInfo(BaseModel):
+class SQLAlchemyConnectionInfo(BackendAISchema):
     pool_type: str = Field(
         description=f"Connection pool type of SQLAlchemy engine. One of {_sqlalchemy_pool_type_names}.",
     )
@@ -63,7 +63,7 @@ class SQLAlchemyConnectionInfo(BaseModel):
         return self.num_checkedout_cxn + self.num_checkedin_cxn
 
 
-class RedisObjectConnectionInfo(BaseModel):
+class RedisObjectConnectionInfo(BackendAISchema):
     name: str
     num_connections: int | None = Field(
         description="The number of connections in Redis Client's connection pool."
@@ -75,7 +75,7 @@ class RedisObjectConnectionInfo(BaseModel):
     )
 
 
-class ConnectionInfoOfProcess(BaseModel):
+class ConnectionInfoOfProcess(BackendAISchema):
     node_id: str = Field(description="Specified Manager ID or hostname.")
     pid: int = Field(description="Process ID.")
     sqlalchemy_info: SQLAlchemyConnectionInfo

--- a/src/ai/backend/manager/models/prometheus_query_preset/row.py
+++ b/src/ai/backend/manager/models/prometheus_query_preset/row.py
@@ -4,9 +4,10 @@ import uuid
 from datetime import datetime
 
 import sqlalchemy as sa
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
 from sqlalchemy.orm import Mapped, mapped_column
 
+from ai.backend.common.types import BackendAISchema
 from ai.backend.manager.data.prometheus_query_preset import PrometheusQueryPresetData
 from ai.backend.manager.models.base import (
     GUID,
@@ -17,7 +18,7 @@ from ai.backend.manager.models.base import (
 __all__ = ("PrometheusQueryPresetRow",)
 
 
-class PresetOptions(BaseModel):
+class PresetOptions(BackendAISchema):
     filter_labels: list[str]
     group_labels: list[str]
 

--- a/src/ai/backend/manager/models/resource_slot/types.py
+++ b/src/ai/backend/manager/models/resource_slot/types.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from ai.backend.common.types import BackendAISchema
 
 __all__ = ("NumberFormat",)
 
 
-class NumberFormat(BaseModel):
+class NumberFormat(BackendAISchema):
     """Display number format configuration for a resource slot type."""
 
     model_config = ConfigDict(frozen=True)

--- a/src/ai/backend/manager/models/scaling_group/row.py
+++ b/src/ai/backend/manager/models/scaling_group/row.py
@@ -14,7 +14,7 @@ from typing import (
 )
 
 import sqlalchemy as sa
-from pydantic import BaseModel, ConfigDict, Field, field_serializer
+from pydantic import ConfigDict, Field, field_serializer
 from sqlalchemy.dialects import postgresql as pgsql
 from sqlalchemy.engine.row import Row
 from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
@@ -85,7 +85,7 @@ __all__: Sequence[str] = (
 )
 
 
-class PreemptionConfig(BaseModel):
+class PreemptionConfig(BackendAISchema):
     model_config = ConfigDict(frozen=True)
 
     preemptible_priority: int = 5

--- a/src/ai/backend/manager/models/scaling_group/types.py
+++ b/src/ai/backend/manager/models/scaling_group/types.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
+from pydantic import ConfigDict, Field, field_serializer, field_validator
 
-from ai.backend.common.types import ResourceSlot
+from ai.backend.common.types import BackendAISchema, ResourceSlot
 
 __all__ = ("FairShareScalingGroupSpec",)
 
 
-class FairShareScalingGroupSpec(BaseModel):
+class FairShareScalingGroupSpec(BackendAISchema):
     """Fair Share calculation configuration for a Resource Group.
 
     Used for Fair Share metric calculation regardless of the scheduler type.

--- a/src/ai/backend/manager/openapi.py
+++ b/src/ai/backend/manager/openapi.py
@@ -15,6 +15,7 @@ from trafaret.lib import _empty
 import ai.backend.common.validators as tx
 from ai.backend.common.api_handlers import BodyParam, PathParam, QueryParam
 from ai.backend.common.json import pretty_json_str
+from ai.backend.common.types import BackendAISchema
 from ai.backend.manager import __version__
 from ai.backend.manager.api import ManagerStatus
 from ai.backend.manager.api.utils import Undefined, undefined
@@ -216,7 +217,9 @@ def parse_trafaret_definition(root: t.Dict) -> list[dict[str, Any]]:
 
 def extract_api_handler_params(
     handler: Any,
-) -> tuple[type[BaseModel] | None, type[BaseModel] | None, type[BaseModel] | None]:
+) -> tuple[
+    type[BackendAISchema] | None, type[BackendAISchema] | None, type[BackendAISchema] | None
+]:
     """
     Extract Pydantic models from @api_handler decorated functions.
 
@@ -227,9 +230,9 @@ def extract_api_handler_params(
     Returns:
         tuple of (body_model, query_model, path_model) - any can be None if not present
     """
-    body_model: type[BaseModel] | None = None
-    query_model: type[BaseModel] | None = None
-    path_model: type[BaseModel] | None = None
+    body_model: type[BackendAISchema] | None = None
+    query_model: type[BackendAISchema] | None = None
+    path_model: type[BackendAISchema] | None = None
 
     try:
         type_hints = get_type_hints(handler)
@@ -249,7 +252,7 @@ def extract_api_handler_params(
             continue
 
         model = args[0]
-        if not (isinstance(model, type) and issubclass(model, BaseModel)):
+        if not (isinstance(model, type) and issubclass(model, BackendAISchema)):
             continue
 
         if origin is BodyParam:
@@ -498,7 +501,7 @@ def generate_openapi(subapps: list[web.Application], verbose: bool = False) -> d
                 response_schema: dict[str, Any]
                 if issubclass(response_cls, list):
                     # Handle list[SomeModel] return type
-                    arg: type[BaseModel]
+                    arg: type[BackendAISchema]
                     (arg,) = get_args(ret_type)
                     schema_name = f"{arg.__name__}_List"
                     response_schema = TypeAdapter(list[arg]).json_schema(  # type: ignore[valid-type]

--- a/src/ai/backend/manager/plugin/keypair/utils.py
+++ b/src/ai/backend/manager/plugin/keypair/utils.py
@@ -2,8 +2,8 @@ from typing import Any
 
 import jwt
 import jwt.exceptions
-from pydantic import BaseModel
 
+from ai.backend.common.types import BackendAISchema
 from ai.backend.common.utils import nmget
 
 from .exception import ExpiredSToken, InvalidSToken
@@ -11,7 +11,7 @@ from .exception import ExpiredSToken, InvalidSToken
 KEYPAIR_PLUGIN_CONFIG_KEY = "plugins.webapp.keypair_auth"
 
 
-class STokenData(BaseModel):
+class STokenData(BackendAISchema):
     access_key: str
     secret_key: str
 

--- a/src/ai/backend/manager/plugin/keypair/webapp.py
+++ b/src/ai/backend/manager/plugin/keypair/webapp.py
@@ -6,9 +6,10 @@ from typing import Any
 import aiohttp_cors
 import yarl
 from aiohttp import web
-from pydantic import BaseModel, ValidationError
+from pydantic import ValidationError
 
 from ai.backend.common.logging_utils import BraceStyleAdapter
+from ai.backend.common.types import BackendAISchema
 from ai.backend.manager.api.rest.types import CORSOptions, WebMiddleware
 from ai.backend.manager.plugin.webapp import WebappPlugin
 
@@ -21,7 +22,7 @@ from .utils import (
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
-class LoginRequestData(BaseModel):
+class LoginRequestData(BackendAISchema):
     access_key: str
     secret_key: str
 

--- a/src/ai/backend/manager/plugin/openid/config.py
+++ b/src/ai/backend/manager/plugin/openid/config.py
@@ -1,10 +1,12 @@
 from collections.abc import Mapping
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from ai.backend.common.types import BackendAISchema
 
 
-class OpenIDProviderConfig(BaseModel):
+class OpenIDProviderConfig(BackendAISchema):
     well_known: str | None = Field(
         default=None,
         description=(
@@ -41,7 +43,7 @@ class OpenIDProviderConfig(BaseModel):
     )
 
 
-class OIDCHookConfig(BaseModel):
+class OIDCHookConfig(BackendAISchema):
     secret: str = Field(
         description="Secret key used for signing and verifying JWT tokens.",
     )
@@ -49,7 +51,7 @@ class OIDCHookConfig(BaseModel):
     model_config = {"extra": "ignore"}
 
 
-class OIDCWebAppConfig(BaseModel):
+class OIDCWebAppConfig(BackendAISchema):
     openid: OpenIDProviderConfig = Field(
         description="OpenID Connect provider configuration.",
     )

--- a/src/ai/backend/manager/plugin/totp/config.py
+++ b/src/ai/backend/manager/plugin/totp/config.py
@@ -1,9 +1,11 @@
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from ai.backend.common.types import BackendAISchema
 
 _DEFAULT_TOKEN_SECRET = "BACKEND_AI_TOKEN_SECRET"
 
 
-class TOTPConfig(BaseModel):
+class TOTPConfig(BackendAISchema):
     issuer: str = Field(
         default="Backend.AI",
         description="Issuer name for TOTP.",

--- a/src/ai/backend/manager/scheduler/types.py
+++ b/src/ai/backend/manager/scheduler/types.py
@@ -13,12 +13,12 @@ from typing import (
 )
 
 import attrs
-import pydantic
 import trafaret as t
 
 from ai.backend.common.types import (
     AgentId,
     ArchName,
+    BackendAISchema,
     KernelId,
     ResourceGroupID,
     ResourceSlot,
@@ -178,14 +178,14 @@ class AbstractScheduler(ABC):
         pass
 
 
-class AbstractResourceGroupState(pydantic.BaseModel, ABC):
+class AbstractResourceGroupState(BackendAISchema, ABC):
     @classmethod
     @abstractmethod
     def create_empty_state(cls) -> Self:
         raise NotImplementedError("must use a concrete subclass")
 
 
-class RoundRobinState(pydantic.BaseModel):
+class RoundRobinState(BackendAISchema):
     next_index: int = 0
 
 

--- a/src/ai/backend/manager/services/metric/types.py
+++ b/src/ai/backend/manager/services/metric/types.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
-
 from ai.backend.common.clients.prometheus.metric_types import (
     ContainerMetricOptionalLabel,
     ContainerMetricResponseInfo,
@@ -9,6 +7,7 @@ from ai.backend.common.clients.prometheus.metric_types import (
     MetricResultValue,
 )
 from ai.backend.common.clients.prometheus.types import ValueType
+from ai.backend.common.types import BackendAISchema
 
 __all__ = [
     "ContainerMetricOptionalLabel",
@@ -19,7 +18,7 @@ __all__ = [
 ]
 
 
-class MetricQueryParameter(BaseModel):
+class MetricQueryParameter(BackendAISchema):
     metric_name: str
     value_type: ValueType
     start: str

--- a/src/ai/backend/manager/sokovan/deployment/strategy/types.py
+++ b/src/ai/backend/manager/sokovan/deployment/strategy/types.py
@@ -7,10 +7,9 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from uuid import UUID
 
-from pydantic import BaseModel
-
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.identifier.deployment import DeploymentID
+from ai.backend.common.types import BackendAISchema
 from ai.backend.manager.data.deployment.types import (
     DeploymentInfo,
     DeploymentLifecycleSubStep,
@@ -88,7 +87,7 @@ class DeploymentStrategyRegistryEntry:
     """Maps a deployment strategy to its implementation class and expected spec type."""
 
     strategy_cls: type[AbstractDeploymentStrategy]
-    spec_type: type[BaseModel]
+    spec_type: type[BackendAISchema]
 
 
 class DeploymentStrategyRegistry:
@@ -101,7 +100,7 @@ class DeploymentStrategyRegistry:
         self,
         strategy: DeploymentStrategy,
         strategy_cls: type[AbstractDeploymentStrategy],
-        spec_type: type[BaseModel],
+        spec_type: type[BackendAISchema],
     ) -> None:
         self._entries[strategy] = DeploymentStrategyRegistryEntry(strategy_cls, spec_type)
 

--- a/src/ai/backend/manager/sokovan/recorder/types.py
+++ b/src/ai/backend/manager/sokovan/recorder/types.py
@@ -5,7 +5,7 @@ from enum import StrEnum
 from typing import TypeVar
 from uuid import UUID
 
-from pydantic import BaseModel
+from ai.backend.common.types import BackendAISchema
 
 # Generic type variable for entity IDs
 # Bound to UUID to ensure all entity IDs are UUID-based
@@ -19,7 +19,7 @@ class StepStatus(StrEnum):
     FAILED = "failed"
 
 
-class StepRecord(BaseModel):
+class StepRecord(BackendAISchema):
     """Represents a recorded execution step (completed)."""
 
     name: str  # e.g., "check_quota", "pull_image"
@@ -30,7 +30,7 @@ class StepRecord(BaseModel):
     error_code: str | None = None
 
 
-class PhaseRecord(BaseModel):
+class PhaseRecord(BackendAISchema):
     """Represents a recorded phase containing multiple steps.
 
     Depth is limited to Phase → Step (no nested phases).
@@ -44,7 +44,7 @@ class PhaseRecord(BaseModel):
     steps: list[StepRecord]
 
 
-class ExecutionRecord(BaseModel):
+class ExecutionRecord(BackendAISchema):
     """Top-level execution record for an entity.
 
     Contains phases, each with their steps.
@@ -55,7 +55,7 @@ class ExecutionRecord(BaseModel):
     phases: list[PhaseRecord]
 
 
-class RecordBuildData(BaseModel):
+class RecordBuildData(BackendAISchema):
     """Data required for building execution records.
 
     Contains shared phases that apply to the entity.

--- a/src/ai/backend/manager/types.py
+++ b/src/ai/backend/manager/types.py
@@ -15,10 +15,10 @@ from typing import (
 
 import attr
 from graphql import UndefinedType
-from pydantic import AliasChoices, BaseModel, Field
+from pydantic import AliasChoices, Field
 from strawberry.types.unset import UnsetType
 
-from ai.backend.common.types import MountPermission, MountTypes
+from ai.backend.common.types import BackendAISchema, MountPermission, MountTypes
 
 if TYPE_CHECKING:
     from ai.backend.common.lock import AbstractDistributedLock
@@ -54,7 +54,7 @@ class DistributedLockFactory(Protocol):
     def __call__(self, lock_id: LockID, lifetime_hint: float) -> AbstractDistributedLock: ...
 
 
-class MountOptionModel(BaseModel):
+class MountOptionModel(BackendAISchema):
     mount_destination: Annotated[
         str | None,
         Field(description="Mount destination, defaults to /home/work/{folder_name}.", default=None),

--- a/src/ai/backend/storage/volumes/hammerspace/client.py
+++ b/src/ai/backend/storage/volumes/hammerspace/client.py
@@ -7,10 +7,10 @@ from functools import partial
 from typing import Any, cast
 
 import aiohttp
-from pydantic_core._pydantic_core import ValidationError
 
 from ai.backend.common.clients.http_client import ClientKey, ClientPool, tcp_client_session_factory
 from ai.backend.common.exception import (
+    BackendAISchemaValidationFailed,
     BaseNFSMountCheckFailed,
     ExportPathNotFound,
     ShowmountNotFound,
@@ -138,7 +138,7 @@ class HammerspaceAPIClient:
                     if share.name == params.name:
                         await self._check_nfs_export(share.path)
                         return share
-                except ValidationError:
+                except BackendAISchemaValidationFailed:
                     continue
             retry -= 1
             await asyncio.sleep(wait_sec)  # wait for a moment and try again
@@ -167,7 +167,7 @@ class HammerspaceAPIClient:
                 share = Share.model_validate(raw_share)
                 if share.name == params.name:
                     return share
-            except ValidationError:
+            except BackendAISchemaValidationFailed:
                 continue
         return None
 
@@ -183,7 +183,7 @@ class HammerspaceAPIClient:
             for raw_share in data:
                 try:
                     share = Share.model_validate(raw_share)
-                except ValidationError:
+                except BackendAISchemaValidationFailed:
                     continue
                 if share.name == params.name:
                     return share
@@ -213,7 +213,7 @@ class HammerspaceAPIClient:
                 try:
                     site = Site.model_validate(s)
                     sites.append(site)
-                except ValidationError:
+                except BackendAISchemaValidationFailed:
                     log.warning("Failed to parse the site data: {}", s)
                     continue
             return sites

--- a/src/ai/backend/storage/volumes/hammerspace/schema/address.py
+++ b/src/ai/backend/storage/volumes/hammerspace/schema/address.py
@@ -1,12 +1,14 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from ai.backend.common.types import BackendAISchema
 
 
-class IPAddress(BaseModel):
+class IPAddress(BackendAISchema):
     address: str  # IPv4 address
     prefixLength: int
 
 
-class QualifiedAddress(BaseModel):
+class QualifiedAddress(BackendAISchema):
     model_config = ConfigDict(extra="allow")
 
     id: int

--- a/src/ai/backend/storage/volumes/hammerspace/schema/capacity.py
+++ b/src/ai/backend/storage/volumes/hammerspace/schema/capacity.py
@@ -1,7 +1,7 @@
-from pydantic import BaseModel
+from ai.backend.common.types import BackendAISchema
 
 
-class Capacity(BaseModel):
+class Capacity(BackendAISchema):
     total: int
     used: int
     free: int

--- a/src/ai/backend/storage/volumes/hammerspace/schema/df_entry.py
+++ b/src/ai/backend/storage/volumes/hammerspace/schema/df_entry.py
@@ -1,7 +1,7 @@
-from pydantic import BaseModel
+from ai.backend.common.types import BackendAISchema
 
 
-class DFEntry(BaseModel):
+class DFEntry(BackendAISchema):
     total: int
     used: int
     available: int

--- a/src/ai/backend/storage/volumes/hammerspace/schema/location.py
+++ b/src/ai/backend/storage/volumes/hammerspace/schema/location.py
@@ -1,11 +1,13 @@
 import uuid
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from ai.backend.common.types import BackendAISchema
 
 from .uoid import UOID
 
 
-class Location(BaseModel):
+class Location(BackendAISchema):
     model_config = ConfigDict(extra="allow")
 
     uoid: UOID
@@ -15,6 +17,6 @@ class Location(BaseModel):
     placeOnObjectiveUuid: uuid.UUID
 
 
-class LocationList(BaseModel):
+class LocationList(BackendAISchema):
     id: int
     placeOn: list[Location]

--- a/src/ai/backend/storage/volumes/hammerspace/schema/logical_volume.py
+++ b/src/ai/backend/storage/volumes/hammerspace/schema/logical_volume.py
@@ -1,6 +1,8 @@
 import enum
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from ai.backend.common.types import BackendAISchema
 
 from .address import IPAddress, QualifiedAddress
 from .capacity import Capacity
@@ -15,7 +17,7 @@ class UsageType(enum.StrEnum):
     OTHER = "OTHER"
 
 
-class LogicalVolume(BaseModel):
+class LogicalVolume(BackendAISchema):
     model_config = ConfigDict(extra="allow")
 
     uoid: UOID

--- a/src/ai/backend/storage/volumes/hammerspace/schema/metric.py
+++ b/src/ai/backend/storage/volumes/hammerspace/schema/metric.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from ai.backend.common.types import BackendAISchema
 
 
-class ClusterMetricRow(BaseModel):
+class ClusterMetricRow(BackendAISchema):
     model_config = ConfigDict(extra="allow")
 
     time: int  # timestamp
@@ -22,21 +24,21 @@ class ClusterMetricRow(BaseModel):
         )
 
 
-class ValidClusterMetricRow(BaseModel):
+class ValidClusterMetricRow(BackendAISchema):
     time: int  # timestamp
     total: int
     used: int
     free: int
 
 
-class MetricSeries(BaseModel):
+class MetricSeries(BackendAISchema):
     model_config = ConfigDict(extra="allow")
 
     tags: dict[str, str]
     rows: list[ClusterMetricRow]
 
 
-class Metric(BaseModel):
+class Metric(BackendAISchema):
     model_config = ConfigDict(extra="allow")
 
     series: list[MetricSeries]

--- a/src/ai/backend/storage/volumes/hammerspace/schema/node.py
+++ b/src/ai/backend/storage/volumes/hammerspace/schema/node.py
@@ -1,6 +1,8 @@
 import enum
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from ai.backend.common.types import BackendAISchema
 
 from .address import IPAddress
 from .uoid import UOID
@@ -69,7 +71,7 @@ class ProductionNodeType(enum.StrEnum):
     DSX = "DSX"
 
 
-class Node(BaseModel):
+class Node(BackendAISchema):
     model_config = ConfigDict(extra="allow")
 
     uoid: UOID

--- a/src/ai/backend/storage/volumes/hammerspace/schema/objective.py
+++ b/src/ai/backend/storage/volumes/hammerspace/schema/objective.py
@@ -1,6 +1,8 @@
 import enum
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from ai.backend.common.types import BackendAISchema
 
 from .placement_objective import PlacementObjective
 from .uoid import UOID
@@ -14,7 +16,7 @@ class Priority(enum.StrEnum):
     HIGH = "HIGH"
 
 
-class SimpleObjective(BaseModel):
+class SimpleObjective(BackendAISchema):
     model_config = ConfigDict(extra="allow")
 
     uoid: UOID
@@ -24,12 +26,12 @@ class SimpleObjective(BaseModel):
     internalId: int
 
 
-class AppliedObjective(BaseModel):
+class AppliedObjective(BackendAISchema):
     applicability: str
     id: int
 
 
-class Objective(BaseModel):
+class Objective(BackendAISchema):
     model_config = ConfigDict(extra="allow")
 
     uoid: UOID

--- a/src/ai/backend/storage/volumes/hammerspace/schema/placement_objective.py
+++ b/src/ai/backend/storage/volumes/hammerspace/schema/placement_objective.py
@@ -1,9 +1,11 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from ai.backend.common.types import BackendAISchema
 
 from .location import Location, LocationList
 
 
-class PlacementObjective(BaseModel):
+class PlacementObjective(BackendAISchema):
     model_config = ConfigDict(extra="allow")
 
     id: int

--- a/src/ai/backend/storage/volumes/hammerspace/schema/share.py
+++ b/src/ai/backend/storage/volumes/hammerspace/schema/share.py
@@ -1,6 +1,8 @@
 import enum
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from ai.backend.common.types import BackendAISchema
 
 from .df_entry import DFEntry
 from .objective import SimpleObjective
@@ -29,7 +31,7 @@ class ShareLifecycle(enum.StrEnum):
     DELETE_FAILED = "DELETE_FAILED"
 
 
-class ShareObjective(BaseModel):
+class ShareObjective(BackendAISchema):
     model_config = ConfigDict(extra="allow")
 
     objective: SimpleObjective
@@ -37,7 +39,7 @@ class ShareObjective(BaseModel):
     removable: bool
 
 
-class SimpleShare(BaseModel):
+class SimpleShare(BackendAISchema):
     model_config = ConfigDict(extra="allow")
 
     uoid: UOID
@@ -45,7 +47,7 @@ class SimpleShare(BaseModel):
     path: str
 
 
-class Share(BaseModel):
+class Share(BackendAISchema):
     model_config = ConfigDict(extra="allow")
 
     uoid: UOID

--- a/src/ai/backend/storage/volumes/hammerspace/schema/site.py
+++ b/src/ai/backend/storage/volumes/hammerspace/schema/site.py
@@ -1,6 +1,8 @@
 import enum
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from ai.backend.common.types import BackendAISchema
 
 from .uoid import UOID
 
@@ -10,7 +12,7 @@ class SiteType(enum.StrEnum):
     REMOTE = "REMOTE"
 
 
-class Site(BaseModel):
+class Site(BackendAISchema):
     model_config = ConfigDict(extra="allow")
 
     uoid: UOID

--- a/src/ai/backend/storage/volumes/hammerspace/schema/storage_volume.py
+++ b/src/ai/backend/storage/volumes/hammerspace/schema/storage_volume.py
@@ -1,10 +1,12 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from ai.backend.common.types import BackendAISchema
 
 from .logical_volume import LogicalVolume
 from .uoid import UOID
 
 
-class StorageVolume(BaseModel):
+class StorageVolume(BackendAISchema):
     model_config = ConfigDict(extra="allow")
 
     uoid: UOID

--- a/src/ai/backend/storage/volumes/hammerspace/schema/uoid.py
+++ b/src/ai/backend/storage/volumes/hammerspace/schema/uoid.py
@@ -1,10 +1,10 @@
 import uuid
 
-from pydantic import BaseModel
+from ai.backend.common.types import BackendAISchema
 
 from .object_type import ObjectType
 
 
-class UOID(BaseModel):
+class UOID(BackendAISchema):
     uuid: uuid.UUID
     objectType: ObjectType

--- a/src/ai/backend/storage/volumes/hammerspace/types.py
+++ b/src/ai/backend/storage/volumes/hammerspace/types.py
@@ -1,10 +1,11 @@
 from dataclasses import dataclass
 
-from pydantic import BaseModel
 from yarl import URL
 
+from ai.backend.common.types import BackendAISchema
 
-class SSLConfig(BaseModel):
+
+class SSLConfig(BackendAISchema):
     cert_file: str | None
     key_file: str | None
 

--- a/src/ai/backend/storage/volumes/stats/types.py
+++ b/src/ai/backend/storage/volumes/stats/types.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 
-from pydantic import BaseModel
-
+from ai.backend.common.types import BackendAISchema
 from ai.backend.storage.types import FSPerfMetric
 
 
@@ -17,7 +16,7 @@ class VolumeStatsObserverOptions:
     cache_ttl: float = 30.0
 
 
-class CachedFSPerfMetricData(BaseModel):
+class CachedFSPerfMetricData(BackendAISchema):
     """Cached performance metric with metadata for Redis serialization."""
 
     volume_name: str

--- a/tests/unit/common/configs/test_generator.py
+++ b/tests/unit/common/configs/test_generator.py
@@ -6,8 +6,6 @@ from typing import Annotated
 import pytest
 from pydantic import Field
 
-from ai.backend.common.types import BackendAISchema
-
 from ai.backend.common.configs.generator import (
     BinarySizeFormatter,
     CompositeFormatter,
@@ -29,6 +27,7 @@ from ai.backend.common.meta import (
     ConfigEnvironment,
     ConfigExample,
 )
+from ai.backend.common.types import BackendAISchema
 
 
 class TestFieldVisibility:

--- a/tests/unit/common/configs/test_generator.py
+++ b/tests/unit/common/configs/test_generator.py
@@ -4,7 +4,9 @@ from enum import Enum
 from typing import Annotated
 
 import pytest
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from ai.backend.common.types import BackendAISchema
 
 from ai.backend.common.configs.generator import (
     BinarySizeFormatter,
@@ -243,7 +245,7 @@ class TestTOMLGenerator:
         assert generator.env == ConfigEnvironment.PROD
 
     def test_generate_simple_config(self) -> None:
-        class SimpleConfig(BaseModel):
+        class SimpleConfig(BackendAISchema):
             name: Annotated[
                 str,
                 Field(default="default-name"),
@@ -265,7 +267,7 @@ class TestTOMLGenerator:
     def test_generate_uses_prod_example(self) -> None:
         """PROD environment uses prod example value."""
 
-        class EnvConfig(BaseModel):
+        class EnvConfig(BackendAISchema):
             endpoint: Annotated[
                 str,
                 Field(default="default-endpoint"),
@@ -285,7 +287,7 @@ class TestTOMLGenerator:
     def test_generate_uses_local_example(self) -> None:
         """LOCAL environment uses local example value."""
 
-        class EnvConfig(BaseModel):
+        class EnvConfig(BackendAISchema):
             endpoint: Annotated[
                 str,
                 Field(default="default-endpoint"),
@@ -303,7 +305,7 @@ class TestTOMLGenerator:
         assert "localhost:8080" in result
 
     def test_optional_field_commented(self) -> None:
-        class OptionalConfig(BaseModel):
+        class OptionalConfig(BackendAISchema):
             optional_field: Annotated[
                 str | None,
                 Field(default=None),
@@ -322,7 +324,7 @@ class TestTOMLGenerator:
         assert "optional_field" in result
 
     def test_secret_field_masked(self) -> None:
-        class SecretConfig(BaseModel):
+        class SecretConfig(BackendAISchema):
             password: Annotated[
                 str,
                 Field(default="secret123"),
@@ -342,7 +344,7 @@ class TestTOMLGenerator:
         assert "dev-pass" not in result
 
     def test_secret_field_unmasked(self) -> None:
-        class SecretConfig(BaseModel):
+        class SecretConfig(BackendAISchema):
             password: Annotated[
                 str,
                 Field(default="secret123"),
@@ -363,7 +365,7 @@ class TestTOMLGenerator:
         assert "***SECRET***" not in result
 
     def test_nested_config_section(self) -> None:
-        class InnerConfig(BaseModel):
+        class InnerConfig(BackendAISchema):
             value: Annotated[
                 int,
                 Field(default=10),
@@ -374,7 +376,7 @@ class TestTOMLGenerator:
                 ),
             ]
 
-        class OuterConfig(BaseModel):
+        class OuterConfig(BackendAISchema):
             inner: Annotated[
                 InnerConfig,
                 Field(default_factory=InnerConfig),
@@ -392,7 +394,7 @@ class TestTOMLGenerator:
         assert "value" in result
 
     def test_runtime_field_hidden(self) -> None:
-        class RuntimeConfig(BaseModel):
+        class RuntimeConfig(BackendAISchema):
             runtime_field: Annotated[
                 str,
                 Field(default="runtime"),
@@ -421,7 +423,7 @@ class TestTOMLGenerator:
         assert "normal_field" in result
 
     def test_skips_fields_without_meta(self) -> None:
-        class MixedConfig(BaseModel):
+        class MixedConfig(BackendAISchema):
             with_meta: Annotated[
                 str,
                 Field(default="has-meta"),
@@ -442,7 +444,7 @@ class TestTOMLGenerator:
 
 class TestConvenienceFunctions:
     def test_generate_sample_toml(self) -> None:
-        class SampleConfig(BaseModel):
+        class SampleConfig(BackendAISchema):
             field: Annotated[
                 str,
                 Field(default="default"),
@@ -458,7 +460,7 @@ class TestConvenienceFunctions:
         assert "local" in result
 
     def test_generate_halfstack_toml(self) -> None:
-        class HalfstackConfig(BaseModel):
+        class HalfstackConfig(BackendAISchema):
             field: Annotated[
                 str,
                 Field(default="default"),

--- a/tests/unit/common/configs/test_inspector.py
+++ b/tests/unit/common/configs/test_inspector.py
@@ -5,8 +5,6 @@ from typing import Annotated
 import pytest
 from pydantic import Field
 
-from ai.backend.common.types import BackendAISchema
-
 from ai.backend.common.configs.inspector import (
     ConfigInspector,
     FieldDocumentation,
@@ -19,6 +17,7 @@ from ai.backend.common.meta import (
     ConfigEnvironment,
     ConfigExample,
 )
+from ai.backend.common.types import BackendAISchema
 
 
 class TestFieldTypeInfo:

--- a/tests/unit/common/configs/test_inspector.py
+++ b/tests/unit/common/configs/test_inspector.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from typing import Annotated
 
 import pytest
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from ai.backend.common.types import BackendAISchema
 
 from ai.backend.common.configs.inspector import (
     ConfigInspector,
@@ -155,7 +157,7 @@ class TestFieldSchema:
 
 class TestConfigInspector:
     def test_extract_simple_field(self) -> None:
-        class SimpleConfig(BaseModel):
+        class SimpleConfig(BackendAISchema):
             name: Annotated[
                 str,
                 Field(default="default-name"),
@@ -181,7 +183,7 @@ class TestConfigInspector:
         assert field.doc.added_version == "25.1.0"
 
     def test_extract_uses_serialization_alias(self) -> None:
-        class AliasedConfig(BaseModel):
+        class AliasedConfig(BackendAISchema):
             my_field: Annotated[
                 str,
                 Field(default="value", serialization_alias="my-field"),
@@ -200,7 +202,7 @@ class TestConfigInspector:
         assert "my_field" not in schema
 
     def test_extract_required_field(self) -> None:
-        class RequiredConfig(BaseModel):
+        class RequiredConfig(BackendAISchema):
             required_field: Annotated[
                 str,
                 Field(),
@@ -217,7 +219,7 @@ class TestConfigInspector:
         assert schema["required_field"].type_info.required is True
 
     def test_extract_secret_field(self) -> None:
-        class SecretConfig(BaseModel):
+        class SecretConfig(BackendAISchema):
             password: Annotated[
                 str,
                 Field(default="secret123"),
@@ -235,7 +237,7 @@ class TestConfigInspector:
         assert schema["password"].type_info.secret is True
 
     def test_extract_composite_field(self) -> None:
-        class InnerConfig(BaseModel):
+        class InnerConfig(BackendAISchema):
             value: Annotated[
                 int,
                 Field(default=10),
@@ -246,7 +248,7 @@ class TestConfigInspector:
                 ),
             ]
 
-        class OuterConfig(BaseModel):
+        class OuterConfig(BackendAISchema):
             inner: Annotated[
                 InnerConfig,
                 Field(default_factory=InnerConfig),
@@ -266,7 +268,7 @@ class TestConfigInspector:
         assert schema["inner"].children["value"].type_info.type_name == "int"
 
     def test_skips_fields_without_meta(self) -> None:
-        class MixedConfig(BaseModel):
+        class MixedConfig(BackendAISchema):
             with_meta: Annotated[
                 str,
                 Field(default="has-meta"),
@@ -285,7 +287,7 @@ class TestConfigInspector:
         assert "without_meta" not in schema
 
     def test_get_example_value_local(self) -> None:
-        class ExampleConfig(BaseModel):
+        class ExampleConfig(BackendAISchema):
             endpoint: Annotated[
                 str,
                 Field(default="localhost"),
@@ -303,7 +305,7 @@ class TestConfigInspector:
         assert example == "localhost:8080"
 
     def test_get_example_value_prod(self) -> None:
-        class ExampleConfig(BaseModel):
+        class ExampleConfig(BackendAISchema):
             endpoint: Annotated[
                 str,
                 Field(default="localhost"),
@@ -321,7 +323,7 @@ class TestConfigInspector:
         assert example == "api.example.com"
 
     def test_get_fields_by_version(self) -> None:
-        class VersionedConfig(BaseModel):
+        class VersionedConfig(BackendAISchema):
             old_field: Annotated[
                 str,
                 Field(default="old"),
@@ -364,7 +366,7 @@ class TestConfigInspector:
         assert versions == ["24.0.0", "24.6.0", "25.1.0"]
 
     def test_get_deprecated_fields(self) -> None:
-        class DeprecatedConfig(BaseModel):
+        class DeprecatedConfig(BackendAISchema):
             current_field: Annotated[
                 str,
                 Field(default="current"),
@@ -395,7 +397,7 @@ class TestConfigInspector:
         assert deprecated[0][1].doc.deprecation_hint == "Use current_field instead"
 
     def test_get_secret_fields(self) -> None:
-        class SecretsConfig(BaseModel):
+        class SecretsConfig(BackendAISchema):
             public_field: Annotated[
                 str,
                 Field(default="public"),
@@ -424,7 +426,7 @@ class TestConfigInspector:
         assert secrets[0][0] == "secret_field"
 
     def test_type_name_simple_types(self) -> None:
-        class TypesConfig(BaseModel):
+        class TypesConfig(BackendAISchema):
             str_field: Annotated[
                 str,
                 Field(default=""),
@@ -461,7 +463,7 @@ class TestConfigInspector:
         assert schema["bool_field"].type_info.type_name == "bool"
 
     def test_type_name_optional(self) -> None:
-        class OptionalConfig(BaseModel):
+        class OptionalConfig(BackendAISchema):
             optional_field: Annotated[
                 str | None,
                 Field(default=None),

--- a/tests/unit/common/configs/test_meta.py
+++ b/tests/unit/common/configs/test_meta.py
@@ -5,8 +5,6 @@ from typing import Annotated
 import pytest
 from pydantic import Field
 
-from ai.backend.common.types import BackendAISchema
-
 from ai.backend.common.meta import (
     BackendAIAPIMeta,
     BackendAIConfigMeta,
@@ -18,6 +16,7 @@ from ai.backend.common.meta import (
     get_field_meta,
     get_field_type,
 )
+from ai.backend.common.types import BackendAISchema
 
 
 class TestConfigExample:

--- a/tests/unit/common/configs/test_meta.py
+++ b/tests/unit/common/configs/test_meta.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from typing import Annotated
 
 import pytest
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from ai.backend.common.types import BackendAISchema
 
 from ai.backend.common.meta import (
     BackendAIAPIMeta,
@@ -113,7 +115,7 @@ class TestBackendAIAPIMeta:
 
 class TestGetFieldMeta:
     def test_get_config_meta(self) -> None:
-        class SampleConfig(BaseModel):
+        class SampleConfig(BackendAISchema):
             name: Annotated[
                 str,
                 Field(default="default"),
@@ -130,7 +132,7 @@ class TestGetFieldMeta:
         assert meta.added_version == "25.1.0"
 
     def test_get_api_meta(self) -> None:
-        class SampleRequest(BaseModel):
+        class SampleRequest(BackendAISchema):
             session_name: Annotated[
                 str,
                 Field(),
@@ -148,14 +150,14 @@ class TestGetFieldMeta:
         assert meta.example.local == "my-session"
 
     def test_field_without_meta(self) -> None:
-        class SampleModel(BaseModel):
+        class SampleModel(BackendAISchema):
             plain_field: str = Field(default="value")
 
         meta = get_field_meta(SampleModel, "plain_field")
         assert meta is None
 
     def test_nonexistent_field(self) -> None:
-        class SampleModel(BaseModel):
+        class SampleModel(BackendAISchema):
             name: str
 
         meta = get_field_meta(SampleModel, "nonexistent")
@@ -164,7 +166,7 @@ class TestGetFieldMeta:
 
 class TestGetFieldType:
     def test_annotated_type(self) -> None:
-        class SampleModel(BaseModel):
+        class SampleModel(BackendAISchema):
             count: Annotated[
                 int,
                 Field(),
@@ -175,14 +177,14 @@ class TestGetFieldType:
         assert field_type is int
 
     def test_plain_type(self) -> None:
-        class SampleModel(BaseModel):
+        class SampleModel(BackendAISchema):
             name: str = Field(default="default")
 
         field_type = get_field_type(SampleModel, "name")
         assert field_type is str
 
     def test_nonexistent_field(self) -> None:
-        class SampleModel(BaseModel):
+        class SampleModel(BackendAISchema):
             name: str
 
         field_type = get_field_type(SampleModel, "nonexistent")
@@ -191,7 +193,7 @@ class TestGetFieldType:
 
 class TestGenerateExample:
     def test_simple_example(self) -> None:
-        class SampleModel(BaseModel):
+        class SampleModel(BackendAISchema):
             name: Annotated[
                 str,
                 Field(),
@@ -206,7 +208,7 @@ class TestGenerateExample:
         assert example == "sample-name"
 
     def test_config_example_returns_local_value(self) -> None:
-        class SampleConfig(BaseModel):
+        class SampleConfig(BackendAISchema):
             endpoint: Annotated[
                 str,
                 Field(),
@@ -222,7 +224,7 @@ class TestGenerateExample:
         assert example == "localhost:8080"
 
     def test_no_example_raises_error(self) -> None:
-        class SampleModel(BaseModel):
+        class SampleModel(BackendAISchema):
             name: Annotated[
                 str,
                 Field(),
@@ -236,7 +238,7 @@ class TestGenerateExample:
             generate_example(SampleModel, "name")
 
     def test_field_without_meta_raises_error(self) -> None:
-        class SampleModel(BaseModel):
+        class SampleModel(BackendAISchema):
             name: str = Field(default="value")
 
         with pytest.raises(ValueError, match="has no BackendAI metadata"):
@@ -245,7 +247,7 @@ class TestGenerateExample:
     def test_composite_field_raises_error_without_example(self) -> None:
         """Composite fields require generate_composite_example instead of generate_example."""
 
-        class ChildConfig(BaseModel):
+        class ChildConfig(BackendAISchema):
             cpu: Annotated[
                 int,
                 Field(),
@@ -256,7 +258,7 @@ class TestGenerateExample:
                 ),
             ]
 
-        class ParentConfig(BaseModel):
+        class ParentConfig(BackendAISchema):
             config: Annotated[
                 ChildConfig,
                 Field(),
@@ -275,7 +277,7 @@ class TestGenerateExample:
 
 class TestGenerateCompositeExample:
     def test_flat_model(self) -> None:
-        class SessionConfig(BaseModel):
+        class SessionConfig(BackendAISchema):
             cpu: Annotated[
                 int,
                 Field(),
@@ -299,7 +301,7 @@ class TestGenerateCompositeExample:
         assert result == {"cpu": "4", "memory": "8g"}
 
     def test_nested_composite(self) -> None:
-        class InnerConfig(BaseModel):
+        class InnerConfig(BackendAISchema):
             value: Annotated[
                 str,
                 Field(),
@@ -310,7 +312,7 @@ class TestGenerateCompositeExample:
                 ),
             ]
 
-        class OuterConfig(BaseModel):
+        class OuterConfig(BackendAISchema):
             inner: Annotated[
                 InnerConfig,
                 Field(),
@@ -332,7 +334,7 @@ class TestGenerateCompositeExample:
         assert result == {"inner": {"value": "inner"}, "name": "outer-name"}
 
     def test_skips_fields_without_meta(self) -> None:
-        class MixedConfig(BaseModel):
+        class MixedConfig(BackendAISchema):
             with_meta: Annotated[
                 str,
                 Field(),
@@ -349,7 +351,7 @@ class TestGenerateCompositeExample:
         assert "without_meta" not in result
 
     def test_config_example_in_composite(self) -> None:
-        class EnvConfig(BaseModel):
+        class EnvConfig(BackendAISchema):
             endpoint: Annotated[
                 str,
                 Field(),
@@ -367,7 +369,7 @@ class TestGenerateCompositeExample:
 
 class TestGenerateModelExample:
     def test_full_model_example(self) -> None:
-        class CreateSessionRequest(BaseModel):
+        class CreateSessionRequest(BackendAISchema):
             name: Annotated[
                 str,
                 Field(),
@@ -393,7 +395,7 @@ class TestGenerateModelExample:
     def test_model_with_composite_skips_composite_fields(self) -> None:
         """generate_model_example skips composite fields - use generate_composite_example for them."""
 
-        class ResourceConfig(BaseModel):
+        class ResourceConfig(BackendAISchema):
             cpu: Annotated[
                 int,
                 Field(),
@@ -404,7 +406,7 @@ class TestGenerateModelExample:
                 ),
             ]
 
-        class SessionRequest(BaseModel):
+        class SessionRequest(BackendAISchema):
             name: Annotated[
                 str,
                 Field(),
@@ -430,7 +432,7 @@ class TestGenerateModelExample:
         assert composite_result == {"name": "session-1", "resources": {"cpu": "2"}}
 
     def test_empty_model(self) -> None:
-        class EmptyModel(BaseModel):
+        class EmptyModel(BackendAISchema):
             plain_field: str = "value"
 
         result = generate_model_example(EmptyModel)

--- a/tests/unit/common/test_typed_validators.py
+++ b/tests/unit/common/test_typed_validators.py
@@ -64,5 +64,5 @@ def test_hostport_pair_valid(
     ],
 )
 def test_hostport_pair_invalid(input: str | list[str] | dict[str, str] | int) -> None:
-    with pytest.raises((ValidationError, TypeError)):
+    with pytest.raises((BackendAISchemaValidationFailed, ValidationError, TypeError)):
         HostPortPair.model_validate(input)


### PR DESCRIPTION
## Stacked PRs

This PR is part of a stack:

1. **#11514 — `fix/BA-5978-pydantic-validation-domain-errors`** *(parent)*
   Foundational machinery: `BackendAISchema`, `BackendAISchemaValidationFailed`, `build_validation_error` override hook, and the four model overrides (`ModelDefinition`, `ModelDefinitionDraft`, `SessionSpec`, `DeploymentConfigInput`). Also promotes the foundational base classes so anything that already inherits them participates automatically. Merge first.
2. **#11554 — `feat/BA-6003-bulk-basemodel-migration`** ← *this PR*
   Mechanical migration on top of #11514: every remaining `class Foo(BaseModel)` subclass under `src/ai/backend/` switched to `BackendAISchema`, the matching `except ValidationError` → `except (BackendAISchemaValidationFailed, ValidationError)` swaps, and the seven CLI `_build_dto` helpers routed through `model_validate`.

> Base branch for review is set to `fix/BA-5978-pydantic-validation-domain-errors`, so the diff shown here is just the bulk migration on top of the parent.

---

## Summary

Stacked on top of #11514 (BA-5978).

Follow-up to BA-5978. The parent PR introduces `BackendAISchema` and promotes the project's foundational pydantic base classes (`BaseRequestModel`, `BaseFieldModel`, `BaseResponseModel`, `BaseConfigSchema`, `BaseConfigModel`, `_OptionsBaseModel`, `_DraftBaseModel`, `_SpecBaseModel`, `BaseAgentRequestModel`, `BaseAgentResponseModel`, and the test/tester variants). This PR finishes the migration by:

* Converting every remaining direct `class Foo(BaseModel)` subclass under `src/ai/backend/` to `class Foo(BackendAISchema)` (121 files, ~120 classes).
* Promoting the three remaining standalone classes in `common/types.py` (`MountInfoEntry`, `MountPoint`, `ResourceSlotEntry`).
* Migrating `ai.backend.logging.config.BaseConfigModel` and `ai.backend.logging.validation_context.BaseConfigValidationContext` too (no circular import since `common.types` doesn't transitively reach `ai.backend.logging`).
* At sites that wrap `.model_validate(...)` on a now-migrated class, replacing `except ValidationError` with a single tuple-catch `except (BackendAISchemaValidationFailed, ValidationError) as e:`. Both classes expose the same `errors()` interface, so the handler body stays uniform; the `ValidationError` arm continues to cover any stray plain `BaseModel` subclass that bypasses the override.
* Dropping the redundant `tests/unit/manager/test_errors.py` unit-test file.

## Naming note

The parent PR (#11514) renamed the foundational types from `BackendAIModel` / `BackendAIModelValidationFailed` / `ModelValidationFailureInfo` to `BackendAISchema` / `BackendAISchemaValidationFailed` / `SchemaValidationFailureInfo` to avoid confusion with LLM-model terminology in client-facing surfaces. This PR applies the same rename to every migrated call site.

## Out of scope

* `RootModel` subclasses — different pydantic base, cannot inherit `BackendAISchema`.
* `TypeDecorator[BaseModel]` generics (SQLAlchemy column types).
* Constructor (`Model(field=...)`) call sites — still raise raw `ValidationError` because the auto-conversion is opt-in on the `model_validate` classmethods only.

## Test plan

- [x] `pants lint --changed-since=...` clean
- [x] `pants check --changed-since=...` clean
- [x] Manual smoke (parent PR): `POST /v2/domains` with `{}` triggers `BackendAISchemaValidationFailed` with structured per-field errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
