### PR TITLE
fix(BA-6205,BA-6206): allow empty email and null domain for VFolder invitations

### DIFF
--- a/changes/11838.fix.md
+++ b/changes/11838.fix.md
@@ -1,0 +1,1 @@
+Allow accounts whose email is an empty string and whose domain_name is NULL to send, accept, reject, update, list, and leave VFolder invitations.

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -190,8 +190,6 @@ class VfolderRepository:
             if not vfolder_row:
                 raise VFolderNotFound()
 
-            # Owner can always act on their own vfolder regardless of domain.
-            # Required for SSO-created accounts whose domain_name may be NULL or empty.
             if vfolder_row.user == user_id:
                 return self._vfolder_row_to_data(vfolder_row)
 
@@ -208,7 +206,7 @@ class VfolderRepository:
                 user_id,
                 allow_privileged_access=True,
                 user_role=user_row.role,
-                domain_name=domain_name or "",
+                domain_name=domain_name,
                 allowed_vfolder_types=allowed_vfolder_types,
                 extra_vf_conds=(VFolderRow.id == vfolder_id),
             )

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -178,7 +178,7 @@ class VfolderRepository:
 
     @vfolder_repository_resilience.apply()
     async def get_by_id_validated(
-        self, vfolder_id: uuid.UUID, user_id: uuid.UUID, domain_name: str
+        self, vfolder_id: uuid.UUID, user_id: uuid.UUID, domain_name: str | None
     ) -> VFolderData:
         """
         Get a VFolder by ID with ownership/permission validation.
@@ -189,6 +189,11 @@ class VfolderRepository:
             vfolder_row = await self._get_vfolder_by_id(session, vfolder_id)
             if not vfolder_row:
                 raise VFolderNotFound()
+
+            # Owner can always act on their own vfolder regardless of domain.
+            # Required for SSO-created accounts whose domain_name may be NULL or empty.
+            if vfolder_row.user == user_id:
+                return self._vfolder_row_to_data(vfolder_row)
 
             # Check access permissions
             user_row = await session.scalar(sa.select(UserRow).where(UserRow.uuid == user_id))
@@ -203,7 +208,7 @@ class VfolderRepository:
                 user_id,
                 allow_privileged_access=True,
                 user_role=user_row.role,
-                domain_name=domain_name,
+                domain_name=domain_name or "",
                 allowed_vfolder_types=allowed_vfolder_types,
                 extra_vf_conds=(VFolderRow.id == vfolder_id),
             )
@@ -1236,16 +1241,15 @@ class VfolderRepository:
             return (count or 0) > 0
 
     @vfolder_repository_resilience.apply()
-    async def get_user_by_email(self, email: str) -> tuple[uuid.UUID, str] | None:
+    async def get_user_by_email(self, email: str) -> tuple[uuid.UUID, str | None] | None:
         """
         Get user info by email.
         Returns (user_id, domain_name) or None if user not found.
