### PR TITLE
fix(BA-6025): add ON DELETE RESTRICT FK on images.registry_id

### DIFF
--- a/changes/11643.fix.md
+++ b/changes/11643.fix.md
@@ -1,0 +1,1 @@
+Enforce `ON DELETE RESTRICT` on `images.registry_id` so deleting a container registry that still has images is blocked at the database level instead of leaving dangling references that surfaced later as a misleading "Image not found in database" error.

--- a/src/ai/backend/manager/models/alembic/versions/045b0e0e4384_add_fk_from_images_registry_id_to_.py
+++ b/src/ai/backend/manager/models/alembic/versions/045b0e0e4384_add_fk_from_images_registry_id_to_.py
@@ -1,0 +1,55 @@
+"""add FK to images.registry_id (RESTRICT)
+
+Adds a foreign key from ``images.registry_id`` to ``container_registries.id``
+with ``ON DELETE RESTRICT``.
+
+Rationale: the column previously carried a UUID with no DB-level FK, so
+deleting a container registry left dangling references on the images
+table. The sokovan scheduler would later surface this as a misleading
+"Image not found in database" error during session launch. RESTRICT
+prevents the registry deletion at the database level, forcing callers
+to ``clear_images`` (soft-delete) or ``admin_purge`` the dependent rows
+first. CASCADE was rejected because it would also hard-delete image
+rows referenced by historical kernels / deployment_revisions via
+SET NULL, erasing audit traceability.
+
+Pre-existing dangling rows (image rows whose ``registry_id`` no longer
+resolves) are hard-deleted before the constraint is created. The column
+remains ``NOT NULL``, so a SET NULL backfill is not an option, and a
+sentinel re-assignment would mask the original deletion intent.
+
+Revision ID: 045b0e0e4384
+Revises: ba42cb865efe
+Create Date: 2026-05-17
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "045b0e0e4384"
+down_revision = "ba42cb865efe"
+# Part of: 26.5.0
+branch_labels = None
+depends_on = None
+
+_FK_NAME = "fk_images_registry_id_container_registries"
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text("DELETE FROM images WHERE registry_id NOT IN (SELECT id FROM container_registries)")
+    )
+    op.create_foreign_key(
+        _FK_NAME,
+        source_table="images",
+        referent_table="container_registries",
+        local_cols=["registry_id"],
+        remote_cols=["id"],
+        ondelete="RESTRICT",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(_FK_NAME, "images", type_="foreignkey")

--- a/src/ai/backend/manager/models/alembic/versions/045b0e0e4384_add_fk_from_images_registry_id_to_.py
+++ b/src/ai/backend/manager/models/alembic/versions/045b0e0e4384_add_fk_from_images_registry_id_to_.py
@@ -19,7 +19,7 @@ remains ``NOT NULL``, so a SET NULL backfill is not an option, and a
 sentinel re-assignment would mask the original deletion intent.
 
 Revision ID: 045b0e0e4384
-Revises: ba42cb865efe
+Revises: ccd5dbb99161
 Create Date: 2026-05-17
 
 """
@@ -29,7 +29,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "045b0e0e4384"
-down_revision = "ba42cb865efe"
+down_revision = "ccd5dbb99161"
 # Part of: 26.5.0
 branch_labels = None
 depends_on = None

--- a/src/ai/backend/manager/models/alembic/versions/ccd5dbb99161_add_ondelete_cascade_to_image_alias.py
+++ b/src/ai/backend/manager/models/alembic/versions/ccd5dbb99161_add_ondelete_cascade_to_image_alias.py
@@ -1,0 +1,34 @@
+"""add ondelete cascade to image alias
+
+Revision ID: ccd5dbb99161
+Revises: 045b0e0e4384
+Create Date: 2026-05-19 09:52:10.921004
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "ccd5dbb99161"
+down_revision = "045b0e0e4384"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("fk_image_aliases_image_images", "image_aliases", type_="foreignkey")
+    op.create_foreign_key(
+        op.f("fk_image_aliases_image_images"),
+        "image_aliases",
+        "images",
+        ["image"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(op.f("fk_image_aliases_image_images"), "image_aliases", type_="foreignkey")
+    op.create_foreign_key(
+        "fk_image_aliases_image_images", "image_aliases", "images", ["image"], ["id"]
+    )

--- a/src/ai/backend/manager/models/alembic/versions/ccd5dbb99161_add_ondelete_cascade_to_image_alias.py
+++ b/src/ai/backend/manager/models/alembic/versions/ccd5dbb99161_add_ondelete_cascade_to_image_alias.py
@@ -1,7 +1,7 @@
 """add ondelete cascade to image alias
 
 Revision ID: ccd5dbb99161
