### PR TITLE
feat(BA-6063): add UserID type and ResolveUserIDByAccessKey action

### DIFF
--- a/changes/11647.feature.md
+++ b/changes/11647.feature.md
@@ -1,0 +1,1 @@
+Add `UserID` identifier type and `ResolveUserIDByAccessKey` auth action for resolving an access_key to its owning user UUID.

--- a/src/ai/backend/common/identifier/user.py
+++ b/src/ai/backend/common/identifier/user.py
@@ -1,0 +1,7 @@
+from typing import NewType
+from uuid import UUID
+
+__all__ = ("UserID",)
+
+
+UserID = NewType("UserID", UUID)

--- a/src/ai/backend/manager/repositories/auth/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/auth/db_source/db_source.py
@@ -17,6 +17,7 @@ from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
 from ai.backend.common.resilience.resilience import Resilience
+from ai.backend.common.types import AccessKey
 from ai.backend.manager.data.auth.login_session_types import LoginHistoryData, LoginSessionData
 from ai.backend.manager.data.auth.types import GroupMembershipData, UserData
 from ai.backend.manager.data.common.types import SearchResult
@@ -295,14 +296,14 @@ class AuthDBSource:
             return row.domain_name, row.role
 
     @auth_db_source_resilience.apply()
-    async def fetch_user_id_by_access_key(self, access_key: str) -> UserID:
+    async def fetch_user_id_by_access_key(self, access_key: AccessKey) -> UserID:
         async with self._db.begin_readonly() as conn:
             query = sa.select(keypairs.c.user).where(keypairs.c.access_key == access_key)
             result = await conn.execute(query)
             row = result.scalar()
             if row is None:
                 raise AccessKeyNotFound("Unknown access key")
-            return UserID(UUID(str(row)))
+            return UserID(cast(UUID, row))
 
     @auth_db_source_resilience.apply()
     async def fetch_user_info_by_email(self, email: str) -> tuple[UUID, UserRole, str]:

