### PR TITLE
fix(BA-6240): look up streaming session by user_uuid instead of access_key

### DIFF
--- a/changes/11859.fix.md
+++ b/changes/11859.fix.md
@@ -1,0 +1,1 @@
+Fix session app connection failure for users with multiple keypairs by looking up streaming sessions by user ID instead of access key.

--- a/src/ai/backend/manager/api/rest/stream/handler.py
+++ b/src/ai/backend/manager/api/rest/stream/handler.py
@@ -31,15 +31,16 @@ from aiohttp import web
 from aiotools import apartial
 
 from ai.backend.common.api_handlers import PathParam, QueryParam
+from ai.backend.common.contexts.user import current_user
 from ai.backend.common.dto.manager.stream.request import SessionNamePath, StreamProxyRequest
 from ai.backend.common.dto.manager.stream.response import StreamAppItem
-from ai.backend.common.exception import BackendAIError
+from ai.backend.common.exception import BackendAIError, UnreachableError
 from ai.backend.common.json import dump_json, load_json
-from ai.backend.common.types import AccessKey, KernelId, SessionId
+from ai.backend.common.types import KernelId, SessionId
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.api.utils import call_non_bursty
 from ai.backend.manager.api.wsproxy import TCPProxy
-from ai.backend.manager.dto.context import RequestCtx, UserContext
+from ai.backend.manager.dto.context import RequestCtx
 from ai.backend.manager.errors.api import InvalidAPIParameters
 from ai.backend.manager.errors.kernel import InvalidStreamMode
 from ai.backend.manager.errors.resource import AppNotFound, NoCurrentTaskContext
@@ -69,6 +70,13 @@ if TYPE_CHECKING:
     from ai.backend.manager.services.stream.processors import StreamProcessors
 
 log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+def _require_current_user_id() -> uuid.UUID:
+    user = current_user()
+    if user is None:
+        raise UnreachableError("User context is not available")
+    return user.user_id
 
 
 @attrs.define(slots=True, auto_attribs=True, init=False)
@@ -109,17 +117,16 @@ class StreamHandler:
         self,
         path: PathParam[SessionNamePath],
         ctx: RequestCtx,
-        user_ctx: UserContext,
     ) -> web.StreamResponse:
         request = ctx.request
         app_ctx = self._ctx
+        user_id = _require_current_user_id()
         session_name = path.parsed.session_name
-        access_key = AccessKey(user_ctx.access_key)
         api_version = request["api_version"]
         result = await self._stream.get_streaming_session.wait_for_complete(
-            GetStreamingSessionAction(session_name=session_name, user_uuid=user_ctx.user_uuid),
+            GetStreamingSessionAction(session_name=session_name, user_uuid=user_id),
         )
-        log.info("STREAM_PTY(ak:{0}, s:{1})", access_key, session_name)
+        log.info("STREAM_PTY(s:{0})", session_name)
         stream_key = KernelId(uuid.UUID(result.kernel_id))
         kernel_host: str
         if result.kernel_host is None:
