### PR TITLE
fix(BA-6107): skip slot-type checks for zero-valued resource slots

### DIFF
--- a/changes/11691.fix.md
+++ b/changes/11691.fix.md
@@ -1,0 +1,1 @@
+Skip resource-group slot-type validation for slots requested with a non-positive quantity (or image minimum), and aggregate per-kernel errors instead of failing on the first offending kernel.

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/image_slot_type_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/image_slot_type_rule.py
@@ -14,8 +14,11 @@ would otherwise let the session reach the scheduler only to fail there.
 
 from __future__ import annotations
 
+from decimal import Decimal
+
 from ai.backend.manager.data.session.spec import SessionSpec
 from ai.backend.manager.errors.api import InvalidAPIParameters
+from ai.backend.manager.sokovan.scheduling_controller.resource_parse import image_min_slots
 from ai.backend.manager.sokovan.scheduling_controller.validators.session_spec_base import (
     SessionSpecValidationContext,
     SessionSpecValidatorRule,
@@ -41,23 +44,26 @@ class ImageSlotTypeRule(SessionSpecValidatorRule):
                     f"agents serving any resource slot."
                 ),
             )
+        errors: list[str] = []
         for idx, kernel in enumerate(spec.kernel_specs):
             image_info = context.image_infos.get(kernel.execution_spec.image_id)
             if image_info is None:
                 continue
+            min_slots = image_min_slots(image_info)
             unknown = sorted(
                 slot_name
                 for slot_name in image_info.resource_spec
                 if slot_name not in rg_slot_types
+                and min_slots.get(slot_name, Decimal(0)) > Decimal(0)
             )
             if unknown:
-                raise InvalidAPIParameters(
-                    extra_msg=(
-                        f"kernel_specs[{idx}]: image '{image_info.canonical}' "
-                        f"requires resource slot(s) {unknown} that resource "
-                        f"group '{spec.scope.resource_group_name}' does not "
-                        f"serve. Pick an image whose required slots are "
-                        f"available here, or switch to a resource group that "
-                        f"supports these slots."
-                    ),
+                errors.append(
+                    f"kernel_specs[{idx}]: image '{image_info.canonical}' "
+                    f"requires resource slot(s) {unknown} that resource "
+                    f"group '{spec.scope.resource_group_name}' does not "
+                    f"serve. Pick an image whose required slots are "
+                    f"available here, or switch to a resource group that "
+                    f"supports these slots."
                 )
+        if errors:
+            raise InvalidAPIParameters(extra_msg=" ".join(errors))

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/requested_slot_type_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/requested_slot_type_rule.py
@@ -15,8 +15,11 @@ to fail there.
 
 from __future__ import annotations
 
+from decimal import Decimal
+
 from ai.backend.manager.data.session.spec import SessionSpec
 from ai.backend.manager.errors.api import InvalidAPIParameters
+from ai.backend.manager.sokovan.scheduling_controller.resource_parse import parse_quantity
 from ai.backend.manager.sokovan.scheduling_controller.validators.session_spec_base import (
     SessionSpecValidationContext,
     SessionSpecValidatorRule,
@@ -42,19 +45,21 @@ class RequestedSlotTypeRule(SessionSpecValidatorRule):
                     f"agents serving any resource slot."
                 ),
             )
+        errors: list[str] = []
         for idx, kernel in enumerate(spec.kernel_specs):
             unknown = sorted({
                 entry.resource_type
                 for entry in kernel.execution_spec.resources
                 if entry.resource_type not in rg_slot_types
+                and parse_quantity(entry.quantity) > Decimal(0)
             })
             if unknown:
-                raise InvalidAPIParameters(
-                    extra_msg=(
-                        f"kernel_specs[{idx}]: the request asks for resource "
-                        f"slot(s) {unknown} that resource group "
-                        f"'{spec.scope.resource_group_name}' does not serve. "
-                        f"Drop these slots from the request or switch to a "
-                        f"resource group that supports them."
-                    ),
+                errors.append(
+                    f"kernel_specs[{idx}]: the request asks for resource "
+                    f"slot(s) {unknown} that resource group "
+                    f"'{spec.scope.resource_group_name}' does not serve. "
+                    f"Drop these slots from the request or switch to a "
+                    f"resource group that supports them."
                 )
+        if errors:
+            raise InvalidAPIParameters(extra_msg=" ".join(errors))

--- a/tests/unit/manager/sokovan/scheduling_controller/validators/test_session_spec_rules.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/validators/test_session_spec_rules.py
@@ -484,6 +484,27 @@ class TestImageSlotTypeRule:
         ctx = _ctx(known_slot_types=dict(_RG_BASE))
         ImageSlotTypeRule().validate(spec, ctx)
 
+    def test_skips_image_slot_when_min_is_zero(self) -> None:
+        img = ImageID(uuid.uuid4())
+        spec = _spec((_kernel(img),))
+        image_info = ImageInfo(
+            id=uuid.UUID(str(img)),
+            canonical="repo/img:tag",
+            architecture="x86_64",
+            registry="repo",
+            labels={},
+            resource_spec={
+                "cpu": {"min": "1", "max": None},
+                "mem": {"min": "1", "max": None},
+                "cuda.device": {"min": "0", "max": None},
+            },
+        )
+        ctx = _ctx(
+            image_infos={img: image_info},
+            known_slot_types=dict(_RG_BASE),
+        )
+        ImageSlotTypeRule().validate(spec, ctx)
+
 
 class TestRequestedSlotTypeRule:
     def test_passes_when_requested_slots_served_by_rg(self) -> None:
@@ -511,6 +532,17 @@ class TestRequestedSlotTypeRule:
         spec = _spec((_kernel_with_resources(img, resources=(("cpu", "1"),)),))
         with pytest.raises(InvalidAPIParameters):
             RequestedSlotTypeRule().validate(spec, _ctx())
+
+    def test_skips_requested_slot_when_quantity_is_zero(self) -> None:
+        img = ImageID(uuid.uuid4())
+        spec = _spec((
+            _kernel_with_resources(
+                img,
+                resources=(("cpu", "1"), ("mem", "1073741824"), ("cuda.device", "0")),
+            ),
+        ))
+        ctx = _ctx(known_slot_types=dict(_RG_BASE))
+        RequestedSlotTypeRule().validate(spec, ctx)
 
 
 class TestRequiredResourceSlotRule:


### PR DESCRIPTION
## Summary
- `ImageSlotTypeRule` and `RequestedSlotTypeRule` now skip slots whose requested quantity (or image-declared minimum) is `<= 0`, matching the behavior of `ResourceLimitRule`.
- Per-kernel validation errors in both rules are aggregated and raised together instead of failing on the first offending `kernel_spec`.
- Added unit tests covering both zero-value skip cases.

## Test plan
- [x] `pants test tests/unit/manager/sokovan/scheduling_controller/validators/test_session_spec_rules.py`
- [x] `pants check` / `pants lint` on changed files

Resolves BA-6107