### PR TITLE
refactor(BA-6149): structure scheduling failure messages with newline join

### DIFF
--- a/changes/11756.enhance.md
+++ b/changes/11756.enhance.md
@@ -1,0 +1,1 @@
+Format scheduling failure messages as newline-separated bullet lists so web UI and CLI can render per-agent and per-kernel reasons on their own lines.

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/exceptions.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/exceptions.py
@@ -2,13 +2,19 @@
 Exceptions for agent selection in sokovan scheduler.
 """
 
+from __future__ import annotations
+
+from abc import ABC
+from collections.abc import Iterable, Mapping, Sequence
+
 from ai.backend.common.exception import (
+    BackendAIError,
     ErrorCode,
     ErrorDetail,
     ErrorDomain,
     ErrorOperation,
 )
-from ai.backend.common.types import AgentId, ResourceSlot
+from ai.backend.common.types import AgentId, KernelId, ResourceSlot
 from ai.backend.manager.sokovan.data import SchedulingPredicate
 from ai.backend.manager.sokovan.scheduler.exceptions import SchedulingError
 
@@ -19,8 +25,7 @@ class AgentSelectionError(SchedulingError):
     error_type = "https://api.backend.ai/probs/agent-selection-failed"
     error_title = "Agent selection failed."
 
-    @classmethod
-    def error_code(cls) -> ErrorCode:
+    def error_code(self) -> ErrorCode:
         return ErrorCode(
             domain=ErrorDomain.AGENT,
             operation=ErrorOperation.SCHEDULE,
@@ -32,19 +37,110 @@ class AgentSelectionError(SchedulingError):
         return [SchedulingPredicate(name=type(self).__name__, msg=str(self))]
 
 
-class NoAvailableAgentError(AgentSelectionError):
-    """Raised when no agents are available."""
+class NoAgentsInScalingGroupError(AgentSelectionError):
+    """Raised when the scaling group has no candidate agents at all.
 
-    error_type = "https://api.backend.ai/probs/no-available-agents"
-    error_title = "Unavailable : No agents can be allocated at this time."
+    Distinct from :class:`NoAvailableAgentError`, which aggregates *per-kernel*
+    compatibility failures across known candidates.
+    """
 
-    @classmethod
-    def error_code(cls) -> ErrorCode:
+    error_type = "https://api.backend.ai/probs/no-agents-in-scaling-group"
+    error_title = "Unavailable : Scaling group has no candidate agents."
+
+    _scaling_group: str
+
+    def __init__(self, scaling_group: str) -> None:
+        self._scaling_group = scaling_group
+        super().__init__(f"No agents available in scaling group '{scaling_group}'")
+
+    def error_code(self) -> ErrorCode:
         return ErrorCode(
             domain=ErrorDomain.AGENT,
             operation=ErrorOperation.SCHEDULE,
             error_detail=ErrorDetail.UNAVAILABLE,
         )
+
+
+class NoAvailableAgentError(AgentSelectionError):
+    """Raised when no agents can satisfy a kernel-group's resource requirement.
+
+    The constructor accepts the structured inputs that describe *which*
+    kernels failed and *why* each candidate agent was rejected, and composes
+    the multi-line, bullet-formatted message itself.
+    """
+
+    error_type = "https://api.backend.ai/probs/no-available-agents"
+    error_title = "Unavailable : No agents can be allocated at this time."
+
+    _kernel_ids: Sequence[KernelId]
+    _required_architecture: str
+    _requested_slots: ResourceSlot
+    _agent_errors: Mapping[AgentId, TrackerCompatibilityError]
+    _designated_agent_ids: Sequence[AgentId] | None
+
+    def __init__(
+        self,
+        *,
+        kernel_ids: Sequence[KernelId],
+        required_architecture: str,
+        requested_slots: ResourceSlot,
+        agent_errors: Mapping[AgentId, TrackerCompatibilityError],
+        designated_agent_ids: Sequence[AgentId] | None = None,
+    ) -> None:
+        self._kernel_ids = kernel_ids
+        self._required_architecture = required_architecture
+        self._requested_slots = requested_slots
+        self._agent_errors = agent_errors
+        self._designated_agent_ids = designated_agent_ids
+        super().__init__(self._build_message())
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.AGENT,
+            operation=ErrorOperation.SCHEDULE,
+            error_detail=ErrorDetail.UNAVAILABLE,
+        )
+
+    def _build_message(self) -> str:
+        header = self._format_header()
+        if self._designated_agent_ids is None:
+            prefix = "no available agents"
+            # Use extra_msg directly so the inner BackendAIError's `title (msg)`
+            # wrapping does not leak into our aggregated layout.
+            reasons: Iterable[str] = (err.extra_msg or "" for err in self._agent_errors.values())
+        else:
+            prefix = "no designated agent is compatible"
+            reasons = self._designated_reasons()
+        details = self._format_reason_lines(reasons)
+        return f"{prefix} for {header}:\n{details}"
+
+    def _format_header(self) -> str:
+        kernel_id_list = ", ".join(str(k) for k in self._kernel_ids)
+        slot_str = " ".join(f"{k}={v}" for k, v in self._requested_slots.items() if v)
+        return f"kernels [{kernel_id_list}] (arch={self._required_architecture}, slots={slot_str})"
+
+    def _designated_reasons(self) -> list[str]:
+        reasons: list[str] = []
+        for agent_id in self._designated_agent_ids or ():
+            err = self._agent_errors.get(agent_id)
+            reason = (err.extra_msg or "") if err is not None else "not found in compatible agents"
+            reasons.append(f"designated agent '{agent_id}': {reason}")
+        return reasons
+
+    @staticmethod
+    def _format_reason_lines(reasons: Iterable[str]) -> str:
+        """Format reasons as a '- '-prefixed bullet list with continuation indent.
+
+        Multi-line inner messages keep their internal indentation so the agent →
+        detail hierarchy stays visually clear in the rendered output.
+        """
+        lines: list[str] = []
+        for reason in reasons:
+            msg_lines = reason.splitlines() or [""]
+            first, *rest = msg_lines
+            lines.append(f"- {first}")
+            lines.extend(f"  {line}" for line in rest)
+        return "\n".join(lines)
 
 
 class NoCompatibleAgentError(AgentSelectionError):
@@ -53,8 +149,7 @@ class NoCompatibleAgentError(AgentSelectionError):
     error_type = "https://api.backend.ai/probs/no-compatible-agents"
     error_title = "No agents meet the resource requirements."
 
-    @classmethod
-    def error_code(cls) -> ErrorCode:
+    def error_code(self) -> ErrorCode:
         return ErrorCode(
             domain=ErrorDomain.AGENT,
             operation=ErrorOperation.SCHEDULE,
@@ -62,27 +157,54 @@ class NoCompatibleAgentError(AgentSelectionError):
         )
 
 
-# Tracker compatibility check exceptions (not inheriting from SchedulingError)
-class TrackerCompatibilityError(Exception):
+# Per-agent compatibility check exceptions. These inherit from BackendAIError so
+# every concrete subclass is forced to declare an `error_code` — otherwise a new
+# compatibility error could silently leak with an undefined RFC-7807 code.
+class TrackerCompatibilityError(BackendAIError, ABC):
     """Base exception for tracker compatibility checks."""
 
-    pass
+    error_type = "https://api.backend.ai/probs/agent-compatibility-failed"
+    error_title = "Agent compatibility check failed."
 
 
 class ArchitectureIncompatibleError(TrackerCompatibilityError):
     """Raised when agent architecture does not match the required architecture."""
 
+    error_type = "https://api.backend.ai/probs/agent-architecture-mismatch"
+    error_title = "Agent architecture does not match the requirement."
+
+    _agent_id: AgentId
+    _agent_arch: str
+    _required_arch: str
+
     def __init__(self, agent_id: AgentId, agent_arch: str, required_arch: str) -> None:
-        self.agent_id = agent_id
-        self.agent_arch = agent_arch
-        self.required_arch = required_arch
+        self._agent_id = agent_id
+        self._agent_arch = agent_arch
+        self._required_arch = required_arch
         super().__init__(
-            f"Agent {agent_id} architecture '{agent_arch}' does not match required architecture '{required_arch}'"
+            f"Agent {agent_id} architecture '{agent_arch}'"
+            f" does not match required architecture '{required_arch}'"
+        )
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.AGENT,
+            operation=ErrorOperation.SCHEDULE,
+            error_detail=ErrorDetail.MISMATCH,
         )
 
 
 class InsufficientResourcesError(TrackerCompatibilityError):
     """Raised when agent does not have sufficient resources available."""
+
+    error_type = "https://api.backend.ai/probs/agent-insufficient-resources"
+    error_title = "Agent has insufficient resources."
+
+    _agent_id: AgentId
+    _requested_slots: ResourceSlot
+    _available_slots: ResourceSlot
+    _occupied_slots: ResourceSlot
+    _insufficient_resources: dict[str, tuple[str, str]]
 
     def __init__(
         self,
@@ -92,25 +214,39 @@ class InsufficientResourcesError(TrackerCompatibilityError):
         occupied_slots: ResourceSlot,
         insufficient_resources: dict[str, tuple[str, str]],
     ) -> None:
-        self.agent_id = agent_id
-        self.requested_slots = requested_slots
-        self.available_slots = available_slots
-        self.occupied_slots = occupied_slots
-        self.insufficient_resources = insufficient_resources
+        self._agent_id = agent_id
+        self._requested_slots = requested_slots
+        self._available_slots = available_slots
+        self._occupied_slots = occupied_slots
+        self._insufficient_resources = insufficient_resources
 
-        # Build detailed message showing which resources are insufficient
-        resource_details = []
-        for resource_name, (requested, available) in insufficient_resources.items():
-            resource_details.append(
-                f"{resource_name}: requested={requested}, available={available}"
-            )
-        details_msg = "; ".join(resource_details)
+        # Build detailed message: one resource shortfall per indented line so that
+        # upstream aggregators (e.g. NoAvailableAgentError) can newline-join cleanly.
+        resource_lines = [
+            f"  - {resource_name}: requested={requested}, available={available}"
+            for resource_name, (requested, available) in insufficient_resources.items()
+        ]
+        details_msg = "\n".join(resource_lines)
 
-        super().__init__(f"Agent {agent_id} has insufficient resources: {details_msg}")
+        super().__init__(f"Agent {agent_id} has insufficient resources:\n{details_msg}")
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.AGENT,
+            operation=ErrorOperation.SCHEDULE,
+            error_detail=ErrorDetail.UNAVAILABLE,
+        )
 
 
 class ContainerLimitExceededError(TrackerCompatibilityError):
     """Raised when agent has reached its maximum container count limit."""
+
+    error_type = "https://api.backend.ai/probs/agent-container-limit-exceeded"
+    error_title = "Agent has reached its container limit."
+
+    _agent_id: AgentId
+    _current_count: int
+    _max_count: int
 
     def __init__(
         self,
@@ -118,9 +254,16 @@ class ContainerLimitExceededError(TrackerCompatibilityError):
         current_count: int,
         max_count: int,
     ) -> None:
-        self.agent_id = agent_id
-        self.current_count = current_count
-        self.max_count = max_count
+        self._agent_id = agent_id
+        self._current_count = current_count
+        self._max_count = max_count
         super().__init__(
             f"Agent {agent_id} container limit exceeded: current={current_count}, max={max_count}"
+        )
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.AGENT,
+            operation=ErrorOperation.SCHEDULE,
+            error_detail=ErrorDetail.UNAVAILABLE,
         )

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/exceptions.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/exceptions.py
@@ -37,21 +37,21 @@ class AgentSelectionError(SchedulingError):
         return [SchedulingPredicate(name=type(self).__name__, msg=str(self))]
 
 
-class NoAgentsInScalingGroupError(AgentSelectionError):
-    """Raised when the scaling group has no candidate agents at all.
+class NoAgentsInResourceGroupError(AgentSelectionError):
+    """Raised when the resource group has no candidate agents at all.
 
     Distinct from :class:`NoAvailableAgentError`, which aggregates *per-kernel*
     compatibility failures across known candidates.
     """
 