@@ -194,7 +201,7 @@ class StreamHandler:
                                 await self._stream.execute_in_stream.wait_for_complete(
                                     ExecuteInStreamAction(
                                         session_name=session_name,
-                                        user_uuid=user_ctx.user_uuid,
+                                        user_uuid=user_id,
                                         api_version=api_version,
                                         run_id=run_id,
                                         mode="query",
@@ -207,7 +214,7 @@ class StreamHandler:
                                 await self._stream.execute_in_stream.wait_for_complete(
                                     ExecuteInStreamAction(
                                         session_name=session_name,
-                                        user_uuid=user_ctx.user_uuid,
+                                        user_uuid=user_id,
                                         api_version=api_version,
                                         run_id=run_id,
                                         mode="query",
@@ -222,7 +229,7 @@ class StreamHandler:
                                     await self._stream.restart_in_stream.wait_for_complete(
                                         RestartInStreamAction(
                                             session_name=session_name,
-                                            user_uuid=user_ctx.user_uuid,
+                                            user_uuid=user_id,
                                         ),
                                     )
                                     socks[0].close()
@@ -242,7 +249,7 @@ class StreamHandler:
             except asyncio.CancelledError:
                 raise
             except Exception:
-                await self.error_monitor.capture_exception(context={"user": user_ctx.user_uuid})
+                await self.error_monitor.capture_exception(context={"user": user_id})
                 log.exception("stream_stdin({0}): unexpected error", stream_key)
             finally:
                 log.debug("stream_stdin({0}): terminated", stream_key)
@@ -275,7 +282,7 @@ class StreamHandler:
             except asyncio.CancelledError:
                 pass
             except Exception:
-                await self.error_monitor.capture_exception(context={"user": user_ctx.user_uuid})
+                await self.error_monitor.capture_exception(context={"user": user_id})
                 log.exception("stream_stdout({0}): unexpected error", stream_key)
             finally:
                 log.debug("stream_stdout({0}): terminated", stream_key)
@@ -285,7 +292,7 @@ class StreamHandler:
         try:
             await stream_stdin()
         except Exception:
-            await self.error_monitor.capture_exception(context={"user": user_ctx.user_uuid})
+            await self.error_monitor.capture_exception(context={"user": user_id})
             log.exception("stream_pty({0}): unexpected error", stream_key)
         finally:
             app_ctx.stream_pty_handlers[stream_key].discard(myself)
@@ -302,19 +309,18 @@ class StreamHandler:
         self,
         path: PathParam[SessionNamePath],
         ctx: RequestCtx,
-        user_ctx: UserContext,
     ) -> web.StreamResponse:
         """WebSocket-version of gateway.kernel.execute()."""
         request = ctx.request
         app_ctx = self._ctx
 
         config = self.config_provider.config
+        user_id = _require_current_user_id()
         session_name = path.parsed.session_name
-        access_key = AccessKey(user_ctx.access_key)
         api_version = request["api_version"]
-        log.info("STREAM_EXECUTE(ak:{0}, s:{1})", access_key, session_name)
+        log.info("STREAM_EXECUTE(s:{0})", session_name)
         session_result = await self._stream.get_streaming_session.wait_for_complete(
-            GetStreamingSessionAction(session_name=session_name, user_uuid=user_ctx.user_uuid),
+            GetStreamingSessionAction(session_name=session_name, user_uuid=user_id),
         )
         stream_key = KernelId(uuid.UUID(session_result.kernel_id))
 
@@ -345,7 +351,7 @@ class StreamHandler:
                 exec_result = await self._stream.execute_in_stream.wait_for_complete(
                     ExecuteInStreamAction(
                         session_name=session_name,
-                        user_uuid=user_ctx.user_uuid,
+                        user_uuid=user_id,
                         api_version=api_version,
                         run_id=run_id,
                         mode=mode,
@@ -360,7 +366,7 @@ class StreamHandler:
                     await self._stream.interrupt_in_stream.wait_for_complete(
                         InterruptInStreamAction(
                             session_name=session_name,
-                            user_uuid=user_ctx.user_uuid,
+                            user_uuid=user_id,
                         ),
                     )
                     break
@@ -418,20 +424,19 @@ class StreamHandler:
         path: PathParam[SessionNamePath],
         query: QueryParam[StreamProxyRequest],
         ctx: RequestCtx,
-        user_ctx: UserContext,
     ) -> web.StreamResponse:
         request = ctx.request
         app_ctx = self._ctx
         rpc_ptask_group = app_ctx.rpc_ptask_group
+        user_id = _require_current_user_id()
         session_name: str = path.parsed.session_name
-        access_key = AccessKey(user_ctx.access_key)
         params = query.parsed
         service: str = params.app
         myself = asyncio.current_task()
         if myself is None:
             raise NoCurrentTaskContext("No current task context")
         session_result = await self._stream.get_streaming_session.wait_for_complete(
-            GetStreamingSessionAction(session_name=session_name, user_uuid=user_ctx.user_uuid),
+            GetStreamingSessionAction(session_name=session_name, user_uuid=user_id),
         )
         kernel_id = KernelId(uuid.UUID(session_result.kernel_id))
         session_id = SessionId(uuid.UUID(session_result.session_id))
@@ -473,8 +478,7 @@ class StreamHandler:
             raise AppNotFound(f"{session_name}:{service}")
 
         log.info(
-            "STREAM_WSPROXY (ak:{}, s:{}): tunneling {}:{} to {}",
-            access_key,
+            "STREAM_WSPROXY (s:{}): tunneling {}:{} to {}",
             session_name,
             service,
             sport["protocol"],
@@ -548,7 +552,7 @@ class StreamHandler:
             start_result = await self._stream.start_service_in_stream.wait_for_complete(
                 StartServiceInStreamAction(
                     session_name=session_name,
-                    user_uuid=user_ctx.user_uuid,
+                    user_uuid=user_id,
                     service=service,
                     opts=opts,
                 ),
@@ -588,11 +592,11 @@ class StreamHandler:
         self,
         path: PathParam[SessionNamePath],
         ctx: RequestCtx,
-        user_ctx: UserContext,
     ) -> web.StreamResponse:
+        user_id = _require_current_user_id()
         session_name = path.parsed.session_name
         result = await self._stream.get_streaming_session.wait_for_complete(
-            GetStreamingSessionAction(session_name=session_name, user_uuid=user_ctx.user_uuid),
+            GetStreamingSessionAction(session_name=session_name, user_uuid=user_id),
         )
         service_ports: list[dict[str, Any]] = result.service_ports
         if not service_ports:

--- a/src/ai/backend/manager/api/rest/stream/handler.py
+++ b/src/ai/backend/manager/api/rest/stream/handler.py
@@ -117,7 +117,7 @@ class StreamHandler:
         access_key = AccessKey(user_ctx.access_key)
         api_version = request["api_version"]
         result = await self._stream.get_streaming_session.wait_for_complete(
-            GetStreamingSessionAction(session_name=session_name, access_key=access_key),
+            GetStreamingSessionAction(session_name=session_name, user_uuid=user_ctx.user_uuid),
         )
         log.info("STREAM_PTY(ak:{0}, s:{1})", access_key, session_name)
         stream_key = KernelId(uuid.UUID(result.kernel_id))
@@ -194,7 +194,7 @@ class StreamHandler:
                                 await self._stream.execute_in_stream.wait_for_complete(
                                     ExecuteInStreamAction(
                                         session_name=session_name,
-                                        access_key=access_key,
+                                        user_uuid=user_ctx.user_uuid,
                                         api_version=api_version,
                                         run_id=run_id,
                                         mode="query",
@@ -207,7 +207,7 @@ class StreamHandler:
                                 await self._stream.execute_in_stream.wait_for_complete(
                                     ExecuteInStreamAction(
                                         session_name=session_name,
-                                        access_key=access_key,
+                                        user_uuid=user_ctx.user_uuid,
                                         api_version=api_version,
                                         run_id=run_id,
                                         mode="query",
@@ -222,7 +222,7 @@ class StreamHandler:
                                     await self._stream.restart_in_stream.wait_for_complete(
                                         RestartInStreamAction(
                                             session_name=session_name,
-                                            access_key=access_key,
+                                            user_uuid=user_ctx.user_uuid,
                                         ),
                                     )
                                     socks[0].close()
@@ -314,7 +314,7 @@ class StreamHandler:
         api_version = request["api_version"]
         log.info("STREAM_EXECUTE(ak:{0}, s:{1})", access_key, session_name)
         session_result = await self._stream.get_streaming_session.wait_for_complete(
-            GetStreamingSessionAction(session_name=session_name, access_key=access_key),
+            GetStreamingSessionAction(session_name=session_name, user_uuid=user_ctx.user_uuid),
         )
         stream_key = KernelId(uuid.UUID(session_result.kernel_id))
 
@@ -345,7 +345,7 @@ class StreamHandler:
                 exec_result = await self._stream.execute_in_stream.wait_for_complete(
                     ExecuteInStreamAction(
                         session_name=session_name,
-                        access_key=access_key,
+                        user_uuid=user_ctx.user_uuid,
                         api_version=api_version,
                         run_id=run_id,
                         mode=mode,
@@ -360,7 +360,7 @@ class StreamHandler:
                     await self._stream.interrupt_in_stream.wait_for_complete(
                         InterruptInStreamAction(
                             session_name=session_name,
-                            access_key=access_key,
+                            user_uuid=user_ctx.user_uuid,
                         ),
                     )
                     break
@@ -431,7 +431,7 @@ class StreamHandler:
         if myself is None:
             raise NoCurrentTaskContext("No current task context")
         session_result = await self._stream.get_streaming_session.wait_for_complete(
-            GetStreamingSessionAction(session_name=session_name, access_key=access_key),
+            GetStreamingSessionAction(session_name=session_name, user_uuid=user_ctx.user_uuid),
         )
         kernel_id = KernelId(uuid.UUID(session_result.kernel_id))
         session_id = SessionId(uuid.UUID(session_result.session_id))
@@ -548,7 +548,7 @@ class StreamHandler:
             start_result = await self._stream.start_service_in_stream.wait_for_complete(
                 StartServiceInStreamAction(
                     session_name=session_name,
-                    access_key=access_key,
+                    user_uuid=user_ctx.user_uuid,
                     service=service,
                     opts=opts,
                 ),
@@ -591,9 +591,8 @@ class StreamHandler:
         user_ctx: UserContext,
     ) -> web.StreamResponse:
         session_name = path.parsed.session_name
-        access_key = AccessKey(user_ctx.access_key)
         result = await self._stream.get_streaming_session.wait_for_complete(
-            GetStreamingSessionAction(session_name=session_name, access_key=access_key),
+            GetStreamingSessionAction(session_name=session_name, user_uuid=user_ctx.user_uuid),
         )
         service_ports: list[dict[str, Any]] = result.service_ports
         if not service_ports:

--- a/src/ai/backend/manager/repositories/stream/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/stream/db_source/db_source.py
@@ -1,5 +1,12 @@
-from ai.backend.common.types import AccessKey
-from ai.backend.manager.models.session import KernelLoadingStrategy, SessionRow
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.orm import joinedload, noload, selectinload
+
+from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.errors.kernel import SessionNotFound, TooManySessionsMatched
+from ai.backend.manager.models.kernel import KernelRow
+from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
 
@@ -12,12 +19,39 @@ class StreamDBSource:
     async def get_streaming_session(
         self,
         session_name: str,
-        access_key: AccessKey,
+        user_uuid: uuid.UUID,
     ) -> SessionRow:
         async with self._db.begin_readonly_session() as db_sess:
-            return await SessionRow.get_session(
-                db_sess,
-                session_name,
-                access_key,
-                kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
+            query = (
+                sa.select(SessionRow)
+                .where(
+                    (SessionRow.name == session_name)
+                    & (SessionRow.user_uuid == user_uuid)
+                    & (SessionRow.status == SessionStatus.RUNNING)
+                )
+                .options(
+                    noload("*"),
+                    selectinload(SessionRow.kernels).options(
+                        noload("*"),
+                        selectinload(KernelRow.agent_row).noload("*"),
+                    ),
+                    joinedload(SessionRow.user),
+                )
+                .execution_options(populate_existing=True)
             )
+            result = await db_sess.execute(query)
+            sessions = result.scalars().all()
+            if not sessions:
+                raise SessionNotFound(f"Session (name={session_name}) does not exist.")
+            if len(sessions) > 1:
+                session_infos = [
+                    {
+                        "session_id": sess.id,
+                        "session_name": sess.name,
+                        "status": sess.status,
+                        "created_at": sess.created_at,
+                    }
+                    for sess in sessions
+                ]
+                raise TooManySessionsMatched(extra_data={"matches": session_infos})
+            return sessions[0]

--- a/src/ai/backend/manager/repositories/stream/repository.py
+++ b/src/ai/backend/manager/repositories/stream/repository.py
@@ -1,4 +1,5 @@
-from ai.backend.common.types import AccessKey
+import uuid
+
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.stream.db_source.db_source import StreamDBSource
@@ -13,6 +14,6 @@ class StreamRepository:
     async def get_streaming_session(
         self,
         session_name: str,
-        access_key: AccessKey,
+        user_uuid: uuid.UUID,
     ) -> SessionRow:
-        return await self._db_source.get_streaming_session(session_name, access_key)
+        return await self._db_source.get_streaming_session(session_name, user_uuid)

--- a/src/ai/backend/manager/services/stream/actions/execute_in_stream.py
+++ b/src/ai/backend/manager/services/stream/actions/execute_in_stream.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass, field
 from typing import Any, override
 
-from ai.backend.common.types import AccessKey
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.services.stream.actions.base import StreamAction
@@ -12,7 +12,7 @@ from ai.backend.manager.services.stream.actions.base import StreamAction
 @dataclass(frozen=True)
 class ExecuteInStreamAction(StreamAction):
     session_name: str
-    access_key: AccessKey
+    user_uuid: uuid.UUID
     api_version: tuple[int, str]
     run_id: str
     mode: str

--- a/src/ai/backend/manager/services/stream/actions/get_streaming_session.py
+++ b/src/ai/backend/manager/services/stream/actions/get_streaming_session.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.types import AccessKey
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.services.stream.actions.base import StreamAction
@@ -12,7 +12,7 @@ from ai.backend.manager.services.stream.actions.base import StreamAction
 @dataclass(frozen=True)
 class GetStreamingSessionAction(StreamAction):
     session_name: str
-    access_key: AccessKey
+    user_uuid: uuid.UUID
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/stream/actions/interrupt_in_stream.py
+++ b/src/ai/backend/manager/services/stream/actions/interrupt_in_stream.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.types import AccessKey
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.services.stream.actions.base import StreamAction
@@ -12,7 +12,7 @@ from ai.backend.manager.services.stream.actions.base import StreamAction
 @dataclass(frozen=True)
 class InterruptInStreamAction(StreamAction):
     session_name: str
-    access_key: AccessKey
+    user_uuid: uuid.UUID
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/stream/actions/restart_in_stream.py
+++ b/src/ai/backend/manager/services/stream/actions/restart_in_stream.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.types import AccessKey
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.services.stream.actions.base import StreamAction
@@ -12,7 +12,7 @@ from ai.backend.manager.services.stream.actions.base import StreamAction
 @dataclass(frozen=True)
 class RestartInStreamAction(StreamAction):
     session_name: str
-    access_key: AccessKey
+    user_uuid: uuid.UUID
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/stream/actions/start_service_in_stream.py
+++ b/src/ai/backend/manager/services/stream/actions/start_service_in_stream.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass, field
 from typing import Any, override
 
-from ai.backend.common.types import AccessKey
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.services.stream.actions.base import StreamAction
@@ -12,7 +12,7 @@ from ai.backend.manager.services.stream.actions.base import StreamAction
 @dataclass(frozen=True)
 class StartServiceInStreamAction(StreamAction):
     session_name: str
-    access_key: AccessKey
+    user_uuid: uuid.UUID
     service: str
     opts: dict[str, Any] = field(default_factory=dict)
 

--- a/src/ai/backend/manager/services/stream/service.py
+++ b/src/ai/backend/manager/services/stream/service.py
@@ -8,7 +8,7 @@ from typing import Final
 from ai.backend.common import validators as tx
 from ai.backend.common.clients.valkey_client.valkey_live.client import ValkeyLiveClient
 from ai.backend.common.etcd import AsyncEtcd
-from ai.backend.common.types import AccessKey, KernelId, SessionId
+from ai.backend.common.types import KernelId, SessionId
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.errors.api import NotImplementedAPI
 from ai.backend.manager.idle import AppStreamingStatus, IdleCheckerHost
@@ -75,7 +75,7 @@ class StreamService:
         self, action: GetStreamingSessionAction
     ) -> GetStreamingSessionActionResult:
         session = await self._repository.get_streaming_session(
-            action.session_name, AccessKey(action.access_key)
+            action.session_name, action.user_uuid
         )
         kernel = session.main_kernel
         return GetStreamingSessionActionResult(
@@ -90,7 +90,7 @@ class StreamService:
 
     async def execute_in_stream(self, action: ExecuteInStreamAction) -> ExecuteInStreamActionResult:
         session = await self._repository.get_streaming_session(
-            action.session_name, AccessKey(action.access_key)
+            action.session_name, action.user_uuid
         )
         result = await self._registry.execute(
             session,
@@ -115,7 +115,7 @@ class StreamService:
         self, action: InterruptInStreamAction
     ) -> InterruptInStreamActionResult:
         session = await self._repository.get_streaming_session(
-            action.session_name, AccessKey(action.access_key)
+            action.session_name, action.user_uuid
         )
         result = await self._registry.interrupt_session(session)
         return InterruptInStreamActionResult(result=dict(result))
@@ -124,7 +124,7 @@ class StreamService:
         self, action: StartServiceInStreamAction
     ) -> StartServiceInStreamActionResult:
         session = await self._repository.get_streaming_session(
-            action.session_name, AccessKey(action.access_key)
+            action.session_name, action.user_uuid
         )
         result = await self._registry.start_service(session, action.service, action.opts)
         return StartServiceInStreamActionResult(result=dict(result))

--- a/tests/unit/manager/repositories/stream/BUILD
+++ b/tests/unit/manager/repositories/stream/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests")

--- a/tests/unit/manager/repositories/stream/test_stream_repository.py
+++ b/tests/unit/manager/repositories/stream/test_stream_repository.py
@@ -1,0 +1,488 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from datetime import datetime
+
+import pytest
+from dateutil.tz import tzutc
+
+from ai.backend.common.types import (
+    AccessKey,
+    ClusterMode,
+    DefaultForUnspecified,
+    KernelId,
+    ResourceSlot,
+    SessionId,
+    SessionResult,
+    SessionTypes,
+)
+from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.errors.kernel import SessionNotFound
+from ai.backend.manager.models.agent.row import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.group import GroupRow, ProjectType
+from ai.backend.manager.models.image import ImageRow
+from ai.backend.manager.models.kernel import KernelRow, KernelStatus
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.resource_slot import ResourceAllocationRow, ResourceSlotTypeRow
+from ai.backend.manager.models.scaling_group import ScalingGroupOpts, ScalingGroupRow
+from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.stream.repository import StreamRepository
+from ai.backend.testutils.db import with_tables
+
+
+@dataclass
+class StreamSessionFixture:
+    user_uuid: uuid.UUID
+    other_user_uuid: uuid.UUID
+    session_id: SessionId
+    session_name: str
+    active_access_key: AccessKey
+    inactive_access_key: AccessKey
+    main_kernel_id: KernelId
+
+
+def _make_session_row(
+    *,
+    session_id: SessionId,
+    name: str,
+    user_uuid: uuid.UUID,
+    access_key: AccessKey,
+    status: SessionStatus,
+    domain_name: str,
+    group_id: uuid.UUID,
+    created_at: datetime,
+) -> SessionRow:
+    return SessionRow(
+        id=session_id,
+        creation_id=uuid.uuid4().hex,
+        name=name,
+        session_type=SessionTypes.INTERACTIVE,
+        cluster_mode=ClusterMode.SINGLE_NODE,
+        cluster_size=1,
+        domain_name=domain_name,
+        group_id=group_id,
+        user_uuid=user_uuid,
+        access_key=access_key,
+        tag=None,
+        status=status,
+        status_info=None,
+        status_data=None,
+        status_history={},
+        result=SessionResult.UNDEFINED,
+        created_at=created_at,
+        terminated_at=None,
+        starts_at=None,
+        startup_command=None,
+        callback_url=None,
+        occupying_slots=ResourceSlot({"cpu": "1", "mem": "1073741824"}),
+        requested_slots=ResourceSlot({"cpu": "1", "mem": "1073741824"}),
+        vfolder_mounts=[],
+        environ=None,
+        bootstrap_script=None,
+        use_host_network=False,
+        scaling_group_name="default",
+    )
+
+
+def _make_kernel_row(
+    *,
+    kernel_id: KernelId,
+    session_id: SessionId,
+    user_uuid: uuid.UUID,
+    access_key: AccessKey,
+    cluster_role: str,
+    cluster_idx: int,
+    domain_name: str,
+    group_id: uuid.UUID,
+    created_at: datetime,
+) -> KernelRow:
+    return KernelRow(
+        id=kernel_id,
+        session_id=session_id,
+        session_type=SessionTypes.INTERACTIVE,
+        domain_name=domain_name,
+        group_id=group_id,
+        user_uuid=user_uuid,
+        access_key=access_key,
+        cluster_mode=ClusterMode.SINGLE_NODE.value,
+        cluster_size=2,
+        cluster_role=cluster_role,
+        cluster_idx=cluster_idx,
+        local_rank=0,
+        cluster_hostname=cluster_role,
+        image="cr.backend.ai/stable/python:latest",
+        architecture="x86_64",
+        registry="cr.backend.ai",
+        agent=None,
+        agent_addr=None,
+        container_id=None,
+        repl_in_port=2000 + cluster_idx * 10,
+        repl_out_port=2001 + cluster_idx * 10,
+        stdin_port=2002 + cluster_idx * 10,
+        stdout_port=2003 + cluster_idx * 10,
+        use_host_network=False,
+        status=KernelStatus.RUNNING,
+        status_info=None,
+        status_data=None,
+        status_history={},
+        status_changed=created_at,
+        result=SessionResult.UNDEFINED,
+        created_at=created_at,
+        terminated_at=None,
+        starts_at=None,
+        occupied_slots=ResourceSlot({"cpu": "1", "mem": "1073741824"}),
+        requested_slots=ResourceSlot({"cpu": "1", "mem": "1073741824"}),
+        occupied_shares={},
+        environ=None,
+        vfolder_mounts=[],
+        attached_devices={},
+        resource_opts=None,
+        preopen_ports=None,
+        bootstrap_script=None,
+        startup_command=None,
+    )
+
+
+class TestStreamRepository:
+    """Tests for StreamRepository.get_streaming_session() using a real database."""
+
+    @pytest.fixture
+    async def db_with_cleanup(
+        self, database_connection: ExtendedAsyncSAEngine
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                DomainRow,
+                ScalingGroupRow,
+                AgentRow,
+                UserResourcePolicyRow,
+                ProjectResourcePolicyRow,
+                KeyPairResourcePolicyRow,
+                UserRow,
+                GroupRow,
+                KeyPairRow,
+                ContainerRegistryRow,
+                ImageRow,
+                SessionRow,
+                KernelRow,
+                ResourceSlotTypeRow,
+                ResourceAllocationRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    def repository(self, db_with_cleanup: ExtendedAsyncSAEngine) -> StreamRepository:
+        return StreamRepository(db_with_cleanup)
+
+    @pytest.fixture
+    async def stream_session(self, db_with_cleanup: ExtendedAsyncSAEngine) -> StreamSessionFixture:
+        """
+        Seed a RUNNING session with two kernels (main + sub) owned by a user
+        who has both an active and an inactive keypair, plus an unrelated user
+        with their own keypair and session.
+        """
+        domain_name = "test-domain"
+        user_uuid = uuid.uuid4()
+        other_user_uuid = uuid.uuid4()
+        group_id = uuid.uuid4()
+        session_id = SessionId(uuid.uuid4())
+        other_session_id = SessionId(uuid.uuid4())
+        terminated_session_id = SessionId(uuid.uuid4())
+        main_kernel_id = KernelId(uuid.uuid4())
+        sub_kernel_id = KernelId(uuid.uuid4())
+        active_access_key = AccessKey("ACTIVEKEY1234567890")
+        inactive_access_key = AccessKey("INACTIVEKEY12345678")
+        other_user_access_key = AccessKey("OTHERUSERKEY1234567")
+        session_name = "shared-session"
+
+        async with db_with_cleanup.begin_session() as db_sess:
+            db_sess.add(
+                DomainRow(
+                    name=domain_name,
+                    description="Test domain",
+                    is_active=True,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts={},
+                    allowed_docker_registries=[],
+                    integration_id=None,
+                )
+            )
+            db_sess.add(
+                ScalingGroupRow(
+                    name="default",
+                    is_active=True,
+                    is_public=True,
+                    driver="static",
+                    driver_opts={},
+                    scheduler="fifo",
+                    scheduler_opts=ScalingGroupOpts(),
+                )
+            )
+            user_resource_policy = UserResourcePolicyRow(
+                name="default-user-policy",
+                max_vfolder_count=100,
+                max_quota_scope_size=-1,
+                max_session_count_per_model_session=10,
+                max_customized_image_count=10,
+            )
+            db_sess.add(user_resource_policy)
+            project_resource_policy = ProjectResourcePolicyRow(
+                name="default-project-policy",
+                max_vfolder_count=100,
+                max_quota_scope_size=-1,
+                max_network_count=10,
+            )
+            db_sess.add(project_resource_policy)
+            keypair_resource_policy = KeyPairResourcePolicyRow(
+                name="default-keypair-policy",
+                default_for_unspecified=DefaultForUnspecified.UNLIMITED,
+                total_resource_slots=ResourceSlot(),
+                max_session_lifetime=0,
+                max_concurrent_sessions=10,
+                max_concurrent_sftp_sessions=5,
+                max_containers_per_session=1,
+                idle_timeout=3600,
+            )
+            db_sess.add(keypair_resource_policy)
+            await db_sess.flush()
+
+            db_sess.add(
+                UserRow(
+                    uuid=user_uuid,
+                    username="owner",
+                    email="owner@example.com",
+                    password=None,
+                    need_password_change=False,
+                    full_name="Owner",
+                    description="",
+                    status=UserStatus.ACTIVE,
+                    status_info="",
+                    domain_name=domain_name,
+                    role=UserRole.USER,
+                    resource_policy=user_resource_policy.name,
+                    allowed_client_ip=None,
+                    totp_key=None,
+                    main_access_key=None,
+                )
+            )
+            db_sess.add(
+                UserRow(
+                    uuid=other_user_uuid,
+                    username="other",
+                    email="other@example.com",
+                    password=None,
+                    need_password_change=False,
+                    full_name="Other",
+                    description="",
+                    status=UserStatus.ACTIVE,
+                    status_info="",
+                    domain_name=domain_name,
+                    role=UserRole.USER,
+                    resource_policy=user_resource_policy.name,
+                    allowed_client_ip=None,
+                    totp_key=None,
+                    main_access_key=None,
+                )
+            )
+            db_sess.add(
+                GroupRow(
+                    id=group_id,
+                    name="test-group",
+                    description="",
+                    is_active=True,
+                    domain_name=domain_name,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts={},
+                    resource_policy=project_resource_policy.name,
+                    type=ProjectType.GENERAL,
+                )
+            )
+            await db_sess.flush()
+
+            db_sess.add(
+                KeyPairRow(
+                    user_id="owner@example.com",
+                    user=user_uuid,
+                    access_key=active_access_key,
+                    secret_key="active-secret",
+                    is_active=True,
+                    is_admin=False,
+                    resource_policy=keypair_resource_policy.name,
+                    rate_limit=1000,
+                )
+            )
+            db_sess.add(
+                KeyPairRow(
+                    user_id="owner@example.com",
+                    user=user_uuid,
+                    access_key=inactive_access_key,
+                    secret_key="inactive-secret",
+                    is_active=False,
+                    is_admin=False,
+                    resource_policy=keypair_resource_policy.name,
+                    rate_limit=1000,
+                )
+            )
+            db_sess.add(
+                KeyPairRow(
+                    user_id="other@example.com",
+                    user=other_user_uuid,
+                    access_key=other_user_access_key,
+                    secret_key="other-secret",
+                    is_active=True,
+                    is_admin=False,
+                    resource_policy=keypair_resource_policy.name,
+                    rate_limit=1000,
+                )
+            )
+            await db_sess.flush()
+
+            now = datetime.now(tzutc())
+            # The target RUNNING session — created with the now-inactive keypair.
+            db_sess.add(
+                _make_session_row(
+                    session_id=session_id,
+                    name=session_name,
+                    user_uuid=user_uuid,
+                    access_key=inactive_access_key,
+                    status=SessionStatus.RUNNING,
+                    domain_name=domain_name,
+                    group_id=group_id,
+                    created_at=now,
+                )
+            )
+            # A terminated session with the same name owned by the same user.
+            db_sess.add(
+                _make_session_row(
+                    session_id=terminated_session_id,
+                    name=session_name,
+                    user_uuid=user_uuid,
+                    access_key=active_access_key,
+                    status=SessionStatus.TERMINATED,
+                    domain_name=domain_name,
+                    group_id=group_id,
+                    created_at=now,
+                )
+            )
+            # A different user's RUNNING session sharing the same name.
+            db_sess.add(
+                _make_session_row(
+                    session_id=other_session_id,
+                    name=session_name,
+                    user_uuid=other_user_uuid,
+                    access_key=other_user_access_key,
+                    status=SessionStatus.RUNNING,
+                    domain_name=domain_name,
+                    group_id=group_id,
+                    created_at=now,
+                )
+            )
+            await db_sess.flush()
+
+            db_sess.add(
+                _make_kernel_row(
+                    kernel_id=main_kernel_id,
+                    session_id=session_id,
+                    user_uuid=user_uuid,
+                    access_key=inactive_access_key,
+                    cluster_role="main",
+                    cluster_idx=0,
+                    domain_name=domain_name,
+                    group_id=group_id,
+                    created_at=now,
+                )
+            )
+            db_sess.add(
+                _make_kernel_row(
+                    kernel_id=sub_kernel_id,
+                    session_id=session_id,
+                    user_uuid=user_uuid,
+                    access_key=inactive_access_key,
+                    cluster_role="sub",
+                    cluster_idx=1,
+                    domain_name=domain_name,
+                    group_id=group_id,
+                    created_at=now,
+                )
+            )
+            await db_sess.commit()
+
+        return StreamSessionFixture(
+            user_uuid=user_uuid,
+            other_user_uuid=other_user_uuid,
+            session_id=session_id,
+            session_name=session_name,
+            active_access_key=active_access_key,
+            inactive_access_key=inactive_access_key,
+            main_kernel_id=main_kernel_id,
+        )
+
+    async def test_returns_running_session_owned_by_user(
+        self,
+        repository: StreamRepository,
+        stream_session: StreamSessionFixture,
+    ) -> None:
+        session = await repository.get_streaming_session(
+            stream_session.session_name, stream_session.user_uuid
+        )
+
+        assert session.id == stream_session.session_id
+        assert session.status == SessionStatus.RUNNING
+        assert session.user_uuid == stream_session.user_uuid
+
+    async def test_main_kernel_is_loaded(
+        self,
+        repository: StreamRepository,
+        stream_session: StreamSessionFixture,
+    ) -> None:
+        session = await repository.get_streaming_session(
+            stream_session.session_name, stream_session.user_uuid
+        )
+
+        assert session.main_kernel.id == stream_session.main_kernel_id
+
+    async def test_isolated_from_other_users_session(
+        self,
+        repository: StreamRepository,
+        stream_session: StreamSessionFixture,
+    ) -> None:
+        with pytest.raises(SessionNotFound):
+            await repository.get_streaming_session(stream_session.session_name, uuid.uuid4())
+
+    async def test_ignores_terminated_session(
+        self,
+        repository: StreamRepository,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        stream_session: StreamSessionFixture,
+    ) -> None:
+        # Terminate the only RUNNING session for the owner.
+        async with db_with_cleanup.begin_session() as db_sess:
+            session = await db_sess.get(SessionRow, stream_session.session_id)
+            assert session is not None
+            session.status = SessionStatus.TERMINATED
+
+        with pytest.raises(SessionNotFound):
+            await repository.get_streaming_session(
+                stream_session.session_name, stream_session.user_uuid
+            )
+
+    async def test_session_not_found_for_unknown_name(
+        self,
+        repository: StreamRepository,
+        stream_session: StreamSessionFixture,
+    ) -> None:
+        with pytest.raises(SessionNotFound):
+            await repository.get_streaming_session("no-such-session", stream_session.user_uuid)

--- a/tests/unit/manager/services/stream/test_stream_service.py
+++ b/tests/unit/manager/services/stream/test_stream_service.py
@@ -7,7 +7,7 @@ import pytest
 
 from ai.backend.common.clients.valkey_client.valkey_live.client import ValkeyLiveClient
 from ai.backend.common.etcd import AsyncEtcd
-from ai.backend.common.types import AccessKey, KernelId, SessionId
+from ai.backend.common.types import KernelId, SessionId
 from ai.backend.manager.errors.kernel import SessionNotFound
 from ai.backend.manager.idle import AppStreamingStatus, IdleCheckerHost
 from ai.backend.manager.models.session.row import SessionRow
@@ -45,7 +45,7 @@ from ai.backend.manager.services.stream.service import StreamService
 
 FAKE_SESSION_ID = SessionId(uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 FAKE_KERNEL_ID = KernelId(uuid.UUID("11111111-2222-3333-4444-555555555555"))
-FAKE_ACCESS_KEY = AccessKey("AKIAIOSFODNN7EXAMPLE")
+FAKE_USER_UUID = uuid.UUID("99999999-8888-7777-6666-555555555555")
 
 
 class TestStreamService:
@@ -111,7 +111,7 @@ class TestGetStreamingSession(TestStreamService):
         mock_repository.get_streaming_session.return_value = mock_session
         action = GetStreamingSessionAction(
             session_name="my-session",
-            access_key=FAKE_ACCESS_KEY,
+            user_uuid=FAKE_USER_UUID,
         )
 
         result = await stream_service.get_streaming_session(action)
@@ -126,9 +126,7 @@ class TestGetStreamingSession(TestStreamService):
         assert result.service_ports == [
             {"name": "jupyter", "protocol": "http", "container_ports": [8080]}
         ]
-        mock_repository.get_streaming_session.assert_awaited_once_with(
-            "my-session", FAKE_ACCESS_KEY
-        )
+        mock_repository.get_streaming_session.assert_awaited_once_with("my-session", FAKE_USER_UUID)
 
     async def test_no_service_ports_returns_empty_list(
         self,
@@ -140,7 +138,7 @@ class TestGetStreamingSession(TestStreamService):
         mock_repository.get_streaming_session.return_value = mock_session
         action = GetStreamingSessionAction(
             session_name="my-session",
-            access_key=FAKE_ACCESS_KEY,
+            user_uuid=FAKE_USER_UUID,
         )
 
         result = await stream_service.get_streaming_session(action)
@@ -155,7 +153,7 @@ class TestGetStreamingSession(TestStreamService):
         mock_repository.get_streaming_session.side_effect = SessionNotFound()
         action = GetStreamingSessionAction(
             session_name="nonexistent",
-            access_key=FAKE_ACCESS_KEY,
+            user_uuid=FAKE_USER_UUID,
         )
 
         with pytest.raises(SessionNotFound):
@@ -174,7 +172,7 @@ class TestExecuteInStream(TestStreamService):
         mock_registry.execute.return_value = {"status": "finished", "exitCode": 0}
         action = ExecuteInStreamAction(
             session_name="my-session",
-            access_key=FAKE_ACCESS_KEY,
+            user_uuid=FAKE_USER_UUID,
             api_version=(4, "websocket"),
             run_id="run-001",
             mode="query",
@@ -208,7 +206,7 @@ class TestExecuteInStream(TestStreamService):
         mock_registry.execute.return_value = {"status": "finished"}
         action = ExecuteInStreamAction(
             session_name="my-session",
-            access_key=FAKE_ACCESS_KEY,
+            user_uuid=FAKE_USER_UUID,
             api_version=(3, "batch"),
             run_id="run-002",
             mode="batch",
@@ -234,7 +232,7 @@ class TestInterruptInStream(TestStreamService):
         mock_registry.interrupt_session.return_value = {"status": "interrupted"}
         action = InterruptInStreamAction(
             session_name="my-session",
-            access_key=FAKE_ACCESS_KEY,
+            user_uuid=FAKE_USER_UUID,
         )
 
         result = await stream_service.interrupt_in_stream(action)
@@ -256,7 +254,7 @@ class TestStartServiceInStream(TestStreamService):
         mock_registry.start_service.return_value = {"status": "started"}
         action = StartServiceInStreamAction(
             session_name="my-session",
-            access_key=FAKE_ACCESS_KEY,
+            user_uuid=FAKE_USER_UUID,
             service="jupyter",
             opts={"port": 8888},
         )


### PR DESCRIPTION
## Summary
- `StreamDBSource.get_streaming_session()` filtered by `access_key`, so users with multiple keypairs (including inactive ones) failed to connect to a session's apps when the request's access_key differed from the session's owner access_key.
- Replace the access_key filter with `user_uuid + status=RUNNING + session_name`. All kernels (not only main) are eager-loaded for the returned session.
- Stream actions (`GetStreamingSession`, `ExecuteInStream`, `StartServiceInStream`, `InterruptInStream`, `RestartInStream`) now carry `user_uuid` instead of `access_key`; handlers pass `user_ctx.user_uuid` directly.

## Test plan
- [x] New unit tests in `tests/unit/manager/repositories/stream/test_stream_repository.py` cover: RUNNING session lookup by user_uuid, main kernel loading, isolation from other users, TERMINATED sessions excluded, unknown name not found.
- [x] Manual: webui terminal app connects successfully for a user whose session was created with a now-inactive keypair.

Resolves BA-6240