### PR TITLE
feat(BA-6096): scoped audit log search action, service, and repository

### DIFF
--- a/changes/11713.feature.md
+++ b/changes/11713.feature.md
@@ -1,0 +1,1 @@
+Add the service and repository core for scoped audit log search — per-target RBAC batch validation plus `OR`'d `SearchScope` against `audit_logs`.

--- a/src/ai/backend/client/v2/domains_v2/audit_log.py
+++ b/src/ai/backend/client/v2/domains_v2/audit_log.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from ai.backend.client.v2.base_domain import BaseDomainClient
 from ai.backend.common.dto.manager.v2.audit_log.request import AdminSearchAuditLogsInput
-from ai.backend.common.dto.manager.v2.audit_log.response import AdminSearchAuditLogsPayload
+from ai.backend.common.dto.manager.v2.audit_log.response import SearchAuditLogsPayload
 
 _PATH = "/v2/audit-logs"
 
@@ -12,11 +12,11 @@ _PATH = "/v2/audit-logs"
 class V2AuditLogClient(BaseDomainClient):
     """SDK client for audit log operations."""
 
-    async def search(self, request: AdminSearchAuditLogsInput) -> AdminSearchAuditLogsPayload:
+    async def search(self, request: AdminSearchAuditLogsInput) -> SearchAuditLogsPayload:
         """Search audit logs with admin scope."""
         return await self._client.typed_request(
             "POST",
             f"{_PATH}/search",
             request=request,
-            response_model=AdminSearchAuditLogsPayload,
+            response_model=SearchAuditLogsPayload,
         )

