### PR TITLE
fix(BA-6022): restore legacy 'vfname/subpath' mount syntax in session creation API

### DIFF
--- a/changes/11582.fix.md
+++ b/changes/11582.fix.md
@@ -1,0 +1,1 @@
+Restore the legacy session creation REST API support for `mounts=['vfname/subpath']` syntax.

--- a/changes/11582.fix.md
+++ b/changes/11582.fix.md
@@ -1,1 +1,1 @@
-Restore the legacy session creation REST API support for `mounts=['vfname/subpath']` syntax.
+Restore session creation REST API support for the legacy `mounts=['vfname/subpath']` form, including the v1 CLI `-v vfname/sub:/dest` shape that routes the destination through `mount_map`.

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -335,14 +335,12 @@ def _merge_resolved_legacy_mounts(
     if not resolutions:
         return creation_config
 
-    merged_mount_ids: list[Any] = list(creation_config.get("mount_ids") or [])
-    existing_uuid_set: set[UUID] = set()
-    for rid in merged_mount_ids:
-        try:
-            existing_uuid_set.add(UUID(str(rid)))
-        except (ValueError, TypeError):
-            continue
-    merged_mount_id_map: dict[Any, str] = dict(creation_config.get("mount_id_map") or {})
+    # ``mount_ids``/``mount_id_map`` are Pydantic-validated to ``list[UUID]``
+    # / ``dict[UUID, str]`` upstream and ``_route_legacy_uuid_mounts`` only
+    # ever appends ``UUID`` instances, so trust the typing here.
+    merged_mount_ids: list[UUID] = list(creation_config.get("mount_ids") or [])
+    existing_uuid_set: set[UUID] = set(merged_mount_ids)
+    merged_mount_id_map: dict[UUID, str] = dict(creation_config.get("mount_id_map") or {})
     merged_mount_options: dict[Any, Any] = dict(creation_config.get("mount_options") or {})
     legacy_mount_map = creation_config.get("mount_map") or {}
     legacy_mount_options = creation_config.get("mount_options") or {}

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -266,17 +266,25 @@ def _split_legacy_mount_key(key: str) -> tuple[str, str | None]:
 
 
 def _route_legacy_uuid_mounts(creation_config: dict[str, Any]) -> dict[str, Any]:
-    """Lift UUID-shaped strings from legacy mount buckets onto the UUID-keyed
-    buckets, leaving only name-shaped entries for the name resolver.
+    """Split mixed legacy mount input by key shape so legacy buckets
+    (``mounts`` / ``mount_map``) carry only names and id buckets
+    (``mount_ids`` / ``mount_id_map``) carry only UUIDs.
+
+    Each entry's key may be a vfolder name or a UUID-shaped string;
+    UUID-shaped keys are parsed to ``UUID`` and lifted into the id
+    buckets, names stay in the legacy buckets for the async resolver.
+    ``mount_options`` is the one exception — both halves coexist on
+    output until :func:`_merge_resolved_legacy_mounts` re-keys the
+    name half onto the resolved UUIDs.
     """
     legacy_mounts = creation_config.get("mounts") or ()
     legacy_mount_map = creation_config.get("mount_map") or {}
     legacy_mount_options = creation_config.get("mount_options") or {}
 
-    mount_ids: list[Any] = list(creation_config.get("mount_ids") or [])
-    mount_id_map: dict[Any, str] = dict(creation_config.get("mount_id_map") or {})
-    mount_options: dict[Any, Any] = {}
-    name_mounts: list[Any] = []
+    mount_ids: list[UUID] = list(creation_config.get("mount_ids") or [])
+    mount_id_map: dict[UUID, str] = dict(creation_config.get("mount_id_map") or {})
+    mount_options: dict[str | UUID, Any] = {}
+    name_mounts: list[str] = []
     name_mount_map: dict[str, str] = {}
 
     legacy_mounts_keys = {str(m) for m in legacy_mounts}
@@ -341,7 +349,7 @@ def _merge_resolved_legacy_mounts(
     merged_mount_ids: list[UUID] = list(creation_config.get("mount_ids") or [])
     existing_uuid_set: set[UUID] = set(merged_mount_ids)
     merged_mount_id_map: dict[UUID, str] = dict(creation_config.get("mount_id_map") or {})
-    merged_mount_options: dict[Any, Any] = dict(creation_config.get("mount_options") or {})
+    merged_mount_options: dict[str | UUID, Any] = dict(creation_config.get("mount_options") or {})
     legacy_mount_map = creation_config.get("mount_map") or {}
     legacy_mount_options = creation_config.get("mount_options") or {}
 

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from datetime import timedelta
 from http import HTTPStatus
+from itertools import chain
 from typing import TYPE_CHECKING, Any, Final, cast
 from uuid import UUID
 
@@ -233,6 +235,36 @@ def _validate_creation_config(
         ) from e
 
 
+@dataclass(frozen=True, slots=True)
+class LegacyMountResolution:
+    """One resolved legacy name-keyed mount entry.
+
+    Produced by :meth:`SessionHandler._resolve_legacy_name_mounts` and
+    consumed by :func:`_merge_resolved_legacy_mounts`. Carries both the
+    resolved vfolder UUID and any subpath suffix peeled off the legacy
+    ``"name/subpath"`` key so the merge step needs a single map keyed by
+    vfolder name.
+    """
+
+    vfid: UUID
+    subpath: str | None = None
+
+
+def _split_legacy_mount_key(key: str) -> tuple[str, str | None]:
+    """Peel an optional ``/<subpath>`` suffix off a legacy mount key.
+
+    The v1 CLI flattens ``-v vfname/sub:/dest`` into ``source="vfname/sub"``
+    + a separate ``target="/dest"``; the REST payload then carries the
+    ``vfname/sub`` source verbatim across ``mounts`` AND the ``mount_map``
+    / ``mount_options`` keys. This helper recovers the bare vfolder name
+    so name resolution and dst/opts lookup all key off the same string.
+    """
+    name, sep, subpath = key.partition("/")
+    if sep and subpath:
+        return name, subpath
+    return key, None
+
+
 def _route_legacy_uuid_mounts(creation_config: dict[str, Any]) -> dict[str, Any]:
     """Lift UUID-shaped strings from legacy mount buckets onto the UUID-keyed
     buckets, leaving only name-shaped entries for the name resolver.
@@ -284,25 +316,23 @@ def _route_legacy_uuid_mounts(creation_config: dict[str, Any]) -> dict[str, Any]
 
 def _merge_resolved_legacy_mounts(
     creation_config: dict[str, Any],
-    name_to_id: dict[str, UUID],
-    name_to_subpath: Mapping[str, str] | None = None,
+    resolutions: Mapping[str, LegacyMountResolution],
 ) -> dict[str, Any]:
-    """Merge a ``name → UUID`` resolution into the UUID-keyed buckets of
-    ``creation_config`` and drop the now-resolved name-keyed legacy keys.
+    """Merge resolved legacy name-keyed mounts into the UUID-keyed buckets
+    of ``creation_config`` and drop the now-resolved name-keyed legacy keys.
 
     The resolved ids are appended to ``mount_ids`` (skipping duplicates),
     and entries from the name-keyed ``mount_map`` / ``mount_options``
     dicts are re-keyed onto the resolved UUIDs without overwriting an
     explicit UUID-keyed entry the caller already supplied.
 
-    When the caller passed a legacy ``mounts`` entry in the
-    ``"vfname/subdir"`` shape, ``name_to_subpath`` carries that parsed
-    subpath suffix for the matching name; it is injected into
-    ``mount_options[uuid]["subpath"]`` so the downstream UUID-keyed
+    When a resolution carries a ``subpath`` (the caller passed a legacy
+    ``mounts`` entry in the ``"vfname/subdir"`` shape), it is injected
+    into ``mount_options[uuid]["subpath"]`` so the downstream UUID-keyed
     consumer (``prepare_vfolder_mounts``) sees the same shape as a
     modern caller supplying ``mount_options`` directly.
     """
-    if not name_to_id:
+    if not resolutions:
         return creation_config
 
     merged_mount_ids: list[Any] = list(creation_config.get("mount_ids") or [])
@@ -316,23 +346,36 @@ def _merge_resolved_legacy_mounts(
     merged_mount_options: dict[Any, Any] = dict(creation_config.get("mount_options") or {})
     legacy_mount_map = creation_config.get("mount_map") or {}
     legacy_mount_options = creation_config.get("mount_options") or {}
-    subpath_by_name = dict(name_to_subpath or {})
 
-    for name, vfid in name_to_id.items():
+    # Re-key legacy mount_map/mount_options entries onto the bare vfolder
+    # name so a CLI-shaped ``{"vfname/sub": "/dest"}`` resolves alongside
+    # the bare-name lookup. First-wins if both shapes appear for one name.
+    mount_map_by_name: dict[str, str] = {}
+    for raw, dst in legacy_mount_map.items():
+        name, _ = _split_legacy_mount_key(str(raw))
+        mount_map_by_name.setdefault(name, dst)
+
+    mount_options_by_name: dict[str, Any] = {}
+    for raw, opts in legacy_mount_options.items():
+        name, _ = _split_legacy_mount_key(str(raw))
+        mount_options_by_name.setdefault(name, opts)
+
+    for name, res in resolutions.items():
+        vfid = res.vfid
         if vfid not in existing_uuid_set:
             merged_mount_ids.append(vfid)
             existing_uuid_set.add(vfid)
-        if (dst := legacy_mount_map.get(name)) and vfid not in merged_mount_id_map:
+        if (dst := mount_map_by_name.get(name)) and vfid not in merged_mount_id_map:
             merged_mount_id_map[vfid] = dst
-        if (opts := legacy_mount_options.get(name)) and vfid not in merged_mount_options:
+        if (opts := mount_options_by_name.get(name)) and vfid not in merged_mount_options:
             merged_mount_options[vfid] = opts
-        if (sub := subpath_by_name.get(name)) is not None:
+        if res.subpath is not None:
             existing_opts = merged_mount_options.get(vfid) or {}
             # Do not clobber a subpath explicitly supplied via the modern
             # UUID-keyed ``mount_options`` surface for the same vfolder —
             # the explicit value wins over the legacy name/subpath form.
             if "subpath" not in existing_opts:
-                merged_mount_options[vfid] = {**existing_opts, "subpath": sub}
+                merged_mount_options[vfid] = {**existing_opts, "subpath": res.subpath}
 
     next_config = dict(creation_config)
     next_config["mount_ids"] = merged_mount_ids
@@ -373,90 +416,75 @@ class SessionHandler:
         if not (legacy_mounts or legacy_mount_map or legacy_mount_options):
             return validated_config
         validated_config = _route_legacy_uuid_mounts(validated_config)
-        name_to_id, name_to_subpath = await self._resolve_legacy_name_mounts(
+        resolutions = await self._resolve_legacy_name_mounts(
             validated_config.get("mounts") or (),
             validated_config.get("mount_map") or {},
             validated_config.get("mount_options") or {},
         )
-        return _merge_resolved_legacy_mounts(validated_config, name_to_id, name_to_subpath)
+        return _merge_resolved_legacy_mounts(validated_config, resolutions)
 
     async def _resolve_legacy_name_mounts(
         self,
         mounts: Sequence[str],
         mount_map: Mapping[str, str],
         mount_options: Mapping[str, Any],
-    ) -> tuple[dict[str, UUID], dict[str, str]]:
-        """Resolve legacy v1 CLI name-keyed mount surfaces into a unified
-        ``name → UUID`` mapping, plus extract any ``name/subpath`` suffix
-        the caller embedded in the ``mounts`` list.
+    ) -> dict[str, LegacyMountResolution]:
+        """Resolve legacy v1 CLI name-keyed mount surfaces into a map
+        ``name → LegacyMountResolution(vfid, subpath_or_None)``.
 
         ``mounts`` (list of names, optionally ``"<name>/<subpath>"``),
-        ``mount_map`` (dict keyed by name), and ``mount_options`` (dict
-        keyed by name) are all name-based legacy inputs populated
-        together by ``-v`` on the v1 CLI; they must be re-keyed onto
-        UUIDs together so a name that appears only in ``mount_map`` or
-        ``mount_options`` is not silently dropped downstream.
+        ``mount_map`` (dict keyed by name, optionally with the same
+        ``"<name>/<subpath>"`` suffix), and ``mount_options`` (same key
+        shape) are all name-based legacy inputs populated together by
+        ``-v vfname[/sub][:dst][,opt]`` on the v1 CLI; the CLI keeps the
+        slash-with-subpath in the source string verbatim, so the same
+        ``"<name>/<sub>"`` key can appear across all three surfaces.
 
-        Legacy ``mounts`` entries of the form ``"vfname/subdir"`` are
-        split here so the lookup uses only the vfolder name; the parsed
-        subpath suffix is returned in the second tuple element so the
-        merge step (:func:`_merge_resolved_legacy_mounts`) can inject it
-        into ``mount_options[uuid]["subpath"]``. Escape validation on the
-        subpath value is performed downstream by ``prepare_vfolder_mounts``
-        once the UUID-keyed shape is assembled.
+        We peel that suffix off every key, resolve only the bare vfolder
+        name, and attach the parsed subpath to the resolution so
+        :func:`_merge_resolved_legacy_mounts` can inject it into
+        ``mount_options[uuid]["subpath"]``. Escape validation on the
+        subpath value is performed downstream by ``prepare_vfolder_mounts``.
         """
         if not mounts and not mount_map and not mount_options:
