### PR TITLE
refactor(BA-6165): migrate deployment revision preset repository to ops (race-free rank)

### DIFF
--- a/changes/11784.fix.md
+++ b/changes/11784.fix.md
@@ -1,0 +1,1 @@
+Assign the deployment revision preset rank race-free within the create transaction (previously two concurrent creates could compute the same rank).

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -83,7 +83,6 @@ from ai.backend.manager.repositories.base import (
     QueryOrder,
     combine_conditions_or,
 )
-from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.deployment_revision_preset.creators import (
     DeploymentRevisionPresetCreatorSpec,
@@ -255,30 +254,27 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
         model_def = input.model_definition
         strategy, strategy_spec = self._convert_required_strategy_input(input.deployment_strategy)
 
-        creator = Creator(
-            spec=DeploymentRevisionPresetCreatorSpec(
-                runtime_variant_id=input.runtime_variant_id,
-                name=input.name,
-                description=input.description,
-                rank=0,
-                image_id=input.image_id,
-                model_definition=model_def,
-                resource_opts=resource_opts,
-                cluster_mode=input.cluster_mode,
-                cluster_size=input.cluster_size,
-                startup_command=input.startup_command,
-                bootstrap_script=input.bootstrap_script,
-                environ=environ,
-                preset_values=preset_values,
-                open_to_public=input.open_to_public,
-                replica_count=input.replica_count,
-                revision_history_limit=input.revision_history_limit,
-                deployment_strategy=strategy,
-                deployment_strategy_spec=strategy_spec,
-            )
+        spec = DeploymentRevisionPresetCreatorSpec(
+            runtime_variant_id=input.runtime_variant_id,
+            name=input.name,
+            description=input.description,
+            image_id=input.image_id,
+            model_definition=model_def,
+            resource_opts=resource_opts,
+            cluster_mode=input.cluster_mode,
+            cluster_size=input.cluster_size,
+            startup_command=input.startup_command,
+            bootstrap_script=input.bootstrap_script,
+            environ=environ,
+            preset_values=preset_values,
+            open_to_public=input.open_to_public,
+            replica_count=input.replica_count,
+            revision_history_limit=input.revision_history_limit,
+            deployment_strategy=strategy,
+            deployment_strategy_spec=strategy_spec,
         )
         result = await self._processors.deployment_revision_preset.create.wait_for_complete(
-            CreateDeploymentRevisionPresetAction(creator=creator, resource_slot_specs=slot_specs)
+            CreateDeploymentRevisionPresetAction(creator_spec=spec, resource_slot_specs=slot_specs)
         )
         return CreateDeploymentRevisionPresetPayload(preset=self._data_to_node(result.preset))
 

--- a/src/ai/backend/manager/dependencies/domain/repositories.py
+++ b/src/ai/backend/manager/dependencies/domain/repositories.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.manager.repositories.repositories import Repositories
 from ai.backend.manager.repositories.types import RepositoryArgs
 
@@ -63,6 +64,7 @@ class RepositoriesDependency(DomainDependency[RepositoriesInput, Repositories]):
         repositories = Repositories.create(
             args=RepositoryArgs(
                 db=setup_input.db,
+                ops_provider=DBOpsProvider(setup_input.db),
                 storage_manager=setup_input.storage_manager,
                 config_provider=setup_input.config_provider,
                 valkey_stat_client=setup_input.valkey_stat,

--- a/src/ai/backend/manager/repositories/base/__init__.py
+++ b/src/ai/backend/manager/repositories/base/__init__.py
@@ -12,11 +12,13 @@ from .creator import (
     CreatorResult,
     CreatorSpec,
     DependentCreatorSpec,
+    NextValuePolicy,
     execute_bulk_creator,
     execute_bulk_creator_partial,
     execute_bulk_dependent_creator,
     execute_creator,
     execute_dependent_creator,
+    execute_next_value_creator,
 )
 from .export import (
     ExportDataStream,
@@ -140,6 +142,9 @@ __all__ = [
     "DependentCreatorSpec",
     "execute_dependent_creator",
     "execute_bulk_dependent_creator",
+    # NextValue
+    "NextValuePolicy",
+    "execute_next_value_creator",
     # BulkCreator
     "BulkCreator",
     "BulkCreatorError",

--- a/src/ai/backend/manager/repositories/base/creator.py
+++ b/src/ai/backend/manager/repositories/base/creator.py
@@ -5,17 +5,18 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import sqlalchemy as sa
 
 from ai.backend.manager.models.base import Base
 
 from .integrity import match_integrity_error, parse_integrity_error
-from .types import IntegrityErrorCheck
+from .types import IntegrityErrorCheck, QueryCondition
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession as SASession
+    from sqlalchemy.orm import InstrumentedAttribute
 
 TRow = TypeVar("TRow", bound=Base)
 
@@ -382,3 +383,62 @@ async def execute_bulk_dependent_creator[TDependency, TRow: Base](
         checks = specs[0].integrity_error_checks
         match_integrity_error(parsed, checks)
     return BulkCreatorResult(rows=rows)
+
+
+@dataclass(frozen=True)
+class NextValuePolicy:
+    """Describes how to compute the next monotonic value for a column within a scope.
+
+    Used by execute_next_value_creator to assign a sequential value (e.g. a display
+    rank) race-free inside a single write transaction.
+
+    Attributes:
+        column: The integer column whose next value is computed (e.g. Row.rank).
+        scope_condition: WHERE clause limiting the MAX aggregation to a scope.
+        lock_selector: SELECT for the parent row to lock with FOR UPDATE, serializing
+            concurrent inserts within the same scope. The scope is assumed to have at
+            least one lockable parent row.
+        gap: Increment added to the current MAX (and the value used when the scope is empty).
+    """
+
+    column: InstrumentedAttribute[int]
+    scope_condition: QueryCondition
+    lock_selector: sa.sql.Select[Any]
+    gap: int
+
+
+async def execute_next_value_creator[TRow: Base](
+    db_sess: SASession,
+    policy: NextValuePolicy,
+    spec: DependentCreatorSpec[int, TRow],
+) -> CreatorResult[TRow]:
+    """Insert a row with the next monotonic column value, race-free.
+
+    Locks the parent row (FOR UPDATE), reads MAX(column) within the scope, computes the
+    next value, and inserts via the dependent spec — all in the caller's single
+    transaction. The caller MUST run this inside ``write_ops()`` so the lock and insert
+    commit together.
+
+    Args:
+        db_sess: Database session (must be writable)
+        policy: How to compute the next value (column, scope, parent lock, gap)
+        spec: Dependent creator spec whose build_row receives the computed next value
+
+    Returns:
+        CreatorResult containing the created row
+    """
+    await db_sess.execute(policy.lock_selector.with_for_update())
+    max_result = await db_sess.execute(
+        sa.select(sa.func.max(policy.column)).where(policy.scope_condition())
+    )
+    max_value = max_result.scalar_one_or_none()
+    next_value = (max_value + policy.gap) if max_value is not None else policy.gap
+
+    row = spec.build_row(next_value)
+    db_sess.add(row)
+    try:
+        await db_sess.flush()
+    except sa.exc.IntegrityError as e:
+        parsed = parse_integrity_error(e)
+        match_integrity_error(parsed, spec.integrity_error_checks)
+    return CreatorResult(row=row)

--- a/src/ai/backend/manager/repositories/base/updater.py
+++ b/src/ai/backend/manager/repositories/base/updater.py
@@ -11,6 +11,7 @@ from uuid import UUID
 import sqlalchemy as sa
 from sqlalchemy.engine import CursorResult
 
+from ai.backend.manager.errors.repository import UnsupportedCompositePrimaryKeyError
 from ai.backend.manager.models.base import Base
 
 from .integrity import match_integrity_error, parse_integrity_error
@@ -199,7 +200,9 @@ async def execute_updater[TRow: Base](
     table = row_class.__table__
     pk_columns = list(table.primary_key.columns)
     if len(pk_columns) != 1:
-        raise ValueError("Updater only supports single-column primary keys")
+        raise UnsupportedCompositePrimaryKeyError(
+            "Updater only supports single-column primary keys",
+        )
     values = updater.spec.build_values()
 
     if not values:

--- a/src/ai/backend/manager/repositories/deployment_revision_preset/creators.py
+++ b/src/ai/backend/manager/repositories/deployment_revision_preset/creators.py
@@ -18,7 +18,7 @@ from ai.backend.manager.models.base import ResourceOptsEntry
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
 from ai.backend.manager.models.deployment_revision_preset.types import PresetValueEntry
 from ai.backend.manager.models.resource_slot.row import PresetResourceSlotRow
-from ai.backend.manager.repositories.base.creator import CreatorSpec, DependentCreatorSpec
+from ai.backend.manager.repositories.base.creator import DependentCreatorSpec
 from ai.backend.manager.repositories.base.types import IntegrityErrorCheck
 
 
@@ -30,11 +30,15 @@ def _parse_quantity(value: str) -> Decimal:
 
 
 @dataclass
-class DeploymentRevisionPresetCreatorSpec(CreatorSpec[DeploymentRevisionPresetRow]):
+class DeploymentRevisionPresetCreatorSpec(DependentCreatorSpec[int, DeploymentRevisionPresetRow]):
+    """Preset creator whose rank is assigned by the ops layer (next-value) at execution.
+
+    ``build_row`` receives the computed next rank as its dependency.
+    """
+
     runtime_variant_id: RuntimeVariantID
     name: str
     description: str | None
-    rank: int
     image_id: ImageID
     model_definition: ModelDefinition | None
     resource_opts: list[ResourceOptsEntry]
@@ -63,12 +67,12 @@ class DeploymentRevisionPresetCreatorSpec(CreatorSpec[DeploymentRevisionPresetRo
         )
 
     @override
-    def build_row(self) -> DeploymentRevisionPresetRow:
+    def build_row(self, next_rank: int) -> DeploymentRevisionPresetRow:
         return DeploymentRevisionPresetRow(
             runtime_variant=self.runtime_variant_id,
             name=self.name,
             description=self.description,
-            rank=self.rank,
+            rank=next_rank,
             image_id=self.image_id,
             model_definition=self.model_definition,
             resource_opts=self.resource_opts,

--- a/src/ai/backend/manager/repositories/deployment_revision_preset/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment_revision_preset/db_source/db_source.py
@@ -14,15 +14,17 @@ from ai.backend.manager.data.deployment_revision_preset.types import DeploymentR
 from ai.backend.manager.errors.resource import DeploymentRevisionPresetNotFound
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
 from ai.backend.manager.models.resource_slot.row import PresetResourceSlotRow, ResourceSlotTypeRow
+from ai.backend.manager.models.runtime_variant.row import RuntimeVariantRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base import (
     BatchPurger,
     BatchQuerier,
+    NextValuePolicy,
     execute_batch_querier,
 )
-from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.deployment_revision_preset.creators import (
+    DeploymentRevisionPresetCreatorSpec,
     PresetResourceSlotDependentCreatorSpec,
     PresetSlotDependency,
 )
@@ -44,21 +46,22 @@ class DeploymentRevisionPresetDBSource:
         self._db = db
         self._ops = DBOpsProvider(db)
 
-    async def get_next_rank(self, variant_id: UUID) -> int:
-        async with self._db.begin_readonly_session_read_committed() as session:
-            stmt = sa.select(sa.func.max(DeploymentRevisionPresetRow.rank)).where(
-                DeploymentRevisionPresetRow.runtime_variant == variant_id
-            )
-            max_rank = (await session.execute(stmt)).scalar_one_or_none()
-            return (max_rank + RANK_GAP) if max_rank is not None else RANK_GAP
-
     async def create(
         self,
-        creator: Creator[DeploymentRevisionPresetRow],
+        spec: DeploymentRevisionPresetCreatorSpec,
         slot_specs: Sequence[PresetResourceSlotDependentCreatorSpec],
     ) -> DeploymentRevisionPresetData:
+        policy = NextValuePolicy(
+            column=DeploymentRevisionPresetRow.rank,
+            scope_condition=lambda: DeploymentRevisionPresetRow.runtime_variant
+            == spec.runtime_variant_id,
+            lock_selector=sa.select(RuntimeVariantRow).where(
+                RuntimeVariantRow.id == spec.runtime_variant_id
+            ),
+            gap=RANK_GAP,
+        )
         async with self._ops.write_ops() as w:
-            created = await w.create(creator)
+            created = await w.create_with_next_value(policy, spec)
             preset = created.row
             await w.bulk_create_dependent(slot_specs, PresetSlotDependency(preset_id=preset.id))
             return preset.to_data()

--- a/src/ai/backend/manager/repositories/deployment_revision_preset/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment_revision_preset/db_source/db_source.py
@@ -15,7 +15,6 @@ from ai.backend.manager.errors.resource import DeploymentRevisionPresetNotFound
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
 from ai.backend.manager.models.resource_slot.row import PresetResourceSlotRow, ResourceSlotTypeRow
 from ai.backend.manager.models.runtime_variant.row import RuntimeVariantRow
-from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base import (
     BatchPurger,
     BatchQuerier,
@@ -43,8 +42,8 @@ RANK_GAP = 100
 class DeploymentRevisionPresetDBSource:
     _ops: DBOpsProvider
 
-    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
-        self._ops = DBOpsProvider(db)
+    def __init__(self, ops_provider: DBOpsProvider) -> None:
+        self._ops = ops_provider
 
     async def create(
         self,

--- a/src/ai/backend/manager/repositories/deployment_revision_preset/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment_revision_preset/db_source/db_source.py
@@ -20,7 +20,9 @@ from ai.backend.manager.repositories.base import (
     BatchPurger,
     BatchQuerier,
     NextValuePolicy,
-    execute_batch_querier,
+    NoPagination,
+    Purger,
+    Querier,
 )
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.deployment_revision_preset.creators import (
@@ -39,11 +41,9 @@ RANK_GAP = 100
 
 
 class DeploymentRevisionPresetDBSource:
-    _db: ExtendedAsyncSAEngine
     _ops: DBOpsProvider
 
     def __init__(self, db: ExtendedAsyncSAEngine) -> None:
-        self._db = db
         self._ops = DBOpsProvider(db)
 
     async def create(
@@ -67,14 +67,13 @@ class DeploymentRevisionPresetDBSource:
             return preset.to_data()
 
     async def get_by_id(self, preset_id: UUID) -> DeploymentRevisionPresetData:
-        async with self._db.begin_readonly_session_read_committed() as session:
-            stmt = sa.select(DeploymentRevisionPresetRow).where(
-                DeploymentRevisionPresetRow.id == preset_id
+        async with self._ops.read_ops() as r:
+            result = await r.query(
+                Querier(row_class=DeploymentRevisionPresetRow, pk_value=preset_id)
             )
-            row = (await session.execute(stmt)).scalar_one_or_none()
-            if row is None:
+            if result is None:
                 raise DeploymentRevisionPresetNotFound()
-            return row.to_data()
+            return result.row.to_data()
 
     async def update(
         self,
@@ -96,24 +95,20 @@ class DeploymentRevisionPresetDBSource:
             return preset.to_data()
 
     async def delete(self, preset_id: UUID) -> DeploymentRevisionPresetData:
-        async with self._db.begin_session() as session:
-            stmt = sa.select(DeploymentRevisionPresetRow).where(
-                DeploymentRevisionPresetRow.id == preset_id
+        async with self._ops.write_ops() as w:
+            result = await w.purge(
+                Purger(row_class=DeploymentRevisionPresetRow, pk_value=preset_id)
             )
-            row = (await session.execute(stmt)).scalar_one_or_none()
-            if row is None:
+            if result is None:
                 raise DeploymentRevisionPresetNotFound()
-            data = row.to_data()
-            await session.delete(row)
-        return data
+            return result.row.to_data()
 
     async def search(
         self,
         querier: BatchQuerier,
     ) -> tuple[list[DeploymentRevisionPresetData], int, bool, bool]:
-        async with self._db.begin_readonly_session() as db_sess:
-            query = sa.select(DeploymentRevisionPresetRow)
-            result = await execute_batch_querier(db_sess, query, querier)
+        async with self._ops.read_ops() as r:
+            result = await r.batch_query_in_global(sa.select(DeploymentRevisionPresetRow), querier)
             items = [row.DeploymentRevisionPresetRow.to_data() for row in result.rows]
             return items, result.total_count, result.has_next_page, result.has_previous_page
 
@@ -122,12 +117,17 @@ class DeploymentRevisionPresetDBSource:
         preset_id: UUID,
     ) -> list[tuple[str, Decimal]]:
         """Get all resource slots for a preset (no pagination)."""
-        async with self._db.begin_readonly_session_read_committed() as db_sess:
-            stmt = sa.select(PresetResourceSlotRow).where(
-                PresetResourceSlotRow.preset_id == preset_id
+        async with self._ops.read_ops() as r:
+            result = await r.batch_query_in_global(
+                sa.select(PresetResourceSlotRow).where(
+                    PresetResourceSlotRow.preset_id == preset_id
+                ),
+                BatchQuerier(pagination=NoPagination()),
             )
-            rows = (await db_sess.execute(stmt)).scalars().all()
-            return [(r.slot_name, r.quantity) for r in rows]
+            return [
+                (row.PresetResourceSlotRow.slot_name, row.PresetResourceSlotRow.quantity)
+                for row in result.rows
+            ]
 
     async def search_resource_slots(
         self,
@@ -139,7 +139,7 @@ class DeploymentRevisionPresetDBSource:
         Returns (items, total_count, has_next_page, has_previous_page).
         Each item is a (slot_name, quantity) tuple.
         """
-        async with self._db.begin_readonly_session_read_committed() as db_sess:
+        async with self._ops.read_ops() as r:
             query = (
                 sa.select(PresetResourceSlotRow, ResourceSlotTypeRow.rank)
                 .join(
@@ -148,7 +148,7 @@ class DeploymentRevisionPresetDBSource:
                 )
                 .where(PresetResourceSlotRow.preset_id == preset_id)
             )
-            result = await execute_batch_querier(db_sess, query, querier)
+            result = await r.batch_query_in_global(query, querier)
             items: list[tuple[str, Decimal]] = [
                 (row.PresetResourceSlotRow.slot_name, row.PresetResourceSlotRow.quantity)
                 for row in result.rows

--- a/src/ai/backend/manager/repositories/deployment_revision_preset/repositories.py
+++ b/src/ai/backend/manager/repositories/deployment_revision_preset/repositories.py
@@ -14,5 +14,5 @@ class DeploymentRevisionPresetRepositories:
     @classmethod
     def create(cls, args: RepositoryArgs) -> Self:
         return cls(
-            repository=DeploymentRevisionPresetRepository(args.db),
+            repository=DeploymentRevisionPresetRepository(args.ops_provider),
         )

--- a/src/ai/backend/manager/repositories/deployment_revision_preset/repository.py
+++ b/src/ai/backend/manager/repositories/deployment_revision_preset/repository.py
@@ -10,9 +10,9 @@ from ai.backend.manager.data.deployment_revision_preset.types import DeploymentR
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base import BatchQuerier
-from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.deployment_revision_preset.creators import (
+    DeploymentRevisionPresetCreatorSpec,
     PresetResourceSlotDependentCreatorSpec,
 )
 from ai.backend.manager.repositories.deployment_revision_preset.db_source.db_source import (
@@ -28,15 +28,12 @@ class DeploymentRevisionPresetRepository:
     def __init__(self, db: ExtendedAsyncSAEngine) -> None:
         self._db_source = DeploymentRevisionPresetDBSource(db)
 
-    async def get_next_rank(self, variant_id: UUID) -> int:
-        return await self._db_source.get_next_rank(variant_id)
-
     async def create(
         self,
-        creator: Creator[DeploymentRevisionPresetRow],
+        spec: DeploymentRevisionPresetCreatorSpec,
         slot_specs: Sequence[PresetResourceSlotDependentCreatorSpec],
     ) -> DeploymentRevisionPresetData:
-        return await self._db_source.create(creator, slot_specs)
+        return await self._db_source.create(spec, slot_specs)
 
     async def get_by_id(self, preset_id: UUID) -> DeploymentRevisionPresetData:
         return await self._db_source.get_by_id(preset_id)

--- a/src/ai/backend/manager/repositories/deployment_revision_preset/repository.py
+++ b/src/ai/backend/manager/repositories/deployment_revision_preset/repository.py
@@ -8,7 +8,6 @@ from uuid import UUID
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.deployment_revision_preset.types import DeploymentRevisionPresetData
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
-from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.deployment_revision_preset.creators import (
@@ -18,6 +17,7 @@ from ai.backend.manager.repositories.deployment_revision_preset.creators import 
 from ai.backend.manager.repositories.deployment_revision_preset.db_source.db_source import (
     DeploymentRevisionPresetDBSource,
 )
+from ai.backend.manager.repositories.ops import DBOpsProvider
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -25,8 +25,8 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 class DeploymentRevisionPresetRepository:
     _db_source: DeploymentRevisionPresetDBSource
 
-    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
-        self._db_source = DeploymentRevisionPresetDBSource(db)
+    def __init__(self, ops_provider: DBOpsProvider) -> None:
+        self._db_source = DeploymentRevisionPresetDBSource(ops_provider)
 
     async def create(
         self,

--- a/src/ai/backend/manager/repositories/ops/provider.py
+++ b/src/ai/backend/manager/repositories/ops/provider.py
@@ -30,6 +30,7 @@ from ai.backend.manager.repositories.base import (
     Creator,
     CreatorResult,
     DependentCreatorSpec,
+    NextValuePolicy,
     Purger,
     PurgerResult,
     Querier,
@@ -47,6 +48,7 @@ from ai.backend.manager.repositories.base import (
     execute_bulk_dependent_creator,
     execute_creator,
     execute_dependent_creator,
+    execute_next_value_creator,
     execute_purger,
     execute_querier,
     execute_updater,
@@ -151,6 +153,19 @@ class WriteOps(ReadOps):
         the repository coordinates the multi-table sequence.
         """
         return await execute_bulk_dependent_creator(self._sess, specs, dependency)
+
+    async def create_with_next_value[TRow: Base](
+        self,
+        policy: NextValuePolicy,
+        spec: DependentCreatorSpec[int, TRow],
+    ) -> CreatorResult[TRow]:
+        """Insert a row assigning the next monotonic column value (e.g. rank), race-free.
+
+        Locks the parent row (FOR UPDATE), computes ``MAX(column) + gap`` within the
+        scope, and inserts via the spec — all within this write transaction so the lock
+        and insert commit together. Must be used inside ``write_ops()``.
+        """
+        return await execute_next_value_creator(self._sess, policy, spec)
 
     async def update[TRow: Base](self, updater: Updater[TRow]) -> UpdaterResult[TRow] | None:
         """Update a single row by primary key."""

--- a/src/ai/backend/manager/repositories/types.py
+++ b/src/ai/backend/manager/repositories/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 from ai.backend.common.clients.valkey_client.valkey_image.client import ValkeyImageClient
@@ -14,11 +16,11 @@ from ai.backend.manager.repositories.ops import DBOpsProvider
 @dataclass
 class RepositoryArgs:
     db: ExtendedAsyncSAEngine
-    ops_provider: "DBOpsProvider"
-    storage_manager: "StorageSessionManager"
-    config_provider: "ManagerConfigProvider"
-    valkey_stat_client: "ValkeyStatClient"
-    valkey_schedule_client: "ValkeyScheduleClient"
-    valkey_image_client: "ValkeyImageClient"
-    valkey_live_client: "ValkeyLiveClient"
-    prometheus_client: "PrometheusClient"
+    ops_provider: DBOpsProvider
+    storage_manager: StorageSessionManager
+    config_provider: ManagerConfigProvider
+    valkey_stat_client: ValkeyStatClient
+    valkey_schedule_client: ValkeyScheduleClient
+    valkey_image_client: ValkeyImageClient
+    valkey_live_client: ValkeyLiveClient
+    prometheus_client: PrometheusClient

--- a/src/ai/backend/manager/repositories/types.py
+++ b/src/ai/backend/manager/repositories/types.py
@@ -8,11 +8,13 @@ from ai.backend.manager.clients.prometheus.client import PrometheusClient
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.models.storage import StorageSessionManager
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.ops import DBOpsProvider
 
 
 @dataclass
 class RepositoryArgs:
     db: ExtendedAsyncSAEngine
+    ops_provider: "DBOpsProvider"
     storage_manager: "StorageSessionManager"
     config_provider: "ManagerConfigProvider"
     valkey_stat_client: "ValkeyStatClient"

--- a/src/ai/backend/manager/services/deployment_revision_preset/actions/create.py
+++ b/src/ai/backend/manager/services/deployment_revision_preset/actions/create.py
@@ -4,9 +4,8 @@ from typing import override
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.deployment_revision_preset.types import DeploymentRevisionPresetData
-from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
-from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.deployment_revision_preset.creators import (
+    DeploymentRevisionPresetCreatorSpec,
     PresetResourceSlotDependentCreatorSpec,
 )
 from ai.backend.manager.services.deployment_revision_preset.actions.base import (
@@ -16,7 +15,7 @@ from ai.backend.manager.services.deployment_revision_preset.actions.base import 
 
 @dataclass
 class CreateDeploymentRevisionPresetAction(DeploymentRevisionPresetAction):
-    creator: Creator[DeploymentRevisionPresetRow]
+    creator_spec: DeploymentRevisionPresetCreatorSpec
     resource_slot_specs: list[PresetResourceSlotDependentCreatorSpec]
 
     @override

--- a/src/ai/backend/manager/services/deployment_revision_preset/service.py
+++ b/src/ai/backend/manager/services/deployment_revision_preset/service.py
@@ -1,10 +1,6 @@
 import logging
-from typing import cast
 
 from ai.backend.logging.utils import BraceStyleAdapter
-from ai.backend.manager.repositories.deployment_revision_preset.creators import (
-    DeploymentRevisionPresetCreatorSpec,
-)
 from ai.backend.manager.repositories.deployment_revision_preset.repository import (
     DeploymentRevisionPresetRepository,
 )
@@ -41,11 +37,7 @@ class DeploymentRevisionPresetService:
     async def create(
         self, action: CreateDeploymentRevisionPresetAction
     ) -> CreateDeploymentRevisionPresetActionResult:
-        spec = cast(DeploymentRevisionPresetCreatorSpec, action.creator.spec)
-        next_rank = await self._repository.get_next_rank(spec.runtime_variant_id)
-        spec.rank = next_rank
-
-        data = await self._repository.create(action.creator, action.resource_slot_specs)
+        data = await self._repository.create(action.creator_spec, action.resource_slot_specs)
         return CreateDeploymentRevisionPresetActionResult(preset=data)
 
     async def update(

--- a/tests/component/deployment_revision_preset/conftest.py
+++ b/tests/component/deployment_revision_preset/conftest.py
@@ -32,6 +32,7 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.deployment_revision_preset.repository import (
     DeploymentRevisionPresetRepository,
 )
+from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.manager.services.deployment_revision_preset.processors import (
     DeploymentRevisionPresetProcessors,
 )
@@ -61,7 +62,7 @@ async def _seed_resource_slot_types(db_engine: SAEngine) -> None:
 def deployment_revision_preset_processors(
     database_engine: ExtendedAsyncSAEngine,
 ) -> DeploymentRevisionPresetProcessors:
-    repo = DeploymentRevisionPresetRepository(database_engine)
+    repo = DeploymentRevisionPresetRepository(DBOpsProvider(database_engine))
     service = DeploymentRevisionPresetService(repo)
     return DeploymentRevisionPresetProcessors(
         service=service,

--- a/tests/unit/manager/repositories/deployment_revision_preset/test_repository.py
+++ b/tests/unit/manager/repositories/deployment_revision_preset/test_repository.py
@@ -1,8 +1,8 @@
 """Tests for deployment revision preset create/update with separated resource slots.
 
 Verifies that preset rows and their resource-slot rows are persisted as separate
-single-table operations, and that update replaces / keeps / clears slots correctly
-(the latter exercising the previously-broken resource-slot update path).
+single-table operations, that the rank is assigned race-free via the next-value op,
+and that update replaces / keeps / clears slots correctly.
 """
 
 from __future__ import annotations
@@ -13,14 +13,15 @@ from uuid import uuid4
 
 import pytest
 
+from ai.backend.common.config import ModelDefinitionDraft
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.manager.data.deployment_revision_preset.types import ResourceSlotEntryData
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
 from ai.backend.manager.models.resource_slot.row import PresetResourceSlotRow, ResourceSlotTypeRow
+from ai.backend.manager.models.runtime_variant.row import RuntimeVariantRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
-from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.deployment_revision_preset.creators import (
     DeploymentRevisionPresetCreatorSpec,
@@ -35,27 +36,27 @@ from ai.backend.manager.repositories.deployment_revision_preset.updaters import 
 from ai.backend.manager.types import OptionalState
 from ai.backend.testutils.db import with_tables
 
+# Shared runtime variant id; the preset's rank scope and the FOR UPDATE lock target it.
+_VARIANT_ID = RuntimeVariantID(uuid4())
 
-def _make_creator(name: str = "preset-1") -> Creator[DeploymentRevisionPresetRow]:
-    return Creator(
-        spec=DeploymentRevisionPresetCreatorSpec(
-            runtime_variant_id=RuntimeVariantID(uuid4()),
-            name=name,
-            description=None,
-            rank=0,
-            image_id=ImageID(uuid4()),
-            model_definition=None,
-            resource_opts=[],
-            cluster_mode="single-node",
-            cluster_size=1,
-            startup_command=None,
-            bootstrap_script=None,
-            environ={},
-            preset_values=[],
-            replica_count=1,
-            deployment_strategy=DeploymentStrategy.ROLLING,
-            deployment_strategy_spec={},
-        )
+
+def _make_spec(name: str = "preset-1") -> DeploymentRevisionPresetCreatorSpec:
+    return DeploymentRevisionPresetCreatorSpec(
+        runtime_variant_id=_VARIANT_ID,
+        name=name,
+        description=None,
+        image_id=ImageID(uuid4()),
+        model_definition=None,
+        resource_opts=[],
+        cluster_mode="single-node",
+        cluster_size=1,
+        startup_command=None,
+        bootstrap_script=None,
+        environ={},
+        preset_values=[],
+        replica_count=1,
+        deployment_strategy=DeploymentStrategy.ROLLING,
+        deployment_strategy_spec={},
     )
 
 
@@ -74,9 +75,21 @@ async def repository(
 ) -> AsyncGenerator[DeploymentRevisionPresetRepository, None]:
     async with with_tables(
         database_connection,
-        [ResourceSlotTypeRow, DeploymentRevisionPresetRow, PresetResourceSlotRow],
+        [
+            RuntimeVariantRow,
+            ResourceSlotTypeRow,
+            DeploymentRevisionPresetRow,
+            PresetResourceSlotRow,
+        ],
     ):
         async with database_connection.begin_session() as session:
+            session.add(
+                RuntimeVariantRow(
+                    id=_VARIANT_ID,
+                    name="rv-test",
+                    default_model_definition=ModelDefinitionDraft(),
+                )
+            )
             session.add_all([
                 ResourceSlotTypeRow(slot_name="cpu", slot_type="count"),
                 ResourceSlotTypeRow(slot_name="mem", slot_type="bytes"),
@@ -88,14 +101,21 @@ class TestCreate:
     async def test_persists_preset_and_slots_separately(
         self, repository: DeploymentRevisionPresetRepository
     ) -> None:
-        data = await repository.create(_make_creator(), _slot_specs(("cpu", "2"), ("mem", "1024")))
+        data = await repository.create(_make_spec(), _slot_specs(("cpu", "2"), ("mem", "1024")))
         slots = await repository.get_resource_slots(data.id)
         assert dict(slots) == {"cpu": Decimal("2"), "mem": Decimal("1024")}
+
+    async def test_create_assigns_increasing_rank(
+        self, repository: DeploymentRevisionPresetRepository
+    ) -> None:
+        first = await repository.create(_make_spec(name="p1"), _slot_specs(("cpu", "1")))
+        second = await repository.create(_make_spec(name="p2"), _slot_specs(("cpu", "1")))
+        assert second.rank > first.rank
 
 
 class TestUpdate:
     async def test_replaces_slots(self, repository: DeploymentRevisionPresetRepository) -> None:
-        data = await repository.create(_make_creator(), _slot_specs(("cpu", "2")))
+        data = await repository.create(_make_spec(), _slot_specs(("cpu", "2")))
         updater = Updater(spec=DeploymentRevisionPresetUpdaterSpec(), pk_value=data.id)
 
         await repository.update(updater, _slot_specs(("cpu", "4"), ("mem", "512")))
@@ -106,7 +126,7 @@ class TestUpdate:
     async def test_none_keeps_slots_and_updates_preset(
         self, repository: DeploymentRevisionPresetRepository
     ) -> None:
-        data = await repository.create(_make_creator(), _slot_specs(("cpu", "2")))
+        data = await repository.create(_make_spec(), _slot_specs(("cpu", "2")))
         updater = Updater(
             spec=DeploymentRevisionPresetUpdaterSpec(name=OptionalState.update("renamed")),
             pk_value=data.id,
@@ -119,7 +139,7 @@ class TestUpdate:
         assert dict(slots) == {"cpu": Decimal("2")}
 
     async def test_empty_clears_slots(self, repository: DeploymentRevisionPresetRepository) -> None:
-        data = await repository.create(_make_creator(), _slot_specs(("cpu", "2")))
+        data = await repository.create(_make_spec(), _slot_specs(("cpu", "2")))
         updater = Updater(spec=DeploymentRevisionPresetUpdaterSpec(), pk_value=data.id)
 
         await repository.update(updater, [])

--- a/tests/unit/manager/repositories/deployment_revision_preset/test_repository.py
+++ b/tests/unit/manager/repositories/deployment_revision_preset/test_repository.py
@@ -33,6 +33,7 @@ from ai.backend.manager.repositories.deployment_revision_preset.repository impor
 from ai.backend.manager.repositories.deployment_revision_preset.updaters import (
     DeploymentRevisionPresetUpdaterSpec,
 )
+from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.manager.types import OptionalState
 from ai.backend.testutils.db import with_tables
 
@@ -94,7 +95,7 @@ async def repository(
                 ResourceSlotTypeRow(slot_name="cpu", slot_type="count"),
                 ResourceSlotTypeRow(slot_name="mem", slot_type="bytes"),
             ])
-        yield DeploymentRevisionPresetRepository(database_connection)
+        yield DeploymentRevisionPresetRepository(DBOpsProvider(database_connection))
 
 
 class TestCreate:

--- a/tests/unit/manager/repositories/deployment_revision_preset/test_repository.py
+++ b/tests/unit/manager/repositories/deployment_revision_preset/test_repository.py
@@ -18,6 +18,7 @@ from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.manager.data.deployment_revision_preset.types import ResourceSlotEntryData
+from ai.backend.manager.errors.resource import DeploymentRevisionPresetNotFound
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
 from ai.backend.manager.models.resource_slot.row import PresetResourceSlotRow, ResourceSlotTypeRow
 from ai.backend.manager.models.runtime_variant.row import RuntimeVariantRow
@@ -147,3 +148,24 @@ class TestUpdate:
 
         slots = await repository.get_resource_slots(data.id)
         assert slots == []
+
+
+class TestGetDelete:
+    async def test_get_by_id_round_trip(
+        self, repository: DeploymentRevisionPresetRepository
+    ) -> None:
+        data = await repository.create(_make_spec(name="p1"), _slot_specs(("cpu", "1")))
+        fetched = await repository.get_by_id(data.id)
+        assert fetched.id == data.id
+        assert fetched.name == "p1"
+
+    async def test_delete_removes_preset_and_slots(
+        self, repository: DeploymentRevisionPresetRepository
+    ) -> None:
+        data = await repository.create(_make_spec(), _slot_specs(("cpu", "1"), ("mem", "8")))
+
+        await repository.delete(data.id)
+
+        with pytest.raises(DeploymentRevisionPresetNotFound):
+            await repository.get_by_id(data.id)
+        assert await repository.get_resource_slots(data.id) == []


### PR DESCRIPTION
## Summary
- Add a generalized race-free "next-value" create op to the ops layer
  (`NextValuePolicy` + `WriteOps.create_with_next_value`): lock the parent row
  `FOR UPDATE`, compute `MAX(column)+gap` within a scope, then insert via a
  `DependentCreatorSpec[int, Row]` — all in one transaction.
- Use it for deployment revision preset `rank`, removing the service-side
  `get_next_rank` read + spec mutation that left a create race window.
- Migrate the whole preset db_source to the ops wrapper (get/delete/search/
  resource-slots) and inject `DBOpsProvider` via `RepositoryArgs` (the db_source no
  longer owns the engine).
- Unify `execute_updater`'s composite-PK guard to raise
  `UnsupportedCompositePrimaryKeyError` instead of the built-in `ValueError`.

## Test plan
- [x] Unit: rank increments across creates; create/update/get/delete + resource
      slots round-trip via ops
- [x] Live (`./bai`): consecutive preset creates -> rank 200 -> 300; get/delete +
      404-after-delete + slot cascade verified

Resolves BA-6165

🤖 Generated with [Claude Code](https://claude.com/claude-code)