--- a/src/ai/backend/common/dto/manager/v2/audit_log/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/audit_log/__init__.py
@@ -9,8 +9,8 @@ from ai.backend.common.dto.manager.v2.audit_log.request import (
     ScopedSearchAuditLogsInput,
 )
 from ai.backend.common.dto.manager.v2.audit_log.response import (
-    AdminSearchAuditLogsPayload,
     AuditLogNode,
+    SearchAuditLogsPayload,
 )
 from ai.backend.common.dto.manager.v2.audit_log.types import (
     AuditLogOrderField,
@@ -20,7 +20,6 @@ from ai.backend.common.dto.manager.v2.audit_log.types import (
 
 __all__ = (
     "AdminSearchAuditLogsInput",
-    "AdminSearchAuditLogsPayload",
     "AuditLogFilter",
     "AuditLogNode",
     "AuditLogOrder",
@@ -30,4 +29,5 @@ __all__ = (
     "AuditLogStatusFilter",
     "OrderDirection",
     "ScopedSearchAuditLogsInput",
+    "SearchAuditLogsPayload",
 )

--- a/src/ai/backend/common/dto/manager/v2/audit_log/response.py
+++ b/src/ai/backend/common/dto/manager/v2/audit_log/response.py
@@ -12,8 +12,8 @@ from ai.backend.common.api_handlers import BaseResponseModel
 from .types import AuditLogStatus
 
 __all__ = (
-    "AdminSearchAuditLogsPayload",
     "AuditLogNode",
+    "SearchAuditLogsPayload",
 )
 
 
@@ -35,7 +35,7 @@ class AuditLogNode(BaseResponseModel):
     status: AuditLogStatus = Field(description="Status of the operation")
 
 
-class AdminSearchAuditLogsPayload(BaseResponseModel):
+class SearchAuditLogsPayload(BaseResponseModel):
     """Payload for audit log search result."""
 
     items: list[AuditLogNode] = Field(description="Audit log list")

--- a/src/ai/backend/manager/actions/validators/rbac/__init__.py
+++ b/src/ai/backend/manager/actions/validators/rbac/__init__.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.legacy import (
     LegacyScopeActionRBACValidator,
     LegacySingleEntityActionRBACValidator,
@@ -14,6 +15,7 @@ from ai.backend.manager.actions.validators.rbac.single_entity import (
 class RBACValidators:
     scope: ScopeActionRBACValidator
     single_entity: SingleEntityActionRBACValidator
+    bulk: BulkActionRBACValidator
 
 
 @dataclass

--- a/src/ai/backend/manager/api/adapters/audit_log/adapter.py
+++ b/src/ai/backend/manager/api/adapters/audit_log/adapter.py
@@ -5,21 +5,24 @@ from __future__ import annotations
 import uuid
 from collections.abc import Sequence
 
+from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.dto.manager.v2.audit_log.request import (
     AdminSearchAuditLogsInput,
     AuditLogFilter,
     AuditLogOrder,
     AuditLogStatusFilter,
+    ScopedSearchAuditLogsInput,
 )
 from ai.backend.common.dto.manager.v2.audit_log.response import (
-    AdminSearchAuditLogsPayload,
     AuditLogNode,
+    SearchAuditLogsPayload,
 )
 from ai.backend.common.dto.manager.v2.audit_log.types import (
     AuditLogOrderField,
     AuditLogStatus,
     OrderDirection,
 )
+from ai.backend.manager.actions.action.types import SearchableActionTarget
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.audit_log.types import AuditLogData
@@ -32,6 +35,11 @@ from ai.backend.manager.repositories.base import (
     QueryOrder,
     combine_conditions_or,
     negate_conditions,
+)
+from ai.backend.manager.services.audit_log.actions.scoped_search import (
+    EntityAuditLogTarget,
+    ScopedSearchAuditLogsAction,
+    TriggeredByAuditLogTarget,
 )
 from ai.backend.manager.services.audit_log.actions.search import SearchAuditLogsAction
 
@@ -64,7 +72,7 @@ class AuditLogAdapter(BaseAdapter):
         audit_log_map = {item.id: self._data_to_node(item) for item in action_result.data}
         return [audit_log_map.get(audit_log_id) for audit_log_id in ids]
 
-    async def admin_search(self, input: AdminSearchAuditLogsInput) -> AdminSearchAuditLogsPayload:
+    async def admin_search(self, input: AdminSearchAuditLogsInput) -> SearchAuditLogsPayload:
         """Search audit logs with filters, ordering, and pagination."""
         conditions = self._convert_filter(input.filter) if input.filter else []
         orders = self._convert_orders(input.order) if input.order else []
@@ -82,12 +90,56 @@ class AuditLogAdapter(BaseAdapter):
         action_result = await self._processors.audit_log.search.wait_for_complete(
             SearchAuditLogsAction(querier=querier)
         )
-        return AdminSearchAuditLogsPayload(
+        return SearchAuditLogsPayload(
             items=[self._data_to_node(item) for item in action_result.data],
             total_count=action_result.total_count,
             has_next_page=action_result.has_next_page,
             has_previous_page=action_result.has_previous_page,
         )
+
+    async def scoped_search(self, input: ScopedSearchAuditLogsInput) -> SearchAuditLogsPayload:
+        """Scoped audit-log search: caller passes a list of scope items; results
+        are the OR-union of matching rows, restricted to items the caller is
+        RBAC-authorized for."""
+        conditions = self._convert_filter(input.filter) if input.filter else []
+        orders = self._convert_orders(input.order) if input.order else []
+        querier = self._build_querier(
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=_AUDIT_LOG_PAGINATION_SPEC,
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+        )
+        targets = self._scope_to_targets(input)
+        action_result = await self._processors.audit_log.scoped_search.wait_for_complete(
+            ScopedSearchAuditLogsAction(items=targets, querier=querier)
+        )
+        return SearchAuditLogsPayload(
+            items=[self._data_to_node(item) for item in action_result.data],
+            total_count=action_result.total_count,
+            has_next_page=action_result.has_next_page,
+            has_previous_page=action_result.has_previous_page,
+        )
+
+    @staticmethod
+    def _scope_to_targets(input: ScopedSearchAuditLogsInput) -> list[SearchableActionTarget]:
+        targets: list[SearchableActionTarget] = []
+        if input.scope.entity:
+            for entity_scope in input.scope.entity:
+                targets.append(
+                    EntityAuditLogTarget(
+                        element_type=RBACElementType(entity_scope.entity_type.value),
+                        element_id=entity_scope.entity_id,
+                    )
+                )
+        if input.scope.triggered_user:
+            for user_scope in input.scope.triggered_user:
+                targets.append(TriggeredByAuditLogTarget(user_id=user_scope.value))
+        return targets
 
     def _convert_filter(self, f: AuditLogFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []

--- a/src/ai/backend/manager/dependencies/processing/composer.py
+++ b/src/ai/backend/manager/dependencies/processing/composer.py
@@ -29,6 +29,7 @@ from ai.backend.manager.actions.monitors.prometheus import PrometheusMonitor
 from ai.backend.manager.actions.monitors.reporter import ReporterMonitor
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import LegacyRBACValidators, RBACValidators
+from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.legacy import (
     LegacyScopeActionRBACValidator,
     LegacySingleEntityActionRBACValidator,
@@ -258,6 +259,7 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
             single_entity=SingleEntityActionRBACValidator(
                 permission_controller_repository, config_provider
             ),
+            bulk=BulkActionRBACValidator(permission_controller_repository, config_provider),
         )
         legacy_rbac_validators = LegacyRBACValidators(
             scope=LegacyScopeActionRBACValidator(permission_controller_repository),

--- a/src/ai/backend/manager/repositories/audit_log/__init__.py
+++ b/src/ai/backend/manager/repositories/audit_log/__init__.py
@@ -4,6 +4,7 @@ from .creators import AuditLogCreatorSpec
 from .options import AuditLogConditions, AuditLogOrders
 from .repositories import AuditLogRepositories
 from .repository import AuditLogRepository
+from .types import EntityAuditLogSearchScope, TriggeredByAuditLogSearchScope
 
 __all__ = (
     "AuditLogConditions",
@@ -11,4 +12,6 @@ __all__ = (
     "AuditLogOrders",
     "AuditLogRepositories",
     "AuditLogRepository",
+    "EntityAuditLogSearchScope",
+    "TriggeredByAuditLogSearchScope",
 )

--- a/src/ai/backend/manager/repositories/audit_log/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/audit_log/db_source/db_source.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
@@ -14,6 +15,7 @@ from ai.backend.manager.models.audit_log import AuditLogRow
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
     Creator,
+    SearchScope,
     execute_batch_querier,
     execute_creator,
 )
@@ -70,6 +72,32 @@ class AuditLogDBSource:
                 db_sess,
                 query,
                 querier,
+            )
+
+            items = [row.AuditLogRow.to_dataclass() for row in result.rows]
+
+            return AuditLogListResult(
+                items=items,
+                total_count=result.total_count,
+                has_next_page=result.has_next_page,
+                has_previous_page=result.has_previous_page,
+            )
+
+    @audit_log_db_source_resilience.apply()
+    async def scoped_search(
+        self,
+        querier: BatchQuerier,
+        scopes: Sequence[SearchScope],
+    ) -> AuditLogListResult:
+        """Search audit logs whose rows match any of ``scopes`` (OR), narrowed by ``querier``."""
+        async with self._db.begin_readonly_session() as db_sess:
+            query = sa.select(AuditLogRow)
+
+            result = await execute_batch_querier(
+                db_sess,
+                query,
+                querier,
+                scopes=scopes,
             )
 
             items = [row.AuditLogRow.to_dataclass() for row in result.rows]

--- a/src/ai/backend/manager/repositories/audit_log/repository.py
+++ b/src/ai/backend/manager/repositories/audit_log/repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from ai.backend.common.exception import BackendAIError
@@ -9,7 +10,7 @@ from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryAr
 from ai.backend.common.resilience.resilience import Resilience
 from ai.backend.manager.data.audit_log.types import AuditLogData, AuditLogListResult
 from ai.backend.manager.models.audit_log import AuditLogRow
-from ai.backend.manager.repositories.base import BatchQuerier, Creator
+from ai.backend.manager.repositories.base import BatchQuerier, Creator, SearchScope
 
 from .db_source import AuditLogDBSource
 
@@ -52,3 +53,12 @@ class AuditLogRepository:
     ) -> AuditLogListResult:
         """Search audit logs with querier pattern."""
         return await self._db_source.search(querier=querier)
+
+    @audit_log_repository_resilience.apply()
+    async def scoped_search(
+        self,
+        querier: BatchQuerier,
+        scopes: Sequence[SearchScope],
+    ) -> AuditLogListResult:
+        """Search audit logs whose rows match any of ``scopes`` (OR), narrowed by ``querier``."""
+        return await self._db_source.scoped_search(querier=querier, scopes=scopes)

--- a/src/ai/backend/manager/repositories/audit_log/types.py
+++ b/src/ai/backend/manager/repositories/audit_log/types.py
@@ -1,0 +1,77 @@
+"""Types for audit log repository operations."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, override
+
+import sqlalchemy as sa
+
+from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.manager.models.audit_log import AuditLogRow
+from ai.backend.manager.repositories.base import (
+    ExistenceCheck,
+    QueryCondition,
+    SearchScope,
+)
+
+__all__ = (
+    "EntityAuditLogSearchScope",
+    "TriggeredByAuditLogSearchScope",
+)
+
+
+@dataclass(frozen=True)
+class EntityAuditLogSearchScope(SearchScope):
+    """Audit log rows tagged with one ``(entity_type, entity_id)`` pair.
+
+    One scope = one item of a scoped audit-log query; the repository layer
+    combines multiple scopes with ``OR`` to realize the ``AuditLogScope``
+    union semantics.
+
+    ``existence_checks`` is empty by ``SearchableActionTarget`` convention —
+    RBAC validation already gates entity reachability.
+    """
+
+    entity_type: RBACElementType
+    entity_id: str
+
+    @override
+    def to_condition(self) -> QueryCondition:
+        entity_type = self.entity_type
+        entity_id = self.entity_id
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return sa.and_(
+                AuditLogRow.entity_type == entity_type,
+                AuditLogRow.entity_id == entity_id,
+            )
+
+        return inner
+
+    @property
+    @override
+    def existence_checks(self) -> Sequence[ExistenceCheck[Any]]:
+        return ()
+
+
+@dataclass(frozen=True)
+class TriggeredByAuditLogSearchScope(SearchScope):
+    """Audit log rows triggered by a single actor user."""
+
+    triggered_by: str
+
+    @override
+    def to_condition(self) -> QueryCondition:
+        triggered_by = self.triggered_by
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AuditLogRow.triggered_by == triggered_by
+
+        return inner
+
+    @property
+    @override
+    def existence_checks(self) -> Sequence[ExistenceCheck[Any]]:
+        return ()

--- a/src/ai/backend/manager/services/audit_log/actions/scoped_search.py
+++ b/src/ai/backend/manager/services/audit_log/actions/scoped_search.py
@@ -1,0 +1,94 @@
+"""Scoped audit-log search action and its searchable targets."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import EntityType, RBACElementType
+from ai.backend.manager.actions.action.bulk import BaseBulkAction, BaseBulkActionResult
+from ai.backend.manager.actions.action.types import SearchableActionTarget
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.audit_log.types import AuditLogData
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.repositories.audit_log.types import (
+    EntityAuditLogSearchScope,
+    TriggeredByAuditLogSearchScope,
+)
+from ai.backend.manager.repositories.base import BatchQuerier, SearchScope
+
+
+@dataclass(frozen=True)
+class EntityAuditLogTarget(SearchableActionTarget):
+    """Scope item keyed by a target entity ``(element_type, element_id)``."""
+
+    element_type: RBACElementType
+    element_id: str
+
+    @override
+    def to_rbac_element_ref(self) -> RBACElementRef:
+        return RBACElementRef(element_type=self.element_type, element_id=self.element_id)
+
+    @override
+    def to_search_scope(self) -> SearchScope:
+        return EntityAuditLogSearchScope(
+            entity_type=self.element_type,
+            entity_id=self.element_id,
+        )
+
+
+@dataclass(frozen=True)
+class TriggeredByAuditLogTarget(SearchableActionTarget):
+    """Scope item keyed by the actor (triggered_by) user."""
+
+    user_id: uuid.UUID
+
+    @override
+    def to_rbac_element_ref(self) -> RBACElementRef:
+        return RBACElementRef(
+            element_type=RBACElementType.USER,
+            element_id=str(self.user_id),
+        )
+
+    @override
+    def to_search_scope(self) -> SearchScope:
+        return TriggeredByAuditLogSearchScope(triggered_by=str(self.user_id))
+
+
+@dataclass
+class ScopedSearchAuditLogsAction(BaseBulkAction[SearchableActionTarget]):
+    items: list[SearchableActionTarget]
+    querier: BatchQuerier
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.AUDIT_LOG
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.SEARCH
+
+    @override
+    def targets(self) -> Sequence[SearchableActionTarget]:
+        return list(self.items)
+
+
+@dataclass
+class ScopedSearchAuditLogsActionResult(BaseBulkActionResult):
+    data: list[AuditLogData]
+    total_count: int
+    has_next_page: bool
+    has_previous_page: bool
+    queried_refs: list[RBACElementRef]
+
+    @override
+    def element_refs(self) -> list[RBACElementRef]:
+        return list(self.queried_refs)

--- a/src/ai/backend/manager/services/audit_log/processors.py
+++ b/src/ai/backend/manager/services/audit_log/processors.py
@@ -4,11 +4,16 @@ from typing import override
 
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
+from ai.backend.manager.actions.processor.bulk import BulkActionProcessor
 from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.audit_log.actions.create import (
     CreateAuditLogAction,
     CreateAuditLogActionResult,
+)
+from ai.backend.manager.services.audit_log.actions.scoped_search import (
+    ScopedSearchAuditLogsAction,
+    ScopedSearchAuditLogsActionResult,
 )
 from ai.backend.manager.services.audit_log.actions.search import (
     SearchAuditLogsAction,
@@ -20,6 +25,9 @@ from ai.backend.manager.services.audit_log.service import AuditLogService
 class AuditLogProcessors(AbstractProcessorPackage):
     create: ActionProcessor[CreateAuditLogAction, CreateAuditLogActionResult]
     search: ActionProcessor[SearchAuditLogsAction, SearchAuditLogsActionResult]
+    scoped_search: BulkActionProcessor[
+        ScopedSearchAuditLogsAction, ScopedSearchAuditLogsActionResult
+    ]
 
     def __init__(
         self,
@@ -29,10 +37,16 @@ class AuditLogProcessors(AbstractProcessorPackage):
     ) -> None:
         self.create = ActionProcessor(service.create, action_monitors)
         self.search = ActionProcessor(service.search, action_monitors)
+        self.scoped_search = BulkActionProcessor(
+            service.scoped_search,
+            monitors=action_monitors,
+            validators=[validators.rbac.bulk],
+        )
 
     @override
     def supported_actions(self) -> list[ActionSpec]:
         return [
             CreateAuditLogAction.spec(),
             SearchAuditLogsAction.spec(),
+            ScopedSearchAuditLogsAction.spec(),
         ]

--- a/src/ai/backend/manager/services/audit_log/service.py
+++ b/src/ai/backend/manager/services/audit_log/service.py
@@ -8,6 +8,10 @@ from ai.backend.manager.services.audit_log.actions.create import (
     CreateAuditLogAction,
     CreateAuditLogActionResult,
 )
+from ai.backend.manager.services.audit_log.actions.scoped_search import (
+    ScopedSearchAuditLogsAction,
+    ScopedSearchAuditLogsActionResult,
+)
 from ai.backend.manager.services.audit_log.actions.search import (
     SearchAuditLogsAction,
     SearchAuditLogsActionResult,
@@ -36,4 +40,18 @@ class AuditLogService:
             total_count=result.total_count,
             has_next_page=result.has_next_page,
             has_previous_page=result.has_previous_page,
+        )
+
+    async def scoped_search(
+        self, action: ScopedSearchAuditLogsAction
+    ) -> ScopedSearchAuditLogsActionResult:
+        targets = list(action.targets())
+        scopes = [t.to_search_scope() for t in targets]
+        result = await self._audit_log_repository.scoped_search(action.querier, scopes)
+        return ScopedSearchAuditLogsActionResult(
+            data=result.items,
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+            queried_refs=[t.to_rbac_element_ref() for t in targets],
         )

--- a/tests/component/artifact/conftest.py
+++ b/tests/component/artifact/conftest.py
@@ -82,7 +82,7 @@ def artifact_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
-            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock()),
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
         ),
     )
 
@@ -121,7 +121,7 @@ def artifact_revision_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
-            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock()),
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
         ),
     )
 

--- a/tests/component/artifact_registry/conftest.py
+++ b/tests/component/artifact_registry/conftest.py
@@ -89,7 +89,7 @@ def artifact_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
-            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock()),
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
         ),
     )
 
