### PR TITLE
feat(BA-6164): add DB ops wrapper for session-bound repository operations

### DIFF
--- a/.claude/skills/repository-guide/SKILL.md
+++ b/.claude/skills/repository-guide/SKILL.md
@@ -70,6 +70,70 @@ Multi-tenant access control for queries.
 - `repositories/base/` - Base utility source code
 - `repositories/fair_share/repository.py` - Usage examples
 
+## DB Ops Wrapper (`ops/`) — Preferred for new code
+
+`ops/provider.py` wraps `ExtendedAsyncSAEngine` and exposes a spec-only operations
+surface. **Migration direction:** db_sources are moving to this wrapper. New or modified
+db_sources SHOULD use `DBOpsProvider` rather than holding the engine and calling
+`session.execute` directly. Existing db_sources are migrated gradually when touched.
+
+### Entry points
+
+```python
+class FooDBSource:
+    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
+        self._ops = DBOpsProvider(db)
+
+    async def foo(self, foo_id: FooID) -> FooData:
+        async with self._ops.read_ops() as r:
+            result = await r.query(Querier(row_class=FooRow, pk_value=foo_id))
+            if result is None:
+                raise FooNotFound()
+            return result.row.to_data()
+
+    async def create(self, spec: FooCreatorSpec) -> FooData:
+        async with self._ops.write_ops() as w:
+            result = await w.create(Creator(spec=spec))
+            return result.row.to_data()
+```
+
+- `read_ops()` / `write_ops()` both open a READ COMMITTED session; the raw engine/
+  session is never exposed.
+- ops methods accept only spec types — never raw `Select/Insert/Update/Delete`.
+
+### Reads with scope (RBAC)
+
+```python
+async with self._ops.read_ops() as r:
+    # default — scoped query:
+    result = await r.batch_query_with_scopes(sa.select(FooRow), querier, scopes)
+    # superadmin / internal only — bypasses scope filtering:
+    result = await r.batch_query_in_global(sa.select(FooRow), querier)
+```
+
+Use `batch_query_in_global` only for superadmin-only endpoints or internal system
+operations; it bypasses RBAC scope filtering. Empty `scopes` for the scoped variant
+raises `EmptySearchScopeError` (400).
+
+### Single-table specs + multi-table coordination
+
+Each spec owns exactly one table — never build child-table rows inside a creator/
+updater spec. For a parent + dependent children, the repository coordinates the
+sequence procedurally (no tree object):
+
+```python
+async with self._ops.write_ops() as w:
+    parent = (await w.create(Creator(spec=parent_spec))).row
+    dep = ChildDependency(parent_id=parent.id)          # build dependency from the result
+    children = (await w.bulk_create_dependent(child_specs, dep)).rows
+```
+
+- `DependentCreatorSpec[TDependency, TRow].build_row(dependency)` builds one row from a
+  dependency resolved at execution time (e.g. the parent's generated id).
+- `create_dependent` (single) / `bulk_create_dependent` (multiple) execute them.
+- An update that must replace child rows = update parent + purge old children +
+  `bulk_create_dependent` new children, all inside one `write_ops()` block.
+
 ## Implementation Pattern
 
 **Pattern:**

--- a/changes/11777.enhance.md
+++ b/changes/11777.enhance.md
@@ -1,0 +1,1 @@
+Add a session-bound DB ops wrapper (`DBOpsProvider`/`ReadOps`/`WriteOps`) and `DependentCreatorSpec` as the basis for repository operations.

--- a/src/ai/backend/manager/errors/repository.py
+++ b/src/ai/backend/manager/errors/repository.py
@@ -59,6 +59,25 @@ class UnsupportedCompositePrimaryKeyError(RepositoryError):
         )
 
 
