### PR TITLE
fix(BA-6021): move resource_group to deployment metadata and remove from revision input

### DIFF
--- a/changes/11583.fix.md
+++ b/changes/11583.fix.md
@@ -1,0 +1,1 @@
+Fix resource_group being specified per-revision by moving it to deployment metadata so the network assignment is fixed at deployment creation time.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -9380,6 +9380,7 @@ input ModelDeploymentMetadataInput
 {
   projectId: ID!
   domainName: String!
+  resourceGroup: String!
   name: String = null
   tags: [String!] = null
 }
@@ -14893,8 +14894,6 @@ type ResourceConfig
 input ResourceConfigInput
   @join__type(graph: STRAWBERRY)
 {
-  resourceGroup: ResourceGroupInput!
-
   """Added in 26.1.0. Resources allocated for the deployment."""
   resourceSlots: ResourceSlotInput!
 
@@ -14996,13 +14995,6 @@ input ResourceGroupFilter
   AND: [ResourceGroupFilter!] = null
   OR: [ResourceGroupFilter!] = null
   NOT: [ResourceGroupFilter!] = null
-}
-
-"""Added in 25.19.0. """
-input ResourceGroupInput
-  @join__type(graph: STRAWBERRY)
-{
-  name: String!
 }
 
 """Added in 26.2.0. Metadata for a resource group."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -6175,6 +6175,7 @@ type ModelDeploymentMetadata {
 input ModelDeploymentMetadataInput {
   projectId: ID!
   domainName: String!
+  resourceGroup: String!
   name: String = null
   tags: [String!] = null
 }
@@ -9970,8 +9971,6 @@ type ResourceConfig {
 
 """Added in 25.19.0. """
 input ResourceConfigInput {
-  resourceGroup: ResourceGroupInput!
-
   """Added in 26.1.0. Resources allocated for the deployment."""
   resourceSlots: ResourceSlotInput!
 
@@ -10062,11 +10061,6 @@ input ResourceGroupFilter {
   AND: [ResourceGroupFilter!] = null
   OR: [ResourceGroupFilter!] = null
   NOT: [ResourceGroupFilter!] = null
-}
-
-"""Added in 25.19.0. """
-input ResourceGroupInput {
-  name: String!
 }
 
 """Added in 26.2.0. Metadata for a resource group."""

--- a/src/ai/backend/client/cli/deployment.py
+++ b/src/ai/backend/client/cli/deployment.py
@@ -48,6 +48,7 @@ def create_deployment_cmd(
         "metadata": {
             "project_id": "uuid",
             "domain_name": "string",
+            "resource_group": "string",
             "name": "optional string",
             "tags": ["optional", "list"]
         },
@@ -62,7 +63,7 @@ def create_deployment_cmd(
         "initial_revision": {
             "name": "optional string",
             "cluster_config": {"mode": "single-node", "size": 1},
-            "resource_config": {"resource_group": "string", "resource_slots": {}},
+            "resource_config": {"resource_slots": {}},
             "image": {"name": "string", "architecture": "x86_64"},
             "model_runtime_config": {"runtime_variant": "CUSTOM"},
             "model_mount_config": {"vfolder_id": "uuid", "definition_path": "string"}
@@ -248,7 +249,7 @@ def add_revision_cmd(
         "revision": {
             "name": "optional string",
             "cluster_config": {"mode": "single-node", "size": 1},
-            "resource_config": {"resource_group": "string", "resource_slots": {}},
+            "resource_config": {"resource_slots": {}},
             "image": {"id": "uuid"},
             "model_runtime_config": {"runtime_variant": "CUSTOM"},
             "model_mount_config": {"vfolder_id": "uuid", "definition_path": "string"},

--- a/src/ai/backend/client/cli/v2/deployment/commands.py
+++ b/src/ai/backend/client/cli/v2/deployment/commands.py
@@ -117,6 +117,7 @@ def get(deployment_id: str) -> None:
 @click.option("--name", required=True, type=str, help="Deployment name.")
 @click.option("--project-id", required=True, type=str, help="Project (group) UUID.")
 @click.option("--domain-name", default="default", type=str, help="Domain name.")
+@click.option("--resource-group", required=True, type=str, help="Resource group name.")
 @click.option("--replicas", default=0, type=int, help="Number of replicas.")
 @click.option("--open-to-public", default=False, is_flag=True, help="Make publicly accessible.")
 @click.option(
@@ -135,6 +136,7 @@ def create(
     name: str,
     project_id: str,
     domain_name: str,
+    resource_group: str,
     replicas: int,
     open_to_public: bool,
     strategy: str,
@@ -152,6 +154,7 @@ def create(
         ModelDeploymentMetadataInput,
         ModelDeploymentNetworkAccessInput,
     )
+    from ai.backend.common.identifier.resource_group import ResourceGroupName
 
     revision_dto: CreateRevisionInputDTO | None = None
     if initial_revision is not None:
@@ -166,6 +169,7 @@ def create(
         metadata=ModelDeploymentMetadataInput(
             project_id=project_id,
             domain_name=domain_name,
+            resource_group=ResourceGroupName(resource_group),
             name=name,
         ),
         network_access=ModelDeploymentNetworkAccessInput(

--- a/src/ai/backend/common/dto/manager/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/deployment/request.py
@@ -21,6 +21,7 @@ from ai.backend.common.data.model_deployment.types import (
 )
 from ai.backend.common.dto.manager.query import IntFilter, StringFilter
 from ai.backend.common.identifier.image import ImageID
+from ai.backend.common.identifier.resource_group import ResourceGroupName
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import ClusterMode, MountPermission, RuntimeVariant
 
@@ -183,6 +184,7 @@ class DeploymentMetadataInput(BaseRequestModel):
 
     project_id: UUID = Field(description="Project ID")
     domain_name: str = Field(description="Domain name")
+    resource_group: ResourceGroupName = Field(description="Resource group name")
     name: str | None = Field(default=None, description="Deployment name")
     tags: list[str] | None = Field(default=None, description="Tags for the deployment")
 
@@ -224,7 +226,6 @@ class ClusterConfigInput(BaseRequestModel):
 class ResourceConfigInput(BaseRequestModel):
     """Resource configuration input."""
 
-    resource_group: str = Field(description="Resource group name")
     resource_slots: Mapping[str, Any] = Field(
         description='Resource slots (e.g., {"cpu": "1", "mem": "1073741824"})'
     )

--- a/src/ai/backend/common/dto/manager/v2/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/request.py
@@ -46,6 +46,7 @@ from ai.backend.common.dto.manager.v2.resource_slot.types import ResourceOptsDTO
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.deployment_preset import DeploymentPresetID
 from ai.backend.common.identifier.image import ImageID
+from ai.backend.common.identifier.resource_group import ResourceGroupName
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import (
@@ -97,7 +98,6 @@ __all__ = (
     "ReplicaStatusFilter",
     "ReplicaTrafficStatusFilter",
     "ResourceConfigInput",
-    "ResourceGroupInput",
     "ResourceSlotEntryInput",
     "ResourceSlotInput",
     "RevisionFilter",
@@ -207,7 +207,6 @@ class ResourceSlotInput(BaseRequestModel):
 class ResourceConfigInput(BaseRequestModel):
     """Resource configuration input for a revision."""
 
-    resource_group: ResourceGroupInput = Field(description="Resource group")
     resource_slots: ResourceSlotInput = Field(description="Resource slot allocations")
     resource_opts: ResourceOptsDTOInput | None = Field(
         default=None, description="Additional resource options"
@@ -363,6 +362,7 @@ class ModelDeploymentMetadataInput(BaseRequestModel):
 
     project_id: UUID = Field(description="Project ID")
     domain_name: str = Field(description="Domain name")
+    resource_group: ResourceGroupName = Field(description="Resource group name")
     name: str | None = Field(
         default=None,
         min_length=1,
@@ -458,7 +458,6 @@ class RevisionInput(BaseRequestModel):
     image_id: UUID = Field(description="Container image ID")
     cluster_mode: ClusterMode = Field(description="Cluster mode for the revision")
     cluster_size: int = Field(default=1, ge=1, description="Number of nodes in the cluster")
-    resource_group: str = Field(description="Resource group for allocation")
     resource_slots: Mapping[str, Any] = Field(description="Resource slot requirements")
     resource_opts: Mapping[str, Any] | None = Field(
         default=None, description="Optional resource options"

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -474,7 +474,6 @@ class DeploymentAdapter(BaseAdapter):
         """Create a new deployment."""
         initial_revision = input.initial_revision
         model_revision_creator: ModelRevisionCreator | None = None
-        resource_group_name: str | None = None
         if initial_revision is not None:
             mounts_creator = VFolderMountsCreator(
                 model_vfolder_id=initial_revision.model_mount_config.vfolder_id,
@@ -520,7 +519,6 @@ class DeploymentAdapter(BaseAdapter):
                     else None,
                 ),
             )
-            resource_group_name = initial_revision.resource_config.resource_group.name
         strategy = input.default_deployment_strategy
         policy: DeploymentPolicyConfig | None = None
         if strategy.rolling_update is not None:
@@ -550,7 +548,7 @@ class DeploymentAdapter(BaseAdapter):
                 name=meta.name or f"deployment-{created_user_id.hex[:8]}",
                 domain=meta.domain_name,
                 project=meta.project_id,
-                resource_group=resource_group_name or "default",
+                resource_group=meta.resource_group,
                 created_user=created_user_id,
                 session_owner=created_user_id,
                 created_at=None,

--- a/src/ai/backend/manager/api/gql/deployment/__init__.py
+++ b/src/ai/backend/manager/api/gql/deployment/__init__.py
@@ -150,7 +150,6 @@ from .types import (
     ReplicaStatusFilter,
     ResourceConfig,
     ResourceConfigInput,
-    ResourceGroupInput,
     RevisionRefreshResult,
     RollingUpdateConfigInputGQL,
     RollingUpdateStrategySpecGQL,
@@ -274,7 +273,6 @@ __all__ = [
     "ProjectDeploymentScopeGQL",
     "ResourceConfig",
     "ResourceConfigInput",
-    "ResourceGroupInput",
     # Route Types
     "Route",
     "RouteConnection",

--- a/src/ai/backend/manager/api/gql/deployment/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/__init__.py
@@ -119,7 +119,6 @@ from .revision import (
     MountPermission,
     ResourceConfig,
     ResourceConfigInput,
-    ResourceGroupInput,
 )
 from .revision_preset import (
     CreateDeploymentRevisionPresetInputGQL,
@@ -258,7 +257,6 @@ __all__ = [
     "MountPermission",
     "ResourceConfig",
     "ResourceConfigInput",
-    "ResourceGroupInput",
     # Allocated Resource Slot
     "AllocatedResourceSlotFilterGQL",
     "AllocatedResourceSlotGQL",

--- a/src/ai/backend/manager/api/gql/deployment/types/deployment.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/deployment.py
@@ -698,6 +698,7 @@ class DeploymentStatusChangedPayload:
 class ModelDeploymentMetadataInput(PydanticInputMixin[ModelDeploymentMetadataInputDTO]):
     project_id: ID
     domain_name: str
+    resource_group: str
     name: str | None = None
     tags: list[str] | None = None
 

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -66,9 +66,6 @@ from ai.backend.common.dto.manager.v2.deployment.request import (
     ResourceConfigInput as ResourceConfigInputDTO,
 )
 from ai.backend.common.dto.manager.v2.deployment.request import (
-    ResourceGroupInput as ResourceGroupInputDTO,
-)
-from ai.backend.common.dto.manager.v2.deployment.request import (
     ResourceSlotInput as ResourceSlotInputDTO,
 )
 from ai.backend.common.dto.manager.v2.deployment.request import (
@@ -696,13 +693,6 @@ class ClusterConfigInput(PydanticInputMixin[ClusterConfigInputDTO]):
 
 
 @gql_pydantic_input(
-    BackendAIGQLMeta(description="", added_version="25.19.0"),
-)
-class ResourceGroupInput(PydanticInputMixin[ResourceGroupInputDTO]):
-    name: str
-
-
-@gql_pydantic_input(
     BackendAIGQLMeta(
         description="A collection of compute resource allocations for input.",
         added_version="26.1.0",
@@ -720,7 +710,6 @@ class ResourceSlotInput(PydanticInputMixin[ResourceSlotInputDTO]):
     BackendAIGQLMeta(description="", added_version="25.19.0"),
 )
 class ResourceConfigInput(PydanticInputMixin[ResourceConfigInputDTO]):
-    resource_group: ResourceGroupInput
     resource_slots: ResourceSlotInput = gql_added_field(
         BackendAIGQLMeta(
             added_version="26.1.0", description="Resources allocated for the deployment."

--- a/src/ai/backend/manager/api/rest/deployment/adapter.py
+++ b/src/ai/backend/manager/api/rest/deployment/adapter.py
@@ -525,7 +525,7 @@ class CreateDeploymentAdapter:
             name=name,
             domain=request.metadata.domain_name,
             project=request.metadata.project_id,
-            resource_group=request.initial_revision.resource_config.resource_group,
+            resource_group=request.metadata.resource_group,
             created_user=user_uuid,
             session_owner=user_uuid,
             created_at=None,

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -57,6 +57,7 @@ from ai.backend.common.defs import (
 )
 from ai.backend.common.etcd import AsyncEtcd, ConfigScopes
 from ai.backend.common.events.dispatcher import EventProducer
+from ai.backend.common.identifier.resource_group import ResourceGroupName
 from ai.backend.common.message_queue.redis_queue.queue import RedisMQArgs, RedisQueue
 from ai.backend.common.plugin.hook import HookPluginContext
 from ai.backend.common.plugin.monitor import ErrorPluginContext, StatsPluginContext
@@ -669,9 +670,9 @@ async def resource_policy_fixture(
 async def scaling_group_fixture(
     db_engine: SAEngine,
     domain_fixture: str,
-) -> AsyncIterator[str]:
+) -> AsyncIterator[ResourceGroupName]:
     """Insert a scaling group and its domain association; yield the name."""
-    sgroup_name = f"sgroup-{secrets.token_hex(6)}"
+    sgroup_name = ResourceGroupName(f"sgroup-{secrets.token_hex(6)}")
     async with db_engine.begin() as conn:
         await conn.execute(
             sa.insert(scaling_groups).values(

--- a/tests/component/deployment/test_deployment.py
+++ b/tests/component/deployment/test_deployment.py
@@ -49,6 +49,7 @@ from ai.backend.common.dto.manager.v2.deployment.request import (
     DeploymentFilter as DeploymentFilterV2,
 )
 from ai.backend.common.identifier.image import ImageID
+from ai.backend.common.identifier.resource_group import ResourceGroupName
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import ClusterMode
 from ai.backend.manager.api.adapters.deployment.adapter import DeploymentAdapter
@@ -94,7 +95,7 @@ class TestSearchDeployments:
         admin_registry: BackendAIClientRegistry,
         group_fixture: uuid.UUID,
         domain_fixture: str,
-        scaling_group_fixture: str,
+        scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
         """Search deployments with pagination returns correct page."""
@@ -106,6 +107,7 @@ class TestSearchDeployments:
                 metadata=DeploymentMetadataInput(
                     project_id=group_fixture,
                     domain_name=domain_fixture,
+                    resource_group=scaling_group_fixture,
                     name=f"test-deployment-{i}-{secrets.token_hex(4)}",
                 ),
                 network_access=NetworkAccessInput(open_to_public=False),
@@ -117,7 +119,6 @@ class TestSearchDeployments:
                     name="v1",
                     cluster_config=ClusterConfigInput(mode=ClusterMode.SINGLE_NODE, size=1),
                     resource_config=ResourceConfigInput(
-                        resource_group=scaling_group_fixture,
                         resource_slots={"cpu": "2", "mem": "2147483648"},
                     ),
                     image=ImageInput(id=image_id),
@@ -157,7 +158,7 @@ class TestGetDeployment:
         admin_registry: BackendAIClientRegistry,
         group_fixture: uuid.UUID,
         domain_fixture: str,
-        scaling_group_fixture: str,
+        scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
         """Get deployment by ID returns correct deployment details."""
@@ -166,6 +167,7 @@ class TestGetDeployment:
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
                 domain_name=domain_fixture,
+                resource_group=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),
             network_access=NetworkAccessInput(open_to_public=False),
@@ -177,7 +179,6 @@ class TestGetDeployment:
                 name="v1",
                 cluster_config=ClusterConfigInput(mode=ClusterMode.SINGLE_NODE, size=1),
                 resource_config=ResourceConfigInput(
-                    resource_group=scaling_group_fixture,
                     resource_slots={"cpu": "2", "mem": "2147483648"},
                 ),
                 image=ImageInput(id=image_id),
@@ -269,7 +270,7 @@ class TestSearchRoutes:
         admin_registry: BackendAIClientRegistry,
         group_fixture: uuid.UUID,
         domain_fixture: str,
-        scaling_group_fixture: str,
+        scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
         """Search routes for a deployment returns route list."""
@@ -278,6 +279,7 @@ class TestSearchRoutes:
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
                 domain_name=domain_fixture,
+                resource_group=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),
             network_access=NetworkAccessInput(open_to_public=False),
@@ -289,7 +291,6 @@ class TestSearchRoutes:
                 name="v1",
                 cluster_config=ClusterConfigInput(mode=ClusterMode.SINGLE_NODE, size=1),
                 resource_config=ResourceConfigInput(
-                    resource_group=scaling_group_fixture,
                     resource_slots={"cpu": "2", "mem": "2147483648"},
                 ),
                 image=ImageInput(id=image_id),
@@ -365,7 +366,7 @@ class TestDeploymentAdapterFilter:
         admin_registry: BackendAIClientRegistry,
         project_id: uuid.UUID,
         domain: str,
-        scaling_group: str,
+        scaling_group: ResourceGroupName,
         seed_data: tuple[ImageID, VFolderUUID],
         tags: list[str],
         name: str | None = None,
@@ -375,6 +376,7 @@ class TestDeploymentAdapterFilter:
             metadata=DeploymentMetadataInput(
                 project_id=project_id,
                 domain_name=domain,
+                resource_group=scaling_group,
                 name=name or f"test-deployment-{secrets.token_hex(4)}",
                 tags=tags,
             ),
@@ -387,7 +389,6 @@ class TestDeploymentAdapterFilter:
                 name="v1",
                 cluster_config=ClusterConfigInput(mode=ClusterMode.SINGLE_NODE, size=1),
                 resource_config=ResourceConfigInput(
-                    resource_group=scaling_group,
                     resource_slots={"cpu": "2", "mem": "2147483648"},
                 ),
                 image=ImageInput(id=image_id),
@@ -410,7 +411,7 @@ class TestDeploymentAdapterFilter:
         deployment_adapter: DeploymentAdapter,
         group_fixture: uuid.UUID,
         domain_fixture: str,
-        scaling_group_fixture: str,
+        scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
         """AND clause must narrow results to deployments matching every nested filter."""
@@ -460,7 +461,7 @@ class TestDeploymentAdapterFilter:
         deployment_adapter: DeploymentAdapter,
         group_fixture: uuid.UUID,
         domain_fixture: str,
-        scaling_group_fixture: str,
+        scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
         """OR clause must widen results to deployments matching any nested filter."""
@@ -510,7 +511,7 @@ class TestDeploymentAdapterFilter:
         deployment_adapter: DeploymentAdapter,
         group_fixture: uuid.UUID,
         domain_fixture: str,
-        scaling_group_fixture: str,
+        scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
         """OR with multi-field sub-filters must AND fields within each branch.