@@ -128,7 +128,7 @@ def artifact_revision_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
-            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock()),
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
         ),
     )
 

--- a/tests/component/artifact_revision/conftest.py
+++ b/tests/component/artifact_revision/conftest.py
@@ -87,7 +87,7 @@ def artifact_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
-            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock()),
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
         ),
     )
 
@@ -126,7 +126,7 @@ def artifact_revision_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
-            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock()),
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
         ),
     )
 

--- a/tests/component/auto_scaling_rule/conftest.py
+++ b/tests/component/auto_scaling_rule/conftest.py
@@ -13,6 +13,7 @@ from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import RBACValidators
+from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.single_entity import (
     SingleEntityActionRBACValidator,
@@ -88,6 +89,7 @@ def deployment_processors(
                 single_entity=SingleEntityActionRBACValidator(
                     permission_controller_repo, MagicMock()
                 ),
+                bulk=BulkActionRBACValidator(permission_controller_repo, MagicMock()),
             ),
         ),
     )

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -78,6 +78,7 @@ from ai.backend.logging.config import ConsoleConfig, LogDriver, LoggingConfig
 from ai.backend.logging.types import LogFormat
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import RBACValidators
+from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.single_entity import SingleEntityActionRBACValidator
 from ai.backend.manager.agent_cache import AgentRPCCache
