### PR TITLE
feat(BA-6117): add nested user filter to admin_roles GraphQL query

### DIFF
--- a/changes/11714.feature.md
+++ b/changes/11714.feature.md
@@ -1,0 +1,1 @@
+Add `assigned_user` nested filter to the `admin_roles` GraphQL query so callers can filter roles by user assignment via a correlated EXISTS subquery.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -15888,6 +15888,7 @@ input RoleFilter
   name: StringFilter = null
   source: RoleSourceFilter = null
   status: RoleStatusFilter = null
+  assignedUser: RoleUserNestedFilter = null
   AND: [RoleFilter!] = null
   OR: [RoleFilter!] = null
   NOT: [RoleFilter!] = null
@@ -16101,6 +16102,18 @@ input RoleStatusFilter
 
   """Excludes roles whose status is in this list."""
   notIn: [RoleStatus!] = null
+}
+
+"""
+Added in UNRELEASED. Nested filter for users within a role filter. Matches roles assigned to at least one user satisfying all conditions.
+"""
+input RoleUserNestedFilter
+  @join__type(graph: STRAWBERRY)
+{
+  userId: UUIDFilter = null
+  AND: [RoleUserNestedFilter!] = null
+  OR: [RoleUserNestedFilter!] = null
+  NOT: [RoleUserNestedFilter!] = null
 }
 
 """

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -16104,9 +16104,7 @@ input RoleStatusFilter
   notIn: [RoleStatus!] = null
 }
 
-"""
-Added in UNRELEASED. Nested filter for users within a role filter. Matches roles assigned to at least one user satisfying all conditions.
-"""
+"""Added in UNRELEASED. Filter roles by their user assignments."""
 input RoleUserNestedFilter
   @join__type(graph: STRAWBERRY)
 {

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -10906,9 +10906,7 @@ input RoleStatusFilter {
   notIn: [RoleStatus!] = null
 }
 
-"""
-Added in UNRELEASED. Nested filter for users within a role filter. Matches roles assigned to at least one user satisfying all conditions.
-"""
+"""Added in UNRELEASED. Filter roles by their user assignments."""
 input RoleUserNestedFilter {
   userId: UUIDFilter = null
   AND: [RoleUserNestedFilter!] = null

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -10723,6 +10723,7 @@ input RoleFilter {
   name: StringFilter = null
   source: RoleSourceFilter = null
   status: RoleStatusFilter = null
+  assignedUser: RoleUserNestedFilter = null
   AND: [RoleFilter!] = null
   OR: [RoleFilter!] = null
   NOT: [RoleFilter!] = null
@@ -10903,6 +10904,16 @@ input RoleStatusFilter {
 
   """Excludes roles whose status is in this list."""
   notIn: [RoleStatus!] = null
+}
+
+"""
+Added in UNRELEASED. Nested filter for users within a role filter. Matches roles assigned to at least one user satisfying all conditions.
+"""
+input RoleUserNestedFilter {
+  userId: UUIDFilter = null
+  AND: [RoleUserNestedFilter!] = null
+  OR: [RoleUserNestedFilter!] = null
+  NOT: [RoleUserNestedFilter!] = null
 }
 
 """

--- a/src/ai/backend/common/dto/manager/v2/rbac/request.py
+++ b/src/ai/backend/common/dto/manager/v2/rbac/request.py
@@ -203,10 +203,7 @@ class ReplaceRolePermissionsInput(BaseRequestModel):
 
 
 class UserNestedFilter(BaseRequestModel):
-    """Nested filter for users within a role filter.
-
-    Matches roles that are assigned to at least one user satisfying the conditions.
-    """
+    """Filter roles by their user assignments."""
 
     user_id: UUIDFilter | None = None
     AND: list[UserNestedFilter] | None = None

--- a/src/ai/backend/common/dto/manager/v2/rbac/request.py
+++ b/src/ai/backend/common/dto/manager/v2/rbac/request.py
@@ -51,6 +51,7 @@ __all__ = (
     "RoleOrderBy",
     "UpdatePermissionInput",
     "UpdateRoleInput",
+    "UserNestedFilter",
 )
 
 
