### PR TITLE
chore: Increase pants lint batch_size to reduce ruff process spawning

### DIFF
--- a/changes/11626.misc.md
+++ b/changes/11626.misc.md
@@ -1,0 +1,1 @@
+Increase `pants lint` `batch_size` from the default 128 to 1024 to reduce the number of spawned ruff processes and their startup overhead.

--- a/pants.toml
+++ b/pants.toml
@@ -47,6 +47,11 @@ extra_env_vars = ["BACKEND_BUILD_ROOT=%(buildroot)s", "HOME"]
 attempts_default = 3
 timeout_default = 180
 
+[lint]
+# Batch more files per linter invocation to reduce ruff process startup overhead.
+# Default is 128; raising it cuts the number of spawned ruff processes ~8x.
+batch_size = 1024
+
 [python]
 enable_resolves = true
 # When changing this main Python version:


### PR DESCRIPTION
## Summary

- Add `[lint] batch_size = 1024` to `pants.toml` (default is `128`).
- For the current ~6.1k Python files in `src/` and `tests/`, this drops the number of spawned ruff processes from ~48 to ~6 per `pants lint` run, cutting per-process startup overhead while still allowing parallelism across cores.
- See [pants `[lint]` reference](https://www.pantsbuild.org/stable/reference/goals/lint#batch_size) for the option semantics (target size, batched at stable boundaries).

## Test plan

- [ ] `pants lint ::` succeeds locally
- [ ] Confirm fewer ruff processes are spawned (e.g. observe via `htop` / `ps` during the lint run)