### PR TITLE
fix(BA-5996): propagate session network_type/network_id to scheduler launcher

### DIFF
--- a/changes/11543.fix.md
+++ b/changes/11543.fix.md
@@ -1,0 +1,1 @@
+Propagate `SessionRow.network_type` and `SessionRow.network_id` through scheduler queries into `SessionDataForStart`, so the launcher correctly reuses pre-created networks for `PERSISTENT` sessions instead of calling `create_network`.

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -2940,6 +2940,8 @@ class ScheduleDBSource:
                 SessionRow.environ,
                 SessionRow.cluster_mode,
                 SessionRow.user_uuid,
+                SessionRow.network_type,
+                SessionRow.network_id,
                 KernelRow.id.label("kernel_id"),
                 KernelRow.agent,
                 KernelRow.agent_addr,
@@ -2994,6 +2996,8 @@ class ScheduleDBSource:
                     "environ": row.environ,
                     "cluster_mode": row.cluster_mode,
                     "user_uuid": row.user_uuid,
+                    "network_type": row.network_type,
+                    "network_id": row.network_id,
                 }
                 if row.user_uuid:
                     user_uuids.add(row.user_uuid)
@@ -3088,6 +3092,8 @@ class ScheduleDBSource:
                     user_uuid=session_info["user_uuid"],
                     user_email=user_info.email,
                     user_name=user_info.username,
+                    network_type=session_info["network_type"],
+                    network_id=session_info["network_id"],
                 )
             )
 


### PR DESCRIPTION
This is a manual backport PR of #11543 to the `25.15` release.

The automated cherry-pick failed with `CONFLICT (directory rename split)` because:

- On `main`, the PR touches three `ScheduleDBSource` query paths that build `SessionDataForStart` (`_get_sessions_for_start`, `_fetch_sessions_for_start_by_ids`, `search_sessions_with_kernels_and_user`).
- On `25.15`, only `_get_sessions_for_start` exists; the other two methods were introduced after 25.15.
- The regression test added on `main` targets `search_sessions_with_kernels_and_user`, which doesn't exist here, so it is not backported.

## Changes

- Add `SessionRow.network_type` / `SessionRow.network_id` to the `_get_sessions_for_start` select and forward them into the `SessionDataForStart` constructor.
- Add the `changes/11543.fix.md` news fragment.

## Original PR

#11543

## Test plan

- [x] `pants check` on the touched file
- [x] `pants lint` on the touched file
- [ ] Manual end-to-end: create a session with `network_type=PERSISTENT` and a pre-created `network_id`, observe the launcher takes the persistent branch instead of calling `create_network`