@@ -201,12 +202,28 @@ class ReplaceRolePermissionsInput(BaseRequestModel):
     )
 
 
+class UserNestedFilter(BaseRequestModel):
+    """Nested filter for users within a role filter.
+
+    Matches roles that are assigned to at least one user satisfying the conditions.
+    """
+
+    user_id: UUIDFilter | None = None
+    AND: list[UserNestedFilter] | None = None
+    OR: list[UserNestedFilter] | None = None
+    NOT: list[UserNestedFilter] | None = None
+
+
+UserNestedFilter.model_rebuild()
+
+
 class RoleFilter(BaseRequestModel):
     """Filter for roles."""
 
     name: StringFilter | None = None
     source: RoleSourceFilter | None = None
     status: RoleStatusFilter | None = None
+    assigned_user: UserNestedFilter | None = None
     AND: list[RoleFilter] | None = None
     OR: list[RoleFilter] | None = None
     NOT: list[RoleFilter] | None = None

--- a/src/ai/backend/manager/api/adapters/rbac/adapter.py
+++ b/src/ai/backend/manager/api/adapters/rbac/adapter.py
@@ -118,6 +118,9 @@ from ai.backend.common.dto.manager.v2.rbac.request import (
 from ai.backend.common.dto.manager.v2.rbac.request import (
     UpdatePermissionInput as UpdatePermissionInputDTO,
 )
+from ai.backend.common.dto.manager.v2.rbac.request import (
+    UserNestedFilter as UserNestedFilterDTO,
+)
 from ai.backend.common.dto.manager.v2.rbac.types import (
     OperationTypeDTO,
     OperationTypeFilter,
@@ -1399,6 +1402,8 @@ class RBACAdapter(BaseAdapter):
                 conditions.append(
                     RoleConditions.by_status_not_in([InternalRoleStatus(s) for s in st.not_in])
                 )
+        if f.assigned_user is not None:
+            conditions.extend(self._convert_user_nested_filter(f.assigned_user))
         if f.AND:
             for sub in f.AND:
                 conditions.extend(self._convert_role_filter_gql(sub))
@@ -1412,6 +1417,36 @@ class RBACAdapter(BaseAdapter):
             not_conditions: list[QueryCondition] = []
             for sub in f.NOT:
                 not_conditions.extend(self._convert_role_filter_gql(sub))
+            if not_conditions:
+                conditions.append(negate_conditions(not_conditions))
+        return conditions
+
+    def _convert_user_nested_filter(self, f: UserNestedFilterDTO) -> list[QueryCondition]:
+        raw_conditions: list[QueryCondition] = []
+        if f.user_id is not None:
+            condition = self.convert_uuid_filter(
+                f.user_id,
+                equals_factory=AssignedUserConditions.by_user_id_equals,
+                in_factory=AssignedUserConditions.by_user_id_in,
+            )
+            if condition is not None:
+                raw_conditions.append(condition)
+        conditions: list[QueryCondition] = []
+        if raw_conditions:
+            conditions.append(RoleConditions.by_assigned_user_id(raw_conditions))
+        if f.AND:
+            for sub in f.AND:
+                conditions.extend(self._convert_user_nested_filter(sub))
+        if f.OR:
+            or_conditions: list[QueryCondition] = []
+            for sub in f.OR:
+                or_conditions.extend(self._convert_user_nested_filter(sub))
+            if or_conditions:
+                conditions.append(combine_conditions_or(or_conditions))
+        if f.NOT:
+            not_conditions: list[QueryCondition] = []
+            for sub in f.NOT:
+                not_conditions.extend(self._convert_user_nested_filter(sub))
             if not_conditions:
                 conditions.append(negate_conditions(not_conditions))
         return conditions

--- a/src/ai/backend/manager/api/gql/rbac/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/__init__.py
@@ -69,6 +69,7 @@ from .role import (
     RoleSourceGQL,
     RoleStatusFilterGQL,
     RoleStatusGQL,
+    RoleUserNestedFilterGQL,
     UpdateRoleInput,
 )
 from .role_invitation import (
@@ -117,6 +118,7 @@ __all__ = [
     "RoleFilter",
     "RoleAssignmentFilter",
     "RoleAssignmentRoleNestedFilterGQL",
+    "RoleUserNestedFilterGQL",
     "PermissionNestedFilterGQL",
     "EntityFilter",
     # OrderBy

--- a/src/ai/backend/manager/api/gql/rbac/types/role.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/role.py
@@ -57,6 +57,9 @@ from ai.backend.common.dto.manager.v2.rbac.request import (
 from ai.backend.common.dto.manager.v2.rbac.request import (
     UpdateRoleInput as UpdateRoleInputDTO,
 )
+from ai.backend.common.dto.manager.v2.rbac.request import (
+    UserNestedFilter as UserNestedFilterDTO,
+)
 from ai.backend.common.dto.manager.v2.rbac.response import (
     BulkAssignRoleFailureInfo as BulkAssignRoleFailureInfoDTO,
 )
@@ -88,6 +91,7 @@ from ai.backend.common.dto.manager.v2.rbac.types import (
 from ai.backend.common.dto.manager.v2.rbac.types import (
     RoleStatusFilter as RoleStatusFilterDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import OrderDirection, StringFilter, UUIDFilter, encode_cursor
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -503,6 +507,24 @@ class RoleStatusFilterGQL(PydanticInputMixin[RoleStatusFilterDTO]):
 
 
 @gql_pydantic_input(
+    BackendAIGQLMeta(
+        description=(
+            "Nested filter for users within a role filter. "
+            "Matches roles assigned to at least one user satisfying all conditions."
+        ),
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="RoleUserNestedFilter",
+)
+class RoleUserNestedFilterGQL(PydanticInputMixin[UserNestedFilterDTO]):
+    user_id: UUIDFilter | None = None
+
+    AND: list[Self] | None = None
+    OR: list[Self] | None = None
+    NOT: list[Self] | None = None
+
+
+@gql_pydantic_input(
     BackendAIGQLMeta(description="Filter for roles", added_version="26.3.0"),
     name="RoleFilter",
 )
@@ -510,6 +532,7 @@ class RoleFilter(PydanticInputMixin[RoleFilterDTO], GQLFilter):
     name: StringFilter | None = None
     source: RoleSourceFilterGQL | None = None
     status: RoleStatusFilterGQL | None = None
+    assigned_user: RoleUserNestedFilterGQL | None = None
 
     AND: list[Self] | None = None
     OR: list[Self] | None = None

--- a/src/ai/backend/manager/api/gql/rbac/types/role.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/role.py
@@ -508,10 +508,7 @@ class RoleStatusFilterGQL(PydanticInputMixin[RoleStatusFilterDTO]):
 
 @gql_pydantic_input(
     BackendAIGQLMeta(
-        description=(
-            "Nested filter for users within a role filter. "
-            "Matches roles assigned to at least one user satisfying all conditions."
-        ),
+        description="Filter roles by their user assignments.",
         added_version=NEXT_RELEASE_VERSION,
     ),
     name="RoleUserNestedFilter",

--- a/src/ai/backend/manager/models/rbac_models/conditions.py
+++ b/src/ai/backend/manager/models/rbac_models/conditions.py
@@ -203,6 +203,22 @@ class RoleConditions:
 
         return inner
 
+    @staticmethod
+    def by_assigned_user_id(
+        user_conditions: list[QueryCondition],
+    ) -> QueryCondition:
+        """Match roles assigned to a user satisfying ``user_conditions`` via a correlated EXISTS subquery."""
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            subq = (
+                sa.select(sa.literal(1)).where(UserRoleRow.role_id == RoleRow.id).correlate(RoleRow)
+            )
+            for cond in user_conditions:
+                subq = subq.where(cond())
+            return sa.exists(subq)
+
+        return inner
+
 
 class PermissionConditions:
     """Query conditions for permissions."""
@@ -274,6 +290,26 @@ class AssignedUserConditions:
     def by_role_id_in(spec: UUIDInMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             condition = UserRoleRow.role_id.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_user_id_equals(spec: UUIDEqualMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = UserRoleRow.user_id == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_user_id_in(spec: UUIDInMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = UserRoleRow.user_id.in_(spec.values)
             if spec.negated:
                 condition = sa.not_(condition)
             return condition

--- a/src/ai/backend/manager/models/rbac_models/conditions.py
+++ b/src/ai/backend/manager/models/rbac_models/conditions.py
@@ -207,7 +207,7 @@ class RoleConditions:
     def by_assigned_user_id(
         user_conditions: list[QueryCondition],
     ) -> QueryCondition:
-        """Match roles assigned to a user satisfying ``user_conditions`` via a correlated EXISTS subquery."""
+        """Match roles whose ``user_roles`` rows satisfy ``user_conditions`` (correlated EXISTS)."""
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             subq = (

--- a/tests/unit/manager/repositories/permission_controller/test_search_roles.py
+++ b/tests/unit/manager/repositories/permission_controller/test_search_roles.py
@@ -12,12 +12,21 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from ai.backend.common.data.filter_specs import StringMatchSpec
+from ai.backend.common.data.filter_specs import (
+    StringMatchSpec,
+    UUIDEqualMatchSpec,
+)
 from ai.backend.common.data.permission.types import EntityType, OperationType
+from ai.backend.common.types import ResourceSlot
+from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac_models import UserRoleRow
-from ai.backend.manager.models.rbac_models.conditions import RoleConditions
+from ai.backend.manager.models.rbac_models.conditions import (
+    AssignedUserConditions,
+    RoleConditions,
+)
 from ai.backend.manager.models.rbac_models.orders import RoleOrders
 from ai.backend.manager.models.rbac_models.permission.object_permission import ObjectPermissionRow
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
@@ -26,7 +35,7 @@ from ai.backend.manager.models.resource_policy import (
     KeyPairResourcePolicyRow,
     UserResourcePolicyRow,
 )
-from ai.backend.manager.models.user import UserRow
+from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
@@ -166,6 +175,131 @@ class TestSearchRoles:
         assert role_ids == expected_role_ids, (
             f"Failed to order roles by created_at: got {[r.created_at for r in result.items]}, expected {[r.created_at for r in created_roles]}"
         )
+
+    @pytest.fixture
+    async def roles_assigned_to_users(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+        created_roles: list[CreatedRole],
+    ) -> tuple[uuid.UUID, uuid.UUID, list[CreatedRole]]:
+        """Create two users and assign the first role to the first user only.
+
+        Returns ``(assigned_user_id, unassigned_user_id, created_roles)``.
+        """
+        assigned_user_id = uuid.uuid4()
+        unassigned_user_id = uuid.uuid4()
+
+        domain_name = f"test-domain-{uuid.uuid4().hex[:8]}"
+        policy_name = f"test-policy-{uuid.uuid4().hex[:8]}"
+        password_info = PasswordInfo(
+            password="dummy",
+            algorithm=PasswordHashAlgorithm.PBKDF2_SHA256,
+            rounds=600_000,
+            salt_size=32,
+        )
+
+        async with db_with_rbac_tables.begin_session() as db_sess:
+            db_sess.add(
+                DomainRow(
+                    name=domain_name,
+                    description="domain for by_assigned_user_id test",
+                    is_active=True,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts={},
+                    allowed_docker_registries=[],
+                )
+            )
+            db_sess.add(
+                UserResourcePolicyRow(
+                    name=policy_name,
+                    max_vfolder_count=10,
+                    max_quota_scope_size=0,
+                    max_session_count_per_model_session=5,
+                    max_customized_image_count=3,
+                )
+            )
+            await db_sess.flush()
+
+            for user_id, suffix in [
+                (assigned_user_id, "assigned"),
+                (unassigned_user_id, "unassigned"),
+            ]:
+                db_sess.add(
+                    UserRow(
+                        uuid=user_id,
+                        username=f"{suffix}-{user_id.hex[:8]}",
+                        email=f"{suffix}-{user_id.hex[:8]}@example.com",
+                        password=password_info,
+                        need_password_change=False,
+                        status=UserStatus.ACTIVE,
+                        status_info="active",
+                        domain_name=domain_name,
+                        role=UserRole.USER,
+                        resource_policy=policy_name,
+                    )
+                )
+            await db_sess.flush()
+
+            db_sess.add(
+                UserRoleRow(
+                    user_id=assigned_user_id,
+                    role_id=created_roles[0].role_id,
+                )
+            )
+            await db_sess.flush()
+
+        return assigned_user_id, unassigned_user_id, created_roles
+
+    async def test_by_assigned_user_id_returns_only_assigned_roles(
+        self,
+        repository: PermissionControllerRepository,
+        roles_assigned_to_users: tuple[uuid.UUID, uuid.UUID, list[CreatedRole]],
+    ) -> None:
+        """``RoleConditions.by_assigned_user_id`` should restrict results
+        to roles assigned to the given user via the correlated EXISTS subquery."""
+        assigned_user_id, _, created_roles = roles_assigned_to_users
+
+        querier = BatchQuerier(
+            conditions=[
+                RoleConditions.by_assigned_user_id([
+                    AssignedUserConditions.by_user_id_equals(
+                        UUIDEqualMatchSpec(value=assigned_user_id, negated=False)
+                    )
+                ]),
+            ],
+            orders=[],
+            pagination=OffsetPagination(limit=10, offset=0),
+        )
+
+        result = await repository.search_roles(querier)
+
+        assert result.total_count == 1
+        assert [item.id for item in result.items] == [created_roles[0].role_id]
+
+    async def test_by_assigned_user_id_returns_empty_for_unassigned_user(
+        self,
+        repository: PermissionControllerRepository,
+        roles_assigned_to_users: tuple[uuid.UUID, uuid.UUID, list[CreatedRole]],
+    ) -> None:
+        """A user with no assignments should yield no roles."""
+        _, unassigned_user_id, _ = roles_assigned_to_users
+
+        querier = BatchQuerier(
+            conditions=[
+                RoleConditions.by_assigned_user_id([
+                    AssignedUserConditions.by_user_id_equals(
+                        UUIDEqualMatchSpec(value=unassigned_user_id, negated=False)
+                    )
+                ]),
+            ],
+            orders=[],
+            pagination=OffsetPagination(limit=10, offset=0),
+        )
+
+        result = await repository.search_roles(querier)
+
+        assert result.total_count == 0
+        assert result.items == []
 
 
 class TestSearchRolesTotalCountNotInflated:


### PR DESCRIPTION
## Summary
- Add `assigned_user` nested filter on `RoleFilter` so `admin_roles` can be filtered by user assignment without falling back to `admin_role_assignments`.
- Translate the new filter to a correlated `EXISTS` subquery (`RoleConditions.by_assigned_user_id`), consistent with existing nested filter patterns (`RoleAssignmentRoleNestedFilter`, `PermissionNestedFilter`).
- Wire through full stack: DTO (`UserNestedFilter`) → GQL input (`RoleUserNestedFilterGQL`) → adapter (`_convert_user_nested_filter`) → repository condition.

## Test plan
- [x] `pants fmt/lint/check` on changed files
- [x] Repository test (`tests/unit/manager/repositories/permission_controller/test_search_roles.py`) — real DB verifies the EXISTS subquery returns only roles assigned to the given user, and zero for users without assignments
- [x] Existing `RoleFilter` AND/OR/NOT tests still pass (no regression in `name`, `source`, `status` fields)

Resolves BA-6117

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11714.org.readthedocs.build/en/11714/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11714.org.readthedocs.build/ko/11714/

<!-- readthedocs-preview sorna-ko end -->