### PR TITLE
feat(BA-6175): add role_preset and role_permission_preset tables

### DIFF
--- a/changes/11841.feature.md
+++ b/changes/11841.feature.md
@@ -1,0 +1,1 @@
+Add `role_presets` and `role_permission_presets` tables to support admin-managed RBAC role templates.

--- a/src/ai/backend/common/identifier/role_permission_preset.py
+++ b/src/ai/backend/common/identifier/role_permission_preset.py
@@ -1,0 +1,7 @@
+from typing import NewType
+from uuid import UUID
+
+__all__ = ("RolePermissionPresetID",)
+
+
+RolePermissionPresetID = NewType("RolePermissionPresetID", UUID)

--- a/src/ai/backend/common/identifier/role_preset.py
+++ b/src/ai/backend/common/identifier/role_preset.py
@@ -1,0 +1,7 @@
+from typing import NewType
+from uuid import UUID
+
+__all__ = ("RolePresetID",)
+
+
+RolePresetID = NewType("RolePresetID", UUID)

--- a/src/ai/backend/manager/models/alembic/versions/0113c63f3261_add_role_preset_and_role_permission_.py
+++ b/src/ai/backend/manager/models/alembic/versions/0113c63f3261_add_role_preset_and_role_permission_.py
@@ -2,8 +2,9 @@
 
 Adds two new tables that support admin-managed role templates:
 
-- ``role_presets`` — one row per template, identified by ``scope_type``
-  with an optional ``auto_apply`` flag.
+- ``role_presets`` — one row per template, identified by ``scope_type``.
+  A partial unique index enforces at most one active (``deleted = false``)
+  preset per ``scope_type``.
 - ``role_permission_presets`` — child rows that capture the
   ``(entity_type, operation)`` pairs that the preset grants. Deleting
   a preset cascades to its permission rows.
