### PR TITLE
feat(BA-6152): track originating client IP on active login_sessions

### DIFF
--- a/changes/.feature.md
+++ b/changes/.feature.md
@@ -1,0 +1,1 @@
+Track the originating client IP on active login sessions, expose it as `clientIp` on `LoginSessionV2` and the v2 REST `LoginSessionNode`, and allow filtering/sorting active sessions by `client_ip`.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -8842,6 +8842,11 @@ input LoginSessionFilter
   accessKey: StringFilter = null
   createdAt: DateTimeFilter = null
   lastAccessedAt: DateTimeFilter = null
+
+  """
+  Added in UNRELEASED. Filter by the originating client IP recorded on the session.
+  """
+  clientIp: StringFilter = null
   AND: [LoginSessionFilter!] = null
   OR: [LoginSessionFilter!] = null
   NOT: [LoginSessionFilter!] = null
@@ -8862,6 +8867,7 @@ enum LoginSessionOrderField
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   STATUS @join__enumValue(graph: STRAWBERRY)
   LAST_ACCESSED_AT @join__enumValue(graph: STRAWBERRY)
+  CLIENT_IP @join__enumValue(graph: STRAWBERRY)
 }
 
 """Added in 26.4.2. Status of a login session."""
@@ -8914,6 +8920,11 @@ type LoginSessionV2 implements Node
 
   """Timestamp when the session was invalidated."""
   invalidatedAt: DateTime