@@ -585,7 +586,7 @@ class TestDeploymentAdapterFilter:
         deployment_adapter: DeploymentAdapter,
         group_fixture: uuid.UUID,
         domain_fixture: str,
-        scaling_group_fixture: str,
+        scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
         """project_search must also honor AND across nested filters."""

--- a/tests/component/deployment/test_deployment_lifecycle.py
+++ b/tests/component/deployment/test_deployment_lifecycle.py
@@ -34,6 +34,7 @@ from ai.backend.common.dto.manager.deployment import (
 )
 from ai.backend.common.dto.manager.deployment.request import ClusterConfigInput
 from ai.backend.common.identifier.image import ImageID
+from ai.backend.common.identifier.resource_group import ResourceGroupName
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import ClusterMode
 
@@ -58,6 +59,7 @@ class TestCreateDeployment:
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
                 domain_name=domain_fixture,
+                resource_group=ResourceGroupName("nonexistent-sgroup"),
                 name="test-deployment",
             ),
             network_access=NetworkAccessInput(open_to_public=False),
@@ -69,7 +71,6 @@ class TestCreateDeployment:
                 name="rev-1",
                 cluster_config=ClusterConfigInput(mode=ClusterMode.SINGLE_NODE, size=1),
                 resource_config=ResourceConfigInput(
-                    resource_group="nonexistent-sgroup",
                     resource_slots={"cpu": "1", "mem": "1073741824"},
                 ),
                 image=ImageInput(id=ImageID(uuid.uuid4())),
