### PR TITLE
feat(BA-6094): generalize execute_batch_querier to accept multiple SearchScopes

### DIFF
--- a/changes/11700.enhance.md
+++ b/changes/11700.enhance.md
@@ -1,0 +1,1 @@
+Generalize `execute_batch_querier` to accept multiple `SearchScope` instances OR-combined into a single predicate that is AND-merged with the rest of the querier conditions.

--- a/src/ai/backend/manager/repositories/auth/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/auth/db_source/db_source.py
@@ -664,7 +664,7 @@ class AuthDBSource:
         """Search all login sessions without scope restriction (admin only)."""
         async with self._db.begin_readonly_session() as db_session:
             query = sa.select(LoginSessionRow)
-            result = await execute_batch_querier(db_session, query, querier, scope=None)
+            result = await execute_batch_querier(db_session, query, querier)
             items = [row.LoginSessionRow.to_data() for row in result.rows]
             return SearchResult(
                 items=items,
@@ -682,7 +682,7 @@ class AuthDBSource:
         """Search login sessions within a given scope."""
         async with self._db.begin_readonly_session() as db_session:
             query = sa.select(LoginSessionRow)
-            result = await execute_batch_querier(db_session, query, querier, scope=scope)
+            result = await execute_batch_querier(db_session, query, querier, scopes=[scope])
             items = [row.LoginSessionRow.to_data() for row in result.rows]
             return SearchResult(
                 items=items,
@@ -757,7 +757,7 @@ class AuthDBSource:
         """Search all login history without scope restriction (admin only)."""
         async with self._db.begin_readonly_session() as db_session:
             query = sa.select(LoginHistoryRow)
-            result = await execute_batch_querier(db_session, query, querier, scope=None)
+            result = await execute_batch_querier(db_session, query, querier)
             items = [row.LoginHistoryRow.to_data() for row in result.rows]
             return SearchResult(
                 items=items,
@@ -775,7 +775,7 @@ class AuthDBSource:
         """Search login history within a given scope."""
         async with self._db.begin_readonly_session() as db_session:
             query = sa.select(LoginHistoryRow)
-            result = await execute_batch_querier(db_session, query, querier, scope=scope)
+            result = await execute_batch_querier(db_session, query, querier, scopes=[scope])
             items = [row.LoginHistoryRow.to_data() for row in result.rows]
             return SearchResult(
                 items=items,

--- a/src/ai/backend/manager/repositories/base/querier.py
+++ b/src/ai/backend/manager/repositories/base/querier.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, TypeVar
 from uuid import UUID
@@ -113,6 +114,12 @@ class BatchQuerierResult[TRow: Base]:
     has_previous_page: bool
 
 
+@dataclass
+class _QueryPair:
+    query: sa.sql.Select[Any]
+    count_query: sa.sql.Select[Any]
+
+
 async def _validate_scope(
     db_sess: SASession,
     checks: list[ExistenceCheck[Any]],
@@ -144,24 +151,35 @@ async def _validate_scope(
 def _apply_batch_querier(
     query: sa.sql.Select[Any],
     querier: BatchQuerier,
-) -> sa.sql.Select[Any]:
+    or_conditions: Sequence[QueryCondition],
+) -> _QueryPair:
     """Apply query conditions, orders, and pagination to a SQLAlchemy select statement.
 
     Args:
         query: The base SELECT statement
         querier: BatchQuerier containing conditions, orders, and pagination to apply
+        or_conditions: Conditions forming a single OR group, AND-merged with
+            `querier.conditions`. Pass an empty sequence to skip the OR group.
 
     Returns:
-        The modified SELECT statement with conditions, orders, and pagination applied
+        _QueryPair with the data query (filtered + paginated + ordered) and the
+        count query (filtered only, no pagination/ordering).
 
     Note:
+        Final WHERE applied to both data and count queries:
+            (cond_1 AND ... AND cond_N) AND (or_1 OR ... OR or_M)
         For cursor-based pagination, the pagination.apply() method applies
         cursor_order first. User-specified orders are applied after,
         serving as secondary sort criteria.
     """
-    # Apply all conditions
+    count_query = sa.select(sa.func.count()).select_from(query.froms[0])
+
     for condition in querier.conditions:
         query = query.where(condition())
+        count_query = count_query.where(condition())
+    if or_conditions:
+        query = query.where(sa.or_(*(c() for c in or_conditions)))
+        count_query = count_query.where(sa.or_(*(c() for c in or_conditions)))
 
     # Apply pagination (includes cursor condition and cursor_order for cursor pagination)
     query = querier.pagination.apply(query)
@@ -170,14 +188,14 @@ def _apply_batch_querier(
     for order in querier.orders:
         query = query.order_by(order)
 
-    return query
+    return _QueryPair(query=query, count_query=count_query)
 
 
 async def execute_batch_querier(
     db_sess: SASession,
     query: sa.sql.Select[Any],
     querier: BatchQuerier,
-    scope: SearchScope | None = None,
+    scopes: Sequence[SearchScope] = (),
 ) -> BatchQuerierResult[Row[Any]]:
     """Execute query with batch querier and return rows with total_count and pagination info.
 
@@ -188,7 +206,10 @@ async def execute_batch_querier(
         db_sess: Database session
         query: Base SELECT query (without count window function)
         querier: BatchQuerier for filtering, ordering, and pagination
-        scope: Optional SearchScope that provides required query conditions
+        scopes: Optional sequence of SearchScope. Each scope contributes its own
+            existence checks (aggregated and validated in a single query) and its
+            own to_condition() result. The to_condition() results form a single
+            OR group that is AND-merged with querier.conditions.
 
     Returns:
         BatchQuerierResult containing rows, total_count, and pagination info
@@ -203,24 +224,21 @@ async def execute_batch_querier(
         print(result.rows)  # List of matching rows
         print(result.total_count)  # Total count
     """
-    # Validate and add scope condition to querier if provided
-    if scope is not None:
-        await _validate_scope(db_sess, list(scope.existence_checks))
-        querier = BatchQuerier(
-            pagination=querier.pagination,
-            conditions=[*querier.conditions, scope.to_condition()],
-            orders=querier.orders,
-        )
+    or_conditions: list[QueryCondition] = []
+    if scopes:
+        aggregated_checks: list[ExistenceCheck[Any]] = []
+        for scope in scopes:
+            aggregated_checks.extend(scope.existence_checks)
+            or_conditions.append(scope.to_condition())
+        await _validate_scope(db_sess, aggregated_checks)
 
-    initial_query = query
+    query_pair = _apply_batch_querier(query, querier, or_conditions)
+    data_query = query_pair.query
+    count_query = query_pair.count_query
 
-    # Add window function for offset pagination
     if querier.pagination.uses_window_function:
-        query = query.add_columns(sa.func.count().over().label("total_count"))
-
-    # Apply conditions and pagination to get data rows
-    query = _apply_batch_querier(query, querier)
-    result = await db_sess.execute(query)
+        data_query = data_query.add_columns(sa.func.count().over().label("total_count"))
+    result = await db_sess.execute(data_query)
     rows = list(result.all())
 
     total_count: int
@@ -228,12 +246,7 @@ async def execute_batch_querier(
         # Offset pagination with results: use window function from rows
         total_count = rows[0].total_count
     else:
-        # Cursor pagination or offset fallback (rows empty):
-        # Execute pure count query with filter conditions only
-        count_query = sa.select(sa.func.count()).select_from(initial_query.froms[0])
-        for condition in querier.conditions:
-            count_query = count_query.where(condition())
-
+        # Cursor pagination or offset fallback (rows empty): separate count query
         count_result = await db_sess.execute(count_query)
         total_count = count_result.scalar() or 0
 

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -1160,7 +1160,7 @@ class DeploymentDBSource:
                 db_sess,
                 query,
                 querier,
-                scope=scope,
+                scopes=[scope],
             )
 
             items = [row.EndpointRow.to_summary_data() for row in result.rows]

--- a/src/ai/backend/manager/repositories/domain/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/domain/db_source/db_source.py
@@ -97,7 +97,7 @@ class DomainDBSource:
                 .distinct()
             )
 
-            result = await execute_batch_querier(db_sess, query, querier, scope=scope)
+            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
 
             items = [row.DomainRow.to_data() for row in result.rows]
 

--- a/src/ai/backend/manager/repositories/fair_share/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/fair_share/db_source/db_source.py
@@ -239,7 +239,7 @@ class FairShareDBSource:
                 )
             )
 
-            result = await execute_batch_querier(db_sess, query, querier, scope)
+            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
 
             # Fetch scaling group spec AND available_slots for default generation
             spec = await self._fetch_fair_share_spec(db_sess, scope.resource_group)
@@ -446,7 +446,7 @@ class FairShareDBSource:
                 )
             )
 
-            result = await execute_batch_querier(db_sess, query, querier, scope)
+            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
 
             # Fetch scaling group spec AND available_slots for default generation
             spec = await self._fetch_fair_share_spec(db_sess, scope.resource_group)
@@ -804,7 +804,7 @@ class FairShareDBSource:
                 )
             )
 
