### PR TITLE
fix(BA-6116): Skip alembic migration if model definition is None

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/b8a85c96607c_rewrap_legacy_string_start_command_via_.py
+++ b/src/ai/backend/manager/models/alembic/versions/b8a85c96607c_rewrap_legacy_string_start_command_via_.py
@@ -32,6 +32,8 @@ def _rewrap_model_definition(conn: Connection, table: str, column: str) -> None:
 
     for row_id, model_definition in rows:
         changed = False
+        if model_definition is None:
+            continue
         for model in model_definition.get("models") or []:
             service = model.get("service") or {}
             start_command = service.get("start_command")


### PR DESCRIPTION
resolves #11705 (BA-6116)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
