### PR TITLE
feat(BA-6230): add guard hooks to Updater and BulkUpdater partial primitive

### DIFF
--- a/changes/11848.feature.md
+++ b/changes/11848.feature.md
@@ -1,0 +1,1 @@
+Add abstract `guard_condition`, `not_found_error`, `on_guard_failure` hooks to `UpdaterSpec` and an abstract `guard_condition` hook to `BatchUpdaterSpec`; introduce a `BulkUpdater` primitive with `bulk_update_partial` that executes each updater inside its own savepoint for partial success.

--- a/src/ai/backend/manager/repositories/agent/updaters.py
+++ b/src/ai/backend/manager/repositories/agent/updaters.py
@@ -6,7 +6,9 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.models.agent import AgentRow, AgentStatus
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState
 
@@ -32,3 +34,15 @@ class AgentStatusUpdaterSpec(UpdaterSpec[AgentRow]):
         }
         self.lost_at.update_dict(to_update, "lost_at")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/app_config/updaters.py
+++ b/src/ai/backend/manager/repositories/app_config/updaters.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.models.app_config import AppConfigRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState
 
@@ -32,3 +34,15 @@ class AppConfigUpdaterSpec(UpdaterSpec[AppConfigRow]):
         to_update: dict[str, Any] = {}
         self.extra_config.update_dict(to_update, "extra_config")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/artifact/updaters.py
+++ b/src/ai/backend/manager/repositories/artifact/updaters.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.models.artifact import ArtifactRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import TriState
 
@@ -28,3 +30,15 @@ class ArtifactUpdaterSpec(UpdaterSpec[ArtifactRow]):
         self.readonly.update_dict(to_update, "readonly")
         self.description.update_dict(to_update, "description")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/base/__init__.py
