### PR TITLE
fix(BA-6151): apply preset resource slots on update via single-table ops

### DIFF
--- a/changes/11783.fix.md
+++ b/changes/11783.fix.md
@@ -1,0 +1,1 @@
+Apply resource slot changes when updating a deployment revision preset (previously the new resource slots were silently ignored).

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -87,6 +87,7 @@ from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.deployment_revision_preset.creators import (
     DeploymentRevisionPresetCreatorSpec,
+    PresetResourceSlotDependentCreatorSpec,
 )
 from ai.backend.manager.repositories.deployment_revision_preset.updaters import (
     DeploymentRevisionPresetUpdaterSpec,
@@ -245,6 +246,9 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
         input: CreateDeploymentRevisionPresetInput,
     ) -> CreateDeploymentRevisionPresetPayload:
         resource_slots = self._convert_resource_slots_input(input.resource_slots)
+        slot_specs = [
+            PresetResourceSlotDependentCreatorSpec(entry=entry) for entry in resource_slots
+        ]
         resource_opts = self._convert_resource_opts_input(input.resource_opts)
         environ = self._convert_environ_input(input.environ)
         preset_values = self._convert_preset_values_input(input.preset_values)
@@ -259,7 +263,6 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
                 rank=0,
                 image_id=input.image_id,
                 model_definition=model_def,
-                resource_slots=resource_slots,
                 resource_opts=resource_opts,
                 cluster_mode=input.cluster_mode,
                 cluster_size=input.cluster_size,
@@ -275,7 +278,7 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
             )
         )
         result = await self._processors.deployment_revision_preset.create.wait_for_complete(
-            CreateDeploymentRevisionPresetAction(creator=creator)
+            CreateDeploymentRevisionPresetAction(creator=creator, resource_slot_specs=slot_specs)
         )
         return CreateDeploymentRevisionPresetPayload(preset=self._data_to_node(result.preset))
 
@@ -283,10 +286,13 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
         self,
         input: UpdateDeploymentRevisionPresetInput,
     ) -> UpdateDeploymentRevisionPresetPayload:
-        resource_slots_state: OptionalState[list[ResourceSlotEntryData]] = (
-            OptionalState.update(self._convert_resource_slots_input(input.resource_slots))
+        slot_specs: list[PresetResourceSlotDependentCreatorSpec] | None = (
+            [
+                PresetResourceSlotDependentCreatorSpec(entry=entry)
+                for entry in self._convert_resource_slots_input(input.resource_slots)
+            ]
             if input.resource_slots is not None
-            else OptionalState.nop()
+            else None
         )
         environ_state: OptionalState[dict[str, str]] = (
             OptionalState.update(self._convert_environ_input(input.environ))
@@ -324,7 +330,6 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
                 else TriState.update(input.image_id)
             ),
             model_definition=model_def_state,
-            resource_slots=resource_slots_state,
             resource_opts=(
                 OptionalState.update(self._convert_resource_opts_input(input.resource_opts))
                 if input.resource_opts is not None
@@ -366,7 +371,9 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
         )
         updater: Updater[DeploymentRevisionPresetRow] = Updater(spec=spec, pk_value=input.id)
         result = await self._processors.deployment_revision_preset.update.wait_for_complete(
-            UpdateDeploymentRevisionPresetAction(id=input.id, updater=updater)
+            UpdateDeploymentRevisionPresetAction(
+                id=input.id, updater=updater, resource_slot_specs=slot_specs
+            )
         )
         return UpdateDeploymentRevisionPresetPayload(preset=self._data_to_node(result.preset))
 

--- a/src/ai/backend/manager/repositories/base/updater.py
+++ b/src/ai/backend/manager/repositories/base/updater.py
@@ -172,8 +172,8 @@ async def execute_updater[TRow: Base](
         updater: Updater containing spec and pk_value
 
     Returns:
-        UpdaterResult containing the updated row, or None if no row matched
-        or if there are no values to update
+        UpdaterResult containing the updated row (or the current row when there are no
+        values to update), or None only if no row matched the primary key.
 
     Example:
         class SessionStatusUpdaterSpec(UpdaterSpec[SessionRow]):
@@ -198,14 +198,18 @@ async def execute_updater[TRow: Base](
     row_class = updater.spec.row_class
     table = row_class.__table__
     pk_columns = list(table.primary_key.columns)
-    values = updater.spec.build_values()
-
-    # Return None if there are no values to update
-    if not values:
-        return None
-
     if len(pk_columns) != 1:
         raise ValueError("Updater only supports single-column primary keys")
+    values = updater.spec.build_values()
+
+    if not values:
+        # No columns to update: return the current row if it exists so callers can tell
+        # "nothing to change" apart from "row not found". None means not found only.
+        existing = await db_sess.execute(
+            sa.select(row_class).where(pk_columns[0] == updater.pk_value)
+        )
+        current_row = existing.scalar_one_or_none()
+        return UpdaterResult(row=current_row) if current_row is not None else None
 
     update_stmt = (
         sa.update(table)

--- a/src/ai/backend/manager/repositories/deployment_revision_preset/creators.py
+++ b/src/ai/backend/manager/repositories/deployment_revision_preset/creators.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
@@ -17,8 +18,15 @@ from ai.backend.manager.models.base import ResourceOptsEntry
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
 from ai.backend.manager.models.deployment_revision_preset.types import PresetValueEntry
 from ai.backend.manager.models.resource_slot.row import PresetResourceSlotRow
-from ai.backend.manager.repositories.base.creator import CreatorSpec
+from ai.backend.manager.repositories.base.creator import CreatorSpec, DependentCreatorSpec
 from ai.backend.manager.repositories.base.types import IntegrityErrorCheck
+
+
+def _parse_quantity(value: str) -> Decimal:
+    try:
+        return Decimal(value)
+    except InvalidOperation:
+        return Decimal(BinarySize.from_str(value))
 
 
 @dataclass
@@ -29,7 +37,6 @@ class DeploymentRevisionPresetCreatorSpec(CreatorSpec[DeploymentRevisionPresetRo
     rank: int
     image_id: ImageID
     model_definition: ModelDefinition | None
-    resource_slots: list[ResourceSlotEntryData]
     resource_opts: list[ResourceOptsEntry]
     cluster_mode: str
     cluster_size: int
@@ -57,37 +64,45 @@ class DeploymentRevisionPresetCreatorSpec(CreatorSpec[DeploymentRevisionPresetRo
 
     @override
     def build_row(self) -> DeploymentRevisionPresetRow:
-        row = DeploymentRevisionPresetRow()
-        row.runtime_variant = self.runtime_variant_id
-        row.name = self.name
-        row.description = self.description
-        row.rank = self.rank
-        row.image_id = self.image_id
-        row.model_definition = self.model_definition
-        row.resource_opts = self.resource_opts
-        row.cluster_mode = self.cluster_mode
-        row.cluster_size = self.cluster_size
-        row.startup_command = self.startup_command
-        row.bootstrap_script = self.bootstrap_script
-        row.environ = self.environ
-        row.preset_values = self.preset_values
-        row.open_to_public = self.open_to_public
-        row.replica_count = self.replica_count
-        row.revision_history_limit = self.revision_history_limit
-        row.deployment_strategy = self.deployment_strategy
-        row.deployment_strategy_spec = self.deployment_strategy_spec
-        row.resource_slot_rows = [
-            PresetResourceSlotRow(
-                slot_name=entry.resource_type,
-                quantity=self._parse_quantity(entry.quantity),
-            )
-            for entry in self.resource_slots
-        ]
-        return row
+        return DeploymentRevisionPresetRow(
+            runtime_variant=self.runtime_variant_id,
+            name=self.name,
+            description=self.description,
+            rank=self.rank,
+            image_id=self.image_id,
+            model_definition=self.model_definition,
+            resource_opts=self.resource_opts,
+            cluster_mode=self.cluster_mode,
+            cluster_size=self.cluster_size,
+            startup_command=self.startup_command,
+            bootstrap_script=self.bootstrap_script,
+            environ=self.environ,
+            preset_values=self.preset_values,
+            open_to_public=self.open_to_public,
+            replica_count=self.replica_count,
+            revision_history_limit=self.revision_history_limit,
+            deployment_strategy=self.deployment_strategy,
+            deployment_strategy_spec=self.deployment_strategy_spec,
+        )
 
-    @staticmethod
-    def _parse_quantity(value: str) -> Decimal:
-        try:
-            return Decimal(value)
-        except InvalidOperation:
-            return Decimal(BinarySize.from_str(value))
+
+@dataclass(frozen=True)
+class PresetSlotDependency:
+    """Dependency value for creating preset resource slots: the owning preset's id."""
+
+    preset_id: uuid.UUID
+
+
+@dataclass
+class PresetResourceSlotDependentCreatorSpec(
+    DependentCreatorSpec[PresetSlotDependency, PresetResourceSlotRow]
+):
+    entry: ResourceSlotEntryData
+
+    @override
+    def build_row(self, dependency: PresetSlotDependency) -> PresetResourceSlotRow:
+        return PresetResourceSlotRow(
+            preset_id=dependency.preset_id,
+            slot_name=self.entry.resource_type,
+            quantity=_parse_quantity(self.entry.quantity),
+        )

--- a/src/ai/backend/manager/repositories/deployment_revision_preset/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment_revision_preset/db_source/db_source.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from decimal import Decimal
 from uuid import UUID
 
@@ -14,9 +15,21 @@ from ai.backend.manager.errors.resource import DeploymentRevisionPresetNotFound
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
 from ai.backend.manager.models.resource_slot.row import PresetResourceSlotRow, ResourceSlotTypeRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
-from ai.backend.manager.repositories.base import BatchQuerier, execute_batch_querier
-from ai.backend.manager.repositories.base.creator import Creator, execute_creator
-from ai.backend.manager.repositories.base.updater import Updater, execute_updater
+from ai.backend.manager.repositories.base import (
+    BatchPurger,
+    BatchQuerier,
+    execute_batch_querier,
+)
+from ai.backend.manager.repositories.base.creator import Creator
+from ai.backend.manager.repositories.base.updater import Updater
+from ai.backend.manager.repositories.deployment_revision_preset.creators import (
+    PresetResourceSlotDependentCreatorSpec,
+    PresetSlotDependency,
+)
+from ai.backend.manager.repositories.deployment_revision_preset.purgers import (
+    PresetResourceSlotBatchPurgerSpec,
+)
+from ai.backend.manager.repositories.ops import DBOpsProvider
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -25,9 +38,11 @@ RANK_GAP = 100
 
 class DeploymentRevisionPresetDBSource:
     _db: ExtendedAsyncSAEngine
+    _ops: DBOpsProvider
 
     def __init__(self, db: ExtendedAsyncSAEngine) -> None:
         self._db = db
+        self._ops = DBOpsProvider(db)
 
     async def get_next_rank(self, variant_id: UUID) -> int:
         async with self._db.begin_readonly_session_read_committed() as session:
@@ -38,11 +53,15 @@ class DeploymentRevisionPresetDBSource:
             return (max_rank + RANK_GAP) if max_rank is not None else RANK_GAP
 
     async def create(
-        self, creator: Creator[DeploymentRevisionPresetRow]
+        self,
+        creator: Creator[DeploymentRevisionPresetRow],
+        slot_specs: Sequence[PresetResourceSlotDependentCreatorSpec],
     ) -> DeploymentRevisionPresetData:
-        async with self._db.begin_session() as session:
-            result = await execute_creator(session, creator)
-            return result.row.to_data()
+        async with self._ops.write_ops() as w:
+            created = await w.create(creator)
+            preset = created.row
+            await w.bulk_create_dependent(slot_specs, PresetSlotDependency(preset_id=preset.id))
+            return preset.to_data()
 
     async def get_by_id(self, preset_id: UUID) -> DeploymentRevisionPresetData:
         async with self._db.begin_readonly_session_read_committed() as session:
@@ -55,15 +74,23 @@ class DeploymentRevisionPresetDBSource:
             return row.to_data()
 
     async def update(
-        self, updater: Updater[DeploymentRevisionPresetRow]
+        self,
+        updater: Updater[DeploymentRevisionPresetRow],
+        slot_specs: Sequence[PresetResourceSlotDependentCreatorSpec] | None,
     ) -> DeploymentRevisionPresetData:
-        async with self._db.begin_session() as session:
-            result = await execute_updater(session, updater)
+        async with self._ops.write_ops() as w:
+            result = await w.update(updater)
             if result is None:
                 raise DeploymentRevisionPresetNotFound(
                     f"Deployment revision preset with ID {updater.pk_value} not found."
                 )
-            return result.row.to_data()
+            preset = result.row
+            if slot_specs is not None:
+                await w.batch_purge(
+                    BatchPurger(spec=PresetResourceSlotBatchPurgerSpec(preset_id=preset.id))
+                )
+                await w.bulk_create_dependent(slot_specs, PresetSlotDependency(preset_id=preset.id))
+            return preset.to_data()
 
     async def delete(self, preset_id: UUID) -> DeploymentRevisionPresetData:
         async with self._db.begin_session() as session:

--- a/src/ai/backend/manager/repositories/deployment_revision_preset/purgers.py
+++ b/src/ai/backend/manager/repositories/deployment_revision_preset/purgers.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import override
+
+import sqlalchemy as sa
+
+from ai.backend.manager.models.resource_slot.row import PresetResourceSlotRow
+from ai.backend.manager.repositories.base.purger import BatchPurgerSpec
+
+
+@dataclass
+class PresetResourceSlotBatchPurgerSpec(BatchPurgerSpec[PresetResourceSlotRow]):
+    """Selects all resource slot rows belonging to a single preset for deletion."""
+
+    preset_id: uuid.UUID
+
+    @override
+    def build_subquery(self) -> sa.sql.Select[tuple[PresetResourceSlotRow]]:
+        return sa.select(PresetResourceSlotRow).where(
+            PresetResourceSlotRow.preset_id == self.preset_id
+        )

--- a/src/ai/backend/manager/repositories/deployment_revision_preset/repository.py
+++ b/src/ai/backend/manager/repositories/deployment_revision_preset/repository.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from decimal import Decimal
 from uuid import UUID
 
@@ -11,6 +12,9 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.updater import Updater
+from ai.backend.manager.repositories.deployment_revision_preset.creators import (
+    PresetResourceSlotDependentCreatorSpec,
+)
 from ai.backend.manager.repositories.deployment_revision_preset.db_source.db_source import (
     DeploymentRevisionPresetDBSource,
 )
@@ -28,17 +32,21 @@ class DeploymentRevisionPresetRepository:
         return await self._db_source.get_next_rank(variant_id)
 
     async def create(
-        self, creator: Creator[DeploymentRevisionPresetRow]
+        self,
+        creator: Creator[DeploymentRevisionPresetRow],
+        slot_specs: Sequence[PresetResourceSlotDependentCreatorSpec],
     ) -> DeploymentRevisionPresetData:
-        return await self._db_source.create(creator)
+        return await self._db_source.create(creator, slot_specs)
 
     async def get_by_id(self, preset_id: UUID) -> DeploymentRevisionPresetData:
         return await self._db_source.get_by_id(preset_id)
 
     async def update(
-        self, updater: Updater[DeploymentRevisionPresetRow]
+        self,
+        updater: Updater[DeploymentRevisionPresetRow],
+        slot_specs: Sequence[PresetResourceSlotDependentCreatorSpec] | None,
     ) -> DeploymentRevisionPresetData:
-        return await self._db_source.update(updater)
+        return await self._db_source.update(updater, slot_specs)
 
     async def delete(self, preset_id: UUID) -> DeploymentRevisionPresetData:
         return await self._db_source.delete(preset_id)

--- a/src/ai/backend/manager/repositories/deployment_revision_preset/updaters.py
+++ b/src/ai/backend/manager/repositories/deployment_revision_preset/updaters.py
@@ -6,7 +6,6 @@ from typing import Any, override
 
 from ai.backend.common.config import ModelDefinition
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
-from ai.backend.manager.data.deployment_revision_preset.types import ResourceSlotEntryData
 from ai.backend.manager.models.base import ResourceOptsEntry
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
 from ai.backend.manager.models.deployment_revision_preset.types import PresetValueEntry
@@ -22,9 +21,6 @@ class DeploymentRevisionPresetUpdaterSpec(UpdaterSpec[DeploymentRevisionPresetRo
     image_id: TriState[uuid.UUID] = field(default_factory=TriState[uuid.UUID].nop)
     model_definition: TriState[ModelDefinition] = field(
         default_factory=TriState[ModelDefinition].nop
-    )
-    resource_slots: OptionalState[list[ResourceSlotEntryData]] = field(
-        default_factory=OptionalState[list[ResourceSlotEntryData]].nop
     )
     resource_opts: OptionalState[list[ResourceOptsEntry]] = field(
         default_factory=OptionalState[list[ResourceOptsEntry]].nop

--- a/src/ai/backend/manager/repositories/model_card/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/model_card/db_source/db_source.py
@@ -99,23 +99,12 @@ class ModelCardDBSource:
     async def update(self, updater: Updater[ModelCardRow]) -> ModelCardData:
         async with self._db.begin_session() as session:
             result = await execute_updater(session, updater)
-            # execute_updater returns None either because the row is missing
-            # OR because build_values() produced an empty dict (e.g., the
-            # caller only wants to sync normalized child rows like
-            # model_card_resource_requirements, which are not plain columns
-            # on the model_cards table). Disambiguate by re-reading the row:
-            # if it exists, this was a child-only update and we continue on
-            # to the child sync step below.
+            # execute_updater returns the current row even when build_values() is empty
+            # (e.g. a child-only update that syncs model_card_resource_requirements), and
+            # None only when the row is missing.
             if result is None:
-                row = (
-                    await session.execute(
-                        sa.select(ModelCardRow).where(ModelCardRow.id == updater.pk_value)
-                    )
-                ).scalar_one_or_none()
-                if row is None:
-                    raise ModelCardNotFound(f"Model card with ID {updater.pk_value} not found.")
-            else:
-                row = result.row
+                raise ModelCardNotFound(f"Model card with ID {updater.pk_value} not found.")
+            row = result.row
 
             # Sync the normalized model_card_resource_requirements table when
             # the updater spec requests a change. Plain column UPDATE cannot

--- a/src/ai/backend/manager/services/deployment_revision_preset/actions/create.py
+++ b/src/ai/backend/manager/services/deployment_revision_preset/actions/create.py
@@ -6,6 +6,9 @@ from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.deployment_revision_preset.types import DeploymentRevisionPresetData
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
 from ai.backend.manager.repositories.base.creator import Creator
+from ai.backend.manager.repositories.deployment_revision_preset.creators import (
+    PresetResourceSlotDependentCreatorSpec,
+)
 from ai.backend.manager.services.deployment_revision_preset.actions.base import (
     DeploymentRevisionPresetAction,
 )
@@ -14,6 +17,7 @@ from ai.backend.manager.services.deployment_revision_preset.actions.base import 
 @dataclass
 class CreateDeploymentRevisionPresetAction(DeploymentRevisionPresetAction):
     creator: Creator[DeploymentRevisionPresetRow]
+    resource_slot_specs: list[PresetResourceSlotDependentCreatorSpec]
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/deployment_revision_preset/actions/update.py
+++ b/src/ai/backend/manager/services/deployment_revision_preset/actions/update.py
@@ -7,6 +7,9 @@ from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.deployment_revision_preset.types import DeploymentRevisionPresetData
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
 from ai.backend.manager.repositories.base.updater import Updater
+from ai.backend.manager.repositories.deployment_revision_preset.creators import (
+    PresetResourceSlotDependentCreatorSpec,
+)
 from ai.backend.manager.services.deployment_revision_preset.actions.base import (
     DeploymentRevisionPresetAction,
 )
@@ -16,6 +19,7 @@ from ai.backend.manager.services.deployment_revision_preset.actions.base import 
 class UpdateDeploymentRevisionPresetAction(DeploymentRevisionPresetAction):
     id: UUID
     updater: Updater[DeploymentRevisionPresetRow]
+    resource_slot_specs: list[PresetResourceSlotDependentCreatorSpec] | None
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/deployment_revision_preset/service.py
+++ b/src/ai/backend/manager/services/deployment_revision_preset/service.py
@@ -45,14 +45,14 @@ class DeploymentRevisionPresetService:
         next_rank = await self._repository.get_next_rank(spec.runtime_variant_id)
         spec.rank = next_rank
 
-        data = await self._repository.create(action.creator)
+        data = await self._repository.create(action.creator, action.resource_slot_specs)
         return CreateDeploymentRevisionPresetActionResult(preset=data)
 
     async def update(
         self, action: UpdateDeploymentRevisionPresetAction
     ) -> UpdateDeploymentRevisionPresetActionResult:
         action.updater.pk_value = action.id
-        data = await self._repository.update(action.updater)
+        data = await self._repository.update(action.updater, action.resource_slot_specs)
         return UpdateDeploymentRevisionPresetActionResult(preset=data)
 
     async def delete(

--- a/tests/unit/manager/repositories/base/test_updater.py
+++ b/tests/unit/manager/repositories/base/test_updater.py
@@ -89,6 +89,17 @@ class IntPKStatusUpdaterSpec(UpdaterSpec[UpdaterTestRowInt]):
         return values
 
 
+class IntPKNoValuesUpdaterSpec(UpdaterSpec[UpdaterTestRowInt]):
+    """Updater spec that produces no column changes (empty build_values)."""
+
+    @property
+    def row_class(self) -> type[UpdaterTestRowInt]:
+        return UpdaterTestRowInt
+
+    def build_values(self) -> dict[str, Any]:
+        return {}
+
+
 class UUIDPKStatusUpdaterSpec(UpdaterSpec[UpdaterTestRowUUID]):
     """Updater spec for updating status on UUID PK table."""
 
@@ -220,6 +231,42 @@ class TestUpdaterIntPK:
         async with database_connection.begin_session() as db_sess:
             updater: Updater[UpdaterTestRowInt] = Updater(
                 spec=IntPKStatusUpdaterSpec(new_status="active"),
+                pk_value=99999,
+            )
+
+            result = await execute_updater(db_sess, updater)
+
+            assert result is None
+
+    async def test_update_no_values_returns_current_row(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        int_row_class: type[UpdaterTestRowInt],
+        sample_data: list[int],
+    ) -> None:
+        """Empty build_values returns the current row, not None (None means not-found only)."""
+        async with database_connection.begin_session() as db_sess:
+            target_id = sample_data[0]
+            updater: Updater[UpdaterTestRowInt] = Updater(
+                spec=IntPKNoValuesUpdaterSpec(),
+                pk_value=target_id,
+            )
+
+            result = await execute_updater(db_sess, updater)
+
+            assert result is not None
+            assert result.row.id == target_id
+
+    async def test_update_no_values_missing_row_returns_none(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        int_row_class: type[UpdaterTestRowInt],
+        sample_data: list[int],
+    ) -> None:
+        """Empty build_values with a missing PK still returns None."""
+        async with database_connection.begin_session() as db_sess:
+            updater: Updater[UpdaterTestRowInt] = Updater(
+                spec=IntPKNoValuesUpdaterSpec(),
                 pk_value=99999,
             )
 

--- a/tests/unit/manager/repositories/deployment_revision_preset/BUILD
+++ b/tests/unit/manager/repositories/deployment_revision_preset/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests")

--- a/tests/unit/manager/repositories/deployment_revision_preset/test_repository.py
+++ b/tests/unit/manager/repositories/deployment_revision_preset/test_repository.py
@@ -1,0 +1,128 @@
+"""Tests for deployment revision preset create/update with separated resource slots.
+
+Verifies that preset rows and their resource-slot rows are persisted as separate
+single-table operations, and that update replaces / keeps / clears slots correctly
+(the latter exercising the previously-broken resource-slot update path).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from ai.backend.common.data.model_deployment.types import DeploymentStrategy
+from ai.backend.common.identifier.image import ImageID
+from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
+from ai.backend.manager.data.deployment_revision_preset.types import ResourceSlotEntryData
+from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
+from ai.backend.manager.models.resource_slot.row import PresetResourceSlotRow, ResourceSlotTypeRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.base.creator import Creator
+from ai.backend.manager.repositories.base.updater import Updater
+from ai.backend.manager.repositories.deployment_revision_preset.creators import (
+    DeploymentRevisionPresetCreatorSpec,
+    PresetResourceSlotDependentCreatorSpec,
+)
+from ai.backend.manager.repositories.deployment_revision_preset.repository import (
+    DeploymentRevisionPresetRepository,
+)
+from ai.backend.manager.repositories.deployment_revision_preset.updaters import (
+    DeploymentRevisionPresetUpdaterSpec,
+)
+from ai.backend.manager.types import OptionalState
+from ai.backend.testutils.db import with_tables
+
+
+def _make_creator(name: str = "preset-1") -> Creator[DeploymentRevisionPresetRow]:
+    return Creator(
+        spec=DeploymentRevisionPresetCreatorSpec(
+            runtime_variant_id=RuntimeVariantID(uuid4()),
+            name=name,
+            description=None,
+            rank=0,
+            image_id=ImageID(uuid4()),
+            model_definition=None,
+            resource_opts=[],
+            cluster_mode="single-node",
+            cluster_size=1,
+            startup_command=None,
+            bootstrap_script=None,
+            environ={},
+            preset_values=[],
+            replica_count=1,
+            deployment_strategy=DeploymentStrategy.ROLLING,
+            deployment_strategy_spec={},
+        )
+    )
+
+
+def _slot_specs(*entries: tuple[str, str]) -> list[PresetResourceSlotDependentCreatorSpec]:
+    return [
+        PresetResourceSlotDependentCreatorSpec(
+            entry=ResourceSlotEntryData(resource_type=name, quantity=quantity)
+        )
+        for name, quantity in entries
+    ]
+
+
+@pytest.fixture
+async def repository(
+    database_connection: ExtendedAsyncSAEngine,
+) -> AsyncGenerator[DeploymentRevisionPresetRepository, None]:
+    async with with_tables(
+        database_connection,
+        [ResourceSlotTypeRow, DeploymentRevisionPresetRow, PresetResourceSlotRow],
+    ):
+        async with database_connection.begin_session() as session:
+            session.add_all([
+                ResourceSlotTypeRow(slot_name="cpu", slot_type="count"),
+                ResourceSlotTypeRow(slot_name="mem", slot_type="bytes"),
+            ])
+        yield DeploymentRevisionPresetRepository(database_connection)
+
+
+class TestCreate:
+    async def test_persists_preset_and_slots_separately(
+        self, repository: DeploymentRevisionPresetRepository
+    ) -> None:
+        data = await repository.create(_make_creator(), _slot_specs(("cpu", "2"), ("mem", "1024")))
+        slots = await repository.get_resource_slots(data.id)
+        assert dict(slots) == {"cpu": Decimal("2"), "mem": Decimal("1024")}
+
+
+class TestUpdate:
+    async def test_replaces_slots(self, repository: DeploymentRevisionPresetRepository) -> None:
+        data = await repository.create(_make_creator(), _slot_specs(("cpu", "2")))
+        updater = Updater(spec=DeploymentRevisionPresetUpdaterSpec(), pk_value=data.id)
+
+        await repository.update(updater, _slot_specs(("cpu", "4"), ("mem", "512")))
+
+        slots = await repository.get_resource_slots(data.id)
+        assert dict(slots) == {"cpu": Decimal("4"), "mem": Decimal("512")}
+
+    async def test_none_keeps_slots_and_updates_preset(
+        self, repository: DeploymentRevisionPresetRepository
+    ) -> None:
+        data = await repository.create(_make_creator(), _slot_specs(("cpu", "2")))
+        updater = Updater(
+            spec=DeploymentRevisionPresetUpdaterSpec(name=OptionalState.update("renamed")),
+            pk_value=data.id,
+        )
+
+        result = await repository.update(updater, None)
+
+        assert result.name == "renamed"
+        slots = await repository.get_resource_slots(data.id)
+        assert dict(slots) == {"cpu": Decimal("2")}
+
+    async def test_empty_clears_slots(self, repository: DeploymentRevisionPresetRepository) -> None:
+        data = await repository.create(_make_creator(), _slot_specs(("cpu", "2")))
+        updater = Updater(spec=DeploymentRevisionPresetUpdaterSpec(), pk_value=data.id)
+
+        await repository.update(updater, [])
+
+        slots = await repository.get_resource_slots(data.id)
+        assert slots == []


### PR DESCRIPTION
## Summary
- Split deployment revision preset create/update so the preset row and its
  `PresetResourceSlotRow` children are separate single-table operations
  (`DependentCreatorSpec` + batch purge), coordinated in the db_source via
  `DBOpsProvider`. This fixes `resource_slots` being silently ignored on update.
- Make `execute_updater` return the current row when there are no column changes
  (`None` now means not-found only), removing the duplicated re-read fallbacks in
  model_card and preset.

## Test plan
- [x] Unit: preset create splits into two tables; update replaces / keeps (None) /
      clears ([]) slots; `execute_updater` no-op returns current row
- [x] Live (`./bai` + DB): create → cpu=2,mem=1024; update → cpu=4 (mem removed,
      bug fixed); name-only update keeps slots; delete cascades

Resolves BA-6151

🤖 Generated with [Claude Code](https://claude.com/claude-code)