### PR TITLE
feat(BA-6041): honor MountOption.mount_destination on session creation

### DIFF
--- a/changes/11610.enhance.md
+++ b/changes/11610.enhance.md
@@ -1,0 +1,1 @@
+Session creation now honors `MountOption.mount_destination` from `mount_options[uuid]` (as a fallback after `mount_id_map`), so both session and inference service paths accept the same `MountOption` shape. Previously the field was silently ignored on the session path, forcing callers to use `mount_map` / `mount_id_map` for destinations.

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -252,7 +252,16 @@ class AgentRegistry:
                     perm = None
             raw_subpath = opts.get("subpath")
             subpath_value = str(raw_subpath) if raw_subpath is not None else None
-            dst_path = mount_id_map.get(vfolder_uuid) or mount_id_map.get(raw_id)
+            # Destination may come from either the explicit ``mount_id_map``
+            # (preferred — atomic to the destination concept) or, as a
+            # fallback, the per-vfolder ``mount_options[uuid].mount_destination``
+            # so callers can express both option and destination in a single
+            # dict — matching the inference service creation surface.
+            dst_path = (
+                mount_id_map.get(vfolder_uuid)
+                or mount_id_map.get(raw_id)
+                or opts.get("mount_destination")
+            )
             entries.append(
                 MountInfoEntry(
                     vfolder_id=VFolderUUID(vfolder_uuid),

--- a/tests/unit/manager/test_registry.py
+++ b/tests/unit/manager/test_registry.py
@@ -392,3 +392,52 @@ class TestWaitForSessionRunning:
                 await mock_registry_obj._wait_for_session_running(
                     session_id, mock_propagator, max_wait=0
                 )
+
+
+class TestMountEntriesFromCreationConfig:
+    """Session creation honors ``mount_destination`` from both ``mount_id_map``
+    (preferred) and ``mount_options[uuid].mount_destination`` (fallback), so the
+    same ``MountOption`` shape that inference service creation accepts also
+    works for sessions.
+    """
+
+    def test_mount_id_map_supplies_destination(self) -> None:
+        vfid = uuid.uuid4()
+        creation_config = {
+            "mount_ids": [vfid],
+            "mount_id_map": {vfid: "/data/dst"},
+            "mount_options": {vfid: {"permission": "ro"}},
+        }
+
+        entries = AgentRegistry._mount_entries_from_creation_config(creation_config)
+
+        assert len(entries) == 1
+        assert entries[0].mount_destination == "/data/dst"
+
+    def test_mount_options_mount_destination_fallback(self) -> None:
+        vfid = uuid.uuid4()
+        creation_config = {
+            "mount_ids": [vfid],
+            "mount_id_map": {},
+            "mount_options": {
+                vfid: {"mount_destination": "/data/from-options", "permission": "ro"},
+            },
+        }
+
+        entries = AgentRegistry._mount_entries_from_creation_config(creation_config)
+
+        assert len(entries) == 1
+        assert entries[0].mount_destination == "/data/from-options"
+
+    def test_mount_id_map_takes_precedence_over_mount_options(self) -> None:
+        vfid = uuid.uuid4()
+        creation_config = {
+            "mount_ids": [vfid],
+            "mount_id_map": {vfid: "/data/winner"},
+            "mount_options": {vfid: {"mount_destination": "/data/loser"}},
+        }
+
+        entries = AgentRegistry._mount_entries_from_creation_config(creation_config)
+
+        assert len(entries) == 1
+        assert entries[0].mount_destination == "/data/winner"


### PR DESCRIPTION
## Summary

Follow-up to #11608 / BA-6040. The unified `MountOption` declared `mount_destination`, but the session-creation runtime (`AgentRegistry._mount_entries_from_creation_config`) silently dropped it — destinations were only read from `mount_id_map`. Inference service creation, on the other hand, always honored the inline `mount_destination` because its wire schema has no separate destination map.

This PR closes that asymmetry with a one-line registry change: session creation now falls back to `mount_options[uuid].mount_destination` if `mount_id_map` does not supply a destination.

**Precedence**: `mount_id_map` (preferred — explicit, atomic to the destination concept) > `mount_options[uuid].mount_destination` (per-vfolder fallback).

This keeps the single unified `MountOption` type and avoids splitting into `SessionMountOption` / `ModelServingMountOption`. Wire change is purely additive — existing callers see no difference.

## Test plan

- [ ] `tests/unit/manager/test_registry.py::TestMountEntriesFromCreationConfig` (three cases) passes
- [ ] `./bai session create` with `mount_options[uuid].mount_destination` mounts at the requested destination
- [ ] `./bai session create` with `mount_id_map` still works (no regression)
- [ ] `./bai service create` (inference) still mounts extras at the requested destination

🤖 Generated with [Claude Code](https://claude.com/claude-code)