-            result = await execute_batch_querier(db_sess, query, querier, scope)
+            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
 
             # Fetch scaling group spec AND available_slots for default generation
             spec = await self._fetch_fair_share_spec(db_sess, scope.resource_group)

--- a/src/ai/backend/manager/repositories/group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/group/db_source/db_source.py
@@ -998,7 +998,7 @@ class GroupDBSource:
         """
         async with self._db.begin_readonly_session() as db_sess:
             query = sa.select(GroupRow)
-            result = await execute_batch_querier(db_sess, query, querier, scope=scope)
+            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
 
             items = [row.GroupRow.to_data() for row in result.rows]
 
@@ -1040,7 +1040,7 @@ class GroupDBSource:
                     ),
                 )
             )
-            result = await execute_batch_querier(db_sess, query, querier, scope=scope)
+            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
 
             items = [row.GroupRow.to_data() for row in result.rows]
 

--- a/src/ai/backend/manager/repositories/model_card/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/model_card/db_source/db_source.py
@@ -303,7 +303,7 @@ class ModelCardDBSource:
             if not is_member:
                 raise GenericForbidden("User is not a member of this project")
             query = sa.select(ModelCardRow)
-            result = await execute_batch_querier(db_sess, query, querier, scope=scope)
+            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
             return ModelCardSearchResult(
                 items=[row.ModelCardRow.to_data() for row in result.rows],
                 total_count=result.total_count,

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -737,7 +737,7 @@ class PermissionDBSource:
                 db_sess,
                 query,
                 querier,
-                scope=scope,
+                scopes=[scope],
             )
 
             items = [row.RoleRow.to_data() for row in result.rows]
@@ -762,7 +762,7 @@ class PermissionDBSource:
                 db_sess,
                 query,
                 querier,
-                scope,
+                scopes=[scope] if scope is not None else (),
             )
 
             items = [row.PermissionRow.to_data() for row in result.rows]
@@ -1355,7 +1355,7 @@ class PermissionDBSource:
     ) -> RoleInvitationSearchResult:
         async with self._db.begin_readonly_session_read_committed() as session:
             query = sa.select(RoleInvitationRow)
-            result = await execute_batch_querier(session, query, querier, scope=scope)
+            result = await execute_batch_querier(session, query, querier, scopes=[scope])
             items = [row.RoleInvitationRow.to_data() for row in result.rows]
             return RoleInvitationSearchResult(
                 items=items,
@@ -1371,7 +1371,7 @@ class PermissionDBSource:
     ) -> RoleInvitationSearchResult:
         async with self._db.begin_readonly_session_read_committed() as session:
             query = sa.select(RoleInvitationRow)
-            result = await execute_batch_querier(session, query, querier, scope=scope)
+            result = await execute_batch_querier(session, query, querier, scopes=[scope])
             items = [row.RoleInvitationRow.to_data() for row in result.rows]
             return RoleInvitationSearchResult(
                 items=items,
@@ -1387,7 +1387,7 @@ class PermissionDBSource:
     ) -> RoleInvitationSearchResult:
         async with self._db.begin_readonly_session_read_committed() as session:
             query = sa.select(RoleInvitationRow)
-            result = await execute_batch_querier(session, query, querier, scope=scope)
+            result = await execute_batch_querier(session, query, querier, scopes=[scope])
             items = [row.RoleInvitationRow.to_data() for row in result.rows]
             return RoleInvitationSearchResult(
                 items=items,

--- a/src/ai/backend/manager/repositories/resource_usage_history/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/resource_usage_history/db_source/db_source.py
@@ -265,7 +265,9 @@ class ResourceUsageHistoryDBSource:
         """Search domain usage buckets with pagination."""
         async with self._db.begin_readonly_session() as db_sess:
             query = sa.select(DomainUsageBucketRow)
-            result = await execute_batch_querier(db_sess, query, querier, scope)
+            result = await execute_batch_querier(
+                db_sess, query, querier, scopes=[scope] if scope is not None else ()
+            )
             items = [
                 DomainUsageBucketData.from_row(row.DomainUsageBucketRow) for row in result.rows
             ]
@@ -308,7 +310,9 @@ class ResourceUsageHistoryDBSource:
         """Search project usage buckets with pagination."""
         async with self._db.begin_readonly_session() as db_sess:
             query = sa.select(ProjectUsageBucketRow)
-            result = await execute_batch_querier(db_sess, query, querier, scope)
+            result = await execute_batch_querier(
+                db_sess, query, querier, scopes=[scope] if scope is not None else ()
+            )
             items = [
                 ProjectUsageBucketData.from_row(row.ProjectUsageBucketRow) for row in result.rows
             ]
@@ -351,7 +355,9 @@ class ResourceUsageHistoryDBSource:
         """Search user usage buckets with pagination."""
         async with self._db.begin_readonly_session() as db_sess:
             query = sa.select(UserUsageBucketRow)
-            result = await execute_batch_querier(db_sess, query, querier, scope)
+            result = await execute_batch_querier(
+                db_sess, query, querier, scopes=[scope] if scope is not None else ()
+            )
             items = [UserUsageBucketData.from_row(row.UserUsageBucketRow) for row in result.rows]
             return UserUsageBucketSearchResult(
                 items=items,

--- a/src/ai/backend/manager/repositories/scheduling_history/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduling_history/db_source/db_source.py
@@ -83,7 +83,7 @@ class SchedulingHistoryDBSource:
         async with self._db.begin_readonly_session() as db_sess:
             query = sa.select(SessionSchedulingHistoryRow)
 
-            result = await execute_batch_querier(db_sess, query, querier, scope)
+            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
 
             items = [row.SessionSchedulingHistoryRow.to_data() for row in result.rows]
 
@@ -155,7 +155,7 @@ class SchedulingHistoryDBSource:
         async with self._db.begin_readonly_session() as db_sess:
             query = sa.select(DeploymentHistoryRow)
 
-            result = await execute_batch_querier(db_sess, query, querier, scope)
+            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
 
             items = [row.DeploymentHistoryRow.to_data() for row in result.rows]
 
@@ -202,7 +202,7 @@ class SchedulingHistoryDBSource:
         async with self._db.begin_readonly_session() as db_sess:
             query = sa.select(RouteHistoryRow)
 
-            result = await execute_batch_querier(db_sess, query, querier, scope)
+            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
 
             items = [row.RouteHistoryRow.to_data() for row in result.rows]
 

--- a/src/ai/backend/manager/repositories/session/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/session/db_source/db_source.py
@@ -551,7 +551,7 @@ class SessionDBSource:
                 db_sess,
                 query,
                 querier,
-                scope=scope,
+                scopes=[scope],
             )
 
             session_rows = [row.SessionRow for row in result.rows]

--- a/src/ai/backend/manager/repositories/user/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/user/db_source/db_source.py
@@ -1307,7 +1307,7 @@ class UserDBSource:
         """
         async with self._db.begin_readonly_session() as db_session:
             query = sa.select(UserRow)
