### PR TITLE
fix(BA-6020): broaden prometheus safe wrapper exception catch from ValueError to Exception

### DIFF
--- a/changes/11577.fix.md
+++ b/changes/11577.fix.md
@@ -1,0 +1,1 @@
+Fix prometheus safe metric wrappers to catch all exceptions (not just ValueError), preventing mmap IndexError from propagating into business logic.

--- a/src/ai/backend/common/metrics/safe.py
+++ b/src/ai/backend/common/metrics/safe.py
@@ -1,10 +1,10 @@
 """Best-effort Prometheus metric wrappers.
 
 Provides SafeCounter, SafeGauge, and SafeHistogram that wrap
-prometheus_client metric types. On mmap corruption (ValueError from
-corrupted multiprocess .db files after OS sleep/wake), all metric
-recording is globally disabled so that metric failures never propagate
-into business logic or trigger retries.
+prometheus_client metric types. On any recording error (e.g. mmap
+corruption from corrupted multiprocess .db files after OS sleep/wake),
+all metric recording is globally disabled so that metric failures never
+propagate into business logic or trigger retries.
 """
 
 from __future__ import annotations
@@ -32,7 +32,7 @@ _trip_error_message: str | None = None
 
 
 def is_metrics_disabled() -> bool:
-    """Return True if metric recording has been disabled due to mmap error."""
+    """Return True if metric recording has been disabled."""
     return _metrics_disabled
 
 
@@ -49,11 +49,11 @@ def _trip(error: Exception) -> None:
             return
         _metrics_disabled = True
         _tripped_at = datetime.now(UTC)
-        _trip_error_message = str(error)
+        _trip_error_message = f"{type(error).__name__}: {error}"
     if not _error_logged:
         _error_logged = True
         log.warning(
-            "Prometheus metric recording disabled due to mmap error: {}",
+            "Prometheus metric recording disabled due to error: {}",
             error,
         )
 
@@ -90,7 +90,7 @@ _NOOP_LABELED = _NoopLabeledMetric()
 
 
 class SafeLabeledMetric:
-    """Wraps a labeled prometheus metric child, catching ValueError."""
+    """Wraps a labeled prometheus metric child, catching all exceptions."""
 
     __slots__ = ("_child",)
 
@@ -102,7 +102,7 @@ class SafeLabeledMetric:
             return
         try:
             self._child.inc(amount)
-        except ValueError as e:
+        except Exception as e:
             _trip(e)
 
     def dec(self, amount: float = 1) -> None:
@@ -110,7 +110,7 @@ class SafeLabeledMetric:
             return
         try:
             self._child.dec(amount)
-        except ValueError as e:
+        except Exception as e:
             _trip(e)
 
     def set(self, value: float) -> None:
@@ -118,7 +118,7 @@ class SafeLabeledMetric:
             return
         try:
             self._child.set(value)
-        except ValueError as e:
+        except Exception as e:
             _trip(e)
 
     def observe(self, amount: float) -> None:
@@ -126,7 +126,7 @@ class SafeLabeledMetric:
             return
         try:
             self._child.observe(amount)
-        except ValueError as e:
+        except Exception as e:
             _trip(e)
 
 
@@ -136,14 +136,14 @@ class SafeLabeledMetric:
 
 
 class SafeCounter(Counter):
-    """Counter that becomes no-op on mmap corruption."""
+    """Counter that becomes no-op on any recording error."""
 
     def labels(self, *args: Any, **kwargs: Any) -> Any:
         if _metrics_disabled:
             return _NOOP_LABELED
         try:
             return SafeLabeledMetric(super().labels(*args, **kwargs))
-        except ValueError as e:
+        except Exception as e:
             _trip(e)
             return _NOOP_LABELED
 
@@ -152,19 +152,19 @@ class SafeCounter(Counter):
             return
         try:
             super().inc(amount, exemplar)
-        except ValueError as e:
+        except Exception as e:
             _trip(e)
 
 
 class SafeGauge(Gauge):
-    """Gauge that becomes no-op on mmap corruption."""
+    """Gauge that becomes no-op on any recording error."""
 
     def labels(self, *args: Any, **kwargs: Any) -> Any:
         if _metrics_disabled:
             return _NOOP_LABELED
         try:
             return SafeLabeledMetric(super().labels(*args, **kwargs))
