### PR TITLE
feat(BA-6044,BA-6048): add UUID id column to domains and scaling_groups

### DIFF
--- a/changes/11623.feature.md
+++ b/changes/11623.feature.md
@@ -1,0 +1,1 @@
+Add UUID `id` primary key to `domains` and `scaling_groups` tables and demote `name` to a UNIQUE constraint, plus introduce `DomainID` and `ResourceGroupID` identifier types.

--- a/src/ai/backend/common/identifier/domain.py
+++ b/src/ai/backend/common/identifier/domain.py
@@ -1,6 +1,11 @@
+import uuid
 from typing import NewType
 
-__all__ = ("DomainName",)
+__all__ = (
+    "DomainID",
+    "DomainName",
+)
 
 
+DomainID = NewType("DomainID", uuid.UUID)
 DomainName = NewType("DomainName", str)

--- a/src/ai/backend/common/identifier/resource_group.py
+++ b/src/ai/backend/common/identifier/resource_group.py
@@ -1,6 +1,11 @@
+import uuid
 from typing import NewType
 
-__all__ = ("ResourceGroupName",)
+__all__ = (
+    "ResourceGroupID",
+    "ResourceGroupName",
+)
 
 
+ResourceGroupID = NewType("ResourceGroupID", uuid.UUID)
 ResourceGroupName = NewType("ResourceGroupName", str)