-            result = await execute_batch_querier(db_session, query, querier, scope=scope)
+            result = await execute_batch_querier(db_session, query, querier, scopes=[scope])
 
             items = [row.UserRow.to_data() for row in result.rows]
             return UserSearchResult(
@@ -1347,7 +1347,7 @@ class UserDBSource:
                     ),
                 )
             )
-            result = await execute_batch_querier(db_session, query, querier, scope=scope)
+            result = await execute_batch_querier(db_session, query, querier, scopes=[scope])
 
             items = [row.UserRow.to_data() for row in result.rows]
             return UserSearchResult(
@@ -1375,7 +1375,7 @@ class UserDBSource:
                     UserRow.uuid == UserRoleRow.user_id,
                 )
             )
-            result = await execute_batch_querier(db_session, query, querier, scope=scope)
+            result = await execute_batch_querier(db_session, query, querier, scopes=[scope])
 
             items = [row.UserRow.to_data() for row in result.rows]
             return UserSearchResult(
@@ -1536,7 +1536,7 @@ class UserDBSource:
         """
         async with self._db.begin_readonly_session() as db_session:
             query = sa.select(KeyPairRow)
-            result = await execute_batch_querier(db_session, query, querier, scope=scope)
+            result = await execute_batch_querier(db_session, query, querier, scopes=[scope])
             items = [row.KeyPairRow.to_data() for row in result.rows]
             return SearchResult(
                 items=items,

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -2313,7 +2313,7 @@ class VfolderRepository:
                 db_sess,
                 query,
                 querier,
-                scope=scope,
+                scopes=[scope],
             )
 
             items = [row.VFolderRow.to_data() for row in result.rows]
@@ -2347,7 +2347,7 @@ class VfolderRepository:
                 db_sess,
                 query,
                 querier,
-                scope=scope,
+                scopes=[scope],
             )
 
             items = [row.VFolderRow.to_data() for row in result.rows]

--- a/tests/unit/manager/repositories/base/test_querier.py
+++ b/tests/unit/manager/repositories/base/test_querier.py
@@ -810,6 +810,34 @@ class TestBatchQuerierMultipleScopes:
             assert len(result.rows) == 1
             assert result.rows[0].name == "item-a"
 
+    async def test_multiple_and_conditions_combined_with_multiple_or_scopes(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        scope_test_row_class: type[ScopeValidationTestRow],
+        sample_data: list[dict[str, int | str]],
+    ) -> None:
+        """Final WHERE is `(c1 AND c2) AND (s1 OR s2)` — multiple ANDs + multiple ORs."""
+        async with database_connection.begin_session() as db_sess:
+            table = scope_test_row_class.__table__
+            query = sa.select(table)
+            querier = BatchQuerier(
+                pagination=OffsetPagination(offset=0, limit=10),
+                conditions=[
+                    lambda: ScopeValidationTestRow.id >= 2,
+                    lambda: ScopeValidationTestRow.id <= 4,
+                ],
+            )
+            scope_cat1 = MockSearchScope(checks=[], filter_category="cat1")
+            scope_cat2 = MockSearchScope(checks=[], filter_category="cat2")
+
+            result = await execute_batch_querier(
+                db_sess, query, querier, scopes=[scope_cat1, scope_cat2]
+            )
+
+            # (id ∈ [2,4]) ∩ (category ∈ {cat1, cat2}) = {2:cat1, 3:cat2, 4:cat2}
+            assert {row.id for row in result.rows} == {2, 3, 4}
+            assert result.total_count == 3
+
     async def test_existence_checks_aggregated_across_scopes(
         self,
         database_connection: ExtendedAsyncSAEngine,

--- a/tests/unit/manager/repositories/base/test_querier.py
+++ b/tests/unit/manager/repositories/base/test_querier.py
@@ -463,7 +463,7 @@ class TestBatchQuerierScopeValidation:
                 pagination=OffsetPagination(offset=0, limit=10),
             )
 
-            result = await execute_batch_querier(db_sess, query, querier, scope=None)
+            result = await execute_batch_querier(db_sess, query, querier)
 
             assert len(result.rows) == 4
             assert result.total_count == 4
@@ -483,7 +483,7 @@ class TestBatchQuerierScopeValidation:
             )
             scope = MockSearchScope(checks=[])
 
-            result = await execute_batch_querier(db_sess, query, querier, scope=scope)
+            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
 
             assert len(result.rows) == 4
             assert result.total_count == 4
@@ -511,7 +511,7 @@ class TestBatchQuerierScopeValidation:
                 ],
             )
 
-            result = await execute_batch_querier(db_sess, query, querier, scope=scope)
+            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
 
             assert len(result.rows) == 4
             assert result.total_count == 4
@@ -540,7 +540,7 @@ class TestBatchQuerierScopeValidation:
             )
 
             with pytest.raises(TestScopeValidationError):
-                await execute_batch_querier(db_sess, query, querier, scope=scope)
+                await execute_batch_querier(db_sess, query, querier, scopes=[scope])
 
     async def test_passes_validation_when_all_checks_succeed(
         self,
@@ -570,7 +570,7 @@ class TestBatchQuerierScopeValidation:
                 ],
             )
 
-            result = await execute_batch_querier(db_sess, query, querier, scope=scope)
+            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
 
             assert len(result.rows) == 4
             assert result.total_count == 4
@@ -604,7 +604,7 @@ class TestBatchQuerierScopeValidation:
             )
 
             with pytest.raises(TestScopeValidationError) as exc_info:
-                await execute_batch_querier(db_sess, query, querier, scope=scope)
+                await execute_batch_querier(db_sess, query, querier, scopes=[scope])
 
             assert "first error" in str(exc_info.value)
 
@@ -637,7 +637,7 @@ class TestBatchQuerierScopeValidation:
             )
 
             with pytest.raises(TestScopeValidationError2) as exc_info:
-                await execute_batch_querier(db_sess, query, querier, scope=scope)
+                await execute_batch_querier(db_sess, query, querier, scopes=[scope])
 
             assert "second error" in str(exc_info.value)
 
@@ -670,7 +670,7 @@ class TestBatchQuerierScopeValidation:
             )
 
             with pytest.raises(TestScopeValidationError) as exc_info:
-                await execute_batch_querier(db_sess, query, querier, scope=scope)
+                await execute_batch_querier(db_sess, query, querier, scopes=[scope])
 
             assert "first error - priority" in str(exc_info.value)
 
@@ -698,9 +698,190 @@ class TestBatchQuerierScopeValidation:
                 filter_category="cat1",  # filter by cat1 category
             )
 
-            result = await execute_batch_querier(db_sess, query, querier, scope=scope)
+            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
 
             assert len(result.rows) == 2  # item-a, item-b belong to cat1
             assert result.total_count == 2
             for row in result.rows:
                 assert row.category == "cat1"
+
+
+class TestBatchQuerierMultipleScopes:
+    """Tests for batch querier with multiple SearchScopes OR-combined."""
+
+    @pytest.fixture
+    async def scope_test_row_class(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[type[ScopeValidationTestRow], None]:
+        async with database_connection.begin() as conn:
+            await conn.run_sync(
+                lambda c: Base.metadata.create_all(c, [ScopeValidationTestRow.__table__])
+            )
+
+        yield ScopeValidationTestRow
+
+        async with database_connection.begin() as conn:
+            await conn.execute(sa.text("DROP TABLE IF EXISTS test_scope_validation CASCADE"))
+
+    @pytest.fixture
+    async def sample_data(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        scope_test_row_class: type[ScopeValidationTestRow],
+    ) -> AsyncGenerator[list[dict[str, int | str]], None]:
+        data: list[dict[str, int | str]] = [
+            {"id": 1, "name": "item-a", "category": "cat1"},
+            {"id": 2, "name": "item-b", "category": "cat1"},
+            {"id": 3, "name": "item-c", "category": "cat2"},
+            {"id": 4, "name": "item-d", "category": "cat2"},
+            {"id": 5, "name": "item-e", "category": "cat3"},
+        ]
+
+        async with database_connection.begin_session() as db_sess:
+            table = scope_test_row_class.__table__
+            await db_sess.execute(table.insert(), data)
+
+        yield data
+
+    async def test_empty_scopes_skips_validation_and_filtering(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        scope_test_row_class: type[ScopeValidationTestRow],
+        sample_data: list[dict[str, int | str]],
+    ) -> None:
+        """When scopes is empty (default), behaves like the no-scope case."""
+        async with database_connection.begin_session() as db_sess:
+            table = scope_test_row_class.__table__
+            query = sa.select(table)
+            querier = BatchQuerier(
+                pagination=OffsetPagination(offset=0, limit=10),
+            )
+
+            result = await execute_batch_querier(db_sess, query, querier, scopes=())
+
+            assert len(result.rows) == 5
+            assert result.total_count == 5
+
+    async def test_multiple_scopes_are_or_combined(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        scope_test_row_class: type[ScopeValidationTestRow],
+        sample_data: list[dict[str, int | str]],
+    ) -> None:
+        """Multiple scopes' to_condition() results are OR-combined, not AND-combined."""
+        async with database_connection.begin_session() as db_sess:
+            table = scope_test_row_class.__table__
+            query = sa.select(table)
+            querier = BatchQuerier(
+                pagination=OffsetPagination(offset=0, limit=10),
+            )
+            scope_cat1 = MockSearchScope(checks=[], filter_category="cat1")
+            scope_cat2 = MockSearchScope(checks=[], filter_category="cat2")
+
+            result = await execute_batch_querier(
+                db_sess, query, querier, scopes=[scope_cat1, scope_cat2]
+            )
+
+            assert {row.category for row in result.rows} == {"cat1", "cat2"}
+            assert result.total_count == 4
+
+    async def test_multiple_scopes_or_combined_with_querier_conditions_as_and(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        scope_test_row_class: type[ScopeValidationTestRow],
+        sample_data: list[dict[str, int | str]],
+    ) -> None:
+        """OR-combined scope predicate is AND-merged with the rest of querier.conditions."""
+        async with database_connection.begin_session() as db_sess:
+            table = scope_test_row_class.__table__
+            query = sa.select(table)
+            querier = BatchQuerier(
+                pagination=OffsetPagination(offset=0, limit=10),
+                conditions=[lambda: ScopeValidationTestRow.name == "item-a"],
+            )
+            scope_cat1 = MockSearchScope(checks=[], filter_category="cat1")
+            scope_cat2 = MockSearchScope(checks=[], filter_category="cat2")
+
+            result = await execute_batch_querier(
+                db_sess, query, querier, scopes=[scope_cat1, scope_cat2]
+            )
+
+            assert len(result.rows) == 1
+            assert result.rows[0].name == "item-a"
+
+    async def test_existence_checks_aggregated_across_scopes(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        scope_test_row_class: type[ScopeValidationTestRow],
+        sample_data: list[dict[str, int | str]],
+    ) -> None:
+        """existence_checks from all scopes are validated together; success path runs."""
+        async with database_connection.begin_session() as db_sess:
+            table = scope_test_row_class.__table__
+            query = sa.select(table)
+            querier = BatchQuerier(
+                pagination=OffsetPagination(offset=0, limit=10),
+            )
+            scope_a = MockSearchScope(
+                checks=[
+                    ExistenceCheck(
+                        column=ScopeValidationTestRow.name,
+                        value="item-a",
+                        error=TestScopeValidationError("item-a missing"),
+                    ),
+                ],
+                filter_category="cat1",
+            )
+            scope_b = MockSearchScope(
+                checks=[
+                    ExistenceCheck(
+                        column=ScopeValidationTestRow.name,
+                        value="item-c",
+                        error=TestScopeValidationError2("item-c missing"),
+                    ),
+                ],
+                filter_category="cat2",
+            )
+
+            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope_a, scope_b])
+
+            assert {row.category for row in result.rows} == {"cat1", "cat2"}
+            assert result.total_count == 4
+
+    async def test_existence_check_failure_in_any_scope_raises(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        scope_test_row_class: type[ScopeValidationTestRow],
+        sample_data: list[dict[str, int | str]],
+    ) -> None:
+        """If any scope's existence check fails, the aggregated validation raises."""
+        async with database_connection.begin_session() as db_sess:
+            table = scope_test_row_class.__table__
+            query = sa.select(table)
+            querier = BatchQuerier(
+                pagination=OffsetPagination(offset=0, limit=10),
+            )
+            scope_a = MockSearchScope(
+                checks=[
+                    ExistenceCheck(
+                        column=ScopeValidationTestRow.name,
+                        value="item-a",
+                        error=TestScopeValidationError("item-a missing"),
+                    ),
+                ],
+                filter_category="cat1",
+            )
+            scope_b = MockSearchScope(
+                checks=[
+                    ExistenceCheck(
+                        column=ScopeValidationTestRow.name,
+                        value="nonexistent",
+                        error=TestScopeValidationError2("nonexistent missing"),
+                    ),
+                ],
+                filter_category="cat2",
+            )
+
+            with pytest.raises(TestScopeValidationError2):
+                await execute_batch_querier(db_sess, query, querier, scopes=[scope_a, scope_b])


### PR DESCRIPTION
## Summary
- Replace `scope: SearchScope | None` with `scopes: Sequence[SearchScope]` in `execute_batch_querier`. Each scope contributes existence checks (aggregated and validated in one query) and a `to_condition()` result.
- All `to_condition()` results form a single OR group that is AND-merged with `querier.conditions`, producing WHERE `(A AND B AND ...) AND (D OR E OR ...)` on both data and count queries.
- Migrate all existing single-scope call sites to the new sequence-based parameter; no behavior change for single-scope callers.

## Test plan
- [x] Existing single-scope behavior preserved (existing tests pass)
- [x] New tests cover: empty scopes, multiple scopes OR-combined, OR group AND-merged with other conditions, existence-check aggregation, failure raising
- [x] `pants fmt / fix / lint / check` all pass
- [x] `pants test tests/unit/manager/repositories/base/test_querier.py` passes

Resolves BA-6094