### PR TITLE
fix(BA-3974): make multi-proxy TUS uploads safe via per-offset chunks

### DIFF
--- a/changes/11757.fix.md
+++ b/changes/11757.fix.md
@@ -1,0 +1,1 @@
+Fix multi-proxy TUS upload corruption by storing each chunk as a separate metadata-tracked file under the session directory, verifying SHA-256, and exposing `/upload/status` for resumable recovery.

--- a/src/ai/backend/storage/api/client.py
+++ b/src/ai/backend/storage/api/client.py
@@ -5,10 +5,12 @@ Client-facing API
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import logging
 import os
 import urllib.parse
-from collections.abc import AsyncGenerator, Iterator, Mapping, MutableMapping
+from collections.abc import AsyncGenerator, Iterator, Mapping
 from contextlib import AbstractAsyncContextManager
 from datetime import UTC, datetime
 from http import HTTPStatus
@@ -38,7 +40,6 @@ from ai.backend.common.dto.storage.request import (
     ArchiveDownloadQueryParams,
     ArchiveDownloadTokenData,
 )
-from ai.backend.common.files import AsyncFileWriter
 from ai.backend.common.json import dump_json_str
 from ai.backend.common.metrics.http import build_api_metric_middleware
 from ai.backend.common.middlewares.exception import general_exception_middleware
@@ -47,9 +48,19 @@ from ai.backend.common.types import BinarySize, VFolderID
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.storage import __version__
 from ai.backend.storage.dto.context import StorageRootCtx
-from ai.backend.storage.errors import InvalidAPIParameters, UploadOffsetMismatchError
+from ai.backend.storage.errors import (
+    ChunkChecksumMismatchError,
+    InvalidAPIParameters,
+    InvalidUploadChecksumHeaderError,
+    UploadOffsetMismatchError,
+)
 from ai.backend.storage.services.file_stream.zip import (
     ZipArchiveStreamReader,
+)
+from ai.backend.storage.services.upload.tus_session import (
+    SessionState,
+    TusUploadSession,
+    stream_chunk_to_temp,
 )
 from ai.backend.storage.types import SENTINEL
 from ai.backend.storage.utils import (
@@ -329,13 +340,38 @@ async def tus_check_session(request: web.Request) -> web.Response:
     ) as params:
         token_data = params["token"]
         async with ctx.get_volume(token_data["volume"]) as volume:
-            headers = await prepare_tus_session_headers(request, token_data, volume)
+            session_dir = _resolve_session_dir(volume, token_data)
+            if not session_dir.exists():
+                raise web.HTTPNotFound(
+                    body=dump_json_str(
+                        {
+                            "title": "No such upload session",
+                            "type": ("https://api.backend.ai/probs/storage/no-such-upload-session"),
+                        },
+                    ),
+                    content_type="application/problem+json",
+                )
+            session = TusUploadSession(
+                session_dir,
+                session_id=token_data["session"],
+                total_size=int(token_data["size"]),
+            )
+            state = await session.read_state()
+            headers = _tus_response_headers(
+                upload_offset=state.committed_offset,
+                upload_length=int(token_data["size"]),
+            )
     return web.Response(headers=headers)
 
 
 async def tus_upload_part(request: web.Request) -> web.Response:
     """
-    Perform the chunk upload.
+    Perform a TUS PATCH chunk upload.
+
+    Concurrent PATCH requests from multiple Storage Proxy replicas are made
+    safe by writing each chunk to its own file under ``chunks/`` and updating
+    the session ``info.json`` under a short ``fcntl.flock``. See
+    ``ai.backend.storage.services.upload.tus_session`` for the layout.
     """
     ctx: RootContext = request.app["ctx"]
     secret = ctx.local_config.storage_proxy.secret
@@ -361,59 +397,216 @@ async def tus_upload_part(request: web.Request) -> web.Response:
         ),
     ) as params:
         token_data = params["token"]
+        total_size = int(token_data["size"])
+
+        upload_offset_header = request.headers.get("Upload-Offset")
+        if upload_offset_header is None:
+            raise InvalidAPIParameters(
+                "Missing required Upload-Offset header for TUS PATCH request"
+            )
+        try:
+            client_offset = int(upload_offset_header)
+        except ValueError as e:
+            raise InvalidAPIParameters(
+                f"Invalid Upload-Offset header value: {upload_offset_header}"
+            ) from e
+        if client_offset < 0 or client_offset > total_size:
+            raise UploadOffsetMismatchError(
+                f"Upload-Offset {client_offset} is out of range [0, {total_size}]"
+            )
+
+        expected_checksum_hex = _parse_upload_checksum_header(
+            request.headers.get("Upload-Checksum")
+        )
+
         async with ctx.get_volume(token_data["volume"]) as volume:
