### PR TITLE
fix(BA-6015): persist resolved model-definition path when set None from request

### DIFF
--- a/changes/11638.fix.md
+++ b/changes/11638.fix.md
@@ -1,0 +1,1 @@
+Record the resolved model-definition file path on model service revisions instead of the request's empty value

--- a/src/ai/backend/common/dto/manager/v2/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/request.py
@@ -266,10 +266,12 @@ class ModelMountConfigInput(BaseRequestModel):
     mount_destination: str = Field(description="Mount destination path inside container")
     definition_path: str | None = Field(
         default=None,
+        min_length=1,
         description=(
             "Optional path to the model definition file within the model vfolder. "
             "When omitted, the server auto-detects `model-definition.yaml` or "
-            "`model-definition.yml`."
+            "`model-definition.yml`. Empty string is rejected; omit the field to "
+            "trigger auto-detection."
         ),
     )
     subpath: str | None = Field(

--- a/src/ai/backend/manager/data/deployment/creator.py
+++ b/src/ai/backend/manager/data/deployment/creator.py
@@ -8,6 +8,7 @@ from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.identifier.deployment_preset import DeploymentPresetID
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.vfolder import VFolderUUID
+from ai.backend.common.types import MountInfoEntry
 from ai.backend.manager.data.deployment.types import (
     DeploymentMetadata,
     DeploymentNetworkSpec,
@@ -17,6 +18,7 @@ from ai.backend.manager.data.deployment.types import (
     ModelRevisionSpec,
     ModelRevisionSpecDraft,
     MountInfo,
+    MountMetadata,
     ReplicaSpec,
     ResourceSpec,
     RevisionDraft,
@@ -65,7 +67,7 @@ class ModelRevisionCreator:
     revision_preset_id: DeploymentPresetID | None = None
     preset_values: list[PresetValueData] = field(default_factory=list)
 
-    def to_draft(self) -> RevisionDraft:
+    def to_draft_with_extra_mount(self, extra_mounts: list[MountInfoEntry]) -> RevisionDraft:
         """Project this v2 creator onto a ``RevisionDraft`` layer.
 
         ``image_id`` is already resolved upstream. Optional ``resource_spec`` /
@@ -77,6 +79,13 @@ class ModelRevisionCreator:
         ex = self.execution
         return RevisionDraft(
             image_id=self.image_id,
+            mounts=MountMetadata(
+                model_vfolder_id=self.mounts.model_vfolder_id,
+                model_definition_path=self.mounts.model_definition_path,
+                model_mount_destination=self.mounts.model_mount_destination,
+                extra_mounts=extra_mounts,
+                vfolder_subpath=self.mounts.vfolder_subpath,
+            ),
             resource_slots=rs.resource_slots if rs is not None else None,
             resource_opts=rs.resource_opts if rs is not None else None,
             cluster_mode=rs.cluster_mode if rs is not None else None,

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -66,6 +66,17 @@ class DeploymentConfig(BackendAISchema):
     environ: dict[str, str] | None = None
 
 
+@dataclass(frozen=True)
+class FetchedModelDefinition:
+    """Model definition draft with the vfolder path it was read from.
+
+    ``path`` is the matched candidate path inside the model vfolder.
+    """
+
+    path: str
+    model_definition: ModelDefinitionDraft
+
+
 class RouteStatus(enum.Enum):
     """Lifecycle status of a route (independent of health)."""
 
@@ -511,12 +522,11 @@ class ModelRevisionSpecDraft(ConfiguredModel):
         """Project this legacy spec draft onto a ``RevisionDraft`` layer.
 
         ``image_id`` is resolved upstream from the spec's ``image_identifier``
-        (canonical + architecture) via the repository; mount-identifying
-        fields live on ``MountMetadata`` and are passed alongside into
-        ``add_revision`` rather than through the draft chain.
+        (canonical + architecture) via the repository.
         """
         return RevisionDraft(
             image_id=image_id,
+            mounts=self.mounts,
             resource_slots=self.resource_spec.resource_slots,
             resource_opts=self.resource_spec.resource_opts,
             cluster_mode=self.resource_spec.cluster_mode,
@@ -548,6 +558,8 @@ class RevisionDraft:
     # (see ``deployment_revisions.image`` SET NULL FK) — downstream
     # resolvers must treat the latter as non-deployable.
     image_id: ImageID | None = None
+    # Mount
+    mounts: MountMetadata | None = None
     # Resource
     resource_slots: Mapping[str, Any] | None = None
     resource_opts: Mapping[str, Any] | None = None
@@ -570,6 +582,7 @@ class RevisionDraft:
         """Return a new draft with ``other`` layered on top of ``self``."""
         return RevisionDraft(
             image_id=other.image_id if other.image_id is not None else self.image_id,
+            mounts=_merge_mounts(self.mounts, other.mounts),
             resource_slots=_merge_mappings(self.resource_slots, other.resource_slots),
             resource_opts=_merge_mappings(self.resource_opts, other.resource_opts),
             cluster_mode=other.cluster_mode
@@ -600,7 +613,7 @@ class RevisionDraft:
             else (list(self.preset_values) if self.preset_values is not None else None),
         )
 
-    def to_model_revision_spec(self, mounts: MountMetadata) -> ModelRevisionSpec:
+    def to_model_revision_spec(self) -> ModelRevisionSpec:
         """Project the merged draft into a final ``ModelRevisionSpec``.
 
         Validates that the merge chain produced an ``image_id`` and a
@@ -611,6 +624,8 @@ class RevisionDraft:
         """
         if self.image_id is None:
             raise InvalidAPIParameters("image_id is required to build a revision")
+        if self.mounts is None:
+            raise InvalidAPIParameters("mounts are required to build a revision")
         if self.runtime_variant_id is None:
             raise InvalidAPIParameters("runtime_variant_id is required to build a revision")
         return ModelRevisionSpec(
@@ -621,7 +636,7 @@ class RevisionDraft:
                 resource_slots=self.resource_slots or {},
                 resource_opts=self.resource_opts,
             ),
-            mounts=mounts,
+            mounts=self.mounts,
             execution=ExecutionSpec(
                 startup_command=self.startup_command,
                 bootstrap_script=self.bootstrap_script,
@@ -634,6 +649,33 @@ class RevisionDraft:
                 self.model_definition.to_resolved() if self.model_definition is not None else None
             ),
         )
+
+
+def _merge_mounts(
+    lower: MountMetadata | None,
+    upper: MountMetadata | None,
+) -> MountMetadata | None:
+    if upper is None:
+        return lower
+    if lower is None:
+        return MountMetadata(
+            model_vfolder_id=upper.model_vfolder_id,
+            model_definition_path=upper.model_definition_path,
+            model_mount_destination=upper.model_mount_destination,
+            extra_mounts=list(upper.extra_mounts),
+            vfolder_subpath=upper.vfolder_subpath,
+        )
+    return MountMetadata(
+        model_vfolder_id=upper.model_vfolder_id,
+        model_definition_path=upper.model_definition_path
+        if upper.model_definition_path is not None
+        else lower.model_definition_path,
+        model_mount_destination=upper.model_mount_destination,
+        extra_mounts=list(upper.extra_mounts),
+        vfolder_subpath=upper.vfolder_subpath
+        if upper.vfolder_subpath is not None
+        else lower.vfolder_subpath,
+    )
 
 
 def _merge_mappings(
@@ -993,6 +1035,17 @@ class ModelRevisionData:
         )
         return RevisionDraft(
             image_id=self.image_id,
+            mounts=(
+                MountMetadata(
+                    model_vfolder_id=self.model_mount_config.vfolder_id,
+                    model_definition_path=self.model_mount_config.definition_path or None,
+                    model_mount_destination=self.model_mount_config.mount_destination or "/models",
+                    extra_mounts=list(self.model_mount_config.extra_mounts),
+                    vfolder_subpath=self.model_mount_config.subpath,
+                )
+                if self.model_mount_config.vfolder_id is not None
+                else None
+            ),
             resource_slots=resource_slots,
             resource_opts=resource_opts,
             cluster_mode=self.cluster_config.mode,

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -668,13 +668,11 @@ def _merge_mounts(
     return MountMetadata(
         model_vfolder_id=upper.model_vfolder_id,
         model_definition_path=upper.model_definition_path
-        if upper.model_definition_path is not None
+        if upper.model_definition_path
         else lower.model_definition_path,
         model_mount_destination=upper.model_mount_destination,
         extra_mounts=list(upper.extra_mounts),
-        vfolder_subpath=upper.vfolder_subpath
-        if upper.vfolder_subpath is not None
-        else lower.vfolder_subpath,
+        vfolder_subpath=upper.vfolder_subpath if upper.vfolder_subpath else lower.vfolder_subpath,
     )
 
 

--- a/src/ai/backend/manager/repositories/deployment/repository.py
+++ b/src/ai/backend/manager/repositories/deployment/repository.py
@@ -14,7 +14,7 @@ from pydantic import HttpUrl
 from ai.backend.common.clients.valkey_client.valkey_live.client import ValkeyLiveClient
 from ai.backend.common.clients.valkey_client.valkey_schedule.client import ValkeyScheduleClient
 from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
-from ai.backend.common.config import ModelDefinitionDraft, ModelHealthCheck
+from ai.backend.common.config import ModelHealthCheck
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.exception import BackendAIError, InvalidAPIParameters
 from ai.backend.common.identifier.deployment import DeploymentID
@@ -64,6 +64,7 @@ from ai.backend.manager.data.deployment.types import (
     DeploymentRevisionReadBundle,
     DeploymentSummarySearchResult,
     DeploymentWithHistory,
+    FetchedModelDefinition,
     LegacyRevisionCreateReadBundle,
     ModelDeploymentAccessTokenData,
     ModelDeploymentAutoScalingRuleData,
@@ -485,12 +486,13 @@ class DeploymentRepository:
         self,
         vfolder_id: VFolderUUID,
         model_definition_path: str | None,
-    ) -> ModelDefinitionDraft | None:
+    ) -> FetchedModelDefinition | None:
         """Fetch and validate the model-definition file from the model vfolder.
 
-        Returns a ``ModelDefinitionDraft`` because the file is user-authored
+        Returns a ``FetchedModelDefinition`` because the file is user-authored
         and may omit optional fields; strict-field validation is deferred to
-        the persistence boundary where the merged result is resolved.
+        the persistence boundary where the merged result is resolved. The
+        result also carries the exact candidate path that matched.
         Returns ``None`` when no candidate file exists.
         """
         vfolder_location = await self._db_source.get_vfolder_by_id(vfolder_id)

--- a/src/ai/backend/manager/repositories/deployment/storage_source/storage_source.py
+++ b/src/ai/backend/manager/repositories/deployment/storage_source/storage_source.py
@@ -1,6 +1,7 @@
 """Storage source implementation for deployment repository."""
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any, override
 
 import tomli
@@ -9,8 +10,15 @@ from ruamel.yaml import YAML
 from ai.backend.common.config import ModelDefinitionDraft
 from ai.backend.common.exception import BackendAIError, InvalidAPIParameters
 from ai.backend.common.types import BackendAISchema, SchemaValidationFailureInfo, VFolderID
+from ai.backend.manager.data.deployment.types import FetchedModelDefinition
 from ai.backend.manager.data.vfolder.types import VFolderLocation
 from ai.backend.manager.models.storage import StorageSessionManager
+
+
+@dataclass(frozen=True)
+class FetchedConfigFile:
+    filename: str
+    payload: Mapping[str, Any]
 
 
 class DeploymentConfigInput(BackendAISchema):
@@ -60,13 +68,13 @@ class DeploymentStorageSource:
         raw = await self._fetch_config_file_in_candidates(vfolder_location, candidates)
         if raw is None:
             return None
-        return DeploymentConfigInput.model_validate(dict(raw))
+        return DeploymentConfigInput.model_validate(dict(raw.payload))
 
     async def fetch_model_definition(
         self,
         vfolder_location: VFolderLocation,
         candidates: list[str],
-    ) -> ModelDefinitionDraft | None:
+    ) -> FetchedModelDefinition | None:
         """Fetch the first existing model-definition file among ``candidates``.
 
         Uses the draft type because user-authored files may supply only a
@@ -77,13 +85,16 @@ class DeploymentStorageSource:
         raw = await self._fetch_config_file_in_candidates(vfolder_location, candidates)
         if raw is None:
             return None
-        return ModelDefinitionDraft.model_validate(dict(raw))
+        return FetchedModelDefinition(
+            path=raw.filename,
+            model_definition=ModelDefinitionDraft.model_validate(dict(raw.payload)),
+        )
 
     async def _fetch_config_file_in_candidates(
         self,
         vfolder_location: VFolderLocation,
         candidates: list[str],
-    ) -> Mapping[str, Any] | None:
+    ) -> FetchedConfigFile | None:
         """Return the first parsed ``Mapping`` among the candidates.
 
         Candidates are tried in priority order (new name first, legacy
@@ -122,5 +133,5 @@ class DeploymentStorageSource:
                 raise InvalidAPIParameters(
                     f"Invalid config file '{filename}': top-level value must be a mapping."
                 )
-            return loaded
+            return FetchedConfigFile(filename=filename, payload=loaded)
         return None

--- a/src/ai/backend/manager/services/model_serving/services/model_serving.py
+++ b/src/ai/backend/manager/services/model_serving/services/model_serving.py
@@ -829,7 +829,20 @@ class ModelServingService:
         if spec.has_revision_changes():
             latest_rev = await self._deployment_repository.get_latest_revision(action.deployment_id)
             latest_draft = latest_rev.to_draft()
+            if latest_draft.mounts is None:
+                raise InvalidAPIParameters("model vfolder id is missing on the latest revision")
             override_draft = await self._build_revision_overrides_from_spec(spec)
+            definition_path_override = spec.model_definition_path.optional_value()
+            draft_with_definition_path_override = RevisionDraft(
+                mounts=MountMetadata(
+                    model_vfolder_id=latest_draft.mounts.model_vfolder_id,
+                    model_definition_path=definition_path_override,
+                    model_mount_destination=latest_draft.mounts.model_mount_destination,
+                    extra_mounts=list(latest_draft.mounts.extra_mounts),
+                    vfolder_subpath=latest_draft.mounts.vfolder_subpath,
+                )
+            )
+            override_draft = override_draft.merge(draft_with_definition_path_override)
             # Legacy ``ModifyEndpoint`` semantics preserve untouched fields by
             # layering overrides on top of the existing revision. The
             # controller's ``add_revision`` no longer accepts a caller-provided
@@ -837,30 +850,9 @@ class ModelServingService:
             # request-level override draft.
             overrides = latest_draft.merge(override_draft)
 
-            vfolder_id = latest_rev.model_mount_config.vfolder_id
-            if vfolder_id is None:
-                raise InvalidAPIParameters("model vfolder id is missing on the latest revision")
-            definition_path_override = spec.model_definition_path.optional_value()
-            mounts = MountMetadata(
-                model_vfolder_id=vfolder_id,
-                model_definition_path=(
-                    definition_path_override
-                    if definition_path_override is not None
-                    else latest_rev.model_mount_config.definition_path
-                ),
-                model_mount_destination=latest_rev.model_mount_config.mount_destination
-                or "/models",
-                # Carry over the latest revision's extra mounts so that an
-                # otherwise unrelated modify (e.g. replica-count) does not
-                # strip them; ``mount_perm`` survives because the
-                # revision-side projection uses the same ``MountInfoEntry``
-                # shape.
-                extra_mounts=list(latest_rev.model_mount_config.extra_mounts),
-            )
             revision = await self._deployment_controller.add_revision(
                 endpoint_id=action.deployment_id,
                 overrides=overrides,
-                mounts=mounts,
             )
             await self._deployment_controller.activate_revision(action.deployment_id, revision.id)
         elif spec.replica_count_modified():

--- a/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
@@ -40,7 +40,6 @@ from ai.backend.manager.data.deployment.types import (
     ModelRevisionSpec,
     ModelRevisionSpecDraft,
     MountInfo,
-    MountMetadata,
     ReplicaSpec,
     RevisionDraft,
     RouteInfo,
@@ -247,14 +246,11 @@ class DeploymentController:
         request_draft = draft.draft_model_revision.to_draft(image_id)
         drafts = await self._revision_draft_reader.read_for_legacy_model_service_deployment(
             request_draft=request_draft,
-            mounts=draft.draft_model_revision.mounts,
             execution=draft.draft_model_revision.execution,
             preset_id=None,
         )
         merged = functools.reduce(RevisionDraft.merge, drafts, RevisionDraft())
-        model_revision_spec = merged.to_model_revision_spec(
-            mounts=draft.draft_model_revision.mounts
-        )
+        model_revision_spec = merged.to_model_revision_spec()
         validation_ctx = await self._build_deployment_revision_validation_context()
         self._deployment_revision_validator.validate_legacy_revision_spec(
             model_revision_spec, validation_ctx
@@ -272,9 +268,9 @@ class DeploymentController:
         # ``draft.draft_model_revision.mounts.extra_mounts`` is already
         # ``list[MountInfoEntry]`` because the legacy validator pre-resolved
         # via ``prepare_vfolder_mounts``. Project into ``MountInfo`` with
-        # the concrete ``mount_perm`` carried over as an explicit
-        # override; ``add_deployment_revision`` then uses it directly
-        # without re-reading the vfolder.
+        # the concrete ``mount_perm`` carried over as an explicit override;
+        # ``add_deployment_revision`` applies the final permission cap before
+        # delegating to ``add_revision``.
         legacy_extra_mounts = [
             MountInfo(
                 vfolder_id=m.vfolder_id,
@@ -376,15 +372,14 @@ class DeploymentController:
         self,
         endpoint_id: DeploymentID,
         overrides: RevisionDraft,
-        mounts: MountMetadata,
         preset_id: DeploymentPresetID | None = None,
     ) -> ModelRevisionData:
         """Create a new immutable revision on an existing deployment.
 
         Revisions are immutable — every mutation (legacy ModifyEndpoint included)
-        must go through this single entry point. ``mounts`` carries the vfolder
-        context required by file-based draft sources and is not part of the
-        merged RevisionDraft — mount identity is not a merge candidate.
+        must go through this single entry point. ``overrides.mounts`` carries
+        the vfolder context required by file-based draft sources and final
+        revision persistence.
 
         Merge order (low → high) is assembled by ``RevisionDraftReader``:
             1. model mount destination as the ``model_path`` default
@@ -419,7 +414,6 @@ class DeploymentController:
         drafts = await self._revision_draft_reader.read_for_deployment_revision(
             runtime_variant_id=runtime_variant_id,
             request_draft=overrides,
-            mounts=mounts,
             preset_id=preset_id,
         )
         merged = functools.reduce(RevisionDraft.merge, drafts, RevisionDraft())
@@ -427,6 +421,8 @@ class DeploymentController:
         endpoint_info = await self._deployment_repository.get_endpoint_info(endpoint_id)
         if merged.image_id is None:
             raise InvalidAPIParameters("image_id is required to add a revision")
+        if merged.mounts is None:
+            raise InvalidAPIParameters("mounts are required to add a revision")
         if merged.model_definition is None:
             raise InvalidAPIParameters(
                 "model_definition is required to add a revision; provide it in the request,"
@@ -443,17 +439,17 @@ class DeploymentController:
             resource_opts=dict(merged.resource_opts) if merged.resource_opts else {},
             cluster_mode=(merged.cluster_mode or ClusterMode.SINGLE_NODE).value,
             cluster_size=merged.cluster_size or 1,
-            model_vfolder_id=mounts.model_vfolder_id,
-            model_mount_destination=mounts.model_mount_destination,
-            vfolder_subpath=mounts.vfolder_subpath,
-            model_definition_path=mounts.model_definition_path,
+            model_vfolder_id=merged.mounts.model_vfolder_id,
+            model_mount_destination=merged.mounts.model_mount_destination,
+            vfolder_subpath=merged.mounts.vfolder_subpath,
+            model_definition_path=merged.mounts.model_definition_path,
             model_definition=resolved_model_definition,
             startup_command=merged.startup_command,
             bootstrap_script=merged.bootstrap_script,
             environ=dict(merged.environ) if merged.environ else {},
             callback_url=str(merged.callback_url) if merged.callback_url else None,
             runtime_variant_id=runtime_variant_id,
-            extra_mounts=list(mounts.extra_mounts),
+            extra_mounts=list(merged.mounts.extra_mounts),
             preset_values=[
                 PresetValueEntry(preset_id=pv.preset_id, value=pv.value)
                 for pv in (merged.preset_values or [])
@@ -514,17 +510,9 @@ class DeploymentController:
             )
             for m in revision.mounts.extra_mounts
         ]
-        mounts = MountMetadata(
-            model_vfolder_id=revision.mounts.model_vfolder_id,
-            model_definition_path=revision.mounts.model_definition_path,
-            model_mount_destination=revision.mounts.model_mount_destination,
-            extra_mounts=extra_mount_entries,
-            vfolder_subpath=revision.mounts.vfolder_subpath,
-        )
         revision_data = await self.add_revision(
             endpoint_id=deployment_id,
-            overrides=revision.to_draft(),
-            mounts=mounts,
+            overrides=revision.to_draft_with_extra_mount(extra_mount_entries),
             preset_id=revision.revision_preset_id,
         )
         if auto_activate:
@@ -618,12 +606,11 @@ class DeploymentController:
         request_draft = draft_revision.to_draft(image_id)
         drafts = await self._revision_draft_reader.read_for_legacy_model_service_deployment(
             request_draft=request_draft,
-            mounts=draft_revision.mounts,
             execution=draft_revision.execution,
             preset_id=None,
         )
         merged = functools.reduce(RevisionDraft.merge, drafts, RevisionDraft())
-        model_revision_spec = merged.to_model_revision_spec(mounts=draft_revision.mounts)
+        model_revision_spec = merged.to_model_revision_spec()
         validation_ctx = await self._build_deployment_revision_validation_context()
         self._deployment_revision_validator.validate_legacy_revision_spec(
             model_revision_spec, validation_ctx

--- a/src/ai/backend/manager/sokovan/deployment/revision_draft/reader.py
+++ b/src/ai/backend/manager/sokovan/deployment/revision_draft/reader.py
@@ -18,6 +18,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from ai.backend.common.config import ModelConfigDraft, ModelDefinitionDraft
+from ai.backend.common.exception import InvalidAPIParameters
 from ai.backend.common.identifier.deployment_preset import DeploymentPresetID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.common.types import ClusterMode
@@ -62,7 +63,6 @@ class RevisionDraftReader:
         self,
         *,
         request_draft: RevisionDraft,
-        mounts: MountMetadata,
         execution: ExecutionSpec,
         preset_id: DeploymentPresetID | None,
     ) -> list[RevisionDraft]:
@@ -80,13 +80,15 @@ class RevisionDraftReader:
             runtime_variant_id=execution.runtime_variant_id,
             preset_id=preset_id,
         )
+        if request_draft.mounts is None:
+            raise InvalidAPIParameters("mounts are required to read revision drafts")
         drafts: list[RevisionDraft] = [
-            self._model_mount_path_default_draft(mounts),
+            self._model_mount_path_default_draft(request_draft.mounts),
             self._variant_baseline_to_draft(bundle.variant),
         ]
         if bundle.preset is not None:
             drafts.append(self._preset_to_draft(bundle.preset, bundle.preset_resource_slots or []))
-        drafts.extend(await self._read_vfolder_drafts(mounts, bundle.variant))
+        drafts.extend(await self._read_vfolder_drafts(request_draft.mounts, bundle.variant))
         drafts.append(request_draft)
         return drafts
 
@@ -95,7 +97,6 @@ class RevisionDraftReader:
         *,
         runtime_variant_id: RuntimeVariantID,
         request_draft: RevisionDraft,
-        mounts: MountMetadata,
         preset_id: DeploymentPresetID | None,
     ) -> list[RevisionDraft]:
         """v2 ``add_revision``: typed variant id, no base layer."""
