### PR TITLE
fix(BA-6037): expose missing replica/state fields on Deployment GQL/DTO

### DIFF
--- a/changes/11605.fix.md
+++ b/changes/11605.fix.md
@@ -1,1 +1,1 @@
-Expose `status`, `traffic_status`, `health_status` on `ModelReplica` and `replica_ids` on `ReplicaState` in the v2 deployment GQL/REST schema.
+Expose `status`, `traffic_status`, `health_status` on `ModelReplica` in the v2 deployment GQL/REST schema.

--- a/changes/11605.fix.md
+++ b/changes/11605.fix.md
@@ -1,0 +1,1 @@
+Expose `status`, `traffic_status`, `health_status` on `ModelReplica` and `replica_ids` on `ReplicaState` in the v2 deployment GQL/REST schema.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -14786,7 +14786,6 @@ type ReplicaState
   @join__type(graph: STRAWBERRY)
 {
   desiredReplicaCount: Int!
-  replicaIds: [UUID!]!
 }
 
 """

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -9595,6 +9595,17 @@ type ModelReplica implements Node
   """Whether the replica is actively receiving traffic."""
   activenessStatus: ActivenessStatus!
 
+  """
+  Added in UNRELEASED. Provisioning status of the replica (mirrors the underlying route status).
+  """
+  status: ReplicaStatus!
+
+  """Added in UNRELEASED. Traffic status of the replica."""
+  trafficStatus: TrafficStatus!
+
+  """Added in UNRELEASED. Health check status of the replica."""
+  healthStatus: ReplicaHealthStatus!
+
   """Timestamp when the replica was created."""
   createdAt: DateTime!
 
@@ -14741,6 +14752,18 @@ input ReplicaFilter
   NOT: [ReplicaFilter!] = null
 }
 
+"""
+Added in UNRELEASED. This enum represents the health check status of a replica.
+"""
+enum ReplicaHealthStatus
+  @join__type(graph: STRAWBERRY)
+{
+  NOT_CHECKED @join__enumValue(graph: STRAWBERRY)
+  HEALTHY @join__enumValue(graph: STRAWBERRY)
+  UNHEALTHY @join__enumValue(graph: STRAWBERRY)
+  DEGRADED @join__enumValue(graph: STRAWBERRY)
+}
+
 """Added in 25.19.0. """
 input ReplicaOrderBy
   @join__type(graph: STRAWBERRY)
@@ -14763,6 +14786,7 @@ type ReplicaState
   @join__type(graph: STRAWBERRY)
 {
   desiredReplicaCount: Int!
+  replicaIds: [UUID!]!
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -9897,7 +9897,6 @@ Added in 25.19.0. Represents the current replica state of a deployment, includin
 """
 type ReplicaState {
   desiredReplicaCount: Int!
-  replicaIds: [UUID!]!
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -6371,6 +6371,17 @@ type ModelReplica implements Node {
   """Whether the replica is actively receiving traffic."""
   activenessStatus: ActivenessStatus!
 
+  """
+  Added in UNRELEASED. Provisioning status of the replica (mirrors the underlying route status).
+  """
+  status: ReplicaStatus!
+
+  """Added in UNRELEASED. Traffic status of the replica."""
+  trafficStatus: TrafficStatus!
+
+  """Added in UNRELEASED. Health check status of the replica."""
+  healthStatus: ReplicaHealthStatus!
+
   """Timestamp when the replica was created."""
   createdAt: DateTime!
 
@@ -9860,6 +9871,16 @@ input ReplicaFilter {
   NOT: [ReplicaFilter!] = null
 }
 
+"""
+Added in UNRELEASED. This enum represents the health check status of a replica.
+"""
+enum ReplicaHealthStatus {
+  NOT_CHECKED
+  HEALTHY
+  UNHEALTHY
+  DEGRADED
+}
+
 """Added in 25.19.0. """
 input ReplicaOrderBy {
   field: ReplicaOrderField!
@@ -9876,6 +9897,7 @@ Added in 25.19.0. Represents the current replica state of a deployment, includin
 """
 type ReplicaState {
   desiredReplicaCount: Int!
+  replicaIds: [UUID!]!
 }
 
 """

--- a/src/ai/backend/common/dto/manager/v2/deployment/response.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/response.py
@@ -433,6 +433,9 @@ class ReplicaNode(BaseResponseModel):
     readiness_status: ReadinessStatus = Field(description="Readiness status")
     liveness_status: LivenessStatus = Field(description="Liveness status")
     activeness_status: ActivenessStatus = Field(description="Activeness status")
+    status: RouteStatus = Field(description="Provisioning status of the replica")
+    traffic_status: RouteTrafficStatus = Field(description="Traffic status of the replica")
+    health_status: RouteHealthStatus = Field(description="Health check status of the replica")
     created_at: datetime = Field(description="Creation timestamp")
 
 

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -437,6 +437,40 @@ def _status_to_lifecycles(status: ModelDeploymentStatus) -> list[EndpointLifecyc
     return _STATUS_TO_LIFECYCLE.get(status, [])
 
 
+def _to_common_route_status(value: ManagerRouteStatus) -> RouteStatus:
+    match value:
+        case ManagerRouteStatus.PROVISIONING:
+            return RouteStatus.PROVISIONING
+        case ManagerRouteStatus.RUNNING:
+            return RouteStatus.RUNNING
+        case ManagerRouteStatus.TERMINATING:
+            return RouteStatus.TERMINATING
+        case ManagerRouteStatus.TERMINATED:
+            return RouteStatus.TERMINATED
+        case ManagerRouteStatus.FAILED_TO_START:
+            return RouteStatus.FAILED_TO_START
+
+
+def _to_common_route_traffic_status(value: ManagerRouteTrafficStatus) -> RouteTrafficStatus:
+    match value:
+        case ManagerRouteTrafficStatus.ACTIVE:
+            return RouteTrafficStatus.ACTIVE
+        case ManagerRouteTrafficStatus.INACTIVE:
+            return RouteTrafficStatus.INACTIVE
+
+
+def _to_common_route_health_status(value: ManagerRouteHealthStatus) -> RouteHealthStatus:
+    match value:
+        case ManagerRouteHealthStatus.NOT_CHECKED:
+            return RouteHealthStatus.NOT_CHECKED
+        case ManagerRouteHealthStatus.HEALTHY:
+            return RouteHealthStatus.HEALTHY
+        case ManagerRouteHealthStatus.UNHEALTHY:
+            return RouteHealthStatus.UNHEALTHY
+        case ManagerRouteHealthStatus.DEGRADED:
+            return RouteHealthStatus.DEGRADED
+
+
 def _statuses_to_lifecycles(
     statuses: Collection[ModelDeploymentStatus],
 ) -> list[EndpointLifecycle]:
@@ -2378,5 +2412,8 @@ class DeploymentAdapter(BaseAdapter):
             readiness_status=data.readiness_status,
             liveness_status=data.liveness_status,
             activeness_status=data.activeness_status,
+            status=_to_common_route_status(data.status),
+            traffic_status=_to_common_route_traffic_status(data.traffic_status),
+            health_status=_to_common_route_health_status(data.health_status),
             created_at=data.created_at,
         )

--- a/src/ai/backend/manager/api/gql/deployment/types/deployment.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/deployment.py
@@ -215,12 +215,6 @@ class DeploymentStrategyGQL:
 )
 class ReplicaState:
     desired_replica_count: int
-    replica_ids: list[UUID] = gql_added_field(
-        BackendAIGQLMeta(
-            added_version=NEXT_RELEASE_VERSION,
-            description="IDs of the replicas currently tracked for this deployment.",
-        )
-    )
 
 
 @gql_pydantic_type(

--- a/src/ai/backend/manager/api/gql/deployment/types/deployment.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/deployment.py
@@ -215,6 +215,12 @@ class DeploymentStrategyGQL:
 )
 class ReplicaState:
     desired_replica_count: int
+    replica_ids: list[UUID] = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="IDs of the replicas currently tracked for this deployment.",
+        )
+    )
 
 
 @gql_pydantic_type(

--- a/src/ai/backend/manager/api/gql/deployment/types/replica.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/replica.py
@@ -35,6 +35,7 @@ from ai.backend.common.dto.manager.v2.deployment.response import (
 from ai.backend.common.dto.manager.v2.deployment.types import (
     ReplicaOrderField,
 )
+from ai.backend.common.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import (
     OrderDirection,
     to_global_id,
@@ -55,6 +56,7 @@ from ai.backend.manager.api.gql.session_federation import Session
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.api.gql_legacy.session import ComputeSessionNode
 from ai.backend.manager.data.deployment.types import (
+    RouteHealthStatus,
     RouteStatus,
     RouteTrafficStatus,
 )
@@ -109,6 +111,15 @@ TrafficStatus: type[RouteTrafficStatus] = gql_enum(
     ),
     RouteTrafficStatus,
     name="TrafficStatus",
+)
+
+ReplicaHealthStatus: type[RouteHealthStatus] = gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="This enum represents the health check status of a replica.",
+    ),
+    RouteHealthStatus,
+    name="ReplicaHealthStatus",
 )
 
 