--- a/src/ai/backend/manager/repositories/auth/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/auth/db_source/db_source.py
@@ -12,6 +12,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import joinedload, selectinload
 
 from ai.backend.common.exception import BackendAIError, UserNotFound
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
@@ -21,6 +22,7 @@ from ai.backend.manager.data.auth.types import GroupMembershipData, UserData
 from ai.backend.manager.data.common.types import SearchResult
 from ai.backend.manager.data.permission.types import EntityType, ScopeType
 from ai.backend.manager.errors.auth import (
+    AccessKeyNotFound,
     AuthorizationFailed,
     GroupMembershipNotFoundError,
     LoginSessionNotFoundError,
@@ -291,6 +293,16 @@ class AuthDBSource:
             if row is None:
                 raise ValueError("Unknown owner access key")
             return row.domain_name, row.role
+
+    @auth_db_source_resilience.apply()
+    async def fetch_user_id_by_access_key(self, access_key: str) -> UserID:
+        async with self._db.begin_readonly() as conn:
+            query = sa.select(keypairs.c.user).where(keypairs.c.access_key == access_key)
+            result = await conn.execute(query)
+            row = result.scalar()
+            if row is None:
+                raise AccessKeyNotFound("Unknown access key")
+            return UserID(UUID(str(row)))
 
     @auth_db_source_resilience.apply()
     async def fetch_user_info_by_email(self, email: str) -> tuple[UUID, UserRole, str]:

--- a/src/ai/backend/manager/repositories/auth/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/auth/db_source/db_source.py
@@ -297,13 +297,12 @@ class AuthDBSource:
 
     @auth_db_source_resilience.apply()
     async def fetch_user_id_by_access_key(self, access_key: AccessKey) -> UserID:
-        async with self._db.begin_readonly() as conn:
-            query = sa.select(keypairs.c.user).where(keypairs.c.access_key == access_key)
-            result = await conn.execute(query)
-            row = result.scalar()
-            if row is None:
+        async with self._db.begin_readonly_session() as db_session:
+            query = sa.select(KeyPairRow.user).where(KeyPairRow.access_key == access_key)
+            user_id = await db_session.scalar(query)
+            if user_id is None:
                 raise AccessKeyNotFound("Unknown access key")
-            return UserID(cast(UUID, row))
+            return UserID(user_id)
 
     @auth_db_source_resilience.apply()
     async def fetch_user_info_by_email(self, email: str) -> tuple[UUID, UserRole, str]:

--- a/src/ai/backend/manager/repositories/auth/repository.py
+++ b/src/ai/backend/manager/repositories/auth/repository.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.resilience import Resilience
@@ -81,6 +82,10 @@ class AuthRepository:
     @auth_repository_resilience.apply()
     async def get_delegation_target_by_access_key(self, access_key: str) -> tuple[str, UserRole]:
         return await self._db_source.fetch_user_info_by_access_key(access_key)
+
+    @auth_repository_resilience.apply()
+    async def get_user_id_by_access_key(self, access_key: str) -> UserID:
+        return await self._db_source.fetch_user_id_by_access_key(access_key)
 
     @auth_repository_resilience.apply()
     async def get_delegation_target_by_email(self, email: str) -> tuple[UUID, UserRole, str]:

--- a/src/ai/backend/manager/repositories/auth/repository.py
+++ b/src/ai/backend/manager/repositories/auth/repository.py
@@ -8,6 +8,7 @@ from ai.backend.common.identifier.user import UserID
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.resilience import Resilience
+from ai.backend.common.types import AccessKey
 from ai.backend.manager.data.auth.login_session_types import LoginHistoryData, LoginSessionData
 from ai.backend.manager.data.auth.types import GroupMembershipData, UserData
 from ai.backend.manager.data.common.types import SearchResult
@@ -84,7 +85,7 @@ class AuthRepository:
         return await self._db_source.fetch_user_info_by_access_key(access_key)
 
     @auth_repository_resilience.apply()
-    async def get_user_id_by_access_key(self, access_key: str) -> UserID:
+    async def get_user_id_by_access_key(self, access_key: AccessKey) -> UserID:
         return await self._db_source.fetch_user_id_by_access_key(access_key)
 
     @auth_repository_resilience.apply()

--- a/src/ai/backend/manager/services/auth/actions/resolve_user_id_by_access_key.py
+++ b/src/ai/backend/manager/services/auth/actions/resolve_user_id_by_access_key.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.identifier.user import UserID
+from ai.backend.common.types import AccessKey
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.services.auth.actions.base import AuthAction
+
+
+@dataclass
+class ResolveUserIDByAccessKeyAction(AuthAction):
+    access_key: AccessKey
+
+    @override
+    def entity_id(self) -> str | None:
+        return str(self.access_key)
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+
+@dataclass
+class ResolveUserIDByAccessKeyResult(BaseActionResult):
+    user_id: UserID
+
+    @override
+    def entity_id(self) -> str | None:
+        return str(self.user_id)

--- a/src/ai/backend/manager/services/auth/processors.py
+++ b/src/ai/backend/manager/services/auth/processors.py
@@ -24,6 +24,10 @@ from ai.backend.manager.services.auth.actions.resolve_access_key_scope import (
     ResolveAccessKeyScopeAction,
     ResolveAccessKeyScopeResult,
 )
+from ai.backend.manager.services.auth.actions.resolve_user_id_by_access_key import (
+    ResolveUserIDByAccessKeyAction,
+    ResolveUserIDByAccessKeyResult,
+)
 from ai.backend.manager.services.auth.actions.resolve_user_scope import (
     ResolveUserScopeAction,
     ResolveUserScopeResult,
@@ -88,6 +92,9 @@ class AuthProcessors(AbstractProcessorPackage):
         ResolveAccessKeyScopeAction, ResolveAccessKeyScopeResult
     ]
     resolve_user_scope: ActionProcessor[ResolveUserScopeAction, ResolveUserScopeResult]
+    resolve_user_id_by_access_key: ActionProcessor[
+        ResolveUserIDByAccessKeyAction, ResolveUserIDByAccessKeyResult
+    ]
     admin_search_login_sessions: ActionProcessor[
         AdminSearchLoginSessionsAction, SearchLoginSessionsActionResult
     ]
@@ -135,6 +142,9 @@ class AuthProcessors(AbstractProcessorPackage):
             service.resolve_access_key_scope, action_monitors
         )
         self.resolve_user_scope = ActionProcessor(service.resolve_user_scope, action_monitors)
+        self.resolve_user_id_by_access_key = ActionProcessor(
+            service.resolve_user_id_by_access_key, action_monitors
+        )
         self.admin_search_login_sessions = ActionProcessor(
             service.admin_search_login_sessions, action_monitors
         )
@@ -167,6 +177,7 @@ class AuthProcessors(AbstractProcessorPackage):
             UpdatePasswordNoAuthAction.spec(),
             ResolveAccessKeyScopeAction.spec(),
             ResolveUserScopeAction.spec(),
+            ResolveUserIDByAccessKeyAction.spec(),
             AdminSearchLoginSessionsAction.spec(),
             SearchLoginSessionsAction.spec(),
             AdminSearchLoginHistoryAction.spec(),