@@ -90,7 +91,7 @@ class TestCreateDeployment:
         admin_registry: BackendAIClientRegistry,
         group_fixture: uuid.UUID,
         domain_fixture: str,
-        scaling_group_fixture: str,
+        scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
         """Creating a deployment with valid config returns deployment with initial status."""
@@ -99,6 +100,7 @@ class TestCreateDeployment:
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
                 domain_name=domain_fixture,
+                resource_group=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),
             network_access=NetworkAccessInput(open_to_public=False),
@@ -110,7 +112,6 @@ class TestCreateDeployment:
                 name="v1",
                 cluster_config=ClusterConfigInput(mode=ClusterMode.SINGLE_NODE, size=1),
                 resource_config=ResourceConfigInput(
-                    resource_group=scaling_group_fixture,
                     resource_slots={"cpu": "2", "mem": "2147483648"},
                 ),
                 image=ImageInput(id=image_id),
@@ -158,7 +159,7 @@ class TestUpdateDeployment:
         admin_registry: BackendAIClientRegistry,
         group_fixture: uuid.UUID,
         domain_fixture: str,
-        scaling_group_fixture: str,
+        scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
         """Updating deployment config (name, replica_count) succeeds."""
@@ -168,6 +169,7 @@ class TestUpdateDeployment:
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
                 domain_name=domain_fixture,
