### PR TITLE
feat(BA-6056): expose deployment_id and deployment Node on ModelRevision

### DIFF
--- a/changes/11631.feature.md
+++ b/changes/11631.feature.md
@@ -1,0 +1,1 @@
+Expose the parent deployment directly on the `ModelRevision` GraphQL Node so any revision (from a mutation result, read query, or connection edge) can be traversed back to its deployment in a single round trip. Adds `deploymentId: ID!` (raw ID for client-side joins) and a DataLoader-backed `deployment: ModelDeployment` resolver.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -9707,6 +9707,11 @@ type ModelRevision implements Node
   """
   revisionPresetId: UUID
 
+  """
+  Added in UNRELEASED. ID of the parent deployment that owns this revision. Exposed alongside the resolved ``deployment`` node so clients can navigate without re-fetching.
+  """
+  deploymentId: ID!
+
   """Timestamp when the revision was created."""
   createdAt: DateTime!
 
@@ -9722,6 +9727,11 @@ type ModelRevision implements Node
   Added in UNRELEASED. The deployment-level preset that produced this revision, resolved via DataLoader. ``None`` when the revision was created without a preset, when the originating preset row has since been deleted (SET NULL FK), or for legacy rows that predate this field.
   """
   revisionPreset: DeploymentRevisionPreset
+
+  """
+  Added in UNRELEASED. The parent deployment owning this revision, resolved via DataLoader.
+  """
+  deployment: ModelDeployment
 
   """Added in 26.4.2. Resource slot allocations for this revision."""
   resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null): [AllocatedResourceSlot!]

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -6476,6 +6476,11 @@ type ModelRevision implements Node {
   """
   revisionPresetId: UUID
 
+  """
+  Added in UNRELEASED. ID of the parent deployment that owns this revision. Exposed alongside the resolved ``deployment`` node so clients can navigate without re-fetching.
+  """
+  deploymentId: ID!
+
   """Timestamp when the revision was created."""
   createdAt: DateTime!
 
@@ -6491,6 +6496,11 @@ type ModelRevision implements Node {
   Added in UNRELEASED. The deployment-level preset that produced this revision, resolved via DataLoader. ``None`` when the revision was created without a preset, when the originating preset row has since been deleted (SET NULL FK), or for legacy rows that predate this field.
   """
   revisionPreset: DeploymentRevisionPreset
+
+  """
+  Added in UNRELEASED. The parent deployment owning this revision, resolved via DataLoader.
+  """
+  deployment: ModelDeployment
 
   """Added in 26.4.2. Resource slot allocations for this revision."""
   resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null): [AllocatedResourceSlot!]

--- a/src/ai/backend/common/dto/manager/v2/deployment/response.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/response.py
@@ -104,6 +104,13 @@ class RevisionNode(BaseResponseModel):
     """Node model representing a deployment revision."""
 
     id: UUID = Field(description="Revision ID")