@@ -1274,6 +1275,7 @@ def auth_processors(
             rbac=RBACValidators(
                 scope=MagicMock(spec=ScopeActionRBACValidator),
                 single_entity=MagicMock(spec=SingleEntityActionRBACValidator),
+                bulk=MagicMock(spec=BulkActionRBACValidator),
             ),
         ),
     )

--- a/tests/component/deployment/conftest.py
+++ b/tests/component/deployment/conftest.py
@@ -19,6 +19,7 @@ from ai.backend.common.plugin.hook import HookPluginContext
 from ai.backend.common.types import QuotaScopeID, QuotaScopeType, VFolderUsageMode
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import RBACValidators
+from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.single_entity import (
     SingleEntityActionRBACValidator,
@@ -150,6 +151,7 @@ def deployment_processors(
                 single_entity=SingleEntityActionRBACValidator(
                     permission_controller_repo, MagicMock()
                 ),
+                bulk=BulkActionRBACValidator(permission_controller_repo, MagicMock()),
             ),
         ),
     )

--- a/tests/component/image/conftest.py
+++ b/tests/component/image/conftest.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import RBACValidators
+from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.single_entity import (
     SingleEntityActionRBACValidator,
@@ -49,8 +50,10 @@ def image_processors(
     mock_scope.validate = AsyncMock()
     mock_single_entity = MagicMock(spec=SingleEntityActionRBACValidator)
     mock_single_entity.validate = AsyncMock()
+    mock_bulk = MagicMock(spec=BulkActionRBACValidator)
+    mock_bulk.validate = AsyncMock()
     validators = ActionValidators(
-        rbac=RBACValidators(scope=mock_scope, single_entity=mock_single_entity),
+        rbac=RBACValidators(scope=mock_scope, single_entity=mock_single_entity, bulk=mock_bulk),
     )
     return ImageProcessors(service=service, action_monitors=[], validators=validators)
 

--- a/tests/component/model_card/conftest.py
+++ b/tests/component/model_card/conftest.py
@@ -21,6 +21,7 @@ from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import QuotaScopeID, QuotaScopeType, VFolderUsageMode
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import RBACValidators
+from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.single_entity import (
     SingleEntityActionRBACValidator,
@@ -78,6 +79,7 @@ def _build_validators(
         rbac=RBACValidators(
             scope=ScopeActionRBACValidator(permission_repo, config_provider),
             single_entity=SingleEntityActionRBACValidator(permission_repo, config_provider),
+            bulk=BulkActionRBACValidator(permission_repo, config_provider),
         ),
     )
 

--- a/tests/component/model_serving/conftest.py
+++ b/tests/component/model_serving/conftest.py
@@ -8,6 +8,7 @@ from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
 from ai.backend.common.events.hub.hub import EventHub
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import RBACValidators
+from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.single_entity import (
     SingleEntityActionRBACValidator,
@@ -81,6 +82,7 @@ def model_serving_processors(
                 single_entity=SingleEntityActionRBACValidator(
                     permission_controller_repo, MagicMock()
                 ),
+                bulk=BulkActionRBACValidator(permission_controller_repo, MagicMock()),
             ),
         ),
     )
@@ -103,6 +105,7 @@ def auto_scaling_processors(
                 single_entity=SingleEntityActionRBACValidator(
                     permission_controller_repo, MagicMock()
                 ),
+                bulk=BulkActionRBACValidator(permission_controller_repo, MagicMock()),
             ),
         ),
     )