@@ -103,17 +104,17 @@ class RevisionDraftReader:
             runtime_variant_id=runtime_variant_id,
             preset_id=preset_id,
         )
+        if request_draft.mounts is None:
+            raise InvalidAPIParameters("mounts are required to read revision drafts")
         drafts: list[RevisionDraft] = [
-            self._model_mount_path_default_draft(mounts),
+            self._model_mount_path_default_draft(request_draft.mounts),
             self._variant_baseline_to_draft(bundle.variant),
         ]
         if bundle.preset is not None:
             drafts.append(self._preset_to_draft(bundle.preset, bundle.preset_resource_slots or []))
-        drafts.extend(await self._read_vfolder_drafts(mounts, bundle.variant))
+        drafts.extend(await self._read_vfolder_drafts(request_draft.mounts, bundle.variant))
         drafts.append(request_draft)
         return drafts
-
-    # ---- Private helpers ----
 
     def _variant_baseline_to_draft(self, variant: RuntimeVariantData) -> RevisionDraft:
         """Project the variant's ``default_model_definition`` into a RevisionDraft."""
@@ -153,7 +154,7 @@ class RevisionDraftReader:
         model_definition = ModelDefinitionDraft(
             models=[ModelConfigDraft(model_path=mounts.model_mount_destination)]
         )
