### PR TITLE
feat(BA-6083): add ResolveDomainIDByName and ResolveResourceGroupIDByName actions

### DIFF
--- a/changes/11660.feature.md
+++ b/changes/11660.feature.md
@@ -1,0 +1,1 @@
+Add `ResolveDomainIDByName` and `ResolveResourceGroupIDByName` actions to resolve entity names to their canonical UUID identifiers.

--- a/src/ai/backend/manager/repositories/domain/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/domain/db_source/db_source.py
@@ -4,6 +4,7 @@ import logging
 
 import sqlalchemy as sa
 
+from ai.backend.common.identifier.domain import DomainID, DomainName
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.data.domain.types import DomainData
 from ai.backend.manager.errors.resource import DomainNotFound
@@ -40,6 +41,14 @@ class DomainDBSource:
             if row is None:
                 raise DomainNotFound(f"Domain '{domain_name}' not found")
             return row.to_data()
+
+    async def get_domain_id_by_name(self, name: DomainName) -> DomainID:
+        async with self._db.begin_readonly_session_read_committed() as db_sess:
+            query = sa.select(DomainRow.id).where(DomainRow.name == name)
+            domain_id = await db_sess.scalar(query)
+            if domain_id is None:
+                raise DomainNotFound(f"Domain '{name}' not found")
+            return domain_id
 
     async def search_domains(self, querier: BatchQuerier) -> DomainSearchResult:
         """Search all domains with pagination and filters.

--- a/src/ai/backend/manager/repositories/domain/repository.py
+++ b/src/ai/backend/manager/repositories/domain/repository.py
@@ -7,6 +7,7 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
 from ai.backend.common.exception import BackendAIError, DomainNotFound, InvalidAPIParameters
+from ai.backend.common.identifier.domain import DomainID, DomainName
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
@@ -379,6 +380,10 @@ class DomainRepository:
             )
 
     # ==================== V2 Repository Methods ====================
+
+    @domain_repository_resilience.apply()
+    async def get_domain_id_by_name(self, name: DomainName) -> DomainID:
+        return await self._db_source.get_domain_id_by_name(name)
 
     @domain_repository_resilience.apply()
     async def get_domain(self, domain_name: str) -> DomainData:

--- a/src/ai/backend/manager/repositories/scaling_group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scaling_group/db_source/db_source.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from ai.backend.common.data.permission.types import RBACElementType, RelationType
-from ai.backend.common.identifier.resource_group import ResourceGroupName
+from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
 from ai.backend.common.types import SlotQuantity
 from ai.backend.manager.data.agent.types import AgentStatus
 from ai.backend.manager.data.deployment.types import DeploymentOptions
@@ -118,6 +118,14 @@ class ScalingGroupDBSource:
                 has_next_page=result.has_next_page,
                 has_previous_page=result.has_previous_page,
             )
+
+    async def get_resource_group_id_by_name(self, name: ResourceGroupName) -> ResourceGroupID:
+        async with self._db.begin_readonly_session_read_committed() as db_sess:
+            query = sa.select(ScalingGroupRow.id).where(ScalingGroupRow.name == name)
+            resource_group_id = await db_sess.scalar(query)
+            if resource_group_id is None:
+                raise ScalingGroupNotFound(name)
+            return resource_group_id
 
     async def get_scaling_group_by_name(
         self,

--- a/src/ai/backend/manager/repositories/scaling_group/repository.py
+++ b/src/ai/backend/manager/repositories/scaling_group/repository.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from ai.backend.common.identifier.resource_group import ResourceGroupName
+from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience import (
     MetricArgs,
@@ -88,6 +88,10 @@ class ScalingGroupRepository:
     ) -> ScalingGroupListResult:
         """Searches scaling groups with total count."""
         return await self._db_source.search_scaling_groups(querier=querier)
+
+    @scaling_group_repository_resilience.apply()
+    async def get_resource_group_id_by_name(self, name: ResourceGroupName) -> ResourceGroupID:
+        return await self._db_source.get_resource_group_id_by_name(name)
 
     @scaling_group_repository_resilience.apply()
     async def get_scaling_group_by_name(

--- a/src/ai/backend/manager/services/domain/actions/resolve_domain_id_by_name.py
+++ b/src/ai/backend/manager/services/domain/actions/resolve_domain_id_by_name.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.identifier.domain import DomainID, DomainName
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.services.domain.actions.base import DomainAction
+
+
+@dataclass
+class ResolveDomainIDByNameAction(DomainAction):
+    name: DomainName
+
+    @override
+    def entity_id(self) -> str | None:
+        return str(self.name)
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+
+@dataclass
+class ResolveDomainIDByNameActionResult(BaseActionResult):
+    domain_id: DomainID
+
+    @override
+    def entity_id(self) -> str | None:
+        return str(self.domain_id)

--- a/src/ai/backend/manager/services/domain/processors.py
+++ b/src/ai/backend/manager/services/domain/processors.py
@@ -32,6 +32,10 @@ from ai.backend.manager.services.domain.actions.purge_domain import (
     PurgeDomainAction,
     PurgeDomainActionResult,
 )
+from ai.backend.manager.services.domain.actions.resolve_domain_id_by_name import (
+    ResolveDomainIDByNameAction,
+    ResolveDomainIDByNameActionResult,
+)
 from ai.backend.manager.services.domain.actions.search_domains import (
     SearchDomainsAction,
     SearchDomainsActionResult,
@@ -54,6 +58,9 @@ class DomainProcessors(AbstractProcessorPackage):
     get_domain: ActionProcessor[GetDomainAction, GetDomainActionResult]
     search_domains: ActionProcessor[SearchDomainsAction, SearchDomainsActionResult]
     search_rg_domains: ActionProcessor[SearchRGDomainsAction, SearchRGDomainsActionResult]
+    resolve_domain_id_by_name: ActionProcessor[
+        ResolveDomainIDByNameAction, ResolveDomainIDByNameActionResult
+    ]
 
     def __init__(
         self,
@@ -70,6 +77,9 @@ class DomainProcessors(AbstractProcessorPackage):
         self.get_domain = ActionProcessor(service.get_domain, action_monitors)
         self.search_domains = ActionProcessor(service.search_domains, action_monitors)
         self.search_rg_domains = ActionProcessor(service.search_rg_domains, action_monitors)
+        self.resolve_domain_id_by_name = ActionProcessor(
+            service.resolve_domain_id_by_name, action_monitors
+        )
 
     @override
     def supported_actions(self) -> list[ActionSpec]:
@@ -83,4 +93,5 @@ class DomainProcessors(AbstractProcessorPackage):
             GetDomainAction.spec(),
             SearchDomainsAction.spec(),
             SearchRGDomainsAction.spec(),
+            ResolveDomainIDByNameAction.spec(),
         ]

--- a/src/ai/backend/manager/services/domain/service.py
+++ b/src/ai/backend/manager/services/domain/service.py
@@ -35,6 +35,10 @@ from ai.backend.manager.services.domain.actions.purge_domain import (
     PurgeDomainAction,
     PurgeDomainActionResult,
 )
+from ai.backend.manager.services.domain.actions.resolve_domain_id_by_name import (
+    ResolveDomainIDByNameAction,
+    ResolveDomainIDByNameActionResult,
+)
 from ai.backend.manager.services.domain.actions.search_domains import (
     SearchDomainsAction,
     SearchDomainsActionResult,
@@ -125,6 +129,12 @@ class DomainService:
         return ModifyDomainNodeActionResult(
             domain_data=domain_data,
         )
+
+    async def resolve_domain_id_by_name(
+        self, action: ResolveDomainIDByNameAction
+    ) -> ResolveDomainIDByNameActionResult:
+        domain_id = await self._repository.get_domain_id_by_name(action.name)
+        return ResolveDomainIDByNameActionResult(domain_id=domain_id)
 
     async def get_domain(self, action: GetDomainAction) -> GetDomainActionResult:
         """Get a single domain by name.

