### PR TITLE
feat(BA-6017): add WARMING_UP route status between PROVISIONING and RUNNING

### DIFF
--- a/changes/11578.feature.md
+++ b/changes/11578.feature.md
@@ -1,0 +1,1 @@
+Add a `WARMING_UP` route status between `PROVISIONING` and `RUNNING` so model-serving routes only graduate to `RUNNING` after the first healthy probe (or immediately when the endpoint has no health check configured).

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -14760,6 +14760,7 @@ enum ReplicaStatus
   @join__type(graph: STRAWBERRY)
 {
   PROVISIONING @join__enumValue(graph: STRAWBERRY)
+  WARMING_UP @join__enumValue(graph: STRAWBERRY)
   RUNNING @join__enumValue(graph: STRAWBERRY)
   TERMINATING @join__enumValue(graph: STRAWBERRY)
   TERMINATED @join__enumValue(graph: STRAWBERRY)
@@ -16237,6 +16238,7 @@ enum RouteStatus
   @join__type(graph: STRAWBERRY)
 {
   PROVISIONING @join__enumValue(graph: STRAWBERRY)
+  WARMING_UP @join__enumValue(graph: STRAWBERRY)
   RUNNING @join__enumValue(graph: STRAWBERRY)
   TERMINATING @join__enumValue(graph: STRAWBERRY)
   TERMINATED @join__enumValue(graph: STRAWBERRY)

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -9871,6 +9871,7 @@ Added in 25.19.0. This enum represents the provisioning status of a replica.
 """
 enum ReplicaStatus {
   PROVISIONING
+  WARMING_UP
   RUNNING
   TERMINATING
   TERMINATED
@@ -11009,6 +11010,7 @@ input RouteScope {
 """Added in 25.19.0. Lifecycle status of a route."""
 enum RouteStatus {
   PROVISIONING
+  WARMING_UP
   RUNNING
   TERMINATING
   TERMINATED

--- a/src/ai/backend/common/clients/valkey_client/valkey_schedule/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_schedule/client.py
@@ -33,15 +33,6 @@ KERNEL_HEALTH_TTL_SEC = 300  # 5 minutes - TTL for kernel health status
 MAX_KERNEL_HEALTH_STALENESS_SEC = 120  # 2 minutes - threshold for kernel health staleness
 AGENT_LAST_CHECK_TTL_SEC = 1200  # 20 minutes - TTL for agent last check timestamp
 ORPHAN_KERNEL_THRESHOLD_SEC = 600  # 10 minutes - threshold for orphan kernel detection
-
-
-class _RouteTimestampField(enum.StrEnum):
-    """Lifecycle transition timestamp fields stored in route health hashes."""
-
-    WARMING_UP_AT = "warming_up_at"
-    RUNNING_AT = "running_at"
-
-
 FORCE_TERMINATED_CLEANUP_TTL_SEC = 1200  # 20 minutes - TTL for force-terminated cleanup queue
 
 
@@ -104,17 +95,14 @@ class RouteHealthRecord:
 
     route_id: str
     created_at: int  # Unix timestamp when route was created
-    initial_delay_until: int  # Unix timestamp = warming_up_at + initial_delay
+    initial_delay_until: int  # Unix timestamp anchored at health-record initialisation
     health_path: str  # extracted from model_definition
     inference_port: int  # extracted from kernel
     replica_host: str  # extracted from kernel
 
-    # Timestamp when route entered WARMING_UP state (set by coordinator).
-    # Anchors the ``initial_delay`` window for health probes since model
-    # loading happens during WARMING_UP.
-    warming_up_at: int | None = None
-    # Timestamp when route entered RUNNING state (set by coordinator).
-    # Marks the moment the route became eligible to receive traffic.
+    # Timestamp when route entered RUNNING state (set by the warming-up
+    # handler after the first health-check pass). Marks the moment the
+    # route became eligible to receive traffic.
     running_at: int | None = None
 
     # Agent check results
@@ -157,8 +145,6 @@ class RouteHealthRecord:
             "manager_healthy": "1" if self.manager_healthy else "0",
             "manager_last_check": str(self.manager_last_check),
         }
-        if self.warming_up_at is not None:
-            data["warming_up_at"] = str(self.warming_up_at)
         if self.running_at is not None:
             data["running_at"] = str(self.running_at)
         return data
@@ -173,7 +159,6 @@ class RouteHealthRecord:
             health_path=data["health_path"],
             inference_port=int(data["inference_port"]),
             replica_host=data["replica_host"],
-            warming_up_at=int(raw) if (raw := data.get("warming_up_at")) and raw != "0" else None,
             running_at=int(raw) if (raw := data.get("running_at")) and raw != "0" else None,
             agent_healthy=data.get("agent_healthy", "0") == "1",
             agent_last_check=int(data.get("agent_last_check", "0")),
@@ -692,36 +677,6 @@ class ValkeyScheduleClient:
         async with self._client.client() as conn:
             await conn.exec(batch, raise_on_error=True)
 
-    async def _mark_routes_timestamp_batch(
-        self,
-        route_ids: Sequence[str],
-        field: _RouteTimestampField,
-    ) -> None:
-        """Batch-write a single timestamp field to multiple route health hashes."""
-        if not route_ids:
-            return
-
-        current_time = str(await self._get_redis_time())
-        batch = Batch(is_atomic=False)
-        for route_id in route_ids:
-            key = self._get_route_health_key(route_id)
-            batch.hset(key, {field.value: current_time})
-            batch.expire(key, ROUTE_HEALTH_TTL_SEC)
-        async with self._client.client() as conn:
-            await conn.exec(batch, raise_on_error=True)
-
-    @valkey_schedule_resilience.apply()
-    async def mark_routes_warming_up_at_batch(self, route_ids: Sequence[str]) -> None:
-        """
-        Batch-record the WARMING_UP transition timestamp for multiple routes.
-        Called when routes transition to WARMING_UP status. Anchors the
-        ``initial_delay`` window because model loading happens during
-        WARMING_UP, not after the route reaches RUNNING.
-
-        :param route_ids: Route IDs that entered WARMING_UP state
-        """
-        await self._mark_routes_timestamp_batch(route_ids, _RouteTimestampField.WARMING_UP_AT)
-
     @valkey_schedule_resilience.apply()
     async def mark_routes_running_at_batch(self, route_ids: Sequence[str]) -> None:
         """
@@ -731,48 +686,17 @@ class ValkeyScheduleClient:
 
         :param route_ids: Route IDs that entered RUNNING state
         """
-        await self._mark_routes_timestamp_batch(route_ids, _RouteTimestampField.RUNNING_AT)
-
-    async def _batch_read_route_timestamp(
-        self,
-        route_ids: Sequence[str],
-        field: _RouteTimestampField,
-    ) -> dict[str, int | None]:
-        """Batch read a single timestamp field from route health hashes."""
         if not route_ids:
-            return {}
+            return
 
+        current_time = str(await self._get_redis_time())
         batch = Batch(is_atomic=False)
         for route_id in route_ids:
             key = self._get_route_health_key(route_id)
-            batch.hget(key, field.value)
-
+            batch.hset(key, {"running_at": current_time})
+            batch.expire(key, ROUTE_HEALTH_TTL_SEC)
         async with self._client.client() as conn:
-            results = await conn.exec(batch, raise_on_error=False)
-        if results is None:
-            return dict.fromkeys(route_ids)
-
-        timestamp_map: dict[str, int | None] = {}
-        for i, route_id in enumerate(route_ids):
-            raw = results[i] if len(results) > i else None
-            if raw and raw != b"0":
-                timestamp_map[route_id] = int(raw)
-            else:
-                timestamp_map[route_id] = None
-        return timestamp_map
-
-    @valkey_schedule_resilience.apply()
-    async def get_route_warming_up_at_batch(
-        self, route_ids: Sequence[str]
-    ) -> dict[str, int | None]:
-        """
-        Batch read warming_up_at field from route health hashes.
-        Works even on partial hashes (before full RouteHealthRecord is initialized).
-
-        :param route_ids: Route IDs to look up
-        :return: Mapping of route_id to warming_up_at timestamp (None if not set)
-        """
-        return await self._batch_read_route_timestamp(route_ids, _RouteTimestampField.WARMING_UP_AT)
+            await conn.exec(batch, raise_on_error=True)
 
     @valkey_schedule_resilience.apply()
     async def get_route_running_at_batch(self, route_ids: Sequence[str]) -> dict[str, int | None]:
@@ -783,7 +707,27 @@ class ValkeyScheduleClient:
         :param route_ids: Route IDs to look up
         :return: Mapping of route_id to running_at timestamp (None if not set)
         """
-        return await self._batch_read_route_timestamp(route_ids, _RouteTimestampField.RUNNING_AT)
+        if not route_ids:
+            return {}
+
+        batch = Batch(is_atomic=False)
+        for route_id in route_ids:
+            key = self._get_route_health_key(route_id)
+            batch.hget(key, "running_at")
+
+        async with self._client.client() as conn:
+            results = await conn.exec(batch, raise_on_error=False)
+        if results is None:
+            return dict.fromkeys(route_ids)
+
+        running_at_map: dict[str, int | None] = {}
+        for i, route_id in enumerate(route_ids):
+            raw = results[i] if len(results) > i else None
+            if raw and raw != b"0":
+                running_at_map[route_id] = int(raw)
+            else:
+                running_at_map[route_id] = None
+        return running_at_map
 
     @valkey_schedule_resilience.apply()
     async def refresh_route_health_ttl(self, route_id: str) -> None:
@@ -986,8 +930,8 @@ class ValkeyScheduleClient:
 
             data = {k.decode(): v.decode() for k, v in raw.items()}
             if "route_id" not in data:
-                # Partial hash (e.g., only warming_up_at set by
-                # mark_routes_warming_up_at_batch before _initialize_health_records runs)
+                # Partial hash (e.g., only running_at set by
+                # mark_routes_running_at_batch before _initialize_health_records runs)
                 records[route_id] = None
                 continue
             records[route_id] = RouteHealthRecord.from_valkey_hash(data)

--- a/src/ai/backend/common/clients/valkey_client/valkey_schedule/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_schedule/client.py
@@ -33,6 +33,15 @@ KERNEL_HEALTH_TTL_SEC = 300  # 5 minutes - TTL for kernel health status
 MAX_KERNEL_HEALTH_STALENESS_SEC = 120  # 2 minutes - threshold for kernel health staleness
 AGENT_LAST_CHECK_TTL_SEC = 1200  # 20 minutes - TTL for agent last check timestamp
 ORPHAN_KERNEL_THRESHOLD_SEC = 600  # 10 minutes - threshold for orphan kernel detection
+
+
+class _RouteTimestampField(enum.StrEnum):
+    """Lifecycle transition timestamp fields stored in route health hashes."""
+
+    WARMING_UP_AT = "warming_up_at"
+    RUNNING_AT = "running_at"
+
+
 FORCE_TERMINATED_CLEANUP_TTL_SEC = 1200  # 20 minutes - TTL for force-terminated cleanup queue
 
 
@@ -95,12 +104,17 @@ class RouteHealthRecord:
 
     route_id: str
     created_at: int  # Unix timestamp when route was created
-    initial_delay_until: int  # Unix timestamp = running_at + initial_delay
+    initial_delay_until: int  # Unix timestamp = warming_up_at + initial_delay
     health_path: str  # extracted from model_definition
     inference_port: int  # extracted from kernel
     replica_host: str  # extracted from kernel
 
-    # Timestamp when route entered RUNNING state (set by coordinator)
+    # Timestamp when route entered WARMING_UP state (set by coordinator).
+    # Anchors the ``initial_delay`` window for health probes since model
+    # loading happens during WARMING_UP.
+    warming_up_at: int | None = None
+    # Timestamp when route entered RUNNING state (set by coordinator).
+    # Marks the moment the route became eligible to receive traffic.
     running_at: int | None = None
 
     # Agent check results
@@ -143,6 +157,8 @@ class RouteHealthRecord:
             "manager_healthy": "1" if self.manager_healthy else "0",
             "manager_last_check": str(self.manager_last_check),
         }
+        if self.warming_up_at is not None:
+            data["warming_up_at"] = str(self.warming_up_at)
         if self.running_at is not None:
             data["running_at"] = str(self.running_at)
         return data
@@ -157,6 +173,7 @@ class RouteHealthRecord:
             health_path=data["health_path"],
             inference_port=int(data["inference_port"]),
             replica_host=data["replica_host"],
+            warming_up_at=int(raw) if (raw := data.get("warming_up_at")) and raw != "0" else None,
             running_at=int(raw) if (raw := data.get("running_at")) and raw != "0" else None,
             agent_healthy=data.get("agent_healthy", "0") == "1",
             agent_last_check=int(data.get("agent_last_check", "0")),
@@ -675,20 +692,87 @@ class ValkeyScheduleClient:
         async with self._client.client() as conn:
             await conn.exec(batch, raise_on_error=True)
 
-    @valkey_schedule_resilience.apply()
-    async def mark_route_running_at(self, route_id: str) -> None:
-        """
-        Record the RUNNING transition timestamp for a route.
-        Called when a route transitions to RUNNING status.
-        Uses Redis time for consistency with health check comparisons.
+    async def _mark_routes_timestamp_batch(
+        self,
+        route_ids: Sequence[str],
+        field: _RouteTimestampField,
+    ) -> None:
+        """Batch-write a single timestamp field to multiple route health hashes."""
+        if not route_ids:
+            return
 
-        :param route_id: The route ID that entered RUNNING state
-        """
-        key = self._get_route_health_key(route_id)
         current_time = str(await self._get_redis_time())
+        batch = Batch(is_atomic=False)
+        for route_id in route_ids:
+            key = self._get_route_health_key(route_id)
+            batch.hset(key, {field.value: current_time})
+            batch.expire(key, ROUTE_HEALTH_TTL_SEC)
         async with self._client.client() as conn:
-            await conn.hset(key, {"running_at": current_time})
-            await conn.expire(key, ROUTE_HEALTH_TTL_SEC)
+            await conn.exec(batch, raise_on_error=True)
+
+    @valkey_schedule_resilience.apply()
+    async def mark_routes_warming_up_at_batch(self, route_ids: Sequence[str]) -> None:
+        """
+        Batch-record the WARMING_UP transition timestamp for multiple routes.
+        Called when routes transition to WARMING_UP status. Anchors the
+        ``initial_delay`` window because model loading happens during
+        WARMING_UP, not after the route reaches RUNNING.
+
+        :param route_ids: Route IDs that entered WARMING_UP state
+        """
+        await self._mark_routes_timestamp_batch(route_ids, _RouteTimestampField.WARMING_UP_AT)
+
+    @valkey_schedule_resilience.apply()
+    async def mark_routes_running_at_batch(self, route_ids: Sequence[str]) -> None:
+        """
+        Batch-record the RUNNING transition timestamp for multiple routes.
+        Called when routes transition to RUNNING status — i.e. the first
+        health gate has passed and the routes are eligible for traffic.
+
+        :param route_ids: Route IDs that entered RUNNING state
+        """
+        await self._mark_routes_timestamp_batch(route_ids, _RouteTimestampField.RUNNING_AT)
+
+    async def _batch_read_route_timestamp(
+        self,
+        route_ids: Sequence[str],
+        field: _RouteTimestampField,
+    ) -> dict[str, int | None]:
+        """Batch read a single timestamp field from route health hashes."""
+        if not route_ids:
+            return {}
+
+        batch = Batch(is_atomic=False)
+        for route_id in route_ids:
+            key = self._get_route_health_key(route_id)
+            batch.hget(key, field.value)
+
+        async with self._client.client() as conn:
+            results = await conn.exec(batch, raise_on_error=False)
+        if results is None:
+            return dict.fromkeys(route_ids)
+
+        timestamp_map: dict[str, int | None] = {}
+        for i, route_id in enumerate(route_ids):
+            raw = results[i] if len(results) > i else None
+            if raw and raw != b"0":
+                timestamp_map[route_id] = int(raw)
+            else:
+                timestamp_map[route_id] = None
+        return timestamp_map
+
+    @valkey_schedule_resilience.apply()
+    async def get_route_warming_up_at_batch(
+        self, route_ids: Sequence[str]
+    ) -> dict[str, int | None]:
+        """
+        Batch read warming_up_at field from route health hashes.
+        Works even on partial hashes (before full RouteHealthRecord is initialized).
+
+        :param route_ids: Route IDs to look up
+        :return: Mapping of route_id to warming_up_at timestamp (None if not set)
+        """
+        return await self._batch_read_route_timestamp(route_ids, _RouteTimestampField.WARMING_UP_AT)
 
     @valkey_schedule_resilience.apply()
     async def get_route_running_at_batch(self, route_ids: Sequence[str]) -> dict[str, int | None]:
@@ -699,27 +783,7 @@ class ValkeyScheduleClient:
         :param route_ids: Route IDs to look up
         :return: Mapping of route_id to running_at timestamp (None if not set)
         """
-        if not route_ids:
-            return {}
-
-        batch = Batch(is_atomic=False)
-        for route_id in route_ids:
-            key = self._get_route_health_key(route_id)
-            batch.hget(key, "running_at")
-
-        async with self._client.client() as conn:
-            results = await conn.exec(batch, raise_on_error=False)
-        if results is None:
-            return dict.fromkeys(route_ids)
-
-        running_at_map: dict[str, int | None] = {}
-        for i, route_id in enumerate(route_ids):
-            raw = results[i] if len(results) > i else None
-            if raw and raw != b"0":
-                running_at_map[route_id] = int(raw)
-            else:
-                running_at_map[route_id] = None
-        return running_at_map
+        return await self._batch_read_route_timestamp(route_ids, _RouteTimestampField.RUNNING_AT)
 
     @valkey_schedule_resilience.apply()
     async def refresh_route_health_ttl(self, route_id: str) -> None:
@@ -922,7 +986,8 @@ class ValkeyScheduleClient:
 
             data = {k.decode(): v.decode() for k, v in raw.items()}
             if "route_id" not in data:
-                # Partial hash (e.g., only running_at set by mark_route_running_at)
+                # Partial hash (e.g., only warming_up_at set by
+                # mark_routes_warming_up_at_batch before _initialize_health_records runs)
                 records[route_id] = None
                 continue
             records[route_id] = RouteHealthRecord.from_valkey_hash(data)

--- a/src/ai/backend/common/data/model_deployment/types.py
+++ b/src/ai/backend/common/data/model_deployment/types.py
@@ -58,6 +58,7 @@ class RouteStatus(CIStrEnum):
     """Lifecycle status of a route in the deployment."""
 
     PROVISIONING = "provisioning"
+    WARMING_UP = "warming_up"
     RUNNING = "running"
     TERMINATING = "terminating"
     TERMINATED = "terminated"

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -12,7 +12,7 @@ from uuid import UUID
 import yarl
 from pydantic import ConfigDict, Field
 
-from ai.backend.common.config import ModelDefinition, ModelDefinitionDraft
+from ai.backend.common.config import ModelDefinition, ModelDefinitionDraft, ModelHealthCheck
 from ai.backend.common.data.endpoint.types import EndpointLifecycle, ScalingState
 from ai.backend.common.data.model_deployment.types import (
     ActivenessStatus,
@@ -32,7 +32,11 @@ from ai.backend.manager.data.session.options import HandlerOptions
 from ai.backend.manager.errors.deployment import DeploymentRevisionNotFound
 
 if TYPE_CHECKING:
-    from ai.backend.manager.data.session.types import SchedulingResult, SubStepResult
+    from ai.backend.manager.data.session.types import (
+        SchedulingResult,
+        SessionStatus,
+        SubStepResult,
+    )
     from ai.backend.manager.models.deployment_policy import BlueGreenSpec, RollingUpdateSpec
 
 from ai.backend.common.types import (
@@ -657,6 +661,45 @@ def _merge_model_definition(
 # every query runs inside one session; the reader layer combines the bundle
 # with storage-backed files (deployment-config.yaml, model-definition.yaml)
 # before assembling the drafts list.
+
+
+@dataclass(frozen=True)
+class ReplicaConnectionInfo:
+    """Inference-port host/port pair for a session's main kernel."""
+
+    host: str
+    port: int
+
+
+@dataclass(frozen=True)
+class WarmingUpRouteReadBundle:
+    """DB reads for a single ``check_warming_up_routes`` cycle.
+
+    Two queries inside one readonly transaction:
+
+    1. ``sessions`` LEFT JOIN ``kernels(cluster_role='main')`` →
+       resolves both the session status and the main kernel's
+       inference host/port (both keyed by session id).
+    2. ``deployment_revisions.model_definition`` → resolves the
+       health-check configuration per revision.
+
+    Callers translate from route to session/revision via
+    :class:`RouteData`.
+
+    Attributes:
+        session_statuses: Session lifecycle status keyed by session
+            id. Sessions whose row is missing are absent from the map.
+        kernel_connection_info: Inference host/port keyed by session
+            id. Sessions whose kernel is not yet up are absent.
+        health_check_configs: Per-revision health-check configuration
+            (``None`` when the revision has no ``service.health_check``
+            defined, which the warming-up handler treats as "opted out
+            of health probes").
+    """
+
+    session_statuses: Mapping[SessionId, SessionStatus]
+    kernel_connection_info: Mapping[SessionId, ReplicaConnectionInfo]
+    health_check_configs: Mapping[DeploymentRevisionID, ModelHealthCheck | None]
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -71,6 +71,7 @@ class RouteStatus(enum.Enum):
     """Lifecycle status of a route (independent of health)."""
 
     PROVISIONING = "provisioning"
+    WARMING_UP = "warming_up"
     RUNNING = "running"
     TERMINATING = "terminating"
     TERMINATED = "terminated"
@@ -81,8 +82,15 @@ class RouteStatus(enum.Enum):
     def active_route_statuses(cls) -> set[RouteStatus]:
         return {
             RouteStatus.PROVISIONING,
+            RouteStatus.WARMING_UP,
             RouteStatus.RUNNING,
         }
+
+    @classmethod
+    @lru_cache(maxsize=1)
+    def pre_running_statuses(cls) -> set[RouteStatus]:
+        """Routes that are alive but not yet eligible to receive traffic."""
+        return {RouteStatus.PROVISIONING, RouteStatus.WARMING_UP}
 
     @classmethod
     @lru_cache(maxsize=1)

--- a/src/ai/backend/manager/defs.py
+++ b/src/ai/backend/manager/defs.py
@@ -107,6 +107,7 @@ class LockID(enum.IntEnum):
     LOCKID_DEPLOYMENT_PROVISIONING_ROUTES = 223  # Lock for provisioning routes
     LOCKID_DEPLOYMENT_HEALTH_CHECK_ROUTES = 224  # Lock for health check routes
     LOCKID_DEPLOYMENT_RUNNING_ROUTES = 225  # Lock for running routes
+    LOCKID_DEPLOYMENT_WARMING_UP_ROUTES = 226  # Lock for warming-up routes (first health gate)
     LOCKID_DEPLOYMENT_CHECK_REPLICA = 227  # For operations checking REPLICA sessions
     LOCKID_DEPLOYMENT_DESTROYING = 228  # For operations destroying deployments
     LOCKID_DEPLOYMENT_DEPLOYING = 229  # For operations deploying deployments

--- a/src/ai/backend/manager/models/endpoint/row.py
+++ b/src/ai/backend/manager/models/endpoint/row.py
@@ -522,10 +522,12 @@ class EndpointRow(Base):  # type: ignore[misc]
         if self.lifecycle_stage == EndpointLifecycle.DESTROYING:
             return {
                 RouteStatus.PROVISIONING,
+                RouteStatus.WARMING_UP,
                 RouteStatus.RUNNING,
                 RouteStatus.FAILED_TO_START,
             }
         return {
+            RouteStatus.WARMING_UP,
             RouteStatus.RUNNING,
             RouteStatus.FAILED_TO_START,
         }

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -70,12 +70,14 @@ from ai.backend.manager.data.deployment.types import (
     ModelDeploymentAccessTokenData,
     ModelDeploymentAutoScalingRuleData,
     ModelRevisionData,
+    ReplicaConnectionInfo,
     RevisionSearchResult,
     RouteHealthStatus,
     RouteInfo,
     RouteSearchResult,
     RouteStatus,
     ScalingGroupCleanupConfig,
+    WarmingUpRouteReadBundle,
 )
 from ai.backend.manager.data.deployment_revision_preset.types import ResourceSlotEntryData
 from ai.backend.manager.data.image.types import ImageIdentifier
@@ -84,6 +86,7 @@ from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.data.resource.types import ScalingGroupProxyTarget
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.data.vfolder.types import VFolderLocation
+from ai.backend.manager.defs import DEFAULT_ROLE
 from ai.backend.manager.errors.deployment import (
     DeploymentHasNoTargetRevision,
     DeploymentRevisionNotFound,
@@ -2044,6 +2047,89 @@ class DeploymentDBSource:
                 ),
                 resolved_presets=resolved_presets,
             )
