### PR TITLE
refactor(BA-6150): expose domain_id in test fixtures via DomainFixtureData

### DIFF
--- a/changes/11752.enhance.md
+++ b/changes/11752.enhance.md
@@ -1,0 +1,1 @@
+Add `DomainFixtureData` and `domain_factory` test fixtures exposing both `domain_name` and `domain_id`.

--- a/src/ai/backend/testutils/fixtures.py
+++ b/src/ai/backend/testutils/fixtures.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from ai.backend.common.identifier.domain import DomainID, DomainName
+
+__all__ = (
+    "DomainFactory",
+    "DomainFixtureData",
+)
+
+
+@dataclass(frozen=True)
+class DomainFixtureData:
+    domain_name: DomainName
+    domain_id: DomainID
+
+
+DomainFactory = Callable[..., Awaitable[DomainFixtureData]]

--- a/tests/component/auth/conftest.py
+++ b/tests/component/auth/conftest.py
@@ -34,6 +34,7 @@ from ai.backend.manager.models.keypair import keypairs
 from ai.backend.manager.models.login_client_type.row import LoginClientTypeRow
 from ai.backend.manager.models.user import users
 from ai.backend.manager.services.auth.processors import AuthProcessors
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 _AUTH_SERVER_SUBAPP_MODULES = (_auth_api,)
 
