### PR TITLE
fix(BA-6161): guard persistent-path echo in runner rc files

### DIFF
--- a/changes/11773.fix.md
+++ b/changes/11773.fix.md
@@ -1,0 +1,1 @@
+Fix `sftp`, `scp`, and other ssh subsystems failing with `Received message too long` when connecting to sessions launched from the `sftp-server` image, caused by the kernel-runner default rc files emitting the persistent-path notice on non-interactive shells.

--- a/src/ai/backend/runner/.bashrc
+++ b/src/ai/backend/runner/.bashrc
@@ -1,13 +1,17 @@
 export PS1="\[\033[01;32m\]\u@${BACKENDAI_CLUSTER_HOST:-main}\[\033[01;33m\][${BACKENDAI_SESSION_NAME}]\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "
 
-if [[ -n "${BACKENDAI_PERSISTENT_PATHS:-}" ]]; then
-  echo -e "\e[33m⚠ Only the following vfolder paths are persistent (all other files will be lost on session termination):\e[0m"
-  IFS=':' read -ra _paths <<< "$BACKENDAI_PERSISTENT_PATHS"
-  for _p in "${_paths[@]}"; do
-    echo -e "\e[33m   - $_p\e[0m"
-  done
-else
-  echo -e "\e[33m⚠ No persistent storage mounted. All files will be lost when the session is terminated.\e[0m"
+# Print the persistent-path notice only in interactive shells; otherwise stdout
+# would corrupt SFTP/SCP/rsync subsystems that use the same channel as data.
+if [[ $- == *i* ]]; then
+  if [[ -n "${BACKENDAI_PERSISTENT_PATHS:-}" ]]; then
+    echo -e "\e[33m⚠ Only the following vfolder paths are persistent (all other files will be lost on session termination):\e[0m"
+    IFS=':' read -ra _paths <<< "$BACKENDAI_PERSISTENT_PATHS"
+    for _p in "${_paths[@]}"; do
+      echo -e "\e[33m   - $_p\e[0m"
+    done
+  else
+    echo -e "\e[33m⚠ No persistent storage mounted. All files will be lost when the session is terminated.\e[0m"
+  fi
 fi
 
 if [[ `uname` == "Linux"  ]]; then

--- a/src/ai/backend/runner/.zshrc
+++ b/src/ai/backend/runner/.zshrc
@@ -1,13 +1,17 @@
 export PS1="%F{green}%n@${BACKENDAI_CLUSTER_HOST:-main}%F{yellow}[${BACKENDAI_SESSION_NAME}]%f:%F{blue}%~%f\$ "
 
-if [[ -n "${BACKENDAI_PERSISTENT_PATHS:-}" ]]; then
-  echo "\e[33m⚠ Only the following vfolder paths are persistent (all other files will be lost on session termination):\e[0m"
-  local IFS=':'
-  for _p in ${=BACKENDAI_PERSISTENT_PATHS}; do
-    echo "\e[33m   - $_p\e[0m"
-  done
-else
-  echo "\e[33m⚠ No persistent storage mounted. All files will be lost when the session is terminated.\e[0m"
+# Print the persistent-path notice only in interactive shells; otherwise stdout
+# would corrupt SFTP/SCP/rsync subsystems that use the same channel as data.
+if [[ -o interactive ]]; then
+  if [[ -n "${BACKENDAI_PERSISTENT_PATHS:-}" ]]; then
+    echo "\e[33m⚠ Only the following vfolder paths are persistent (all other files will be lost on session termination):\e[0m"
+    local IFS=':'
+    for _p in ${=BACKENDAI_PERSISTENT_PATHS}; do
+      echo "\e[33m   - $_p\e[0m"
+    done
+  else
+    echo "\e[33m⚠ No persistent storage mounted. All files will be lost when the session is terminated.\e[0m"
+  fi
 fi
 
 # Set up autocompletion