--- a/src/ai/backend/manager/data/domain/types.py
+++ b/src/ai/backend/manager/data/domain/types.py
@@ -8,6 +8,7 @@ from typing import Any, override
 
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.data.user.types import UserRole
+from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.data.permission.id import ScopeId
 from ai.backend.manager.data.permission.types import (
@@ -27,7 +28,7 @@ class UserInfo:
 
 @dataclass
 class DomainData:
-    id: uuid.UUID
+    id: DomainID
     name: str
     description: str | None
     is_active: bool

--- a/src/ai/backend/manager/data/domain/types.py
+++ b/src/ai/backend/manager/data/domain/types.py
@@ -27,6 +27,7 @@ class UserInfo:
 
 @dataclass
 class DomainData:
+    id: uuid.UUID
     name: str
     description: str | None
     is_active: bool

--- a/src/ai/backend/manager/data/scaling_group/types.py
+++ b/src/ai/backend/manager/data/scaling_group/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -115,6 +116,7 @@ class ScalingGroupSchedulerConfig:
 
 @dataclass
 class ScalingGroupData:
+    id: uuid.UUID
     name: str
     status: ScalingGroupStatus
     metadata: ScalingGroupMetadata

--- a/src/ai/backend/manager/data/scaling_group/types.py
+++ b/src/ai/backend/manager/data/scaling_group/types.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import dataclasses
-import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import (
     AgentSelectionStrategy,
     PreemptionMode,
@@ -116,7 +116,7 @@ class ScalingGroupSchedulerConfig:
 
 @dataclass
 class ScalingGroupData:
-    id: uuid.UUID
+    id: ResourceGroupID
     name: str
     status: ScalingGroupStatus
     metadata: ScalingGroupMetadata

--- a/src/ai/backend/manager/models/alembic/versions/a1c3e5d7b9f2_add_id_column_to_domains.py
+++ b/src/ai/backend/manager/models/alembic/versions/a1c3e5d7b9f2_add_id_column_to_domains.py
@@ -1,0 +1,102 @@
+"""add ``id`` UUID column to ``domains`` and demote ``name`` to unique
+
+Adds a UUID ``id`` column as the new primary key of the ``domains`` table.
+The legacy ``name`` column becomes a UNIQUE column so that existing foreign
+key references continue to function.
+
+Because PostgreSQL tracks foreign-key dependencies on the primary-key index
+itself (not the underlying column), the swap requires temporarily dropping
+and recreating every FK that points to ``domains.name``. The FK definitions
+are restored with identical semantics (column, target column, and
+ON UPDATE/DELETE rules unchanged).
+
+Revision ID: a1c3e5d7b9f2
+Revises: b2c3d4e5f6a7
+Create Date: 2026-05-15
+
+"""
+
+# Part of: 26.5.0
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.base import GUID
+
+# revision identifiers, used by Alembic.
+revision = "a1c3e5d7b9f2"
+down_revision = "b2c3d4e5f6a7"
+branch_labels = None
+depends_on = None
+
+
+# (referencing_table, fk_constraint_name, fk_column, on_update, on_delete)
+_DOMAIN_FK_REFS: tuple[tuple[str, str, str, str | None, str | None], ...] = (
+    ("endpoint_tokens", "fk_endpoint_tokens_domain_domains", "domain", None, "CASCADE"),
+    ("endpoints", "fk_endpoints_domain_domains", "domain", None, "RESTRICT"),
+    ("groups", "fk_groups_domain_name_domains", "domain_name", "CASCADE", "CASCADE"),
+    ("kernels", "fk_kernels_domain_name_domains", "domain_name", None, None),
+    ("model_cards", "fk_model_cards_domain_domains", "domain", None, "RESTRICT"),
+    ("routings", "fk_routings_domain_domains", "domain", None, "RESTRICT"),
+    ("session_templates", "fk_session_templates_domain_name_domains", "domain_name", None, None),
+    ("sessions", "fk_sessions_domain_name_domains", "domain_name", None, None),
+    (
+        "sgroups_for_domains",
+        "fk_sgroups_for_domains_domain_domains",
+        "domain",
+        "CASCADE",
+        "CASCADE",
+    ),
+    ("users", "fk_users_domain_name_domains", "domain_name", None, None),
+)
+
+
+def upgrade() -> None:
+    op.add_column(
+        "domains",
+        sa.Column(
+            "id",
+            GUID(),
+            server_default=sa.text("uuid_generate_v4()"),
+            nullable=False,
+        ),
+    )
+
+    for table, fk_name, _column, _on_update, _on_delete in _DOMAIN_FK_REFS:
+        op.drop_constraint(fk_name, table, type_="foreignkey")
+
+    op.create_unique_constraint("uq_domains_name", "domains", ["name"])
+    op.drop_constraint("pk_domains", "domains", type_="primary")
+    op.create_primary_key("pk_domains", "domains", ["id"])
+
+    for table, fk_name, column, on_update, on_delete in _DOMAIN_FK_REFS:
+        op.create_foreign_key(
+            fk_name,
+            table,
+            "domains",
+            [column],
+            ["name"],
+            onupdate=on_update,
+            ondelete=on_delete,
+        )
+
+
+def downgrade() -> None:
+    for table, fk_name, _column, _on_update, _on_delete in _DOMAIN_FK_REFS:
+        op.drop_constraint(fk_name, table, type_="foreignkey")
+
+    op.drop_constraint("pk_domains", "domains", type_="primary")
+    op.drop_constraint("uq_domains_name", "domains", type_="unique")
+    op.create_primary_key("pk_domains", "domains", ["name"])
+    op.drop_column("domains", "id")
+
+    for table, fk_name, column, on_update, on_delete in _DOMAIN_FK_REFS:
+        op.create_foreign_key(
+            fk_name,
+            table,
+            "domains",
+            [column],
+            ["name"],
+            onupdate=on_update,
+            ondelete=on_delete,
+        )

--- a/src/ai/backend/manager/models/alembic/versions/a1c3e5d7b9f2_add_id_column_to_domains.py
+++ b/src/ai/backend/manager/models/alembic/versions/a1c3e5d7b9f2_add_id_column_to_domains.py
@@ -18,6 +18,8 @@ Create Date: 2026-05-15
 
 # Part of: 26.5.0
 
+from dataclasses import dataclass
+
 import sqlalchemy as sa
 from alembic import op
 
@@ -30,24 +32,38 @@ branch_labels = None
 depends_on = None
 
 
-# (referencing_table, fk_constraint_name, fk_column, on_update, on_delete)
-_DOMAIN_FK_REFS: tuple[tuple[str, str, str, str | None, str | None], ...] = (
-    ("endpoint_tokens", "fk_endpoint_tokens_domain_domains", "domain", None, "CASCADE"),
-    ("endpoints", "fk_endpoints_domain_domains", "domain", None, "RESTRICT"),
-    ("groups", "fk_groups_domain_name_domains", "domain_name", "CASCADE", "CASCADE"),
-    ("kernels", "fk_kernels_domain_name_domains", "domain_name", None, None),
-    ("model_cards", "fk_model_cards_domain_domains", "domain", None, "RESTRICT"),
-    ("routings", "fk_routings_domain_domains", "domain", None, "RESTRICT"),
-    ("session_templates", "fk_session_templates_domain_name_domains", "domain_name", None, None),
-    ("sessions", "fk_sessions_domain_name_domains", "domain_name", None, None),
-    (
+@dataclass(frozen=True)
+class _FKRef:
+    table: str
+    constraint: str
+    column: str
+    on_update: str | None
+    on_delete: str | None
+
+
+_DOMAIN_FK_REFS: tuple[_FKRef, ...] = (
+    _FKRef("endpoint_tokens", "fk_endpoint_tokens_domain_domains", "domain", None, "CASCADE"),
+    _FKRef("endpoints", "fk_endpoints_domain_domains", "domain", None, "RESTRICT"),
+    _FKRef("groups", "fk_groups_domain_name_domains", "domain_name", "CASCADE", "CASCADE"),
+    _FKRef("kernels", "fk_kernels_domain_name_domains", "domain_name", None, None),
+    _FKRef("model_cards", "fk_model_cards_domain_domains", "domain", None, "RESTRICT"),
+    _FKRef("routings", "fk_routings_domain_domains", "domain", None, "RESTRICT"),
+    _FKRef(
+        "session_templates",
+        "fk_session_templates_domain_name_domains",
+        "domain_name",
+        None,
+        None,
+    ),
+    _FKRef("sessions", "fk_sessions_domain_name_domains", "domain_name", None, None),
+    _FKRef(
         "sgroups_for_domains",
         "fk_sgroups_for_domains_domain_domains",
         "domain",
         "CASCADE",
         "CASCADE",
     ),
-    ("users", "fk_users_domain_name_domains", "domain_name", None, None),
+    _FKRef("users", "fk_users_domain_name_domains", "domain_name", None, None),
 )
 
 
@@ -62,41 +78,41 @@ def upgrade() -> None:
         ),
     )
 
-    for table, fk_name, _column, _on_update, _on_delete in _DOMAIN_FK_REFS:
-        op.drop_constraint(fk_name, table, type_="foreignkey")
+    for ref in _DOMAIN_FK_REFS:
+        op.drop_constraint(ref.constraint, ref.table, type_="foreignkey")
 
     op.create_unique_constraint("uq_domains_name", "domains", ["name"])
     op.drop_constraint("pk_domains", "domains", type_="primary")
     op.create_primary_key("pk_domains", "domains", ["id"])
 
-    for table, fk_name, column, on_update, on_delete in _DOMAIN_FK_REFS:
+    for ref in _DOMAIN_FK_REFS:
         op.create_foreign_key(
-            fk_name,
-            table,
+            ref.constraint,
+            ref.table,
             "domains",
-            [column],
+            [ref.column],
             ["name"],
-            onupdate=on_update,
-            ondelete=on_delete,
+            onupdate=ref.on_update,
+            ondelete=ref.on_delete,
         )
 
 
 def downgrade() -> None:
-    for table, fk_name, _column, _on_update, _on_delete in _DOMAIN_FK_REFS:
-        op.drop_constraint(fk_name, table, type_="foreignkey")
+    for ref in _DOMAIN_FK_REFS:
+        op.drop_constraint(ref.constraint, ref.table, type_="foreignkey")
 
     op.drop_constraint("pk_domains", "domains", type_="primary")
     op.drop_constraint("uq_domains_name", "domains", type_="unique")
     op.create_primary_key("pk_domains", "domains", ["name"])
     op.drop_column("domains", "id")
 
-    for table, fk_name, column, on_update, on_delete in _DOMAIN_FK_REFS:
+    for ref in _DOMAIN_FK_REFS:
         op.create_foreign_key(
-            fk_name,
-            table,
+            ref.constraint,
+            ref.table,
             "domains",
-            [column],
+            [ref.column],
             ["name"],
-            onupdate=on_update,
-            ondelete=on_delete,
+            onupdate=ref.on_update,
+            ondelete=ref.on_delete,
         )

--- a/src/ai/backend/manager/models/alembic/versions/a1c3e5d7b9f2_add_id_column_to_domains.py
+++ b/src/ai/backend/manager/models/alembic/versions/a1c3e5d7b9f2_add_id_column_to_domains.py
@@ -1,14 +1,10 @@
-"""add ``id`` UUID column to ``domains`` and demote ``name`` to unique
+"""add ``id`` UUID column to ``domains``
 
-Adds a UUID ``id`` column as the new primary key of the ``domains`` table.
-The legacy ``name`` column becomes a UNIQUE column so that existing foreign
-key references continue to function.
-
-Because PostgreSQL tracks foreign-key dependencies on the primary-key index
-itself (not the underlying column), the swap requires temporarily dropping
-and recreating every FK that points to ``domains.name``. The FK definitions
-are restored with identical semantics (column, target column, and
-ON UPDATE/DELETE rules unchanged).
+Adds a UUID ``id`` column to the ``domains`` table as a UNIQUE alternate
+key. The existing ``name`` column remains the primary key in this
+migration; the PK swap is deferred to the FK migration step so it can
+land atomically with the FK column transition (``domain_name`` →
+``domain_id``).
 
 Revision ID: a1c3e5d7b9f2
 Revises: b2c3d4e5f6a7
@@ -17,8 +13,6 @@ Create Date: 2026-05-15
 """
 
 # Part of: 26.5.0
-
-from dataclasses import dataclass
 
 import sqlalchemy as sa
 from alembic import op
@@ -32,41 +26,6 @@ branch_labels = None
 depends_on = None
 
 
-@dataclass(frozen=True)
-class _FKRef:
-    table: str
-    constraint: str
-    column: str
-    on_update: str | None
-    on_delete: str | None
-
-
-_DOMAIN_FK_REFS: tuple[_FKRef, ...] = (
-    _FKRef("endpoint_tokens", "fk_endpoint_tokens_domain_domains", "domain", None, "CASCADE"),
-    _FKRef("endpoints", "fk_endpoints_domain_domains", "domain", None, "RESTRICT"),
-    _FKRef("groups", "fk_groups_domain_name_domains", "domain_name", "CASCADE", "CASCADE"),
-    _FKRef("kernels", "fk_kernels_domain_name_domains", "domain_name", None, None),
-    _FKRef("model_cards", "fk_model_cards_domain_domains", "domain", None, "RESTRICT"),
-    _FKRef("routings", "fk_routings_domain_domains", "domain", None, "RESTRICT"),
-    _FKRef(
-        "session_templates",
-        "fk_session_templates_domain_name_domains",
-        "domain_name",
-        None,
-        None,
-    ),
-    _FKRef("sessions", "fk_sessions_domain_name_domains", "domain_name", None, None),
-    _FKRef(
-        "sgroups_for_domains",
-        "fk_sgroups_for_domains_domain_domains",
-        "domain",
-        "CASCADE",
-        "CASCADE",
-    ),
-    _FKRef("users", "fk_users_domain_name_domains", "domain_name", None, None),
-)
-
-
 def upgrade() -> None:
     op.add_column(
         "domains",
@@ -77,42 +36,9 @@ def upgrade() -> None:
             nullable=False,
         ),
     )
-
-    for ref in _DOMAIN_FK_REFS:
-        op.drop_constraint(ref.constraint, ref.table, type_="foreignkey")
-
-    op.create_unique_constraint("uq_domains_name", "domains", ["name"])
-    op.drop_constraint("pk_domains", "domains", type_="primary")
-    op.create_primary_key("pk_domains", "domains", ["id"])
-
-    for ref in _DOMAIN_FK_REFS:
-        op.create_foreign_key(
-            ref.constraint,
-            ref.table,
-            "domains",
-            [ref.column],
-            ["name"],
-            onupdate=ref.on_update,
-            ondelete=ref.on_delete,
-        )
+    op.create_unique_constraint("uq_domains_id", "domains", ["id"])
 
 
 def downgrade() -> None:
-    for ref in _DOMAIN_FK_REFS:
-        op.drop_constraint(ref.constraint, ref.table, type_="foreignkey")
-
-    op.drop_constraint("pk_domains", "domains", type_="primary")
-    op.drop_constraint("uq_domains_name", "domains", type_="unique")
-    op.create_primary_key("pk_domains", "domains", ["name"])
+    op.drop_constraint("uq_domains_id", "domains", type_="unique")
     op.drop_column("domains", "id")
-
-    for ref in _DOMAIN_FK_REFS:
-        op.create_foreign_key(
-            ref.constraint,
-            ref.table,
-            "domains",
-            [ref.column],
-            ["name"],
-            onupdate=ref.on_update,
-            ondelete=ref.on_delete,
-        )

--- a/src/ai/backend/manager/models/alembic/versions/b2d4f6e8c1a3_add_id_column_to_scaling_groups.py
+++ b/src/ai/backend/manager/models/alembic/versions/b2d4f6e8c1a3_add_id_column_to_scaling_groups.py
@@ -1,13 +1,10 @@
-"""add ``id`` UUID column to ``scaling_groups`` and demote ``name`` to unique
+"""add ``id`` UUID column to ``scaling_groups``
 
-Adds a UUID ``id`` column as the new primary key of the ``scaling_groups``
-table. The legacy ``name`` column becomes a UNIQUE column so existing
-foreign-key references continue to function.
-
-PostgreSQL tracks foreign-key dependencies on the primary-key index, so the
-swap requires temporarily dropping and recreating every FK that points to
-``scaling_groups.name``. The FK definitions are restored with identical
-semantics (column, target column, and ON UPDATE/DELETE rules unchanged).
+Adds a UUID ``id`` column to the ``scaling_groups`` table as a UNIQUE
+alternate key. The existing ``name`` column remains the primary key in
+this migration; the PK swap is deferred to the FK migration step so it
+can land atomically with the FK column transition (``scaling_group`` /
+``resource_group`` → ``scaling_group_id``).
 
 Revision ID: b2d4f6e8c1a3
 Revises: a1c3e5d7b9f2
@@ -16,8 +13,6 @@ Create Date: 2026-05-15
 """
 
 # Part of: 26.5.0
-
-from dataclasses import dataclass
 
 import sqlalchemy as sa
 from alembic import op
@@ -31,56 +26,6 @@ branch_labels = None
 depends_on = None
 
 
-@dataclass(frozen=True)
-class _FKRef:
-    table: str
-    constraint: str
-    column: str
-    on_update: str | None
-    on_delete: str | None
-
-
-_SCALING_GROUP_FK_REFS: tuple[_FKRef, ...] = (
-    _FKRef("agents", "fk_agents_scaling_group_scaling_groups", "scaling_group", None, None),
-    _FKRef(
-        "endpoints",
-        "fk_endpoints_resource_group_scaling_groups",
-        "resource_group",
-        None,
-        "RESTRICT",
-    ),
-    _FKRef("kernels", "fk_kernels_scaling_group_scaling_groups", "scaling_group", None, None),
-    _FKRef(
-        "sessions",
-        "fk_sessions_scaling_group_name_scaling_groups",
-        "scaling_group_name",
-        None,
-        None,
-    ),
-    _FKRef(
-        "sgroups_for_domains",
-        "fk_sgroups_for_domains_scaling_group_scaling_groups",
-        "scaling_group",
-        "CASCADE",
-        "CASCADE",
-    ),
-    _FKRef(
-        "sgroups_for_groups",
-        "fk_sgroups_for_groups_scaling_group_scaling_groups",
-        "scaling_group",
-        "CASCADE",
-        "CASCADE",
-    ),
-    _FKRef(
-        "sgroups_for_keypairs",
-        "fk_sgroups_for_keypairs_scaling_group_scaling_groups",
-        "scaling_group",
-        "CASCADE",
-        "CASCADE",
-    ),
-)
-
-
 def upgrade() -> None:
     op.add_column(
         "scaling_groups",
@@ -91,42 +36,9 @@ def upgrade() -> None:
             nullable=False,
         ),
     )
-
-    for ref in _SCALING_GROUP_FK_REFS:
-        op.drop_constraint(ref.constraint, ref.table, type_="foreignkey")
-
-    op.create_unique_constraint("uq_scaling_groups_name", "scaling_groups", ["name"])
-    op.drop_constraint("pk_scaling_groups", "scaling_groups", type_="primary")
-    op.create_primary_key("pk_scaling_groups", "scaling_groups", ["id"])
-
-    for ref in _SCALING_GROUP_FK_REFS:
-        op.create_foreign_key(
-            ref.constraint,
-            ref.table,
-            "scaling_groups",
-            [ref.column],
-            ["name"],
-            onupdate=ref.on_update,
-            ondelete=ref.on_delete,
-        )
+    op.create_unique_constraint("uq_scaling_groups_id", "scaling_groups", ["id"])
 
 
 def downgrade() -> None:
-    for ref in _SCALING_GROUP_FK_REFS:
-        op.drop_constraint(ref.constraint, ref.table, type_="foreignkey")
-
-    op.drop_constraint("pk_scaling_groups", "scaling_groups", type_="primary")
-    op.drop_constraint("uq_scaling_groups_name", "scaling_groups", type_="unique")
-    op.create_primary_key("pk_scaling_groups", "scaling_groups", ["name"])
+    op.drop_constraint("uq_scaling_groups_id", "scaling_groups", type_="unique")
     op.drop_column("scaling_groups", "id")
-
-    for ref in _SCALING_GROUP_FK_REFS:
-        op.create_foreign_key(
-            ref.constraint,
-            ref.table,
-            "scaling_groups",
-            [ref.column],
-            ["name"],
-            onupdate=ref.on_update,
-            ondelete=ref.on_delete,
-        )

--- a/src/ai/backend/manager/models/alembic/versions/b2d4f6e8c1a3_add_id_column_to_scaling_groups.py
+++ b/src/ai/backend/manager/models/alembic/versions/b2d4f6e8c1a3_add_id_column_to_scaling_groups.py
@@ -1,0 +1,122 @@
+"""add ``id`` UUID column to ``scaling_groups`` and demote ``name`` to unique
+
+Adds a UUID ``id`` column as the new primary key of the ``scaling_groups``
+table. The legacy ``name`` column becomes a UNIQUE column so existing
+foreign-key references continue to function.
+
+PostgreSQL tracks foreign-key dependencies on the primary-key index, so the
+swap requires temporarily dropping and recreating every FK that points to
+``scaling_groups.name``. The FK definitions are restored with identical
+semantics (column, target column, and ON UPDATE/DELETE rules unchanged).
+
+Revision ID: b2d4f6e8c1a3
+Revises: a1c3e5d7b9f2
+Create Date: 2026-05-15
+
+"""
+
+# Part of: 26.5.0
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.base import GUID
+
+# revision identifiers, used by Alembic.
+revision = "b2d4f6e8c1a3"
+down_revision = "a1c3e5d7b9f2"
+branch_labels = None
+depends_on = None
+
+
+# (referencing_table, fk_constraint_name, fk_column, on_update, on_delete)
+_SCALING_GROUP_FK_REFS: tuple[tuple[str, str, str, str | None, str | None], ...] = (
+    ("agents", "fk_agents_scaling_group_scaling_groups", "scaling_group", None, None),
+    (
+        "endpoints",
+        "fk_endpoints_resource_group_scaling_groups",
+        "resource_group",
+        None,
+        "RESTRICT",
+    ),
+    ("kernels", "fk_kernels_scaling_group_scaling_groups", "scaling_group", None, None),
+    (
+        "sessions",
+        "fk_sessions_scaling_group_name_scaling_groups",
+        "scaling_group_name",
+        None,
+        None,
+    ),
+    (
+        "sgroups_for_domains",
+        "fk_sgroups_for_domains_scaling_group_scaling_groups",
+        "scaling_group",
+        "CASCADE",
+        "CASCADE",
+    ),
+    (
+        "sgroups_for_groups",
+        "fk_sgroups_for_groups_scaling_group_scaling_groups",
+        "scaling_group",
+        "CASCADE",
+        "CASCADE",
+    ),
+    (
+        "sgroups_for_keypairs",
+        "fk_sgroups_for_keypairs_scaling_group_scaling_groups",
+        "scaling_group",
+        "CASCADE",
+        "CASCADE",
+    ),
+)
+
+
+def upgrade() -> None:
+    op.add_column(
+        "scaling_groups",
+        sa.Column(
+            "id",
+            GUID(),
+            server_default=sa.text("uuid_generate_v4()"),
+            nullable=False,
+        ),
+    )
+
+    for table, fk_name, _column, _on_update, _on_delete in _SCALING_GROUP_FK_REFS:
+        op.drop_constraint(fk_name, table, type_="foreignkey")
+
+    op.create_unique_constraint("uq_scaling_groups_name", "scaling_groups", ["name"])
+    op.drop_constraint("pk_scaling_groups", "scaling_groups", type_="primary")
+    op.create_primary_key("pk_scaling_groups", "scaling_groups", ["id"])
+
+    for table, fk_name, column, on_update, on_delete in _SCALING_GROUP_FK_REFS:
+        op.create_foreign_key(
+            fk_name,
+            table,
+            "scaling_groups",
+            [column],
+            ["name"],
+            onupdate=on_update,
+            ondelete=on_delete,
+        )
+
+
+def downgrade() -> None:
+    for table, fk_name, _column, _on_update, _on_delete in _SCALING_GROUP_FK_REFS:
+        op.drop_constraint(fk_name, table, type_="foreignkey")
+
+    op.drop_constraint("pk_scaling_groups", "scaling_groups", type_="primary")
+    op.drop_constraint("uq_scaling_groups_name", "scaling_groups", type_="unique")
+    op.create_primary_key("pk_scaling_groups", "scaling_groups", ["name"])
+    op.drop_column("scaling_groups", "id")
+
+    for table, fk_name, column, on_update, on_delete in _SCALING_GROUP_FK_REFS:
+        op.create_foreign_key(
+            fk_name,
+            table,
+            "scaling_groups",
+            [column],
+            ["name"],
+            onupdate=on_update,
+            ondelete=on_delete,
+        )

--- a/src/ai/backend/manager/models/alembic/versions/b2d4f6e8c1a3_add_id_column_to_scaling_groups.py
+++ b/src/ai/backend/manager/models/alembic/versions/b2d4f6e8c1a3_add_id_column_to_scaling_groups.py
@@ -17,6 +17,8 @@ Create Date: 2026-05-15
 
 # Part of: 26.5.0
 
+from dataclasses import dataclass
+
 import sqlalchemy as sa
 from alembic import op
 
@@ -29,39 +31,47 @@ branch_labels = None
 depends_on = None
 
 
-# (referencing_table, fk_constraint_name, fk_column, on_update, on_delete)
-_SCALING_GROUP_FK_REFS: tuple[tuple[str, str, str, str | None, str | None], ...] = (
-    ("agents", "fk_agents_scaling_group_scaling_groups", "scaling_group", None, None),
-    (
+@dataclass(frozen=True)
+class _FKRef:
+    table: str
+    constraint: str
+    column: str
+    on_update: str | None
+    on_delete: str | None
+
+
+_SCALING_GROUP_FK_REFS: tuple[_FKRef, ...] = (
+    _FKRef("agents", "fk_agents_scaling_group_scaling_groups", "scaling_group", None, None),
+    _FKRef(
         "endpoints",
         "fk_endpoints_resource_group_scaling_groups",
         "resource_group",
         None,
         "RESTRICT",
     ),
-    ("kernels", "fk_kernels_scaling_group_scaling_groups", "scaling_group", None, None),
-    (
+    _FKRef("kernels", "fk_kernels_scaling_group_scaling_groups", "scaling_group", None, None),
+    _FKRef(
         "sessions",
         "fk_sessions_scaling_group_name_scaling_groups",
         "scaling_group_name",
         None,
         None,
     ),
-    (
+    _FKRef(
         "sgroups_for_domains",
         "fk_sgroups_for_domains_scaling_group_scaling_groups",
         "scaling_group",
         "CASCADE",
         "CASCADE",
     ),
-    (
+    _FKRef(
         "sgroups_for_groups",
         "fk_sgroups_for_groups_scaling_group_scaling_groups",
         "scaling_group",
         "CASCADE",
         "CASCADE",
     ),
-    (
+    _FKRef(
         "sgroups_for_keypairs",
         "fk_sgroups_for_keypairs_scaling_group_scaling_groups",
         "scaling_group",
@@ -82,41 +92,41 @@ def upgrade() -> None:
         ),
     )
 
-    for table, fk_name, _column, _on_update, _on_delete in _SCALING_GROUP_FK_REFS:
-        op.drop_constraint(fk_name, table, type_="foreignkey")
+    for ref in _SCALING_GROUP_FK_REFS:
+        op.drop_constraint(ref.constraint, ref.table, type_="foreignkey")
 
     op.create_unique_constraint("uq_scaling_groups_name", "scaling_groups", ["name"])
     op.drop_constraint("pk_scaling_groups", "scaling_groups", type_="primary")
     op.create_primary_key("pk_scaling_groups", "scaling_groups", ["id"])
 
-    for table, fk_name, column, on_update, on_delete in _SCALING_GROUP_FK_REFS:
+    for ref in _SCALING_GROUP_FK_REFS:
         op.create_foreign_key(
-            fk_name,
-            table,
+            ref.constraint,
+            ref.table,
             "scaling_groups",
-            [column],
+            [ref.column],
             ["name"],
-            onupdate=on_update,
-            ondelete=on_delete,
+            onupdate=ref.on_update,
+            ondelete=ref.on_delete,
         )
 
 
 def downgrade() -> None:
-    for table, fk_name, _column, _on_update, _on_delete in _SCALING_GROUP_FK_REFS:
-        op.drop_constraint(fk_name, table, type_="foreignkey")
+    for ref in _SCALING_GROUP_FK_REFS:
+        op.drop_constraint(ref.constraint, ref.table, type_="foreignkey")
 
     op.drop_constraint("pk_scaling_groups", "scaling_groups", type_="primary")
     op.drop_constraint("uq_scaling_groups_name", "scaling_groups", type_="unique")
     op.create_primary_key("pk_scaling_groups", "scaling_groups", ["name"])
     op.drop_column("scaling_groups", "id")
 
-    for table, fk_name, column, on_update, on_delete in _SCALING_GROUP_FK_REFS:
+    for ref in _SCALING_GROUP_FK_REFS:
         op.create_foreign_key(
-            fk_name,
-            table,
+            ref.constraint,
+            ref.table,
             "scaling_groups",
-            [column],
+            [ref.column],
             ["name"],
-            onupdate=on_update,
-            ondelete=on_delete,
+            onupdate=ref.on_update,
+            ondelete=ref.on_delete,
         )

--- a/src/ai/backend/manager/models/domain/row.py
+++ b/src/ai/backend/manager/models/domain/row.py
@@ -93,14 +93,15 @@ def _get_network_join_condition() -> sa.ColumnElement[bool]:
 class DomainRow(Base):  # type: ignore[misc]
     __tablename__ = "domains"
 
-    id: Mapped[DomainID] = mapped_column(
-        "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
-    )
     name: Mapped[str] = mapped_column(
-        "name",
-        SlugType(length=64, allow_unicode=True, allow_dot=True),
+        "name", SlugType(length=64, allow_unicode=True, allow_dot=True), primary_key=True
+    )
+    id: Mapped[DomainID] = mapped_column(
+        "id",
+        GUID,
         nullable=False,
         unique=True,
+        server_default=sa.text("uuid_generate_v4()"),
     )
     description: Mapped[str | None] = mapped_column("description", sa.String(length=512))
     is_active: Mapped[bool] = mapped_column("is_active", sa.Boolean, default=True, nullable=False)

--- a/src/ai/backend/manager/models/domain/row.py
+++ b/src/ai/backend/manager/models/domain/row.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import uuid
 from collections.abc import Container, Iterable, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -25,6 +26,7 @@ from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.domain.types import DomainData
 from ai.backend.manager.defs import RESERVED_DOTFILES
 from ai.backend.manager.models.base import (
+    GUID,
     Base,
     ResourceSlotColumn,
     SlugType,
@@ -68,6 +70,7 @@ MAXIMUM_DOTFILE_SIZE = 64 * 1024  # 61 KiB
 
 def row_to_data(row: DomainRow | Row[Any]) -> DomainData:
     return DomainData(
+        id=row.id,
         name=row.name,
         description=row.description,
         is_active=row.is_active,
@@ -90,8 +93,14 @@ def _get_network_join_condition() -> sa.ColumnElement[bool]:
 class DomainRow(Base):  # type: ignore[misc]
     __tablename__ = "domains"
 
+    id: Mapped[uuid.UUID] = mapped_column(
+        "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
+    )
     name: Mapped[str] = mapped_column(
-        "name", SlugType(length=64, allow_unicode=True, allow_dot=True), primary_key=True
+        "name",
+        SlugType(length=64, allow_unicode=True, allow_dot=True),
+        nullable=False,
+        unique=True,
     )
     description: Mapped[str | None] = mapped_column("description", sa.String(length=512))
     is_active: Mapped[bool] = mapped_column("is_active", sa.Boolean, default=True, nullable=False)
@@ -149,6 +158,7 @@ domains = DomainRow.__table__
 
 @dataclass
 class DomainModel(RBACModel[DomainPermission]):
+    id: uuid.UUID
     name: str
     description: str | None
     is_active: bool
@@ -196,6 +206,7 @@ class DomainModel(RBACModel[DomainPermission]):
     @classmethod
     def from_row(cls, row: DomainRow, permissions: Iterable[DomainPermission]) -> Self:
         return cls(
+            id=row.id,
             name=row.name,
             description=row.description,
             is_active=row.is_active,

--- a/src/ai/backend/manager/models/domain/row.py
+++ b/src/ai/backend/manager/models/domain/row.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import uuid
 from collections.abc import Container, Iterable, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -21,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession as SASession
 from sqlalchemy.orm import Mapped, foreign, load_only, mapped_column, relationship
 
 from ai.backend.common import msgpack
+from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.domain.types import DomainData
@@ -93,7 +93,7 @@ def _get_network_join_condition() -> sa.ColumnElement[bool]:
 class DomainRow(Base):  # type: ignore[misc]
     __tablename__ = "domains"
 
-    id: Mapped[uuid.UUID] = mapped_column(
+    id: Mapped[DomainID] = mapped_column(
         "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
     )
     name: Mapped[str] = mapped_column(
@@ -158,7 +158,7 @@ domains = DomainRow.__table__
 
 @dataclass
 class DomainModel(RBACModel[DomainPermission]):
-    id: uuid.UUID
+    id: DomainID
     name: str
     description: str | None
     is_active: bool

--- a/src/ai/backend/manager/models/scaling_group/row.py
+++ b/src/ai/backend/manager/models/scaling_group/row.py
@@ -31,6 +31,7 @@ from sqlalchemy.orm import (
 from sqlalchemy.sql.expression import true
 
 from ai.backend.common.identifier.project import ProjectID
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import (
     AgentSelectionStrategy,
     BackendAISchema,
@@ -267,7 +268,7 @@ def _get_resource_preset_join_condition() -> Any:
 
 class ScalingGroupRow(Base):  # type: ignore[misc]
     __tablename__ = "scaling_groups"
-    id: Mapped[uuid.UUID] = mapped_column(
+    id: Mapped[ResourceGroupID] = mapped_column(
         "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
     )
     name: Mapped[str] = mapped_column("name", sa.String(length=64), nullable=False, unique=True)
@@ -428,7 +429,7 @@ scaling_groups = ScalingGroupRow.__table__
 
 @dataclass
 class ScalingGroupModel(RBACModel[ScalingGroupPermission]):
-    id: uuid.UUID
+    id: ResourceGroupID
     name: str
     description: str | None
     is_active: bool

--- a/src/ai/backend/manager/models/scaling_group/row.py
+++ b/src/ai/backend/manager/models/scaling_group/row.py
@@ -268,10 +268,14 @@ def _get_resource_preset_join_condition() -> Any:
 
 class ScalingGroupRow(Base):  # type: ignore[misc]
     __tablename__ = "scaling_groups"
+    name: Mapped[str] = mapped_column("name", sa.String(length=64), primary_key=True)
     id: Mapped[ResourceGroupID] = mapped_column(
-        "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
+        "id",
+        GUID,
+        nullable=False,
+        unique=True,
+        server_default=sa.text("uuid_generate_v4()"),
     )
-    name: Mapped[str] = mapped_column("name", sa.String(length=64), nullable=False, unique=True)
     description: Mapped[str | None] = mapped_column("description", sa.String(length=512))
     is_active: Mapped[bool | None] = mapped_column(
         "is_active", sa.Boolean, index=True, default=True

--- a/src/ai/backend/manager/models/scaling_group/row.py
+++ b/src/ai/backend/manager/models/scaling_group/row.py
@@ -267,7 +267,10 @@ def _get_resource_preset_join_condition() -> Any:
 
 class ScalingGroupRow(Base):  # type: ignore[misc]
     __tablename__ = "scaling_groups"
-    name: Mapped[str] = mapped_column("name", sa.String(length=64), primary_key=True)
+    id: Mapped[uuid.UUID] = mapped_column(
+        "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
+    )
+    name: Mapped[str] = mapped_column("name", sa.String(length=64), nullable=False, unique=True)
     description: Mapped[str | None] = mapped_column("description", sa.String(length=512))
     is_active: Mapped[bool | None] = mapped_column(
         "is_active", sa.Boolean, index=True, default=True
@@ -359,6 +362,7 @@ class ScalingGroupRow(Base):  # type: ignore[misc]
         )
 
         return ScalingGroupData(
+            id=self.id,
             name=self.name,
             status=ScalingGroupStatus(
                 is_active=self.is_active if self.is_active is not None else True,
@@ -424,6 +428,7 @@ scaling_groups = ScalingGroupRow.__table__
 
 @dataclass
 class ScalingGroupModel(RBACModel[ScalingGroupPermission]):
+    id: uuid.UUID
     name: str
     description: str | None
     is_active: bool
@@ -448,6 +453,7 @@ class ScalingGroupModel(RBACModel[ScalingGroupPermission]):
     @classmethod
     def from_row(cls, row: ScalingGroupRow, permissions: Iterable[ScalingGroupPermission]) -> Self:
         return cls(
+            id=row.id,
             name=row.name,
             description=row.description,
             is_active=row.is_active if row.is_active is not None else True,

--- a/tests/unit/manager/data/domain/test_types.py
+++ b/tests/unit/manager/data/domain/test_types.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import uuid
 from datetime import UTC, datetime
 
 from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.data.domain.types import DomainData
 from ai.backend.manager.data.permission.types import OperationType
@@ -11,6 +13,7 @@ from ai.backend.manager.data.permission.types import OperationType
 def _make_domain_data() -> DomainData:
     now = datetime.now(tz=UTC)
     return DomainData(
+        id=DomainID(uuid.uuid4()),
         name="default",
         description=None,
         is_active=True,

--- a/tests/unit/manager/services/domain/test_domain_service.py
+++ b/tests/unit/manager/services/domain/test_domain_service.py
@@ -14,6 +14,7 @@ import pytest
 
 from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.exception import DomainNotFound, InvalidAPIParameters
+from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.data.domain.types import DomainData, UserInfo
 from ai.backend.manager.errors.resource import (
@@ -47,6 +48,7 @@ def _make_domain_data(
 ) -> DomainData:
     now = datetime.now(tz=UTC)
     return DomainData(
+        id=DomainID(uuid.uuid4()),
         name=name,
         description=description,
         is_active=is_active,

--- a/tests/unit/manager/services/scaling_group/test_scaling_group_service.py
+++ b/tests/unit/manager/services/scaling_group/test_scaling_group_service.py
@@ -12,6 +12,7 @@ import pytest
 
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.exception import ScalingGroupConflict
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import AccessKey, AgentSelectionStrategy, ResourceSlot, SessionTypes
 from ai.backend.manager.data.deployment.types import DeploymentOptions
 from ai.backend.manager.data.permission.types import RBACElementRef
@@ -123,6 +124,7 @@ class TestScalingGroupService:
     def sample_scaling_group(self) -> ScalingGroupData:
         """Create sample scaling group data"""
         return ScalingGroupData(
+            id=ResourceGroupID(uuid.uuid4()),
             name="default",
             status=ScalingGroupStatus(
                 is_active=True,
@@ -257,6 +259,7 @@ class TestScalingGroupService:
         """Test searching scaling groups with multiple results"""
         scaling_groups = [
             ScalingGroupData(
+                id=ResourceGroupID(uuid.uuid4()),
                 name=f"sgroup-{i}",
                 status=ScalingGroupStatus(
                     is_active=True,
@@ -694,6 +697,7 @@ class TestGetWsproxyVersion:
     @pytest.fixture
     def sample_sgroup_with_wsproxy(self) -> ScalingGroupData:
         return ScalingGroupData(
+            id=ResourceGroupID(uuid.uuid4()),
             name="gpu-group",
             status=ScalingGroupStatus(is_active=True, is_public=True),
             metadata=ScalingGroupMetadata(
@@ -785,6 +789,7 @@ class TestGetWsproxyVersion:
     ) -> None:
         """wsproxy_addr not set returns v1 version."""
         no_wsproxy = ScalingGroupData(
+            id=ResourceGroupID(uuid.uuid4()),
             name="gpu-group",
             status=sample_sgroup_with_wsproxy.status,
             metadata=sample_sgroup_with_wsproxy.metadata,
@@ -842,6 +847,7 @@ class TestListAllowedScalingGroups:
 
     def _make_sgroup(self, name: str, *, is_public: bool = True) -> ScalingGroupData:
         return ScalingGroupData(
+            id=ResourceGroupID(uuid.uuid4()),
             name=name,
             status=ScalingGroupStatus(is_active=True, is_public=is_public),
             metadata=ScalingGroupMetadata(

--- a/tests/unit/manager/services/scaling_group/test_update_fair_share_spec.py
+++ b/tests/unit/manager/services/scaling_group/test_update_fair_share_spec.py
@@ -6,12 +6,14 @@ Tests resource weight validation and capacity-based filtering.
 
 from __future__ import annotations
 
+import uuid
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import AgentSelectionStrategy, ResourceSlot, SessionTypes, SlotQuantity
 from ai.backend.manager.data.deployment.types import DeploymentOptions
 from ai.backend.manager.data.scaling_group.types import (
@@ -66,6 +68,7 @@ def _create_scaling_group(
         route_cleanup_target_statuses=[],
     )
     return ScalingGroupData(
+        id=ResourceGroupID(uuid.uuid4()),
         name="default",
         status=ScalingGroupStatus(is_active=True, is_public=True),
         metadata=ScalingGroupMetadata(description="Test", created_at=datetime.now(tz=UTC)),

--- a/tests/unit/manager/services/test_domain.py
+++ b/tests/unit/manager/services/test_domain.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 
 from ai.backend.common.exception import DomainNotFound, InvalidAPIParameters
+from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.types import ResourceSlot, VFolderHostPermission, VFolderHostPermissionMap
 from ai.backend.manager.data.domain.types import DomainData, UserInfo
 from ai.backend.manager.errors.resource import (
@@ -88,6 +89,7 @@ class TestCreateDomain:
     @pytest.fixture
     def sample_domain_data(self) -> DomainData:
         return DomainData(
+            id=DomainID(uuid4()),
             name="test-create-domain",
             description="Test domain",
             is_active=True,
@@ -103,6 +105,7 @@ class TestCreateDomain:
     @pytest.fixture
     def complex_resource_domain_data(self) -> DomainData:
         return DomainData(
+            id=DomainID(uuid4()),
             name="test-complex-resources",
             description="Test domain with complex resource slots",
             is_active=True,
@@ -270,6 +273,7 @@ class TestModifyDomain:
     @pytest.fixture
     def modified_domain_data(self) -> DomainData:
         return DomainData(
+            id=DomainID(uuid4()),
             name="test-modify-domain",
             description="Domain Description Modified",
             is_active=True,
@@ -285,6 +289,7 @@ class TestModifyDomain:
     @pytest.fixture
     def deactivated_domain_data(self) -> DomainData:
         return DomainData(
+            id=DomainID(uuid4()),
             name="test-domain",
             description="Test domain",
             is_active=False,
@@ -300,6 +305,7 @@ class TestModifyDomain:
     @pytest.fixture
     def nullified_domain_data(self) -> DomainData:
         return DomainData(
+            id=DomainID(uuid4()),
             name="test-nullify-domain",
             description=None,
             is_active=True,
@@ -629,6 +635,7 @@ class TestCreateDomainNode:
     @pytest.fixture
     def sample_domain_node_data(self) -> DomainData:
         return DomainData(
+            id=DomainID(uuid4()),
             name="test-domain-node",
             description="Test domain node",
             is_active=True,
@@ -760,6 +767,7 @@ class TestModifyDomainNode:
     @pytest.fixture
     def modified_domain_node_data(self) -> DomainData:
         return DomainData(
+            id=DomainID(uuid4()),
             name="test-domain-node",
             description="Modified description",
             is_active=True,
@@ -775,6 +783,7 @@ class TestModifyDomainNode:
     @pytest.fixture
     def sample_domain_data(self) -> DomainData:
         return DomainData(
+            id=DomainID(uuid4()),
             name="test-domain",
             description="Test domain",
             is_active=True,


### PR DESCRIPTION
## Summary

- Add UUID `id` column as the new primary key on `domains` and `scaling_groups`; demote `name` to a UNIQUE constraint so existing `domain_name` / `scaling_group` FK references continue to function unchanged.
- Add `DomainID` and `ResourceGroupID` `NewType` definitions alongside the existing `DomainName` / `ResourceGroupName` identifiers.
- PostgreSQL ties FK dependencies to the primary-key index, so each Alembic migration temporarily drops and recreates the 10 (domains) / 7 (scaling_groups) referencing FK constraints with identical column, target column, and ON UPDATE/DELETE rules.

## Test plan

- [x] `pants fmt fix lint` on changed files passes
- [x] `pants check` (mypy + visibility) on changed files passes
- [x] `./py -m alembic upgrade head` applies both new migrations cleanly
- [x] `./py -m alembic downgrade` reverses both migrations back to the previous head
- [x] After upgrade, existing rows have `id` backfilled by `uuid_generate_v4()`
- [x] `name` UNIQUE constraint rejects duplicate inserts after the PK swap
- [x] All 17 FK constraints retain their original columns / targets / ON UPDATE/DELETE rules

This PR is the first of four planned per entity under epic BA-6043. Follow-up issues will migrate API identifiers (BA-6045, BA-6049), FK column types (BA-6046, BA-6050), and RBAC data/logic (BA-6047, BA-6051).

Resolves BA-6044
Resolves BA-6048