### PR TITLE
fix(BA-6110): transition rollback without current_revision to DESTROYING

### DIFF
--- a/changes/11706.fix.md
+++ b/changes/11706.fix.md
@@ -1,0 +1,1 @@
+Transition deployments to DESTROYING (instead of READY) when rollback is triggered but no `current_revision` exists to revert to.

--- a/src/ai/backend/manager/sokovan/CLAUDE.md
+++ b/src/ai/backend/manager/sokovan/CLAUDE.md
@@ -1,0 +1,25 @@
+# Manager Sokovan Layer — Guardrails
+
+> Sokovan is the coordinator layer that advances deployment / route
+> lifecycles tick by tick.
+
+## Handler File Layout
+
+- **One handler = one file**: every `*Handler` class under
+  `sokovan/**/handlers/` lives in its own module.
+- Name the file after the lifecycle stage or sub-step it handles
+  (e.g., `deploying_provisioning.py`, `deploying_rolling_back.py`,
+  `warming_up.py`, `terminating.py`).
+- `base.py` is reserved for the abstract `*Handler` base class. Put
+  shared utilities in their own module — never in `base.py`.
+- `__init__.py` only re-exports handler classes; it must not contain
+  implementation.
+
+## Status Transitions
+
+- `status_transitions()` must declare the target lifecycle for each
+  outcome (`success`, `need_retry`, `expired`, `give_up`). Outcomes
+  with no target stay in the current state
+  (see `coordinator._handle_status_transitions`).
+- The coordinator classifies failures from history; handlers only
+  return the failure reason in `DeploymentExecutionError`.

