### PR TITLE
feat(BA-6155): add metadata-driven chunk-store upload session engine

### DIFF
--- a/changes/11766.feature.md
+++ b/changes/11766.feature.md
@@ -1,0 +1,1 @@
+Introduce `TusUploadSession`, a concurrency-safe upload engine for resumable (TUS) uploads that keeps session metadata and a per-session lock in Valkey (via `ValkeyTusClient`) while storing chunk payloads on the shared filesystem, so multiple storage-proxy replicas can accept chunks without corruption and without relying on filesystem lock semantics.

--- a/src/ai/backend/common/clients/valkey_client/valkey_tus/__init__.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_tus/__init__.py
@@ -1,0 +1,5 @@
+"""Valkey client for TUS resumable-upload session metadata."""
+
+from .client import ValkeyTusClient
+
+__all__ = ["ValkeyTusClient"]

--- a/src/ai/backend/common/clients/valkey_client/valkey_tus/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_tus/client.py
@@ -1,0 +1,116 @@
+"""
+Valkey client for TUS resumable-upload sessions.
+
+Stores per-session upload metadata (the source of truth) on the Glide-based
+valkey connection so that multiple Storage Proxy replicas share one view of an
+upload's progress without relying on shared-filesystem semantics. This client is
+metadata-only; the per-session distributed lock that serializes the
+read-modify-write window is a separate :class:`DistributedLockFactory` resource
+(see :mod:`ai.backend.storage.services.upload.tus_session`). The payload bytes
+stay on the shared filesystem; only this small metadata lives in Valkey.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Final, Self
+
+from glide import ExpirySet, ExpiryType
+
+from ai.backend.common.clients.valkey_client.client import (
+    AbstractValkeyClient,
+    create_valkey_client,
+)
+from ai.backend.common.exception import BackendAIError
+from ai.backend.common.metrics.metric import DomainType, LayerType
+from ai.backend.common.resilience import (
+    BackoffStrategy,
+    MetricArgs,
+    MetricPolicy,
+    Resilience,
+    RetryArgs,
+    RetryPolicy,
+)
+from ai.backend.common.types import TusSessionId, ValkeyTarget
+from ai.backend.logging import BraceStyleAdapter
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+valkey_tus_resilience = Resilience(
+    policies=[
+        MetricPolicy(MetricArgs(domain=DomainType.VALKEY, layer=LayerType.VALKEY_TUS)),
+        RetryPolicy(
+            RetryArgs(
+                max_retries=3,
+                retry_delay=0.1,
+                backoff_strategy=BackoffStrategy.FIXED,
+                non_retryable_exceptions=(BackendAIError,),
+            )
+        ),
+    ]
+)
+
+_STATE_KEY_PREFIX: Final = "tus.upload.session"  # tus.upload.session:{session_id}
+
+# Stale (never-completed / abandoned) sessions are reclaimed by this TTL, so no
+# separate GC sweep is needed.
+_DEFAULT_STATE_TTL_SECONDS: Final = 24 * 60 * 60
+
+
+class ValkeyTusClient:
+    """Valkey-backed metadata store for TUS uploads."""
+
+    _client: AbstractValkeyClient
+
+    def __init__(self, client: AbstractValkeyClient) -> None:
+        self._client = client
+
+    @classmethod
+    async def create(
+        cls,
+        valkey_target: ValkeyTarget,
+        *,
+        db_id: int,
+        human_readable_name: str,
+    ) -> Self:
+        client = create_valkey_client(
+            valkey_target=valkey_target,
+            db_id=db_id,
+            human_readable_name=human_readable_name,
+        )
+        await client.connect()
+        return cls(client=client)
+
+    @valkey_tus_resilience.apply()
+    async def close(self) -> None:
+        await self._client.disconnect()
+
+    @staticmethod
+    def _state_key(session_id: TusSessionId) -> str:
+        return f"{_STATE_KEY_PREFIX}:{session_id}"
+
+    @valkey_tus_resilience.apply()
+    async def get_session_state(self, session_id: TusSessionId) -> bytes | None:
+        """Return the raw serialized session state, or ``None`` if absent."""
+        async with self._client.client() as conn:
+            return await conn.get(self._state_key(session_id))
+
+    @valkey_tus_resilience.apply()
+    async def set_session_state(
+        self,
+        session_id: TusSessionId,
+        payload: str | bytes,
+        *,
+        ttl_seconds: int = _DEFAULT_STATE_TTL_SECONDS,
+    ) -> None:
+        async with self._client.client() as conn:
+            await conn.set(
+                self._state_key(session_id),
+                payload,
+                expiry=ExpirySet(ExpiryType.SEC, ttl_seconds),
+            )
+
+    @valkey_tus_resilience.apply()
+    async def delete_session_state(self, session_id: TusSessionId) -> None:
+        async with self._client.client() as conn:
+            await conn.delete([self._state_key(session_id)])

--- a/src/ai/backend/common/defs/__init__.py
+++ b/src/ai/backend/common/defs/__init__.py
@@ -11,6 +11,7 @@ REDIS_STREAM_DB: Final = 4
 REDIS_STREAM_LOCK: Final = 5
 REDIS_CONTAINER_LOG: Final = 6
 REDIS_BGTASK_DB: Final = 7
+REDIS_TUS_DB: Final = 8
 
 
 class RedisRole(StrEnum):

--- a/src/ai/backend/common/lock.py
+++ b/src/ai/backend/common/lock.py
@@ -7,7 +7,7 @@ import logging
 from collections.abc import Mapping
 from io import IOBase
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Protocol, runtime_checkable
 
 import trafaret as t
 from etcd_client import Client as EtcdClient
@@ -50,6 +50,11 @@ class AbstractDistributedLock(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     async def __aexit__(self, *exc_info: Any) -> bool | None:
         raise NotImplementedError
+
+
+@runtime_checkable
+class DistributedLockFactory(Protocol):
+    def __call__(self, lock_id: str, lifetime_hint: float) -> AbstractDistributedLock: ...
 
 
 class FileLock(AbstractDistributedLock):

--- a/src/ai/backend/common/metrics/metric.py
+++ b/src/ai/backend/common/metrics/metric.py
@@ -489,6 +489,7 @@ class LayerType(enum.StrEnum):
     VALKEY_STREAM = "valkey_stream"
     VALKEY_BGTASK = "valkey_bgtask"
     VALKEY_VOLUME_STATS = "valkey_volume_stats"
+    VALKEY_TUS = "valkey_tus"
 
     # Client layers
     AGENT_CLIENT = "agent_client"

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -157,6 +157,7 @@ __all__ = (
     "SlotName",
     "SlotNameField",
     "SlotTypes",
+    "TusSessionId",
     "VFolderHostPermission",
     "VFolderID",
     "VFolderMount",
@@ -395,6 +396,7 @@ HostPID = NewType("HostPID", PID)
 ContainerPID = NewType("ContainerPID", PID)
 
 ContainerId = NewType("ContainerId", str)
+TusSessionId = NewType("TusSessionId", str)
 RuleId = NewType("RuleId", UUID)
 SessionId = NewType("SessionId", UUID)
 KernelId = NewType("KernelId", UUID)

--- a/src/ai/backend/storage/context.py
+++ b/src/ai/backend/storage/context.py
@@ -15,12 +15,14 @@ from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
 from ai.backend.common.clients.valkey_client.valkey_artifact.client import (
     ValkeyArtifactDownloadTrackingClient,
 )
+from ai.backend.common.clients.valkey_client.valkey_tus import ValkeyTusClient
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.events.dispatcher import (
     EventDispatcher,
     EventProducer,
 )
 from ai.backend.common.health_checker.probe import HealthProbe
+from ai.backend.common.lock import DistributedLockFactory
 from ai.backend.common.metrics.metric import CommonMetricRegistry
 from ai.backend.logging import BraceStyleAdapter
 
@@ -106,6 +108,8 @@ class RootContext:
     cors_options: Mapping[str, aiohttp_cors.ResourceOptions]
     manager_client_pool: ManagerHTTPClientPool
     valkey_artifact_client: ValkeyArtifactDownloadTrackingClient
+    valkey_tus_client: ValkeyTusClient
+    tus_lock_factory: DistributedLockFactory
     health_probe: HealthProbe
     volume_stats_observer: VolumeStatsObserver
     volume_stats_state: VolumeState

--- a/src/ai/backend/storage/errors/__init__.py
+++ b/src/ai/backend/storage/errors/__init__.py
@@ -62,6 +62,10 @@ from .quota import (
     QuotaScopeNotFoundError,
     QuotaTreeNotFoundError,
 )
+from .upload import (
+    ChunkConflictError,
+    UploadSessionCorruptedError,
+)
 from .vfolder import (
     InvalidSubpathError,
     VFolderNotFoundError,
@@ -90,6 +94,9 @@ __all__ = [
     "InvalidDataLengthError",
     "ServiceNotInitializedError",
     "UploadOffsetMismatchError",
+    # upload
+    "ChunkConflictError",
+    "UploadSessionCorruptedError",
     # vfolder
     "VFolderNotFoundError",
     "InvalidSubpathError",

--- a/src/ai/backend/storage/errors/upload.py
+++ b/src/ai/backend/storage/errors/upload.py
@@ -1,0 +1,49 @@
+"""
+Upload session related exceptions.
+"""
+
+from __future__ import annotations
+
+from aiohttp import web
+
+from ai.backend.common.exception import (
+    BackendAIError,
+    ErrorCode,
+    ErrorDetail,
+    ErrorDomain,
+    ErrorOperation,
+)
+
+
+class ChunkConflictError(BackendAIError, web.HTTPConflict):
+    """
+    Raised when an incoming chunk targets an offset that already holds a
+    different chunk in the upload session (409 Conflict).
+    """
+
+    error_type = "https://api.backend.ai/probs/storage/chunk-conflict"
+    error_title = "Upload Chunk Conflict"
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.STORAGE_PROXY,
+            operation=ErrorOperation.UPDATE,
+            error_detail=ErrorDetail.CONFLICT,
+        )
+
+
+class UploadSessionCorruptedError(BackendAIError, web.HTTPInternalServerError):
+    """
+    Raised when the upload session metadata stored in Valkey cannot be parsed,
+    is structurally invalid, or has gone missing at a stage that requires it.
+    """
+
+    error_type = "https://api.backend.ai/probs/storage/upload-session-corrupted"
+    error_title = "Upload Session Corrupted"
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.STORAGE_PROXY,
+            operation=ErrorOperation.READ,
+            error_detail=ErrorDetail.INTERNAL_ERROR,
+        )

--- a/src/ai/backend/storage/migration.py
+++ b/src/ai/backend/storage/migration.py
@@ -280,6 +280,8 @@ async def check_and_upgrade(
         cors_options={},
         manager_client_pool=manager_client_pool,
         valkey_artifact_client=None,  # type: ignore[arg-type]
+        valkey_tus_client=None,  # type: ignore[arg-type]
+        tus_lock_factory=None,  # type: ignore[arg-type]
         backends={**DEFAULT_BACKENDS},
         volumes={},
         health_probe=health_probe,

--- a/src/ai/backend/storage/server.py
+++ b/src/ai/backend/storage/server.py
@@ -26,11 +26,13 @@ from aiohttp import web
 from aiohttp.typedefs import Middleware
 from setproctitle import setproctitle
 
+from ai.backend.common import redis_helper
 from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
 from ai.backend.common.clients.valkey_client.valkey_artifact.client import (
     ValkeyArtifactDownloadTrackingClient,
 )
 from ai.backend.common.clients.valkey_client.valkey_bgtask.client import ValkeyBgtaskClient
+from ai.backend.common.clients.valkey_client.valkey_tus import ValkeyTusClient
 from ai.backend.common.clients.valkey_client.valkey_volume_stats import ValkeyVolumeStatsClient
 from ai.backend.common.config import (
     ConfigurationError,
@@ -42,6 +44,8 @@ from ai.backend.common.defs import (
     REDIS_BGTASK_DB,
     REDIS_STATISTICS_DB,
     REDIS_STREAM_DB,
+    REDIS_STREAM_LOCK,
+    REDIS_TUS_DB,
     RedisRole,
 )
 from ai.backend.common.etcd import AsyncEtcd
@@ -111,6 +115,7 @@ from .plugin import (
     StorageManagerWebappPluginContext,
     StoragePluginContext,
 )
+from .services.upload.lock import create_tus_lock_factory
 from .storages.storage_pool import StoragePool
 from .volumes.noop import init_noop_volume
 from .volumes.pool import VolumePool
@@ -644,6 +649,24 @@ async def server_main(
         )
         storage_init_stack.push_async_callback(valkey_artifact_client.close)
 
+        # TUS upload session metadata store (Valkey) and the per-session lock
+        # factory, kept as separate resources. The lock backend is a dedicated
+        # redis-for-lock connection (redis.asyncio, required by RedisLock),
+        # provisioned and owned here; the factory closes over it.
+        valkey_tus_client = await ValkeyTusClient.create(
+            valkey_target=valkey_target,
+            db_id=REDIS_TUS_DB,
+            human_readable_name=f"storage-proxy-tus-uploader-{pidx}",
+        )
+        storage_init_stack.push_async_callback(valkey_tus_client.close)
+        tus_lock_redis = redis_helper.get_redis_object_for_lock(
+            redis_config.to_redis_profile_target().profile_target(RedisRole.STREAM_LOCK),
+            name=f"storage-proxy-tus-lock-{pidx}",
+            db=REDIS_STREAM_LOCK,
+        )
+        storage_init_stack.push_async_callback(tus_lock_redis.close)
+        tus_lock_factory = create_tus_lock_factory(tus_lock_redis)
+
         # Initialize health probe
         health_probe = HealthProbe(options=HealthProbeOptions(check_interval=60))
         # Liveness-registered: also surfaced in readiness — connection-stuck
@@ -724,6 +747,8 @@ async def server_main(
             },
             manager_client_pool=manager_client_pool,
             valkey_artifact_client=valkey_artifact_client,
+            valkey_tus_client=valkey_tus_client,
+            tus_lock_factory=tus_lock_factory,
             health_probe=health_probe,
             volume_stats_observer=volume_stats_observer,
             volume_stats_state=volume_stats_state,

--- a/src/ai/backend/storage/services/upload/__init__.py
+++ b/src/ai/backend/storage/services/upload/__init__.py
@@ -1,0 +1,3 @@
+"""
+Chunk-based TUS upload session services.
+"""

--- a/src/ai/backend/storage/services/upload/lock.py
+++ b/src/ai/backend/storage/services/upload/lock.py
@@ -1,0 +1,37 @@
+"""TUS upload session locking — distributed lock factory and constants."""
+
+from __future__ import annotations
+
+from ai.backend.common.lock import DistributedLockFactory, RedisLock
+from ai.backend.common.types import RedisConnectionInfo
+
+# Public — used by the engine to build session lock keys and pass lifetime to
+# the factory.
+LOCK_KEY_PREFIX = "tus.upload.lock"  # tus.upload.lock:{session_id}
+LOCK_LIFETIME_SECONDS = 30.0  # lock auto-expires after this (crash safety)
+
+_ACQUIRE_TIMEOUT_SECONDS = 10.0  # max wait to acquire the per-session lock
+# Poll interval while waiting for the lock; the RedisLock default (1s) is far
+# too coarse for the short, highly-contended per-chunk critical section.
+_RETRY_INTERVAL_SECONDS = 0.05
+
+
+def create_tus_lock_factory(redis: RedisConnectionInfo) -> DistributedLockFactory:
+    """
+    Build the per-session lock factory backed by :class:`RedisLock` over ``redis``.
+
+    Mirrors the manager's ``create_lock_factory``: the caller owns ``redis``
+    (lifecycle/close) and the returned factory closes over it, producing a fresh
+    lock per ``lock_id`` so the factory can live as a standalone resource.
+    """
+
+    def _factory(lock_id: str, lifetime_hint: float) -> RedisLock:
+        return RedisLock(
+            lock_id,
+            redis,
+            timeout=_ACQUIRE_TIMEOUT_SECONDS,
+            lifetime=lifetime_hint,
+            lock_retry_interval=_RETRY_INTERVAL_SECONDS,
+        )
+
+    return _factory

--- a/src/ai/backend/storage/services/upload/tus_session.py
+++ b/src/ai/backend/storage/services/upload/tus_session.py
@@ -1,0 +1,301 @@
+"""Valkey-backed TUS upload session.
+
+Session metadata lives in Valkey (via :class:`ValkeyTusClient`), guarded by a
+per-session distributed lock from an injected :class:`DistributedLockFactory`.
+Chunk payload bytes live on the shared filesystem, content-addressed by
+``(offset, sha256)``::
+
+    <session_dir>/
+      chunks/
+        chunk_<offset>.dat
+        chunk_<offset>.<token>.tmp
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+from pathlib import Path
+
+import aiofiles
+import aiofiles.os
+
+from ai.backend.common.clients.valkey_client.valkey_tus import ValkeyTusClient
+from ai.backend.common.lock import AbstractDistributedLock, DistributedLockFactory
+from ai.backend.common.types import StreamReader, TusSessionId
+from ai.backend.logging import BraceStyleAdapter
+from ai.backend.storage.errors.upload import (
+    ChunkConflictError,
+    UploadSessionCorruptedError,
+)
+
+from .lock import LOCK_KEY_PREFIX, LOCK_LIFETIME_SECONDS
+from .types import (
+    ChunkCommitResult,
+    ChunkMetadata,
+    TusSessionState,
+    TusUploadSessionArgs,
+    UploadStatus,
+    WrittenChunk,
+)
+from .utils import (
+    CHUNKS_DIRNAME,
+    committed_chunk_path,
+    staging_path,
+    temp_chunk_path,
+    unlink_quietly,
+)
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class TusUploadSession:
+    """
+    A TUS upload session whose metadata lives in Valkey and whose chunk payloads
+    live under ``session_dir`` on the shared filesystem.
+
+    Instances are cheap to construct; all state lives in Valkey (metadata) and on
+    disk (chunk bytes). The metadata read-modify-write window is serialized across
+    replicas by a per-session distributed lock obtained from the injected
+    :class:`DistributedLockFactory`.
+    """
+
+    _session_dir: Path
+    _session_id: TusSessionId
+    _total_size: int
+    _valkey: ValkeyTusClient
+    _lock_factory: DistributedLockFactory
+
+    def __init__(self, args: TusUploadSessionArgs) -> None:
+        self._session_dir = args.session_dir
+        self._session_id = args.session_id
+        self._total_size = args.total_size
+        self._valkey = args.valkey_client
+        self._lock_factory = args.lock_factory
+
+    @property
+    def session_dir(self) -> Path:
+        return self._session_dir
+
+    @property
+    def session_id(self) -> TusSessionId:
+        return self._session_id
+
+    @property
+    def chunks_dir(self) -> Path:
+        return self._session_dir / CHUNKS_DIRNAME
+
+    @property
+    def _lock_key(self) -> str:
+        return f"{LOCK_KEY_PREFIX}:{self._session_id}"
+
+    def _lock(self) -> AbstractDistributedLock:
+        return self._lock_factory(self._lock_key, LOCK_LIFETIME_SECONDS)
+
+    async def _load_state(self) -> TusSessionState | None:
+        raw = await self._valkey.get_session_state(self._session_id)
+        if raw is None:
+            return None
+        return TusSessionState.model_validate_json(raw)
+
+    async def _store_state(self, state: TusSessionState) -> None:
+        await self._valkey.set_session_state(self._session_id, state.model_dump_json())
+
+    async def ensure_initialized(self) -> None:
+        """Create an initial Valkey state for this session if missing.
+
+        If the state is absent but ``chunks_dir`` still holds files, those are
+        leftovers from a prior session whose Valkey state expired by TTL. The
+        new state would not know about them and could silently mix their bytes
+        into the assembled output, so drop them before starting fresh.
+        """
+        async with self._lock():
+            if await self._load_state() is not None:
+                return
+            await self._delete_chunk_files()
+            await self._store_state(TusSessionState.empty(self._session_id, self._total_size))
+
+    async def exists(self) -> bool:
+        """Return True iff a Valkey state currently exists for this session.
+
+        Valkey is the source of truth — a missing state means the session was
+        never registered or its TTL elapsed, regardless of what is on disk.
+        """
+        return (await self._load_state()) is not None
+
+    async def read_state(self) -> TusSessionState:
+        state = await self._load_state()
+        if state is None:
+            return TusSessionState.empty(self._session_id, self._total_size)
+        return state
+
+    def open_temp_chunk(self, offset: int) -> Path:
+        """
+        Allocate a unique temp file path under chunks/ for a chunk at
+        ``offset``. The caller writes payload bytes into the returned path and
+        then passes it to :meth:`commit_chunk`.
+        """
+        self.chunks_dir.mkdir(parents=True, exist_ok=True)
+        return temp_chunk_path(self.chunks_dir, offset)
+
+    async def write_temp_chunk(self, offset: int, reader: StreamReader) -> WrittenChunk:
+        """
+        Open a fresh temp chunk file for ``offset``, drain ``reader`` into it,
+        and return the resulting :class:`WrittenChunk`.
+
+        ``reader`` is the common :class:`StreamReader`; its ``read()`` yields
+        the body in bounded chunks (granularity owned by the concrete reader,
+        e.g. the PATCH-body adapter built in the handler), so only one chunk is
+        held in memory at a time. The temp file is removed if draining fails;
+        otherwise the caller promotes it via :meth:`commit_chunk`.
+        """
+        temp_path = self.open_temp_chunk(offset)
+        hasher = hashlib.sha256()
+        total = 0
+        try:
+            async with aiofiles.open(temp_path, "wb") as chunk_file:
+                async for chunk in reader.read():
+                    hasher.update(chunk)
+                    total += len(chunk)
+                    await chunk_file.write(chunk)
+                await chunk_file.flush()
+                await asyncio.to_thread(os.fsync, chunk_file.fileno())
+        except BaseException:
+            await unlink_quietly(temp_path)
+            raise
+        return WrittenChunk(path=temp_path, length=total, sha256=hasher.hexdigest())
+
+    async def commit_chunk(
+        self,
+        offset: int,
+        chunk_path: Path,
+        length: int,
+        sha256: str,
+    ) -> ChunkCommitResult:
+        """
+        Promote a fully-written temp chunk file at ``chunk_path`` into the
+        session, updating Valkey metadata under the per-session lock.
+
+        - Same ``(offset, length, sha256)`` already present → idempotent;
+          ``chunk_path`` is removed and ``committed=False``.
+        - Conflicting record at the same offset → ``ChunkConflictError``;
+          ``chunk_path`` is removed.
+        - Already-completed session → idempotent no-op (a late duplicate that
+          raced completion on another replica); ``chunk_path`` is removed.
+        - Otherwise the chunk file is renamed into place and the record added.
+        """
+        target = committed_chunk_path(self.chunks_dir, offset)
+        async with self._lock():
+            state = await self._load_state()
+            if state is None:
+                # `ensure_initialized` must run before `commit_chunk`; reaching
+                # here means either the caller skipped it or the Valkey state
+                # disappeared (TTL/external delete). Either way, the session is
+                # not in a coherent state to accept new chunks. Drop the temp
+                # chunk file so it does not leak under the chunks dir.
+                await unlink_quietly(chunk_path)
+                raise UploadSessionCorruptedError(
+                    f"upload session {self._session_id} has no metadata at commit time"
+                )
+
+            # Late duplicate PATCH: another replica already assembled and marked
+            # COMPLETED. Drop the temp file silently and return a no-op so the
+            # client observes idempotent success rather than an error.
+            if state.status == UploadStatus.COMPLETED:
+                await unlink_quietly(chunk_path)
+                return ChunkCommitResult(state=state, committed=False, is_final_commit=False)
+
+            existing = state.find_at_offset(offset)
+            if existing is not None:
+                await unlink_quietly(chunk_path)
+                if existing.length == length and existing.sha256 == sha256:
+                    return ChunkCommitResult(state=state, committed=False, is_final_commit=False)
+                raise ChunkConflictError(
+                    f"chunk at offset {offset} already exists with different content"
+                )
+
+            await aiofiles.os.replace(chunk_path, target)
+            previous_committed_offset = state.committed_offset
+            state.append_chunk(ChunkMetadata(offset=offset, length=length, sha256=sha256))
+            await self._store_state(state)
+            is_final_commit = (
+                previous_committed_offset < state.total_size <= state.committed_offset
+                and state.total_size > 0
+            )
+            progress_percent = (
+                100.0 * state.committed_offset / state.total_size if state.total_size > 0 else 0.0
+            )
+            log.trace(
+                "TUS chunk committed: session={}, offset={}, length={}, progress={}/{} ({:.1f}%)",
+                self._session_id,
+                offset,
+                length,
+                state.committed_offset,
+                state.total_size,
+                progress_percent,
+            )
+            return ChunkCommitResult(state=state, committed=True, is_final_commit=is_final_commit)
+
+    async def assemble(self, target_path: Path) -> None:
+        """Concatenate all chunks in offset order into ``target_path``."""
+        async with self._lock():
+            state = await self._load_state()
+            if state is None:
+                raise UploadSessionCorruptedError("no session metadata to assemble")
+            if state.status == UploadStatus.COMPLETED:
+                return
+            if state.committed_offset < state.total_size:
+                raise UploadSessionCorruptedError("cannot assemble: not all chunks received")
+            await self._assemble_chunks_to_disk(state, target_path)
+            state.set_complete()
+            await self._store_state(state)
+            log.info(
+                "TUS upload completed: session={}, target={}, size={} bytes, chunks={}",
+                self._session_id,
+                target_path,
+                state.total_size,
+                len(state.committed_chunks),
+            )
+
+    async def _assemble_chunks_to_disk(self, state: TusSessionState, target_path: Path) -> None:
+        await aiofiles.os.makedirs(target_path.parent, exist_ok=True)
+        staging = staging_path(target_path)
+        copy_buffer = 1024 * 1024
+        try:
+            async with aiofiles.open(staging, "wb") as out:
+                for rec in state.committed_chunks:
+                    chunk_file = committed_chunk_path(self.chunks_dir, rec.offset)
+                    async with aiofiles.open(chunk_file, "rb") as chunk_fp:
+                        while True:
+                            buf = await chunk_fp.read(copy_buffer)
+                            if not buf:
+                                break
+                            await out.write(buf)
+            await aiofiles.os.replace(staging, target_path)
+        except BaseException:
+            await unlink_quietly(staging)
+            raise
+
+    async def cleanup(self) -> None:
+        """
+        Delete chunk payload files after a completed upload.
+
+        Only the chunk files are removed; the Valkey state (status="completed")
+        is intentionally kept so a late duplicate PATCH that raced completion on
+        another replica observes the completed marker and no-ops instead of
+        re-creating a stray session. The marker itself is reclaimed by its
+        Valkey TTL.
+        """
+        async with self._lock():
+            state = await self._load_state()
+            if state is None or state.status != UploadStatus.COMPLETED:
+                return
+            await self._delete_chunk_files()
+
+    async def _delete_chunk_files(self) -> None:
+        if not await aiofiles.os.path.exists(self.chunks_dir):
+            return
+        for name in await aiofiles.os.listdir(self.chunks_dir):
+            await unlink_quietly(self.chunks_dir / name)

