### PR TITLE
fix(BA-6121): Insert `reads_vfolder_config_files` false value in non-custom variants

### DIFF
--- a/changes/11712.fix.md
+++ b/changes/11712.fix.md
@@ -1,0 +1,1 @@
+Fix custom runtime variant's `reads_vfolder_config_files` flag being silently dropped during fixture load, which caused model service deployments with the custom variant to fail on fresh installs.

--- a/fixtures/manager/example-runtime-variants.json
+++ b/fixtures/manager/example-runtime-variants.json
@@ -3,6 +3,7 @@
     {
       "name": "vllm",
       "description": "vLLM",
+      "reads_vfolder_config_files": false,
       "default_model_definition": {
         "models": [
           {
@@ -24,6 +25,7 @@
     {
       "name": "nim",
       "description": "NVIDIA NIM",
+      "reads_vfolder_config_files": false,
       "default_model_definition": {
         "models": [
           {
@@ -44,6 +46,7 @@
     {
       "name": "cmd",
       "description": "Predefined Image Command",
+      "reads_vfolder_config_files": false,
       "default_model_definition": {
         "models": [
           {
@@ -58,6 +61,7 @@
     {
       "name": "huggingface-tgi",
       "description": "Huggingface TGI",
+      "reads_vfolder_config_files": false,
       "default_model_definition": {
         "models": [
           {
@@ -79,6 +83,7 @@
     {
       "name": "sglang",
       "description": "SGLang",
+      "reads_vfolder_config_files": false,
       "default_model_definition": {
         "models": [
           {
@@ -106,6 +111,7 @@
     {
       "name": "modular-max",
       "description": "Modular MAX",
+      "reads_vfolder_config_files": false,
       "default_model_definition": {
         "models": [
           {

--- a/src/ai/backend/install/fixtures/example-runtime-variants.json
+++ b/src/ai/backend/install/fixtures/example-runtime-variants.json
@@ -3,6 +3,7 @@
     {
       "name": "vllm",
       "description": "vLLM",
+      "reads_vfolder_config_files": false,
       "default_model_definition": {
         "models": [
           {
@@ -24,6 +25,7 @@
     {
       "name": "nim",
       "description": "NVIDIA NIM",
+      "reads_vfolder_config_files": false,
       "default_model_definition": {
         "models": [
           {
@@ -44,6 +46,7 @@
     {
       "name": "cmd",
       "description": "Predefined Image Command",
+      "reads_vfolder_config_files": false,
       "default_model_definition": {
         "models": [
           {
@@ -58,6 +61,7 @@
     {
       "name": "huggingface-tgi",
       "description": "Huggingface TGI",
+      "reads_vfolder_config_files": false,
       "default_model_definition": {
         "models": [
           {
@@ -79,6 +83,7 @@
     {
       "name": "sglang",
       "description": "SGLang",
+      "reads_vfolder_config_files": false,
       "default_model_definition": {
         "models": [
           {
@@ -106,6 +111,7 @@
     {
       "name": "modular-max",
       "description": "Modular MAX",
+      "reads_vfolder_config_files": false,
       "default_model_definition": {
         "models": [
           {


### PR DESCRIPTION
## Summary

On fresh installs, every runtime variant — including `custom` — ended up with `reads_vfolder_config_files = false`, so the deployment revision draft chain never read `model-definition.yaml` and `add_revision` failed with `ModelConfig.name Field required`.

Resolves #11711 (BA-6121). The backfill migration `0b10b2c6a972` (BA-6085) covers upgrades but does **not** run on fresh installs because `mgr schema oneshot` stamps `alembic_version` straight to head without executing any data migrations.

## Root cause

`populate_fixture` inserts the rows via `sa.insert(table).values(list_of_dicts).on_conflict_do_nothing()`. SQLAlchemy uses **only the keys from the first dict** to build the column list; keys that appear only on later rows are silently dropped from the rendered SQL.

The first variant in the fixture (`vllm`) omitted `reads_vfolder_config_files`, so the `true` value declared on the last variant (`custom`) never made it into the INSERT, and every row took the server default `false`.

## Fix

Add an explicit `"reads_vfolder_config_files": false` to every non-custom variant in both fixture files (`fixtures/manager/...` and `src/ai/backend/install/fixtures/...`, kept in sync). The column is now in the first row's keyset, survives the values() flattening, and `custom` arrives with `true` as intended.

Not touching `populate_fixture` itself — making the fixture data explicit is the lowest-risk fix; the mixed-key drop is a separate footgun to address later.

## Test plan

- [x] SQL compile preview confirms the rendered INSERT now includes `reads_vfolder_config_files` and `custom` arrives as `true`.
- [ ] Fresh install via `install-dev.sh`; confirm `custom = t`, others `= f` in `runtime_variants`.
- [ ] Create a model service deployment with `RuntimeVariant=custom`; revision must reach `READY` and the replica must reach `HEALTHY`.