+
+  """
+  Added in UNRELEASED. Originating client IP of the login that created this session, if known.
+  """
+  clientIp: String
 
   """Added in 26.4.3. The user who owns this login session."""
   user: UserV2

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -5773,6 +5773,11 @@ input LoginSessionFilter {
   accessKey: StringFilter = null
   createdAt: DateTimeFilter = null
   lastAccessedAt: DateTimeFilter = null
+
+  """
+  Added in UNRELEASED. Filter by the originating client IP recorded on the session.
+  """
+  clientIp: StringFilter = null
   AND: [LoginSessionFilter!] = null
   OR: [LoginSessionFilter!] = null
   NOT: [LoginSessionFilter!] = null
@@ -5789,6 +5794,7 @@ enum LoginSessionOrderField {
   CREATED_AT
   STATUS
   LAST_ACCESSED_AT
+  CLIENT_IP
 }
 
 """Added in 26.4.2. Status of a login session."""
@@ -5834,6 +5840,11 @@ type LoginSessionV2 implements Node {
 
   """Timestamp when the session was invalidated."""
   invalidatedAt: DateTime
+
+  """
+  Added in UNRELEASED. Originating client IP of the login that created this session, if known.
+  """
+  clientIp: String
 
   """Added in 26.4.3. The user who owns this login session."""
   user: UserV2

--- a/src/ai/backend/common/dto/manager/v2/login_session/request.py
+++ b/src/ai/backend/common/dto/manager/v2/login_session/request.py
@@ -50,6 +50,9 @@ class LoginSessionFilter(BaseRequestModel):
     last_accessed_at: DateTimeFilter | None = Field(
         default=None, description="Filter sessions by last_accessed_at datetime"
     )
+    client_ip: StringFilter | None = Field(
+        default=None, description="Client IP filter (origin IP recorded on the session)"
+    )
     AND: list[LoginSessionFilter] | None = Field(
         default=None, description="All conditions must match"
     )

--- a/src/ai/backend/common/dto/manager/v2/login_session/response.py
+++ b/src/ai/backend/common/dto/manager/v2/login_session/response.py
@@ -34,6 +34,10 @@ class LoginSessionNode(BaseResponseModel):
     invalidated_at: datetime | None = Field(
         default=None, description="Timestamp when the session was invalidated"
     )
+    client_ip: str | None = Field(
+        default=None,
+        description="Originating client IP of the login that created this session, if known",
+    )
 
 
 class AdminSearchLoginSessionsPayload(BaseResponseModel):

--- a/src/ai/backend/common/dto/manager/v2/login_session/types.py
+++ b/src/ai/backend/common/dto/manager/v2/login_session/types.py
@@ -27,3 +27,4 @@ class LoginSessionOrderField(StrEnum):
     CREATED_AT = "created_at"
     STATUS = "status"
     LAST_ACCESSED_AT = "last_accessed_at"
+    CLIENT_IP = "client_ip"

--- a/src/ai/backend/manager/api/adapters/login_session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/login_session/adapter.py
@@ -186,6 +186,17 @@ class LoginSessionAdapter(BaseAdapter):
             )
             if condition is not None:
                 conditions.append(condition)
+        if f.client_ip is not None:
+            condition = self.convert_string_filter(
+                f.client_ip,
+                contains_factory=LoginSessionConditions.by_client_ip_contains,
+                equals_factory=LoginSessionConditions.by_client_ip_equals,
+                starts_with_factory=LoginSessionConditions.by_client_ip_starts_with,
+                ends_with_factory=LoginSessionConditions.by_client_ip_ends_with,
+                in_factory=LoginSessionConditions.by_client_ip_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
         if f.AND:
             for sub_filter in f.AND:
                 conditions.extend(self._convert_filter(sub_filter))
@@ -226,6 +237,8 @@ class LoginSessionAdapter(BaseAdapter):
                     result.append(LoginSessionOrders.status(ascending))
                 case LoginSessionOrderField.LAST_ACCESSED_AT:
                     result.append(LoginSessionOrders.last_accessed_at(ascending))
+                case LoginSessionOrderField.CLIENT_IP:
+                    result.append(LoginSessionOrders.client_ip(ascending))
         return result
 
     @staticmethod
@@ -238,4 +251,5 @@ class LoginSessionAdapter(BaseAdapter):
             created_at=data.created_at,
             last_accessed_at=data.last_accessed_at,
             invalidated_at=data.invalidated_at,
+            client_ip=data.client_ip,
         )

--- a/src/ai/backend/manager/api/gql/login_session/types/filter.py
+++ b/src/ai/backend/manager/api/gql/login_session/types/filter.py
@@ -8,9 +8,11 @@ from ai.backend.common.dto.manager.v2.login_session.request import (
     LoginSessionFilter,
     LoginSessionStatusFilter,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import DateTimeFilter, StringFilter, UUIDFilter
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
+    gql_added_field,
     gql_field,
     gql_pydantic_input,
 )
@@ -50,6 +52,13 @@ class LoginSessionFilterGQL(PydanticInputMixin[LoginSessionFilter]):
     access_key: StringFilter | None = None
     created_at: DateTimeFilter | None = None
     last_accessed_at: DateTimeFilter | None = None
+    client_ip: StringFilter | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Filter by the originating client IP recorded on the session.",
+        ),
+        default=None,
+    )
 
     AND: list[Self] | None = None
     OR: list[Self] | None = None

