### PR TITLE
fix(BA-6005): split multi-node inference session into main + sub kernels

### DIFF
--- a/changes/11575.fix.md
+++ b/changes/11575.fix.md
@@ -1,0 +1,1 @@
+Fix TooManyKernelsFound error on multi-node inference sessions by splitting kernel groups into main + sub roles

--- a/src/ai/backend/manager/services/model_serving/services/model_serving.py
+++ b/src/ai/backend/manager/services/model_serving/services/model_serving.py
@@ -84,6 +84,7 @@ from ai.backend.manager.data.session.options import (
 )
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.data.vfolder.types import VFolderOwnershipType
+from ai.backend.manager.defs import DEFAULT_ROLE
 from ai.backend.manager.errors.resource import RuntimeVariantNotFound
 from ai.backend.manager.errors.service import (
     EndpointAccessForbiddenError,
@@ -439,6 +440,18 @@ class ModelServingService:
         resource_opts = ResourceOpts.model_validate(action.config.resource_opts or {})
         environ = dict(action.config.environ or {})
         callback_url = URL(action.callback_url.unicode_string()) if action.callback_url else None
+        kernel_groups = await self._resolve_kernel_groups(
+            cluster_size=action.cluster_size,
+            execution_spec=KernelExecutionSpecDraft(
+                image_id=ImageID(image_data.id),
+                resources=resource_entries,
+                resource_opts=resource_opts,
+                environ=environ,
+                mounts=mount_entries,
+                startup_command=action.startup_command,
+                bootstrap_script=action.bootstrap_script or None,
+            ),
+        )
 
         if service_prepare_ctx.scaling_group:
             resource_group_name = ResourceGroupName(service_prepare_ctx.scaling_group)
@@ -474,21 +487,7 @@ class ModelServingService:
                 cluster_mode=action.cluster_mode,
                 cluster_size=action.cluster_size,
                 scheduling_target=SchedulingTargetDraft(),
-                kernel_groups=(
-                    KernelGroupDraft(
-                        role="main",
-                        replica_count=action.cluster_size,
-                        execution_spec=KernelExecutionSpecDraft(
-                            image_id=ImageID(image_data.id),
-                            resources=resource_entries,
-                            resource_opts=resource_opts,
-                            environ=environ,
-                            mounts=mount_entries,
-                            startup_command=action.startup_command,
-                            bootstrap_script=action.bootstrap_script or None,
-                        ),
-                    ),
-                ),
+                kernel_groups=kernel_groups,
                 handler_options=SessionHandlerOptions(),
             ),
             internal_data_extras=InternalDataExtras(
@@ -537,6 +536,29 @@ class ModelServingService:
 
         task_id = await self._background_task_manager.start(_task)
         return DryRunModelServiceActionResult(task_id)
+
+    async def _resolve_kernel_groups(
+        self,
+        cluster_size: int,
+        execution_spec: KernelExecutionSpecDraft,
+    ) -> tuple[KernelGroupDraft, ...]:
+        # 1 main + (cluster_size - 1) sub, matching legacy registry Shape (a).
+        groups: tuple[KernelGroupDraft, ...] = (
+            KernelGroupDraft(
+                role=DEFAULT_ROLE,
+                replica_count=1,
+                execution_spec=execution_spec,
+            ),
+        )
+        if cluster_size > 1:
+            groups += (
+                KernelGroupDraft(
+                    role="sub",
+                    replica_count=cluster_size - 1,
+                    execution_spec=execution_spec,
+                ),
+            )
+        return groups
 
     async def get_model_service_info(
         self, action: GetModelServiceInfoAction

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -68,6 +68,7 @@ from ai.backend.manager.data.session.options import (
     SessionHandlerOptions,
 )
 from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.defs import DEFAULT_ROLE
 from ai.backend.manager.errors.common import (
     InternalServerError,
     ServiceUnavailable,
@@ -1599,6 +1600,21 @@ class SessionService:
                 domain_name=domain_name,
                 project_id=ProjectID(action.group_id),
             )
+        kernel_groups = await self._resolve_kernel_groups(
+            cluster_size=action.resource.cluster_size,
+            preopen_ports=preopen_ports,
+            execution_spec=KernelExecutionSpecDraft(
+                image_id=ImageID(action.image_id),
+                resources=resource_entries,
+                resource_opts=resource_opts,
+                environ=environ,
+                mounts=mount_entries,
+                startup_command=startup_command,
+                bootstrap_script=bootstrap_script,
+                starts_at=starts_at,
+                batch_timeout_sec=batch_timeout_sec,
+            ),
+        )
 
         draft = SessionSpecDraft(
             identity=SessionIdentityDraft(
@@ -1636,24 +1652,7 @@ class SessionService:
                         AgentId(a) for a in (action.scheduling.agent_list or ())
                     ),
                 ),
-                kernel_groups=(
-                    KernelGroupDraft(
-                        role="main",
-                        replica_count=action.resource.cluster_size,
-                        preopen_ports=preopen_ports,
-                        execution_spec=KernelExecutionSpecDraft(
-                            image_id=ImageID(action.image_id),
-                            resources=resource_entries,
-                            resource_opts=resource_opts,
-                            environ=environ,
-                            mounts=mount_entries,
-                            startup_command=startup_command,
-                            bootstrap_script=bootstrap_script,
-                            starts_at=starts_at,
-                            batch_timeout_sec=batch_timeout_sec,
-                        ),
-                    ),
-                ),
+                kernel_groups=kernel_groups,
                 handler_options=SessionHandlerOptions(),
             ),
             internal_data_extras=InternalDataExtras(
@@ -1666,3 +1665,29 @@ class SessionService:
         session_data = await self._session_repository.get_session_data_by_id(session_id)
 
         return EnqueueSessionActionResult(session_data=session_data)
+
+    async def _resolve_kernel_groups(
+        self,
+        cluster_size: int,
+        preopen_ports: tuple[int, ...],
+        execution_spec: KernelExecutionSpecDraft,
+    ) -> tuple[KernelGroupDraft, ...]:
+        # 1 main + (cluster_size - 1) sub, matching legacy registry Shape (a).
+        groups: tuple[KernelGroupDraft, ...] = (
+            KernelGroupDraft(
+                role=DEFAULT_ROLE,
+                replica_count=1,
+                preopen_ports=preopen_ports,
+                execution_spec=execution_spec,
+            ),
+        )
+        if cluster_size > 1:
+            groups += (
+                KernelGroupDraft(
+                    role="sub",
+                    replica_count=cluster_size - 1,
+                    preopen_ports=preopen_ports,
+                    execution_spec=execution_spec,
+                ),
+            )
+        return groups

--- a/src/ai/backend/manager/sokovan/deployment/deployment_draft_builder.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_draft_builder.py
@@ -44,6 +44,7 @@ from ai.backend.manager.data.session.options import (
     ResourceOpts,
     SessionHandlerOptions,
 )
+from ai.backend.manager.defs import DEFAULT_ROLE
 from ai.backend.manager.errors.deployment import RevisionMissingModelVFolder
 from ai.backend.manager.repositories.scheduler.types.session_creation import DeploymentContext
 
@@ -80,6 +81,18 @@ class DeploymentSessionDraftBuilder:
             raise RevisionMissingModelVFolder(
                 f"Revision {target_revision.id} has no model vfolder; cannot build session draft"
             )
+        kernel_groups = cls._resolve_kernel_groups(
+            cluster_size=target_revision.cluster_config.size,
+            execution_spec=KernelExecutionSpecDraft(
+                image_id=target_revision.image_id,
+                resources=resource_entries,
+                resource_opts=resource_opts,
+                environ=environ,
+                mounts=mounts,
+                startup_command=startup_command,
+                bootstrap_script=(target_revision.execution.bootstrap_script or None),
+            ),
+        )
 
         return SessionSpecDraft(
             identity=SessionIdentityDraft(
@@ -106,21 +119,7 @@ class DeploymentSessionDraftBuilder:
                 cluster_mode=target_revision.cluster_config.mode,
                 cluster_size=target_revision.cluster_config.size,
                 scheduling_target=SchedulingTargetDraft(),
-                kernel_groups=(
-                    KernelGroupDraft(
-                        role="main",
-                        replica_count=target_revision.cluster_config.size,
-                        execution_spec=KernelExecutionSpecDraft(
-                            image_id=target_revision.image_id,
-                            resources=resource_entries,
-                            resource_opts=resource_opts,
-                            environ=environ,
-                            mounts=mounts,
-                            startup_command=startup_command,
-                            bootstrap_script=(target_revision.execution.bootstrap_script or None),
-                        ),
-                    ),
-                ),
+                kernel_groups=kernel_groups,
                 handler_options=SessionHandlerOptions(),
             ),
             internal_data_extras=InternalDataExtras(
@@ -129,6 +128,29 @@ class DeploymentSessionDraftBuilder:
                 model_definition=model_definition_payload,
             ),
         )
+
+    @staticmethod
+    def _resolve_kernel_groups(
+        cluster_size: int,
+        execution_spec: KernelExecutionSpecDraft,
+    ) -> tuple[KernelGroupDraft, ...]:
+        # 1 main + (cluster_size - 1) sub, matching legacy registry Shape (a).
+        groups: tuple[KernelGroupDraft, ...] = (
+            KernelGroupDraft(
+                role=DEFAULT_ROLE,
+                replica_count=1,
+                execution_spec=execution_spec,
+            ),
+        )
+        if cluster_size > 1:
+            groups += (
+                KernelGroupDraft(
+                    role="sub",
+                    replica_count=cluster_size - 1,
+                    execution_spec=execution_spec,
+                ),
+            )
+        return groups
 
     @staticmethod
     def _resolve_environ(

--- a/tests/unit/manager/sokovan/deployment/test_deployment_draft_builder.py
+++ b/tests/unit/manager/sokovan/deployment/test_deployment_draft_builder.py
@@ -11,6 +11,8 @@ from ai.backend.common.config import (
     ModelServiceConfig,
 )
 from ai.backend.manager.data.deployment.types import ModelRevisionData
+from ai.backend.manager.data.session.draft import KernelExecutionSpecDraft
+from ai.backend.manager.defs import DEFAULT_ROLE
 from ai.backend.manager.repositories.scheduler.types.session_creation import (
     DeploymentContext,
     ResolvedPresetValues,
@@ -118,3 +120,54 @@ class TestModelDefinitionPayload:
         cmd = payload["models"][0]["service"]["start_command"]
         assert cmd == ["vllm", "serve", "/models", *tokens]
         assert all(" " not in token for token in cmd)
+
+
+class TestKernelGroups:
+    """Multi-node deployment lays out 1 main + (cluster_size - 1) sub."""
+
+    @pytest.fixture
+    def execution_spec(self) -> KernelExecutionSpecDraft:
+        return KernelExecutionSpecDraft()
+
+    @pytest.fixture
+    def kernel_draft_builder(self) -> DeploymentSessionDraftBuilder:
+        return DeploymentSessionDraftBuilder()
+
+    def test_single_node_yields_one_main_group(
+        self,
+        execution_spec: KernelExecutionSpecDraft,
+        kernel_draft_builder: DeploymentSessionDraftBuilder,
+    ) -> None:
+        groups = kernel_draft_builder._resolve_kernel_groups(
+            cluster_size=1, execution_spec=execution_spec
+        )
+
+        assert len(groups) == 1
+        assert groups[0].role == DEFAULT_ROLE
+        assert groups[0].replica_count == 1
+
+    @pytest.mark.parametrize(
+        ("cluster_size", "expected_sub_replicas"),
+        [
+            pytest.param(2, 1, id="size-2"),
+            pytest.param(3, 2, id="size-3"),
+            pytest.param(5, 4, id="size-5"),
+        ],
+    )
+    def test_multi_node_splits_main_and_sub(
+        self,
+        execution_spec: KernelExecutionSpecDraft,
+        cluster_size: int,
+        expected_sub_replicas: int,
+        kernel_draft_builder: DeploymentSessionDraftBuilder,
+    ) -> None:
+        groups = kernel_draft_builder._resolve_kernel_groups(
+            cluster_size=cluster_size, execution_spec=execution_spec
+        )
+
+        assert len(groups) == 2
+        main, sub = groups
+        assert main.role == DEFAULT_ROLE
+        assert main.replica_count == 1
+        assert sub.role == "sub"
+        assert sub.replica_count == expected_sub_replicas


### PR DESCRIPTION
## Summary

- Fix a bug where `DeploymentSessionDraftBuilder` produced a single `role="main"` group with `replica_count=cluster_size` for multi-node INFERENCE sessions, resulting in N kernels all stored with `cluster_role="main"` after expansion.
- Mirror the legacy `registry.py` Shape (a) layout: one `main` kernel + (`cluster_size` - 1) `sub` kernels.
- Resolves the `TooManyKernelsFound` error raised from `SessionRow.main_kernel`, which previously broke the `computeSessionNodeResult` GraphQL query on multi-node sessions.

## Test plan

- [x] Unit tests for `_resolve_kernel_groups` (single-node + parametrized 2/3/5 multi-node cases)
- [ ] Live verification: create a revision with `cluster_size >= 2`, run `add_revision`, enqueue a session, and confirm `computeSessionNodeResult` returns successfully
- [ ] Regression check for single-node (`cluster_size=1`) revisions

Resolves BA-6005