### PR TITLE
feat(BA-6095): add scoped audit log GraphQL schema stub

### DIFF
--- a/changes/11694.feature.md
+++ b/changes/11694.feature.md
@@ -1,0 +1,1 @@
+Add `scopedAuditLogsV2` GraphQL query schema (stub) with `AuditLogScope` input for category-separated, OR-combined scope leaves.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -1535,7 +1535,7 @@ input AuditLogScope
   entity: [EntityTypeScope!] = null
 
   """Actor UUIDs (matches audit_logs.triggered_by)."""
-  triggeredUser: [UUID!] = null
+  triggeredUser: [UUIDScope!] = null
 }
 
 """Added in 26.3.0. Status of an audit log entry."""
@@ -20177,6 +20177,14 @@ Verifies that the key is a UUID (represented as a string) and the value is a flo
 """
 scalar UUIDFloatMap
   @join__type(graph: GRAPHENE)
+
+"""Added in UNRELEASED. Single-UUID scope item wrapper."""
+input UUIDScope
+  @join__type(graph: STRAWBERRY)
+{
+  """UUID value."""
+  value: UUID!
+}
 
 """Added in 24.09.0. Input for validate notification channel mutation"""
 input ValidateNotificationChannelInput

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -1435,6 +1435,7 @@ input AuditLogFilter
   @join__type(graph: STRAWBERRY)
 {
   entityType: StringFilter = null
+  entityId: StringFilter = null
   operation: StringFilter = null
   status: AuditLogStatusFilter = null
   createdAt: DateTimeFilter = null
@@ -1522,6 +1523,19 @@ type AuditLogSchema
   Possible values of "AuditLogNode.status"
   """
   status_variants: [String]
+}
+
+"""
+Added in UNRELEASED. Scope target for the scoped audit log query. All items are OR'd; raises an error if every field is empty.
+"""
+input AuditLogScope
+  @join__type(graph: STRAWBERRY)
+{
+  """Entity-tagged scope items."""
+  entity: [EntityTypeScope!] = null
+
+  """Actor UUIDs (matches audit_logs.triggered_by)."""
+  triggeredUser: [UUID!] = null
 }
 
 """Added in 26.3.0. Status of an audit log entry."""
@@ -6681,6 +6695,19 @@ type EntityTimestamps
 
   """Timestamp when this entity was last modified."""
   modifiedAt: DateTime