+
+    async def fetch_warming_up_route_bundle(
+        self,
+        *,
+        session_ids: list[SessionId],
+        revision_ids: set[DeploymentRevisionID],
+    ) -> WarmingUpRouteReadBundle:
+        """Bundle the DB reads ``check_warming_up_routes`` needs.
+
+        Two queries inside one readonly transaction:
+
+        1. ``sessions`` LEFT JOIN ``kernels(cluster_role='main')`` →
+           ``session_statuses`` + ``kernel_connection_info`` (both
+           keyed by session id).
+        2. ``deployment_revisions.model_definition`` →
+           ``health_check_configs`` (keyed by revision id).
+
+        Empty ``session_ids`` / ``revision_ids`` skip the
+        corresponding query.
+        """
+        session_statuses: dict[SessionId, SessionStatus] = {}
+        kernel_info: dict[SessionId, ReplicaConnectionInfo] = {}
+        health_configs: dict[DeploymentRevisionID, ModelHealthCheck | None] = {}
+
+        if not session_ids and not revision_ids:
+            return WarmingUpRouteReadBundle(
+                session_statuses=session_statuses,
+                kernel_connection_info=kernel_info,
+                health_check_configs=health_configs,
+            )
+
+        async with self._begin_readonly_session_read_committed() as db_sess:
+            if session_ids:
+                session_query = (
+                    sa.select(
+                        SessionRow.id.label("session_id"),
+                        SessionRow.status.label("session_status"),
+                        KernelRow.kernel_host.label("kernel_host"),
+                        KernelRow.service_ports.label("service_ports"),
+                    )
+                    .select_from(SessionRow)
+                    .outerjoin(
+                        KernelRow,
+                        sa.and_(
+                            KernelRow.session_id == SessionRow.id,
+                            KernelRow.cluster_role == DEFAULT_ROLE,
+                        ),
+                    )
+                    .where(SessionRow.id.in_(session_ids))
+                )
+                result = await db_sess.execute(session_query)
+                for row in result:
+                    sid = SessionId(row.session_id)
+                    session_statuses[sid] = row.session_status
+                    if row.kernel_host and row.service_ports:
+                        for sp in row.service_ports:
+                            if sp.get("is_inference"):
+                                host_ports = sp.get("host_ports", [])
+                                if host_ports:
+                                    kernel_info[sid] = ReplicaConnectionInfo(
+                                        host=row.kernel_host,
+                                        port=host_ports[0],
+                                    )
+                                break
+
+            if revision_ids:
+                health_query = sa.select(
+                    DeploymentRevisionRow.id,
+                    DeploymentRevisionRow.model_definition,
+                ).where(DeploymentRevisionRow.id.in_(revision_ids))
+                result = await db_sess.execute(health_query)
+                for revision_id, model_definition in result.all():
+                    health_configs[DeploymentRevisionID(revision_id)] = (
+                        model_definition.health_check_config()
+                        if model_definition is not None
+                        else None
+                    )
+
+        return WarmingUpRouteReadBundle(
+            session_statuses=session_statuses,
+            kernel_connection_info=kernel_info,
+            health_check_configs=health_configs,
+        )
 
     async def fetch_session_statuses_by_route_ids(
         self,

--- a/src/ai/backend/manager/repositories/deployment/repository.py
+++ b/src/ai/backend/manager/repositories/deployment/repository.py
@@ -71,6 +71,7 @@ from ai.backend.manager.data.deployment.types import (
     RouteSearchResult,
     RouteStatus,
     ScalingGroupCleanupConfig,
+    WarmingUpRouteReadBundle,
 )
 from ai.backend.manager.data.image.types import ImageIdentifier
 from ai.backend.manager.data.model_serving.types import AppProxyRouteEntry
@@ -1096,6 +1097,19 @@ class DeploymentRepository:
     ) -> Mapping[uuid.UUID, SessionStatus | None]:
         """Fetch session IDs for multiple routes."""
         return await self._db_source.fetch_session_statuses_by_route_ids(route_ids)