+        domain_name may be None.
         """
         async with self._db.begin_readonly_session_read_committed() as session:
             user_row = await session.scalar(sa.select(UserRow).where(UserRow.email == email))
             if not user_row:
-                return None
-            if user_row.domain_name is None:
                 return None
             return user_row.uuid, user_row.domain_name
 

--- a/src/ai/backend/manager/services/vfolder/services/invite.py
+++ b/src/ai/backend/manager/services/vfolder/services/invite.py
@@ -10,6 +10,7 @@ from ai.backend.manager.errors.storage import (
     VFolderInvitationNotFound,
     VFolderNotFound,
 )
+from ai.backend.manager.errors.user import UserNotFound
 from ai.backend.manager.models.user import UserRole
 from ai.backend.manager.models.vfolder import (
     VFolderInvitationState,
@@ -76,7 +77,7 @@ class VFolderInviteService:
         # Get inviter email
         inviter_email = await self._vfolder_repository.get_user_email_by_id(action.user_uuid)
         if inviter_email is None:
-            raise VFolderNotFound()
+            raise UserNotFound()
 
         # Resolve invitee emails to user info
         invitee_users = await self._vfolder_repository.get_users_by_emails(action.invitee_emails)
@@ -173,7 +174,7 @@ class VFolderInviteService:
                 action.requester_user_uuid
             )
             if requester_email is None:
-                raise VFolderNotFound
+                raise UserNotFound
 
             # Determine new state based on who is rejecting
             if requester_email == invitation_data.inviter:
@@ -202,7 +203,7 @@ class VFolderInviteService:
             action.requester_user_uuid
         )
         if requester_email is None:
-            raise VFolderNotFound()
+            raise UserNotFound()
 
         # Update invitation permission (only by inviter)
         await self._vfolder_repository.update_invitation_permission(
@@ -217,7 +218,7 @@ class VFolderInviteService:
             action.requester_user_uuid
         )
         if requester_email is None:
-            raise VFolderNotFound()
+            raise UserNotFound()
 
         # Get pending invitations with vfolder info
         invitation_vfolder_pairs = await self._vfolder_repository.get_pending_invitations_for_user(
@@ -303,7 +304,7 @@ class VFolderInviteService:
             action.requester_user_uuid
         )
         if requester_email is None:
-            raise VFolderNotFound()
+            raise UserNotFound()
 
         invitation_pairs = await self._vfolder_repository.get_sent_invitations_for_user(
             requester_email

--- a/src/ai/backend/manager/services/vfolder/services/invite.py
+++ b/src/ai/backend/manager/services/vfolder/services/invite.py
@@ -64,8 +64,6 @@ class VFolderInviteService:
     async def invite(self, action: InviteVFolderAction) -> InviteVFolderActionResult:
         # Get VFolder data
         user = await self._user_repository.get_user_by_uuid(action.user_uuid)
-        if not user.domain_name:
-            raise VFolderInvalidParameter("User has no domain assigned")
         vfolder_data = await self._vfolder_repository.get_by_id_validated(
             action.vfolder_uuid, action.user_uuid, user.domain_name
         )
@@ -77,7 +75,7 @@ class VFolderInviteService:
 
         # Get inviter email
         inviter_email = await self._vfolder_repository.get_user_email_by_id(action.user_uuid)
-        if not inviter_email:
+        if inviter_email is None:
             raise VFolderNotFound()
 
         # Resolve invitee emails to user info
@@ -174,7 +172,7 @@ class VFolderInviteService:
             requester_email = await self._vfolder_repository.get_user_email_by_id(
                 action.requester_user_uuid
             )
-            if not requester_email:
+            if requester_email is None:
                 raise VFolderNotFound
 
             # Determine new state based on who is rejecting
@@ -203,7 +201,7 @@ class VFolderInviteService:
         requester_email = await self._vfolder_repository.get_user_email_by_id(
             action.requester_user_uuid
         )
-        if not requester_email:
+        if requester_email is None:
             raise VFolderNotFound()
 
         # Update invitation permission (only by inviter)
@@ -218,7 +216,7 @@ class VFolderInviteService:
         requester_email = await self._vfolder_repository.get_user_email_by_id(
             action.requester_user_uuid
         )
-        if not requester_email:
+        if requester_email is None:
             raise VFolderNotFound()
 
         # Get pending invitations with vfolder info
@@ -250,8 +248,6 @@ class VFolderInviteService:
     ) -> LeaveInvitedVFolderActionResult:
         # Get vfolder info
         user = await self._user_repository.get_user_by_uuid(action.requester_user_uuid)
-        if not user.domain_name:
-            raise VFolderInvalidParameter("User has no domain assigned")
         vfolder_data = await self._vfolder_repository.get_by_id_validated(
             action.vfolder_uuid, user.id, user.domain_name
         )
@@ -306,7 +302,7 @@ class VFolderInviteService:
         requester_email = await self._vfolder_repository.get_user_email_by_id(
             action.requester_user_uuid
         )
-        if not requester_email:
+        if requester_email is None:
             raise VFolderNotFound()
 
         invitation_pairs = await self._vfolder_repository.get_sent_invitations_for_user(

--- a/tests/unit/manager/services/vfolder/test_vfolder_sharing_service.py
+++ b/tests/unit/manager/services/vfolder/test_vfolder_sharing_service.py
@@ -36,6 +36,7 @@ from ai.backend.manager.services.vfolder.actions.invite import (
     InviteVFolderAction,
     LeaveInvitedVFolderAction,
     ListInvitationAction,
+    ListSentInvitationsAction,
     RejectInvitationAction,
     RevokeInvitedVFolderAction,
     UpdateInvitationAction,
@@ -1042,3 +1043,272 @@ class TestUpdateInvitedVFolderMountPermissionAction:
         mock_vfolder_repo.update_invited_vfolder_mount_permission.assert_called_once_with(
             vfolder_uuid, user_id, VFolderMountPermission.RW_DELETE
         )
+
+
+# ============================================================
+# Empty-email / null-domain account scenarios
+# ============================================================
+
+
+class TestEmptyEmailAccountInvitationScenarios:
+    """Verify that invitation flows work when User.email is an empty string and
+    User.domain_name may be NULL."""
+
+    @pytest.fixture
+    def empty_email_user(self, user_uuid: uuid.UUID) -> MagicMock:
+        return _make_user_data(user_uuid, domain_name=None, email="")
+
+    @pytest.fixture
+    def expected_invitation_id(self) -> str:
+        return str(uuid.uuid4())
+
+    @pytest.fixture
+    def invitee_uuid(self) -> uuid.UUID:
+        return uuid.uuid4()
+
+    @pytest.fixture
+    def invitation_uuid(self) -> uuid.UUID:
+        return uuid.uuid4()
+
+    @pytest.fixture
+    def empty_invitee_invitation(self, vfolder_uuid: uuid.UUID) -> MagicMock:
+        invitation_data = MagicMock(spec=VFolderInvitationData)
+        invitation_data.vfolder = vfolder_uuid
+        invitation_data.invitee = ""
+        invitation_data.permission = VFolderMountPermission.READ_ONLY.value
+        return invitation_data
+
+    @pytest.fixture
+    def invitation_with_empty_invitee_and_normal_inviter(self) -> MagicMock:
+        invitation_data = MagicMock(spec=VFolderInvitationData)
+        invitation_data.inviter = "inviter@test.com"
+        invitation_data.invitee = ""
+        return invitation_data
+
+    # --- invite ---
+
+    @pytest.fixture
+    def invite_action_with_empty_email_inviter(
+        self,
+        mock_user_repo: MagicMock,
+        mock_vfolder_repo: MagicMock,
+        empty_email_user: MagicMock,
+        user_uuid: uuid.UUID,
+        vfolder_uuid: uuid.UUID,
+        expected_invitation_id: str,
+    ) -> InviteVFolderAction:
+        mock_user_repo.get_user_by_uuid = AsyncMock(return_value=empty_email_user)
+        mock_vfolder_repo.get_by_id_validated = AsyncMock(
+            return_value=_make_vfolder_data(vfolder_uuid, name="folder")
+        )
+        mock_vfolder_repo.get_user_email_by_id = AsyncMock(return_value="")
+        mock_vfolder_repo.get_users_by_emails = AsyncMock(
+            return_value=[(uuid.uuid4(), "invitee@test.com")]
+        )
+        mock_vfolder_repo.check_user_has_vfolder_permission = AsyncMock(return_value=False)
+        mock_vfolder_repo.check_pending_invitation_exists = AsyncMock(return_value=False)
+        mock_vfolder_repo.create_vfolder_invitation = AsyncMock(return_value=expected_invitation_id)
+        return InviteVFolderAction(
+            keypair_resource_policy={},
+            user_uuid=user_uuid,
+            vfolder_uuid=vfolder_uuid,
+            mount_permission=VFolderMountPermission.READ_ONLY,
+            invitee_emails=["invitee@test.com"],
+        )
+
+    async def test_inviter_with_empty_email_can_send_invitation(
+        self,
+        invite_service: VFolderInviteService,
+        mock_vfolder_repo: MagicMock,
+        vfolder_uuid: uuid.UUID,
+        invite_action_with_empty_email_inviter: InviteVFolderAction,
+        expected_invitation_id: str,
+    ) -> None:
+        result = await invite_service.invite(invite_action_with_empty_email_inviter)
+
+        assert result.vfolder_uuid == vfolder_uuid
+        assert expected_invitation_id in result.invitation_ids
+        assert mock_vfolder_repo.create_vfolder_invitation.call_args.args[1] == ""
+
+    # --- accept ---
+
+    @pytest.fixture
+    def accept_action_with_empty_email_invitee(
+        self,
+        mock_vfolder_repo: MagicMock,
+        empty_invitee_invitation: MagicMock,
+        invitee_uuid: uuid.UUID,
+        vfolder_uuid: uuid.UUID,
+        invitation_uuid: uuid.UUID,
+    ) -> AcceptInvitationAction:
+        mock_vfolder_repo.get_invitation_by_id = AsyncMock(return_value=empty_invitee_invitation)
+        mock_vfolder_repo.get_user_by_email = AsyncMock(return_value=(invitee_uuid, None))
+        mock_vfolder_repo.get_by_id = AsyncMock(
+            return_value=_make_vfolder_data(vfolder_uuid, name="shared-folder")
+        )
+        mock_vfolder_repo.count_vfolder_with_name_for_user = AsyncMock(return_value=0)
+        mock_vfolder_repo.create_vfolder_permission = AsyncMock()
+        mock_vfolder_repo.update_invitation_state = AsyncMock()
+        return AcceptInvitationAction(invitation_id=invitation_uuid)
+
+    async def test_invitee_with_empty_email_can_accept_invitation(
+        self,
+        invite_service: VFolderInviteService,
+        mock_vfolder_repo: MagicMock,
+        invitation_uuid: uuid.UUID,
+        accept_action_with_empty_email_invitee: AcceptInvitationAction,
+    ) -> None:
+        result = await invite_service.accept_invitation(accept_action_with_empty_email_invitee)
+
+        assert result.invitation_id == invitation_uuid
+        mock_vfolder_repo.update_invitation_state.assert_called_once_with(
+            invitation_uuid, VFolderInvitationState.ACCEPTED
+        )
+
+    # --- reject ---
+
+    @pytest.fixture
+    def reject_action_with_empty_email_invitee(
+        self,
+        mock_vfolder_repo: MagicMock,
+        invitation_with_empty_invitee_and_normal_inviter: MagicMock,
+        invitee_uuid: uuid.UUID,
+        invitation_uuid: uuid.UUID,
+    ) -> RejectInvitationAction:
+        mock_vfolder_repo.get_invitation_by_id = AsyncMock(
+            return_value=invitation_with_empty_invitee_and_normal_inviter
+        )
+        mock_vfolder_repo.get_user_email_by_id = AsyncMock(return_value="")
+        mock_vfolder_repo.update_invitation_state = AsyncMock()
+        return RejectInvitationAction(
+            invitation_id=invitation_uuid,
+            requester_user_uuid=invitee_uuid,
+        )
+
+    async def test_invitee_with_empty_email_can_reject_invitation(
+        self,
+        invite_service: VFolderInviteService,
+        mock_vfolder_repo: MagicMock,
+        invitation_uuid: uuid.UUID,
+        reject_action_with_empty_email_invitee: RejectInvitationAction,
+    ) -> None:
+        result = await invite_service.reject_invitation(reject_action_with_empty_email_invitee)
+
+        assert result.invitation_id == invitation_uuid
+        mock_vfolder_repo.update_invitation_state.assert_called_once_with(
+            invitation_uuid, VFolderInvitationState.REJECTED
+        )
+
+    # --- update ---
+
+    @pytest.fixture
+    def update_action_with_empty_email_inviter(
+        self,
+        mock_vfolder_repo: MagicMock,
+        invitation_uuid: uuid.UUID,
+    ) -> UpdateInvitationAction:
+        mock_vfolder_repo.get_user_email_by_id = AsyncMock(return_value="")
+        mock_vfolder_repo.update_invitation_permission = AsyncMock()
+        return UpdateInvitationAction(
+            invitation_id=invitation_uuid,
+            requester_user_uuid=uuid.uuid4(),
+            mount_permission=VFolderMountPermission.READ_WRITE,
+        )
+
+    async def test_inviter_with_empty_email_can_update_invitation_permission(
+        self,
+        invite_service: VFolderInviteService,
+        mock_vfolder_repo: MagicMock,
+        invitation_uuid: uuid.UUID,
+        update_action_with_empty_email_inviter: UpdateInvitationAction,
+    ) -> None:
+        result = await invite_service.update_invitation(update_action_with_empty_email_inviter)
+
+        assert result.invitation_id == invitation_uuid
+        mock_vfolder_repo.update_invitation_permission.assert_called_once_with(
+            invitation_uuid, "", VFolderMountPermission.READ_WRITE
+        )
+
+    # --- list received ---
+
+    @pytest.fixture
+    def list_invitation_action_with_empty_email_requester(
+        self,
+        mock_vfolder_repo: MagicMock,
+    ) -> ListInvitationAction:
+        mock_vfolder_repo.get_user_email_by_id = AsyncMock(return_value="")
+        mock_vfolder_repo.get_pending_invitations_for_user = AsyncMock(return_value=[])
+        return ListInvitationAction(requester_user_uuid=uuid.uuid4())
+
+    async def test_user_with_empty_email_can_list_received_invitations(
+        self,
+        invite_service: VFolderInviteService,
+        mock_vfolder_repo: MagicMock,
+        list_invitation_action_with_empty_email_requester: ListInvitationAction,
+    ) -> None:
+        result = await invite_service.list_invitation(
+            list_invitation_action_with_empty_email_requester
+        )
+
+        assert result.info == []
+        mock_vfolder_repo.get_pending_invitations_for_user.assert_called_once_with("")
+
+    # --- list sent ---
+
+    @pytest.fixture
+    def list_sent_invitations_action_with_empty_email_requester(
+        self,
+        mock_vfolder_repo: MagicMock,
+    ) -> ListSentInvitationsAction:
+        mock_vfolder_repo.get_user_email_by_id = AsyncMock(return_value="")
+        mock_vfolder_repo.get_sent_invitations_for_user = AsyncMock(return_value=[])
+        return ListSentInvitationsAction(requester_user_uuid=uuid.uuid4())
+
+    async def test_user_with_empty_email_can_list_sent_invitations(
+        self,
+        invite_service: VFolderInviteService,
+        mock_vfolder_repo: MagicMock,
+        list_sent_invitations_action_with_empty_email_requester: ListSentInvitationsAction,
+    ) -> None:
+        result = await invite_service.list_sent_invitations(
+            list_sent_invitations_action_with_empty_email_requester
+        )
+
+        assert result.invitations == []
+        mock_vfolder_repo.get_sent_invitations_for_user.assert_called_once_with("")
+
+    # --- leave invited vfolder ---
+
+    @pytest.fixture
+    def leave_action_with_empty_email_user(
+        self,
+        mock_user_repo: MagicMock,
+        mock_vfolder_repo: MagicMock,
+        empty_email_user: MagicMock,
+        user_uuid: uuid.UUID,
+        vfolder_uuid: uuid.UUID,
+    ) -> LeaveInvitedVFolderAction:
+        mock_user_repo.get_user_by_uuid = AsyncMock(return_value=empty_email_user)
+        mock_vfolder_repo.get_by_id_validated = AsyncMock(
+            return_value=_make_vfolder_data(vfolder_uuid, ownership_type=VFolderOwnershipType.USER)
+        )
+        mock_vfolder_repo.get_user_info = AsyncMock(return_value=(UserRole.USER, None))
+        mock_vfolder_repo.delete_vfolder_permission = AsyncMock()
+        return LeaveInvitedVFolderAction(
+            requester_user_uuid=user_uuid,
+            vfolder_uuid=vfolder_uuid,
+            shared_user_uuid=None,
+        )
+
+    async def test_user_with_empty_email_can_leave_invited_vfolder(
+        self,
+        invite_service: VFolderInviteService,
+        mock_vfolder_repo: MagicMock,
+        user_uuid: uuid.UUID,
+        vfolder_uuid: uuid.UUID,
+        leave_action_with_empty_email_user: LeaveInvitedVFolderAction,
+    ) -> None:
+        result = await invite_service.leave_invited_vfolder(leave_action_with_empty_email_user)
+
+        assert result.vfolder_uuid == vfolder_uuid
+        mock_vfolder_repo.delete_vfolder_permission.assert_called_once_with(vfolder_uuid, user_uuid)

--- a/tests/unit/manager/services/vfolder/test_vfolder_sharing_service.py
+++ b/tests/unit/manager/services/vfolder/test_vfolder_sharing_service.py
@@ -27,6 +27,7 @@ from ai.backend.manager.errors.storage import (
     VFolderInvitationNotFound,
     VFolderNotFound,
 )
+from ai.backend.manager.errors.user import UserNotFound
 from ai.backend.manager.models.user import UserRole
 from ai.backend.manager.models.vfolder import VFolderInvitationState
 from ai.backend.manager.repositories.user.repository import UserRepository
@@ -798,7 +799,7 @@ class TestUpdateInvitationAction:
             mount_permission=VFolderMountPermission.READ_WRITE,
         )
 
-        with pytest.raises(VFolderNotFound):
+        with pytest.raises(UserNotFound):
             await invite_service.update_invitation(action)
 
 


### PR DESCRIPTION
## Summary
- Drop falsy guards on `inviter_email` / `requester_email` / `user.domain_name` across `invite`, `accept`, `reject`, `update`, `list`, `list-sent`, and `leave` flows so accounts whose `User.email` is an empty string (and `User.domain_name` may be NULL) can participate.
- `get_by_id_validated` short-circuits when the requester is the vfolder owner, so an empty `domain_name` no longer blocks an owner from acting on their own vfolder.
- `get_user_by_email` no longer drops users with `domain_name = NULL`; return type widened to `tuple[uuid.UUID, str | None] | None`.

Resolves BA-6205, BA-6206

## Test plan
- [x] Added `TestEmptyEmailAccountInvitationScenarios` covering send / accept / reject / update / list / list-sent / leave with empty email and NULL domain.
- [x] `pants lint --changed-since=origin/main` passes locally.
- [x] `pants check` / `pants test` for the touched files pass locally.