-        return RevisionDraft(model_definition=model_definition)
+        return RevisionDraft(mounts=mounts, model_definition=model_definition)
 
     async def _read_vfolder_drafts(
         self,
@@ -203,5 +204,16 @@ class RevisionDraftReader:
             )
             model_def = None
         if model_def is not None:
-            drafts.append(RevisionDraft(model_definition=model_def))
+            drafts.append(
+                RevisionDraft(
+                    mounts=MountMetadata(
+                        model_vfolder_id=mounts.model_vfolder_id,
+                        model_definition_path=model_def.path,
+                        model_mount_destination=mounts.model_mount_destination,
+                        extra_mounts=list(mounts.extra_mounts),
+                        vfolder_subpath=mounts.vfolder_subpath,
+                    ),
+                    model_definition=model_def.model_definition,
+                )
+            )
         return drafts

--- a/tests/unit/common/dto/manager/v2/deployment/test_request.py
+++ b/tests/unit/common/dto/manager/v2/deployment/test_request.py
@@ -70,6 +70,25 @@ def _make_create_revision_input_dto(**kwargs: object) -> CreateRevisionInput:
     return CreateRevisionInput(**defaults)
 
 
+class TestModelMountConfigInput:
+    """Tests for ModelMountConfigInput model."""
+
+    def test_definition_path_defaults_to_none(self) -> None:
+        config = ModelMountConfigInput(
+            vfolder_id=VFolderUUID(uuid.uuid4()),
+            mount_destination="/models",
+        )
+        assert config.definition_path is None
+
+    def test_empty_definition_path_raises_validation_error(self) -> None:
+        with pytest.raises((BackendAISchemaValidationFailed, ValidationError)):
+            ModelMountConfigInput.model_validate({
+                "vfolder_id": str(uuid.uuid4()),
+                "mount_destination": "/models",
+                "definition_path": "",
+            })
+
+
 class TestExtraVFolderMountInput:
     """Tests for ExtraVFolderMountInput model."""
 