+
+    @deployment_repository_resilience.apply()
+    async def fetch_warming_up_route_bundle(
+        self,
+        *,
+        session_ids: list[SessionId],
+        revision_ids: set[DeploymentRevisionID],
+    ) -> WarmingUpRouteReadBundle:
+        """Bundle the DB reads ``check_warming_up_routes`` needs into a single call."""
+        return await self._db_source.fetch_warming_up_route_bundle(
+            session_ids=session_ids,
+            revision_ids=revision_ids,
+        )
 
     @deployment_repository_resilience.apply()
     async def fetch_route_connection_infos(

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -284,6 +284,7 @@ _HEALTH_STATUS_TO_READINESS: dict[RouteHealthStatus, ReadinessStatus] = {
 _ROUTE_STATUS_TO_LIVENESS: dict[RouteStatus, LivenessStatus] = {
     RouteStatus.RUNNING: LivenessStatus.HEALTHY,
     RouteStatus.PROVISIONING: LivenessStatus.NOT_CHECKED,
+    RouteStatus.WARMING_UP: LivenessStatus.NOT_CHECKED,
     RouteStatus.TERMINATING: LivenessStatus.DEGRADED,
     RouteStatus.TERMINATED: LivenessStatus.UNHEALTHY,
     RouteStatus.FAILED_TO_START: LivenessStatus.UNHEALTHY,

--- a/src/ai/backend/manager/services/model_serving/services/model_serving.py
+++ b/src/ai/backend/manager/services/model_serving/services/model_serving.py
@@ -859,8 +859,10 @@ class ModelServingService:
         if not route_data:
             raise RouteNotFound
 
-        if route_data.status == RouteStatus.PROVISIONING:
-            raise InvalidAPIParameters("Cannot remove route in PROVISIONING status")
+        if route_data.status in RouteStatus.pre_running_statuses():
+            raise InvalidAPIParameters(
+                f"Cannot remove route in {route_data.status.value.upper()} status"
+            )
 
         # Get session for destruction
         route_row = await self._repository.get_route_with_session(action.route_id)

--- a/src/ai/backend/manager/sokovan/deployment/route/coordinator.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/coordinator.py
@@ -398,17 +398,6 @@ class RouteCoordinator:
                 batch_updaters, BulkCreator(specs=all_history_specs)
             )
 
-        # Stamp lifecycle transition timestamps in Valkey: warming_up_at
-        # anchors the health-probe initial_delay window (model loading
-        # happens during WARMING_UP); running_at marks the moment the
-        # first health gate passed and the route is eligible for traffic.
-        if transitions.success is not None and result.successes:
-            success_route_ids = [str(route.route_id) for route in result.successes]
-            if transitions.success.status == RouteStatus.WARMING_UP:
-                await self._valkey_schedule.mark_routes_warming_up_at_batch(success_route_ids)
-            elif transitions.success.status == RouteStatus.RUNNING:
-                await self._valkey_schedule.mark_routes_running_at_batch(success_route_ids)
-
     async def process_if_needed(self, lifecycle_type: RouteLifecycleType) -> None:
         """
         Process route lifecycle operation if needed (based on internal state).

--- a/src/ai/backend/manager/sokovan/deployment/route/coordinator.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/coordinator.py
@@ -39,6 +39,7 @@ from ai.backend.manager.sokovan.deployment.route.handlers import (
     RouteHandler,
     ServiceDiscoverySyncHandler,
     TerminatingRouteHandler,
+    WarmingUpRouteHandler,
 )
 from ai.backend.manager.sokovan.deployment.route.handlers.observer import (
     RouteHealthObserver,
@@ -147,6 +148,10 @@ class RouteCoordinator:
                 route_executor=executor,
                 event_producer=self._event_producer,
             ),
+            RouteLifecycleType.WARMING_UP: WarmingUpRouteHandler(
+                route_executor=executor,
+                event_producer=self._event_producer,
+            ),
             RouteLifecycleType.RUNNING: RunningRouteHandler(
                 route_executor=executor,
                 event_producer=self._event_producer,
@@ -240,7 +245,10 @@ class RouteCoordinator:
                 querier=BatchQuerier(
                     pagination=NoPagination(),
                     conditions=[
-                        RouteConditions.by_lifecycle_statuses([RouteStatus.RUNNING]),
+                        RouteConditions.by_lifecycle_statuses([
+                            RouteStatus.WARMING_UP,
+                            RouteStatus.RUNNING,
+                        ]),
                         RouteConditions.by_health_statuses(list(RouteHealthStatus)),
                     ],
                 ),
@@ -390,14 +398,16 @@ class RouteCoordinator:
                 batch_updaters, BulkCreator(specs=all_history_specs)
             )
 
-        # Record running_at in Valkey for routes that just transitioned to RUNNING
-        if (
-            transitions.success is not None
-            and transitions.success.status == RouteStatus.RUNNING
-            and result.successes
-        ):
-            for route in result.successes:
-                await self._valkey_schedule.mark_route_running_at(str(route.route_id))
+        # Stamp lifecycle transition timestamps in Valkey: warming_up_at
+        # anchors the health-probe initial_delay window (model loading
+        # happens during WARMING_UP); running_at marks the moment the
+        # first health gate passed and the route is eligible for traffic.
+        if transitions.success is not None and result.successes:
+            success_route_ids = [str(route.route_id) for route in result.successes]
+            if transitions.success.status == RouteStatus.WARMING_UP:
+                await self._valkey_schedule.mark_routes_warming_up_at_batch(success_route_ids)
+            elif transitions.success.status == RouteStatus.RUNNING:
+                await self._valkey_schedule.mark_routes_running_at_batch(success_route_ids)
 
     async def process_if_needed(self, lifecycle_type: RouteLifecycleType) -> None:
         """
@@ -421,6 +431,13 @@ class RouteCoordinator:
             # Provision routes frequently with both short and long cycles
             RouteTaskSpec(
                 RouteLifecycleType.PROVISIONING,
+                short_interval=5.0,
+                long_interval=60.0,
+                initial_delay=10.0,
+            ),
+            # Promote warming-up routes once their first health gate passes.
+            RouteTaskSpec(
+                RouteLifecycleType.WARMING_UP,
                 short_interval=5.0,
                 long_interval=60.0,
                 initial_delay=10.0,

--- a/src/ai/backend/manager/sokovan/deployment/route/executor.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/executor.py
@@ -9,6 +9,7 @@ from ai.backend.common.clients.valkey_client.valkey_schedule import (
     RouteHealthRecord,
     ValkeyScheduleClient,
 )
+from ai.backend.common.config import ModelHealthCheck
 from ai.backend.common.dto.appproxy_coordinator.v2.endpoint.request import (
     BulkRegisterRoutesRequest,
     BulkUnregisterRoutesRequest,
@@ -32,6 +33,7 @@ from ai.backend.manager.clients.appproxy.client import AppProxyClientPool
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.deployment.types import (
     DeploymentInfo,
+    ReplicaConnectionInfo,
     RouteHealthStatus,
     RouteStatus,
     RouteTrafficStatus,
@@ -222,26 +224,36 @@ class RouteExecutor:
         """Decide which warming-up routes are ready to graduate to RUNNING.
 
         1. Verify session liveness; dead sessions go to FAILED_TO_START.
-        2. Populate replica info and ensure a Valkey health record exists.
-        3. Classify readiness: ready if health check is disabled or a
-           probe has succeeded; otherwise leave for the next cycle.
+        2. Populate replica info for routes whose kernel just came up.
+        3. Health-disabled routes with replica info graduate immediately;
+           health-enabled routes need a Valkey probe pass first.
         """
         if not routes:
             return RouteExecutionResult(successes=[], errors=[])
 
-        # Phase 1: Verify session liveness
         with RouteRecorderContext.shared_phase("load_status"):
-            with RouteRecorderContext.shared_step("load_session_status"):
-                route_ids = {route.route_id for route in routes}
-                session_statuses = await self._deployment_repo.fetch_session_statuses_by_route_ids(
-                    route_ids
+            with RouteRecorderContext.shared_step("load_warming_up_bundle"):
+                session_ids = [r.session_id for r in routes if r.session_id is not None]
+                revision_ids = {r.revision_id for r in routes}
+                bundle = await self._deployment_repo.fetch_warming_up_route_bundle(
+                    session_ids=session_ids,
+                    revision_ids=revision_ids,
                 )
 
+        # Phase 1: Verify session liveness
+        session_statuses_by_route_id: dict[UUID, SessionStatus | None] = {
+            route.route_id: (
+                bundle.session_statuses.get(route.session_id)
+                if route.session_id is not None
+                else None
+            )
+            for route in routes
+        }
         alive: list[RouteData] = []
         errors: list[RouteExecutionError] = []
         for route in routes:
             try:
-                self._verify_route_session_status(route, session_statuses)
+                self._verify_route_session_status(route, session_statuses_by_route_id)
                 alive.append(route)
             except (RouteSessionNotFound, RouteSessionTerminated) as e:
                 log.debug("Warming-up route {} session check failed: {}", route.route_id, e)
@@ -254,60 +266,72 @@ class RouteExecutor:
                     )
                 )
 
+        alive_health_disabled: list[RouteData] = []
+        alive_health_enabled: list[RouteData] = []
+        routes_missing_replica: list[RouteData] = []
+        for route in alive:
+            if route.replica_host is None or route.replica_port is None:
+                routes_missing_replica.append(route)
+            if bundle.health_check_configs.get(route.revision_id) is None:
+                alive_health_disabled.append(route)
+            else:
+                alive_health_enabled.append(route)
+
         # Phase 2: Populate replica info for routes missing it
-        routes_missing_replica = [r for r in alive if not r.replica_host or not r.replica_port]
         if routes_missing_replica:
             with RouteRecorderContext.shared_phase("populate_replica_info"):
                 with RouteRecorderContext.shared_step("fetch_kernel_connection_info"):
-                    await self._populate_replica_info(routes_missing_replica)
+                    await self._populate_replica_info(
+                        routes_missing_replica, bundle.kernel_connection_info
+                    )
 
-        # Phase 3: Ensure health records exist for routes with replica info
-        routes_with_replica = [r for r in alive if r.replica_host and r.replica_port]
-        if routes_with_replica:
-            await self._ensure_health_records(routes_with_replica)
+        # Phase 3: Graduate ready routes. Health-disabled routes are
+        # ready as soon as they have replica info; health-enabled routes
+        # need a Valkey health record and a passing probe first.
+        successes: list[RouteData] = [
+            r for r in alive_health_disabled if r.replica_host and r.replica_port
+        ]
+        health_enabled_with_replica = [
+            r for r in alive_health_enabled if r.replica_host and r.replica_port
+        ]
+        if health_enabled_with_replica:
+            await self._ensure_health_records(
+                health_enabled_with_replica, bundle.health_check_configs
+            )
+            ready_routes = await self._pick_ready_warming_up_routes(health_enabled_with_replica)
+            successes.extend(ready_routes)
 
-        # Phase 4: Pick out routes that have cleared their first health gate
-        successes = await self._classify_warming_up_routes(alive)
+        if successes:
+            await self._valkey_schedule.mark_routes_running_at_batch([
+                str(r.route_id) for r in successes
+            ])
 
         return RouteExecutionResult(successes=successes, errors=errors)
 
-    async def _classify_warming_up_routes(
+    async def _pick_ready_warming_up_routes(
         self,
         routes: Sequence[RouteData],
     ) -> list[RouteData]:
-        """Return routes that have cleared the first health gate."""
+        """Return routes whose first health probe has passed.
+
+        The caller (``check_warming_up_routes``) pre-filters to routes
+        whose revision has a non-null health-check config and whose
+        replica info is populated, so this method only consults the
+        Valkey probe record per route.
+        """
         if not routes:
             return []
 
-        revision_ids = {route.revision_id for route in routes}
-        health_configs = await self._deployment_repo.fetch_health_check_configs_by_revision_ids(
-            revision_ids
-        )
-
+        probe_ids = [str(r.route_id) for r in routes]
+        records = await self._valkey_schedule.get_route_health_records_batch(probe_ids)
+        current_time = await self._valkey_schedule.get_redis_time()
         ready: list[RouteData] = []
-        needs_probe: list[RouteData] = []
         for route in routes:
-            if route.revision_id not in health_configs:
-                # Revision row vanished between fetch and classify — leave the
-                # route in WARMING_UP so route_eviction can clean it up rather
-                # than promoting an orphan to RUNNING.
+            record = records.get(str(route.route_id))
+            if record is None:
                 continue
-            if health_configs[route.revision_id] is None:
-                # Endpoint opted out of health checks — accept immediately.
+            if record.last_check > 0 and not record.is_stale(current_time) and record.healthy:
                 ready.append(route)
-            else:
-                needs_probe.append(route)
-
-        if needs_probe:
-            probe_ids = [str(r.route_id) for r in needs_probe]
-            records = await self._valkey_schedule.get_route_health_records_batch(probe_ids)
-            current_time = await self._valkey_schedule.get_redis_time()
-            for route in needs_probe:
-                record = records.get(str(route.route_id))
-                if record is None:
-                    continue
-                if record.last_check > 0 and not record.is_stale(current_time) and record.healthy:
-                    ready.append(route)
 
         return ready
 
@@ -345,29 +369,30 @@ class RouteExecutor:
             errors=errors,
         )
 
-    async def _populate_replica_info(self, routes: Sequence[RouteData]) -> None:
-        """Fetch kernel host/port, store on route, and initialize RouteHealthRecords in Valkey."""
-        session_ids = [r.session_id for r in routes if r.session_id]
-        if not session_ids:
+    async def _populate_replica_info(
+        self,
+        routes: Sequence[RouteData],
+        kernel_info: Mapping[SessionId, ReplicaConnectionInfo],
+    ) -> None:
+        """Write fetched kernel host/port back to ``routings`` for routes whose kernel just came up."""
+        if not routes:
             return
 
-        kernel_info = await self._deployment_repo.fetch_kernel_connection_info(session_ids)
         updates: dict[UUID, tuple[str, int]] = {}
-        populated_routes: list[RouteData] = []
         for route in routes:
             if route.session_id and route.session_id in kernel_info:
                 info = kernel_info[route.session_id]
-                if info[0] and info[1]:
-                    updates[route.route_id] = info
-                    populated_routes.append(route)
+                if info.host and info.port:
+                    updates[route.route_id] = (info.host, info.port)
 
         if updates:
             await self._deployment_repo.update_route_replica_info(updates)
 
-        if populated_routes:
-            await self._initialize_health_records(populated_routes, updates)
-
-    async def _ensure_health_records(self, routes: Sequence[RouteData]) -> None:
+    async def _ensure_health_records(
+        self,
+        routes: Sequence[RouteData],
+        health_configs: Mapping[DeploymentRevisionID, ModelHealthCheck | None],
+    ) -> None:
         """Ensure RouteHealthRecords exist in Valkey for routes that already have replica info.
 
         Routes may already have replica_host/port in DB (set by a previous cycle or legacy code)
@@ -384,54 +409,44 @@ class RouteExecutor:
             [str(r.route_id)[:8] for r in missing],
         )
         replica_info = {
-            r.route_id: (r.replica_host, r.replica_port)
+            r.route_id: ReplicaConnectionInfo(host=r.replica_host, port=r.replica_port)
             for r in missing
             if r.replica_host and r.replica_port
         }
-        await self._initialize_health_records(missing, replica_info)
+        await self._initialize_health_records(missing, replica_info, health_configs)
 
     async def _initialize_health_records(
         self,
         routes: Sequence[RouteData],
-        replica_info: Mapping[UUID, tuple[str, int]],
+        replica_info: Mapping[UUID, ReplicaConnectionInfo],
+        health_configs: Mapping[DeploymentRevisionID, ModelHealthCheck | None],
     ) -> None:
-        """Create RouteHealthRecords in Valkey for routes that just got replica info."""
-        revision_ids = {r.revision_id for r in routes}
-        health_configs = await self._deployment_repo.fetch_health_check_configs_by_revision_ids(
-            revision_ids
-        )
-        redis_time = await self._valkey_schedule.get_redis_time()
+        """Create RouteHealthRecords in Valkey for routes that just got replica info.
 
-        # Anchor initial_delay on warming_up_at — model loading happens
-        # during WARMING_UP, so the grace window starts at WARMING_UP entry.
-        # Falls back to current redis_time if the marker is missing (e.g.
-        # legacy routes from before the WARMING_UP split).
-        warming_up_at_map = await self._valkey_schedule.get_route_warming_up_at_batch([
-            str(r.route_id) for r in routes
-        ])
+        ``initial_delay_until`` is anchored at the current redis time —
+        i.e. the moment the record is initialised. Probe failures before
+        ``initial_delay_until`` are ignored by the observer, giving the
+        model time to warm up.
+        """
+        redis_time = await self._valkey_schedule.get_redis_time()
 
         records: list[RouteHealthRecord] = []
         for route in routes:
-            host, port = replica_info[route.route_id]
+            info = replica_info[route.route_id]
             health_config = health_configs.get(route.revision_id)
 
             health_path = health_config.path if health_config else "/"
             initial_delay = health_config.initial_delay if health_config else 60.0
             created_at = int(route.created_at.timestamp())
 
-            route_id_str = str(route.route_id)
-            warming_up_at = warming_up_at_map.get(route_id_str) or redis_time
-            initial_delay_until = warming_up_at + int(initial_delay)
-
             records.append(
                 RouteHealthRecord(
-                    route_id=route_id_str,
+                    route_id=str(route.route_id),
                     created_at=created_at,
-                    initial_delay_until=initial_delay_until,
+                    initial_delay_until=redis_time + int(initial_delay),
                     health_path=health_path,
-                    inference_port=port,
-                    replica_host=host,
-                    warming_up_at=warming_up_at,
+                    inference_port=info.port,
+                    replica_host=info.host,
                 )
             )
 

--- a/src/ai/backend/manager/sokovan/deployment/route/executor.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/executor.py
@@ -2,7 +2,6 @@
 
 import logging
 from collections.abc import Mapping, Sequence
-from typing import Any
 from uuid import UUID
 
 from ai.backend.common.clients.http_client.client_pool import ClientPool
@@ -37,6 +36,7 @@ from ai.backend.manager.data.deployment.types import (
     RouteStatus,
     RouteTrafficStatus,
 )
+from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.errors.deployment import (
     EndpointNotFound,
     RouteSessionNotFound,
@@ -218,16 +218,102 @@ class RouteExecutor:
             errors=[],
         )
 
-    async def check_running_routes(self, routes: Sequence[RouteData]) -> RouteExecutionResult:
-        """Check health status of running routes.
+    async def check_warming_up_routes(self, routes: Sequence[RouteData]) -> RouteExecutionResult:
+        """Decide which warming-up routes are ready to graduate to RUNNING.
 
-        Args:
-            routes: Routes to check (should be HEALTHY or UNHEALTHY status)
-
-        Returns:
-            Result containing routes with updated health status
+        1. Verify session liveness; dead sessions go to FAILED_TO_START.
+        2. Populate replica info and ensure a Valkey health record exists.
+        3. Classify readiness: ready if health check is disabled or a
+           probe has succeeded; otherwise leave for the next cycle.
         """
-        # Phase 1: Load status
+        if not routes:
+            return RouteExecutionResult(successes=[], errors=[])
+
+        # Phase 1: Verify session liveness
+        with RouteRecorderContext.shared_phase("load_status"):
+            with RouteRecorderContext.shared_step("load_session_status"):
+                route_ids = {route.route_id for route in routes}
+                session_statuses = await self._deployment_repo.fetch_session_statuses_by_route_ids(
+                    route_ids
+                )
+
+        alive: list[RouteData] = []
+        errors: list[RouteExecutionError] = []
+        for route in routes:
+            try:
+                self._verify_route_session_status(route, session_statuses)
+                alive.append(route)
+            except (RouteSessionNotFound, RouteSessionTerminated) as e:
+                log.debug("Warming-up route {} session check failed: {}", route.route_id, e)
+                errors.append(
+                    RouteExecutionError(
+                        route_info=route,
+                        reason=e.error_title,
+                        error_detail=str(e),
+                        error_code=_extract_error_code(e),
+                    )
+                )
+
+        # Phase 2: Populate replica info for routes missing it
+        routes_missing_replica = [r for r in alive if not r.replica_host or not r.replica_port]
+        if routes_missing_replica:
+            with RouteRecorderContext.shared_phase("populate_replica_info"):
+                with RouteRecorderContext.shared_step("fetch_kernel_connection_info"):
+                    await self._populate_replica_info(routes_missing_replica)
+
+        # Phase 3: Ensure health records exist for routes with replica info
+        routes_with_replica = [r for r in alive if r.replica_host and r.replica_port]
+        if routes_with_replica:
+            await self._ensure_health_records(routes_with_replica)
+
+        # Phase 4: Pick out routes that have cleared their first health gate
+        successes = await self._classify_warming_up_routes(alive)
+
+        return RouteExecutionResult(successes=successes, errors=errors)
+
+    async def _classify_warming_up_routes(
+        self,
+        routes: Sequence[RouteData],
+    ) -> list[RouteData]:
+        """Return routes that have cleared the first health gate."""
+        if not routes:
+            return []
+
+        revision_ids = {route.revision_id for route in routes}
+        health_configs = await self._deployment_repo.fetch_health_check_configs_by_revision_ids(
+            revision_ids
+        )
+
+        ready: list[RouteData] = []
+        needs_probe: list[RouteData] = []
+        for route in routes:
+            if route.revision_id not in health_configs:
+                # Revision row vanished between fetch and classify — leave the
+                # route in WARMING_UP so route_eviction can clean it up rather
+                # than promoting an orphan to RUNNING.
+                continue
+            if health_configs[route.revision_id] is None:
+                # Endpoint opted out of health checks — accept immediately.
+                ready.append(route)
+            else:
+                needs_probe.append(route)
+
+        if needs_probe:
+            probe_ids = [str(r.route_id) for r in needs_probe]
+            records = await self._valkey_schedule.get_route_health_records_batch(probe_ids)
+            current_time = await self._valkey_schedule.get_redis_time()
+            for route in needs_probe:
+                record = records.get(str(route.route_id))
+                if record is None:
+                    continue
+                if record.last_check > 0 and not record.is_stale(current_time) and record.healthy:
+                    ready.append(route)
+
+        return ready
+
+    async def check_running_routes(self, routes: Sequence[RouteData]) -> RouteExecutionResult:
+        """Verify RUNNING routes still have a live session; failures move to TERMINATING."""
+        # Phase 1: Load session statuses
         with RouteRecorderContext.shared_phase("load_status"):
             with RouteRecorderContext.shared_step("load_session_status"):
                 route_ids = {route.route_id for route in routes}
@@ -238,7 +324,7 @@ class RouteExecutor:
         successes: list[RouteData] = []
         errors: list[RouteExecutionError] = []
 
-        # Phase 2: Verify status (per-route)
+        # Phase 2: Verify each session is still alive
         for route in routes:
             try:
                 self._verify_route_session_status(route, session_statuses)
@@ -253,18 +339,6 @@ class RouteExecutor:
                         error_code=_extract_error_code(e),
                     )
                 )
-
-        # Phase 3: Populate replica connection info for routes missing it
-        routes_missing_replica = [r for r in successes if not r.replica_host]
-        if routes_missing_replica:
-            with RouteRecorderContext.shared_phase("populate_replica_info"):
-                with RouteRecorderContext.shared_step("fetch_kernel_connection_info"):
-                    await self._populate_replica_info(routes_missing_replica)
-
-        # Phase 4: Ensure RouteHealthRecords exist in Valkey for routes with replica info
-        routes_with_replica = [r for r in successes if r.replica_host and r.replica_port]
-        if routes_with_replica:
-            await self._ensure_health_records(routes_with_replica)
 
         return RouteExecutionResult(
             successes=successes,
@@ -328,9 +402,11 @@ class RouteExecutor:
         )
         redis_time = await self._valkey_schedule.get_redis_time()
 
-        # Read existing running_at values that were set when routes transitioned to RUNNING
-        # These may be in partial hashes (only running_at field), so read raw field directly
-        running_at_map = await self._valkey_schedule.get_route_running_at_batch([
+        # Anchor initial_delay on warming_up_at — model loading happens
+        # during WARMING_UP, so the grace window starts at WARMING_UP entry.
+        # Falls back to current redis_time if the marker is missing (e.g.
+        # legacy routes from before the WARMING_UP split).
+        warming_up_at_map = await self._valkey_schedule.get_route_warming_up_at_batch([
             str(r.route_id) for r in routes
         ])
 
@@ -343,10 +419,9 @@ class RouteExecutor:
             initial_delay = health_config.initial_delay if health_config else 60.0
             created_at = int(route.created_at.timestamp())
 
-            # Use running_at from Valkey (set at RUNNING transition), fallback to redis_time
             route_id_str = str(route.route_id)
-            running_at = running_at_map.get(route_id_str) or redis_time
-            initial_delay_until = running_at + int(initial_delay)
+            warming_up_at = warming_up_at_map.get(route_id_str) or redis_time
+            initial_delay_until = warming_up_at + int(initial_delay)
 
             records.append(
                 RouteHealthRecord(
@@ -356,7 +431,7 @@ class RouteExecutor:
                     health_path=health_path,
                     inference_port=port,
                     replica_host=host,
-                    running_at=running_at,
+                    warming_up_at=warming_up_at,
                 )
             )
 
@@ -1065,7 +1140,7 @@ class RouteExecutor:
     def _verify_route_session_status(
         self,
         route: RouteData,
-        session_statuses: Mapping[UUID, Any],
+        session_statuses: Mapping[UUID, SessionStatus | None],
     ) -> None:
         """Verify that route's session is in a valid state."""
         pool = RouteRecorderContext.current_pool()

--- a/src/ai/backend/manager/sokovan/deployment/route/handlers/__init__.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/handlers/__init__.py
@@ -7,6 +7,7 @@ from .provisioning import ProvisioningRouteHandler
 from .route_eviction import RouteEvictionHandler
 from .service_discovery_sync import ServiceDiscoverySyncHandler
 from .terminating import TerminatingRouteHandler
+from .warming_up import WarmingUpRouteHandler
 
 __all__ = [
     "AppProxySyncRouteHandler",
@@ -16,4 +17,5 @@ __all__ = [
     "RouteHandler",
     "ServiceDiscoverySyncHandler",
     "TerminatingRouteHandler",
+    "WarmingUpRouteHandler",
 ]

--- a/src/ai/backend/manager/sokovan/deployment/route/handlers/route_eviction.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/handlers/route_eviction.py
@@ -31,10 +31,11 @@ class RouteEvictionHandler(RouteHandler):
 
     - **Health-based**: a RUNNING route whose health status is listed in
       the scaling group's ``cleanup_target_statuses`` (default: UNHEALTHY).
-    - **Orphan revision**: an active (PROVISIONING / RUNNING) route whose
-      ``revision_id`` belongs to neither the endpoint's ``current_revision``
-      nor its ``deploying_revision``. This catches leftovers from a
-      preempted rollout, regardless of endpoint lifecycle.
+    - **Orphan revision**: an active (PROVISIONING / WARMING_UP / RUNNING)
+      route whose ``revision_id`` belongs to neither the endpoint's
+      ``current_revision`` nor its ``deploying_revision``. This catches
+      leftovers from a preempted rollout, regardless of endpoint
+      lifecycle.
     """
 
     def __init__(
@@ -61,12 +62,17 @@ class RouteEvictionHandler(RouteHandler):
 
     @classmethod
     def target_statuses(cls) -> RouteTargetStatuses:
-        # The handler runs over every active route (PROVISIONING / RUNNING)
-        # regardless of health, because the orphan-revision check applies
-        # to both lifecycle states. The scaling-group health policy still
-        # filters to UNHEALTHY internally inside the executor.
+        # The handler runs over every active route
+        # (PROVISIONING / WARMING_UP / RUNNING) regardless of health,
+        # because the orphan-revision check applies to all alive lifecycle
+        # states. The scaling-group health policy still filters to
+        # UNHEALTHY internally inside the executor.
         return RouteTargetStatuses(
-            lifecycle=[RouteStatus.PROVISIONING, RouteStatus.RUNNING],
+            lifecycle=[
+                RouteStatus.PROVISIONING,
+                RouteStatus.WARMING_UP,
+                RouteStatus.RUNNING,
+            ],
             health=list(RouteHealthStatus),
         )
 

--- a/src/ai/backend/manager/sokovan/deployment/route/handlers/warming_up.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/handlers/warming_up.py
@@ -1,4 +1,4 @@
-"""Handler for provisioning routes."""
+"""Handler for warming-up routes (first health check gate)."""
 
 import logging
 from collections.abc import Sequence
@@ -23,8 +23,23 @@ from .base import RouteHandler
 log = BraceStyleAdapter(logging.getLogger(__name__))
 
 
-class ProvisioningRouteHandler(RouteHandler):
-    """Handler for provisioning routes (PROVISIONING -> WARMING_UP)."""
+class WarmingUpRouteHandler(RouteHandler):
+    """Handler for warming-up routes (WARMING_UP -> RUNNING).
+
+    A route enters WARMING_UP after its session has been provisioned but
+    before traffic is allowed in. This handler decides when the route is
+    ready to graduate:
+
+    - When the endpoint has no health check configured, the route is
+      considered ready as soon as its session is alive.
+    - Otherwise, the route is held in WARMING_UP until the first healthy
+      probe is observed in Valkey (written by ``RouteHealthObserver``).
+
+    On readiness the route transitions to ``RUNNING`` + ``HEALTHY`` so
+    the next ``AppProxySyncRouteHandler`` cycle picks it up for traffic
+    routing. Sessions that died before becoming healthy fail to
+    ``FAILED_TO_START``.
+    """
 
     def __init__(
         self,
@@ -36,13 +51,11 @@ class ProvisioningRouteHandler(RouteHandler):
 
     @classmethod
     def name(cls) -> str:
-        """Get the name of the handler."""
-        return "provision-routes"
+        return "warming-up-routes"
 
     @property
     def lock_id(self) -> LockID | None:
-        """Lock for provisioning routes."""
-        return LockID.LOCKID_DEPLOYMENT_PROVISIONING_ROUTES
+        return LockID.LOCKID_DEPLOYMENT_WARMING_UP_ROUTES
 
     @classmethod
     def category(cls) -> RouteHandlerCategory:
@@ -51,38 +64,31 @@ class ProvisioningRouteHandler(RouteHandler):
     @classmethod
     def target_statuses(cls) -> RouteTargetStatuses:
         return RouteTargetStatuses(
-            lifecycle=[RouteStatus.PROVISIONING],
+            lifecycle=[RouteStatus.WARMING_UP],
             health=list(RouteHealthStatus),
         )
 
     @classmethod
     def status_transitions(cls) -> RouteStatusTransitions:
-        """Provisioning → WARMING_UP + NOT_CHECKED on success, FAILED_TO_START on failure.
-
-        WARMING_UP holds the route until the dedicated warming-up handler
-        observes the first healthy probe (or accepts immediately when the
-        endpoint has no health check configured).
-        """
         return RouteStatusTransitions(
             success=RouteTransitionTarget(
-                status=RouteStatus.WARMING_UP,
+                status=RouteStatus.RUNNING,
+                health_status=RouteHealthStatus.HEALTHY,
+            ),
+            failure=RouteTransitionTarget(
+                status=RouteStatus.FAILED_TO_START,
                 health_status=RouteHealthStatus.NOT_CHECKED,
             ),
-            failure=RouteTransitionTarget(status=RouteStatus.FAILED_TO_START),
             stale=None,
         )
 
     async def execute(self, routes: Sequence[RouteData]) -> RouteExecutionResult:
-        """Execute provisioning for routes."""
-        log.debug("Provisioning {} routes", len(routes))
-
-        # Execute route provisioning logic via executor
-        return await self._route_executor.provision_routes(routes)
+        log.debug("Evaluating {} warming-up routes", len(routes))
+        return await self._route_executor.check_warming_up_routes(routes)
 
     async def post_process(self, result: RouteExecutionResult) -> None:
-        """Handle post-processing after provisioning routes."""
         log.info(
-            "Provisioned {} routes successfully, {} failed",
+            "Warming-up: {} promoted to RUNNING, {} failed",
             len(result.successes),
             len(result.errors),
         )

--- a/src/ai/backend/manager/sokovan/deployment/route/types.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/types.py
@@ -10,6 +10,7 @@ class RouteLifecycleType(StrEnum):
     """Types of route lifecycle operations."""
 
     PROVISIONING = "provisioning"
+    WARMING_UP = "warming_up"
     RUNNING = "running"
     HEALTH_CHECK = "health_check"
     ROUTE_EVICTION = "route_eviction"

--- a/src/ai/backend/manager/sokovan/deployment/strategy/rolling_update.py
+++ b/src/ai/backend/manager/sokovan/deployment/strategy/rolling_update.py
@@ -124,7 +124,11 @@ class RollingUpdateStrategy(AbstractDeploymentStrategy):
                     classified.old_active.append(route)
                 continue
 
-            if route.status == RouteStatus.PROVISIONING:
+            if route.status in RouteStatus.pre_running_statuses():
+                # Routes still in PROVISIONING / WARMING_UP are alive but not
+                # yet eligible to serve traffic; bucket them with the
+                # provisioning count so the strategy waits for them before
+                # counting capacity as healthy.
                 classified.new_provisioning_count += 1
             elif route.status.is_inactive():
                 classified.new_failed_count += 1

--- a/src/ai/backend/manager/sokovan/deployment/types.py
+++ b/src/ai/backend/manager/sokovan/deployment/types.py
@@ -108,7 +108,7 @@ class RouteCreationSpec:
         return sum(
             1
             for route in deployment_with_routes.routes
-            if route.status in {RouteStatus.RUNNING, RouteStatus.PROVISIONING}
+            if route.status in RouteStatus.active_route_statuses()
         )
 
     @staticmethod
@@ -119,7 +119,7 @@ class RouteCreationSpec:
         healthy_routes = [
             r
             for r in deployment_with_routes.routes
-            if r.status in {RouteStatus.RUNNING, RouteStatus.PROVISIONING}
+            if r.status in RouteStatus.active_route_statuses()
         ]
         current_count = len(healthy_routes)
         if current_count <= target_count:

--- a/tests/unit/manager/sokovan/deployment/route/executor/test_check_warming_up_routes.py
+++ b/tests/unit/manager/sokovan/deployment/route/executor/test_check_warming_up_routes.py
@@ -7,11 +7,14 @@ Covers the WARMING_UP graduation pipeline:
 - WU-004: dead session → in errors (handler maps to FAILED_TO_START)
 - WU-005: revision row vanished → not promoted (left for route_eviction)
 - WU-006: empty route list → empty result
+- WU-007: health-disabled route without replica info → stays
 """
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -22,7 +25,12 @@ from ai.backend.common.config import ModelHealthCheck
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
 from ai.backend.common.types import SessionId
-from ai.backend.manager.data.deployment.types import RouteHealthStatus, RouteStatus
+from ai.backend.manager.data.deployment.types import (
+    ReplicaConnectionInfo,
+    RouteHealthStatus,
+    RouteStatus,
+    WarmingUpRouteReadBundle,
+)
 from ai.backend.manager.repositories.deployment.types import RouteData
 from ai.backend.manager.sokovan.deployment.route.executor import RouteExecutor
 from ai.backend.manager.sokovan.deployment.route.recorder.context import RouteRecorderContext
@@ -31,34 +39,26 @@ from ai.backend.manager.sokovan.deployment.route.recorder.context import RouteRe
 def _warming_up_route(
     *,
     revision_id: DeploymentRevisionID | None = None,
-) -> RouteData:
-    """WARMING_UP route with replica info pre-populated."""
-    return RouteData(
+    with_replica: bool = True,
+) -> tuple[RouteData, SessionId]:
+    """WARMING_UP route + its session id (returned separately so callers
+    can use the typed ``SessionId`` as a dict key without re-narrowing
+    the ``SessionId | None`` field on ``RouteData``).
+    """
+    session_id = SessionId(uuid4())
+    route = RouteData(
         route_id=uuid4(),
         deployment_id=DeploymentID(uuid4()),
-        session_id=SessionId(uuid4()),
+        session_id=session_id,
         status=RouteStatus.WARMING_UP,
         health_status=RouteHealthStatus.NOT_CHECKED,
         traffic_ratio=1.0,
         created_at=datetime.now(tzutc()),
         revision_id=revision_id or DeploymentRevisionID(uuid4()),
-        replica_host="10.0.0.1",
-        replica_port=8000,
+        replica_host="10.0.0.1" if with_replica else None,
+        replica_port=8000 if with_replica else None,
     )
-
-
-def _live_session_status() -> MagicMock:
-    status = MagicMock()
-    status.is_terminal = MagicMock(return_value=False)
-    status.value = "RUNNING"
-    return status
-
-
-def _terminal_session_status() -> MagicMock:
-    status = MagicMock()
-    status.is_terminal = MagicMock(return_value=True)
-    status.value = "TERMINATED"
-    return status
+    return route, session_id
 
 
 def _stub_health_record(
@@ -80,13 +80,19 @@ def _stub_health_record(
     )
 
 
-def _wire_live_session(
+def _wire_bundle(
     mock_deployment_repo: AsyncMock,
-    routes: list[RouteData],
+    *,
+    session_statuses: Mapping[SessionId, Any],
+    kernel_connection_info: Mapping[SessionId, ReplicaConnectionInfo] | None = None,
+    health_check_configs: Mapping[DeploymentRevisionID, ModelHealthCheck | None] | None = None,
 ) -> None:
-    mock_deployment_repo.fetch_session_statuses_by_route_ids.return_value = {
-        r.route_id: _live_session_status() for r in routes
-    }
+    """Wire ``fetch_warming_up_route_bundle`` to return a pre-built bundle."""
+    mock_deployment_repo.fetch_warming_up_route_bundle.return_value = WarmingUpRouteReadBundle(
+        session_statuses=dict(session_statuses),
+        kernel_connection_info=dict(kernel_connection_info or {}),
+        health_check_configs=dict(health_check_configs or {}),
+    )
 
 
 class TestCheckWarmingUpRoutes:
@@ -102,22 +108,28 @@ class TestCheckWarmingUpRoutes:
 
         assert result.successes == []
         assert result.errors == []
-        mock_deployment_repo.fetch_session_statuses_by_route_ids.assert_not_awaited()
+        mock_deployment_repo.fetch_warming_up_route_bundle.assert_not_awaited()
 
     async def test_health_check_disabled_promotes_immediately(
         self,
         route_executor: RouteExecutor,
         mock_deployment_repo: AsyncMock,
         mock_valkey_schedule: AsyncMock,
+        session_status_running: MagicMock,
     ) -> None:
-        """WU-001: Endpoint with no health_check config → ready in the first cycle."""
-        route = _warming_up_route()
-        _wire_live_session(mock_deployment_repo, [route])
+        """WU-001: Endpoint with no health_check config → ready in the first cycle.
+
+        Promoted routes get ``running_at`` stamped in Valkey inside
+        ``check_warming_up_routes`` itself (not in handler post_process).
+        """
+        route, session_id = _warming_up_route()
+        _wire_bundle(
+            mock_deployment_repo,
+            session_statuses={session_id: session_status_running},
+            health_check_configs={route.revision_id: None},
+        )
         mock_valkey_schedule.get_route_health_records_batch.return_value = {
             str(route.route_id): _stub_health_record(route),
-        }
-        mock_deployment_repo.fetch_health_check_configs_by_revision_ids.return_value = {
-            route.revision_id: None,
         }
 
         with RouteRecorderContext.scope("test", entity_ids=[route.route_id]):
@@ -125,19 +137,26 @@ class TestCheckWarmingUpRoutes:
 
         assert [r.route_id for r in result.successes] == [route.route_id]
         assert result.errors == []
+        mock_valkey_schedule.mark_routes_running_at_batch.assert_awaited_once_with([
+            str(route.route_id)
+        ])
 
     async def test_health_enabled_and_probe_passed_promotes(
         self,
         route_executor: RouteExecutor,
         mock_deployment_repo: AsyncMock,
         mock_valkey_schedule: AsyncMock,
+        session_status_running: MagicMock,
     ) -> None:
         """WU-002: Health enabled and a passing probe is recorded → ready."""
-        route = _warming_up_route()
-        _wire_live_session(mock_deployment_repo, [route])
-        mock_deployment_repo.fetch_health_check_configs_by_revision_ids.return_value = {
-            route.revision_id: ModelHealthCheck(path="/health", initial_delay=60.0),
-        }
+        route, session_id = _warming_up_route()
+        _wire_bundle(
+            mock_deployment_repo,
+            session_statuses={session_id: session_status_running},
+            health_check_configs={
+                route.revision_id: ModelHealthCheck(path="/health", initial_delay=60.0),
+            },
+        )
 
         current_time = 5000
         passing_record = _stub_health_record(
@@ -161,13 +180,17 @@ class TestCheckWarmingUpRoutes:
         route_executor: RouteExecutor,
         mock_deployment_repo: AsyncMock,
         mock_valkey_schedule: AsyncMock,
+        session_status_running: MagicMock,
     ) -> None:
         """WU-003: Health enabled but no probe yet → not promoted, no error."""
-        route = _warming_up_route()
-        _wire_live_session(mock_deployment_repo, [route])
-        mock_deployment_repo.fetch_health_check_configs_by_revision_ids.return_value = {
-            route.revision_id: ModelHealthCheck(path="/health", initial_delay=60.0),
-        }
+        route, session_id = _warming_up_route()
+        _wire_bundle(
+            mock_deployment_repo,
+            session_statuses={session_id: session_status_running},
+            health_check_configs={
+                route.revision_id: ModelHealthCheck(path="/health", initial_delay=60.0),
+            },
+        )
         # Health record exists but no probe has run (last_check=0).
         mock_valkey_schedule.get_route_health_records_batch.return_value = {
             str(route.route_id): _stub_health_record(route),
@@ -184,12 +207,14 @@ class TestCheckWarmingUpRoutes:
         self,
         route_executor: RouteExecutor,
         mock_deployment_repo: AsyncMock,
+        session_status_terminated: MagicMock,
     ) -> None:
         """WU-004: Terminal session yields an error so the handler can fail to FAILED_TO_START."""
-        route = _warming_up_route()
-        mock_deployment_repo.fetch_session_statuses_by_route_ids.return_value = {
-            route.route_id: _terminal_session_status(),
-        }
+        route, session_id = _warming_up_route()
+        _wire_bundle(
+            mock_deployment_repo,
+            session_statuses={session_id: session_status_terminated},
+        )
 
         with RouteRecorderContext.scope("test", entity_ids=[route.route_id]):
             result = await route_executor.check_warming_up_routes([route])
@@ -198,20 +223,46 @@ class TestCheckWarmingUpRoutes:
         assert len(result.errors) == 1
         assert result.errors[0].route_info.route_id == route.route_id
 
-    async def test_missing_revision_is_skipped_not_promoted(
+    async def test_missing_revision_treated_as_health_disabled(
         self,
         route_executor: RouteExecutor,
         mock_deployment_repo: AsyncMock,
-        mock_valkey_schedule: AsyncMock,
+        session_status_running: MagicMock,
     ) -> None:
-        """WU-005: Revision row missing from health-config map → leave for route_eviction."""
-        route = _warming_up_route()
-        _wire_live_session(mock_deployment_repo, [route])
-        mock_valkey_schedule.get_route_health_records_batch.return_value = {
-            str(route.route_id): _stub_health_record(route),
-        }
-        # Repo returns an empty map (revision row vanished between fetch and classify).
-        mock_deployment_repo.fetch_health_check_configs_by_revision_ids.return_value = {}
+        """WU-005: Revision row missing → treated as health-disabled.
+
+        The orphan route is promoted to RUNNING in this cycle; the
+        ``route_eviction`` handler later removes it because its revision
+        is neither current nor deploying.
+        """
+        route, session_id = _warming_up_route()
+        _wire_bundle(
+            mock_deployment_repo,
+            session_statuses={session_id: session_status_running},
+            health_check_configs={},  # revision vanished between fetch and classify
+        )
+
+        with RouteRecorderContext.scope("test", entity_ids=[route.route_id]):
+            result = await route_executor.check_warming_up_routes([route])
+
+        assert [r.route_id for r in result.successes] == [route.route_id]
+        assert result.errors == []
+
+    async def test_health_disabled_route_without_replica_info_stays(
+        self,
+        route_executor: RouteExecutor,
+        mock_deployment_repo: AsyncMock,
+        session_status_running: MagicMock,
+    ) -> None:
+        """WU-007: A health-check-disabled route with no replica info must not be promoted."""
+        route, session_id = _warming_up_route(with_replica=False)
+        _wire_bundle(
+            mock_deployment_repo,
+            session_statuses={session_id: session_status_running},
+            # Kernel info empty → populate fails → replica_host stays None
+            kernel_connection_info={},
+            health_check_configs={route.revision_id: None},
+        )
 
         with RouteRecorderContext.scope("test", entity_ids=[route.route_id]):
             result = await route_executor.check_warming_up_routes([route])
@@ -224,19 +275,22 @@ class TestCheckWarmingUpRoutes:
         route_executor: RouteExecutor,
         mock_deployment_repo: AsyncMock,
         mock_valkey_schedule: AsyncMock,
+        session_status_running: MagicMock,
+        session_status_terminated: MagicMock,
     ) -> None:
         """A live + a dead route are classified into successes / errors respectively."""
-        live_route = _warming_up_route()
-        dead_route = _warming_up_route()
-        mock_deployment_repo.fetch_session_statuses_by_route_ids.return_value = {
-            live_route.route_id: _live_session_status(),
-            dead_route.route_id: _terminal_session_status(),
-        }
+        live_route, live_sid = _warming_up_route()
+        dead_route, dead_sid = _warming_up_route()
+        _wire_bundle(
+            mock_deployment_repo,
+            session_statuses={
+                live_sid: session_status_running,
+                dead_sid: session_status_terminated,
+            },
+            health_check_configs={live_route.revision_id: None},
+        )
         mock_valkey_schedule.get_route_health_records_batch.return_value = {
             str(live_route.route_id): _stub_health_record(live_route),
-        }
-        mock_deployment_repo.fetch_health_check_configs_by_revision_ids.return_value = {
-            live_route.revision_id: None,  # disabled → live route promotes
         }
 
         with RouteRecorderContext.scope(

--- a/tests/unit/manager/sokovan/deployment/route/executor/test_check_warming_up_routes.py
+++ b/tests/unit/manager/sokovan/deployment/route/executor/test_check_warming_up_routes.py
@@ -1,0 +1,248 @@
+"""Unit tests for ``RouteExecutor.check_warming_up_routes``.
+
+Covers the WARMING_UP graduation pipeline:
+- WU-001: health check disabled → ready immediately
+- WU-002: health check enabled & probe passed → ready
+- WU-003: health check enabled & probe missing/not yet passed → stays in WARMING_UP
+- WU-004: dead session → in errors (handler maps to FAILED_TO_START)
+- WU-005: revision row vanished → not promoted (left for route_eviction)
+- WU-006: empty route list → empty result
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+from dateutil.tz import tzutc
+
+from ai.backend.common.clients.valkey_client.valkey_schedule import RouteHealthRecord
+from ai.backend.common.config import ModelHealthCheck
+from ai.backend.common.identifier.deployment import DeploymentID
+from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
+from ai.backend.common.types import SessionId
+from ai.backend.manager.data.deployment.types import RouteHealthStatus, RouteStatus
+from ai.backend.manager.repositories.deployment.types import RouteData
+from ai.backend.manager.sokovan.deployment.route.executor import RouteExecutor
+from ai.backend.manager.sokovan.deployment.route.recorder.context import RouteRecorderContext
+
+
+def _warming_up_route(
+    *,
+    revision_id: DeploymentRevisionID | None = None,
+) -> RouteData:
+    """WARMING_UP route with replica info pre-populated."""
+    return RouteData(
+        route_id=uuid4(),
+        deployment_id=DeploymentID(uuid4()),
+        session_id=SessionId(uuid4()),
+        status=RouteStatus.WARMING_UP,
+        health_status=RouteHealthStatus.NOT_CHECKED,
+        traffic_ratio=1.0,
+        created_at=datetime.now(tzutc()),
+        revision_id=revision_id or DeploymentRevisionID(uuid4()),
+        replica_host="10.0.0.1",
+        replica_port=8000,
+    )
+
+
+def _live_session_status() -> MagicMock:
+    status = MagicMock()
+    status.is_terminal = MagicMock(return_value=False)
+    status.value = "RUNNING"
+    return status
+
+
+def _terminal_session_status() -> MagicMock:
+    status = MagicMock()
+    status.is_terminal = MagicMock(return_value=True)
+    status.value = "TERMINATED"
+    return status
+
+
+def _stub_health_record(
+    route: RouteData,
+    *,
+    agent_healthy: bool = False,
+    agent_last_check: int = 0,
+) -> RouteHealthRecord:
+    """Stub RouteHealthRecord so _ensure_health_records sees the record as present and skips re-init."""
+    return RouteHealthRecord(
+        route_id=str(route.route_id),
+        created_at=4900,
+        initial_delay_until=4960,
+        health_path="/health",
+        inference_port=8000,
+        replica_host="10.0.0.1",
+        agent_healthy=agent_healthy,
+        agent_last_check=agent_last_check,
+    )
+
+
+def _wire_live_session(
+    mock_deployment_repo: AsyncMock,
+    routes: list[RouteData],
+) -> None:
+    mock_deployment_repo.fetch_session_statuses_by_route_ids.return_value = {
+        r.route_id: _live_session_status() for r in routes
+    }
+
+
+class TestCheckWarmingUpRoutes:
+    """Tests for the WARMING_UP graduation pipeline."""
+
+    async def test_empty_input_returns_empty_result(
+        self,
+        route_executor: RouteExecutor,
+        mock_deployment_repo: AsyncMock,
+    ) -> None:
+        """WU-006: Empty route list short-circuits without touching the repo."""
+        result = await route_executor.check_warming_up_routes([])
+
+        assert result.successes == []
+        assert result.errors == []
+        mock_deployment_repo.fetch_session_statuses_by_route_ids.assert_not_awaited()
+
+    async def test_health_check_disabled_promotes_immediately(
+        self,
+        route_executor: RouteExecutor,
+        mock_deployment_repo: AsyncMock,
+        mock_valkey_schedule: AsyncMock,
+    ) -> None:
+        """WU-001: Endpoint with no health_check config → ready in the first cycle."""
+        route = _warming_up_route()
+        _wire_live_session(mock_deployment_repo, [route])
+        mock_valkey_schedule.get_route_health_records_batch.return_value = {
+            str(route.route_id): _stub_health_record(route),
+        }
+        mock_deployment_repo.fetch_health_check_configs_by_revision_ids.return_value = {
+            route.revision_id: None,
+        }
+
+        with RouteRecorderContext.scope("test", entity_ids=[route.route_id]):
+            result = await route_executor.check_warming_up_routes([route])
+
+        assert [r.route_id for r in result.successes] == [route.route_id]
+        assert result.errors == []
+
+    async def test_health_enabled_and_probe_passed_promotes(
+        self,
+        route_executor: RouteExecutor,
+        mock_deployment_repo: AsyncMock,
+        mock_valkey_schedule: AsyncMock,
+    ) -> None:
+        """WU-002: Health enabled and a passing probe is recorded → ready."""
+        route = _warming_up_route()
+        _wire_live_session(mock_deployment_repo, [route])
+        mock_deployment_repo.fetch_health_check_configs_by_revision_ids.return_value = {
+            route.revision_id: ModelHealthCheck(path="/health", initial_delay=60.0),
+        }
+
+        current_time = 5000
+        passing_record = _stub_health_record(
+            route,
+            agent_healthy=True,
+            agent_last_check=current_time - 5,
+        )
+        mock_valkey_schedule.get_route_health_records_batch.return_value = {
+            str(route.route_id): passing_record,
+        }
+        mock_valkey_schedule.get_redis_time.return_value = current_time
+
+        with RouteRecorderContext.scope("test", entity_ids=[route.route_id]):
+            result = await route_executor.check_warming_up_routes([route])
+
+        assert [r.route_id for r in result.successes] == [route.route_id]
+        assert result.errors == []
+
+    async def test_health_enabled_but_probe_missing_stays_in_warming_up(
+        self,
+        route_executor: RouteExecutor,
+        mock_deployment_repo: AsyncMock,
+        mock_valkey_schedule: AsyncMock,
+    ) -> None:
+        """WU-003: Health enabled but no probe yet → not promoted, no error."""
+        route = _warming_up_route()
+        _wire_live_session(mock_deployment_repo, [route])
+        mock_deployment_repo.fetch_health_check_configs_by_revision_ids.return_value = {
+            route.revision_id: ModelHealthCheck(path="/health", initial_delay=60.0),
+        }
+        # Health record exists but no probe has run (last_check=0).
+        mock_valkey_schedule.get_route_health_records_batch.return_value = {
+            str(route.route_id): _stub_health_record(route),
+        }
+        mock_valkey_schedule.get_redis_time.return_value = 5000
+
+        with RouteRecorderContext.scope("test", entity_ids=[route.route_id]):
+            result = await route_executor.check_warming_up_routes([route])
+
+        assert result.successes == []
+        assert result.errors == []
+
+    async def test_dead_session_goes_to_errors(
+        self,
+        route_executor: RouteExecutor,
+        mock_deployment_repo: AsyncMock,
+    ) -> None:
+        """WU-004: Terminal session yields an error so the handler can fail to FAILED_TO_START."""
+        route = _warming_up_route()
+        mock_deployment_repo.fetch_session_statuses_by_route_ids.return_value = {
+            route.route_id: _terminal_session_status(),
+        }
+
+        with RouteRecorderContext.scope("test", entity_ids=[route.route_id]):
+            result = await route_executor.check_warming_up_routes([route])
+
+        assert result.successes == []
+        assert len(result.errors) == 1
+        assert result.errors[0].route_info.route_id == route.route_id
+
+    async def test_missing_revision_is_skipped_not_promoted(
+        self,
+        route_executor: RouteExecutor,
+        mock_deployment_repo: AsyncMock,
+        mock_valkey_schedule: AsyncMock,
+    ) -> None:
+        """WU-005: Revision row missing from health-config map → leave for route_eviction."""
+        route = _warming_up_route()
+        _wire_live_session(mock_deployment_repo, [route])
+        mock_valkey_schedule.get_route_health_records_batch.return_value = {
+            str(route.route_id): _stub_health_record(route),
+        }
+        # Repo returns an empty map (revision row vanished between fetch and classify).
+        mock_deployment_repo.fetch_health_check_configs_by_revision_ids.return_value = {}
+
+        with RouteRecorderContext.scope("test", entity_ids=[route.route_id]):
+            result = await route_executor.check_warming_up_routes([route])
+
+        assert result.successes == []
+        assert result.errors == []
+
+    async def test_mixed_routes_classified_correctly(
+        self,
+        route_executor: RouteExecutor,
+        mock_deployment_repo: AsyncMock,
+        mock_valkey_schedule: AsyncMock,
+    ) -> None:
+        """A live + a dead route are classified into successes / errors respectively."""
+        live_route = _warming_up_route()
+        dead_route = _warming_up_route()
+        mock_deployment_repo.fetch_session_statuses_by_route_ids.return_value = {
+            live_route.route_id: _live_session_status(),
+            dead_route.route_id: _terminal_session_status(),
+        }
+        mock_valkey_schedule.get_route_health_records_batch.return_value = {
+            str(live_route.route_id): _stub_health_record(live_route),
+        }
+        mock_deployment_repo.fetch_health_check_configs_by_revision_ids.return_value = {
+            live_route.revision_id: None,  # disabled → live route promotes
+        }
+
+        with RouteRecorderContext.scope(
+            "test", entity_ids=[live_route.route_id, dead_route.route_id]
+        ):
+            result = await route_executor.check_warming_up_routes([live_route, dead_route])
+
+        assert [r.route_id for r in result.successes] == [live_route.route_id]
+        assert [e.route_info.route_id for e in result.errors] == [dead_route.route_id]

--- a/tests/unit/manager/sokovan/deployment/route/executor/test_initial_delay.py
+++ b/tests/unit/manager/sokovan/deployment/route/executor/test_initial_delay.py
@@ -1,11 +1,15 @@
-"""Tests for initial_delay calculation based on warming_up_at.
+"""Tests for ``_initialize_health_records`` and observer ``initial_delay`` behaviour.
+
+``initial_delay_until`` is anchored at health-record initialisation time
+(current redis time), so probe failures during ``initial_delay`` after
+init are ignored by the observer.
 
 Test scenarios:
-- ID-001: warming_up_at is set → initial_delay_until based on warming_up_at
-- ID-002: warming_up_at is None → fallback to redis_time
-- ID-003: created_at has expired but warming_up_at has not → still within initial_delay
-- ID-005: observer ignores failure within initial_delay (warming_up_at based)
-- ID-006: observer writes failure after initial_delay expires (warming_up_at based)
+- ID-001: redis_time + initial_delay → initial_delay_until
+- ID-002: different initial_delay values
+- ID-005: observer ignores failure within initial_delay
+- ID-006: observer writes failure after initial_delay expires
+- ID-007: observer writes success even within initial_delay
 """
 
 from __future__ import annotations
@@ -21,7 +25,11 @@ from ai.backend.common.config import ModelHealthCheck
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
 from ai.backend.common.types import SessionId
-from ai.backend.manager.data.deployment.types import RouteHealthStatus, RouteStatus
+from ai.backend.manager.data.deployment.types import (
+    ReplicaConnectionInfo,
+    RouteHealthStatus,
+    RouteStatus,
+)
 from ai.backend.manager.repositories.deployment.types import RouteData
 from ai.backend.manager.sokovan.deployment.route.executor import RouteExecutor
 from ai.backend.manager.sokovan.deployment.route.handlers.observer.health_check import (
@@ -55,120 +63,60 @@ def _make_route(
 class TestInitializeHealthRecordsInitialDelay:
     """Tests for initial_delay_until calculation in _initialize_health_records."""
 
-    async def test_warming_up_at_present_uses_warming_up_at(
+    async def test_initial_delay_anchored_at_redis_time(
         self,
         route_executor: RouteExecutor,
-        mock_deployment_repo: AsyncMock,
         mock_valkey_schedule: AsyncMock,
     ) -> None:
-        """ID-001: When warming_up_at exists in Valkey, initial_delay_until is anchored to it.
-
-        Given: Route with warming_up_at=5000 in Valkey, initial_delay=720
-        When: _initialize_health_records
-        Then: initial_delay_until = 5000 + 720 = 5720
-        """
+        """ID-001: initial_delay_until = current redis_time + configured initial_delay."""
         route = _make_route(created_at_ts=1000)
-        route_id_str = str(route.route_id)
-
-        mock_valkey_schedule.get_route_warming_up_at_batch.return_value = {
-            route_id_str: 5000,
-        }
-        mock_valkey_schedule.get_redis_time.return_value = 5100
-        mock_deployment_repo.fetch_health_check_configs_by_revision_ids.return_value = {
-            route.revision_id: ModelHealthCheck(path="/health", initial_delay=720.0),
-        }
-
-        await route_executor._initialize_health_records(
-            [route],
-            {route.route_id: ("10.0.0.1", 8000)},
-        )
-
-        call_args = mock_valkey_schedule.initialize_route_health_records_batch.call_args
-        records: list[RouteHealthRecord] = call_args[0][0]
-        assert len(records) == 1
-        assert records[0].warming_up_at == 5000
-        assert records[0].initial_delay_until == 5000 + 720
-
-    async def test_warming_up_at_none_falls_back_to_redis_time(
-        self,
-        route_executor: RouteExecutor,
-        mock_deployment_repo: AsyncMock,
-        mock_valkey_schedule: AsyncMock,
-    ) -> None:
-        """ID-002: When warming_up_at is None, fallback to current redis_time.
-
-        Given: No existing record in Valkey (warming_up_at not set), redis_time=6000
-        When: _initialize_health_records
-        Then: initial_delay_until = 6000 + 720 = 6720, warming_up_at = 6000
-        """
-        route = _make_route(created_at_ts=1000)
-
-        mock_valkey_schedule.get_route_warming_up_at_batch.return_value = {}
         mock_valkey_schedule.get_redis_time.return_value = 6000
-        mock_deployment_repo.fetch_health_check_configs_by_revision_ids.return_value = {
-            route.revision_id: ModelHealthCheck(path="/health", initial_delay=720.0),
-        }
 
         await route_executor._initialize_health_records(
             [route],
-            {route.route_id: ("10.0.0.1", 8000)},
+            {route.route_id: ReplicaConnectionInfo(host="10.0.0.1", port=8000)},
+            {route.revision_id: ModelHealthCheck(path="/health", initial_delay=720.0)},
         )
 
         call_args = mock_valkey_schedule.initialize_route_health_records_batch.call_args
         records: list[RouteHealthRecord] = call_args[0][0]
         assert len(records) == 1
-        assert records[0].warming_up_at == 6000
         assert records[0].initial_delay_until == 6000 + 720
+        assert records[0].running_at is None
 
-    async def test_created_at_expired_but_warming_up_at_not_expired(
+    async def test_default_initial_delay_when_no_health_check(
         self,
         route_executor: RouteExecutor,
-        mock_deployment_repo: AsyncMock,
         mock_valkey_schedule: AsyncMock,
     ) -> None:
-        """ID-003: created_at-based delay would have expired, but warming_up_at-based has not.
-
-        Given: created_at=1000, warming_up_at=5000, initial_delay=720, current_time=1800
-               created_at + 720 = 1720 < 1800 (expired if created_at based)
-               warming_up_at + 720 = 5720 > 1800 (NOT expired with warming_up_at based)
-        When: _initialize_health_records
-        Then: initial_delay_until = 5720 (based on warming_up_at, not created_at)
-        """
+        """ID-002: When the revision has no health check, default initial_delay=60s applies."""
         route = _make_route(created_at_ts=1000)
-        route_id_str = str(route.route_id)
-
-        mock_valkey_schedule.get_route_warming_up_at_batch.return_value = {
-            route_id_str: 5000,
-        }
-        mock_valkey_schedule.get_redis_time.return_value = 1800
-        mock_deployment_repo.fetch_health_check_configs_by_revision_ids.return_value = {
-            route.revision_id: ModelHealthCheck(path="/health", initial_delay=720.0),
-        }
+        mock_valkey_schedule.get_redis_time.return_value = 6000
 
         await route_executor._initialize_health_records(
             [route],
-            {route.route_id: ("10.0.0.1", 8000)},
+            {route.route_id: ReplicaConnectionInfo(host="10.0.0.1", port=8000)},
+            {route.revision_id: None},
         )
 
         call_args = mock_valkey_schedule.initialize_route_health_records_batch.call_args
         records: list[RouteHealthRecord] = call_args[0][0]
-        assert records[0].initial_delay_until == 5720
-        assert records[0].created_at == 1000
+        assert records[0].health_path == "/"
+        assert records[0].initial_delay_until == 6000 + 60
 
 
 # =============================================================================
-# RouteHealthObserver: within_initial_delay based on warming_up_at
+# RouteHealthObserver: within_initial_delay behaviour
 # =============================================================================
 
 
 class TestObserverInitialDelay:
-    """Tests for observer's initial_delay behavior with warming_up_at-based records."""
+    """Tests for observer's initial_delay behaviour."""
 
     async def test_observer_ignores_failure_within_initial_delay(self) -> None:
         """ID-005: Observer does not write failure during initial_delay period.
 
-        Given: warming_up_at=5000, initial_delay=720 → initial_delay_until=5720
-               current redis_time=5500 (within initial_delay)
+        Given: initial_delay_until=5720, current redis_time=5500 (within window),
                health check fails
         When: Observer runs
         Then: update_route_manager_health NOT called for failure
@@ -190,7 +138,6 @@ class TestObserverInitialDelay:
             health_path="/health",
             inference_port=8000,
             replica_host="10.0.0.1",
-            warming_up_at=5000,
         )
         mock_valkey.get_route_health_records_batch.return_value = {route_id_str: record}
         mock_valkey.get_redis_time.return_value = 5500  # Within initial_delay
@@ -199,25 +146,15 @@ class TestObserverInitialDelay:
             deployment_repository=mock_deployment_repo,
             valkey_schedule=mock_valkey,
         )
-        # Patch HTTP check to always fail
         observer._http_health_check = AsyncMock(return_value=False)  # type: ignore[method-assign]
 
         await observer.observe([route_data])
 
-        # refresh_route_health_ttl should be called (always)
         mock_valkey.refresh_route_health_ttl.assert_awaited_once_with(route_id_str)
-        # update_route_manager_health should NOT be called (failure ignored during initial_delay)
         mock_valkey.update_route_manager_health.assert_not_awaited()
 
     async def test_observer_writes_failure_after_initial_delay(self) -> None:
-        """ID-006: Observer writes failure after initial_delay expires.
-
-        Given: warming_up_at=5000, initial_delay=720 → initial_delay_until=5720
-               current redis_time=5800 (past initial_delay)
-               health check fails
-        When: Observer runs
-        Then: update_route_manager_health called with False
-        """
+        """ID-006: Observer writes failure after initial_delay expires."""
         mock_deployment_repo = AsyncMock()
         mock_valkey = AsyncMock()
 
@@ -235,7 +172,6 @@ class TestObserverInitialDelay:
             health_path="/health",
             inference_port=8000,
             replica_host="10.0.0.1",
-            warming_up_at=5000,
         )
         mock_valkey.get_route_health_records_batch.return_value = {route_id_str: record}
         mock_valkey.get_redis_time.return_value = 5800  # Past initial_delay
@@ -251,12 +187,7 @@ class TestObserverInitialDelay:
         mock_valkey.update_route_manager_health.assert_awaited_once_with(route_id_str, False)
 
     async def test_observer_writes_success_within_initial_delay(self) -> None:
-        """ID-007: Observer writes success even during initial_delay.
-
-        Given: Within initial_delay, health check succeeds
-        When: Observer runs
-        Then: update_route_manager_health called with True
-        """
+        """ID-007: Observer writes success even during initial_delay."""
         mock_deployment_repo = AsyncMock()
         mock_valkey = AsyncMock()
 
@@ -274,7 +205,6 @@ class TestObserverInitialDelay:
             health_path="/health",
             inference_port=8000,
             replica_host="10.0.0.1",
-            warming_up_at=5000,
         )
         mock_valkey.get_route_health_records_batch.return_value = {route_id_str: record}
         mock_valkey.get_redis_time.return_value = 5500  # Within initial_delay
@@ -291,15 +221,14 @@ class TestObserverInitialDelay:
 
 
 # =============================================================================
-# RouteHealthRecord serialization: warming_up_at and running_at
+# RouteHealthRecord serialization: running_at
 # =============================================================================
 
 
-class TestRouteHealthRecordTimestamps:
-    """Tests for RouteHealthRecord warming_up_at / running_at serialization."""
+class TestRouteHealthRecordRunningAt:
+    """Tests for RouteHealthRecord running_at serialization."""
 
-    def test_timestamps_none_not_in_hash(self) -> None:
-        """warming_up_at=None and running_at=None should not appear in serialized hash."""
+    def test_running_at_none_not_in_hash(self) -> None:
         record = RouteHealthRecord(
             route_id="r1",
             created_at=1000,
@@ -309,11 +238,9 @@ class TestRouteHealthRecordTimestamps:
             replica_host="10.0.0.1",
         )
         h = record.to_valkey_hash()
-        assert "warming_up_at" not in h
         assert "running_at" not in h
 
-    def test_timestamps_present_in_hash(self) -> None:
-        """warming_up_at and running_at with values should appear in serialized hash."""
+    def test_running_at_present_in_hash(self) -> None:
         record = RouteHealthRecord(
             route_id="r1",
             created_at=1000,
@@ -321,15 +248,12 @@ class TestRouteHealthRecordTimestamps:
             health_path="/health",
             inference_port=8000,
             replica_host="10.0.0.1",
-            warming_up_at=5000,
             running_at=5100,
         )
         h = record.to_valkey_hash()
-        assert h["warming_up_at"] == "5000"
         assert h["running_at"] == "5100"
 
-    def test_from_hash_missing_timestamps_are_none(self) -> None:
-        """Deserializing hash without warming_up_at/running_at fields yields None."""
+    def test_from_hash_missing_running_at_is_none(self) -> None:
         data = {
             "route_id": "r1",
             "created_at": "1000",
@@ -339,11 +263,9 @@ class TestRouteHealthRecordTimestamps:
             "replica_host": "10.0.0.1",
         }
         record = RouteHealthRecord.from_valkey_hash(data)
-        assert record.warming_up_at is None
         assert record.running_at is None
 
-    def test_from_hash_zero_timestamps_are_none(self) -> None:
-        """Deserializing hash with timestamp=0 yields None (backward compat)."""
+    def test_from_hash_zero_running_at_is_none(self) -> None:
         data = {
             "route_id": "r1",
             "created_at": "1000",
@@ -351,15 +273,12 @@ class TestRouteHealthRecordTimestamps:
             "health_path": "/health",
             "inference_port": "8000",
             "replica_host": "10.0.0.1",
-            "warming_up_at": "0",
             "running_at": "0",
         }
         record = RouteHealthRecord.from_valkey_hash(data)
-        assert record.warming_up_at is None
         assert record.running_at is None
 
-    def test_from_hash_valid_timestamps(self) -> None:
-        """Deserializing hash with valid timestamps yields ints."""
+    def test_from_hash_valid_running_at(self) -> None:
         data = {
             "route_id": "r1",
             "created_at": "1000",
@@ -367,15 +286,12 @@ class TestRouteHealthRecordTimestamps:
             "health_path": "/health",
             "inference_port": "8000",
             "replica_host": "10.0.0.1",
-            "warming_up_at": "5000",
             "running_at": "5100",
         }
         record = RouteHealthRecord.from_valkey_hash(data)
-        assert record.warming_up_at == 5000
         assert record.running_at == 5100
 
-    def test_roundtrip_with_timestamps(self) -> None:
-        """Serialize → deserialize preserves warming_up_at and running_at."""
+    def test_roundtrip_with_running_at(self) -> None:
         original = RouteHealthRecord(
             route_id="r1",
             created_at=1000,
@@ -383,16 +299,13 @@ class TestRouteHealthRecordTimestamps:
             health_path="/health",
             inference_port=8000,
             replica_host="10.0.0.1",
-            warming_up_at=5000,
             running_at=5100,
         )
         restored = RouteHealthRecord.from_valkey_hash(original.to_valkey_hash())
-        assert restored.warming_up_at == 5000
         assert restored.running_at == 5100
         assert restored.initial_delay_until == 5720
 
-    def test_roundtrip_without_timestamps(self) -> None:
-        """Serialize → deserialize preserves None timestamps."""
+    def test_roundtrip_without_running_at(self) -> None:
         original = RouteHealthRecord(
             route_id="r1",
             created_at=1000,
@@ -402,5 +315,4 @@ class TestRouteHealthRecordTimestamps:
             replica_host="10.0.0.1",
         )
         restored = RouteHealthRecord.from_valkey_hash(original.to_valkey_hash())
-        assert restored.warming_up_at is None
         assert restored.running_at is None

--- a/tests/unit/manager/sokovan/deployment/route/executor/test_initial_delay.py
+++ b/tests/unit/manager/sokovan/deployment/route/executor/test_initial_delay.py
@@ -1,12 +1,11 @@
-"""Tests for initial_delay calculation based on running_at.
+"""Tests for initial_delay calculation based on warming_up_at.
 
 Test scenarios:
-- ID-001: running_at is set → initial_delay_until based on running_at
-- ID-002: running_at is None → fallback to redis_time
-- ID-003: created_at has expired but running_at has not → still within initial_delay
-- ID-004: running_at has also expired → initial_delay over
-- ID-005: observer ignores failure within initial_delay (running_at based)
-- ID-006: observer writes failure after initial_delay expires (running_at based)
+- ID-001: warming_up_at is set → initial_delay_until based on warming_up_at
+- ID-002: warming_up_at is None → fallback to redis_time
+- ID-003: created_at has expired but warming_up_at has not → still within initial_delay
+- ID-005: observer ignores failure within initial_delay (warming_up_at based)
+- ID-006: observer writes failure after initial_delay expires (warming_up_at based)
 """
 
 from __future__ import annotations
@@ -38,7 +37,7 @@ def _make_route(
         route_id=uuid4(),
         deployment_id=DeploymentID(uuid4()),
         session_id=session_id or SessionId(uuid4()),
-        status=RouteStatus.RUNNING,
+        status=RouteStatus.WARMING_UP,
         health_status=RouteHealthStatus.NOT_CHECKED,
         traffic_ratio=1.0,
         created_at=datetime.fromtimestamp(created_at_ts, tz=tzutc()),
@@ -56,22 +55,22 @@ def _make_route(
 class TestInitializeHealthRecordsInitialDelay:
     """Tests for initial_delay_until calculation in _initialize_health_records."""
 
-    async def test_running_at_present_uses_running_at(
+    async def test_warming_up_at_present_uses_warming_up_at(
         self,
         route_executor: RouteExecutor,
         mock_deployment_repo: AsyncMock,
         mock_valkey_schedule: AsyncMock,
     ) -> None:
-        """ID-001: When running_at exists in Valkey, initial_delay_until is based on running_at.
+        """ID-001: When warming_up_at exists in Valkey, initial_delay_until is anchored to it.
 
-        Given: Route with running_at=5000 in Valkey, initial_delay=720
+        Given: Route with warming_up_at=5000 in Valkey, initial_delay=720
         When: _initialize_health_records
         Then: initial_delay_until = 5000 + 720 = 5720
         """
         route = _make_route(created_at_ts=1000)
         route_id_str = str(route.route_id)
 
-        mock_valkey_schedule.get_route_running_at_batch.return_value = {
+        mock_valkey_schedule.get_route_warming_up_at_batch.return_value = {
             route_id_str: 5000,
         }
         mock_valkey_schedule.get_redis_time.return_value = 5100
@@ -87,24 +86,24 @@ class TestInitializeHealthRecordsInitialDelay:
         call_args = mock_valkey_schedule.initialize_route_health_records_batch.call_args
         records: list[RouteHealthRecord] = call_args[0][0]
         assert len(records) == 1
-        assert records[0].running_at == 5000
+        assert records[0].warming_up_at == 5000
         assert records[0].initial_delay_until == 5000 + 720
 
-    async def test_running_at_none_falls_back_to_redis_time(
+    async def test_warming_up_at_none_falls_back_to_redis_time(
         self,
         route_executor: RouteExecutor,
         mock_deployment_repo: AsyncMock,
         mock_valkey_schedule: AsyncMock,
     ) -> None:
-        """ID-002: When running_at is None, fallback to current redis_time.
+        """ID-002: When warming_up_at is None, fallback to current redis_time.
 
-        Given: No existing record in Valkey (running_at not set), redis_time=6000
+        Given: No existing record in Valkey (warming_up_at not set), redis_time=6000
         When: _initialize_health_records
-        Then: initial_delay_until = 6000 + 720 = 6720, running_at = 6000
+        Then: initial_delay_until = 6000 + 720 = 6720, warming_up_at = 6000
         """
         route = _make_route(created_at_ts=1000)
 
-        mock_valkey_schedule.get_route_running_at_batch.return_value = {}
+        mock_valkey_schedule.get_route_warming_up_at_batch.return_value = {}
         mock_valkey_schedule.get_redis_time.return_value = 6000
         mock_deployment_repo.fetch_health_check_configs_by_revision_ids.return_value = {
             route.revision_id: ModelHealthCheck(path="/health", initial_delay=720.0),
@@ -118,27 +117,27 @@ class TestInitializeHealthRecordsInitialDelay:
         call_args = mock_valkey_schedule.initialize_route_health_records_batch.call_args
         records: list[RouteHealthRecord] = call_args[0][0]
         assert len(records) == 1
-        assert records[0].running_at == 6000
+        assert records[0].warming_up_at == 6000
         assert records[0].initial_delay_until == 6000 + 720
 
-    async def test_created_at_expired_but_running_at_not_expired(
+    async def test_created_at_expired_but_warming_up_at_not_expired(
         self,
         route_executor: RouteExecutor,
         mock_deployment_repo: AsyncMock,
         mock_valkey_schedule: AsyncMock,
     ) -> None:
-        """ID-003: created_at-based delay would have expired, but running_at-based has not.
+        """ID-003: created_at-based delay would have expired, but warming_up_at-based has not.
 
-        Given: created_at=1000, running_at=5000, initial_delay=720, current_time=1800
+        Given: created_at=1000, warming_up_at=5000, initial_delay=720, current_time=1800
                created_at + 720 = 1720 < 1800 (expired if created_at based)
-               running_at + 720 = 5720 > 1800 (NOT expired with running_at based)
+               warming_up_at + 720 = 5720 > 1800 (NOT expired with warming_up_at based)
         When: _initialize_health_records
-        Then: initial_delay_until = 5720 (based on running_at, not created_at)
+        Then: initial_delay_until = 5720 (based on warming_up_at, not created_at)
         """
         route = _make_route(created_at_ts=1000)
         route_id_str = str(route.route_id)
 
-        mock_valkey_schedule.get_route_running_at_batch.return_value = {
+        mock_valkey_schedule.get_route_warming_up_at_batch.return_value = {
             route_id_str: 5000,
         }
         mock_valkey_schedule.get_redis_time.return_value = 1800
@@ -158,17 +157,17 @@ class TestInitializeHealthRecordsInitialDelay:
 
 
 # =============================================================================
-# RouteHealthObserver: within_initial_delay based on running_at
+# RouteHealthObserver: within_initial_delay based on warming_up_at
 # =============================================================================
 
 
 class TestObserverInitialDelay:
-    """Tests for observer's initial_delay behavior with running_at-based records."""
+    """Tests for observer's initial_delay behavior with warming_up_at-based records."""
 
     async def test_observer_ignores_failure_within_initial_delay(self) -> None:
         """ID-005: Observer does not write failure during initial_delay period.
 
-        Given: running_at=5000, initial_delay=720 → initial_delay_until=5720
+        Given: warming_up_at=5000, initial_delay=720 → initial_delay_until=5720
                current redis_time=5500 (within initial_delay)
                health check fails
         When: Observer runs
@@ -191,7 +190,7 @@ class TestObserverInitialDelay:
             health_path="/health",
             inference_port=8000,
             replica_host="10.0.0.1",
-            running_at=5000,
+            warming_up_at=5000,
         )
         mock_valkey.get_route_health_records_batch.return_value = {route_id_str: record}
         mock_valkey.get_redis_time.return_value = 5500  # Within initial_delay
@@ -213,7 +212,7 @@ class TestObserverInitialDelay:
     async def test_observer_writes_failure_after_initial_delay(self) -> None:
         """ID-006: Observer writes failure after initial_delay expires.
 
-        Given: running_at=5000, initial_delay=720 → initial_delay_until=5720
+        Given: warming_up_at=5000, initial_delay=720 → initial_delay_until=5720
                current redis_time=5800 (past initial_delay)
                health check fails
         When: Observer runs
@@ -236,7 +235,7 @@ class TestObserverInitialDelay:
             health_path="/health",
             inference_port=8000,
             replica_host="10.0.0.1",
-            running_at=5000,
+            warming_up_at=5000,
         )
         mock_valkey.get_route_health_records_batch.return_value = {route_id_str: record}
         mock_valkey.get_redis_time.return_value = 5800  # Past initial_delay
@@ -275,7 +274,7 @@ class TestObserverInitialDelay:
             health_path="/health",
             inference_port=8000,
             replica_host="10.0.0.1",
-            running_at=5000,
+            warming_up_at=5000,
         )
         mock_valkey.get_route_health_records_batch.return_value = {route_id_str: record}
         mock_valkey.get_redis_time.return_value = 5500  # Within initial_delay
@@ -292,15 +291,15 @@ class TestObserverInitialDelay:
 
 
 # =============================================================================
-# RouteHealthRecord serialization: running_at
+# RouteHealthRecord serialization: warming_up_at and running_at
 # =============================================================================
 
 
-class TestRouteHealthRecordRunningAt:
-    """Tests for RouteHealthRecord running_at serialization."""
+class TestRouteHealthRecordTimestamps:
+    """Tests for RouteHealthRecord warming_up_at / running_at serialization."""
 
-    def test_running_at_none_not_in_hash(self) -> None:
-        """running_at=None should not appear in serialized hash."""
+    def test_timestamps_none_not_in_hash(self) -> None:
+        """warming_up_at=None and running_at=None should not appear in serialized hash."""
         record = RouteHealthRecord(
             route_id="r1",
             created_at=1000,
@@ -308,13 +307,13 @@ class TestRouteHealthRecordRunningAt:
             health_path="/health",
             inference_port=8000,
             replica_host="10.0.0.1",
-            running_at=None,
         )
         h = record.to_valkey_hash()
+        assert "warming_up_at" not in h
         assert "running_at" not in h
 
-    def test_running_at_present_in_hash(self) -> None:
-        """running_at with value should appear in serialized hash."""
+    def test_timestamps_present_in_hash(self) -> None:
+        """warming_up_at and running_at with values should appear in serialized hash."""
         record = RouteHealthRecord(
             route_id="r1",
             created_at=1000,
@@ -322,13 +321,15 @@ class TestRouteHealthRecordRunningAt:
             health_path="/health",
             inference_port=8000,
             replica_host="10.0.0.1",
-            running_at=5000,
+            warming_up_at=5000,
+            running_at=5100,
         )
         h = record.to_valkey_hash()
-        assert h["running_at"] == "5000"
+        assert h["warming_up_at"] == "5000"
+        assert h["running_at"] == "5100"
 
-    def test_from_hash_missing_running_at_is_none(self) -> None:
-        """Deserializing hash without running_at field yields None."""
+    def test_from_hash_missing_timestamps_are_none(self) -> None:
+        """Deserializing hash without warming_up_at/running_at fields yields None."""
         data = {
             "route_id": "r1",
             "created_at": "1000",
@@ -338,10 +339,11 @@ class TestRouteHealthRecordRunningAt:
             "replica_host": "10.0.0.1",
         }
         record = RouteHealthRecord.from_valkey_hash(data)
+        assert record.warming_up_at is None
         assert record.running_at is None
 
-    def test_from_hash_zero_running_at_is_none(self) -> None:
-        """Deserializing hash with running_at=0 yields None (backward compat)."""
+    def test_from_hash_zero_timestamps_are_none(self) -> None:
+        """Deserializing hash with timestamp=0 yields None (backward compat)."""
         data = {
             "route_id": "r1",
             "created_at": "1000",
@@ -349,13 +351,15 @@ class TestRouteHealthRecordRunningAt:
             "health_path": "/health",
             "inference_port": "8000",
             "replica_host": "10.0.0.1",
+            "warming_up_at": "0",
             "running_at": "0",
         }
         record = RouteHealthRecord.from_valkey_hash(data)
+        assert record.warming_up_at is None
         assert record.running_at is None
 
-    def test_from_hash_valid_running_at(self) -> None:
-        """Deserializing hash with valid running_at yields int."""
+    def test_from_hash_valid_timestamps(self) -> None:
+        """Deserializing hash with valid timestamps yields ints."""
         data = {
             "route_id": "r1",
             "created_at": "1000",
@@ -363,13 +367,15 @@ class TestRouteHealthRecordRunningAt:
             "health_path": "/health",
             "inference_port": "8000",
             "replica_host": "10.0.0.1",
-            "running_at": "5000",
+            "warming_up_at": "5000",
+            "running_at": "5100",
         }
         record = RouteHealthRecord.from_valkey_hash(data)
-        assert record.running_at == 5000
+        assert record.warming_up_at == 5000
+        assert record.running_at == 5100
 
-    def test_roundtrip_with_running_at(self) -> None:
-        """Serialize → deserialize preserves running_at."""
+    def test_roundtrip_with_timestamps(self) -> None:
+        """Serialize → deserialize preserves warming_up_at and running_at."""
         original = RouteHealthRecord(
             route_id="r1",
             created_at=1000,
@@ -377,14 +383,16 @@ class TestRouteHealthRecordRunningAt:
             health_path="/health",
             inference_port=8000,
             replica_host="10.0.0.1",
-            running_at=5000,
+            warming_up_at=5000,
+            running_at=5100,
         )
         restored = RouteHealthRecord.from_valkey_hash(original.to_valkey_hash())
-        assert restored.running_at == 5000
+        assert restored.warming_up_at == 5000
+        assert restored.running_at == 5100
         assert restored.initial_delay_until == 5720
 
-    def test_roundtrip_without_running_at(self) -> None:
-        """Serialize → deserialize preserves running_at=None."""
+    def test_roundtrip_without_timestamps(self) -> None:
+        """Serialize → deserialize preserves None timestamps."""
         original = RouteHealthRecord(
             route_id="r1",
             created_at=1000,
@@ -392,7 +400,7 @@ class TestRouteHealthRecordRunningAt:
             health_path="/health",
             inference_port=8000,
             replica_host="10.0.0.1",
-            running_at=None,
         )
         restored = RouteHealthRecord.from_valkey_hash(original.to_valkey_hash())
+        assert restored.warming_up_at is None
         assert restored.running_at is None

--- a/tests/unit/manager/sokovan/deployment/route/handlers/test_warming_up_handler.py
+++ b/tests/unit/manager/sokovan/deployment/route/handlers/test_warming_up_handler.py
@@ -1,0 +1,104 @@
+"""Unit tests for WarmingUpRouteHandler.
+
+The handler is a thin shim over ``RouteExecutor.check_warming_up_routes``.
+The actual session-verification, replica-info population, and first-health
+gate logic is exercised in the executor tests; here we only verify that
+the handler declares the right targets/transitions and pass-throughs.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+from dateutil.tz import tzutc
+
+from ai.backend.common.identifier.deployment import DeploymentID
+from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
+from ai.backend.common.types import SessionId
+from ai.backend.manager.data.deployment.types import (
+    RouteHandlerCategory,
+    RouteHealthStatus,
+    RouteStatus,
+)
+from ai.backend.manager.repositories.deployment.types import RouteData
+from ai.backend.manager.sokovan.deployment.route.handlers.warming_up import (
+    WarmingUpRouteHandler,
+)
+from ai.backend.manager.sokovan.deployment.route.types import RouteExecutionResult
+
+
+def _route() -> RouteData:
+    return RouteData(
+        route_id=uuid4(),
+        deployment_id=DeploymentID(uuid4()),
+        session_id=SessionId(uuid4()),
+        status=RouteStatus.WARMING_UP,
+        health_status=RouteHealthStatus.NOT_CHECKED,
+        traffic_ratio=1.0,
+        revision_id=DeploymentRevisionID(uuid4()),
+        replica_host="10.0.0.1",
+        replica_port=8000,
+        created_at=datetime.now(tzutc()),
+    )
+
+
+class TestWarmingUpRouteHandlerDeclarations:
+    """Static handler declarations: category, targets, transitions."""
+
+    def test_category_is_lifecycle(self) -> None:
+        assert WarmingUpRouteHandler.category() == RouteHandlerCategory.LIFECYCLE
+
+    def test_target_lifecycle_is_warming_up_only(self) -> None:
+        target = WarmingUpRouteHandler.target_statuses()
+        assert target.lifecycle == [RouteStatus.WARMING_UP]
+
+    def test_target_health_covers_all_health_statuses(self) -> None:
+        target = WarmingUpRouteHandler.target_statuses()
+        assert set(target.health) == set(RouteHealthStatus)
+
+    def test_success_transition_promotes_to_running_healthy(self) -> None:
+        transitions = WarmingUpRouteHandler.status_transitions()
+        assert transitions.success is not None
+        assert transitions.success.status == RouteStatus.RUNNING
+        assert transitions.success.health_status == RouteHealthStatus.HEALTHY
+
+    def test_failure_transition_drops_to_failed_to_start(self) -> None:
+        transitions = WarmingUpRouteHandler.status_transitions()
+        assert transitions.failure is not None
+        assert transitions.failure.status == RouteStatus.FAILED_TO_START
+        assert transitions.failure.health_status == RouteHealthStatus.NOT_CHECKED
+
+    def test_no_stale_transition(self) -> None:
+        assert WarmingUpRouteHandler.status_transitions().stale is None
+
+
+class TestWarmingUpRouteHandlerDelegation:
+    """Handler.execute is a thin pass-through to check_warming_up_routes."""
+
+    async def test_execute_delegates_to_check_warming_up_routes(self) -> None:
+        executor = AsyncMock()
+        check_result = RouteExecutionResult(successes=[], errors=[])
+        executor.check_warming_up_routes = AsyncMock(return_value=check_result)
+        event_producer = MagicMock()
+        handler = WarmingUpRouteHandler(executor, event_producer)
+        routes = [_route()]
+
+        result = await handler.execute(routes)
+
+        executor.check_warming_up_routes.assert_awaited_once_with(routes)
+        assert result is check_result
+
+    async def test_post_process_logs_only(self) -> None:
+        executor = AsyncMock()
+        event_producer = MagicMock()
+        handler = WarmingUpRouteHandler(executor, event_producer)
+
+        await handler.post_process(
+            RouteExecutionResult(successes=[_route()], errors=[]),
+        )
+
+        # Logging-only shim — no executor / event_producer side effects.
+        assert executor.method_calls == []
+        assert event_producer.method_calls == []


### PR DESCRIPTION
## Summary

- Adds a new `WARMING_UP` value to `RouteStatus` between `PROVISIONING` and `RUNNING`. The provisioning handler now lands routes in `WARMING_UP` (session enqueued, replica info pending) and a new `WarmingUpRouteHandler` graduates them to `RUNNING` on the first healthy probe — or immediately when the endpoint has no health check configured. `RunningRouteHandler` is narrowed to session-liveness monitoring only.
- Splits the lifecycle transition timestamps in Valkey: `warming_up_at` anchors the health-probe `initial_delay` window (since model loading happens during `WARMING_UP`), while `running_at` records the moment the route first becomes eligible for traffic. Both marks are written via batched APIs typed by a private `_RouteTimestampField` enum.
- Audits and updates every direct `RouteStatus` enum comparison touched by this change (rolling-update classifier, healthy-route count, terminatable-status set, route eviction targets, liveness mapping, delete-route guard) and adds `RouteStatus.pre_running_statuses()` / extends `active_route_statuses()` so future call sites use named helpers instead of hard-coded sets.

## Test plan

- [x] Unit: new `TestCheckWarmingUpRoutes` covers health-disabled / probe-pass / probe-missing / dead-session / missing-revision / mixed paths
- [x] Unit: new `TestWarmingUpRouteHandler` verifies static declarations and `execute` delegation
- [x] Unit: existing `test_initial_delay.py` updated to drive `warming_up_at`-anchored behaviour
- [x] Unit: full route handler/executor suite (`tests/unit/manager/sokovan/deployment/route::`) passes
- [x] mypy + ruff (lint/format) pass on the changed surface
- [ ] Manual verification on a live deployment: provision a route with `health_check_enabled=true` and confirm it sits in `WARMING_UP` until the first probe succeeds, then transitions to `RUNNING`
- [ ] Manual verification with `health_check_enabled=false`: confirm the route promotes to `RUNNING` immediately after the session goes live

Resolves BA-6017

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11578.org.readthedocs.build/en/11578/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11578.org.readthedocs.build/ko/11578/

<!-- readthedocs-preview sorna-ko end -->