--- a/src/ai/backend/manager/api/gql/login_session/types/node.py
+++ b/src/ai/backend/manager/api/gql/login_session/types/node.py
@@ -12,6 +12,7 @@ from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID
 
 from ai.backend.common.dto.manager.v2.login_session.response import LoginSessionNode
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     gql_added_field,
@@ -56,6 +57,13 @@ class LoginSessionV2GQL(PydanticNodeMixin[LoginSessionNode]):
     )
     invalidated_at: datetime | None = gql_field(
         description="Timestamp when the session was invalidated."
+    )
+    client_ip: str | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Originating client IP of the login that created this session, if known.",
+        ),
+        default=None,
     )
 
     @gql_added_field(

--- a/src/ai/backend/manager/api/gql/login_session/types/order.py
+++ b/src/ai/backend/manager/api/gql/login_session/types/order.py
@@ -25,6 +25,7 @@ class LoginSessionOrderFieldGQL(StrEnum):
     CREATED_AT = "created_at"
     STATUS = "status"
     LAST_ACCESSED_AT = "last_accessed_at"
+    CLIENT_IP = "client_ip"
 
 
 @gql_pydantic_input(

--- a/src/ai/backend/manager/data/auth/login_session_types.py
+++ b/src/ai/backend/manager/data/auth/login_session_types.py
@@ -17,6 +17,7 @@ class LoginSessionData:
     created_at: datetime
     last_accessed_at: datetime | None
     invalidated_at: datetime | None
+    client_ip: str | None
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/models/alembic/versions/c4d2f8b6e9a1_add_client_ip_to_login_sessions.py
+++ b/src/ai/backend/manager/models/alembic/versions/c4d2f8b6e9a1_add_client_ip_to_login_sessions.py
@@ -1,0 +1,28 @@
+"""add client_ip to login_sessions
+
+Revision ID: c4d2f8b6e9a1
+Revises: a1b3e7c2d4f5
+Create Date: 2026-05-22
+
+"""
+
+# Part of: 26.5.0
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "c4d2f8b6e9a1"
+down_revision = "a1b3e7c2d4f5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "login_sessions",
+        sa.Column("client_ip", sa.String(length=45), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("login_sessions", "client_ip")

--- a/src/ai/backend/manager/models/login_session/row.py
+++ b/src/ai/backend/manager/models/login_session/row.py
@@ -64,6 +64,9 @@ class LoginSessionRow(Base):  # type: ignore[misc]
     invalidated_at: Mapped[datetime | None] = mapped_column(
         "invalidated_at", sa.DateTime(timezone=True), nullable=True
     )
+    # 45 = INET6_ADDRSTRLEN - 1: the longest possible textual representation of an
+    # IP address is an IPv4-mapped IPv6 form like "0000:0000:0000:0000:0000:ffff:255.255.255.255".
+    client_ip: Mapped[str | None] = mapped_column("client_ip", sa.String(45), nullable=True)
 
     __table_args__ = (sa.Index("ix_login_sessions_user_id_status", "user_id", "status"),)
 
@@ -81,6 +84,7 @@ class LoginSessionRow(Base):  # type: ignore[misc]
             created_at=self.created_at,
             last_accessed_at=self.last_accessed_at,
             invalidated_at=self.invalidated_at,
+            client_ip=self.client_ip,
         )
 
 

--- a/src/ai/backend/manager/repositories/auth/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/auth/db_source/db_source.py
@@ -525,6 +525,7 @@ class AuthDBSource:
                     session_token=session_token,
                     status=LoginSessionStatus.ACTIVE,
                     login_client_type_id=login_client_type_id,
+                    client_ip=client_ip,
                 )
             )
 

--- a/src/ai/backend/manager/repositories/auth/options.py
+++ b/src/ai/backend/manager/repositories/auth/options.py
@@ -131,6 +131,62 @@ class LoginSessionConditions:
 
     by_access_key_in = staticmethod(make_string_in_factory(LoginSessionRow.access_key))
 
+    # --- client_ip string filters ---
+
+    @staticmethod
+    def by_client_ip_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = LoginSessionRow.client_ip.ilike(f"%{spec.value}%")
+            else:
+                condition = LoginSessionRow.client_ip.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_client_ip_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = sa.func.lower(LoginSessionRow.client_ip) == spec.value.lower()
+            else:
+                condition = LoginSessionRow.client_ip == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_client_ip_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = LoginSessionRow.client_ip.ilike(f"{spec.value}%")
+            else:
+                condition = LoginSessionRow.client_ip.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_client_ip_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = LoginSessionRow.client_ip.ilike(f"%{spec.value}")
+            else:
+                condition = LoginSessionRow.client_ip.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    by_client_ip_in = staticmethod(make_string_in_factory(LoginSessionRow.client_ip))
+
     # --- created_at datetime filters ---
 
     @staticmethod
@@ -224,6 +280,12 @@ class LoginSessionOrders:
         if ascending:
             return LoginSessionRow.last_accessed_at.asc()
         return LoginSessionRow.last_accessed_at.desc()
