### PR TITLE
feat(BA-6097): wire scopedAuditLogsV2 resolver to scoped_search adapter

### DIFF
--- a/changes/11726.feature.md
+++ b/changes/11726.feature.md
@@ -1,0 +1,1 @@
+Wire `scopedAuditLogsV2` GraphQL resolver to the scoped audit-log search service.

--- a/src/ai/backend/manager/api/gql/audit_log/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/audit_log/resolver/query.py
@@ -90,15 +90,28 @@ async def scoped_audit_logs_v2(
     limit: int | None = None,
     offset: int | None = None,
 ) -> AuditLogV2ConnectionGQL | None:
-    ScopedSearchAuditLogsInput(
-        scope=scope.to_pydantic(),
-        filter=filter.to_pydantic() if filter else None,
-        order=[o.to_pydantic() for o in order_by] if order_by else None,
-        first=first,
-        after=after,
-        last=last,
-        before=before,
-        limit=limit,
-        offset=offset,
+    result = await info.context.adapters.audit_log.scoped_search(
+        ScopedSearchAuditLogsInput(
+            scope=scope.to_pydantic(),
+            filter=filter.to_pydantic() if filter else None,
+            order=[o.to_pydantic() for o in order_by] if order_by else None,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        )
     )
-    raise NotImplementedError("scoped_audit_logs_v2 resolver body lands in BA-6097")
+    nodes = [AuditLogV2GQL.from_pydantic(item) for item in result.items]
+    edges = [AuditLogV2EdgeGQL(node=node, cursor=encode_cursor(node.id)) for node in nodes]
+    return AuditLogV2ConnectionGQL(
+        edges=edges,
+        page_info=strawberry.relay.PageInfo(
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        ),
+        count=result.total_count,
+    )


### PR DESCRIPTION
## Summary
- Replace the stub body with a working resolver for `scopedAuditLogsV2`.
- Convert GraphQL inputs (`scope`, `filter`, `orderBy`, pagination) into `ScopedSearchAuditLogsInput`, delegate to `info.context.adapters.audit_log.scoped_search`, and map the resulting payload to the standard GraphQL connection shape (edges + `PageInfo` + `count`).
- RBAC denials raised inside the service layer propagate through Strawberry's standard error path; empty-scope input is rejected uniformly by the DTO `model_validator`.

## Test plan
- [x] Live GraphQL — `triggered_user` scope returns matching rows with cursor `pageInfo`.
- [x] Live GraphQL — `entity` scope (`AGENT` element) returns matching rows.
- [x] Live GraphQL — mixed `entity` + `triggered_user` scope behaves as OR-union; `orderBy` is honored.
- [x] Live GraphQL — empty scope (`{}`) is rejected via `AuditLogScope` Pydantic validator with a clear error.
- [x] CI runs `pants check` / `pants test` on the changed surface.

Resolves BA-6097

🤖 Generated with [Claude Code](https://claude.com/claude-code)