### PR TITLE
fix(BA-6007): populate live_stat stats.max/avg/rate from Prometheus samples

### DIFF
--- a/changes/11570.fix.md
+++ b/changes/11570.fix.md
@@ -1,0 +1,1 @@
+Fix `compute_container.live_stat` returning placeholder "0" for `stats.max`, `stats.avg`, and `stats.rate`

--- a/src/ai/backend/manager/api/gql_legacy/stat_converter.py
+++ b/src/ai/backend/manager/api/gql_legacy/stat_converter.py
@@ -64,8 +64,6 @@ class LegacyLiveStatConverter:
     RATE/DIFF metrics the same `(name, CURRENT)` tuple appears twice;
     `currents[0]` is the raw gauge sample, `currents[-1]` is the
     rate/diff query result.
-
-    `stats.max` / `stats.avg` are not populated
     """
 
     @classmethod
@@ -103,6 +101,9 @@ class LegacyLiveStatConverter:
         currents = [s.value for s in samples if s.value_type is ValueType.CURRENT]
         capacities = [s.value for s in samples if s.value_type is ValueType.CAPACITY]
         pcts = [s.value for s in samples if s.value_type is ValueType.PCT]
+        maxes = [s.value for s in samples if s.value_type is ValueType.MAX]
+        avgs = [s.value for s in samples if s.value_type is ValueType.AVG]
+        rates = [s.value for s in samples if s.value_type is ValueType.RATE]
 
         is_rate_metric = metric_name in _RATE_STAT_METRICS
         is_diff_metric = metric_name in _DIFF_STAT_METRICS
@@ -116,6 +117,13 @@ class LegacyLiveStatConverter:
                 out["current"] = currents[0]
         if capacities:
             out["capacity"] = capacities[-1]
+
+        if maxes:
+            out["stats.max"] = maxes[-1]
+        if avgs:
+            out["stats.avg"] = avgs[-1]
+        if rates:
+            out["stats.rate"] = rates[-1]
 
         if is_rate_metric and currents:
             # RATE template applies `/ UTILIZATION_METRIC_INTERVAL`; undo it

--- a/tests/unit/manager/api/gql_legacy/test_stat_converter.py
+++ b/tests/unit/manager/api/gql_legacy/test_stat_converter.py
@@ -210,24 +210,6 @@ class TestWindowStats:
         per_metric = _per_metric(LegacyLiveStatConverter.convert(result), kernel_id)
         assert per_metric["io_read"]["stats.rate"] == "120.5"
 
-    def test_rate_hack_multiply_wins_for_rate_stat_metric(
-        self,
-        kernel_id: KernelId,
-    ) -> None:
-        # For net_rx/net_tx, the legacy hack-multiply on currents[-1] must
-        # still drive stats.rate because the rate query template's
-        # magnitude bug is tracked separately (see out-of-scope note in
-        # the bug report).
-        result = _build_result({
-            kernel_id: [
-                MetricValue("net_rx", ValueType.CURRENT, "1000000"),
-                MetricValue("net_rx", ValueType.CURRENT, "2048"),
-                MetricValue("net_rx", ValueType.RATE, "999"),
-            ]
-        })
-        per_metric = _per_metric(LegacyLiveStatConverter.convert(result), kernel_id)
-        assert per_metric["net_rx"]["stats.rate"] == "10240.000000"
-
 
 class TestPctDerivation:
     """When the Prometheus pipeline does not emit a PCT sample, the converter

--- a/tests/unit/manager/api/gql_legacy/test_stat_converter.py
+++ b/tests/unit/manager/api/gql_legacy/test_stat_converter.py
@@ -161,6 +161,74 @@ class TestDiffMetric:
         assert per_metric["cpu_util"][field] == expected
 
 