+
+    @staticmethod
+    def client_ip(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return LoginSessionRow.client_ip.asc()
+        return LoginSessionRow.client_ip.desc()
 
 
 class LoginHistoryConditions:

--- a/tests/unit/manager/repositories/auth/test_login_session_client_ip.py
+++ b/tests/unit/manager/repositories/auth/test_login_session_client_ip.py
@@ -1,0 +1,175 @@
+"""Tests that verify ``client_ip`` is persisted on the ``login_sessions`` row.
+
+``create_login_session`` writes the same client_ip to both ``login_sessions`` (the
+active session) and the ``login_history`` SUCCESS row (the audit log entry).
+This module covers the session-row side; ``test_login_history_client_ip.py``
+covers the history side.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+
+import pytest
+import sqlalchemy as sa
+
+from ai.backend.common.types import ResourceSlot
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.login_client_type.row import LoginClientTypeRow
+from ai.backend.manager.models.login_session.row import LoginHistoryRow, LoginSessionRow
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.user import UserRole, UserRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.auth.db_source.db_source import AuthDBSource
+from ai.backend.testutils.db import with_tables
+
+
+@dataclass
+class SampleUser:
+    user_id: uuid.UUID
+    domain_name: str
+    access_key: str
+
+
+class TestLoginSessionClientIP:
+    """``create_login_session`` persists ``client_ip`` on the active session row."""
+
+    @pytest.fixture
+    async def db(
+        self, database_connection: ExtendedAsyncSAEngine
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                DomainRow,
+                UserResourcePolicyRow,
+                KeyPairResourcePolicyRow,
+                UserRow,
+                KeyPairRow,
+                LoginClientTypeRow,
+                LoginSessionRow,
+                LoginHistoryRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    async def auth_db_source(self, db: ExtendedAsyncSAEngine) -> AuthDBSource:
+        return AuthDBSource(db)
+
+    @pytest.fixture
+    def client_ip(self) -> str:
+        return "1.2.3.4"
+
+    @pytest.fixture
+    async def sample(self, db: ExtendedAsyncSAEngine) -> AsyncGenerator[SampleUser, None]:
+        domain_name = f"test-domain-{uuid.uuid4()}"
+        user_uuid = uuid.uuid4()
+        email = f"test-{uuid.uuid4()}@example.com"
+        access_key = f"AKIA{uuid.uuid4().hex[:16]}"
+
+        async with db.begin_session() as db_sess:
+            db_sess.add(
+                DomainRow(
+                    name=domain_name,
+                    description="test",
+                    is_active=True,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts={},
+                    allowed_docker_registries=[],
+                )
+            )
+            db_sess.add(
+                UserResourcePolicyRow(
+                    name="test-user-policy",
+                    max_vfolder_count=10,
+                    max_quota_scope_size=-1,
+                    max_session_count_per_model_session=10,
+                    max_customized_image_count=10,
+                )
+            )
+            db_sess.add(
+                KeyPairResourcePolicyRow(
+                    name="test-keypair-policy",
+                    max_concurrent_sessions=10,
+                    max_concurrent_sftp_sessions=2,
+                    max_containers_per_session=10,
+                    idle_timeout=3600,
+                )
+            )
+            await db_sess.flush()
+
+            user_row = UserRow(
+                uuid=user_uuid,
+                username=email,
+                email=email,
+                password=None,
+                domain_name=domain_name,
+                role=UserRole.USER,
+                resource_policy="test-user-policy",
+                need_password_change=False,
+            )
+            db_sess.add(user_row)
+            await db_sess.flush()
+
+            keypair = KeyPairRow(
+                access_key=access_key,
+                secret_key="test_secret_key",
+                user_id=email,
+                user=user_uuid,
+                is_active=True,
+                resource_policy="test-keypair-policy",
+            )
+            db_sess.add(keypair)
+            await db_sess.flush()
+            user_row.main_access_key = access_key
+            await db_sess.commit()
+
+        yield SampleUser(user_id=user_uuid, domain_name=domain_name, access_key=access_key)
+
+    @staticmethod
+    async def _fetch_session_client_ip(
+        db: ExtendedAsyncSAEngine, session_token: str
+    ) -> str | None:
+        async with db.begin_readonly() as conn:
+            return await conn.scalar(
+                sa.select(LoginSessionRow.__table__.c.client_ip).where(
+                    LoginSessionRow.__table__.c.session_token == session_token
+                )
+            )
+
+    async def test_create_login_session_persists_client_ip_on_session_row(
+        self,
+        auth_db_source: AuthDBSource,
+        db: ExtendedAsyncSAEngine,
+        sample: SampleUser,
+        client_ip: str,
+    ) -> None:
+        result = await auth_db_source.create_login_session(
+            user_id=sample.user_id,
+            access_key=sample.access_key,
+            domain_name=sample.domain_name,
+            client_ip=client_ip,
+        )
+        stored = await self._fetch_session_client_ip(db, result.session_token)
+        assert stored == client_ip
+
+    async def test_client_ip_defaults_to_null_when_not_provided(
+        self,
+        auth_db_source: AuthDBSource,
+        db: ExtendedAsyncSAEngine,
+        sample: SampleUser,
+    ) -> None:
+        result = await auth_db_source.create_login_session(
+            user_id=sample.user_id,
+            access_key=sample.access_key,
+            domain_name=sample.domain_name,
+        )
+        stored = await self._fetch_session_client_ip(db, result.session_token)
+        assert stored is None


### PR DESCRIPTION
## Summary

Mirror the BA-5733 client_ip work on the **active session table** (BA-5733 only added the column to `login_history`). With this change, the manager can answer ‘where am I currently logged in from?’ and ‘show me / revoke all active sessions originating from IP X’ without joining against possibly-pruned history rows.

- Adds a nullable `client_ip VARCHAR(45)` column to `login_sessions` via a new Alembic migration (`c4d2f8b6e9a1`) chained after BA-5733's `a1b3e7c2d4f5`.
- Populates the column inside `create_login_session` alongside the existing SUCCESS `login_history` row, using the same `client_ip` argument the service already threads in.
- Exposes `clientIp` on `LoginSessionV2` (Strawberry) and the v2 REST `LoginSessionNode`.
- Adds `client_ip` to `LoginSessionFilter` and a `CLIENT_IP` value to `LoginSessionOrderField` (DTO + GraphQL inputs), with matching `LoginSessionConditions.by_client_ip_*` + `LoginSessionOrders.client_ip` helpers and adapter wiring.
- Regenerates the supergraph / v2 schema dumps.
- Adds a unit test under `tests/unit/manager/repositories/auth/` confirming the supplied `client_ip` lands on the session row (and falls back to NULL when not provided).

Resolves [BA-6152](https://lablup.atlassian.net/browse/BA-6152).

## Stack

Stacked on top of [#11733](https://github.com/lablup/backend.ai/pull/11733) (BA-5733 — client_ip on `login_history`). This PR's base branch is \`feat/BA-5733-login-history-client-ip\`; rebase onto \`main\` once #11733 merges.

## Test plan

- [x] \`pants fmt --changed-since=origin/main\` — clean
- [x] \`pants lint --changed-since=origin/main\` — clean
- [x] \`pants check --changed-since=origin/main\` — mypy clean
- [x] \`pants test tests/unit/manager/repositories/auth/test_login_session_client_ip.py\` — passes
- [x] \`pants test tests/unit/manager/repositories/auth/test_login_history_client_ip.py\` — passes (no regression)
- [ ] Apply migration on a halfstack DB and confirm \`login_sessions.client_ip\` is populated for successful logins
- [ ] Confirm \`clientIp\` appears on \`myLoginSessionsV2\` / \`adminLoginSessionsV2\` GraphQL responses after restarting the manager and Hive (Apollo Router) containers
- [ ] Filter active sessions by \`clientIp\` via GraphQL (\`filter: { clientIp: { equals: "…" } }\`) and confirm the result

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BA-6152]: https://lablup.atlassian.net/browse/BA-6152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