--- a/tests/unit/manager/data/deployment/test_revision_draft_merge.py
+++ b/tests/unit/manager/data/deployment/test_revision_draft_merge.py
@@ -160,3 +160,12 @@ class TestRevisionDraftMerge:
 
         assert merged.mounts is not None
         assert merged.mounts.model_definition_path == "model-definition.yml"
+
+    def test_mount_definition_path_treats_empty_string_as_missing(self) -> None:
+        base = RevisionDraft(mounts=_mounts("model-definition.yml"))
+        override = RevisionDraft(mounts=_mounts(""))
+
+        merged = base.merge(override)
+
+        assert merged.mounts is not None
+        assert merged.mounts.model_definition_path == "model-definition.yml"

--- a/tests/unit/manager/data/deployment/test_revision_draft_merge.py
+++ b/tests/unit/manager/data/deployment/test_revision_draft_merge.py
@@ -11,13 +11,23 @@ from ai.backend.common.config import ModelConfigDraft, ModelDefinitionDraft
 from ai.backend.common.identifier.deployment_preset import DeploymentPresetID
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
+from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import ClusterMode
-from ai.backend.manager.data.deployment.types import RevisionDraft
+from ai.backend.manager.data.deployment.types import MountMetadata, RevisionDraft
 from ai.backend.manager.data.deployment_revision_preset.types import PresetValueData
 
 
 def _merge_all(*drafts: RevisionDraft) -> RevisionDraft:
     return functools.reduce(RevisionDraft.merge, drafts, RevisionDraft())