--- a/src/ai/backend/manager/sokovan/deployment/handlers/__init__.py
+++ b/src/ai/backend/manager/sokovan/deployment/handlers/__init__.py
@@ -3,10 +3,8 @@ Deployment lifecycle operation handlers.
 """
 
 from .base import DeploymentHandler
-from .deploying import (
-    DeployingProvisioningHandler,
-    DeployingRollingBackHandler,
-)
+from .deploying_provisioning import DeployingProvisioningHandler
+from .deploying_rolling_back import DeployingRollingBackHandler
 from .destroying import DestroyingDeploymentHandler
 from .reconcile import ReconcileDeploymentHandler
 from .replica import CheckReplicaDeploymentHandler

--- a/src/ai/backend/manager/sokovan/deployment/handlers/deploying_provisioning.py
+++ b/src/ai/backend/manager/sokovan/deployment/handlers/deploying_provisioning.py
@@ -1,28 +1,3 @@
-"""Handlers for DEPLOYING sub-steps (BEP-1049).
-
-Two DEPLOYING handlers are registered in the coordinator's HandlerRegistry:
-
-- **DeployingProvisioningHandler**: Runs the strategy FSM each cycle to
-  create/drain routes and check for completion.
-- **DeployingRollingBackHandler**: Clears ``deploying_revision`` and
-  transitions directly to READY.
-
-Sub-step flow::
-
-    PROVISIONING ──(need_retry)──▸ PROVISIONING  (route mutations, logged)
-         │
-         │ (success)
-         ▼
-       READY  (completed — all routes replaced)
-
-    PROVISIONING ──(timeout)──▸ ROLLING_BACK ──(success)──▸ READY
-
-The evaluator determines sub-step assignments and route mutations;
-the applier persists them to DB atomically.  Each handler classifies
-deployments into successes (transition forward), need_retry (route mutations
-with history logged), and skipped (no change — waiting).
-"""
-
 from __future__ import annotations
 
 import logging
@@ -62,11 +37,6 @@ from ai.backend.manager.sokovan.deployment.types import (
 from .base import DeploymentHandler
 
 log = BraceStyleAdapter(logging.getLogger(__name__))
-
-
-# ---------------------------------------------------------------------------
-# DEPLOYING sub-step handlers
-# ---------------------------------------------------------------------------
 
 
 class DeployingProvisioningHandler(DeploymentHandler):
@@ -265,77 +235,6 @@ class DeployingProvisioningHandler(DeploymentHandler):
             DeploymentLifecycleType.DEPLOYING,
             sub_step=DeploymentLifecycleSubStep.DEPLOYING_PROVISIONING,
         )
-        await self._deployment_controller.mark_lifecycle_needed(
-            DeploymentLifecycleType.DEPLOYING,
-            sub_step=DeploymentLifecycleSubStep.DEPLOYING_ROLLING_BACK,
-        )
-        await self._route_controller.mark_lifecycle_needed(RouteLifecycleType.PROVISIONING)
-
-
-class DeployingRollingBackHandler(DeploymentHandler):
-    """Handler for DEPLOYING / ROLLING_BACK sub-step.
-
-    Clears ``deploying_revision`` and transitions directly to READY.
-    """
-
-    def __init__(
-        self,
-        deployment_controller: DeploymentController,
-        route_controller: RouteController,
-        deployment_repo: DeploymentRepository,
-    ) -> None:
-        self._deployment_controller = deployment_controller
-        self._route_controller = route_controller
-        self._deployment_repo = deployment_repo
-
-    @classmethod
-    @override
-    def name(cls) -> str:
-        return "deploying-rolling-back"
-
-    @classmethod
-    @override
-    def category(cls) -> DeploymentHandlerCategory:
-        return DeploymentHandlerCategory.LIFECYCLE
-
-    @property
-    @override
-    def lock_id(self) -> LockID | None:
-        return LockID.LOCKID_DEPLOYMENT_DEPLOYING
-
-    @classmethod
-    @override
-    def target_statuses(cls) -> DeploymentTargetStatuses:
-        return DeploymentTargetStatuses(
-            lifecycle_stages=[EndpointLifecycle.DEPLOYING],
-            sub_steps=[DeploymentLifecycleSubStep.DEPLOYING_ROLLING_BACK],
-        )
-
-    @classmethod
-    @override
-    def status_transitions(cls) -> DeploymentStatusTransitions:
-        return DeploymentStatusTransitions(
-            success=DeploymentLifecycleStatus(
-                lifecycle=EndpointLifecycle.READY,
-                sub_step=None,
-            ),
-        )
-
-    @override
-    async def execute(
-        self, deployments: Sequence[DeploymentWithHistory]
-    ) -> DeploymentExecutionResult:
-        all_deployment_ids = {deployment.deployment_info.id for deployment in deployments}
-        await self._deployment_repo.clear_deploying_revision(all_deployment_ids)
-        log.info(
-            "Cleared deploying_revision for {} rolling-back deployments",
-            len(all_deployment_ids),
-        )
-
-        return DeploymentExecutionResult(successes=list(deployments))
-
-    @override
-    async def post_process(self, result: DeploymentExecutionResult) -> None:
         await self._deployment_controller.mark_lifecycle_needed(
             DeploymentLifecycleType.DEPLOYING,
             sub_step=DeploymentLifecycleSubStep.DEPLOYING_ROLLING_BACK,

--- a/src/ai/backend/manager/sokovan/deployment/handlers/deploying_rolling_back.py
+++ b/src/ai/backend/manager/sokovan/deployment/handlers/deploying_rolling_back.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import override
+
+from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.data.deployment.types import (
+    DeploymentHandlerCategory,
+    DeploymentLifecycleStatus,
+    DeploymentLifecycleSubStep,
+    DeploymentStatusTransitions,
+    DeploymentTargetStatuses,
+)
+from ai.backend.manager.data.model_serving.types import EndpointLifecycle
+from ai.backend.manager.defs import LockID
+from ai.backend.manager.repositories.deployment.repository import DeploymentRepository
+from ai.backend.manager.sokovan.deployment.deployment_controller import DeploymentController
+from ai.backend.manager.sokovan.deployment.route.route_controller import RouteController
+from ai.backend.manager.sokovan.deployment.route.types import RouteLifecycleType
+from ai.backend.manager.sokovan.deployment.types import (
+    DeploymentExecutionResult,
+    DeploymentLifecycleType,
+    DeploymentWithHistory,
+)
+
+from .base import DeploymentHandler
+
+log = BraceStyleAdapter(logging.getLogger(__name__))
+
+
+class DeployingRollingBackHandler(DeploymentHandler):
+    """Handler for DEPLOYING / ROLLING_BACK sub-step."""
+
+    def __init__(
+        self,
+        deployment_controller: DeploymentController,
+        route_controller: RouteController,
+        deployment_repo: DeploymentRepository,
+    ) -> None:
+        self._deployment_controller = deployment_controller
+        self._route_controller = route_controller
+        self._deployment_repo = deployment_repo
+
+    @classmethod
+    @override
+    def name(cls) -> str:
+        return "deploying-rolling-back"
+
+    @classmethod
+    @override
+    def category(cls) -> DeploymentHandlerCategory:
+        return DeploymentHandlerCategory.LIFECYCLE
+
+    @property
+    @override
+    def lock_id(self) -> LockID | None:
+        return LockID.LOCKID_DEPLOYMENT_DEPLOYING
+
+    @classmethod
+    @override
+    def target_statuses(cls) -> DeploymentTargetStatuses:
+        return DeploymentTargetStatuses(
+            lifecycle_stages=[EndpointLifecycle.DEPLOYING],
+            sub_steps=[DeploymentLifecycleSubStep.DEPLOYING_ROLLING_BACK],
+        )
+
+    @classmethod
+    @override
+    def status_transitions(cls) -> DeploymentStatusTransitions:
+        return DeploymentStatusTransitions(
+            success=DeploymentLifecycleStatus(
+                lifecycle=EndpointLifecycle.READY,
+                sub_step=None,
+            ),
+        )
+
+    @override
+    async def execute(
+        self, deployments: Sequence[DeploymentWithHistory]
+    ) -> DeploymentExecutionResult:
+        all_deployment_ids = {deployment.deployment_info.id for deployment in deployments}
+        await self._deployment_repo.clear_deploying_revision(all_deployment_ids)
+        log.info(
+            "Cleared deploying_revision for {} rolling-back deployments",
+            len(all_deployment_ids),
+        )
+
+        return DeploymentExecutionResult(successes=list(deployments))
+
+    @override
+    async def post_process(self, result: DeploymentExecutionResult) -> None:
+        await self._deployment_controller.mark_lifecycle_needed(
+            DeploymentLifecycleType.DEPLOYING,
+            sub_step=DeploymentLifecycleSubStep.DEPLOYING_ROLLING_BACK,
+        )
+        await self._route_controller.mark_lifecycle_needed(RouteLifecycleType.PROVISIONING)

--- a/src/ai/backend/manager/sokovan/deployment/handlers/deploying_rolling_back.py
+++ b/src/ai/backend/manager/sokovan/deployment/handlers/deploying_rolling_back.py
@@ -19,6 +19,7 @@ from ai.backend.manager.sokovan.deployment.deployment_controller import Deployme
 from ai.backend.manager.sokovan.deployment.route.route_controller import RouteController
 from ai.backend.manager.sokovan.deployment.route.types import RouteLifecycleType
 from ai.backend.manager.sokovan.deployment.types import (
+    DeploymentExecutionError,
     DeploymentExecutionResult,
     DeploymentLifecycleType,
     DeploymentWithHistory,
@@ -68,25 +69,58 @@ class DeployingRollingBackHandler(DeploymentHandler):
     @classmethod
     @override
     def status_transitions(cls) -> DeploymentStatusTransitions:
+        destroying = DeploymentLifecycleStatus(
+            lifecycle=EndpointLifecycle.DESTROYING,
+            sub_step=None,
+        )
         return DeploymentStatusTransitions(
             success=DeploymentLifecycleStatus(
                 lifecycle=EndpointLifecycle.READY,
                 sub_step=None,
             ),
+            need_retry=destroying,
+            expired=destroying,
+            give_up=destroying,
         )
 
     @override
     async def execute(
         self, deployments: Sequence[DeploymentWithHistory]
     ) -> DeploymentExecutionResult:
-        all_deployment_ids = {deployment.deployment_info.id for deployment in deployments}
-        await self._deployment_repo.clear_deploying_revision(all_deployment_ids)
-        log.info(
-            "Cleared deploying_revision for {} rolling-back deployments",
-            len(all_deployment_ids),
-        )
+        rollback_targets: list[DeploymentWithHistory] = []
+        failures: list[DeploymentExecutionError] = []
 
-        return DeploymentExecutionResult(successes=list(deployments))
+        for deployment in deployments:
+            if deployment.deployment_info.current_revision is None:
+                failures.append(
+                    DeploymentExecutionError(
+                        deployment_info=deployment,
+                        reason="No current revision to roll back to",
+                        error_detail=(
+                            "Initial deployment failed; current_revision is None. "
+                            "Transitioning to DESTROYING."
+                        ),
+                    )
+                )
+            else:
+                rollback_targets.append(deployment)
+
+        if rollback_targets:
+            await self._deployment_repo.clear_deploying_revision({
+                d.deployment_info.id for d in rollback_targets
+            })
+            log.info(
+                "Cleared deploying_revision for {} rolling-back deployments",
+                len(rollback_targets),
+            )
+
+        if failures:
+            log.warning(
+                "Rolling back {} deployments with no current_revision -> DESTROYING",
+                len(failures),
+            )
+
+        return DeploymentExecutionResult(successes=rollback_targets, failures=failures)
 
     @override
     async def post_process(self, result: DeploymentExecutionResult) -> None:

--- a/tests/unit/manager/sokovan/deployment/handlers/test_deploying_handler.py
+++ b/tests/unit/manager/sokovan/deployment/handlers/test_deploying_handler.py
@@ -31,7 +31,7 @@ from ai.backend.manager.data.deployment.types import (
     ReplicaData,
 )
 from ai.backend.manager.data.resource.types import ScalingGroupProxyTarget
-from ai.backend.manager.sokovan.deployment.handlers.deploying import (
+from ai.backend.manager.sokovan.deployment.handlers.deploying_provisioning import (
     DeployingProvisioningHandler,
 )
 from ai.backend.manager.sokovan.deployment.strategy.applier import StrategyApplyResult

--- a/tests/unit/manager/sokovan/deployment/handlers/test_deploying_rolling_back_handler.py
+++ b/tests/unit/manager/sokovan/deployment/handlers/test_deploying_rolling_back_handler.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from dateutil.tz import tzutc
+
+from ai.backend.common.data.endpoint.types import EndpointLifecycle, ScalingState
+from ai.backend.common.identifier.deployment import DeploymentID
+from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
+from ai.backend.manager.data.deployment.types import (
+    DeploymentInfo,
+    DeploymentLifecycleSubStep,
+    DeploymentMetadata,
+    DeploymentNetworkData,
+    DeploymentOptions,
+    DeploymentState,
+    ModelRevisionData,
+    ReplicaData,
+)
+from ai.backend.manager.sokovan.deployment.handlers.deploying_rolling_back import (
+    DeployingRollingBackHandler,
+)
+from ai.backend.manager.sokovan.deployment.types import (
+    DeploymentWithHistory,
+)
+
+
+def _build_deployment(
+    *,
+    has_current_revision: bool,
+) -> DeploymentWithHistory:
+    current_revision: ModelRevisionData | None = None
+    if has_current_revision:
+        current_mock = MagicMock()
+        current_mock.id = DeploymentRevisionID(uuid4())
+        current_revision = cast(ModelRevisionData, current_mock)
+
+    deploying_mock = MagicMock()
+    deploying_mock.id = DeploymentRevisionID(uuid4())
+
+    return DeploymentWithHistory(
+        deployment_info=DeploymentInfo(
+            id=DeploymentID(uuid4()),
+            metadata=DeploymentMetadata(
+                name="test-deployment",
+                domain="default",
+                project=uuid4(),
+                resource_group="default",
+                created_user=uuid4(),
+                session_owner=uuid4(),
+                created_at=datetime.now(tzutc()),
+                revision_history_limit=10,
+            ),
+            state=DeploymentState(
+                lifecycle=EndpointLifecycle.DEPLOYING,
+                scaling_state=ScalingState.STABLE,
+                retry_count=0,
+            ),
+            replica=ReplicaData(
+                replica_count=1,
+                desired_replica_count=1,
+            ),
+            network=DeploymentNetworkData(
+                open_to_public=False,
+                access_token_ids=None,
+                url="http://endpoint/v1",
+                preferred_domain_name=None,
+            ),
+            current_revision=current_revision,
+            deploying_revision=cast(ModelRevisionData, deploying_mock),
+            sub_step=DeploymentLifecycleSubStep.DEPLOYING_ROLLING_BACK,
+            options=DeploymentOptions(),
+        ),
+        last_history=None,
+    )
+
+
+class TestDeployingRollingBackHandler:
+    """Tests for DeployingRollingBackHandler."""
+
+    @pytest.fixture
+    def mock_deployment_repo(self) -> AsyncMock:
+        repo = AsyncMock()
+        repo.clear_deploying_revision = AsyncMock()
+        return repo
+
+    @pytest.fixture
+    def handler(
+        self,
+        mock_deployment_repo: AsyncMock,
+    ) -> DeployingRollingBackHandler:
+        return DeployingRollingBackHandler(
+            deployment_controller=AsyncMock(),
+            route_controller=AsyncMock(),
+            deployment_repo=mock_deployment_repo,
+        )
+
+    async def test_with_current_revision_clears_and_marks_success(
+        self,
+        handler: DeployingRollingBackHandler,
+        mock_deployment_repo: AsyncMock,
+    ) -> None:
+        deployment = _build_deployment(has_current_revision=True)
+
+        result = await handler.execute([deployment])
+
+        assert len(result.successes) == 1
+        assert result.successes[0] is deployment
+        assert result.failures == []
+        mock_deployment_repo.clear_deploying_revision.assert_awaited_once_with({
+            deployment.deployment_info.id
+        })
+
+    async def test_without_current_revision_is_failure(
+        self,
+        handler: DeployingRollingBackHandler,
+        mock_deployment_repo: AsyncMock,
+    ) -> None:
+        deployment = _build_deployment(has_current_revision=False)
+
+        result = await handler.execute([deployment])
+
+        assert result.successes == []
+        assert len(result.failures) == 1
+        assert result.failures[0].deployment_info is deployment
+        mock_deployment_repo.clear_deploying_revision.assert_not_awaited()
+
+    async def test_mixed_batch_separates_successes_and_failures(
+        self,
+        handler: DeployingRollingBackHandler,
+        mock_deployment_repo: AsyncMock,
+    ) -> None:
+        with_revision = _build_deployment(has_current_revision=True)
+        without_revision = _build_deployment(has_current_revision=False)
+
+        result = await handler.execute([with_revision, without_revision])
+
+        assert [d.deployment_info.id for d in result.successes] == [
+            with_revision.deployment_info.id
+        ]
+        assert [e.deployment_info.deployment_info.id for e in result.failures] == [
+            without_revision.deployment_info.id
+        ]
+        mock_deployment_repo.clear_deploying_revision.assert_awaited_once_with({
+            with_revision.deployment_info.id
+        })
+
+    def test_status_transitions_route_failures_to_destroying(self) -> None:
+        transitions = DeployingRollingBackHandler.status_transitions()
+
+        assert transitions.success is not None
+        assert transitions.success.lifecycle == EndpointLifecycle.READY
+        for failure_transition in (
+            transitions.need_retry,
+            transitions.expired,
+            transitions.give_up,
+        ):
+            assert failure_transition is not None
+            assert failure_transition.lifecycle == EndpointLifecycle.DESTROYING


### PR DESCRIPTION
## Summary
- `DeployingRollingBackHandler` previously cleared `deploying_revision` and unconditionally transitioned to READY, leaving deployments whose initial rollout failed (no `current_revision`) in a serving-less READY state.
- Now classifies such deployments as failures and routes them to DESTROYING via `status_transitions`; deployments with a `current_revision` continue to roll back to READY.
- Splits `deployment/handlers/deploying.py` into per-handler modules (`deploying_provisioning.py`, `deploying_rolling_back.py`) and documents the "1 handler = 1 file" rule in a new `sokovan/CLAUDE.md`.

## Test plan
- [x] `pants fmt/fix/lint --changed-since=origin/main` pass
- [x] Existing `test_deploying_handler.py` passes with new import path
- [x] New `test_deploying_rolling_back_handler.py` covers: has-current-revision → success, no-current-revision → failure, mixed batch separation, status_transitions routing to DESTROYING
- [ ] Manual: create a model service with an image that fails to start; verify the endpoint transitions to `destroying` after the strategy timeout instead of READY

Resolves BA-6110