-            headers = await prepare_tus_session_headers(request, token_data, volume)
-            vfpath = volume.mangle_vfpath(token_data["vfid"])
-            upload_temp_path: Path = vfpath / ".upload" / token_data["session"]
-
-            # TUS protocol requires Upload-Offset validation before appending data
-            upload_offset_header = request.headers.get("Upload-Offset")
-            if upload_offset_header is None:
-                raise InvalidAPIParameters(
-                    "Missing required Upload-Offset header for TUS PATCH request"
+            session_dir = _resolve_session_dir(volume, token_data)
+            if not session_dir.exists():
+                raise web.HTTPNotFound(
+                    body=dump_json_str(
+                        {
+                            "title": "No such upload session",
+                            "type": ("https://api.backend.ai/probs/storage/no-such-upload-session"),
+                        },
+                    ),
+                    content_type="application/problem+json",
                 )
+            session = TusUploadSession(
+                session_dir,
+                session_id=token_data["session"],
+                total_size=total_size,
+            )
+            await session.ensure_initialized()
 
+            temp_chunk = session.open_temp_chunk(client_offset)
             try:
-                client_offset = int(upload_offset_header)
-            except ValueError as e:
-                raise InvalidAPIParameters(
-                    f"Invalid Upload-Offset header value: {upload_offset_header}"
-                ) from e
-
-            actual_offset = int(headers["Upload-Offset"])
-            if client_offset != actual_offset:
-                raise UploadOffsetMismatchError(
-                    f"Upload offset mismatch: expected {actual_offset}, got {client_offset}"
+                length, sha256 = await stream_chunk_to_temp(
+                    request.content, temp_chunk.path, DEFAULT_CHUNK_SIZE
                 )
-
-            async with AsyncFileWriter(
-                target_filename=upload_temp_path,
-                access_mode="ab",
-                max_chunks=DEFAULT_INFLIGHT_CHUNKS,
-            ) as writer:
-                while not request.content.at_eof():
-                    chunk = await request.content.read(DEFAULT_CHUNK_SIZE)
-                    await writer.write(chunk)
-
-            current_size = Path(upload_temp_path).stat().st_size
-            if current_size >= int(token_data["size"]):
-                parent_dir = vfpath
-                if (dst_dir := params["dst_dir"]) is not None:
-                    parent_dir = vfpath / dst_dir
-                target_path: Path = parent_dir / token_data["relpath"]
-                if not target_path.parent.exists():
-                    target_path.parent.mkdir(parents=True, exist_ok=True)
-                upload_temp_path.rename(target_path)
-                try:
-                    loop = asyncio.get_running_loop()
-                    await loop.run_in_executor(
-                        None,
-                        lambda: upload_temp_path.parent.rmdir(),
+                if client_offset + length > total_size:
+                    raise UploadOffsetMismatchError(
+                        f"Chunk at offset {client_offset} with length {length} "
+                        f"exceeds declared size {total_size}"
                     )
-                except OSError:
-                    pass
-            headers["Upload-Offset"] = str(current_size)
+                if expected_checksum_hex is not None and expected_checksum_hex != sha256:
+                    raise ChunkChecksumMismatchError(
+                        f"Chunk at offset {client_offset} failed SHA-256 verification"
+                    )
+                acceptance = await session.commit_chunk(
+                    offset=client_offset,
+                    chunk_path=temp_chunk.path,
+                    length=length,
+                    sha256=sha256,
+                )
+            except BaseException:
+                if temp_chunk.path.exists():
+                    await asyncio.to_thread(temp_chunk.path.unlink)
+                raise
+
+            state = acceptance.state
+            if acceptance.completed_now:
+                parent_dir = volume.mangle_vfpath(token_data["vfid"])
+                if (dst_dir := params["dst_dir"]) is not None:
+                    parent_dir = parent_dir / dst_dir
+                target_path = parent_dir / token_data["relpath"]
+                await session.assemble(target_path)
+                await session.cleanup()
+
+            headers = _tus_response_headers(
+                upload_offset=state.committed_offset,
+                upload_length=total_size,
+            )
+            headers.update(_progress_response_headers(state))
     return web.Response(status=HTTPStatus.NO_CONTENT, headers=headers)
+
+
+async def tus_upload_status(request: web.Request) -> web.Response:
+    """
+    GET /upload/status — JSON snapshot of an in-flight upload session.
+
+    Used by clients to recover after a Storage Proxy crash or network error:
+    they discover which byte ranges are still missing and resend only those.
+    """
+    ctx: RootContext = request.app["ctx"]
+    secret = ctx.local_config.storage_proxy.secret
+
+    class Params(TypedDict):
+        token: UploadTokenData
+        dst_dir: str
+
+    async with cast(
+        AbstractAsyncContextManager[Params],
+        check_params(
+            request,
+            t.Dict(
+                {
+                    t.Key("token"): tx.JsonWebToken(
+                        secret=secret,
+                        inner_iv=upload_token_data_iv,
+                    ),
+                    t.Key("dst_dir", default=None): t.Null | t.String,
+                },
+            ),
+            read_from=CheckParamSource.QUERY,
+        ),
+    ) as params:
+        token_data = params["token"]
+        total_size = int(token_data["size"])
+        async with ctx.get_volume(token_data["volume"]) as volume:
+            session_dir = _resolve_session_dir(volume, token_data)
+            if not session_dir.exists():
+                raise web.HTTPNotFound(
+                    body=dump_json_str(
+                        {
+                            "title": "No such upload session",
+                            "type": ("https://api.backend.ai/probs/storage/no-such-upload-session"),
+                        },
+                    ),
+                    content_type="application/problem+json",
+                )
+            session = TusUploadSession(
+                session_dir,
+                session_id=token_data["session"],
+                total_size=total_size,
+            )
+            state = await session.read_state()
+            body = {
+                "session": token_data["session"],
+                "total_size": total_size,
+                "committed_offset": state.committed_offset,
+                "chunks_received": [rec.offset for rec in state.received],
+                "missing_ranges": [
+                    {"offset": offset, "length": length}
+                    for offset, length in state.missing_ranges()
+                ],
+                "progress_percent": state.progress_percent(),
+                "status": state.status,
+            }
+    return web.json_response(body, status=HTTPStatus.OK)
+
+
+def _resolve_session_dir(volume: AbstractVolume, token_data: UploadTokenData) -> Path:
+    return volume.mangle_vfpath(token_data["vfid"]) / ".upload" / token_data["session"]
+
+
+_TUS_HEADER_LIST = (
+    "Tus-Resumable, Upload-Length, Upload-Metadata, Upload-Offset, Upload-Checksum, Content-Type"
+)
+_PROGRESS_HEADER_LIST = (
+    "X-Backend-Ai-Chunks-Received, X-Backend-Ai-Progress-Percent, X-Backend-Ai-Total-Expected"
+)
+
+
+def _tus_response_headers(*, upload_offset: int, upload_length: int) -> dict[str, str]:
+    return {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Headers": _TUS_HEADER_LIST,
+        "Access-Control-Expose-Headers": f"{_TUS_HEADER_LIST}, {_PROGRESS_HEADER_LIST}",
+        "Access-Control-Allow-Methods": "*",
+        "Cache-Control": "no-store",
+        "Tus-Resumable": "1.0.0",
+        "Upload-Offset": str(upload_offset),
+        "Upload-Length": str(upload_length),
+    }
+
+
+def _progress_response_headers(state: SessionState) -> dict[str, str]:
+    return {
+        "X-Backend-Ai-Chunks-Received": str(len(state.received)),
+        "X-Backend-Ai-Progress-Percent": str(state.progress_percent()),
+        "X-Backend-Ai-Total-Expected": str(state.total_size),
+    }
+
+
+def _parse_upload_checksum_header(raw: str | None) -> str | None:
+    """
+    Parse a TUS Checksum extension header value into a hex SHA-256 digest.
+
+    Returns ``None`` if no header was sent. Raises
+    ``InvalidUploadChecksumHeaderError`` for malformed values or unsupported
+    algorithms (only sha256 is accepted).
+    """
+    if raw is None:
+        return None
+    parts = raw.strip().split(None, 1)
+    if len(parts) != 2:
+        raise InvalidUploadChecksumHeaderError(
+            f"Upload-Checksum must be '<algorithm> <base64>', got {raw!r}"
+        )
+    algorithm, encoded = parts
+    if algorithm.lower() != "sha256":
+        raise InvalidUploadChecksumHeaderError(
+            f"Unsupported checksum algorithm: {algorithm}. Only 'sha256' is accepted."
+        )
+    try:
+        digest = base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError) as e:
+        raise InvalidUploadChecksumHeaderError(
+            f"Invalid base64 in Upload-Checksum: {encoded!r}"
+        ) from e
+    if len(digest) != 32:
+        raise InvalidUploadChecksumHeaderError(f"sha256 digest must be 32 bytes, got {len(digest)}")
+    return digest.hex()
 
 
 async def tus_options(request: web.Request) -> web.Response:
@@ -423,53 +616,18 @@ async def tus_options(request: web.Request) -> web.Response:
     ctx: RootContext = request.app["ctx"]
     headers = {}
     headers["Access-Control-Allow-Origin"] = "*"
-    headers["Access-Control-Allow-Headers"] = (
-        "Tus-Resumable, Upload-Length, Upload-Metadata, Upload-Offset, Content-Type"
-    )
-    headers["Access-Control-Expose-Headers"] = (
-        "Tus-Resumable, Upload-Length, Upload-Metadata, Upload-Offset, Content-Type"
-    )
+    headers["Access-Control-Allow-Headers"] = _TUS_HEADER_LIST
+    headers["Access-Control-Expose-Headers"] = f"{_TUS_HEADER_LIST}, {_PROGRESS_HEADER_LIST}"
     headers["Access-Control-Allow-Methods"] = "*"
     headers["Tus-Resumable"] = "1.0.0"
     headers["Tus-Version"] = "1.0.0"
+    headers["Tus-Extension"] = "checksum"
+    headers["Tus-Checksum-Algorithm"] = "sha256"
     headers["Tus-Max-Size"] = str(
         int(BinarySize.from_str(ctx.local_config.storage_proxy.max_upload_size)),
     )
     headers["X-Content-Type-Options"] = "nosniff"
     return web.Response(headers=headers)
-
-
-async def prepare_tus_session_headers(
-    _request: web.Request,
-    token_data: Mapping[str, Any],
-    volume: AbstractVolume,
-) -> MutableMapping[str, str]:
-    vfpath = volume.mangle_vfpath(token_data["vfid"])
-    upload_temp_path = vfpath / ".upload" / token_data["session"]
-    if not Path(upload_temp_path).exists():
-        raise web.HTTPNotFound(
-            body=dump_json_str(
-                {
-                    "title": "No such upload session",
-                    "type": "https://api.backend.ai/probs/storage/no-such-upload-session",
-                },
-            ),
-            content_type="application/problem+json",
-        )
-    headers = {}
-    headers["Access-Control-Allow-Origin"] = "*"
-    headers["Access-Control-Allow-Headers"] = (
-        "Tus-Resumable, Upload-Length, Upload-Metadata, Upload-Offset, Content-Type"
-    )
-    headers["Access-Control-Expose-Headers"] = (
-        "Tus-Resumable, Upload-Length, Upload-Metadata, Upload-Offset, Content-Type"
-    )
-    headers["Access-Control-Allow-Methods"] = "*"
-    headers["Cache-Control"] = "no-store"
-    headers["Tus-Resumable"] = "1.0.0"
-    headers["Upload-Offset"] = str(Path(upload_temp_path).stat().st_size)
-    headers["Upload-Length"] = str(token_data["size"])
-    return headers
 
 
 class DownloadHandler:
@@ -546,5 +704,8 @@ async def init_client_app(ctx: RootContext) -> web.Application:
     r.add_route("OPTIONS", tus_options)
     r.add_route("HEAD", tus_check_session)
     r.add_route("PATCH", tus_upload_part)
+
+    status_resource = app.router.add_resource("/upload/status")
+    status_resource.add_route("GET", tus_upload_status)
 
     return app

--- a/src/ai/backend/storage/errors/__init__.py
+++ b/src/ai/backend/storage/errors/__init__.py
@@ -62,6 +62,12 @@ from .quota import (
     QuotaScopeNotFoundError,
     QuotaTreeNotFoundError,
 )
+from .upload import (
+    ChunkChecksumMismatchError,
+    ChunkConflictError,
+    InvalidUploadChecksumHeaderError,
+    UploadSessionCorruptedError,
+)
 from .vfolder import (
     InvalidSubpathError,
     VFolderNotFoundError,
@@ -90,6 +96,11 @@ __all__ = [
     "InvalidDataLengthError",
     "ServiceNotInitializedError",
     "UploadOffsetMismatchError",
+    # upload
+    "ChunkChecksumMismatchError",
+    "ChunkConflictError",
+    "InvalidUploadChecksumHeaderError",
+    "UploadSessionCorruptedError",
     # vfolder
     "VFolderNotFoundError",
     "InvalidSubpathError",

--- a/src/ai/backend/storage/errors/upload.py
+++ b/src/ai/backend/storage/errors/upload.py
@@ -1,0 +1,92 @@
+"""
+Upload session related exceptions.
+"""
+
+from __future__ import annotations
+
+from aiohttp import web
+
+from ai.backend.common.exception import (
+    BackendAIError,
+    ErrorCode,
+    ErrorDetail,
+    ErrorDomain,
+    ErrorOperation,
+)
+
+
+class ChunkConflictError(BackendAIError, web.HTTPConflict):
+    """
+    Raised when an incoming chunk targets an offset that already holds a
+    different chunk in the upload session (409 Conflict).
+    """
+
+    error_type = "https://api.backend.ai/probs/storage/chunk-conflict"
+    error_title = "Upload Chunk Conflict"
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.STORAGE_PROXY,
+            operation=ErrorOperation.UPDATE,
+            error_detail=ErrorDetail.CONFLICT,
+        )
+
+
+class UploadSessionCorruptedError(BackendAIError, web.HTTPInternalServerError):
+    """
+    Raised when the on-disk upload session metadata cannot be parsed or is
+    structurally invalid.
+    """
+
+    error_type = "https://api.backend.ai/probs/storage/upload-session-corrupted"
+    error_title = "Upload Session Corrupted"
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.STORAGE_PROXY,
+            operation=ErrorOperation.READ,
+            error_detail=ErrorDetail.INTERNAL_ERROR,
+        )
+
+
+class _ChecksumMismatch(web.HTTPClientError):
+    """
+    TUS Checksum extension defines HTTP 460 for checksum mismatches.
+    aiohttp does not ship a built-in class for this code, so we declare one.
+    """
+
+    status_code = 460
+
+
+class ChunkChecksumMismatchError(BackendAIError, _ChecksumMismatch):
+    """
+    Raised when ``Upload-Checksum`` header does not match the SHA-256 digest
+    of the received chunk body (HTTP 460 per TUS Checksum extension).
+    """
+
+    error_type = "https://api.backend.ai/probs/storage/chunk-checksum-mismatch"
+    error_title = "Upload Chunk Checksum Mismatch"
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.STORAGE_PROXY,
+            operation=ErrorOperation.UPDATE,
+            error_detail=ErrorDetail.MISMATCH,
+        )
+
+
+class InvalidUploadChecksumHeaderError(BackendAIError, web.HTTPBadRequest):
+    """
+    Raised when ``Upload-Checksum`` header is malformed or specifies an
+    unsupported algorithm (only ``sha256`` is accepted).
+    """
+
+    error_type = "https://api.backend.ai/probs/storage/invalid-upload-checksum"
+    error_title = "Invalid Upload-Checksum header"
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.STORAGE_PROXY,
+            operation=ErrorOperation.REQUEST,
+            error_detail=ErrorDetail.INVALID_PARAMETERS,
+        )