+
+
+def _mounts(model_definition_path: str | None) -> MountMetadata:
+    return MountMetadata(
+        model_vfolder_id=VFolderUUID(uuid4()),
+        model_definition_path=model_definition_path,
+        model_mount_destination="/models",
+        extra_mounts=[],
+    )
 
 
 class TestRevisionDraftMerge:
@@ -141,3 +151,12 @@ class TestRevisionDraftMerge:
         assert merged.model_definition.models is not None
         assert merged.model_definition.models[0].name == "override"
         assert merged.model_definition.models[0].model_path == "/mnt/models"
+
+    def test_mount_definition_path_preserves_lower_value_when_higher_omits_it(self) -> None:
+        base = RevisionDraft(mounts=_mounts("model-definition.yml"))
+        override = RevisionDraft(mounts=_mounts(None))
+
+        merged = base.merge(override)
+
+        assert merged.mounts is not None
+        assert merged.mounts.model_definition_path == "model-definition.yml"

--- a/tests/unit/manager/sokovan/deployment/test_revision_draft_reader.py
+++ b/tests/unit/manager/sokovan/deployment/test_revision_draft_reader.py
@@ -3,12 +3,20 @@
 from __future__ import annotations
 
 import functools
+from datetime import UTC, datetime
 from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 from ai.backend.common.config import ModelConfigDraft, ModelDefinitionDraft