--- a/src/ai/backend/manager/services/scaling_group/actions/resolve_resource_group_id_by_name.py
+++ b/src/ai/backend/manager/services/scaling_group/actions/resolve_resource_group_id_by_name.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.services.scaling_group.actions.base import ScalingGroupAction
+
+
+@dataclass(frozen=True)
+class ResolveResourceGroupIDByNameAction(ScalingGroupAction):
+    name: ResourceGroupName
+
+    @override
+    def entity_id(self) -> str | None:
+        return str(self.name)
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+
+@dataclass(frozen=True)
+class ResolveResourceGroupIDByNameActionResult(BaseActionResult):
+    resource_group_id: ResourceGroupID
+
+    @override
+    def entity_id(self) -> str | None:
+        return str(self.resource_group_id)

--- a/src/ai/backend/manager/services/scaling_group/processors.py
+++ b/src/ai/backend/manager/services/scaling_group/processors.py
@@ -80,6 +80,10 @@ from ai.backend.manager.services.scaling_group.actions.replace_default_session_o
     ReplaceDefaultSessionOptionsAction,
     ReplaceDefaultSessionOptionsActionResult,
 )
+from ai.backend.manager.services.scaling_group.actions.resolve_resource_group_id_by_name import (
+    ResolveResourceGroupIDByNameAction,
+    ResolveResourceGroupIDByNameActionResult,
+)
 from ai.backend.manager.services.scaling_group.actions.update_allowed_domains_for_rg import (
     UpdateAllowedDomainsForResourceGroupAction,
     UpdateAllowedDomainsForResourceGroupActionResult,
@@ -177,6 +181,10 @@ class ScalingGroupProcessors(AbstractProcessorPackage):
         GetAllowedProjectsForResourceGroupAction,
         GetAllowedProjectsForResourceGroupActionResult,
     ]
