### PR TITLE
feat(BA-6158): support TUS Checksum extension

### DIFF
--- a/changes/11768.enhance.md
+++ b/changes/11768.enhance.md
@@ -1,0 +1,1 @@
+Add a multi-proxy regression test that reproduces concurrent TUS chunk-upload corruption on shared NFS and locks in the chunk-store fix.

--- a/changes/11769.feature.md
+++ b/changes/11769.feature.md
@@ -1,0 +1,1 @@
+Support the TUS Checksum extension on storage proxy uploads: clients may now send `Upload-Checksum: sha256 <base64>` and the server rejects mismatched chunks with HTTP 460.

--- a/src/ai/backend/storage/api/client.py
+++ b/src/ai/backend/storage/api/client.py
@@ -5,6 +5,8 @@ Client-facing API
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import logging
 import os
 import urllib.parse
@@ -47,7 +49,9 @@ from ai.backend.logging import BraceStyleAdapter
 from ai.backend.storage import __version__
 from ai.backend.storage.dto.context import StorageRootCtx
 from ai.backend.storage.errors import (
+    ChunkChecksumMismatchError,
     InvalidAPIParameters,
+    InvalidUploadChecksumHeaderError,
     TusSessionNotFoundError,
     UploadChunkExceedsTotalSizeError,
     UploadOffsetMismatchError,
@@ -400,6 +404,10 @@ async def tus_upload_part(request: web.Request) -> web.Response:
                 f"Upload-Offset {client_offset} is out of range [0, {total_size}]"
             )
 
