### PR TITLE
feat(BA-6098): expose scoped audit-log search via REST v2, SDK, and CLI

### DIFF
--- a/changes/11731.feature.md
+++ b/changes/11731.feature.md
@@ -1,0 +1,1 @@
+Expose scoped audit-log search via REST v2 (`POST /v2/audit-logs/scoped-search`), the Python SDK, and `./bai audit-log scoped-search`.

--- a/src/ai/backend/client/cli/v2/audit_log/commands.py
+++ b/src/ai/backend/client/cli/v2/audit_log/commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import uuid
 
 import click
 
@@ -12,6 +13,55 @@ from ai.backend.client.cli.v2.helpers import (
     parse_order_options,
     print_result,
 )
+from ai.backend.common.dto.manager.v2.rbac.types import (
+    EntityTypeScope,
+    RBACElementTypeDTO,
+    UUIDScope,
+)
+
+_TRIGGERED_USER_KEYWORD = "triggered_user"
+
+
+def _parse_scope_items(
+    raw_scopes: tuple[str, ...],
+) -> tuple[list[EntityTypeScope], list[UUIDScope]]:
+    """Parse ``--scope`` values of form ``<type>:<id>`` into entity / triggered_user buckets."""
+    entity: list[EntityTypeScope] = []
+    triggered_user: list[UUIDScope] = []
+    for raw in raw_scopes:
+        if ":" not in raw:
+            raise click.BadParameter(
+                f"--scope must be in '<type>:<id>' form (got: {raw!r})",
+                param_hint="--scope",
+            )
+        type_part, id_part = raw.split(":", 1)
+        type_part = type_part.strip()
+        id_part = id_part.strip()
+        if not type_part or not id_part:
+            raise click.BadParameter(
+                f"--scope requires both type and id (got: {raw!r})",
+                param_hint="--scope",
+            )
+        if type_part == _TRIGGERED_USER_KEYWORD:
+            try:
+                triggered_user.append(UUIDScope(value=uuid.UUID(id_part)))
+            except ValueError as exc:
+                raise click.BadParameter(
+                    f"--scope triggered_user requires a UUID id (got: {id_part!r})",
+                    param_hint="--scope",
+                ) from exc
+            continue
+        try:
+            element_type = RBACElementTypeDTO(type_part)
+        except ValueError as exc:
+            valid = ", ".join(sorted(t.value for t in RBACElementTypeDTO))
+            raise click.BadParameter(
+                f"unknown scope type {type_part!r}; "
+                f"expected one of: {_TRIGGERED_USER_KEYWORD}, {valid}",
+                param_hint="--scope",
+            ) from exc
+        entity.append(EntityTypeScope(entity_type=element_type, entity_id=id_part))
+    return entity, triggered_user
 
 
 @click.group(name="audit-log")