@@ -145,6 +148,7 @@ def deployment_processors(
                 single_entity=SingleEntityActionRBACValidator(
                     permission_controller_repo, MagicMock()
                 ),
+                bulk=BulkActionRBACValidator(permission_controller_repo, MagicMock()),
             ),
         ),
     )

--- a/tests/component/project/conftest.py
+++ b/tests/component/project/conftest.py
@@ -27,6 +27,7 @@ from ai.backend.common.data.permission.types import RelationType
 from ai.backend.common.data.user.types import UserRole
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import RBACValidators
+from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.single_entity import SingleEntityActionRBACValidator
 from ai.backend.manager.api.adapters.project.adapter import ProjectAdapter
@@ -87,6 +88,7 @@ def _build_validators(
         rbac=RBACValidators(
             scope=ScopeActionRBACValidator(permission_repo, config_provider),
             single_entity=SingleEntityActionRBACValidator(permission_repo, config_provider),
+            bulk=BulkActionRBACValidator(permission_repo, config_provider),
         ),
     )
 

--- a/tests/component/session/conftest.py
+++ b/tests/component/session/conftest.py
@@ -106,7 +106,7 @@ async def session_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
-            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock())
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock())
         ),
     )
 
@@ -118,7 +118,7 @@ def agent_processors_mock() -> AgentProcessors:
         service=AsyncMock(),
         action_monitors=[],
         validators=ActionValidators(
-            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock())
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock())
         ),
     )
 
@@ -130,7 +130,7 @@ def vfolder_processors_mock() -> VFolderProcessors:
         service=AsyncMock(),
         action_monitors=[],
         validators=ActionValidators(
-            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock())
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock())
         ),
     )
 

--- a/tests/component/session_v2/conftest.py
+++ b/tests/component/session_v2/conftest.py
@@ -122,6 +122,7 @@ async def session_processors(
             rbac=RBACValidators(
                 scope=AsyncMock(),
                 single_entity=real_single_entity_validator,
+                bulk=AsyncMock(),
             )
         ),
     )

--- a/tests/component/vfolder/conftest.py
+++ b/tests/component/vfolder/conftest.py
@@ -115,7 +115,7 @@ def vfolder_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
-            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock())
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock())
         ),
     )
 
@@ -138,7 +138,7 @@ def vfolder_file_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
-            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock())
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock())
         ),
     )
 
@@ -159,7 +159,7 @@ def vfolder_invite_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
-            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock())
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock())
         ),
     )
 
@@ -180,7 +180,7 @@ def vfolder_sharing_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
-            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock())
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock())
         ),
     )
 

--- a/tests/component/vfolder_v2/conftest.py
+++ b/tests/component/vfolder_v2/conftest.py
@@ -113,6 +113,7 @@ def vfolder_processors(
             rbac=RBACValidators(
                 scope=AsyncMock(),
                 single_entity=real_single_entity_validator,
+                bulk=AsyncMock(),
             )
         ),
     )

--- a/tests/component/vfolder_v2/test_vfolder_mutation.py
+++ b/tests/component/vfolder_v2/test_vfolder_mutation.py
@@ -32,6 +32,7 @@ from ai.backend.common.types import (
 )
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import RBACValidators
+from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.single_entity import (
     SingleEntityActionRBACValidator,
@@ -122,6 +123,7 @@ def vfolder_processors(
             rbac=RBACValidators(
                 scope=ScopeActionRBACValidator(rbac_permission_repo, MagicMock()),
                 single_entity=SingleEntityActionRBACValidator(rbac_permission_repo, MagicMock()),
+                bulk=BulkActionRBACValidator(rbac_permission_repo, MagicMock()),
             )
         ),
     )

