### PR TITLE
feat(BA-6061): Add root CLI `--version` option to display loaded package versions

### DIFF
--- a/changes/11641.feature.md
+++ b/changes/11641.feature.md
@@ -1,0 +1,1 @@
+Add `--version` option to the root `backend.ai` CLI to display the versions of loaded `backend.ai-*` packages in the current Python environment.

--- a/src/ai/backend/cli/main.py
+++ b/src/ai/backend/cli/main.py
@@ -5,6 +5,7 @@ import click
 from .completion import get_completion_command
 from .extensions import ExtendedCommandGroup
 from .types import CliContextInfo
+from .version import print_version
 
 
 @click.group(
@@ -12,6 +13,14 @@ from .types import CliContextInfo
     context_settings={
         "help_option_names": ["-h", "--help"],
     },
+)
+@click.option(
+    "--version",
+    is_flag=True,
+    is_eager=True,
+    expose_value=False,
+    callback=print_version,
+    help="Show versions of backend.ai-* packages in the current environment and exit.",
 )
 @click.option(
     "--skip-sslcert-validation",

--- a/src/ai/backend/cli/version.py
+++ b/src/ai/backend/cli/version.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from importlib.metadata import distributions
+from pathlib import Path
+from typing import Any
+
+import click
+
+_BACKEND_DIST_PREFIX = "backend.ai-"
+
+
+def _collect_dist_versions() -> dict[str, str]:
+    """Collect versions of installed backend.ai-* distributions."""
+    versions: dict[str, str] = {}
+    for dist in distributions():
+        name = dist.metadata["Name"]
+        if name and name.lower().startswith(_BACKEND_DIST_PREFIX):
+            versions[name] = dist.version
+    return versions
+
+
+def _collect_namespace_versions() -> dict[str, str]:
+    """
+    Collect versions from VERSION files under the `ai.backend` namespace package.
+
+    This handles dev-mode layouts where subpackages are loaded directly from
+    the source tree and are not registered as separate distributions.
+    Walks one level into nested namespace packages (e.g., `ai.backend.appproxy.*`)
+    so multi-distribution namespaces are covered.
+    """
+    versions: dict[str, str] = {}
+    try:
+        import ai.backend as ns
+    except ImportError:
+        return versions
+    seen: set[Path] = set()
+    for root_str in ns.__path__:
+        root = Path(root_str)
+        if not root.is_dir():
+            continue
+        for child in sorted(root.iterdir()):
+            if not child.is_dir() or child in seen:
+                continue
+            seen.add(child)
+            version_file = child / "VERSION"
+            if version_file.is_file():
+                key = f"{_BACKEND_DIST_PREFIX}{child.name.replace('_', '-')}"
+                versions.setdefault(key, version_file.read_text().strip())
+                continue
+            # Recurse one level for namespace subpackages (e.g., appproxy/*).
+            for grand in sorted(child.iterdir()):
+                if not grand.is_dir():
+                    continue
+                version_file = grand / "VERSION"
+                if not version_file.is_file():
+                    continue
+                parent = child.name.replace("_", "-")
+                leaf = grand.name.replace("_", "-")
+                key = f"{_BACKEND_DIST_PREFIX}{parent}-{leaf}"
+                versions.setdefault(key, version_file.read_text().strip())
+    return versions
+
+
+def collect_versions() -> list[tuple[str, str]]:
+    """Return sorted (name, version) pairs of backend.ai-* packages."""
+    merged = _collect_namespace_versions()
+    for name, version in _collect_dist_versions().items():
+        merged[name] = version
+    return sorted(merged.items())
+
+
+def print_version(ctx: click.Context, _param: click.Parameter, value: Any) -> None:
+    if not value or ctx.resilient_parsing:
+        return
+    versions = collect_versions()
+    if not versions:
+        click.echo("No backend.ai-* packages found.")
+    else:
+        width = max(len(name) for name, _ in versions)
+        for name, version in versions:
+            click.echo(f"{name:<{width}}  {version}")
+    ctx.exit()


### PR DESCRIPTION
## Summary
- Add a `--version` option on the root `backend.ai` CLI that prints versions of `backend.ai-*` packages found in the current Python environment and exits.
- Versions are collected from both `importlib.metadata.distributions()` (for pex/wheel installs) and `VERSION` files under the `ai.backend` namespace package (for dev-mode layouts, including nested namespaces like `appproxy/*`).

## Test plan
- [x] `backend.ai --version` prints aligned `name  version` lines and exits 0 in a dev checkout
- [x] `backend.ai --version` works in a built pex/wheel environment (shows distributions like `backend.ai-krunner-*`)
- [x] `backend.ai --help` lists the new `--version` option
- [x] `pants lint` / `pants check` pass for `src/ai/backend/cli/`

Resolves #11642
Resolves [BA-6061](https://lablup.atlassian.net/browse/BA-6061)

[BA-6061]: https://lablup.atlassian.net/browse/BA-6061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