### PR TITLE
fix(BA-6239): plug zmq.Context leak in AgentClientPool on connect failure

### DIFF
--- a/changes/11857.fix.md
+++ b/changes/11857.fix.md
@@ -1,0 +1,10 @@
+Plug a `zmq.asyncio.Context` leak in `AgentClientPool._create_entry`: when the
+initial `client.connect()` failed, the partially-initialized peer was raised
+away without being closed, leaving its callosum-allocated ZMQ context (and
+its background IO thread) dangling. Because the failure also never cached
+an unhealthy entry, every subsequent `acquire()` rebuilt a fresh peer and
+leaked again. The fix closes the peer in the connect-failure path and stores
+an unhealthy `_CachedEntry` so subsequent acquires short-circuit via the
+existing unhealthy branch in `_get_or_create`. `AgentClient.close()` now
+also logs teardown exceptions instead of swallowing them, so future
+regressions are observable.

--- a/src/ai/backend/manager/clients/agent/client.py
+++ b/src/ai/backend/manager/clients/agent/client.py
@@ -83,15 +83,48 @@ class AgentClient(BackendAIClient):
         return self._agent_id
 
     async def connect(self) -> None:
-        """Establish connection to the agent."""
-        await self._peer.__aenter__()
+        """Establish connection to the agent.
+
+        Atomic: if the peer's ``__aenter__`` raises mid-way, the
+        partially-initialized peer — which already owns a
+        ``zmq.asyncio.Context`` and the background IO thread the
+        context manages — is released here before re-raising.
+        Without this the caller would have to remember to call
+        ``close()`` on every failure path; a missed cleanup leaks
+        one IO thread per attempt.
+        """
+        try:
+            await self._peer.__aenter__()
+        except BaseException:
+            # The original error must propagate; swallow only the
+            # cleanup exception (the peer may not have reached a state
+            # where ``__aexit__`` can run cleanly).
+            try:
+                await self._peer.__aexit__(None, None, None)
+            except Exception as exit_exc:
+                log.debug(
+                    "agent {} peer __aexit__ raised during connect cleanup: {}",
+                    self._agent_id,
+                    exit_exc,
+                )
+            raise
 
     async def close(self) -> None:
-        """Close connection to the agent."""
+        """Close connection to the agent.
+
+        Errors during teardown are logged at DEBUG instead of being
+        swallowed silently so that regressions in callosum's exit chain
+        (which is what releases the underlying ``zmq.asyncio.Context``)
+        are at least observable.
+        """
         try:
             await self._peer.__aexit__(None, None, None)
-        except Exception:
-            pass
+        except Exception as e:
+            log.debug(
+                "agent {} peer __aexit__ raised during close: {}",
+                self._agent_id,
+                e,
+            )
 
     async def ping(self) -> str:
         """Ping the agent to check connection health."""

--- a/src/ai/backend/manager/clients/agent/pool.py
+++ b/src/ai/backend/manager/clients/agent/pool.py
@@ -129,11 +129,23 @@ class AgentClientPool:
             if entry is None:
                 entry = await self._create_entry(agent_id)
                 self._entries[agent_id] = entry
+                if not entry.is_healthy:
+                    # Surface the connect failure to the caller that triggered
+                    # creation. The cached unhealthy entry already protects
+                    # subsequent acquires via the branch above.
+                    raise AgentConnectionUnavailable(agent_id, "connection unhealthy")
 
             return entry.client
 
     async def _create_entry(self, agent_id: AgentId) -> _CachedEntry:
-        """Create new entry (called within lock)."""
+        """Create new entry (called within lock).
+
+        On connect failure, releases the partially-initialized peer and
+        returns an unhealthy entry instead of raising. ``_get_or_create``
+        is responsible for caching the entry and surfacing the failure;
+        ``_health_check_loop`` later evicts the unhealthy entry once
+        ``recovery_timeout`` has elapsed so a fresh connect can be retried.
+        """
         try:
             agent_addr, agent_public_key = await self._agent_cache.get_rpc_args(agent_id)
         except ValueError as e:
@@ -169,7 +181,22 @@ class AgentClientPool:
         try:
             await client.connect()
         except Exception as e:
-            raise AgentConnectionUnavailable(agent_id, str(e)) from e
+            # ``AgentClient.connect()`` is atomic: it has already released
+            # the partially-initialized peer (and its zmq.Context). We
+            # cache an unhealthy entry so subsequent acquires short-circuit
+            # via the existing ``is_healthy=False`` branch in
+            # ``_get_or_create`` instead of re-creating peers.
+            log.debug(
+                "agent {} connect failed during pool entry creation: {}",
+                agent_id,
+                e,
+            )
+            return _CachedEntry(
+                client=client,
+                is_healthy=False,
+                failure_count=self._spec.failure_threshold,
+                unhealthy_since=time.perf_counter(),
+            )
 
         return _CachedEntry(
             client=client,

--- a/tests/unit/manager/clients/agent/BUILD
+++ b/tests/unit/manager/clients/agent/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/clients/agent/test_pool.py
+++ b/tests/unit/manager/clients/agent/test_pool.py
@@ -1,0 +1,149 @@
+"""
+Tests for ``AgentClient.connect()`` atomicity and ``AgentClientPool``
+caching when peer creation fails before the connection becomes healthy.
+
+Regression: each PeerInvoker allocates a ``zmq.asyncio.Context`` that
+owns OS-level IO threads. If ``connect()`` fails after that allocation
+and the partially-initialized peer is not released, every retry against
+an unreachable agent leaks one ``zmq.asyncio.Context`` plus its
+background IO thread.
+
+The fix has two responsibilities, tested independently:
+
+- ``AgentClient.connect()`` is *atomic*: it must release the peer on
+  ``__aenter__`` failure so callers never have to remember cleanup on
+  every error path.
+- ``AgentClientPool._create_entry`` must cache an unhealthy
+  ``_CachedEntry`` on failure so subsequent ``acquire()`` calls
+  short-circuit via the existing unhealthy-cache branch in
+  ``_get_or_create``, instead of repeatedly re-creating peers.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ai.backend.common.types import AgentId
+from ai.backend.manager.agent_cache import PeerInvoker
+from ai.backend.manager.clients.agent.client import AgentClient
+from ai.backend.manager.clients.agent.pool import AgentClientPool
+from ai.backend.manager.clients.agent.types import AgentPoolSpec
+from ai.backend.manager.errors.agent import AgentConnectionUnavailable
+
+
+class _StubPeer:
+    """Stand-in for callosum ``PeerInvoker`` that never opens real zmq.
+
+    ``AgentClient.connect()`` delegates to ``self._peer.__aenter__()`` and
+    ``AgentClient.close()`` delegates to ``self._peer.__aexit__(...)``,
+    so making this object mimic those hooks lets us drive the pool's
+    failure paths without standing up an actual ZMQ transport.
+    """
+
+    def __init__(self) -> None:
+        self.enter_called = 0
+        self.exit_called = 0
+
+    async def __aenter__(self) -> _StubPeer:
+        self.enter_called += 1
+        raise ConnectionRefusedError("simulated agent unreachable")
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        self.exit_called += 1
+
+
+def _make_pool() -> AgentClientPool:
+    agent_cache = MagicMock()
+    agent_cache.get_rpc_args = AsyncMock(return_value=("tcp://127.0.0.1:65535", None))
+    agent_cache.manager_public_key = b"pk"
+    agent_cache.manager_secret_key = b"sk"
+    agent_cache.rpc_keepalive_timeout = 60
+    spec = AgentPoolSpec(
+        health_check_interval=3600.0,
+        failure_threshold=3,
+        recovery_timeout=60.0,
+    )
+    return AgentClientPool(agent_cache, spec)
+
+
+class TestAgentClientConnectAtomicity:
+    """``AgentClient.connect()`` releases the peer on failure."""
+
+    async def test_connect_failure_releases_peer(self) -> None:
+        stub_peer = _StubPeer()
+        client = AgentClient(cast(PeerInvoker, stub_peer), AgentId("i-test"))
+
+        with pytest.raises(ConnectionRefusedError):
+            await client.connect()
+
+        # The peer's ``__aexit__`` must run so its ``zmq.asyncio.Context``
+        # (and the background IO thread the context owns) is destroyed;
+        # otherwise every connect failure leaks one IO thread.
+        assert stub_peer.enter_called == 1
+        assert stub_peer.exit_called == 1, (
+            "connect() must release the partially-initialized peer when "
+            "__aenter__ raises, so callers don't need a separate cleanup"
+        )
+
+
+class TestCreateEntryConnectFailure:
+    """Covers the connect-failure path of ``AgentClientPool._create_entry``."""
+
+    async def test_caches_unhealthy_entry_on_connect_failure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        pool = _make_pool()
+        stub_peer = _StubPeer()
+        monkeypatch.setattr(pool, "_create_peer", lambda *a, **kw: stub_peer)
+
+        agent_id = AgentId("i-dead")
+
+        with pytest.raises(AgentConnectionUnavailable):
+            async with pool.acquire(agent_id):
+                pass
+
+        # The failure must be cached so the existing unhealthy short-circuit
+        # in _get_or_create takes effect on subsequent calls (avoiding
+        # repeated peer creation on each retry).
+        assert agent_id in pool._entries
+        assert pool._entries[agent_id].is_healthy is False
+
+        await pool.close()
+
+    async def test_subsequent_acquire_short_circuits_without_recreating_peer(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        pool = _make_pool()
+
+        peers_created: list[_StubPeer] = []
+
+        def _track_create_peer(*_args: Any, **_kwargs: Any) -> _StubPeer:
+            peer = _StubPeer()
+            peers_created.append(peer)
+            return peer
+
+        monkeypatch.setattr(pool, "_create_peer", _track_create_peer)
+
+        agent_id = AgentId("i-dead")
+
+        with pytest.raises(AgentConnectionUnavailable):
+            async with pool.acquire(agent_id):
+                pass
+        assert len(peers_created) == 1
+
+        # Second acquire must hit the cached-unhealthy branch and refuse
+        # immediately, without constructing a fresh peer (no new zmq.Context).
+        with pytest.raises(AgentConnectionUnavailable):
+            async with pool.acquire(agent_id):
+                pass
+        assert len(peers_created) == 1, (
+            "subsequent acquire must short-circuit via cached unhealthy entry, "
+            "not create another PeerInvoker (each one allocates a zmq.Context)"
+        )
+
+        await pool.close()


### PR DESCRIPTION
## Summary

When `AgentClientPool._create_entry` raised on `client.connect()` failure, the partially-initialized `PeerInvoker` was discarded without `close()`. Its callosum-allocated `zmq.asyncio.Context` (and the background IO thread the context owns) leaked. Because the failure also never stored a `_CachedEntry`, every subsequent `acquire()` for the same agent rebuilt a fresh peer and leaked again.

In production (dogbowl 26.4.4rc6) this accumulated ~36k ZMQ IO threads cluster-wide over ~7 days and melted down the 4-core manager hosts (load 100+, `/metrics` scrape timeouts). The acute trigger this round was `sokovan.scheduler.terminator`'s periodic `check_running` against an intentionally-offline agent that still had 4 orphan RUNNING kernels — any unreachable agent reproduces it.

Linked Jira: [BA-6239](https://lablup.atlassian.net/browse/BA-6239)

## Fix

| Layer | Change |
|---|---|
| `pool.py:_create_entry` | On `client.connect()` failure, `await client.close()` to destroy the peer's `zmq.asyncio.Context` (releasing the IO thread), and return an **unhealthy `_CachedEntry`** instead of raising. |
| `pool.py:_get_or_create` | Store the unhealthy entry returned by `_create_entry` and surface `AgentConnectionUnavailable` to the current caller. Subsequent acquires now hit the existing `is_healthy=False` short-circuit immediately — no new peer, no new context. |
| `client.py:close` | Upgrade the silent `except Exception: pass` to `log.debug(...)` so future regressions in callosum's exit chain are observable. |

`_health_check_loop` continues to evict unhealthy entries after `recovery_timeout`, so a fresh retry happens once the agent comes back.

## Tests

`tests/unit/manager/clients/agent/test_pool.py`:

- `test_closes_peer_and_caches_unhealthy_on_connect_failure` — verifies `peer.__aexit__` is called on connect failure (= zmq cleanup) and an unhealthy entry is stored.
- `test_subsequent_acquire_short_circuits_without_recreating_peer` — verifies a second acquire against an unreachable agent does **not** construct a fresh `PeerInvoker` (= no new `zmq.Context`).

## Out of Scope

- Defensive cleanup of orphan RUNNING kernels when an agent transitions to TERMINATED (`mark_agent_exit` currently only touches the agent row). The terminator's design — "only mark dead when the agent explicitly confirms" — is deliberately conservative to support agent restarts while containers stay alive. Tracking separately.
- WebUI display policy for sessions owned by non-ALIVE agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BA-6239]: https://lablup.atlassian.net/browse/BA-6239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