### PR TITLE
fix(BA-6136): make `options` nullable in BulkPurgeVFoldersV2Input GQL schema

### DIFF
--- a/changes/11732.fix.md
+++ b/changes/11732.fix.md
@@ -1,0 +1,1 @@
+Make `options` nullable in the `BulkPurgeVFoldersV2Input` GraphQL input so clients can omit it and fall back to the server-side defaults.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -2084,7 +2084,7 @@ input BulkPurgeVFoldersV2Input
   """
   Added in UNRELEASED. Optional behavior flags applied to every vfolder in the batch. Defaults to all-false when omitted.
   """
-  options: PurgeVFolderOptionsInput!
+  options: PurgeVFolderOptionsInput
 }
 
 """Added in 26.4.2. Payload for bulk virtual folder purge."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1466,7 +1466,7 @@ input BulkPurgeVFoldersV2Input {
   """
   Added in UNRELEASED. Optional behavior flags applied to every vfolder in the batch. Defaults to all-false when omitted.
   """
-  options: PurgeVFolderOptionsInput!
+  options: PurgeVFolderOptionsInput
 }
 
 """Added in 26.4.2. Payload for bulk virtual folder purge."""

--- a/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
@@ -471,7 +471,7 @@ class PurgeVFolderOptionsInputGQL(PydanticInputMixin[PurgeVFolderOptionsDTO]):
 )
 class BulkPurgeVFoldersInputGQL(PydanticInputMixin[BulkPurgeInputDTO]):
     ids: list[UUID] = gql_field(description="List of VFolder UUIDs to purge.")
-    options: PurgeVFolderOptionsInputGQL = gql_added_field(
+    options: PurgeVFolderOptionsInputGQL | None = gql_added_field(
         BackendAIGQLMeta(
             added_version=NEXT_RELEASE_VERSION,
             description=(


### PR DESCRIPTION
## Summary
- `BulkPurgeVFoldersV2Input.options` was emitted as a required (non-null) GQL field even though the Pydantic DTO declares `default_factory=PurgeVFolderOptions` and the description says it defaults to all-false when omitted.
- Root cause: Strawberry derives the GQL schema from the type annotation and `default` argument, not from Pydantic's `default_factory`. Mark the GQL field as `... | None` so the schema reflects the DTO's optionality.
- When the client omits `options`, the GQL attribute is `UNSET`; `_to_pydantic_kwargs` skips it and the DTO's `default_factory` produces an all-false options object.

## Test plan
- [x] `pants fmt :: && pants fix :: && pants lint --changed-since=origin/main`
- [x] Regenerated `docs/manager/graphql-reference/{v2-schema,supergraph}.graphql` — `options` changes from `PurgeVFolderOptionsInput!` to `PurgeVFolderOptionsInput`
- [x] Run `bulkPurgeVfoldersV2` mutation without `options` and confirm it succeeds with default flags

Resolves BA-6136

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11732.org.readthedocs.build/en/11732/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11732.org.readthedocs.build/ko/11732/

<!-- readthedocs-preview sorna-ko end -->