+    resolve_resource_group_id_by_name: ActionProcessor[
+        ResolveResourceGroupIDByNameAction,
+        ResolveResourceGroupIDByNameActionResult,
+    ]
 
     def __init__(
         self,
@@ -242,6 +250,9 @@ class ScalingGroupProcessors(AbstractProcessorPackage):
         self.get_allowed_projects_for_rg = ActionProcessor(
             service.get_allowed_projects_for_resource_group, action_monitors
         )
+        self.resolve_resource_group_id_by_name = ActionProcessor(
+            service.resolve_resource_group_id_by_name, action_monitors
+        )
 
     @override
     def supported_actions(self) -> list[ActionSpec]:
@@ -270,4 +281,5 @@ class ScalingGroupProcessors(AbstractProcessorPackage):
             GetAllowedResourceGroupsForProjectAction.spec(),
             GetAllowedDomainsForResourceGroupAction.spec(),
             GetAllowedProjectsForResourceGroupAction.spec(),
+            ResolveResourceGroupIDByNameAction.spec(),
         ]

--- a/src/ai/backend/manager/services/scaling_group/service.py
+++ b/src/ai/backend/manager/services/scaling_group/service.py
@@ -95,6 +95,10 @@ from ai.backend.manager.services.scaling_group.actions.replace_default_session_o
     ReplaceDefaultSessionOptionsAction,
     ReplaceDefaultSessionOptionsActionResult,
 )
+from ai.backend.manager.services.scaling_group.actions.resolve_resource_group_id_by_name import (
+    ResolveResourceGroupIDByNameAction,
+    ResolveResourceGroupIDByNameActionResult,
+)
 from ai.backend.manager.services.scaling_group.actions.update_allowed_domains_for_rg import (
     UpdateAllowedDomainsForResourceGroupAction,
     UpdateAllowedDomainsForResourceGroupActionResult,
@@ -172,6 +176,12 @@ class ScalingGroupService:
         )
         status = await client.fetch_status()
         return GetWsproxyVersionActionResult(wsproxy_version=status.api_version)
