### PR TITLE
fix(BA-6138): use SESSION entity_type for SearchKernelsAction RBAC

### DIFF
--- a/changes/11736.fix.md
+++ b/changes/11736.fix.md
@@ -1,0 +1,1 @@
+Fix `RBACTypeConversionError` when resolving the `kernels` field under a session in GraphQL.

--- a/src/ai/backend/common/data/permission/types.py
+++ b/src/ai/backend/common/data/permission/types.py
@@ -149,7 +149,6 @@ class EntityType(enum.StrEnum):
     APP_CONFIG_DOMAIN = "app_config:domain"
     APP_CONFIG_USER = "app_config:user"
     # Session sub
-    SESSION_KERNEL = "session:kernel"
     SESSION_FILE = "session:file"
     SESSION_DIRECTORY = "session:directory"
     SESSION_APP_SERVICE = "session:app_service"

--- a/src/ai/backend/manager/services/session/actions/search_kernel.py
+++ b/src/ai/backend/manager/services/session/actions/search_kernel.py
@@ -27,7 +27,7 @@ class SearchKernelsAction(SessionScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EntityType.SESSION_KERNEL
+        return EntityType.SESSION
 
     @override
     def entity_id(self) -> str | None:


### PR DESCRIPTION
## Summary
- `SearchKernelsAction` used `EntityType.SESSION_KERNEL`, which has no corresponding `RBACElementType`, causing `RBACTypeConversionError` when resolving the `kernels` field under a session in GraphQL (e.g. `projectSessionsV2.edges.node.kernels`).
- Switch to `EntityType.SESSION` so the RBAC check matches existing session-level role bindings — kernel access is governed by the same permission as the owning session.

## Test plan
- [x] Restart manager and query `projectSessionsV2 { edges { node { kernels { ... } } } }` as a regular user — expect 200, no `permission_generic_internal-error`.

Resolves BA-6138

🤖 Generated with [Claude Code](https://claude.com/claude-code)