### PR TITLE
fix(BA-6170): preserve extra_mounts and vfolder_subpath on revision refresh

### DIFF
--- a/changes/11790.fix.md
+++ b/changes/11790.fix.md
@@ -1,0 +1,1 @@
+Preserve extra vfolder mounts and the model vfolder subpath when refreshing deployment revisions via `./bai admin deployment revision refresh`; previously the rebuilder hard-coded `extra_mounts=[]` and omitted `vfolder_subpath`, silently stripping both fields from the new revision.

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -32,6 +32,7 @@ from ai.backend.manager.data.deployment.types import (
     ModelDeploymentMetadataInfo,
     ModelReplicaData,
     ModelRevisionData,
+    MountInfo,
     ReplicaStateData,
     ResourceSpec,
     RevisionRefreshResult,
@@ -322,13 +323,11 @@ def _convert_route_info_to_replica_data(route: RouteInfo) -> ModelReplicaData:
 
 
 def _build_creator_from_revision_data(data: ModelRevisionData) -> ModelRevisionCreator:
-    """Rebuild a ``ModelRevisionCreator`` from an existing revision's persisted data.
+    """Rebuild a ``ModelRevisionCreator`` from a persisted revision.
 
-    ``model_definition`` is reset to ``None`` so ``DeploymentController.add_revision``
-    re-resolves it from the vfolder. ``revision_preset_id`` and ``preset_values`` are
-    carried over so the new revision keeps the same preset attribution. ``extra_mounts``
-    is left empty because ``add_revision`` does not propagate this field to the new
-    revision spec.
+    ``model_definition`` is cleared so ``add_revision`` re-resolves it via
+    the merge chain. Mount identity (``extra_mounts``, ``vfolder_subpath``)
+    is copied verbatim — refreshing must not silently drop them.
     """
     if data.model_mount_config.vfolder_id is None:
         raise InvalidAPIParameters(
@@ -346,7 +345,16 @@ def _build_creator_from_revision_data(data: ModelRevisionData) -> ModelRevisionC
             model_vfolder_id=data.model_mount_config.vfolder_id,
             model_definition_path=data.model_mount_config.definition_path or None,
             model_mount_destination=data.model_mount_config.mount_destination or "/models",
-            extra_mounts=[],
+            extra_mounts=[
+                MountInfo(
+                    vfolder_id=m.vfolder_id,
+                    mount_destination=m.mount_destination,
+                    mount_perm=m.mount_perm,
+                    subpath=m.subpath,
+                )
+                for m in data.model_mount_config.extra_mounts
+            ],
+            vfolder_subpath=data.model_mount_config.subpath,
         ),
         execution=ExecutionSpec(
             startup_command=data.execution.startup_command,

--- a/tests/unit/manager/services/deployment/test_refresh_revision_mount_preservation.py
+++ b/tests/unit/manager/services/deployment/test_refresh_revision_mount_preservation.py
@@ -1,0 +1,156 @@
+"""
+Mock-based unit tests for ``_build_creator_from_revision_data``.
+
+Tests verify that the rebuilder used by
+``DeploymentService.admin_refresh_deployment_revisions`` preserves mount
+identity (``extra_mounts`` and ``vfolder_subpath``) when projecting an
+existing revision back into a ``ModelRevisionCreator``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from datetime import UTC, datetime
+
+import pytest
+
+from ai.backend.common.identifier.deployment import DeploymentID
+from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
+from ai.backend.common.identifier.image import ImageID
+from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
+from ai.backend.common.identifier.vfolder import VFolderUUID
+from ai.backend.common.types import (
+    ClusterMode,
+    MountInfoEntry,
+    MountPermission,
+    ResourceSlot,
+)
+from ai.backend.manager.data.deployment.types import (
+    ClusterConfigData,
+    ExecutionData,
+    ModelMountConfigData,
+    ModelRevisionData,
+    ModelRuntimeConfigData,
+    PresetAttributionData,
+    ResourceConfigData,
+)
+from ai.backend.manager.services.deployment.service import (
+    _build_creator_from_revision_data,
+)
+
+
+class RefreshRevisionBaseFixtures:
+    """Base class containing shared fixtures for refresh-revision rebuilder tests."""
+
+    @pytest.fixture
+    def model_vfolder_id(self) -> VFolderUUID:
+        """Model vfolder ID referenced by the persisted revision."""
+        return VFolderUUID(uuid.uuid4())
+
+    @pytest.fixture
+    def revision_data_factory(
+        self, model_vfolder_id: VFolderUUID
+    ) -> Callable[..., ModelRevisionData]:
+        """Build a ModelRevisionData with configurable mount metadata."""
+
+        def make(
+            *,
+            extra_mounts: list[MountInfoEntry] | None = None,
+            vfolder_subpath: str | None = None,
+        ) -> ModelRevisionData:
+            return ModelRevisionData(
+                id=DeploymentRevisionID(uuid.uuid4()),
+                deployment_id=DeploymentID(uuid.uuid4()),
+                revision_number=2,
+                created_at=datetime(2026, 5, 26, tzinfo=UTC),
+                image_id=ImageID(uuid.uuid4()),
+                cluster_config=ClusterConfigData(mode=ClusterMode.SINGLE_NODE, size=1),
+                resource_config=ResourceConfigData(
+                    resource_group_name="default",
+                    resource_slot=ResourceSlot(),
+                ),
+                model_runtime_config=ModelRuntimeConfigData(
+                    runtime_variant_id=RuntimeVariantID(uuid.uuid4()),
+                ),
+                execution=ExecutionData(
+                    startup_command=None,
+                    bootstrap_script=None,
+                    callback_url=None,
+                ),
+                model_mount_config=ModelMountConfigData(
+                    vfolder_id=model_vfolder_id,
+                    mount_destination="/models",
+                    definition_path="model-definition.yaml",
+                    extra_mounts=extra_mounts or [],
+                    subpath=vfolder_subpath,
+                ),
+                preset=PresetAttributionData(preset_id=None, values=[]),
+                model_definition=None,
+            )
+
+        return make
+
+
+class TestBuildCreatorFromRevisionData(RefreshRevisionBaseFixtures):
+    """Tests for ``_build_creator_from_revision_data``."""
+
+    def test_extra_mounts_are_projected_onto_creator(
+        self,
+        revision_data_factory: Callable[..., ModelRevisionData],
+    ) -> None:
+        """Each extra mount survives verbatim (vfolder, destination, perm, subpath)."""
+        vfolder_a = VFolderUUID(uuid.uuid4())
+        vfolder_b = VFolderUUID(uuid.uuid4())
+        revision = revision_data_factory(
+            extra_mounts=[
+                MountInfoEntry(
+                    vfolder_id=vfolder_a,
+                    mount_destination="/data",
+                    mount_perm=MountPermission.READ_ONLY,
+                    subpath=None,
+                ),
+                MountInfoEntry(
+                    vfolder_id=vfolder_b,
+                    mount_destination="/workspace",
+                    mount_perm=MountPermission.READ_WRITE,
+                    subpath="checkpoints",
+                ),
+            ],
+        )
+
+        creator = _build_creator_from_revision_data(revision)
+
+        assert [m.vfolder_id for m in creator.mounts.extra_mounts] == [vfolder_a, vfolder_b]
+        assert [m.mount_destination for m in creator.mounts.extra_mounts] == [
+            "/data",
+            "/workspace",
+        ]
+        assert [m.mount_perm for m in creator.mounts.extra_mounts] == [
+            MountPermission.READ_ONLY,
+            MountPermission.READ_WRITE,
+        ]
+        assert [m.subpath for m in creator.mounts.extra_mounts] == [None, "checkpoints"]
+
+    def test_vfolder_subpath_is_projected_onto_creator(
+        self,
+        revision_data_factory: Callable[..., ModelRevisionData],
+    ) -> None:
+        """Non-root model vfolder subpath survives the rebuild."""
+        revision = revision_data_factory(vfolder_subpath="release/v3")
+
+        creator = _build_creator_from_revision_data(revision)
+
+        assert creator.mounts.vfolder_subpath == "release/v3"
+
+    def test_empty_mount_metadata_round_trips(
+        self,
+        revision_data_factory: Callable[..., ModelRevisionData],
+    ) -> None:
+        """Empty extra_mounts and unset subpath stay empty/None (no false injection)."""
+        revision = revision_data_factory()
+
+        creator = _build_creator_from_revision_data(revision)
+
+        assert creator.mounts.extra_mounts == []
+        assert creator.mounts.vfolder_subpath is None

--- a/tests/unit/manager/services/deployment/test_refresh_revision_mount_preservation.py
+++ b/tests/unit/manager/services/deployment/test_refresh_revision_mount_preservation.py
@@ -1,5 +1,5 @@
 """
-Mock-based unit tests for ``_build_creator_from_revision_data``.
+Unit tests for ``_build_creator_from_revision_data``.
 
 Tests verify that the rebuilder used by
 ``DeploymentService.admin_refresh_deployment_revisions`` preserves mount


### PR DESCRIPTION
## Summary
- `admin_refresh_deployment_revisions` rebuilds a `ModelRevisionCreator` from the active revision via `_build_creator_from_revision_data`. The rebuilder hard-coded `extra_mounts=[]` and omitted `vfolder_subpath`, so refreshing silently stripped user-configured extra vfolder mounts and the model vfolder subpath from the new revision.
- The outdated docstring claimed `add_revision` did not propagate `extra_mounts`; current `add_revision` does (line 452 of `deployment_controller.py`) — the bug was the rebuilder dropping them before the merge chain even saw them.
- Project both fields verbatim from `ModelMountConfigData`. Permissions on each extra mount are still re-capped against the vfolder's current stored permission by `add_deployment_revision`.

## Test plan
- [x] `pants test tests/unit/manager/services/deployment/test_refresh_revision_mount_preservation.py`
- [x] `pants check src/ai/backend/manager/services/deployment/service.py`
- [x] Live verification: run `./bai admin deployment revision refresh` against a deployment with extra mounts + non-root subpath; confirm the new revision row carries both fields

Resolves BA-6170