--- a/tests/unit/manager/repositories/audit_log/test_scoped_search.py
+++ b/tests/unit/manager/repositories/audit_log/test_scoped_search.py
@@ -1,0 +1,227 @@
+"""Integration tests for ``AuditLogRepository.scoped_search``.
+
+Exercises the OR-union semantics of multiple :class:`SearchScope` inputs
+against a real database, including mixed entity-tagged and triggered-by
+scopes and combination with ``AuditLogFilter``-style narrowing conditions.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.manager.actions.types import OperationStatus
+from ai.backend.manager.models.audit_log import AuditLogRow
+from ai.backend.manager.repositories.audit_log import (
+    AuditLogCreatorSpec,
+    AuditLogRepository,
+    EntityAuditLogSearchScope,
+    TriggeredByAuditLogSearchScope,
+)
+from ai.backend.manager.repositories.base import BatchQuerier, Creator, OffsetPagination
+from ai.backend.testutils.db import with_tables
+
+if TYPE_CHECKING:
+    from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+
+
+@pytest.fixture
+async def db_with_cleanup(
+    database_connection: ExtendedAsyncSAEngine,
+) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+    async with with_tables(database_connection, [AuditLogRow]):
+        yield database_connection
+
+
+@pytest.fixture
+def audit_log_repository(
+    db_with_cleanup: ExtendedAsyncSAEngine,
+) -> AuditLogRepository:
+    return AuditLogRepository(db=db_with_cleanup)
+
+
+_USER_A = str(uuid.uuid4())
+_USER_B = str(uuid.uuid4())
+
+
+async def _seed(
+    repo: AuditLogRepository,
+    *,
+    entity_type: str,
+    entity_id: str | None,
+    triggered_by: str | None,
+    operation: str = "update",
+) -> uuid.UUID:
+    creator = Creator(
+        spec=AuditLogCreatorSpec(
+            action_id=uuid.uuid4(),
+            entity_type=entity_type,
+            operation=operation,
+            created_at=datetime.now(UTC),
+            description=f"{entity_type} {operation}",
+            status=OperationStatus.SUCCESS,
+            entity_id=entity_id,
+            request_id=None,
+            triggered_by=triggered_by,
+            duration=None,
+        )
+    )
+    data = await repo.create(creator)
+    return data.id
+
+
+@pytest.fixture
+async def seeded_audit_logs(
+    audit_log_repository: AuditLogRepository,
+) -> dict[str, uuid.UUID]:
+    """Six rows spanning two entity targets and two actors plus one unrelated row."""
+    return {
+        "vfolder_vf1_by_a": await _seed(
+            audit_log_repository,
+            entity_type="vfolder",
+            entity_id="vf-1",
+            triggered_by=_USER_A,
+        ),
+        "vfolder_vf1_by_b": await _seed(
+            audit_log_repository,
+            entity_type="vfolder",
+            entity_id="vf-1",
+            triggered_by=_USER_B,
+        ),
+        "session_sess1_by_a": await _seed(
+            audit_log_repository,
+            entity_type="session",
+            entity_id="sess-1",
+            triggered_by=_USER_A,
+        ),
+        "session_sess2_by_b": await _seed(
+            audit_log_repository,
+            entity_type="session",
+            entity_id="sess-2",
+            triggered_by=_USER_B,
+            operation="delete",
+        ),
+        "vfolder_vf2_by_c": await _seed(
+            audit_log_repository,
+            entity_type="vfolder",
+            entity_id="vf-2",
+            triggered_by=str(uuid.uuid4()),
+        ),
+        "untargeted": await _seed(
+            audit_log_repository,
+            entity_type="agent",
+            entity_id="ag-1",
+            triggered_by=None,
+        ),
+    }
+
+
+def _empty_querier() -> BatchQuerier:
+    return BatchQuerier(
+        pagination=OffsetPagination(limit=50, offset=0),
+        conditions=[],
+        orders=[],
+    )
+
+
+class TestScopedSearch:
+    async def test_single_entity_scope_returns_only_matching_target(
+        self,
+        audit_log_repository: AuditLogRepository,
+        seeded_audit_logs: dict[str, uuid.UUID],
+    ) -> None:
+        scopes = [EntityAuditLogSearchScope(entity_type=RBACElementType.VFOLDER, entity_id="vf-1")]
+
+        result = await audit_log_repository.scoped_search(_empty_querier(), scopes)
+
+        returned_ids = {item.id for item in result.items}
+        assert returned_ids == {
+            seeded_audit_logs["vfolder_vf1_by_a"],
+            seeded_audit_logs["vfolder_vf1_by_b"],
+        }
+        assert result.total_count == 2
+
+    async def test_single_triggered_by_scope_returns_actor_rows(
+        self,
+        audit_log_repository: AuditLogRepository,
+        seeded_audit_logs: dict[str, uuid.UUID],
+    ) -> None:
+        scopes = [TriggeredByAuditLogSearchScope(triggered_by=_USER_A)]
+
+        result = await audit_log_repository.scoped_search(_empty_querier(), scopes)
+
+        returned_ids = {item.id for item in result.items}
+        assert returned_ids == {
+            seeded_audit_logs["vfolder_vf1_by_a"],
+            seeded_audit_logs["session_sess1_by_a"],
+        }
+        assert result.total_count == 2
+
+    async def test_multiple_scopes_form_or_union(
+        self,
+        audit_log_repository: AuditLogRepository,
+        seeded_audit_logs: dict[str, uuid.UUID],
+    ) -> None:
+        """Multiple scopes return the union — overlapping rows count once."""
+        scopes = [
+            EntityAuditLogSearchScope(entity_type=RBACElementType.VFOLDER, entity_id="vf-1"),
+            EntityAuditLogSearchScope(entity_type=RBACElementType.SESSION, entity_id="sess-1"),
+        ]
+
+        result = await audit_log_repository.scoped_search(_empty_querier(), scopes)
+
+        returned_ids = {item.id for item in result.items}
+        assert returned_ids == {
+            seeded_audit_logs["vfolder_vf1_by_a"],
+            seeded_audit_logs["vfolder_vf1_by_b"],
+            seeded_audit_logs["session_sess1_by_a"],
+        }
+        assert result.total_count == 3
+
+    async def test_mixed_entity_and_triggered_by_scopes(
+        self,
+        audit_log_repository: AuditLogRepository,
+        seeded_audit_logs: dict[str, uuid.UUID],
+    ) -> None:
+        """Entity-tagged and triggered-by scopes combine as a single OR group."""
+        scopes = [
+            EntityAuditLogSearchScope(entity_type=RBACElementType.VFOLDER, entity_id="vf-1"),
+            TriggeredByAuditLogSearchScope(triggered_by=_USER_B),
+        ]
+
+        result = await audit_log_repository.scoped_search(_empty_querier(), scopes)
+
+        returned_ids = {item.id for item in result.items}
+        assert returned_ids == {
+            seeded_audit_logs["vfolder_vf1_by_a"],
+            seeded_audit_logs["vfolder_vf1_by_b"],
+            seeded_audit_logs["session_sess2_by_b"],
+        }
+        assert result.total_count == 3
+
+    async def test_querier_conditions_narrow_within_scope_union(
+        self,
+        audit_log_repository: AuditLogRepository,
+        seeded_audit_logs: dict[str, uuid.UUID],
+    ) -> None:
+        """Additional ``querier.conditions`` AND-narrow the OR'd union."""
+        querier = BatchQuerier(
+            pagination=OffsetPagination(limit=50, offset=0),
+            conditions=[lambda: AuditLogRow.operation == "delete"],
+            orders=[],
+        )
+        scopes = [
+            EntityAuditLogSearchScope(entity_type=RBACElementType.VFOLDER, entity_id="vf-1"),
+            EntityAuditLogSearchScope(entity_type=RBACElementType.SESSION, entity_id="sess-2"),
+        ]
+
+        result = await audit_log_repository.scoped_search(querier, scopes)
+
+        returned_ids = {item.id for item in result.items}
+        assert returned_ids == {seeded_audit_logs["session_sess2_by_b"]}
+        assert result.total_count == 1