+
+    async def resolve_resource_group_id_by_name(
+        self, action: ResolveResourceGroupIDByNameAction
+    ) -> ResolveResourceGroupIDByNameActionResult:
+        resource_group_id = await self._repository.get_resource_group_id_by_name(action.name)
+        return ResolveResourceGroupIDByNameActionResult(resource_group_id=resource_group_id)
 
     async def search_scaling_groups(
         self, action: SearchScalingGroupsAction

--- a/tests/unit/manager/repositories/domain/test_domain_repository.py
+++ b/tests/unit/manager/repositories/domain/test_domain_repository.py
@@ -12,6 +12,7 @@ import pytest
 import sqlalchemy as sa
 
 from ai.backend.common.exception import DomainNotFound, InvalidAPIParameters
+from ai.backend.common.identifier.domain import DomainName
 from ai.backend.common.types import (
     DefaultForUnspecified,
     ResourceSlot,
@@ -26,6 +27,7 @@ from ai.backend.manager.errors.resource import (
     DomainHasGroups,
     DomainHasUsers,
 )
+from ai.backend.manager.errors.resource import DomainNotFound as ResourceDomainNotFound
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
@@ -681,3 +683,18 @@ class TestDomainRepository:
         # Try to purge domain (should fail due to active kernels)
         with pytest.raises(DomainHasActiveKernels):
             await domain_repository.purge_domain(domain_with_active_kernel)
+
+    async def test_get_domain_id_by_name_success(
+        self,
+        domain_repository: DomainRepository,
+        sample_domain: DomainData,
+    ) -> None:
+        domain_id = await domain_repository.get_domain_id_by_name(DomainName(sample_domain.name))
+        assert domain_id == sample_domain.id
+
+    async def test_get_domain_id_by_name_not_found(
+        self,
+        domain_repository: DomainRepository,
+    ) -> None:
+        with pytest.raises(ResourceDomainNotFound):
+            await domain_repository.get_domain_id_by_name(DomainName("nonexistent-domain"))

--- a/tests/unit/manager/repositories/scaling_group/test_scaling_group_repository.py
+++ b/tests/unit/manager/repositories/scaling_group/test_scaling_group_repository.py
@@ -9,6 +9,7 @@ import sqlalchemy as sa
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.exception import ScalingGroupConflict
 from ai.backend.common.identifier.deployment import DeploymentID
+from ai.backend.common.identifier.resource_group import ResourceGroupName
 from ai.backend.common.types import AccessKey, DefaultForUnspecified, ResourceSlot, SessionTypes
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.permission.types import RBACElementRef
@@ -1433,3 +1434,24 @@ class TestScalingGroupRepositoryDB:
                 sa.select(RoutingRow).where(RoutingRow.id == route_id)
             )
             assert route_result.scalar_one_or_none() is None
+
+    async def test_get_resource_group_id_by_name_success(
+        self,
+        scaling_group_repository: ScalingGroupRepository,
+        sample_scaling_groups_small: list[str],
+    ) -> None:
+        target_name = sample_scaling_groups_small[0]
+        resource_group_id = await scaling_group_repository.get_resource_group_id_by_name(
+            ResourceGroupName(target_name)
+        )
+        fetched = await scaling_group_repository.get_scaling_group_by_name(target_name)
+        assert resource_group_id == fetched.id
+
+    async def test_get_resource_group_id_by_name_not_found(
+        self,
+        scaling_group_repository: ScalingGroupRepository,
+    ) -> None:
+        with pytest.raises(ScalingGroupNotFound):
+            await scaling_group_repository.get_resource_group_id_by_name(
+                ResourceGroupName("nonexistent-scaling-group")
+            )


### PR DESCRIPTION
## Summary
- Introduce `ResolveDomainIDByNameAction` and `ResolveResourceGroupIDByNameAction` with corresponding Service / Repository / DBSource layers, mirroring the BA-6063 (`ResolveUserIDByAccessKey`) pattern.
- Foundation primitive for the BA-6043 epic: legacy entry points still receiving names (REST v1, agent RPC payloads, CLI compat paths) can obtain the canonical `DomainID` / `ResourceGroupID` before invoking id-based downstream code introduced by BA-6045~6047, BA-6049~6051.
- Pure additive change — no existing call site is modified.

## Test plan
- [x] `pants fmt / fix / lint / check` clean
- [x] New repository tests cover success and `NotFound` cases for both resolvers
- [x] Existing domain/scaling_group repository & service tests still pass

Resolves BA-6083