--- a/src/ai/backend/storage/services/upload/types.py
+++ b/src/ai/backend/storage/services/upload/types.py
@@ -1,0 +1,131 @@
+"""TUS upload session data types.
+
+Holds the state schemas (`TusSessionState`, `ChunkMetadata`, `WrittenChunk`,
+`ChunkCommitResult`) that the engine reads/writes, plus `TusUploadSessionArgs`
+— the construction-time dependency bundle for `TusUploadSession`. The args
+dataclass references I/O collaborators (Valkey client, lock factory, session
+dir path) but performs no I/O of its own; the state schemas are pure data."""
+
+from __future__ import annotations
+
+import bisect
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Self, override
+
+from pydantic import ConfigDict, Field
+
+from ai.backend.common.clients.valkey_client.valkey_tus import ValkeyTusClient
+from ai.backend.common.exception import BackendAIError
+from ai.backend.common.lock import DistributedLockFactory
+from ai.backend.common.types import (
+    BackendAISchema,
+    SchemaValidationFailureInfo,
+    TusSessionId,
+)
+from ai.backend.storage.errors.upload import UploadSessionCorruptedError
+
+
+class UploadStatus(StrEnum):
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+
+
+class ChunkMetadata(BackendAISchema):
+    model_config = ConfigDict(frozen=True)
+
+    offset: int
+    length: int
+    sha256: str
+
+    @property
+    def end(self) -> int:
+        return self.offset + self.length
+
+
+class TusSessionState(BackendAISchema):
+    session_id: TusSessionId
+    total_size: int
+    committed_chunks: list[ChunkMetadata] = Field(default_factory=list)
+    status: UploadStatus = UploadStatus.IN_PROGRESS
+
+    @override
+    @classmethod
+    def build_validation_error(cls, info: SchemaValidationFailureInfo) -> BackendAIError:
+        # Stored session metadata that fails to parse is server-side corruption
+        # (500), not a client error, so map the ValidationError accordingly.
+        return UploadSessionCorruptedError(
+            f"upload session metadata is malformed: {info.summary}",
+            extra_data={"errors": info.errors},
+        )
+
+    @property
+    def committed_offset(self) -> int:
+        """End offset of the largest contiguous prefix from byte 0.
+
+        Not the same as the last entry's ``end``: out-of-order commits (multi-
+        replica race, retry/resume, partial re-send via ``/upload/status``) can
+        leave gaps in ``committed_chunks``. We must stop at the first gap so the
+        value matches TUS ``Upload-Offset`` semantics ("send the next chunk from
+        here") — using last-entry-end would tell the client to skip past gaps
+        and drop data.
+        """
+        cursor = 0
+        for rec in self.committed_chunks:
+            if rec.offset != cursor:
+                break
+            cursor = rec.end
+        return cursor
+
+    def find_at_offset(self, offset: int) -> ChunkMetadata | None:
+        for rec in self.committed_chunks:
+            if rec.offset == offset:
+                return rec
+            if rec.offset > offset:
+                return None
+        return None
+
+    @classmethod
+    def empty(cls, session_id: TusSessionId, total_size: int) -> Self:
+        return cls(session_id=session_id, total_size=total_size)
+
+    def append_chunk(self, chunk: ChunkMetadata) -> None:
+        """Insert ``chunk`` at the correct sorted position to keep
+        ``committed_chunks`` ordered by offset. The sortedness invariant is
+        what ``committed_offset`` and ``find_at_offset`` rely on."""
+        bisect.insort(self.committed_chunks, chunk, key=lambda r: r.offset)
+
+    def set_complete(self) -> None:
+        """Mark the upload session as fully received and assembled."""
+        self.status = UploadStatus.COMPLETED
+
+
+@dataclass(frozen=True, slots=True)
+class ChunkCommitResult:
+    """Result of attempting to commit a chunk into a session."""
+
+    state: TusSessionState
+    committed: bool  # False means duplicate (idempotent) replay
+    is_final_commit: bool  # True if this commit just completed the upload
+
+
+@dataclass(frozen=True, slots=True)
+class WrittenChunk:
+    """
+    Result of :meth:`TusUploadSession.write_temp_chunk`: the staged temp file
+    path plus the byte count actually drained and its SHA-256 digest.
+    """
+
+    path: Path
+    length: int
+    sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class TusUploadSessionArgs:
+    session_dir: Path
+    session_id: TusSessionId
+    total_size: int
+    valkey_client: ValkeyTusClient
+    lock_factory: DistributedLockFactory