-    error_type = "https://api.backend.ai/probs/no-agents-in-scaling-group"
-    error_title = "Unavailable : Scaling group has no candidate agents."
+    error_type = "https://api.backend.ai/probs/no-agents-in-resource-group"
+    error_title = "Unavailable : Resource group has no candidate agents."
 
-    _scaling_group: str
+    _resource_group: str
 
-    def __init__(self, scaling_group: str) -> None:
-        self._scaling_group = scaling_group
-        super().__init__(f"No agents available in scaling group '{scaling_group}'")
+    def __init__(self, resource_group: str) -> None:
+        self._resource_group = resource_group
+        super().__init__(f"No agents available in resource group '{resource_group}'")
 
     def error_code(self) -> ErrorCode:
         return ErrorCode(

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/selector.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/selector.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -19,6 +18,7 @@ from ai.backend.common.types import (
     AgentId,
     BinarySize,
     ClusterMode,
+    KernelId,
     ResourceSlot,
     SessionId,
     SessionTypes,
@@ -28,8 +28,10 @@ from ai.backend.logging.utils import BraceStyleAdapter
 from .exceptions import (
     ContainerLimitExceededError,
     InsufficientResourcesError,
+    NoAgentsInScalingGroupError,
     NoAvailableAgentError,
     NoCompatibleAgentError,
+    TrackerCompatibilityError,
 )
 
 if TYPE_CHECKING:
@@ -157,7 +159,7 @@ class ResourceRequirements:
     # Kernel IDs that these requirements are for
     # For single-node, this includes all kernel IDs
     # For multi-node, this includes only one kernel ID
-    kernel_ids: Sequence[UUID]
+    kernel_ids: Sequence[KernelId]
 
 
 @dataclass
@@ -219,7 +221,7 @@ class AgentSelectionCriteria:
             # Use the common architecture
             architecture = list(architectures)[0]
             # Include all kernel IDs in the aggregated requirement
-            kernel_ids = list(self.kernel_requirements.keys())
+            kernel_ids = [KernelId(k) for k in self.kernel_requirements.keys()]
             return [
                 ResourceRequirements(
                     requested_slots=total_slots,
@@ -232,7 +234,7 @@ class AgentSelectionCriteria:
             ResourceRequirements(
                 requested_slots=req.requested_slots,
                 required_architecture=req.required_architecture,
-                kernel_ids=[kernel_id],
+                kernel_ids=[KernelId(kernel_id)],
             )
             for kernel_id, req in self.kernel_requirements.items()
         ]
@@ -343,9 +345,7 @@ class AgentSelector:
             # Return empty list for sessions with no kernels
             return []
         if not agents:
-            raise NoAvailableAgentError(
-                f"No agents available in scaling group '{criteria.session_metadata.scaling_group}'"
-            )
+            raise NoAgentsInScalingGroupError(criteria.session_metadata.scaling_group)
 
         # Track agent state changes as diffs using AgentStateTracker
         state_trackers = [AgentStateTracker(original_agent=agent) for agent in agents]
@@ -407,8 +407,7 @@ class AgentSelector:
 
         # Second pass: filter by resource availability (quantitative check)
         compatible_trackers: list[AgentStateTracker] = []
-        error_messages: defaultdict[str, int] = defaultdict(int)
-        agent_errors: dict[AgentId, str] = {}
+        agent_errors: dict[AgentId, TrackerCompatibilityError] = {}
         for tracker in arch_compatible_trackers:
             try:
                 self._check_tracker_compatibility(
@@ -417,15 +416,16 @@ class AgentSelector:
                     config,
                 )
                 compatible_trackers.append(tracker)
-            except Exception as e:
-                error_messages[str(e)] += 1
-                agent_errors[tracker.original_agent.agent_id] = str(e)
+            except TrackerCompatibilityError as e:
+                agent_errors[tracker.original_agent.agent_id] = e
 
         if not compatible_trackers:
-            error_messages_summary = "; ".join(
-                f"{count}x {msg}" for msg, count in error_messages.items()
+            raise NoAvailableAgentError(
+                kernel_ids=resource_req.kernel_ids,
+                required_architecture=resource_req.required_architecture,
+                requested_slots=resource_req.requested_slots,
+                agent_errors=agent_errors,
             )
-            raise NoAvailableAgentError(f"no available agents. Details: {error_messages_summary}")
 
         # Handle designated agent first (user's explicit choice takes precedence)
         if designated_agent_ids:
@@ -433,15 +433,12 @@ class AgentSelector:
                 if tracker.original_agent.agent_id in designated_agent_ids:
                     return tracker
 
-            error_messages_list = []
-            for designated_agent_id in designated_agent_ids:
-                if designated_agent_id in agent_errors:
-                    error_messages_list.append(
-                        f"Designated agent '{designated_agent_id}' is not compatible. Details: {agent_errors[designated_agent_id]}"
-                    )
-            error_message = " ".join(error_messages) if error_messages else "not found"
             raise NoAvailableAgentError(
-                f"Designated agent '{designated_agent_ids}' is not compatible. Details: {error_message}"
+                kernel_ids=resource_req.kernel_ids,
+                required_architecture=resource_req.required_architecture,
+                requested_slots=resource_req.requested_slots,
+                agent_errors=agent_errors,
+                designated_agent_ids=designated_agent_ids,
             )
 
         # Third pass: deprioritize agents that previously failed for this session

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/selector.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/selector.py
@@ -28,7 +28,7 @@ from ai.backend.logging.utils import BraceStyleAdapter
 from .exceptions import (
     ContainerLimitExceededError,
     InsufficientResourcesError,
-    NoAgentsInScalingGroupError,
+    NoAgentsInResourceGroupError,
     NoAvailableAgentError,
     NoCompatibleAgentError,
     TrackerCompatibilityError,
@@ -345,7 +345,7 @@ class AgentSelector:
             # Return empty list for sessions with no kernels
             return []
         if not agents:
-            raise NoAgentsInScalingGroupError(criteria.session_metadata.scaling_group)
+            raise NoAgentsInResourceGroupError(criteria.session_metadata.scaling_group)
 
         # Track agent state changes as diffs using AgentStateTracker
         state_trackers = [AgentStateTracker(original_agent=agent) for agent in agents]

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/concurrency.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/concurrency.py
@@ -49,5 +49,6 @@ class ConcurrencyValidator(ValidatorRule):
 
         if current_count >= max_sessions:
             raise ConcurrencyLimitExceeded(
-                f"You cannot run more than {max_sessions} {session_type} sessions"
+                max_sessions=max_sessions,
+                session_type=session_type,
             )

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/dependencies.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/dependencies.py
@@ -39,6 +39,4 @@ class DependenciesValidator(ValidatorRule):
             dep_names = [
                 f"{dep.dependency_name} ({dep.depends_on})" for dep in pending_dependencies
             ]
-            raise DependenciesNotSatisfied(
-                f"Waiting dependency sessions to finish as success. ({', '.join(dep_names)})"
-            )
+            raise DependenciesNotSatisfied(pending_dependency_names=dep_names)

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/domain_resource_limit.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/domain_resource_limit.py
@@ -39,12 +39,4 @@ class DomainResourceLimitValidator(ValidatorRule):
         # Check if adding this workload would exceed the limit
         total_after = domain_occupied + workload.requested_slots
         if not (total_after <= domain_limit):
-            # Format the limit for human-readable output
-            if domain_limit and any(v for v in domain_limit.values()):
-                limit_str = " ".join(f"{k}={v}" for k, v in domain_limit.items() if v)
-                exceeded_msg = f"limit: {limit_str}, current: {domain_occupied}, requested: {workload.requested_slots}"
-            else:
-                exceeded_msg = f"No resource limits defined. current: {domain_occupied}, requested: {workload.requested_slots}"
-            raise DomainResourceQuotaExceeded(
-                f"Your domain resource quota is exceeded. ({exceeded_msg})"
-            )
+            raise DomainResourceQuotaExceeded(quota_slots=domain_limit)

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/exceptions.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/exceptions.py
@@ -1,5 +1,11 @@
 """Exceptions for validators."""
 
+from __future__ import annotations
+
+from abc import abstractmethod
+from collections.abc import Sequence
+from datetime import datetime
+
 from aiohttp import web
 
 from ai.backend.common.exception import (
@@ -8,27 +14,45 @@ from ai.backend.common.exception import (
     ErrorDomain,
     ErrorOperation,
 )
+from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.sokovan.data import SchedulingPredicate
 from ai.backend.manager.sokovan.scheduler.exceptions import SchedulingError
 
 
 class SchedulingValidationError(SchedulingError, web.HTTPPreconditionFailed):
-    """Base exception for validation errors in the Sokovan scheduler."""
+    """Base exception for validation errors in the Sokovan scheduler.
+
+    Subclasses carry the structured data that describes *what* was violated
+    and provide :meth:`summary` so aggregators (e.g.
+    :class:`MultipleValidationErrors`) can render a single readable line
+    without re-parsing the exception's string representation.
+    """
 
     error_type = "https://api.backend.ai/probs/scheduling-validation-failed"
     error_title = "Scheduling validation failed."
 
-    @classmethod
-    def error_code(cls) -> ErrorCode:
+    def error_code(self) -> ErrorCode:
         return ErrorCode(
             domain=ErrorDomain.SESSION,
             operation=ErrorOperation.SCHEDULE,
             error_detail=ErrorDetail.FORBIDDEN,
         )
 
+    @abstractmethod
+    def summary(self) -> str:
+        """Return a one-line, human-readable summary of this validation error.
+
+        Used by aggregators to format the error inside a bullet list.
+        """
+        raise NotImplementedError
+
     def failed_predicates(self) -> list[SchedulingPredicate]:
         """Return list of failed predicates for this error."""
         return [SchedulingPredicate(name=type(self).__name__, msg=str(self))]
+
+
+def _format_slots(slots: ResourceSlot) -> str:
+    return " ".join(f"{k}={v}" for k, v in slots.items() if v)
 
 
 class ConcurrencyLimitExceeded(SchedulingValidationError):
@@ -37,8 +61,18 @@ class ConcurrencyLimitExceeded(SchedulingValidationError):
     error_type = "https://api.backend.ai/probs/concurrency-limit-exceeded"
     error_title = "Concurrent session limit exceeded."
 
-    @classmethod
-    def error_code(cls) -> ErrorCode:
+    _max_sessions: int
+    _session_type: str
+
+    def __init__(self, *, max_sessions: int, session_type: str) -> None:
+        self._max_sessions = max_sessions
+        self._session_type = session_type
+        super().__init__(self.summary())
+
+    def summary(self) -> str:
+        return f"You cannot run more than {self._max_sessions} {self._session_type} sessions"
+
+    def error_code(self) -> ErrorCode:
         return ErrorCode(
             domain=ErrorDomain.SESSION,
             operation=ErrorOperation.CHECK_LIMIT,
@@ -52,8 +86,17 @@ class DependenciesNotSatisfied(SchedulingValidationError):
     error_type = "https://api.backend.ai/probs/dependencies-not-satisfied"
     error_title = "Session dependencies not satisfied."
 
-    @classmethod
-    def error_code(cls) -> ErrorCode:
+    _pending_dependency_names: list[str]
+
+    def __init__(self, *, pending_dependency_names: Sequence[str]) -> None:
+        self._pending_dependency_names = list(pending_dependency_names)
+        super().__init__(self.summary())
+
+    def summary(self) -> str:
+        names = ", ".join(self._pending_dependency_names)
+        return f"Waiting dependency sessions to finish as success. ({names})"
+
+    def error_code(self) -> ErrorCode:
         return ErrorCode(
             domain=ErrorDomain.SESSION,
             operation=ErrorOperation.CHECK_LIMIT,
@@ -67,8 +110,16 @@ class KeypairResourceQuotaExceeded(SchedulingValidationError):
     error_type = "https://api.backend.ai/probs/keypair-resource-quota-exceeded"
     error_title = "Keypair resource quota exceeded."
 
-    @classmethod
-    def error_code(cls) -> ErrorCode:
+    _quota_slots: ResourceSlot
+
+    def __init__(self, *, quota_slots: ResourceSlot) -> None:
+        self._quota_slots = quota_slots
+        super().__init__(self.summary())
+
+    def summary(self) -> str:
+        return f"Your keypair resource quota is exceeded. ({_format_slots(self._quota_slots)})"
+
+    def error_code(self) -> ErrorCode:
         return ErrorCode(
             domain=ErrorDomain.KEYPAIR,
             operation=ErrorOperation.CHECK_LIMIT,
@@ -82,8 +133,16 @@ class UserResourceQuotaExceeded(SchedulingValidationError):
     error_type = "https://api.backend.ai/probs/user-resource-quota-exceeded"
     error_title = "User resource quota exceeded."
 
-    @classmethod
-    def error_code(cls) -> ErrorCode:
+    _quota_slots: ResourceSlot
+
+    def __init__(self, *, quota_slots: ResourceSlot) -> None:
+        self._quota_slots = quota_slots
+        super().__init__(self.summary())
+
+    def summary(self) -> str:
+        return f"Your main-keypair resource quota is exceeded. ({_format_slots(self._quota_slots)})"
+
+    def error_code(self) -> ErrorCode:
         return ErrorCode(
             domain=ErrorDomain.USER,
             operation=ErrorOperation.CHECK_LIMIT,
@@ -97,8 +156,16 @@ class GroupResourceQuotaExceeded(SchedulingValidationError):
     error_type = "https://api.backend.ai/probs/group-resource-quota-exceeded"
     error_title = "Group resource quota exceeded."
 
-    @classmethod
-    def error_code(cls) -> ErrorCode:
+    _quota_slots: ResourceSlot
+
+    def __init__(self, *, quota_slots: ResourceSlot) -> None:
+        self._quota_slots = quota_slots
+        super().__init__(self.summary())
+
+    def summary(self) -> str:
+        return f"Your group resource quota is exceeded. ({_format_slots(self._quota_slots)})"
+
+    def error_code(self) -> ErrorCode:
         return ErrorCode(
             domain=ErrorDomain.GROUP,
             operation=ErrorOperation.CHECK_LIMIT,
@@ -112,8 +179,16 @@ class DomainResourceQuotaExceeded(SchedulingValidationError):
     error_type = "https://api.backend.ai/probs/domain-resource-quota-exceeded"
     error_title = "Domain resource quota exceeded."
 
-    @classmethod
-    def error_code(cls) -> ErrorCode:
+    _quota_slots: ResourceSlot
+
+    def __init__(self, *, quota_slots: ResourceSlot) -> None:
+        self._quota_slots = quota_slots
+        super().__init__(self.summary())
+
+    def summary(self) -> str:
+        return f"Your domain resource quota is exceeded. ({_format_slots(self._quota_slots)})"
+
+    def error_code(self) -> ErrorCode:
         return ErrorCode(
             domain=ErrorDomain.DOMAIN,
             operation=ErrorOperation.CHECK_LIMIT,
@@ -127,8 +202,16 @@ class PendingSessionCountLimitExceeded(SchedulingValidationError):
     error_type = "https://api.backend.ai/probs/pending-session-count-limit-exceeded"
     error_title = "Pending session count limit exceeded."
 
-    @classmethod
-    def error_code(cls) -> ErrorCode:
+    _max_pending_session_count: int
+
+    def __init__(self, *, max_pending_session_count: int) -> None:
+        self._max_pending_session_count = max_pending_session_count
+        super().__init__(self.summary())
+
+    def summary(self) -> str:
+        return f"You cannot create more than {self._max_pending_session_count} pending session(s)."
+
+    def error_code(self) -> ErrorCode:
         return ErrorCode(
             domain=ErrorDomain.SESSION,
             operation=ErrorOperation.CHECK_LIMIT,
@@ -142,8 +225,45 @@ class PendingSessionResourceLimitExceeded(SchedulingValidationError):
     error_type = "https://api.backend.ai/probs/pending-session-resource-limit-exceeded"
     error_title = "Pending session resource limit exceeded."
 
-    @classmethod
-    def error_code(cls) -> ErrorCode:
+    _current_pending_slots: ResourceSlot
+
+    def __init__(self, *, current_pending_slots: ResourceSlot) -> None:
+        self._current_pending_slots = current_pending_slots
+        super().__init__(self.summary())
+
+    def summary(self) -> str:
+        return (
+            f"Your pending session quota is exceeded."
+            f" ({_format_slots(self._current_pending_slots)})"
+        )
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.SESSION,
+            operation=ErrorOperation.CHECK_LIMIT,
+            error_detail=ErrorDetail.FORBIDDEN,
+        )
+
+
+class ReservedBatchSessionNotReady(SchedulingValidationError):
+    """Raised when a batch session has not yet reached its scheduled start time."""
+
+    error_type = "https://api.backend.ai/probs/reserved-batch-session-not-ready"
+    error_title = "Reserved batch session is not yet ready to start."
+
+    _scheduled_start: datetime
+
+    def __init__(self, *, scheduled_start: datetime) -> None:
+        self._scheduled_start = scheduled_start
+        super().__init__(self.summary())
+
+    def summary(self) -> str:
+        return (
+            f"Batch session is scheduled to start at {self._scheduled_start.isoformat()};"
+            " current time is before that."
+        )
+
+    def error_code(self) -> ErrorCode:
         return ErrorCode(
             domain=ErrorDomain.SESSION,
             operation=ErrorOperation.CHECK_LIMIT,
@@ -159,34 +279,22 @@ class MultipleValidationErrors(SchedulingValidationError):
 
     _errors: list[SchedulingValidationError]
 
-    def __init__(self, errors: list[SchedulingValidationError]) -> None:
-        """
-        Initialize with a list of validation errors.
+    def __init__(self, errors: Sequence[SchedulingValidationError]) -> None:
+        self._errors = list(errors)
+        super().__init__(self.summary())
 
-        Args:
-            errors: List of validation errors that occurred
-        """
-        self._errors = errors
-        # Format each error on a new line for better readability
-        messages = []
-        for i, e in enumerate(errors, 1):
-            error_name = type(e).__name__
-            error_msg = str(e)
-            messages.append(f"  {i}. {error_name}: {error_msg}")
-
-        # Join with newlines for better formatting
-        formatted_errors = "\n".join(messages)
-        super().__init__(f"Multiple validation errors occurred:\n{formatted_errors}")
+    def summary(self) -> str:
+        lines = [f"- {type(e).__name__}: {e.summary()}" for e in self._errors]
+        return "Multiple validation errors occurred:\n" + "\n".join(lines)
 
     def failed_predicates(self) -> list[SchedulingPredicate]:
         """Return list of all failed predicates from all errors."""
-        predicates = []
+        predicates: list[SchedulingPredicate] = []
         for error in self._errors:
             predicates.extend(error.failed_predicates())
         return predicates
 
-    @classmethod
-    def error_code(cls) -> ErrorCode:
+    def error_code(self) -> ErrorCode:
         return ErrorCode(
             domain=ErrorDomain.BACKENDAI,
             operation=ErrorOperation.SCHEDULE,

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/group_resource_limit.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/group_resource_limit.py
@@ -37,12 +37,4 @@ class GroupResourceLimitValidator(ValidatorRule):
         # Check if adding this workload would exceed the limit
         total_after = group_occupied + workload.requested_slots
         if not (total_after <= group_limit):
-            # Format the limit for human-readable output
-            if group_limit and any(v for v in group_limit.values()):
-                limit_str = " ".join(f"{k}={v}" for k, v in group_limit.items() if v)
-                exceeded_msg = f"limit: {limit_str}, current: {group_occupied}, requested: {workload.requested_slots}"
-            else:
-                exceeded_msg = f"No resource limits defined. current: {group_occupied}, requested: {workload.requested_slots}"
-            raise GroupResourceQuotaExceeded(
-                f"Your group resource quota is exceeded. ({exceeded_msg})"
-            )
+            raise GroupResourceQuotaExceeded(quota_slots=group_limit)

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/keypair_resource_limit.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/keypair_resource_limit.py
@@ -43,7 +43,4 @@ class KeypairResourceLimitValidator(ValidatorRule):
         # Check if adding this workload would exceed the limit
         total_after = key_occupied + workload.requested_slots
         if not (total_after <= policy.total_resource_slots):
-            exceeded_msg = " ".join(f"{k}={v}" for k, v in policy.total_resource_slots.items() if v)
-            raise KeypairResourceQuotaExceeded(
-                f"Your keypair resource quota is exceeded. ({exceeded_msg})"
-            )
+            raise KeypairResourceQuotaExceeded(quota_slots=policy.total_resource_slots)

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/pending_session_count_limit.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/pending_session_count_limit.py
@@ -40,5 +40,5 @@ class PendingSessionCountLimitValidator(ValidatorRule):
         # Check if creating this session would exceed the limit
         if current_pending_count >= pending_count_limit:
             raise PendingSessionCountLimitExceeded(
-                f"You cannot create more than {pending_count_limit} pending session(s)."
+                max_pending_session_count=pending_count_limit,
             )

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/pending_session_resource_limit.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/pending_session_resource_limit.py
@@ -43,8 +43,6 @@ class PendingSessionResourceLimitValidator(ValidatorRule):
         # Check if adding this workload would exceed the limit
         total_after = current_pending_slots
         if total_after > pending_resource_limit:
-            # Format the current usage for human-readable output
-            usage_str = " ".join(f"{k}={v}" for k, v in current_pending_slots.items() if v)
             raise PendingSessionResourceLimitExceeded(
-                f"Your pending session quota is exceeded. ({usage_str})"
+                current_pending_slots=current_pending_slots,
             )

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/reserved_batch.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/reserved_batch.py
@@ -7,7 +7,7 @@ from dateutil.tz import tzutc
 from ai.backend.common.types import SessionTypes
 from ai.backend.manager.sokovan.data import SessionWorkload, SystemSnapshot
 
-from .exceptions import SchedulingValidationError
+from .exceptions import ReservedBatchSessionNotReady
 from .validator import ValidatorRule
 
 
@@ -30,4 +30,4 @@ class ReservedBatchSessionValidator(ValidatorRule):
         if workload.session_type == SessionTypes.BATCH and workload.starts_at is not None:
             # Check if the current time is before the scheduled start time
             if datetime.now(tzutc()) < workload.starts_at:
-                raise SchedulingValidationError("Before start time")
+                raise ReservedBatchSessionNotReady(scheduled_start=workload.starts_at)

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/user_resource_limit.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/user_resource_limit.py
@@ -35,7 +35,4 @@ class UserResourceLimitValidator(ValidatorRule):
         # Check if adding this workload would exceed the limit
         total_after = user_occupied + workload.requested_slots
         if not (total_after <= policy.total_resource_slots):
-            exceeded_msg = " ".join(f"{k}={v}" for k, v in policy.total_resource_slots.items() if v)
-            raise UserResourceQuotaExceeded(
-                f"Your main-keypair resource quota is exceeded. ({exceeded_msg})"
-            )
+            raise UserResourceQuotaExceeded(quota_slots=policy.total_resource_slots)

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_agent_selection_with_resources.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_agent_selection_with_resources.py
@@ -198,8 +198,13 @@ class TestAgentSelectionWithResources:
             )
 
         # Should raise error because designated agent lacks resources
-        assert "Designated agent '['designated']' is not compatible" in str(exc_info.value)
-        assert "insufficient resources" in str(exc_info.value)
+        message = str(exc_info.value)
+        assert "no designated agent is compatible" in message
+        assert "designated agent 'designated'" in message
+        assert "insufficient resources" in message
+        # Aggregated detail lines must be split with newlines, not "; ".
+        assert "; " not in message
+        assert "\n" in message
 
     async def test_container_limit_with_resource_requirements(
         self,

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_concentrated_selector.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_concentrated_selector.py
@@ -7,7 +7,14 @@ from decimal import Decimal
 
 import pytest
 
-from ai.backend.common.types import AgentId, ClusterMode, ResourceSlot, SessionId, SessionTypes
+from ai.backend.common.types import (
+    AgentId,
+    ClusterMode,
+    KernelId,
+    ResourceSlot,
+    SessionId,
+    SessionTypes,
+)
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.concentrated import (
     ConcentratedAgentSelector,
 )
@@ -59,7 +66,7 @@ class TestConcentratedAgentSelector:
     ) -> None:
         """Test that concentrated selector prefers agents with less available resources."""
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("2048")}),
             required_architecture="x86_64",
         )
@@ -90,7 +97,7 @@ class TestConcentratedAgentSelector:
         """Test preference for agents with fewer unutilized resource types."""
         # Request only CPU and memory (explicitly no GPU)
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({
                 "cpu": Decimal("2"),
                 "mem": Decimal("4096"),
@@ -119,7 +126,7 @@ class TestConcentratedAgentSelector:
         selector = ConcentratedAgentSelector(agent_selection_resource_priority=["mem", "cpu"])
 
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("1024")}),
             required_architecture="x86_64",
         )
@@ -165,7 +172,7 @@ class TestConcentratedAgentSelector:
         )
 
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("2048")}),
             required_architecture="x86_64",
         )
@@ -188,7 +195,7 @@ class TestConcentratedAgentSelector:
     ) -> None:
         """Test consistent tie-breaking when agents have identical resources."""
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("2048")}),
             required_architecture="x86_64",
         )
@@ -225,7 +232,7 @@ class TestConcentratedAgentSelector:
     ) -> None:
         """Test selection with GPU resources."""
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({
                 "cpu": Decimal("2"),
                 "mem": Decimal("4096"),
@@ -259,7 +266,7 @@ class TestConcentratedAgentSelector:
         )
 
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({
                 "cpu": Decimal("1"),
                 "mem": Decimal("2048"),

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_dispersed_selector.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_dispersed_selector.py
@@ -7,7 +7,14 @@ from decimal import Decimal
 
 import pytest
 
-from ai.backend.common.types import AgentId, ClusterMode, ResourceSlot, SessionId, SessionTypes
+from ai.backend.common.types import (
+    AgentId,
+    ClusterMode,
+    KernelId,
+    ResourceSlot,
+    SessionId,
+    SessionTypes,
+)
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.concentrated import (
     ConcentratedAgentSelector,
 )
@@ -62,7 +69,7 @@ class TestDispersedAgentSelector:
     ) -> None:
         """Test that dispersed selector prefers agents with more available resources."""
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("2048")}),
             required_architecture="x86_64",
         )