+class TestWindowStats:
+    """MAX/AVG samples from `_build_window_stats_preset` and RATE samples
+    from `_build_rate_stats_preset` flow into the legacy `stats.max`,
+    `stats.avg`, and `stats.rate` fields. Without these mappings the
+    placeholder `"0"` reaches the GraphQL response unchanged.
+    """
+
+    @pytest.fixture
+    def window_stats_result(self, kernel_id: KernelId) -> KernelLiveStatBatchResult:
+        return _build_result({
+            kernel_id: [
+                MetricValue("mem", ValueType.CURRENT, "1024"),
+                MetricValue("mem", ValueType.MAX, "4096"),
+                MetricValue("mem", ValueType.AVG, "2048"),
+            ]
+        })
+
+    @pytest.mark.parametrize(
+        "field, expected",
+        [
+            ("stats.max", "4096"),
+            ("stats.avg", "2048"),
+        ],
+    )
+    def test_window_stats_are_populated(
+        self,
+        kernel_id: KernelId,
+        window_stats_result: KernelLiveStatBatchResult,
+        field: str,
+        expected: str,
+    ) -> None:
+        per_metric = _per_metric(LegacyLiveStatConverter.convert(window_stats_result), kernel_id)
+        assert per_metric["mem"][field] == expected
+
+    def test_rate_sample_populates_stats_rate_for_counter_rate_metric(
+        self,
+        kernel_id: KernelId,
+    ) -> None:
+        # io_read is in STATS_RATE_COUNTER_METRICS — RATE sample is exposed
+        # directly without the net_rx/net_tx hack-multiply path.
+        result = _build_result({
+            kernel_id: [
+                MetricValue("io_read", ValueType.CURRENT, "5000"),
+                MetricValue("io_read", ValueType.RATE, "120.5"),
+            ]
+        })
+        per_metric = _per_metric(LegacyLiveStatConverter.convert(result), kernel_id)
+        assert per_metric["io_read"]["stats.rate"] == "120.5"
+
+    def test_rate_hack_multiply_wins_for_rate_stat_metric(
+        self,
+        kernel_id: KernelId,
+    ) -> None:
+        # For net_rx/net_tx, the legacy hack-multiply on currents[-1] must
+        # still drive stats.rate because the rate query template's
+        # magnitude bug is tracked separately (see out-of-scope note in
+        # the bug report).
+        result = _build_result({
+            kernel_id: [
+                MetricValue("net_rx", ValueType.CURRENT, "1000000"),
+                MetricValue("net_rx", ValueType.CURRENT, "2048"),
+                MetricValue("net_rx", ValueType.RATE, "999"),
+            ]
+        })
+        per_metric = _per_metric(LegacyLiveStatConverter.convert(result), kernel_id)
+        assert per_metric["net_rx"]["stats.rate"] == "10240.000000"
+
+
 class TestPctDerivation:
     """When the Prometheus pipeline does not emit a PCT sample, the converter
     derives the percentage from current/capacity, matching the value the


### PR DESCRIPTION
## Summary

- `LegacyLiveStatConverter._convert_metric_samples` previously dropped `ValueType.MAX`, `AVG`, and `RATE` samples, so `compute_container.live_stat` returned the placeholder `"0"` for `stats.max` / `stats.avg` / `stats.rate` after BA-5744 + BA-5878 migrated the live-stat pipeline to Prometheus.
- Wire `maxes[-1] -> stats.max`, `avgs[-1] -> stats.avg`, and `rates[-1] -> stats.rate` so the window-stats infrastructure built in BA-5878 actually reaches the GraphQL response.
- Keep the existing `net_rx` / `net_tx` hack-multiply on `currents[-1]` (its template magnitude bug is tracked separately).

## Test plan

- [x] `pants test tests/unit/manager/api/gql_legacy/test_stat_converter.py` — added `TestWindowStats` covering MAX/AVG population, RATE → `stats.rate` for counter-rate metrics (`io_read`), and verifying the `net_rx` hack-multiply still wins.
- [x] `pants fmt / lint / check --changed-since=HEAD`
- [ ] Manually verify against a live kernel that `stats.max` / `stats.avg` are populated in `compute_container.live_stat`.

## Out of scope

- `cpu_util.stats.max` / `stats.avg` will still appear as cumulative msec (two MAX series collide — separate dedup fix).
- `net_rx` / `net_tx` `stats.rate` continues to use the hack-multiply path (separate magnitude fix for `_RATE_TEMPLATE`).

Resolves BA-6007