### PR TITLE
feat(BA-6030): add RouteSubStatus enum and DB migration for provisioning sub-stages

### DIFF
--- a/changes/11602.feature.md
+++ b/changes/11602.feature.md
@@ -1,0 +1,1 @@
+Add `RouteSubStatus` enum and DB columns (`sub_status`, `updated_at`) to track fine-grained provisioning stages; change `traffic_status` default to `inactive` so new routes start with traffic disabled until healthy.

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -150,6 +150,20 @@ class RouteTrafficStatus(enum.StrEnum):
     INACTIVE = "inactive"
 
 
+class RouteSubStatus(enum.StrEnum):
+    """Sub-status for routes in the PROVISIONING lifecycle stage.
+
+    Tracks fine-grained progress within the provisioning pipeline:
+    - PENDING: session has been enqueued, waiting for scheduler
+    - STARTING: session is running, waiting for replica host/port
+    - WARMING_UP: replica is up, waiting for health check to pass
+    """
+
+    PENDING = "pending"
+    STARTING = "starting"
+    WARMING_UP = "warming_up"
+
+
 # ========== Status Transition Types (BEP-1030) ==========
 
 

--- a/src/ai/backend/manager/models/alembic/versions/a1b2c3d4e5f7_add_route_sub_status_and_updated_at.py
+++ b/src/ai/backend/manager/models/alembic/versions/a1b2c3d4e5f7_add_route_sub_status_and_updated_at.py
@@ -1,0 +1,58 @@
+"""Add route sub_status, updated_at columns and fix traffic_status default.
+
+Revision ID: a1b2c3d4e5f7
+Revises: d3f4a5b6c7d8
+Create Date: 2026-05-14
+
+"""
+
+# Part of: 26.5.0
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f7"
+down_revision = "d3f4a5b6c7d8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Add sub_status column (nullable, defaults to 'pending' for new rows)
+    conn.exec_driver_sql(
+        "ALTER TABLE routings ADD COLUMN IF NOT EXISTS sub_status VARCHAR(64) DEFAULT 'pending'"
+    )
+
+    # Add updated_at as nullable first, backfill, then enforce NOT NULL
+    conn.exec_driver_sql(
+        "ALTER TABLE routings ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP WITH TIME ZONE"
+    )
+    conn.exec_driver_sql("UPDATE routings SET updated_at = created_at WHERE updated_at IS NULL")
+    conn.exec_driver_sql("ALTER TABLE routings ALTER COLUMN updated_at SET NOT NULL")
+    conn.exec_driver_sql("ALTER TABLE routings ALTER COLUMN updated_at SET DEFAULT now()")
+
+    # Clear sub_status for non-PROVISIONING rows — only meaningful during provisioning
+    conn.exec_driver_sql("UPDATE routings SET sub_status = NULL WHERE status != 'provisioning'")
+
+    # Backfill traffic_status based on lifecycle: RUNNING keeps ACTIVE, all others become INACTIVE
+    conn.exec_driver_sql("""
+        UPDATE routings
+        SET traffic_status = CASE
+            WHEN status = 'running' THEN 'active'
+            ELSE 'inactive'
+        END
+    """)
+
+    # Change server default for new inserts
+    conn.exec_driver_sql("ALTER TABLE routings ALTER COLUMN traffic_status SET DEFAULT 'inactive'")
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    conn.exec_driver_sql("ALTER TABLE routings ALTER COLUMN traffic_status SET DEFAULT 'active'")
+    conn.exec_driver_sql("UPDATE routings SET traffic_status = 'active'")
+    op.drop_column("routings", "updated_at")
+    op.drop_column("routings", "sub_status")

--- a/src/ai/backend/manager/models/routing/row.py
+++ b/src/ai/backend/manager/models/routing/row.py
@@ -19,6 +19,7 @@ from ai.backend.manager.data.deployment.types import (
     RouteHealthStatus,
     RouteInfo,
     RouteStatus,
+    RouteSubStatus,
     RouteTrafficStatus,
 )
 from ai.backend.manager.data.model_serving.types import RoutingData
@@ -114,8 +115,22 @@ class RoutingRow(Base):  # type: ignore[misc]
         "traffic_status",
         StrEnumType(RouteTrafficStatus, use_name=False),
         nullable=False,
-        server_default=sa.text("'active'"),
-        default=RouteTrafficStatus.ACTIVE,
+        server_default=sa.text("'inactive'"),
+        default=RouteTrafficStatus.INACTIVE,
+    )
+    sub_status: Mapped[RouteSubStatus | None] = mapped_column(
+        "sub_status",
+        StrEnumType(RouteSubStatus, use_name=False),
+        nullable=True,
+        default=None,
+        server_default=sa.text("'pending'"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        "updated_at",
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+        onupdate=sa.func.now(),
     )
 
     endpoint_row: Mapped[EndpointRow] = relationship("EndpointRow", back_populates="routings")

--- a/src/ai/backend/manager/repositories/deployment/creators/route.py
+++ b/src/ai/backend/manager/repositories/deployment/creators/route.py
@@ -32,7 +32,7 @@ class RouteCreatorSpec(CreatorSpec[RoutingRow]):
     project_id: uuid.UUID
     revision_id: DeploymentRevisionID
     traffic_ratio: float = 1.0
-    traffic_status: RouteTrafficStatus = RouteTrafficStatus.ACTIVE
+    traffic_status: RouteTrafficStatus = RouteTrafficStatus.INACTIVE
 
     @override
     def build_row(self) -> RoutingRow:


### PR DESCRIPTION
## Summary

- Introduce `RouteSubStatus` enum (`PENDING`, `STARTING`, `WARMING_UP`) to track fine-grained progress within the `PROVISIONING` lifecycle stage
- Add `routings.sub_status` (nullable, server_default `pending`) and `routings.updated_at` (NOT NULL, server_default `now()`) columns via Alembic migration
- Change `routings.traffic_status` server_default from `active` to `inactive` so new routes start with traffic disabled until healthy; backfill existing rows based on lifecycle status (`RUNNING` → active, others → inactive)

## Test plan

- [x] `pants lint --changed-since=origin/main` passes
- [x] `alembic upgrade head` and `alembic downgrade -1` both succeed
- [x] DB schema verified: `sub_status` nullable with default `pending`, `updated_at` NOT NULL with default `now()`, `traffic_status` default changed to `inactive`

Resolves BA-6030