### PR TITLE
fix: auto-proceed installer warnings in headless mode

### DIFF
--- a/changes/11564.fix.md
+++ b/changes/11564.fix.md
@@ -1,0 +1,1 @@
+Fix the installer hanging on the WSL/LiveCD environment warning when run with `--headless` because the "Press Enter to continue" prompt could not receive keystrokes; in headless mode it now auto-proceeds after printing the warning.

--- a/src/ai/backend/install/widgets.py
+++ b/src/ai/backend/install/widgets.py
@@ -97,7 +97,12 @@ class SetupLog(RichLog):
         """
         Block until the user concludes the dialog.
         If the user cancels, the result will be None.
+        In headless mode there is no terminal-attached UI to receive the Enter
+        keypress, so we auto-proceed instead of blocking forever.
         """
+        if self.app.is_headless:
+            self.write(Text.from_markup("\n[dim](headless mode: auto-continuing)[/]\n"))
+            return
         self.write(Text.from_markup("\nPress [bold]Enter[/] to continue...\n"))
         self._continue.clear()
         await self._continue.wait()


### PR DESCRIPTION
## Summary

- `./backend.ai install --headless --non-interactive ...` hangs after the WSL (or LiveCD) environment warning is printed: it waits forever on a "Press Enter to continue" prompt that no terminal keystroke can satisfy.
- Root cause: `SetupLog.wait_continue()` blocks on an `asyncio.Event` that is only set by the Textual `enter` key binding (`widgets.py`). In headless mode Textual is not attached to the terminal, so keystrokes typed in the shell never reach the binding — the event is never set.
- Fix: short-circuit `wait_continue()` when `self.app.is_headless` is true, after printing the warning. This matches the existing headless special-casing in `SetupLog.on_mount()` / `write()` that already mirrors output to stdout.

The two call sites this unblocks are both in `PackageContext.check_prerequisites()` (`context.py:537` for the LiveCD warning and `context.py:551` for the WSL warning).

## Test plan

- [ ] Run `./backend.ai install --headless --non-interactive ...` on a WSL host and confirm the installer proceeds past the WSL warning without manual input.
- [ ] Run the same on a non-WSL/non-LiveCD host and confirm behavior is unchanged.
- [ ] Run interactively (without `--headless`) and confirm the "Press Enter to continue" prompt still appears and still requires Enter.