+++ b/src/ai/backend/manager/repositories/base/__init__.py
@@ -75,11 +75,14 @@ from .updater import (
     BatchUpdater,
     BatchUpdaterResult,
     BatchUpdaterSpec,
+    BulkUpdater,
     BulkUpdaterError,
+    BulkUpdaterPartialResult,
     Updater,
     UpdaterResult,
     UpdaterSpec,
     execute_batch_updater,
+    execute_bulk_updater_partial,
     execute_updater,
 )
 from .upserter import (
@@ -163,7 +166,10 @@ __all__ = [
     "BatchUpdaterResult",
     "execute_batch_updater",
     # BulkUpdater
+    "BulkUpdater",
     "BulkUpdaterError",
+    "BulkUpdaterPartialResult",
+    "execute_bulk_updater_partial",
     # Upserter
     "UpserterSpec",
     "Upserter",

--- a/src/ai/backend/manager/repositories/base/updater.py
+++ b/src/ai/backend/manager/repositories/base/updater.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 from uuid import UUID
 
 import sqlalchemy as sa
 from sqlalchemy.engine import CursorResult
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.errors.repository import UnsupportedCompositePrimaryKeyError
 from ai.backend.manager.models.base import Base
 
@@ -29,6 +30,11 @@ class UpdaterSpec[TRow: Base](ABC):
     Implementations specify what to update by providing:
     - row_class property for target table and PK detection
     - build_values() for column-value mapping
+
+    Optional hooks for declarative pre/postconditions:
+    - guard_condition(): an extra WHERE predicate AND-merged into the UPDATE
+    - not_found_error(): domain error raised when no row matches the PK
+    - on_guard_failure(): domain error raised when the row exists but the guard rejects
     """
 
     @property
@@ -58,6 +64,32 @@ class UpdaterSpec[TRow: Base](ABC):
         """
         return ()
 
+    @abstractmethod
+    def guard_condition(self) -> QueryCondition | None:
+        """Optional precondition AND-merged into the WHERE clause.
+
+        Implementations return ``None`` when there is no extra guard.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def not_found_error(self) -> BackendAIError | None:
+        """Error raised by the executor when no row matches the primary key.
+
+        Implementations return ``None`` to preserve the historical behaviour
+        of returning ``None`` from ``execute_updater`` on a missing row.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def on_guard_failure(self) -> BackendAIError | None:
+        """Error raised when the row exists but the guard rejects the update.
+
+        Implementations return ``None`` to make the executor return the
+        existing row data unchanged instead of raising.
+        """
+        raise NotImplementedError
+
     def apply_to_row(self, row: TRow) -> None:
         """Apply update values to a row object via setattr.
 
@@ -67,8 +99,8 @@ class UpdaterSpec[TRow: Base](ABC):
         Args:
             row: The ORM row object to apply updates to
         """
-        for field, value in self.build_values().items():
-            setattr(row, field, value)
+        for col, value in self.build_values().items():
+            setattr(row, col, value)
 
 
 class BatchUpdaterSpec[TRow: Base](ABC):
@@ -77,6 +109,7 @@ class BatchUpdaterSpec[TRow: Base](ABC):
     Implementations specify what to update by providing:
     - row_class property for target table access
     - build_values() for column-value mapping
+    - guard_condition() (optional) for an extra WHERE predicate
     """
 
     @property
@@ -103,6 +136,14 @@ class BatchUpdaterSpec[TRow: Base](ABC):
         """
         return ()
 
+    @abstractmethod
+    def guard_condition(self) -> QueryCondition | None:
+        """Optional precondition AND-merged into the WHERE clause.
+
+        Implementations return ``None`` when there is no extra guard.
+        """
+        raise NotImplementedError
+
 
 @dataclass
 class Updater[TRow: Base]:
@@ -128,6 +169,18 @@ class BatchUpdater[TRow: Base]:
 
     spec: BatchUpdaterSpec[TRow]
     conditions: list[QueryCondition]
+
+
+@dataclass
+class BulkUpdater[TRow: Base]:
+    """Bundles multiple updaters for partial-success bulk update operations.
+
+    Attributes:
+        updaters: Sequence of single-row Updater instances; each is executed
+            inside its own savepoint by ``execute_bulk_updater_partial``.
+    """
+
+    updaters: Sequence[Updater[TRow]]
 
 
 @dataclass
@@ -162,79 +215,103 @@ class BulkUpdaterError[TRow: Base]:
     index: int
 
 
+@dataclass
+class BulkUpdaterPartialResult[TRow: Base]:
+    """Result of a bulk update operation supporting partial failures.
+
+    Mirrors the BulkCreatorResultWithFailures pattern: each updater runs
+    in its own savepoint so failures are isolated and the enclosing
+    transaction stays alive.
+    """
+
+    successes: list[TRow] = field(default_factory=list)
+    errors: list[BulkUpdaterError[TRow]] = field(default_factory=list)
+
+    def success_count(self) -> int:
+        return len(self.successes)
+
+    def has_failures(self) -> bool:
+        return bool(self.errors)
+
+
 async def execute_updater[TRow: Base](
     db_sess: SASession,
     updater: Updater[TRow],
 ) -> UpdaterResult[TRow] | None:
     """Execute UPDATE for a single row by primary key.
 
+    The base WHERE clause is ``pk = :pk``; if the spec defines
+    ``guard_condition()``, that predicate is AND-merged in.
+
+    Behaviour when the UPDATE affects zero rows:
+    - Re-query the row by primary key.
+    - Not present: raise ``spec.not_found_error()`` if defined, else return ``None``
+      (existing behaviour preserved).
+    - Present (guard rejected): raise ``spec.on_guard_failure()`` if defined, else
+      return ``UpdaterResult(row=existing)``.
+
     Args:
         db_sess: Database session (must be writable)
         updater: Updater containing spec and pk_value
 
     Returns:
-        UpdaterResult containing the updated row (or the current row when there are no
-        values to update), or None only if no row matched the primary key.
-
-    Example:
-        class SessionStatusUpdaterSpec(UpdaterSpec[SessionRow]):
-            def __init__(self, new_status: str):
-                self._new_status = new_status
-
-            @property
-            def row_class(self) -> type[SessionRow]:
-                return SessionRow
-
-            def build_values(self) -> dict[str, Any]:
-                return {"status": self._new_status}
-
-        updater = Updater(
-            spec=SessionStatusUpdaterSpec("terminated"),
-            pk_value=session_id,
-        )
-        result = await execute_updater(db_sess, updater)
-        if result:
-            print(result.row.status)  # "terminated"
+        ``UpdaterResult`` with the updated row (or the existing row when there are no
+        values to update or the guard rejected). ``None`` only when the row does not
+        exist and the spec does not declare a ``not_found_error``.
     """
-    row_class = updater.spec.row_class
+    spec = updater.spec
+    row_class = spec.row_class
     table = row_class.__table__
     pk_columns = list(table.primary_key.columns)
     if len(pk_columns) != 1:
         raise UnsupportedCompositePrimaryKeyError(
             "Updater only supports single-column primary keys",
         )
-    values = updater.spec.build_values()
+    pk_col = pk_columns[0]
+    values = spec.build_values()
+    guard = spec.guard_condition()
 
     if not values:
         # No columns to update: return the current row if it exists so callers can tell
-        # "nothing to change" apart from "row not found". None means not found only.
-        existing = await db_sess.execute(
-            sa.select(row_class).where(pk_columns[0] == updater.pk_value)
-        )
+        # "nothing to change" apart from "row not found".
+        existing = await db_sess.execute(sa.select(row_class).where(pk_col == updater.pk_value))
         current_row = existing.scalar_one_or_none()
-        return UpdaterResult(row=current_row) if current_row is not None else None
+        if current_row is None:
+            not_found = spec.not_found_error()
+            if not_found is not None:
+                raise not_found
+            return None
+        return UpdaterResult(row=current_row)
+
+    where_conditions: list[sa.sql.expression.ColumnElement[bool]] = [pk_col == updater.pk_value]
+    if guard is not None:
+        where_conditions.append(guard())
 
     update_stmt = (
-        sa.update(table)
-        .values(values)
-        .where(pk_columns[0] == updater.pk_value)
-        .returning(*table.columns)
+        sa.update(table).values(values).where(sa.and_(*where_conditions)).returning(*table.columns)
     )
-
-    # Use from_statement to properly construct ORM objects
-    # This allows SQLAlchemy to handle column mapping correctly
     select_stmt = sa.select(row_class).from_statement(update_stmt)
     try:
         result = await db_sess.execute(select_stmt)
     except sa.exc.IntegrityError as e:
         parsed = parse_integrity_error(e)
-        match_integrity_error(parsed, updater.spec.integrity_error_checks)
+        match_integrity_error(parsed, spec.integrity_error_checks)
     updated_row = result.scalar_one_or_none()
+    if updated_row is not None:
+        return UpdaterResult(row=updated_row)
 
-    if updated_row is None:
+    # Zero rows updated — distinguish missing row from guard rejection.
+    check = await db_sess.execute(sa.select(row_class).where(pk_col == updater.pk_value))
+    existing_row = check.scalar_one_or_none()
+    if existing_row is None:
+        not_found = spec.not_found_error()
+        if not_found is not None:
+            raise not_found
         return None
-
-    return UpdaterResult(row=updated_row)
+    guard_failure = spec.on_guard_failure()
+    if guard_failure is not None:
+        raise guard_failure
+    return UpdaterResult(row=existing_row)
 
 
 async def execute_batch_updater[TRow: Base](
@@ -243,31 +320,15 @@ async def execute_batch_updater[TRow: Base](
 ) -> BatchUpdaterResult:
     """Execute UPDATE with multiple conditions (AND combined).
 
+    The WHERE clause is the AND of ``updater.conditions`` and, when defined,
+    ``updater.spec.guard_condition()``.
+
     Args:
         db_sess: Database session (must be writable)
         updater: BatchUpdater containing spec and conditions for the batch update
 
     Returns:
         BatchUpdaterResult with count of updated rows
-
-    Example:
-        class ItemStatusBatchUpdaterSpec(BatchUpdaterSpec[ItemRow]):
-            def __init__(self, new_status: str):
-                self._new_status = new_status
-
-            @property
-            def row_class(self) -> type[ItemRow]:
-                return ItemRow
-
-            def build_values(self) -> dict[str, Any]:
-                return {"status": self._new_status}
-
-        updater = BatchUpdater(
-            spec=ItemStatusBatchUpdaterSpec("processed"),
-            conditions=[lambda: ItemRow.__table__.c.status == "pending"],
-        )
-        result = await execute_batch_updater(db_sess, updater)
-        print(result.updated_count)  # N
     """
     spec = updater.spec
     row_class = spec.row_class
@@ -277,10 +338,35 @@ async def execute_batch_updater[TRow: Base](
     stmt = sa.update(table).values(values)
     for condition in updater.conditions:
         stmt = stmt.where(condition())
+    guard = spec.guard_condition()
+    if guard is not None:
+        stmt = stmt.where(guard())
 
     try:
         result = await db_sess.execute(stmt)
     except sa.exc.IntegrityError as e:
         parsed = parse_integrity_error(e)
-        match_integrity_error(parsed, updater.spec.integrity_error_checks)
+        match_integrity_error(parsed, spec.integrity_error_checks)
     return BatchUpdaterResult(updated_count=cast(CursorResult[Any], result).rowcount)
+
+
+async def execute_bulk_updater_partial[TRow: Base](
+    db_sess: SASession,
+    bulk: BulkUpdater[TRow],
+) -> BulkUpdaterPartialResult[TRow]:
+    """Execute each updater in its own savepoint, collecting successes and failures.
+
+    Mirrors ``execute_bulk_creator_partial``: a failure in one updater (integrity
+    violation, guard error, missing row error) is recorded against that updater
+    and does not abort the enclosing transaction.
+    """
+    partial: BulkUpdaterPartialResult[TRow] = BulkUpdaterPartialResult()
+    for index, updater in enumerate(bulk.updaters):
+        try:
+            async with db_sess.begin_nested():
+                result = await execute_updater(db_sess, updater)
+                if result is not None:
+                    partial.successes.append(result.row)
+        except Exception as exc:
+            partial.errors.append(BulkUpdaterError(spec=updater.spec, exception=exc, index=index))
+    return partial

--- a/src/ai/backend/manager/repositories/container_registry/updaters.py
+++ b/src/ai/backend/manager/repositories/container_registry/updaters.py
@@ -7,7 +7,9 @@ from dataclasses import dataclass, field
 from typing import Any, override
 
 from ai.backend.common.container_registry import AllowedGroupsModel, ContainerRegistryType
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -56,3 +58,15 @@ class ContainerRegistryUpdaterSpec(UpdaterSpec[ContainerRegistryRow]):
         self.extra.update_dict(to_update, "extra")
         # Note: allowed_groups is handled separately in the repository method
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/deployment/creators/deployment.py
+++ b/src/ai/backend/manager/repositories/deployment/creators/deployment.py
@@ -23,6 +23,7 @@ from ai.backend.manager.data.deployment.types import (
 )
 from ai.backend.manager.models.endpoint import EndpointLifecycle, EndpointRow
 from ai.backend.manager.repositories.base import CreatorSpec
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import BatchUpdaterSpec
 
 # ========== Field groups for DeploymentCreatorSpec ==========
@@ -196,3 +197,7 @@ class EndpointLifecycleBatchUpdaterSpec(BatchUpdaterSpec[EndpointRow]):
         if self.scaling_state is not None:
             values["scaling_state"] = self.scaling_state
         return values
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None

--- a/src/ai/backend/manager/repositories/deployment/creators/route.py
+++ b/src/ai/backend/manager/repositories/deployment/creators/route.py
@@ -17,6 +17,7 @@ from ai.backend.manager.data.deployment.types import (
 )
 from ai.backend.manager.models.routing import RoutingRow
 from ai.backend.manager.repositories.base import CreatorSpec
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import BatchUpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -83,3 +84,7 @@ class RouteBatchUpdaterSpec(BatchUpdaterSpec[RoutingRow]):
         self.traffic_status.update_dict(values, "traffic_status")
         self.sub_status.update_dict(values, "sub_status")
         return values
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None

--- a/src/ai/backend/manager/repositories/deployment/updaters.py
+++ b/src/ai/backend/manager/repositories/deployment/updaters.py
@@ -8,6 +8,7 @@ from typing import Any, override
 from uuid import UUID
 
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
+from ai.backend.common.exception import BackendAIError
 from ai.backend.common.types import AutoScalingMetricComparator, AutoScalingMetricSource
 from ai.backend.manager.data.deployment.types import RouteStatus, RouteTrafficStatus
 from ai.backend.manager.models.deployment_auto_scaling_policy import (
@@ -20,6 +21,7 @@ from ai.backend.manager.models.deployment_policy import (
 )
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.routing import RoutingRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -49,6 +51,18 @@ class DeploymentMetadataUpdaterSpec(UpdaterSpec[EndpointRow]):
         self.tag.update_dict(to_update, "tag")
         return to_update
 
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
+
 
 @dataclass
 class ReplicaSpecUpdaterSpec(UpdaterSpec[EndpointRow]):
@@ -67,6 +81,18 @@ class ReplicaSpecUpdaterSpec(UpdaterSpec[EndpointRow]):
         # Use the actual database column names
         self.replica_count.update_dict(to_update, "replicas")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
 
 
 @dataclass
@@ -88,6 +114,18 @@ class DeploymentNetworkSpecUpdaterSpec(UpdaterSpec[EndpointRow]):
         self.url.update_dict(to_update, "url")
         return to_update
 
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
+
 
 @dataclass
 class MountUpdaterSpec(UpdaterSpec[EndpointRow]):
@@ -105,6 +143,18 @@ class MountUpdaterSpec(UpdaterSpec[EndpointRow]):
         to_update: dict[str, Any] = {}
         self.model_vfolder_id.update_dict(to_update, "model_vfolder_id")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
 
 
 @dataclass
@@ -136,6 +186,18 @@ class DeploymentUpdaterSpec(UpdaterSpec[EndpointRow]):
         if self.mount:
             to_update.update(self.mount.build_values())
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
 
 
 @dataclass
@@ -181,6 +243,18 @@ class DeploymentAutoScalingPolicyUpdaterSpec(UpdaterSpec[DeploymentAutoScalingPo
         self.cooldown_seconds.update_dict(to_update, "cooldown_seconds")
         return to_update
 
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
+
 
 @dataclass
 class DeploymentPolicyUpdaterSpec(UpdaterSpec[DeploymentPolicyRow]):
@@ -212,6 +286,18 @@ class DeploymentPolicyUpdaterSpec(UpdaterSpec[DeploymentPolicyRow]):
             to_update["strategy_spec"] = spec_value.model_dump()
         return to_update
 
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
+
 
 @dataclass
 class RouteStatusUpdaterSpec(UpdaterSpec[RoutingRow]):
@@ -237,6 +323,18 @@ class RouteStatusUpdaterSpec(UpdaterSpec[RoutingRow]):
         self.traffic_status.update_dict(to_update, "traffic_status")
         return to_update
 
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
+
 
 @dataclass
 class RouteSessionUpdaterSpec(UpdaterSpec[RoutingRow]):
@@ -258,6 +356,18 @@ class RouteSessionUpdaterSpec(UpdaterSpec[RoutingRow]):
             "session": self.session,
             "status": RouteStatus.PROVISIONING,
         }
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
 
 
 @dataclass
@@ -294,3 +404,15 @@ class RouteUpdaterSpec(UpdaterSpec[RoutingRow]):
         self.revision.update_dict(to_update, "revision")
         self.error_data.update_dict(to_update, "error_data")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/deployment_revision_preset/updaters.py
+++ b/src/ai/backend/manager/repositories/deployment_revision_preset/updaters.py
@@ -6,9 +6,11 @@ from typing import Any, override
 
 from ai.backend.common.config import ModelDefinition
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.models.base import ResourceOptsEntry
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
 from ai.backend.manager.models.deployment_revision_preset.types import PresetValueEntry
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -71,3 +73,15 @@ class DeploymentRevisionPresetUpdaterSpec(UpdaterSpec[DeploymentRevisionPresetRo
         self.deployment_strategy.update_dict(to_update, "deployment_strategy")
         self.deployment_strategy_spec.update_dict(to_update, "deployment_strategy_spec")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/domain/updaters.py
+++ b/src/ai/backend/manager/repositories/domain/updaters.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -41,6 +43,18 @@ class DomainUpdaterSpec(UpdaterSpec[DomainRow]):
         self.integration_name.update_dict(to_update, "integration_id")
         return to_update
 
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
+
 
 @dataclass
 class DomainNodeUpdaterSpec(UpdaterSpec[DomainRow]):
@@ -75,3 +89,15 @@ class DomainNodeUpdaterSpec(UpdaterSpec[DomainRow]):
         self.integration_name.update_dict(to_update, "integration_id")
         self.dotfiles.update_dict(to_update, "dotfiles")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/group/updaters.py
+++ b/src/ai/backend/manager/repositories/group/updaters.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.models.group import GroupRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -48,3 +50,15 @@ class GroupUpdaterSpec(UpdaterSpec[GroupRow]):
         self.resource_policy.update_dict(to_update, "resource_policy")
         self.container_registry.update_dict(to_update, "container_registry")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/huggingface_registry/updaters.py
+++ b/src/ai/backend/manager/repositories/huggingface_registry/updaters.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.models.huggingface_registry import HuggingFaceRegistryRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState
 
@@ -28,3 +30,15 @@ class HuggingFaceRegistryUpdaterSpec(UpdaterSpec[HuggingFaceRegistryRow]):
         self.url.update_dict(to_update, "url")
         self.token.update_dict(to_update, "token")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/image/updaters.py
+++ b/src/ai/backend/manager/repositories/image/updaters.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.models.image import ImageRow, ImageType
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -52,3 +54,15 @@ class ImageUpdaterSpec(UpdaterSpec[ImageRow]):
         self.accelerators.update_dict(to_update, "accelerators")
         self.resources.update_dict(to_update, "resources")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/keypair/updaters.py
+++ b/src/ai/backend/manager/repositories/keypair/updaters.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.models.keypair.row import KeyPairRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -33,6 +35,18 @@ class KeyPairUpdaterSpec(UpdaterSpec[KeyPairRow]):
         self.rate_limit.update_dict(to_update, "rate_limit")
         return to_update
 
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
+
 
 @dataclass
 class KeyPairSSHUpdaterSpec(UpdaterSpec[KeyPairRow]):
@@ -56,3 +70,15 @@ class KeyPairSSHUpdaterSpec(UpdaterSpec[KeyPairRow]):
         self.ssh_public_key.update_dict(to_update, "ssh_public_key")
         self.ssh_private_key.update_dict(to_update, "ssh_private_key")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/keypair_resource_policy/updaters.py
+++ b/src/ai/backend/manager/repositories/keypair_resource_policy/updaters.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.common.types import DefaultForUnspecified, ResourceSlot
 from ai.backend.manager.models.resource_policy import KeyPairResourcePolicyRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -55,3 +57,15 @@ class KeyPairResourcePolicyUpdaterSpec(UpdaterSpec["KeyPairResourcePolicyRow"]):
         self.max_session_lifetime.update_dict(to_update, "max_session_lifetime")
         self.total_resource_slots.update_dict(to_update, "total_resource_slots")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/login_client_type/updaters.py
+++ b/src/ai/backend/manager/repositories/login_client_type/updaters.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.models.login_client_type.row import LoginClientTypeRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -28,3 +30,15 @@ class LoginClientTypeUpdaterSpec(UpdaterSpec[LoginClientTypeRow]):
         self.name.update_dict(to_update, "name")
         self.description.update_dict(to_update, "description")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/model_card/updaters.py
+++ b/src/ai/backend/manager/repositories/model_card/updaters.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.data.model_card.types import ResourceRequirementEntry
 from ai.backend.manager.models.model_card.row import ModelCardRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -50,3 +52,15 @@ class ModelCardUpdaterSpec(UpdaterSpec[ModelCardRow]):
         self.readme.update_dict(to_update, "readme")
         self.access_level.update_dict(to_update, "access_level")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/model_serving/updaters.py
+++ b/src/ai/backend/manager/repositories/model_serving/updaters.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.common.types import (
     AutoScalingMetricComparator,
@@ -13,6 +14,7 @@ from ai.backend.common.types import (
 )
 from ai.backend.manager.data.model_serving.modifier import ExtraMount, ImageRef
 from ai.backend.manager.models.endpoint import EndpointAutoScalingRuleRow, EndpointRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -79,6 +81,18 @@ class EndpointUpdaterSpec(UpdaterSpec[EndpointRow]):
             self.runtime_variant_id.optional_value() is not None,
         ])
 
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
+
 
 @dataclass
 class EndpointAutoScalingRuleUpdaterSpec(UpdaterSpec[EndpointAutoScalingRuleRow]):
@@ -123,3 +137,15 @@ class EndpointAutoScalingRuleUpdaterSpec(UpdaterSpec[EndpointAutoScalingRuleRow]
         self.min_replicas.update_dict(to_update, "min_replicas")
         self.max_replicas.update_dict(to_update, "max_replicas")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/notification/updaters.py
+++ b/src/ai/backend/manager/repositories/notification/updaters.py
@@ -5,7 +5,9 @@ from typing import Any, override
 
 from ai.backend.common.data.notification import WebhookSpec
 from ai.backend.common.data.notification.types import EmailSpec
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.models.notification import NotificationChannelRow, NotificationRuleRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -37,6 +39,18 @@ class NotificationChannelUpdaterSpec(UpdaterSpec[NotificationChannelRow]):
         self.enabled.update_dict(to_update, "enabled")
         return to_update
 
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
+
 
 @dataclass
 class NotificationRuleUpdaterSpec(UpdaterSpec[NotificationRuleRow]):
@@ -60,3 +74,15 @@ class NotificationRuleUpdaterSpec(UpdaterSpec[NotificationRuleRow]):
         self.message_template.update_dict(to_update, "message_template")
         self.enabled.update_dict(to_update, "enabled")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/object_storage/updaters.py
+++ b/src/ai/backend/manager/repositories/object_storage/updaters.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.models.object_storage import ObjectStorageRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -36,3 +38,15 @@ class ObjectStorageUpdaterSpec(UpdaterSpec[ObjectStorageRow]):
         self.endpoint.update_dict(to_update, "endpoint")
         self.region.update_dict(to_update, "region")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/ops/provider.py
+++ b/src/ai/backend/manager/repositories/ops/provider.py
@@ -27,6 +27,8 @@ from ai.backend.manager.repositories.base import (
     BulkCreator,
     BulkCreatorResult,
     BulkCreatorResultWithFailures,
+    BulkUpdater,
+    BulkUpdaterPartialResult,
     Creator,
     CreatorResult,
     DependentCreatorSpec,
@@ -46,6 +48,7 @@ from ai.backend.manager.repositories.base import (
     execute_bulk_creator,
     execute_bulk_creator_partial,
     execute_bulk_dependent_creator,
+    execute_bulk_updater_partial,
     execute_creator,
     execute_dependent_creator,
     execute_next_value_creator,
@@ -190,6 +193,13 @@ class WriteOps(ReadOps):
     async def batch_purge[TRow: Base](self, purger: BatchPurger[TRow]) -> BatchPurgerResult:
         """Delete rows in batches matching the purger subquery."""
         return await execute_batch_purger(self._sess, purger)
+
+    async def bulk_update_partial[TRow: Base](
+        self,
+        bulk: BulkUpdater[TRow],
+    ) -> BulkUpdaterPartialResult[TRow]:
+        """Update multiple rows, isolating each via a savepoint for partial success."""
+        return await execute_bulk_updater_partial(self._sess, bulk)
 
     @asynccontextmanager
     async def savepoint(self) -> AsyncIterator[WriteOps]:

--- a/src/ai/backend/manager/repositories/permission_controller/updaters.py
+++ b/src/ai/backend/manager/repositories/permission_controller/updaters.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any, override
 
 from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import (
     OperationType,
@@ -11,6 +12,7 @@ from ai.backend.manager.data.permission.types import (
 )
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -38,6 +40,18 @@ class RoleUpdaterSpec(UpdaterSpec[RoleRow]):
         self.description.update_dict(to_update, "description")
         return to_update
 
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
+
 
 @dataclass
 class PermissionUpdaterSpec(UpdaterSpec[PermissionRow]):
@@ -61,3 +75,15 @@ class PermissionUpdaterSpec(UpdaterSpec[PermissionRow]):
         self.entity_type.map(lambda v: v.to_entity_type()).update_dict(to_update, "entity_type")
         self.operation.update_dict(to_update, "operation")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/project_resource_policy/updaters.py
+++ b/src/ai/backend/manager/repositories/project_resource_policy/updaters.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.models.resource_policy import ProjectResourcePolicyRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState
 
@@ -30,3 +32,15 @@ class ProjectResourcePolicyUpdaterSpec(UpdaterSpec[ProjectResourcePolicyRow]):
         self.max_vfolder_size.update_dict(to_update, "max_vfolder_size")
         self.max_network_count.update_dict(to_update, "max_network_count")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/prometheus_query_preset/updaters.py
+++ b/src/ai/backend/manager/repositories/prometheus_query_preset/updaters.py
@@ -6,10 +6,12 @@ from dataclasses import dataclass, field
 from typing import Any, override
 from uuid import UUID
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.models.prometheus_query_preset.row import (
     PresetOptions,
     PrometheusQueryPresetRow,
 )
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -54,3 +56,15 @@ class PrometheusQueryPresetUpdaterSpec(UpdaterSpec[PrometheusQueryPresetRow]):
                 group_labels=group_value if group_value is not None else [],
             )
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/reservoir_registry/updaters.py
+++ b/src/ai/backend/manager/repositories/reservoir_registry/updaters.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.models.reservoir_registry import ReservoirRegistryRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState
 
@@ -32,3 +34,15 @@ class ReservoirRegistryUpdaterSpec(UpdaterSpec[ReservoirRegistryRow]):
         self.secret_key.update_dict(to_update, "secret_key")
         self.api_version.update_dict(to_update, "api_version")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/resource_preset/updaters.py
+++ b/src/ai/backend/manager/repositories/resource_preset/updaters.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.common.types import BinarySize, ResourceSlot
 from ai.backend.manager.models.resource_preset import ResourcePresetRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -33,3 +35,15 @@ class ResourcePresetUpdaterSpec(UpdaterSpec[ResourcePresetRow]):
         self.shared_memory.update_dict(to_update, "shared_memory")
         self.scaling_group_name.update_dict(to_update, "scaling_group_name")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/runtime_variant/updaters.py
+++ b/src/ai/backend/manager/repositories/runtime_variant/updaters.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.models.runtime_variant.row import RuntimeVariantRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -24,3 +26,15 @@ class RuntimeVariantUpdaterSpec(UpdaterSpec[RuntimeVariantRow]):
         self.name.update_dict(to_update, "name")
         self.description.update_dict(to_update, "description")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/runtime_variant_preset/updaters.py
+++ b/src/ai/backend/manager/repositories/runtime_variant_preset/updaters.py
@@ -7,8 +7,10 @@ from ai.backend.common.dto.manager.v2.runtime_variant_preset.types import (
     PresetTarget,
     PresetValueType,
 )
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.models.runtime_variant_preset.row import RuntimeVariantPresetRow
 from ai.backend.manager.models.runtime_variant_preset.types import UIOption
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -49,3 +51,15 @@ class RuntimeVariantPresetUpdaterSpec(UpdaterSpec[RuntimeVariantPresetRow]):
         self.display_name.update_dict(to_update, "display_name")
         self.ui_option.update_dict(to_update, "ui_option")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/scaling_group/updaters.py
+++ b/src/ai/backend/manager/repositories/scaling_group/updaters.py
@@ -12,9 +12,11 @@ from sqlalchemy import cast, func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import array as pg_array
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.data.scaling_group.types import PreemptionConfig as DataPreemptionConfig
 from ai.backend.manager.models.scaling_group import ScalingGroupOpts, ScalingGroupRow
 from ai.backend.manager.models.scaling_group.types import FairShareScalingGroupSpec
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -41,6 +43,18 @@ class ScalingGroupStatusUpdaterSpec(UpdaterSpec[ScalingGroupRow]):
         self.is_public.update_dict(to_update, "is_public")
         return to_update
 
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
+
 
 @dataclass
 class ScalingGroupMetadataUpdaterSpec(UpdaterSpec[ScalingGroupRow]):
@@ -62,6 +76,18 @@ class ScalingGroupMetadataUpdaterSpec(UpdaterSpec[ScalingGroupRow]):
         to_update: dict[str, Any] = {}
         self.description.update_dict(to_update, "description")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
 
 
 @dataclass
@@ -88,6 +114,18 @@ class ScalingGroupNetworkConfigUpdaterSpec(UpdaterSpec[ScalingGroupRow]):
         self.use_host_network.update_dict(to_update, "use_host_network")
         return to_update
 
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
+
 
 @dataclass
 class ScalingGroupDriverConfigUpdaterSpec(UpdaterSpec[ScalingGroupRow]):
@@ -113,6 +151,18 @@ class ScalingGroupDriverConfigUpdaterSpec(UpdaterSpec[ScalingGroupRow]):
         if (driver_opts := self.driver_opts.optional_value()) is not None:
             to_update["driver_opts"] = dict(driver_opts)
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
 
 
 @dataclass
@@ -154,6 +204,18 @@ class ScalingGroupSchedulerConfigUpdaterSpec(UpdaterSpec[ScalingGroupRow]):
             )
         return to_update
 
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
+
 
 @dataclass
 class ResourceGroupFairShareUpdaterSpec(UpdaterSpec[ScalingGroupRow]):
@@ -176,6 +238,18 @@ class ResourceGroupFairShareUpdaterSpec(UpdaterSpec[ScalingGroupRow]):
         to_update: dict[str, Any] = {}
         self.fair_share_spec.update_dict(to_update, "fair_share_spec")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
 
 
 @dataclass
@@ -214,3 +288,15 @@ class ScalingGroupUpdaterSpec(UpdaterSpec[ScalingGroupRow]):
         if self.fair_share:
             to_update.update(self.fair_share.build_values())
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/scheduler/updaters.py
+++ b/src/ai/backend/manager/repositories/scheduler/updaters.py
@@ -8,6 +8,7 @@ from typing import Any, override
 
 from ai.backend.manager.models.session import SessionRow, SessionStatus
 from ai.backend.manager.models.utils import sql_json_merge
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import BatchUpdaterSpec
 
 
@@ -47,3 +48,7 @@ class SessionStatusBatchUpdaterSpec(BatchUpdaterSpec[SessionRow]):
             values["terminated_at"] = self.status_changed_at
 
         return values
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None

--- a/src/ai/backend/manager/repositories/session/updaters.py
+++ b/src/ai/backend/manager/repositories/session/updaters.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState
 
@@ -28,3 +30,15 @@ class SessionUpdaterSpec(UpdaterSpec[SessionRow]):
         self.name.update_dict(to_update, "name")
         self.priority.update_dict(to_update, "priority")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/user/updaters.py
+++ b/src/ai/backend/manager/repositories/user/updaters.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -82,3 +84,15 @@ class UserUpdaterSpec(UpdaterSpec[UserRow]):
     def group_ids_value(self) -> list[str] | None:
         """Helper property for group_ids access."""
         return self.group_ids.optional_value()
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/user_resource_policy/updaters.py
+++ b/src/ai/backend/manager/repositories/user_resource_policy/updaters.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.models.resource_policy import UserResourcePolicyRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -36,3 +38,15 @@ class UserResourcePolicyUpdaterSpec(UpdaterSpec[UserResourcePolicyRow]):
         self.max_customized_image_count.update_dict(to_update, "max_customized_image_count")
         self.max_concurrent_logins.update_dict(to_update, "max_concurrent_logins")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/vfolder/updaters.py
+++ b/src/ai/backend/manager/repositories/vfolder/updaters.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.data.vfolder.types import VFolderOperationStatus
 from ai.backend.manager.models.vfolder import VFolderPermission, VFolderRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState
 
@@ -32,6 +34,18 @@ class VFolderAttributeUpdaterSpec(UpdaterSpec[VFolderRow]):
         self.mount_permission.update_dict(to_update, "permission")
         return to_update
 
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
+
 
 class VFolderTrashUpdaterSpec(UpdaterSpec[VFolderRow]):
     """Set vfolder status to DELETE_PENDING (soft-delete / move to trash)."""
@@ -44,3 +58,15 @@ class VFolderTrashUpdaterSpec(UpdaterSpec[VFolderRow]):
     @override
     def build_values(self) -> dict[str, Any]:
         return {"status": VFolderOperationStatus.DELETE_PENDING}
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/src/ai/backend/manager/repositories/vfs_storage/updaters.py
+++ b/src/ai/backend/manager/repositories/vfs_storage/updaters.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.models.vfs_storage import VFSStorageRow
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState
 
@@ -30,3 +32,15 @@ class VFSStorageUpdaterSpec(UpdaterSpec[VFSStorageRow]):
         self.host.update_dict(to_update, "host")
         self.base_path.update_dict(to_update, "base_path")
         return to_update
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None

--- a/tests/unit/manager/repositories/base/test_updater.py
+++ b/tests/unit/manager/repositories/base/test_updater.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncGenerator, Callable, Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 from uuid import UUID
 
 import pytest
@@ -32,6 +32,8 @@ from ai.backend.manager.repositories.base.types import IntegrityErrorCheck
 
 if TYPE_CHECKING:
     from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.common.exception import BackendAIError
+from ai.backend.manager.repositories.base.types import QueryCondition
 
 
 class UpdaterTestRowInt(Base):  # type: ignore[misc]
@@ -88,6 +90,18 @@ class IntPKStatusUpdaterSpec(UpdaterSpec[UpdaterTestRowInt]):
             values["value"] = self._new_value
         return values
 
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
+
 
 class IntPKNoValuesUpdaterSpec(UpdaterSpec[UpdaterTestRowInt]):
     """Updater spec that produces no column changes (empty build_values)."""
@@ -98,6 +112,18 @@ class IntPKNoValuesUpdaterSpec(UpdaterSpec[UpdaterTestRowInt]):
 
     def build_values(self) -> dict[str, Any]:
         return {}
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
 
 
 class UUIDPKStatusUpdaterSpec(UpdaterSpec[UpdaterTestRowUUID]):
@@ -113,6 +139,18 @@ class UUIDPKStatusUpdaterSpec(UpdaterSpec[UpdaterTestRowUUID]):
     def build_values(self) -> dict[str, Any]:
         return {"status": self._new_status}
 
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
+
 
 class StrPKStatusUpdaterSpec(UpdaterSpec[UpdaterTestRowStr]):
     """Updater spec for updating status on string PK table."""
@@ -126,6 +164,18 @@ class StrPKStatusUpdaterSpec(UpdaterSpec[UpdaterTestRowStr]):
 
     def build_values(self) -> dict[str, Any]:
         return {"status": self._new_status}
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
 
 
 # Batch Updater Specs
@@ -143,6 +193,10 @@ class IntPKBatchUpdaterSpec(BatchUpdaterSpec[UpdaterTestRowInt]):
 
     def build_values(self) -> dict[str, Any]:
         return {"status": self._new_status}
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
 
 
 class TestUpdaterIntPK:
@@ -720,6 +774,18 @@ class UniqueNameUpdaterSpec(UpdaterSpec[UpdaterTestRowWithUnique]):
     def integrity_error_checks(self) -> Sequence[IntegrityErrorCheck]:
         return self._checks
 
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
+
 
 class UniqueNameBatchUpdaterSpec(BatchUpdaterSpec[UpdaterTestRowWithUnique]):
     """Batch updater spec that triggers unique constraint violation."""
@@ -742,6 +808,10 @@ class UniqueNameBatchUpdaterSpec(BatchUpdaterSpec[UpdaterTestRowWithUnique]):
     @property
     def integrity_error_checks(self) -> Sequence[IntegrityErrorCheck]:
         return self._checks
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
 
 
 class TestUpdaterIntegrityError:

--- a/tests/unit/manager/repositories/ops/test_provider.py
+++ b/tests/unit/manager/repositories/ops/test_provider.py
@@ -9,13 +9,14 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator, Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 from unittest.mock import AsyncMock
 
 import pytest
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
+from ai.backend.common.exception import BackendAIError
 from ai.backend.manager.errors.repository import EmptySearchScopeError
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
@@ -76,6 +77,18 @@ class ParentUpdaterSpec(UpdaterSpec[OpsTestParentRow]):
 
     def build_values(self) -> dict[str, Any]:
         return {"name": self.new_name}
+
+    @override
+    def guard_condition(self) -> QueryCondition | None:
+        return None
+
+    @override
+    def not_found_error(self) -> BackendAIError | None:
+        return None
+
+    @override
+    def on_guard_failure(self) -> BackendAIError | None:
+        return None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- `UpdaterSpec` gains abstract `guard_condition`, `not_found_error`, `on_guard_failure` hooks. `execute_updater` AND-merges the guard into the WHERE clause and, on a zero-row UPDATE, re-queries the row to differentiate `not_found_error` (raised when set) from `on_guard_failure` (raised when set, otherwise the existing row is returned).
- `BatchUpdaterSpec` gains an abstract `guard_condition` hook. `execute_batch_updater` only AND-merges the guard; the return type and `updated_count` semantics are unchanged.
- New `BulkUpdater` (sequence of `Updater`), `BulkUpdaterPartialResult`, and `execute_bulk_updater_partial` run each updater inside its own savepoint so failures are isolated. Exposed on `WriteOps` as `bulk_update_partial`.
- Every existing `UpdaterSpec` / `BatchUpdaterSpec` subclass implements the new abstract methods returning `None` — no behaviour change for existing specs.


Resolves BA-6230