+                resource_group=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),
             network_access=NetworkAccessInput(open_to_public=False),
@@ -179,7 +181,6 @@ class TestUpdateDeployment:
                 name="v1",
                 cluster_config=ClusterConfigInput(mode=ClusterMode.SINGLE_NODE, size=1),
                 resource_config=ResourceConfigInput(
-                    resource_group=scaling_group_fixture,
                     resource_slots={"cpu": "2", "mem": "2147483648"},
                 ),
                 image=ImageInput(id=image_id),
@@ -229,7 +230,7 @@ class TestDestroyDeployment:
         admin_registry: BackendAIClientRegistry,
         group_fixture: uuid.UUID,
         domain_fixture: str,
-        scaling_group_fixture: str,
+        scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
         """Destroying a deployment terminates it successfully."""
@@ -239,6 +240,7 @@ class TestDestroyDeployment:
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
                 domain_name=domain_fixture,
+                resource_group=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),
             network_access=NetworkAccessInput(open_to_public=False),
@@ -250,7 +252,6 @@ class TestDestroyDeployment:
                 name="v1",
                 cluster_config=ClusterConfigInput(mode=ClusterMode.SINGLE_NODE, size=1),
                 resource_config=ResourceConfigInput(
-                    resource_group=scaling_group_fixture,
                     resource_slots={"cpu": "2", "mem": "2147483648"},
                 ),
                 image=ImageInput(id=image_id),
