### PR TITLE
feat(BA-6100): generalize bulk action to mixed RBAC element types

### DIFF
--- a/changes/11695.feature.md
+++ b/changes/11695.feature.md
@@ -1,0 +1,1 @@
+Generalize `BaseBulkAction` to carry `list[RBACElementRef]` so bulk actions can mix RBAC element types in a single bulk permission check; any denial across the validator chain aggregates and raises `PermissionDeniedError` with per-entity reasons.

--- a/src/ai/backend/manager/actions/action/__init__.py
+++ b/src/ai/backend/manager/actions/action/__init__.py
@@ -11,6 +11,8 @@ from .base import (
 from .bulk import (
     BaseBulkAction,
     BaseBulkActionResult,
+    BulkActionTarget,
+    SearchableBulkActionTarget,
 )
 from .rbac import (
     BaseRBACAction,
@@ -125,6 +127,8 @@ __all__ = (
     "BaseActionTriggerMeta",
     "BaseBulkAction",
     "BaseBulkActionResult",
+    "BulkActionTarget",
+    "SearchableBulkActionTarget",
     "BaseRBACAction",
     "RBACActionName",
     "RBACRequiredPermission",

--- a/src/ai/backend/manager/actions/action/__init__.py
+++ b/src/ai/backend/manager/actions/action/__init__.py
@@ -11,8 +11,6 @@ from .base import (
 from .bulk import (
     BaseBulkAction,
     BaseBulkActionResult,
-    BulkActionTarget,
-    SearchableBulkActionTarget,
 )
 from .rbac import (
     BaseRBACAction,
@@ -74,6 +72,10 @@ from .rbac_vfolder import (
     VFolderSoftDeleteRBACAction,
     VFolderUpdateRBACAction,
 )
+from .types import (
+    ActionTarget,
+    SearchableActionTarget,
+)
 
 RBAC_ACTION_REGISTRY: tuple[type[BaseRBACAction], ...] = (
     ModelDeploymentCreateRBACAction,
@@ -127,8 +129,8 @@ __all__ = (
     "BaseActionTriggerMeta",
     "BaseBulkAction",
     "BaseBulkActionResult",
-    "BulkActionTarget",
-    "SearchableBulkActionTarget",
+    "ActionTarget",
+    "SearchableActionTarget",
     "BaseRBACAction",
     "RBACActionName",
     "RBACRequiredPermission",

--- a/src/ai/backend/manager/actions/action/bulk.py
+++ b/src/ai/backend/manager/actions/action/bulk.py
@@ -1,30 +1,18 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from collections.abc import Sequence
 from typing import override
 
 from ai.backend.manager.data.permission.types import RBACElementRef
-from ai.backend.manager.repositories.base.types import SearchScope
 
 from .base import BaseAction, BaseActionResult
+from .types import ActionTarget
 
 
-class BulkActionTarget(ABC):
-    @abstractmethod
-    def to_rbac_element_ref(self) -> RBACElementRef:
-        raise NotImplementedError
-
-
-class SearchableBulkActionTarget(BulkActionTarget):
-    @abstractmethod
-    def to_search_scope(self) -> SearchScope:
-        raise NotImplementedError
-
-
-class BaseBulkAction[TTarget: BulkActionTarget](BaseAction):
-    """Bulk action over a sequence of :class:`BulkActionTarget`.
+class BaseBulkAction[TTarget: ActionTarget](BaseAction):
+    """Bulk action over a sequence of :class:`ActionTarget`.
 
     Parametrize the target type to require a richer contract — e.g.
-    ``BaseBulkAction[SearchableBulkActionTarget]`` for a scoped search.
+    ``BaseBulkAction[SearchableActionTarget]`` for a scoped search.
     """
 
     @abstractmethod

--- a/src/ai/backend/manager/actions/action/bulk.py
+++ b/src/ai/backend/manager/actions/action/bulk.py
@@ -1,20 +1,34 @@
-from abc import abstractmethod
-from typing import TypeVar, override
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from typing import override
 
 from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.repositories.base.types import SearchScope
 
 from .base import BaseAction, BaseActionResult
 
 
-class BaseBulkAction(BaseAction):
-    """Bulk action over a list of ``RBACElementRef`` (may mix element types).
+class BulkActionTarget(ABC):
+    @abstractmethod
+    def to_rbac_element_ref(self) -> RBACElementRef:
+        raise NotImplementedError
 
-    For example, a scoped audit-log search may pass refs of different
-    types — ``[(PROJECT, p1), (DOMAIN, default)]``.
+
+class SearchableBulkActionTarget(BulkActionTarget):
+    @abstractmethod
+    def to_search_scope(self) -> SearchScope:
+        raise NotImplementedError
+
+
+class BaseBulkAction[TTarget: BulkActionTarget](BaseAction):
+    """Bulk action over a sequence of :class:`BulkActionTarget`.
+
+    Parametrize the target type to require a richer contract — e.g.
+    ``BaseBulkAction[SearchableBulkActionTarget]`` for a scoped search.
     """
 
     @abstractmethod
-    def element_refs(self) -> list[RBACElementRef]:
+    def targets(self) -> Sequence[TTarget]:
         raise NotImplementedError
 
 
@@ -26,7 +40,3 @@ class BaseBulkActionResult(BaseActionResult):
     @abstractmethod
     def element_refs(self) -> list[RBACElementRef]:
         raise NotImplementedError
-
-
-TBulkAction = TypeVar("TBulkAction", bound=BaseBulkAction)
-TBulkActionResult = TypeVar("TBulkActionResult", bound=BaseBulkActionResult)

--- a/src/ai/backend/manager/actions/action/bulk.py
+++ b/src/ai/backend/manager/actions/action/bulk.py
@@ -1,33 +1,17 @@
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Any, TypeVar, override
+from typing import TypeVar, override
+
+from ai.backend.manager.data.permission.types import RBACElementRef
 
 from .base import BaseAction, BaseActionResult
 
 
 @dataclass
-class BaseBulkAction[T](BaseAction):
-    """Base class for actions operating on a bulk of entities.
+class BaseBulkAction(BaseAction):
+    """Bulk action over a list of ``RBACElementRef`` (may mix element types)."""
 
-    ``entity_ids`` is stored as ``list[str]`` so ``BulkActionValidator``
-    implementations can match against validator verdicts directly. The
-    original ``T``-typed view is exposed via ``typed_entity_ids()``.
-
-    Bulk actions intentionally carry **only** ``entity_ids``. User context
-    (user id, role) flows through ``current_user()``, not the action, so
-    ``BulkActionProcessor`` can reconstruct a filtered action by calling
-    ``type(action)(entity_ids=...)`` directly — no ``__init__`` override or
-    factory hook is required. Subclasses that try to add required fields
-    break that constructor call and will fail fast at runtime, which is
-    intentional.
-    """
-
-    entity_ids: list[str]
-
-    @abstractmethod
-    def typed_entity_ids(self) -> list[T]:
-        """Return ``entity_ids`` converted back to the native ID type ``T``."""
-        raise NotImplementedError
+    element_refs: list[RBACElementRef]
 
 
 class BaseBulkActionResult(BaseActionResult):
@@ -36,9 +20,9 @@ class BaseBulkActionResult(BaseActionResult):
         return None
 
     @abstractmethod
-    def entity_ids(self) -> list[str]:
+    def element_refs(self) -> list[RBACElementRef]:
         raise NotImplementedError
 
 
-TBulkAction = TypeVar("TBulkAction", bound=BaseBulkAction[Any])
+TBulkAction = TypeVar("TBulkAction", bound=BaseBulkAction)
 TBulkActionResult = TypeVar("TBulkActionResult", bound=BaseBulkActionResult)

--- a/src/ai/backend/manager/actions/action/bulk.py
+++ b/src/ai/backend/manager/actions/action/bulk.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod
-from dataclasses import dataclass
 from typing import TypeVar, override
 
 from ai.backend.manager.data.permission.types import RBACElementRef
@@ -7,7 +6,6 @@ from ai.backend.manager.data.permission.types import RBACElementRef
 from .base import BaseAction, BaseActionResult
 
 
-@dataclass
 class BaseBulkAction(BaseAction):
     """Bulk action over a list of ``RBACElementRef`` (may mix element types).
 
@@ -15,7 +13,9 @@ class BaseBulkAction(BaseAction):
     types — ``[(PROJECT, p1), (DOMAIN, default)]``.
     """
 
-    element_refs: list[RBACElementRef]
+    @abstractmethod
+    def element_refs(self) -> list[RBACElementRef]:
+        raise NotImplementedError
 
 
 class BaseBulkActionResult(BaseActionResult):

--- a/src/ai/backend/manager/actions/action/bulk.py
+++ b/src/ai/backend/manager/actions/action/bulk.py
@@ -9,7 +9,11 @@ from .base import BaseAction, BaseActionResult
 
 @dataclass
 class BaseBulkAction(BaseAction):
-    """Bulk action over a list of ``RBACElementRef`` (may mix element types)."""
+    """Bulk action over a list of ``RBACElementRef`` (may mix element types).
+
+    For example, a scoped audit-log search may pass refs of different
+    types — ``[(PROJECT, p1), (DOMAIN, default)]``.
+    """
 
     element_refs: list[RBACElementRef]
 

--- a/src/ai/backend/manager/actions/action/types.py
+++ b/src/ai/backend/manager/actions/action/types.py
@@ -1,6 +1,9 @@
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 from ai.backend.common.data.permission.types import EntityType
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.repositories.base.types import SearchScope
 
 
 @dataclass
@@ -13,3 +16,15 @@ class FieldData:
 class BatchFieldData:
     field_type: EntityType
     field_ids: list[str]
+
+
+class ActionTarget(ABC):
+    @abstractmethod
+    def to_rbac_element_ref(self) -> RBACElementRef:
+        raise NotImplementedError
+
+
+class SearchableActionTarget(ActionTarget):
+    @abstractmethod
+    def to_search_scope(self) -> SearchScope:
+        raise NotImplementedError

--- a/src/ai/backend/manager/actions/processor/bulk.py
+++ b/src/ai/backend/manager/actions/processor/bulk.py
@@ -3,8 +3,8 @@ import uuid
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any
 
+from ai.backend.common.exception import PermissionDeniedError
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.actions.action import (
     BaseActionTriggerMeta,
@@ -17,21 +17,23 @@ from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.validator.bulk import (
     BulkActionValidator,
     BulkValidationResult,
+    DeniedEntity,
 )
 
 from .base import ActionRunner
+
+__all__ = (
+    "BulkActionProcessor",
+    "BulkProcessResult",
+    "ValidatorDecision",
+)
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @dataclass(frozen=True)
 class ValidatorDecision:
-    """One validator's per-entity verdict observed during bulk processing.
-
-    Mirrors the ``SubStepResult`` pattern used by the scheduler history so
-    callers can trace where in the validator chain each ID was filtered and
-    *why*. ``results`` carries the validator's classification unchanged.
-    """
+    """One validator's per-element verdict observed during bulk processing."""
 
     validator_name: str
     results: BulkValidationResult
@@ -39,20 +41,14 @@ class ValidatorDecision:
 
 @dataclass(frozen=True)
 class BulkProcessResult[TBulkActionResult: BaseBulkActionResult]:
-    """Outcome of a ``BulkActionProcessor`` run.
-
-    ``result`` is what the service function returned for the permitted subset
-    of entity IDs. ``validator_decisions`` keeps the per-validator trace in
-    iteration order; callers assemble the partial-success response by
-    walking it (each decision carries the denied IDs and their reasons).
-    """
+    """Outcome of a ``BulkActionProcessor`` run."""
 
     result: TBulkActionResult
     validator_decisions: list[ValidatorDecision]
 
 
 class BulkActionProcessor[
-    TBulkAction: BaseBulkAction[Any],
+    TBulkAction: BaseBulkAction,
     TBulkActionResult: BaseBulkActionResult,
 ]:
     _validators: Sequence[BulkActionValidator]
@@ -69,43 +65,32 @@ class BulkActionProcessor[
 
         self._validators = validators or []
 
-    def _filter_by_validation(
-        self,
-        action: TBulkAction,
-        validation: BulkValidationResult,
-    ) -> TBulkAction:
-        """Return a new action narrowed to the IDs this validator permitted.
-
-        Returns the incoming action unchanged when the validator denied
-        nothing; otherwise constructs a fresh instance of the same class
-        via its ``entity_ids``-only constructor so the original stays
-        immutable.
-        """
-        if not validation.denied_entities:
-            return action
-        allowed_set = set(validation.allowed_entity_ids)
-        filtered_ids = [eid for eid in action.entity_ids if eid in allowed_set]
-        return type(action)(entity_ids=filtered_ids)
-
     async def _run(self, action: TBulkAction) -> BulkProcessResult[TBulkActionResult]:
         started_at = datetime.now(UTC)
         action_id = uuid.uuid4()
         action_trigger_meta = BaseActionTriggerMeta(action_id=action_id, started_at=started_at)
 
-        filtered_action: TBulkAction = action
         decisions: list[ValidatorDecision] = []
+        denied_entities: list[DeniedEntity] = []
 
         for validator in self._validators:
-            validation = await validator.validate(filtered_action, action_trigger_meta)
+            validation = await validator.validate(action, action_trigger_meta)
             decisions.append(
                 ValidatorDecision(
                     validator_name=validator.name(),
                     results=validation,
                 )
             )
-            filtered_action = self._filter_by_validation(filtered_action, validation)
+            if validation.denied_entities:
+                denied_entities.extend(validation.denied_entities)
 
-        action_result = await self._runner.run(filtered_action, action_trigger_meta)
+        if denied_entities:
+            err_msg = f"Bulk action denied for {len(denied_entities)} entity(ies): " + ", ".join(
+                f"{d.entity_ref.to_str()} ({d.deny_reason})" for d in denied_entities
+            )
+            raise PermissionDeniedError(err_msg)
+
+        action_result = await self._runner.run(action, action_trigger_meta)
         return BulkProcessResult(result=action_result, validator_decisions=decisions)
 
     async def wait_for_complete(self, action: TBulkAction) -> BulkProcessResult[TBulkActionResult]:

--- a/src/ai/backend/manager/actions/processor/bulk.py
+++ b/src/ai/backend/manager/actions/processor/bulk.py
@@ -1,10 +1,8 @@
-import logging
 import uuid
 from collections.abc import Awaitable, Callable, Sequence
 from datetime import UTC, datetime
 
 from ai.backend.common.exception import PermissionDeniedError
-from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.actions.action import (
     BaseActionTriggerMeta,
 )
@@ -21,8 +19,6 @@ from ai.backend.manager.actions.validator.bulk import (
 from .base import ActionRunner
 
 __all__ = ("BulkActionProcessor",)
-
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class BulkActionProcessor[

--- a/src/ai/backend/manager/actions/processor/bulk.py
+++ b/src/ai/backend/manager/actions/processor/bulk.py
@@ -1,7 +1,6 @@
 import logging
 import uuid
 from collections.abc import Awaitable, Callable, Sequence
-from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from ai.backend.common.exception import PermissionDeniedError
@@ -16,35 +15,14 @@ from ai.backend.manager.actions.action.bulk import (
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.validator.bulk import (
     BulkActionValidator,
-    BulkValidationResult,
     DeniedEntity,
 )
 
 from .base import ActionRunner
 
-__all__ = (
-    "BulkActionProcessor",
-    "BulkProcessResult",
-    "ValidatorDecision",
-)
+__all__ = ("BulkActionProcessor",)
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
-
-
-@dataclass(frozen=True)
-class ValidatorDecision:
-    """One validator's per-element verdict observed during bulk processing."""
-
-    validator_name: str
-    results: BulkValidationResult
-
-
-@dataclass(frozen=True)
-class BulkProcessResult[TBulkActionResult: BaseBulkActionResult]:
-    """Outcome of a ``BulkActionProcessor`` run."""
-
-    result: TBulkActionResult
-    validator_decisions: list[ValidatorDecision]
 
 
 class BulkActionProcessor[
@@ -65,22 +43,14 @@ class BulkActionProcessor[
 
         self._validators = validators or []
 
-    async def _run(self, action: TBulkAction) -> BulkProcessResult[TBulkActionResult]:
+    async def _run(self, action: TBulkAction) -> TBulkActionResult:
         started_at = datetime.now(UTC)
         action_id = uuid.uuid4()
         action_trigger_meta = BaseActionTriggerMeta(action_id=action_id, started_at=started_at)
 
-        decisions: list[ValidatorDecision] = []
         denied_entities: list[DeniedEntity] = []
-
         for validator in self._validators:
             validation = await validator.validate(action, action_trigger_meta)
-            decisions.append(
-                ValidatorDecision(
-                    validator_name=validator.name(),
-                    results=validation,
-                )
-            )
             if validation.denied_entities:
                 denied_entities.extend(validation.denied_entities)
 
@@ -90,8 +60,7 @@ class BulkActionProcessor[
             )
             raise PermissionDeniedError(err_msg)
 
-        action_result = await self._runner.run(action, action_trigger_meta)
-        return BulkProcessResult(result=action_result, validator_decisions=decisions)
+        return await self._runner.run(action, action_trigger_meta)
 
-    async def wait_for_complete(self, action: TBulkAction) -> BulkProcessResult[TBulkActionResult]:
+    async def wait_for_complete(self, action: TBulkAction) -> TBulkActionResult:
         return await self._run(action)

--- a/src/ai/backend/manager/actions/processor/bulk.py
+++ b/src/ai/backend/manager/actions/processor/bulk.py
@@ -1,6 +1,7 @@
 import uuid
 from collections.abc import Awaitable, Callable, Sequence
 from datetime import UTC, datetime
+from typing import Any
 
 from ai.backend.common.exception import PermissionDeniedError
 from ai.backend.manager.actions.action import (
@@ -22,7 +23,7 @@ __all__ = ("BulkActionProcessor",)
 
 
 class BulkActionProcessor[
-    TBulkAction: BaseBulkAction,
+    TBulkAction: BaseBulkAction[Any],
     TBulkActionResult: BaseBulkActionResult,
 ]:
     _validators: Sequence[BulkActionValidator]

--- a/src/ai/backend/manager/actions/validator/bulk.py
+++ b/src/ai/backend/manager/actions/validator/bulk.py
@@ -1,30 +1,24 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any
 
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.action.bulk import BaseBulkAction
+from ai.backend.manager.data.permission.types import RBACElementRef
 
 
 @dataclass(frozen=True)
 class DeniedEntity:
     """A bulk entity that a validator rejected, paired with its reason."""
 
-    entity_id: str
+    entity_ref: RBACElementRef
     deny_reason: str
 
 
 @dataclass(frozen=True)
 class BulkValidationResult:
-    """Per-entity validation outcome for a bulk action.
+    """Per-entity validation outcome for a bulk action."""
 
-    ``BulkActionProcessor`` intersects ``allowed_entity_ids`` across
-    validators and records each ``DeniedEntity`` — with its reason — on the
-    corresponding ``ValidatorDecision`` so the final response can
-    surface *why* each ID was filtered out.
-    """
-
-    allowed_entity_ids: list[str]
+    allowed_entities: list[RBACElementRef]
     denied_entities: list[DeniedEntity]
 
 
@@ -32,26 +26,12 @@ class BulkActionValidator(ABC):
     @classmethod
     @abstractmethod
     def name(cls) -> str:
-        """Stable identifier used in ``ValidatorDecision.validator_name``.
-
-        Chosen by the implementation so logs and partial-success responses can
-        attribute denials to a specific validator independently of the Python
-        class name.
-        """
+        """Stable identifier for ``ValidatorDecision.validator_name``."""
         raise NotImplementedError
 
     @abstractmethod
     async def validate(
-        self, action: BaseBulkAction[Any], meta: BaseActionTriggerMeta
+        self, action: BaseBulkAction, meta: BaseActionTriggerMeta
     ) -> BulkValidationResult:
-        """Validate the bulk action and return per-entity permission results.
-
-        Implementations must classify every ID in ``action.entity_ids`` as
-        either allowed or denied. Validators that cannot make a decision for
-        an ID should treat it as allowed.
-
-        The processor wraps each call in its own async context manager so
-        cross-cutting concerns (timing, audit) live in one place — validators
-        do not need to own them.
-        """
+        """Classify each ref in ``action.element_refs`` as allowed or denied."""
         raise NotImplementedError

--- a/src/ai/backend/manager/actions/validator/bulk.py
+++ b/src/ai/backend/manager/actions/validator/bulk.py
@@ -33,5 +33,5 @@ class BulkActionValidator(ABC):
     async def validate(
         self, action: BaseBulkAction, meta: BaseActionTriggerMeta
     ) -> BulkValidationResult:
-        """Classify each ref in ``action.element_refs`` as allowed or denied."""
+        """Classify each ref in ``action.element_refs()`` as allowed or denied."""
         raise NotImplementedError

--- a/src/ai/backend/manager/actions/validator/bulk.py
+++ b/src/ai/backend/manager/actions/validator/bulk.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import Any
 
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.action.bulk import BaseBulkAction
@@ -31,7 +32,7 @@ class BulkActionValidator(ABC):
 
     @abstractmethod
     async def validate(
-        self, action: BaseBulkAction, meta: BaseActionTriggerMeta
+        self, action: BaseBulkAction[Any], meta: BaseActionTriggerMeta
     ) -> BulkValidationResult:
-        """Classify each ref in ``action.element_refs()`` as allowed or denied."""
+        """Classify each target in ``action.targets()`` as allowed or denied."""
         raise NotImplementedError

--- a/src/ai/backend/manager/actions/validators/rbac/bulk.py
+++ b/src/ai/backend/manager/actions/validators/rbac/bulk.py
@@ -1,4 +1,4 @@
-from typing import Any, override
+from typing import override
 
 from ai.backend.common.contexts.user import current_user
 from ai.backend.common.exception import UnreachableError
@@ -14,6 +14,7 @@ from ai.backend.manager.data.permission.role import (
     BulkPermissionCheckInput,
     PermissionResolutionKey,
 )
+from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.repositories.permission_controller.repository import (
     PermissionControllerRepository,
 )
@@ -22,6 +23,8 @@ _DENY_REASON = "permission_denied"
 
 
 class BulkActionRBACValidator(BulkActionValidator):
+    """RBAC validator for bulk actions; one bulk check across mixed element types."""
+
     def __init__(
         self,
         repository: PermissionControllerRepository,
@@ -37,12 +40,12 @@ class BulkActionRBACValidator(BulkActionValidator):
 
     @override
     async def validate(
-        self, action: BaseBulkAction[Any], meta: BaseActionTriggerMeta
+        self, action: BaseBulkAction, meta: BaseActionTriggerMeta
     ) -> BulkValidationResult:
-        entity_ids = list(action.entity_ids)
+        element_refs = list(action.element_refs)
         if not self._config_provider.config.manager.rbac.enforcement_enabled:
             return BulkValidationResult(
-                allowed_entity_ids=entity_ids,
+                allowed_entities=element_refs,
                 denied_entities=[],
             )
 
@@ -51,35 +54,36 @@ class BulkActionRBACValidator(BulkActionValidator):
             raise UnreachableError("User context is not available")
         if user.is_superadmin:
             return BulkValidationResult(
-                allowed_entity_ids=entity_ids,
+                allowed_entities=element_refs,
                 denied_entities=[],
             )
-        element_type = action.entity_type().to_element()
+
         keys = [
             PermissionResolutionKey(
                 user_id=user.user_id,
-                element_type=element_type,
-                entity_id=eid,
-                subject_entity_type=element_type,
+                element_type=ref.element_type,
+                entity_id=ref.element_id,
+                subject_entity_type=ref.element_type,
             )
-            for eid in entity_ids
+            for ref in element_refs
         ]
+
         permission_map = await self._repository.check_bulk_permission_with_scope_chain(
             BulkPermissionCheckInput(
                 keys=keys,
                 operation=action.operation_type().to_permission_operation(),
             )
         )
-        allowed_entity_ids: list[str] = []
+
+        allowed_entities: list[RBACElementRef] = []
         denied_entities: list[DeniedEntity] = []
         for key in keys:
+            ref = RBACElementRef(element_type=key.element_type, element_id=key.entity_id)
             if permission_map.get(key, False):
-                allowed_entity_ids.append(key.entity_id)
+                allowed_entities.append(ref)
             else:
-                denied_entities.append(
-                    DeniedEntity(entity_id=key.entity_id, deny_reason=_DENY_REASON)
-                )
+                denied_entities.append(DeniedEntity(entity_ref=ref, deny_reason=_DENY_REASON))
         return BulkValidationResult(
-            allowed_entity_ids=allowed_entity_ids,
+            allowed_entities=allowed_entities,
             denied_entities=denied_entities,
         )

--- a/src/ai/backend/manager/actions/validators/rbac/bulk.py
+++ b/src/ai/backend/manager/actions/validators/rbac/bulk.py
@@ -1,4 +1,4 @@
-from typing import override
+from typing import Any, override
 
 from ai.backend.common.contexts.user import current_user
 from ai.backend.common.exception import UnreachableError
@@ -40,9 +40,9 @@ class BulkActionRBACValidator(BulkActionValidator):
 
     @override
     async def validate(
-        self, action: BaseBulkAction, meta: BaseActionTriggerMeta
+        self, action: BaseBulkAction[Any], meta: BaseActionTriggerMeta
     ) -> BulkValidationResult:
-        element_refs = list(action.element_refs())
+        element_refs = [t.to_rbac_element_ref() for t in action.targets()]
         if not self._config_provider.config.manager.rbac.enforcement_enabled:
             return BulkValidationResult(
                 allowed_entities=element_refs,

--- a/src/ai/backend/manager/actions/validators/rbac/bulk.py
+++ b/src/ai/backend/manager/actions/validators/rbac/bulk.py
@@ -42,7 +42,7 @@ class BulkActionRBACValidator(BulkActionValidator):
     async def validate(
         self, action: BaseBulkAction, meta: BaseActionTriggerMeta
     ) -> BulkValidationResult:
-        element_refs = list(action.element_refs)
+        element_refs = list(action.element_refs())
         if not self._config_provider.config.manager.rbac.enforcement_enabled:
             return BulkValidationResult(
                 allowed_entities=element_refs,

--- a/tests/unit/manager/actions/test_bulk_processor.py
+++ b/tests/unit/manager/actions/test_bulk_processor.py
@@ -28,13 +28,19 @@ from ai.backend.manager.actions.validator.bulk import (
 from ai.backend.manager.data.permission.types import RBACElementRef
 
 
-def _ref(element_type: RBACElementType, element_id: str) -> RBACElementRef:
-    return RBACElementRef(element_type=element_type, element_id=element_id)
+@pytest.fixture
+def ref_a() -> RBACElementRef:
+    return RBACElementRef(element_type=RBACElementType.SESSION, element_id="a")
 
 
-_REF_A = _ref(RBACElementType.SESSION, "a")
-_REF_B = _ref(RBACElementType.SESSION, "b")
-_REF_C = _ref(RBACElementType.SESSION, "c")
+@pytest.fixture
+def ref_b() -> RBACElementRef:
+    return RBACElementRef(element_type=RBACElementType.SESSION, element_id="b")
+
+
+@pytest.fixture
+def ref_c() -> RBACElementRef:
+    return RBACElementRef(element_type=RBACElementType.SESSION, element_id="c")
 
 
 @dataclass
@@ -119,92 +125,94 @@ def _echo_func() -> Callable[[_MockBulkAction], Awaitable[_MockBulkActionResult]
 
 
 class TestBulkActionProcessor:
-    async def test_no_validators_passes_all_refs_through(self) -> None:
+    async def test_no_validators_passes_all_refs_through(
+        self,
+        ref_a: RBACElementRef,
+        ref_b: RBACElementRef,
+        ref_c: RBACElementRef,
+    ) -> None:
         processor = BulkActionProcessor[_MockBulkAction, _MockBulkActionResult](
             func=_echo_func(),
         )
-        action = _MockBulkAction(element_refs=[_REF_A, _REF_B, _REF_C])
+        action = _MockBulkAction(element_refs=[ref_a, ref_b, ref_c])
 
         result = await processor.wait_for_complete(action)
 
-        assert result.processed_refs == [_REF_A, _REF_B, _REF_C]
+        assert result.processed_refs == [ref_a, ref_b, ref_c]
 
-    async def test_all_allowed_runs_action_normally(self) -> None:
+    async def test_all_allowed_runs_action_normally(
+        self,
+        ref_a: RBACElementRef,
+        ref_b: RBACElementRef,
+        ref_c: RBACElementRef,
+    ) -> None:
         processor = BulkActionProcessor[_MockBulkAction, _MockBulkActionResult](
             func=_echo_func(),
-            validators=[_AllowSetValidator(allowed={_REF_A, _REF_B, _REF_C})],
+            validators=[_AllowSetValidator(allowed={ref_a, ref_b, ref_c})],
         )
-        action = _MockBulkAction(element_refs=[_REF_A, _REF_B, _REF_C])
+        action = _MockBulkAction(element_refs=[ref_a, ref_b, ref_c])
 
         result = await processor.wait_for_complete(action)
 
-        assert result.processed_refs == [_REF_A, _REF_B, _REF_C]
+        assert result.processed_refs == [ref_a, ref_b, ref_c]
 
-    async def test_single_validator_partial_denial_raises(self) -> None:
+    async def test_single_validator_partial_denial_raises(
+        self,
+        ref_a: RBACElementRef,
+        ref_b: RBACElementRef,
+        ref_c: RBACElementRef,
+    ) -> None:
         processor = BulkActionProcessor[_MockBulkAction, _MockBulkActionResult](
             func=_echo_func(),
-            validators=[_AllowSetValidator(allowed={_REF_A, _REF_C})],
+            validators=[_AllowSetValidator(allowed={ref_a, ref_c})],
         )
-        action = _MockBulkAction(element_refs=[_REF_A, _REF_B, _REF_C])
+        action = _MockBulkAction(element_refs=[ref_a, ref_b, ref_c])
 
         with pytest.raises(PermissionDeniedError) as exc_info:
             await processor.wait_for_complete(action)
 
         msg = str(exc_info.value)
-        assert _REF_B.to_str() in msg
+        assert ref_b.to_str() in msg
         assert "not in allow-set" in msg
 
-    async def test_full_chain_runs_before_raising(self) -> None:
+    async def test_full_chain_runs_before_raising(
+        self,
+        ref_a: RBACElementRef,
+        ref_b: RBACElementRef,
+        ref_c: RBACElementRef,
+    ) -> None:
         """Every validator runs even when an earlier one denied refs."""
-        first = _RecordingValidator(allowed={_REF_A, _REF_B})
-        second = _RecordingValidator(allowed={_REF_A})
+        first = _RecordingValidator(allowed={ref_a, ref_b})
+        second = _RecordingValidator(allowed={ref_a})
         processor = BulkActionProcessor[_MockBulkAction, _MockBulkActionResult](
             func=_echo_func(),
             validators=[first, second],
         )
-        action = _MockBulkAction(element_refs=[_REF_A, _REF_B, _REF_C])
+        action = _MockBulkAction(element_refs=[ref_a, ref_b, ref_c])
 
         with pytest.raises(PermissionDeniedError) as exc_info:
             await processor.wait_for_complete(action)
 
         # Both validators saw the original (unfiltered) action.
-        assert first.observed_batches == [[_REF_A, _REF_B, _REF_C]]
-        assert second.observed_batches == [[_REF_A, _REF_B, _REF_C]]
+        assert first.observed_batches == [[ref_a, ref_b, ref_c]]
+        assert second.observed_batches == [[ref_a, ref_b, ref_c]]
         # Aggregated denials from both validators surface in the error,
         # each paired with its deny reason.
         msg = str(exc_info.value)
-        assert f"{_REF_B.to_str()} (blocked)" in msg
-        assert f"{_REF_C.to_str()} (blocked)" in msg
+        assert f"{ref_b.to_str()} (blocked)" in msg
+        assert f"{ref_c.to_str()} (blocked)" in msg
 
-    async def test_original_action_is_not_mutated(self) -> None:
+    async def test_original_action_is_not_mutated(
+        self,
+        ref_a: RBACElementRef,
+        ref_b: RBACElementRef,
+    ) -> None:
         processor = BulkActionProcessor[_MockBulkAction, _MockBulkActionResult](
             func=_echo_func(),
-            validators=[_AllowSetValidator(allowed={_REF_A, _REF_B})],
+            validators=[_AllowSetValidator(allowed={ref_a, ref_b})],
         )
-        original = _MockBulkAction(element_refs=[_REF_A, _REF_B])
+        original = _MockBulkAction(element_refs=[ref_a, ref_b])
 
         await processor.wait_for_complete(original)
 
-        assert original.element_refs == [_REF_A, _REF_B]
-
-
-@pytest.mark.parametrize(
-    ("allowed", "batch", "expected_processed"),
-    [
-        ({_REF_A, _REF_B}, [_REF_A, _REF_B], [_REF_A, _REF_B]),
-    ],
-)
-async def test_full_allow_scenarios(
-    allowed: set[RBACElementRef],
-    batch: list[RBACElementRef],
-    expected_processed: list[RBACElementRef],
-) -> None:
-    processor = BulkActionProcessor[_MockBulkAction, _MockBulkActionResult](
-        func=_echo_func(),
-        validators=[_AllowSetValidator(allowed=allowed)],
-    )
-    action = _MockBulkAction(element_refs=batch)
-
-    result = await processor.wait_for_complete(action)
-
-    assert result.processed_refs == expected_processed
+        assert original.element_refs == [ref_a, ref_b]

--- a/tests/unit/manager/actions/test_bulk_processor.py
+++ b/tests/unit/manager/actions/test_bulk_processor.py
@@ -125,10 +125,9 @@ class TestBulkActionProcessor:
         )
         action = _MockBulkAction(element_refs=[_REF_A, _REF_B, _REF_C])
 
-        outcome = await processor.wait_for_complete(action)
+        result = await processor.wait_for_complete(action)
 
-        assert outcome.result.processed_refs == [_REF_A, _REF_B, _REF_C]
-        assert outcome.validator_decisions == []
+        assert result.processed_refs == [_REF_A, _REF_B, _REF_C]
 
     async def test_all_allowed_runs_action_normally(self) -> None:
         processor = BulkActionProcessor[_MockBulkAction, _MockBulkActionResult](
@@ -137,12 +136,9 @@ class TestBulkActionProcessor:
         )
         action = _MockBulkAction(element_refs=[_REF_A, _REF_B, _REF_C])
 
-        outcome = await processor.wait_for_complete(action)
+        result = await processor.wait_for_complete(action)
 
-        assert outcome.result.processed_refs == [_REF_A, _REF_B, _REF_C]
-        decision = outcome.validator_decisions[0]
-        assert decision.results.allowed_entities == [_REF_A, _REF_B, _REF_C]
-        assert decision.results.denied_entities == []
+        assert result.processed_refs == [_REF_A, _REF_B, _REF_C]
 
     async def test_single_validator_partial_denial_raises(self) -> None:
         processor = BulkActionProcessor[_MockBulkAction, _MockBulkActionResult](
@@ -209,6 +205,6 @@ async def test_full_allow_scenarios(
     )
     action = _MockBulkAction(element_refs=batch)
 
-    outcome = await processor.wait_for_complete(action)
+    result = await processor.wait_for_complete(action)
 
-    assert outcome.result.processed_refs == expected_processed
+    assert result.processed_refs == expected_processed

--- a/tests/unit/manager/actions/test_bulk_processor.py
+++ b/tests/unit/manager/actions/test_bulk_processor.py
@@ -45,6 +45,12 @@ def ref_c() -> RBACElementRef:
 
 @dataclass
 class _MockBulkAction(BaseBulkAction):
+    refs: list[RBACElementRef]
+
+    @override
+    def element_refs(self) -> list[RBACElementRef]:
+        return list(self.refs)
+
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
@@ -80,7 +86,7 @@ class _AllowSetValidator(BulkActionValidator):
     async def validate(
         self, action: BaseBulkAction, meta: BaseActionTriggerMeta
     ) -> BulkValidationResult:
-        current = list(action.element_refs)
+        current = list(action.element_refs())
         allowed = [r for r in current if r in self._allowed]
         denied = [
             DeniedEntity(entity_ref=r, deny_reason="not in allow-set")
@@ -106,7 +112,7 @@ class _RecordingValidator(BulkActionValidator):
     async def validate(
         self, action: BaseBulkAction, meta: BaseActionTriggerMeta
     ) -> BulkValidationResult:
-        current = list(action.element_refs)
+        current = list(action.element_refs())
         self.observed_batches.append(current)
         allowed = [r for r in current if r in self._allowed]
         denied = [
@@ -119,7 +125,7 @@ class _RecordingValidator(BulkActionValidator):
 
 def _echo_func() -> Callable[[_MockBulkAction], Awaitable[_MockBulkActionResult]]:
     async def _run(action: _MockBulkAction) -> _MockBulkActionResult:
-        return _MockBulkActionResult(processed_refs=list(action.element_refs))
+        return _MockBulkActionResult(processed_refs=list(action.element_refs()))
 
     return _run
 
@@ -134,7 +140,7 @@ class TestBulkActionProcessor:
         processor = BulkActionProcessor[_MockBulkAction, _MockBulkActionResult](
             func=_echo_func(),
         )
-        action = _MockBulkAction(element_refs=[ref_a, ref_b, ref_c])
+        action = _MockBulkAction(refs=[ref_a, ref_b, ref_c])
 
         result = await processor.wait_for_complete(action)
 
@@ -150,7 +156,7 @@ class TestBulkActionProcessor:
             func=_echo_func(),
             validators=[_AllowSetValidator(allowed={ref_a, ref_b, ref_c})],
         )
-        action = _MockBulkAction(element_refs=[ref_a, ref_b, ref_c])
+        action = _MockBulkAction(refs=[ref_a, ref_b, ref_c])
 
         result = await processor.wait_for_complete(action)
 
@@ -166,7 +172,7 @@ class TestBulkActionProcessor:
             func=_echo_func(),
             validators=[_AllowSetValidator(allowed={ref_a, ref_c})],
         )
-        action = _MockBulkAction(element_refs=[ref_a, ref_b, ref_c])
+        action = _MockBulkAction(refs=[ref_a, ref_b, ref_c])
 
         with pytest.raises(PermissionDeniedError) as exc_info:
             await processor.wait_for_complete(action)
@@ -188,7 +194,7 @@ class TestBulkActionProcessor:
             func=_echo_func(),
             validators=[first, second],
         )
-        action = _MockBulkAction(element_refs=[ref_a, ref_b, ref_c])
+        action = _MockBulkAction(refs=[ref_a, ref_b, ref_c])
 
         with pytest.raises(PermissionDeniedError) as exc_info:
             await processor.wait_for_complete(action)
@@ -211,8 +217,8 @@ class TestBulkActionProcessor:
             func=_echo_func(),
             validators=[_AllowSetValidator(allowed={ref_a, ref_b})],
         )
-        original = _MockBulkAction(element_refs=[ref_a, ref_b])
+        original = _MockBulkAction(refs=[ref_a, ref_b])
 
         await processor.wait_for_complete(original)
 
-        assert original.element_refs == [ref_a, ref_b]
+        assert original.element_refs() == [ref_a, ref_b]

--- a/tests/unit/manager/actions/test_bulk_processor.py
+++ b/tests/unit/manager/actions/test_bulk_processor.py
@@ -18,8 +18,8 @@ from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.action.bulk import (
     BaseBulkAction,
     BaseBulkActionResult,
-    BulkActionTarget,
 )
+from ai.backend.manager.actions.action.types import ActionTarget
 from ai.backend.manager.actions.processor.bulk import (
     BulkActionProcessor,
 )
@@ -33,8 +33,8 @@ from ai.backend.manager.data.permission.types import RBACElementRef
 
 
 @dataclass(frozen=True)
-class _RefTarget(BulkActionTarget):
-    """Wraps a bare ``RBACElementRef`` as a ``BulkActionTarget`` for tests."""
+class _RefTarget(ActionTarget):
+    """Wraps a bare ``RBACElementRef`` as an :class:`ActionTarget` for tests."""
 
     ref: RBACElementRef
 
@@ -59,11 +59,11 @@ def ref_c() -> RBACElementRef:
 
 
 @dataclass
-class _MockBulkAction(BaseBulkAction[BulkActionTarget]):
+class _MockBulkAction(BaseBulkAction[ActionTarget]):
     refs: list[RBACElementRef]
 
     @override
-    def targets(self) -> list[BulkActionTarget]:
+    def targets(self) -> list[ActionTarget]:
         return [_RefTarget(ref=r) for r in self.refs]
 
     @override

--- a/tests/unit/manager/actions/test_bulk_processor.py
+++ b/tests/unit/manager/actions/test_bulk_processor.py
@@ -8,14 +8,18 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import override
+from typing import Any, override
 
 import pytest
 
 from ai.backend.common.data.permission.types import EntityType, RBACElementType
 from ai.backend.common.exception import PermissionDeniedError
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
-from ai.backend.manager.actions.action.bulk import BaseBulkAction, BaseBulkActionResult
+from ai.backend.manager.actions.action.bulk import (
+    BaseBulkAction,
+    BaseBulkActionResult,
+    BulkActionTarget,
+)
 from ai.backend.manager.actions.processor.bulk import (
     BulkActionProcessor,
 )
@@ -26,6 +30,17 @@ from ai.backend.manager.actions.validator.bulk import (
     DeniedEntity,
 )
 from ai.backend.manager.data.permission.types import RBACElementRef
+
+
+@dataclass(frozen=True)
+class _RefTarget(BulkActionTarget):
+    """Wraps a bare ``RBACElementRef`` as a ``BulkActionTarget`` for tests."""
+
+    ref: RBACElementRef
+
+    @override
+    def to_rbac_element_ref(self) -> RBACElementRef:
+        return self.ref
 
 
 @pytest.fixture
@@ -44,12 +59,12 @@ def ref_c() -> RBACElementRef:
 
 
 @dataclass
-class _MockBulkAction(BaseBulkAction):
+class _MockBulkAction(BaseBulkAction[BulkActionTarget]):
     refs: list[RBACElementRef]
 
     @override
-    def element_refs(self) -> list[RBACElementRef]:
-        return list(self.refs)
+    def targets(self) -> list[BulkActionTarget]:
+        return [_RefTarget(ref=r) for r in self.refs]
 
     @override
     @classmethod
@@ -84,9 +99,9 @@ class _AllowSetValidator(BulkActionValidator):
 
     @override
     async def validate(
-        self, action: BaseBulkAction, meta: BaseActionTriggerMeta
+        self, action: BaseBulkAction[Any], meta: BaseActionTriggerMeta
     ) -> BulkValidationResult:
-        current = list(action.element_refs())
+        current = [t.to_rbac_element_ref() for t in action.targets()]
         allowed = [r for r in current if r in self._allowed]
         denied = [
             DeniedEntity(entity_ref=r, deny_reason="not in allow-set")
@@ -110,9 +125,9 @@ class _RecordingValidator(BulkActionValidator):
 
     @override
     async def validate(
-        self, action: BaseBulkAction, meta: BaseActionTriggerMeta
+        self, action: BaseBulkAction[Any], meta: BaseActionTriggerMeta
     ) -> BulkValidationResult:
-        current = list(action.element_refs())
+        current = [t.to_rbac_element_ref() for t in action.targets()]
         self.observed_batches.append(current)
         allowed = [r for r in current if r in self._allowed]
         denied = [
@@ -125,7 +140,9 @@ class _RecordingValidator(BulkActionValidator):
 
 def _echo_func() -> Callable[[_MockBulkAction], Awaitable[_MockBulkActionResult]]:
     async def _run(action: _MockBulkAction) -> _MockBulkActionResult:
-        return _MockBulkActionResult(processed_refs=list(action.element_refs()))
+        return _MockBulkActionResult(
+            processed_refs=[t.to_rbac_element_ref() for t in action.targets()],
+        )
 
     return _run
 
@@ -221,4 +238,4 @@ class TestBulkActionProcessor:
 
         await processor.wait_for_complete(original)
 
-        assert original.element_refs() == [ref_a, ref_b]
+        assert [t.to_rbac_element_ref() for t in original.targets()] == [ref_a, ref_b]

--- a/tests/unit/manager/actions/test_bulk_processor.py
+++ b/tests/unit/manager/actions/test_bulk_processor.py
@@ -1,19 +1,19 @@
-"""Tests for ``BulkActionProcessor`` filtering infrastructure (BA-5777).
+"""Tests for ``BulkActionProcessor``: validator chain + all-or-nothing denial.
 
-Verifies that the processor narrows ``entity_ids`` exactly to what each
-validator allowed — no more, no less — and that later validators only
-see IDs that survived earlier ones.
+Any denial across the full validator chain raises ``PermissionDeniedError``
+after every validator has run, aggregating all denied refs into the error.
 """
 
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Any, override
+from typing import override
 
 import pytest
 
-from ai.backend.common.data.permission.types import EntityType
+from ai.backend.common.data.permission.types import EntityType, RBACElementType
+from ai.backend.common.exception import PermissionDeniedError
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.action.bulk import BaseBulkAction, BaseBulkActionResult
 from ai.backend.manager.actions.processor.bulk import (
@@ -25,14 +25,20 @@ from ai.backend.manager.actions.validator.bulk import (
     BulkValidationResult,
     DeniedEntity,
 )
+from ai.backend.manager.data.permission.types import RBACElementRef
+
+
+def _ref(element_type: RBACElementType, element_id: str) -> RBACElementRef:
+    return RBACElementRef(element_type=element_type, element_id=element_id)
+
+
+_REF_A = _ref(RBACElementType.SESSION, "a")
+_REF_B = _ref(RBACElementType.SESSION, "b")
+_REF_C = _ref(RBACElementType.SESSION, "c")
 
 
 @dataclass
-class _MockBulkAction(BaseBulkAction[str]):
-    @override
-    def typed_entity_ids(self) -> list[str]:
-        return list(self.entity_ids)
-
+class _MockBulkAction(BaseBulkAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
@@ -46,17 +52,17 @@ class _MockBulkAction(BaseBulkAction[str]):
 
 @dataclass
 class _MockBulkActionResult(BaseBulkActionResult):
-    processed_ids: list[str] = field(default_factory=list)
+    processed_refs: list[RBACElementRef] = field(default_factory=list)
 
     @override
-    def entity_ids(self) -> list[str]:
-        return list(self.processed_ids)
+    def element_refs(self) -> list[RBACElementRef]:
+        return list(self.processed_refs)
 
 
 class _AllowSetValidator(BulkActionValidator):
-    """Approves any ID in ``allowed``; anything else visible is denied."""
+    """Approves any ref in ``allowed``; anything else visible is denied."""
 
-    def __init__(self, allowed: set[str]) -> None:
+    def __init__(self, allowed: set[RBACElementRef]) -> None:
         self._allowed = set(allowed)
 
     @classmethod
@@ -66,24 +72,24 @@ class _AllowSetValidator(BulkActionValidator):
 
     @override
     async def validate(
-        self, action: BaseBulkAction[Any], meta: BaseActionTriggerMeta
+        self, action: BaseBulkAction, meta: BaseActionTriggerMeta
     ) -> BulkValidationResult:
-        current = list(action.entity_ids)
-        allowed = [eid for eid in current if eid in self._allowed]
+        current = list(action.element_refs)
+        allowed = [r for r in current if r in self._allowed]
         denied = [
-            DeniedEntity(entity_id=eid, deny_reason="not in allow-set")
-            for eid in current
-            if eid not in self._allowed
+            DeniedEntity(entity_ref=r, deny_reason="not in allow-set")
+            for r in current
+            if r not in self._allowed
         ]
-        return BulkValidationResult(allowed_entity_ids=allowed, denied_entities=denied)
+        return BulkValidationResult(allowed_entities=allowed, denied_entities=denied)
 
 
 class _RecordingValidator(BulkActionValidator):
-    """Captures the entity IDs each ``validate()`` call received."""
+    """Captures the refs each ``validate()`` call received."""
 
-    def __init__(self, allowed: set[str]) -> None:
+    def __init__(self, allowed: set[RBACElementRef]) -> None:
         self._allowed = set(allowed)
-        self.observed_batches: list[list[str]] = []
+        self.observed_batches: list[list[RBACElementRef]] = []
 
     @classmethod
     @override
@@ -92,150 +98,117 @@ class _RecordingValidator(BulkActionValidator):
 
     @override
     async def validate(
-        self, action: BaseBulkAction[Any], meta: BaseActionTriggerMeta
+        self, action: BaseBulkAction, meta: BaseActionTriggerMeta
     ) -> BulkValidationResult:
-        current = list(action.entity_ids)
+        current = list(action.element_refs)
         self.observed_batches.append(current)
-        allowed = [eid for eid in current if eid in self._allowed]
+        allowed = [r for r in current if r in self._allowed]
         denied = [
-            DeniedEntity(entity_id=eid, deny_reason="blocked")
-            for eid in current
-            if eid not in self._allowed
+            DeniedEntity(entity_ref=r, deny_reason="blocked")
+            for r in current
+            if r not in self._allowed
         ]
-        return BulkValidationResult(allowed_entity_ids=allowed, denied_entities=denied)
+        return BulkValidationResult(allowed_entities=allowed, denied_entities=denied)
 
 
 def _echo_func() -> Callable[[_MockBulkAction], Awaitable[_MockBulkActionResult]]:
     async def _run(action: _MockBulkAction) -> _MockBulkActionResult:
-        return _MockBulkActionResult(processed_ids=list(action.entity_ids))
+        return _MockBulkActionResult(processed_refs=list(action.element_refs))
 
     return _run
 
 
-class TestBulkActionProcessorFiltering:
-    async def test_no_validators_passes_all_ids_through(self) -> None:
+class TestBulkActionProcessor:
+    async def test_no_validators_passes_all_refs_through(self) -> None:
         processor = BulkActionProcessor[_MockBulkAction, _MockBulkActionResult](
             func=_echo_func(),
         )
-        action = _MockBulkAction(entity_ids=["a", "b", "c"])
+        action = _MockBulkAction(element_refs=[_REF_A, _REF_B, _REF_C])
 
         outcome = await processor.wait_for_complete(action)
 
-        assert outcome.result.processed_ids == ["a", "b", "c"]
+        assert outcome.result.processed_refs == [_REF_A, _REF_B, _REF_C]
         assert outcome.validator_decisions == []
 
-    async def test_validator_denies_subset_reports_denied_ids(self) -> None:
+    async def test_all_allowed_runs_action_normally(self) -> None:
         processor = BulkActionProcessor[_MockBulkAction, _MockBulkActionResult](
             func=_echo_func(),
-            validators=[_AllowSetValidator(allowed={"a", "c"})],
+            validators=[_AllowSetValidator(allowed={_REF_A, _REF_B, _REF_C})],
         )
-        action = _MockBulkAction(entity_ids=["a", "b", "c"])
+        action = _MockBulkAction(element_refs=[_REF_A, _REF_B, _REF_C])
 
         outcome = await processor.wait_for_complete(action)
 
-        assert outcome.result.processed_ids == ["a", "c"]
-        assert len(outcome.validator_decisions) == 1
+        assert outcome.result.processed_refs == [_REF_A, _REF_B, _REF_C]
         decision = outcome.validator_decisions[0]
-        assert decision.validator_name == "allow-set"
-        assert decision.results.allowed_entity_ids == ["a", "c"]
-        assert decision.results.denied_entities == [
-            DeniedEntity(entity_id="b", deny_reason="not in allow-set"),
-        ]
+        assert decision.results.allowed_entities == [_REF_A, _REF_B, _REF_C]
+        assert decision.results.denied_entities == []
 
-    async def test_validator_denies_all_still_runs_service_with_empty_batch(self) -> None:
+    async def test_single_validator_partial_denial_raises(self) -> None:
         processor = BulkActionProcessor[_MockBulkAction, _MockBulkActionResult](
             func=_echo_func(),
-            validators=[_AllowSetValidator(allowed=set())],
+            validators=[_AllowSetValidator(allowed={_REF_A, _REF_C})],
         )
-        action = _MockBulkAction(entity_ids=["a", "b"])
+        action = _MockBulkAction(element_refs=[_REF_A, _REF_B, _REF_C])
 
-        outcome = await processor.wait_for_complete(action)
+        with pytest.raises(PermissionDeniedError) as exc_info:
+            await processor.wait_for_complete(action)
 
-        assert outcome.result.processed_ids == []
-        decision = outcome.validator_decisions[0]
-        assert decision.results.allowed_entity_ids == []
-        assert [d.entity_id for d in decision.results.denied_entities] == ["a", "b"]
+        msg = str(exc_info.value)
+        assert _REF_B.to_str() in msg
+        assert "not in allow-set" in msg
 
-    async def test_later_validator_only_sees_surviving_ids(self) -> None:
-        first = _RecordingValidator(allowed={"a", "b"})
-        second = _RecordingValidator(allowed={"a"})
+    async def test_full_chain_runs_before_raising(self) -> None:
+        """Every validator runs even when an earlier one denied refs."""
+        first = _RecordingValidator(allowed={_REF_A, _REF_B})
+        second = _RecordingValidator(allowed={_REF_A})
         processor = BulkActionProcessor[_MockBulkAction, _MockBulkActionResult](
             func=_echo_func(),
             validators=[first, second],
         )
-        action = _MockBulkAction(entity_ids=["a", "b", "c"])
+        action = _MockBulkAction(element_refs=[_REF_A, _REF_B, _REF_C])
 
-        outcome = await processor.wait_for_complete(action)
+        with pytest.raises(PermissionDeniedError) as exc_info:
+            await processor.wait_for_complete(action)
 
-        # First validator sees the full batch; second only sees IDs that
-        # survived the first.
-        assert first.observed_batches == [["a", "b", "c"]]
-        assert second.observed_batches == [["a", "b"]]
-
-        assert outcome.result.processed_ids == ["a"]
-        assert [
-            (
-                d.validator_name,
-                d.results.allowed_entity_ids,
-                [de.entity_id for de in d.results.denied_entities],
-            )
-            for d in outcome.validator_decisions
-        ] == [
-            ("recording", ["a", "b"], ["c"]),
-            ("recording", ["a"], ["b"]),
-        ]
+        # Both validators saw the original (unfiltered) action.
+        assert first.observed_batches == [[_REF_A, _REF_B, _REF_C]]
+        assert second.observed_batches == [[_REF_A, _REF_B, _REF_C]]
+        # Aggregated denials from both validators surface in the error,
+        # each paired with its deny reason.
+        msg = str(exc_info.value)
+        assert f"{_REF_B.to_str()} (blocked)" in msg
+        assert f"{_REF_C.to_str()} (blocked)" in msg
 
     async def test_original_action_is_not_mutated(self) -> None:
         processor = BulkActionProcessor[_MockBulkAction, _MockBulkActionResult](
             func=_echo_func(),
-            validators=[_AllowSetValidator(allowed={"a"})],
+            validators=[_AllowSetValidator(allowed={_REF_A, _REF_B})],
         )
-        original = _MockBulkAction(entity_ids=["a", "b"])
-
-        outcome = await processor.wait_for_complete(original)
-
-        assert outcome.result.processed_ids == ["a"]
-        # The processor constructs a fresh action; it must not mutate the caller's.
-        assert original.entity_ids == ["a", "b"]
-
-    async def test_pass_through_reuses_same_action_instance(self) -> None:
-        seen: list[_MockBulkAction] = []
-
-        async def _capture(action: _MockBulkAction) -> _MockBulkActionResult:
-            seen.append(action)
-            return _MockBulkActionResult(processed_ids=list(action.entity_ids))
-
-        processor = BulkActionProcessor[_MockBulkAction, _MockBulkActionResult](
-            func=_capture,
-            validators=[_AllowSetValidator(allowed={"a", "b"})],
-        )
-        original = _MockBulkAction(entity_ids=["a", "b"])
+        original = _MockBulkAction(element_refs=[_REF_A, _REF_B])
 
         await processor.wait_for_complete(original)
 
-        # No denials → no filtering copy was created.
-        assert seen[0] is original
+        assert original.element_refs == [_REF_A, _REF_B]
 
 
 @pytest.mark.parametrize(
     ("allowed", "batch", "expected_processed"),
     [
-        ({"a", "b"}, ["a", "b"], ["a", "b"]),
-        ({"a"}, ["a", "b"], ["a"]),
-        (set(), ["a", "b"], []),
+        ({_REF_A, _REF_B}, [_REF_A, _REF_B], [_REF_A, _REF_B]),
     ],
 )
-async def test_single_validator_scenarios(
-    allowed: set[str],
-    batch: list[str],
-    expected_processed: list[str],
+async def test_full_allow_scenarios(
+    allowed: set[RBACElementRef],
+    batch: list[RBACElementRef],
+    expected_processed: list[RBACElementRef],
 ) -> None:
     processor = BulkActionProcessor[_MockBulkAction, _MockBulkActionResult](
         func=_echo_func(),
         validators=[_AllowSetValidator(allowed=allowed)],
     )
-    action = _MockBulkAction(entity_ids=batch)
+    action = _MockBulkAction(element_refs=batch)
 
     outcome = await processor.wait_for_complete(action)
 
-    assert outcome.result.processed_ids == expected_processed
+    assert outcome.result.processed_refs == expected_processed

--- a/tests/unit/manager/actions/test_bulk_targets.py
+++ b/tests/unit/manager/actions/test_bulk_targets.py
@@ -1,0 +1,122 @@
+"""Contract tests for bulk-action target abstracts.
+
+Covers the hierarchy added in BA-6100:
+
+* :class:`BulkActionTarget` — RBAC element ref (universal).
+* :class:`SearchableBulkActionTarget` — RBAC ref + per-leaf :class:`SearchScope`,
+  used by bulk actions whose semantics include a SQL search.
+* :class:`BaseBulkAction` parametrized on the target type so consumers see
+  ``to_search_scope()`` without isinstance checks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, override
+
+import sqlalchemy as sa
+
+from ai.backend.common.data.permission.types import EntityType, RBACElementType
+from ai.backend.manager.actions.action.bulk import (
+    BaseBulkAction,
+    BulkActionTarget,
+    SearchableBulkActionTarget,
+)
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.repositories.base.types import (
+    ExistenceCheck,
+    QueryCondition,
+    SearchScope,
+)
+
+
+@dataclass(frozen=True)
+class _StubSearchScope(SearchScope):
+    column_value: str
+
+    @override
+    def to_condition(self) -> QueryCondition:
+        value = self.column_value
+        return lambda: sa.literal(value) == sa.literal(value)
+
+    @property
+    @override
+    def existence_checks(self) -> Sequence[ExistenceCheck[Any]]:
+        return ()
+
+
+@dataclass(frozen=True)
+class _SearchableRefTarget(SearchableBulkActionTarget):
+    ref: RBACElementRef
+    scope: _StubSearchScope
+
+    @override
+    def to_rbac_element_ref(self) -> RBACElementRef:
+        return self.ref
+
+    @override
+    def to_search_scope(self) -> SearchScope:
+        return self.scope
+
+
+@dataclass
+class _MockSearchableBulkAction(BaseBulkAction[SearchableBulkActionTarget]):
+    items: list[_SearchableRefTarget]
+
+    @override
+    def targets(self) -> Sequence[SearchableBulkActionTarget]:
+        return list(self.items)
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.VFOLDER
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.SEARCH
+
+
+class TestSearchableBulkActionTarget:
+    def test_is_a_bulk_action_target(self) -> None:
+        target = _SearchableRefTarget(
+            ref=RBACElementRef(element_type=RBACElementType.VFOLDER, element_id="vf-1"),
+            scope=_StubSearchScope(column_value="vf-1"),
+        )
+
+        assert isinstance(target, BulkActionTarget)
+
+    def test_exposes_both_rbac_ref_and_search_scope(self) -> None:
+        ref = RBACElementRef(element_type=RBACElementType.VFOLDER, element_id="vf-1")
+        scope = _StubSearchScope(column_value="vf-1")
+        target = _SearchableRefTarget(ref=ref, scope=scope)
+
+        assert target.to_rbac_element_ref() == ref
+        assert target.to_search_scope() is scope
+
+
+class TestBulkActionWithSearchableTarget:
+    def test_is_a_bulk_action(self) -> None:
+        action = _MockSearchableBulkAction(items=[])
+
+        assert isinstance(action, BaseBulkAction)
+
+    def test_targets_yield_searchable_contract(self) -> None:
+        ref_a = RBACElementRef(element_type=RBACElementType.VFOLDER, element_id="vf-a")
+        ref_b = RBACElementRef(element_type=RBACElementType.USER, element_id="u-b")
+        scope_a = _StubSearchScope(column_value="vf-a")
+        scope_b = _StubSearchScope(column_value="u-b")
+        action = _MockSearchableBulkAction(
+            items=[
+                _SearchableRefTarget(ref=ref_a, scope=scope_a),
+                _SearchableRefTarget(ref=ref_b, scope=scope_b),
+            ],
+        )
+
+        # Consumer can call both contracts on every target without isinstance.
+        observed = [(t.to_rbac_element_ref(), t.to_search_scope()) for t in action.targets()]
+
+        assert observed == [(ref_a, scope_a), (ref_b, scope_b)]

--- a/tests/unit/manager/actions/test_bulk_targets.py
+++ b/tests/unit/manager/actions/test_bulk_targets.py
@@ -1,10 +1,9 @@
-"""Contract tests for bulk-action target abstracts.
+"""Contract tests for action-target abstracts and their use in bulk actions.
 
-Covers the hierarchy added in BA-6100:
+Covers:
 
-* :class:`BulkActionTarget` — RBAC element ref (universal).
-* :class:`SearchableBulkActionTarget` — RBAC ref + per-leaf :class:`SearchScope`,
-  used by bulk actions whose semantics include a SQL search.
+* :class:`ActionTarget` — RBAC element ref (universal across all action shapes).
+* :class:`SearchableActionTarget` — RBAC ref + per-leaf :class:`SearchScope`.
 * :class:`BaseBulkAction` parametrized on the target type so consumers see
   ``to_search_scope()`` without isinstance checks.
 """
@@ -18,11 +17,8 @@ from typing import Any, override
 import sqlalchemy as sa
 
 from ai.backend.common.data.permission.types import EntityType, RBACElementType
-from ai.backend.manager.actions.action.bulk import (
-    BaseBulkAction,
-    BulkActionTarget,
-    SearchableBulkActionTarget,
-)
+from ai.backend.manager.actions.action.bulk import BaseBulkAction
+from ai.backend.manager.actions.action.types import ActionTarget, SearchableActionTarget
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.repositories.base.types import (
@@ -48,7 +44,7 @@ class _StubSearchScope(SearchScope):
 
 
 @dataclass(frozen=True)
-class _SearchableRefTarget(SearchableBulkActionTarget):
+class _SearchableRefTarget(SearchableActionTarget):
     ref: RBACElementRef
     scope: _StubSearchScope
 
@@ -62,11 +58,11 @@ class _SearchableRefTarget(SearchableBulkActionTarget):
 
 
 @dataclass
-class _MockSearchableBulkAction(BaseBulkAction[SearchableBulkActionTarget]):
+class _MockSearchableBulkAction(BaseBulkAction[SearchableActionTarget]):
     items: list[_SearchableRefTarget]
 
     @override
-    def targets(self) -> Sequence[SearchableBulkActionTarget]:
+    def targets(self) -> Sequence[SearchableActionTarget]:
         return list(self.items)
 
     @override
@@ -80,14 +76,14 @@ class _MockSearchableBulkAction(BaseBulkAction[SearchableBulkActionTarget]):
         return ActionOperationType.SEARCH
 
 
-class TestSearchableBulkActionTarget:
-    def test_is_a_bulk_action_target(self) -> None:
+class TestSearchableActionTarget:
+    def test_is_an_action_target(self) -> None:
         target = _SearchableRefTarget(
             ref=RBACElementRef(element_type=RBACElementType.VFOLDER, element_id="vf-1"),
             scope=_StubSearchScope(column_value="vf-1"),
         )
 
-        assert isinstance(target, BulkActionTarget)
+        assert isinstance(target, ActionTarget)
 
     def test_exposes_both_rbac_ref_and_search_scope(self) -> None:
         ref = RBACElementRef(element_type=RBACElementType.VFOLDER, element_id="vf-1")

--- a/tests/unit/manager/actions/validators/test_rbac_validators.py
+++ b/tests/unit/manager/actions/validators/test_rbac_validators.py
@@ -72,6 +72,12 @@ _TARGET_DOMAIN = "default"
 _TARGET_VFOLDER = "vf-1"
 _BULK_VFOLDER_GRANTED = "bulk-vf-granted"
 _BULK_VFOLDER_DENIED = "bulk-vf-denied"
+_BULK_REF_GRANTED = RBACElementRef(
+    element_type=RBACElementType.VFOLDER, element_id=_BULK_VFOLDER_GRANTED
+)
+_BULK_REF_DENIED = RBACElementRef(
+    element_type=RBACElementType.VFOLDER, element_id=_BULK_VFOLDER_DENIED
+)
 
 
 class _ProjectCreateAction(BaseScopeAction):
@@ -133,12 +139,8 @@ class _VfolderUpdateAction(BaseSingleEntityAction):
 
 
 @dataclass
-class _BulkVfolderUpdateAction(BaseBulkAction[str]):
+class _BulkVfolderUpdateAction(BaseBulkAction):
     """VFOLDER:UPDATE on multiple vfolders — exercises the bulk validator path."""
-
-    @override
-    def typed_entity_ids(self) -> list[str]:
-        return list(self.entity_ids)
 
     @classmethod
     @override
@@ -327,7 +329,7 @@ async def regular_user_with_vfolder_update(
 @pytest.fixture
 def bulk_vfolder_action() -> _BulkVfolderUpdateAction:
     return _BulkVfolderUpdateAction(
-        entity_ids=[_BULK_VFOLDER_GRANTED, _BULK_VFOLDER_DENIED],
+        element_refs=[_BULK_REF_GRANTED, _BULK_REF_DENIED],
     )
 
 
@@ -545,12 +547,12 @@ class TestBulkActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         superadmin_user: UserData,
     ) -> None:
-        # No permission rows seeded; bypass must approve every entity_id.
+        # No permission rows seeded; bypass must approve every ref.
         validator = BulkActionRBACValidator(repository, MagicMock())
         with with_user(superadmin_user):
             result = await validator.validate(bulk_vfolder_action, trigger_meta)
 
-        assert result.allowed_entity_ids == [_BULK_VFOLDER_GRANTED, _BULK_VFOLDER_DENIED]
+        assert result.allowed_entities == [_BULK_REF_GRANTED, _BULK_REF_DENIED]
         assert result.denied_entities == []
 
     async def test_missing_user_raises(
@@ -574,9 +576,9 @@ class TestBulkActionRBACValidator:
         with with_user(regular_user_with_partial_bulk_vfolder_update):
             result = await validator.validate(bulk_vfolder_action, trigger_meta)
 
-        assert result.allowed_entity_ids == [_BULK_VFOLDER_GRANTED]
+        assert result.allowed_entities == [_BULK_REF_GRANTED]
         assert result.denied_entities == [
-            DeniedEntity(entity_id=_BULK_VFOLDER_DENIED, deny_reason="permission_denied"),
+            DeniedEntity(entity_ref=_BULK_REF_DENIED, deny_reason="permission_denied"),
         ]
 
     async def test_no_permission_denies_every_entity(
@@ -590,13 +592,13 @@ class TestBulkActionRBACValidator:
         with with_user(regular_user_without_permission):
             result = await validator.validate(bulk_vfolder_action, trigger_meta)
 
-        assert result.allowed_entity_ids == []
+        assert result.allowed_entities == []
         assert result.denied_entities == [
-            DeniedEntity(entity_id=_BULK_VFOLDER_GRANTED, deny_reason="permission_denied"),
-            DeniedEntity(entity_id=_BULK_VFOLDER_DENIED, deny_reason="permission_denied"),
+            DeniedEntity(entity_ref=_BULK_REF_GRANTED, deny_reason="permission_denied"),
+            DeniedEntity(entity_ref=_BULK_REF_DENIED, deny_reason="permission_denied"),
         ]
 
-    async def test_empty_entity_ids_returns_empty_result(
+    async def test_empty_element_refs_returns_empty_result(
         self,
         repository: PermissionControllerRepository,
         trigger_meta: BaseActionTriggerMeta,
@@ -605,9 +607,9 @@ class TestBulkActionRBACValidator:
         validator = BulkActionRBACValidator(repository, MagicMock())
         with with_user(regular_user_without_permission):
             result = await validator.validate(
-                _BulkVfolderUpdateAction(entity_ids=[]),
+                _BulkVfolderUpdateAction(element_refs=[]),
                 trigger_meta,
             )
 
-        assert result.allowed_entity_ids == []
+        assert result.allowed_entities == []
         assert result.denied_entities == []

--- a/tests/unit/manager/actions/validators/test_rbac_validators.py
+++ b/tests/unit/manager/actions/validators/test_rbac_validators.py
@@ -30,10 +30,10 @@ from ai.backend.common.data.permission.types import (
 from ai.backend.common.data.user.types import UserData, UserRole
 from ai.backend.common.exception import UnreachableError
 from ai.backend.manager.actions.action.base import BaseActionTriggerMeta
-from ai.backend.manager.actions.action.bulk import BaseBulkAction, BulkActionTarget
+from ai.backend.manager.actions.action.bulk import BaseBulkAction
 from ai.backend.manager.actions.action.scope import BaseScopeAction
 from ai.backend.manager.actions.action.single_entity import BaseSingleEntityAction
-from ai.backend.manager.actions.action.types import FieldData
+from ai.backend.manager.actions.action.types import ActionTarget, FieldData
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.validator.bulk import DeniedEntity
 from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
@@ -70,8 +70,8 @@ from ai.backend.testutils.db import with_tables
 
 
 @dataclass(frozen=True)
-class _RefTarget(BulkActionTarget):
-    """Wraps a bare ``RBACElementRef`` as a ``BulkActionTarget`` for tests."""
+class _RefTarget(ActionTarget):
+    """Wraps a bare ``RBACElementRef`` as an :class:`ActionTarget` for tests."""
 
     ref: RBACElementRef
 
@@ -151,13 +151,13 @@ class _VfolderUpdateAction(BaseSingleEntityAction):
 
 
 @dataclass
-class _BulkVfolderUpdateAction(BaseBulkAction[BulkActionTarget]):
+class _BulkVfolderUpdateAction(BaseBulkAction[ActionTarget]):
     """VFOLDER:UPDATE on multiple vfolders — exercises the bulk validator path."""
 
     refs: list[RBACElementRef]
 
     @override
-    def targets(self) -> list[BulkActionTarget]:
+    def targets(self) -> list[ActionTarget]:
         return [_RefTarget(ref=r) for r in self.refs]
 
     @classmethod

--- a/tests/unit/manager/actions/validators/test_rbac_validators.py
+++ b/tests/unit/manager/actions/validators/test_rbac_validators.py
@@ -30,7 +30,7 @@ from ai.backend.common.data.permission.types import (
 from ai.backend.common.data.user.types import UserData, UserRole
 from ai.backend.common.exception import UnreachableError
 from ai.backend.manager.actions.action.base import BaseActionTriggerMeta
-from ai.backend.manager.actions.action.bulk import BaseBulkAction
+from ai.backend.manager.actions.action.bulk import BaseBulkAction, BulkActionTarget
 from ai.backend.manager.actions.action.scope import BaseScopeAction
 from ai.backend.manager.actions.action.single_entity import BaseSingleEntityAction
 from ai.backend.manager.actions.action.types import FieldData
@@ -67,6 +67,18 @@ from ai.backend.manager.repositories.permission_controller.repository import (
     PermissionControllerRepository,
 )
 from ai.backend.testutils.db import with_tables
+
+
+@dataclass(frozen=True)
+class _RefTarget(BulkActionTarget):
+    """Wraps a bare ``RBACElementRef`` as a ``BulkActionTarget`` for tests."""
+
+    ref: RBACElementRef
+
+    @override
+    def to_rbac_element_ref(self) -> RBACElementRef:
+        return self.ref
+
 
 _TARGET_DOMAIN = "default"
 _TARGET_VFOLDER = "vf-1"
@@ -139,14 +151,14 @@ class _VfolderUpdateAction(BaseSingleEntityAction):
 
 
 @dataclass
-class _BulkVfolderUpdateAction(BaseBulkAction):
+class _BulkVfolderUpdateAction(BaseBulkAction[BulkActionTarget]):
     """VFOLDER:UPDATE on multiple vfolders — exercises the bulk validator path."""
 
     refs: list[RBACElementRef]
 
     @override
-    def element_refs(self) -> list[RBACElementRef]:
-        return list(self.refs)
+    def targets(self) -> list[BulkActionTarget]:
+        return [_RefTarget(ref=r) for r in self.refs]
 
     @classmethod
     @override
@@ -604,7 +616,7 @@ class TestBulkActionRBACValidator:
             DeniedEntity(entity_ref=_BULK_REF_DENIED, deny_reason="permission_denied"),
         ]
 
-    async def test_empty_element_refs_returns_empty_result(
+    async def test_empty_targets_returns_empty_result(
         self,
         repository: PermissionControllerRepository,
         trigger_meta: BaseActionTriggerMeta,

--- a/tests/unit/manager/actions/validators/test_rbac_validators.py
+++ b/tests/unit/manager/actions/validators/test_rbac_validators.py
@@ -142,6 +142,12 @@ class _VfolderUpdateAction(BaseSingleEntityAction):
 class _BulkVfolderUpdateAction(BaseBulkAction):
     """VFOLDER:UPDATE on multiple vfolders — exercises the bulk validator path."""
 
+    refs: list[RBACElementRef]
+
+    @override
+    def element_refs(self) -> list[RBACElementRef]:
+        return list(self.refs)
+
     @classmethod
     @override
     def entity_type(cls) -> EntityType:
@@ -329,7 +335,7 @@ async def regular_user_with_vfolder_update(
 @pytest.fixture
 def bulk_vfolder_action() -> _BulkVfolderUpdateAction:
     return _BulkVfolderUpdateAction(
-        element_refs=[_BULK_REF_GRANTED, _BULK_REF_DENIED],
+        refs=[_BULK_REF_GRANTED, _BULK_REF_DENIED],
     )
 
 
@@ -607,7 +613,7 @@ class TestBulkActionRBACValidator:
         validator = BulkActionRBACValidator(repository, MagicMock())
         with with_user(regular_user_without_permission):
             result = await validator.validate(
-                _BulkVfolderUpdateAction(element_refs=[]),
+                _BulkVfolderUpdateAction(refs=[]),
                 trigger_meta,
             )
 


### PR DESCRIPTION
## Summary
- `BaseBulkAction` now carries `element_refs: list[RBACElementRef]` (was `entity_ids: list[str]`), so one bulk action can mix RBAC element types.
- `BulkActionProcessor` runs every validator against the original action, aggregates all denials across the chain, and raises `PermissionDeniedError` with each denied entity paired with its `deny_reason`. Any denial fails the whole action.
- `BulkActionRBACValidator` builds one `PermissionResolutionKey` per ref using the ref's own `element_type`, so heterogeneous types resolve in a single bulk repository call.

Resolves BA-6100