+        expected_checksum_hex = _parse_upload_checksum_header(
+            request.headers.get("Upload-Checksum")
+        )
+
         async with ctx.get_volume(token_data["volume"]) as volume:
             session_dir = (
                 volume.mangle_vfpath(token_data["vfid"]) / ".upload" / token_data["session"]
@@ -425,6 +433,10 @@ async def tus_upload_part(request: web.Request) -> web.Response:
                     raise UploadChunkExceedsTotalSizeError(
                         f"Chunk at offset {client_offset} with length {written.length} "
                         f"exceeds declared size {total_size}"
+                    )
+                if expected_checksum_hex is not None and expected_checksum_hex != written.sha256:
+                    raise ChunkChecksumMismatchError(
+                        f"Chunk at offset {client_offset} failed SHA-256 verification"
                     )
                 commit_result = await session.commit_chunk(
                     offset=client_offset,
@@ -468,9 +480,15 @@ async def tus_upload_part(request: web.Request) -> web.Response:
 # - Upload-Offset: byte position from which the next PATCH must continue;
 #   required on PATCH requests and present on HEAD/PATCH responses. The core
 #   resumability primitive of TUS.
+# - Upload-Checksum: `<algorithm> <base64>` payload integrity check for PATCH
+#   bodies (TUS Checksum extension). Only `sha256` is accepted; the server
+#   verifies the PATCH body's digest against the supplied value and returns
+#   460 on mismatch.
 # - Content-Type: PATCH bodies must be `application/offset+octet-stream` per
 #   the TUS spec.
-_TUS_HEADER_LIST = "Tus-Resumable, Upload-Length, Upload-Metadata, Upload-Offset, Content-Type"
+_TUS_HEADER_LIST = (
+    "Tus-Resumable, Upload-Length, Upload-Metadata, Upload-Offset, Upload-Checksum, Content-Type"
+)
 
 
 def _prepare_tus_session_headers(*, upload_offset: int, upload_length: int) -> dict[str, str]:
@@ -486,6 +504,37 @@ def _prepare_tus_session_headers(*, upload_offset: int, upload_length: int) -> d
     }
 
 
+def _parse_upload_checksum_header(raw: str | None) -> str | None:
+    """
+    Parse a TUS Checksum extension header value into a hex SHA-256 digest.
+
+    Returns ``None`` if no header was sent. Raises
+    ``InvalidUploadChecksumHeaderError`` for malformed values or unsupported
+    algorithms (only ``sha256`` is accepted).
+    """
+    if raw is None:
+        return None
+    parts = raw.strip().split(None, 1)
+    if len(parts) != 2:
+        raise InvalidUploadChecksumHeaderError(
+            f"Upload-Checksum must be '<algorithm> <base64>', got {raw!r}"
+        )
+    algorithm, encoded = parts
+    if algorithm.lower() != "sha256":
+        raise InvalidUploadChecksumHeaderError(
+            f"Unsupported checksum algorithm: {algorithm}. Only 'sha256' is accepted."
+        )
+    try:
+        digest = base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError) as e:
+        raise InvalidUploadChecksumHeaderError(
+            f"Invalid base64 in Upload-Checksum: {encoded!r}"
+        ) from e
+    if len(digest) != 32:
+        raise InvalidUploadChecksumHeaderError(f"sha256 digest must be 32 bytes, got {len(digest)}")
+    return digest.hex()
+
+
 async def tus_options(request: web.Request) -> web.Response:
     """
     Let clients discover the supported features of our tus.io server-side implementation.
@@ -493,15 +542,13 @@ async def tus_options(request: web.Request) -> web.Response:
     ctx: RootContext = request.app["ctx"]
     headers = {}
     headers["Access-Control-Allow-Origin"] = "*"
-    headers["Access-Control-Allow-Headers"] = (
-        "Tus-Resumable, Upload-Length, Upload-Metadata, Upload-Offset, Content-Type"
-    )
-    headers["Access-Control-Expose-Headers"] = (
-        "Tus-Resumable, Upload-Length, Upload-Metadata, Upload-Offset, Content-Type"
-    )
+    headers["Access-Control-Allow-Headers"] = _TUS_HEADER_LIST
+    headers["Access-Control-Expose-Headers"] = _TUS_HEADER_LIST
     headers["Access-Control-Allow-Methods"] = "*"
     headers["Tus-Resumable"] = "1.0.0"
     headers["Tus-Version"] = "1.0.0"
+    headers["Tus-Extension"] = "checksum"
+    headers["Tus-Checksum-Algorithm"] = "sha256"
     headers["Tus-Max-Size"] = str(
         int(BinarySize.from_str(ctx.local_config.storage_proxy.max_upload_size)),
     )

--- a/src/ai/backend/storage/errors/__init__.py
+++ b/src/ai/backend/storage/errors/__init__.py
@@ -63,7 +63,9 @@ from .quota import (
     QuotaTreeNotFoundError,
 )
 from .upload import (
+    ChunkChecksumMismatchError,
     ChunkConflictError,
+    InvalidUploadChecksumHeaderError,
     TusSessionNotFoundError,
     UploadChunkExceedsTotalSizeError,
     UploadSessionCorruptedError,
@@ -97,10 +99,12 @@ __all__ = [
     "ServiceNotInitializedError",
     "UploadOffsetMismatchError",
     # upload
+    "ChunkChecksumMismatchError",
     "ChunkConflictError",
+    "InvalidUploadChecksumHeaderError",
+    "TusSessionNotFoundError",
     "UploadChunkExceedsTotalSizeError",
     "UploadSessionCorruptedError",
-    "TusSessionNotFoundError",
     # vfolder
     "VFolderNotFoundError",
     "InvalidSubpathError",

--- a/src/ai/backend/storage/errors/upload.py
+++ b/src/ai/backend/storage/errors/upload.py
@@ -82,3 +82,46 @@ class UploadSessionCorruptedError(BackendAIError, web.HTTPInternalServerError):
             operation=ErrorOperation.READ,
             error_detail=ErrorDetail.INTERNAL_ERROR,
         )
+
+
+class _ChecksumMismatch(web.HTTPClientError):
+    """
+    TUS Checksum extension defines HTTP 460 for checksum mismatches.
+    aiohttp does not ship a built-in class for this code, so we declare one.
+    """
+
+    status_code = 460
+
+
+class ChunkChecksumMismatchError(BackendAIError, _ChecksumMismatch):
+    """
+    Raised when ``Upload-Checksum`` header does not match the SHA-256 digest
+    of the received chunk body (HTTP 460 per TUS Checksum extension).
+    """
+
+    error_type = "https://api.backend.ai/probs/storage/chunk-checksum-mismatch"
+    error_title = "Upload Chunk Checksum Mismatch"
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.STORAGE_PROXY,
+            operation=ErrorOperation.UPDATE,
+            error_detail=ErrorDetail.MISMATCH,
+        )
+
+
+class InvalidUploadChecksumHeaderError(BackendAIError, web.HTTPBadRequest):
+    """
+    Raised when ``Upload-Checksum`` header is malformed or specifies an
+    unsupported algorithm (only ``sha256`` is accepted).
+    """
+
+    error_type = "https://api.backend.ai/probs/storage/invalid-upload-checksum"
+    error_title = "Invalid Upload-Checksum header"
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.STORAGE_PROXY,
+            operation=ErrorOperation.REQUEST,
+            error_detail=ErrorDetail.INVALID_PARAMETERS,
+        )

--- a/tests/unit/storage/api/test_tus_upload.py
+++ b/tests/unit/storage/api/test_tus_upload.py
@@ -10,7 +10,9 @@ range bounds) plus the end-to-end happy path that writes through to
 
 from __future__ import annotations
 
+import base64
 import dataclasses
+import hashlib
 import secrets
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -29,7 +31,9 @@ from ai.backend.common.typed_validators import HostPortPair as HostPortPairModel
 from ai.backend.common.types import RedisConnectionInfo, TusSessionId, ValkeyTarget
 from ai.backend.storage.api.client import tus_upload_part
 from ai.backend.storage.errors import (
+    ChunkChecksumMismatchError,
     InvalidAPIParameters,
+    InvalidUploadChecksumHeaderError,
     UploadChunkExceedsTotalSizeError,
     UploadOffsetMismatchError,
 )
@@ -88,6 +92,7 @@ def _build_request(
     offset_header: str | None,
     valkey_client: ValkeyTusClient,
     lock_factory: DistributedLockFactory,
+    checksum_header: str | None = None,
 ) -> MagicMock:
     volume = MagicMock()
     volume.mangle_vfpath.return_value = vfpath
@@ -104,6 +109,8 @@ def _build_request(
     request.headers = {}
     if offset_header is not None:
         request.headers["Upload-Offset"] = offset_header
+    if checksum_header is not None:
+        request.headers["Upload-Checksum"] = checksum_header
     request.query = {"token": "test-token"}
 
     if body is None:
@@ -441,3 +448,107 @@ class TestHappyPath:
         chunks_dir = patch_env.session_dir / "chunks"
         if chunks_dir.exists():
             assert list(chunks_dir.glob("*.tmp")) == []
+
+
+def _sha256_b64(data: bytes) -> str:
+    return base64.b64encode(hashlib.sha256(data).digest()).decode("ascii")
+
+
+class TestUploadChecksum:
+    async def test_matching_checksum_accepted(
+        self,
+        patch_env: _PatchEnv,
+        valkey_tus_client: ValkeyTusClient,
+        tus_lock_factory: DistributedLockFactory,
+    ) -> None:
+        payload = b"X" * 1024
+        token_data = _token_data(
+            session_id=patch_env.session_id, total_size=1024, relpath="result.bin"
+        )
+        cp = _patch_handler_params(token_data)
+        try:
+            request = _build_request(
+                vfpath=patch_env.vfpath,
+                session_id=patch_env.session_id,
+                total_size=1024,
+                body=payload,
+                offset_header="0",
+                valkey_client=valkey_tus_client,
+                lock_factory=tus_lock_factory,
+                checksum_header=f"sha256 {_sha256_b64(payload)}",
+            )
+            response = await tus_upload_part(request)
+        finally:
+            cp.stop()
+        assert response.headers["Upload-Offset"] == "1024"
+        assert (patch_env.vfpath / "result.bin").read_bytes() == payload
+
+    async def test_mismatched_checksum_rejected(
+        self,
+        patch_env: _PatchEnv,
+        valkey_tus_client: ValkeyTusClient,
+        tus_lock_factory: DistributedLockFactory,
+    ) -> None:
+        payload = b"X" * 1024
+        wrong = _sha256_b64(b"different-payload")
+        token_data = _token_data(
+            session_id=patch_env.session_id, total_size=1024, relpath="result.bin"
+        )
+        cp = _patch_handler_params(token_data)
+        try:
+            request = _build_request(
+                vfpath=patch_env.vfpath,
+                session_id=patch_env.session_id,
+                total_size=1024,
+                body=payload,
+                offset_header="0",
+                valkey_client=valkey_tus_client,
+                lock_factory=tus_lock_factory,
+                checksum_header=f"sha256 {wrong}",
+            )
+            with pytest.raises(ChunkChecksumMismatchError):
+                await tus_upload_part(request)
+        finally:
+            cp.stop()
+
+        # The mismatched chunk must not be committed.
+        assert not (patch_env.vfpath / "result.bin").exists()
+        chunks_dir = patch_env.session_dir / "chunks"
+        if chunks_dir.exists():
+            assert list(chunks_dir.glob("*")) == []
+
+    @pytest.mark.parametrize(
+        "header",
+        [
+            "sha256",  # missing digest
+            "sha1 abc",  # unsupported algorithm
+            "sha256 not_base64!!",  # invalid base64
+            "sha256 " + base64.b64encode(b"too-short").decode("ascii"),  # wrong length
+        ],
+    )
+    async def test_malformed_checksum_header_rejected(
+        self,
+        patch_env: _PatchEnv,
+        valkey_tus_client: ValkeyTusClient,
+        tus_lock_factory: DistributedLockFactory,
+        header: str,
+    ) -> None:
+        token_data = _token_data(
+            session_id=patch_env.session_id, total_size=1024, relpath="result.bin"
+        )
+        cp = _patch_handler_params(token_data)
+        try:
+            request = _build_request(
+                vfpath=patch_env.vfpath,
+                session_id=patch_env.session_id,
+                total_size=1024,
+                body=b"X" * 1024,
+                offset_header="0",
+                valkey_client=valkey_tus_client,
+                lock_factory=tus_lock_factory,
+                checksum_header=header,
+            )
+            with pytest.raises(InvalidUploadChecksumHeaderError):
+                await tus_upload_part(request)
+        finally:
+            cp.stop()

--- a/tests/unit/storage/services/upload/test_nfs_race_reproduction.py
+++ b/tests/unit/storage/services/upload/test_nfs_race_reproduction.py
@@ -1,0 +1,329 @@
+"""
+BA-3974 — multi-proxy NFS race condition reproduction.
+
+This file does two things:
+
+1. Reconstructs the *pre-PR* upload model (single temp file, ``stat()`` to
+   discover position, then append) and shows it CORRUPTS data when two or
+   more workers race — without needing a real NFS mount.
+
+2. Drives the *new* metadata-driven model under the exact same chaos and
+   confirms the assembled output is byte-perfect.
+
+How the NFS race is faked on a local filesystem
+-----------------------------------------------
+On NFS, two things conspire to break the old append model:
+
+  (a) Each NFS client caches file attributes (``st_size`` in particular).
+      Two storage-proxy replicas calling ``stat()`` close together can
+      both see the same cached "end of file" value, even though writes
+      from the other replica are already in flight.
+
+  (b) NFS does not give cross-client ``O_APPEND`` atomicity. Each client
+      issues a positioned write based on its cached size, and the writes
+      do NOT serialize at the byte level the way they do on a local
+      kernel.
+
+Linux on local ext4 makes both go away — ``stat()`` is always coherent and
+``O_APPEND`` writes are atomic. To expose the bug in a unit test we replace
+both behaviors:
+
+  (a) is faked by ``unittest.mock.patch`` on ``pathlib.Path.stat`` to
+      return a frozen snapshot for the upload temp file.
+  (b) is faked by using ``os.lseek`` + ``os.write`` (no ``O_APPEND``).
+
+Under that combination, the old offset-check guard from BA-3678 passes
+for every concurrent worker — they all observe the same stale ``st_size``
+— and they all race to write at the same byte position, clobbering each
+other. That is exactly the corruption pattern reported on production
+multi-proxy + shared NFS deployments.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import secrets
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ai.backend.common.clients.valkey_client.valkey_tus import ValkeyTusClient
+from ai.backend.common.lock import DistributedLockFactory
+from ai.backend.common.types import TusSessionId
+from ai.backend.storage.services.upload.tus_session import TusUploadSession
+from ai.backend.storage.services.upload.types import TusUploadSessionArgs
+
+# -----------------------------------------------------------------------------
+# Legacy model reconstruction
+# -----------------------------------------------------------------------------
+
+
+class _FakeStat:
+    """A minimal ``stat_result`` stand-in (only ``st_size`` is used)."""
+
+    __slots__ = ("st_size",)
+
+    def __init__(self, st_size: int) -> None:
+        self.st_size = st_size
+
+
+def _legacy_upload_chunk(file_path: Path, expected_offset: int, payload: bytes) -> str:
+    """
+    Distilled reconstruction of the pre-PR ``tus_upload_part`` body:
+
+        actual = file_path.stat().st_size
+        if actual != expected_offset:
+            raise UploadOffsetMismatchError(...)
+        # AsyncFileWriter(access_mode="ab"): append the chunk
+
+    Critically, we use ``os.lseek`` + ``os.write`` here rather than the real
+    ``O_APPEND``-backed writer, because that is what NFS effectively does
+    across clients: the kernel cannot serialize positions across hosts, so
+    a write lands at the offset the client computed from its own cached
+    view of the file size.
+    """
+    actual = file_path.stat().st_size
+    if actual != expected_offset:
+        return "offset-mismatch"
+    fd = os.open(file_path, os.O_WRONLY)
+    try:
+        os.lseek(fd, actual, os.SEEK_SET)
+        os.write(fd, payload)
+    finally:
+        os.close(fd)
+    return "wrote"
+
+
+# -----------------------------------------------------------------------------
+# Test scenario shared between legacy and new models
+# -----------------------------------------------------------------------------
+
+
+CHUNK_SIZE = 64 * 1024
+NUM_CHUNKS = 8
+TOTAL_SIZE = CHUNK_SIZE * NUM_CHUNKS
+
+
+@pytest.fixture
+def random_chunks() -> list[bytes]:
+    rng = secrets.SystemRandom()
+    return [bytes(rng.randbytes(CHUNK_SIZE)) for _ in range(NUM_CHUNKS)]
+
+
+# -----------------------------------------------------------------------------
+# 1) Legacy model demonstrably corrupts under NFS-like stale stat
+# -----------------------------------------------------------------------------
+
+
+class TestLegacyModelCorruptsUnderStaleStatCache:
+    def test_concurrent_writes_clobber_each_other(
+        self, tmp_path: Path, random_chunks: list[bytes]
+    ) -> None:
+        upload_path = tmp_path / "upload.bin"
+        upload_path.touch()
+
+        # All concurrent workers will see this frozen value, mirroring NFS
+        # attribute cache staleness across clients.
+        stale = _FakeStat(st_size=0)
+
+        original_stat = Path.stat
+
+        def fake_stat(self: Path, *, follow_symlinks: bool = True) -> object:
+            if self == upload_path:
+                return stale
+            return original_stat(self, follow_symlinks=follow_symlinks)
+
+        # Force all workers to start at the same instant so they all
+        # observe the empty-file snapshot together.
+        barrier = threading.Barrier(NUM_CHUNKS)
+
+        def worker(payload: bytes) -> str:
+            barrier.wait()
+            return _legacy_upload_chunk(upload_path, 0, payload)
+
+        with patch.object(Path, "stat", fake_stat):
+            with ThreadPoolExecutor(max_workers=NUM_CHUNKS) as pool:
+                results = list(pool.map(worker, random_chunks))
+
+        # The post-BA-3678 offset guard passes for *every* worker because
+        # they all see st_size = 0. None are rejected.
+        assert all(r == "wrote" for r in results), (
+            f"expected every worker to pass the offset check, got {results}"
+        )
+
+        # The on-disk file CANNOT match a correct concatenation of all
+        # chunks — every write went to position 0.
+        expected = b"".join(random_chunks)
+        actual = upload_path.read_bytes()
+        assert actual != expected, (
+            "test setup failure: legacy model unexpectedly produced the "
+            "correct output (race window did not open)"
+        )
+
+        # File length should be at most one chunk's worth of bytes,
+        # because every writer started at position 0 and overlapped.
+        # On a healthy upload it would be NUM_CHUNKS * CHUNK_SIZE.
+        assert len(actual) <= CHUNK_SIZE, (
+            f"corrupted file should be at most {CHUNK_SIZE} bytes, "
+            f"got {len(actual)} (expected correct length "
+            f"{TOTAL_SIZE} on a non-broken model)"
+        )
+
+    def test_legacy_guard_does_not_help_when_two_workers_see_same_size(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        Even with the BA-3678 offset guard, two workers that race past the
+        guard cause corruption. Proves the guard fixes single-client
+        ordering only, not multi-proxy concurrency.
+        """
+        upload_path = tmp_path / "upload.bin"
+        upload_path.write_bytes(b"\x00" * CHUNK_SIZE)  # 1 chunk already there
+
+        # NFS-like stale cache: both workers see size = CHUNK_SIZE.
+        stale = _FakeStat(st_size=CHUNK_SIZE)
+        original_stat = Path.stat
+
+        def fake_stat(self: Path, *, follow_symlinks: bool = True) -> object:
+            if self == upload_path:
+                return stale
+            return original_stat(self, follow_symlinks=follow_symlinks)
+
+        a = b"A" * CHUNK_SIZE
+        b = b"B" * CHUNK_SIZE
+        barrier = threading.Barrier(2)
+
+        def worker(payload: bytes) -> str:
+            barrier.wait()
+            # Both pass `expected_offset=CHUNK_SIZE` (correct per their view).
+            return _legacy_upload_chunk(upload_path, CHUNK_SIZE, payload)
+
+        with patch.object(Path, "stat", fake_stat):
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                results = list(pool.map(worker, [a, b]))
+
+        # Both passed the guard.
+        assert results == ["wrote", "wrote"]
+
+        # File contents at position CHUNK_SIZE onwards is either all A or
+        # all B — never the correct A-then-B concatenation. Both writers
+        # claimed the same range.
+        contents = upload_path.read_bytes()
+        assert len(contents) == 2 * CHUNK_SIZE
+        chunk2 = contents[CHUNK_SIZE:]
+        # One writer clobbered the other: the slot holds a single writer's
+        # bytes, never a clean A-then-B concatenation — so one chunk is lost.
+        assert chunk2 in (a, b), (
+            "byte-interleaving acceptable, but at minimum chunk2 must come "
+            "from a single writer (not a clean concatenation of both)"
+        )
+
+
+# -----------------------------------------------------------------------------
+# 2) New model survives the same chaos
+# -----------------------------------------------------------------------------
+
+
+class TestNewModelSurvivesSameChaos:
+    async def test_concurrent_chunks_assemble_byte_perfect(
+        self,
+        tmp_path: Path,
+        random_chunks: list[bytes],
+        valkey_tus_client: ValkeyTusClient,
+        tus_lock_factory: DistributedLockFactory,
+    ) -> None:
+        """
+        Drive ``TusUploadSession`` with the same workload pattern as the
+        legacy test above — NUM_CHUNKS workers, all firing at once — and
+        confirm the assembled output equals the original payload, bit for
+        bit.
+        """
+        session = TusUploadSession(
+            TusUploadSessionArgs(
+                session_dir=tmp_path / "sess",
+                session_id=TusSessionId(secrets.token_hex(8)),
+                total_size=TOTAL_SIZE,
+                valkey_client=valkey_tus_client,
+                lock_factory=tus_lock_factory,
+            )
+        )
+        await session.ensure_initialized()
+
+        async def commit_chunk(idx: int) -> None:
+            offset = idx * CHUNK_SIZE
+            payload = random_chunks[idx]
+            temp = session.open_temp_chunk(offset)
+            temp.write_bytes(payload)
+            await session.commit_chunk(
+                offset=offset,
+                chunk_path=temp,
+                length=CHUNK_SIZE,
+                sha256=hashlib.sha256(payload).hexdigest(),
+            )
+
+        await asyncio.gather(*(commit_chunk(i) for i in range(NUM_CHUNKS)))
+
+        target = tmp_path / "out.bin"
+        await session.assemble(target)
+        await session.cleanup()
+
+        expected = b"".join(random_chunks)
+        actual = target.read_bytes()
+        assert actual == expected, "assembled file diverges from source payload"
+        assert hashlib.sha256(actual).hexdigest() == hashlib.sha256(expected).hexdigest()
+
+    async def test_duplicate_retries_under_chaos_remain_idempotent(
+        self,
+        tmp_path: Path,
+        random_chunks: list[bytes],
+        valkey_tus_client: ValkeyTusClient,
+        tus_lock_factory: DistributedLockFactory,
+    ) -> None:
+        """
+        Each chunk is fired THREE times concurrently — modeling a retry
+        storm where the original request is still in flight to one proxy
+        while two replicas of it arrive at others. The assembled file
+        must still equal the original payload.
+        """
+        session = TusUploadSession(
+            TusUploadSessionArgs(
+                session_dir=tmp_path / "sess",
+                session_id=TusSessionId(secrets.token_hex(8)),
+                total_size=TOTAL_SIZE,
+                valkey_client=valkey_tus_client,
+                lock_factory=tus_lock_factory,
+            )
+        )
+        await session.ensure_initialized()
+
+        async def commit_chunk(idx: int) -> bool:
+            offset = idx * CHUNK_SIZE
+            payload = random_chunks[idx]
+            temp = session.open_temp_chunk(offset)
+            temp.write_bytes(payload)
+            acc = await session.commit_chunk(
+                offset=offset,
+                chunk_path=temp,
+                length=CHUNK_SIZE,
+                sha256=hashlib.sha256(payload).hexdigest(),
+            )
+            return acc.committed
+
+        # 3 replicas of every chunk → 3 * NUM_CHUNKS concurrent tasks.
+        tasks = [commit_chunk(i) for i in range(NUM_CHUNKS) for _ in range(3)]
+        committed_flags = await asyncio.gather(*tasks)
+
+        committed = sum(1 for c in committed_flags if c)
+        replays = sum(1 for c in committed_flags if not c)
+        assert committed == NUM_CHUNKS, f"exactly one commit per offset should win, got {committed}"
+        assert replays == NUM_CHUNKS * 2
+
+        target = tmp_path / "out.bin"
+        await session.assemble(target)
+        await session.cleanup()
+        assert target.read_bytes() == b"".join(random_chunks)


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 5-PR stack implementing BA-3974 (epic: BA-6153). **Merge in order:**

1. ⬇️ #11766 — `feat(BA-6155): add metadata-driven chunk-store upload session engine`
2. ⬇️ #11767 — `fix(BA-6156): rewire TUS PATCH/HEAD to chunk-based store` (**actual user-visible fix**)
3. ⬇️ #11768 — `test(BA-6157): add multi-proxy NFS race regression test`
4. 👉 **#11769** — `feat(BA-6158): support TUS Checksum extension` ← you are here
5. ⬇️ #11770 — `feat(BA-6159): add /upload/status endpoint + progress headers`

## Summary
- Parse \`Upload-Checksum: sha256 <base64>\` on PATCH and compare to the SHA-256 computed while streaming the chunk body. Mismatch returns HTTP 460 (\`ChunkChecksumMismatchError\`).
- Reject malformed header values (missing digest, unsupported algorithm, invalid base64, wrong digest length) with 400 (\`InvalidUploadChecksumHeaderError\`).
- Advertise the extension in OPTIONS via \`Tus-Extension: checksum\` and \`Tus-Checksum-Algorithm: sha256\`.
- Clients that do not send the header observe no behavior change.

Resolves BA-6158.