--- a/src/ai/backend/storage/services/upload/utils.py
+++ b/src/ai/backend/storage/services/upload/utils.py
@@ -1,0 +1,50 @@
+"""Filesystem helpers and constants for TUS chunk payload files."""
+
+from __future__ import annotations
+
+import errno
+import secrets
+from pathlib import Path
+
+import aiofiles.os
+
+CHUNKS_DIRNAME = "chunks"
+
+_TEMP_SUFFIX_BYTES = 8
+
+
+def committed_chunk_path(chunks_dir: Path, offset: int) -> Path:
+    """Final on-disk path of the committed chunk for ``offset``."""
+    return chunks_dir / f"chunk_{offset}.dat"
+
+
+def temp_chunk_path(chunks_dir: Path, offset: int) -> Path:
+    """Unique staging path for an in-flight chunk at ``offset``.
+
+    The random suffix lets concurrent storage-proxy replicas write into the
+    same offset without sharing a temp path.
+    """
+    return chunks_dir / f"chunk_{offset}.{_random_token()}.tmp"
+
+
+def staging_path(target: Path) -> Path:
+    """Unique sibling path of ``target`` for atomic-rename writes."""
+    return target.with_name(f"{target.name}.{_random_token()}.tmp")
+
+
+async def unlink_quietly(path: Path) -> None:
+    """
+    Best-effort delete used in rollback/cleanup paths where the file may have
+    already been removed by a concurrent worker or never created.
+    """
+    try:
+        await aiofiles.os.remove(path)
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise
+
+
+def _random_token() -> str:
+    return secrets.token_hex(_TEMP_SUFFIX_BYTES)