@@ -93,7 +100,7 @@ class TestDispersedAgentSelector:
         """Test preference for agents with fewer unutilized resource types."""
         # Request only CPU and memory (explicitly no GPU)
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({
                 "cpu": Decimal("2"),
                 "mem": Decimal("4096"),
@@ -125,7 +132,7 @@ class TestDispersedAgentSelector:
         selector = DispersedAgentSelector(agent_selection_resource_priority=["mem", "cpu"])
 
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("1024")}),
             required_architecture="x86_64",
         )
@@ -152,7 +159,7 @@ class TestDispersedAgentSelector:
     ) -> None:
         """Test behavior when some agents have zero available resources."""
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("2048")}),
             required_architecture="x86_64",
         )
@@ -178,7 +185,7 @@ class TestDispersedAgentSelector:
     ) -> None:
         """Test consistent tie-breaking when agents have identical resources."""
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("2048")}),
             required_architecture="x86_64",
         )
@@ -216,7 +223,7 @@ class TestDispersedAgentSelector:
         """Test selection with heterogeneous resource types."""
         # Request only CPU and memory
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({"cpu": Decimal("4"), "mem": Decimal("8192")}),
             required_architecture="x86_64",
         )
@@ -248,7 +255,7 @@ class TestDispersedAgentSelector:
         concentrated = ConcentratedAgentSelector(agent_selection_resource_priority=["cpu", "mem"])
 
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({"cpu": Decimal("0.5"), "mem": Decimal("1024")}),
             required_architecture="x86_64",
         )

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_failure_message_format.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_failure_message_format.py
@@ -1,0 +1,619 @@
+"""Format-level tests for scheduling failure messages (BA-6149).
+
+These tests pin down the user-facing layout of error messages so that future
+refactors do not accidentally regress to ";"-joined single-line aggregates.
+Golden assertions compare entire messages to lock down the exact layout.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from decimal import Decimal
+from uuid import UUID
+
+import pytest
+
+from ai.backend.common.types import (
+    AgentId,
+    ClusterMode,
+    KernelId,
+    ResourceSlot,
+    SessionId,
+    SessionTypes,
+)
+from ai.backend.manager.sokovan.scheduler.provisioner.selectors.concentrated import (
+    ConcentratedAgentSelector,
+)
+from ai.backend.manager.sokovan.scheduler.provisioner.selectors.exceptions import (
+    ArchitectureIncompatibleError,
+    ContainerLimitExceededError,
+    InsufficientResourcesError,
+    NoAgentsInScalingGroupError,
+    NoAvailableAgentError,
+)
+from ai.backend.manager.sokovan.scheduler.provisioner.selectors.selector import (
+    AgentInfo,
+    AgentSelectionConfig,
+    AgentSelectionCriteria,
+    AgentSelector,
+    KernelResourceSpec,
+    SessionMetadata,
+)
+from ai.backend.manager.sokovan.scheduler.provisioner.validators.exceptions import (
+    ConcurrencyLimitExceeded,
+    DependenciesNotSatisfied,
+    MultipleValidationErrors,
+)
+
+
+class TestInsufficientResourcesErrorFormat:
+    """InsufficientResourcesError must use a header + indented bullet list."""
+
+    def test_multi_resource_shortfall_uses_newlines(self) -> None:
+        error = InsufficientResourcesError(
+            agent_id=AgentId("agent-a"),
+            requested_slots=ResourceSlot({"cpu": Decimal("4"), "mem": Decimal("8192")}),
+            available_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("2048")}),
+            occupied_slots=ResourceSlot({}),
+            insufficient_resources={
+                "cpu": ("4", "1"),
+                "mem": ("8192", "2048"),
+            },
+        )
+        message = error.extra_msg or ""
+        lines = message.splitlines()
+        assert lines[0] == "Agent agent-a has insufficient resources:"
+        assert "  - cpu: requested=4, available=1" in lines
+        assert "  - mem: requested=8192, available=2048" in lines
+        # No legacy "; " join must remain.
+        assert "; " not in message
+
+
+class TestNoAvailableAgentErrorAggregationFormat:
+    """The NoAvailableAgentError aggregator must list per-agent reasons line-by-line."""
+
+    @pytest.fixture
+    def heterogeneous_failing_agents(self) -> list[AgentInfo]:
+        return [
+            AgentInfo(
+                agent_id=AgentId("agent-a"),
+                agent_addr="agent-a:6001",
+                architecture="x86_64",
+                available_slots=ResourceSlot({
+                    "cpu": Decimal("1"),
+                    "mem": Decimal("2048"),
+                }),
+                occupied_slots=ResourceSlot({"cpu": Decimal("0"), "mem": Decimal("0")}),
+                scaling_group="default",
+                container_count=0,
+            ),
+            AgentInfo(
+                agent_id=AgentId("agent-b"),
+                agent_addr="agent-b:6001",
+                architecture="x86_64",
+                available_slots=ResourceSlot({
+                    "cpu": Decimal("8"),
+                    "mem": Decimal("16384"),
+                }),
+                occupied_slots=ResourceSlot({"cpu": Decimal("0"), "mem": Decimal("0")}),
+                scaling_group="default",
+                container_count=10,  # at container limit
+            ),
+        ]
+
+    async def test_multi_agent_failure_message_layout(
+        self,
+        heterogeneous_failing_agents: list[AgentInfo],
+    ) -> None:
+        kernel_id = uuid.uuid4()
+        criteria = AgentSelectionCriteria(
+            session_metadata=SessionMetadata(
+                session_id=SessionId(uuid.uuid4()),
+                session_type=SessionTypes.INTERACTIVE,
+                scaling_group="default",
+                cluster_mode=ClusterMode.SINGLE_NODE,
+            ),
+            kernel_requirements={
+                kernel_id: KernelResourceSpec(
+                    requested_slots=ResourceSlot({
+                        "cpu": Decimal("4"),
+                        "mem": Decimal("8192"),
+                    }),
+                    required_architecture="x86_64",
+                ),
+            },
+        )
+        config = AgentSelectionConfig(max_container_count=10)
+        selector = AgentSelector(
+            ConcentratedAgentSelector(agent_selection_resource_priority=["cpu", "mem"]),
+        )
+
+        with pytest.raises(NoAvailableAgentError) as exc_info:
+            await selector.select_agents_for_batch_requirements(
+                heterogeneous_failing_agents,
+                criteria,
+                config,
+            )
+
+        # Inspect the raw payload we constructed (not the aiohttp title wrapper),
+        # since SchedulingFailure.msg is derived from str(e) but the format
+        # contract lives in extra_msg.
+        message = exc_info.value.extra_msg or ""
+        lines = message.splitlines()
+        assert lines[0].startswith("no available agents for kernels [")
+        assert "arch=x86_64" in lines[0]
+        assert any(line.startswith("- ") for line in lines[1:])
+        assert "; " not in message
+        # No "Nx ErrorType" count-prefix aggregation.
+        for line in lines[1:]:
+            stripped = line.lstrip("- ")
+            if stripped and stripped[0].isdigit():
+                # e.g. "3x Insufficient..." would have a digit then "x ".
+                head = stripped[:4]
+                assert "x " not in head, f"unexpected count-prefix in: {line!r}"
+
+
+class TestDesignatedAgentFailureFormat:
+    """Designated-agent failure path must list each candidate reason on its own line."""
+
+    @pytest.fixture
+    def two_designated_candidates(self) -> list[AgentInfo]:
+        # The designated-only-incompatible path requires at least one
+        # non-designated compatible agent so the early "no available agents"
+        # branch does not short-circuit before reaching the designated check.
+        return [
+            AgentInfo(
+                agent_id=AgentId("designated-a"),
+                agent_addr="designated-a:6001",
+                architecture="x86_64",
+                available_slots=ResourceSlot({
+                    "cpu": Decimal("1"),
+                    "mem": Decimal("1024"),
+                }),
+                occupied_slots=ResourceSlot({"cpu": Decimal("0"), "mem": Decimal("0")}),
+                scaling_group="default",
+                container_count=0,
+            ),
+            AgentInfo(
+                agent_id=AgentId("designated-b"),
+                agent_addr="designated-b:6001",
+                architecture="x86_64",
+                available_slots=ResourceSlot({
+                    "cpu": Decimal("8"),
+                    "mem": Decimal("16384"),
+                }),
+                occupied_slots=ResourceSlot({"cpu": Decimal("0"), "mem": Decimal("0")}),
+                scaling_group="default",
+                container_count=10,  # at container limit
+            ),
+            AgentInfo(
+                agent_id=AgentId("non-designated-ok"),
+                agent_addr="non-designated-ok:6001",
+                architecture="x86_64",
+                available_slots=ResourceSlot({
+                    "cpu": Decimal("16"),
+                    "mem": Decimal("65536"),
+                }),
+                occupied_slots=ResourceSlot({"cpu": Decimal("0"), "mem": Decimal("0")}),
+                scaling_group="default",
+                container_count=0,
+            ),
+        ]
+
+    async def test_each_designated_reason_is_on_its_own_line(
+        self,
+        two_designated_candidates: list[AgentInfo],
+    ) -> None:
+        kernel_id = uuid.uuid4()
+        criteria = AgentSelectionCriteria(
+            session_metadata=SessionMetadata(
+                session_id=SessionId(uuid.uuid4()),
+                session_type=SessionTypes.INTERACTIVE,
+                scaling_group="default",
+                cluster_mode=ClusterMode.SINGLE_NODE,
+            ),
+            kernel_requirements={
+                kernel_id: KernelResourceSpec(
+                    requested_slots=ResourceSlot({
+                        "cpu": Decimal("4"),
+                        "mem": Decimal("8192"),
+                    }),
+                    required_architecture="x86_64",
+                ),
+            },
+        )
+        config = AgentSelectionConfig(max_container_count=10)
+        selector = AgentSelector(
+            ConcentratedAgentSelector(agent_selection_resource_priority=["cpu", "mem"]),
+        )
+
+        with pytest.raises(NoAvailableAgentError) as exc_info:
+            await selector.select_agents_for_batch_requirements(
+                two_designated_candidates,
+                criteria,
+                config,
+                designated_agent_ids=[
+                    AgentId("designated-a"),
+                    AgentId("designated-b"),
+                ],
+            )
+
+        message = exc_info.value.extra_msg or ""
+        assert message.startswith("no designated agent is compatible for kernels [")
+        assert "designated agent 'designated-a'" in message
+        assert "designated agent 'designated-b'" in message
+        # Earlier bug: `error_messages_list` was populated but never used, and
+        # `" ".join(error_messages)` joined defaultdict keys into an empty string.
+        # The reasons must actually appear, separated by newlines, not "; ".
+        assert "; " not in message
+        assert "\n" in message
+
+
+class TestMultipleValidationErrorsFormat:
+    """MultipleValidationErrors must use the unified '- ' bullet prefix."""
+
+    def test_uses_dash_prefix_and_newline_separation(self) -> None:
+        errors = [
+            ConcurrencyLimitExceeded(max_sessions=5, session_type="concurrent"),
+            DependenciesNotSatisfied(pending_dependency_names=["dep-x (uuid)"]),
+        ]
+        aggregated = MultipleValidationErrors(errors)
+        message = aggregated.extra_msg or ""
+        lines = message.splitlines()
+        assert lines[0] == "Multiple validation errors occurred:"
+        # Each enumerated error starts with the unified '- ' prefix.
+        assert any(line.startswith("- ConcurrencyLimitExceeded:") for line in lines[1:])
+        assert any(line.startswith("- DependenciesNotSatisfied:") for line in lines[1:])
+        # No legacy "  1. " / "  2. " numbered prefix.
+        assert "  1. " not in message
+        assert "  2. " not in message
+
+
+class TestSchedulingFailureMsgRoundTripsAsJson:
+    """status_data JSON round-trip must preserve newline-formatted messages."""
+
+    def test_newlines_survive_json_serialization(self) -> None:
+        error = InsufficientResourcesError(
+            agent_id=AgentId("agent-a"),
+            requested_slots=ResourceSlot({"cpu": Decimal("4")}),
+            available_slots=ResourceSlot({"cpu": Decimal("1")}),
+            occupied_slots=ResourceSlot({}),
+            insufficient_resources={"cpu": ("4", "1")},
+        )
+        original = error.extra_msg or ""
+        # Simulate the SchedulingFailure.msg → JSON path.
+        encoded = json.dumps({"msg": original})
+        decoded = json.loads(encoded)
+        assert decoded["msg"] == original
+        assert "\n" in decoded["msg"]
+
+
+class TestArchitectureMessageStaysSinglePhrase:
+    """Short single-phrase joins (', '-separated) should not be touched."""
+
+    def test_architecture_incompatible_still_uses_comma_join(self) -> None:
+        err = ArchitectureIncompatibleError(
+            agent_id=AgentId("agent-a"),
+            agent_arch="aarch64",
+            required_arch="x86_64",
+        )
+        # The message is a single phrase; ", " join (if present in upstream
+        # listings) is appropriate. The exception itself should not contain
+        # any "; " aggregator.
+        assert "; " not in (err.extra_msg or "")
+
+
+class TestContainerLimitMessageIsSinglePhrase:
+    def test_container_limit_message(self) -> None:
+        err = ContainerLimitExceededError(
+            agent_id=AgentId("agent-a"),
+            current_count=10,
+            max_count=10,
+        )
+        assert "; " not in (err.extra_msg or "")
+
+
+# ============================================================================
+# Golden assertions — full message equality, not just substring presence.
+# Each test below pins the entire user-visible message text. To keep the
+# comparison deterministic, kernel UUIDs are fixed and slot dicts hold a
+# single key so iteration order is not a factor.
+# ============================================================================
+
+
+_GOLDEN_KERNEL_ID = KernelId(UUID("00000000-0000-0000-0000-000000000001"))
+
+
+class TestGoldenInsufficientResourcesError:
+    def test_single_resource_shortfall_full_message(self) -> None:
+        error = InsufficientResourcesError(
+            agent_id=AgentId("agent-a"),
+            requested_slots=ResourceSlot({"cpu": Decimal("4")}),
+            available_slots=ResourceSlot({"cpu": Decimal("1")}),
+            occupied_slots=ResourceSlot({}),
+            insufficient_resources={"cpu": ("4", "1")},
+        )
+        expected = "Agent agent-a has insufficient resources:\n  - cpu: requested=4, available=1"
+        assert error.extra_msg == expected
+
+    def test_multi_resource_shortfall_full_message(self) -> None:
+        error = InsufficientResourcesError(
+            agent_id=AgentId("agent-a"),
+            requested_slots=ResourceSlot({"cpu": Decimal("4"), "mem": Decimal("8192")}),
+            available_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("2048")}),
+            occupied_slots=ResourceSlot({}),
+            # dict literal preserves insertion order in Python 3.7+
+            insufficient_resources={
+                "cpu": ("4", "1"),
+                "mem": ("8 GiB", "2 GiB"),
+            },
+        )
+        expected = (
+            "Agent agent-a has insufficient resources:\n"
+            "  - cpu: requested=4, available=1\n"
+            "  - mem: requested=8 GiB, available=2 GiB"
+        )
+        assert error.extra_msg == expected
+
+
+class TestGoldenContainerLimitExceededError:
+    def test_full_message(self) -> None:
+        err = ContainerLimitExceededError(
+            agent_id=AgentId("agent-b"),
+            current_count=10,
+            max_count=10,
+        )
+        assert err.extra_msg == "Agent agent-b container limit exceeded: current=10, max=10"
+
+
+class TestGoldenArchitectureIncompatibleError:
+    def test_full_message(self) -> None:
+        err = ArchitectureIncompatibleError(
+            agent_id=AgentId("agent-a"),
+            agent_arch="aarch64",
+            required_arch="x86_64",
+        )
+        assert err.extra_msg == (
+            "Agent agent-a architecture 'aarch64' does not match required architecture 'x86_64'"
+        )
+
+
+class TestGoldenMultipleValidationErrors:
+    def test_full_extra_msg_equals_expected(self) -> None:
+        errors = [
+            ConcurrencyLimitExceeded(max_sessions=5, session_type="concurrent"),
+            DependenciesNotSatisfied(pending_dependency_names=["dep-x not finished"]),
+        ]
+        aggregated = MultipleValidationErrors(errors)
+        expected = (
+            "Multiple validation errors occurred:\n"
+            "- ConcurrencyLimitExceeded: You cannot run more than 5 concurrent sessions\n"
+            "- DependenciesNotSatisfied: Waiting dependency sessions to finish"
+            " as success. (dep-x not finished)"
+        )
+        assert aggregated.extra_msg == expected
+
+
+class TestGoldenNoAvailableAgentError:
+    """End-to-end golden test that exercises the selector path."""
+
+    @pytest.fixture
+    def agents_with_two_failure_modes(self) -> list[AgentInfo]:
+        return [
+            AgentInfo(
+                agent_id=AgentId("agent-a"),
+                agent_addr="agent-a:6001",
+                architecture="x86_64",
+                available_slots=ResourceSlot({"cpu": Decimal("1")}),
+                occupied_slots=ResourceSlot({"cpu": Decimal("0")}),
+                scaling_group="default",
+                container_count=0,
+            ),
+            AgentInfo(
+                agent_id=AgentId("agent-b"),
+                agent_addr="agent-b:6001",
+                architecture="x86_64",
+                available_slots=ResourceSlot({"cpu": Decimal("8")}),
+                occupied_slots=ResourceSlot({"cpu": Decimal("0")}),
+                scaling_group="default",
+                container_count=10,  # at container limit
+            ),
+        ]
+
+    async def test_all_agents_failing_full_extra_msg(
+        self,
+        agents_with_two_failure_modes: list[AgentInfo],
+    ) -> None:
+        criteria = AgentSelectionCriteria(
+            session_metadata=SessionMetadata(
+                session_id=SessionId(uuid.uuid4()),
+                session_type=SessionTypes.INTERACTIVE,
+                scaling_group="default",
+                cluster_mode=ClusterMode.SINGLE_NODE,
+            ),
+            kernel_requirements={
+                _GOLDEN_KERNEL_ID: KernelResourceSpec(
+                    requested_slots=ResourceSlot({"cpu": Decimal("4")}),
+                    required_architecture="x86_64",
+                ),
+            },
+        )
+        config = AgentSelectionConfig(max_container_count=10)
+        selector = AgentSelector(
+            ConcentratedAgentSelector(agent_selection_resource_priority=["cpu"]),
+        )
+
+        with pytest.raises(NoAvailableAgentError) as exc_info:
+            await selector.select_agents_for_batch_requirements(
+                agents_with_two_failure_modes,
+                criteria,
+                config,
+            )
+
+        expected = (
+            f"no available agents for kernels [{_GOLDEN_KERNEL_ID}]"
+            " (arch=x86_64, slots=cpu=4):\n"
+            "- Agent agent-a has insufficient resources:\n"
+            "    - cpu: requested=4, available=1\n"
+            "- Agent agent-b container limit exceeded: current=10, max=10"
+        )
+        assert exc_info.value.extra_msg == expected
+
+
+class TestGoldenNoDesignatedAgentCompatible:
+    """End-to-end golden test for the designated-agent failure path."""
+
+    @pytest.fixture
+    def designated_agents_plus_fallback(self) -> list[AgentInfo]:
+        # The designated-only-incompatible branch requires at least one
+        # non-designated compatible agent so the early "no available agents"
+        # branch does not short-circuit before reaching it.
+        return [
+            AgentInfo(
+                agent_id=AgentId("designated-a"),
+                agent_addr="designated-a:6001",
+                architecture="x86_64",
+                available_slots=ResourceSlot({"cpu": Decimal("1")}),
+                occupied_slots=ResourceSlot({"cpu": Decimal("0")}),
+                scaling_group="default",
+                container_count=0,
+            ),
+            AgentInfo(
+                agent_id=AgentId("designated-b"),
+                agent_addr="designated-b:6001",
+                architecture="x86_64",
+                available_slots=ResourceSlot({"cpu": Decimal("8")}),
+                occupied_slots=ResourceSlot({"cpu": Decimal("0")}),
+                scaling_group="default",
+                container_count=10,
+            ),
+            AgentInfo(
+                agent_id=AgentId("non-designated-ok"),
+                agent_addr="non-designated-ok:6001",
+                architecture="x86_64",
+                available_slots=ResourceSlot({"cpu": Decimal("16")}),
+                occupied_slots=ResourceSlot({"cpu": Decimal("0")}),
+                scaling_group="default",
+                container_count=0,
+            ),
+        ]
+
+    async def test_full_extra_msg_when_designated_incompatible(
+        self,
+        designated_agents_plus_fallback: list[AgentInfo],
+    ) -> None:
+        criteria = AgentSelectionCriteria(
+            session_metadata=SessionMetadata(
+                session_id=SessionId(uuid.uuid4()),
+                session_type=SessionTypes.INTERACTIVE,
+                scaling_group="default",
+                cluster_mode=ClusterMode.SINGLE_NODE,
+            ),
+            kernel_requirements={
+                _GOLDEN_KERNEL_ID: KernelResourceSpec(
+                    requested_slots=ResourceSlot({"cpu": Decimal("4")}),
+                    required_architecture="x86_64",
+                ),
+            },
+        )
+        config = AgentSelectionConfig(max_container_count=10)
+        selector = AgentSelector(
+            ConcentratedAgentSelector(agent_selection_resource_priority=["cpu"]),
+        )
+
+        with pytest.raises(NoAvailableAgentError) as exc_info:
+            await selector.select_agents_for_batch_requirements(
+                designated_agents_plus_fallback,
+                criteria,
+                config,
+                designated_agent_ids=[
+                    AgentId("designated-a"),
+                    AgentId("designated-b"),
+                ],
+            )
+
+        expected = (
+            f"no designated agent is compatible for kernels [{_GOLDEN_KERNEL_ID}]"
+            " (arch=x86_64, slots=cpu=4):\n"
+            "- designated agent 'designated-a': Agent designated-a"
+            " has insufficient resources:\n"
+            "    - cpu: requested=4, available=1\n"
+            "- designated agent 'designated-b': Agent designated-b"
+            " container limit exceeded: current=10, max=10"
+        )
+        assert exc_info.value.extra_msg == expected
+
+
+class TestGoldenNoAvailableAgentDirectConstruction:
+    """Drive NoAvailableAgentError's constructor directly with structured inputs.
+
+    These tests do not pre-format any newline-containing strings on the caller
+    side; the exception class itself is responsible for laying out the message.
+    """
+
+    def test_compat_failures_with_mixed_inner_errors(self) -> None:
+        kernel_id = KernelId(UUID("00000000-0000-0000-0000-000000000002"))
+        err = NoAvailableAgentError(
+            kernel_ids=[kernel_id],
+            required_architecture="x86_64",
+            requested_slots=ResourceSlot({"cpu": Decimal("4")}),
+            agent_errors={
+                AgentId("agent-a"): InsufficientResourcesError(
+                    agent_id=AgentId("agent-a"),
+                    requested_slots=ResourceSlot({"cpu": Decimal("4")}),
+                    available_slots=ResourceSlot({"cpu": Decimal("1")}),
+                    occupied_slots=ResourceSlot({}),
+                    insufficient_resources={"cpu": ("4", "1")},
+                ),
+                AgentId("agent-b"): ContainerLimitExceededError(
+                    agent_id=AgentId("agent-b"),
+                    current_count=10,
+                    max_count=10,
+                ),
+            },
+        )
+        expected = (
+            f"no available agents for kernels [{kernel_id}]"
+            " (arch=x86_64, slots=cpu=4):\n"
+            "- Agent agent-a has insufficient resources:\n"
+            "    - cpu: requested=4, available=1\n"
+            "- Agent agent-b container limit exceeded: current=10, max=10"
+        )
+        assert err.extra_msg == expected
+
+    def test_designated_failures_reports_missing_designations(self) -> None:
+        kernel_id = KernelId(UUID("00000000-0000-0000-0000-000000000003"))
+        # Only 'designated-a' has a recorded failure; 'designated-b' was not
+        # even considered (e.g. filtered out by arch). The constructor must
+        # synthesize the 'not found in compatible agents' message for it.
+        err = NoAvailableAgentError(
+            kernel_ids=[kernel_id],
+            required_architecture="x86_64",
+            requested_slots=ResourceSlot({"cpu": Decimal("2")}),
+            agent_errors={
+                AgentId("designated-a"): ContainerLimitExceededError(
+                    agent_id=AgentId("designated-a"),
+                    current_count=5,
+                    max_count=5,
+                ),
+            },
+            designated_agent_ids=[
+                AgentId("designated-a"),
+                AgentId("designated-b"),
+            ],
+        )
+        expected = (
+            f"no designated agent is compatible for kernels [{kernel_id}]"
+            " (arch=x86_64, slots=cpu=2):\n"
+            "- designated agent 'designated-a': Agent designated-a"
+            " container limit exceeded: current=5, max=5\n"
+            "- designated agent 'designated-b': not found in compatible agents"
+        )
+        assert err.extra_msg == expected
+
+
+class TestGoldenNoAgentsInScalingGroupError:
+    def test_full_message(self) -> None:
+        err = NoAgentsInScalingGroupError("default")
+        assert err.extra_msg == "No agents available in scaling group 'default'"

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_failure_message_format.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_failure_message_format.py
@@ -29,7 +29,7 @@ from ai.backend.manager.sokovan.scheduler.provisioner.selectors.exceptions impor
     ArchitectureIncompatibleError,
     ContainerLimitExceededError,
     InsufficientResourcesError,
-    NoAgentsInScalingGroupError,
+    NoAgentsInResourceGroupError,
     NoAvailableAgentError,
 )
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.selector import (
@@ -613,7 +613,7 @@ class TestGoldenNoAvailableAgentDirectConstruction:
         assert err.extra_msg == expected
 
 
-class TestGoldenNoAgentsInScalingGroupError:
+class TestGoldenNoAgentsInResourceGroupError:
     def test_full_message(self) -> None:
-        err = NoAgentsInScalingGroupError("default")
-        assert err.extra_msg == "No agents available in scaling group 'default'"
+        err = NoAgentsInResourceGroupError("default")
+        assert err.extra_msg == "No agents available in resource group 'default'"

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_legacy_selector.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_legacy_selector.py
@@ -7,7 +7,14 @@ from decimal import Decimal
 
 import pytest
 
-from ai.backend.common.types import AgentId, ClusterMode, ResourceSlot, SessionId, SessionTypes
+from ai.backend.common.types import (
+    AgentId,
+    ClusterMode,
+    KernelId,
+    ResourceSlot,
+    SessionId,
+    SessionTypes,
+)
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.concentrated import (
     ConcentratedAgentSelector,
 )
@@ -64,7 +71,7 @@ class TestLegacyAgentSelector:
         """Test that legacy selector prioritizes fewer unutilized capabilities."""
         # Request only CPU and memory (explicitly no GPU/TPU)
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({
                 "cpu": Decimal("2"),
                 "mem": Decimal("4096"),
@@ -95,7 +102,7 @@ class TestLegacyAgentSelector:
     ) -> None:
         """Test that ties in unutilized capabilities are broken by resource availability."""
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("2048")}),
             required_architecture="x86_64",
         )
@@ -127,7 +134,7 @@ class TestLegacyAgentSelector:
         selector = LegacyAgentSelector(agent_selection_resource_priority=["mem", "cpu"])
 
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("1024")}),
             required_architecture="x86_64",
         )
@@ -156,7 +163,7 @@ class TestLegacyAgentSelector:
         """Test selection when agents have partially utilized special resources."""
         # Request includes GPU
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({
                 "cpu": Decimal("2"),
                 "mem": Decimal("4096"),
@@ -192,7 +199,7 @@ class TestLegacyAgentSelector:
 
         # Request only CPU and memory
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("2048")}),
             required_architecture="x86_64",
         )
@@ -230,7 +237,7 @@ class TestLegacyAgentSelector:
         )
 
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({
                 "cpu": Decimal("2"),
                 "mem": Decimal("4096"),

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_roundrobin_selector.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_roundrobin_selector.py
@@ -7,7 +7,14 @@ from decimal import Decimal
 
 import pytest
 
-from ai.backend.common.types import AgentId, ClusterMode, ResourceSlot, SessionId, SessionTypes
+from ai.backend.common.types import (
+    AgentId,
+    ClusterMode,
+    KernelId,
+    ResourceSlot,
+    SessionId,
+    SessionTypes,
+)
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.roundrobin import (
     RoundRobinAgentSelector,
 )
@@ -51,7 +58,7 @@ class TestRoundRobinAgentSelector:
         return ResourceRequirements(
             requested_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("2048")}),
             required_architecture="x86_64",
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
         )
 
     def test_sequential_selection(

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_selector_edge_cases.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_selector_edge_cases.py
@@ -7,7 +7,14 @@ from decimal import Decimal
 
 import pytest
 
-from ai.backend.common.types import AgentId, ClusterMode, ResourceSlot, SessionId, SessionTypes
+from ai.backend.common.types import (
+    AgentId,
+    ClusterMode,
+    KernelId,
+    ResourceSlot,
+    SessionId,
+    SessionTypes,
+)
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.concentrated import (
     ConcentratedAgentSelector,
 )
@@ -61,7 +68,7 @@ class TestSelectorEdgeCases:
         """Test handling of empty resource requirements."""
         # Empty resource request
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({}),  # No resources requested
             required_architecture="x86_64",
         )
@@ -92,7 +99,7 @@ class TestSelectorEdgeCases:
         """Test handling of zero resource values in requests."""
         # Request with zero values
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({
                 "cpu": Decimal("0"),
                 "mem": Decimal("0"),
@@ -117,7 +124,7 @@ class TestSelectorEdgeCases:
         """Test when requested resource type doesn't exist on any agent."""
         # Request TPU which no agent has
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({
                 "cpu": Decimal("2"),
                 "mem": Decimal("4096"),
@@ -143,7 +150,7 @@ class TestSelectorEdgeCases:
     ) -> None:
         """Test handling of very large resource values."""
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("2048")}),
             required_architecture="x86_64",
         )