+    deployment_id: UUID = Field(
+        description=(
+            "ID of the parent deployment that owns this revision. "
+            "Exposed alongside the resolved deployment node so clients can "
+            "navigate without re-fetching."
+        ),
+    )
     revision_number: int = Field(
         description=(
             "Per-deployment sequential revision number assigned at insert "

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -2287,6 +2287,7 @@ class DeploymentAdapter(BaseAdapter):
             )
         return RevisionNode(
             id=data.id,
+            deployment_id=data.deployment_id,
             revision_number=data.revision_number,
             image_id=data.image_id,
             cluster_config=ClusterConfigInfoDTO(

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -509,6 +509,16 @@ class ModelRevision(PydanticNodeMixin[RevisionNodeDTO]):
         ),
         default=None,
     )
+    deployment_id: ID = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "ID of the parent deployment that owns this revision. "
+                "Exposed alongside the resolved ``deployment`` node so "
+                "clients can navigate without re-fetching."
+            ),
+        ),
+    )
     created_at: datetime = gql_field(description="Timestamp when the revision was created.")
 
     @gql_field(
@@ -564,6 +574,17 @@ class ModelRevision(PydanticNodeMixin[RevisionNodeDTO]):
         if self.revision_preset_id is None:
             return None
         return await info.context.data_loaders.revision_preset_loader.load(self.revision_preset_id)
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The parent deployment owning this revision, resolved via DataLoader.",
+        )
+    )  # type: ignore[misc]
+    async def deployment(
+        self, info: Info[StrawberryGQLContext]
+    ) -> Annotated[ModelDeployment, strawberry.lazy(".deployment")] | None:
+        return await info.context.data_loaders.deployment_loader.load(UUID(str(self.deployment_id)))
 
     @gql_added_field(
         BackendAIGQLMeta(

--- a/tests/unit/common/dto/manager/v2/deployment/test_response.py
+++ b/tests/unit/common/dto/manager/v2/deployment/test_response.py
@@ -143,6 +143,7 @@ def _make_deployment_strategy(**kwargs: object) -> DeploymentStrategyInfoDTO:
 def _make_revision_node(**kwargs: object) -> RevisionNode:
     defaults: dict[str, Any] = {
         "id": uuid.uuid4(),
+        "deployment_id": uuid.uuid4(),
         "revision_number": 1,
         "image_id": ImageID(uuid.uuid4()),
         "cluster_config": _make_cluster_config(),
@@ -212,9 +213,11 @@ class TestRevisionNode:
 
     def test_creation_with_all_fields(self) -> None:
         revision_id = uuid.uuid4()
+        deployment_id = uuid.uuid4()
         now = datetime.now(tz=UTC)
         node = RevisionNode(
             id=revision_id,
+            deployment_id=deployment_id,
             revision_number=1,
             image_id=ImageID(uuid.uuid4()),
             cluster_config=_make_cluster_config(),
@@ -224,12 +227,14 @@ class TestRevisionNode:
             extra_mounts=[],
         )
         assert node.id == revision_id
+        assert node.deployment_id == deployment_id
         assert node.created_at == now
         assert node.extra_mounts == []
 
     def test_extra_mounts_defaults_to_empty_list(self) -> None:
         node = RevisionNode(
             id=uuid.uuid4(),
+            deployment_id=uuid.uuid4(),
             revision_number=1,
             image_id=ImageID(uuid.uuid4()),
             cluster_config=_make_cluster_config(),


### PR DESCRIPTION
## Summary

Expose the parent deployment directly on the `ModelRevision` GraphQL Node so that *any* revision — whether returned from a mutation, fetched by ID, or surfaced through a connection edge — can be traversed back to its deployment in a single round trip.

This supersedes an earlier design that only added the deployment to the `addModelRevision` mutation payload; putting the fields on the Node itself avoids client-side branching between mutation results and read paths.

### What changes

- `common/dto/manager/v2/deployment/response.py`: add `deployment_id: UUID` (required) to `RevisionNode`.
- `manager/api/adapters/deployment/adapter.py`: populate `deployment_id` in the data → DTO conversion.
- `manager/api/gql/deployment/types/revision.py`: expose `deploymentId: ID!` as a plain field and add a DataLoader-backed `deployment: ModelDeployment` resolver.
- `tests/unit/common/dto/manager/v2/deployment/test_response.py`: cover the new required field.
- `docs/manager/graphql-reference/{v2-schema,supergraph}.graphql`: regenerated.

Jira: [BA-6056](https://lablup.atlassian.net/browse/BA-6056)

## Test plan

- [x] `pants --changed-since=HEAD~2 lint check` passes.
- [x] `pants test tests/unit/common/dto/manager/v2/deployment/test_response.py` passes.
- [x] End-to-end against a live manager: create a deployment, call `addModelRevision`, and confirm the returned `revision.deploymentId` matches the parent UUID and `revision.deployment` resolves to the correct `ModelDeployment` node (verified via local script).
- [x] Same fields also resolve correctly when reading `deployment.revisionHistory` edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BA-6056]: https://lablup.atlassian.net/browse/BA-6056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11631.org.readthedocs.build/en/11631/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11631.org.readthedocs.build/ko/11631/

<!-- readthedocs-preview sorna-ko end -->