@@ -296,7 +297,7 @@ class TestRevisionManagement:
         admin_registry: BackendAIClientRegistry,
         group_fixture: uuid.UUID,
         domain_fixture: str,
-        scaling_group_fixture: str,
+        scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
         """Adding a revision and searching revisions works correctly."""
@@ -305,7 +306,6 @@ class TestRevisionManagement:
             name="v1",
             cluster_config=ClusterConfigInput(mode=ClusterMode.SINGLE_NODE, size=1),
             resource_config=ResourceConfigInput(
-                resource_group=scaling_group_fixture,
                 resource_slots={"cpu": "2", "mem": "2147483648"},
             ),
             image=ImageInput(id=image_id),
@@ -323,6 +323,7 @@ class TestRevisionManagement:
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
                 domain_name=domain_fixture,
+                resource_group=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),
             network_access=NetworkAccessInput(open_to_public=False),
@@ -343,7 +344,6 @@ class TestRevisionManagement:
                     name="v2",
                     cluster_config=ClusterConfigInput(mode=ClusterMode.SINGLE_NODE, size=1),
                     resource_config=ResourceConfigInput(
-                        resource_group=scaling_group_fixture,
                         resource_slots={"cpu": "2", "mem": "2147483648"},
                     ),
                     image=ImageInput(id=image_id),