--- a/src/ai/backend/storage/services/upload/__init__.py
+++ b/src/ai/backend/storage/services/upload/__init__.py
@@ -1,0 +1,3 @@
+"""
+Chunk-based TUS upload session services.
+"""

--- a/src/ai/backend/storage/services/upload/tus_session.py
+++ b/src/ai/backend/storage/services/upload/tus_session.py
@@ -1,0 +1,455 @@
+"""
+Metadata-driven TUS upload session.
+
+A single TUS upload session backed by a directory:
+
+    <root>/
+      info.json                   # the source of truth (atomic rename writes)
+      info.json.<token>.tmp       # transient files used for atomic rename
+      .lock                       # fcntl.flock target, scoped to info.json access
+      chunks/
+        chunk_<offset>.dat        # committed chunks, named by absolute byte offset
+        chunk_<offset>.<token>.tmp
+
+The session is safe against multiple Storage Proxy replicas writing to the same
+NFS-mounted directory: chunk payloads are written without holding the lock,
+and only the short metadata read-modify-write window is serialized via
+``fcntl.flock`` on ``.lock``.
+
+PATCH requests with overlapping offsets are de-duplicated by ``(offset, length,
+sha256)``; conflicting writes raise ``ChunkConflictError``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import errno
+import fcntl
+import hashlib
+import json
+import os
+import secrets
+import shutil
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import IO, Any, Protocol, Self
+
+from ai.backend.storage.errors.upload import (
+    ChunkConflictError,
+    UploadSessionCorruptedError,
+)
+
+INFO_FILENAME = "info.json"
+LOCK_FILENAME = ".lock"
+CHUNKS_DIRNAME = "chunks"
+CHUNK_FILENAME_FMT = "chunk_{offset}.dat"
+TEMP_SUFFIX_BYTES = 8
+
+
+@dataclass(frozen=True, slots=True)
+class ChunkRecord:
+    offset: int
+    length: int
+    sha256: str
+
+    @property
+    def end(self) -> int:
+        return self.offset + self.length
+
+    def to_json(self) -> dict[str, int | str]:
+        return {"offset": self.offset, "length": self.length, "sha256": self.sha256}
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> Self:
+        return cls(
+            offset=int(data["offset"]),
+            length=int(data["length"]),
+            sha256=str(data["sha256"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SessionState:
+    session_id: str
+    total_size: int
+    received: tuple[ChunkRecord, ...]
+    status: str
+
+    @property
+    def committed_offset(self) -> int:
+        """End offset of the largest contiguous prefix from byte 0."""
+        cursor = 0
+        for rec in self.received:
+            if rec.offset != cursor:
+                break
+            cursor = rec.end
+        return cursor
+
+    @property
+    def is_complete(self) -> bool:
+        return self.status == "completed" or (
+            self.committed_offset >= self.total_size and self.total_size > 0
+        )
+
+    def find_at_offset(self, offset: int) -> ChunkRecord | None:
+        for rec in self.received:
+            if rec.offset == offset:
+                return rec
+            if rec.offset > offset:
+                return None
+        return None
+
+    def missing_ranges(self) -> list[tuple[int, int]]:
+        """
+        Return the list of ``(offset, length)`` byte ranges in
+        ``[0, total_size)`` that are NOT yet covered by any received chunk.
+
+        Overlapping or out-of-bounds received chunks are tolerated: ranges are
+        coalesced and clipped against the declared total size.
+        """
+        if self.total_size <= 0:
+            return []
+        covered: list[tuple[int, int]] = []
+        for rec in self.received:
+            start = max(0, rec.offset)
+            end = min(self.total_size, rec.end)
+            if start < end:
+                covered.append((start, end))
+        if not covered:
+            return [(0, self.total_size)]
+        covered.sort()
+        merged: list[tuple[int, int]] = [covered[0]]
+        for start, end in covered[1:]:
+            last_start, last_end = merged[-1]
+            if start <= last_end:
+                merged[-1] = (last_start, max(last_end, end))
+            else:
+                merged.append((start, end))
+        gaps: list[tuple[int, int]] = []
+        cursor = 0
+        for start, end in merged:
+            if cursor < start:
+                gaps.append((cursor, start - cursor))
+            cursor = end
+        if cursor < self.total_size:
+            gaps.append((cursor, self.total_size - cursor))
+        return gaps
+
+    def progress_percent(self) -> float:
+        if self.total_size <= 0:
+            return 100.0
+        return round(100.0 * self.committed_offset / self.total_size, 2)
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "session": self.session_id,
+            "total_size": self.total_size,
+            "received": [rec.to_json() for rec in self.received],
+            "status": self.status,
+            "updated_at": datetime.now(UTC).isoformat(),
+        }
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> Self:
+        raw_received = data.get("received", [])
+        if not isinstance(raw_received, list):
+            raise UploadSessionCorruptedError("'received' must be a list")
+        records: list[ChunkRecord] = []
+        for item in raw_received:
+            if not isinstance(item, dict):
+                raise UploadSessionCorruptedError("malformed chunk record")
+            records.append(ChunkRecord.from_json(item))
+        records.sort(key=lambda r: r.offset)
+        return cls(
+            session_id=str(data["session"]),
+            total_size=int(data["total_size"]),
+            received=tuple(records),
+            status=str(data.get("status", "pending")),
+        )
+
+    @classmethod
+    def empty(cls, session_id: str, total_size: int) -> Self:
+        return cls(
+            session_id=session_id,
+            total_size=total_size,
+            received=(),
+            status="pending",
+        )
+
+    def with_record(self, record: ChunkRecord) -> Self:
+        merged = list(self.received)
+        merged.append(record)
+        merged.sort(key=lambda r: r.offset)
+        return dataclasses.replace(self, received=tuple(merged))
+
+    def with_status(self, status: str) -> Self:
+        return dataclasses.replace(self, status=status)
+
+
+@dataclass(frozen=True, slots=True)
+class ChunkAcceptance:
+    """Result of attempting to commit a chunk."""
+
+    state: SessionState
+    committed: bool  # False means duplicate (idempotent) replay
+    completed_now: bool  # True if this commit just completed the upload
+
+
+class TusUploadSession:
+    """
+    A TUS upload session backed by a chunks-per-offset directory layout.
+
+    Instances are cheap to construct; all state lives on disk under ``root``.
+    """
+
+    def __init__(self, root: Path, session_id: str, total_size: int) -> None:
+        self._root = root
+        self._session_id = session_id
+        self._total_size = total_size
+
+    @property
+    def root(self) -> Path:
+        return self._root
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    @property
+    def chunks_dir(self) -> Path:
+        return self._root / CHUNKS_DIRNAME
+
+    @property
+    def info_path(self) -> Path:
+        return self._root / INFO_FILENAME
+
+    @property
+    def lock_path(self) -> Path:
+        return self._root / LOCK_FILENAME
+
+    async def ensure_initialized(self) -> SessionState:
+        """Create the on-disk layout and an initial info.json if missing."""
+        return await asyncio.to_thread(self._ensure_initialized_sync)
+
+    def _ensure_initialized_sync(self) -> SessionState:
+        self._root.mkdir(parents=True, exist_ok=True)
+        self.chunks_dir.mkdir(parents=True, exist_ok=True)
+        self.lock_path.touch(exist_ok=True)
+        with self._locked():
+            existing = self._read_info_locked()
+            if existing is not None:
+                return existing
+            state = SessionState.empty(self._session_id, self._total_size)
+            self._write_info_locked(state)
+            return state
+
+    async def read_state(self) -> SessionState:
+        return await asyncio.to_thread(self._read_state_sync)
+
+    def _read_state_sync(self) -> SessionState:
+        # info.json is always rewritten via atomic rename, so a lock-free read
+        # observes a fully consistent snapshot (either the old or the new file,
+        # never a partial mix). Skip the lock to keep read_state() usable when
+        # the session directory does not yet exist.
+        if not self.info_path.exists():
+            return SessionState.empty(self._session_id, self._total_size)
+        state = self._read_info_locked()
+        if state is None:
+            return SessionState.empty(self._session_id, self._total_size)
+        return state
+
+    async def commit_chunk(
+        self,
+        offset: int,
+        chunk_path: Path,
+        length: int,
+        sha256: str,
+    ) -> ChunkAcceptance:
+        """
+        Promote a fully-written temp chunk file at ``chunk_path`` into the
+        session, updating metadata atomically.
+
+        - Same ``(offset, length, sha256)`` already present → idempotent;
+          ``chunk_path`` is removed and ``committed=False``.
+        - Conflicting record at the same offset → ``ChunkConflictError``;
+          ``chunk_path`` is removed.
+        - Otherwise the chunk file is renamed into place and the record added.
+        """
+        return await asyncio.to_thread(self._commit_chunk_sync, offset, chunk_path, length, sha256)
+
+    def _commit_chunk_sync(
+        self,
+        offset: int,
+        chunk_path: Path,
+        length: int,
+        sha256: str,
+    ) -> ChunkAcceptance:
+        target = self.chunks_dir / CHUNK_FILENAME_FMT.format(offset=offset)
+        with self._locked():
+            state = self._read_info_locked()
+            if state is None:
+                state = SessionState.empty(self._session_id, self._total_size)
+
+            existing = state.find_at_offset(offset)
+            if existing is not None:
+                _unlink_quietly(chunk_path)
+                if existing.length == length and existing.sha256 == sha256:
+                    return ChunkAcceptance(state=state, committed=False, completed_now=False)
+                raise ChunkConflictError(
+                    f"chunk at offset {offset} already exists with different content"
+                )
+
+            chunk_path.replace(target)
+            new_state = state.with_record(ChunkRecord(offset, length, sha256))
+            self._write_info_locked(new_state)
+            completed_now = (
+                state.committed_offset < new_state.total_size <= new_state.committed_offset
+                and new_state.total_size > 0
+            )
+            return ChunkAcceptance(state=new_state, committed=True, completed_now=completed_now)
+
+    async def assemble(self, target_path: Path) -> None:
+        """Concatenate all chunks in offset order into ``target_path``."""
+        await asyncio.to_thread(self._assemble_sync, target_path)
+
+    def _assemble_sync(self, target_path: Path) -> None:
+        with self._locked():
+            state = self._read_info_locked()
+            if state is None:
+                raise UploadSessionCorruptedError("no session metadata to assemble")
+            if state.status == "completed":
+                return
+            if state.committed_offset < state.total_size:
+                raise UploadSessionCorruptedError("cannot assemble: not all chunks received")
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            staging = target_path.with_name(f"{target_path.name}.{_random_token()}.tmp")
+            try:
+                with staging.open("wb") as out:
+                    for rec in state.received:
+                        chunk_file = self.chunks_dir / CHUNK_FILENAME_FMT.format(offset=rec.offset)
+                        with chunk_file.open("rb") as chunk_fp:
+                            shutil.copyfileobj(chunk_fp, out, length=1024 * 1024)
+                staging.replace(target_path)
+            except BaseException:
+                _unlink_quietly(staging)
+                raise
+            self._write_info_locked(state.with_status("completed"))
+
+    async def cleanup(self) -> None:
+        """Remove the session directory (chunks + metadata)."""
+        await asyncio.to_thread(self._cleanup_sync)
+
+    def _cleanup_sync(self) -> None:
+        if not self._root.exists():
+            return
+        shutil.rmtree(self._root, ignore_errors=True)
+
+    def open_temp_chunk(self, offset: int) -> _TempChunkFile:
+        """
+        Allocate a unique temp file under chunks/ for a chunk at ``offset``.
+        The caller writes payload bytes into ``.path`` and then passes that
+        path to :meth:`commit_chunk`.
+        """
+        self.chunks_dir.mkdir(parents=True, exist_ok=True)
+        token = _random_token()
+        return _TempChunkFile(
+            path=self.chunks_dir / f"chunk_{offset}.{token}.tmp",
+            offset=offset,
+        )
+
+    @contextmanager
+    def _locked(self) -> Iterator[IO[bytes]]:
+        fd = self.lock_path.open("a+b")
+        try:
+            fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
+            try:
+                yield fd
+            finally:
+                fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+        finally:
+            fd.close()
+
+    def _read_info_locked(self) -> SessionState | None:
+        if not self.info_path.exists():
+            return None
+        try:
+            raw = self.info_path.read_bytes()
+        except FileNotFoundError:
+            return None
+        if not raw:
+            return None
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise UploadSessionCorruptedError(f"info.json is not valid JSON: {e}") from e
+        if not isinstance(data, dict):
+            raise UploadSessionCorruptedError("info.json must be a JSON object")
+        return SessionState.from_json(data)
+
+    def _write_info_locked(self, state: SessionState) -> None:
+        token = _random_token()
+        tmp_path = self._root / f"{INFO_FILENAME}.{token}.tmp"
+        payload = json.dumps(state.to_json(), separators=(",", ":")).encode("utf-8")
+        with tmp_path.open("wb") as fp:
+            fp.write(payload)
+            fp.flush()
+            os.fsync(fp.fileno())
+        tmp_path.replace(self.info_path)
+
+
+@dataclass(slots=True)
+class _TempChunkFile:
+    path: Path
+    offset: int
+
+
+def _random_token() -> str:
+    return secrets.token_hex(TEMP_SUFFIX_BYTES)
+
+
+def _unlink_quietly(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise
+
+
+class _AsyncByteReader(Protocol):
+    async def read(self, n: int) -> bytes: ...
+
+
+async def stream_chunk_to_temp(
+    request_reader: _AsyncByteReader,
+    temp_path: Path,
+    read_chunk_size: int,
+) -> tuple[int, str]:
+    """
+    Drain ``request_reader`` into ``temp_path`` and return ``(length, sha256)``.
+
+    ``request_reader`` is anything with an async ``read(n)`` method that yields
+    ``b""`` at EOF (e.g. ``aiohttp.web.Request.content``).
+    """
+    hasher = hashlib.sha256()
+    total = 0
+    loop = asyncio.get_running_loop()
+    fp = await loop.run_in_executor(None, lambda: temp_path.open("wb"))
+    try:
+        while True:
+            chunk = await request_reader.read(read_chunk_size)
+            if not chunk:
+                break
+            hasher.update(chunk)
+            total += len(chunk)
+            await loop.run_in_executor(None, fp.write, chunk)
+        await loop.run_in_executor(None, fp.flush)
+        await loop.run_in_executor(None, os.fsync, fp.fileno())
+    finally:
+        await loop.run_in_executor(None, fp.close)
+    return total, hasher.hexdigest()

--- a/src/ai/backend/storage/volumes/vfs/__init__.py
+++ b/src/ai/backend/storage/volumes/vfs/__init__.py
@@ -624,8 +624,8 @@ class BaseVolume(AbstractVolume):
         def _create_target() -> None:
             upload_base_path = vfpath / ".upload"
             upload_base_path.mkdir(exist_ok=True)
-            upload_target_path = upload_base_path / session_id
-            upload_target_path.touch()
+            session_dir = upload_base_path / session_id
+            session_dir.mkdir(parents=True, exist_ok=True)
 
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, _create_target)

--- a/tests/unit/storage/api/test_tus_upload.py
+++ b/tests/unit/storage/api/test_tus_upload.py
@@ -1,10 +1,18 @@
 """
