### PR TITLE
feat(BA-6154): add upload session state model

### DIFF
--- a/src/ai/backend/storage/errors/__init__.py
+++ b/src/ai/backend/storage/errors/__init__.py
@@ -62,6 +62,10 @@ from .quota import (
     QuotaScopeNotFoundError,
     QuotaTreeNotFoundError,
 )
+from .upload import (
+    ChunkConflictError,
+    UploadSessionCorruptedError,
+)
 from .vfolder import (
     InvalidSubpathError,
     VFolderNotFoundError,
@@ -90,6 +94,9 @@ __all__ = [
     "InvalidDataLengthError",
     "ServiceNotInitializedError",
     "UploadOffsetMismatchError",
+    # upload
+    "ChunkConflictError",
+    "UploadSessionCorruptedError",
     # vfolder
     "VFolderNotFoundError",
     "InvalidSubpathError",

--- a/src/ai/backend/storage/errors/upload.py
+++ b/src/ai/backend/storage/errors/upload.py
@@ -1,0 +1,49 @@
+"""
+Upload session related exceptions.
+"""
+
+from __future__ import annotations
+
+from aiohttp import web
+
+from ai.backend.common.exception import (
+    BackendAIError,
+    ErrorCode,
+    ErrorDetail,
+    ErrorDomain,
+    ErrorOperation,
+)
+
+
+class ChunkConflictError(BackendAIError, web.HTTPConflict):
+    """
+    Raised when an incoming chunk targets an offset that already holds a
+    different chunk in the upload session (409 Conflict).
+    """
+
+    error_type = "https://api.backend.ai/probs/storage/chunk-conflict"
+    error_title = "Upload Chunk Conflict"
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.STORAGE_PROXY,
+            operation=ErrorOperation.UPDATE,
+            error_detail=ErrorDetail.CONFLICT,
+        )
+
+
+class UploadSessionCorruptedError(BackendAIError, web.HTTPInternalServerError):
+    """
+    Raised when the on-disk upload session metadata cannot be parsed or is
+    structurally invalid.
+    """
+
+    error_type = "https://api.backend.ai/probs/storage/upload-session-corrupted"
+    error_title = "Upload Session Corrupted"
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.STORAGE_PROXY,
+            operation=ErrorOperation.READ,
+            error_detail=ErrorDetail.INTERNAL_ERROR,
+        )

--- a/src/ai/backend/storage/services/upload/__init__.py
+++ b/src/ai/backend/storage/services/upload/__init__.py
@@ -1,0 +1,3 @@
+"""
+Chunk-based TUS upload session services.
+"""