--- a/tests/unit/storage/services/upload/BUILD
+++ b/tests/unit/storage/services/upload/BUILD
@@ -1,0 +1,10 @@
+python_test_utils(
+    sources=[
+        "*.py",
+        "!test_*.py",
+    ],
+)
+
+python_tests(
+    name="tests",
+)

--- a/tests/unit/storage/services/upload/conftest.py
+++ b/tests/unit/storage/services/upload/conftest.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+from redis.asyncio import Redis
+
+from ai.backend.common import config
+from ai.backend.common.clients.valkey_client.valkey_tus import ValkeyTusClient
+from ai.backend.common.defs import REDIS_STREAM_LOCK, REDIS_TUS_DB
+from ai.backend.common.lock import DistributedLockFactory
+from ai.backend.common.typed_validators import HostPortPair as HostPortPairModel
+from ai.backend.common.types import RedisConnectionInfo, ValkeyTarget
+from ai.backend.storage.services.upload.lock import create_tus_lock_factory
+from ai.backend.testutils.bootstrap import redis_container  # noqa: F401
+
+
+@pytest.fixture
+async def valkey_tus_client(
+    redis_container: tuple[str, HostPortPairModel],  # noqa: F811
+) -> AsyncIterator[ValkeyTusClient]:
+    hostport_pair = redis_container[1]
+    client = await ValkeyTusClient.create(
+        ValkeyTarget(addr=hostport_pair.address),
+        db_id=REDIS_TUS_DB,
+        human_readable_name="test.tus",
+    )
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+@pytest.fixture
+async def tus_lock_factory(
+    redis_container: tuple[str, HostPortPairModel],  # noqa: F811
+) -> AsyncIterator[DistributedLockFactory]:
+    hostport_pair = redis_container[1]
+    lock_redis = RedisConnectionInfo(
+        Redis.from_url(f"redis://{hostport_pair.address}/{REDIS_STREAM_LOCK}"),
+        sentinel=None,
+        name="test.tus.lock",
+        service_name=None,
+        redis_helper_config=config.redis_helper_default_config,
+    )
+    try:
+        yield create_tus_lock_factory(lock_redis)
+    finally:
+        await lock_redis.close()

