### PR TITLE
refactor(BA-6038): rename ModelDeploymentMetadataInput.resourceGroup to resourceGroupName

### DIFF
--- a/changes/.enhance.md
+++ b/changes/.enhance.md
@@ -1,1 +1,0 @@
-Rename `ModelDeploymentMetadataInput.resourceGroup` to `resourceGroupName` for consistency with other resource group field names across the v2 deployment API.

--- a/changes/.enhance.md
+++ b/changes/.enhance.md
@@ -1,0 +1,1 @@
+Rename `ModelDeploymentMetadataInput.resourceGroup` to `resourceGroupName` for consistency with other resource group field names across the v2 deployment API.

--- a/changes/11600.enhance.md
+++ b/changes/11600.enhance.md
@@ -1,0 +1,1 @@
+Rename `ModelDeploymentMetadataInput.resourceGroup` to `resourceGroupName` to align with the resource group field naming used elsewhere in the v2 deployment API.

--- a/changes/11600.enhance.md
+++ b/changes/11600.enhance.md
@@ -1,1 +1,1 @@
-Rename `ModelDeploymentMetadataInput.resourceGroup` to `resourceGroupName` to align with the resource group field naming used elsewhere in the v2 deployment API.
+Rename the resource group field on deployment metadata inputs to align with the resource group naming used elsewhere in the deployment API: `ModelDeploymentMetadataInput.resourceGroup` → `resourceGroupName` (v2 GraphQL/DTO) and `DeploymentMetadataInput.resource_group` → `resource_group_name` (v1 REST DTO; `POST /deployments` body).

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -9386,7 +9386,7 @@ input ModelDeploymentMetadataInput
 {
   projectId: ID!
   domainName: String!
-  resourceGroup: String!
+  resourceGroupName: String!
   name: String = null
   tags: [String!] = null
 }

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -6181,7 +6181,7 @@ type ModelDeploymentMetadata {
 input ModelDeploymentMetadataInput {
   projectId: ID!
   domainName: String!
-  resourceGroup: String!
+  resourceGroupName: String!
   name: String = null
   tags: [String!] = null
 }

--- a/src/ai/backend/client/cli/v2/deployment/commands.py
+++ b/src/ai/backend/client/cli/v2/deployment/commands.py
@@ -169,7 +169,7 @@ def create(
         metadata=ModelDeploymentMetadataInput(
             project_id=project_id,
             domain_name=domain_name,
-            resource_group=ResourceGroupName(resource_group),
+            resource_group_name=ResourceGroupName(resource_group),
             name=name,
         ),
         network_access=ModelDeploymentNetworkAccessInput(

--- a/src/ai/backend/common/dto/manager/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/deployment/request.py
@@ -184,7 +184,7 @@ class DeploymentMetadataInput(BaseRequestModel):
 
     project_id: UUID = Field(description="Project ID")
     domain_name: str = Field(description="Domain name")
-    resource_group: ResourceGroupName = Field(description="Resource group name")
+    resource_group_name: ResourceGroupName = Field(description="Resource group name")
     name: str | None = Field(default=None, description="Deployment name")
     tags: list[str] | None = Field(default=None, description="Tags for the deployment")
 

--- a/src/ai/backend/common/dto/manager/v2/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/request.py
@@ -362,7 +362,7 @@ class ModelDeploymentMetadataInput(BaseRequestModel):
 
     project_id: UUID = Field(description="Project ID")
     domain_name: str = Field(description="Domain name")
-    resource_group: ResourceGroupName = Field(description="Resource group name")
+    resource_group_name: ResourceGroupName = Field(description="Resource group name")
     name: str | None = Field(
         default=None,
         min_length=1,

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -548,7 +548,7 @@ class DeploymentAdapter(BaseAdapter):
                 name=meta.name or f"deployment-{created_user_id.hex[:8]}",
                 domain=meta.domain_name,
                 project=meta.project_id,
-                resource_group=meta.resource_group,
+                resource_group=meta.resource_group_name,
                 created_user=created_user_id,
                 session_owner=created_user_id,
                 created_at=None,

--- a/src/ai/backend/manager/api/gql/deployment/types/deployment.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/deployment.py
@@ -722,7 +722,7 @@ class DeploymentStatusChangedPayload:
 class ModelDeploymentMetadataInput(PydanticInputMixin[ModelDeploymentMetadataInputDTO]):
     project_id: ID
     domain_name: str
-    resource_group: str
+    resource_group_name: str
     name: str | None = None
     tags: list[str] | None = None
 

--- a/src/ai/backend/manager/api/rest/deployment/adapter.py
+++ b/src/ai/backend/manager/api/rest/deployment/adapter.py
@@ -525,7 +525,7 @@ class CreateDeploymentAdapter:
             name=name,
             domain=request.metadata.domain_name,
             project=request.metadata.project_id,
-            resource_group=request.metadata.resource_group_name,
+            resource_group=request.metadata.resource_group,
             created_user=user_uuid,
             session_owner=user_uuid,
             created_at=None,

--- a/src/ai/backend/manager/api/rest/deployment/adapter.py
+++ b/src/ai/backend/manager/api/rest/deployment/adapter.py
@@ -525,7 +525,7 @@ class CreateDeploymentAdapter:
             name=name,
             domain=request.metadata.domain_name,
             project=request.metadata.project_id,
-            resource_group=request.metadata.resource_group,
+            resource_group=request.metadata.resource_group_name,
             created_user=user_uuid,
             session_owner=user_uuid,
             created_at=None,

--- a/tests/component/deployment/test_deployment.py
+++ b/tests/component/deployment/test_deployment.py
@@ -107,7 +107,7 @@ class TestSearchDeployments:
                 metadata=DeploymentMetadataInput(
                     project_id=group_fixture,
                     domain_name=domain_fixture,
-                    resource_group=scaling_group_fixture,
+                    resource_group_name=scaling_group_fixture,
                     name=f"test-deployment-{i}-{secrets.token_hex(4)}",
                 ),
                 network_access=NetworkAccessInput(open_to_public=False),
@@ -167,7 +167,7 @@ class TestGetDeployment:
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
                 domain_name=domain_fixture,
-                resource_group=scaling_group_fixture,
+                resource_group_name=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),
             network_access=NetworkAccessInput(open_to_public=False),
@@ -279,7 +279,7 @@ class TestSearchRoutes:
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
                 domain_name=domain_fixture,
-                resource_group=scaling_group_fixture,
+                resource_group_name=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),
             network_access=NetworkAccessInput(open_to_public=False),
@@ -376,7 +376,7 @@ class TestDeploymentAdapterFilter:
             metadata=DeploymentMetadataInput(
                 project_id=project_id,
                 domain_name=domain,
-                resource_group=scaling_group,
+                resource_group_name=scaling_group,
                 name=name or f"test-deployment-{secrets.token_hex(4)}",
                 tags=tags,
             ),

--- a/tests/component/deployment/test_deployment_lifecycle.py
+++ b/tests/component/deployment/test_deployment_lifecycle.py
@@ -59,7 +59,7 @@ class TestCreateDeployment:
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
                 domain_name=domain_fixture,
-                resource_group=ResourceGroupName("nonexistent-sgroup"),
+                resource_group_name=ResourceGroupName("nonexistent-sgroup"),
                 name="test-deployment",
             ),
             network_access=NetworkAccessInput(open_to_public=False),
@@ -100,7 +100,7 @@ class TestCreateDeployment:
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
                 domain_name=domain_fixture,
-                resource_group=scaling_group_fixture,
+                resource_group_name=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),
             network_access=NetworkAccessInput(open_to_public=False),