+class EmptySearchScopeError(RepositoryError, web.HTTPBadRequest):
+    """Raised when a scoped search is requested with no search scopes.
+
+    A scoped query must carry at least one scope; an empty scope list would silently
+    widen the query into a global scan and bypass RBAC restrictions. Callers that
+    genuinely need an unscoped query must use the explicit global query path instead.
+    """
+
+    error_type = "https://api.backend.ai/probs/empty-search-scope"
+    error_title = "Search scope must not be empty."
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.DATABASE,
+            operation=ErrorOperation.LIST,
+            error_detail=ErrorDetail.INVALID_PARAMETERS,
+        )
+
+
 class RepositoryIntegrityError(RepositoryError, web.HTTPConflict):
     """Base class for integrity constraint violation errors.
 

--- a/src/ai/backend/manager/repositories/CLAUDE.md
+++ b/src/ai/backend/manager/repositories/CLAUDE.md
@@ -30,6 +30,26 @@ Optional per-operation helpers: `creators.py`, `updaters.py`, `purgers.py`, `ups
 - All SQLAlchemy query code belongs in `db_source/db_source.py`.
 - `repository.py` only delegates — no query logic allowed there.
 
+## DB Ops Wrapper (`ops/`)
+
+`ops/provider.py` wraps `ExtendedAsyncSAEngine` and is the preferred way to run
+standard operations. **Direction: db_sources are being migrated to ops gradually —
+new and modified db_sources SHOULD use `DBOpsProvider` instead of holding the engine
+and calling `session.execute` directly.** Existing db_sources stay as-is until touched.
+
+- `DBOpsProvider(engine)` isolates the engine. Obtain session-bound ops via
+  `async with provider.write_ops() as w` / `async with provider.read_ops() as r`.
+  Both use READ COMMITTED. The raw engine/session is never exposed to callers.
+- ops methods accept **only our spec types** (Querier/Creator/Updater/Upserter/Purger,
+  `DependentCreatorSpec`) — never raw `Select/Insert/Update/Delete`.
+- **Each spec owns exactly one table.** Do NOT build child-table rows inside a
+  creator/updater spec. For multi-table writes, the repository coordinates the sequence
+  procedurally: create the parent, build a dependency value from its result, then call
+  `create_dependent` / `bulk_create_dependent` with a `DependentCreatorSpec`.
+- Reads: `batch_query_with_scopes(query, querier, scopes)` is the default. Use
+  `batch_query_in_global(query, querier)` **only** for superadmin-only or internal
+  system paths — it bypasses RBAC scope filtering. Empty scopes raise `EmptySearchScopeError`.
+
 ## What Does NOT Belong Here
 
 - Business logic or domain validation (belongs in `services/`).

--- a/src/ai/backend/manager/repositories/base/__init__.py
+++ b/src/ai/backend/manager/repositories/base/__init__.py
@@ -11,9 +11,12 @@ from .creator import (
     Creator,
     CreatorResult,
     CreatorSpec,
+    DependentCreatorSpec,
     execute_bulk_creator,
     execute_bulk_creator_partial,
+    execute_bulk_dependent_creator,
     execute_creator,
+    execute_dependent_creator,
 )
 from .export import (
     ExportDataStream,
@@ -133,6 +136,10 @@ __all__ = [
     "Creator",
     "CreatorResult",
     "execute_creator",
+    # DependentCreator
+    "DependentCreatorSpec",
+    "execute_dependent_creator",
+    "execute_bulk_dependent_creator",
     # BulkCreator
     "BulkCreator",
     "BulkCreatorError",

--- a/src/ai/backend/manager/repositories/base/creator.py
+++ b/src/ai/backend/manager/repositories/base/creator.py
@@ -46,6 +46,37 @@ class CreatorSpec[TRow: Base](ABC):
         raise NotImplementedError
 
 
+class DependentCreatorSpec[TDependency, TRow: Base](ABC):
+    """Abstract base class defining a row whose construction depends on a resolved value.
+
+    Unlike CreatorSpec, ``build_row`` receives a dependency value (e.g. a parent row's
+    generated id) that is only known at execution time. The caller (repository) builds
+    the dependency from a prior operation's result and passes it in. Each spec still
+    owns exactly one table's row.
+    """
+
+    @property
+    def integrity_error_checks(self) -> Sequence[IntegrityErrorCheck]:
+        """Integrity error checks to match after flush.
+
+        Override to declare expected constraint violations and their domain errors.
+        Empty by default (unmatched errors raise RepositoryIntegrityError).
+        """
+        return ()
+
+    @abstractmethod
+    def build_row(self, dependency: TDependency) -> TRow:
+        """Build ORM row instance to insert, using the resolved dependency value.
+
+        Args:
+            dependency: Value resolved from a prior operation (e.g. a parent id).
+
+        Returns:
+            An ORM model instance to be inserted
+        """
+        raise NotImplementedError
+
+
 @dataclass
 class Creator[TRow: Base]:
     """Bundles creator spec for insert operations.