@@ -173,7 +180,7 @@ class TestSelectorEdgeCases:
     ) -> None:
         """Test handling of decimal precision edge cases."""
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({
                 "cpu": Decimal("0.000000000000000000000001"),
                 "mem": Decimal("0.000000000000000000000001"),
@@ -196,7 +203,7 @@ class TestSelectorEdgeCases:
     ) -> None:
         """Test all strategies with only one agent available."""
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("2048")}),
             required_architecture="x86_64",
         )
@@ -222,7 +229,7 @@ class TestSelectorEdgeCases:
     ) -> None:
         """Test when all agents have zero available resources."""
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("2048")}),
             required_architecture="x86_64",
         )
@@ -243,7 +250,7 @@ class TestSelectorEdgeCases:
     ) -> None:
         """Test resource priority list containing non-existent resource types."""
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("2048")}),
             required_architecture="x86_64",
         )
@@ -266,7 +273,7 @@ class TestSelectorEdgeCases:
     ) -> None:
         """Test handling of special characters in resource names."""
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({
                 "cpu": Decimal("1"),
                 "mem": Decimal("2048"),

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_selector_integration.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_selector_integration.py
@@ -7,7 +7,14 @@ from decimal import Decimal
 
 import pytest
 
-from ai.backend.common.types import AgentId, ClusterMode, ResourceSlot, SessionId, SessionTypes
+from ai.backend.common.types import (
+    AgentId,
+    ClusterMode,
+    KernelId,
+    ResourceSlot,
+    SessionId,
+    SessionTypes,
+)
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.concentrated import (
     ConcentratedAgentSelector,
 )
@@ -66,7 +73,7 @@ class TestSelectorIntegration:
     ) -> None:
         """Test that different strategies make different choices for the same scenario."""
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("2048")}),
             required_architecture="x86_64",
         )