@@ -169,7 +169,7 @@ class TestUpdateDeployment:
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
                 domain_name=domain_fixture,
-                resource_group=scaling_group_fixture,
+                resource_group_name=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),
             network_access=NetworkAccessInput(open_to_public=False),
@@ -240,7 +240,7 @@ class TestDestroyDeployment:
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
                 domain_name=domain_fixture,
-                resource_group=scaling_group_fixture,
+                resource_group_name=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),
             network_access=NetworkAccessInput(open_to_public=False),
@@ -323,7 +323,7 @@ class TestRevisionManagement:
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
                 domain_name=domain_fixture,
-                resource_group=scaling_group_fixture,
+                resource_group_name=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),
             network_access=NetworkAccessInput(open_to_public=False),
@@ -389,7 +389,7 @@ class TestReplicaManagement:
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
                 domain_name=domain_fixture,
-                resource_group=scaling_group_fixture,
+                resource_group_name=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),
             network_access=NetworkAccessInput(open_to_public=False),

--- a/tests/unit/client_v2/test_deployment.py
+++ b/tests/unit/client_v2/test_deployment.py
@@ -164,7 +164,7 @@ class TestDeploymentCRUD:
             metadata=DeploymentMetadataInput(
                 project_id=_SAMPLE_PROJECT_ID,
                 domain_name="default",
-                resource_group=ResourceGroupName("default"),
+                resource_group_name=ResourceGroupName("default"),
                 name="my-deployment",
             ),
             network_access=NetworkAccessInput(open_to_public=False),

--- a/tests/unit/common/dto/manager/v2/deployment/test_request.py
+++ b/tests/unit/common/dto/manager/v2/deployment/test_request.py
@@ -293,7 +293,7 @@ class TestCreateDeploymentInput:
         defaults: dict[str, Any] = {
             "project_id": uuid.uuid4(),
             "domain_name": "default",
-            "resource_group": "default",
+            "resource_group_name": "default",
         }
         defaults.update(kwargs)
         return ModelDeploymentMetadataInput(**defaults)


### PR DESCRIPTION
Jira: [BA-6038](https://lablup.atlassian.net/browse/BA-6038)

## Summary
- Rename the `resource_group` field on `ModelDeploymentMetadataInput` (v2 deployment DTO) to `resource_group_name` so the GraphQL input field becomes `resourceGroupName`, matching the naming used by sibling response fields (e.g., `DeploymentMetadataInfo.resource_group_name`, `ResourceConfigData.resource_group_name`).
- Propagate the rename through the v2 DTO, Strawberry GQL input, REST adapter, GQL adapter, client CLI invocation, and DTO unit test fixture.
- Leave the internal `DeploymentMetadata` data dataclass field name (`resource_group`) untouched, since it is not part of the public API surface.

## Test plan
- [ ] `pants test tests/unit/common/dto/manager/v2/deployment::`
- [ ] `pants test tests/unit/manager/api/gql/deployment::`
- [ ] `pants check ::`
- [ ] Verify via `./bai admin deployment create ...` that the renamed field is accepted by the live server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BA-6038]: https://lablup.atlassian.net/browse/BA-6038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11600.org.readthedocs.build/en/11600/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11600.org.readthedocs.build/ko/11600/

<!-- readthedocs-preview sorna-ko end -->