-            return {}, {}
+            return {}
 
         names_to_resolve: list[str] = []
         seen: set[str] = set()
-        name_to_subpath: dict[str, str] = {}
+        subpath_by_name: dict[str, str] = {}
 
-        # ``mounts`` may carry "<name>/<subpath>" — partition off the
-        # subpath suffix and remember it keyed by the resolved name. The
-        # subpath itself is validated downstream against root-escape via
-        # ``_normalize_mount_subpath``.
-        for raw in mounts:
-            entry = str(raw)
-            name, sep, subpath = entry.partition("/")
-            if sep and subpath:
-                name_to_subpath[name] = subpath
-            if name in seen:
-                continue
-            seen.add(name)
-            names_to_resolve.append(name)
-
-        # ``mount_map`` keys are plain names (no subpath syntax).
-        for raw in mount_map.keys():
-            name = str(raw)
-            if name in seen:
-                continue
-            seen.add(name)
-            names_to_resolve.append(name)
-
-        # ``mount_options`` is the single polymorphic field shared by
-        # both legacy (name-keyed) and modern (UUID-string-keyed)
-        # callers; skip keys that already parse as UUID strings since
-        # they are not vfolder names to resolve.
-        for raw in mount_options.keys():
-            name = str(raw)
-            if name in seen:
-                continue
+        # Walk the three legacy name-keyed surfaces, peel any
+        # ``"name/subpath"`` suffix, and skip keys whose bare-name parses
+        # as a UUID — those represent UUID-keyed entries that
+        # ``_route_legacy_uuid_mounts`` should already have lifted, or
+        # malformed ``<UUID>/<sub>`` inputs outside the legacy contract.
+        for raw in chain(mounts, mount_map.keys(), mount_options.keys()):
+            name, subpath = _split_legacy_mount_key(str(raw))
             try:
                 UUID(name)
                 continue
             except (ValueError, TypeError):
                 pass