@@ -102,6 +152,123 @@ def search(
                     order=orders,
                     limit=limit,
                     offset=offset,
+                ),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@audit_log.command(name="scoped-search")
+@click.option(
+    "--scope",
+    "scopes",
+    multiple=True,
+    required=True,
+    help=(
+        "Scope item in '<type>:<id>' form. "
+        f"Use '{_TRIGGERED_USER_KEYWORD}:<user-uuid>' to scope by actor; "
+        "otherwise '<entity_type>:<entity_id>' (e.g., 'vfolder:<uuid>', 'project:<uuid>'). "
+        "Repeatable; items are OR'd."
+    ),
+)
+@click.option("--limit", type=int, default=None, help="Maximum items to return.")
+@click.option("--offset", type=int, default=None, help="Number of items to skip.")
+@click.option("--first", type=int, default=None, help="Cursor-forward page size.")
+@click.option("--after", type=str, default=None, help="Cursor-forward start cursor.")
+@click.option(
+    "--entity-type",
+    type=str,
+    default=None,
+    help="Filter by entity type (contains).",
+)
+@click.option(
+    "--operation",
+    type=str,
+    default=None,
+    help="Filter by operation (contains).",
+)
+@click.option(
+    "--status",
+    type=click.Choice(["success", "error", "unknown", "running"], case_sensitive=False),
+    default=None,
+    help="Filter by audit log status.",
+)
+@click.option(
+    "--triggered-by",
+    type=str,
+    default=None,
+    help="Filter by triggered-by user (contains).",
+)
+@click.option(
+    "--order-by",
+    multiple=True,
+    help=(
+        "Order by field:direction (e.g., created_at:desc). "
+        "Fields: created_at, entity_type, operation, status."
+    ),
+)
+def scoped_search(
+    scopes: tuple[str, ...],
+    limit: int | None,
+    offset: int | None,
+    first: int | None,
+    after: str | None,
+    entity_type: str | None,
+    operation: str | None,
+    status: str | None,
+    triggered_by: str | None,
+    order_by: tuple[str, ...],
+) -> None:
+    """Search audit logs within an RBAC-authorized scope (non-admin)."""
+    from ai.backend.common.dto.manager.query import StringFilter
+    from ai.backend.common.dto.manager.v2.audit_log.request import (
+        AuditLogFilter,
+        AuditLogOrder,
+        AuditLogScope,
+        AuditLogStatusFilter,
+        ScopedSearchAuditLogsInput,
+    )
+    from ai.backend.common.dto.manager.v2.audit_log.types import (
+        AuditLogOrderField,
+        AuditLogStatus,
+    )
+
+    entity_items, triggered_user_items = _parse_scope_items(scopes)
+    scope_dto = AuditLogScope(
+        entity=entity_items or None,
+        triggered_user=triggered_user_items or None,
+    )
+
+    filter_dto: AuditLogFilter | None = None
+    if any(opt is not None for opt in (entity_type, operation, status, triggered_by)):
+        filter_dto = AuditLogFilter(
+            entity_type=(StringFilter(contains=entity_type) if entity_type is not None else None),
+            operation=StringFilter(contains=operation) if operation is not None else None,
+            status=(
+                AuditLogStatusFilter(equals=AuditLogStatus(status)) if status is not None else None
+            ),
+            triggered_by=(
+                StringFilter(contains=triggered_by) if triggered_by is not None else None
+            ),
+        )
+
+    orders = parse_order_options(order_by, AuditLogOrderField, AuditLogOrder) if order_by else None
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.audit_log.scoped_search(
+                ScopedSearchAuditLogsInput(
+                    scope=scope_dto,
+                    filter=filter_dto,
+                    order=orders,
+                    limit=limit,
+                    offset=offset,
+                    first=first,
+                    after=after,
                 ),
             )
             print_result(result)

--- a/src/ai/backend/client/cli/v2/audit_log/commands.py
+++ b/src/ai/backend/client/cli/v2/audit_log/commands.py
@@ -13,6 +13,7 @@ from ai.backend.client.cli.v2.helpers import (
     parse_order_options,
     print_result,
 )