--- a/src/ai/backend/manager/services/auth/service.py
+++ b/src/ai/backend/manager/services/auth/service.py
@@ -765,7 +765,7 @@ class AuthService:
     async def resolve_user_id_by_access_key(
         self, action: ResolveUserIDByAccessKeyAction
     ) -> ResolveUserIDByAccessKeyResult:
-        user_id = await self._auth_repository.get_user_id_by_access_key(str(action.access_key))
+        user_id = await self._auth_repository.get_user_id_by_access_key(action.access_key)
         return ResolveUserIDByAccessKeyResult(user_id=user_id)
 
     async def resolve_user_scope(self, action: ResolveUserScopeAction) -> ResolveUserScopeResult:

--- a/src/ai/backend/manager/services/auth/service.py
+++ b/src/ai/backend/manager/services/auth/service.py
@@ -77,6 +77,10 @@ from ai.backend.manager.services.auth.actions.resolve_access_key_scope import (
     ResolveAccessKeyScopeAction,
     ResolveAccessKeyScopeResult,
 )
+from ai.backend.manager.services.auth.actions.resolve_user_id_by_access_key import (
+    ResolveUserIDByAccessKeyAction,
+    ResolveUserIDByAccessKeyResult,
+)
 from ai.backend.manager.services.auth.actions.resolve_user_scope import (
     ResolveUserScopeAction,
     ResolveUserScopeResult,
@@ -757,6 +761,12 @@ class AuthService:
             requester_access_key=requester_ak,
             owner_access_key=owner_ak,
         )
+
+    async def resolve_user_id_by_access_key(
+        self, action: ResolveUserIDByAccessKeyAction
+    ) -> ResolveUserIDByAccessKeyResult:
+        user_id = await self._auth_repository.get_user_id_by_access_key(str(action.access_key))
+        return ResolveUserIDByAccessKeyResult(user_id=user_id)
 
     async def resolve_user_scope(self, action: ResolveUserScopeAction) -> ResolveUserScopeResult:
         if action.owner_user_email is None:

--- a/tests/unit/manager/repositories/auth/test_auth_repository.py
+++ b/tests/unit/manager/repositories/auth/test_auth_repository.py
@@ -15,12 +15,12 @@ import sqlalchemy as sa
 
 from ai.backend.common.data.permission.types import RelationType
 from ai.backend.common.exception import UserNotFound
-from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
+from ai.backend.common.types import AccessKey, ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.auth.types import UserData
 from ai.backend.manager.data.group.types import GroupData
 from ai.backend.manager.data.permission.types import EntityType, ScopeType
-from ai.backend.manager.errors.auth import GroupMembershipNotFoundError
+from ai.backend.manager.errors.auth import AccessKeyNotFound, GroupMembershipNotFoundError
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
@@ -535,3 +535,20 @@ class TestAuthRepository:
         now_utc = datetime.now(UTC)
         time_diff = abs((now_utc - result).total_seconds())
         assert time_diff < 1.0
+
+    async def test_get_user_id_by_access_key_success(
+        self,
+        auth_repository: AuthRepository,
+        sample_user_data: UserTestData,
+    ) -> None:
+        result = await auth_repository.get_user_id_by_access_key(
+            AccessKey(sample_user_data.access_key)
+        )
+
+        assert result == sample_user_data.uuid
+
+    async def test_get_user_id_by_access_key_not_found(
+        self, auth_repository: AuthRepository
+    ) -> None:
+        with pytest.raises(AccessKeyNotFound):
+            await auth_repository.get_user_id_by_access_key(AccessKey("AKIANONEXISTENT"))


### PR DESCRIPTION
## Summary
- Add `UserID = NewType("UserID", UUID)` under `common/identifier/user.py` so handler/service signatures can carry the keypair owner's UUID with static-type discrimination (mirrors the existing `common/identifier/vfolder.py` pattern).
- Add `ResolveUserIDByAccessKeyAction` on the auth service plus a backing `get_user_id_by_access_key` in the auth repository / db_source (selects `keypairs.c.user`, raises `AccessKeyNotFound` when missing) so any handler or service can resolve an access_key to its owning user_uuid without depending on the keypairs table directly.
- Register the new action processor on `AuthProcessors` and add the spec to `supported_actions()`. Pure additive — no existing call site is modified.

## Test plan
- [x] `pants fmt fix lint check` on the touched files (passes locally)
- [x] No behavior change to existing REST v1/v2, GraphQL, agent RPC, or events surfaces

Resolves BA-6063