+            if subpath is not None:
+                # The same ``-v`` flag populates mounts/mount_map/mount_options
+                # with the same source, so the subpath should agree across all
+                # three; if a caller supplies divergent forms, first-wins.
+                subpath_by_name.setdefault(name, subpath)
+            if name in seen:
+                continue
             seen.add(name)
             names_to_resolve.append(name)
 
         if not names_to_resolve:
-            return {}, name_to_subpath
+            return {}
 
         result = await self._vfolder.resolve_vfolder_ids_by_names.wait_for_complete(
             ResolveIdsByNamesAction(vfolder_names=names_to_resolve)
         )
-        return dict(result.name_to_id), name_to_subpath
+        return {
+            name: LegacyMountResolution(vfid=vfid, subpath=subpath_by_name.get(name))
+            for name, vfid in result.name_to_id.items()
+        }
 
     # ------------------------------------------------------------------
     # create_from_template (POST /_/create-from-template)

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -285,6 +285,7 @@ def _route_legacy_uuid_mounts(creation_config: dict[str, Any]) -> dict[str, Any]
 def _merge_resolved_legacy_mounts(
     creation_config: dict[str, Any],
     name_to_id: dict[str, UUID],
+    name_to_subpath: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     """Merge a ``name → UUID`` resolution into the UUID-keyed buckets of
     ``creation_config`` and drop the now-resolved name-keyed legacy keys.
@@ -293,6 +294,13 @@ def _merge_resolved_legacy_mounts(
     and entries from the name-keyed ``mount_map`` / ``mount_options``
     dicts are re-keyed onto the resolved UUIDs without overwriting an
     explicit UUID-keyed entry the caller already supplied.
+
+    When the caller passed a legacy ``mounts`` entry in the
+    ``"vfname/subdir"`` shape, ``name_to_subpath`` carries that parsed
+    subpath suffix for the matching name; it is injected into
+    ``mount_options[uuid]["subpath"]`` so the downstream UUID-keyed
+    consumer (``prepare_vfolder_mounts``) sees the same shape as a
+    modern caller supplying ``mount_options`` directly.
     """
     if not name_to_id:
         return creation_config
@@ -308,6 +316,7 @@ def _merge_resolved_legacy_mounts(
     merged_mount_options: dict[Any, Any] = dict(creation_config.get("mount_options") or {})
     legacy_mount_map = creation_config.get("mount_map") or {}
     legacy_mount_options = creation_config.get("mount_options") or {}
+    subpath_by_name = dict(name_to_subpath or {})
 
     for name, vfid in name_to_id.items():
         if vfid not in existing_uuid_set:
@@ -317,6 +326,13 @@ def _merge_resolved_legacy_mounts(
             merged_mount_id_map[vfid] = dst
         if (opts := legacy_mount_options.get(name)) and vfid not in merged_mount_options:
             merged_mount_options[vfid] = opts
+        if (sub := subpath_by_name.get(name)) is not None:
+            existing_opts = merged_mount_options.get(vfid) or {}
+            # Do not clobber a subpath explicitly supplied via the modern
+            # UUID-keyed ``mount_options`` surface for the same vfolder —
+            # the explicit value wins over the legacy name/subpath form.
+            if "subpath" not in existing_opts:
+                merged_mount_options[vfid] = {**existing_opts, "subpath": sub}
 
     next_config = dict(creation_config)
     next_config["mount_ids"] = merged_mount_ids
@@ -357,55 +373,61 @@ class SessionHandler:
         if not (legacy_mounts or legacy_mount_map or legacy_mount_options):
             return validated_config
         validated_config = _route_legacy_uuid_mounts(validated_config)
-        name_to_id = await self._resolve_legacy_name_mounts(
+        name_to_id, name_to_subpath = await self._resolve_legacy_name_mounts(
             validated_config.get("mounts") or (),
             validated_config.get("mount_map") or {},
             validated_config.get("mount_options") or {},
         )
-        return _merge_resolved_legacy_mounts(validated_config, name_to_id)
+        return _merge_resolved_legacy_mounts(validated_config, name_to_id, name_to_subpath)
 
     async def _resolve_legacy_name_mounts(
         self,
         mounts: Sequence[str],
         mount_map: Mapping[str, str],
         mount_options: Mapping[str, Any],
-    ) -> dict[str, UUID]:
+    ) -> tuple[dict[str, UUID], dict[str, str]]:
         """Resolve legacy v1 CLI name-keyed mount surfaces into a unified
-        ``name → UUID`` mapping.
+        ``name → UUID`` mapping, plus extract any ``name/subpath`` suffix
+        the caller embedded in the ``mounts`` list.
 
-        ``mounts`` (list of names), ``mount_map`` (dict keyed by name), and
-        ``mount_options`` (dict keyed by name) are all name-based legacy
-        inputs populated together by ``-v`` on the v1 CLI; they must be
-        re-keyed onto UUIDs together so a name that appears only in
-        ``mount_map`` or ``mount_options`` is not silently dropped
-        downstream.
+        ``mounts`` (list of names, optionally ``"<name>/<subpath>"``),
+        ``mount_map`` (dict keyed by name), and ``mount_options`` (dict
+        keyed by name) are all name-based legacy inputs populated
+        together by ``-v`` on the v1 CLI; they must be re-keyed onto
+        UUIDs together so a name that appears only in ``mount_map`` or
+        ``mount_options`` is not silently dropped downstream.
 
-        Subpath syntax (``name/subdir``) is rejected here because
-        :class:`MountInfoEntry` carries no subpath field; silently dropping
-        it would mount the wrong directory. Subpath mounts must use the
-        UUID-keyed surface where the storage proxy handles vfsubpath
-        separately.
-
-        Merging the resolved ids/maps back into ``creation_config`` is the
-        caller's responsibility — see :func:`_merge_resolved_legacy_mounts`.
+        Legacy ``mounts`` entries of the form ``"vfname/subdir"`` are
+        split here so the lookup uses only the vfolder name; the parsed
+        subpath suffix is returned in the second tuple element so the
+        merge step (:func:`_merge_resolved_legacy_mounts`) can inject it
+        into ``mount_options[uuid]["subpath"]``. Escape validation on the
+        subpath value is performed downstream by ``prepare_vfolder_mounts``
+        once the UUID-keyed shape is assembled.
         """
         if not mounts and not mount_map and not mount_options:
-            return {}
-
-        subpath_entries = [m for m in mounts if "/" in str(m)]
-        if subpath_entries:
-            raise InvalidAPIParameters(
-                "Legacy 'mounts' field with subpath syntax "
-                f"({subpath_entries}) is not supported. "
-                "Use UUID-keyed 'mount_ids' / 'mount_id_map' instead."
-            )
+            return {}, {}
 
         names_to_resolve: list[str] = []
         seen: set[str] = set()
+        name_to_subpath: dict[str, str] = {}
 
-        # ``mounts`` and ``mount_map`` are strictly name-keyed legacy
-        # surfaces — every entry is treated as a vfolder name.
-        for raw in list(mounts) + list(mount_map.keys()):
+        # ``mounts`` may carry "<name>/<subpath>" — partition off the
+        # subpath suffix and remember it keyed by the resolved name. The
+        # subpath itself is validated downstream against root-escape via
+        # ``_normalize_mount_subpath``.
+        for raw in mounts:
+            entry = str(raw)
+            name, sep, subpath = entry.partition("/")
+            if sep and subpath:
+                name_to_subpath[name] = subpath
+            if name in seen:
+                continue
+            seen.add(name)
+            names_to_resolve.append(name)
+
+        # ``mount_map`` keys are plain names (no subpath syntax).
+        for raw in mount_map.keys():
             name = str(raw)
             if name in seen:
                 continue
@@ -429,12 +451,12 @@ class SessionHandler:
             names_to_resolve.append(name)
 
         if not names_to_resolve:
-            return {}
+            return {}, name_to_subpath
 
         result = await self._vfolder.resolve_vfolder_ids_by_names.wait_for_complete(
             ResolveIdsByNamesAction(vfolder_names=names_to_resolve)
         )
-        return dict(result.name_to_id)
+        return dict(result.name_to_id), name_to_subpath
 
     # ------------------------------------------------------------------
     # create_from_template (POST /_/create-from-template)

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -375,10 +375,18 @@ def _merge_resolved_legacy_mounts(
             if "subpath" not in existing_opts:
                 merged_mount_options[vfid] = {**existing_opts, "subpath": res.subpath}
 
+    # Drop any leftover name-keyed entries from ``mount_options`` — once
+    # they have been re-keyed onto the resolved UUID, the original
+    # name-keyed copy is dead weight that downstream consumers (which
+    # look up by UUID only) would never read.
+    uuid_keyed_mount_options: dict[UUID, Any] = {
+        k: v for k, v in merged_mount_options.items() if isinstance(k, UUID)
+    }
+
     next_config = dict(creation_config)
     next_config["mount_ids"] = merged_mount_ids
     next_config["mount_id_map"] = merged_mount_id_map
-    next_config["mount_options"] = merged_mount_options
+    next_config["mount_options"] = uuid_keyed_mount_options
     next_config.pop("mounts", None)
     next_config.pop("mount_map", None)
     return next_config

--- a/tests/unit/manager/services/session/test_session_lifecycle_service.py
+++ b/tests/unit/manager/services/session/test_session_lifecycle_service.py
@@ -1067,12 +1067,12 @@ class TestCreateFromParams:
             "mount_map": {"vf-a": "/data"},
             "mount_options": {"vf-a": {"permission": "ro", "type": "bind"}},
         }
-        name_to_id = await handler._resolve_legacy_name_mounts(
+        name_to_id, name_to_subpath = await handler._resolve_legacy_name_mounts(
             legacy_config["mounts"],
             legacy_config["mount_map"],
             legacy_config["mount_options"],
         )
-        resolved_config = _merge_resolved_legacy_mounts(legacy_config, name_to_id)
+        resolved_config = _merge_resolved_legacy_mounts(legacy_config, name_to_id, name_to_subpath)
 
         # Step 2: feed the resolved config to the service and verify it
         # arrives at AgentRegistry.create_session intact.
@@ -1167,6 +1167,83 @@ class TestCreateFromParams:
         assert routed["mount_options"] == {legacy_uuid_mount_vfid: {"permission": "ro"}}
         assert routed["mount_ids"] == [legacy_uuid_mount_vfid]
         assert routed["mount_id_map"] == {legacy_uuid_mount_vfid: "/data"}
+
+    async def test_legacy_name_subpath_routes_to_uuid_mount_options(
+        self,
+    ) -> None:
+        """Regression for BA-6022: a legacy ``mounts=['vfname/subpath']``
+        entry — silently dropped by PR #11250 and outright rejected by
+        PR #11434 — must now parse cleanly, look up ``vfname`` as a
+        plain name, and inject the parsed subpath into the UUID-keyed
+        ``mount_options[uuid]['subpath']``."""
+        vfid = UUID("33333333-3333-3333-3333-333333333333")
+
+        async def _wait_for_complete(action: Any) -> ResolveIdsByNamesActionResult:
+            # The subpath suffix must be stripped before the name lookup.
+            assert list(action.vfolder_names) == ["vf-a"]
+            return ResolveIdsByNamesActionResult(name_to_id={"vf-a": vfid})
+
+        resolver = MagicMock()
+        resolver.wait_for_complete = AsyncMock(side_effect=_wait_for_complete)
+        vfolder_pkg = MagicMock()
+        vfolder_pkg.resolve_vfolder_ids_by_names = resolver
+        handler = SessionHandler.__new__(SessionHandler)
+        handler._vfolder = vfolder_pkg
+
+        legacy_config: dict[str, Any] = {
+            "mounts": ["vf-a/weights/v2"],
+            "mount_map": {"vf-a": "/data"},
+            "mount_options": {},
+        }
+        name_to_id, name_to_subpath = await handler._resolve_legacy_name_mounts(
+            legacy_config["mounts"],
+            legacy_config["mount_map"],
+            legacy_config["mount_options"],
+        )
+        assert name_to_id == {"vf-a": vfid}
+        assert name_to_subpath == {"vf-a": "weights/v2"}
+
+        resolved = _merge_resolved_legacy_mounts(legacy_config, name_to_id, name_to_subpath)
+        assert resolved["mount_ids"] == [vfid]
+        assert resolved["mount_id_map"] == {vfid: "/data"}
+        assert resolved["mount_options"] == {vfid: {"subpath": "weights/v2"}}
+        assert "mounts" not in resolved
+        assert "mount_map" not in resolved
+
+    async def test_explicit_uuid_subpath_wins_over_legacy_name_subpath(
+        self,
+    ) -> None:
+        """When both an explicit UUID-keyed ``mount_options[uuid]['subpath']``
+        and a legacy ``mounts=['<sameName>/<sub>']`` are supplied for the
+        same vfolder, the explicit UUID-keyed value must NOT be clobbered
+        by the legacy name-form's subpath."""
+        vfid = UUID("44444444-4444-4444-4444-444444444444")
+
+        async def _wait_for_complete(action: Any) -> ResolveIdsByNamesActionResult:
+            assert list(action.vfolder_names) == ["vf-a"]
+            return ResolveIdsByNamesActionResult(name_to_id={"vf-a": vfid})
+
+        resolver = MagicMock()
+        resolver.wait_for_complete = AsyncMock(side_effect=_wait_for_complete)
+        vfolder_pkg = MagicMock()
+        vfolder_pkg.resolve_vfolder_ids_by_names = resolver
+        handler = SessionHandler.__new__(SessionHandler)
+        handler._vfolder = vfolder_pkg
+
+        legacy_config: dict[str, Any] = {
+            "mounts": ["vf-a/legacy-form-subpath"],
+            "mount_map": {},
+            "mount_options": {str(vfid): {"subpath": "uuid-form-subpath"}},
+        }
+        # Step 1: lift UUID-shaped entries onto mount_ids/mount_options.
+        routed = _route_legacy_uuid_mounts(legacy_config)
+        # Step 2: name resolution + subpath extraction from name-form.
+        name_to_id, name_to_subpath = await handler._resolve_legacy_name_mounts(
+            routed["mounts"], routed["mount_map"], routed["mount_options"]
+        )
+        # Step 3: merge — explicit UUID-keyed subpath must persist.
+        merged = _merge_resolved_legacy_mounts(routed, name_to_id, name_to_subpath)
+        assert merged["mount_options"][vfid] == {"subpath": "uuid-form-subpath"}
 
     async def test_owner_access_key_uses_owner_user_scope(
         self,

--- a/tests/unit/manager/services/session/test_session_lifecycle_service.py
+++ b/tests/unit/manager/services/session/test_session_lifecycle_service.py
@@ -27,6 +27,7 @@ from ai.backend.common.types import (
     SessionTypes,
 )
 from ai.backend.manager.api.rest.session.handler import (
+    LegacyMountResolution,
     SessionHandler,
     _merge_resolved_legacy_mounts,
     _route_legacy_uuid_mounts,
@@ -1067,12 +1068,12 @@ class TestCreateFromParams:
             "mount_map": {"vf-a": "/data"},
             "mount_options": {"vf-a": {"permission": "ro", "type": "bind"}},
         }
-        name_to_id, name_to_subpath = await handler._resolve_legacy_name_mounts(
+        resolutions = await handler._resolve_legacy_name_mounts(
             legacy_config["mounts"],
             legacy_config["mount_map"],
             legacy_config["mount_options"],
         )
-        resolved_config = _merge_resolved_legacy_mounts(legacy_config, name_to_id, name_to_subpath)
+        resolved_config = _merge_resolved_legacy_mounts(legacy_config, resolutions)
 
         # Step 2: feed the resolved config to the service and verify it
         # arrives at AgentRegistry.create_session intact.
@@ -1195,15 +1196,16 @@ class TestCreateFromParams:
             "mount_map": {"vf-a": "/data"},
             "mount_options": {},
         }
-        name_to_id, name_to_subpath = await handler._resolve_legacy_name_mounts(
+        resolutions = await handler._resolve_legacy_name_mounts(
             legacy_config["mounts"],
             legacy_config["mount_map"],
             legacy_config["mount_options"],
         )
-        assert name_to_id == {"vf-a": vfid}
-        assert name_to_subpath == {"vf-a": "weights/v2"}
+        assert resolutions == {
+            "vf-a": LegacyMountResolution(vfid=vfid, subpath="weights/v2"),
+        }
 
-        resolved = _merge_resolved_legacy_mounts(legacy_config, name_to_id, name_to_subpath)
+        resolved = _merge_resolved_legacy_mounts(legacy_config, resolutions)
         assert resolved["mount_ids"] == [vfid]
         assert resolved["mount_id_map"] == {vfid: "/data"}
         assert resolved["mount_options"] == {vfid: {"subpath": "weights/v2"}}
@@ -1238,12 +1240,62 @@ class TestCreateFromParams:
         # Step 1: lift UUID-shaped entries onto mount_ids/mount_options.
         routed = _route_legacy_uuid_mounts(legacy_config)
         # Step 2: name resolution + subpath extraction from name-form.
-        name_to_id, name_to_subpath = await handler._resolve_legacy_name_mounts(
+        resolutions = await handler._resolve_legacy_name_mounts(
             routed["mounts"], routed["mount_map"], routed["mount_options"]
         )
         # Step 3: merge — explicit UUID-keyed subpath must persist.
-        merged = _merge_resolved_legacy_mounts(routed, name_to_id, name_to_subpath)
+        merged = _merge_resolved_legacy_mounts(routed, resolutions)
         assert merged["mount_options"][vfid] == {"subpath": "uuid-form-subpath"}
+
+    async def test_legacy_cli_colon_form_carries_dst_and_subpath(self) -> None:
+        """Regression for BA-6022: the v1 CLI flattens ``-v vfname/sub:/dest``
+        into ``mounts=['vfname/sub']`` AND ``mount_map={'vfname/sub': '/dest'}``
+        — the same slash-with-subpath string appears as both a list entry
+        and a dict key. The handler must peel the subpath off both surfaces
+        so the bare name resolves, the destination lands on the UUID-keyed
+        ``mount_id_map``, and the subpath lands on
+        ``mount_options[uuid]['subpath']``."""
+        vfid = UUID("55555555-5555-5555-5555-555555555555")
+
+        async def _wait_for_complete(action: Any) -> ResolveIdsByNamesActionResult:
+            # The bare name must be resolved — not the slashed source.
+            assert list(action.vfolder_names) == ["vf-a"]
+            return ResolveIdsByNamesActionResult(name_to_id={"vf-a": vfid})
+
+        resolver = MagicMock()
+        resolver.wait_for_complete = AsyncMock(side_effect=_wait_for_complete)
+        vfolder_pkg = MagicMock()
+        vfolder_pkg.resolve_vfolder_ids_by_names = resolver
+        handler = SessionHandler.__new__(SessionHandler)
+        handler._vfolder = vfolder_pkg
+
+        # Shape produced by ``prepare_mount_arg("vf-a/weights/v2:/data")``.
+        legacy_config: dict[str, Any] = {
+            "mounts": ["vf-a/weights/v2"],
+            "mount_map": {"vf-a/weights/v2": "/data"},
+            "mount_options": {"vf-a/weights/v2": {"permission": "ro"}},
+        }
+        resolutions = await handler._resolve_legacy_name_mounts(
+            legacy_config["mounts"],
+            legacy_config["mount_map"],
+            legacy_config["mount_options"],
+        )
+        assert resolutions == {
+            "vf-a": LegacyMountResolution(vfid=vfid, subpath="weights/v2"),
+        }
+
+        resolved = _merge_resolved_legacy_mounts(legacy_config, resolutions)
+        assert resolved["mount_ids"] == [vfid]
+        # The destination from ``vf-a/weights/v2:/data`` must survive
+        # the re-keying onto the UUID-keyed mount_id_map.
+        assert resolved["mount_id_map"] == {vfid: "/data"}
+        # Pre-existing options (permission) merge with the parsed subpath.
+        assert resolved["mount_options"][vfid] == {
+            "permission": "ro",
+            "subpath": "weights/v2",
+        }
+        assert "mounts" not in resolved
+        assert "mount_map" not in resolved
 
     async def test_owner_access_key_uses_owner_user_scope(
         self,

--- a/tests/unit/manager/services/session/test_session_lifecycle_service.py
+++ b/tests/unit/manager/services/session/test_session_lifecycle_service.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import inspect
 import uuid
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1169,18 +1170,104 @@ class TestCreateFromParams:
         assert routed["mount_ids"] == [legacy_uuid_mount_vfid]
         assert routed["mount_id_map"] == {legacy_uuid_mount_vfid: "/data"}
 
-    async def test_legacy_name_subpath_routes_to_uuid_mount_options(
-        self,
-    ) -> None:
-        """Regression for BA-6022: a legacy ``mounts=['vfname/subpath']``
-        entry — silently dropped by PR #11250 and outright rejected by
-        PR #11434 — must now parse cleanly, look up ``vfname`` as a
-        plain name, and inject the parsed subpath into the UUID-keyed
-        ``mount_options[uuid]['subpath']``."""
-        vfid = UUID("33333333-3333-3333-3333-333333333333")
+    @dataclass(frozen=True)
+    class ExpectedLegacyMount:
+        """Expected post-merge state across the UUID-keyed buckets.
+
+        ``subpath`` is what the resolver returns on
+        :class:`LegacyMountResolution`. ``mount_id_map`` and ``mount_options``
+        mirror the full UUID-keyed dicts ``_merge_resolved_legacy_mounts``
+        should produce — keys are vfolder UUIDs since all legacy name-keyed
+        entries have been resolved by the time we assert.
+        """
+
+        subpath: str | None
+        mount_id_map: dict[UUID, str] = field(default_factory=dict)
+        mount_options: dict[UUID, dict[str, Any]] = field(default_factory=dict)
+
+    @dataclass(frozen=True)
+    class LegacyMountCase:
+        """One legacy-mount route → resolve → merge scenario."""
+
+        case_id: str
+        legacy_config: dict[str, Any]
+        expected: TestCreateFromParams.ExpectedLegacyMount
+
+    LEGACY_MOUNT_VFID = UUID("33333333-3333-3333-3333-333333333333")
+
+    LEGACY_MOUNT_CASES = [
+        # BA-6022 base case: mounts=[vfname/sub] gets parsed and the subpath
+        # lands on mount_options[uuid][subpath]; mount_map keyed by plain name
+        # supplies the destination. Previously rejected with 400 by PR #11434.
+        LegacyMountCase(
+            case_id="mounts_subpath_with_plain_mount_map",
+            legacy_config={
+                "mounts": ["vf-a/weights/v2"],
+                "mount_map": {"vf-a": "/data"},
+                "mount_options": {},
+            },
+            expected=ExpectedLegacyMount(
+                subpath="weights/v2",
+                mount_id_map={LEGACY_MOUNT_VFID: "/data"},
+                mount_options={LEGACY_MOUNT_VFID: {"subpath": "weights/v2"}},
+            ),
+        ),
+        # v1 CLI flattens ``-v vfname/sub:/dest,permission=ro`` into the same
+        # slash-with-subpath source string across all three surfaces. The
+        # handler must peel the suffix off every key so dst and per-mount opts
+        # survive the re-keying onto the UUID-keyed buckets.
+        LegacyMountCase(
+            case_id="cli_colon_form_slashy_keys_in_all_surfaces",
+            legacy_config={
+                "mounts": ["vf-a/weights/v2"],
+                "mount_map": {"vf-a/weights/v2": "/data"},
+                "mount_options": {"vf-a/weights/v2": {"permission": "ro"}},
+            },
+            expected=ExpectedLegacyMount(
+                subpath="weights/v2",
+                mount_id_map={LEGACY_MOUNT_VFID: "/data"},
+                mount_options={
+                    LEGACY_MOUNT_VFID: {"permission": "ro", "subpath": "weights/v2"},
+                },
+            ),
+        ),
+        # An explicit UUID-keyed ``mount_options[uuid][subpath]`` must beat
+        # a competing legacy ``mounts=[vfname/sub]`` for the same vfolder —
+        # the legacy name form does NOT clobber the modern surface.
+        LegacyMountCase(
+            case_id="explicit_uuid_subpath_wins_over_legacy_form",
+            legacy_config={
+                "mounts": ["vf-a/legacy-form-subpath"],
+                "mount_map": {},
+                "mount_options": {
+                    str(LEGACY_MOUNT_VFID): {"subpath": "uuid-form-subpath"},
+                },
+            },
+            expected=ExpectedLegacyMount(
+                subpath="legacy-form-subpath",
+                mount_options={LEGACY_MOUNT_VFID: {"subpath": "uuid-form-subpath"}},
+            ),
+        ),
+    ]
+
+    @pytest.mark.parametrize(
+        "case",
+        LEGACY_MOUNT_CASES,
+        ids=[c.case_id for c in LEGACY_MOUNT_CASES],
+    )
+    async def test_legacy_mount_route_resolve_merge(self, case: LegacyMountCase) -> None:
+        """End-to-end ``_route_legacy_uuid_mounts`` → ``_resolve_legacy_name_mounts``
+        → ``_merge_resolved_legacy_mounts`` for the legacy mount surfaces.
+
+        Every scenario resolves ``vf-a`` to ``LEGACY_MOUNT_VFID`` and asserts
+        that the UUID-keyed buckets carry the expected destination + subpath +
+        per-mount options on the resolved vfolder id.
+        """
+        vfid = self.LEGACY_MOUNT_VFID
 
         async def _wait_for_complete(action: Any) -> ResolveIdsByNamesActionResult:
-            # The subpath suffix must be stripped before the name lookup.
+            # The bare name must be resolved — not the slashed source — and
+            # UUID-shaped keys must already have been lifted by the route step.
             assert list(action.vfolder_names) == ["vf-a"]
             return ResolveIdsByNamesActionResult(name_to_id={"vf-a": vfid})
 
@@ -1191,111 +1278,20 @@ class TestCreateFromParams:
         handler = SessionHandler.__new__(SessionHandler)
         handler._vfolder = vfolder_pkg
 
-        legacy_config: dict[str, Any] = {
-            "mounts": ["vf-a/weights/v2"],
-            "mount_map": {"vf-a": "/data"},
-            "mount_options": {},
-        }
-        resolutions = await handler._resolve_legacy_name_mounts(
-            legacy_config["mounts"],
-            legacy_config["mount_map"],
-            legacy_config["mount_options"],
-        )
-        assert resolutions == {
-            "vf-a": LegacyMountResolution(vfid=vfid, subpath="weights/v2"),
-        }
-
-        resolved = _merge_resolved_legacy_mounts(legacy_config, resolutions)
-        assert resolved["mount_ids"] == [vfid]
-        assert resolved["mount_id_map"] == {vfid: "/data"}
-        assert resolved["mount_options"] == {vfid: {"subpath": "weights/v2"}}
-        assert "mounts" not in resolved
-        assert "mount_map" not in resolved
-
-    async def test_explicit_uuid_subpath_wins_over_legacy_name_subpath(
-        self,
-    ) -> None:
-        """When both an explicit UUID-keyed ``mount_options[uuid]['subpath']``
-        and a legacy ``mounts=['<sameName>/<sub>']`` are supplied for the
-        same vfolder, the explicit UUID-keyed value must NOT be clobbered
-        by the legacy name-form's subpath."""
-        vfid = UUID("44444444-4444-4444-4444-444444444444")
-
-        async def _wait_for_complete(action: Any) -> ResolveIdsByNamesActionResult:
-            assert list(action.vfolder_names) == ["vf-a"]
-            return ResolveIdsByNamesActionResult(name_to_id={"vf-a": vfid})
-
-        resolver = MagicMock()
-        resolver.wait_for_complete = AsyncMock(side_effect=_wait_for_complete)
-        vfolder_pkg = MagicMock()
-        vfolder_pkg.resolve_vfolder_ids_by_names = resolver
-        handler = SessionHandler.__new__(SessionHandler)
-        handler._vfolder = vfolder_pkg
-
-        legacy_config: dict[str, Any] = {
-            "mounts": ["vf-a/legacy-form-subpath"],
-            "mount_map": {},
-            "mount_options": {str(vfid): {"subpath": "uuid-form-subpath"}},
-        }
-        # Step 1: lift UUID-shaped entries onto mount_ids/mount_options.
-        routed = _route_legacy_uuid_mounts(legacy_config)
-        # Step 2: name resolution + subpath extraction from name-form.
+        routed = _route_legacy_uuid_mounts(case.legacy_config)
         resolutions = await handler._resolve_legacy_name_mounts(
             routed["mounts"], routed["mount_map"], routed["mount_options"]
         )
-        # Step 3: merge — explicit UUID-keyed subpath must persist.
-        merged = _merge_resolved_legacy_mounts(routed, resolutions)
-        assert merged["mount_options"][vfid] == {"subpath": "uuid-form-subpath"}
-
-    async def test_legacy_cli_colon_form_carries_dst_and_subpath(self) -> None:
-        """Regression for BA-6022: the v1 CLI flattens ``-v vfname/sub:/dest``
-        into ``mounts=['vfname/sub']`` AND ``mount_map={'vfname/sub': '/dest'}``
-        — the same slash-with-subpath string appears as both a list entry
-        and a dict key. The handler must peel the subpath off both surfaces
-        so the bare name resolves, the destination lands on the UUID-keyed
-        ``mount_id_map``, and the subpath lands on
-        ``mount_options[uuid]['subpath']``."""
-        vfid = UUID("55555555-5555-5555-5555-555555555555")
-
-        async def _wait_for_complete(action: Any) -> ResolveIdsByNamesActionResult:
-            # The bare name must be resolved — not the slashed source.
-            assert list(action.vfolder_names) == ["vf-a"]
-            return ResolveIdsByNamesActionResult(name_to_id={"vf-a": vfid})
-
-        resolver = MagicMock()
-        resolver.wait_for_complete = AsyncMock(side_effect=_wait_for_complete)
-        vfolder_pkg = MagicMock()
-        vfolder_pkg.resolve_vfolder_ids_by_names = resolver
-        handler = SessionHandler.__new__(SessionHandler)
-        handler._vfolder = vfolder_pkg
-
-        # Shape produced by ``prepare_mount_arg("vf-a/weights/v2:/data")``.
-        legacy_config: dict[str, Any] = {
-            "mounts": ["vf-a/weights/v2"],
-            "mount_map": {"vf-a/weights/v2": "/data"},
-            "mount_options": {"vf-a/weights/v2": {"permission": "ro"}},
-        }
-        resolutions = await handler._resolve_legacy_name_mounts(
-            legacy_config["mounts"],
-            legacy_config["mount_map"],
-            legacy_config["mount_options"],
-        )
         assert resolutions == {
-            "vf-a": LegacyMountResolution(vfid=vfid, subpath="weights/v2"),
+            "vf-a": LegacyMountResolution(vfid=vfid, subpath=case.expected.subpath),
         }
 
-        resolved = _merge_resolved_legacy_mounts(legacy_config, resolutions)
-        assert resolved["mount_ids"] == [vfid]
-        # The destination from ``vf-a/weights/v2:/data`` must survive
-        # the re-keying onto the UUID-keyed mount_id_map.
-        assert resolved["mount_id_map"] == {vfid: "/data"}
-        # Pre-existing options (permission) merge with the parsed subpath.
-        assert resolved["mount_options"][vfid] == {
-            "permission": "ro",
-            "subpath": "weights/v2",
-        }
-        assert "mounts" not in resolved
-        assert "mount_map" not in resolved
+        merged = _merge_resolved_legacy_mounts(routed, resolutions)
+        assert merged["mount_ids"] == [vfid]
+        assert merged["mount_id_map"] == case.expected.mount_id_map
+        assert merged["mount_options"] == case.expected.mount_options
+        assert "mounts" not in merged
+        assert "mount_map" not in merged
 
     async def test_owner_access_key_uses_owner_user_scope(
         self,


### PR DESCRIPTION
resolves [BA-6022](https://lablup.atlassian.net/browse/BA-6022)

## Stack

- ⬇ Base: #9149 (BA-2983 — UUID-keyed subpath surface)
- ➤ This PR (BA-6022) — re-enable the legacy `mounts=['vfname/subpath']` shape on top

## Summary

Pre-sokovan, callers (notably the v1 CLI `-v vfname/subdir[:/dest]`) could pass `mounts=['vfname/subdir']` to mount a subdirectory of the named vfolder. PR #11250 (sokovan refactor) silently dropped that shape; PR #11434 made it an explicit 400 reject pointing at a future UUID-keyed surface. The base PR (#9149, BA-2983) has now delivered that UUID-keyed surface.

This PR re-routes the legacy shape onto the modern surface end-to-end:

1. `_resolve_legacy_name_mounts` in `manager/api/rest/session/handler.py` walks all three name-keyed surfaces (`mounts`, `mount_map`, `mount_options`) and peels any `"<name>/<subpath>"` suffix off every key — the v1 CLI flattens `-v vfname/sub:/dest,perm=ro` into the same slashy source string verbatim across all three (source ↦ `mounts` entry + dict key on the other two; target ↦ `mount_map` value), so the destination and per-mount options must survive the peel.
2. The bare name resolves via the existing `ResolveIdsByNamesAction` lookup; the parsed subpath rides along on a `LegacyMountResolution` dataclass returned by the resolver.
3. `_merge_resolved_legacy_mounts` re-keys `mount_map` / `mount_options` entries onto the resolved UUID and injects the subpath into `mount_options[uuid]['subpath']`, then drops any name-keyed leftovers from `mount_options` so the bucket is purely `dict[UUID, ...]` downstream.
4. From that point the shape is identical to a modern caller supplying UUID-keyed `mount_options` directly — the existing UUID-keyed path (`MountInfoEntry.subpath` / `VFolderMountOptions.subpath` / `prepare_vfolder_mounts` escape guard from #9149) handles validation and materialisation uniformly.

## Two-API split

| Surface | Subpath input | Destination input |
|---|---|---|
| Legacy `mounts` (v1 CLI / pre-sokovan callers) | `mounts=['vfname/subpath']` | `mount_map={'vfname/subpath': '/dest'}` (same slashy key) |
| Modern UUID-keyed (#9149) | `mount_options[uuid]={"subpath": "..."}` | `mount_id_map[uuid]='/dest'` |

## Conflict resolution

A caller that supplies BOTH shapes for the same vfolder — a UUID-keyed `mount_options[uuid]['subpath']` AND a name-form `mounts=['<sameName>/<sub>']` — gets the explicit UUID-keyed value honored. The legacy name form does NOT clobber an existing subpath on the modern surface.

## Escape validation

No new escape check needed here. Once the parsed subpath lands in `mount_options[uuid]['subpath']`, the downstream UUID-keyed path runs `_normalize_mount_subpath` in `prepare_vfolder_mounts` (introduced in #9149), which rejects `..`, `../…`, and absolute paths.

## Verification

- **Unit** — `tests/unit/manager/services/session/test_session_lifecycle_service.py::TestCreateFromParams::test_legacy_mount_route_resolve_merge`, parametrized over three scenarios via `LegacyMountCase` / `ExpectedLegacyMount` dataclasses:
  - Base case: `mounts=['vf-a/weights/v2']` + plain-name `mount_map={'vf-a': '/data'}`.
  - v1 CLI colon form: slashy key `'vf-a/weights/v2'` across `mounts` / `mount_map` / `mount_options` simultaneously — destination and pre-existing per-mount opts must both survive the bare-name re-key.
  - Explicit UUID-keyed `mount_options[uuid]['subpath']` precedence over a competing legacy name/subpath form.
- **Integration** — `scripts/bg_test/create_deployment_custom_with_subpath.py` (local dev harness) exercises the same three scenarios against the live manager REST API and asserts `vfolder_mounts[*].vfsubpath` + `kernel_path` on the resulting session row.

Resolves BA-6022.

[BA-6022]: https://lablup.atlassian.net/browse/BA-6022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