@@ -284,3 +315,70 @@ async def execute_bulk_creator_partial[TRow: Base](
                 )
 
     return BulkCreatorResultWithFailures(successes=successes, errors=errors)
+
+
+async def execute_dependent_creator[TDependency, TRow: Base](
+    db_sess: SASession,
+    spec: DependentCreatorSpec[TDependency, TRow],
+    dependency: TDependency,
+) -> CreatorResult[TRow]:
+    """Execute INSERT for a single dependent spec with a resolved dependency.
+
+    The caller builds ``dependency`` from a prior operation's result (e.g. a parent id)
+    and passes it in; the spec's build_row receives it.
+
+    Args:
+        db_sess: Database session (must be writable)
+        spec: Dependent creator spec to insert
+        dependency: The resolved dependency value passed to the spec's build_row
+
+    Returns:
+        CreatorResult containing the created row with generated values
+
+    Note:
+        The caller controls the transaction boundary (commit/rollback).
+    """
+    row = spec.build_row(dependency)
+    db_sess.add(row)
+    try:
+        await db_sess.flush()
+    except sa.exc.IntegrityError as e:
+        parsed = parse_integrity_error(e)
+        match_integrity_error(parsed, spec.integrity_error_checks)
+    return CreatorResult(row=row)
+
+
+async def execute_bulk_dependent_creator[TDependency, TRow: Base](
+    db_sess: SASession,
+    specs: Sequence[DependentCreatorSpec[TDependency, TRow]],
+    dependency: TDependency,
+) -> BulkCreatorResult[TRow]:
+    """Execute bulk INSERT for dependent specs sharing one resolved dependency.
+
+    Each spec builds its row from the same dependency value (e.g. a parent id resolved
+    by the caller after creating the parent). All rows are inserted in a single flush.
+
+    Args:
+        db_sess: Database session (must be writable)
+        specs: Dependent creator specs to insert
+        dependency: The resolved dependency value passed to every spec's build_row
+
+    Returns:
+        BulkCreatorResult containing all created rows with generated values
+
+    Note:
+        The caller controls the transaction boundary (commit/rollback).
+    """
+    if not specs:
+        return BulkCreatorResult(rows=[])
+
+    rows = [spec.build_row(dependency) for spec in specs]
+    db_sess.add_all(rows)
+    try:
+        await db_sess.flush()
+    except sa.exc.IntegrityError as e:
+        parsed = parse_integrity_error(e)
+        # Use first spec's checks (all specs share the same DependentCreatorSpec subclass)
+        checks = specs[0].integrity_error_checks
+        match_integrity_error(parsed, checks)
+    return BulkCreatorResult(rows=rows)

--- a/src/ai/backend/manager/repositories/ops/__init__.py
+++ b/src/ai/backend/manager/repositories/ops/__init__.py
@@ -1,0 +1,9 @@
+"""Session-bound DB operations wrapper for the repository layer."""
+
+from .provider import DBOpsProvider, ReadOps, WriteOps
+
+__all__ = [
+    "DBOpsProvider",
+    "ReadOps",
+    "WriteOps",
+]