--- a/src/ai/backend/storage/services/upload/tus_session.py
+++ b/src/ai/backend/storage/services/upload/tus_session.py
@@ -1,0 +1,172 @@
+"""
+TUS upload session state model.
+
+This module defines the pure data classes that describe an in-flight upload
+session — what byte ranges have been received, how that maps to the standard
+TUS ``Upload-Offset`` semantics, and which ranges are still missing. No I/O
+or locking lives here; the storage class that mutates this state on disk
+arrives in a follow-up change.
+
+The model is the source of truth for an upload session: instead of inferring
+progress from the size of a single temp file (which is racy on a shared NFS
+mount with multiple Storage Proxy replicas), every committed chunk is recorded
+as an explicit ``ChunkRecord`` keyed by its absolute byte offset.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Self
+
+from ai.backend.storage.errors.upload import UploadSessionCorruptedError
+
+
+@dataclass(frozen=True, slots=True)
+class ChunkRecord:
+    offset: int
+    length: int
+    sha256: str
+
+    @property
+    def end(self) -> int:
+        return self.offset + self.length
+
+    def to_json(self) -> dict[str, int | str]:
+        return {"offset": self.offset, "length": self.length, "sha256": self.sha256}
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> Self:
+        return cls(
+            offset=int(data["offset"]),
+            length=int(data["length"]),
+            sha256=str(data["sha256"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SessionState:
+    session_id: str
+    total_size: int
+    received: tuple[ChunkRecord, ...]
+    status: str
+
+    @property
+    def committed_offset(self) -> int:
+        """End offset of the largest contiguous prefix from byte 0."""
+        cursor = 0
+        for rec in self.received:
+            if rec.offset != cursor:
+                break
+            cursor = rec.end
+        return cursor
+
+    @property
+    def is_complete(self) -> bool:
+        return self.status == "completed" or (
+            self.committed_offset >= self.total_size and self.total_size > 0
+        )
+
+    def find_at_offset(self, offset: int) -> ChunkRecord | None:
+        for rec in self.received:
+            if rec.offset == offset:
+                return rec
+            if rec.offset > offset:
+                return None
+        return None
+
+    def missing_ranges(self) -> list[tuple[int, int]]:
+        """
+        Return the list of ``(offset, length)`` byte ranges in
+        ``[0, total_size)`` that are NOT yet covered by any received chunk.
+
+        Overlapping or out-of-bounds received chunks are tolerated: ranges
+        are coalesced and clipped against the declared total size.
+        """
+        if self.total_size <= 0:
+            return []
+        covered: list[tuple[int, int]] = []
+        for rec in self.received:
+            start = max(0, rec.offset)
+            end = min(self.total_size, rec.end)
+            if start < end:
+                covered.append((start, end))
+        if not covered:
+            return [(0, self.total_size)]
+        covered.sort()
+        merged: list[tuple[int, int]] = [covered[0]]
+        for start, end in covered[1:]:
+            last_start, last_end = merged[-1]
+            if start <= last_end:
+                merged[-1] = (last_start, max(last_end, end))
+            else:
+                merged.append((start, end))
+        gaps: list[tuple[int, int]] = []
+        cursor = 0
+        for start, end in merged:
+            if cursor < start:
+                gaps.append((cursor, start - cursor))
+            cursor = end
+        if cursor < self.total_size:
+            gaps.append((cursor, self.total_size - cursor))
+        return gaps
+
+    def progress_percent(self) -> float:
+        if self.total_size <= 0:
+            return 100.0
+        return round(100.0 * self.committed_offset / self.total_size, 2)
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "session": self.session_id,
+            "total_size": self.total_size,
+            "received": [rec.to_json() for rec in self.received],
+            "status": self.status,
+            "updated_at": datetime.now(UTC).isoformat(),
+        }
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> Self:
+        raw_received = data.get("received", [])
+        if not isinstance(raw_received, list):
+            raise UploadSessionCorruptedError("'received' must be a list")
+        records: list[ChunkRecord] = []
+        for item in raw_received:
+            if not isinstance(item, dict):
+                raise UploadSessionCorruptedError("malformed chunk record")
+            records.append(ChunkRecord.from_json(item))
+        records.sort(key=lambda r: r.offset)
+        return cls(
+            session_id=str(data["session"]),
+            total_size=int(data["total_size"]),
+            received=tuple(records),
+            status=str(data.get("status", "pending")),
+        )
+
+    @classmethod
+    def empty(cls, session_id: str, total_size: int) -> Self:
+        return cls(
+            session_id=session_id,
+            total_size=total_size,
+            received=(),
+            status="pending",
+        )
+
+    def with_record(self, record: ChunkRecord) -> Self:
+        merged = list(self.received)
+        merged.append(record)
+        merged.sort(key=lambda r: r.offset)
+        return dataclasses.replace(self, received=tuple(merged))
+
+    def with_status(self, status: str) -> Self:
+        return dataclasses.replace(self, status=status)
+
+
+@dataclass(frozen=True, slots=True)
+class ChunkAcceptance:
+    """Result of attempting to commit a chunk into a session."""
+
+    state: SessionState
+    committed: bool  # False means duplicate (idempotent) replay
+    completed_now: bool  # True if this commit just completed the upload

--- a/tests/unit/storage/services/upload/BUILD
+++ b/tests/unit/storage/services/upload/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/storage/services/upload/test_tus_session.py
+++ b/tests/unit/storage/services/upload/test_tus_session.py
@@ -1,0 +1,195 @@
+"""
+Unit tests for the TUS upload session state model.
+
+These tests cover the pure data-layer behavior of ``SessionState``:
+computing the contiguous prefix offset, finding records by offset, gap
+analysis (``missing_ranges``), and progress reporting. Nothing here touches
+the filesystem.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ai.backend.storage.errors.upload import UploadSessionCorruptedError
+from ai.backend.storage.services.upload.tus_session import (
+    ChunkRecord,
+    SessionState,
+)
+
+
+class TestSessionStatePrefix:
+    @pytest.mark.parametrize(
+        ("records", "expected_prefix"),
+        [
+            ([], 0),
+            ([ChunkRecord(0, 100, "x")], 100),
+            ([ChunkRecord(0, 100, "x"), ChunkRecord(100, 50, "y")], 150),
+            # Gap after a contiguous prefix: prefix ends at the gap.
+            ([ChunkRecord(0, 100, "x"), ChunkRecord(200, 50, "y")], 100),
+            # No prefix from byte 0.
+            ([ChunkRecord(50, 100, "x")], 0),
+        ],
+    )
+    def test_committed_offset(self, records: list[ChunkRecord], expected_prefix: int) -> None:
+        state = SessionState(
+            session_id="s",
+            total_size=1024,
+            received=tuple(records),
+            status="pending",
+        )
+        assert state.committed_offset == expected_prefix
+
+
+class TestFindAtOffset:
+    def test_returns_record_at_matching_offset(self) -> None:
+        rec = ChunkRecord(100, 50, "x")
+        state = SessionState(
+            session_id="s",
+            total_size=1024,
+            received=(ChunkRecord(0, 100, "a"), rec),
+            status="pending",
+        )
+        assert state.find_at_offset(100) == rec
+
+    def test_returns_none_when_offset_not_present(self) -> None:
+        state = SessionState(
+            session_id="s",
+            total_size=1024,
+            received=(ChunkRecord(0, 100, "a"),),
+            status="pending",
+        )
+        assert state.find_at_offset(500) is None
+
+
+class TestMissingRanges:
+    @pytest.mark.parametrize(
+        ("total_size", "records", "expected"),
+        [
+            # Empty session: the whole declared size is missing.
+            (1000, [], [(0, 1000)]),
+            # Single chunk at start.
+            (1000, [ChunkRecord(0, 400, "x")], [(400, 600)]),
+            # Single chunk in the middle.
+            (1000, [ChunkRecord(200, 300, "x")], [(0, 200), (500, 500)]),
+            # Contiguous prefix.
+            (1000, [ChunkRecord(0, 400, "x"), ChunkRecord(400, 100, "y")], [(500, 500)]),
+            # Two disjoint chunks leaving two gaps.
+            (
+                1000,
+                [ChunkRecord(0, 200, "x"), ChunkRecord(500, 300, "y")],
+                [(200, 300), (800, 200)],
+            ),
+            # Fully complete: no gaps.
+            (500, [ChunkRecord(0, 500, "x")], []),
+            # Overlapping/duplicate ranges are coalesced.
+            (
+                1000,
+                [ChunkRecord(0, 600, "x"), ChunkRecord(400, 200, "y")],
+                [(600, 400)],
+            ),
+            # Record extending past total_size is clipped.
+            (1000, [ChunkRecord(800, 500, "x")], [(0, 800)]),
+        ],
+    )
+    def test_missing_ranges(
+        self,
+        total_size: int,
+        records: list[ChunkRecord],
+        expected: list[tuple[int, int]],
+    ) -> None:
+        state = SessionState(
+            session_id="s",
+            total_size=total_size,
+            received=tuple(records),
+            status="pending",
+        )
+        assert state.missing_ranges() == expected
+
+    @pytest.mark.parametrize(
+        ("total_size", "records", "expected_percent"),
+        [
+            (1000, [], 0.0),
+            (1000, [ChunkRecord(0, 250, "x")], 25.0),
+            (1000, [ChunkRecord(0, 500, "x"), ChunkRecord(500, 500, "y")], 100.0),
+            # Non-contiguous prefix only counts the contiguous head.
+            (1000, [ChunkRecord(500, 500, "x")], 0.0),
+            # Zero-size sessions are reported as 100%.
+            (0, [], 100.0),
+        ],
+    )
+    def test_progress_percent(
+        self,
+        total_size: int,
+        records: list[ChunkRecord],
+        expected_percent: float,
+    ) -> None:
+        state = SessionState(
+            session_id="s",
+            total_size=total_size,
+            received=tuple(records),
+            status="pending",
+        )
+        assert state.progress_percent() == expected_percent
+
+
+class TestRoundtripJson:
+    def test_to_json_then_from_json_preserves_records(self) -> None:
+        state = SessionState(
+            session_id="abc",
+            total_size=2048,
+            received=(
+                ChunkRecord(0, 1024, "deadbeef"),
+                ChunkRecord(1024, 1024, "feedface"),
+            ),
+            status="pending",
+        )
+        roundtrip = SessionState.from_json(state.to_json())
+        assert roundtrip.session_id == state.session_id
+        assert roundtrip.total_size == state.total_size
+        assert roundtrip.received == state.received
+        assert roundtrip.status == state.status
+
+    def test_from_json_sorts_received_by_offset(self) -> None:
+        raw = {
+            "session": "abc",
+            "total_size": 2048,
+            "status": "pending",
+            "received": [
+                {"offset": 1024, "length": 1024, "sha256": "second"},
+                {"offset": 0, "length": 1024, "sha256": "first"},
+            ],
+        }
+        state = SessionState.from_json(raw)
+        assert [r.offset for r in state.received] == [0, 1024]
+
+    def test_from_json_rejects_non_list_received(self) -> None:
+        with pytest.raises(UploadSessionCorruptedError):
+            SessionState.from_json({"session": "s", "total_size": 0, "received": "x"})
+
+    def test_from_json_rejects_malformed_record(self) -> None:
+        with pytest.raises(UploadSessionCorruptedError):
+            SessionState.from_json({"session": "s", "total_size": 0, "received": ["not a dict"]})
+
+    def test_to_json_is_json_serializable(self) -> None:
+        state = SessionState.empty("abc", 1024)
+        # Should not raise.
+        json.dumps(state.to_json())
+
+
+class TestWithModifiers:
+    def test_with_record_keeps_received_sorted(self) -> None:
+        state = SessionState.empty("s", 3000)
+        state = state.with_record(ChunkRecord(2000, 500, "c"))
+        state = state.with_record(ChunkRecord(0, 1000, "a"))
+        state = state.with_record(ChunkRecord(1000, 1000, "b"))
+        assert [r.offset for r in state.received] == [0, 1000, 2000]
+
+    def test_with_status_returns_updated_copy(self) -> None:
+        state = SessionState.empty("s", 1024)
+        updated = state.with_status("completed")
+        assert state.status == "pending"
+        assert updated.status == "completed"
+        assert updated.session_id == state.session_id


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 6-PR stack implementing BA-3974 (epic: BA-6153). **Merge in order:**

1. 👉 **#11765** — `feat(BA-6154): add upload session state model` ← you are here
2. ⬇️ #11766 — `feat(BA-6155): add TusUploadSession storage class`
3. ⬇️ #11767 — `fix(BA-6156): rewire TUS PATCH/HEAD to chunk-based store` (user-visible fix)
4. ⬇️ #11768 — `test(BA-6157): add multi-proxy NFS race regression test`
5. ⬇️ #11769 — `feat(BA-6158): support TUS Checksum extension`
6. ⬇️ #11770 — `feat(BA-6159): add /upload/status endpoint + progress headers`

## Summary
- Introduce pure data classes (\`ChunkRecord\`, \`SessionState\`, \`ChunkAcceptance\`) that will back the chunk-based TUS upload session designed for BA-3974.
- Add \`SessionState\` computed properties: \`committed_offset\` (contiguous prefix used as TUS \`Upload-Offset\`), \`missing_ranges\`, and \`progress_percent\`.
- Add \`ChunkConflictError\` (409) and \`UploadSessionCorruptedError\` (500) in a new \`storage/errors/upload.py\`.
- No HTTP wiring or filesystem I/O yet; this PR is additive and behavior-neutral.

Resolves BA-6154. Part of epic BA-6153 (implements BA-3974).