@@ -108,7 +109,7 @@ async def seed_login_client_types(
 async def auth_user_fixture(
     db_engine: SAEngine,
     group_fixture: uuid.UUID,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[AuthUserFixtureData]:
     """Insert a regular user with a known password for auth tests.
@@ -125,7 +126,7 @@ async def auth_user_fixture(
         secret_key=secrets.token_hex(20),
         password=password,
         email=email,
-        domain_name=domain_fixture,
+        domain_name=domain_fixture.domain_name,
     )
     async with db_engine.begin() as conn:
         await conn.execute(
@@ -144,7 +145,7 @@ async def auth_user_fixture(
                 description=f"Test auth user {unique_id}",
                 status=UserStatus.ACTIVE,
                 status_info="admin-requested",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
                 role=UserRole.USER,
             )
@@ -281,14 +282,14 @@ async def _create_auth_user(
 async def inactive_user_fixture(
     db_engine: SAEngine,
     group_fixture: uuid.UUID,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[AuthUserFixtureData]:
     """Insert a user with INACTIVE status for authorization rejection tests."""
     async with _create_auth_user(
         db_engine,
         group_id=group_fixture,
-        domain_name=domain_fixture,
+        domain_name=domain_fixture.domain_name,
         resource_policy=resource_policy_fixture,
         email_prefix="auth-inactive",
         username_prefix="auth-inactive",
@@ -303,14 +304,14 @@ async def inactive_user_fixture(
 async def before_verification_user_fixture(
     db_engine: SAEngine,
     group_fixture: uuid.UUID,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[AuthUserFixtureData]:
     """Insert a user with BEFORE_VERIFICATION status for authorization rejection tests."""
     async with _create_auth_user(
         db_engine,
         group_id=group_fixture,
-        domain_name=domain_fixture,
+        domain_name=domain_fixture.domain_name,
         resource_policy=resource_policy_fixture,
         email_prefix="auth-unverified",
         username_prefix="auth-unverified",
@@ -325,14 +326,14 @@ async def before_verification_user_fixture(
 async def expired_password_user_fixture(
     db_engine: SAEngine,
     group_fixture: uuid.UUID,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[AuthUserFixtureData]:
     """Insert a user whose password_changed_at is far in the past for expiry tests."""
     async with _create_auth_user(
         db_engine,
         group_id=group_fixture,
-        domain_name=domain_fixture,
+        domain_name=domain_fixture.domain_name,
         resource_policy=resource_policy_fixture,
         email_prefix="auth-expired",
         username_prefix="auth-expired",

--- a/tests/component/auth/test_auth.py
+++ b/tests/component/auth/test_auth.py
@@ -54,6 +54,7 @@ from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
 )
 from ai.backend.manager.models.user import UserRole, users
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 from .conftest import AuthUserFixtureData
 
@@ -120,7 +121,7 @@ class _SignupDefaultProjectData:
 @pytest.fixture()
 async def signup_default_project(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[_SignupDefaultProjectData]:
     """Create a project named ``default`` in the test domain so that the
@@ -135,7 +136,7 @@ async def signup_default_project(
                 name="default",
                 description="Default project for signup binding test",
                 is_active=True,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
             )
         )
@@ -158,7 +159,7 @@ async def signup_default_project(
 async def expired_password_user(
     db_engine: SAEngine,
     group_fixture: uuid.UUID,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[_ExpiredPasswordUserData]:
     """Insert a user whose password_changed_at is far in the past."""
@@ -171,7 +172,7 @@ async def expired_password_user(
         secret_key=secrets.token_hex(20),
         password=password,
         email=email,
-        domain_name=domain_fixture,
+        domain_name=domain_fixture.domain_name,
     )
     # Set password_changed_at to 200 days ago so it's expired with a 90-day policy
     expired_at = datetime.now(UTC) - timedelta(days=200)
@@ -192,7 +193,7 @@ async def expired_password_user(
                 description=f"Test expired password user {unique_id}",
                 status=UserStatus.ACTIVE,
                 status_info="admin-requested",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
                 role=UserRole.USER,
                 password_changed_at=expired_at,
@@ -971,7 +972,7 @@ class TestSignup:
     async def test_signup_creates_user_with_keypair(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         resource_policy_fixture: str,
         db_engine: SAEngine,
     ) -> None:
@@ -980,7 +981,7 @@ class TestSignup:
         email = f"signup-{unique}@test.local"
         result = await admin_registry.auth.signup(
             SignupRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 email=email,
                 password=f"SignupP@ss{unique}",
                 username=f"signup-{unique}",
@@ -999,7 +1000,7 @@ class TestSignup:
     async def test_signup_binds_user_to_default_project_via_ase(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         db_engine: SAEngine,
         signup_default_project: _SignupDefaultProjectData,
     ) -> None:
@@ -1013,7 +1014,7 @@ class TestSignup:
 
         result = await admin_registry.auth.signup(
             SignupRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 email=email,
                 password=f"SignupP@ss{unique}",
                 username=f"signup-bind-{unique}",

--- a/tests/component/auth/test_auth_core.py
+++ b/tests/component/auth/test_auth_core.py
@@ -22,6 +22,7 @@ from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.models.group import association_groups_users
 from ai.backend.manager.models.keypair import keypairs
 from ai.backend.manager.models.user import users
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 from .conftest import AuthUserFixtureData
 
@@ -147,14 +148,14 @@ class TestSignup:
         self,
         admin_registry: BackendAIClientRegistry,
         db_engine: SAEngine,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         unique_id = secrets.token_hex(4)
         email = f"signup-test-{unique_id}@test.local"
         password = f"TestP@ss{unique_id}"
         result = await admin_registry.auth.signup(
             SignupRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 email=email,
                 password=password,
             ),

--- a/tests/component/auto_scaling_rule/conftest.py
+++ b/tests/component/auto_scaling_rule/conftest.py
@@ -37,6 +37,7 @@ from ai.backend.manager.repositories.permission_controller.repository import (
 )
 from ai.backend.manager.services.deployment.processors import DeploymentProcessors
 from ai.backend.manager.services.deployment.service import DeploymentService
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 
 @dataclass
@@ -119,7 +120,7 @@ def server_module_registries(
 @pytest.fixture()
 async def model_deployment_fixture(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     group_fixture: uuid.UUID,
     scaling_group_fixture: str,
     admin_user_fixture: UserFixtureData,
@@ -170,7 +171,7 @@ async def model_deployment_fixture(
                 name=f"test-endpoint-{uuid.uuid4().hex[:8]}",
                 created_user=str(admin_user_fixture.user_uuid),
                 session_owner=str(admin_user_fixture.user_uuid),
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 project=str(group_fixture),
                 resource_group=scaling_group_fixture,
                 lifecycle_stage=EndpointLifecycle.CREATED,

--- a/tests/component/config/conftest.py
+++ b/tests/component/config/conftest.py
@@ -33,6 +33,7 @@ from ai.backend.manager.repositories.dotfile.repository import DotfileRepository
 from ai.backend.manager.services.auth.processors import AuthProcessors
 from ai.backend.manager.services.dotfile.processors import DotfileProcessors
 from ai.backend.manager.services.dotfile.service import DotfileService
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 UserDotfileFactory = Callable[..., Coroutine[Any, Any, CreateDotfileResponse]]
 GroupDotfileFactory = Callable[..., Coroutine[Any, Any, CreateDotfileResponse]]
@@ -131,7 +132,7 @@ async def group_dotfile_factory(
 @pytest.fixture()
 async def domain_dotfile_factory(
     admin_registry: BackendAIClientRegistry,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
 ) -> AsyncIterator[DomainDotfileFactory]:
     """Factory fixture that creates domain dotfiles via SDK and deletes on teardown."""
     created_paths: list[str] = []
@@ -139,7 +140,7 @@ async def domain_dotfile_factory(
     async def _create(**overrides: Any) -> CreateDotfileResponse:
         unique = secrets.token_hex(4)
         params: dict[str, Any] = {
-            "domain": domain_fixture,
+            "domain": domain_fixture.domain_name,
             "path": f".test-domain-dotfile-{unique}",
             "data": f"# domain test content {unique}",
             "permission": "644",
@@ -156,7 +157,7 @@ async def domain_dotfile_factory(
     for path in reversed(created_paths):
         try:
             await admin_registry.config.delete_domain_dotfile(
-                DeleteDomainDotfileRequest(domain=domain_fixture, path=path)
+                DeleteDomainDotfileRequest(domain=domain_fixture.domain_name, path=path)
             )
         except Exception:
             pass

--- a/tests/component/config/test_config.py
+++ b/tests/component/config/test_config.py
@@ -33,6 +33,7 @@ from ai.backend.common.dto.manager.config import (
     UpdateGroupDotfileRequest,
     UpdateUserDotfileRequest,
 )
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 from .conftest import DomainDotfileFactory, GroupDotfileFactory, UserDotfileFactory
 
@@ -458,13 +459,13 @@ class TestDomainDotfileCreate:
     async def test_regular_user_cannot_create_domain_dotfile(
         self,
         user_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         unique = secrets.token_hex(4)
         with pytest.raises(PermissionDeniedError):
             await user_registry.config.create_domain_dotfile(
                 CreateDomainDotfileRequest(
-                    domain=domain_fixture,
+                    domain=domain_fixture.domain_name,
                     path=f".denied-{unique}",
                     data="denied",
                     permission="644",
@@ -476,14 +477,14 @@ class TestDomainDotfileGet:
     async def test_admin_gets_domain_dotfile(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         domain_dotfile_factory: DomainDotfileFactory,
     ) -> None:
         unique = secrets.token_hex(4)
         path = f".domain-get-{unique}"
         await domain_dotfile_factory(path=path, data="domain-get-data", permission="600")
         result = await admin_registry.config.get_domain_dotfile(
-            GetDomainDotfileRequest(domain=domain_fixture, path=path)
+            GetDomainDotfileRequest(domain=domain_fixture.domain_name, path=path)
         )
         assert isinstance(result, GetDotfileResponse)
         assert result.path == path
@@ -493,7 +494,7 @@ class TestDomainDotfileGet:
     async def test_admin_lists_domain_dotfiles(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         domain_dotfile_factory: DomainDotfileFactory,
     ) -> None:
         unique1 = secrets.token_hex(4)
@@ -501,7 +502,7 @@ class TestDomainDotfileGet:
         await domain_dotfile_factory(path=f".dlist-a-{unique1}", data="a", permission="644")
         await domain_dotfile_factory(path=f".dlist-b-{unique2}", data="b", permission="644")
         result = await admin_registry.config.list_domain_dotfiles(
-            GetDomainDotfileRequest(domain=domain_fixture)
+            GetDomainDotfileRequest(domain=domain_fixture.domain_name)
         )
         assert isinstance(result, ListDotfilesResponse)
         # List response is a plain array (via BaseRootResponseModel)
@@ -512,7 +513,7 @@ class TestDomainDotfileGet:
     async def test_list_domain_dotfiles_returns_plain_array_json(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         domain_dotfile_factory: DomainDotfileFactory,
     ) -> None:
         """Verify the API returns a plain JSON array with 'permission' field.
@@ -526,7 +527,7 @@ class TestDomainDotfileGet:
         await domain_dotfile_factory(path=path, data="test-data", permission="755")
         try:
             result = await admin_registry.config.list_domain_dotfiles(
-                GetDomainDotfileRequest(domain=domain_fixture)
+                GetDomainDotfileRequest(domain=domain_fixture.domain_name)
             )
             # The response should be a plain array
             assert isinstance(result.root, list)
@@ -547,7 +548,7 @@ class TestDomainDotfileGet:
         finally:
             # Cleanup
             await admin_registry.config.delete_domain_dotfile(
-                DeleteDomainDotfileRequest(domain=domain_fixture, path=path)
+                DeleteDomainDotfileRequest(domain=domain_fixture.domain_name, path=path)
             )
 
 
@@ -555,7 +556,7 @@ class TestDomainDotfileUpdate:
     async def test_admin_updates_domain_dotfile(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         domain_dotfile_factory: DomainDotfileFactory,
     ) -> None:
         unique = secrets.token_hex(4)
@@ -563,7 +564,7 @@ class TestDomainDotfileUpdate:
         await domain_dotfile_factory(path=path, data="original-domain", permission="644")
         update_result = await admin_registry.config.update_domain_dotfile(
             UpdateDomainDotfileRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 path=path,
                 data="updated-domain-data",
                 permission="755",
@@ -571,7 +572,7 @@ class TestDomainDotfileUpdate:
         )
         assert isinstance(update_result, UpdateDotfileResponse)
         get_result = await admin_registry.config.get_domain_dotfile(
-            GetDomainDotfileRequest(domain=domain_fixture, path=path)
+            GetDomainDotfileRequest(domain=domain_fixture.domain_name, path=path)
         )
         assert get_result.data == "updated-domain-data"
         assert get_result.perm == "755"
@@ -581,18 +582,18 @@ class TestDomainDotfileDelete:
     async def test_admin_deletes_domain_dotfile(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         domain_dotfile_factory: DomainDotfileFactory,
     ) -> None:
         unique = secrets.token_hex(4)
         path = f".domain-del-{unique}"
         await domain_dotfile_factory(path=path, data="to-delete", permission="644")
         delete_result = await admin_registry.config.delete_domain_dotfile(
-            DeleteDomainDotfileRequest(domain=domain_fixture, path=path)
+            DeleteDomainDotfileRequest(domain=domain_fixture.domain_name, path=path)
         )
         assert isinstance(delete_result, DeleteDotfileResponse)
         assert delete_result.success is True
         with pytest.raises(NotFoundError):
             await admin_registry.config.get_domain_dotfile(
-                GetDomainDotfileRequest(domain=domain_fixture, path=path)
+                GetDomainDotfileRequest(domain=domain_fixture.domain_name, path=path)
             )

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -151,6 +151,7 @@ from ai.backend.testutils.bootstrap import (  # noqa: F401
     postgres_container,
     redis_container,
 )
+from ai.backend.testutils.fixtures import DomainFixtureData
 from ai.backend.testutils.pants import get_parallel_slot
 
 log = logging.getLogger("tests.component.conftest")
@@ -543,20 +544,23 @@ async def database_engine(
 @pytest.fixture()
 async def domain_fixture(
     db_engine: SAEngine,
-) -> AsyncIterator[str]:
-    """Insert a test domain and yield its name."""
+) -> AsyncIterator[DomainFixtureData]:
+    """Insert a test domain and yield its identifiers."""
     domain_name = f"domain-{secrets.token_hex(6)}"
     async with db_engine.begin() as conn:
-        await conn.execute(
-            sa.insert(domains).values(
+        result = await conn.execute(
+            sa.insert(domains)
+            .values(
                 name=domain_name,
                 description=f"Test domain {domain_name}",
                 is_active=True,
                 total_resource_slots=ResourceSlot(),
                 allowed_vfolder_hosts=VFolderHostPermissionMap(),
             )
+            .returning(domains.c.id, domains.c.name)
         )
-    yield domain_name
+        row = result.one()
+    yield DomainFixtureData(domain_name=row.name, domain_id=row.id)
     async with db_engine.begin() as conn:
         await conn.execute(domains.delete().where(domains.c.name == domain_name))
 

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -674,7 +674,7 @@ async def resource_policy_fixture(
 @pytest.fixture()
 async def scaling_group_fixture(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
 ) -> AsyncIterator[ResourceGroupName]:
     """Insert a scaling group and its domain association; yield the name."""
     sgroup_name = ResourceGroupName(f"sgroup-{secrets.token_hex(6)}")
@@ -693,7 +693,7 @@ async def scaling_group_fixture(
         await conn.execute(
             sa.insert(sgroups_for_domains).values(
                 scaling_group=sgroup_name,
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
             )
         )
     yield sgroup_name
@@ -707,7 +707,7 @@ async def scaling_group_fixture(
 @pytest.fixture()
 async def group_fixture(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[uuid.UUID]:
     """Insert a test group (project) and yield its UUID."""
@@ -720,7 +720,7 @@ async def group_fixture(
                 name=group_name,
                 description=f"Test group {group_name}",
                 is_active=True,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
             )
         )
@@ -733,7 +733,7 @@ async def group_fixture(
 async def admin_user_fixture(
     db_engine: SAEngine,
     group_fixture: uuid.UUID,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[UserFixtureData]:
     """Insert admin user, keypair, and group membership; yield identifiers."""
@@ -764,7 +764,7 @@ async def admin_user_fixture(
                 description=f"Test admin account {unique_id}",
                 status=UserStatus.ACTIVE,
                 status_info="admin-requested",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
                 role=UserRole.SUPERADMIN,
             )
@@ -834,7 +834,7 @@ async def admin_user_fixture(
 async def regular_user_fixture(
     db_engine: SAEngine,
     group_fixture: uuid.UUID,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[UserFixtureData]:
     """Insert regular user, keypair, and group membership; yield identifiers."""
@@ -865,7 +865,7 @@ async def regular_user_fixture(
                 description=f"Test user account {unique_id}",
                 status=UserStatus.ACTIVE,
                 status_info="admin-requested",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
                 role=UserRole.USER,
             )

--- a/tests/component/deployment/conftest.py
+++ b/tests/component/deployment/conftest.py
@@ -63,6 +63,7 @@ from ai.backend.manager.sokovan.scheduling_controller import (
     SchedulingController,
     SchedulingControllerArgs,
 )
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 # Type aliases for fixture factories
 ImageFactoryFunc = Callable[[], Coroutine[Any, Any, ImageID]]
@@ -287,7 +288,7 @@ async def image_factory(
 @pytest.fixture()
 async def vfolder_factory(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     admin_user_fixture: Any,
 ) -> AsyncIterator[VFolderFactoryFunc]:
     """Factory that creates VFolder entries for deployment model mounts."""
@@ -307,7 +308,7 @@ async def vfolder_factory(
                     id=vfolder_id,
                     name=f"deployment-model-{unique}",
                     host="local",
-                    domain_name=domain_fixture,
+                    domain_name=domain_fixture.domain_name,
                     quota_scope_id=str(quota_scope_id),
                     usage_mode=VFolderUsageMode.MODEL,
                     permission=VFolderMountPermission.READ_ONLY,
@@ -332,7 +333,7 @@ async def vfolder_factory(
 @pytest.fixture()
 async def deployment_seed_data(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     image_factory: ImageFactoryFunc,
     vfolder_factory: VFolderFactoryFunc,
 ) -> AsyncIterator[tuple[ImageID, VFolderUUID]]:
@@ -349,7 +350,7 @@ async def deployment_seed_data(
     # Clean up endpoints and soft-FK children created during the test
     async with db_engine.begin() as conn:
         endpoint_ids_q = sa.select(EndpointRow.__table__.c.id).where(
-            EndpointRow.__table__.c.domain == domain_fixture
+            EndpointRow.__table__.c.domain == domain_fixture.domain_name
         )
         await conn.execute(
             DeploymentRevisionRow.__table__.delete().where(
@@ -362,5 +363,7 @@ async def deployment_seed_data(
             )
         )
         await conn.execute(
-            EndpointRow.__table__.delete().where(EndpointRow.__table__.c.domain == domain_fixture)
+            EndpointRow.__table__.delete().where(
+                EndpointRow.__table__.c.domain == domain_fixture.domain_name
+            )
         )

--- a/tests/component/deployment/test_deployment.py
+++ b/tests/component/deployment/test_deployment.py
@@ -56,6 +56,7 @@ from ai.backend.manager.api.adapters.deployment.adapter import DeploymentAdapter
 from ai.backend.manager.services.deployment.processors import DeploymentProcessors
 from ai.backend.manager.services.deployment.service import _map_lifecycle_to_status
 from ai.backend.manager.services.processors import Processors
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 if TYPE_CHECKING:
     from tests.component.conftest import UserFixtureData
@@ -94,7 +95,7 @@ class TestSearchDeployments:
         self,
         admin_registry: BackendAIClientRegistry,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
@@ -106,7 +107,7 @@ class TestSearchDeployments:
             request = CreateDeploymentRequest(
                 metadata=DeploymentMetadataInput(
                     project_id=group_fixture,
-                    domain_name=domain_fixture,
+                    domain_name=domain_fixture.domain_name,
                     resource_group_name=scaling_group_fixture,
                     name=f"test-deployment-{i}-{secrets.token_hex(4)}",
                 ),
@@ -156,7 +157,7 @@ class TestGetDeployment:
         self,
         admin_registry: BackendAIClientRegistry,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
@@ -165,7 +166,7 @@ class TestGetDeployment:
         request = CreateDeploymentRequest(
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_group_name=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),
@@ -267,7 +268,7 @@ class TestSearchRoutes:
         self,
         admin_registry: BackendAIClientRegistry,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
@@ -276,7 +277,7 @@ class TestSearchRoutes:
         request = CreateDeploymentRequest(
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_group_name=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),
@@ -406,7 +407,7 @@ class TestDeploymentAdapterFilter:
         admin_user_fixture: UserFixtureData,
         deployment_adapter: DeploymentAdapter,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
@@ -414,7 +415,7 @@ class TestDeploymentAdapterFilter:
         await self._create_deployment_with_tags(
             admin_registry,
             group_fixture,
-            domain_fixture,
+            domain_fixture.domain_name,
             scaling_group_fixture,
             deployment_seed_data,
             ["alpha", "production"],
@@ -422,7 +423,7 @@ class TestDeploymentAdapterFilter:
         await self._create_deployment_with_tags(
             admin_registry,
             group_fixture,
-            domain_fixture,
+            domain_fixture.domain_name,
             scaling_group_fixture,
             deployment_seed_data,
             ["beta", "production"],
@@ -430,7 +431,7 @@ class TestDeploymentAdapterFilter:
         target_id = await self._create_deployment_with_tags(
             admin_registry,
             group_fixture,
-            domain_fixture,
+            domain_fixture.domain_name,
             scaling_group_fixture,
             deployment_seed_data,
             ["alpha", "beta"],
@@ -442,7 +443,9 @@ class TestDeploymentAdapterFilter:
                 DeploymentFilterV2(tags=StringFilter(i_contains="beta")),
             ],
         )
-        with with_user(self._admin_user_data(admin_user_fixture.user_uuid, domain_fixture)):
+        with with_user(
+            self._admin_user_data(admin_user_fixture.user_uuid, domain_fixture.domain_name)
+        ):
             payload = await deployment_adapter.my_search(
                 AdminSearchDeploymentsInput(filter=filter_input, limit=50),
             )
@@ -456,7 +459,7 @@ class TestDeploymentAdapterFilter:
         admin_user_fixture: UserFixtureData,
         deployment_adapter: DeploymentAdapter,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
@@ -464,7 +467,7 @@ class TestDeploymentAdapterFilter:
         alpha_id = await self._create_deployment_with_tags(
             admin_registry,
             group_fixture,
-            domain_fixture,
+            domain_fixture.domain_name,
             scaling_group_fixture,
             deployment_seed_data,
             ["alpha"],
@@ -472,7 +475,7 @@ class TestDeploymentAdapterFilter:
         beta_id = await self._create_deployment_with_tags(
             admin_registry,
             group_fixture,
-            domain_fixture,
+            domain_fixture.domain_name,
             scaling_group_fixture,
             deployment_seed_data,
             ["beta"],
@@ -480,7 +483,7 @@ class TestDeploymentAdapterFilter:
         await self._create_deployment_with_tags(
             admin_registry,
             group_fixture,
-            domain_fixture,
+            domain_fixture.domain_name,
             scaling_group_fixture,
             deployment_seed_data,
             ["gamma"],
@@ -492,7 +495,9 @@ class TestDeploymentAdapterFilter:
                 DeploymentFilterV2(tags=StringFilter(i_contains="beta")),
             ],
         )
-        with with_user(self._admin_user_data(admin_user_fixture.user_uuid, domain_fixture)):
+        with with_user(
+            self._admin_user_data(admin_user_fixture.user_uuid, domain_fixture.domain_name)
+        ):
             payload = await deployment_adapter.my_search(
                 AdminSearchDeploymentsInput(filter=filter_input, limit=50),
             )
@@ -506,7 +511,7 @@ class TestDeploymentAdapterFilter:
         admin_user_fixture: UserFixtureData,
         deployment_adapter: DeploymentAdapter,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
@@ -521,7 +526,7 @@ class TestDeploymentAdapterFilter:
         branch1_id = await self._create_deployment_with_tags(
             admin_registry,
             group_fixture,
-            domain_fixture,
+            domain_fixture.domain_name,
             scaling_group_fixture,
             deployment_seed_data,
             ["alpha"],
@@ -530,7 +535,7 @@ class TestDeploymentAdapterFilter:
         branch2_id = await self._create_deployment_with_tags(
             admin_registry,
             group_fixture,
-            domain_fixture,
+            domain_fixture.domain_name,
             scaling_group_fixture,
             deployment_seed_data,
             ["beta"],
@@ -539,7 +544,7 @@ class TestDeploymentAdapterFilter:
         await self._create_deployment_with_tags(
             admin_registry,
             group_fixture,
-            domain_fixture,
+            domain_fixture.domain_name,
             scaling_group_fixture,
             deployment_seed_data,
             ["beta"],
@@ -548,7 +553,7 @@ class TestDeploymentAdapterFilter:
         await self._create_deployment_with_tags(
             admin_registry,
             group_fixture,
-            domain_fixture,
+            domain_fixture.domain_name,
             scaling_group_fixture,
             deployment_seed_data,
             ["alpha"],
@@ -567,7 +572,9 @@ class TestDeploymentAdapterFilter:
                 ),
             ],
         )
-        with with_user(self._admin_user_data(admin_user_fixture.user_uuid, domain_fixture)):
+        with with_user(
+            self._admin_user_data(admin_user_fixture.user_uuid, domain_fixture.domain_name)
+        ):
             payload = await deployment_adapter.my_search(
                 AdminSearchDeploymentsInput(filter=filter_input, limit=50),
             )
@@ -581,7 +588,7 @@ class TestDeploymentAdapterFilter:
         admin_user_fixture: UserFixtureData,
         deployment_adapter: DeploymentAdapter,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
@@ -589,7 +596,7 @@ class TestDeploymentAdapterFilter:
         await self._create_deployment_with_tags(
             admin_registry,
             group_fixture,
-            domain_fixture,
+            domain_fixture.domain_name,
             scaling_group_fixture,
             deployment_seed_data,
             ["alpha"],
@@ -597,7 +604,7 @@ class TestDeploymentAdapterFilter:
         target_id = await self._create_deployment_with_tags(
             admin_registry,
             group_fixture,
-            domain_fixture,
+            domain_fixture.domain_name,
             scaling_group_fixture,
             deployment_seed_data,
             ["alpha", "beta"],
@@ -609,7 +616,9 @@ class TestDeploymentAdapterFilter:
                 DeploymentFilterV2(tags=StringFilter(i_contains="beta")),
             ],
         )
-        with with_user(self._admin_user_data(admin_user_fixture.user_uuid, domain_fixture)):
+        with with_user(
+            self._admin_user_data(admin_user_fixture.user_uuid, domain_fixture.domain_name)
+        ):
             payload = await deployment_adapter.project_search(
                 group_fixture,
                 AdminSearchDeploymentsInput(filter=filter_input, limit=50),

--- a/tests/component/deployment/test_deployment_lifecycle.py
+++ b/tests/component/deployment/test_deployment_lifecycle.py
@@ -37,6 +37,7 @@ from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.resource_group import ResourceGroupName
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import ClusterMode
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 _RANDOM_DEPLOYMENT_ID = uuid.uuid4()
 _RANDOM_REVISION_ID = uuid.uuid4()
@@ -52,13 +53,13 @@ class TestCreateDeployment:
         self,
         admin_registry: BackendAIClientRegistry,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """Creating a deployment with a non-existent image raises an error."""
         request = CreateDeploymentRequest(
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_group_name=ResourceGroupName("nonexistent-sgroup"),
                 name="test-deployment",
             ),
@@ -89,7 +90,7 @@ class TestCreateDeployment:
         self,
         admin_registry: BackendAIClientRegistry,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
@@ -98,7 +99,7 @@ class TestCreateDeployment:
         request = CreateDeploymentRequest(
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_group_name=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),
@@ -156,7 +157,7 @@ class TestUpdateDeployment:
         self,
         admin_registry: BackendAIClientRegistry,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
@@ -166,7 +167,7 @@ class TestUpdateDeployment:
         request = CreateDeploymentRequest(
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_group_name=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),
@@ -226,7 +227,7 @@ class TestDestroyDeployment:
         self,
         admin_registry: BackendAIClientRegistry,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
@@ -236,7 +237,7 @@ class TestDestroyDeployment:
         request = CreateDeploymentRequest(
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_group_name=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),
@@ -292,7 +293,7 @@ class TestRevisionManagement:
         self,
         admin_registry: BackendAIClientRegistry,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
@@ -317,7 +318,7 @@ class TestRevisionManagement:
         request = CreateDeploymentRequest(
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_group_name=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),
@@ -373,7 +374,7 @@ class TestReplicaManagement:
         self,
         admin_registry: BackendAIClientRegistry,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         scaling_group_fixture: ResourceGroupName,
         deployment_seed_data: tuple[ImageID, VFolderUUID],
     ) -> None:
@@ -382,7 +383,7 @@ class TestReplicaManagement:
         request = CreateDeploymentRequest(
             metadata=DeploymentMetadataInput(
                 project_id=group_fixture,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_group_name=scaling_group_fixture,
                 name=f"test-deployment-{secrets.token_hex(4)}",
             ),

--- a/tests/component/fair_share/conftest.py
+++ b/tests/component/fair_share/conftest.py
@@ -28,6 +28,7 @@ from ai.backend.manager.services.resource_usage.processors import ResourceUsageP
 from ai.backend.manager.services.resource_usage.service import ResourceUsageService
 from ai.backend.manager.services.scaling_group.processors import ScalingGroupProcessors
 from ai.backend.manager.services.scaling_group.service import ScalingGroupService
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 
 @pytest.fixture()
@@ -80,7 +81,7 @@ def server_module_registries(
 @pytest.fixture()
 async def group_fixture(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
     scaling_group_fixture: str,
 ) -> AsyncIterator[uuid.UUID]:
@@ -94,7 +95,7 @@ async def group_fixture(
                 name=group_name,
                 description=f"Test group {group_name}",
                 is_active=True,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
             )
         )

--- a/tests/component/fair_share/test_fair_share.py
+++ b/tests/component/fair_share/test_fair_share.py
@@ -44,6 +44,7 @@ from ai.backend.common.dto.manager.fair_share import (
     UpsertUserFairShareWeightResponse,
     UserWeightEntryInput,
 )
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 # ---- Domain Fair Share (Global-scoped) ----
 
@@ -53,11 +54,11 @@ class TestGetDomainFairShare:
         self,
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         result = await admin_registry.fair_share.get_domain_fair_share(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
         )
         assert isinstance(result, GetDomainFairShareResponse)
 
@@ -65,12 +66,12 @@ class TestGetDomainFairShare:
         self,
         user_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         with pytest.raises(PermissionDeniedError):
             await user_registry.fair_share.get_domain_fair_share(
                 resource_group=scaling_group_fixture,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
             )
 
 
@@ -228,11 +229,11 @@ class TestRGGetDomainFairShare:
         self,
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         result = await admin_registry.fair_share.rg_get_domain_fair_share(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
         )
         assert isinstance(result, GetDomainFairShareResponse)
 
@@ -240,11 +241,11 @@ class TestRGGetDomainFairShare:
         self,
         user_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         result = await user_registry.fair_share.rg_get_domain_fair_share(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
         )
         assert isinstance(result, GetDomainFairShareResponse)
 
@@ -271,12 +272,12 @@ class TestRGGetProjectFairShare:
         self,
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_fixture: uuid.UUID,
     ) -> None:
         result = await admin_registry.fair_share.rg_get_project_fair_share(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
             project_id=group_fixture,
         )
         assert isinstance(result, GetProjectFairShareResponse)
@@ -287,11 +288,11 @@ class TestRGSearchProjectFairShares:
         self,
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         result = await admin_registry.fair_share.rg_search_project_fair_shares(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
             request=SearchProjectFairSharesRequest(),
         )
         assert isinstance(result, SearchProjectFairSharesResponse)
@@ -306,13 +307,13 @@ class TestRGGetUserFairShare:
         self,
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_fixture: uuid.UUID,
         admin_user_fixture: Any,
     ) -> None:
         result = await admin_registry.fair_share.rg_get_user_fair_share(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
             project_id=group_fixture,
             user_uuid=admin_user_fixture.user_uuid,
         )
@@ -324,12 +325,12 @@ class TestRGSearchUserFairShares:
         self,
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_fixture: uuid.UUID,
     ) -> None:
         result = await admin_registry.fair_share.rg_search_user_fair_shares(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
             project_id=group_fixture,
             request=SearchUserFairSharesRequest(),
         )
@@ -359,11 +360,11 @@ class TestRGSearchProjectUsageBuckets:
         self,
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         result = await admin_registry.fair_share.rg_search_project_usage_buckets(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
             request=SearchProjectUsageBucketsRequest(),
         )
         assert isinstance(result, SearchProjectUsageBucketsResponse)
@@ -375,12 +376,12 @@ class TestRGSearchUserUsageBuckets:
         self,
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_fixture: uuid.UUID,
     ) -> None:
         result = await admin_registry.fair_share.rg_search_user_usage_buckets(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
             project_id=group_fixture,
             request=SearchUserUsageBucketsRequest(),
         )
@@ -396,27 +397,27 @@ class TestUpsertDomainFairShareWeight:
         self,
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         result = await admin_registry.fair_share.upsert_domain_fair_share_weight(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
             request=UpsertDomainFairShareWeightRequest(weight=Decimal("1.5")),
         )
         assert isinstance(result, UpsertDomainFairShareWeightResponse)
-        assert result.item.domain_name == domain_fixture
+        assert result.item.domain_name == domain_fixture.domain_name
         assert result.item.resource_group == scaling_group_fixture
 
     async def test_user_upsert_domain_weight_forbidden(
         self,
         user_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         with pytest.raises(PermissionDeniedError):
             await user_registry.fair_share.upsert_domain_fair_share_weight(
                 resource_group=scaling_group_fixture,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 request=UpsertDomainFairShareWeightRequest(weight=Decimal("1.0")),
             )
 
@@ -427,13 +428,13 @@ class TestUpsertProjectFairShareWeight:
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         result = await admin_registry.fair_share.upsert_project_fair_share_weight(
             resource_group=scaling_group_fixture,
             project_id=group_fixture,
             request=UpsertProjectFairShareWeightRequest(
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 weight=Decimal("2.0"),
             ),
         )
@@ -448,7 +449,7 @@ class TestUpsertUserFairShareWeight:
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         admin_user_fixture: Any,
     ) -> None:
         result = await admin_registry.fair_share.upsert_user_fair_share_weight(
@@ -456,7 +457,7 @@ class TestUpsertUserFairShareWeight:
             project_id=group_fixture,
             user_uuid=admin_user_fixture.user_uuid,
             request=UpsertUserFairShareWeightRequest(
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 weight=Decimal("3.0"),
             ),
         )
@@ -473,14 +474,14 @@ class TestBulkUpsertDomainFairShareWeight:
         self,
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         result = await admin_registry.fair_share.bulk_upsert_domain_fair_share_weight(
             BulkUpsertDomainFairShareWeightRequest(
                 resource_group=scaling_group_fixture,
                 inputs=[
                     DomainWeightEntryInput(
-                        domain_name=domain_fixture,
+                        domain_name=domain_fixture.domain_name,
                         weight=Decimal("1.0"),
                     ),
                 ],
@@ -496,7 +497,7 @@ class TestBulkUpsertProjectFairShareWeight:
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         result = await admin_registry.fair_share.bulk_upsert_project_fair_share_weight(
             BulkUpsertProjectFairShareWeightRequest(
@@ -504,7 +505,7 @@ class TestBulkUpsertProjectFairShareWeight:
                 inputs=[
                     ProjectWeightEntryInput(
                         project_id=group_fixture,
-                        domain_name=domain_fixture,
+                        domain_name=domain_fixture.domain_name,
                         weight=Decimal("2.0"),
                     ),
                 ],
@@ -520,7 +521,7 @@ class TestBulkUpsertUserFairShareWeight:
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         admin_user_fixture: Any,
     ) -> None:
         result = await admin_registry.fair_share.bulk_upsert_user_fair_share_weight(
@@ -530,7 +531,7 @@ class TestBulkUpsertUserFairShareWeight:
                     UserWeightEntryInput(
                         user_uuid=admin_user_fixture.user_uuid,
                         project_id=group_fixture,
-                        domain_name=domain_fixture,
+                        domain_name=domain_fixture.domain_name,
                         weight=Decimal("3.0"),
                     ),
                 ],

--- a/tests/component/fair_share/test_fair_share_domain_weights.py
+++ b/tests/component/fair_share/test_fair_share_domain_weights.py
@@ -16,6 +16,7 @@ from ai.backend.common.dto.manager.fair_share import (
     UpsertDomainFairShareWeightRequest,
     UpsertDomainFairShareWeightResponse,
 )
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 
 class TestDomainFairShareWeights:
@@ -25,16 +26,16 @@ class TestDomainFairShareWeights:
         self,
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """Get domain fair share → returns weight data."""
         result = await admin_registry.fair_share.get_domain_fair_share(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
         )
         assert isinstance(result, GetDomainFairShareResponse)
         assert result.item is not None
-        assert result.item.domain_name == domain_fixture
+        assert result.item.domain_name == domain_fixture.domain_name
         assert result.item.resource_group == scaling_group_fixture
 
     async def test_search_domain_fair_shares(
@@ -52,24 +53,24 @@ class TestDomainFairShareWeights:
         self,
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """Upsert domain fair share → weight created/updated."""
         weight = Decimal("2.5")
         result = await admin_registry.fair_share.upsert_domain_fair_share_weight(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
             request=UpsertDomainFairShareWeightRequest(weight=weight),
         )
         assert isinstance(result, UpsertDomainFairShareWeightResponse)
-        assert result.item.domain_name == domain_fixture
+        assert result.item.domain_name == domain_fixture.domain_name
         assert result.item.resource_group == scaling_group_fixture
         assert result.item.spec.weight == weight
 
         # Verify the weight persists
         get_result = await admin_registry.fair_share.get_domain_fair_share(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
         )
         assert get_result.item is not None
         assert get_result.item.spec.weight == weight
@@ -82,7 +83,7 @@ class TestBulkUpsertDomainWeights:
         self,
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """Bulk upsert success → all weights updated."""
         result = await admin_registry.fair_share.bulk_upsert_domain_fair_share_weight(
@@ -90,7 +91,7 @@ class TestBulkUpsertDomainWeights:
                 resource_group=scaling_group_fixture,
                 inputs=[
                     DomainWeightEntryInput(
-                        domain_name=domain_fixture,
+                        domain_name=domain_fixture.domain_name,
                         weight=Decimal("5.0"),
                     ),
                 ],
@@ -118,12 +119,12 @@ class TestBulkUpsertDomainWeights:
         self,
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """Bulk upsert overwrites existing weight."""
         await admin_registry.fair_share.upsert_domain_fair_share_weight(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
             request=UpsertDomainFairShareWeightRequest(weight=Decimal("10.0")),
         )
 
@@ -133,7 +134,7 @@ class TestBulkUpsertDomainWeights:
                 resource_group=scaling_group_fixture,
                 inputs=[
                     DomainWeightEntryInput(
-                        domain_name=domain_fixture,
+                        domain_name=domain_fixture.domain_name,
                         weight=new_weight,
                     ),
                 ],
@@ -144,7 +145,7 @@ class TestBulkUpsertDomainWeights:
 
         get_result = await admin_registry.fair_share.get_domain_fair_share(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
         )
         assert get_result.item is not None
         assert get_result.item.spec.weight == new_weight
@@ -157,13 +158,13 @@ class TestDomainScopeAccessControl:
         self,
         user_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """Global-scoped domain access as regular user → 403 (denied)."""
         with pytest.raises(PermissionDeniedError):
             await user_registry.fair_share.get_domain_fair_share(
                 resource_group=scaling_group_fixture,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
             )
 
         with pytest.raises(PermissionDeniedError):
@@ -174,7 +175,7 @@ class TestDomainScopeAccessControl:
         with pytest.raises(PermissionDeniedError):
             await user_registry.fair_share.upsert_domain_fair_share_weight(
                 resource_group=scaling_group_fixture,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 request=UpsertDomainFairShareWeightRequest(weight=Decimal("1.0")),
             )
 
@@ -182,12 +183,12 @@ class TestDomainScopeAccessControl:
         self,
         user_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """RG-scoped domain access as regular user → 200 (allowed)."""
         get_result = await user_registry.fair_share.rg_get_domain_fair_share(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
         )
         assert isinstance(get_result, GetDomainFairShareResponse)
 
@@ -201,12 +202,12 @@ class TestDomainScopeAccessControl:
         self,
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """Admin global scope access → 200 (allowed)."""
         result = await admin_registry.fair_share.get_domain_fair_share(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
         )
         assert isinstance(result, GetDomainFairShareResponse)
 
@@ -218,12 +219,12 @@ class TestDomainDefaultValueFallback:
         self,
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """Get existing domain with no fair-share row → default value returned."""
         result = await admin_registry.fair_share.get_domain_fair_share(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
         )
         assert isinstance(result, GetDomainFairShareResponse)
         assert result.item is not None

--- a/tests/component/fair_share/test_fair_share_project_weights.py
+++ b/tests/component/fair_share/test_fair_share_project_weights.py
@@ -17,6 +17,7 @@ from ai.backend.common.dto.manager.fair_share import (
     UpsertProjectFairShareWeightRequest,
     UpsertProjectFairShareWeightResponse,
 )
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 
 class TestProjectFairShareWeights:
@@ -54,7 +55,7 @@ class TestProjectFairShareWeights:
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """Upsert project fair share → weight created/updated."""
         weight = Decimal("3.5")
@@ -62,7 +63,7 @@ class TestProjectFairShareWeights:
             resource_group=scaling_group_fixture,
             project_id=group_fixture,
             request=UpsertProjectFairShareWeightRequest(
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 weight=weight,
             ),
         )
@@ -88,7 +89,7 @@ class TestBulkUpsertProjectWeights:
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """Bulk upsert success → all weights updated."""
         result = await admin_registry.fair_share.bulk_upsert_project_fair_share_weight(
@@ -97,7 +98,7 @@ class TestBulkUpsertProjectWeights:
                 inputs=[
                     ProjectWeightEntryInput(
                         project_id=group_fixture,
-                        domain_name=domain_fixture,
+                        domain_name=domain_fixture.domain_name,
                         weight=Decimal("6.0"),
                     ),
                 ],
@@ -126,14 +127,14 @@ class TestBulkUpsertProjectWeights:
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """Bulk upsert overwrites existing weight."""
         await admin_registry.fair_share.upsert_project_fair_share_weight(
             resource_group=scaling_group_fixture,
             project_id=group_fixture,
             request=UpsertProjectFairShareWeightRequest(
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 weight=Decimal("10.0"),
             ),
         )
@@ -145,7 +146,7 @@ class TestBulkUpsertProjectWeights:
                 inputs=[
                     ProjectWeightEntryInput(
                         project_id=group_fixture,
-                        domain_name=domain_fixture,
+                        domain_name=domain_fixture.domain_name,
                         weight=new_weight,
                     ),
                 ],
@@ -187,20 +188,20 @@ class TestProjectScopeAccessControl:
         self,
         user_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_fixture: uuid.UUID,
     ) -> None:
         """RG-scoped project access as regular user → 200 (allowed)."""
         get_result = await user_registry.fair_share.rg_get_project_fair_share(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
             project_id=group_fixture,
         )
         assert isinstance(get_result, GetProjectFairShareResponse)
 
         search_result = await user_registry.fair_share.rg_search_project_fair_shares(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
             request=SearchProjectFairSharesRequest(),
         )
         assert isinstance(search_result, SearchProjectFairSharesResponse)

--- a/tests/component/fair_share/test_fair_share_user_weights.py
+++ b/tests/component/fair_share/test_fair_share_user_weights.py
@@ -18,6 +18,7 @@ from ai.backend.common.dto.manager.fair_share import (
     UpsertUserFairShareWeightResponse,
     UserWeightEntryInput,
 )
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 
 class TestUserFairShareWeights:
@@ -57,7 +58,7 @@ class TestUserFairShareWeights:
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         admin_user_fixture: Any,
     ) -> None:
         """Upsert user fair share → weight created/updated."""
@@ -67,7 +68,7 @@ class TestUserFairShareWeights:
             project_id=group_fixture,
             user_uuid=admin_user_fixture.user_uuid,
             request=UpsertUserFairShareWeightRequest(
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 weight=weight,
             ),
         )
@@ -94,7 +95,7 @@ class TestBulkUpsertUserWeights:
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         admin_user_fixture: Any,
     ) -> None:
         """Bulk upsert success → all weights updated."""
@@ -105,7 +106,7 @@ class TestBulkUpsertUserWeights:
                     UserWeightEntryInput(
                         user_uuid=admin_user_fixture.user_uuid,
                         project_id=group_fixture,
-                        domain_name=domain_fixture,
+                        domain_name=domain_fixture.domain_name,
                         weight=Decimal("7.0"),
                     ),
                 ],
@@ -134,7 +135,7 @@ class TestBulkUpsertUserWeights:
         admin_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
         group_fixture: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         admin_user_fixture: Any,
     ) -> None:
         """Bulk upsert overwrites existing weight."""
@@ -143,7 +144,7 @@ class TestBulkUpsertUserWeights:
             project_id=group_fixture,
             user_uuid=admin_user_fixture.user_uuid,
             request=UpsertUserFairShareWeightRequest(
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 weight=Decimal("10.0"),
             ),
         )
@@ -156,7 +157,7 @@ class TestBulkUpsertUserWeights:
                     UserWeightEntryInput(
                         user_uuid=admin_user_fixture.user_uuid,
                         project_id=group_fixture,
-                        domain_name=domain_fixture,
+                        domain_name=domain_fixture.domain_name,
                         weight=new_weight,
                     ),
                 ],
@@ -201,14 +202,14 @@ class TestUserScopeAccessControl:
         self,
         user_registry: BackendAIClientRegistry,
         scaling_group_fixture: str,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_fixture: uuid.UUID,
         admin_user_fixture: Any,
     ) -> None:
         """RG-scoped user access as regular user → 200 (allowed)."""
         get_result = await user_registry.fair_share.rg_get_user_fair_share(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
             project_id=group_fixture,
             user_uuid=admin_user_fixture.user_uuid,
         )
@@ -216,7 +217,7 @@ class TestUserScopeAccessControl:
 
         search_result = await user_registry.fair_share.rg_search_user_fair_shares(
             resource_group=scaling_group_fixture,
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
             project_id=group_fixture,
             request=SearchUserFairSharesRequest(),
         )

--- a/tests/component/group/conftest.py
+++ b/tests/component/group/conftest.py
@@ -32,6 +32,7 @@ from ai.backend.manager.service.container_registry.harbor import (
 from ai.backend.manager.services.container_registry.processors import ContainerRegistryProcessors
 from ai.backend.manager.services.container_registry.service import ContainerRegistryService
 from ai.backend.manager.services.group.service import GroupService
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 
 class InMemoryQuotaService:
@@ -121,7 +122,7 @@ def group_service(
 @pytest.fixture()
 async def target_group(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[uuid.UUID]:
     """Insert a test group (project) and yield its UUID."""
@@ -134,7 +135,7 @@ async def target_group(
                 name=group_name,
                 description=f"Test group {group_name}",
                 is_active=True,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
             )
         )

--- a/tests/component/group/test_group.py
+++ b/tests/component/group/test_group.py
@@ -17,6 +17,7 @@ from ai.backend.common.dto.manager.registry.request import (
     ReadRegistryQuotaReq,
 )
 from ai.backend.common.dto.manager.registry.response import RegistryQuotaResponse
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 
 class TestGroupRegistryQuota:
@@ -83,13 +84,13 @@ class TestGroupCreate:
     async def test_admin_creates_group(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         resource_policy_fixture: str,
     ) -> None:
         result = await admin_registry.group.create(
             CreateGroupRequest(
                 name="test-group-create",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 description="Test group created via SDK",
                 resource_policy=resource_policy_fixture,
             ),
@@ -196,14 +197,14 @@ class TestGroupLifecycle:
     async def test_full_lifecycle(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         resource_policy_fixture: str,
     ) -> None:
         # 1. Create group
         create_result = await admin_registry.group.create(
             CreateGroupRequest(
                 name="lifecycle-test-group",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 description="Lifecycle test",
                 resource_policy=resource_policy_fixture,
             ),

--- a/tests/component/group/test_group_crud.py
+++ b/tests/component/group/test_group_crud.py
@@ -14,6 +14,7 @@ from ai.backend.common.dto.manager.group import (
     UpdateGroupRequest,
     UpdateGroupResponse,
 )
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 _XFAIL_ROUTES_NOT_IMPLEMENTED = pytest.mark.xfail(
     strict=True,
@@ -33,26 +34,26 @@ class TestGroupCreateCRUD:
     async def test_superadmin_creates_group_with_required_fields(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """S-1: Superadmin creates group with required fields."""
         unique = secrets.token_hex(4)
         result = await admin_registry.group.create(
             CreateGroupRequest(
                 name=f"test-group-{unique}",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
             ),
         )
         assert isinstance(result, CreateGroupResponse)
         assert result.group.name == f"test-group-{unique}"
-        assert result.group.domain_name == domain_fixture
+        assert result.group.domain_name == domain_fixture.domain_name
         assert result.group.is_active is True
 
     @_XFAIL_ROUTES_NOT_IMPLEMENTED
     async def test_create_group_with_all_optional_fields(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         resource_policy_fixture: str,
     ) -> None:
         """S-2: Create group with all optional fields."""
@@ -60,7 +61,7 @@ class TestGroupCreateCRUD:
         result = await admin_registry.group.create(
             CreateGroupRequest(
                 name=f"test-group-full-{unique}",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 description=f"Full group {unique}",
                 resource_policy=resource_policy_fixture,
                 total_resource_slots={"cpu": "4"},
@@ -76,14 +77,14 @@ class TestGroupCreateCRUD:
     async def test_create_group_then_set_inactive(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """S-3: Create group then deactivate it (is_active=False)."""
         unique = secrets.token_hex(4)
         create_result = await admin_registry.group.create(
             CreateGroupRequest(
                 name=f"test-group-inactive-{unique}",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
             ),
         )
         update_result = await admin_registry.group.update(
@@ -96,20 +97,20 @@ class TestGroupCreateCRUD:
     async def test_create_multiple_groups_with_different_names(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """S-4: Create multiple groups with different names."""
         unique = secrets.token_hex(4)
         result_a = await admin_registry.group.create(
             CreateGroupRequest(
                 name=f"test-group-alpha-{unique}",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
             ),
         )
         result_b = await admin_registry.group.create(
             CreateGroupRequest(
                 name=f"test-group-beta-{unique}",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
             ),
         )
         assert result_a.group.name != result_b.group.name
@@ -119,30 +120,30 @@ class TestGroupCreateCRUD:
     async def test_duplicate_group_name_in_same_domain_raises_error(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """F-BIZ-1: Duplicate group name in same domain → error."""
         unique = secrets.token_hex(4)
         name = f"test-group-dup-{unique}"
         await admin_registry.group.create(
-            CreateGroupRequest(name=name, domain_name=domain_fixture),
+            CreateGroupRequest(name=name, domain_name=domain_fixture.domain_name),
         )
         await admin_registry.group.create(
-            CreateGroupRequest(name=name, domain_name=domain_fixture),
+            CreateGroupRequest(name=name, domain_name=domain_fixture.domain_name),
         )
 
     @_XFAIL_ROUTES_NOT_IMPLEMENTED
     async def test_regular_user_cannot_create_group(
         self,
         user_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """F-AUTH-1: Regular user cannot create group → error."""
         unique = secrets.token_hex(4)
         await user_registry.group.create(
             CreateGroupRequest(
                 name=f"test-group-user-{unique}",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
             ),
         )
 
@@ -255,13 +256,13 @@ class TestGroupModifyCRUD:
         self,
         admin_registry: BackendAIClientRegistry,
         target_group: uuid.UUID,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """F-BIZ-3: Rename to duplicate name → error."""
         unique = secrets.token_hex(4)
         other_name = f"other-group-{unique}"
         await admin_registry.group.create(
-            CreateGroupRequest(name=other_name, domain_name=domain_fixture),
+            CreateGroupRequest(name=other_name, domain_name=domain_fixture.domain_name),
         )
         await admin_registry.group.update(
             target_group,

--- a/tests/component/group/test_group_management.py
+++ b/tests/component/group/test_group_management.py
@@ -49,12 +49,13 @@ from ai.backend.manager.models.image import ImageRow, ImageType
 from ai.backend.manager.models.kernel import KernelRow, KernelStatus
 from ai.backend.manager.models.session import SessionRow, SessionStatus
 from ai.backend.manager.models.vfolder import VFolderRow
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 
 @pytest.fixture()
 async def test_group_for_deletion(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[uuid.UUID]:
     """Create a test group specifically for deletion/purge tests."""
@@ -67,7 +68,7 @@ async def test_group_for_deletion(
                 name=group_name,
                 description=f"Group for deletion test {group_name}",
                 is_active=True,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
             )
         )
@@ -80,7 +81,7 @@ async def test_group_for_deletion(
 @pytest.fixture()
 async def group_with_vfolder_mounted(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     scaling_group_fixture: str,
     resource_policy_fixture: str,
     regular_user_fixture: Any,
@@ -102,7 +103,7 @@ async def group_with_vfolder_mounted(
                 name=group_name,
                 description="Group with mounted vfolder",
                 is_active=True,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
             )
         )
@@ -114,7 +115,7 @@ async def group_with_vfolder_mounted(
                 user=user_uuid,
                 group=group_id,
                 host="local",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 quota_scope_id=QuotaScopeID(QuotaScopeType.USER, user_uuid),
             )
         )
@@ -127,7 +128,7 @@ async def group_with_vfolder_mounted(
                 session_type=SessionTypes.INTERACTIVE,
                 cluster_size=1,
                 cluster_mode="single-node",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_id,
                 user_uuid=user_uuid,
                 scaling_group_name=scaling_group_fixture,
@@ -151,7 +152,7 @@ async def group_with_vfolder_mounted(
                 cluster_size=1,
                 group_id=group_id,
                 user_uuid=user_uuid,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 scaling_group=scaling_group_fixture,
                 status=KernelStatus.RUNNING,
                 image="python:3.9",
@@ -184,7 +185,7 @@ async def group_with_vfolder_mounted(
 @pytest.fixture()
 async def group_with_active_kernel(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     scaling_group_fixture: str,
     resource_policy_fixture: str,
     regular_user_fixture: Any,
@@ -205,7 +206,7 @@ async def group_with_active_kernel(
                 name=group_name,
                 description="Group with active kernel",
                 is_active=True,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
             )
         )
@@ -218,7 +219,7 @@ async def group_with_active_kernel(
                 session_type=SessionTypes.INTERACTIVE,
                 cluster_size=1,
                 cluster_mode="single-node",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_id,
                 user_uuid=user_uuid,
                 scaling_group_name=scaling_group_fixture,
@@ -242,7 +243,7 @@ async def group_with_active_kernel(
                 cluster_size=1,
                 group_id=group_id,
                 user_uuid=user_uuid,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 scaling_group=scaling_group_fixture,
                 status=KernelStatus.RUNNING,
                 image="python:3.9",
@@ -271,7 +272,7 @@ async def group_with_active_kernel(
 @pytest.fixture()
 async def group_with_active_endpoint(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
     regular_user_fixture: Any,
     scaling_group_fixture: str,
@@ -292,7 +293,7 @@ async def group_with_active_endpoint(
                 name=group_name,
                 description="Group with active endpoint",
                 is_active=True,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
             )
         )
@@ -331,7 +332,7 @@ async def group_with_active_endpoint(
                 id=endpoint_id,
                 name=f"ep-{secrets.token_hex(4)}",
                 project=group_id,
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 created_user=user_uuid,
                 session_owner=user_uuid,
                 resource_group=scaling_group_fixture,
@@ -360,7 +361,7 @@ async def group_with_active_endpoint(
 @pytest.fixture()
 async def multiple_test_groups(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[list[uuid.UUID]]:
     """Create multiple test groups for search tests."""
@@ -376,7 +377,7 @@ async def multiple_test_groups(
                     name=f"search-test-{unique}-{i}",
                     description=f"Search test group {i}",
                     is_active=True,
-                    domain_name=domain_fixture,
+                    domain_name=domain_fixture.domain_name,
                     resource_policy=resource_policy_fixture,
                 )
             )
@@ -570,18 +571,18 @@ class TestGroupSearch:
     async def test_search_with_domain_filter(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """S-3: Search with domain filter → groups in domain."""
         result = await admin_registry.group.search(
             SearchGroupsRequest(
-                filter=GroupFilter(domain_name=StringFilter(equals=domain_fixture)),
+                filter=GroupFilter(domain_name=StringFilter(equals=domain_fixture.domain_name)),
                 limit=10,
             ),
         )
         assert isinstance(result, SearchGroupsResponse)
         for group in result.groups:
-            assert group.domain_name == domain_fixture
+            assert group.domain_name == domain_fixture.domain_name
 
     @pytest.mark.xfail(
         strict=True,

--- a/tests/component/model_card/conftest.py
+++ b/tests/component/model_card/conftest.py
@@ -65,6 +65,7 @@ from ai.backend.manager.services.permission_contoller.processors import (
 )
 from ai.backend.manager.services.permission_contoller.service import PermissionControllerService
 from ai.backend.manager.services.processors import Processors
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 if TYPE_CHECKING:
     from tests.component.conftest import ServerInfo, UserFixtureData
@@ -182,7 +183,7 @@ def server_module_registries(
 @pytest.fixture()
 async def model_store_project_fixture(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[uuid.UUID]:
     """Insert a MODEL_STORE type project and yield its UUID."""
@@ -194,7 +195,7 @@ async def model_store_project_fixture(
                 name=f"model-store-{secrets.token_hex(6)}",
                 description="Test MODEL_STORE project",
                 is_active=True,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
                 type=ProjectType.MODEL_STORE,
             )
@@ -210,7 +211,7 @@ async def model_store_project_fixture(
 @pytest.fixture()
 async def second_project_fixture(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[uuid.UUID]:
     """Insert a second MODEL_STORE project for cross-project isolation tests."""
@@ -222,7 +223,7 @@ async def second_project_fixture(
                 name=f"model-store-b-{secrets.token_hex(6)}",
                 description="Second MODEL_STORE project",
                 is_active=True,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
                 type=ProjectType.MODEL_STORE,
             )
@@ -238,7 +239,7 @@ async def second_project_fixture(
 @pytest.fixture()
 async def vfolder_fixture(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     admin_user_fixture: Any,
 ) -> AsyncIterator[VFolderUUID]:
     """Insert a MODEL-usage vfolder (storage proxy is mocked)."""
@@ -250,7 +251,7 @@ async def vfolder_fixture(
                 id=vfolder_id,
                 name=f"test-model-vfolder-{secrets.token_hex(4)}",
                 host="local",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 quota_scope_id=str(QuotaScopeID(QuotaScopeType.USER, user_uuid)),
                 usage_mode=VFolderUsageMode.MODEL,
                 user=str(user_uuid),

--- a/tests/component/project/conftest.py
+++ b/tests/component/project/conftest.py
@@ -74,6 +74,7 @@ from ai.backend.manager.services.permission_contoller.service import PermissionC
 from ai.backend.manager.services.processors import Processors
 from ai.backend.manager.services.user.processors import UserProcessors
 from ai.backend.manager.services.user.service import UserService
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 if TYPE_CHECKING:
     from tests.component.conftest import ServerInfo, UserFixtureData
@@ -303,7 +304,7 @@ async def admin_target_project_permission(
 @pytest.fixture()
 async def target_project_fixture(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[uuid.UUID]:
     """Insert a fresh project where regular_user is NOT pre-bound.
@@ -321,7 +322,7 @@ async def target_project_fixture(
                 name=f"target-project-{secrets.token_hex(6)}",
                 description="Primary test project for membership scenarios",
                 is_active=True,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
             )
         )
@@ -333,7 +334,7 @@ async def target_project_fixture(
 @pytest.fixture()
 async def other_project_fixture(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[uuid.UUID]:
     """Insert another project for cross-project isolation tests."""
@@ -345,7 +346,7 @@ async def other_project_fixture(
                 name=f"other-project-{secrets.token_hex(6)}",
                 description="Secondary test project",
                 is_active=True,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
             )
         )
@@ -460,7 +461,7 @@ async def user_v2_registry(
 async def assigned_users(
     db_engine: SAEngine,
     group_fixture: uuid.UUID,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[list[uuid.UUID]]:
     """Insert test users and assign them to the target project via ASE.
@@ -496,7 +497,7 @@ async def assigned_users(
                     description=f"Test assigned user {i}",
                     status=UserStatus.ACTIVE,
                     status_info="admin-requested",
-                    domain_name=domain_fixture,
+                    domain_name=domain_fixture.domain_name,
                     resource_policy=resource_policy_fixture,
                     role=UserRole.USER,
                 )

--- a/tests/component/project/test_project_purge.py
+++ b/tests/component/project/test_project_purge.py
@@ -24,12 +24,13 @@ from ai.backend.manager.models.rbac_models.association_scopes_entities import (
 )
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 
 @pytest.fixture()
 async def project_with_rbac_rows(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[tuple[uuid.UUID, str]]:
     """Insert a project along with the RBAC rows that the create flow would
@@ -50,7 +51,7 @@ async def project_with_rbac_rows(
                 name=f"rbac-purge-{unique}",
                 description="Test project for RBAC purge cleanup",
                 is_active=True,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
             )
         )
@@ -88,7 +89,7 @@ async def project_with_rbac_rows(
                 # Project registered as an entity in the domain scope.
                 {
                     "scope_type": ScopeType.DOMAIN,
-                    "scope_id": domain_fixture,
+                    "scope_id": domain_fixture.domain_name,
                     "entity_type": EntityType.PROJECT,
                     "entity_id": scope_id,
                     "relation_type": RelationType.AUTO,

--- a/tests/component/rbac/test_rbac.py
+++ b/tests/component/rbac/test_rbac.py
@@ -44,6 +44,7 @@ from ai.backend.common.dto.manager.rbac.types import (
     RoleSource,
     RoleStatus,
 )
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 RoleFactory = Callable[..., Coroutine[Any, Any, CreateRoleResponse]]
 
@@ -589,13 +590,13 @@ class TestEntityManagement:
     async def test_search_entities_in_domain(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """Search entities within a domain scope."""
         # Search for users in the test domain
         result = await admin_registry.rbac.search_entities(
             scope_type="domain",
-            scope_id=domain_fixture,
+            scope_id=domain_fixture.domain_name,
             entity_type="user",
             request=SearchEntitiesRequest(),
         )
@@ -608,12 +609,12 @@ class TestEntityManagement:
     async def test_search_entities_with_pagination(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """Search entities with pagination returns correct page."""
         result = await admin_registry.rbac.search_entities(
             scope_type="domain",
-            scope_id=domain_fixture,
+            scope_id=domain_fixture.domain_name,
             entity_type="user",
             request=SearchEntitiesRequest(limit=1, offset=0),
         )
@@ -632,14 +633,14 @@ class TestEntityManagement:
     async def test_regular_user_cannot_search_entities(
         self,
         user_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """Regular user cannot search entities."""
         # Entity search should be admin-only
         with pytest.raises(PermissionDeniedError):
             await user_registry.rbac.search_entities(
                 scope_type="domain",
-                scope_id=domain_fixture,
+                scope_id=domain_fixture.domain_name,
                 entity_type="user",
                 request=SearchEntitiesRequest(),
             )

--- a/tests/component/rbac/test_rbac_permission.py
+++ b/tests/component/rbac/test_rbac_permission.py
@@ -43,6 +43,7 @@ from ai.backend.manager.services.permission_contoller.actions.revoke_role import
 from ai.backend.manager.services.permission_contoller.processors import (
     PermissionControllerProcessors,
 )
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 from .conftest import RoleFactory
 
@@ -60,14 +61,14 @@ class TestPermissionCreate:
         self,
         permission_controller_processors: PermissionControllerProcessors,
         target_role: Any,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """S-CREATE-1: Create basic permission with valid params → PermissionData returned."""
         creator = Creator(
             spec=PermissionCreatorSpec(
                 role_id=target_role.role.id,
                 scope_type=RBACElementType.DOMAIN,
-                scope_id=domain_fixture,
+                scope_id=domain_fixture.domain_name,
                 entity_type=RBACElementType.SESSION,
                 operation=OperationType.READ,
             )
@@ -91,15 +92,25 @@ class TestPermissionCreate:
         self,
         permission_controller_processors: PermissionControllerProcessors,
         target_role: Any,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """S-CREATE-2: Create permissions with various scope/entity/operation combinations."""
         combos: list[tuple[RBACElementType, str, RBACElementType, OperationType]] = [
-            (RBACElementType.DOMAIN, domain_fixture, RBACElementType.SESSION, OperationType.READ),
-            (RBACElementType.DOMAIN, domain_fixture, RBACElementType.IMAGE, OperationType.UPDATE),
             (
                 RBACElementType.DOMAIN,
-                domain_fixture,
+                domain_fixture.domain_name,
+                RBACElementType.SESSION,
+                OperationType.READ,
+            ),
+            (
+                RBACElementType.DOMAIN,
+                domain_fixture.domain_name,
+                RBACElementType.IMAGE,
+                OperationType.UPDATE,
+            ),
+            (
+                RBACElementType.DOMAIN,
+                domain_fixture.domain_name,
                 RBACElementType.VFOLDER,
                 OperationType.SOFT_DELETE,
             ),
@@ -135,13 +146,13 @@ class TestPermissionCreate:
         self,
         permission_controller_processors: PermissionControllerProcessors,
         target_role: Any,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """F-BIZ-4: Create duplicate permission → unique constraint error."""
         spec = PermissionCreatorSpec(
             role_id=target_role.role.id,
             scope_type=RBACElementType.DOMAIN,
-            scope_id=domain_fixture,
+            scope_id=domain_fixture.domain_name,
             entity_type=RBACElementType.VFOLDER,
             operation=OperationType.READ,
         )
@@ -169,7 +180,7 @@ class TestPermissionDelete:
         self,
         permission_controller_processors: PermissionControllerProcessors,
         target_role: Any,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """S-DELETE-1: Delete existing permission → deletion response."""
         create_result = await permission_controller_processors.create_permission.wait_for_complete(
@@ -178,7 +189,7 @@ class TestPermissionDelete:
                     spec=PermissionCreatorSpec(
                         role_id=target_role.role.id,
                         scope_type=RBACElementType.DOMAIN,
-                        scope_id=domain_fixture,
+                        scope_id=domain_fixture.domain_name,
                         entity_type=RBACElementType.SESSION,
                         operation=OperationType.HARD_DELETE,
                     )
@@ -198,7 +209,7 @@ class TestPermissionDelete:
         self,
         permission_controller_processors: PermissionControllerProcessors,
         target_role: Any,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """S-DELETE-2: Verify deleted permission no longer exists."""
         create_result = await permission_controller_processors.create_permission.wait_for_complete(
@@ -207,7 +218,7 @@ class TestPermissionDelete:
                     spec=PermissionCreatorSpec(
                         role_id=target_role.role.id,
                         scope_type=RBACElementType.DOMAIN,
-                        scope_id=domain_fixture,
+                        scope_id=domain_fixture.domain_name,
                         entity_type=RBACElementType.IMAGE,
                         operation=OperationType.SOFT_DELETE,
                     )
@@ -268,7 +279,7 @@ class TestCheckPermissionInScope:
         permission_repo: PermissionControllerRepository,
         role_factory: RoleFactory,
         admin_user_fixture: Any,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """S-SCOPE-1: User has permission in target scope → True."""
         role = await role_factory()
@@ -281,7 +292,7 @@ class TestCheckPermissionInScope:
                     spec=PermissionCreatorSpec(
                         role_id=role_id,
                         scope_type=RBACElementType.DOMAIN,
-                        scope_id=domain_fixture,
+                        scope_id=domain_fixture.domain_name,
                         entity_type=RBACElementType.SESSION,
                         operation=OperationType.READ,
                     )
@@ -298,7 +309,9 @@ class TestCheckPermissionInScope:
                 ScopePermissionCheckInput(
                     user_id=user_id,
                     target_entity_type=EntityType.SESSION,
-                    target_scope_id=ScopeId(scope_type=ScopeType.DOMAIN, scope_id=domain_fixture),
+                    target_scope_id=ScopeId(
+                        scope_type=ScopeType.DOMAIN, scope_id=domain_fixture.domain_name
+                    ),
                     operation=OperationType.READ,
                 )
             )
@@ -316,14 +329,16 @@ class TestCheckPermissionInScope:
     async def test_user_without_permission_in_scope_returns_false(
         self,
         permission_repo: PermissionControllerRepository,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """S-SCOPE-2: User lacks permission in target scope → False."""
         has_perm = await permission_repo.check_permission_in_scope(
             ScopePermissionCheckInput(
                 user_id=uuid.uuid4(),  # random user with no roles
                 target_entity_type=EntityType.SESSION,
-                target_scope_id=ScopeId(scope_type=ScopeType.DOMAIN, scope_id=domain_fixture),
+                target_scope_id=ScopeId(
+                    scope_type=ScopeType.DOMAIN, scope_id=domain_fixture.domain_name
+                ),
                 operation=OperationType.READ,
             )
         )

--- a/tests/component/rbac/test_rbac_role_permissions_bulk_v2.py
+++ b/tests/component/rbac/test_rbac_role_permissions_bulk_v2.py
@@ -50,6 +50,7 @@ from ai.backend.manager.api.rest.v2.rbac.registry import register_v2_rbac_routes
 from ai.backend.manager.services.permission_contoller.processors import (
     PermissionControllerProcessors,
 )
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 if TYPE_CHECKING:
     from tests.component.conftest import ServerInfo, UserFixtureData
@@ -141,13 +142,13 @@ class TestBulkAddRolePermissionsV2:
         self,
         admin_v2_registry: V2ClientRegistry,
         target_role: CreateRoleResponse,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         result = await admin_v2_registry.rbac.bulk_add_role_permissions(
             BulkAddRolePermissionsInput(
                 permissions=[
-                    _entry(target_role.role.id, domain_fixture, "session", "read"),
-                    _entry(target_role.role.id, domain_fixture, "image", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "session", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "image", "read"),
                 ],
             ),
         )
@@ -161,13 +162,13 @@ class TestBulkAddRolePermissionsV2:
         self,
         admin_v2_registry: V2ClientRegistry,
         target_role: CreateRoleResponse,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         # Seed one entry first
         first = await admin_v2_registry.rbac.bulk_add_role_permissions(
             BulkAddRolePermissionsInput(
                 permissions=[
-                    _entry(target_role.role.id, domain_fixture, "vfolder", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "vfolder", "read"),
                 ],
             ),
         )
@@ -177,8 +178,8 @@ class TestBulkAddRolePermissionsV2:
         result = await admin_v2_registry.rbac.bulk_add_role_permissions(
             BulkAddRolePermissionsInput(
                 permissions=[
-                    _entry(target_role.role.id, domain_fixture, "vfolder", "read"),
-                    _entry(target_role.role.id, domain_fixture, "agent", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "vfolder", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "agent", "read"),
                 ],
             ),
         )
@@ -203,13 +204,13 @@ class TestBulkAddRolePermissionsV2:
         self,
         user_v2_registry: V2ClientRegistry,
         target_role: CreateRoleResponse,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         with pytest.raises(PermissionDeniedError):
             await user_v2_registry.rbac.bulk_add_role_permissions(
                 BulkAddRolePermissionsInput(
                     permissions=[
-                        _entry(target_role.role.id, domain_fixture, "session", "read"),
+                        _entry(target_role.role.id, domain_fixture.domain_name, "session", "read"),
                     ],
                 ),
             )
@@ -222,13 +223,13 @@ class TestBulkRemoveRolePermissionsV2:
         self,
         admin_v2_registry: V2ClientRegistry,
         target_role: CreateRoleResponse,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         added = await admin_v2_registry.rbac.bulk_add_role_permissions(
             BulkAddRolePermissionsInput(
                 permissions=[
-                    _entry(target_role.role.id, domain_fixture, "session", "read"),
-                    _entry(target_role.role.id, domain_fixture, "image", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "session", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "image", "read"),
                 ],
             ),
         )
@@ -256,12 +257,12 @@ class TestBulkRemoveRolePermissionsV2:
         self,
         admin_v2_registry: V2ClientRegistry,
         target_role: CreateRoleResponse,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         added = await admin_v2_registry.rbac.bulk_add_role_permissions(
             BulkAddRolePermissionsInput(
                 permissions=[
-                    _entry(target_role.role.id, domain_fixture, "session", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "session", "read"),
                 ],
             ),
         )
@@ -300,14 +301,14 @@ class TestReplaceRolePermissionsV2:
         self,
         admin_v2_registry: V2ClientRegistry,
         target_role: CreateRoleResponse,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         # Seed prior set
         await admin_v2_registry.rbac.bulk_add_role_permissions(
             BulkAddRolePermissionsInput(
                 permissions=[
-                    _entry(target_role.role.id, domain_fixture, "session", "read"),
-                    _entry(target_role.role.id, domain_fixture, "image", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "session", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "image", "read"),
                 ],
             ),
         )
@@ -317,8 +318,8 @@ class TestReplaceRolePermissionsV2:
             ReplaceRolePermissionsInput(
                 role_id=target_role.role.id,
                 permissions=[
-                    _entry(target_role.role.id, domain_fixture, "vfolder", "read"),
-                    _entry(target_role.role.id, domain_fixture, "agent", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "vfolder", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "agent", "read"),
                 ],
             ),
         )
@@ -333,12 +334,12 @@ class TestReplaceRolePermissionsV2:
         self,
         admin_v2_registry: V2ClientRegistry,
         target_role: CreateRoleResponse,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         await admin_v2_registry.rbac.bulk_add_role_permissions(
             BulkAddRolePermissionsInput(
                 permissions=[
-                    _entry(target_role.role.id, domain_fixture, "session", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "session", "read"),
                 ],
             ),
         )
@@ -352,7 +353,7 @@ class TestReplaceRolePermissionsV2:
         self,
         admin_v2_registry: V2ClientRegistry,
         target_role: CreateRoleResponse,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         wrong_role_id = uuid.uuid4()
         with pytest.raises(InvalidRequestError):
@@ -360,7 +361,7 @@ class TestReplaceRolePermissionsV2:
                 ReplaceRolePermissionsInput(
                     role_id=target_role.role.id,
                     permissions=[
-                        _entry(wrong_role_id, domain_fixture, "session", "read"),
+                        _entry(wrong_role_id, domain_fixture.domain_name, "session", "read"),
                     ],
                 ),
             )
@@ -390,15 +391,15 @@ class TestPermissionFilterScopeIdNarrowing:
         self,
         admin_v2_registry: V2ClientRegistry,
         target_role: CreateRoleResponse,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         # Seed two permissions in the same scope and an unrelated one in another scope.
-        scope_b = f"{domain_fixture}-other"
+        scope_b = f"{domain_fixture.domain_name}-other"
         await admin_v2_registry.rbac.bulk_add_role_permissions(
             BulkAddRolePermissionsInput(
                 permissions=[
-                    _entry(target_role.role.id, domain_fixture, "session", "read"),
-                    _entry(target_role.role.id, domain_fixture, "image", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "session", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "image", "read"),
                     CreatePermissionInput(
                         role_id=target_role.role.id,
                         scope_type="domain",
@@ -414,24 +415,24 @@ class TestPermissionFilterScopeIdNarrowing:
             AdminSearchPermissionsGQLInput(
                 filter=PermissionFilter(
                     role_id=UUIDFilter(equals=target_role.role.id),
-                    scope_id=StringFilter(equals=domain_fixture),
+                    scope_id=StringFilter(equals=domain_fixture.domain_name),
                 ),
                 limit=100,
             ),
         )
-        assert {item.scope_id for item in result.items} == {domain_fixture}
+        assert {item.scope_id for item in result.items} == {domain_fixture.domain_name}
         assert len(result.items) == 2
 
     async def test_role_id_in_filter_returns_matching_rows(
         self,
         admin_v2_registry: V2ClientRegistry,
         target_role: CreateRoleResponse,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         await admin_v2_registry.rbac.bulk_add_role_permissions(
             BulkAddRolePermissionsInput(
                 permissions=[
-                    _entry(target_role.role.id, domain_fixture, "session", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "session", "read"),
                 ],
             ),
         )
@@ -448,7 +449,7 @@ class TestPermissionFilterScopeIdNarrowing:
         self,
         admin_v2_registry: V2ClientRegistry,
         target_role: CreateRoleResponse,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """``PermissionRow.entity_type`` is a ``StrEnumType``-wrapped column.
 
@@ -459,8 +460,8 @@ class TestPermissionFilterScopeIdNarrowing:
         await admin_v2_registry.rbac.bulk_add_role_permissions(
             BulkAddRolePermissionsInput(
                 permissions=[
-                    _entry(target_role.role.id, domain_fixture, "session", "read"),
-                    _entry(target_role.role.id, domain_fixture, "image", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "session", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "image", "read"),
                 ],
             ),
         )
@@ -479,15 +480,15 @@ class TestPermissionFilterScopeIdNarrowing:
         self,
         admin_v2_registry: V2ClientRegistry,
         target_role: CreateRoleResponse,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """``RBACElementTypeFilter.in_`` returns rows whose entity_type is in the list."""
         await admin_v2_registry.rbac.bulk_add_role_permissions(
             BulkAddRolePermissionsInput(
                 permissions=[
-                    _entry(target_role.role.id, domain_fixture, "session", "read"),
-                    _entry(target_role.role.id, domain_fixture, "image", "read"),
-                    _entry(target_role.role.id, domain_fixture, "vfolder", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "session", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "image", "read"),
+                    _entry(target_role.role.id, domain_fixture.domain_name, "vfolder", "read"),
                 ],
             ),
         )

--- a/tests/component/resource_allocation/test_resource_allocation.py
+++ b/tests/component/resource_allocation/test_resource_allocation.py
@@ -19,6 +19,7 @@ from ai.backend.common.dto.manager.v2.resource_allocation.response import (
     ProjectResourceAllocationPayload,
     ResourceGroupResourceAllocationPayload,
 )
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 
 class TestKeypairUsage:
@@ -70,11 +71,11 @@ class TestDomainUsage:
     async def test_admin_domain_usage_returns_data(
         self,
         admin_v2_registry: V2ClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """Admin can query domain usage with valid domain name."""
         result = await admin_v2_registry.resource_allocation.admin_domain_usage(
-            domain_fixture,
+            domain_fixture.domain_name,
         )
         assert isinstance(result, DomainResourceAllocationPayload)
         assert result.domain is not None
@@ -85,12 +86,12 @@ class TestDomainUsage:
     async def test_regular_user_domain_usage_returns_403(
         self,
         user_v2_registry: V2ClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
     ) -> None:
         """Non-admin user gets 403 when querying domain usage (superadmin_required)."""
         with pytest.raises(BackendAPIError) as exc_info:
             await user_v2_registry.resource_allocation.admin_domain_usage(
-                domain_fixture,
+                domain_fixture.domain_name,
             )
         assert exc_info.value.status == 403
 

--- a/tests/component/resource_group/test_resource_group_allow.py
+++ b/tests/component/resource_group/test_resource_group_allow.py
@@ -25,6 +25,7 @@ from ai.backend.common.dto.manager.v2.resource_group.response import (
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.models.domain import domains
 from ai.backend.manager.models.scaling_group.row import ScalingGroupOpts, ScalingGroupRow
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 
 @pytest.fixture()
@@ -116,14 +117,14 @@ class TestAllowedResourceGroupsForDomain:
     async def test_add_and_get_allowed(
         self,
         admin_v2_registry: V2ClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         extra_scaling_group: str,
     ) -> None:
         """Allow a resource group for a domain, then verify it's listed."""
         result = await admin_v2_registry.resource_group.update_allowed_resource_groups_for_domain(
-            domain_fixture,
+            domain_fixture.domain_name,
             UpdateAllowedResourceGroupsForDomainInput(
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 add=[extra_scaling_group],
             ),
         )
@@ -133,24 +134,24 @@ class TestAllowedResourceGroupsForDomain:
     async def test_add_and_remove_atomically(
         self,
         admin_v2_registry: V2ClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         extra_scaling_group: str,
         second_scaling_group: str,
     ) -> None:
         """Add one and remove another in a single request."""
         # First, allow extra
         await admin_v2_registry.resource_group.update_allowed_resource_groups_for_domain(
-            domain_fixture,
+            domain_fixture.domain_name,
             UpdateAllowedResourceGroupsForDomainInput(
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 add=[extra_scaling_group, second_scaling_group],
             ),
         )
         # Then remove extra, verify second remains
         result = await admin_v2_registry.resource_group.update_allowed_resource_groups_for_domain(
-            domain_fixture,
+            domain_fixture.domain_name,
             UpdateAllowedResourceGroupsForDomainInput(
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 add=[],
                 remove=[extra_scaling_group],
             ),
@@ -161,21 +162,21 @@ class TestAllowedResourceGroupsForDomain:
     async def test_idempotent_add(
         self,
         admin_v2_registry: V2ClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         extra_scaling_group: str,
     ) -> None:
         """Adding the same resource group twice should not error."""
         await admin_v2_registry.resource_group.update_allowed_resource_groups_for_domain(
-            domain_fixture,
+            domain_fixture.domain_name,
             UpdateAllowedResourceGroupsForDomainInput(
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 add=[extra_scaling_group],
             ),
         )
         result = await admin_v2_registry.resource_group.update_allowed_resource_groups_for_domain(
-            domain_fixture,
+            domain_fixture.domain_name,
             UpdateAllowedResourceGroupsForDomainInput(
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 add=[extra_scaling_group],
             ),
         )
@@ -200,7 +201,7 @@ class TestAllowedDomainsForResourceGroup:
     async def test_add_and_get_allowed_domains(
         self,
         admin_v2_registry: V2ClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         extra_scaling_group: str,
     ) -> None:
         """Allow a domain for a resource group, then verify."""
@@ -208,11 +209,11 @@ class TestAllowedDomainsForResourceGroup:
             extra_scaling_group,
             UpdateAllowedDomainsForResourceGroupInput(
                 resource_group_name=extra_scaling_group,
-                add=[domain_fixture],
+                add=[domain_fixture.domain_name],
             ),
         )
         assert isinstance(result, AllowedDomainsPayload)
-        assert domain_fixture in result.items
+        assert domain_fixture.domain_name in result.items
 
 
 class TestAllowedResourceGroupsForProject:

--- a/tests/component/scaling_group/test_scaling_group_associations.py
+++ b/tests/component/scaling_group/test_scaling_group_associations.py
@@ -28,12 +28,13 @@ from ai.backend.manager.models.scaling_group import (
     scaling_groups,
     sgroups_for_domains,
 )
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 
 @pytest.fixture()
 async def private_sgroup_for_visibility(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
 ) -> AsyncIterator[str]:
     """Insert a private (is_public=False) scaling group with domain association; yield name."""
     name = f"private-vis-{secrets.token_hex(8)}"
@@ -53,7 +54,7 @@ async def private_sgroup_for_visibility(
         await conn.execute(
             sa.insert(sgroups_for_domains).values(
                 scaling_group=name,
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
             )
         )
     yield name

--- a/tests/component/scaling_group/test_scaling_group_crud.py
+++ b/tests/component/scaling_group/test_scaling_group_crud.py
@@ -17,12 +17,13 @@ from ai.backend.manager.models.scaling_group import (
     sgroups_for_domains,
     sgroups_for_groups,
 )
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 
 @pytest.fixture()
 async def extra_scaling_group_fixture(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     group_fixture: uuid.UUID,
 ) -> AsyncIterator[str]:
     """Create a second scaling group associated with the domain AND group."""
@@ -43,7 +44,7 @@ async def extra_scaling_group_fixture(
         await conn.execute(
             sa.insert(sgroups_for_domains).values(
                 scaling_group=sgroup_name,
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
             )
         )
         await conn.execute(
@@ -66,7 +67,7 @@ async def extra_scaling_group_fixture(
 @pytest.fixture()
 async def private_scaling_group_fixture(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
 ) -> AsyncIterator[str]:
     """Create a private (is_public=False) scaling group associated with the domain."""
     sgroup_name = f"private-sgroup-{secrets.token_hex(6)}"
@@ -86,7 +87,7 @@ async def private_scaling_group_fixture(
         await conn.execute(
             sa.insert(sgroups_for_domains).values(
                 scaling_group=sgroup_name,
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
             )
         )
     yield sgroup_name

--- a/tests/component/session/conftest.py
+++ b/tests/component/session/conftest.py
@@ -38,6 +38,7 @@ from ai.backend.manager.services.auth.processors import AuthProcessors
 from ai.backend.manager.services.session.processors import SessionProcessors
 from ai.backend.manager.services.session.service import SessionService, SessionServiceArgs
 from ai.backend.manager.services.vfolder.processors.vfolder import VFolderProcessors
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 
 @dataclass
@@ -162,7 +163,7 @@ def server_module_registries(
 @pytest.fixture()
 async def session_seed(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     group_fixture: uuid.UUID,
     admin_user_fixture: UserFixtureData,
     scaling_group_fixture: str,
@@ -194,7 +195,7 @@ async def session_seed(
                 session_type=SessionTypes.INTERACTIVE,
                 cluster_size=1,
                 cluster_mode="single-node",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_fixture,
                 user_uuid=admin_user_fixture.user_uuid,
                 access_key=admin_user_fixture.keypair.access_key,
@@ -219,7 +220,7 @@ async def session_seed(
                 cluster_hostname="main0",
                 cluster_mode="single-node",
                 cluster_size=1,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_fixture,
                 user_uuid=admin_user_fixture.user_uuid,
                 access_key=admin_user_fixture.keypair.access_key,
@@ -241,7 +242,7 @@ async def session_seed(
         session_name=session_name,
         kernel_id=kernel_id,
         access_key=admin_user_fixture.keypair.access_key,
-        domain_name=domain_fixture,
+        domain_name=domain_fixture.domain_name,
         user_uuid=admin_user_fixture.user_uuid,
     )
 
@@ -255,7 +256,7 @@ async def session_seed(
 @pytest.fixture()
 async def terminated_session_seed(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     group_fixture: uuid.UUID,
     admin_user_fixture: UserFixtureData,
     scaling_group_fixture: str,
@@ -286,7 +287,7 @@ async def terminated_session_seed(
                 session_type=SessionTypes.INTERACTIVE,
                 cluster_size=1,
                 cluster_mode="single-node",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_fixture,
                 user_uuid=admin_user_fixture.user_uuid,
                 access_key=admin_user_fixture.keypair.access_key,
@@ -312,7 +313,7 @@ async def terminated_session_seed(
                 cluster_hostname="main0",
                 cluster_mode="single-node",
                 cluster_size=1,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_fixture,
                 user_uuid=admin_user_fixture.user_uuid,
                 access_key=admin_user_fixture.keypair.access_key,
@@ -336,7 +337,7 @@ async def terminated_session_seed(
         session_name=session_name,
         kernel_id=kernel_id,
         access_key=admin_user_fixture.keypair.access_key,
-        domain_name=domain_fixture,
+        domain_name=domain_fixture.domain_name,
         user_uuid=admin_user_fixture.user_uuid,
     )
 
@@ -350,7 +351,7 @@ async def terminated_session_seed(
 @pytest.fixture()
 async def user_session_seed(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     group_fixture: uuid.UUID,
     regular_user_fixture: UserFixtureData,
     scaling_group_fixture: str,
@@ -376,7 +377,7 @@ async def user_session_seed(
                 session_type=SessionTypes.INTERACTIVE,
                 cluster_size=1,
                 cluster_mode="single-node",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_fixture,
                 user_uuid=regular_user_fixture.user_uuid,
                 access_key=regular_user_fixture.keypair.access_key,
@@ -401,7 +402,7 @@ async def user_session_seed(
                 cluster_hostname="main0",
                 cluster_mode="single-node",
                 cluster_size=1,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_fixture,
                 user_uuid=regular_user_fixture.user_uuid,
                 access_key=regular_user_fixture.keypair.access_key,
@@ -423,7 +424,7 @@ async def user_session_seed(
         session_name=session_name,
         kernel_id=kernel_id,
         access_key=regular_user_fixture.keypair.access_key,
-        domain_name=domain_fixture,
+        domain_name=domain_fixture.domain_name,
         user_uuid=regular_user_fixture.user_uuid,
     )
 

--- a/tests/component/session/test_session_create_delegation.py
+++ b/tests/component/session/test_session_create_delegation.py
@@ -18,6 +18,7 @@ from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.repositories.session.repository import SessionRepository
 from ai.backend.manager.types import UserScope
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 if TYPE_CHECKING:
     from tests.component.conftest import UserFixtureData
@@ -87,7 +88,7 @@ class TestDelegatedSessionCreation:
     async def test_admin_create_with_owner_access_key_routes_owner_into_user_scope(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_name_for_fixture: str,
         admin_user_fixture: UserFixtureData,
         regular_user_fixture: UserFixtureData,
@@ -105,7 +106,7 @@ class TestDelegatedSessionCreation:
             image="python:latest",
             architecture="x86_64",
             session_type=SessionTypes.INTERACTIVE,
-            domain=domain_fixture,
+            domain=domain_fixture.domain_name,
             group=group_name_for_fixture,
             owner_access_key=regular_user_fixture.keypair.access_key,
             # ``reuse=False`` skips the existing-session lookup branch in

--- a/tests/component/session/test_session_lifecycle.py
+++ b/tests/component/session/test_session_lifecycle.py
@@ -25,6 +25,7 @@ from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.models.kernel import kernels
 from ai.backend.manager.models.session import SessionRow
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 from .conftest import SessionSeedData, UserFixtureData
 
@@ -69,7 +70,7 @@ def _build_kernel_values(
 @pytest.fixture()
 async def degraded_session_seed(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     group_fixture: uuid.UUID,
     admin_user_fixture: UserFixtureData,
     scaling_group_fixture: str,
@@ -91,7 +92,7 @@ async def degraded_session_seed(
         unique=unique,
         session_name=session_name,
         cluster_size=2,
-        domain_name=domain_fixture,
+        domain_name=domain_fixture.domain_name,
         group_id=group_fixture,
         user_uuid=admin_user_fixture.user_uuid,
         access_key=admin_user_fixture.keypair.access_key,
@@ -108,7 +109,7 @@ async def degraded_session_seed(
                 session_type=SessionTypes.INTERACTIVE,
                 cluster_size=2,
                 cluster_mode="single-node",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_fixture,
                 user_uuid=admin_user_fixture.user_uuid,
                 access_key=admin_user_fixture.keypair.access_key,
@@ -147,7 +148,7 @@ async def degraded_session_seed(
         session_name=session_name,
         kernel_id=uuid.UUID(int=0),  # not meaningful for multi-kernel
         access_key=admin_user_fixture.keypair.access_key,
-        domain_name=domain_fixture,
+        domain_name=domain_fixture.domain_name,
         user_uuid=admin_user_fixture.user_uuid,
     )
 
@@ -161,7 +162,7 @@ async def degraded_session_seed(
 @pytest.fixture()
 async def full_lifecycle_session_seed(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     group_fixture: uuid.UUID,
     admin_user_fixture: UserFixtureData,
     scaling_group_fixture: str,
@@ -189,7 +190,7 @@ async def full_lifecycle_session_seed(
         unique=unique,
         session_name=session_name,
         cluster_size=1,
-        domain_name=domain_fixture,
+        domain_name=domain_fixture.domain_name,
         group_id=group_fixture,
         user_uuid=admin_user_fixture.user_uuid,
         access_key=admin_user_fixture.keypair.access_key,
@@ -206,7 +207,7 @@ async def full_lifecycle_session_seed(
                 session_type=SessionTypes.INTERACTIVE,
                 cluster_size=1,
                 cluster_mode="single-node",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_fixture,
                 user_uuid=admin_user_fixture.user_uuid,
                 access_key=admin_user_fixture.keypair.access_key,
@@ -235,7 +236,7 @@ async def full_lifecycle_session_seed(
         session_name=session_name,
         kernel_id=kernel_id,
         access_key=admin_user_fixture.keypair.access_key,
-        domain_name=domain_fixture,
+        domain_name=domain_fixture.domain_name,
         user_uuid=admin_user_fixture.user_uuid,
     )
 

--- a/tests/component/session/test_session_query.py
+++ b/tests/component/session/test_session_query.py
@@ -54,6 +54,7 @@ from ai.backend.manager.services.agent.processors import AgentProcessors
 from ai.backend.manager.services.auth.processors import AuthProcessors
 from ai.backend.manager.services.session.processors import SessionProcessors
 from ai.backend.manager.services.vfolder.processors.vfolder import VFolderProcessors
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 from .conftest import SessionSeedData, UserFixtureData
 
@@ -93,7 +94,7 @@ def server_module_registries(
 @pytest.fixture()
 async def system_session_seed(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     group_fixture: uuid.UUID,
     admin_user_fixture: UserFixtureData,
     scaling_group_fixture: str,
@@ -150,7 +151,7 @@ async def system_session_seed(
                 session_type=SessionTypes.SYSTEM,
                 cluster_size=1,
                 cluster_mode="single-node",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_fixture,
                 user_uuid=admin_user_fixture.user_uuid,
                 access_key=admin_user_fixture.keypair.access_key,
@@ -175,7 +176,7 @@ async def system_session_seed(
                 cluster_hostname="main0",
                 cluster_mode="single-node",
                 cluster_size=1,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_fixture,
                 user_uuid=admin_user_fixture.user_uuid,
                 access_key=admin_user_fixture.keypair.access_key,
@@ -201,7 +202,7 @@ async def system_session_seed(
         session_name=session_name,
         kernel_id=kernel_id,
         access_key=admin_user_fixture.keypair.access_key,
-        domain_name=domain_fixture,
+        domain_name=domain_fixture.domain_name,
     )
 
     async with db_engine.begin() as conn:
@@ -215,7 +216,7 @@ async def system_session_seed(
 @pytest.fixture()
 async def system_session_no_agent_seed(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     group_fixture: uuid.UUID,
     admin_user_fixture: UserFixtureData,
     scaling_group_fixture: str,
@@ -245,7 +246,7 @@ async def system_session_no_agent_seed(
                 session_type=SessionTypes.SYSTEM,
                 cluster_size=1,
                 cluster_mode="single-node",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_fixture,
                 user_uuid=admin_user_fixture.user_uuid,
                 access_key=admin_user_fixture.keypair.access_key,
@@ -270,7 +271,7 @@ async def system_session_no_agent_seed(
                 cluster_hostname="main0",
                 cluster_mode="single-node",
                 cluster_size=1,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_fixture,
                 user_uuid=admin_user_fixture.user_uuid,
                 access_key=admin_user_fixture.keypair.access_key,
@@ -293,7 +294,7 @@ async def system_session_no_agent_seed(
         session_name=session_name,
         kernel_id=kernel_id,
         access_key=admin_user_fixture.keypair.access_key,
-        domain_name=domain_fixture,
+        domain_name=domain_fixture.domain_name,
     )
 
     async with db_engine.begin() as conn:
@@ -306,7 +307,7 @@ async def system_session_no_agent_seed(
 @pytest.fixture()
 async def second_session_seed(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     group_fixture: uuid.UUID,
     admin_user_fixture: UserFixtureData,
     scaling_group_fixture: str,
@@ -338,7 +339,7 @@ async def second_session_seed(
                 session_type=SessionTypes.INTERACTIVE,
                 cluster_size=1,
                 cluster_mode="single-node",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_fixture,
                 user_uuid=admin_user_fixture.user_uuid,
                 access_key=admin_user_fixture.keypair.access_key,
@@ -363,7 +364,7 @@ async def second_session_seed(
                 cluster_hostname="main0",
                 cluster_mode="single-node",
                 cluster_size=1,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_fixture,
                 user_uuid=admin_user_fixture.user_uuid,
                 access_key=admin_user_fixture.keypair.access_key,
@@ -385,7 +386,7 @@ async def second_session_seed(
         session_name=session_name,
         kernel_id=kernel_id,
         access_key=admin_user_fixture.keypair.access_key,
-        domain_name=domain_fixture,
+        domain_name=domain_fixture.domain_name,
     )
 
     async with db_engine.begin() as conn:

--- a/tests/component/session_v2/conftest.py
+++ b/tests/component/session_v2/conftest.py
@@ -56,6 +56,7 @@ from ai.backend.manager.repositories.session.repository import SessionRepository
 from ai.backend.manager.services.processors import Processors
 from ai.backend.manager.services.session.processors import SessionProcessors
 from ai.backend.manager.services.session.service import SessionService, SessionServiceArgs
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
@@ -397,7 +398,7 @@ async def _cleanup_session(db_engine: SAEngine, session_id: SessionId) -> None:
 @pytest.fixture()
 async def admin_session_seed(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     group_fixture: uuid.UUID,
     admin_user_fixture: UserFixtureData,
     scaling_group_fixture: str,
@@ -405,7 +406,7 @@ async def admin_session_seed(
     """Seed a RUNNING session owned by the admin user."""
     seed = await _seed_session(
         db_engine,
-        domain_name=domain_fixture,
+        domain_name=domain_fixture.domain_name,
         group_id=group_fixture,
         user_uuid=admin_user_fixture.user_uuid,
         access_key=admin_user_fixture.keypair.access_key,
@@ -418,7 +419,7 @@ async def admin_session_seed(
 @pytest.fixture()
 async def user_session_seed(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     group_fixture: uuid.UUID,
     regular_user_fixture: UserFixtureData,
     scaling_group_fixture: str,
@@ -430,7 +431,7 @@ async def user_session_seed(
     """
     seed = await _seed_session(
         db_engine,
-        domain_name=domain_fixture,
+        domain_name=domain_fixture.domain_name,
         group_id=group_fixture,
         user_uuid=regular_user_fixture.user_uuid,
         access_key=regular_user_fixture.keypair.access_key,

--- a/tests/component/stream/conftest.py
+++ b/tests/component/stream/conftest.py
@@ -31,6 +31,7 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.stream.repository import StreamRepository
 from ai.backend.manager.services.stream.processors import StreamProcessors
 from ai.backend.manager.services.stream.service import StreamService
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 _STREAMING_SERVER_SUBAPP_MODULES = (_auth_api,)
 
@@ -100,7 +101,7 @@ def server_module_registries(
 @pytest.fixture()
 async def session_seed(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     group_fixture: uuid.UUID,
     admin_user_fixture: UserFixtureData,
     scaling_group_fixture: str,
@@ -126,7 +127,7 @@ async def session_seed(
                 session_type=SessionTypes.INTERACTIVE,
                 cluster_size=1,
                 cluster_mode="single-node",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_fixture,
                 user_uuid=admin_user_fixture.user_uuid,
                 access_key=admin_user_fixture.keypair.access_key,
@@ -151,7 +152,7 @@ async def session_seed(
                 cluster_hostname="main0",
                 cluster_mode="single-node",
                 cluster_size=1,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_fixture,
                 user_uuid=admin_user_fixture.user_uuid,
                 access_key=admin_user_fixture.keypair.access_key,
@@ -187,7 +188,7 @@ async def session_seed(
         session_name=session_name,
         kernel_id=kernel_id,
         access_key=admin_user_fixture.keypair.access_key,
-        domain_name=domain_fixture,
+        domain_name=domain_fixture.domain_name,
     )
 
     async with db_engine.begin() as conn:

--- a/tests/component/streaming/conftest.py
+++ b/tests/component/streaming/conftest.py
@@ -31,6 +31,7 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.stream.repository import StreamRepository
 from ai.backend.manager.services.stream.processors import StreamProcessors
 from ai.backend.manager.services.stream.service import StreamService
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 _STREAMING_SERVER_SUBAPP_MODULES = (_auth_api,)
 
@@ -100,7 +101,7 @@ def server_module_registries(
 @pytest.fixture()
 async def session_seed(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     group_fixture: uuid.UUID,
     admin_user_fixture: UserFixtureData,
     scaling_group_fixture: str,
@@ -130,7 +131,7 @@ async def session_seed(
                 session_type=SessionTypes.INTERACTIVE,
                 cluster_size=1,
                 cluster_mode="single-node",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_fixture,
                 user_uuid=admin_user_fixture.user_uuid,
                 access_key=admin_user_fixture.keypair.access_key,
@@ -155,7 +156,7 @@ async def session_seed(
                 cluster_hostname="main0",
                 cluster_mode="single-node",
                 cluster_size=1,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_fixture,
                 user_uuid=admin_user_fixture.user_uuid,
                 access_key=admin_user_fixture.keypair.access_key,
@@ -191,7 +192,7 @@ async def session_seed(
         session_name=session_name,
         kernel_id=kernel_id,
         access_key=admin_user_fixture.keypair.access_key,
-        domain_name=domain_fixture,
+        domain_name=domain_fixture.domain_name,
     )
 
     async with db_engine.begin() as conn:
@@ -204,7 +205,7 @@ async def session_seed(
 @pytest.fixture()
 async def session_seed_no_ports(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     group_fixture: uuid.UUID,
     admin_user_fixture: UserFixtureData,
     scaling_group_fixture: str,
@@ -234,7 +235,7 @@ async def session_seed_no_ports(
                 session_type=SessionTypes.INTERACTIVE,
                 cluster_size=1,
                 cluster_mode="single-node",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_fixture,
                 user_uuid=admin_user_fixture.user_uuid,
                 access_key=admin_user_fixture.keypair.access_key,
@@ -259,7 +260,7 @@ async def session_seed_no_ports(
                 cluster_hostname="main0",
                 cluster_mode="single-node",
                 cluster_size=1,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 group_id=group_fixture,
                 user_uuid=admin_user_fixture.user_uuid,
                 access_key=admin_user_fixture.keypair.access_key,
@@ -282,7 +283,7 @@ async def session_seed_no_ports(
         session_name=session_name,
         kernel_id=kernel_id,
         access_key=admin_user_fixture.keypair.access_key,
-        domain_name=domain_fixture,
+        domain_name=domain_fixture.domain_name,
     )
 
     async with db_engine.begin() as conn:

--- a/tests/component/template/test_template.py
+++ b/tests/component/template/test_template.py
@@ -24,6 +24,7 @@ from ai.backend.common.dto.manager.template import (
     UpdateSessionTemplateRequest,
     UpdateSessionTemplateResponse,
 )
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 
 def _session_template_payload(name: str = "test-template") -> str:
@@ -72,12 +73,12 @@ class TestCreateSessionTemplate:
     async def test_admin_creates_session_template(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_name_fixture: str,
     ) -> None:
         result = await admin_registry.template.create_session_template(
             CreateSessionTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_session_template_payload("admin-tpl"),
             ),
@@ -91,12 +92,12 @@ class TestCreateSessionTemplate:
     async def test_user_creates_session_template(
         self,
         user_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_name_fixture: str,
     ) -> None:
         result = await user_registry.template.create_session_template(
             CreateSessionTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_session_template_payload("user-tpl"),
             ),
@@ -111,12 +112,12 @@ class TestGetSessionTemplate:
     async def test_admin_gets_session_template(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_name_fixture: str,
     ) -> None:
         create_result = await admin_registry.template.create_session_template(
             CreateSessionTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_session_template_payload("get-test"),
             ),
@@ -131,12 +132,12 @@ class TestGetSessionTemplate:
     async def test_user_gets_session_template(
         self,
         user_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_name_fixture: str,
     ) -> None:
         create_result = await user_registry.template.create_session_template(
             CreateSessionTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_session_template_payload("user-get-test"),
             ),
@@ -150,12 +151,12 @@ class TestGetSessionTemplate:
     async def test_get_with_format_param(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_name_fixture: str,
     ) -> None:
         create_result = await admin_registry.template.create_session_template(
             CreateSessionTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_session_template_payload("fmt-test"),
             ),
@@ -173,12 +174,12 @@ class TestListSessionTemplates:
     async def test_list_session_templates(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_name_fixture: str,
     ) -> None:
         await admin_registry.template.create_session_template(
             CreateSessionTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_session_template_payload("list-test"),
             ),
@@ -194,12 +195,12 @@ class TestUpdateSessionTemplate:
     async def test_admin_updates_session_template(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_name_fixture: str,
     ) -> None:
         create_result = await admin_registry.template.create_session_template(
             CreateSessionTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_session_template_payload("update-before"),
             ),
@@ -209,7 +210,7 @@ class TestUpdateSessionTemplate:
         result = await admin_registry.template.update_session_template(
             template_id,
             UpdateSessionTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_session_template_payload("update-after"),
             ),
@@ -225,12 +226,12 @@ class TestDeleteSessionTemplate:
     async def test_admin_deletes_session_template(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_name_fixture: str,
     ) -> None:
         create_result = await admin_registry.template.create_session_template(
             CreateSessionTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_session_template_payload("delete-test"),
             ),
@@ -244,12 +245,12 @@ class TestDeleteSessionTemplate:
     async def test_get_deleted_template_returns_empty(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_name_fixture: str,
     ) -> None:
         create_result = await admin_registry.template.create_session_template(
             CreateSessionTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_session_template_payload("del-verify"),
             ),
@@ -272,13 +273,13 @@ class TestCreateClusterTemplate:
     async def test_admin_creates_cluster_template(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_name_fixture: str,
     ) -> None:
         # First, create a session template to reference.
         st_result = await admin_registry.template.create_session_template(
             CreateSessionTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_session_template_payload("cluster-dep"),
             ),
@@ -287,7 +288,7 @@ class TestCreateClusterTemplate:
 
         result = await admin_registry.template.create_cluster_template(
             CreateClusterTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_cluster_template_payload("test-cluster", session_tpl_id),
             ),
@@ -301,12 +302,12 @@ class TestGetClusterTemplate:
     async def test_admin_gets_cluster_template(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_name_fixture: str,
     ) -> None:
         st_result = await admin_registry.template.create_session_template(
             CreateSessionTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_session_template_payload("ct-get-dep"),
             ),
@@ -315,7 +316,7 @@ class TestGetClusterTemplate:
 
         ct_result = await admin_registry.template.create_cluster_template(
             CreateClusterTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_cluster_template_payload("ct-get-test", session_tpl_id),
             ),
@@ -332,12 +333,12 @@ class TestGetClusterTemplate:
     async def test_get_with_format_param(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_name_fixture: str,
     ) -> None:
         st_result = await admin_registry.template.create_session_template(
             CreateSessionTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_session_template_payload("ct-fmt-dep"),
             ),
@@ -346,7 +347,7 @@ class TestGetClusterTemplate:
 
         ct_result = await admin_registry.template.create_cluster_template(
             CreateClusterTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_cluster_template_payload("ct-fmt-test", session_tpl_id),
             ),
@@ -364,12 +365,12 @@ class TestListClusterTemplates:
     async def test_list_cluster_templates(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_name_fixture: str,
     ) -> None:
         st_result = await admin_registry.template.create_session_template(
             CreateSessionTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_session_template_payload("ct-list-dep"),
             ),
@@ -378,7 +379,7 @@ class TestListClusterTemplates:
 
         await admin_registry.template.create_cluster_template(
             CreateClusterTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_cluster_template_payload("ct-list-test", session_tpl_id),
             ),
@@ -394,12 +395,12 @@ class TestUpdateClusterTemplate:
     async def test_admin_updates_cluster_template(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_name_fixture: str,
     ) -> None:
         st_result = await admin_registry.template.create_session_template(
             CreateSessionTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_session_template_payload("ct-upd-dep"),
             ),
@@ -408,7 +409,7 @@ class TestUpdateClusterTemplate:
 
         ct_result = await admin_registry.template.create_cluster_template(
             CreateClusterTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_cluster_template_payload("ct-upd-before", session_tpl_id),
             ),
@@ -429,12 +430,12 @@ class TestDeleteClusterTemplate:
     async def test_admin_deletes_cluster_template(
         self,
         admin_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         group_name_fixture: str,
     ) -> None:
         st_result = await admin_registry.template.create_session_template(
             CreateSessionTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_session_template_payload("ct-del-dep"),
             ),
@@ -443,7 +444,7 @@ class TestDeleteClusterTemplate:
 
         ct_result = await admin_registry.template.create_cluster_template(
             CreateClusterTemplateRequest(
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
                 group=group_name_fixture,
                 payload=_cluster_template_payload("ct-del-test", session_tpl_id),
             ),

--- a/tests/component/user/conftest.py
+++ b/tests/component/user/conftest.py
@@ -34,6 +34,7 @@ from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.repositories.user.repository import UserRepository
 from ai.backend.manager.services.user.processors import UserProcessors
 from ai.backend.manager.services.user.service import UserService
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 UserFactory = Callable[..., Coroutine[Any, Any, CreateUserResponse]]
 
@@ -93,7 +94,7 @@ def server_module_registries(
 @pytest.fixture()
 async def user_factory(
     admin_registry: BackendAIClientRegistry,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
     db_engine: SAEngine,
 ) -> AsyncIterator[UserFactory]:
@@ -106,7 +107,7 @@ async def user_factory(
             "email": f"test-{unique}@test.local",
             "username": f"test-{unique}",
             "password": "test-password-1234",
-            "domain_name": domain_fixture,
+            "domain_name": domain_fixture.domain_name,
             "resource_policy": resource_policy_fixture,
             "status": UserStatus.ACTIVE,
         }

--- a/tests/component/user/test_user.py
+++ b/tests/component/user/test_user.py
@@ -41,6 +41,7 @@ from ai.backend.manager.models.rbac_models.association_scopes_entities import (
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.user import users
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 from .conftest import UserFactory
 
@@ -65,7 +66,7 @@ class TestUserCreate:
     async def test_regular_user_cannot_create_user(
         self,
         user_registry: BackendAIClientRegistry,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         resource_policy_fixture: str,
     ) -> None:
         unique = secrets.token_hex(4)
@@ -73,7 +74,7 @@ class TestUserCreate:
             email=f"denied-{unique}@test.local",
             username=f"denied-{unique}",
             password="test-password-1234",
-            domain_name=domain_fixture,
+            domain_name=domain_fixture.domain_name,
             resource_policy=resource_policy_fixture,
         )
         with pytest.raises(PermissionDeniedError):
@@ -360,7 +361,7 @@ class TestUserDelete:
 @pytest.fixture()
 async def user_with_rbac_rows(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[tuple[uuid.UUID, str]]:
     """Insert a user along with the RBAC rows that the create flow would
@@ -390,7 +391,7 @@ async def user_with_rbac_rows(
                 description="Test user for RBAC purge cleanup",
                 status=UserStatus.ACTIVE,
                 status_info="admin-requested",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
                 role=UserRole.USER,
             )
@@ -416,7 +417,7 @@ async def user_with_rbac_rows(
         await conn.execute(
             sa.insert(AssociationScopesEntitiesRow.__table__).values(
                 scope_type=ScopeType.DOMAIN,
-                scope_id=domain_fixture,
+                scope_id=domain_fixture.domain_name,
                 entity_type=EntityType.USER,
                 entity_id=scope_id,
                 relation_type=RelationType.AUTO,

--- a/tests/component/user/test_user_crud.py
+++ b/tests/component/user/test_user_crud.py
@@ -22,6 +22,7 @@ from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
 )
 from ai.backend.manager.models.user import users
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 from .conftest import UserFactory
 
@@ -114,7 +115,7 @@ class TestUserCreateCrud:
     async def test_f_biz_1_duplicate_email_raises_conflict(
         self,
         user_factory: UserFactory,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         resource_policy_fixture: str,
         admin_registry: BackendAIClientRegistry,
     ) -> None:
@@ -127,7 +128,7 @@ class TestUserCreateCrud:
                     email=existing.user.email,
                     username="another-username-xyz",
                     password="test-password-1234",
-                    domain_name=domain_fixture,
+                    domain_name=domain_fixture.domain_name,
                     resource_policy=resource_policy_fixture,
                 )
             )
@@ -151,7 +152,7 @@ class TestUserCreateCrud:
 
     async def test_f_biz_3_nonexistent_resource_policy_raises_error(
         self,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         admin_registry: BackendAIClientRegistry,
     ) -> None:
         """F-BIZ-3: Non-existent resource_policy → ConflictError (409, FK violation)."""
@@ -161,7 +162,7 @@ class TestUserCreateCrud:
                     email="no-policy@test.local",
                     username="no-policy-user",
                     password="test-password-1234",
-                    domain_name=domain_fixture,
+                    domain_name=domain_fixture.domain_name,
                     resource_policy="nonexistent-policy-xyz",
                 )
             )

--- a/tests/component/vfolder/conftest.py
+++ b/tests/component/vfolder/conftest.py
@@ -59,6 +59,7 @@ from ai.backend.manager.services.vfolder.services.file import VFolderFileService
 from ai.backend.manager.services.vfolder.services.invite import VFolderInviteService
 from ai.backend.manager.services.vfolder.services.sharing import VFolderSharingService
 from ai.backend.manager.services.vfolder.services.vfolder import VFolderService
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 _VFOLDER_SERVER_SUBAPP_MODULES = (_auth_api,)
 
@@ -213,7 +214,7 @@ def server_module_registries(
 @pytest.fixture()
 async def vfolder_host_permission_fixture(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[None]:
     """Update allowed_vfolder_hosts on the test domain and keypair resource policy.
@@ -226,7 +227,7 @@ async def vfolder_host_permission_fixture(
     async with db_engine.begin() as conn:
         await conn.execute(
             sa.update(domains)
-            .where(domains.c.name == domain_fixture)
+            .where(domains.c.name == domain_fixture.domain_name)
             .values(allowed_vfolder_hosts=host_perms)
         )
         await conn.execute(
@@ -247,7 +248,7 @@ async def vfolder_host_permission_fixture(
     async with db_engine.begin() as conn:
         await conn.execute(
             sa.update(domains)
-            .where(domains.c.name == domain_fixture)
+            .where(domains.c.name == domain_fixture.domain_name)
             .values(allowed_vfolder_hosts=empty_perms)
         )
         await conn.execute(
@@ -260,7 +261,7 @@ async def vfolder_host_permission_fixture(
 @pytest.fixture()
 async def vfolder_factory(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     admin_user_fixture: Any,
     vfolder_host_permission_fixture: None,
 ) -> AsyncIterator[VFolderFactory]:
@@ -283,7 +284,7 @@ async def vfolder_factory(
             "id": vfolder_id,
             "name": f"test-vfolder-{unique}",
             "host": "local",
-            "domain_name": domain_fixture,
+            "domain_name": domain_fixture.domain_name,
             "quota_scope_id": str(quota_scope_id),
             "usage_mode": VFolderUsageMode.GENERAL,
             "permission": VFolderMountPermission.READ_WRITE,

--- a/tests/component/vfolder/test_vfolder_io.py
+++ b/tests/component/vfolder/test_vfolder_io.py
@@ -43,6 +43,7 @@ from ai.backend.common.types import VFolderHostPermission, VFolderHostPermission
 from ai.backend.manager.models.domain import domains
 from ai.backend.manager.models.resource_policy import keypair_resource_policies
 from ai.backend.manager.models.storage import StorageSessionManager
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 VFolderFixtureData = dict[str, Any]
 VFolderFactory = Callable[..., Coroutine[Any, Any, VFolderFixtureData]]
@@ -84,7 +85,7 @@ def _configure_storage_mock(storage_manager: StorageSessionManager) -> AsyncMock
 @pytest.fixture()
 async def no_upload_permission_vfolder(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
     vfolder_factory: VFolderFactory,
 ) -> AsyncIterator[VFolderFixtureData]:
@@ -102,7 +103,7 @@ async def no_upload_permission_vfolder(
     async with db_engine.begin() as conn:
         await conn.execute(
             sa.update(domains)
-            .where(domains.c.name == domain_fixture)
+            .where(domains.c.name == domain_fixture.domain_name)
             .values(allowed_vfolder_hosts=host_perms)
         )
         await conn.execute(
@@ -122,7 +123,7 @@ async def no_upload_permission_vfolder(
 @pytest.fixture()
 async def no_download_permission_vfolder(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
     vfolder_factory: VFolderFactory,
 ) -> AsyncIterator[VFolderFixtureData]:
@@ -135,7 +136,7 @@ async def no_download_permission_vfolder(
     async with db_engine.begin() as conn:
         await conn.execute(
             sa.update(domains)
-            .where(domains.c.name == domain_fixture)
+            .where(domains.c.name == domain_fixture.domain_name)
             .values(allowed_vfolder_hosts=host_perms)
         )
         await conn.execute(

--- a/tests/component/vfolder_v2/conftest.py
+++ b/tests/component/vfolder_v2/conftest.py
@@ -49,6 +49,7 @@ from ai.backend.manager.repositories.vfolder.repository import VfolderRepository
 from ai.backend.manager.services.processors import Processors
 from ai.backend.manager.services.vfolder.processors.vfolder import VFolderProcessors
 from ai.backend.manager.services.vfolder.services.vfolder import VFolderService
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
@@ -175,7 +176,7 @@ async def user_v2_registry(
 @pytest.fixture()
 async def vfolder_host_permission_fixture(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[None]:
     """Grant all VFolderHostPermission flags for the 'local' host."""
@@ -184,7 +185,7 @@ async def vfolder_host_permission_fixture(
     async with db_engine.begin() as conn:
         await conn.execute(
             domains.update()
-            .where(domains.c.name == domain_fixture)
+            .where(domains.c.name == domain_fixture.domain_name)
             .values(allowed_vfolder_hosts=host_perms)
         )
         await conn.execute(
@@ -202,7 +203,7 @@ async def vfolder_host_permission_fixture(
     async with db_engine.begin() as conn:
         await conn.execute(
             domains.update()
-            .where(domains.c.name == domain_fixture)
+            .where(domains.c.name == domain_fixture.domain_name)
             .values(allowed_vfolder_hosts=empty_perms)
         )
         await conn.execute(
@@ -215,7 +216,7 @@ async def vfolder_host_permission_fixture(
 @pytest.fixture()
 async def vfolder_factory(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     admin_user_fixture: UserFixtureData,
     vfolder_host_permission_fixture: None,
 ) -> AsyncIterator[VFolderFactory]:
@@ -234,7 +235,7 @@ async def vfolder_factory(
             "id": vfolder_id,
             "name": f"test-vfolder-{unique}",
             "host": "local",
-            "domain_name": domain_fixture,
+            "domain_name": domain_fixture.domain_name,
             "quota_scope_id": str(quota_scope_id),
             "usage_mode": VFolderUsageMode.GENERAL,
             "permission": VFolderMountPermission.READ_WRITE,

--- a/tests/component/vfolder_v2/test_vfolder_mutation.py
+++ b/tests/component/vfolder_v2/test_vfolder_mutation.py
@@ -63,6 +63,7 @@ from ai.backend.manager.repositories.vfolder.repository import VfolderRepository
 from ai.backend.manager.services.processors import Processors
 from ai.backend.manager.services.vfolder.processors.vfolder import VFolderProcessors
 from ai.backend.manager.services.vfolder.services.vfolder import VFolderService
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
@@ -265,7 +266,7 @@ async def created_vfolder_cleanup(
 @pytest.fixture()
 async def project_vfolder(
     db_engine: SAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     group_fixture: uuid.UUID,
     vfolder_host_permission_fixture: None,
 ) -> AsyncIterator[ProjectVFolderFixtureData]:
@@ -279,7 +280,7 @@ async def project_vfolder(
                 id=vfolder_id,
                 name=f"test-proj-vfolder-{unique}",
                 host="local",
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 quota_scope_id=str(quota_scope_id),
                 usage_mode=VFolderUsageMode.GENERAL,
                 permission=VFolderMountPermission.READ_WRITE,

--- a/tests/unit/manager/conftest.py
+++ b/tests/unit/manager/conftest.py
@@ -3,24 +3,30 @@ from __future__ import annotations
 import logging
 import os
 import secrets
+import uuid
 from collections.abc import Callable, Generator
 from functools import partial
 from pathlib import Path
 from typing import Any
 
 import pytest
+import sqlalchemy as sa
 
 from ai.backend.common.lock import FileLock
+from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.logging import LocalLogger, LogLevel
 from ai.backend.logging.config import ConsoleConfig, LogDriver, LoggingConfig
 from ai.backend.logging.types import LogFormat
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
+from ai.backend.manager.models.domain import domains
 from ai.backend.manager.models.hasher.types import PasswordInfo
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.testutils.bootstrap import (  # noqa: F401
     etcd_container,
     postgres_container,
     redis_container,
 )
+from ai.backend.testutils.fixtures import DomainFactory, DomainFixtureData
 
 
 def create_test_password_info(password: str = "test_password") -> PasswordInfo:
@@ -129,3 +135,39 @@ def file_lock_factory(
         return lock
 
     return _make_lock
+
+
+@pytest.fixture
+def domain_factory() -> DomainFactory:
+    """Return an async callable that inserts a domain row and returns its identifiers.
+
+    The factory takes the target SQLAlchemy engine (so each test class can
+    supply its own ``with_tables``-managed engine) along with any keyword
+    overrides for the ``domains`` row. The returned ``DomainFixtureData``
+    exposes both ``domain_name`` and ``domain_id`` so call sites are ready for
+    the upcoming domain PK migration to UUID.
+    """
+
+    async def _create(
+        engine: ExtendedAsyncSAEngine,
+        **overrides: Any,
+    ) -> DomainFixtureData:
+        values: dict[str, Any] = {
+            "name": f"test-domain-{uuid.uuid4().hex[:8]}",
+            "description": "Test domain",
+            "is_active": True,
+            "total_resource_slots": ResourceSlot({}),
+            "allowed_vfolder_hosts": VFolderHostPermissionMap({}),
+            "allowed_docker_registries": [],
+            "dotfiles": b"",
+            "integration_id": None,
+        }
+        values.update(overrides)
+        async with engine.begin() as conn:
+            result = await conn.execute(
+                sa.insert(domains).values(values).returning(domains.c.id, domains.c.name)
+            )
+            row = result.one()
+        return DomainFixtureData(domain_name=row.name, domain_id=row.id)
+
+    return _create

--- a/tests/unit/manager/repositories/container_registry/test_container_registry_repository.py
+++ b/tests/unit/manager/repositories/container_registry/test_container_registry_repository.py
@@ -67,6 +67,7 @@ from ai.backend.manager.repositories.container_registry.updaters import (
 )
 from ai.backend.manager.types import OptionalState, TriState
 from ai.backend.testutils.db import with_tables
+from ai.backend.testutils.fixtures import DomainFactory, DomainFixtureData
 
 
 @dataclass
@@ -151,21 +152,20 @@ class TestContainerRegistryRepository:
         return ContainerRegistryRepository(db=db_with_cleanup)
 
     @pytest.fixture
-    async def sample_domain(self, db_with_cleanup: ExtendedAsyncSAEngine) -> str:
-        """Pre-created domain for group tests. Returns domain name."""
-        domain_name = "test-domain-" + str(uuid.uuid4())[:8]
-        async with db_with_cleanup.begin_session() as session:
-            domain = DomainRow(name=domain_name, total_resource_slots=ResourceSlot())
-            session.add(domain)
-            await session.commit()
-        return domain_name
+    async def sample_domain(
+        self,
+        domain_factory: DomainFactory,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> DomainFixtureData:
+        """Pre-created domain for group tests."""
+        return await domain_factory(db_with_cleanup)
 
     @pytest.fixture
     async def sample_groups(
-        self, db_with_cleanup: ExtendedAsyncSAEngine, sample_domain: str
+        self, db_with_cleanup: ExtendedAsyncSAEngine, sample_domain: DomainFixtureData
     ) -> list[UUID]:
-        """Pre-created 2 groups with required policies. Depends on sample_domain."""
-        resource_policy_name = f"test-policy-{sample_domain}"
+        """Pre-created 2 groups with required policies. Depends on sample_domain.domain_name."""
+        resource_policy_name = f"test-policy-{sample_domain.domain_name}"
         group_ids: list[UUID] = []
 
         async with db_with_cleanup.begin_session() as session:
@@ -190,8 +190,8 @@ class TestContainerRegistryRepository:
             # Create 2 groups
             for i in range(2):
                 group = GroupRow(
-                    name=f"test-group-{i}-{sample_domain}",
-                    domain_name=sample_domain,
+                    name=f"test-group-{i}-{sample_domain.domain_name}",
+                    domain_name=sample_domain.domain_name,
                     total_resource_slots=ResourceSlot(),
                     resource_policy=resource_policy_name,
                 )
@@ -882,12 +882,12 @@ class TestContainerRegistryRepository:
 
     @pytest.fixture
     async def registry_with_associated_groups(
-        self, db_with_cleanup: ExtendedAsyncSAEngine, sample_domain: str
+        self, db_with_cleanup: ExtendedAsyncSAEngine, sample_domain: DomainFixtureData
     ) -> _RegistryWithGroups:
         """Pre-created registry with 3 groups already associated."""
         registry_name = str(uuid.uuid4())[:8] + ".example.com"
         project = "project-" + str(uuid.uuid4())[:8]
-        resource_policy_name = f"test-policy-{sample_domain}-3groups"
+        resource_policy_name = f"test-policy-{sample_domain.domain_name}-3groups"
         group_ids: list[UUID] = []
 
         async with db_with_cleanup.begin_session() as session:
@@ -922,8 +922,8 @@ class TestContainerRegistryRepository:
             # Create 3 groups and associate them
             for i in range(3):
                 group = GroupRow(
-                    name=f"test-group-{i}-{sample_domain}-assoc",
-                    domain_name=sample_domain,
+                    name=f"test-group-{i}-{sample_domain.domain_name}-assoc",
+                    domain_name=sample_domain.domain_name,
                     total_resource_slots=ResourceSlot(),
                     resource_policy=resource_policy_name,
                 )
@@ -1009,12 +1009,12 @@ class TestContainerRegistryRepository:
 
     @pytest.fixture
     async def registry_with_partial_groups(
-        self, db_with_cleanup: ExtendedAsyncSAEngine, sample_domain: str
+        self, db_with_cleanup: ExtendedAsyncSAEngine, sample_domain: DomainFixtureData
     ) -> _RegistryWithPartialGroups:
         """Pre-created registry with 2 out of 4 groups associated."""
         registry_name = str(uuid.uuid4())[:8] + ".example.com"
         project = "project-" + str(uuid.uuid4())[:8]
-        resource_policy_name = f"test-policy-{sample_domain}-4groups"
+        resource_policy_name = f"test-policy-{sample_domain.domain_name}-4groups"
         group_ids: list[UUID] = []
 
         async with db_with_cleanup.begin_session() as session:
@@ -1049,8 +1049,8 @@ class TestContainerRegistryRepository:
             # Create 4 groups
             for i in range(4):
                 group = GroupRow(
-                    name=f"test-group-{i}-{sample_domain}-partial",
-                    domain_name=sample_domain,
+                    name=f"test-group-{i}-{sample_domain.domain_name}-partial",
+                    domain_name=sample_domain.domain_name,
                     total_resource_slots=ResourceSlot(),
                     resource_policy=resource_policy_name,
                 )

--- a/tests/unit/manager/repositories/container_registry_quota/test_container_registry_quota_repository.py
+++ b/tests/unit/manager/repositories/container_registry_quota/test_container_registry_quota_repository.py
@@ -30,6 +30,7 @@ from ai.backend.manager.repositories.container_registry_quota.repository import 
 )
 from ai.backend.manager.repositories.types import RepositoryArgs
 from ai.backend.testutils.db import with_tables
+from ai.backend.testutils.fixtures import DomainFactory, DomainFixtureData
 
 
 @dataclass
@@ -97,21 +98,20 @@ class TestPerProjectRegistryQuotaRepository:
         return PerProjectRegistryQuotaRepository(db_with_cleanup)
 
     @pytest.fixture
-    async def sample_domain(self, db_with_cleanup: ExtendedAsyncSAEngine) -> str:
-        """Pre-created domain for group tests. Returns domain name."""
-        domain_name = "test-domain-" + str(uuid.uuid4())[:8]
-        async with db_with_cleanup.begin_session() as session:
-            domain = DomainRow(name=domain_name, total_resource_slots=ResourceSlot())
-            session.add(domain)
-            await session.commit()
-        return domain_name
+    async def sample_domain(
+        self,
+        domain_factory: DomainFactory,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> DomainFixtureData:
+        """Pre-created domain for group tests."""
+        return await domain_factory(db_with_cleanup)
 
     @pytest.fixture
     async def sample_resource_policy(
-        self, db_with_cleanup: ExtendedAsyncSAEngine, sample_domain: str
+        self, db_with_cleanup: ExtendedAsyncSAEngine, sample_domain: DomainFixtureData
     ) -> str:
         """Pre-created resource policy. Returns policy name."""
-        policy_name = f"test-policy-{sample_domain}"
+        policy_name = f"test-policy-{sample_domain.domain_name}"
         async with db_with_cleanup.begin_session() as session:
             project_policy = ProjectResourcePolicyRow(
                 name=policy_name,
@@ -127,7 +127,7 @@ class TestPerProjectRegistryQuotaRepository:
     async def project_with_registry(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         sample_resource_policy: str,
     ) -> _ProjectWithRegistry:
         """Pre-created project with valid container_registry config linked to a ContainerRegistryRow."""
@@ -157,7 +157,7 @@ class TestPerProjectRegistryQuotaRepository:
 
             group = GroupRow(
                 name=f"test-group-{str(uuid.uuid4())[:8]}",
-                domain_name=sample_domain,
+                domain_name=sample_domain.domain_name,
                 total_resource_slots=ResourceSlot(),
                 resource_policy=sample_resource_policy,
                 container_registry={
@@ -189,14 +189,14 @@ class TestPerProjectRegistryQuotaRepository:
     async def project_without_registry(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         sample_resource_policy: str,
     ) -> _ProjectWithoutRegistry:
         """Pre-created project with no container_registry configured."""
         async with db_with_cleanup.begin_session() as session:
             group = GroupRow(
                 name=f"test-group-no-reg-{str(uuid.uuid4())[:8]}",
-                domain_name=sample_domain,
+                domain_name=sample_domain.domain_name,
                 total_resource_slots=ResourceSlot(),
                 resource_policy=sample_resource_policy,
                 container_registry=None,
@@ -212,14 +212,14 @@ class TestPerProjectRegistryQuotaRepository:
     async def project_with_invalid_registry(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         sample_resource_policy: str,
     ) -> _ProjectWithInvalidRegistry:
         """Pre-created project with empty container_registry dict (missing required keys)."""
         async with db_with_cleanup.begin_session() as session:
             group = GroupRow(
                 name=f"test-group-invalid-{str(uuid.uuid4())[:8]}",
-                domain_name=sample_domain,
+                domain_name=sample_domain.domain_name,
                 total_resource_slots=ResourceSlot(),
                 resource_policy=sample_resource_policy,
                 container_registry={},
@@ -235,14 +235,14 @@ class TestPerProjectRegistryQuotaRepository:
     async def project_with_orphaned_registry(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         sample_resource_policy: str,
     ) -> _ProjectWithOrphanedRegistry:
         """Pre-created project whose container_registry config points to a non-existent registry."""
         async with db_with_cleanup.begin_session() as session:
             group = GroupRow(
                 name=f"test-group-orphan-{str(uuid.uuid4())[:8]}",
-                domain_name=sample_domain,
+                domain_name=sample_domain.domain_name,
                 total_resource_slots=ResourceSlot(),
                 resource_policy=sample_resource_policy,
                 container_registry={
@@ -261,7 +261,7 @@ class TestPerProjectRegistryQuotaRepository:
     async def project_with_minimal_registry(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         sample_resource_policy: str,
     ) -> _ProjectWithRegistry:
         """Pre-created project with a registry that has only required fields (no username/password/extra)."""
@@ -281,7 +281,7 @@ class TestPerProjectRegistryQuotaRepository:
 
             group = GroupRow(
                 name=f"test-group-minimal-{str(uuid.uuid4())[:8]}",
-                domain_name=sample_domain,
+                domain_name=sample_domain.domain_name,
                 total_resource_slots=ResourceSlot(),
                 resource_policy=sample_resource_policy,
                 container_registry={

--- a/tests/unit/manager/repositories/domain/test_domain_purgers.py
+++ b/tests/unit/manager/repositories/domain/test_domain_purgers.py
@@ -37,6 +37,7 @@ from ai.backend.manager.repositories.domain.purgers import (
     DomainKernelBatchPurgerSpec,
 )
 from ai.backend.testutils.db import with_tables
+from ai.backend.testutils.fixtures import DomainFactory, DomainFixtureData
 
 if TYPE_CHECKING:
     from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
@@ -71,22 +72,13 @@ class TestDomainPurgersIntegration:
             yield database_connection
 
     @pytest.fixture
-    async def sample_domain(self, db_with_cleanup: ExtendedAsyncSAEngine) -> str:
+    async def sample_domain(
+        self,
+        domain_factory: DomainFactory,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> DomainFixtureData:
         """Create a test domain."""
-        domain_name = f"test-domain-{uuid.uuid4().hex[:8]}"
-        async with db_with_cleanup.begin_session() as session:
-            domain = DomainRow(
-                name=domain_name,
-                description=f"Test domain {domain_name}",
-                is_active=True,
-                total_resource_slots=ResourceSlot({}),
-                allowed_vfolder_hosts=VFolderHostPermissionMap({}),
-                allowed_docker_registries=[],
-                dotfiles=b"",
-                integration_id=None,
-            )
-            session.add(domain)
-        return domain_name
+        return await domain_factory(db_with_cleanup)
 
     @pytest.fixture
     async def project_resource_policy(self, db_with_cleanup: ExtendedAsyncSAEngine) -> str:
@@ -121,7 +113,7 @@ class TestDomainPurgersIntegration:
     async def sample_user(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         user_resource_policy: str,
     ) -> UserRow:
         """Create a test user."""
@@ -143,7 +135,7 @@ class TestDomainPurgersIntegration:
                 description="Test user for integration tests",
                 status=UserStatus.ACTIVE,
                 status_info="",
-                domain_name=sample_domain,
+                domain_name=sample_domain.domain_name,
                 role=UserRole.USER,
                 resource_policy=user_resource_policy,
             )
@@ -156,7 +148,7 @@ class TestDomainPurgersIntegration:
     async def sample_group(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         project_resource_policy: str,
     ) -> GroupRow:
         """Create a test group."""
@@ -167,7 +159,7 @@ class TestDomainPurgersIntegration:
                 name=f"test-group-{uuid.uuid4().hex[:8]}",
                 description="Test group for integration tests",
                 is_active=True,
-                domain_name=sample_domain,
+                domain_name=sample_domain.domain_name,
                 total_resource_slots=ResourceSlot({}),
                 allowed_vfolder_hosts=VFolderHostPermissionMap({}),
                 dotfiles=b"\x90",
@@ -184,7 +176,7 @@ class TestDomainPurgersIntegration:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
         sample_group: GroupRow,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         sample_user: UserRow,
     ) -> list[SessionRow]:
         """Create test sessions belonging to the domain."""
@@ -196,7 +188,7 @@ class TestDomainPurgersIntegration:
                     session_type=SessionTypes.INTERACTIVE,
                     cluster_mode="single-node",
                     cluster_size=1,
-                    domain_name=sample_domain,
+                    domain_name=sample_domain.domain_name,
                     group_id=sample_group.id,
                     user_uuid=sample_user.uuid,
                     occupying_slots=ResourceSlot({}),
@@ -219,7 +211,7 @@ class TestDomainPurgersIntegration:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
         sample_sessions: list[SessionRow],
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         sample_group: GroupRow,
         sample_user: UserRow,
     ) -> list[KernelRow]:
@@ -229,7 +221,7 @@ class TestDomainPurgersIntegration:
             for sess in sample_sessions:
                 kernel = KernelRow(
                     session_id=sess.id,
-                    domain_name=sample_domain,
+                    domain_name=sample_domain.domain_name,
                     group_id=sample_group.id,
                     user_uuid=sample_user.uuid,
                     occupied_slots=ResourceSlot({}),
@@ -252,11 +244,11 @@ class TestDomainPurgersIntegration:
     async def test_purge_domain_kernels(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         sample_kernels: list[KernelRow],
     ) -> None:
         """Test purging kernels belonging to a domain."""
-        domain_name = sample_domain
+        domain_name = sample_domain.domain_name
 
         # Purge kernels
         async with db_with_cleanup.begin_session() as session:
@@ -276,10 +268,10 @@ class TestDomainPurgersIntegration:
     async def test_purge_domain(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
     ) -> None:
         """Test purging the domain itself."""
-        domain_name = sample_domain
+        domain_name = sample_domain.domain_name
 
         # Purge domain
         async with db_with_cleanup.begin_session() as session:

--- a/tests/unit/manager/repositories/group/test_group_purgers.py
+++ b/tests/unit/manager/repositories/group/test_group_purgers.py
@@ -45,6 +45,7 @@ from ai.backend.manager.repositories.group.purgers import (
     SessionByIdsBatchPurgerSpec,
 )
 from ai.backend.testutils.db import with_tables
+from ai.backend.testutils.fixtures import DomainFactory, DomainFixtureData
 
 if TYPE_CHECKING:
     from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
@@ -82,22 +83,13 @@ class TestGroupPurgersIntegration:
             yield database_connection
 
     @pytest.fixture
-    async def sample_domain(self, db_with_cleanup: ExtendedAsyncSAEngine) -> str:
+    async def sample_domain(
+        self,
+        domain_factory: DomainFactory,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> DomainFixtureData:
         """Create a test domain."""
-        domain_name = f"test-domain-{uuid.uuid4().hex[:8]}"
-        async with db_with_cleanup.begin_session() as session:
-            domain = DomainRow(
-                name=domain_name,
-                description=f"Test domain {domain_name}",
-                is_active=True,
-                total_resource_slots=ResourceSlot(),
-                allowed_vfolder_hosts={},
-                allowed_docker_registries=[],
-                dotfiles=b"",
-                integration_id=None,
-            )
-            session.add(domain)
-        return domain_name
+        return await domain_factory(db_with_cleanup)
 
     @pytest.fixture
     async def project_resource_policy(self, db_with_cleanup: ExtendedAsyncSAEngine) -> str:
@@ -132,7 +124,7 @@ class TestGroupPurgersIntegration:
     async def sample_user(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         user_resource_policy: str,
     ) -> UserRow:
         """Create a test user."""
@@ -154,7 +146,7 @@ class TestGroupPurgersIntegration:
                 description="Test user for integration tests",
                 status=UserStatus.ACTIVE,
                 status_info="",
-                domain_name=sample_domain,
+                domain_name=sample_domain.domain_name,
                 role=UserRole.USER,
                 resource_policy=user_resource_policy,
             )
@@ -167,7 +159,7 @@ class TestGroupPurgersIntegration:
     async def sample_group(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         project_resource_policy: str,
     ) -> GroupRow:
         """Create a test group."""
@@ -178,7 +170,7 @@ class TestGroupPurgersIntegration:
                 name=f"test-group-{uuid.uuid4().hex[:8]}",
                 description="Test group for integration tests",
                 is_active=True,
-                domain_name=sample_domain,
+                domain_name=sample_domain.domain_name,
                 total_resource_slots=ResourceSlot(),
                 allowed_vfolder_hosts={},
                 dotfiles=b"\x90",
@@ -210,7 +202,7 @@ class TestGroupPurgersIntegration:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
         sample_group: GroupRow,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         sample_user: UserRow,
     ) -> list[SessionRow]:
         """Create test sessions belonging to the group."""
@@ -222,7 +214,7 @@ class TestGroupPurgersIntegration:
                     session_type=SessionTypes.INTERACTIVE,
                     cluster_mode="single-node",
                     cluster_size=1,
-                    domain_name=sample_domain,
+                    domain_name=sample_domain.domain_name,
                     group_id=sample_group.id,
                     user_uuid=sample_user.uuid,
                     occupying_slots=ResourceSlot({}),
@@ -245,7 +237,7 @@ class TestGroupPurgersIntegration:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
         sample_sessions: list[SessionRow],
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         sample_group: GroupRow,
         sample_user: UserRow,
     ) -> list[KernelRow]:
@@ -255,7 +247,7 @@ class TestGroupPurgersIntegration:
             for sess in sample_sessions:
                 kernel = KernelRow(
                     session_id=sess.id,
-                    domain_name=sample_domain,
+                    domain_name=sample_domain.domain_name,
                     group_id=sample_group.id,
                     user_uuid=sample_user.uuid,
                     occupied_slots=ResourceSlot({}),
@@ -279,7 +271,7 @@ class TestGroupPurgersIntegration:
     async def sample_endpoints(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         sample_group: GroupRow,
         sample_user: UserRow,
         sample_scaling_group: str,
@@ -292,7 +284,7 @@ class TestGroupPurgersIntegration:
                     name=f"test-endpoint-{i}-{uuid.uuid4().hex[:8]}",
                     created_user=sample_user.uuid,
                     session_owner=sample_user.uuid,
-                    domain=sample_domain,
+                    domain=sample_domain.domain_name,
                     project=sample_group.id,
                     resource_group=sample_scaling_group,
                     lifecycle_stage=EndpointLifecycle.DESTROYED,
@@ -311,7 +303,7 @@ class TestGroupPurgersIntegration:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
         sample_endpoints: list[EndpointRow],
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         sample_group: GroupRow,
         sample_user: UserRow,
     ) -> tuple[list[SessionRow], list[RoutingRow]]:
@@ -326,7 +318,7 @@ class TestGroupPurgersIntegration:
                     session_type=SessionTypes.INFERENCE,
                     cluster_mode="single-node",
                     cluster_size=1,
-                    domain_name=sample_domain,
+                    domain_name=sample_domain.domain_name,
                     group_id=sample_group.id,
                     user_uuid=sample_user.uuid,
                     occupying_slots=ResourceSlot({}),
@@ -348,7 +340,7 @@ class TestGroupPurgersIntegration:
                     endpoint=endpoint.id,
                     session=sess.id,
                     session_owner=sample_user.uuid,
-                    domain=sample_domain,
+                    domain=sample_domain.domain_name,
                     project=sample_group.id,
                     status=RouteStatus.TERMINATED,
                     traffic_ratio=1.0,

--- a/tests/unit/manager/repositories/scaling_group/test_scaling_group_repository.py
+++ b/tests/unit/manager/repositories/scaling_group/test_scaling_group_repository.py
@@ -81,6 +81,7 @@ from ai.backend.manager.repositories.scaling_group.updaters import (
 )
 from ai.backend.manager.types import OptionalState, TriState
 from ai.backend.testutils.db import with_tables
+from ai.backend.testutils.fixtures import DomainFactory, DomainFixtureData
 
 
 class TestScalingGroupRepositoryDB:
@@ -477,20 +478,11 @@ class TestScalingGroupRepositoryDB:
     @pytest.fixture
     async def sample_domain(
         self,
+        domain_factory: DomainFactory,
         db_with_cleanup: ExtendedAsyncSAEngine,
-    ) -> AsyncGenerator[str, None]:
+    ) -> DomainFixtureData:
         """Create a sample domain for testing"""
-        domain_name = "test-domain-for-sgroup"
-        async with db_with_cleanup.begin_session() as db_sess:
-            domain = DomainRow(
-                name=domain_name,
-                description="Test domain",
-                is_active=True,
-                total_resource_slots=ResourceSlot(),
-            )
-            db_sess.add(domain)
-
-        yield domain_name
+        return await domain_factory(db_with_cleanup, name="test-domain-for-sgroup")
 
     @pytest.fixture
     async def sample_scaling_group_for_association(
@@ -796,7 +788,7 @@ class TestScalingGroupRepositoryDB:
         self,
         scaling_group_repository: ScalingGroupRepository,
         sample_scaling_group_for_association: str,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
     ) -> None:
         """Test associating a scaling group with domains"""
         binder = RBACScopeBinder(
@@ -804,7 +796,7 @@ class TestScalingGroupRepositoryDB:
                 RBACScopeBindingPair(
                     spec=ScalingGroupForDomainCreatorSpec(
                         scaling_group=sample_scaling_group_for_association,
-                        domain=sample_domain,
+                        domain=sample_domain.domain_name,
                     ),
                     entity_ref=RBACElementRef(
                         RBACElementType.RESOURCE_GROUP,
@@ -812,7 +804,7 @@ class TestScalingGroupRepositoryDB:
                     ),
                     scope_ref=RBACElementRef(
                         RBACElementType.DOMAIN,
-                        sample_domain,
+                        sample_domain.domain_name,
                     ),
                 )
             ]
@@ -823,7 +815,7 @@ class TestScalingGroupRepositoryDB:
         association_exists = (
             await scaling_group_repository.check_scaling_group_domain_association_exists(
                 scaling_group=sample_scaling_group_for_association,
-                domain=sample_domain,
+                domain=sample_domain.domain_name,
             )
         )
         assert association_exists is True
@@ -833,17 +825,17 @@ class TestScalingGroupRepositoryDB:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
         sample_scaling_group_for_association: str,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
     ) -> AsyncGenerator[tuple[str, str], None]:
         """Create a scaling group with a single domain association for testing"""
         async with db_with_cleanup.begin_session() as db_sess:
             association = ScalingGroupForDomainRow(
                 scaling_group=sample_scaling_group_for_association,
-                domain=sample_domain,
+                domain=sample_domain.domain_name,
             )
             db_sess.add(association)
 
-        yield sample_scaling_group_for_association, sample_domain
+        yield sample_scaling_group_for_association, sample_domain.domain_name
 
     # Disassociate with Domain Tests
     async def test_disassociate_scaling_group_with_domains_success(
@@ -871,13 +863,13 @@ class TestScalingGroupRepositoryDB:
         self,
         scaling_group_repository: ScalingGroupRepository,
         sample_scaling_group_for_association: str,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
     ) -> None:
         """Test disassociating a non-existent association (should not raise error)"""
         # Disassociate without prior association should succeed without error
         unbinder = ResourceGroupDomainEntityUnbinder(
             scaling_groups=[sample_scaling_group_for_association],
-            domain=sample_domain,
+            domain=sample_domain.domain_name,
         )
         await scaling_group_repository.disassociate_scaling_group_with_domains(unbinder)
 

--- a/tests/unit/manager/repositories/user/test_user_purgers.py
+++ b/tests/unit/manager/repositories/user/test_user_purgers.py
@@ -51,6 +51,7 @@ from ai.backend.manager.repositories.user.purgers import (
     create_user_vfolder_permission_purger,
 )
 from ai.backend.testutils.db import with_tables
+from ai.backend.testutils.fixtures import DomainFactory, DomainFixtureData
 
 if TYPE_CHECKING:
     from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
@@ -212,22 +213,13 @@ class TestUserPurgersIntegration:
             yield database_connection
 
     @pytest.fixture
-    async def sample_domain(self, db_with_cleanup: ExtendedAsyncSAEngine) -> str:
+    async def sample_domain(
+        self,
+        domain_factory: DomainFactory,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> DomainFixtureData:
         """Create a test domain."""
-        domain_name = f"test-domain-{uuid.uuid4().hex[:8]}"
-        async with db_with_cleanup.begin_session() as session:
-            domain = DomainRow(
-                name=domain_name,
-                description=f"Test domain {domain_name}",
-                is_active=True,
-                total_resource_slots=ResourceSlot(),
-                allowed_vfolder_hosts={},
-                allowed_docker_registries=[],
-                dotfiles=b"",
-                integration_id=None,
-            )
-            session.add(domain)
-        return domain_name
+        return await domain_factory(db_with_cleanup)
 
     @pytest.fixture
     async def user_resource_policy(self, db_with_cleanup: ExtendedAsyncSAEngine) -> str:
@@ -281,7 +273,7 @@ class TestUserPurgersIntegration:
     async def sample_user(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         user_resource_policy: str,
         test_password_info: PasswordInfo,
     ) -> UserRow:
@@ -298,7 +290,7 @@ class TestUserPurgersIntegration:
                 description="Test Description",
                 status=UserStatus.ACTIVE,
                 status_info="admin-requested",
-                domain_name=sample_domain,
+                domain_name=sample_domain.domain_name,
                 role=UserRole.USER,
                 resource_policy=user_resource_policy,
             )
@@ -362,7 +354,7 @@ class TestUserPurgersIntegration:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
         sample_user: UserRow,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         project_resource_policy: str,
     ) -> list[AssocGroupUserRow]:
         """Create test groups and associations for the user."""
@@ -374,7 +366,7 @@ class TestUserPurgersIntegration:
                     name=f"test-group-{uuid.uuid4().hex[:8]}",
                     description="Test group",
                     is_active=True,
-                    domain_name=sample_domain,
+                    domain_name=sample_domain.domain_name,
                     total_resource_slots=ResourceSlot(),
                     allowed_vfolder_hosts={},
                     integration_id=None,
@@ -397,7 +389,7 @@ class TestUserPurgersIntegration:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
         sample_user: UserRow,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
     ) -> list[VFolderPermissionRow]:
         """Create test vfolder and permissions for the user."""
         permissions: list[VFolderPermissionRow] = []
@@ -406,7 +398,7 @@ class TestUserPurgersIntegration:
             vfolder = VFolderRow(
                 id=vfolder_id,
                 host="local",
-                domain_name=sample_domain,
+                domain_name=sample_domain.domain_name,
                 quota_scope_id=QuotaScopeID(QuotaScopeType.USER, sample_user.uuid),
                 name=f"test-vfolder-{uuid.uuid4().hex[:8]}",
                 usage_mode=VFolderUsageMode.GENERAL,

--- a/tests/unit/manager/repositories/user/test_user_repository.py
+++ b/tests/unit/manager/repositories/user/test_user_repository.py
@@ -57,6 +57,7 @@ from ai.backend.manager.repositories.user.updaters import UserUpdaterSpec
 from ai.backend.manager.services.user.types import UserCreateSpec, UserUpdateSpec
 from ai.backend.manager.types import OptionalState, TriState
 from ai.backend.testutils.db import with_tables
+from ai.backend.testutils.fixtures import DomainFactory, DomainFixtureData
 
 
 @dataclass(frozen=True)
@@ -126,23 +127,13 @@ class TestUserRepository:
         return UserRepository(db=db_with_cleanup)
 
     @pytest.fixture
-    async def sample_domain(self, db_with_cleanup: ExtendedAsyncSAEngine) -> str:
-        """Create a test domain and return its name."""
-        domain_name = f"test-domain-{uuid.uuid4().hex[:8]}"
-        async with db_with_cleanup.begin_session() as session:
-            domain = DomainRow(
-                name=domain_name,
-                description=f"Test domain {domain_name}",
-                is_active=True,
-                total_resource_slots=ResourceSlot(),
-                allowed_vfolder_hosts={},
-                allowed_docker_registries=[],
-                dotfiles=b"",
-                integration_id=None,
-            )
-            session.add(domain)
-            await session.commit()
-        return domain_name
+    async def sample_domain(
+        self,
+        domain_factory: DomainFactory,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> DomainFixtureData:
+        """Create a test domain and return its identifiers."""
+        return await domain_factory(db_with_cleanup)
 
     @pytest.fixture
     async def user_resource_policy(self, db_with_cleanup: ExtendedAsyncSAEngine) -> str:
@@ -199,7 +190,7 @@ class TestUserRepository:
     async def sample_user_email(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         user_resource_policy: str,
     ) -> str:
         """Create a test user and return the email."""
@@ -215,7 +206,7 @@ class TestUserRepository:
                 description="Test Description",
                 status=UserStatus.ACTIVE,
                 status_info="admin-requested",
-                domain_name=sample_domain,
+                domain_name=sample_domain.domain_name,
                 role=UserRole.USER,
                 resource_policy=user_resource_policy,
             )
@@ -227,7 +218,7 @@ class TestUserRepository:
     async def sample_user_username(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         user_resource_policy: str,
     ) -> str:
         """Create a test user and return the username."""
@@ -243,7 +234,7 @@ class TestUserRepository:
                 description="Test Description",
                 status=UserStatus.ACTIVE,
                 status_info="admin-requested",
-                domain_name=sample_domain,
+                domain_name=sample_domain.domain_name,
                 role=UserRole.USER,
                 resource_policy=user_resource_policy,
             )
@@ -255,7 +246,7 @@ class TestUserRepository:
     async def sample_group_id(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         project_resource_policy: str,
     ) -> str:
         """Create a test group with both admin and member roles bound at
@@ -271,7 +262,7 @@ class TestUserRepository:
                 name=f"test-group-{uuid.uuid4().hex[:8]}",
                 description="Test group",
                 is_active=True,
-                domain_name=sample_domain,
+                domain_name=sample_domain.domain_name,
                 total_resource_slots=ResourceSlot(),
                 allowed_vfolder_hosts={},
                 integration_id=None,
@@ -303,7 +294,7 @@ class TestUserRepository:
     @pytest.fixture
     def sample_user_creator(
         self,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         user_resource_policy: str,
     ) -> Creator[UserRow]:
         """Create a Creator for a test user."""
@@ -315,7 +306,7 @@ class TestUserRepository:
             full_name="Test User",
             description="Test Description",
             status=UserStatus.ACTIVE,
-            domain_name=sample_domain,
+            domain_name=sample_domain.domain_name,
             role=UserRole.USER,
             resource_policy=user_resource_policy,
             allowed_client_ip=None,
@@ -370,7 +361,7 @@ class TestUserRepository:
     async def test_create_user_validated_success(
         self,
         user_repository: UserRepository,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         user_resource_policy: str,
         default_keypair_resource_policy: str,
         sample_group_id: str,
@@ -385,7 +376,7 @@ class TestUserRepository:
             full_name="New User",
             description="New User Description",
             status=UserStatus.ACTIVE,
-            domain_name=sample_domain,
+            domain_name=sample_domain.domain_name,
             role=UserRole.USER,
             resource_policy=user_resource_policy,
             allowed_client_ip=None,
@@ -443,7 +434,7 @@ class TestUserRepository:
         self,
         user_repository: UserRepository,
         sample_user_email: str,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         user_resource_policy: str,
     ) -> None:
         """Test user creation fails when email already exists"""
@@ -456,7 +447,7 @@ class TestUserRepository:
             full_name="New User",
             description="New User Description",
             status=UserStatus.ACTIVE,
-            domain_name=sample_domain,
+            domain_name=sample_domain.domain_name,
             role=UserRole.USER,
             resource_policy=user_resource_policy,
             allowed_client_ip=None,
@@ -475,7 +466,7 @@ class TestUserRepository:
         self,
         user_repository: UserRepository,
         sample_user_username: str,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         user_resource_policy: str,
     ) -> None:
         """Test user creation fails when username already exists"""
@@ -487,7 +478,7 @@ class TestUserRepository:
             full_name="New User",
             description="New User Description",
             status=UserStatus.ACTIVE,
-            domain_name=sample_domain,
+            domain_name=sample_domain.domain_name,
             role=UserRole.USER,
             resource_policy=user_resource_policy,
             allowed_client_ip=None,
@@ -506,7 +497,7 @@ class TestUserRepository:
     async def model_store_project_id(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         project_resource_policy: str,
     ) -> uuid.UUID:
         """Create a model store project and return its id."""
@@ -517,7 +508,7 @@ class TestUserRepository:
                 name=f"model-store-{uuid.uuid4().hex[:8]}",
                 description="Model Store Project",
                 is_active=True,
-                domain_name=sample_domain,
+                domain_name=sample_domain.domain_name,
                 total_resource_slots=ResourceSlot(),
                 allowed_vfolder_hosts={},
                 integration_id=None,
@@ -532,7 +523,7 @@ class TestUserRepository:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
         user_repository: UserRepository,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         user_resource_policy: str,
         default_keypair_resource_policy: str,
     ) -> None:
@@ -546,7 +537,7 @@ class TestUserRepository:
             full_name="New User",
             description="New User Description",
             status=UserStatus.ACTIVE,
-            domain_name=sample_domain,
+            domain_name=sample_domain.domain_name,
             role=UserRole.USER,
             resource_policy=user_resource_policy,
             allowed_client_ip=None,
@@ -567,7 +558,7 @@ class TestUserRepository:
                     AssociationScopesEntitiesRow.entity_type == EntityType.USER,
                     AssociationScopesEntitiesRow.entity_id == str(result.user.uuid),
                     AssociationScopesEntitiesRow.scope_type == ScopeType.DOMAIN,
-                    AssociationScopesEntitiesRow.scope_id == sample_domain,
+                    AssociationScopesEntitiesRow.scope_id == sample_domain.domain_name,
                 )
             )
             assert domain_assoc is not None
@@ -576,7 +567,7 @@ class TestUserRepository:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
         user_repository: UserRepository,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         user_resource_policy: str,
         default_keypair_resource_policy: str,
         sample_group_id: str,
@@ -591,7 +582,7 @@ class TestUserRepository:
             full_name="New User",
             description="New User Description",
             status=UserStatus.ACTIVE,
-            domain_name=sample_domain,
+            domain_name=sample_domain.domain_name,
             role=UserRole.USER,
             resource_policy=user_resource_policy,
             allowed_client_ip=None,
@@ -621,7 +612,7 @@ class TestUserRepository:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
         user_repository: UserRepository,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         user_resource_policy: str,
         default_keypair_resource_policy: str,
         model_store_project_id: uuid.UUID,
@@ -636,7 +627,7 @@ class TestUserRepository:
             full_name="New User",
             description="New User Description",
             status=UserStatus.ACTIVE,
-            domain_name=sample_domain,
+            domain_name=sample_domain.domain_name,
             role=UserRole.USER,
             resource_policy=user_resource_policy,
             allowed_client_ip=None,
@@ -938,7 +929,7 @@ class TestUserRepository:
     async def test_bulk_create_users_validated_success(
         self,
         user_repository: UserRepository,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         user_resource_policy: str,
         default_keypair_resource_policy: str,
     ) -> None:
@@ -954,7 +945,7 @@ class TestUserRepository:
                 full_name=f"Bulk User {i}",
                 description=f"Bulk created user {i}",
                 status=UserStatus.ACTIVE,
-                domain_name=sample_domain,
+                domain_name=sample_domain.domain_name,
                 role=UserRole.USER,
                 resource_policy=user_resource_policy,
                 allowed_client_ip=None,
@@ -973,14 +964,14 @@ class TestUserRepository:
         assert len(result.successes) == 3
         # Verify each created user has expected data
         for user_data in result.successes:
-            assert user_data.domain_name == sample_domain
+            assert user_data.domain_name == sample_domain.domain_name
             assert user_data.role == UserRole.USER
             assert user_data.status == UserStatus.ACTIVE
 
     async def test_bulk_create_users_validated_partial_failure(
         self,
         user_repository: UserRepository,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         user_resource_policy: str,
         default_keypair_resource_policy: str,
     ) -> None:
@@ -999,7 +990,7 @@ class TestUserRepository:
                 full_name=f"Bulk User {i}",
                 description=f"Bulk created user {i}",
                 status=UserStatus.ACTIVE,
-                domain_name=sample_domain,
+                domain_name=sample_domain.domain_name,
                 role=UserRole.USER,
                 resource_policy=user_resource_policy,
                 allowed_client_ip=None,
@@ -1026,7 +1017,7 @@ class TestUserRepository:
     async def test_bulk_update_users_validated_success(
         self,
         user_repository: UserRepository,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         user_resource_policy: str,
         default_keypair_resource_policy: str,
     ) -> None:
@@ -1043,7 +1034,7 @@ class TestUserRepository:
                 full_name=f"Bulk Update User {i}",
                 description=f"Bulk update test user {i}",
                 status=UserStatus.ACTIVE,
-                domain_name=sample_domain,
+                domain_name=sample_domain.domain_name,
                 role=UserRole.USER,
                 resource_policy=user_resource_policy,
                 allowed_client_ip=None,
@@ -1076,13 +1067,13 @@ class TestUserRepository:
         for i, user_data in enumerate(result.successes):
             assert user_data.full_name == f"Updated Name {i}"
             assert user_data.description == f"Updated Description {i}"
-            assert user_data.domain_name == sample_domain
+            assert user_data.domain_name == sample_domain.domain_name
             assert user_data.role == UserRole.USER
 
     async def test_bulk_update_users_validated_partial_failure(
         self,
         user_repository: UserRepository,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         user_resource_policy: str,
         default_keypair_resource_policy: str,
     ) -> None:
@@ -1097,7 +1088,7 @@ class TestUserRepository:
             full_name="Bulk Update User",
             description="Bulk update test user",
             status=UserStatus.ACTIVE,
-            domain_name=sample_domain,
+            domain_name=sample_domain.domain_name,
             role=UserRole.USER,
             resource_policy=user_resource_policy,
             allowed_client_ip=None,

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_purgers.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_purgers.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 import pytest
 import sqlalchemy as sa
 
-from ai.backend.common.types import QuotaScopeID, QuotaScopeType, ResourceSlot, VFolderUsageMode
+from ai.backend.common.types import QuotaScopeID, QuotaScopeType, VFolderUsageMode
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.vfolder.types import VFolderMountPermission, VFolderOwnershipType
 from ai.backend.manager.models.agent import AgentRow  # noqa: F401
@@ -37,6 +37,7 @@ from ai.backend.manager.repositories.vfolder.purgers import (
     VFolderPermissionBatchPurgerSpec,
 )
 from ai.backend.testutils.db import with_tables
+from ai.backend.testutils.fixtures import DomainFactory, DomainFixtureData
 
 if TYPE_CHECKING:
     from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
@@ -67,22 +68,13 @@ class TestVFolderPurgersIntegration:
             yield database_connection
 
     @pytest.fixture
-    async def sample_domain(self, db_with_cleanup: ExtendedAsyncSAEngine) -> str:
+    async def sample_domain(
+        self,
+        domain_factory: DomainFactory,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> DomainFixtureData:
         """Create a test domain."""
-        domain_name = f"test-domain-{uuid.uuid4().hex[:8]}"
-        async with db_with_cleanup.begin_session() as session:
-            domain = DomainRow(
-                name=domain_name,
-                description=f"Test domain {domain_name}",
-                is_active=True,
-                total_resource_slots=ResourceSlot(),
-                allowed_vfolder_hosts={},
-                allowed_docker_registries=[],
-                dotfiles=b"",
-                integration_id=None,
-            )
-            session.add(domain)
-        return domain_name
+        return await domain_factory(db_with_cleanup)
 
     @pytest.fixture
     async def user_resource_policy(self, db_with_cleanup: ExtendedAsyncSAEngine) -> str:
@@ -103,7 +95,7 @@ class TestVFolderPurgersIntegration:
     async def sample_user(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         user_resource_policy: str,
     ) -> UserRow:
         """Create a test user."""
@@ -125,7 +117,7 @@ class TestVFolderPurgersIntegration:
                 description="Test user for integration tests",
                 status=UserStatus.ACTIVE,
                 status_info="",
-                domain_name=sample_domain,
+                domain_name=sample_domain.domain_name,
                 role=UserRole.USER,
                 resource_policy=user_resource_policy,
             )
@@ -138,7 +130,7 @@ class TestVFolderPurgersIntegration:
     async def sample_vfolder(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
-        sample_domain: str,
+        sample_domain: DomainFixtureData,
         sample_user: UserRow,
     ) -> VFolderRow:
         """Create a test vfolder."""
@@ -147,7 +139,7 @@ class TestVFolderPurgersIntegration:
             vfolder = VFolderRow(
                 id=vfolder_id,
                 host="local",
-                domain_name=sample_domain,
+                domain_name=sample_domain.domain_name,
                 quota_scope_id=QuotaScopeID(QuotaScopeType.USER, sample_user.uuid),
                 name=f"test-vfolder-{uuid.uuid4().hex[:8]}",
                 usage_mode=VFolderUsageMode.GENERAL,

--- a/tests/unit/manager/services/scaling_group/conftest.py
+++ b/tests/unit/manager/services/scaling_group/conftest.py
@@ -46,6 +46,7 @@ from ai.backend.manager.repositories.scaling_group.repository import ScalingGrou
 from ai.backend.manager.services.scaling_group.processors import ScalingGroupProcessors
 from ai.backend.manager.services.scaling_group.service import ScalingGroupService
 from ai.backend.testutils.db import with_tables
+from ai.backend.testutils.fixtures import DomainFactory, DomainFixtureData
 
 
 @dataclass
@@ -193,29 +194,19 @@ async def resource_policy_fixture(
 
 @pytest.fixture
 async def domain_fixture(
+    domain_factory: DomainFactory,
     database_engine: ExtendedAsyncSAEngine,
     database_fixture: None,
-) -> AsyncIterator[str]:
-    """Insert a test domain and yield its name."""
-    domain_name = f"domain-{secrets.token_hex(6)}"
-    async with database_engine.begin() as conn:
-        await conn.execute(
-            sa.insert(DomainRow.__table__).values(
-                name=domain_name,
-                description=f"Test domain {domain_name}",
-                is_active=True,
-                total_resource_slots=ResourceSlot(),
-                allowed_vfolder_hosts=VFolderHostPermissionMap(),
-            )
-        )
-    yield domain_name
+) -> DomainFixtureData:
+    """Insert a test domain and yield its identifiers."""
+    return await domain_factory(database_engine, name=f"domain-{secrets.token_hex(6)}")
     # Cleanup handled by database_fixture TRUNCATE CASCADE
 
 
 @pytest.fixture
 async def admin_user_fixture(
     database_engine: ExtendedAsyncSAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[Any]:
     """Insert an admin user and keypair; yield UserFixtureData."""
@@ -233,7 +224,7 @@ async def admin_user_fixture(
                 email=email,
                 need_password_change=False,
                 status=UserStatus.ACTIVE,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
                 role=UserRole.SUPERADMIN,
             )
@@ -262,7 +253,7 @@ async def admin_user_fixture(
 @pytest.fixture
 async def regular_user_fixture(
     database_engine: ExtendedAsyncSAEngine,
-    domain_fixture: str,
+    domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
 ) -> AsyncIterator[Any]:
     """Insert a regular user and keypair; yield UserFixtureData."""
@@ -280,7 +271,7 @@ async def regular_user_fixture(
                 email=email,
                 need_password_change=False,
                 status=UserStatus.ACTIVE,
-                domain_name=domain_fixture,
+                domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
                 role=UserRole.USER,
             )

--- a/tests/unit/manager/services/scaling_group/test_scaling_group_crud.py
+++ b/tests/unit/manager/services/scaling_group/test_scaling_group_crud.py
@@ -70,6 +70,7 @@ from ai.backend.manager.services.scaling_group.actions.purge_scaling_group impor
 )
 from ai.backend.manager.services.scaling_group.processors import ScalingGroupProcessors
 from ai.backend.manager.types import OptionalState, TriState
+from ai.backend.testutils.fixtures import DomainFixtureData
 
 # ---------------------------------------------------------------------------
 # Module-level helpers — shared across all test classes
@@ -297,7 +298,7 @@ class TestScalingGroupDomainAssociation:
         self,
         scaling_group_processors: ScalingGroupProcessors,
         scaling_group_repository: ScalingGroupRepository,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         database_fixture: None,
     ) -> None:
         """S-1: Associate a scaling group with a single domain; association exists in DB."""
@@ -309,10 +310,10 @@ class TestScalingGroupDomainAssociation:
                     RBACScopeBindingPair(
                         spec=ScalingGroupForDomainCreatorSpec(
                             scaling_group=name,
-                            domain=domain_fixture,
+                            domain=domain_fixture.domain_name,
                         ),
                         entity_ref=RBACElementRef(RBACElementType.RESOURCE_GROUP, name),
-                        scope_ref=RBACElementRef(RBACElementType.DOMAIN, domain_fixture),
+                        scope_ref=RBACElementRef(RBACElementType.DOMAIN, domain_fixture.domain_name),
                     )
                 ]
             )
@@ -322,7 +323,7 @@ class TestScalingGroupDomainAssociation:
 
             exists = await scaling_group_repository.check_scaling_group_domain_association_exists(
                 scaling_group=name,
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
             )
             assert exists is True
         finally:
@@ -336,7 +337,7 @@ class TestScalingGroupDomainAssociation:
         self,
         scaling_group_processors: ScalingGroupProcessors,
         scaling_group_repository: ScalingGroupRepository,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         database_fixture: None,
     ) -> None:
         """S-3: Disassociate domain; check_exists returns False afterwards."""
@@ -349,10 +350,10 @@ class TestScalingGroupDomainAssociation:
                     RBACScopeBindingPair(
                         spec=ScalingGroupForDomainCreatorSpec(
                             scaling_group=name,
-                            domain=domain_fixture,
+                            domain=domain_fixture.domain_name,
                         ),
                         entity_ref=RBACElementRef(RBACElementType.RESOURCE_GROUP, name),
-                        scope_ref=RBACElementRef(RBACElementType.DOMAIN, domain_fixture),
+                        scope_ref=RBACElementRef(RBACElementType.DOMAIN, domain_fixture.domain_name),
                     )
                 ]
             )
@@ -364,14 +365,14 @@ class TestScalingGroupDomainAssociation:
             assert (
                 await scaling_group_repository.check_scaling_group_domain_association_exists(
                     scaling_group=name,
-                    domain=domain_fixture,
+                    domain=domain_fixture.domain_name,
                 )
             ) is True
 
             # Now disassociate
             unbinder = ResourceGroupDomainEntityUnbinder(
                 scaling_groups=[name],
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
             )
             await (
                 scaling_group_processors.disassociate_scaling_group_with_domains.wait_for_complete(
@@ -382,7 +383,7 @@ class TestScalingGroupDomainAssociation:
             # Association should be gone
             exists = await scaling_group_repository.check_scaling_group_domain_association_exists(
                 scaling_group=name,
-                domain=domain_fixture,
+                domain=domain_fixture.domain_name,
             )
             assert exists is False
         finally:
@@ -396,7 +397,7 @@ class TestScalingGroupDomainAssociation:
         self,
         scaling_group_processors: ScalingGroupProcessors,
         scaling_group_repository: ScalingGroupRepository,
-        domain_fixture: str,
+        domain_fixture: DomainFixtureData,
         database_fixture: None,
     ) -> None:
         """S-5: check_scaling_group_domain_association_exists returns True/False correctly."""
@@ -407,7 +408,7 @@ class TestScalingGroupDomainAssociation:
             assert (
                 await scaling_group_repository.check_scaling_group_domain_association_exists(
                     scaling_group=name,
-                    domain=domain_fixture,
+                    domain=domain_fixture.domain_name,
                 )
             ) is False
 
@@ -417,10 +418,10 @@ class TestScalingGroupDomainAssociation:
                     RBACScopeBindingPair(
                         spec=ScalingGroupForDomainCreatorSpec(
                             scaling_group=name,
-                            domain=domain_fixture,
+                            domain=domain_fixture.domain_name,
                         ),
                         entity_ref=RBACElementRef(RBACElementType.RESOURCE_GROUP, name),
-                        scope_ref=RBACElementRef(RBACElementType.DOMAIN, domain_fixture),
+                        scope_ref=RBACElementRef(RBACElementType.DOMAIN, domain_fixture.domain_name),
                     )
                 ]
             )
@@ -430,7 +431,7 @@ class TestScalingGroupDomainAssociation:
             assert (
                 await scaling_group_repository.check_scaling_group_domain_association_exists(
                     scaling_group=name,
-                    domain=domain_fixture,
+                    domain=domain_fixture.domain_name,
                 )
             ) is True
         finally:

--- a/tests/unit/manager/services/scaling_group/test_scaling_group_crud.py
+++ b/tests/unit/manager/services/scaling_group/test_scaling_group_crud.py
@@ -313,7 +313,9 @@ class TestScalingGroupDomainAssociation:
                             domain=domain_fixture.domain_name,
                         ),
                         entity_ref=RBACElementRef(RBACElementType.RESOURCE_GROUP, name),
-                        scope_ref=RBACElementRef(RBACElementType.DOMAIN, domain_fixture.domain_name),
+                        scope_ref=RBACElementRef(
+                            RBACElementType.DOMAIN, domain_fixture.domain_name
+                        ),
                     )
                 ]
             )
@@ -353,7 +355,9 @@ class TestScalingGroupDomainAssociation:
                             domain=domain_fixture.domain_name,
                         ),
                         entity_ref=RBACElementRef(RBACElementType.RESOURCE_GROUP, name),
-                        scope_ref=RBACElementRef(RBACElementType.DOMAIN, domain_fixture.domain_name),
+                        scope_ref=RBACElementRef(
+                            RBACElementType.DOMAIN, domain_fixture.domain_name
+                        ),
                     )
                 ]
             )
@@ -421,7 +425,9 @@ class TestScalingGroupDomainAssociation:
                             domain=domain_fixture.domain_name,
                         ),
                         entity_ref=RBACElementRef(RBACElementType.RESOURCE_GROUP, name),
-                        scope_ref=RBACElementRef(RBACElementType.DOMAIN, domain_fixture.domain_name),
+                        scope_ref=RBACElementRef(
+                            RBACElementType.DOMAIN, domain_fixture.domain_name
+                        ),
                     )
                 ]
             )


### PR DESCRIPTION
## Summary
- Introduce `DomainFixtureData(domain_name, domain_id)` and `DomainFactory` in `ai.backend.testutils.fixtures`.
- Rework `tests/component/conftest.py::domain_fixture` to `INSERT ... RETURNING` and yield the dataclass; updated 42 component test files to access `.domain_name`.
- Add a shared `domain_factory` fixture in `tests/unit/manager/conftest.py`; rewrite 8 unit-repository `sample_domain` fixtures to delegate to it and propagate the new return type to consumers.

## Test plan
- [x] `pants check tests/component:: tests/unit/manager/repositories:: tests/unit/manager/services/scaling_group::` passes (verified locally on 289 files).
- [x] CI runs the full component + unit test suite against the new fixtures.

Resolves BA-6150