--- a/tests/unit/manager/services/audit_log/test_audit_log_service.py
+++ b/tests/unit/manager/services/audit_log/test_audit_log_service.py
@@ -11,12 +11,24 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.manager.actions.action.types import SearchableActionTarget
 from ai.backend.manager.actions.types import OperationStatus
 from ai.backend.manager.data.audit_log.types import AuditLogData, AuditLogListResult
-from ai.backend.manager.repositories.audit_log import AuditLogRepository
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.repositories.audit_log import (
+    AuditLogRepository,
+    EntityAuditLogSearchScope,
+    TriggeredByAuditLogSearchScope,
+)
 from ai.backend.manager.repositories.audit_log.creators import AuditLogCreatorSpec
 from ai.backend.manager.repositories.base import BatchQuerier, Creator, OffsetPagination
 from ai.backend.manager.services.audit_log.actions.create import CreateAuditLogAction
+from ai.backend.manager.services.audit_log.actions.scoped_search import (
+    EntityAuditLogTarget,
+    ScopedSearchAuditLogsAction,
+    TriggeredByAuditLogTarget,
+)
 from ai.backend.manager.services.audit_log.actions.search import SearchAuditLogsAction
 from ai.backend.manager.services.audit_log.service import AuditLogService
 
@@ -171,3 +183,110 @@ class TestAuditLogService:
         assert result.total_count == 25
         assert result.has_next_page is True
         assert result.has_previous_page is True
+
+    # =========================================================================
+    # Fixtures - Scoped Search
+    # =========================================================================
+
+    @pytest.fixture
+    def scoped_search_user_id(self) -> uuid.UUID:
+        return uuid.uuid4()
+
+    @pytest.fixture
+    def scoped_search_querier(self) -> BatchQuerier:
+        return BatchQuerier(
+            pagination=OffsetPagination(limit=10, offset=0),
+            conditions=[],
+            orders=[],
+        )
+
+    @pytest.fixture
+    def scoped_search_targets(
+        self, scoped_search_user_id: uuid.UUID
+    ) -> list[SearchableActionTarget]:
+        return [
+            EntityAuditLogTarget(element_type=RBACElementType.VFOLDER, element_id="vf-1"),
+            TriggeredByAuditLogTarget(user_id=scoped_search_user_id),
+        ]
+
+    @pytest.fixture
+    def scoped_search_action(
+        self,
+        scoped_search_targets: list[SearchableActionTarget],
+        scoped_search_querier: BatchQuerier,
+    ) -> ScopedSearchAuditLogsAction:
+        return ScopedSearchAuditLogsAction(
+            items=scoped_search_targets, querier=scoped_search_querier
+        )
+
+    @pytest.fixture
+    def mock_repository_with_one_scoped_hit(
+        self,
+        mock_repository: MagicMock,
+        sample_audit_log_data: AuditLogData,
+    ) -> MagicMock:
+        mock_repository.scoped_search = AsyncMock(
+            return_value=AuditLogListResult(
+                items=[sample_audit_log_data],
+                total_count=1,
+                has_next_page=False,
+                has_previous_page=False,
+            )
+        )
+        return mock_repository
+
+    @pytest.fixture
+    def mock_repository_with_empty_scoped_result(self, mock_repository: MagicMock) -> MagicMock:
+        mock_repository.scoped_search = AsyncMock(
+            return_value=AuditLogListResult(
+                items=[],
+                total_count=0,
+                has_next_page=False,
+                has_previous_page=False,
+            )
+        )
+        return mock_repository
+
+    # =========================================================================
+    # Tests - Scoped Search
+    # =========================================================================
+
+    async def test_scoped_search_passes_per_target_search_scopes_to_repository(
+        self,
+        audit_log_service: AuditLogService,
+        mock_repository_with_one_scoped_hit: MagicMock,
+        scoped_search_action: ScopedSearchAuditLogsAction,
+        scoped_search_querier: BatchQuerier,
+        scoped_search_user_id: uuid.UUID,
+        sample_audit_log_data: AuditLogData,
+    ) -> None:
+        """Service calls repository.scoped_search with one SearchScope per target."""
+        result = await audit_log_service.scoped_search(scoped_search_action)
+
+        assert result.data == [sample_audit_log_data]
+        # Repository receives the same querier + the two target-derived SearchScopes.
+        mock_repository_with_one_scoped_hit.scoped_search.assert_called_once()
+        call_args = mock_repository_with_one_scoped_hit.scoped_search.call_args
+        assert call_args.args[0] is scoped_search_querier
+        scopes = list(call_args.args[1])
+        assert scopes == [
+            EntityAuditLogSearchScope(entity_type=RBACElementType.VFOLDER, entity_id="vf-1"),
+            TriggeredByAuditLogSearchScope(triggered_by=str(scoped_search_user_id)),
+        ]
+
+    async def test_scoped_search_records_queried_rbac_refs_on_result(
+        self,
+        audit_log_service: AuditLogService,
+        mock_repository_with_empty_scoped_result: MagicMock,
+        scoped_search_action: ScopedSearchAuditLogsAction,
+        scoped_search_user_id: uuid.UUID,
+    ) -> None:
+        """``element_refs()`` on the result returns the RBAC refs of the input targets."""
+        result = await audit_log_service.scoped_search(scoped_search_action)
+
+        assert result.element_refs() == [
+            RBACElementRef(element_type=RBACElementType.VFOLDER, element_id="vf-1"),
+            RBACElementRef(
+                element_type=RBACElementType.USER, element_id=str(scoped_search_user_id)
+            ),
+        ]