@@ -380,7 +380,7 @@ class TestReplicaManagement:
         admin_registry: BackendAIClientRegistry,
         group_fixture: uuid.UUID,
         domain_fixture: str,
-        scaling_group_fixture: str,
+        scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
         """Changing replica_count updates the replica count."""
@@ -389,6 +389,7 @@ class TestReplicaManagement:
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
                 domain_name=domain_fixture,
+                resource_group=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),
             network_access=NetworkAccessInput(open_to_public=False),
@@ -400,7 +401,6 @@ class TestReplicaManagement:
                 name="v1",
                 cluster_config=ClusterConfigInput(mode=ClusterMode.SINGLE_NODE, size=1),
                 resource_config=ResourceConfigInput(
-                    resource_group=scaling_group_fixture,
                     resource_slots={"cpu": "2", "mem": "2147483648"},
                 ),
                 image=ImageInput(id=image_id),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -29,6 +29,7 @@ from ai.backend.common.configs.etcd import EtcdConfig
 from ai.backend.common.configs.pyroscope import PyroscopeConfig
 from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.dependencies import DependencyBuilderStack
+from ai.backend.common.identifier.resource_group import ResourceGroupName
 from ai.backend.common.typed_validators import HostPortPair as HostPortPairModel
 from ai.backend.common.types import DefaultForUnspecified, ResourceSlot, VFolderHostPermissionMap
 from ai.backend.logging import LocalLogger, LogLevel