+from ai.backend.client.cli.v2.types import ScopeArg, ScopeArgType
 from ai.backend.common.dto.manager.v2.rbac.types import (
     EntityTypeScope,
     RBACElementTypeDTO,
@@ -22,45 +23,37 @@ from ai.backend.common.dto.manager.v2.rbac.types import (
 _TRIGGERED_USER_KEYWORD = "triggered_user"
 
 
-def _parse_scope_items(
-    raw_scopes: tuple[str, ...],
+def _to_audit_log_scope_buckets(
+    scopes: tuple[ScopeArg, ...],
 ) -> tuple[list[EntityTypeScope], list[UUIDScope]]:
-    """Parse ``--scope`` values of form ``<type>:<id>`` into entity / triggered_user buckets."""
+    """Sort parsed ``--scope`` args into audit-log entity / actor buckets.
+
+    ``triggered_user:<uuid>`` routes to the actor list (parsed as UUID); any
+    other ``<type>`` is validated against :class:`RBACElementTypeDTO` and
+    routed to the entity list.
+    """
     entity: list[EntityTypeScope] = []
     triggered_user: list[UUIDScope] = []
-    for raw in raw_scopes:
-        if ":" not in raw:
-            raise click.BadParameter(
-                f"--scope must be in '<type>:<id>' form (got: {raw!r})",
-                param_hint="--scope",
-            )
-        type_part, id_part = raw.split(":", 1)
-        type_part = type_part.strip()
-        id_part = id_part.strip()
-        if not type_part or not id_part:
-            raise click.BadParameter(
-                f"--scope requires both type and id (got: {raw!r})",
-                param_hint="--scope",
-            )
-        if type_part == _TRIGGERED_USER_KEYWORD:
+    for scope in scopes:
+        if scope.type == _TRIGGERED_USER_KEYWORD:
             try:
-                triggered_user.append(UUIDScope(value=uuid.UUID(id_part)))
+                triggered_user.append(UUIDScope(value=uuid.UUID(scope.id)))
             except ValueError as exc:
                 raise click.BadParameter(
-                    f"--scope triggered_user requires a UUID id (got: {id_part!r})",
+                    f"--scope {_TRIGGERED_USER_KEYWORD} requires a UUID id (got: {scope.id!r})",
                     param_hint="--scope",
                 ) from exc
             continue
         try:
-            element_type = RBACElementTypeDTO(type_part)
+            element_type = RBACElementTypeDTO(scope.type)
         except ValueError as exc:
             valid = ", ".join(sorted(t.value for t in RBACElementTypeDTO))
             raise click.BadParameter(
-                f"unknown scope type {type_part!r}; "
+                f"unknown scope type {scope.type!r}; "
                 f"expected one of: {_TRIGGERED_USER_KEYWORD}, {valid}",
                 param_hint="--scope",
             ) from exc
-        entity.append(EntityTypeScope(entity_type=element_type, entity_id=id_part))
+        entity.append(EntityTypeScope(entity_type=element_type, entity_id=scope.id))
     return entity, triggered_user
 
 
@@ -165,6 +158,7 @@ def search(
 @click.option(
     "--scope",
     "scopes",
+    type=ScopeArgType(),
     multiple=True,
     required=True,
     help=(
@@ -211,7 +205,7 @@ def search(
     ),
 )
 def scoped_search(
-    scopes: tuple[str, ...],
+    scopes: tuple[ScopeArg, ...],
     limit: int | None,
     offset: int | None,
     first: int | None,
@@ -236,7 +230,7 @@ def scoped_search(
         AuditLogStatus,
     )
 
-    entity_items, triggered_user_items = _parse_scope_items(scopes)
+    entity_items, triggered_user_items = _to_audit_log_scope_buckets(scopes)
     scope_dto = AuditLogScope(
         entity=entity_items or None,
         triggered_user=triggered_user_items or None,

--- a/src/ai/backend/client/cli/v2/types.py
+++ b/src/ai/backend/client/cli/v2/types.py
@@ -1,0 +1,48 @@
+"""Reusable Click parameter types for v2 CLI commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import click
+
+
+@dataclass(frozen=True)
+class ScopeArg:
+    """Parsed ``--scope <type>:<id>`` CLI value.
+
+    Both fields are kept as raw strings; domain-specific interpretation (e.g.
+    mapping ``type`` to an enum, parsing ``id`` as UUID) is the caller's
+    responsibility.
+    """
+
+    type: str
+    id: str
+
+
+class ScopeArgType(click.ParamType):
+    """Click parameter type for ``<type>:<id>`` scope arguments.
+
+    Validates syntax only — splits on the first ``:`` and checks that both
+    sides are non-empty. Returns a :class:`ScopeArg` with raw string fields.
+    """
+
+    name = "scope"
+
+    def convert(
+        self,
+        value: Any,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> ScopeArg:
+        if isinstance(value, ScopeArg):
+            return value
+        if not isinstance(value, str) or ":" not in value:
+            self.fail(f"must be in '<type>:<id>' form (got: {value!r})", param, ctx)
+        type_part, id_part = value.split(":", 1)
+        type_part = type_part.strip()
+        id_part = id_part.strip()
+        if not type_part or not id_part:
+            self.fail(f"requires both type and id (got: {value!r})", param, ctx)
+        return ScopeArg(type=type_part, id=id_part)

--- a/src/ai/backend/client/v2/domains_v2/audit_log.py
+++ b/src/ai/backend/client/v2/domains_v2/audit_log.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from ai.backend.client.v2.base_domain import BaseDomainClient
-from ai.backend.common.dto.manager.v2.audit_log.request import AdminSearchAuditLogsInput
+from ai.backend.common.dto.manager.v2.audit_log.request import (
+    AdminSearchAuditLogsInput,
+    ScopedSearchAuditLogsInput,
+)
 from ai.backend.common.dto.manager.v2.audit_log.response import SearchAuditLogsPayload
 
 _PATH = "/v2/audit-logs"
@@ -17,6 +20,15 @@ class V2AuditLogClient(BaseDomainClient):
         return await self._client.typed_request(
             "POST",
             f"{_PATH}/search",
+            request=request,
+            response_model=SearchAuditLogsPayload,
+        )
+
+    async def scoped_search(self, request: ScopedSearchAuditLogsInput) -> SearchAuditLogsPayload:
+        """Search audit logs within an RBAC-authorized scope (non-admin)."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/scoped-search",
             request=request,
             response_model=SearchAuditLogsPayload,
         )

--- a/src/ai/backend/manager/api/rest/v2/audit_log/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/audit_log/handler.py
@@ -7,7 +7,10 @@ from http import HTTPStatus
 from typing import TYPE_CHECKING, Final
 
 from ai.backend.common.api_handlers import APIResponse, BodyParam
-from ai.backend.common.dto.manager.v2.audit_log.request import AdminSearchAuditLogsInput
+from ai.backend.common.dto.manager.v2.audit_log.request import (
+    AdminSearchAuditLogsInput,
+    ScopedSearchAuditLogsInput,
+)
 from ai.backend.logging import BraceStyleAdapter
 
 if TYPE_CHECKING:
@@ -28,4 +31,12 @@ class V2AuditLogHandler:
     ) -> APIResponse:
         """Search audit logs with admin scope."""
         result = await self._adapter.admin_search(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def scoped_search_audit_logs(
+        self,
+        body: BodyParam[ScopedSearchAuditLogsInput],
+    ) -> APIResponse:
+        """Search audit logs within an RBAC-authorized scope (non-admin)."""
+        result = await self._adapter.scoped_search(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/audit_log/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/audit_log/registry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ai.backend.manager.api.rest.middleware.auth import superadmin_required
+from ai.backend.manager.api.rest.middleware.auth import auth_required, superadmin_required
 from ai.backend.manager.api.rest.routing import RouteRegistry
 
 from .handler import V2AuditLogHandler
@@ -25,6 +25,12 @@ def register_v2_audit_log_routes(
         "/search",
         handler.admin_search_audit_logs,
         middlewares=[superadmin_required],
+    )
+    registry.add(
+        "POST",
+        "/scoped-search",
+        handler.scoped_search_audit_logs,
+        middlewares=[auth_required],
     )
 
     return registry

--- a/tests/component/audit_log/BUILD
+++ b/tests/component/audit_log/BUILD
@@ -1,0 +1,5 @@
+python_test_utils()
+
+python_tests(
+    name="tests",
+)

--- a/tests/component/audit_log/conftest.py
+++ b/tests/component/audit_log/conftest.py
@@ -1,0 +1,154 @@
+"""Fixtures for audit log REST v2 component tests."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Awaitable, Callable
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yarl
+
+from ai.backend.client.v2.auth import HMACAuth
+from ai.backend.client.v2.config import ClientConfig
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.manager.actions.types import OperationStatus
+from ai.backend.manager.actions.validator.bulk import BulkActionValidator, BulkValidationResult
+from ai.backend.manager.actions.validators import ActionValidators
+from ai.backend.manager.api.adapters.audit_log.adapter import AuditLogAdapter
+from ai.backend.manager.api.rest.routing import RouteRegistry
+from ai.backend.manager.api.rest.types import RouteDeps
+from ai.backend.manager.api.rest.v2.audit_log.handler import V2AuditLogHandler
+from ai.backend.manager.api.rest.v2.audit_log.registry import register_v2_audit_log_routes
+from ai.backend.manager.models.audit_log import AuditLogRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.audit_log import AuditLogCreatorSpec, AuditLogRepository
+from ai.backend.manager.repositories.base import Creator
+from ai.backend.manager.services.audit_log.processors import AuditLogProcessors
+from ai.backend.manager.services.audit_log.service import AuditLogService
+from ai.backend.manager.services.processors import Processors
+
+if TYPE_CHECKING:
+    from tests.component.conftest import ServerInfo, UserFixtureData
+
+
+AuditLogFactory = Callable[..., Awaitable[uuid.UUID]]
+
+
+@pytest.fixture()
+def audit_log_processors(
+    database_engine: ExtendedAsyncSAEngine,
+) -> AuditLogProcessors:
+    """Real repository + service stack; bulk RBAC validator is stubbed out.
+
+    Component tests verify REST plumbing (auth, body parsing, routing,
+    pagination) — RBAC enforcement is covered in
+    ``tests/unit/manager/repositories/audit_log/test_scoped_search.py``.
+    """
+    repo = AuditLogRepository(db=database_engine)
+    service = AuditLogService(repo)
+
+    bulk_validator = MagicMock(spec=BulkActionValidator)
+    bulk_validator.validate = AsyncMock(
+        return_value=BulkValidationResult(allowed_entities=[], denied_entities=[])
+    )
+    validators = MagicMock(spec=ActionValidators)
+    validators.rbac = MagicMock()
+    validators.rbac.bulk = bulk_validator
+
+    return AuditLogProcessors(service=service, action_monitors=[], validators=validators)
+
+
+@pytest.fixture()
+def server_module_registries(
+    route_deps: RouteDeps,
+    audit_log_processors: AuditLogProcessors,
+) -> list[RouteRegistry]:
+    """Register the REST v2 audit log routes for the test server."""
+    processors = MagicMock(spec=Processors)
+    processors.audit_log = audit_log_processors
+    adapter = AuditLogAdapter(processors)
+
+    handler = V2AuditLogHandler(adapter=adapter)
+    v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
+    v2_reg.add_subregistry(register_v2_audit_log_routes(handler, route_deps))
+    return [v2_reg]
+
+
+@pytest.fixture()
+async def admin_v2_registry(
+    server: ServerInfo,
+    admin_user_fixture: UserFixtureData,
+) -> AsyncIterator[V2ClientRegistry]:
+    registry = await V2ClientRegistry.create(
+        ClientConfig(endpoint=yarl.URL(server.url)),
+        HMACAuth(
+            access_key=admin_user_fixture.keypair.access_key,
+            secret_key=admin_user_fixture.keypair.secret_key,
+        ),
+    )
+    try:
+        yield registry
+    finally:
+        await registry.close()
+
+
+@pytest.fixture()
+async def user_v2_registry(
+    server: ServerInfo,
+    regular_user_fixture: UserFixtureData,
+) -> AsyncIterator[V2ClientRegistry]:
+    registry = await V2ClientRegistry.create(
+        ClientConfig(endpoint=yarl.URL(server.url)),
+        HMACAuth(
+            access_key=regular_user_fixture.keypair.access_key,
+            secret_key=regular_user_fixture.keypair.secret_key,
+        ),
+    )
+    try:
+        yield registry
+    finally:
+        await registry.close()
+
+
+@pytest.fixture()
+async def audit_log_factory(
+    database_engine: ExtendedAsyncSAEngine,
+) -> AsyncIterator[AuditLogFactory]:
+    """Insert audit_log rows on demand; clean them up at teardown."""
+    repo = AuditLogRepository(db=database_engine)
+    created: list[uuid.UUID] = []
+
+    async def _factory(
+        *,
+        entity_type: str,
+        entity_id: str | None = None,
+        triggered_by: str | None = None,
+        operation: str = "update",
+        status: OperationStatus = OperationStatus.SUCCESS,
+    ) -> uuid.UUID:
+        creator = Creator(
+            spec=AuditLogCreatorSpec(
+                action_id=uuid.uuid4(),
+                entity_type=entity_type,
+                operation=operation,
+                created_at=datetime.now(UTC),
+                description=f"{entity_type} {operation}",
+                status=status,
+                entity_id=entity_id,
+                request_id=None,
+                triggered_by=triggered_by,
+                duration=None,
+            )
+        )
+        data = await repo.create(creator)
+        created.append(data.id)
+        return data.id
+
+    yield _factory
+
+    if created:
+        async with database_engine.begin() as conn:
+            await conn.execute(AuditLogRow.__table__.delete().where(AuditLogRow.id.in_(created)))

--- a/tests/component/audit_log/test_scoped_search_rest.py
+++ b/tests/component/audit_log/test_scoped_search_rest.py
@@ -9,7 +9,6 @@ import pytest
 
 from ai.backend.client.v2.exceptions import InvalidRequestError, PermissionDeniedError
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
-from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.dto.manager.v2.audit_log.request import (
     AdminSearchAuditLogsInput,
     AuditLogFilter,
@@ -18,55 +17,71 @@ from ai.backend.common.dto.manager.v2.audit_log.request import (
     ScopedSearchAuditLogsInput,
 )
 from ai.backend.common.dto.manager.v2.audit_log.types import AuditLogStatus
-from ai.backend.common.dto.manager.v2.rbac.types import EntityTypeScope, UUIDScope
+from ai.backend.common.dto.manager.v2.rbac.types import (
+    EntityTypeScope,
+    RBACElementTypeDTO,
+    UUIDScope,
+)
 from ai.backend.manager.actions.types import OperationStatus
 
 if TYPE_CHECKING:
     from tests.component.audit_log.conftest import AuditLogFactory
 
 
-_ENTITY_ID = "ba-6098-vf"
-_ACTOR = uuid.uuid4()
+@pytest.fixture()
+def entity_id() -> str:
+    return f"ba-6098-vf-{uuid.uuid4().hex[:8]}"
 
 
 @pytest.fixture()
-async def seeded_rows(audit_log_factory: AuditLogFactory) -> dict[str, uuid.UUID]:
-    """Two SUCCESS rows + one ERROR row on the same target/actor."""
-    return {
-        "success_a": await audit_log_factory(
-            entity_type=RBACElementType.VFOLDER.value,
-            entity_id=_ENTITY_ID,
-            triggered_by=str(_ACTOR),
-            operation="update",
-            status=OperationStatus.SUCCESS,
-        ),
-        "success_b": await audit_log_factory(
-            entity_type=RBACElementType.VFOLDER.value,
-            entity_id=_ENTITY_ID,
-            triggered_by=str(_ACTOR),
-            operation="delete",
-            status=OperationStatus.SUCCESS,
-        ),
-        "error_a": await audit_log_factory(
-            entity_type=RBACElementType.VFOLDER.value,
-            entity_id=_ENTITY_ID,
-            triggered_by=str(_ACTOR),
-            operation="update",
-            status=OperationStatus.ERROR,
-        ),
-    }
+def actor_uuid() -> uuid.UUID:
+    return uuid.uuid4()
 
 
-def _entity_scope() -> AuditLogScope:
+@pytest.fixture()
+def entity_scope(entity_id: str) -> AuditLogScope:
     return AuditLogScope(
         entity=[
-            EntityTypeScope(entity_type=RBACElementType.VFOLDER, entity_id=_ENTITY_ID),
+            EntityTypeScope(entity_type=RBACElementTypeDTO.VFOLDER, entity_id=entity_id),
         ]
     )
 
 
-def _actor_scope() -> AuditLogScope:
-    return AuditLogScope(triggered_user=[UUIDScope(value=_ACTOR)])
+@pytest.fixture()
+def actor_scope(actor_uuid: uuid.UUID) -> AuditLogScope:
+    return AuditLogScope(triggered_user=[UUIDScope(value=actor_uuid)])
+
+
+@pytest.fixture()
+async def seeded_rows(
+    audit_log_factory: AuditLogFactory,
+    entity_id: str,
+    actor_uuid: uuid.UUID,
+) -> dict[str, uuid.UUID]:
+    """Two SUCCESS rows + one ERROR row on the same target/actor."""
+    return {
+        "success_a": await audit_log_factory(
+            entity_type=RBACElementTypeDTO.VFOLDER.value,
+            entity_id=entity_id,
+            triggered_by=str(actor_uuid),
+            operation="update",
+            status=OperationStatus.SUCCESS,
+        ),
+        "success_b": await audit_log_factory(
+            entity_type=RBACElementTypeDTO.VFOLDER.value,
+            entity_id=entity_id,
+            triggered_by=str(actor_uuid),
+            operation="delete",
+            status=OperationStatus.SUCCESS,
+        ),
+        "error_a": await audit_log_factory(
+            entity_type=RBACElementTypeDTO.VFOLDER.value,
+            entity_id=entity_id,
+            triggered_by=str(actor_uuid),
+            operation="update",
+            status=OperationStatus.ERROR,
+        ),
+    }
 
 
 class TestAuditLogAdminSearchUnchanged:
@@ -96,10 +111,11 @@ class TestAuditLogScopedSearchAuth:
     async def test_regular_user_can_call_scoped_search(
         self,
         user_v2_registry: V2ClientRegistry,
+        entity_scope: AuditLogScope,
         seeded_rows: dict[str, uuid.UUID],
     ) -> None:
         result = await user_v2_registry.audit_log.scoped_search(
-            ScopedSearchAuditLogsInput(scope=_entity_scope(), limit=10),
+            ScopedSearchAuditLogsInput(scope=entity_scope, limit=10),
         )
         ids = {item.id for item in result.items}
         assert {seeded_rows["success_a"], seeded_rows["success_b"], seeded_rows["error_a"]} <= ids
@@ -125,11 +141,12 @@ class TestAuditLogScopedSearchFilter:
     async def test_status_filter_narrows_results(
         self,
         user_v2_registry: V2ClientRegistry,
+        entity_scope: AuditLogScope,
         seeded_rows: dict[str, uuid.UUID],
     ) -> None:
         result = await user_v2_registry.audit_log.scoped_search(
             ScopedSearchAuditLogsInput(
-                scope=_entity_scope(),
+                scope=entity_scope,
                 filter=AuditLogFilter(
                     status=AuditLogStatusFilter(equals=AuditLogStatus.ERROR),
                 ),
@@ -148,10 +165,11 @@ class TestAuditLogScopedSearchPagination:
     async def test_offset_pagination_limits_page_size(
         self,
         user_v2_registry: V2ClientRegistry,
+        actor_scope: AuditLogScope,
         seeded_rows: dict[str, uuid.UUID],
     ) -> None:
         result = await user_v2_registry.audit_log.scoped_search(
-            ScopedSearchAuditLogsInput(scope=_actor_scope(), limit=2, offset=0),
+            ScopedSearchAuditLogsInput(scope=actor_scope, limit=2, offset=0),
         )
         assert len(result.items) <= 2
         assert result.total_count >= len(seeded_rows)
@@ -159,10 +177,11 @@ class TestAuditLogScopedSearchPagination:
     async def test_cursor_pagination_returns_page_info(
         self,
         user_v2_registry: V2ClientRegistry,
+        actor_scope: AuditLogScope,
         seeded_rows: dict[str, uuid.UUID],
     ) -> None:
         first_page = await user_v2_registry.audit_log.scoped_search(
-            ScopedSearchAuditLogsInput(scope=_actor_scope(), first=1),
+            ScopedSearchAuditLogsInput(scope=actor_scope, first=1),
         )
         assert len(first_page.items) == 1
         assert first_page.has_next_page is True

--- a/tests/component/audit_log/test_scoped_search_rest.py
+++ b/tests/component/audit_log/test_scoped_search_rest.py
@@ -1,0 +1,168 @@
+"""Component tests for the scoped audit-log REST v2 endpoint."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ai.backend.client.v2.exceptions import InvalidRequestError, PermissionDeniedError
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.common.dto.manager.v2.audit_log.request import (
+    AdminSearchAuditLogsInput,
+    AuditLogFilter,
+    AuditLogScope,
+    AuditLogStatusFilter,
+    ScopedSearchAuditLogsInput,
+)
+from ai.backend.common.dto.manager.v2.audit_log.types import AuditLogStatus
+from ai.backend.common.dto.manager.v2.rbac.types import EntityTypeScope, UUIDScope
+from ai.backend.manager.actions.types import OperationStatus
+
+if TYPE_CHECKING:
+    from tests.component.audit_log.conftest import AuditLogFactory
+
+
+_ENTITY_ID = "ba-6098-vf"
+_ACTOR = uuid.uuid4()
+
+
+@pytest.fixture()
+async def seeded_rows(audit_log_factory: AuditLogFactory) -> dict[str, uuid.UUID]:
+    """Two SUCCESS rows + one ERROR row on the same target/actor."""
+    return {
+        "success_a": await audit_log_factory(
+            entity_type=RBACElementType.VFOLDER.value,
+            entity_id=_ENTITY_ID,
+            triggered_by=str(_ACTOR),
+            operation="update",
+            status=OperationStatus.SUCCESS,
+        ),
+        "success_b": await audit_log_factory(
+            entity_type=RBACElementType.VFOLDER.value,
+            entity_id=_ENTITY_ID,
+            triggered_by=str(_ACTOR),
+            operation="delete",
+            status=OperationStatus.SUCCESS,
+        ),
+        "error_a": await audit_log_factory(
+            entity_type=RBACElementType.VFOLDER.value,
+            entity_id=_ENTITY_ID,
+            triggered_by=str(_ACTOR),
+            operation="update",
+            status=OperationStatus.ERROR,
+        ),
+    }
+
+
+def _entity_scope() -> AuditLogScope:
+    return AuditLogScope(
+        entity=[
+            EntityTypeScope(entity_type=RBACElementType.VFOLDER, entity_id=_ENTITY_ID),
+        ]
+    )
+
+
+def _actor_scope() -> AuditLogScope:
+    return AuditLogScope(triggered_user=[UUIDScope(value=_ACTOR)])
+
+
+class TestAuditLogAdminSearchUnchanged:
+    """The pre-existing admin endpoint stays superadmin-only and continues to work."""
+
+    async def test_admin_can_call_admin_search(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        seeded_rows: dict[str, uuid.UUID],
+    ) -> None:
+        result = await admin_v2_registry.audit_log.search(
+            AdminSearchAuditLogsInput(limit=10, offset=0),
+        )
+        assert result.total_count >= len(seeded_rows)
+
+    async def test_regular_user_cannot_call_admin_search(
+        self,
+        user_v2_registry: V2ClientRegistry,
+    ) -> None:
+        with pytest.raises(PermissionDeniedError):
+            await user_v2_registry.audit_log.search(AdminSearchAuditLogsInput(limit=1))
+
+
+class TestAuditLogScopedSearchAuth:
+    """The new scoped endpoint is reachable by any authenticated user."""
+
+    async def test_regular_user_can_call_scoped_search(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        seeded_rows: dict[str, uuid.UUID],
+    ) -> None:
+        result = await user_v2_registry.audit_log.scoped_search(
+            ScopedSearchAuditLogsInput(scope=_entity_scope(), limit=10),
+        )
+        ids = {item.id for item in result.items}
+        assert {seeded_rows["success_a"], seeded_rows["success_b"], seeded_rows["error_a"]} <= ids
+
+
+class TestAuditLogScopedSearchValidation:
+    """Empty scope is rejected at the API boundary (DTO model_validator)."""
+
+    async def test_empty_scope_rejected(
+        self,
+        user_v2_registry: V2ClientRegistry,
+    ) -> None:
+        bad_input = ScopedSearchAuditLogsInput.model_construct(
+            scope=AuditLogScope.model_construct(entity=None, triggered_user=None),
+        )
+        with pytest.raises(InvalidRequestError):
+            await user_v2_registry.audit_log.scoped_search(bad_input)
+
+
+class TestAuditLogScopedSearchFilter:
+    """Attribute filters narrow the scoped result set."""
+
+    async def test_status_filter_narrows_results(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        seeded_rows: dict[str, uuid.UUID],
+    ) -> None:
+        result = await user_v2_registry.audit_log.scoped_search(
+            ScopedSearchAuditLogsInput(
+                scope=_entity_scope(),
+                filter=AuditLogFilter(
+                    status=AuditLogStatusFilter(equals=AuditLogStatus.ERROR),
+                ),
+                limit=10,
+            ),
+        )
+        ids = {item.id for item in result.items}
+        assert seeded_rows["error_a"] in ids
+        assert seeded_rows["success_a"] not in ids
+        assert seeded_rows["success_b"] not in ids
+
+
+class TestAuditLogScopedSearchPagination:
+    """Both pagination modes work against the scoped endpoint."""
+
+    async def test_offset_pagination_limits_page_size(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        seeded_rows: dict[str, uuid.UUID],
+    ) -> None:
+        result = await user_v2_registry.audit_log.scoped_search(
+            ScopedSearchAuditLogsInput(scope=_actor_scope(), limit=2, offset=0),
+        )
+        assert len(result.items) <= 2
+        assert result.total_count >= len(seeded_rows)
+
+    async def test_cursor_pagination_returns_page_info(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        seeded_rows: dict[str, uuid.UUID],
+    ) -> None:
+        first_page = await user_v2_registry.audit_log.scoped_search(
+            ScopedSearchAuditLogsInput(scope=_actor_scope(), first=1),
+        )
+        assert len(first_page.items) == 1
+        assert first_page.has_next_page is True


### PR DESCRIPTION
## Summary
- Add the non-admin scoped audit-log search across the full v2 stack on top of the adapter introduced in BA-6096.
- New `POST /v2/audit-logs/scoped-search` (`auth_required`) — accepts `ScopedSearchAuditLogsInput` in the body and delegates to `AuditLogAdapter.scoped_search`. Existing `POST /v2/audit-logs/search` (`superadmin_required`) is unchanged.
- New SDK method `V2AuditLogClient.scoped_search()`, and new CLI `./bai audit-log scoped-search` with repeatable `--scope <type>:<id>` flags (`triggered_user:<uuid>` → actor scope, any other `<type>` → entity scope via `RBACElementTypeDTO`).
- Component tests covering admin endpoint unchanged, scoped-search auth, empty-scope rejection at the API boundary, attribute filter, and both pagination modes.

### URL pattern note
The scoped audit-log query is a multi-item OR-union (entity list + triggered_user list), so it cannot be expressed via the `/v2/{entity}/{scope_type}/{scope_id}/search` nested-path pattern. The Jira ticket explicitly specifies the scope as a body field, so the endpoint is `/v2/audit-logs/scoped-search`.

## Test plan
- [x] Live REST/SDK/CLI smoke test against running manager (admin keypair):
  - `./bai audit-log scoped-search --scope triggered_user:<uuid> --limit 2` returns rows.
  - `./bai audit-log scoped-search --scope agent:i-MacBook-Air.local --scope triggered_user:<uuid> --status error` honors OR-union scope and `--status` filter.
  - Existing `./bai audit-log search` (admin) still works.
  - Unknown scope type / invalid UUID / missing `--scope` produce clean CLI errors.
- [x] `pants fmt`, `pants fix`, `pants lint --changed-since=origin/main` clean.
- [x] CI runs `pants check` and the new `tests/component/audit_log/test_scoped_search_rest.py`.

Resolves BA-6098

🤖 Generated with [Claude Code](https://claude.com/claude-code)