+}
+
+"""
+Added in UNRELEASED. Entity reference parametrized by RBAC element type.
+"""
+input EntityTypeScope
+  @join__type(graph: STRAWBERRY)
+{
+  """RBAC element type of the entity."""
+  entityType: RBACElementType!
+
+  """ID of the entity."""
+  entityId: String!
 }
 
 """
@@ -13835,6 +13862,11 @@ type Query
   Added in 26.3.0. Query audit logs with pagination and filtering. (admin only)
   """
   adminAuditLogsV2(filter: AuditLogFilter = null, orderBy: [AuditLogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AuditLogV2Connection @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. Query audit logs within a scope target (non-admin accessible, subject to RBAC). All scope items are OR'd; raises an error if every field is empty.
+  """
+  scopedAuditLogsV2(scopeTarget: AuditLogScope!, filter: AuditLogFilter = null, orderBy: [AuditLogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AuditLogV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. List container registries with filtering, ordering, and pagination (admin only).

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -1526,7 +1526,7 @@ type AuditLogSchema
 }
 
 """
-Added in UNRELEASED. Scope target for the scoped audit log query. All items are OR'd; raises an error if every field is empty.
+Added in UNRELEASED. Scope for the scoped audit log query. All items are OR'd; raises an error if every field is empty.
 """
 input AuditLogScope
   @join__type(graph: STRAWBERRY)
@@ -13864,9 +13864,9 @@ type Query
   adminAuditLogsV2(filter: AuditLogFilter = null, orderBy: [AuditLogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AuditLogV2Connection @join__field(graph: STRAWBERRY)
 
   """
-  Added in UNRELEASED. Query audit logs within a scope target (non-admin accessible, subject to RBAC). All scope items are OR'd; raises an error if every field is empty.
+  Added in UNRELEASED. Query audit logs within a scope (non-admin accessible, subject to RBAC). All scope items are OR'd; raises an error if every field is empty.
   """
-  scopedAuditLogsV2(scopeTarget: AuditLogScope!, filter: AuditLogFilter = null, orderBy: [AuditLogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AuditLogV2Connection @join__field(graph: STRAWBERRY)
+  scopedAuditLogsV2(scope: AuditLogScope!, filter: AuditLogFilter = null, orderBy: [AuditLogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AuditLogV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. List container registries with filtering, ordering, and pagination (admin only).

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1007,6 +1007,7 @@ input AssignRoleInput {
 """Added in 24.09.0. Filter criteria for querying audit logs."""
 input AuditLogFilter {
   entityType: StringFilter = null
+  entityId: StringFilter = null
   operation: StringFilter = null
   status: AuditLogStatusFilter = null
   createdAt: DateTimeFilter = null
@@ -1028,6 +1029,17 @@ enum AuditLogOrderField {
   ENTITY_TYPE
   OPERATION
   STATUS
+}
+
+"""
+Added in UNRELEASED. Scope target for the scoped audit log query. All items are OR'd; raises an error if every field is empty.
+"""
+input AuditLogScope {
+  """Entity-tagged scope items."""
+  entity: [EntityTypeScope!] = null
+
+  """Actor UUIDs (matches audit_logs.triggered_by)."""
+  triggeredUser: [UUID!] = null
 }
 
 """Added in 26.3.0. Status of an audit log entry."""
@@ -4402,6 +4414,17 @@ type EntityTimestamps {
 
   """Timestamp when this entity was last modified."""
   modifiedAt: DateTime
+}
+
+"""
+Added in UNRELEASED. Entity reference parametrized by RBAC element type.
+"""
+input EntityTypeScope {
+  """RBAC element type of the entity."""
+  entityType: RBACElementType!
+
+  """ID of the entity."""
+  entityId: String!
 }
 
 """
@@ -8959,6 +8982,11 @@ type Query {
   Added in 26.3.0. Query audit logs with pagination and filtering. (admin only)
   """
   adminAuditLogsV2(filter: AuditLogFilter = null, orderBy: [AuditLogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AuditLogV2Connection
+
+  """
+  Added in UNRELEASED. Query audit logs within a scope target (non-admin accessible, subject to RBAC). All scope items are OR'd; raises an error if every field is empty.
+  """
+  scopedAuditLogsV2(scopeTarget: AuditLogScope!, filter: AuditLogFilter = null, orderBy: [AuditLogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AuditLogV2Connection
 
   """
   Added in 26.4.2. List container registries with filtering, ordering, and pagination (admin only).

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1032,7 +1032,7 @@ enum AuditLogOrderField {
 }
 
 """
-Added in UNRELEASED. Scope target for the scoped audit log query. All items are OR'd; raises an error if every field is empty.
+Added in UNRELEASED. Scope for the scoped audit log query. All items are OR'd; raises an error if every field is empty.
 """
 input AuditLogScope {
   """Entity-tagged scope items."""
@@ -8984,9 +8984,9 @@ type Query {
   adminAuditLogsV2(filter: AuditLogFilter = null, orderBy: [AuditLogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AuditLogV2Connection
 
   """
-  Added in UNRELEASED. Query audit logs within a scope target (non-admin accessible, subject to RBAC). All scope items are OR'd; raises an error if every field is empty.
+  Added in UNRELEASED. Query audit logs within a scope (non-admin accessible, subject to RBAC). All scope items are OR'd; raises an error if every field is empty.
   """
-  scopedAuditLogsV2(scopeTarget: AuditLogScope!, filter: AuditLogFilter = null, orderBy: [AuditLogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AuditLogV2Connection
+  scopedAuditLogsV2(scope: AuditLogScope!, filter: AuditLogFilter = null, orderBy: [AuditLogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AuditLogV2Connection
 
   """
   Added in 26.4.2. List container registries with filtering, ordering, and pagination (admin only).

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1039,7 +1039,7 @@ input AuditLogScope {
   entity: [EntityTypeScope!] = null
 
   """Actor UUIDs (matches audit_logs.triggered_by)."""
-  triggeredUser: [UUID!] = null
+  triggeredUser: [UUIDScope!] = null
 }
 
 """Added in 26.3.0. Status of an audit log entry."""
@@ -12270,6 +12270,12 @@ input UUIDFilter {
   in: [UUID!] = null
   notEquals: UUID = null
   notIn: [UUID!] = null
+}
+
+"""Added in UNRELEASED. Single-UUID scope item wrapper."""
+input UUIDScope {
+  """UUID value."""
+  value: UUID!
 }
 
 """

--- a/src/ai/backend/common/dto/manager/v2/audit_log/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/audit_log/__init__.py
@@ -4,7 +4,9 @@ from ai.backend.common.dto.manager.v2.audit_log.request import (
     AdminSearchAuditLogsInput,
     AuditLogFilter,
     AuditLogOrder,
+    AuditLogScope,
     AuditLogStatusFilter,
+    ScopedSearchAuditLogsInput,
 )
 from ai.backend.common.dto.manager.v2.audit_log.response import (
     AdminSearchAuditLogsPayload,
@@ -23,7 +25,9 @@ __all__ = (
     "AuditLogNode",
     "AuditLogOrder",
     "AuditLogOrderField",
+    "AuditLogScope",
     "AuditLogStatus",
     "AuditLogStatusFilter",
     "OrderDirection",
+    "ScopedSearchAuditLogsInput",
 )

--- a/src/ai/backend/common/dto/manager/v2/audit_log/request.py
+++ b/src/ai/backend/common/dto/manager/v2/audit_log/request.py
@@ -79,7 +79,7 @@ class AdminSearchAuditLogsInput(BaseRequestModel):
 
 
 class AuditLogScope(BaseRequestModel):
-    """Scope target for the scoped audit log query.
+    """Scope for the scoped audit log query.
 
     Each category list is OR'd internally and across categories. Raises an error
     if every field is empty.
@@ -102,9 +102,9 @@ class AuditLogScope(BaseRequestModel):
 
 
 class ScopedSearchAuditLogsInput(BaseRequestModel):
-    """Input for searching audit logs under a non-admin scope target."""
+    """Input for searching audit logs under a non-admin scope."""
 
-    scope_target: AuditLogScope = Field(description="Scope target (OR across all items)")
+    scope: AuditLogScope = Field(description="Scope (OR across all items)")
     filter: AuditLogFilter | None = Field(default=None, description="Filter criteria")
     order: list[AuditLogOrder] | None = Field(default=None, description="Sort order")
     first: int | None = Field(default=None, ge=1, description="Cursor-forward page size")

--- a/src/ai/backend/common/dto/manager/v2/audit_log/request.py
+++ b/src/ai/backend/common/dto/manager/v2/audit_log/request.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
-from pydantic import Field
+from typing import Self
+from uuid import UUID
+
+from pydantic import Field, model_validator
 
 from ai.backend.common.api_handlers import BaseRequestModel
 from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter
+from ai.backend.common.dto.manager.v2.rbac.types import EntityTypeScope
 
 from .types import AuditLogOrderField, AuditLogStatus, OrderDirection
 
@@ -13,7 +17,9 @@ __all__ = (
     "AdminSearchAuditLogsInput",
     "AuditLogFilter",
     "AuditLogOrder",
+    "AuditLogScope",
     "AuditLogStatusFilter",
+    "ScopedSearchAuditLogsInput",
 )
 
 
@@ -34,6 +40,7 @@ class AuditLogFilter(BaseRequestModel):
     """Filter for audit logs."""
 
     entity_type: StringFilter | None = Field(default=None, description="Entity type filter")
+    entity_id: StringFilter | None = Field(default=None, description="Entity ID filter")
     operation: StringFilter | None = Field(default=None, description="Operation filter")
     status: AuditLogStatusFilter | None = Field(default=None, description="Status filter")
     triggered_by: StringFilter | None = Field(default=None, description="Triggered-by filter")
@@ -62,6 +69,43 @@ class AuditLogOrder(BaseRequestModel):
 class AdminSearchAuditLogsInput(BaseRequestModel):
     """Input for searching audit logs (admin, no scope)."""
 
+    filter: AuditLogFilter | None = Field(default=None, description="Filter criteria")
+    order: list[AuditLogOrder] | None = Field(default=None, description="Sort order")
+    first: int | None = Field(default=None, ge=1, description="Cursor-forward page size")
+    after: str | None = Field(default=None, description="Cursor-forward start cursor")
+    last: int | None = Field(default=None, ge=1, description="Cursor-backward page size")
+    before: str | None = Field(default=None, description="Cursor-backward end cursor")
+    limit: int | None = Field(default=None, ge=1, description="Offset-based page size")
+    offset: int | None = Field(default=None, ge=0, description="Offset-based page offset")
+
+
+class AuditLogScope(BaseRequestModel):
+    """Scope target for the scoped audit log query.
+
+    Each category list is OR'd internally and across categories. Raises an error
+    if every field is empty.
+    """
+
+    entity: list[EntityTypeScope] | None = Field(
+        default=None, description="Entity-tagged scope items"
+    )
+    triggered_user: list[UUID] | None = Field(
+        default=None, description="Actor UUIDs (matches audit_logs.triggered_by)"
+    )
+
+    @model_validator(mode="after")
+    def _require_non_empty(self) -> Self:
+        if not self.entity and not self.triggered_user:
+            raise ValueError(
+                "AuditLogScope requires a non-empty value for 'entity' or 'triggered_user'"
+            )
+        return self
+
+
+class ScopedSearchAuditLogsInput(BaseRequestModel):
+    """Input for searching audit logs under a non-admin scope target."""
+
+    scope_target: AuditLogScope = Field(description="Scope target (OR across all items)")
     filter: AuditLogFilter | None = Field(default=None, description="Filter criteria")
     order: list[AuditLogOrder] | None = Field(default=None, description="Sort order")
     first: int | None = Field(default=None, ge=1, description="Cursor-forward page size")

--- a/src/ai/backend/common/dto/manager/v2/audit_log/request.py
+++ b/src/ai/backend/common/dto/manager/v2/audit_log/request.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 from typing import Self
-from uuid import UUID
 
 from pydantic import Field, model_validator
 
 from ai.backend.common.api_handlers import BaseRequestModel
 from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter
-from ai.backend.common.dto.manager.v2.rbac.types import EntityTypeScope
+from ai.backend.common.dto.manager.v2.rbac.types import EntityTypeScope, UUIDScope
 
 from .types import AuditLogOrderField, AuditLogStatus, OrderDirection
 
@@ -89,7 +88,7 @@ class AuditLogScope(BaseRequestModel):
     entity: list[EntityTypeScope] | None = Field(
         default=None, description="Entity-tagged scope items"
     )
-    triggered_user: list[UUID] | None = Field(
+    triggered_user: list[UUIDScope] | None = Field(
         default=None, description="Actor UUIDs (matches audit_logs.triggered_by)"
     )
 

--- a/src/ai/backend/common/dto/manager/v2/rbac/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/rbac/__init__.py
@@ -61,6 +61,7 @@ from ai.backend.common.dto.manager.v2.rbac.response import (
 from ai.backend.common.dto.manager.v2.rbac.types import (
     EntityOrderField,
     EntityType,
+    EntityTypeScope,
     OperationType,
     OperationTypeDTO,
     OperationTypeFilter,
@@ -84,6 +85,7 @@ __all__ = (
     # Types
     "EntityOrderField",
     "EntityType",
+    "EntityTypeScope",
     "OperationType",
     "OperationTypeDTO",
     "OperationTypeFilter",

--- a/src/ai/backend/common/dto/manager/v2/rbac/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/rbac/__init__.py
@@ -79,6 +79,7 @@ from ai.backend.common.dto.manager.v2.rbac.types import (
     RoleStatusDTO,
     RoleStatusFilter,
     ScopeInputDTO,
+    UUIDScope,
 )
 
 __all__ = (
@@ -103,6 +104,7 @@ __all__ = (
     "RoleStatusDTO",
     "RoleStatusFilter",
     "ScopeInputDTO",
+    "UUIDScope",
     # Input models (request)
     "AdminSearchEntitiesGQLInput",
     "AdminSearchPermissionsGQLInput",

--- a/src/ai/backend/common/dto/manager/v2/rbac/types.py
+++ b/src/ai/backend/common/dto/manager/v2/rbac/types.py
@@ -5,6 +5,7 @@ Common types for RBAC DTO v2.
 from __future__ import annotations
 
 from enum import StrEnum
+from uuid import UUID
 
 from ai.backend.common.api_handlers import BaseRequestModel, BaseResponseModel
 from ai.backend.common.data.permission.types import (
@@ -36,6 +37,7 @@ __all__ = (
     "RoleStatusDTO",
     "RoleStatusFilter",
     "ScopeInputDTO",
+    "UUIDScope",
 )
 
 
@@ -216,6 +218,17 @@ class EntityTypeScope(BaseRequestModel):
 
     entity_type: RBACElementTypeDTO
     entity_id: str
+
+
+class UUIDScope(BaseRequestModel):
+    """Single-UUID scope item wrapper.
+
+    A thin wrapper around a UUID used as a scope item. The wrapper exists so
+    that scope-input lists stay structurally uniform with other scope item
+    types and leave room for per-item metadata in the future.
+    """
+
+    value: UUID
 
 
 class PermissionSummary(BaseResponseModel):

--- a/src/ai/backend/common/dto/manager/v2/rbac/types.py
+++ b/src/ai/backend/common/dto/manager/v2/rbac/types.py
@@ -18,6 +18,7 @@ from ai.backend.common.dto.manager.v2.common import OrderDirection
 __all__ = (
     "EntityOrderField",
     "EntityType",
+    "EntityTypeScope",
     "OperationType",
     "OperationTypeDTO",
     "OperationTypeFilter",
@@ -204,6 +205,17 @@ class ScopeInputDTO(BaseRequestModel):
 
     scope_type: RBACElementTypeDTO
     scope_id: str
+
+
+class EntityTypeScope(BaseRequestModel):
+    """Entity reference parametrized by RBAC element type.
+
+    A typed (element_type, id) pair used to reference a specific entity in
+    contexts such as batch RBAC validation or scoped queries.
+    """
+
+    entity_type: RBACElementTypeDTO
+    entity_id: str
 
 
 class PermissionSummary(BaseResponseModel):

--- a/src/ai/backend/manager/api/gql/CLAUDE.md
+++ b/src/ai/backend/manager/api/gql/CLAUDE.md
@@ -60,14 +60,20 @@
 
 **search — always two variants:**
 - `adminFoosV2`: superadmin only, no scope — queries entire system.
-- `{scope}FoosV2` (e.g., `projectSessionsV2`): non-admin, scope parameter required — queries within the given scope only.
+- `scopedFoosV2` (e.g., `scopedSessionsV2`): non-admin, scope target required — queries within the given scope only.
 - `myFoosV2`: self-service, adapter resolves current user as scope internally.
 - There is NO "search everything without scope" for non-admin users.
 
 **Scoped search naming convention:**
-- GQL query names use scope as prefix: `projectSessionsV2`, `domainUsersV2`.
-- The scope ID is a required argument, not an optional filter.
-- Maps to REST pattern: `POST /v2/{entity}/{scope_type}/{scope_id}/search`.
+- GQL query name: `scopedFoosV2` (single root field per entity).
+- The scope target is a required argument typed as an entity-specific input
+  (`FooScopeGQL`), defined under `api/gql/{entity}/types/scope.py`.
+- The scope input is not a bare ID — it carries the shape the entity needs
+  (e.g., a single scope ID, a list of entity-tagged refs, or category-separated lists).
+- Non-empty validation lives on the DTO via a Pydantic `model_validator`, so empty
+  input is rejected at the GQL/REST boundary uniformly.
+- Legacy `{scope}FoosV2` queries (e.g., `projectSessionsV2`) predate this convention;
+  do NOT add new ones — use `scopedFoosV2` instead.
 
 **create / update / get / delete / purge — when to separate `admin_` vs non-admin:**
 - **Admin-only entity** (e.g., Domain, ContainerRegistry): single `admin_` mutation/query.
@@ -123,6 +129,21 @@ Clients must be able to choose between cursor and offset pagination freely.
 - Use this mode for infinite scrolling / "load more" UX where stable page boundaries matter.
 
 Only one pagination mode is allowed per request. Combining `first` with `limit` raises an error.
+
+## `scoped_` Resolver Pattern
+
+`scopedFoosV2` is the standard naming for non-admin scoped search queries.
+
+- Naming: `scopedFoosV2` (e.g., `scopedSessionsV2`, `scopedAuditLogsV2`).
+- Scope target argument: required, typed as an entity-specific input (`FooScopeGQL`)
+  defined under `api/gql/{entity}/types/scope.py`. Never accept a bare scope ID.
+- Scope input shape is entity-specific. A simple case may carry a single field
+  (e.g., a project ID); a complex case may carry category-separated lists.
+- Non-empty validation MUST live on the DTO via a Pydantic `model_validator`, so the
+  GQL/REST boundary rejects empty input uniformly without resolver-side checks.
+- The resolver forwards the scope target to the adapter alongside the search input DTO.
+  Authorization (RBAC validation, batch or single) is the adapter/service's
+  responsibility, not the resolver's.
 
 ## `my_` Resolver Pattern
 

--- a/src/ai/backend/manager/api/gql/CLAUDE.md
+++ b/src/ai/backend/manager/api/gql/CLAUDE.md
@@ -60,13 +60,13 @@
 
 **search — always two variants:**
 - `adminFoosV2`: superadmin only, no scope — queries entire system.
-- `scopedFoosV2` (e.g., `scopedSessionsV2`): non-admin, scope target required — queries within the given scope only.
+- `scopedFoosV2` (e.g., `scopedSessionsV2`): non-admin, scope required — queries within the given scope only.
 - `myFoosV2`: self-service, adapter resolves current user as scope internally.
 - There is NO "search everything without scope" for non-admin users.
 
 **Scoped search naming convention:**
 - GQL query name: `scopedFoosV2` (single root field per entity).
-- The scope target is a required argument typed as an entity-specific input
+- The scope is a required argument typed as an entity-specific input
   (`FooScopeGQL`), defined under `api/gql/{entity}/types/scope.py`.
 - The scope input is not a bare ID — it carries the shape the entity needs
   (e.g., a single scope ID, a list of entity-tagged refs, or category-separated lists).
@@ -135,13 +135,13 @@ Only one pagination mode is allowed per request. Combining `first` with `limit` 
 `scopedFoosV2` is the standard naming for non-admin scoped search queries.
 
 - Naming: `scopedFoosV2` (e.g., `scopedSessionsV2`, `scopedAuditLogsV2`).
-- Scope target argument: required, typed as an entity-specific input (`FooScopeGQL`)
+- Scope argument: required, typed as an entity-specific input (`FooScopeGQL`)
   defined under `api/gql/{entity}/types/scope.py`. Never accept a bare scope ID.
 - Scope input shape is entity-specific. A simple case may carry a single field
   (e.g., a project ID); a complex case may carry category-separated lists.
 - Non-empty validation MUST live on the DTO via a Pydantic `model_validator`, so the
   GQL/REST boundary rejects empty input uniformly without resolver-side checks.
-- The resolver forwards the scope target to the adapter alongside the search input DTO.
+- The resolver forwards the scope to the adapter alongside the search input DTO.
   Authorization (RBAC validation, batch or single) is the adapter/service's
   responsibility, not the resolver's.
 

--- a/src/ai/backend/manager/api/gql/audit_log/__init__.py
+++ b/src/ai/backend/manager/api/gql/audit_log/__init__.py
@@ -1,7 +1,8 @@
 """AuditLog GraphQL API package."""
 
-from .resolver import admin_audit_logs_v2
+from .resolver import admin_audit_logs_v2, scoped_audit_logs_v2
 
 __all__ = [
     "admin_audit_logs_v2",
+    "scoped_audit_logs_v2",
 ]

--- a/src/ai/backend/manager/api/gql/audit_log/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/audit_log/resolver/__init__.py
@@ -1,3 +1,3 @@
-from .query import admin_audit_logs_v2
+from .query import admin_audit_logs_v2, scoped_audit_logs_v2
 
-__all__ = ["admin_audit_logs_v2"]
+__all__ = ["admin_audit_logs_v2", "scoped_audit_logs_v2"]

--- a/src/ai/backend/manager/api/gql/audit_log/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/audit_log/resolver/query.py
@@ -73,14 +73,14 @@ async def admin_audit_logs_v2(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
         description=(
-            "Query audit logs within a scope target (non-admin accessible, subject to RBAC). "
+            "Query audit logs within a scope (non-admin accessible, subject to RBAC). "
             "All scope items are OR'd; raises an error if every field is empty."
         ),
     )
 )  # type: ignore[misc]
 async def scoped_audit_logs_v2(
     info: Info[StrawberryGQLContext],
-    scope_target: AuditLogScopeGQL,
+    scope: AuditLogScopeGQL,
     filter: AuditLogFilterGQL | None = None,
     order_by: list[AuditLogOrderByGQL] | None = None,
     before: str | None = None,
@@ -91,7 +91,7 @@ async def scoped_audit_logs_v2(
     offset: int | None = None,
 ) -> AuditLogV2ConnectionGQL | None:
     ScopedSearchAuditLogsInput(
-        scope_target=scope_target.to_pydantic(),
+        scope=scope.to_pydantic(),
         filter=filter.to_pydantic() if filter else None,
         order=[o.to_pydantic() for o in order_by] if order_by else None,
         first=first,

--- a/src/ai/backend/manager/api/gql/audit_log/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/audit_log/resolver/query.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 import strawberry
 from strawberry import Info
 
-from ai.backend.common.dto.manager.v2.audit_log.request import AdminSearchAuditLogsInput
+from ai.backend.common.dto.manager.v2.audit_log.request import (
+    AdminSearchAuditLogsInput,
+    ScopedSearchAuditLogsInput,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.audit_log.types import (
     AuditLogFilterGQL,
     AuditLogOrderByGQL,
+    AuditLogScopeGQL,
     AuditLogV2ConnectionGQL,
     AuditLogV2EdgeGQL,
     AuditLogV2GQL,
@@ -62,3 +67,38 @@ async def admin_audit_logs_v2(
         ),
         count=result.total_count,
     )
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Query audit logs within a scope target (non-admin accessible, subject to RBAC). "
+            "All scope items are OR'd; raises an error if every field is empty."
+        ),
+    )
+)  # type: ignore[misc]
+async def scoped_audit_logs_v2(
+    info: Info[StrawberryGQLContext],
+    scope_target: AuditLogScopeGQL,
+    filter: AuditLogFilterGQL | None = None,
+    order_by: list[AuditLogOrderByGQL] | None = None,
+    before: str | None = None,
+    after: str | None = None,
+    first: int | None = None,
+    last: int | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> AuditLogV2ConnectionGQL | None:
+    ScopedSearchAuditLogsInput(
+        scope_target=scope_target.to_pydantic(),
+        filter=filter.to_pydantic() if filter else None,
+        order=[o.to_pydantic() for o in order_by] if order_by else None,
+        first=first,
+        after=after,
+        last=last,
+        before=before,
+        limit=limit,
+        offset=offset,
+    )
+    raise NotImplementedError("scoped_audit_logs_v2 resolver body lands in BA-6097")

--- a/src/ai/backend/manager/api/gql/audit_log/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/audit_log/types/__init__.py
@@ -8,9 +8,11 @@ from .node import (
     AuditLogV2GQL,
 )
 from .order import AuditLogOrderByGQL, AuditLogOrderFieldGQL
+from .scope import AuditLogScopeGQL
 
 __all__ = [
     "AuditLogFilterGQL",
+    "AuditLogScopeGQL",
     "AuditLogStatusFilterGQL",
     "AuditLogOrderByGQL",
     "AuditLogOrderFieldGQL",

--- a/src/ai/backend/manager/api/gql/audit_log/types/filter.py
+++ b/src/ai/backend/manager/api/gql/audit_log/types/filter.py
@@ -42,6 +42,7 @@ class AuditLogStatusFilterGQL(PydanticInputMixin[AuditLogStatusFilter]):
 )
 class AuditLogFilterGQL(PydanticInputMixin[AuditLogFilter]):
     entity_type: StringFilter | None = None
+    entity_id: StringFilter | None = None
     operation: StringFilter | None = None
     status: AuditLogStatusFilterGQL | None = None
     created_at: DateTimeFilter | None = None

--- a/src/ai/backend/manager/api/gql/audit_log/types/scope.py
+++ b/src/ai/backend/manager/api/gql/audit_log/types/scope.py
@@ -16,7 +16,7 @@ from ai.backend.manager.api.gql.rbac.types.scope import EntityTypeScopeGQL, UUID
 @gql_pydantic_input(
     BackendAIGQLMeta(
         description=(
-            "Scope target for the scoped audit log query. "
+            "Scope for the scoped audit log query. "
             "All items are OR'd; raises an error if every field is empty."
         ),
         added_version=NEXT_RELEASE_VERSION,

--- a/src/ai/backend/manager/api/gql/audit_log/types/scope.py
+++ b/src/ai/backend/manager/api/gql/audit_log/types/scope.py
@@ -1,0 +1,36 @@
+"""AuditLog GraphQL scope input types."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from ai.backend.common.dto.manager.v2.audit_log.request import AuditLogScope
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_input,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
+from ai.backend.manager.api.gql.rbac.types.scope import EntityTypeScopeGQL
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description=(
+            "Scope target for the scoped audit log query. "
+            "All items are OR'd; raises an error if every field is empty."
+        ),
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="AuditLogScope",
+)
+class AuditLogScopeGQL(PydanticInputMixin[AuditLogScope]):
+    entity: list[EntityTypeScopeGQL] | None = gql_field(
+        description="Entity-tagged scope items.",
+        default=None,
+    )
+    triggered_user: list[UUID] | None = gql_field(
+        description="Actor UUIDs (matches audit_logs.triggered_by).",
+        default=None,
+    )

--- a/src/ai/backend/manager/api/gql/audit_log/types/scope.py
+++ b/src/ai/backend/manager/api/gql/audit_log/types/scope.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from uuid import UUID
-
 from ai.backend.common.dto.manager.v2.audit_log.request import AuditLogScope
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
@@ -12,7 +10,7 @@ from ai.backend.manager.api.gql.decorators import (
     gql_pydantic_input,
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
-from ai.backend.manager.api.gql.rbac.types.scope import EntityTypeScopeGQL
+from ai.backend.manager.api.gql.rbac.types.scope import EntityTypeScopeGQL, UUIDScopeGQL
 
 
 @gql_pydantic_input(
@@ -30,7 +28,7 @@ class AuditLogScopeGQL(PydanticInputMixin[AuditLogScope]):
         description="Entity-tagged scope items.",
         default=None,
     )
-    triggered_user: list[UUID] | None = gql_field(
+    triggered_user: list[UUIDScopeGQL] | None = gql_field(
         description="Actor UUIDs (matches audit_logs.triggered_by).",
         default=None,
     )

--- a/src/ai/backend/manager/api/gql/rbac/types/scope.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/scope.py
@@ -7,10 +7,13 @@ Both permission.py and role.py can safely import from this module.
 
 from __future__ import annotations
 
+from uuid import UUID
+
 from ai.backend.common.dto.manager.v2.rbac.types import (
     EntityTypeScope,
     RBACElementTypeDTO,
     ScopeInputDTO,
+    UUIDScope,
 )
 from ai.backend.common.dto.manager.v2.rbac.types import (
     RBACElementTypeFilter as RBACElementTypeFilterDTO,
@@ -30,6 +33,7 @@ __all__ = (
     "RBACElementTypeFilterGQL",
     "RBACElementTypeGQL",
     "ScopeInputGQL",
+    "UUIDScopeGQL",
 )
 
 # ==================== Enums ====================
@@ -71,6 +75,19 @@ class EntityTypeScopeGQL(PydanticInputMixin[EntityTypeScope]):
     )
     entity_id: str = gql_field(
         description="ID of the entity.",
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Single-UUID scope item wrapper.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="UUIDScope",
+)
+class UUIDScopeGQL(PydanticInputMixin[UUIDScope]):
+    value: UUID = gql_field(
+        description="UUID value.",
     )
 
 

--- a/src/ai/backend/manager/api/gql/rbac/types/scope.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/scope.py
@@ -8,6 +8,7 @@ Both permission.py and role.py can safely import from this module.
 from __future__ import annotations
 
 from ai.backend.common.dto.manager.v2.rbac.types import (
+    EntityTypeScope,
     RBACElementTypeDTO,
     ScopeInputDTO,
 )
@@ -21,6 +22,14 @@ from ai.backend.manager.api.gql.decorators import (
     gql_enum,
     gql_field,
     gql_pydantic_input,
+)
+
+# Re-export for stable import paths in audit_log scope
+__all__ = (
+    "EntityTypeScopeGQL",
+    "RBACElementTypeFilterGQL",
+    "RBACElementTypeGQL",
+    "ScopeInputGQL",
 )
 
 # ==================== Enums ====================
@@ -47,6 +56,22 @@ RBACElementTypeGQL: type[RBACElementTypeDTO] = gql_enum(
 class ScopeInputGQL(PydanticInputMixin[ScopeInputDTO]):
     scope_type: RBACElementTypeGQL
     scope_id: str
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Entity reference parametrized by RBAC element type.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="EntityTypeScope",
+)
+class EntityTypeScopeGQL(PydanticInputMixin[EntityTypeScope]):
+    entity_type: RBACElementTypeGQL = gql_field(
+        description="RBAC element type of the entity.",
+    )
+    entity_id: str = gql_field(
+        description="ID of the entity.",
+    )
 
 
 @gql_pydantic_input(

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -48,7 +48,7 @@ from .artifact import (
     update_artifact,
 )
 from .artifact_registry import default_artifact_registry
-from .audit_log import admin_audit_logs_v2
+from .audit_log import admin_audit_logs_v2, scoped_audit_logs_v2
 from .background_task import background_task_events
 from .container_registry import (
     admin_container_registries_v2,
@@ -514,6 +514,7 @@ class Query:
     admin_images_v2 = admin_images_v2
     admin_kernels_v2 = admin_kernels_v2
     admin_audit_logs_v2 = admin_audit_logs_v2
+    scoped_audit_logs_v2 = scoped_audit_logs_v2
     admin_container_registries_v2 = admin_container_registries_v2
     admin_login_sessions_v2 = admin_login_sessions_v2
     admin_login_history_v2 = admin_login_history_v2


### PR DESCRIPTION
## Summary
- Add `scopedAuditLogsV2` root field with a stub resolver that validates the scope target (via Pydantic) and then raises `NotImplementedError`.
- Add `AuditLogScope` input with category-separated lists (`entity`, `triggeredUser`); leaves are OR'd and the combined set must be non-empty (Pydantic `model_validator`).
- Add `EntityTypeScope` as a shared `(RBACElementType, id)` primitive under `common/dto/manager/v2/rbac` and `api/gql/rbac` so it can be reused outside audit log contexts.

## Test plan
- [x] `pants check` / `pants lint` pass on changed files
- [x] GraphQL introspection exposes `scopedAuditLogsV2`, `AuditLogScope`, `EntityTypeScope`

Resolves BA-6095

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11694.org.readthedocs.build/en/11694/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11694.org.readthedocs.build/ko/11694/

<!-- readthedocs-preview sorna-ko end -->