-Tests for TUS upload offset validation in tus_upload_part().
+Tests for the TUS PATCH handler (``tus_upload_part``).
+
+The handler is exercised against real ``tmp_path`` session directories;
+only the volume/context plumbing is mocked. This validates both header-level
+guard checks (Upload-Offset parsing, range bounds) and the end-to-end happy
+path that writes through to ``TusUploadSession``.
 """
 
 from __future__ import annotations
 
-from collections.abc import Generator
+import base64
+import dataclasses
+import hashlib
+import json
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -12,248 +20,502 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from aiohttp import web
 
-from ai.backend.storage.api.client import tus_upload_part
-from ai.backend.storage.errors import InvalidAPIParameters, UploadOffsetMismatchError
+from ai.backend.storage.api.client import tus_upload_part, tus_upload_status
+from ai.backend.storage.errors import (
+    ChunkChecksumMismatchError,
+    InvalidAPIParameters,
+    InvalidUploadChecksumHeaderError,
+    UploadOffsetMismatchError,
+)
 
 
-class TestTusUploadPartOffsetValidation:
-    """Tests for Upload-Offset header validation in tus_upload_part()."""
+@dataclasses.dataclass(slots=True)
+class _PatchEnv:
+    vfpath: Path
+    session_dir: Path
 
-    # =========================================================================
-    # Low-level fixtures (internal building blocks)
-    # =========================================================================
 
-    @pytest.fixture
-    def token_data(self) -> dict[str, Any]:
-        """Create mock token data."""
-        return {
-            "volume": "test-volume",
-            "vfid": MagicMock(),
-            "session": "test-session",
-            "size": "10240",
-            "relpath": "test-file.txt",
-        }
+def _build_request(
+    *,
+    vfpath: Path,
+    session_id: str,
+    total_size: int,
+    body: bytes | None,
+    offset_header: str | None,
+    checksum_header: str | None = None,
+) -> MagicMock:
+    volume = MagicMock()
+    volume.mangle_vfpath.return_value = vfpath
 
-    def _create_mock_request(
-        self,
-        tmp_path: Path,
-        client_offset: str | None,
-    ) -> MagicMock:
-        """Create a fully configured mock request."""
-        # Mock volume
-        volume = MagicMock()
-        volume.mangle_vfpath.return_value = tmp_path
+    ctx = MagicMock()
+    ctx.local_config.storage_proxy.secret = "test-secret"
+    ctx.get_volume.return_value.__aenter__ = AsyncMock(return_value=volume)
+    ctx.get_volume.return_value.__aexit__ = AsyncMock(return_value=None)
 
-        # Mock context
-        ctx = MagicMock()
-        ctx.local_config.storage_proxy.secret = "test-secret"
-        ctx.get_volume.return_value.__aenter__ = AsyncMock(return_value=volume)
-        ctx.get_volume.return_value.__aexit__ = AsyncMock(return_value=None)
+    request = MagicMock(spec=web.Request)
+    request.app = {"ctx": ctx}
+    request.headers = {}
+    if offset_header is not None:
+        request.headers["Upload-Offset"] = offset_header
+    if checksum_header is not None:
+        request.headers["Upload-Checksum"] = checksum_header
+    request.query = {"token": "test-token"}
 
-        # Mock request
-        request = MagicMock(spec=web.Request)
-        request.app = {"ctx": ctx}
-        request.headers = {}
-        request.query = {"token": "test-token"}
-
-        if client_offset is not None:
-            request.headers["Upload-Offset"] = client_offset
-
-        # Mock content reader (returns EOF immediately)
+    if body is None:
         content = AsyncMock()
-        content.at_eof.return_value = True
+        content.read = AsyncMock(return_value=b"")
+        request.content = content
+    else:
+        body_state = {"pos": 0}
+
+        async def _read(_n: int) -> bytes:
+            if body_state["pos"] >= len(body):
+                return b""
+            chunk = body[body_state["pos"] :]
+            body_state["pos"] = len(body)
+            return chunk
+
+        content = AsyncMock()
+        content.read = AsyncMock(side_effect=_read)
         request.content = content
 
-        return request
+    return request
 
-    # =========================================================================
-    # Scenario fixtures (composed, one per test scenario)
-    # =========================================================================
 
-    @pytest.fixture
-    def request_without_offset_header(
-        self, tmp_path: Path, token_data: dict[str, Any]
-    ) -> Generator[MagicMock, None, None]:
-        """Scenario: Missing Upload-Offset header."""
-        request = self._create_mock_request(tmp_path, client_offset=None)
+def _sha256_b64(data: bytes) -> str:
+    return base64.b64encode(hashlib.sha256(data).digest()).decode("ascii")
 
-        with (
-            patch("ai.backend.storage.api.client.check_params") as mock_check_params,
-            patch("ai.backend.storage.api.client.prepare_tus_session_headers") as mock_headers,
-        ):
-            mock_check_params.return_value.__aenter__ = AsyncMock(
-                return_value={"token": token_data, "dst_dir": None}
+
+def _body_bytes(response: web.Response) -> bytes:
+    body = response.body
+    assert isinstance(body, (bytes, bytearray))
+    return bytes(body)
+
+
+@pytest.fixture
+def patch_env(tmp_path: Path) -> _PatchEnv:
+    session_id = "test-session"
+    vfpath = tmp_path / "vfpath"
+    session_dir = vfpath / ".upload" / session_id
+    session_dir.mkdir(parents=True)
+    return _PatchEnv(vfpath=vfpath, session_dir=session_dir)
+
+
+def _token_data(*, session_id: str, total_size: int, relpath: str) -> dict[str, Any]:
+    return {
+        "volume": "test-volume",
+        "vfid": MagicMock(),
+        "session": session_id,
+        "size": total_size,
+        "relpath": relpath,
+    }
+
+
+def _patch_handler_params(token_data: dict[str, Any]) -> Any:
+    cp = patch("ai.backend.storage.api.client.check_params")
+    mock_check_params = cp.start()
+    mock_check_params.return_value.__aenter__ = AsyncMock(
+        return_value={"token": token_data, "dst_dir": None}
+    )
+    mock_check_params.return_value.__aexit__ = AsyncMock(return_value=None)
+    return cp
+
+
+class TestUploadOffsetHeaderValidation:
+    async def test_missing_offset_header_raises(self, patch_env: _PatchEnv) -> None:
+        request = _build_request(
+            vfpath=patch_env.vfpath,
+            session_id="test-session",
+            total_size=1024,
+            body=None,
+            offset_header=None,
+        )
+        token_data = _token_data(session_id="test-session", total_size=1024, relpath="f.bin")
+        cp = _patch_handler_params(token_data)
+        try:
+            with pytest.raises(InvalidAPIParameters):
+                await tus_upload_part(request)
+        finally:
+            cp.stop()
+
+    async def test_non_integer_offset_header_raises(self, patch_env: _PatchEnv) -> None:
+        request = _build_request(
+            vfpath=patch_env.vfpath,
+            session_id="test-session",
+            total_size=1024,
+            body=None,
+            offset_header="not-a-number",
+        )
+        token_data = _token_data(session_id="test-session", total_size=1024, relpath="f.bin")
+        cp = _patch_handler_params(token_data)
+        try:
+            with pytest.raises(InvalidAPIParameters):
+                await tus_upload_part(request)
+        finally:
+            cp.stop()
+
+    async def test_negative_offset_raises_conflict(self, patch_env: _PatchEnv) -> None:
+        request = _build_request(
+            vfpath=patch_env.vfpath,
+            session_id="test-session",
+            total_size=1024,
+            body=None,
+            offset_header="-1",
+        )
+        token_data = _token_data(session_id="test-session", total_size=1024, relpath="f.bin")
+        cp = _patch_handler_params(token_data)
+        try:
+            with pytest.raises(UploadOffsetMismatchError):
+                await tus_upload_part(request)
+        finally:
+            cp.stop()
+
+    async def test_offset_above_total_size_raises_conflict(self, patch_env: _PatchEnv) -> None:
+        request = _build_request(
+            vfpath=patch_env.vfpath,
+            session_id="test-session",
+            total_size=1024,
+            body=None,
+            offset_header="2048",
+        )
+        token_data = _token_data(session_id="test-session", total_size=1024, relpath="f.bin")
+        cp = _patch_handler_params(token_data)
+        try:
+            with pytest.raises(UploadOffsetMismatchError):
+                await tus_upload_part(request)
+        finally:
+            cp.stop()
+
+
+class TestSessionNotFound:
+    async def test_missing_session_dir_raises_not_found(self, tmp_path: Path) -> None:
+        vfpath = tmp_path / "vfpath"
+        vfpath.mkdir()
+        # NOTE: do not create .upload/<session> — session has not been prepared.
+
+        request = _build_request(
+            vfpath=vfpath,
+            session_id="missing-session",
+            total_size=1024,
+            body=b"",
+            offset_header="0",
+        )
+        token_data = _token_data(session_id="missing-session", total_size=1024, relpath="f.bin")
+        cp = _patch_handler_params(token_data)
+        try:
+            with pytest.raises(web.HTTPNotFound):
+                await tus_upload_part(request)
+        finally:
+            cp.stop()
+
+
+class TestHappyPath:
+    async def test_single_chunk_upload_completes_and_assembles(self, patch_env: _PatchEnv) -> None:
+        payload = b"hello world" * 100
+        request = _build_request(
+            vfpath=patch_env.vfpath,
+            session_id="test-session",
+            total_size=len(payload),
+            body=payload,
+            offset_header="0",
+        )
+        token_data = _token_data(
+            session_id="test-session",
+            total_size=len(payload),
+            relpath="result.bin",
+        )
+        cp = _patch_handler_params(token_data)
+        try:
+            response = await tus_upload_part(request)
+        finally:
+            cp.stop()
+
+        assert response.headers["Upload-Offset"] == str(len(payload))
+
+        final_path = patch_env.vfpath / "result.bin"
+        assert final_path.read_bytes() == payload
+        # Session directory must be cleaned up after assembly.
+        assert not patch_env.session_dir.exists()
+
+    async def test_two_chunks_assemble_in_order(self, patch_env: _PatchEnv) -> None:
+        token_data = _token_data(session_id="test-session", total_size=2048, relpath="result.bin")
+
+        cp = _patch_handler_params(token_data)
+        try:
+            first = _build_request(
+                vfpath=patch_env.vfpath,
+                session_id="test-session",
+                total_size=2048,
+                body=b"A" * 1024,
+                offset_header="0",
             )
-            mock_check_params.return_value.__aexit__ = AsyncMock(return_value=None)
-            mock_headers.return_value = {"Upload-Offset": "1024"}
+            await tus_upload_part(first)
 
-            yield request
-
-    @pytest.fixture
-    def request_with_invalid_offset(
-        self, tmp_path: Path, token_data: dict[str, Any]
-    ) -> Generator[MagicMock, None, None]:
-        """Scenario: Invalid (non-integer) Upload-Offset header."""
-        request = self._create_mock_request(tmp_path, client_offset="not-a-number")
-
-        with (
-            patch("ai.backend.storage.api.client.check_params") as mock_check_params,
-            patch("ai.backend.storage.api.client.prepare_tus_session_headers") as mock_headers,
-        ):
-            mock_check_params.return_value.__aenter__ = AsyncMock(
-                return_value={"token": token_data, "dst_dir": None}
+            second = _build_request(
+                vfpath=patch_env.vfpath,
+                session_id="test-session",
+                total_size=2048,
+                body=b"B" * 1024,
+                offset_header="1024",
             )
-            mock_check_params.return_value.__aexit__ = AsyncMock(return_value=None)
-            mock_headers.return_value = {"Upload-Offset": "1024"}
+            response = await tus_upload_part(second)
+        finally:
+            cp.stop()
 
-            yield request
+        assert response.headers["Upload-Offset"] == "2048"
+        final_path = patch_env.vfpath / "result.bin"
+        assert final_path.read_bytes() == b"A" * 1024 + b"B" * 1024
 
-    @pytest.fixture
-    def request_offset_mismatch_client_behind(
-        self, tmp_path: Path, token_data: dict[str, Any]
-    ) -> Generator[MagicMock, None, None]:
-        """Scenario: Client offset (512) behind server offset (1024)."""
-        request = self._create_mock_request(tmp_path, client_offset="512")
-
-        with (
-            patch("ai.backend.storage.api.client.check_params") as mock_check_params,
-            patch("ai.backend.storage.api.client.prepare_tus_session_headers") as mock_headers,
-        ):
-            mock_check_params.return_value.__aenter__ = AsyncMock(
-                return_value={"token": token_data, "dst_dir": None}
+    async def test_duplicate_chunk_replay_is_idempotent(self, patch_env: _PatchEnv) -> None:
+        token_data = _token_data(session_id="test-session", total_size=2048, relpath="result.bin")
+        cp = _patch_handler_params(token_data)
+        try:
+            payload = b"A" * 1024
+            first = _build_request(
+                vfpath=patch_env.vfpath,
+                session_id="test-session",
+                total_size=2048,
+                body=payload,
+                offset_header="0",
             )
-            mock_check_params.return_value.__aexit__ = AsyncMock(return_value=None)
-            mock_headers.return_value = {"Upload-Offset": "1024"}
+            await tus_upload_part(first)
 
-            yield request
-
-    @pytest.fixture
-    def request_offset_mismatch_client_ahead(
-        self, tmp_path: Path, token_data: dict[str, Any]
-    ) -> Generator[MagicMock, None, None]:
-        """Scenario: Client offset (2048) ahead of server offset (1024)."""
-        request = self._create_mock_request(tmp_path, client_offset="2048")
-
-        with (
-            patch("ai.backend.storage.api.client.check_params") as mock_check_params,
-            patch("ai.backend.storage.api.client.prepare_tus_session_headers") as mock_headers,
-        ):
-            mock_check_params.return_value.__aenter__ = AsyncMock(
-                return_value={"token": token_data, "dst_dir": None}
+            # Replay the same chunk; must not change committed offset.
+            replay = _build_request(
+                vfpath=patch_env.vfpath,
+                session_id="test-session",
+                total_size=2048,
+                body=payload,
+                offset_header="0",
             )
-            mock_check_params.return_value.__aexit__ = AsyncMock(return_value=None)
-            mock_headers.return_value = {"Upload-Offset": "1024"}
+            response = await tus_upload_part(replay)
+        finally:
+            cp.stop()
 
-            yield request
+        assert response.headers["Upload-Offset"] == "1024"
+        # Session is still pending (not finalized).
+        assert patch_env.session_dir.exists()
 
-    @pytest.fixture
-    def request_with_matching_offset(
-        self, tmp_path: Path, token_data: dict[str, Any]
-    ) -> Generator[MagicMock, None, None]:
-        """Scenario: Client offset matches server offset (both 1024)."""
-        request = self._create_mock_request(tmp_path, client_offset="1024")
+    async def test_chunk_exceeding_declared_size_raises(self, patch_env: _PatchEnv) -> None:
+        token_data = _token_data(session_id="test-session", total_size=10, relpath="result.bin")
+        request = _build_request(
+            vfpath=patch_env.vfpath,
+            session_id="test-session",
+            total_size=10,
+            body=b"too-much-data",  # 13 bytes > 10
+            offset_header="0",
+        )
+        cp = _patch_handler_params(token_data)
+        try:
+            with pytest.raises(UploadOffsetMismatchError):
+                await tus_upload_part(request)
+        finally:
+            cp.stop()
 
-        # Create upload temp file
-        upload_parent = tmp_path / ".upload"
-        upload_parent.mkdir(parents=True, exist_ok=True)
-        temp_file = upload_parent / token_data["session"]
-        temp_file.write_bytes(b"x" * 1024)
+        # The aborted temp chunk file must be cleaned up.
+        chunks_dir = patch_env.session_dir / "chunks"
+        if chunks_dir.exists():
+            assert list(chunks_dir.glob("*.tmp")) == []
 
-        with (
-            patch("ai.backend.storage.api.client.check_params") as mock_check_params,
-            patch("ai.backend.storage.api.client.prepare_tus_session_headers") as mock_headers,
-            patch("ai.backend.storage.api.client.AsyncFileWriter") as mock_writer,
-        ):
-            mock_check_params.return_value.__aenter__ = AsyncMock(
-                return_value={"token": token_data, "dst_dir": None}
+
+class TestProgressHeaders:
+    async def test_patch_response_includes_progress_headers(self, patch_env: _PatchEnv) -> None:
+        token_data = _token_data(session_id="test-session", total_size=2048, relpath="result.bin")
+        cp = _patch_handler_params(token_data)
+        try:
+            request = _build_request(
+                vfpath=patch_env.vfpath,
+                session_id="test-session",
+                total_size=2048,
+                body=b"A" * 1024,
+                offset_header="0",
             )
-            mock_check_params.return_value.__aexit__ = AsyncMock(return_value=None)
-            mock_headers.return_value = {"Upload-Offset": "1024"}
+            response = await tus_upload_part(request)
+        finally:
+            cp.stop()
 
-            writer = AsyncMock()
-            mock_writer.return_value.__aenter__ = AsyncMock(return_value=writer)
-            mock_writer.return_value.__aexit__ = AsyncMock(return_value=None)
+        assert response.headers["X-Backend-Ai-Chunks-Received"] == "1"
+        assert response.headers["X-Backend-Ai-Total-Expected"] == "2048"
+        assert response.headers["X-Backend-Ai-Progress-Percent"] == "50.0"
 
-            yield request
 
-    @pytest.fixture
-    def request_with_zero_offset(
-        self, tmp_path: Path, token_data: dict[str, Any]
-    ) -> Generator[MagicMock, None, None]:
-        """Scenario: New file upload with zero offset."""
-        request = self._create_mock_request(tmp_path, client_offset="0")
-
-        # Create empty upload temp file
-        upload_parent = tmp_path / ".upload"
-        upload_parent.mkdir(parents=True, exist_ok=True)
-        temp_file = upload_parent / token_data["session"]
-        temp_file.write_bytes(b"")
-
-        with (
-            patch("ai.backend.storage.api.client.check_params") as mock_check_params,
-            patch("ai.backend.storage.api.client.prepare_tus_session_headers") as mock_headers,
-            patch("ai.backend.storage.api.client.AsyncFileWriter") as mock_writer,
-        ):
-            mock_check_params.return_value.__aenter__ = AsyncMock(
-                return_value={"token": token_data, "dst_dir": None}
+class TestUploadChecksum:
+    async def test_matching_checksum_accepted(self, patch_env: _PatchEnv) -> None:
+        payload = b"X" * 1024
+        token_data = _token_data(session_id="test-session", total_size=1024, relpath="result.bin")
+        cp = _patch_handler_params(token_data)
+        try:
+            request = _build_request(
+                vfpath=patch_env.vfpath,
+                session_id="test-session",
+                total_size=1024,
+                body=payload,
+                offset_header="0",
+                checksum_header=f"sha256 {_sha256_b64(payload)}",
             )
-            mock_check_params.return_value.__aexit__ = AsyncMock(return_value=None)
-            mock_headers.return_value = {"Upload-Offset": "0"}
+            response = await tus_upload_part(request)
+        finally:
+            cp.stop()
+        assert response.headers["Upload-Offset"] == "1024"
+        assert (patch_env.vfpath / "result.bin").read_bytes() == payload
 
-            writer = AsyncMock()
-            mock_writer.return_value.__aenter__ = AsyncMock(return_value=writer)
-            mock_writer.return_value.__aexit__ = AsyncMock(return_value=None)
+    async def test_mismatched_checksum_rejected(self, patch_env: _PatchEnv) -> None:
+        payload = b"X" * 1024
+        wrong = _sha256_b64(b"different-payload")
+        token_data = _token_data(session_id="test-session", total_size=1024, relpath="result.bin")
+        cp = _patch_handler_params(token_data)
+        try:
+            request = _build_request(
+                vfpath=patch_env.vfpath,
+                session_id="test-session",
+                total_size=1024,
+                body=payload,
+                offset_header="0",
+                checksum_header=f"sha256 {wrong}",
+            )
+            with pytest.raises(ChunkChecksumMismatchError):
+                await tus_upload_part(request)
+        finally:
+            cp.stop()
 
-            yield request
+        # The mismatched chunk must not be committed.
+        assert not (patch_env.vfpath / "result.bin").exists()
+        chunks_dir = patch_env.session_dir / "chunks"
+        if chunks_dir.exists():
+            assert list(chunks_dir.glob("*")) == []
 
-    # =========================================================================
-    # Test methods (minimal fixture injection, Act & Assert only)
-    # =========================================================================
-
-    async def test_missing_upload_offset_header_raises_bad_request(
-        self,
-        request_without_offset_header: MagicMock,
+    @pytest.mark.parametrize(
+        "header",
+        [
+            "sha256",  # missing digest
+            "sha1 abc",  # unsupported algorithm
+            "sha256 not_base64!!",  # invalid base64
+            "sha256 " + base64.b64encode(b"too-short").decode("ascii"),  # wrong length
+        ],
+    )
+    async def test_malformed_checksum_header_rejected(
+        self, patch_env: _PatchEnv, header: str
     ) -> None:
-        """When Upload-Offset header is missing, should raise InvalidAPIParameters (400)."""
-        with pytest.raises(InvalidAPIParameters):
-            await tus_upload_part(request_without_offset_header)
+        token_data = _token_data(session_id="test-session", total_size=1024, relpath="result.bin")
+        cp = _patch_handler_params(token_data)
+        try:
+            request = _build_request(
+                vfpath=patch_env.vfpath,
+                session_id="test-session",
+                total_size=1024,
+                body=b"X" * 1024,
+                offset_header="0",
+                checksum_header=header,
+            )
+            with pytest.raises(InvalidUploadChecksumHeaderError):
+                await tus_upload_part(request)
+        finally:
+            cp.stop()
 
-    async def test_invalid_upload_offset_header_raises_bad_request(
-        self,
-        request_with_invalid_offset: MagicMock,
-    ) -> None:
-        """When Upload-Offset header is not a valid integer, should raise InvalidAPIParameters (400)."""
-        with pytest.raises(InvalidAPIParameters):
-            await tus_upload_part(request_with_invalid_offset)
 
-    async def test_offset_mismatch_client_behind_raises_conflict(
-        self,
-        request_offset_mismatch_client_behind: MagicMock,
-    ) -> None:
-        """When client offset is behind server file size, should raise UploadOffsetMismatchError (409)."""
-        with pytest.raises(UploadOffsetMismatchError):
-            await tus_upload_part(request_offset_mismatch_client_behind)
+class TestUploadStatus:
+    async def test_status_for_empty_session(self, patch_env: _PatchEnv) -> None:
+        token_data = _token_data(session_id="test-session", total_size=2048, relpath="result.bin")
+        request = _build_request(
+            vfpath=patch_env.vfpath,
+            session_id="test-session",
+            total_size=2048,
+            body=None,
+            offset_header=None,
+        )
+        cp = _patch_handler_params(token_data)
+        try:
+            response = await tus_upload_status(request)
+        finally:
+            cp.stop()
 
-    async def test_offset_mismatch_client_ahead_raises_conflict(
-        self,
-        request_offset_mismatch_client_ahead: MagicMock,
-    ) -> None:
-        """When client offset is ahead of server file size, should raise UploadOffsetMismatchError (409)."""
-        with pytest.raises(UploadOffsetMismatchError):
-            await tus_upload_part(request_offset_mismatch_client_ahead)
+        payload = json.loads(_body_bytes(response))
+        assert payload["total_size"] == 2048
+        assert payload["committed_offset"] == 0
+        assert payload["chunks_received"] == []
+        assert payload["missing_ranges"] == [{"offset": 0, "length": 2048}]
+        assert payload["progress_percent"] == 0.0
+        assert payload["status"] == "pending"
 
-    async def test_matching_offset_proceeds_with_upload(
-        self,
-        request_with_matching_offset: MagicMock,
-    ) -> None:
-        """When client offset matches server file size, upload should proceed successfully."""
-        # No exception should be raised
-        await tus_upload_part(request_with_matching_offset)
+    async def test_status_after_partial_upload(self, patch_env: _PatchEnv) -> None:
+        token_data = _token_data(session_id="test-session", total_size=4096, relpath="result.bin")
+        cp = _patch_handler_params(token_data)
+        try:
+            patch_request = _build_request(
+                vfpath=patch_env.vfpath,
+                session_id="test-session",
+                total_size=4096,
+                body=b"A" * 1024,
+                offset_header="0",
+            )
+            await tus_upload_part(patch_request)
 
-    async def test_new_file_upload_with_zero_offset(
-        self,
-        request_with_zero_offset: MagicMock,
-    ) -> None:
-        """When both client offset and file size are 0, upload should proceed successfully."""
-        # No exception should be raised
-        await tus_upload_part(request_with_zero_offset)
+            status_request = _build_request(
+                vfpath=patch_env.vfpath,
+                session_id="test-session",
+                total_size=4096,
+                body=None,
+                offset_header=None,
+            )
+            response = await tus_upload_status(status_request)
+        finally:
+            cp.stop()
+
+        payload = json.loads(_body_bytes(response))
+        assert payload["committed_offset"] == 1024
+        assert payload["chunks_received"] == [0]
+        assert payload["missing_ranges"] == [{"offset": 1024, "length": 3072}]
+        assert payload["progress_percent"] == 25.0
+        assert payload["status"] == "pending"
+
+    async def test_status_with_out_of_order_chunks_reports_gaps(self, patch_env: _PatchEnv) -> None:
+        token_data = _token_data(session_id="test-session", total_size=4096, relpath="result.bin")
+        cp = _patch_handler_params(token_data)
+        try:
+            # Commit the *second* chunk first, leaving [0, 1024) missing.
+            second = _build_request(
+                vfpath=patch_env.vfpath,
+                session_id="test-session",
+                total_size=4096,
+                body=b"B" * 1024,
+                offset_header="1024",
+            )
+            await tus_upload_part(second)
+
+            status_request = _build_request(
+                vfpath=patch_env.vfpath,
+                session_id="test-session",
+                total_size=4096,
+                body=None,
+                offset_header=None,
+            )
+            response = await tus_upload_status(status_request)
+        finally:
+            cp.stop()
+
+        payload = json.loads(_body_bytes(response))
+        # The contiguous prefix has not advanced because [0,1024) is missing.
+        assert payload["committed_offset"] == 0
+        assert payload["chunks_received"] == [1024]
+        assert payload["missing_ranges"] == [
+            {"offset": 0, "length": 1024},
+            {"offset": 2048, "length": 2048},
+        ]
+
+    async def test_status_for_missing_session_returns_404(self, tmp_path: Path) -> None:
+        vfpath = tmp_path / "vfpath"
+        vfpath.mkdir()
+        token_data = _token_data(session_id="missing", total_size=1024, relpath="result.bin")
+        request = _build_request(
+            vfpath=vfpath,
+            session_id="missing",
+            total_size=1024,
+            body=None,
+            offset_header=None,
+        )
+        cp = _patch_handler_params(token_data)
+        try:
+            with pytest.raises(web.HTTPNotFound):
+                await tus_upload_status(request)
+        finally:
+            cp.stop()

--- a/tests/unit/storage/services/upload/BUILD
+++ b/tests/unit/storage/services/upload/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/storage/services/upload/test_tus_session.py
+++ b/tests/unit/storage/services/upload/test_tus_session.py
@@ -1,0 +1,421 @@
+"""
+Tests for the metadata-driven TUS upload session.
+
+These tests exercise the on-disk layout (info.json + chunks/*.dat + .lock)
+directly via ``tmp_path``: nothing is mocked. Concurrency tests run the
+synchronous internals under ``concurrent.futures`` to model multiple Storage
+Proxy replicas hitting the same NFS-mounted session directory.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import hashlib
+import json
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from ai.backend.storage.errors.upload import (
+    ChunkConflictError,
+    UploadSessionCorruptedError,
+)
+from ai.backend.storage.services.upload.tus_session import (
+    INFO_FILENAME,
+    ChunkAcceptance,
+    ChunkRecord,
+    SessionState,
+    TusUploadSession,
+    stream_chunk_to_temp,
+)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _Chunk:
+    offset: int
+    payload: bytes
+
+    @property
+    def length(self) -> int:
+        return len(self.payload)
+
+    @property
+    def sha256(self) -> str:
+        return hashlib.sha256(self.payload).hexdigest()
+
+
+def _make_chunks(total_size: int, chunk_size: int, *, seed: bytes = b"abc") -> list[_Chunk]:
+    payload = (seed * ((total_size // len(seed)) + 1))[:total_size]
+    chunks: list[_Chunk] = []
+    for offset in range(0, total_size, chunk_size):
+        end = min(offset + chunk_size, total_size)
+        chunks.append(_Chunk(offset=offset, payload=payload[offset:end]))
+    return chunks
+
+
+def _write_temp_chunk(session: TusUploadSession, chunk: _Chunk) -> Path:
+    temp = session.open_temp_chunk(chunk.offset)
+    temp.path.write_bytes(chunk.payload)
+    return temp.path
+
+
+async def _commit(session: TusUploadSession, chunk: _Chunk) -> ChunkAcceptance:
+    return await session.commit_chunk(
+        offset=chunk.offset,
+        chunk_path=_write_temp_chunk(session, chunk),
+        length=chunk.length,
+        sha256=chunk.sha256,
+    )
+
+
+@pytest.fixture
+def session_root(tmp_path: Path) -> Path:
+    return tmp_path / "session-abc"
+
+
+@pytest.fixture
+def session(session_root: Path) -> TusUploadSession:
+    return TusUploadSession(session_root, session_id="abc", total_size=1024)
+
+
+class TestSessionStatePrefix:
+    @pytest.mark.parametrize(
+        ("records", "expected_prefix"),
+        [
+            ([], 0),
+            ([ChunkRecord(0, 100, "x")], 100),
+            ([ChunkRecord(0, 100, "x"), ChunkRecord(100, 50, "y")], 150),
+            # Gap after a contiguous prefix: prefix ends at the gap.
+            ([ChunkRecord(0, 100, "x"), ChunkRecord(200, 50, "y")], 100),
+            # No prefix from byte 0.
+            ([ChunkRecord(50, 100, "x")], 0),
+        ],
+    )
+    def test_committed_offset(self, records: list[ChunkRecord], expected_prefix: int) -> None:
+        state = SessionState(
+            session_id="s", total_size=1024, received=tuple(records), status="pending"
+        )
+        assert state.committed_offset == expected_prefix
+
+
+class TestMissingRanges:
+    @pytest.mark.parametrize(
+        ("total_size", "records", "expected"),
+        [
+            # Empty session: the whole declared size is missing.
+            (1000, [], [(0, 1000)]),
+            # Single chunk at start.
+            (1000, [ChunkRecord(0, 400, "x")], [(400, 600)]),
+            # Single chunk in the middle.
+            (1000, [ChunkRecord(200, 300, "x")], [(0, 200), (500, 500)]),
+            # Contiguous prefix.
+            (1000, [ChunkRecord(0, 400, "x"), ChunkRecord(400, 100, "y")], [(500, 500)]),
+            # Two disjoint chunks leaving two gaps.
+            (
+                1000,
+                [ChunkRecord(0, 200, "x"), ChunkRecord(500, 300, "y")],
+                [(200, 300), (800, 200)],
+            ),
+            # Fully complete: no gaps.
+            (500, [ChunkRecord(0, 500, "x")], []),
+            # Overlapping/duplicate ranges are coalesced.
+            (
+                1000,
+                [ChunkRecord(0, 600, "x"), ChunkRecord(400, 200, "y")],
+                [(600, 400)],
+            ),
+            # Record extending past total_size is clipped.
+            (1000, [ChunkRecord(800, 500, "x")], [(0, 800)]),
+        ],
+    )
+    def test_missing_ranges(
+        self,
+        total_size: int,
+        records: list[ChunkRecord],
+        expected: list[tuple[int, int]],
+    ) -> None:
+        state = SessionState(
+            session_id="s",
+            total_size=total_size,
+            received=tuple(records),
+            status="pending",
+        )
+        assert state.missing_ranges() == expected
+
+    @pytest.mark.parametrize(
+        ("total_size", "records", "expected_percent"),
+        [
+            (1000, [], 0.0),
+            (1000, [ChunkRecord(0, 250, "x")], 25.0),
+            (1000, [ChunkRecord(0, 500, "x"), ChunkRecord(500, 500, "y")], 100.0),
+            # Non-contiguous prefix only counts the contiguous head.
+            (1000, [ChunkRecord(500, 500, "x")], 0.0),
+            # Zero-size sessions are reported as 100%.
+            (0, [], 100.0),
+        ],
+    )
+    def test_progress_percent(
+        self,
+        total_size: int,
+        records: list[ChunkRecord],
+        expected_percent: float,
+    ) -> None:
+        state = SessionState(
+            session_id="s",
+            total_size=total_size,
+            received=tuple(records),
+            status="pending",
+        )
+        assert state.progress_percent() == expected_percent
+
+
+class TestSessionLifecycle:
+    async def test_ensure_initialized_creates_layout(self, session: TusUploadSession) -> None:
+        state = await session.ensure_initialized()
+        assert state.committed_offset == 0
+        assert state.status == "pending"
+        assert session.info_path.exists()
+        assert session.chunks_dir.is_dir()
+        assert session.lock_path.exists()
+
+    async def test_ensure_initialized_is_idempotent(self, session: TusUploadSession) -> None:
+        await session.ensure_initialized()
+        chunks = _make_chunks(total_size=512, chunk_size=512)
+        await _commit(session, chunks[0])
+
+        # Re-initializing must not wipe the existing state.
+        state = await session.ensure_initialized()
+        assert state.committed_offset == chunks[0].length
+
+    async def test_read_state_on_missing_info_returns_empty(
+        self, session: TusUploadSession
+    ) -> None:
+        state = await session.read_state()
+        assert state.committed_offset == 0
+        assert state.received == ()
+
+
+class TestSequentialCommit:
+    async def test_commits_advance_committed_offset(self, session: TusUploadSession) -> None:
+        await session.ensure_initialized()
+        chunks = _make_chunks(total_size=1024, chunk_size=256)
+        last_acceptance: ChunkAcceptance | None = None
+        for chunk in chunks:
+            last_acceptance = await _commit(session, chunk)
+        assert last_acceptance is not None
+        assert last_acceptance.state.committed_offset == 1024
+        assert last_acceptance.completed_now is True
+
+    async def test_completed_now_fires_only_on_threshold_crossing(
+        self, session: TusUploadSession
+    ) -> None:
+        await session.ensure_initialized()
+        chunks = _make_chunks(total_size=1024, chunk_size=512)
+        first = await _commit(session, chunks[0])
+        last = await _commit(session, chunks[1])
+        assert first.completed_now is False
+        assert last.completed_now is True
+
+
+class TestOutOfOrderCommit:
+    async def test_prefix_only_advances_when_gap_filled(self, session: TusUploadSession) -> None:
+        await session.ensure_initialized()
+        chunks = _make_chunks(total_size=1024, chunk_size=256)
+        # Commit last chunk first.
+        acceptance = await _commit(session, chunks[3])
+        assert acceptance.state.committed_offset == 0
+        # Fill earlier chunks in reverse order.
+        await _commit(session, chunks[2])
+        await _commit(session, chunks[1])
+        final = await _commit(session, chunks[0])
+        assert final.state.committed_offset == 1024
+        assert final.completed_now is True
+
+
+class TestIdempotencyAndConflict:
+    async def test_duplicate_chunk_is_idempotent(self, session: TusUploadSession) -> None:
+        await session.ensure_initialized()
+        chunks = _make_chunks(total_size=512, chunk_size=512)
+        first = await _commit(session, chunks[0])
+        assert first.committed is True
+        replay = await _commit(session, chunks[0])
+        assert replay.committed is False
+        assert replay.state.committed_offset == 512
+
+    async def test_conflicting_chunk_raises(self, session: TusUploadSession) -> None:
+        await session.ensure_initialized()
+        original = _Chunk(offset=0, payload=b"A" * 512)
+        await _commit(session, original)
+
+        tampered = _Chunk(offset=0, payload=b"B" * 512)
+        with pytest.raises(ChunkConflictError):
+            await _commit(session, tampered)
+
+        # State must reflect the original chunk only.
+        state = await session.read_state()
+        assert state.received == (ChunkRecord(0, 512, original.sha256),)
+
+    async def test_conflicting_chunk_temp_file_is_cleaned_up(
+        self, session: TusUploadSession
+    ) -> None:
+        await session.ensure_initialized()
+        await _commit(session, _Chunk(offset=0, payload=b"A" * 512))
+
+        temp = session.open_temp_chunk(0)
+        temp.path.write_bytes(b"B" * 512)
+        with pytest.raises(ChunkConflictError):
+            await session.commit_chunk(
+                offset=0,
+                chunk_path=temp.path,
+                length=512,
+                sha256=hashlib.sha256(b"B" * 512).hexdigest(),
+            )
+        assert not temp.path.exists()
+
+
+class TestAssembly:
+    async def test_assembled_file_matches_payload(
+        self, session: TusUploadSession, tmp_path: Path
+    ) -> None:
+        await session.ensure_initialized()
+        chunks = _make_chunks(total_size=1024, chunk_size=128)
+        for chunk in chunks:
+            await _commit(session, chunk)
+
+        target = tmp_path / "out" / "final.bin"
+        await session.assemble(target)
+
+        expected = b"".join(c.payload for c in chunks)
+        assert target.read_bytes() == expected
+
+    async def test_assemble_is_idempotent_on_completed_status(
+        self, session: TusUploadSession, tmp_path: Path
+    ) -> None:
+        await session.ensure_initialized()
+        chunks = _make_chunks(total_size=1024, chunk_size=1024)
+        await _commit(session, chunks[0])
+
+        target = tmp_path / "out" / "final.bin"
+        await session.assemble(target)
+        first_mtime = target.stat().st_mtime_ns
+
+        # Calling again must not raise nor rewrite the target.
+        await session.assemble(target)
+        assert target.stat().st_mtime_ns == first_mtime
+
+    async def test_assemble_before_completion_raises(
+        self, session: TusUploadSession, tmp_path: Path
+    ) -> None:
+        await session.ensure_initialized()
+        chunks = _make_chunks(total_size=1024, chunk_size=512)
+        await _commit(session, chunks[0])  # only half
+
+        with pytest.raises(UploadSessionCorruptedError):
+            await session.assemble(tmp_path / "final.bin")
+
+    async def test_cleanup_removes_session_dir(
+        self, session: TusUploadSession, tmp_path: Path
+    ) -> None:
+        await session.ensure_initialized()
+        chunks = _make_chunks(total_size=1024, chunk_size=1024)
+        await _commit(session, chunks[0])
+        await session.assemble(tmp_path / "final.bin")
+        await session.cleanup()
+        assert not session.root.exists()
+
+
+class TestCorruption:
+    async def test_garbage_info_json_raises(self, session: TusUploadSession) -> None:
+        session.root.mkdir(parents=True, exist_ok=True)
+        (session.root / INFO_FILENAME).write_text("{not json")
+        with pytest.raises(UploadSessionCorruptedError):
+            await session.read_state()
+
+    async def test_non_object_info_json_raises(self, session: TusUploadSession) -> None:
+        session.root.mkdir(parents=True, exist_ok=True)
+        (session.root / INFO_FILENAME).write_text(json.dumps([1, 2, 3]))
+        with pytest.raises(UploadSessionCorruptedError):
+            await session.read_state()
+
+
+class TestConcurrentCommits:
+    """Models multiple Storage Proxy replicas hitting the same session."""
+
+    @pytest.fixture
+    def disjoint_chunks(self) -> Iterator[list[_Chunk]]:
+        yield _make_chunks(total_size=4096, chunk_size=256)
+
+    async def test_concurrent_disjoint_offsets_all_succeed(
+        self, session: TusUploadSession, disjoint_chunks: list[_Chunk]
+    ) -> None:
+        await session.ensure_initialized()
+
+        def worker(chunk: _Chunk) -> ChunkAcceptance:
+            return session._commit_chunk_sync(
+                offset=chunk.offset,
+                chunk_path=_write_temp_chunk(session, chunk),
+                length=chunk.length,
+                sha256=chunk.sha256,
+            )
+
+        loop = asyncio.get_running_loop()
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [loop.run_in_executor(pool, worker, chunk) for chunk in disjoint_chunks]
+            results = await asyncio.gather(*futures)
+
+        assert all(r.committed for r in results)
+        assert sum(1 for r in results if r.completed_now) == 1
+
+        state = await session.read_state()
+        assert state.committed_offset == 4096
+
+    async def test_concurrent_same_offset_one_winner(self, session: TusUploadSession) -> None:
+        await session.ensure_initialized()
+        chunk = _Chunk(offset=0, payload=b"x" * 1024)
+
+        def worker() -> ChunkAcceptance:
+            return session._commit_chunk_sync(
+                offset=chunk.offset,
+                chunk_path=_write_temp_chunk(session, chunk),
+                length=chunk.length,
+                sha256=chunk.sha256,
+            )
+
+        loop = asyncio.get_running_loop()
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [loop.run_in_executor(pool, worker) for _ in range(8)]
+            results = list(await asyncio.gather(*futures, return_exceptions=True))
+
+        winners = [r for r in results if isinstance(r, ChunkAcceptance) and r.committed]
+        replays = [r for r in results if isinstance(r, ChunkAcceptance) and not r.committed]
+        assert len(winners) == 1
+        assert len(winners) + len(replays) == 8
+
+
+class TestStreamChunkToTemp:
+    async def test_streams_and_hashes_payload(self, tmp_path: Path) -> None:
+        class _Reader:
+            def __init__(self, data: bytes, chunk_size: int) -> None:
+                self._data = data
+                self._pos = 0
+                self._chunk_size = chunk_size
+
+            async def read(self, _n: int) -> bytes:
+                if self._pos >= len(self._data):
+                    return b""
+                end = min(self._pos + self._chunk_size, len(self._data))
+                buf = self._data[self._pos : end]
+                self._pos = end
+                return buf
+
+        payload = b"hello-world" * 500
+        reader = _Reader(payload, chunk_size=64)
+        target = tmp_path / "chunk.tmp"
+        length, sha256 = await stream_chunk_to_temp(reader, target, read_chunk_size=64)
+
+        assert length == len(payload)
+        assert sha256 == hashlib.sha256(payload).hexdigest()
+        assert target.read_bytes() == payload


### PR DESCRIPTION
## Summary
- Replace single-file append in `tus_upload_part` with a metadata-driven per-offset chunk store (`info.json` + `chunks/chunk_<offset>.dat`) so concurrent PATCH requests from multiple Storage Proxy replicas can no longer corrupt an upload on a shared NFS mount.
- Add TUS Checksum extension (`Upload-Checksum: sha256 <b64>`, HTTP 460 on mismatch) and advertise it in OPTIONS.
- Add `GET /upload/status` returning `chunks_received`, `missing_ranges`, `committed_offset`, and `progress_percent` so clients can resume after a proxy crash without retransmitting completed ranges.
- Enrich PATCH responses with `X-Backend-Ai-Chunks-Received` / `X-Backend-Ai-Progress-Percent` headers (additive, optional).

The wire contract on `/upload` (PATCH/HEAD/OPTIONS) remains TUS 1.0.0-compatible, so existing tus-js-client based callers work unchanged.

Resolves BA-3974.