### PR TITLE
fix(BA-6010): drop `last_used_at` from v1 CLI admin image list default fields

### DIFF
--- a/changes/11563.fix.md
+++ b/changes/11563.fix.md
@@ -1,0 +1,1 @@
+Fix `backend.ai admin image list` failing with `Cannot query field 'last_used_at' on type 'Image'` by removing `last_used_at` from the default field list of the v1 admin image listing.

--- a/src/ai/backend/client/func/image.py
+++ b/src/ai/backend/client/func/image.py
@@ -20,7 +20,6 @@ _default_list_fields_admin = (
     image_fields["digest"],
     image_fields["size_bytes"],
     image_fields["aliases"],
-    image_fields["last_used_at"],
 )
 
 


### PR DESCRIPTION
## Summary
- `backend.ai admin image list` was failing with `Cannot query field 'last_used_at' on type 'Image'.` because the legacy GraphQL `Image` type does not expose `last_used_at`.
- The legacy GQL schema is in maintenance-only mode, so instead of extending it, drop `last_used_at` from the v1 CLI admin image listing default fields. Consumers who need `last_used_at` should query it via the v2 GraphQL API.

Resolves BA-6010.