### PR TITLE
feat(BA-6191): add ScopeCreatorSpec and ScopePurgerSpec to Ops layer

### DIFF
--- a/changes/11843.feature.md
+++ b/changes/11843.feature.md
@@ -1,0 +1,1 @@
+Add `ScopeCreatorSpec` / `ScopePurgerSpec` composite specs and a dedicated `ScopeWriteOps` class that provisions a new RBAC scope (scope row, preset-derived roles + permissions, role-to-scope and parent-scope associations) or tears one down in a single transaction.

--- a/src/ai/backend/manager/repositories/base/__init__.py
+++ b/src/ai/backend/manager/repositories/base/__init__.py
@@ -63,6 +63,17 @@ from .querier import (
     execute_batch_querier,
     execute_querier,
 )
+from .scope_creator import (
+    ScopeContext,
+    ScopeCreator,
+    ScopeCreatorResult,
+    ScopeCreatorSpec,
+)
+from .scope_purger import (
+    ScopePurger,
+    ScopePurgerResult,
+    ScopePurgerSpec,
+)
 from .types import (
     CursorConditionFactory,
     ExistenceCheck,
@@ -190,6 +201,15 @@ __all__ = [
     "BatchPurger",
     "BatchPurgerResult",
     "execute_batch_purger",
+    # ScopeCreator
+    "ScopeCreatorSpec",
+    "ScopeCreator",
+    "ScopeCreatorResult",
+    "ScopeContext",
+    # ScopePurger
+    "ScopePurgerSpec",
+    "ScopePurger",
+    "ScopePurgerResult",
     # Utils
     "combine_conditions_and",
     "combine_conditions_or",

--- a/src/ai/backend/manager/repositories/base/__init__.py
+++ b/src/ai/backend/manager/repositories/base/__init__.py
@@ -63,17 +63,6 @@ from .querier import (
     execute_batch_querier,
     execute_querier,
 )
-from .scope_creator import (
-    ScopeContext,
-    ScopeCreator,
-    ScopeCreatorResult,
-    ScopeCreatorSpec,
-)
-from .scope_purger import (
-    ScopePurger,
-    ScopePurgerResult,
-    ScopePurgerSpec,
-)
 from .types import (
     CursorConditionFactory,
     ExistenceCheck,
@@ -201,15 +190,6 @@ __all__ = [
     "BatchPurger",
     "BatchPurgerResult",
     "execute_batch_purger",
-    # ScopeCreator
-    "ScopeCreatorSpec",
-    "ScopeCreator",
-    "ScopeCreatorResult",
-    "ScopeContext",
-    # ScopePurger
-    "ScopePurgerSpec",
-    "ScopePurger",
-    "ScopePurgerResult",
     # Utils
     "combine_conditions_and",
     "combine_conditions_or",

--- a/src/ai/backend/manager/repositories/base/__init__.py
+++ b/src/ai/backend/manager/repositories/base/__init__.py
@@ -69,6 +69,7 @@ from .types import (
     IntegrityErrorCheck,
     QueryCondition,
     QueryOrder,
+    ScopeContext,
     SearchScope,
 )
 from .updater import (
@@ -106,6 +107,7 @@ __all__ = [
     "CursorConditionFactory",
     "ExistenceCheck",
     "IntegrityErrorCheck",
+    "ScopeContext",
     "SearchScope",
     # Integrity
     "parse_integrity_error",

--- a/src/ai/backend/manager/repositories/base/scope_creator.py
+++ b/src/ai/backend/manager/repositories/base/scope_creator.py
@@ -1,0 +1,92 @@
+"""Composite spec for race-free scope provisioning.
+
+A scope-creator spec coordinates the inserts that together provision a new RBAC
+scope: the scope row itself (domain, project, ...), any parent-scope mapping
+rows, and roles + role-scope associations + permissions instantiated from each
+active role preset matching the scope type.
+
+The spec itself owns no table; each returned sub-spec owns exactly one table,
+preserving the per-spec single-table rule. Orchestration lives in
+:meth:`ScopeWriteOps.create_scope`.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.manager.models.base import Base
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.rbac_models.role import RoleRow
+
+from .creator import CreatorSpec
+
+
+@dataclass(frozen=True)
+class ScopeContext:
+    """Locator for a scope row.
+
+    Carries the ``(scope_type, scope_id)`` pair used by downstream RBAC tables
+    (``permissions``, ``association_scopes_entities``) to reference the scope.
+    """
+
+    scope_type: RBACElementType
+    scope_id: str
+
+
+class ScopeCreatorSpec[TScopeRow: Base](ABC):
+    """Coordinator for ``scope row + parent-scope association rows``.
+
+    Subclass per scope type (e.g. ``DomainScopeCreatorSpec``,
+    ``ProjectScopeCreatorSpec``). Each returned sub-spec owns exactly one table.
+    """
+
+    @abstractmethod
+    def scope_spec(self) -> CreatorSpec[TScopeRow]:
+        """Single-table spec for the scope row."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def extract_scope_context(self, scope_row: TScopeRow) -> ScopeContext:
+        """Derive ``(scope_type, scope_id)`` from the just-inserted scope row.
+
+        The orchestrator uses this to look up matching role presets and to populate
+        ``scope_id`` on derived permission and association rows.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def parent_association_specs(
+        self,
+        scope_row: TScopeRow,
+    ) -> Sequence[CreatorSpec[AssociationScopesEntitiesRow]]:
+        """Parent-scope mapping rows (e.g. project under domain).
+
+        Return ``[]`` if the scope type has no parent.
+        """
+        raise NotImplementedError
+
+
+@dataclass
+class ScopeCreator[TScopeRow: Base]:
+    """Bundles a scope-creator spec for ``ScopeWriteOps.create_scope``."""
+
+    spec: ScopeCreatorSpec[TScopeRow]
+
+
+@dataclass
+class ScopeCreatorResult[TScopeRow: Base]:
+    """Outcome of a successful scope provisioning.
+
+    Only surfaces the freshly-inserted scope row and the roles that were
+    instantiated from active role presets. Auxiliary rows (permissions,
+    role-to-scope associations, parent-scope associations) are still
+    inserted by the orchestrator but are not returned.
+    """
+
+    scope_row: TScopeRow
+    role_rows: list[RoleRow]

--- a/src/ai/backend/manager/repositories/base/scope_creator.py
+++ b/src/ai/backend/manager/repositories/base/scope_creator.py
@@ -21,7 +21,7 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.permission.types import EntityType, RBACElementType, RelationType
+from ai.backend.common.data.permission.types import EntityType, RelationType
 from ai.backend.common.identifier.role_preset import RolePresetID
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
@@ -35,21 +35,10 @@ from ai.backend.manager.models.rbac_models.role_permission_preset import (
 from ai.backend.manager.models.rbac_models.role_preset import RolePresetRow
 
 from .creator import BulkCreator, Creator, CreatorSpec, execute_bulk_creator, execute_creator
+from .types import ScopeContext
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession as SASession
-
-
-@dataclass(frozen=True)
-class ScopeContext:
-    """Locator for a scope row.
-
-    Carries the ``(scope_type, scope_id)`` pair used by downstream RBAC tables
-    (``permissions``, ``association_scopes_entities``) to reference the scope.
-    """
-
-    scope_type: RBACElementType
-    scope_id: str
 
 
 class ScopeCreatorSpec[TScopeRow: Base](ABC):

--- a/src/ai/backend/manager/repositories/base/scope_creator.py
+++ b/src/ai/backend/manager/repositories/base/scope_creator.py
@@ -5,25 +5,39 @@ scope: the scope row itself (domain, project, ...), any parent-scope mapping
 rows, and roles + role-scope associations + permissions instantiated from each
 active role preset matching the scope type.
 
-The spec itself owns no table; each returned sub-spec owns exactly one table,
-preserving the per-spec single-table rule. Orchestration lives in
-:meth:`ScopeWriteOps.create_scope`.
+``ScopeCreator`` extends :class:`Creator`: its inherited ``spec`` builds the scope
+row (so the insert is delegated to ``execute_creator``), while ``scope_spec`` (a
+:class:`ScopeCreatorSpec`) supplies the scope-extension hooks. Orchestration of the
+surrounding RBAC rows lives in :func:`execute_scope_creator`.
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
-from dataclasses import dataclass
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+from uuid import UUID
 
-from ai.backend.common.data.permission.types import RBACElementType
+import sqlalchemy as sa
+
+from ai.backend.common.data.permission.types import EntityType, RBACElementType, RelationType
+from ai.backend.common.identifier.role_preset import RolePresetID
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
 )
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.models.rbac_models.role_permission_preset import (
+    RolePermissionPresetRow,
+)
+from ai.backend.manager.models.rbac_models.role_preset import RolePresetRow
 
-from .creator import CreatorSpec
+from .creator import BulkCreator, Creator, CreatorSpec, execute_bulk_creator, execute_creator
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
 
 @dataclass(frozen=True)
@@ -39,16 +53,12 @@ class ScopeContext:
 
 
 class ScopeCreatorSpec[TScopeRow: Base](ABC):
-    """Coordinator for ``scope row + parent-scope association rows``.
+    """Scope-extension hooks for a scope type.
 
     Subclass per scope type (e.g. ``DomainScopeCreatorSpec``,
-    ``ProjectScopeCreatorSpec``). Each returned sub-spec owns exactly one table.
+    ``ProjectScopeCreatorSpec``). Owns no table and does not build the scope row; it
+    derives the new scope's context and declares its pre-existing parent scope(s).
     """
-
-    @abstractmethod
-    def scope_spec(self) -> CreatorSpec[TScopeRow]:
-        """Single-table spec for the scope row."""
-        raise NotImplementedError
 
     @abstractmethod
     def extract_scope_context(self, scope_row: TScopeRow) -> ScopeContext:
@@ -60,22 +70,27 @@ class ScopeCreatorSpec[TScopeRow: Base](ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def parent_association_specs(
-        self,
-        scope_row: TScopeRow,
-    ) -> Sequence[CreatorSpec[AssociationScopesEntitiesRow]]:
-        """Parent-scope mapping rows (e.g. project under domain).
+    def parent_scopes(self) -> Iterable[ScopeContext]:
+        """Pre-existing parent scope(s) the new scope should be mapped under.
 
-        Return ``[]`` if the scope type has no parent.
+        Held by this spec (set at construction), independent of the new scope. The
+        orchestrator builds one parent-to-new-scope association row per returned
+        scope.
         """
         raise NotImplementedError
 
 
 @dataclass
-class ScopeCreator[TScopeRow: Base]:
-    """Bundles a scope-creator spec for ``ScopeWriteOps.create_scope``."""
+class ScopeCreator[TScopeRow: Base](Creator[TScopeRow]):
+    """Bundles the scope-row creator spec and its scope hooks for
+    :func:`execute_scope_creator`.
 
-    spec: ScopeCreatorSpec[TScopeRow]
+    Extends :class:`Creator`: the inherited ``spec`` builds the scope row (insert
+    delegated to ``execute_creator``); ``scope_spec`` supplies the scope-extension
+    hooks.
+    """
+
+    scope_spec: ScopeCreatorSpec[TScopeRow]
 
 
 @dataclass
@@ -90,3 +105,165 @@ class ScopeCreatorResult[TScopeRow: Base]:
 
     scope_row: TScopeRow
     role_rows: list[RoleRow]
+
+
+@dataclass(frozen=True)
+class _RoleCreatorSpec(CreatorSpec[RoleRow]):
+    """Insert a role row as a shallow snapshot of a role preset."""
+
+    name: str
+
+    def build_row(self) -> RoleRow:
+        return RoleRow(name=self.name)
+
+
+@dataclass(frozen=True)
+class _PresetPermissionCreatorSpec(CreatorSpec[PermissionRow]):
+    """Insert a permission row snapshotted from a ``role_permission_presets`` entry.
+
+    Built after the owning role row has been flushed, so ``role_id`` is known.
+    """
+
+    scope_context: ScopeContext
+    role_id: UUID
+    permission_preset: RolePermissionPresetRow
+
+    def build_row(self) -> PermissionRow:
+        return PermissionRow(
+            role_id=self.role_id,
+            scope_type=self.scope_context.scope_type.to_scope_type(),
+            scope_id=self.scope_context.scope_id,
+            entity_type=self.permission_preset.entity_type,
+            operation=self.permission_preset.operation,
+        )
+
+
+@dataclass(frozen=True)
+class _RoleScopeAssociationSpec(CreatorSpec[AssociationScopesEntitiesRow]):
+    """Insert the association_scopes_entities row tying a role to its scope."""
+
+    role_id: UUID
+    scope_context: ScopeContext
+
+    def build_row(self) -> AssociationScopesEntitiesRow:
+        return AssociationScopesEntitiesRow(
+            scope_type=self.scope_context.scope_type.to_scope_type(),
+            scope_id=self.scope_context.scope_id,
+            entity_type=EntityType.ROLE,
+            entity_id=str(self.role_id),
+            relation_type=RelationType.AUTO,
+        )
+
+
+@dataclass(frozen=True)
+class _ParentScopeAssociationSpec(CreatorSpec[AssociationScopesEntitiesRow]):
+    """Insert the association_scopes_entities row tying a scope to its parent scope."""
+
+    child_scope_context: ScopeContext
+    parent_scope_context: ScopeContext
+
+    def build_row(self) -> AssociationScopesEntitiesRow:
+        return AssociationScopesEntitiesRow(
+            scope_type=self.parent_scope_context.scope_type.to_scope_type(),
+            scope_id=self.parent_scope_context.scope_id,
+            entity_type=self.child_scope_context.scope_type.to_entity_type(),
+            entity_id=self.child_scope_context.scope_id,
+            relation_type=RelationType.AUTO,
+        )
+
+
+@dataclass(frozen=True)
+class _PresetRoleGroup:
+    """An active role preset with its permission preset entries, grouped per preset."""
+
+    role_name: str
+    permission_presets: list[RolePermissionPresetRow] = field(default_factory=list)
+
+
+async def _collect_preset_groups(
+    db_sess: SASession,
+    scope_context: ScopeContext,
+) -> list[_PresetRoleGroup]:
+    """Fetch active role presets matching the scope, grouped with their permissions.
+
+    One ``LEFT OUTER JOIN`` between ``role_presets`` and ``role_permission_presets``
+    is issued; the returned ``(preset, permission_preset_or_None)`` rows are grouped
+    by preset id in Python.
+    """
+    rows = await db_sess.execute(
+        sa.select(RolePresetRow, RolePermissionPresetRow)
+        .select_from(RolePresetRow)
+        .outerjoin(
+            RolePermissionPresetRow,
+            RolePermissionPresetRow.role_preset_id == RolePresetRow.id,
+        )
+        .where(
+            RolePresetRow.scope_type == scope_context.scope_type.to_scope_type(),
+            RolePresetRow.deleted.is_(False),
+        )
+    )
+
+    groups_by_id: dict[RolePresetID, _PresetRoleGroup] = {}
+    for preset, permission_preset in rows:
+        group = groups_by_id.setdefault(preset.id, _PresetRoleGroup(role_name=preset.name))
+        if permission_preset is not None:
+            group.permission_presets.append(permission_preset)
+    return list(groups_by_id.values())
+
+
+async def execute_scope_creator[TScopeRow: Base](
+    db_sess: SASession,
+    scope_creator: ScopeCreator[TScopeRow],
+) -> ScopeCreatorResult[TScopeRow]:
+    """Provision a scope row together with its preset-derived roles, permissions,
+    and the scope's association rows.
+
+    For every active role preset (``deleted = false``) matching the new scope's
+    ``scope_type``, a role row, a role-to-scope association row, and one permission
+    row per ``role_permission_presets`` entry are inserted in the same transaction
+    as the scope row itself. The scope row insert is delegated to ``execute_creator``
+    (``ScopeCreator`` is a ``Creator``); the surrounding rows reuse
+    ``execute_bulk_creator``. Only the preset lookup is a raw read (no single-table
+    querier covers the two-table join).
+
+    The caller controls the transaction boundary (commit/rollback).
+    """
+    scope_spec = scope_creator.scope_spec
+
+    scope_res = await execute_creator(db_sess, scope_creator)
+    scope_context = scope_spec.extract_scope_context(scope_res.row)
+
+    preset_groups = await _collect_preset_groups(db_sess, scope_context)
+    role_rows = (
+        await execute_bulk_creator(
+            db_sess,
+            BulkCreator(specs=[_RoleCreatorSpec(name=g.role_name) for g in preset_groups]),
+        )
+    ).rows
+
+    permission_specs: list[CreatorSpec[PermissionRow]] = []
+    for role, group in zip(role_rows, preset_groups, strict=True):
+        for permission_preset in group.permission_presets:
+            permission_specs.append(
+                _PresetPermissionCreatorSpec(
+                    scope_context=scope_context,
+                    role_id=role.id,
+                    permission_preset=permission_preset,
+                )
+            )
+    await execute_bulk_creator(db_sess, BulkCreator(specs=permission_specs))
+
+    association_specs: list[CreatorSpec[AssociationScopesEntitiesRow]] = [
+        _RoleScopeAssociationSpec(role_id=role.id, scope_context=scope_context)
+        for role in role_rows
+    ]
+    for parent_scope in scope_spec.parent_scopes():
+        association_specs.append(
+            _ParentScopeAssociationSpec(
+                child_scope_context=scope_context,
+                parent_scope_context=parent_scope,
+            )
+        )
+    await execute_bulk_creator(db_sess, BulkCreator(specs=association_specs))
+
+    return ScopeCreatorResult(scope_row=scope_res.row, role_rows=role_rows)

--- a/src/ai/backend/manager/repositories/base/scope_purger.py
+++ b/src/ai/backend/manager/repositories/base/scope_purger.py
@@ -1,9 +1,10 @@
 """Composite spec for race-free scope teardown.
 
-Mirror of :mod:`scope_creator`. A scope-purger spec only locates the scope to
-tear down; the orchestrator runs the inverse sequence: drop scope-bound
-permission rows, drop the scope's association rows, and finally drop the scope
-row itself.
+Mirror of :mod:`scope_creator`. ``ScopePurger`` extends the generic :class:`Purger`
+(its inherited ``row_class`` / ``pk_value`` identify the scope row to delete) and
+adds the scope's :class:`ScopeContext`. :func:`execute_scope_purger` runs the
+inverse sequence: drop scope-bound permission rows, drop the scope's association
+rows, and finally drop the scope row itself.
 
 Roles are intentionally left alone — role lifecycle is independent of scope
 lifecycle, and a role may be reused or reassigned after a scope is gone.
@@ -12,54 +13,38 @@ The permission and association rows are deleted generically from the scope's
 :class:`ScopeContext`: they are written uniformly at provisioning time
 (``scope_type`` / ``scope_id`` on permissions; the scope referenced as scope or
 as entity on associations), so the inverse filter needs no per-scope-type spec.
-Orchestration lives in :meth:`ScopeWriteOps.purge_scope`.
 """
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from uuid import UUID
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
 
 from ai.backend.manager.models.base import Base
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 
+from .purger import BatchPurger, BatchPurgerSpec, Purger, execute_batch_purger, execute_purger
 from .scope_creator import ScopeContext
 
-
-class ScopePurgerSpec[TScopeRow: Base](ABC):
-    """Locator for a scope to purge along with the scope-bound RBAC rows it leaves behind.
-
-    Subclass per scope type. The orchestrator derives the permission and
-    association deletions from :meth:`scope_context`; the spec only needs to
-    identify the scope row itself.
-    """
-
-    @abstractmethod
-    def scope_row_class(self) -> type[TScopeRow]:
-        """ORM class of the scope row being purged."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def scope_pk_value(self) -> UUID | str:
-        """Primary-key value of the scope row to delete."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def scope_context(self) -> ScopeContext:
-        """``(scope_type, scope_id)`` locator for the scope-bound RBAC rows.
-
-        The orchestrator uses this to delete every permission row pinned to the
-        scope and every association row that references the scope (as scope or as
-        entity), mirroring how those rows were written at provisioning time.
-        """
-        raise NotImplementedError
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
 
 @dataclass
-class ScopePurger[TScopeRow: Base]:
-    """Bundles a scope-purger spec for ``ScopeWriteOps.purge_scope``."""
+class ScopePurger[TScopeRow: Base](Purger[TScopeRow]):
+    """Bundles a scope teardown for :func:`execute_scope_purger`.
 
-    spec: ScopePurgerSpec[TScopeRow]
+    Extends :class:`Purger`: the inherited ``row_class`` / ``pk_value`` identify the
+    scope row to delete, so the row delete is delegated to ``execute_purger``
+    directly. ``scope_context`` locates the scope-bound RBAC rows to purge first.
+    """
+
+    scope_context: ScopeContext
 
 
 @dataclass
@@ -69,3 +54,80 @@ class ScopePurgerResult[TScopeRow: Base]:
     scope_row: TScopeRow | None
     deleted_permission_count: int
     deleted_association_count: int
+
+
+@dataclass(frozen=True)
+class _ScopePermissionsPurgeSpec(BatchPurgerSpec[PermissionRow]):
+    """Select every permission row pinned to a scope, derived from its context.
+
+    Mirrors how :func:`execute_scope_creator` stamps ``scope_type`` / ``scope_id``
+    onto each permission at provisioning time.
+    """
+
+    scope_context: ScopeContext
+
+    def build_subquery(self) -> sa.sql.Select[tuple[PermissionRow]]:
+        return sa.select(PermissionRow).where(
+            PermissionRow.scope_type == self.scope_context.scope_type.to_scope_type(),
+            PermissionRow.scope_id == self.scope_context.scope_id,
+        )
+
+
+@dataclass(frozen=True)
+class _ScopeAssociationsPurgeSpec(BatchPurgerSpec[AssociationScopesEntitiesRow]):
+    """Select every association row that references a scope, as scope or as entity.
+
+    Role-to-scope rows reference the scope as the scope side; parent-scope rows
+    (e.g. a project under its domain) reference it as the entity side. Both are
+    OR-combined so a single batched delete drops the whole set.
+    """
+
+    scope_context: ScopeContext
+
+    def build_subquery(self) -> sa.sql.Select[tuple[AssociationScopesEntitiesRow]]:
+        scope_type = self.scope_context.scope_type
+        scope_id = self.scope_context.scope_id
+        return sa.select(AssociationScopesEntitiesRow).where(
+            sa.or_(
+                sa.and_(
+                    AssociationScopesEntitiesRow.scope_type == scope_type.to_scope_type(),
+                    AssociationScopesEntitiesRow.scope_id == scope_id,
+                ),
+                sa.and_(
+                    AssociationScopesEntitiesRow.entity_type == scope_type.to_entity_type(),
+                    AssociationScopesEntitiesRow.entity_id == scope_id,
+                ),
+            )
+        )
+
+
+async def execute_scope_purger[TScopeRow: Base](
+    db_sess: SASession,
+    scope_purger: ScopePurger[TScopeRow],
+) -> ScopePurgerResult[TScopeRow]:
+    """Tear down a scope and the scope-bound RBAC rows it leaves behind.
+
+    Order: scope-pinned permission rows, then association rows, then the scope row
+    itself. Roles are not touched — role lifecycle is independent of scope
+    lifecycle. The scope row delete is delegated to ``execute_purger``
+    (``ScopePurger`` is a ``Purger``); the RBAC rows reuse ``execute_batch_purger``.
+
+    The caller controls the transaction boundary (commit/rollback).
+    """
+    scope_context = scope_purger.scope_context
+
+    perm_res = await execute_batch_purger(
+        db_sess,
+        BatchPurger(spec=_ScopePermissionsPurgeSpec(scope_context=scope_context)),
+    )
+    assoc_res = await execute_batch_purger(
+        db_sess,
+        BatchPurger(spec=_ScopeAssociationsPurgeSpec(scope_context=scope_context)),
+    )
+    scope_res = await execute_purger(db_sess, scope_purger)
+
+    return ScopePurgerResult(
+        scope_row=scope_res.row if scope_res is not None else None,
+        deleted_permission_count=perm_res.deleted_count,
+        deleted_association_count=assoc_res.deleted_count,
+    )

--- a/src/ai/backend/manager/repositories/base/scope_purger.py
+++ b/src/ai/backend/manager/repositories/base/scope_purger.py
@@ -29,7 +29,7 @@ from ai.backend.manager.models.rbac_models.association_scopes_entities import (
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 
 from .purger import BatchPurger, BatchPurgerSpec, Purger, execute_batch_purger, execute_purger
-from .scope_creator import ScopeContext
+from .types import ScopeContext
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession as SASession

--- a/src/ai/backend/manager/repositories/base/scope_purger.py
+++ b/src/ai/backend/manager/repositories/base/scope_purger.py
@@ -1,0 +1,71 @@
+"""Composite spec for race-free scope teardown.
+
+Mirror of :mod:`scope_creator`. A scope-purger spec only locates the scope to
+tear down; the orchestrator runs the inverse sequence: drop scope-bound
+permission rows, drop the scope's association rows, and finally drop the scope
+row itself.
+
+Roles are intentionally left alone — role lifecycle is independent of scope
+lifecycle, and a role may be reused or reassigned after a scope is gone.
+
+The permission and association rows are deleted generically from the scope's
+:class:`ScopeContext`: they are written uniformly at provisioning time
+(``scope_type`` / ``scope_id`` on permissions; the scope referenced as scope or
+as entity on associations), so the inverse filter needs no per-scope-type spec.
+Orchestration lives in :meth:`ScopeWriteOps.purge_scope`.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from uuid import UUID
+
+from ai.backend.manager.models.base import Base
+
+from .scope_creator import ScopeContext
+
+
+class ScopePurgerSpec[TScopeRow: Base](ABC):
+    """Locator for a scope to purge along with the scope-bound RBAC rows it leaves behind.
+
+    Subclass per scope type. The orchestrator derives the permission and
+    association deletions from :meth:`scope_context`; the spec only needs to
+    identify the scope row itself.
+    """
+
+    @abstractmethod
+    def scope_row_class(self) -> type[TScopeRow]:
+        """ORM class of the scope row being purged."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def scope_pk_value(self) -> UUID | str:
+        """Primary-key value of the scope row to delete."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def scope_context(self) -> ScopeContext:
+        """``(scope_type, scope_id)`` locator for the scope-bound RBAC rows.
+
+        The orchestrator uses this to delete every permission row pinned to the
+        scope and every association row that references the scope (as scope or as
+        entity), mirroring how those rows were written at provisioning time.
+        """
+        raise NotImplementedError
+
+
+@dataclass
+class ScopePurger[TScopeRow: Base]:
+    """Bundles a scope-purger spec for ``ScopeWriteOps.purge_scope``."""
+
+    spec: ScopePurgerSpec[TScopeRow]
+
+
+@dataclass
+class ScopePurgerResult[TScopeRow: Base]:
+    """Outcome of a scope teardown."""
+
+    scope_row: TScopeRow | None
+    deleted_permission_count: int
+    deleted_association_count: int

--- a/src/ai/backend/manager/repositories/base/types.py
+++ b/src/ai/backend/manager/repositories/base/types.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.exception import BackendAIError
 
 if TYPE_CHECKING:
@@ -18,6 +19,18 @@ if TYPE_CHECKING:
 
 # QueryCondition now returns a ColumnElement (whereclause) instead of modifying stmt
 type QueryCondition = Callable[[], sa.sql.expression.ColumnElement[bool]]
+
+
+@dataclass(frozen=True)
+class ScopeContext:
+    """Locator for a scope row.
+
+    Carries the ``(scope_type, scope_id)`` pair used by downstream RBAC tables
+    (``permissions``, ``association_scopes_entities``) to reference the scope.
+    """
+
+    scope_type: RBACElementType
+    scope_id: str
 
 
 T = TypeVar("T")

--- a/src/ai/backend/manager/repositories/ops/provider.py
+++ b/src/ai/backend/manager/repositories/ops/provider.py
@@ -10,30 +10,16 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
-from uuid import UUID
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.permission.types import EntityType, RelationType
-from ai.backend.common.identifier.role_preset import RolePresetID
 from ai.backend.manager.errors.repository import EmptySearchScopeError
 from ai.backend.manager.models.base import Base
-from ai.backend.manager.models.rbac_models.association_scopes_entities import (
-    AssociationScopesEntitiesRow,
-)
-from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
-from ai.backend.manager.models.rbac_models.role import RoleRow
-from ai.backend.manager.models.rbac_models.role_permission_preset import (
-    RolePermissionPresetRow,
-)
-from ai.backend.manager.models.rbac_models.role_preset import RolePresetRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base import (
     BatchPurger,
     BatchPurgerResult,
-    BatchPurgerSpec,
     BatchQuerier,
     BatchQuerierResult,
     BatchUpdater,
@@ -45,18 +31,12 @@ from ai.backend.manager.repositories.base import (
     BulkUpdaterResult,
     Creator,
     CreatorResult,
-    CreatorSpec,
     DependentCreatorSpec,
     NextValuePolicy,
     Purger,
     PurgerResult,
     Querier,
     QuerierResult,
-    ScopeContext,
-    ScopeCreator,
-    ScopeCreatorResult,
-    ScopePurger,
-    ScopePurgerResult,
     SearchScope,
     Updater,
     UpdaterResult,
@@ -78,86 +58,20 @@ from ai.backend.manager.repositories.base import (
     execute_updater,
     execute_upserter,
 )
+from ai.backend.manager.repositories.base.scope_creator import (
+    ScopeCreator,
+    ScopeCreatorResult,
+    execute_scope_creator,
+)
+from ai.backend.manager.repositories.base.scope_purger import (
+    ScopePurger,
+    ScopePurgerResult,
+    execute_scope_purger,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import Row
     from sqlalchemy.ext.asyncio import AsyncSession as SASession
-
-
-@dataclass(frozen=True)
-class _RoleScopeAssociationSpec(CreatorSpec[AssociationScopesEntitiesRow]):
-    """Insert the association_scopes_entities row tying a role to its scope."""
-
-    role_id: UUID
-    scope_context: ScopeContext
-
-    def build_row(self) -> AssociationScopesEntitiesRow:
-        return AssociationScopesEntitiesRow(
-            scope_type=self.scope_context.scope_type.to_scope_type(),
-            scope_id=self.scope_context.scope_id,
-            entity_type=EntityType.ROLE,
-            entity_id=str(self.role_id),
-            relation_type=RelationType.AUTO,
-        )
-
-
-@dataclass(frozen=True)
-class _ScopePermissionsPurgeSpec(BatchPurgerSpec[PermissionRow]):
-    """Select every permission row pinned to a scope, derived from its context.
-
-    Mirrors how :meth:`ScopeWriteOps._collect_role_entries_for_scope_type` stamps
-    ``scope_type`` / ``scope_id`` onto each permission at provisioning time.
-    """
-
-    scope_context: ScopeContext
-
-    def build_subquery(self) -> sa.sql.Select[tuple[PermissionRow]]:
-        return sa.select(PermissionRow).where(
-            PermissionRow.scope_type == self.scope_context.scope_type.to_scope_type(),
-            PermissionRow.scope_id == self.scope_context.scope_id,
-        )
-
-
-@dataclass(frozen=True)
-class _ScopeAssociationsPurgeSpec(BatchPurgerSpec[AssociationScopesEntitiesRow]):
-    """Select every association row that references a scope, as scope or as entity.
-
-    Role-to-scope rows reference the scope as the scope side; parent-scope rows
-    (e.g. a project under its domain) reference it as the entity side. Both are
-    OR-combined so a single batched delete drops the whole set.
-    """
-
-    scope_context: ScopeContext
-
-    def build_subquery(self) -> sa.sql.Select[tuple[AssociationScopesEntitiesRow]]:
-        scope_type = self.scope_context.scope_type
-        scope_id = self.scope_context.scope_id
-        return sa.select(AssociationScopesEntitiesRow).where(
-            sa.or_(
-                sa.and_(
-                    AssociationScopesEntitiesRow.scope_type == scope_type.to_scope_type(),
-                    AssociationScopesEntitiesRow.scope_id == scope_id,
-                ),
-                sa.and_(
-                    AssociationScopesEntitiesRow.entity_type == scope_type.to_entity_type(),
-                    AssociationScopesEntitiesRow.entity_id == scope_id,
-                ),
-            )
-        )
-
-
-@dataclass(frozen=True)
-class _RoleEntry:
-    """A role row and its permission rows derived from a role preset.
-
-    Both rows are pre-built (without ``role_id`` on the permissions) by the
-    collector. The orchestrator adds the role row to the session, lets the
-    flush populate ``role.id``, then back-fills that id onto every permission
-    row before adding them.
-    """
-
-    role: RoleRow
-    permissions: list[PermissionRow]
 
 
 class ReadOps:
@@ -305,6 +219,29 @@ class WriteOps(ReadOps):
         """Delete multiple rows individually, isolating each via a savepoint for partial success."""
         return await execute_bulk_purger_partial(self._sess, purgers)
 
+    async def create_scope[TScopeRow: Base](
+        self,
+        creator: ScopeCreator[TScopeRow],
+    ) -> ScopeCreatorResult[TScopeRow]:
+        """Provision a scope row together with its preset-derived roles, permissions,
+        and the scope's association rows, in this single transaction.
+
+        Orchestration lives in :func:`execute_scope_creator`; this method only binds
+        it to the session.
+        """
+        return await execute_scope_creator(self._sess, creator)
+
+    async def purge_scope[TScopeRow: Base](
+        self,
+        purger: ScopePurger[TScopeRow],
+    ) -> ScopePurgerResult[TScopeRow]:
+        """Tear down a scope and the scope-bound RBAC rows it leaves behind.
+
+        Orchestration lives in :func:`execute_scope_purger`; this method only binds
+        it to the session.
+        """
+        return await execute_scope_purger(self._sess, purger)
+
     @asynccontextmanager
     async def savepoint(self) -> AsyncIterator[WriteOps]:
         """Open a nested transaction (savepoint) bound to the same session.
@@ -316,180 +253,11 @@ class WriteOps(ReadOps):
             yield WriteOps(self._sess)
 
 
-class ScopeWriteOps:
-    """Scope lifecycle write operations bound to a single session.
-
-    Owns the scope provisioning / teardown orchestration that touches multiple
-    RBAC tables (role presets, roles, permissions, association_scopes_entities,
-    and the scope row itself). Generic single-table ops live on
-    :class:`WriteOps`; this class is a sibling, not a subclass.
-    """
-
-    _sess: SASession
-
-    def __init__(self, sess: SASession) -> None:
-        self._sess = sess
-
-    async def _collect_role_entries_for_scope_type(
-        self,
-        scope_context: ScopeContext,
-    ) -> list[_RoleEntry]:
-        """Fetch active role presets matching the scope and build the role and
-        permission rows snapshotted from each preset.
-
-        One ``LEFT OUTER JOIN`` between ``role_presets`` and
-        ``role_permission_presets`` is issued; the returned ``(preset,
-        permission_preset_or_None)`` rows are grouped by preset id in Python.
-        """
-        rows = await self._sess.execute(
-            sa.select(RolePresetRow, RolePermissionPresetRow)
-            .select_from(RolePresetRow)
-            .outerjoin(
-                RolePermissionPresetRow,
-                RolePermissionPresetRow.role_preset_id == RolePresetRow.id,
-            )
-            .where(
-                RolePresetRow.scope_type == scope_context.scope_type.to_scope_type(),
-                RolePresetRow.deleted.is_(False),
-            )
-        )
-
-        entries_by_id: dict[RolePresetID, _RoleEntry] = {}
-        for preset, permission_preset in rows:
-            entry = entries_by_id.setdefault(
-                preset.id,
-                _RoleEntry(role=RoleRow(name=preset.name), permissions=[]),
-            )
-            if permission_preset is not None:
-                # ``role_id`` is left unset; it is back-filled after the owning
-                # role row is flushed.
-                entry.permissions.append(
-                    PermissionRow(
-                        scope_type=scope_context.scope_type.to_scope_type(),
-                        scope_id=scope_context.scope_id,
-                        entity_type=permission_preset.entity_type,
-                        operation=permission_preset.operation,
-                    )
-                )
-        return list(entries_by_id.values())
-
-    async def _create_preset_derived_roles_and_permissions(
-        self,
-        role_entries: list[_RoleEntry],
-    ) -> list[RoleRow]:
-        """Persist the pre-built role rows and their permission rows.
-
-        Returned ``role_rows`` order matches ``role_entries``. Permission rows
-        are inserted in the same transaction but are not returned.
-        """
-        if not role_entries:
-            return []
-
-        role_rows = [e.role for e in role_entries]
-        self._sess.add_all(role_rows)
-        await self._sess.flush()
-
-        permission_rows: list[PermissionRow] = []
-        for entry in role_entries:
-            for permission in entry.permissions:
-                permission.role_id = entry.role.id
-                permission_rows.append(permission)
-        if permission_rows:
-            self._sess.add_all(permission_rows)
-            await self._sess.flush()
-        return role_rows
-
-    async def _create_scope_associations(
-        self,
-        role_rows: list[RoleRow],
-        parent_association_specs: Sequence[CreatorSpec[AssociationScopesEntitiesRow]],
-        scope_context: ScopeContext,
-    ) -> None:
-        """Insert the scope's association_scopes_entities rows in one bulk call.
-
-        Bundles two distinct kinds of mapping into a single insert: role-to-scope
-        rows derived from ``role_rows`` and parent-scope mapping rows supplied
-        by the scope creator spec.
-        """
-        role_scope_assoc_specs = [
-            _RoleScopeAssociationSpec(role_id=r.id, scope_context=scope_context) for r in role_rows
-        ]
-        association_specs = role_scope_assoc_specs + list(parent_association_specs)
-        if not association_specs:
-            return
-        await execute_bulk_creator(
-            self._sess,
-            BulkCreator(specs=association_specs),
-        )
-
-    async def create_scope[TScopeRow: Base](
-        self,
-        creator: ScopeCreator[TScopeRow],
-    ) -> ScopeCreatorResult[TScopeRow]:
-        """Provision a scope row together with its preset-derived roles and
-        the scope's association rows.
-
-        For every active role preset (``deleted = false``) matching the new
-        scope's ``scope_type``, a role row, a role-to-scope association row,
-        and one permission row per ``role_permission_presets`` entry are
-        inserted in the same transaction as the scope row itself.
-        """
-        spec = creator.spec
-
-        scope_res = await execute_creator(self._sess, Creator(spec=spec.scope_spec()))
-        scope_context = spec.extract_scope_context(scope_res.row)
-
-        role_entries = await self._collect_role_entries_for_scope_type(scope_context)
-        role_rows = await self._create_preset_derived_roles_and_permissions(role_entries)
-        await self._create_scope_associations(
-            role_rows,
-            spec.parent_association_specs(scope_res.row),
-            scope_context,
-        )
-
-        return ScopeCreatorResult(scope_row=scope_res.row, role_rows=role_rows)
-
-    async def purge_scope[TScopeRow: Base](
-        self,
-        purger: ScopePurger[TScopeRow],
-    ) -> ScopePurgerResult[TScopeRow]:
-        """Tear down a scope and the scope-bound RBAC rows it leaves behind.
-
-        Order: scope-pinned permission rows, then association rows, then the scope
-        row itself. Roles are not touched — role lifecycle is independent of scope
-        lifecycle.
-        """
-        spec = purger.spec
-        sess = self._sess
-        scope_context = spec.scope_context()
-
-        perm_res = await execute_batch_purger(
-            sess,
-            BatchPurger(spec=_ScopePermissionsPurgeSpec(scope_context=scope_context)),
-        )
-
-        assoc_res = await execute_batch_purger(
-            sess,
-            BatchPurger(spec=_ScopeAssociationsPurgeSpec(scope_context=scope_context)),
-        )
-
-        scope_res = await execute_purger(
-            sess,
-            Purger(row_class=spec.scope_row_class(), pk_value=spec.scope_pk_value()),
-        )
-
-        return ScopePurgerResult(
-            scope_row=scope_res.row if scope_res is not None else None,
-            deleted_permission_count=perm_res.deleted_count,
-            deleted_association_count=assoc_res.deleted_count,
-        )
-
-
 class DBOpsProvider:
     """Entry point that isolates the engine and hands out session-bound ops.
 
-    The engine is private; the only surface is ``read_ops()`` / ``write_ops()`` /
-    ``scope_write_ops()``. All three use the READ COMMITTED isolation level.
+    The engine is private; the only surface is ``read_ops()`` / ``write_ops()``.
+    Both use the READ COMMITTED isolation level.
     """
 
     _db: ExtendedAsyncSAEngine
@@ -508,9 +276,3 @@ class DBOpsProvider:
         """Open a read-write transaction and yield read-write ops."""
         async with self._db.begin_session_read_committed() as sess:
             yield WriteOps(sess)
-
-    @asynccontextmanager
-    async def scope_write_ops(self) -> AsyncIterator[ScopeWriteOps]:
-        """Open a read-write transaction and yield the scope lifecycle writer ops."""
-        async with self._db.begin_session_read_committed() as sess:
-            yield ScopeWriteOps(sess)

--- a/src/ai/backend/manager/repositories/ops/provider.py
+++ b/src/ai/backend/manager/repositories/ops/provider.py
@@ -10,16 +10,30 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+from uuid import UUID
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.permission.types import EntityType, RelationType
+from ai.backend.common.identifier.role_preset import RolePresetID
 from ai.backend.manager.errors.repository import EmptySearchScopeError
 from ai.backend.manager.models.base import Base
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
+from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.models.rbac_models.role_permission_preset import (
+    RolePermissionPresetRow,
+)
+from ai.backend.manager.models.rbac_models.role_preset import RolePresetRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base import (
     BatchPurger,
     BatchPurgerResult,
+    BatchPurgerSpec,
     BatchQuerier,
     BatchQuerierResult,
     BatchUpdater,
@@ -31,12 +45,18 @@ from ai.backend.manager.repositories.base import (
     BulkUpdaterResult,
     Creator,
     CreatorResult,
+    CreatorSpec,
     DependentCreatorSpec,
     NextValuePolicy,
     Purger,
     PurgerResult,
     Querier,
     QuerierResult,
+    ScopeContext,
+    ScopeCreator,
+    ScopeCreatorResult,
+    ScopePurger,
+    ScopePurgerResult,
     SearchScope,
     Updater,
     UpdaterResult,
@@ -62,6 +82,82 @@ from ai.backend.manager.repositories.base import (
 if TYPE_CHECKING:
     from sqlalchemy.engine import Row
     from sqlalchemy.ext.asyncio import AsyncSession as SASession
+
+
+@dataclass(frozen=True)
+class _RoleScopeAssociationSpec(CreatorSpec[AssociationScopesEntitiesRow]):
+    """Insert the association_scopes_entities row tying a role to its scope."""
+
+    role_id: UUID
+    scope_context: ScopeContext
+
+    def build_row(self) -> AssociationScopesEntitiesRow:
+        return AssociationScopesEntitiesRow(
+            scope_type=self.scope_context.scope_type.to_scope_type(),
+            scope_id=self.scope_context.scope_id,
+            entity_type=EntityType.ROLE,
+            entity_id=str(self.role_id),
+            relation_type=RelationType.AUTO,
+        )
+
+
+@dataclass(frozen=True)
+class _ScopePermissionsPurgeSpec(BatchPurgerSpec[PermissionRow]):
+    """Select every permission row pinned to a scope, derived from its context.
+
+    Mirrors how :meth:`ScopeWriteOps._build_permission_row_from_preset` stamps
+    ``scope_type`` / ``scope_id`` onto each permission at provisioning time.
+    """
+
+    scope_context: ScopeContext
+
+    def build_subquery(self) -> sa.sql.Select[tuple[PermissionRow]]:
+        return sa.select(PermissionRow).where(
+            PermissionRow.scope_type == self.scope_context.scope_type.to_scope_type(),
+            PermissionRow.scope_id == self.scope_context.scope_id,
+        )
+
+
+@dataclass(frozen=True)
+class _ScopeAssociationsPurgeSpec(BatchPurgerSpec[AssociationScopesEntitiesRow]):
+    """Select every association row that references a scope, as scope or as entity.
+
+    Role-to-scope rows reference the scope as the scope side; parent-scope rows
+    (e.g. a project under its domain) reference it as the entity side. Both are
+    OR-combined so a single batched delete drops the whole set.
+    """
+
+    scope_context: ScopeContext
+
+    def build_subquery(self) -> sa.sql.Select[tuple[AssociationScopesEntitiesRow]]:
+        scope_type = self.scope_context.scope_type
+        scope_id = self.scope_context.scope_id
+        return sa.select(AssociationScopesEntitiesRow).where(
+            sa.or_(
+                sa.and_(
+                    AssociationScopesEntitiesRow.scope_type == scope_type.to_scope_type(),
+                    AssociationScopesEntitiesRow.scope_id == scope_id,
+                ),
+                sa.and_(
+                    AssociationScopesEntitiesRow.entity_type == scope_type.to_entity_type(),
+                    AssociationScopesEntitiesRow.entity_id == scope_id,
+                ),
+            )
+        )
+
+
+@dataclass(frozen=True)
+class _RoleEntry:
+    """A role row and its permission rows derived from a role preset.
+
+    Both rows are pre-built (without ``role_id`` on the permissions) by the
+    collector. The orchestrator adds the role row to the session, lets the
+    flush populate ``role.id``, then back-fills that id onto every permission
+    row before adding them.
+    """
+
+    role: RoleRow
+    permissions: list[PermissionRow]
 
 
 class ReadOps:
@@ -220,11 +316,194 @@ class WriteOps(ReadOps):
             yield WriteOps(self._sess)
 
 
+class ScopeWriteOps:
+    """Scope lifecycle write operations bound to a single session.
+
+    Owns the scope provisioning / teardown orchestration that touches multiple
+    RBAC tables (role presets, roles, permissions, association_scopes_entities,
+    and the scope row itself). Generic single-table ops live on
+    :class:`WriteOps`; this class is a sibling, not a subclass.
+    """
+
+    _sess: SASession
+
+    def __init__(self, sess: SASession) -> None:
+        self._sess = sess
+
+    def _build_role_row_from_preset(self, preset: RolePresetRow) -> RoleRow:
+        """Build a role row as a shallow snapshot of a role preset."""
+        return RoleRow(name=preset.name)
+
+    def _build_permission_row_from_preset(
+        self,
+        preset: RolePermissionPresetRow,
+        scope_context: ScopeContext,
+    ) -> PermissionRow:
+        """Build a permission row from a role_permission_preset entry.
+
+        ``role_id`` is left unset; the orchestrator back-fills it after the
+        owning role row is flushed.
+        """
+        return PermissionRow(
+            scope_type=scope_context.scope_type.to_scope_type(),
+            scope_id=scope_context.scope_id,
+            entity_type=preset.entity_type,
+            operation=preset.operation,
+        )
+
+    async def _collect_role_entries_for_scope_type(
+        self,
+        scope_context: ScopeContext,
+    ) -> list[_RoleEntry]:
+        """Fetch active role presets matching the scope and build the role and
+        permission rows snapshotted from each preset.
+
+        One ``LEFT OUTER JOIN`` between ``role_presets`` and
+        ``role_permission_presets`` is issued; the returned ``(preset,
+        permission_preset_or_None)`` rows are grouped by preset id in Python.
+        """
+        rows = await self._sess.execute(
+            sa.select(RolePresetRow, RolePermissionPresetRow)
+            .select_from(RolePresetRow)
+            .outerjoin(
+                RolePermissionPresetRow,
+                RolePermissionPresetRow.role_preset_id == RolePresetRow.id,
+            )
+            .where(
+                RolePresetRow.scope_type == scope_context.scope_type.to_scope_type(),
+                RolePresetRow.deleted.is_(False),
+            )
+        )
+
+        entries_by_id: dict[RolePresetID, _RoleEntry] = {}
+        for preset, permission_preset in rows:
+            entry = entries_by_id.setdefault(
+                preset.id,
+                _RoleEntry(role=self._build_role_row_from_preset(preset), permissions=[]),
+            )
+            if permission_preset is not None:
+                entry.permissions.append(
+                    self._build_permission_row_from_preset(permission_preset, scope_context)
+                )
+        return list(entries_by_id.values())
+
+    async def _create_preset_derived_roles_and_permissions(
+        self,
+        role_entries: list[_RoleEntry],
+    ) -> list[RoleRow]:
+        """Persist the pre-built role rows and their permission rows.
+
+        Returned ``role_rows`` order matches ``role_entries``. Permission rows
+        are inserted in the same transaction but are not returned.
+        """
+        if not role_entries:
+            return []
+
+        role_rows = [e.role for e in role_entries]
+        self._sess.add_all(role_rows)
+        await self._sess.flush()
+
+        permission_rows: list[PermissionRow] = []
+        for entry in role_entries:
+            for permission in entry.permissions:
+                permission.role_id = entry.role.id
+                permission_rows.append(permission)
+        if permission_rows:
+            self._sess.add_all(permission_rows)
+            await self._sess.flush()
+        return role_rows
+
+    async def _create_scope_associations(
+        self,
+        role_rows: list[RoleRow],
+        parent_association_specs: Sequence[CreatorSpec[AssociationScopesEntitiesRow]],
+        scope_context: ScopeContext,
+    ) -> None:
+        """Insert the scope's association_scopes_entities rows in one bulk call.
+
+        Bundles two distinct kinds of mapping into a single insert: role-to-scope
+        rows derived from ``role_rows`` and parent-scope mapping rows supplied
+        by the scope creator spec.
+        """
+        role_scope_assoc_specs = [
+            _RoleScopeAssociationSpec(role_id=r.id, scope_context=scope_context) for r in role_rows
+        ]
+        association_specs = role_scope_assoc_specs + list(parent_association_specs)
+        if not association_specs:
+            return
+        await execute_bulk_creator(
+            self._sess,
+            BulkCreator(specs=association_specs),
+        )
+
+    async def create_scope[TScopeRow: Base](
+        self,
+        creator: ScopeCreator[TScopeRow],
+    ) -> ScopeCreatorResult[TScopeRow]:
+        """Provision a scope row together with its preset-derived roles and
+        the scope's association rows.
+
+        For every active role preset (``deleted = false``) matching the new
+        scope's ``scope_type``, a role row, a role-to-scope association row,
+        and one permission row per ``role_permission_presets`` entry are
+        inserted in the same transaction as the scope row itself.
+        """
+        spec = creator.spec
+
+        scope_res = await execute_creator(self._sess, Creator(spec=spec.scope_spec()))
+        scope_context = spec.extract_scope_context(scope_res.row)
+
+        role_entries = await self._collect_role_entries_for_scope_type(scope_context)
+        role_rows = await self._create_preset_derived_roles_and_permissions(role_entries)
+        await self._create_scope_associations(
+            role_rows,
+            spec.parent_association_specs(scope_res.row),
+            scope_context,
+        )
+
+        return ScopeCreatorResult(scope_row=scope_res.row, role_rows=role_rows)
+
+    async def purge_scope[TScopeRow: Base](
+        self,
+        purger: ScopePurger[TScopeRow],
+    ) -> ScopePurgerResult[TScopeRow]:
+        """Tear down a scope and the scope-bound RBAC rows it leaves behind.
+
+        Order: scope-pinned permission rows, then association rows, then the scope
+        row itself. Roles are not touched — role lifecycle is independent of scope
+        lifecycle.
+        """
+        spec = purger.spec
+        sess = self._sess
+        scope_context = spec.scope_context()
+
+        perm_res = await execute_batch_purger(
+            sess,
+            BatchPurger(spec=_ScopePermissionsPurgeSpec(scope_context=scope_context)),
+        )
+
+        assoc_res = await execute_batch_purger(
+            sess,
+            BatchPurger(spec=_ScopeAssociationsPurgeSpec(scope_context=scope_context)),
+        )
+
+        scope_res = await execute_purger(
+            sess,
+            Purger(row_class=spec.scope_row_class(), pk_value=spec.scope_pk_value()),
+        )
+
+        return ScopePurgerResult(
+            scope_row=scope_res.row if scope_res is not None else None,
+            deleted_permission_count=perm_res.deleted_count,
+            deleted_association_count=assoc_res.deleted_count,
+        )
+
+
 class DBOpsProvider:
     """Entry point that isolates the engine and hands out session-bound ops.
 
-    The engine is private; the only surface is ``read_ops()`` / ``write_ops()``.
-    Both use the READ COMMITTED isolation level.
+    The engine is private; the only surface is ``read_ops()`` / ``write_ops()`` /
+    ``scope_write_ops()``. All three use the READ COMMITTED isolation level.
     """
 
     _db: ExtendedAsyncSAEngine
@@ -243,3 +522,9 @@ class DBOpsProvider:
         """Open a read-write transaction and yield read-write ops."""
         async with self._db.begin_session_read_committed() as sess:
             yield WriteOps(sess)
+
+    @asynccontextmanager
+    async def scope_write_ops(self) -> AsyncIterator[ScopeWriteOps]:
+        """Open a read-write transaction and yield the scope lifecycle writer ops."""
+        async with self._db.begin_session_read_committed() as sess:
+            yield ScopeWriteOps(sess)

--- a/src/ai/backend/manager/repositories/ops/provider.py
+++ b/src/ai/backend/manager/repositories/ops/provider.py
@@ -105,7 +105,7 @@ class _RoleScopeAssociationSpec(CreatorSpec[AssociationScopesEntitiesRow]):
 class _ScopePermissionsPurgeSpec(BatchPurgerSpec[PermissionRow]):
     """Select every permission row pinned to a scope, derived from its context.
 
-    Mirrors how :meth:`ScopeWriteOps._build_permission_row_from_preset` stamps
+    Mirrors how :meth:`ScopeWriteOps._collect_role_entries_for_scope_type` stamps
     ``scope_type`` / ``scope_id`` onto each permission at provisioning time.
     """
 
@@ -330,27 +330,6 @@ class ScopeWriteOps:
     def __init__(self, sess: SASession) -> None:
         self._sess = sess
 
-    def _build_role_row_from_preset(self, preset: RolePresetRow) -> RoleRow:
-        """Build a role row as a shallow snapshot of a role preset."""
-        return RoleRow(name=preset.name)
-
-    def _build_permission_row_from_preset(
-        self,
-        preset: RolePermissionPresetRow,
-        scope_context: ScopeContext,
-    ) -> PermissionRow:
-        """Build a permission row from a role_permission_preset entry.
-
-        ``role_id`` is left unset; the orchestrator back-fills it after the
-        owning role row is flushed.
-        """
-        return PermissionRow(
-            scope_type=scope_context.scope_type.to_scope_type(),
-            scope_id=scope_context.scope_id,
-            entity_type=preset.entity_type,
-            operation=preset.operation,
-        )
-
     async def _collect_role_entries_for_scope_type(
         self,
         scope_context: ScopeContext,
@@ -379,11 +358,18 @@ class ScopeWriteOps:
         for preset, permission_preset in rows:
             entry = entries_by_id.setdefault(
                 preset.id,
-                _RoleEntry(role=self._build_role_row_from_preset(preset), permissions=[]),
+                _RoleEntry(role=RoleRow(name=preset.name), permissions=[]),
             )
             if permission_preset is not None:
+                # ``role_id`` is left unset; it is back-filled after the owning
+                # role row is flushed.
                 entry.permissions.append(
-                    self._build_permission_row_from_preset(permission_preset, scope_context)
+                    PermissionRow(
+                        scope_type=scope_context.scope_type.to_scope_type(),
+                        scope_id=scope_context.scope_id,
+                        entity_type=permission_preset.entity_type,
+                        operation=permission_preset.operation,
+                    )
                 )
         return list(entries_by_id.values())
 


### PR DESCRIPTION
## Summary

- Add `ScopeCreatorSpec` / `ScopePurgerSpec` as composite coordinators for scope provisioning and teardown. Leaf sub-specs stay single-table.
- New `RBACWriterOps` class owns `create_scope` / `purge_scope`. Provisioning inserts the scope row, snapshots a role + its permissions per active preset matching the new scope, and writes role-to-scope plus parent-scope association rows in a single transaction.
- Teardown runs the inverse: scope-bound permissions, then association rows, then the scope row. Roles are intentionally left alone — their lifecycle is independent of the scope's.

## Test plan

- [x] CI typecheck + lint

Resolves BA-6191