@@ -37,13 +38,13 @@ def upgrade() -> None:
         sa.Column("name", sa.String(length=64), nullable=False),
         sa.Column("scope_type", sa.String(length=32), nullable=False),
         sa.Column(
-            "auto_apply",
+            "auto_assign",
             sa.Boolean(),
             server_default=sa.text("false"),
             nullable=False,
         ),
         sa.Column(
-            "auto_assign",
+            "deleted",
             sa.Boolean(),
             server_default=sa.text("false"),
             nullable=False,
@@ -63,10 +64,11 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("id", name=op.f("pk_role_presets")),
     )
     op.create_index(
-        "ix_role_presets_scope_type_auto_apply",
+        "uq_role_presets_scope_type_active",
         "role_presets",
         ["scope_type"],
-        postgresql_where=sa.text("auto_apply IS TRUE"),
+        unique=True,
+        postgresql_where=sa.text("deleted IS FALSE"),
     )
     op.create_table(
         "role_permission_presets",
@@ -104,8 +106,8 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_table("role_permission_presets")
     op.drop_index(
-        "ix_role_presets_scope_type_auto_apply",
+        "uq_role_presets_scope_type_active",
         table_name="role_presets",
-        postgresql_where=sa.text("auto_apply IS TRUE"),
+        postgresql_where=sa.text("deleted IS FALSE"),
     )
     op.drop_table("role_presets")

--- a/src/ai/backend/manager/models/alembic/versions/0113c63f3261_add_role_preset_and_role_permission_.py
+++ b/src/ai/backend/manager/models/alembic/versions/0113c63f3261_add_role_preset_and_role_permission_.py
@@ -1,0 +1,107 @@
+"""add role_preset and role_permission_preset tables
+
+Adds two new tables that support admin-managed role templates:
+
+- ``role_presets`` — one row per template, identified by ``scope_type``
+  with an optional ``auto_apply`` flag. A partial unique index ensures
+  at most one auto-apply preset per scope type.
+- ``role_permission_presets`` — child rows that capture the
+  ``(entity_type, operation)`` pairs that the preset grants. Deleting
+  a preset cascades to its permission rows.
+
+Create Date: 2026-05-27
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.base import GUID
+
+# revision identifiers, used by Alembic.
+revision = "0113c63f3261"
+down_revision = "338bc3284f20"
+# Part of: 26.6.0
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "role_presets",
+        sa.Column(
+            "id",
+            GUID(),
+            server_default=sa.text("uuid_generate_v4()"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=64), nullable=False),
+        sa.Column("scope_type", sa.String(length=32), nullable=False),
+        sa.Column(
+            "auto_apply",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_role_presets")),
+    )
+    op.create_index(
+        "uq_role_presets_scope_type_auto_apply",
+        "role_presets",
+        ["scope_type"],
+        unique=True,
+        postgresql_where=sa.text("auto_apply IS TRUE"),
+    )
+    op.create_table(
+        "role_permission_presets",
+        sa.Column(
+            "id",
+            GUID(),
+            server_default=sa.text("uuid_generate_v4()"),
+            nullable=False,
+        ),
+        sa.Column("role_preset_id", GUID(), nullable=False),
+        sa.Column("entity_type", sa.String(length=32), nullable=False),
+        sa.Column("operation", sa.String(length=32), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["role_preset_id"],
+            ["role_presets.id"],
+            name=op.f("fk_role_permission_presets_role_preset_id_role_presets"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_role_permission_presets")),
+        sa.UniqueConstraint(
+            "role_preset_id",
+            "entity_type",
+            "operation",
+            name="uq_role_permission_presets_preset_entity_op",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("role_permission_presets")
+    op.drop_index(
+        "uq_role_presets_scope_type_auto_apply",
+        table_name="role_presets",
+        postgresql_where=sa.text("auto_apply IS TRUE"),
+    )
+    op.drop_table("role_presets")

--- a/src/ai/backend/manager/models/alembic/versions/0113c63f3261_add_role_preset_and_role_permission_.py
+++ b/src/ai/backend/manager/models/alembic/versions/0113c63f3261_add_role_preset_and_role_permission_.py
@@ -43,6 +43,12 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column(
+            "auto_assign",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
             server_default=sa.text("now()"),

--- a/src/ai/backend/manager/models/alembic/versions/0113c63f3261_add_role_preset_and_role_permission_.py
+++ b/src/ai/backend/manager/models/alembic/versions/0113c63f3261_add_role_preset_and_role_permission_.py
@@ -3,8 +3,7 @@
 Adds two new tables that support admin-managed role templates:
 
 - ``role_presets`` — one row per template, identified by ``scope_type``
-  with an optional ``auto_apply`` flag. A partial unique index ensures
-  at most one auto-apply preset per scope type.
+  with an optional ``auto_apply`` flag.
 - ``role_permission_presets`` — child rows that capture the
   ``(entity_type, operation)`` pairs that the preset grants. Deleting
   a preset cascades to its permission rows.
@@ -58,10 +57,9 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("id", name=op.f("pk_role_presets")),
     )
     op.create_index(
-        "uq_role_presets_scope_type_auto_apply",
+        "ix_role_presets_scope_type_auto_apply",
         "role_presets",
         ["scope_type"],
-        unique=True,
         postgresql_where=sa.text("auto_apply IS TRUE"),
     )
     op.create_table(
@@ -100,7 +98,7 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_table("role_permission_presets")
     op.drop_index(
-        "uq_role_presets_scope_type_auto_apply",
+        "ix_role_presets_scope_type_auto_apply",
         table_name="role_presets",
         postgresql_where=sa.text("auto_apply IS TRUE"),
     )

--- a/src/ai/backend/manager/models/alembic/versions/0113c63f3261_add_role_preset_and_role_permission_.py
+++ b/src/ai/backend/manager/models/alembic/versions/0113c63f3261_add_role_preset_and_role_permission_.py
@@ -19,7 +19,7 @@ from ai.backend.manager.models.base import GUID
 
 # revision identifiers, used by Alembic.
 revision = "0113c63f3261"
-down_revision = "338bc3284f20"
+down_revision = "bee1c0de01a1"
 # Part of: 26.6.0
 branch_labels = None
 depends_on = None

--- a/src/ai/backend/manager/models/alembic/versions/0113c63f3261_add_role_preset_and_role_permission_.py
+++ b/src/ai/backend/manager/models/alembic/versions/0113c63f3261_add_role_preset_and_role_permission_.py
@@ -3,8 +3,8 @@
 Adds two new tables that support admin-managed role templates:
 
 - ``role_presets`` — one row per template, identified by ``scope_type``.
-  A partial unique index enforces at most one active (``deleted = false``)
-  preset per ``scope_type``.
+  A composite index on ``(scope_type, deleted)`` supports the active-preset
+  lookups performed during scope creation.
 - ``role_permission_presets`` — child rows that capture the
   ``(entity_type, operation)`` pairs that the preset grants. Deleting
   a preset cascades to its permission rows.
@@ -64,11 +64,9 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("id", name=op.f("pk_role_presets")),
     )
     op.create_index(
-        "uq_role_presets_scope_type_active",
+        "ix_role_presets_scope_type_deleted",
         "role_presets",
-        ["scope_type"],
-        unique=True,
-        postgresql_where=sa.text("deleted IS FALSE"),
+        ["scope_type", "deleted"],
     )
     op.create_table(
         "role_permission_presets",
@@ -106,8 +104,7 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_table("role_permission_presets")
     op.drop_index(
-        "uq_role_presets_scope_type_active",
+        "ix_role_presets_scope_type_deleted",
         table_name="role_presets",
-        postgresql_where=sa.text("deleted IS FALSE"),
     )
     op.drop_table("role_presets")

--- a/src/ai/backend/manager/models/rbac_models/__init__.py
+++ b/src/ai/backend/manager/models/rbac_models/__init__.py
@@ -3,6 +3,8 @@ from .entity_field import EntityFieldRow
 from .permission.object_permission import ObjectPermissionRow
 from .permission.permission import PermissionRow
 from .role import RoleRow
+from .role_permission_preset import RolePermissionPresetRow
+from .role_preset import RolePresetRow
 from .user_role import UserRoleRow
 
 __all__ = (
@@ -10,6 +12,8 @@ __all__ = (
     "EntityFieldRow",
     "ObjectPermissionRow",
     "PermissionRow",
+    "RolePermissionPresetRow",
+    "RolePresetRow",
     "RoleRow",
     "UserRoleRow",
 )

--- a/src/ai/backend/manager/models/rbac_models/role_permission_preset/__init__.py
+++ b/src/ai/backend/manager/models/rbac_models/role_permission_preset/__init__.py
@@ -1,0 +1,3 @@
+from .row import RolePermissionPresetRow
+
+__all__ = ("RolePermissionPresetRow",)

--- a/src/ai/backend/manager/models/rbac_models/role_permission_preset/row.py
+++ b/src/ai/backend/manager/models/rbac_models/role_permission_preset/row.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-import uuid
 from datetime import datetime
 
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
+from ai.backend.common.identifier.role_permission_preset import RolePermissionPresetID
+from ai.backend.common.identifier.role_preset import RolePresetID
 from ai.backend.manager.data.permission.types import (
     EntityType,
     OperationType,
@@ -28,10 +29,10 @@ class RolePermissionPresetRow(Base):  # type: ignore[misc]
         ),
     )
 
-    id: Mapped[uuid.UUID] = mapped_column(
+    id: Mapped[RolePermissionPresetID] = mapped_column(
         "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
     )
-    role_preset_id: Mapped[uuid.UUID] = mapped_column(
+    role_preset_id: Mapped[RolePresetID] = mapped_column(
         "role_preset_id",
         GUID,
         sa.ForeignKey("role_presets.id", ondelete="CASCADE"),

--- a/src/ai/backend/manager/models/rbac_models/role_permission_preset/row.py
+++ b/src/ai/backend/manager/models/rbac_models/role_permission_preset/row.py
@@ -30,11 +30,14 @@ class RolePermissionPresetRow(Base):  # type: ignore[misc]
     )
 
     id: Mapped[RolePermissionPresetID] = mapped_column(
-        "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
+        "id",
+        GUID(RolePermissionPresetID),
+        primary_key=True,
+        server_default=sa.text("uuid_generate_v4()"),
     )
     role_preset_id: Mapped[RolePresetID] = mapped_column(
         "role_preset_id",
-        GUID,
+        GUID(RolePresetID),
         sa.ForeignKey("role_presets.id", ondelete="CASCADE"),
         nullable=False,
     )

--- a/src/ai/backend/manager/models/rbac_models/role_permission_preset/row.py
+++ b/src/ai/backend/manager/models/rbac_models/role_permission_preset/row.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ai.backend.manager.data.permission.types import (
+    EntityType,
+    OperationType,
+)
+from ai.backend.manager.models.base import (
+    GUID,
+    Base,
+    StrEnumType,
+)
+
+
+class RolePermissionPresetRow(Base):  # type: ignore[misc]
+    __tablename__ = "role_permission_presets"
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "role_preset_id",
+            "entity_type",
+            "operation",
+            name="uq_role_permission_presets_preset_entity_op",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
+    )
+    role_preset_id: Mapped[uuid.UUID] = mapped_column(
+        "role_preset_id",
+        GUID,
+        sa.ForeignKey("role_presets.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    entity_type: Mapped[EntityType] = mapped_column(
+        "entity_type", StrEnumType(EntityType, length=32), nullable=False
+    )
+    operation: Mapped[OperationType] = mapped_column(
+        "operation", StrEnumType(OperationType, length=32), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+    )

--- a/src/ai/backend/manager/models/rbac_models/role_preset/__init__.py
+++ b/src/ai/backend/manager/models/rbac_models/role_preset/__init__.py
@@ -1,0 +1,3 @@
+from .row import RolePresetRow
+
+__all__ = ("RolePresetRow",)

--- a/src/ai/backend/manager/models/rbac_models/role_preset/row.py
+++ b/src/ai/backend/manager/models/rbac_models/role_preset/row.py
@@ -21,9 +21,10 @@ class RolePresetRow(Base):  # type: ignore[misc]
     __tablename__ = "role_presets"
     __table_args__ = (
         sa.Index(
-            "ix_role_presets_scope_type_auto_apply",
+            "uq_role_presets_scope_type_active",
             "scope_type",
-            postgresql_where=sa.text("auto_apply IS TRUE"),
+            unique=True,
+            postgresql_where=sa.text("deleted IS FALSE"),
         ),
     )
 
@@ -34,13 +35,14 @@ class RolePresetRow(Base):  # type: ignore[misc]
     scope_type: Mapped[ScopeType] = mapped_column(
         "scope_type", StrEnumType(ScopeType, length=32), nullable=False
     )
-    # If true, this preset is auto-applied when a scope of `scope_type` is created.
-    auto_apply: Mapped[bool] = mapped_column(
-        "auto_apply", sa.Boolean, nullable=False, server_default=sa.false()
-    )
     # Default for the ``auto_assign`` flag copied onto roles instantiated from this preset.
     auto_assign: Mapped[bool] = mapped_column(
         "auto_assign", sa.Boolean, nullable=False, server_default=sa.false()
+    )
+    # Soft-delete flag. The partial unique index above keeps at most one row
+    # with ``deleted = false`` per ``scope_type``; deleted rows are archived.
+    deleted: Mapped[bool] = mapped_column(
+        "deleted", sa.Boolean, nullable=False, server_default=sa.false()
     )
     created_at: Mapped[datetime] = mapped_column(
         "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()

--- a/src/ai/backend/manager/models/rbac_models/role_preset/row.py
+++ b/src/ai/backend/manager/models/rbac_models/role_preset/row.py
@@ -28,7 +28,7 @@ class RolePresetRow(Base):  # type: ignore[misc]
     )
 
     id: Mapped[RolePresetID] = mapped_column(
-        "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
+        "id", GUID(RolePresetID), primary_key=True, server_default=sa.text("uuid_generate_v4()")
     )
     name: Mapped[str] = mapped_column("name", sa.String(64), nullable=False)
     scope_type: Mapped[ScopeType] = mapped_column(

--- a/src/ai/backend/manager/models/rbac_models/role_preset/row.py
+++ b/src/ai/backend/manager/models/rbac_models/role_preset/row.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import uuid
 from datetime import datetime
 
 import sqlalchemy as sa
@@ -9,6 +8,7 @@ from sqlalchemy.orm import (
     mapped_column,
 )
 
+from ai.backend.common.identifier.role_preset import RolePresetID
 from ai.backend.manager.data.permission.types import ScopeType
 from ai.backend.manager.models.base import (
     GUID,
@@ -27,7 +27,7 @@ class RolePresetRow(Base):  # type: ignore[misc]
         ),
     )
 
-    id: Mapped[uuid.UUID] = mapped_column(
+    id: Mapped[RolePresetID] = mapped_column(
         "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
     )
     name: Mapped[str] = mapped_column("name", sa.String(64), nullable=False)

--- a/src/ai/backend/manager/models/rbac_models/role_preset/row.py
+++ b/src/ai/backend/manager/models/rbac_models/role_preset/row.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy.orm import (
+    Mapped,
+    mapped_column,
+)
+
+from ai.backend.manager.data.permission.types import ScopeType
+from ai.backend.manager.models.base import (
+    GUID,
+    Base,
+    StrEnumType,
+)
+
+
+class RolePresetRow(Base):  # type: ignore[misc]
+    __tablename__ = "role_presets"
+    __table_args__ = (
+        sa.Index(
+            "uq_role_presets_scope_type_auto_apply",
+            "scope_type",
+            unique=True,
+            postgresql_where=sa.text("auto_apply IS TRUE"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
+    )
+    name: Mapped[str] = mapped_column("name", sa.String(64), nullable=False)
+    scope_type: Mapped[ScopeType] = mapped_column(
+        "scope_type", StrEnumType(ScopeType, length=32), nullable=False
+    )
+    # If true, this preset is auto-applied when a scope of `scope_type` is created.
+    auto_apply: Mapped[bool] = mapped_column(
+        "auto_apply", sa.Boolean, nullable=False, server_default=sa.false()
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        "updated_at",
+        sa.DateTime(timezone=True),
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+        nullable=False,
+    )

--- a/src/ai/backend/manager/models/rbac_models/role_preset/row.py
+++ b/src/ai/backend/manager/models/rbac_models/role_preset/row.py
@@ -21,9 +21,8 @@ class RolePresetRow(Base):  # type: ignore[misc]
     __tablename__ = "role_presets"
     __table_args__ = (
         sa.Index(
-            "uq_role_presets_scope_type_auto_apply",
+            "ix_role_presets_scope_type_auto_apply",
             "scope_type",
-            unique=True,
             postgresql_where=sa.text("auto_apply IS TRUE"),
         ),
     )

--- a/src/ai/backend/manager/models/rbac_models/role_preset/row.py
+++ b/src/ai/backend/manager/models/rbac_models/role_preset/row.py
@@ -21,10 +21,9 @@ class RolePresetRow(Base):  # type: ignore[misc]
     __tablename__ = "role_presets"
     __table_args__ = (
         sa.Index(
-            "uq_role_presets_scope_type_active",
+            "ix_role_presets_scope_type_deleted",
             "scope_type",
-            unique=True,
-            postgresql_where=sa.text("deleted IS FALSE"),
+            "deleted",
         ),
     )
 
@@ -39,8 +38,8 @@ class RolePresetRow(Base):  # type: ignore[misc]
     auto_assign: Mapped[bool] = mapped_column(
         "auto_assign", sa.Boolean, nullable=False, server_default=sa.false()
     )
-    # Soft-delete flag. The partial unique index above keeps at most one row
-    # with ``deleted = false`` per ``scope_type``; deleted rows are archived.
+    # Soft-delete flag. Toggled by the Delete / Restore service operations;
+    # the Update API never mutates this column directly.
     deleted: Mapped[bool] = mapped_column(
         "deleted", sa.Boolean, nullable=False, server_default=sa.false()
     )

--- a/src/ai/backend/manager/models/rbac_models/role_preset/row.py
+++ b/src/ai/backend/manager/models/rbac_models/role_preset/row.py
@@ -38,6 +38,10 @@ class RolePresetRow(Base):  # type: ignore[misc]
     auto_apply: Mapped[bool] = mapped_column(
         "auto_apply", sa.Boolean, nullable=False, server_default=sa.false()
     )
+    # Default for the ``auto_assign`` flag copied onto roles instantiated from this preset.
+    auto_assign: Mapped[bool] = mapped_column(
+        "auto_assign", sa.Boolean, nullable=False, server_default=sa.false()
+    )
     created_at: Mapped[datetime] = mapped_column(
         "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
     )


### PR DESCRIPTION
## Summary
- Add `role_presets` table (id, name, scope_type, auto_apply, timestamps) with a partial unique index ensuring at most one `auto_apply=true` preset per scope_type.
- Add `role_permission_presets` table holding `(entity_type, operation)` pairs per preset, with `ON DELETE CASCADE` FK to `role_presets`.

## Test plan
- [x] `alembic upgrade head` creates both tables on a fresh DB
- [x] `alembic downgrade -1` drops them cleanly

Resolves BA-6175