@@ -189,6 +200,24 @@ class ModelReplica(PydanticNodeMixin[ReplicaNodeDTO]):
     )
     activeness_status: ActivenessStatus = gql_field(
         description="Whether the replica is actively receiving traffic."
+    )
+    status: ReplicaStatus = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Provisioning status of the replica (mirrors the underlying route status).",
+        )
+    )
+    traffic_status: TrafficStatus = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Traffic status of the replica.",
+        )
+    )
+    health_status: ReplicaHealthStatus = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Health check status of the replica.",
+        )
     )
     created_at: datetime = gql_field(description="Timestamp when the replica was created.")
 

--- a/src/ai/backend/manager/api/gql/deployment/types/replica.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/replica.py
@@ -113,7 +113,7 @@ TrafficStatus: type[RouteTrafficStatus] = gql_enum(
     name="TrafficStatus",
 )
 
-ReplicaHealthStatus: type[RouteHealthStatus] = gql_enum(
+ReplicaHealthStatusGQL: type[RouteHealthStatus] = gql_enum(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
         description="This enum represents the health check status of a replica.",
@@ -213,7 +213,7 @@ class ModelReplica(PydanticNodeMixin[ReplicaNodeDTO]):
             description="Traffic status of the replica.",
         )
     )
-    health_status: ReplicaHealthStatus = gql_added_field(
+    health_status: ReplicaHealthStatusGQL = gql_added_field(
         BackendAIGQLMeta(
             added_version=NEXT_RELEASE_VERSION,
             description="Health check status of the replica.",

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -873,6 +873,9 @@ class ModelReplicaData:
     readiness_status: ReadinessStatus
     liveness_status: LivenessStatus
     activeness_status: ActivenessStatus
+    status: RouteStatus
+    traffic_status: RouteTrafficStatus
+    health_status: RouteHealthStatus
     detail: dict[str, Any]
     created_at: datetime
 

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -323,6 +323,9 @@ def _convert_route_info_to_replica_data(route: RouteInfo) -> ModelReplicaData:
         readiness_status=readiness,
         liveness_status=liveness,
         activeness_status=_resolve_activeness(route.traffic_status, readiness, liveness),
+        status=route.status,
+        traffic_status=route.traffic_status,
+        health_status=route.health_status,
         detail=route.error_data,
         created_at=route.created_at,
     )


### PR DESCRIPTION
## Summary
- Add `status`, `traffic_status`, `health_status` fields to `ReplicaNode` DTO and `ModelReplica` GQL — `ReplicaStatusFilter`/`TrafficStatusFilter` already referenced these but the node itself didn't expose them, leaving clients unable to read the values they filter by.
- Mirror the three fields on `ModelReplicaData` domain type so the route → replica conversion in the service layer passes them through.
- Centralize manager → common enum conversion in private adapter helpers (`_to_common_route_status`, `_to_common_route_traffic_status`, `_to_common_route_health_status`) using exhaustive `match`/`case` so future enum additions surface as mypy errors.
- Expose `replica_ids` on GQL `ReplicaState` (already present in the DTO `ReplicaStateInfo`).

## Test plan
- [ ] `pants check` / `pants lint` / `pants test` on changed targets
- [ ] Manual GraphQL query against ModelReplica confirms new `status`, `traffic_status`, `health_status` fields are populated
- [ ] Existing `ReplicaStatusFilter` / `TrafficStatusFilter` filters still match the returned node values

Resolves BA-6037

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11605.org.readthedocs.build/en/11605/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11605.org.readthedocs.build/ko/11605/

<!-- readthedocs-preview sorna-ko end -->