+from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.common.identifier.vfolder import VFolderUUID
-from ai.backend.manager.data.deployment.types import MountMetadata, RevisionDraft
+from ai.backend.manager.data.deployment.types import (
+    FetchedModelDefinition,
+    MountMetadata,
+    RevisionDraft,
+)
+from ai.backend.manager.data.runtime_variant.types import RuntimeVariantData
 from ai.backend.manager.sokovan.deployment.revision_draft.reader import RevisionDraftReader
 
 
@@ -22,6 +30,18 @@ def _mounts(model_mount_destination: str = "/models") -> MountMetadata:
         model_definition_path=None,
         model_mount_destination=model_mount_destination,
         extra_mounts=[],
+    )
+
+
+def _variant(reads_vfolder_config_files: bool = False) -> RuntimeVariantData:
+    return RuntimeVariantData(
+        id=RuntimeVariantID(uuid4()),
+        name="custom",
+        description=None,
+        reads_vfolder_config_files=reads_vfolder_config_files,
+        default_model_definition=ModelDefinitionDraft(),
+        created_at=datetime(2026, 5, 15, tzinfo=UTC),
+        updated_at=None,
     )
 
 
@@ -51,3 +71,26 @@ class TestRevisionDraftReaderModelPathDefault:
         assert merged.model_definition.models is not None
         assert merged.model_definition.models[0].name == "override-0"
         assert merged.model_definition.models[0].model_path == "/mnt/models"