--- a/src/ai/backend/manager/repositories/ops/provider.py
+++ b/src/ai/backend/manager/repositories/ops/provider.py
@@ -29,6 +29,7 @@ from ai.backend.manager.repositories.base import (
     BulkCreatorResultWithFailures,
     Creator,
     CreatorResult,
+    DependentCreatorSpec,
     Purger,
     PurgerResult,
     Querier,
@@ -43,7 +44,9 @@ from ai.backend.manager.repositories.base import (
     execute_batch_updater,
     execute_bulk_creator,
     execute_bulk_creator_partial,
+    execute_bulk_dependent_creator,
     execute_creator,
+    execute_dependent_creator,
     execute_purger,
     execute_querier,
     execute_updater,
@@ -123,6 +126,31 @@ class WriteOps(ReadOps):
     ) -> BulkCreatorResultWithFailures[TRow]:
         """Insert multiple rows, isolating each via a savepoint for partial success."""
         return await execute_bulk_creator_partial(self._sess, bulk)
+
+    async def create_dependent[TDependency, TRow: Base](
+        self,
+        spec: DependentCreatorSpec[TDependency, TRow],
+        dependency: TDependency,
+    ) -> CreatorResult[TRow]:
+        """Insert a single row that depends on a resolved value (e.g. a parent id).
+
+        The caller builds ``dependency`` from a prior operation's result and passes it
+        in; the spec's ``build_row`` receives it.
+        """
+        return await execute_dependent_creator(self._sess, spec, dependency)
+
+    async def bulk_create_dependent[TDependency, TRow: Base](
+        self,
+        specs: Sequence[DependentCreatorSpec[TDependency, TRow]],
+        dependency: TDependency,
+    ) -> BulkCreatorResult[TRow]:
+        """Insert rows that depend on a resolved value (e.g. a just-created parent id).
+
+        The caller builds ``dependency`` from a prior operation's result and passes it
+        in; every spec's ``build_row`` receives it. Keeps each spec single-table while
+        the repository coordinates the multi-table sequence.
+        """
+        return await execute_bulk_dependent_creator(self._sess, specs, dependency)
 
     async def update[TRow: Base](self, updater: Updater[TRow]) -> UpdaterResult[TRow] | None:
         """Update a single row by primary key."""

--- a/src/ai/backend/manager/repositories/ops/provider.py
+++ b/src/ai/backend/manager/repositories/ops/provider.py
@@ -1,0 +1,184 @@
+"""DB ops provider.
+
+Wraps an :class:`ExtendedAsyncSAEngine` and exposes a spec-only operations surface.
+The engine is isolated inside :class:`DBOpsProvider`; callers obtain a session-bound
+:class:`ReadOps` / :class:`WriteOps` via the ``read_ops()`` / ``write_ops()`` context
+managers and never touch the engine, raw sessions, or raw SQLAlchemy statements.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Sequence
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+
+import sqlalchemy as sa
+
+from ai.backend.manager.errors.repository import EmptySearchScopeError
+from ai.backend.manager.models.base import Base
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.base import (
+    BatchPurger,
+    BatchPurgerResult,
+    BatchQuerier,
+    BatchQuerierResult,
+    BatchUpdater,
+    BatchUpdaterResult,
+    BulkCreator,
+    BulkCreatorResult,
+    BulkCreatorResultWithFailures,
+    Creator,
+    CreatorResult,
+    Purger,
+    PurgerResult,
+    Querier,
+    QuerierResult,
+    SearchScope,
+    Updater,
+    UpdaterResult,
+    Upserter,
+    UpserterResult,
+    execute_batch_purger,
+    execute_batch_querier,
+    execute_batch_updater,
+    execute_bulk_creator,
+    execute_bulk_creator_partial,
+    execute_creator,
+    execute_purger,
+    execute_querier,
+    execute_updater,
+    execute_upserter,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Row
+    from sqlalchemy.ext.asyncio import AsyncSession as SASession
+
+
+class ReadOps:
+    """Read-only operations bound to a single session.
+
+    Input is restricted to our spec types (Querier, BatchQuerier); raw SQLAlchemy
+    statements are not accepted. The bound session is private and never exposed.
+    """
+
+    _sess: SASession
+
+    def __init__(self, sess: SASession) -> None:
+        self._sess = sess
+
+    async def query[TRow: Base](self, querier: Querier[TRow]) -> QuerierResult[TRow] | None:
+        """Fetch a single row by primary key."""
+        return await execute_querier(self._sess, querier)
+
+    async def batch_query_in_global(
+        self,
+        query: sa.sql.Select[Any],
+        querier: BatchQuerier,
+    ) -> BatchQuerierResult[Row[Any]]:
+        """Run a filtered/ordered/paginated query across the entire table, with NO scope filter.
+
+        WARNING: This bypasses RBAC scope restrictions and returns rows regardless of
+        ownership. It is permitted ONLY for callers that already hold full authority —
+        superadmin-only endpoints or internal system operations (e.g. schedulers,
+        background reconciliation). For any request acting on behalf of a regular user,
+        use :meth:`batch_query_with_scopes` instead. Choosing this method is an explicit,
+        auditable decision to query globally; never use it as a convenience default.
+        """
+        return await execute_batch_querier(self._sess, query, querier)
+
+    async def batch_query_with_scopes(
+        self,
+        query: sa.sql.Select[Any],
+        querier: BatchQuerier,
+        scopes: Sequence[SearchScope],
+    ) -> BatchQuerierResult[Row[Any]]:
+        """Run a filtered/ordered/paginated query restricted to the given scopes.
+
+        At least one scope is required: an empty scope list would degrade into an
+        unscoped global scan. Use :meth:`batch_query_in_global` for that, explicitly.
+        """
+        if not scopes:
+            raise EmptySearchScopeError(
+                "batch_query_with_scopes requires at least one scope; "
+                "use batch_query_in_global for an explicit unscoped global query."
+            )
+        return await execute_batch_querier(self._sess, query, querier, scopes)
+
+
+class WriteOps(ReadOps):
+    """Read-write operations bound to a single session."""
+
+    async def create[TRow: Base](self, creator: Creator[TRow]) -> CreatorResult[TRow]:
+        """Insert a single row."""
+        return await execute_creator(self._sess, creator)
+
+    async def bulk_create[TRow: Base](self, bulk: BulkCreator[TRow]) -> BulkCreatorResult[TRow]:
+        """Insert multiple rows atomically (all-or-nothing)."""
+        return await execute_bulk_creator(self._sess, bulk)
+
+    async def bulk_create_partial[TRow: Base](
+        self,
+        bulk: BulkCreator[TRow],
+    ) -> BulkCreatorResultWithFailures[TRow]:
+        """Insert multiple rows, isolating each via a savepoint for partial success."""
+        return await execute_bulk_creator_partial(self._sess, bulk)
+
+    async def update[TRow: Base](self, updater: Updater[TRow]) -> UpdaterResult[TRow] | None:
+        """Update a single row by primary key."""
+        return await execute_updater(self._sess, updater)
+
+    async def batch_update[TRow: Base](self, updater: BatchUpdater[TRow]) -> BatchUpdaterResult:
+        """Update all rows matching the updater conditions."""
+        return await execute_batch_updater(self._sess, updater)
+
+    async def upsert[TRow: Base](
+        self,
+        upserter: Upserter[TRow],
+        index_elements: list[str],
+    ) -> UpserterResult[TRow]:
+        """Insert or update a single row on conflict."""
+        return await execute_upserter(self._sess, upserter, index_elements=index_elements)
+
+    async def purge[TRow: Base](self, purger: Purger[TRow]) -> PurgerResult[TRow] | None:
+        """Delete a single row by primary key."""
+        return await execute_purger(self._sess, purger)
+
+    async def batch_purge[TRow: Base](self, purger: BatchPurger[TRow]) -> BatchPurgerResult:
+        """Delete rows in batches matching the purger subquery."""
+        return await execute_batch_purger(self._sess, purger)
+
+    @asynccontextmanager
+    async def savepoint(self) -> AsyncIterator[WriteOps]:
+        """Open a nested transaction (savepoint) bound to the same session.
+
+        A failure inside the block rolls back to the savepoint without aborting the
+        enclosing transaction.
+        """
+        async with self._sess.begin_nested():
+            yield WriteOps(self._sess)
+
+
+class DBOpsProvider:
+    """Entry point that isolates the engine and hands out session-bound ops.
+
+    The engine is private; the only surface is ``read_ops()`` / ``write_ops()``.
+    Both use the READ COMMITTED isolation level.
+    """
+
+    _db: ExtendedAsyncSAEngine
+
+    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
+        self._db = db
+
+    @asynccontextmanager
+    async def read_ops(self) -> AsyncIterator[ReadOps]:
+        """Open a read-only transaction and yield read-only ops."""
+        async with self._db.begin_readonly_session_read_committed() as sess:
+            yield ReadOps(sess)
+
+    @asynccontextmanager
+    async def write_ops(self) -> AsyncIterator[WriteOps]:
+        """Open a read-write transaction and yield read-write ops."""
+        async with self._db.begin_session_read_committed() as sess:
+            yield WriteOps(sess)

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -34,6 +34,28 @@ Each directory has its own `CLAUDE.md` with setup patterns.
 - Repositories/Models: Integration points where actual behavior matters
 - Other layers: Logic verification where isolation improves speed and clarity
 
+## What to Test (Behavior, Not Implementation)
+
+Test **observable contracts**, not how they are implemented internally. A good test
+survives a refactor that keeps behavior the same.
+
+**Do test:**
+- **Constraints / preconditions** the code enforces — e.g. an empty scope list raises
+  `EmptySearchScopeError`; an invalid argument is rejected.
+- **Abstraction guarantees** — the promise a method makes to its caller — e.g. a
+  dependent insert receives the resolved dependency, and the child row actually carries
+  the parent's id.
+- **Real outcomes** (for repositories/models, via `with_tables`) — create then read back
+  the same row; update is reflected; purge removes it; a scoped query filters by scope.
+
+**Do NOT test:**
+- **Implementation details / internal call wiring** — e.g. asserting that `savepoint()`
+  calls `session.begin_nested()`, that `write_ops()` opens one specific session method, or
+  spying on which delegate function was invoked. Such tests break on harmless refactors
+  and verify nothing the caller actually relies on.
+- **Behavior already covered by a lower layer's own tests** — do not re-assert delegated
+  logic (e.g. a thin wrapper that forwards to an already-tested `execute_*` function).
+
 ## Test Structure & Organization
 
 ### Use Test Classes

--- a/tests/unit/manager/repositories/ops/BUILD
+++ b/tests/unit/manager/repositories/ops/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests")

--- a/tests/unit/manager/repositories/ops/test_provider.py
+++ b/tests/unit/manager/repositories/ops/test_provider.py
@@ -1,0 +1,216 @@
+"""Tests for the DB ops wrapper (DBOpsProvider / ReadOps / WriteOps).
+
+These verify observable contracts — the empty-scope constraint, real create/query/
+update/purge outcomes, and that dependent inserts carry the resolved dependency — not
+internal call wiring.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Sequence
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ai.backend.manager.errors.repository import EmptySearchScopeError
+from ai.backend.manager.models.base import Base
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.base import (
+    BatchQuerier,
+    Creator,
+    CreatorSpec,
+    DependentCreatorSpec,
+    ExistenceCheck,
+    NoPagination,
+    Purger,
+    Querier,
+    QueryCondition,
+    SearchScope,
+    Updater,
+    UpdaterSpec,
+)
+from ai.backend.manager.repositories.ops import DBOpsProvider, ReadOps
+from ai.backend.testutils.db import with_tables
+
+
+class OpsTestParentRow(Base):  # type: ignore[misc]
+    __tablename__ = "test_ops_parent"
+    __table_args__ = {"extend_existing": True}
+
+    id: Mapped[int] = mapped_column(sa.Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    domain_name: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
+
+class OpsTestChildRow(Base):  # type: ignore[misc]
+    __tablename__ = "test_ops_child"
+    __table_args__ = {"extend_existing": True}
+
+    id: Mapped[int] = mapped_column(sa.Integer, primary_key=True, autoincrement=True)
+    parent_id: Mapped[int] = mapped_column(
+        sa.Integer, sa.ForeignKey("test_ops_parent.id"), nullable=False
+    )
+    label: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
+
+@dataclass
+class ParentCreatorSpec(CreatorSpec[OpsTestParentRow]):
+    name: str
+    domain_name: str
+
+    def build_row(self) -> OpsTestParentRow:
+        return OpsTestParentRow(name=self.name, domain_name=self.domain_name)
+
+
+@dataclass
+class ParentUpdaterSpec(UpdaterSpec[OpsTestParentRow]):
+    new_name: str
+
+    @property
+    def row_class(self) -> type[OpsTestParentRow]:
+        return OpsTestParentRow
+
+    def build_values(self) -> dict[str, Any]:
+        return {"name": self.new_name}
+
+
+@dataclass(frozen=True)
+class ChildDependency:
+    parent_id: int
+
+
+@dataclass
+class ChildDependentCreatorSpec(DependentCreatorSpec[ChildDependency, OpsTestChildRow]):
+    label: str
+
+    def build_row(self, dependency: ChildDependency) -> OpsTestChildRow:
+        return OpsTestChildRow(parent_id=dependency.parent_id, label=self.label)
+
+
+@dataclass(frozen=True)
+class ParentDomainScope(SearchScope):
+    domain_name: str
+
+    def to_condition(self) -> QueryCondition:
+        return lambda: OpsTestParentRow.domain_name == self.domain_name
+
+    @property
+    def existence_checks(self) -> Sequence[ExistenceCheck[Any]]:
+        return ()
+
+
+@pytest.fixture
+async def ops_tables(
+    database_connection: ExtendedAsyncSAEngine,
+) -> AsyncGenerator[None, None]:
+    async with with_tables(database_connection, [OpsTestParentRow, OpsTestChildRow]):
+        yield
+
+
+@pytest.fixture
+def provider(database_connection: ExtendedAsyncSAEngine) -> DBOpsProvider:
+    return DBOpsProvider(database_connection)
+
+
+class TestScopeConstraint:
+    async def test_with_scopes_rejects_empty_scopes(self) -> None:
+        ops = ReadOps(AsyncMock())  # session is never touched before the guard raises
+        querier = BatchQuerier(pagination=NoPagination())
+        with pytest.raises(EmptySearchScopeError):
+            await ops.batch_query_with_scopes(sa.select(OpsTestParentRow), querier, [])
+
+
+class TestWriteRoundTrip:
+    async def test_create_then_query(self, provider: DBOpsProvider, ops_tables: None) -> None:
+        async with provider.write_ops() as w:
+            created = await w.create(Creator(spec=ParentCreatorSpec(name="p1", domain_name="d1")))
+        parent_id = created.row.id
+
+        async with provider.read_ops() as r:
+            fetched = await r.query(Querier(row_class=OpsTestParentRow, pk_value=parent_id))
+
+        assert fetched is not None
+        assert fetched.row.name == "p1"
+        assert fetched.row.domain_name == "d1"
+
+    async def test_update_reflected(self, provider: DBOpsProvider, ops_tables: None) -> None:
+        async with provider.write_ops() as w:
+            created = await w.create(Creator(spec=ParentCreatorSpec(name="p1", domain_name="d1")))
+            parent_id = created.row.id
+            await w.update(Updater(spec=ParentUpdaterSpec(new_name="p2"), pk_value=parent_id))
+
+        async with provider.read_ops() as r:
+            fetched = await r.query(Querier(row_class=OpsTestParentRow, pk_value=parent_id))
+
+        assert fetched is not None
+        assert fetched.row.name == "p2"
+
+    async def test_purge_removes(self, provider: DBOpsProvider, ops_tables: None) -> None:
+        async with provider.write_ops() as w:
+            created = await w.create(Creator(spec=ParentCreatorSpec(name="p1", domain_name="d1")))
+            parent_id = created.row.id
+            await w.purge(Purger(row_class=OpsTestParentRow, pk_value=parent_id))
+
+        async with provider.read_ops() as r:
+            fetched = await r.query(Querier(row_class=OpsTestParentRow, pk_value=parent_id))
+
+        assert fetched is None
+
+
+class TestDependentCreate:
+    async def test_bulk_create_dependent_carries_parent_id(
+        self, provider: DBOpsProvider, ops_tables: None
+    ) -> None:
+        async with provider.write_ops() as w:
+            parent = (
+                await w.create(Creator(spec=ParentCreatorSpec(name="p", domain_name="d")))
+            ).row
+            dependency = ChildDependency(parent_id=parent.id)
+            specs = [
+                ChildDependentCreatorSpec(label="a"),
+                ChildDependentCreatorSpec(label="b"),
+            ]
+            result = await w.bulk_create_dependent(specs, dependency)
+
+        assert {child.label for child in result.rows} == {"a", "b"}
+        assert all(child.parent_id == parent.id for child in result.rows)
+
+    async def test_create_dependent_single(self, provider: DBOpsProvider, ops_tables: None) -> None:
+        async with provider.write_ops() as w:
+            parent = (
+                await w.create(Creator(spec=ParentCreatorSpec(name="p", domain_name="d")))
+            ).row
+            dependency = ChildDependency(parent_id=parent.id)
+            child = (
+                await w.create_dependent(ChildDependentCreatorSpec(label="solo"), dependency)
+            ).row
+
+        assert child.parent_id == parent.id
+        assert child.label == "solo"
+
+
+class TestScopeFiltering:
+    async def test_with_scopes_filters_and_global_returns_all(
+        self, provider: DBOpsProvider, ops_tables: None
+    ) -> None:
+        async with provider.write_ops() as w:
+            await w.create(Creator(spec=ParentCreatorSpec(name="a", domain_name="d1")))
+            await w.create(Creator(spec=ParentCreatorSpec(name="b", domain_name="d2")))
+
+        async with provider.read_ops() as r:
+            scoped = await r.batch_query_with_scopes(
+                sa.select(OpsTestParentRow),
+                BatchQuerier(pagination=NoPagination()),
+                [ParentDomainScope(domain_name="d1")],
+            )
+            full = await r.batch_query_in_global(
+                sa.select(OpsTestParentRow),
+                BatchQuerier(pagination=NoPagination()),
+            )
+
+        assert {row[0].domain_name for row in scoped.rows} == {"d1"}
+        assert len(full.rows) == 2


### PR DESCRIPTION
## Summary
- Introduce `repositories/ops/` with `DBOpsProvider`/`ReadOps`/`WriteOps`: the engine is
  isolated in the provider; callers get session-bound, spec-only ops over READ COMMITTED
  sessions. `batch_query` is split into `batch_query_in_global` (superadmin/internal only)
  and `batch_query_with_scopes`, which rejects empty scopes via `EmptySearchScopeError` (400).
- Add `DependentCreatorSpec[TDependency, TRow]` + `create_dependent`/`bulk_create_dependent`,
  so each spec owns exactly one table while a caller-resolved dependency (e.g. a parent id)
  is injected at execution time. No tree object — repositories coordinate multi-table writes
  procedurally.
- Add ops unit tests and document the ops pattern + gradual db_source migration direction.

## Test plan
- [x] `pants test tests/unit/manager/repositories/ops/test_provider.py` (7 scenarios)

Resolves BA-6164

🤖 Generated with [Claude Code](https://claude.com/claude-code)