@@ -544,9 +545,9 @@ async def resource_policy_fixture(
 async def scaling_group_fixture(
     db_engine: SAEngine,
     domain_fixture: str,
-) -> AsyncIterator[str]:
+) -> AsyncIterator[ResourceGroupName]:
     """Insert a scaling group and its domain association; yield the name."""
-    sgroup_name = f"sgroup-{secrets.token_hex(6)}"
+    sgroup_name = ResourceGroupName(f"sgroup-{secrets.token_hex(6)}")
     async with db_engine.begin() as conn:
         await conn.execute(
             sa.insert(scaling_groups).values(

--- a/tests/unit/client_v2/test_deployment.py
+++ b/tests/unit/client_v2/test_deployment.py
@@ -50,6 +50,7 @@ from ai.backend.common.dto.manager.deployment.request import (
     UpdateRouteTrafficStatusRequest,
 )
 from ai.backend.common.identifier.image import ImageID
+from ai.backend.common.identifier.resource_group import ResourceGroupName
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import ClusterMode
 
@@ -163,6 +164,7 @@ class TestDeploymentCRUD:
             metadata=DeploymentMetadataInput(
                 project_id=_SAMPLE_PROJECT_ID,
                 domain_name="default",
+                resource_group=ResourceGroupName("default"),
                 name="my-deployment",
             ),
             network_access=NetworkAccessInput(open_to_public=False),
@@ -173,7 +175,6 @@ class TestDeploymentCRUD:
             initial_revision=RevisionInput(
                 cluster_config=ClusterConfigInput(mode=ClusterMode.SINGLE_NODE, size=1),
                 resource_config=ResourceConfigInput(
-                    resource_group="default",
                     resource_slots={"cpu": "1"},
                 ),
                 image=ImageInput(id=_SAMPLE_IMAGE_ID),

--- a/tests/unit/common/dto/manager/v2/deployment/test_request.py
+++ b/tests/unit/common/dto/manager/v2/deployment/test_request.py
@@ -293,6 +293,7 @@ class TestCreateDeploymentInput:
         defaults: dict[str, Any] = {
             "project_id": uuid.uuid4(),
             "domain_name": "default",
+            "resource_group": "default",
         }
         defaults.update(kwargs)
         return ModelDeploymentMetadataInput(**defaults)

--- a/tests/unit/common/dto/manager/v2/deployment/test_request.py
+++ b/tests/unit/common/dto/manager/v2/deployment/test_request.py
@@ -30,7 +30,6 @@ from ai.backend.common.dto.manager.v2.deployment.request import (
     ModelMountConfigInput,
     ModelRuntimeConfigInput,
     ResourceConfigInput,
-    ResourceGroupInput,
     ResourceSlotEntryInput,
     ResourceSlotInput,
     RevisionInput,
@@ -51,7 +50,6 @@ def _make_revision_input(**kwargs: object) -> RevisionInput:
         "image_id": ImageID(uuid.uuid4()),
         "cluster_mode": ClusterMode.SINGLE_NODE,
         "cluster_size": 1,
-        "resource_group": "default",
         "resource_slots": {"cpu": "2", "mem": "4g"},
         "runtime_variant_id": RuntimeVariantID(uuid.uuid4()),
         "model_vfolder_id": VFolderUUID(uuid.uuid4()),
@@ -66,7 +64,6 @@ def _make_create_revision_input_dto(**kwargs: object) -> CreateRevisionInputDTO:
     defaults: dict[str, Any] = {
         "cluster_config": ClusterConfigInput(mode=ClusterMode.SINGLE_NODE, size=1),
         "resource_config": ResourceConfigInput(
-            resource_group=ResourceGroupInput(name="default"),
             resource_slots=ResourceSlotInput(
                 entries=[
                     ResourceSlotEntryInput(resource_type="cpu", quantity="2"),
@@ -99,7 +96,6 @@ class TestRevisionInput:
         rev = RevisionInput(
             image_id=image_id,
             cluster_mode=ClusterMode.SINGLE_NODE,
-            resource_group="default",
             resource_slots={"cpu": "2"},
             runtime_variant_id=runtime_variant_id,
             model_vfolder_id=model_id,
@@ -108,7 +104,6 @@ class TestRevisionInput:
         )
         assert rev.image_id == image_id
         assert rev.cluster_mode == ClusterMode.SINGLE_NODE
-        assert rev.resource_group == "default"
         assert rev.model_vfolder_id == model_id
         assert rev.model_definition_path == "/models/def.yaml"
 


### PR DESCRIPTION
## Summary

- `resource_group` is now a required field in **deployment metadata** (create time) instead of being nested inside `initial_revision.resource_config`
- Revision inputs (`CreateRevisionInputDTO`, `AddRevisionGQLInputDTO`, flat `RevisionInput`) no longer accept `resource_group` — each revision inherits the value fixed at deployment creation time
- Prevents network mismatches caused by the app proxy resolving coordinator addresses per resource group on each deploy action
- Updated CLI `deployment create` to expose `--resource-group` as a top-level required option
- Typed `scaling_group_fixture` as `ResourceGroupName` in both component and integration conftest files

## Test plan

- [x] `pants check` passes on all 15 changed files
- [x] `pants lint` passes
- [x] `pants test tests/unit/client_v2/test_deployment.py` passes
- [x] `pants test tests/unit/common/dto/manager/v2/deployment/test_request.py` passes
- [x] Live server: `./bai deployment create --resource-group default ...` successfully creates deployment with resource_group stored in DB

Resolves BA-6021

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11583.org.readthedocs.build/en/11583/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11583.org.readthedocs.build/ko/11583/

<!-- readthedocs-preview sorna-ko end -->