+
+
+class TestRevisionDraftReaderVFolderDrafts:
+    async def test_records_resolved_default_model_definition_path(self) -> None:
+        repository = MagicMock()
+        repository.fetch_deployment_config = AsyncMock(return_value=None)
+        repository.fetch_model_definition = AsyncMock(
+            return_value=FetchedModelDefinition(
+                path="model-definition.yml",
+                model_definition=ModelDefinitionDraft(models=[ModelConfigDraft(name="from-file")]),
+            )
+        )
+        reader = RevisionDraftReader(deployment_repository=repository)
+        variant = _variant(reads_vfolder_config_files=True)
+
+        drafts = await reader._read_vfolder_drafts(_mounts(), variant)
+        merged = _merge_all(*drafts)
+
+        assert merged.mounts is not None
+        assert merged.mounts.model_definition_path == "model-definition.yml"
+        assert merged.model_definition is not None
+        assert merged.model_definition.models is not None
+        assert merged.model_definition.models[0].name == "from-file"


### PR DESCRIPTION
## Problem
When a request omits `model_definition_path`, the model service revision was persisted with the request's empty / `None` value instead of the model-definition file actually resolved from the model vfolder. The resolved path was used at runtime but never written back, so the stored revision did not reflect what was really mounted.

## Fix
The vfolder scan now records the matched candidate path (`model-definition.yaml` / `.yml`, or an explicit override) back into the merged draft, so the resolved `model_definition_path` is persisted on the revision instead of the empty input value.