-        except ValueError as e:
+        except Exception as e:
             _trip(e)
             return _NOOP_LABELED
 
@@ -173,7 +173,7 @@ class SafeGauge(Gauge):
             return
         try:
             super().inc(amount)
-        except ValueError as e:
+        except Exception as e:
             _trip(e)
 
     def dec(self, amount: float = 1) -> None:
@@ -181,7 +181,7 @@ class SafeGauge(Gauge):
             return
         try:
             super().dec(amount)
-        except ValueError as e:
+        except Exception as e:
             _trip(e)
 
     def set(self, value: float) -> None:
@@ -189,19 +189,19 @@ class SafeGauge(Gauge):
             return
         try:
             super().set(value)
-        except ValueError as e:
+        except Exception as e:
             _trip(e)
 
 
 class SafeHistogram(Histogram):
-    """Histogram that becomes no-op on mmap corruption."""
+    """Histogram that becomes no-op on any recording error."""
 
     def labels(self, *args: Any, **kwargs: Any) -> Any:
         if _metrics_disabled:
             return _NOOP_LABELED
         try:
             return SafeLabeledMetric(super().labels(*args, **kwargs))
-        except ValueError as e:
+        except Exception as e:
             _trip(e)
             return _NOOP_LABELED
 
@@ -210,5 +210,5 @@ class SafeHistogram(Histogram):
             return
         try:
             super().observe(amount, exemplar)
-        except ValueError as e:
+        except Exception as e:
             _trip(e)

--- a/tests/unit/common/metrics/test_safe.py
+++ b/tests/unit/common/metrics/test_safe.py
@@ -38,7 +38,7 @@ class TestCircuitBreakerState:
         _trip(ValueError("mmap slice assignment is wrong size"))
         tripped_at, error_msg = metrics_trip_info()
         assert tripped_at is not None
-        assert error_msg == "mmap slice assignment is wrong size"
+        assert error_msg == "ValueError: mmap slice assignment is wrong size"
 
     def test_trip_is_idempotent(self) -> None:
         _trip(ValueError("first error"))
@@ -46,7 +46,7 @@ class TestCircuitBreakerState:
         _trip(ValueError("second error"))
         second_tripped_at, second_msg = metrics_trip_info()
         assert first_tripped_at == second_tripped_at
-        assert first_msg == second_msg == "first error"
+        assert first_msg == second_msg == "ValueError: first error"
 
     def test_trip_logs_warning_once(self) -> None:
         with patch.object(safe_mod, "log") as mock_log:
@@ -103,13 +103,12 @@ class TestSafeLabeledMetric:
         metric.observe(1.0)
         assert is_metrics_disabled() is True
 
-    def test_other_exceptions_propagate(self) -> None:
+    def test_other_exceptions_trip_circuit_breaker(self) -> None:
         child = MagicMock()
-        child.inc.side_effect = TypeError("unexpected")
+        child.inc.side_effect = IndexError("mmap slice assignment is wrong size")
         metric = SafeLabeledMetric(child)
-        with pytest.raises(TypeError, match="unexpected"):
-            metric.inc()
-        assert is_metrics_disabled() is False
+        metric.inc()
+        assert is_metrics_disabled() is True
 
 
 class TestNoopLabeledMetric:


### PR DESCRIPTION
## Summary
- Change all `except ValueError` to `except Exception` in `SafeCounter`, `SafeGauge`, `SafeHistogram`, and `SafeLabeledMetric`
- The actual error was `IndexError: mmap slice assignment is wrong size`, not `ValueError` — the circuit-breaker was not tripping and the exception was propagating into business logic (e.g. `myDeployments` GQL query returning null with errors)
- Improve `_trip_error_message` format to `"ExceptionType: message"` so the exception type is visible in health check output

## Test plan
- [x] Replace `test_other_exceptions_propagate` with `test_other_exceptions_trip_circuit_breaker` to verify non-ValueError exceptions now trip the circuit breaker
- [x] Update expected error message format in `test_trip_stores_error_info` and `test_trip_is_idempotent`

Resolves BA-6020