--- a/tests/unit/storage/services/upload/test_tus_session.py
+++ b/tests/unit/storage/services/upload/test_tus_session.py
@@ -1,0 +1,84 @@
+"""
+Unit tests for the TUS upload session state model.
+
+These tests cover the pure data-layer behavior of ``TusSessionState``:
+computing the contiguous prefix offset, finding records by offset, and
+serialization. Nothing here touches the filesystem.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from ai.backend.common.types import TusSessionId
+from ai.backend.storage.services.upload.types import (
+    ChunkMetadata,
+    TusSessionState,
+)
+
+
+def _make_chunk_metadata(offset: int, length: int, sha256: str = "x") -> ChunkMetadata:
+    return ChunkMetadata(offset=offset, length=length, sha256=sha256)
+
+
+@dataclass(frozen=True)
+class _CommittedOffsetCase:
+    records: list[ChunkMetadata]
+    expected_prefix: int
+
+
+class TestTusSessionStatePrefix:
+    @pytest.mark.parametrize(
+        "case",
+        [
+            # Empty session: nothing received yet, prefix is at 0.
+            _CommittedOffsetCase(records=[], expected_prefix=0),
+            # Single chunk at the start fills offsets [0, 100).
+            _CommittedOffsetCase(
+                records=[_make_chunk_metadata(0, 100)],
+                expected_prefix=100,
+            ),
+            # Two adjacent chunks form a contiguous prefix [0, 150).
+            _CommittedOffsetCase(
+                records=[_make_chunk_metadata(0, 100), _make_chunk_metadata(100, 50)],
+                expected_prefix=150,
+            ),
+            # Gap after a contiguous prefix: prefix ends at the gap, not at the
+            # last entry's end.
+            _CommittedOffsetCase(
+                records=[_make_chunk_metadata(0, 100), _make_chunk_metadata(200, 50)],
+                expected_prefix=100,
+            ),
+            # No chunk covers byte 0: there is no prefix to report.
+            _CommittedOffsetCase(
+                records=[_make_chunk_metadata(50, 100)],
+                expected_prefix=0,
+            ),
+        ],
+    )
+    def test_committed_offset(self, case: _CommittedOffsetCase) -> None:
+        state = TusSessionState(
+            session_id=TusSessionId("s"), total_size=1024, committed_chunks=list(case.records)
+        )
+        assert state.committed_offset == case.expected_prefix
+
+
+class TestFindAtOffset:
+    def test_returns_record_at_matching_offset(self) -> None:
+        rec = _make_chunk_metadata(100, 50)
+        state = TusSessionState(
+            session_id=TusSessionId("s"),
+            total_size=1024,
+            committed_chunks=[_make_chunk_metadata(0, 100, "a"), rec],
+        )
+        assert state.find_at_offset(100) == rec
+
+    def test_returns_none_when_offset_not_present(self) -> None:
+        state = TusSessionState(
+            session_id=TusSessionId("s"),
+            total_size=1024,
+            committed_chunks=[_make_chunk_metadata(0, 100, "a")],
+        )
+        assert state.find_at_offset(500) is None

--- a/tests/unit/storage/services/upload/test_tus_upload_session.py
+++ b/tests/unit/storage/services/upload/test_tus_upload_session.py
@@ -1,0 +1,361 @@
+"""
+Integration tests for the ``TusUploadSession`` storage class.
+
+Metadata + the per-session lock live in a real Valkey (the ``valkey_tus_client``
+fixture, backed by a redis container); chunk payloads live under ``tmp_path``.
+Nothing is mocked. Concurrency tests fire ``commit_chunk`` coroutines together to
+model multiple Storage Proxy replicas hitting the same session.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import hashlib
+import json
+import secrets
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+
+from ai.backend.common.clients.valkey_client.valkey_tus import ValkeyTusClient
+from ai.backend.common.lock import DistributedLockFactory
+from ai.backend.common.types import StreamReader, TusSessionId
+from ai.backend.storage.errors.upload import (
+    ChunkConflictError,
+    UploadSessionCorruptedError,
+)
+from ai.backend.storage.services.upload.tus_session import TusUploadSession
+from ai.backend.storage.services.upload.types import (
+    ChunkCommitResult,
+    ChunkMetadata,
+    TusUploadSessionArgs,
+    UploadStatus,
+)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _Chunk:
+    offset: int
+    payload: bytes
+
+    @property
+    def length(self) -> int:
+        return len(self.payload)
+
+    @property
+    def sha256(self) -> str:
+        return hashlib.sha256(self.payload).hexdigest()
+
+
+class _Reader(StreamReader):
+    def __init__(self, data: bytes, chunk_size: int) -> None:
+        self._data = data
+        self._chunk_size = chunk_size
+
+    async def read(self) -> AsyncIterator[bytes]:
+        for start in range(0, len(self._data), self._chunk_size):
+            yield self._data[start : start + self._chunk_size]
+
+    def content_type(self) -> str | None:
+        return None
+
+
+def _make_chunks(total_size: int, chunk_size: int, *, seed: bytes = b"abc") -> list[_Chunk]:
+    payload = (seed * ((total_size // len(seed)) + 1))[:total_size]
+    chunks: list[_Chunk] = []
+    for offset in range(0, total_size, chunk_size):
+        end = min(offset + chunk_size, total_size)
+        chunks.append(_Chunk(offset=offset, payload=payload[offset:end]))
+    return chunks
+
+
+def _write_temp_chunk(session: TusUploadSession, chunk: _Chunk) -> Path:
+    temp = session.open_temp_chunk(chunk.offset)
+    temp.write_bytes(chunk.payload)
+    return temp
+
+
+async def _commit(session: TusUploadSession, chunk: _Chunk) -> ChunkCommitResult:
+    return await session.commit_chunk(
+        offset=chunk.offset,
+        chunk_path=_write_temp_chunk(session, chunk),
+        length=chunk.length,
+        sha256=chunk.sha256,
+    )
+
+
+@pytest.fixture
+def session_root(tmp_path: Path) -> Path:
+    return tmp_path / "session"
+
+
+@pytest.fixture
+def session(
+    session_root: Path,
+    valkey_tus_client: ValkeyTusClient,
+    tus_lock_factory: DistributedLockFactory,
+) -> TusUploadSession:
+    # A unique session id keeps each test isolated within the shared Valkey.
+    return TusUploadSession(
+        TusUploadSessionArgs(
+            session_dir=session_root,
+            session_id=TusSessionId(secrets.token_hex(8)),
+            total_size=1024,
+            valkey_client=valkey_tus_client,
+            lock_factory=tus_lock_factory,
+        )
+    )
+
+
+class TestSessionLifecycle:
+    async def test_ensure_initialized_creates_state(self, session: TusUploadSession) -> None:
+        await session.ensure_initialized()
+        state = await session.read_state()
+        assert state.committed_offset == 0
+        assert state.status == UploadStatus.IN_PROGRESS
+
+    async def test_ensure_initialized_is_idempotent(self, session: TusUploadSession) -> None:
+        await session.ensure_initialized()
+        chunks = _make_chunks(total_size=512, chunk_size=512)
+        await _commit(session, chunks[0])
+
+        # Re-initializing must not wipe the existing state.
+        await session.ensure_initialized()
+        state = await session.read_state()
+        assert state.committed_offset == chunks[0].length
+
+    async def test_read_state_on_missing_info_returns_empty(
+        self, session: TusUploadSession
+    ) -> None:
+        state = await session.read_state()
+        assert state.committed_offset == 0
+        assert state.committed_chunks == []
+
+    async def test_ensure_initialized_drops_stale_chunks_after_ttl_expiry(
+        self, session: TusUploadSession, valkey_tus_client: ValkeyTusClient
+    ) -> None:
+        # Simulate a session that wrote chunks, then had its Valkey state
+        # reclaimed by TTL while leftover chunk files stayed on disk.
+        await session.ensure_initialized()
+        await _commit(session, _Chunk(offset=0, payload=b"old" * 100))
+        await valkey_tus_client.delete_session_state(session.session_id)
+        assert list(session.chunks_dir.iterdir())
+
+        # The next ensure_initialized must clear the stale chunks so the fresh
+        # state does not silently mix the old bytes into the new upload.
+        await session.ensure_initialized()
+        assert list(session.chunks_dir.iterdir()) == []
+        state = await session.read_state()
+        assert state.committed_chunks == []
+
+
+class TestSequentialCommit:
+    async def test_commits_advance_committed_offset(self, session: TusUploadSession) -> None:
+        await session.ensure_initialized()
+        chunks = _make_chunks(total_size=1024, chunk_size=256)
+        last_commit_result: ChunkCommitResult | None = None
+        for chunk in chunks:
+            last_commit_result = await _commit(session, chunk)
+        assert last_commit_result is not None
+        assert last_commit_result.state.committed_offset == 1024
+        assert last_commit_result.is_final_commit is True
+
+    async def test_is_final_commit_fires_only_on_threshold_crossing(
+        self, session: TusUploadSession
+    ) -> None:
+        await session.ensure_initialized()
+        chunks = _make_chunks(total_size=1024, chunk_size=512)
+        first = await _commit(session, chunks[0])
+        last = await _commit(session, chunks[1])
+        assert first.is_final_commit is False
+        assert last.is_final_commit is True
+
+
+class TestOutOfOrderCommit:
+    async def test_prefix_only_advances_when_gap_filled(self, session: TusUploadSession) -> None:
+        await session.ensure_initialized()
+        chunks = _make_chunks(total_size=1024, chunk_size=256)
+        result = await _commit(session, chunks[3])
+        assert result.state.committed_offset == 0
+        await _commit(session, chunks[2])
+        await _commit(session, chunks[1])
+        final = await _commit(session, chunks[0])
+        assert final.state.committed_offset == 1024
+        assert final.is_final_commit is True
+
+
+class TestIdempotencyAndConflict:
+    async def test_duplicate_chunk_is_idempotent(self, session: TusUploadSession) -> None:
+        await session.ensure_initialized()
+        chunks = _make_chunks(total_size=512, chunk_size=512)
+        first = await _commit(session, chunks[0])
+        assert first.committed is True
+        replay = await _commit(session, chunks[0])
+        assert replay.committed is False
+        assert replay.state.committed_offset == 512
+
+    async def test_conflicting_chunk_raises(self, session: TusUploadSession) -> None:
+        await session.ensure_initialized()
+        original = _Chunk(offset=0, payload=b"A" * 512)
+        await _commit(session, original)
+
+        tampered = _Chunk(offset=0, payload=b"B" * 512)
+        with pytest.raises(ChunkConflictError):
+            await _commit(session, tampered)
+
+        state = await session.read_state()
+        assert state.committed_chunks == [
+            ChunkMetadata(offset=0, length=512, sha256=original.sha256)
+        ]
+
+    async def test_conflicting_chunk_temp_file_is_cleaned_up(
+        self, session: TusUploadSession
+    ) -> None:
+        await session.ensure_initialized()
+        await _commit(session, _Chunk(offset=0, payload=b"A" * 512))
+
+        temp = session.open_temp_chunk(0)
+        temp.write_bytes(b"B" * 512)
+        with pytest.raises(ChunkConflictError):
+            await session.commit_chunk(
+                offset=0,
+                chunk_path=temp,
+                length=512,
+                sha256=hashlib.sha256(b"B" * 512).hexdigest(),
+            )
+        assert not temp.exists()
+
+
+class TestAssembly:
+    async def test_assembled_file_matches_payload(
+        self, session: TusUploadSession, tmp_path: Path
+    ) -> None:
+        await session.ensure_initialized()
+        chunks = _make_chunks(total_size=1024, chunk_size=128)
+        for chunk in chunks:
+            await _commit(session, chunk)
+
+        target = tmp_path / "out" / "final.bin"
+        await session.assemble(target)
+
+        expected = b"".join(c.payload for c in chunks)
+        assert target.read_bytes() == expected
+
+    async def test_assemble_is_idempotent_on_completed_status(
+        self, session: TusUploadSession, tmp_path: Path
+    ) -> None:
+        await session.ensure_initialized()
+        chunks = _make_chunks(total_size=1024, chunk_size=1024)
+        await _commit(session, chunks[0])
+
+        target = tmp_path / "out" / "final.bin"
+        await session.assemble(target)
+        first_mtime = target.stat().st_mtime_ns
+
+        await session.assemble(target)
+        assert target.stat().st_mtime_ns == first_mtime
+
+    async def test_assemble_before_completion_raises(
+        self, session: TusUploadSession, tmp_path: Path
+    ) -> None:
+        await session.ensure_initialized()
+        chunks = _make_chunks(total_size=1024, chunk_size=512)
+        await _commit(session, chunks[0])
+
+        with pytest.raises(UploadSessionCorruptedError):
+            await session.assemble(tmp_path / "final.bin")
+
+    async def test_cleanup_reclaims_chunks_but_keeps_completed_marker(
+        self, session: TusUploadSession, tmp_path: Path
+    ) -> None:
+        await session.ensure_initialized()
+        chunks = _make_chunks(total_size=1024, chunk_size=1024)
+        await _commit(session, chunks[0])
+        await session.assemble(tmp_path / "final.bin")
+        await session.cleanup()
+
+        # Chunk data is reclaimed...
+        assert list(session.chunks_dir.glob("*.dat")) == []
+        # ...but the completed marker is intentionally kept in Valkey (reclaimed
+        # by its TTL) so that late duplicate PATCHes can no-op instead of racing
+        # a teardown.
+        assert (await session.read_state()).status == UploadStatus.COMPLETED
+
+    async def test_late_commit_after_completion_is_idempotent_noop(
+        self, session: TusUploadSession, tmp_path: Path
+    ) -> None:
+        """A duplicate chunk that arrives after the upload completed (and was
+        cleaned up) must no-op, not crash — this is the multi-proxy race the
+        real-NFS reproduction surfaced."""
+        await session.ensure_initialized()
+        chunks = _make_chunks(total_size=1024, chunk_size=1024)
+        await _commit(session, chunks[0])
+        await session.assemble(tmp_path / "final.bin")
+        await session.cleanup()
+
+        # A late retry of the same chunk lands now.
+        result = await _commit(session, chunks[0])
+        assert result.committed is False
+        assert result.is_final_commit is False
+        assert result.state.status == UploadStatus.COMPLETED
+
+
+class TestCorruption:
+    async def test_garbage_state_raises(
+        self, session: TusUploadSession, valkey_tus_client: ValkeyTusClient
+    ) -> None:
+        await valkey_tus_client.set_session_state(session.session_id, "{not json")
+        with pytest.raises(UploadSessionCorruptedError):
+            await session.read_state()
+
+    async def test_non_object_state_raises(
+        self, session: TusUploadSession, valkey_tus_client: ValkeyTusClient
+    ) -> None:
+        await valkey_tus_client.set_session_state(session.session_id, json.dumps([1, 2, 3]))
+        with pytest.raises(UploadSessionCorruptedError):
+            await session.read_state()
+
+
+class TestConcurrentCommits:
+    """Models multiple Storage Proxy replicas hitting the same session."""
+
+    async def test_concurrent_disjoint_offsets_all_succeed(self, session: TusUploadSession) -> None:
+        await session.ensure_initialized()
+        chunks = _make_chunks(total_size=4096, chunk_size=256)
+
+        results = await asyncio.gather(*(_commit(session, chunk) for chunk in chunks))
+
+        assert all(r.committed for r in results)
+        assert sum(1 for r in results if r.is_final_commit) == 1
+
+        state = await session.read_state()
+        assert state.committed_offset == 4096
+
+    async def test_concurrent_same_offset_one_winner(self, session: TusUploadSession) -> None:
+        await session.ensure_initialized()
+        chunk = _Chunk(offset=0, payload=b"x" * 1024)
+
+        results = list(
+            await asyncio.gather(
+                *(_commit(session, chunk) for _ in range(8)), return_exceptions=True
+            )
+        )
+
+        winners = [r for r in results if isinstance(r, ChunkCommitResult) and r.committed]
+        replays = [r for r in results if isinstance(r, ChunkCommitResult) and not r.committed]
+        assert len(winners) == 1
+        assert len(winners) + len(replays) == 8
+
+
+class TestWriteTempChunk:
+    async def test_drains_reader_and_hashes_payload(self, session: TusUploadSession) -> None:
+        await session.ensure_initialized()
+        payload = b"hello-world" * 500
+        reader = _Reader(payload, chunk_size=64)
+        written = await session.write_temp_chunk(0, reader)
+
+        assert written.length == len(payload)
+        assert written.sha256 == hashlib.sha256(payload).hexdigest()
+        assert written.path.read_bytes() == payload


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 5-PR stack implementing BA-3974 (epic: BA-6153). **Merge in order:**

1. 👉 **#11766** — `feat(BA-6155): add Valkey-backed chunk-store upload session engine` ← you are here
2. ⬇️ #11767 — `fix(BA-6156): rewire TUS PATCH/HEAD to chunk-based store` (**actual user-visible fix**)
3. ⬇️ #11768 — `test(BA-6157): add multi-proxy NFS race regression test`
4. ⬇️ #11769 — `feat(BA-6158): support TUS Checksum extension`
5. ⬇️ #11770 — `feat(BA-6159): add /upload/status endpoint + progress headers`

## Summary

Introduces the concurrency-safe TUS upload session engine. Per-session metadata
is the source of truth in **Valkey** (keyed by session id) and is guarded by a
**per-session distributed lock** produced by an injected `DistributedLockFactory`.
Chunk payload bytes live as individual files under `chunks/chunk_<offset>.dat`
on the shared filesystem; they are content-addressed by `(offset, sha256)` and
idempotent, so the heavy write path needs no coordination at all. Only the small
metadata read-modify-write window is serialized — and across Storage Proxy
replicas, since the lock is distributed.

> **Note:** This PR combines two originally stacked issues — the pure
> session-state model (BA-6154) and the on-disk storage engine (BA-6155). They
> live in the same package and the model has no consumer on its own, so splitting
> them across PRs hurt reviewability. Both issues are resolved here.

## Architecture

The handler (PR #11767) only adapts the request body; **all chunk file I/O and
metadata management lives in the engine** (this PR).

```mermaid
flowchart TB
    classDef pr66 fill:#e6f7ff,stroke:#1890ff,color:#000
    classDef pr67 fill:#fff7e6,stroke:#fa8c16,color:#000
    classDef redis fill:#fff1f0,stroke:#cf1322,color:#000
    classDef disk fill:#f6ffed,stroke:#52c41a,color:#000

    subgraph L1["PATCH handler (PR #11767)"]
        REQ["request.content"]:::pr67
        ADP["TusChunkUploadStreamReader"]:::pr67
        HND["tus_upload_part"]:::pr67
        REQ --> ADP --> HND
    end

    subgraph L2["Upload engine (PR #11766)"]
        WTC["write_temp_chunk"]:::pr66
        CC["commit_chunk"]:::pr66
        FIN["assemble + cleanup"]:::pr66
    end

    subgraph L3R["Valkey · source of truth"]
        STATE["tus.upload.session:id"]:::redis
        LOCK["tus.upload.lock:id"]:::redis
    end

    subgraph L3F["shared FS · chunk payloads"]
        TMP["chunk_off.tok.tmp"]:::disk
        DAT["chunk_off.dat"]:::disk
        OUT["assembled file"]:::disk
    end

    HND -->|"1. drain body"| WTC
    HND -->|"2. promote temp"| CC
    HND -->|"3. on final commit"| FIN
    WTC -->|"lock-free write"| TMP
    CC -->|"acquire"| LOCK
    CC -->|"get / set"| STATE
    CC -->|"atomic rename"| DAT
    FIN -->|"concat in order"| OUT
    FIN -->|"mark COMPLETED"| STATE
    FIN -->|"unlink chunks"| DAT
```

### Data model

```mermaid
classDiagram
    class TusUploadSession {
        +ensure_initialized()
        +read_state() TusSessionState
        +open_temp_chunk(offset) Path
        +write_temp_chunk(offset, reader) WrittenChunk
        +commit_chunk(offset, path, length, sha256) ChunkCommitResult
        +assemble(target)
        +cleanup()
    }
    class TusSessionState {
        +session_id
        +total_size
        +committed_chunks : ChunkMetadata[]
        +status : UploadStatus
        +committed_offset
        +find_at_offset(offset)
        +append_chunk(chunk)
    }
    class ChunkMetadata {
        +offset
        +length
        +sha256
    }
    class WrittenChunk {
        +path
        +length
        +sha256
    }
    class ChunkCommitResult {
        +state : TusSessionState
        +committed : bool
        +is_final_commit : bool
    }
    class TusUploadSessionArgs {
        +session_dir
        +session_id
        +total_size
        +valkey_client : ValkeyTusClient
        +lock_factory : DistributedLockFactory
    }
    TusSessionState o-- ChunkMetadata
    TusUploadSession ..> TusSessionState
    TusUploadSession ..> ChunkCommitResult
    TusUploadSession ..> WrittenChunk
    TusUploadSession ..> TusUploadSessionArgs
```

### One PATCH lifecycle

The expensive body write is lock-free; only the short metadata read-modify-write
is serialized via the distributed lock, so concurrent replicas never corrupt
each other.

```mermaid
sequenceDiagram
    autonumber
    participant H as tus_upload_part
    participant S as TusUploadSession
    participant V as Valkey
    participant D as shared FS

    H->>S: ensure_initialized()
    S->>V: acquire lock + SET state if missing
    H->>S: write_temp_chunk(offset, reader)
    loop async for chunk in reader.read()
        S->>D: write chunk_off.tok.tmp (lock-free) + sha256
    end
    S-->>H: WrittenChunk(path, length, sha256)
    H->>S: commit_chunk(offset, path, length, sha256)
    Note over S,V: distributed lock window (short)
    alt status == COMPLETED
        S-->>H: no-op (late duplicate from another replica)
    else duplicate (same offset, length, sha256)
        S-->>H: committed=False (idempotent)
    else conflict (same offset, different content)
        S-->>H: ChunkConflictError 409
    else new chunk
        S->>D: atomic rename tmp to chunk_off.dat
        S->>V: update TusSessionState with new record
        S-->>H: ChunkCommitResult(is_final_commit?)
    end
    opt is_final_commit
        H->>S: assemble(target)
        S->>D: concat chunks in offset order
        S->>V: mark status=COMPLETED
        H->>S: cleanup()
        S->>D: unlink chunk files (state kept for TTL)
    end
    H-->>H: 204 No Content
```

## Locking & HA semantics

**Session state is NOT held in memory and NOT on the shared filesystem.**
`TusUploadSession` is stateless in-process — every operation reads/writes the
TusSessionState in Valkey, and chunk payload files are content-addressed.

This makes it safe for the production topology of **multiple storage-proxy
processes/replicas** sharing an NFS mount: no in-process state to synchronize,
no dependency on filesystem lock semantics, no dependency on NFS attribute-cache
coherence.

How replicas coordinate:

- **Source of truth = Valkey**, fetched per request (no in-process cache).
- **Per-session distributed lock** (RedisLock via `DistributedLockFactory`)
  serializes the metadata read-modify-write window. The factory pattern mirrors
  the manager's `DistributedLockFactory` — the lock backend lives in
  `RootContext.tus_lock_factory` and is injected into the engine.
- **Atomic rename** (`Path.replace`) promotes a temp chunk file
  (`chunk_<offset>.<token>.tmp`) to its canonical name (`chunk_<offset>.dat`).
  Readers see old-or-new, never a partial file.
- **Per-offset content-addressed chunk files** — duplicates are idempotent
  no-ops, mismatched content surfaces as a 409 `ChunkConflictError`.
- **Stateless JWT upload tokens** — any PATCH may land on any replica with no
  session affinity, and still resolves to the same Valkey key and same chunk
  file path.

Stale or abandoned sessions are reclaimed by the Valkey state's TTL (24h), so
there is no separate GC sweep.

Resolves BA-6154, BA-6155.