--- a/tests/unit/agent/test_runner_rc_files.py
+++ b/tests/unit/agent/test_runner_rc_files.py
@@ -1,0 +1,66 @@
+"""Tests for the kernel-runner ``.bashrc`` / ``.zshrc`` files.
+
+These rc files are sourced by the in-container shell. When the shell is
+non-interactive, sourcing them must not write anything to stdout.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def runner_dir() -> Path:
+    return Path(__file__).resolve().parents[3] / "src" / "ai" / "backend" / "runner"
+
+
+@pytest.fixture
+def bashrc(runner_dir: Path) -> Path:
+    return runner_dir / ".bashrc"
+
+
+@pytest.fixture
+def zshrc(runner_dir: Path) -> Path:
+    return runner_dir / ".zshrc"
+
+
+@pytest.fixture
+def shell_env() -> dict[str, str]:
+    return {
+        "BACKENDAI_PERSISTENT_PATHS": "/home/work/abc",
+        "BACKENDAI_CLUSTER_HOST": "main1",
+        "BACKENDAI_SESSION_NAME": "test-session",
+        "PATH": "/usr/bin:/bin",
+        "TERM": "dumb",
+    }
+
+
+class TestRunnerRcStdout:
+    def test_bashrc_produces_no_stdout_when_noninteractive(
+        self, bashrc: Path, shell_env: dict[str, str]
+    ) -> None:
+        result = subprocess.run(
+            ["bash", "--noprofile", "--norc", "-c", f"source {bashrc}"],
+            env=shell_env,
+            capture_output=True,
+            timeout=5,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout == b"", f"unexpected stdout: {result.stdout!r}"
+
+    @pytest.mark.skipif(shutil.which("zsh") is None, reason="zsh not installed")
+    def test_zshrc_produces_no_stdout_when_noninteractive(
+        self, zshrc: Path, shell_env: dict[str, str]
+    ) -> None:
+        result = subprocess.run(
+            ["zsh", "--no-rcs", "--no-globalrcs", "-c", f"source {zshrc}"],
+            env=shell_env,
+            capture_output=True,
+            timeout=5,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout == b"", f"unexpected stdout: {result.stdout!r}"


### PR DESCRIPTION
## Summary
- Wrap the persistent-path notice in `src/ai/backend/runner/.bashrc` and `.zshrc` in interactive-shell guards (`[[ $- == *i* ]]` / `[[ -o interactive ]]`) so the rc files still run for env-var and `PS1` setup on non-interactive shells, but no bytes leak to stdout.
- Fixes `Received message too long 458961715` on `sftp`, `scp`, and any other ssh subsystem launched against sessions from the `sftp-server` image, where dropbear executes the subsystem through the user shell and the echoed `\e[33` sequence was decoded as a 460 MB packet length.

Resolves BA-6161.

## Root cause

SFTP/SCP/rsync use the **same stdin/stdout channel** for both the spawned process and the SSH data wire. The OpenSSH client reads the first 4 bytes of every server reply as a big-endian `uint32` packet length.

`openssh-portable/sftp-client.c::get_msg_extended()`:

```c
if (msg_len > SFTP_MAX_MSG_LENGTH) {
    do_log2(initial ? SYSLOG_LEVEL_ERROR : SYSLOG_LEVEL_FATAL,
        "Received message too long %u", msg_len);
    fatal("Ensure the remote shell produces no output "
        "for non-interactive sessions.");
}
```

with `#define SFTP_MAX_MSG_LENGTH (256 * 1024)`.

The runner `.bashrc` printed `\e[33m⚠ Only the following vfolder paths are persistent ...`. Its first 4 bytes `1B 5B 33 33` (`ESC [ 3 3`) decode big-endian to **458,961,715 (~460 MB)**, which exceeds the 256 KB cap, so every client aborts immediately.

### Wire format (draft-ietf-secsh-filexfer §3)

```
uint32  length              # bytes that follow (type + payload)
byte    type                # SSH2_FXP_VERSION(2), STATUS(101), DATA(103), NAME(104)...
byte[length-1]  payload
```

A normal first reply (`SSH2_FXP_VERSION`) is `00 00 00 05  02  00 00 00 03` — i.e. the leading byte is `0x00` because the length is small. Any shell text prepended to the stream therefore corrupts the length field and is misread as a huge packet.

## Why it hits sftp, scp, and rsync

- **sftp**: `get_msg_extended()` as above.
- **scp**: modern scp (OpenSSH 9.0+) defaults to `MODE_SFTP` (`scp.c`), routing through the *same* `sftp-client.c::get_msg_extended()` — so the identical error string appears. Legacy mode (`-O`, or the remote `-f`/`-t` side) uses the rcp text protocol parsed by `sink()`, which also breaks on stray stdout but with a different/garbled error.
- **rsync**: runs its own protocol over ssh; stray stdout corrupts the handshake (`protocol version mismatch`, etc.).

## Fix

Gate only the `echo` block behind an interactive-shell check. The rc files are still fully sourced (env vars, `PS1`, aliases keep working in non-interactive shells), but nothing reaches stdout unless the shell is interactive (a real user terminal). This also protects against any future stdout output users may add to these rc files.

## Tests

`tests/unit/agent/test_runner_rc_files.py`:
- non-interactive bash sourcing `.bashrc` must emit **zero** stdout bytes,
- interactive bash still prints the persistent-path notice (UX preserved),
- the leaked-byte length hint must never exceed `SFTP_MAX_MSG_LENGTH` (256 KB),
- static guard-pattern check for `.zshrc` (zsh not always installed on CI hosts).
