### PR TITLE
fix(BA-6085): seed reads_vfolder_config_files=true for custom variant

### DIFF
--- a/changes/11661.fix.md
+++ b/changes/11661.fix.md
@@ -1,0 +1,1 @@
+Fix custom runtime variant not reading model-definition.yaml from the model vfolder during revision creation

--- a/src/ai/backend/manager/models/alembic/versions/0b10b2c6a972_seed_reads_vfolder_for_custom_variant.py
+++ b/src/ai/backend/manager/models/alembic/versions/0b10b2c6a972_seed_reads_vfolder_for_custom_variant.py
@@ -1,0 +1,47 @@
+"""seed reads_vfolder_config_files for custom runtime variant
+
+The original seed migration (``9229f72fa447``) inserted runtime variants
+with only ``name`` / ``description``, so ``reads_vfolder_config_files``
+took its server default of ``false`` for every row. The install fixture
+sets the flag to ``true`` for the ``custom`` variant, but
+``populate_fixture`` uses ``ON CONFLICT DO NOTHING`` and therefore never
+overwrites the already-seeded row. Backfill the intended value here so
+``custom`` actually triggers the vfolder ``model-definition.yaml`` scan
+at revision-creation time.
+
+Revision ID: 0b10b2c6a972
+Revises: ba42cb865efe
+Create Date: 2026-05-18
+
+"""
+
+# Part of: 26.5.0
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0b10b2c6a972"
+down_revision = "ba42cb865efe"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE runtime_variants "
+            "SET reads_vfolder_config_files = true "
+            "WHERE name = 'custom'"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE runtime_variants "
+            "SET reads_vfolder_config_files = false "
+            "WHERE name = 'custom'"
+        )
+    )

--- a/src/ai/backend/manager/models/alembic/versions/0b10b2c6a972_seed_reads_vfolder_for_custom_variant.py
+++ b/src/ai/backend/manager/models/alembic/versions/0b10b2c6a972_seed_reads_vfolder_for_custom_variant.py
@@ -36,8 +36,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.execute(
-        sa.text(
-            "UPDATE runtime_variants SET reads_vfolder_config_files = false WHERE name = 'custom'"
-        )
-    )
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/0b10b2c6a972_seed_reads_vfolder_for_custom_variant.py
+++ b/src/ai/backend/manager/models/alembic/versions/0b10b2c6a972_seed_reads_vfolder_for_custom_variant.py
@@ -30,9 +30,7 @@ depends_on = None
 def upgrade() -> None:
     op.execute(
         sa.text(
-            "UPDATE runtime_variants "
-            "SET reads_vfolder_config_files = true "
-            "WHERE name = 'custom'"
+            "UPDATE runtime_variants SET reads_vfolder_config_files = true WHERE name = 'custom'"
         )
     )
 
@@ -40,8 +38,6 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.execute(
         sa.text(
-            "UPDATE runtime_variants "
-            "SET reads_vfolder_config_files = false "
-            "WHERE name = 'custom'"
+            "UPDATE runtime_variants SET reads_vfolder_config_files = false WHERE name = 'custom'"
         )
     )


### PR DESCRIPTION
## Summary
- The original `runtime_variants` seed migration (`9229f72fa447`) inserted rows with only `name` / `description`, so `reads_vfolder_config_files` took its server default of `false` for every variant.
- `populate_fixture` uses `INSERT … ON CONFLICT DO NOTHING`, so the install fixture's `"reads_vfolder_config_files": true` for `custom` is silently dropped on databases that already have the seed row.
- Add a one-shot migration that `UPDATE runtime_variants SET reads_vfolder_config_files = true WHERE name = 'custom'` so existing databases get the intended flag and the vfolder `model-definition.yaml` scan kicks in at revision-creation time.

## Test plan
- [x] `alembic upgrade head` from `ba42cb865efe`: `custom` becomes `true`, other 6 variants untouched
- [x] `alembic downgrade -1`: `custom` reverts to `false`, version returns to `ba42cb865efe`
- [x] Re-running `upgrade head` on a database where `custom` is already `true` is a no-op (UPDATE is idempotent)
- [x] After upgrade, v2 `add_revision` with `custom` variant and a model vfolder persists the resolved `model_definition_path` (`model-definition.yaml`) instead of an empty string

Resolves BA-6085