## How (mechanism)
To do this cleanly, mount identity (model vfolder, definition path, destination, extra mounts, subpath) is folded into `RevisionDraft` and participates in the merge chain, instead of being threaded as a separate sidecar `mounts` argument through `add_revision` and the draft readers:

- New `FetchedModelDefinition` / `FetchedConfigFile` types carry the matched filename out of the storage source so the resolved path can flow back into the draft.
- `_merge_mounts` uses upper-priority semantics with `None`-fallback for `model_definition_path` / `vfolder_subpath`; every other mount field is sourced from the same `request_draft.mounts`, so the merge cannot tangle values.
- `ModelRevisionCreator.to_draft` → `to_draft_with_extra_mount`: the creator derives the full `MountMetadata` from `self.mounts` and only takes the permission-resolved `extra_mounts`.

## Test plan
- [ ] `pants test tests/unit/manager/data/deployment:: tests/unit/manager/sokovan/deployment::`
- [ ] v2 add-revision with no `model_definition_path`: resolved `model-definition.yml` path is persisted on the revision
- [ ] Explicit `model_definition_path` override on modify takes precedence over the resolved/stored path
- [ ] Legacy ModifyEndpoint: untouched mount fields (extra mounts, destination, subpath) survive a replica-only modify

Resolves BA-6015