--- a/tests/unit/manager/services/deployment/test_deployment_crud_actions.py
+++ b/tests/unit/manager/services/deployment/test_deployment_crud_actions.py
@@ -27,6 +27,7 @@ from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import ClusterMode, ResourceSlot, SessionId
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import RBACValidators
+from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.single_entity import (
     SingleEntityActionRBACValidator,
@@ -120,6 +121,7 @@ class DeploymentCRUDBaseFixtures:
                 rbac=RBACValidators(
                     scope=MagicMock(spec=ScopeActionRBACValidator),
                     single_entity=MagicMock(spec=SingleEntityActionRBACValidator),
+                    bulk=MagicMock(spec=BulkActionRBACValidator),
                 ),
             ),
         )

--- a/tests/unit/manager/services/deployment/test_deployment_service.py
+++ b/tests/unit/manager/services/deployment/test_deployment_service.py
@@ -29,6 +29,7 @@ from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import ClusterMode, ResourceSlot
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import RBACValidators
+from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.single_entity import (
     SingleEntityActionRBACValidator,
@@ -129,6 +130,7 @@ class DeploymentServiceBaseFixtures:
                 rbac=RBACValidators(
                     scope=MagicMock(spec=ScopeActionRBACValidator),
                     single_entity=MagicMock(spec=SingleEntityActionRBACValidator),
+                    bulk=MagicMock(spec=BulkActionRBACValidator),
                 ),
             ),
         )

--- a/tests/unit/manager/services/image/test_image_service.py
+++ b/tests/unit/manager/services/image/test_image_service.py
@@ -23,6 +23,7 @@ from ai.backend.common.exception import UnknownImageReference
 from ai.backend.common.types import AgentId, ImageCanonical, ImageID, SlotName
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import RBACValidators
+from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.single_entity import (
     SingleEntityActionRBACValidator,
@@ -131,8 +132,10 @@ class ImageServiceBaseFixtures:
         mock_scope.validate = AsyncMock()
         mock_single_entity = MagicMock(spec=SingleEntityActionRBACValidator)
         mock_single_entity.validate = AsyncMock()
+        mock_bulk = MagicMock(spec=BulkActionRBACValidator)
+        mock_bulk.validate = AsyncMock()
         validators = ActionValidators(
-            rbac=RBACValidators(scope=mock_scope, single_entity=mock_single_entity),
+            rbac=RBACValidators(scope=mock_scope, single_entity=mock_single_entity, bulk=mock_bulk),
         )
         return ImageProcessors(image_service, [], validators)
 

--- a/tests/unit/manager/services/model_serving/actions/conftest.py
+++ b/tests/unit/manager/services/model_serving/actions/conftest.py
@@ -4,6 +4,7 @@ import pytest
 
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import RBACValidators
+from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.single_entity import (
     SingleEntityActionRBACValidator,
@@ -16,5 +17,6 @@ def mock_action_validators() -> ActionValidators:
         rbac=RBACValidators(
             scope=MagicMock(spec=ScopeActionRBACValidator),
             single_entity=MagicMock(spec=SingleEntityActionRBACValidator),
+            bulk=MagicMock(spec=BulkActionRBACValidator),
         ),
     )


### PR DESCRIPTION
## Summary
- Add `ScopedSearchAuditLogsAction` on `BaseBulkAction[SearchableActionTarget]`, with two leaf-target classes that bind each input scope item to both an RBAC element ref (for `BulkActionRBACValidator`) and a per-item `SearchScope` (for `audit_logs` WHERE).
- Wire `AuditLogService.scoped_search` through `BulkActionProcessor` with the newly composer-registered `BulkActionRBACValidator`; repository `scoped_search` OR's the per-leaf scopes via `execute_batch_querier(..., scopes=)`.
- Adapter `scoped_search(ScopedSearchAuditLogsInput)`; admin and scoped variants now share a single `SearchAuditLogsPayload`.

## Test plan
- [x] `pants test tests/unit/manager/repositories/audit_log/test_search_scopes.py`
- [x] `pants test tests/unit/manager/repositories/audit_log/test_scoped_search.py`
- [x] `pants test tests/unit/manager/services/audit_log/test_scoped_search_action.py`
- [x] `pants test tests/unit/manager/services/audit_log/test_audit_log_service.py`
- [x] Existing admin path still works (`pants test tests/unit/manager/repositories/audit_log/test_audit_log_repository.py`)

Resolves BA-6096