@@ -109,7 +116,7 @@ class TestSelectorIntegration:
         """Test strategy differences with mixed resource types."""
         # Request only CPU/memory (explicitly no GPU/TPU)
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({
                 "cpu": Decimal("2"),
                 "mem": Decimal("4096"),
@@ -155,7 +162,7 @@ class TestSelectorIntegration:
     ) -> None:
         """Test selector performance with many agents."""
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("2048")}),
             required_architecture="x86_64",
         )
@@ -220,7 +227,7 @@ class TestSelectorIntegration:
         )
 
         resource_req = ResourceRequirements(
-            kernel_ids=[uuid.uuid4()],
+            kernel_ids=[KernelId(uuid.uuid4())],
             requested_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("2048")}),
             required_architecture="x86_64",
         )

--- a/tests/unit/manager/sokovan/scheduler/provisioner/validators/test_reserved_batch.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/validators/test_reserved_batch.py
@@ -79,5 +79,8 @@ class TestReservedBatchSessionValidator:
 
         workload = batch_session_future_start_time
 
-        with pytest.raises(SchedulingValidationError, match="Before start time"):
+        with pytest.raises(
+            SchedulingValidationError,
+            match="Batch session is scheduled to start at",
+        ):
             validator.validate(snapshot, workload)


### PR DESCRIPTION
## Summary
- Aggregated scheduling failure messages are now newline-joined bullet lists instead of `"; "`-joined single lines; the `Nx ErrorType` count prefix is gone, so each kernel resource group and each candidate agent appears on its own line.
- Failure exceptions became data-driven: `NoAvailableAgentError`, `NoAgentsInScalingGroupError` (new), and every `SchedulingValidationError` subclass take structured kwargs and compose their own message via instance methods / `summary()`. `TrackerCompatibilityError` now inherits `BackendAIError` so every concrete compat error must declare an RFC-7807 `error_code`.
- Golden full-message assertions added in `test_failure_message_format.py` pin the exact user-visible layout for each failure path.

## Test plan
- [x] `pants fmt/fix/lint --changed-since=origin/main`
- [x] `pants check --changed-since=HEAD`
- [x] `pants test tests/unit/manager/sokovan/scheduler/provisioner/selectors:: tests/unit/manager/sokovan/scheduler/provisioner/validators::` (20 modules, all passed)
- [ ] Inspect a real scheduling failure on a live cluster: `./dev restart mgr`, force a session into PENDING with insufficient resources, and confirm `session.status_info` shows the new newline-formatted message.

Resolves BA-6149