-Revises: 045b0e0e4384
+Revises: ba42cb865efe
 Create Date: 2026-05-19 09:52:10.921004
 
 """
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "ccd5dbb99161"
-down_revision = "045b0e0e4384"
+down_revision = "ba42cb865efe"
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/image/row.py
+++ b/src/ai/backend/manager/models/image/row.py
@@ -334,7 +334,13 @@ class ImageRow(Base):  # type: ignore[misc]
     )
     tag: Mapped[str | None] = mapped_column("tag", sa.TEXT, nullable=True)
     registry: Mapped[str] = mapped_column("registry", sa.String, nullable=False, index=True)
-    registry_id: Mapped[UUID] = mapped_column("registry_id", GUID, nullable=False, index=True)
+    registry_id: Mapped[UUID] = mapped_column(
+        "registry_id",
+        GUID,
+        sa.ForeignKey("container_registries.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
     architecture: Mapped[str] = mapped_column(
         "architecture", sa.String, nullable=False, index=True, default="x86_64"
     )

--- a/src/ai/backend/manager/models/image/row.py
+++ b/src/ai/backend/manager/models/image/row.py
@@ -1027,7 +1027,7 @@ class ImageAliasRow(Base):  # type: ignore[misc]
     )
     alias: Mapped[str | None] = mapped_column("alias", sa.String, unique=True, index=True)
     image_id: Mapped[ImageID] = mapped_column(
-        "image", GUID(ImageID), sa.ForeignKey("images.id"), nullable=False
+        "image", GUID(ImageID), sa.ForeignKey("images.id", ondelete="CASCADE"), nullable=False
     )
     image: Mapped[ImageRow] = relationship("ImageRow", back_populates="aliases")
 

--- a/tests/unit/manager/models/domain/test_conditions.py
+++ b/tests/unit/manager/models/domain/test_conditions.py
@@ -15,6 +15,7 @@ from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.group.types import ProjectType
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import (
     DeploymentAutoScalingPolicyRow,
 )
@@ -70,6 +71,7 @@ _WITH_TABLES = [
     UserRow,
     KeyPairRow,
     GroupRow,
+    ContainerRegistryRow,
     ImageRow,
     VFolderRow,
     EndpointRow,

--- a/tests/unit/manager/models/group/test_conditions.py
+++ b/tests/unit/manager/models/group/test_conditions.py
@@ -16,6 +16,7 @@ from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.group.types import ProjectType
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import (
     DeploymentAutoScalingPolicyRow,
 )
@@ -62,6 +63,7 @@ _WITH_TABLES = [
     KeyPairRow,
     GroupRow,
     AssocGroupUserRow,
+    ContainerRegistryRow,
     ImageRow,
     VFolderRow,
     EndpointRow,

--- a/tests/unit/manager/models/scaling_group/test_conditions.py
+++ b/tests/unit/manager/models/scaling_group/test_conditions.py
@@ -8,6 +8,7 @@ import pytest
 import sqlalchemy as sa
 
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -47,6 +48,7 @@ _WITH_TABLES = [
     UserRow,
     KeyPairRow,
     GroupRow,
+    ContainerRegistryRow,
     ImageRow,
     VFolderRow,
     EndpointRow,

--- a/tests/unit/manager/models/test_deployment_auto_scaling_policy.py
+++ b/tests/unit/manager/models/test_deployment_auto_scaling_policy.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 import pytest
 import sqlalchemy as sa
 
+from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.types import (
     AutoScalingMetricComparator,
@@ -226,13 +227,23 @@ class TestDeploymentAutoScalingPolicyRow:
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> AsyncGenerator[ImageRow, None]:
         """Create test image."""
+        registry_id = uuid.uuid4()
         async with db_with_cleanup.begin_session() as db_sess:
+            db_sess.add(
+                ContainerRegistryRow(
+                    id=registry_id,
+                    url="https://docker.io",
+                    registry_name=f"reg-{uuid.uuid4().hex[:8]}",
+                    type=ContainerRegistryType.DOCKER,
+                )
+            )
+            await db_sess.flush()
             image = ImageRow(
                 name="test-image:latest",
                 project=str(uuid.uuid4()),
                 image="test-image",
                 registry="docker.io",
-                registry_id=uuid.uuid4(),
+                registry_id=registry_id,
                 architecture="x86_64",
                 is_local=False,
                 config_digest="sha256:abc123",

--- a/tests/unit/manager/models/test_deployment_auto_scaling_policy.py
+++ b/tests/unit/manager/models/test_deployment_auto_scaling_policy.py
@@ -20,6 +20,7 @@ from ai.backend.common.types import (
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.image.types import ImageType
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import (
     DeploymentAutoScalingPolicyData,
     DeploymentAutoScalingPolicyRow,
@@ -90,6 +91,7 @@ class TestDeploymentAutoScalingPolicyRow:
                 KeyPairRow,
                 GroupRow,
                 VFolderRow,
+                ContainerRegistryRow,
                 ImageRow,
                 SessionRow,
                 KernelRow,

--- a/tests/unit/manager/models/test_deployment_revision.py
+++ b/tests/unit/manager/models/test_deployment_revision.py
@@ -25,6 +25,7 @@ from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.deployment.types import ModelRevisionData
 from ai.backend.manager.data.image.types import ImageType
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -95,6 +96,7 @@ class TestDeploymentRevisionRow:
                 GroupRow,
                 AgentRow,
                 VFolderRow,
+                ContainerRegistryRow,
                 ImageRow,
                 ResourcePresetRow,
                 ResourceSlotTypeRow,

--- a/tests/unit/manager/models/test_deployment_revision.py
+++ b/tests/unit/manager/models/test_deployment_revision.py
@@ -11,6 +11,7 @@ import pytest
 import sqlalchemy as sa
 
 from ai.backend.common.config import ModelDefinitionDraft
+from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import (
@@ -244,13 +245,23 @@ class TestDeploymentRevisionRow:
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> AsyncGenerator[ImageRow, None]:
         """Create test image."""
+        registry_id = uuid.uuid4()
         async with db_with_cleanup.begin_session() as db_sess:
+            db_sess.add(
+                ContainerRegistryRow(
+                    id=registry_id,
+                    url="https://docker.io",
+                    registry_name=f"reg-{uuid.uuid4().hex[:8]}",
+                    type=ContainerRegistryType.DOCKER,
+                )
+            )
+            await db_sess.flush()
             image = ImageRow(
                 name="test-image:latest",
                 project=str(uuid.uuid4()),
                 image="test-image",
                 registry="docker.io",
-                registry_id=uuid.uuid4(),
+                registry_id=registry_id,
                 architecture="x86_64",
                 is_local=False,
                 config_digest="sha256:abc123",

--- a/tests/unit/manager/models/test_session.py
+++ b/tests/unit/manager/models/test_session.py
@@ -10,6 +10,7 @@ from sqlalchemy.exc import IntegrityError
 from ai.backend.common.types import BinarySize, ResourceSlot
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -80,6 +81,7 @@ class TestSessionUniqueNamePerUser:
                 GroupRow,
                 AgentRow,
                 VFolderRow,
+                ContainerRegistryRow,
                 ImageRow,
                 ResourcePresetRow,
                 EndpointRow,

--- a/tests/unit/manager/models/test_vfolder_prepare_mounts.py
+++ b/tests/unit/manager/models/test_vfolder_prepare_mounts.py
@@ -20,6 +20,7 @@ from ai.backend.common.types import (
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.errors.api import InvalidAPIParameters
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -128,6 +129,7 @@ class TestPrepareVFolderMountsSubpathFlow:
                 AgentRow,
                 VFolderRow,
                 VFolderPermissionRow,
+                ContainerRegistryRow,
                 ImageRow,
                 ResourcePresetRow,
                 RuntimeVariantRow,

--- a/tests/unit/manager/models/test_vfolder_quota_scope.py
+++ b/tests/unit/manager/models/test_vfolder_quota_scope.py
@@ -13,6 +13,7 @@ from ai.backend.manager.data.permission.types import (
 )
 from ai.backend.manager.errors.api import InvalidAPIParameters
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -74,6 +75,7 @@ class TestEnsureQuotaScopeAccessibleByUser:
                 GroupRow,
                 AgentRow,
                 VFolderRow,
+                ContainerRegistryRow,
                 ImageRow,
                 ResourcePresetRow,
                 EndpointRow,

--- a/tests/unit/manager/models/user/test_conditions.py
+++ b/tests/unit/manager/models/user/test_conditions.py
@@ -14,6 +14,7 @@ from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.group.types import ProjectType
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import (
     DeploymentAutoScalingPolicyRow,
 )
@@ -60,6 +61,7 @@ _WITH_TABLES = [
     KeyPairRow,
     GroupRow,
     AssocGroupUserRow,
+    ContainerRegistryRow,
     ImageRow,
     VFolderRow,
     EndpointRow,

--- a/tests/unit/manager/repositories/agent/test_repository.py
+++ b/tests/unit/manager/repositories/agent/test_repository.py
@@ -40,6 +40,7 @@ from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.errors.resource import ScalingGroupNotFound
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -110,6 +111,7 @@ class TestAgentRepositoryDB:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,
@@ -620,6 +622,7 @@ class TestAgentDBSourceKernelFiltering:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/app_config/test_app_config.py
+++ b/tests/unit/manager/repositories/app_config/test_app_config.py
@@ -15,6 +15,7 @@ from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.app_config import AppConfigRow, AppConfigScopeType
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -84,6 +85,7 @@ class TestAppConfigRepository:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/artifact/test_artifact_repository.py
+++ b/tests/unit/manager/repositories/artifact/test_artifact_repository.py
@@ -23,6 +23,7 @@ from ai.backend.manager.errors.artifact import (
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.artifact import ArtifactRow
 from ai.backend.manager.models.artifact_revision import ArtifactRevisionRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -82,6 +83,7 @@ class TestArtifactRepository:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/artifact_revision/test_artifact_revision_repository.py
+++ b/tests/unit/manager/repositories/artifact_revision/test_artifact_revision_repository.py
@@ -24,6 +24,7 @@ from ai.backend.manager.errors.artifact import (
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.artifact import ArtifactRow
 from ai.backend.manager.models.artifact_revision import ArtifactRevisionRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -87,6 +88,7 @@ class TestArtifactRevisionRepository:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/auth/test_auth_repository.py
+++ b/tests/unit/manager/repositories/auth/test_auth_repository.py
@@ -22,6 +22,7 @@ from ai.backend.manager.data.group.types import GroupData
 from ai.backend.manager.data.permission.types import EntityType, ScopeType
 from ai.backend.manager.errors.auth import GroupMembershipNotFoundError
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -100,6 +101,7 @@ class TestAuthRepository:
                 GroupRow,
                 AssocGroupUserRow,
                 AssociationScopesEntitiesRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/domain/test_domain_repository.py
+++ b/tests/unit/manager/repositories/domain/test_domain_repository.py
@@ -29,6 +29,7 @@ from ai.backend.manager.errors.resource import (
 )
 from ai.backend.manager.errors.resource import DomainNotFound as ResourceDomainNotFound
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -84,6 +85,7 @@ class TestDomainRepository:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/error_log/test_error_log_repository.py
+++ b/tests/unit/manager/repositories/error_log/test_error_log_repository.py
@@ -16,6 +16,7 @@ from ai.backend.manager.data.error_log.types import (
     ErrorLogSeverity,
 )
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -80,6 +81,7 @@ class TestErrorLogRepository:
                 GroupRow,
                 AgentRow,
                 VFolderRow,
+                ContainerRegistryRow,
                 ImageRow,
                 ResourcePresetRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/fair_share/test_fair_share_repository.py
+++ b/tests/unit/manager/repositories/fair_share/test_fair_share_repository.py
@@ -14,6 +14,7 @@ import pytest
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.errors.resource import DomainNotFound
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.fair_share import (
     DomainFairShareRow,
@@ -91,6 +92,7 @@ class TestFairShareRepository:
                 ScalingGroupForProjectRow,
                 AssocGroupUserRow,
                 AgentRow,
+                ContainerRegistryRow,
                 ImageRow,
                 SessionRow,
                 KernelRow,

--- a/tests/unit/manager/repositories/group/test_assign_users_to_project.py
+++ b/tests/unit/manager/repositories/group/test_assign_users_to_project.py
@@ -13,6 +13,7 @@ from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.group.types import ProjectType
 from ai.backend.manager.data.permission.types import EntityType, ScopeType
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -73,6 +74,7 @@ class TestAssignUsersToProject:
                 KeyPairRow,
                 GroupRow,
                 AssociationScopesEntitiesRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,
@@ -462,6 +464,7 @@ class TestUnassignUsersFromProject:
                 KeyPairRow,
                 GroupRow,
                 AssociationScopesEntitiesRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/group/test_group_db_source.py
+++ b/tests/unit/manager/repositories/group/test_group_db_source.py
@@ -16,6 +16,7 @@ from ai.backend.manager.data.group.types import ProjectType
 from ai.backend.manager.data.model_serving.types import EndpointLifecycle
 from ai.backend.manager.errors.resource import ProjectHasActiveEndpointsError
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -90,6 +91,7 @@ class TestGroupDBSourceDeleteEndpoints:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/group/test_group_repository.py
+++ b/tests/unit/manager/repositories/group/test_group_repository.py
@@ -39,6 +39,7 @@ from ai.backend.manager.errors.resource import (
     ProjectNotFound,
 )
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -258,6 +259,7 @@ class TestGroupRepository:
                 KeyPairRow,
                 GroupRow,
                 AssociationScopesEntitiesRow,  # RBAC scopes-entities association
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/group/test_unassign_users_from_project.py
+++ b/tests/unit/manager/repositories/group/test_unassign_users_from_project.py
@@ -13,6 +13,7 @@ from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.group.types import ProjectType
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -72,6 +73,7 @@ class TestUnassignUsersFromProject:
                 KeyPairRow,
                 GroupRow,
                 AssociationScopesEntitiesRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/keypair_resource_policy/test_keypair_resource_policy.py
+++ b/tests/unit/manager/repositories/keypair_resource_policy/test_keypair_resource_policy.py
@@ -14,6 +14,7 @@ from ai.backend.common.types import (
     VFolderHostPermission,
 )
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -76,6 +77,7 @@ class TestKeypairResourcePolicyRepository:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/model_card/test_model_card_creator.py
+++ b/tests/unit/manager/repositories/model_card/test_model_card_creator.py
@@ -13,6 +13,7 @@ from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.model_card.types import ResourceRequirementEntry
 from ai.backend.manager.data.permission.types import RBACElementRef, RBACElementType
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.hasher.types import PasswordInfo
@@ -72,6 +73,7 @@ class TestModelCardCreatorResourceRequirements:
                 KeyPairRow,
                 GroupRow,
                 AgentRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 SessionRow,

--- a/tests/unit/manager/repositories/model_card/test_model_card_delete.py
+++ b/tests/unit/manager/repositories/model_card/test_model_card_delete.py
@@ -28,6 +28,7 @@ from ai.backend.manager.data.permission.types import RBACElementRef, RBACElement
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.data.vfolder.types import VFolderOperationStatus
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.hasher.types import PasswordInfo
@@ -123,6 +124,7 @@ class TestModelCardDelete:
                 KeyPairRow,
                 GroupRow,
                 AgentRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 SessionRow,

--- a/tests/unit/manager/repositories/model_card/test_model_card_scan.py
+++ b/tests/unit/manager/repositories/model_card/test_model_card_scan.py
@@ -26,6 +26,7 @@ from ai.backend.common.types import QuotaScopeID, QuotaScopeType, ResourceSlot, 
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.model_card.types import ResourceRequirementEntry
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
@@ -89,6 +90,7 @@ class TestModelCardScanResourceRequirements:
                 KeyPairRow,
                 GroupRow,
                 AgentRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 SessionRow,

--- a/tests/unit/manager/repositories/model_card/test_model_card_search_in_project.py
+++ b/tests/unit/manager/repositories/model_card/test_model_card_search_in_project.py
@@ -19,6 +19,7 @@ from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.errors.common import GenericForbidden
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.hasher.types import PasswordInfo
@@ -71,6 +72,7 @@ class TestSearchInProjectMembership:
                 KeyPairRow,
                 GroupRow,
                 AgentRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 SessionRow,

--- a/tests/unit/manager/repositories/notification/test_notification_options.py
+++ b/tests/unit/manager/repositories/notification/test_notification_options.py
@@ -20,6 +20,7 @@ from ai.backend.common.data.notification import (
 )
 from ai.backend.common.types import BinarySize, ResourceSlot
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -97,6 +98,7 @@ class TestNotificationOptions:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,
@@ -984,6 +986,7 @@ class TestNotificationCursorPagination:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/notification/test_notification_repository.py
+++ b/tests/unit/manager/repositories/notification/test_notification_repository.py
@@ -24,6 +24,7 @@ from ai.backend.manager.errors.notification import (
     NotificationRuleNotFound,
 )
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -105,6 +106,7 @@ class TestNotificationRepository:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/permission_controller/test_role_assignment.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_assignment.py
@@ -17,6 +17,7 @@ from ai.backend.manager.data.permission.role import (
 )
 from ai.backend.manager.data.permission.types import EntityType, ScopeType
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -79,6 +80,7 @@ class TestRoleAssignment:
                 KeyPairRow,
                 GroupRow,
                 AssociationScopesEntitiesRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/permission_controller/test_role_invitation.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_invitation.py
@@ -18,6 +18,7 @@ from ai.backend.manager.errors.role_invitation import (
     RoleInvitationNotFound,
 )
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -80,6 +81,7 @@ async def db(
             GroupRow,
             AssocGroupUserRow,
             AssociationScopesEntitiesRow,
+            ContainerRegistryRow,
             ImageRow,
             VFolderRow,
             EndpointRow,

--- a/tests/unit/manager/repositories/permission_controller/test_search_scopes.py
+++ b/tests/unit/manager/repositories/permission_controller/test_search_scopes.py
@@ -14,6 +14,7 @@ from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.common.data.permission.types import RBACElementType, ScopeType
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -88,6 +89,7 @@ class TestSearchDomainScopes:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,
@@ -342,6 +344,7 @@ class TestSearchProjectScopes:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,
@@ -556,6 +559,7 @@ class TestSearchUserScopes:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,
@@ -770,6 +774,7 @@ class TestSearchGlobalScope:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,
@@ -819,6 +824,7 @@ class TestSearchScopesEmptyResult:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/permission_controller/test_user_scope_sync.py
+++ b/tests/unit/manager/repositories/permission_controller/test_user_scope_sync.py
@@ -17,6 +17,7 @@ from ai.backend.manager.data.permission.role import (
 )
 from ai.backend.manager.data.permission.types import EntityType, ScopeType
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -79,6 +80,7 @@ class TestUserScopeSync:
                 GroupRow,
                 AssocGroupUserRow,
                 AssociationScopesEntitiesRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/project_resource_policy/test_project_resource_policy.py
+++ b/tests/unit/manager/repositories/project_resource_policy/test_project_resource_policy.py
@@ -17,6 +17,7 @@ from ai.backend.manager.data.resource.types import ProjectResourcePolicyData
 from ai.backend.manager.errors.common import ObjectNotFound
 from ai.backend.manager.errors.repository import RepositoryIntegrityError
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -83,6 +84,7 @@ class TestProjectResourcePolicyRepository:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/resource_preset/test_check_presets.py
+++ b/tests/unit/manager/repositories/resource_preset/test_check_presets.py
@@ -39,6 +39,7 @@ from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -118,6 +119,7 @@ class TestCheckPresetsOccupiedSlots:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,
@@ -1196,6 +1198,7 @@ class TestCheckPresetsZeroValues:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/resource_preset/test_resource_preset_cache_invalidation.py
+++ b/tests/unit/manager/repositories/resource_preset/test_resource_preset_cache_invalidation.py
@@ -16,6 +16,7 @@ from ai.backend.common.typed_validators import HostPortPair as HostPortPairModel
 from ai.backend.common.types import AccessKey, BinarySize, ResourceSlot, ValkeyTarget
 from ai.backend.manager.data.resource_preset.types import ResourcePresetData
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -75,6 +76,7 @@ class TestResourcePresetCacheInvalidation:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/resource_usage_history/test_resource_usage_history_repository.py
+++ b/tests/unit/manager/repositories/resource_usage_history/test_resource_usage_history_repository.py
@@ -14,6 +14,7 @@ import pytest
 
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.image import ImageRow
@@ -85,6 +86,7 @@ class TestResourceUsageHistoryRepository:
                 KeyPairRow,
                 GroupRow,
                 AgentRow,
+                ContainerRegistryRow,
                 ImageRow,
                 SessionRow,
                 KernelRow,

--- a/tests/unit/manager/repositories/resource_usage_history/test_usage_bucket_entries.py
+++ b/tests/unit/manager/repositories/resource_usage_history/test_usage_bucket_entries.py
@@ -16,6 +16,7 @@ import sqlalchemy as sa
 
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.image import ImageRow
@@ -73,6 +74,7 @@ class TestUsageBucketEntries:
                 KeyPairRow,
                 GroupRow,
                 AgentRow,
+                ContainerRegistryRow,
                 ImageRow,
                 SessionRow,
                 KernelRow,

--- a/tests/unit/manager/repositories/scaling_group/test_scaling_group_repository.py
+++ b/tests/unit/manager/repositories/scaling_group/test_scaling_group_repository.py
@@ -17,6 +17,7 @@ from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.defs import DEFAULT_ROLE
 from ai.backend.manager.errors.resource import ScalingGroupNotFound
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -109,6 +110,7 @@ class TestScalingGroupRepositoryDB:
                 KeyPairRow,
                 ScalingGroupForKeypairsRow,  # depends on ScalingGroupRow and KeyPairRow
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/scheduler/test_session_network_propagation.py
+++ b/tests/unit/manager/repositories/scheduler/test_session_network_propagation.py
@@ -26,6 +26,7 @@ from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.image.row import ImageRow
@@ -64,6 +65,7 @@ class TestPersistentNetworkNotRecreated:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 AgentRow,
                 SessionRow,

--- a/tests/unit/manager/repositories/scheduler/test_termination.py
+++ b/tests/unit/manager/repositories/scheduler/test_termination.py
@@ -28,6 +28,7 @@ from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy.row import (
     DeploymentAutoScalingPolicyRow,
 )
@@ -79,6 +80,7 @@ class TestKernelTermination:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/scheduling_history/test_scheduling_history_repository.py
+++ b/tests/unit/manager/repositories/scheduling_history/test_scheduling_history_repository.py
@@ -22,6 +22,7 @@ from ai.backend.manager.data.session.types import (
     SessionStatus,
 )
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import (
     DeploymentAutoScalingPolicyRow,
 )
@@ -96,6 +97,7 @@ class TestSchedulingHistoryRepository:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/test_utils.py
+++ b/tests/unit/manager/repositories/test_utils.py
@@ -14,6 +14,7 @@ from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.defs import DEFAULT_ROLE
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -76,6 +77,7 @@ async def db_with_cleanup(
             UserRow,
             KeyPairRow,
             GroupRow,
+            ContainerRegistryRow,
             ImageRow,
             VFolderRow,
             EndpointRow,

--- a/tests/unit/manager/repositories/user/test_user_repository.py
+++ b/tests/unit/manager/repositories/user/test_user_repository.py
@@ -18,6 +18,7 @@ from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.user.types import UserData
 from ai.backend.manager.errors.user import UserConflict, UserCreationBadRequest, UserNotFound
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -101,6 +102,7 @@ class TestUserRepository:
                 KeyPairRow,
                 GroupRow,
                 AssocGroupUserRow,  # Association table for users-groups
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/user_resource_policy/test_user_resource_policy_repository.py
+++ b/tests/unit/manager/repositories/user_resource_policy/test_user_resource_policy_repository.py
@@ -7,6 +7,7 @@ import pytest
 from ai.backend.common.exception import UserResourcePolicyNotFound
 from ai.backend.manager.data.resource.types import UserResourcePolicyData
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -69,6 +70,7 @@ class TestUserResourcePolicyRepository:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_repository.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_repository.py
@@ -35,6 +35,7 @@ from ai.backend.manager.errors.storage import (
 )
 from ai.backend.manager.errors.user import UserNotFound
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -139,6 +140,7 @@ class TestVfolderRepository:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
                 EndpointRow,
@@ -1348,6 +1350,7 @@ class TestVFolderRepositoryTrashAndRestore:
                 KeyPairRow,
                 GroupRow,
                 VFolderRow,
+                ContainerRegistryRow,
                 ImageRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/test_query_userinfo.py
+++ b/tests/unit/manager/test_query_userinfo.py
@@ -20,6 +20,7 @@ from ai.backend.common.types import AccessKey, ResourceSlot
 from ai.backend.manager.errors.api import InvalidAPIParameters
 from ai.backend.manager.errors.auth import AccessKeyNotFound
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
@@ -62,6 +63,7 @@ ALL_ROWS = [
     KeyPairRow,
     GroupRow,
     AssociationScopesEntitiesRow,
+    ContainerRegistryRow,
     ImageRow,
     VFolderRow,
     EndpointRow,


### PR DESCRIPTION
## Summary
- Add a real DB-level foreign key from `images.registry_id` to `container_registries.id` with `ON DELETE RESTRICT`. Previously only an ORM-level `foreign()` join existed, so deleting a registry left dangling references that the sokovan scheduler later surfaced as a misleading "Image not found in database" error during session launch.
- `ON DELETE RESTRICT` (over CASCADE) preserves audit traceability on `kernels` and `deployment_revisions` (whose image FKs use SET NULL) and forces operators to clear or purge images via the existing `clear_images` / `admin_purge` flows before removing a registry.
- The migration hard-deletes any pre-existing dangling image rows before creating the constraint, since the column is `NOT NULL` and a sentinel reassignment would mask the original deletion intent.
- Affected test fixtures using `with_tables` now include `ContainerRegistryRow`, and the two `test_image` fixtures in deployment tests seed a real container_registry row instead of fabricating a random `registry_id`.

## Test plan
- [x] `pants test` for all `with_tables`-based image tests (~46 files) passes locally.
- [x] `alembic upgrade head` and round-trip `downgrade -1 → upgrade head` succeed on local DB.
- [x] CI green.
- [x] Manual: attempt to delete a registry that still has images via REST v2 — expect HTTP 409 `ForeignKeyViolationError`. (Follow-up ticket recommended to convert this into a domain-specific 400 with a clearer message.)

Resolves BA-6025