### PR TITLE
fix(BA-6099): avoid f-string in BraceStyleAdapter `log.exception` call (#11680)

### DIFF
--- a/changes/11680.fix.md
+++ b/changes/11680.fix.md
@@ -1,0 +1,1 @@
+Fix `BraceStyleAdapter` log calls that fail when f-string interpolations contain literal brace characters (`EventDispatcher` single site).

--- a/src/ai/backend/common/events/dispatcher.py
+++ b/src/ai/backend/common/events/dispatcher.py
@@ -563,7 +563,7 @@ class EventDispatcher(EventDispatcherGroup):
                 duration=time.perf_counter() - start,
                 exception=e,
             )
-            log.exception(f"EventDispatcher.{evh_type}(): unexpected-error, {repr(e)}")
+            log.exception("EventDispatcher.{}(): unexpected-error", evh_type)
             raise
         except BaseException as e:
             self._metric_observer.observe_event_failure(


### PR DESCRIPTION
This is an auto-generated backport PR of #11680 to the 25.15 release.