### PR TITLE
feat(BA-6242): give custom runtime variant a default health check

### DIFF
--- a/changes/11863.feature.md
+++ b/changes/11863.feature.md
@@ -1,0 +1,1 @@
+Apply a default health check (/health, 1800s initial delay) to the custom runtime variant so model deployments no longer fail health checks while large models load

--- a/changes/11863.feature.md
+++ b/changes/11863.feature.md
@@ -1,1 +1,1 @@
-Apply a default health check (/health, 1800s initial delay) to the custom runtime variant so model deployments no longer fail health checks while large models load
+Add an `enable` flag to model-deployment health checks (default off), making health checks opt-in. The custom runtime variant ships with a disabled default health check, and a model-definition file that declares a health check is treated as enabled.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -9673,6 +9673,11 @@ input ModelDeploymentNetworkAccessInput
 type ModelHealthCheck
   @join__type(graph: STRAWBERRY)
 {
+  """
+  Whether the route is health-checked. When false the route activates immediately.
+  """
+  enable: Boolean!
+
   """Interval in seconds between health checks."""
   interval: Float!
 
@@ -9696,6 +9701,11 @@ type ModelHealthCheck
 input ModelHealthCheckInput
   @join__type(graph: STRAWBERRY)
 {
+  """
+  Whether the route should be health-checked. When false the route activates immediately and the remaining fields are ignored.
+  """
+  enable: Boolean = null
+
   """Interval in seconds between health checks."""
   interval: Float = null
 

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -9704,7 +9704,7 @@ input ModelHealthCheckInput
   """
   Whether the route should be health-checked. When false the route activates immediately and the remaining fields are ignored.
   """
-  enable: Boolean = null
+  enable: Boolean! = false
 
   """Interval in seconds between health checks."""
   interval: Float = null

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -6453,7 +6453,7 @@ input ModelHealthCheckInput {
   """
   Whether the route should be health-checked. When false the route activates immediately and the remaining fields are ignored.
   """
-  enable: Boolean = null
+  enable: Boolean! = false
 
   """Interval in seconds between health checks."""
   interval: Float = null

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -6424,6 +6424,11 @@ input ModelDeploymentNetworkAccessInput {
 
 """Added in 26.4.2. Health check configuration for a model service."""
 type ModelHealthCheck {
+  """
+  Whether the route is health-checked. When false the route activates immediately.
+  """
+  enable: Boolean!
+
   """Interval in seconds between health checks."""
   interval: Float!
 
@@ -6445,6 +6450,11 @@ type ModelHealthCheck {
 
 """Added in 26.4.0. Health check configuration for a model service."""
 input ModelHealthCheckInput {
+  """
+  Whether the route should be health-checked. When false the route activates immediately and the remaining fields are ignored.
+  """
+  enable: Boolean = null
+
   """Interval in seconds between health checks."""
   interval: Float = null
 

--- a/fixtures/manager/example-runtime-variants.json
+++ b/fixtures/manager/example-runtime-variants.json
@@ -12,6 +12,7 @@
               "start_command": ["vllm", "serve", "{model_path}"],
               "port": 8000,
               "health_check": {
+                "enable": false,
                 "path": "/health",
                 "interval": 10.0,
                 "max_retries": 10,
@@ -33,6 +34,7 @@
             "service": {
               "port": 8000,
               "health_check": {
+                "enable": false,
                 "path": "/v1/health/ready",
                 "interval": 10.0,
                 "max_retries": 10,
@@ -70,6 +72,7 @@
               "start_command": ["text-generation-launcher", "--model-id", "{model_path}"],
               "port": 3000,
               "health_check": {
+                "enable": false,
                 "path": "/info",
                 "interval": 10.0,
                 "max_retries": 10,
@@ -98,6 +101,7 @@
               ],
               "port": 9001,
               "health_check": {
+                "enable": false,
                 "path": "/health",
                 "interval": 10.0,
                 "max_retries": 10,
@@ -120,6 +124,7 @@
               "start_command": ["max", "serve", "--model", "{model_path}"],
               "port": 8000,
               "health_check": {
+                "enable": false,
                 "path": "/health",
                 "interval": 10.0,
                 "max_retries": 10,
@@ -140,6 +145,7 @@
             "name": "custom-model",
             "service": {
               "health_check": {
+                "enable": false,
                 "path": "/health",
                 "interval": 10.0,
                 "max_retries": 10,

--- a/fixtures/manager/example-runtime-variants.json
+++ b/fixtures/manager/example-runtime-variants.json
@@ -12,7 +12,7 @@
               "start_command": ["vllm", "serve", "{model_path}"],
               "port": 8000,
               "health_check": {
-                "enable": false,
+                "enable": true,
                 "path": "/health",
                 "interval": 10.0,
                 "max_retries": 10,
@@ -34,7 +34,7 @@
             "service": {
               "port": 8000,
               "health_check": {
-                "enable": false,
+                "enable": true,
                 "path": "/v1/health/ready",
                 "interval": 10.0,
                 "max_retries": 10,
@@ -72,7 +72,7 @@
               "start_command": ["text-generation-launcher", "--model-id", "{model_path}"],
               "port": 3000,
               "health_check": {
-                "enable": false,
+                "enable": true,
                 "path": "/info",
                 "interval": 10.0,
                 "max_retries": 10,
@@ -101,7 +101,7 @@
               ],
               "port": 9001,
               "health_check": {
-                "enable": false,
+                "enable": true,
                 "path": "/health",
                 "interval": 10.0,
                 "max_retries": 10,
@@ -124,7 +124,7 @@
               "start_command": ["max", "serve", "--model", "{model_path}"],
               "port": 8000,
               "health_check": {
-                "enable": false,
+                "enable": true,
                 "path": "/health",
                 "interval": 10.0,
                 "max_retries": 10,

--- a/fixtures/manager/example-runtime-variants.json
+++ b/fixtures/manager/example-runtime-variants.json
@@ -135,7 +135,19 @@
       "description": "Custom (Default)",
       "reads_vfolder_config_files": true,
       "default_model_definition": {
-        "models": null
+        "models": [
+          {
+            "name": "custom-model",
+            "service": {
+              "health_check": {
+                "path": "/health",
+                "interval": 10.0,
+                "max_retries": 10,
+                "initial_delay": 1800.0
+              }
+            }
+          }
+        ]
       }
     }
   ]

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -170,12 +170,21 @@ class PreStartAction(BaseConfigModel):
 
 
 class ModelHealthCheck(BaseConfigModel):
+    enable: bool = Field(
+        default=False,
+        description=(
+            "Whether the route should be health-checked. When false the route "
+            "becomes active immediately and the remaining fields are ignored."
+        ),
+        examples=[False],
+    )
     interval: float = Field(
         default=10.0,
         description="Interval in seconds between health checks.",
         examples=[10.0],
     )
     path: str = Field(
+        default="/health",
         description="Path to check for health status.",
         examples=["/health"],
     )
@@ -351,6 +360,7 @@ def _merge_service_config(
         hb, ho = base.health_check, override.health_check
         hs = ho.model_fields_set
         health_check = ModelHealthCheck.model_construct(
+            enable=_pick(hb.enable, ho.enable, "enable" in hs),
             interval=_pick(hb.interval, ho.interval, "interval" in hs),
             path=_pick(hb.path, ho.path, "path" in hs),
             max_retries=_pick(hb.max_retries, ho.max_retries, "max_retries" in hs),
@@ -441,9 +451,8 @@ class ModelDefinition(BaseConfigModel):
 
     def health_check_config(self) -> ModelHealthCheck | None:
         for model in self.models:
-            if model.service and model.service.health_check:
-                if model.service.health_check is not None:
-                    return model.service.health_check
+            if model.service and model.service.health_check and model.service.health_check.enable:
+                return model.service.health_check
         return None
 
     def with_args_appended(self, args: list[str]) -> ModelDefinition:
@@ -481,6 +490,7 @@ class ModelDefinition(BaseConfigModel):
 
 
 class ModelHealthCheckDraft(BaseConfigModel):
+    enable: bool | None = None
     interval: float | None = None
     path: str | None = None
     max_retries: int | None = None
@@ -491,8 +501,6 @@ class ModelHealthCheckDraft(BaseConfigModel):
     def to_resolved(self) -> ModelHealthCheck:
         # Drop unset (None) fields so the strict type's ``Field(default=...)``
         # declarations remain the single source of truth for default values.
-        # Missing required fields (e.g. ``path``) surface as the strict
-        # type's ``BackendAISchemaValidationFailed`` via ``model_validate``.
         return ModelHealthCheck.model_validate(self.model_dump(exclude_none=True))
 
 
@@ -511,10 +519,9 @@ class ModelServiceConfigDraft(BaseConfigModel):
     def to_resolved(self) -> ModelServiceConfig:
         # Drop unset (None) scalars so the strict type's ``Field(default=...)``
         # declarations remain the single source of truth for default values;
-        # resolve the nested ``health_check`` draft explicitly so its own
-        # required-field check (``path``) fires through its own
-        # ``model_validate``. Missing required fields (e.g. ``port``)
-        # surface as ``BackendAISchemaValidationFailed``.
+        # resolve the nested ``health_check`` draft explicitly. Missing
+        # required fields (e.g. ``port``) surface as
+        # ``BackendAISchemaValidationFailed``.
         payload = self.model_dump(exclude_none=True, exclude={"health_check"})
         payload["health_check"] = self.health_check.to_resolved() if self.health_check else None
         return ModelServiceConfig.model_validate(payload)
@@ -547,6 +554,7 @@ def _merge_health_check_draft(
 ) -> ModelHealthCheckDraft:
     s = override.model_fields_set
     return ModelHealthCheckDraft.model_construct(
+        enable=_pick(base.enable, override.enable, "enable" in s),
         interval=_pick(base.interval, override.interval, "interval" in s),
         path=_pick(base.path, override.path, "path" in s),
         max_retries=_pick(base.max_retries, override.max_retries, "max_retries" in s),
@@ -649,6 +657,34 @@ class ModelDefinitionDraft(BaseConfigModel):
         return ModelDefinition.model_validate({
             "models": [m.to_resolved() for m in (self.models or [])],
         })
+
+    @classmethod
+    def from_file_payload(cls, payload: Mapping[str, Any]) -> ModelDefinitionDraft:
+        """Parse a model-definition file into a draft.
+
+        A declared ``health_check`` block implies opt-in, so ``enable`` is
+        defaulted to ``True`` when unset.
+        """
+        draft = cls.model_validate(dict(payload))
+        if not draft.models:
+            return draft
+        new_models: list[ModelConfigDraft] = []
+        changed = False
+        for model in draft.models:
+            service = model.service
+            if (
+                service is not None
+                and service.health_check is not None
+                and (service.health_check.enable is None)
+            ):
+                new_health_check = service.health_check.model_copy(update={"enable": True})
+                new_service = service.model_copy(update={"health_check": new_health_check})
+                model = model.model_copy(update={"service": new_service})
+                changed = True
+            new_models.append(model)
+        if not changed:
+            return draft
+        return draft.model_copy(update={"models": new_models})
 
 
 def find_config_file(daemon_name: str) -> Path:

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -660,31 +660,25 @@ class ModelDefinitionDraft(BaseConfigModel):
 
     @classmethod
     def from_file_payload(cls, payload: Mapping[str, Any]) -> ModelDefinitionDraft:
-        """Parse a model-definition file into a draft.
-
-        A declared ``health_check`` block implies opt-in, so ``enable`` is
-        defaulted to ``True`` when unset.
-        """
-        draft = cls.model_validate(dict(payload))
-        if not draft.models:
-            return draft
-        new_models: list[ModelConfigDraft] = []
-        changed = False
-        for model in draft.models:
-            service = model.service
-            if (
-                service is not None
-                and service.health_check is not None
-                and (service.health_check.enable is None)
-            ):
-                new_health_check = service.health_check.model_copy(update={"enable": True})
-                new_service = service.model_copy(update={"health_check": new_health_check})
-                model = model.model_copy(update={"service": new_service})
-                changed = True
-            new_models.append(model)
-        if not changed:
-            return draft
-        return draft.model_copy(update={"models": new_models})
+        """Parse a model-definition file into a draft, normalizing the ``health_check`` block."""
+        # Dump by field name so the keys below match regardless of snake/kebab input.
+        data = cls.model_validate(dict(payload)).model_dump(exclude_unset=True, by_alias=False)
+        for model in data.get("models") or []:
+            service = model.get("service")
+            if service is None:
+                continue
+            if "health_check" not in service:
+                continue
+            health_check = service["health_check"]
+            # An empty health_check (null or {}) is an explicit opt-out; disable it so it
+            # overrides any enabled baseline instead of inheriting one.
+            if not health_check:
+                service["health_check"] = {"enable": False}
+                continue
+            # A non-empty block opts in; default enable to True when unset.
+            if health_check.get("enable") is None:
+                health_check["enable"] = True
+        return cls.model_validate(data)
 
 
 def find_config_file(daemon_name: str) -> Path:

--- a/src/ai/backend/common/dto/manager/v2/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/request.py
@@ -122,6 +122,7 @@ __all__ = (
 
 
 class ModelHealthCheckInput(BaseRequestModel):
+    enable: bool | None = None
     interval: float | None = None
     path: str | None = None
     max_retries: int | None = None

--- a/src/ai/backend/common/dto/manager/v2/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/request.py
@@ -122,7 +122,7 @@ __all__ = (
 
 
 class ModelHealthCheckInput(BaseRequestModel):
-    enable: bool | None = None
+    enable: bool = False
     interval: float | None = None
     path: str | None = None
     max_retries: int | None = None

--- a/src/ai/backend/common/dto/manager/v2/deployment/types.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/types.py
@@ -278,6 +278,10 @@ class PreStartActionInfoDTO(BaseResponseModel):
 class ModelHealthCheckInfoDTO(BaseResponseModel):
     """Output DTO for model health check configuration."""
 
+    enable: bool = Field(
+        default=False,
+        description="Whether the route is health-checked. When false the route activates immediately.",
+    )
     interval: float = Field(description="Interval in seconds between health checks.")
     path: str = Field(description="Path to check for health status.")
     max_retries: int = Field(description="Maximum number of retries for health check.")

--- a/src/ai/backend/install/fixtures/example-runtime-variants.json
+++ b/src/ai/backend/install/fixtures/example-runtime-variants.json
@@ -12,6 +12,7 @@
               "start_command": ["vllm", "serve", "{model_path}"],
               "port": 8000,
               "health_check": {
+                "enable": false,
                 "path": "/health",
                 "interval": 10.0,
                 "max_retries": 10,
@@ -33,6 +34,7 @@
             "service": {
               "port": 8000,
               "health_check": {
+                "enable": false,
                 "path": "/v1/health/ready",
                 "interval": 10.0,
                 "max_retries": 10,
@@ -70,6 +72,7 @@
               "start_command": ["text-generation-launcher", "--model-id", "{model_path}"],
               "port": 3000,
               "health_check": {
+                "enable": false,
                 "path": "/info",
                 "interval": 10.0,
                 "max_retries": 10,
@@ -98,6 +101,7 @@
               ],
               "port": 9001,
               "health_check": {
+                "enable": false,
                 "path": "/health",
                 "interval": 10.0,
                 "max_retries": 10,
@@ -120,6 +124,7 @@
               "start_command": ["max", "serve", "--model", "{model_path}"],
               "port": 8000,
               "health_check": {
+                "enable": false,
                 "path": "/health",
                 "interval": 10.0,
                 "max_retries": 10,
@@ -140,6 +145,7 @@
             "name": "custom-model",
             "service": {
               "health_check": {
+                "enable": false,
                 "path": "/health",
                 "interval": 10.0,
                 "max_retries": 10,

--- a/src/ai/backend/install/fixtures/example-runtime-variants.json
+++ b/src/ai/backend/install/fixtures/example-runtime-variants.json
@@ -12,7 +12,7 @@
               "start_command": ["vllm", "serve", "{model_path}"],
               "port": 8000,
               "health_check": {
-                "enable": false,
+                "enable": true,
                 "path": "/health",
                 "interval": 10.0,
                 "max_retries": 10,
@@ -34,7 +34,7 @@
             "service": {
               "port": 8000,
               "health_check": {
-                "enable": false,
+                "enable": true,
                 "path": "/v1/health/ready",
                 "interval": 10.0,
                 "max_retries": 10,
@@ -72,7 +72,7 @@
               "start_command": ["text-generation-launcher", "--model-id", "{model_path}"],
               "port": 3000,
               "health_check": {
-                "enable": false,
+                "enable": true,
                 "path": "/info",
                 "interval": 10.0,
                 "max_retries": 10,
@@ -101,7 +101,7 @@
               ],
               "port": 9001,
               "health_check": {
-                "enable": false,
+                "enable": true,
                 "path": "/health",
                 "interval": 10.0,
                 "max_retries": 10,
@@ -124,7 +124,7 @@
               "start_command": ["max", "serve", "--model", "{model_path}"],
               "port": 8000,
               "health_check": {
-                "enable": false,
+                "enable": true,
                 "path": "/health",
                 "interval": 10.0,
                 "max_retries": 10,

--- a/src/ai/backend/install/fixtures/example-runtime-variants.json
+++ b/src/ai/backend/install/fixtures/example-runtime-variants.json
@@ -135,7 +135,19 @@
       "description": "Custom (Default)",
       "reads_vfolder_config_files": true,
       "default_model_definition": {
-        "models": null
+        "models": [
+          {
+            "name": "custom-model",
+            "service": {
+              "health_check": {
+                "path": "/health",
+                "interval": 10.0,
+                "max_retries": 10,
+                "initial_delay": 1800.0
+              }
+            }
+          }
+        ]
       }
     }
   ]

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -135,6 +135,7 @@ def _pre_start_action_to_dto(action: PreStartAction) -> PreStartActionInfoDTO:
 
 def _model_health_check_to_dto(check: ModelHealthCheck) -> ModelHealthCheckInfoDTO:
     return ModelHealthCheckInfoDTO(
+        enable=check.enable,
         interval=check.interval,
         path=check.path,
         max_retries=check.max_retries,

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -871,12 +871,12 @@ class PreStartActionInputGQL(PydanticInputMixin[PreStartActionDTO]):
     name="ModelHealthCheckInput",
 )
 class ModelHealthCheckInputGQL(PydanticInputMixin[ModelHealthCheckInputDTO]):
-    enable: bool | None = gql_field(
+    enable: bool = gql_field(
         description=(
             "Whether the route should be health-checked. When false the route activates "
             "immediately and the remaining fields are ignored."
         ),
-        default=None,
+        default=False,
     )
     interval: float | None = gql_field(
         description="Interval in seconds between health checks.", default=None

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -357,6 +357,16 @@ class PreStartActionGQL:
     name="ModelHealthCheck",
 )
 class ModelHealthCheckGQL:
+    enable: bool = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Whether the route is health-checked. When false the route activates "
+                "immediately and the remaining fields are ignored."
+            ),
+        ),
+        default=False,
+    )
     interval: float = gql_field(description="Interval in seconds between health checks.")
     path: str = gql_field(description="Path to check for health status.")
     max_retries: int = gql_field(description="Maximum number of retries for health check.")
@@ -861,6 +871,13 @@ class PreStartActionInputGQL(PydanticInputMixin[PreStartActionDTO]):
     name="ModelHealthCheckInput",
 )
 class ModelHealthCheckInputGQL(PydanticInputMixin[ModelHealthCheckInputDTO]):
+    enable: bool | None = gql_field(
+        description=(
+            "Whether the route should be health-checked. When false the route activates "
+            "immediately and the remaining fields are ignored."
+        ),
+        default=None,
+    )
     interval: float | None = gql_field(
         description="Interval in seconds between health checks.", default=None
     )

--- a/src/ai/backend/manager/models/alembic/versions/ed42bc179b91_set_custom_runtime_variant_default_definition.py
+++ b/src/ai/backend/manager/models/alembic/versions/ed42bc179b91_set_custom_runtime_variant_default_definition.py
@@ -1,16 +1,14 @@
-"""seed custom runtime_variant default_model_definition
+"""seed the custom runtime_variant default model definition
 
-The ``custom`` variant previously held an empty Draft ({"models": null}),
-so a deployment that omitted ``health_check`` in its model-definition.yaml
-fell back to the schema default ``initial_delay`` of 60s — too short for
-large models that take minutes to load, causing premature unhealthy
-routes. Seed a baseline ``health_check`` (path ``/health``,
-``initial_delay`` 1800s) matching the prebuilt variants. The user's
-model-definition.yaml / request still override it field-by-field, so this
-acts purely as a fallback layer. Operator-customised rows are left as-is.
+``ModelHealthCheck`` gained an ``enable`` flag (default ``False``), so health
+checks are now opt-in. The ``custom`` runtime variant shipped with an empty
+definition (``{"models": null}``); seed it with a default model definition whose
+health check is present but disabled, so a custom deployment can opt in later by
+flipping ``enable``. Pre-existing health_check blocks need no backfill: without
+the ``enable`` key they read back as disabled, matching the new opt-in default.
 
 Revision ID: ed42bc179b91
-Revises: 0113c63f3261
+Revises: eb9d9c018e85
 Create Date: 2026-05-29
 
 """
@@ -25,17 +23,18 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "ed42bc179b91"
-down_revision = "0113c63f3261"
+down_revision = "eb9d9c018e85"
 branch_labels = None
 depends_on = None
 
 
-_CUSTOM_DEFINITION_WITH_HEALTH_CHECK: dict[str, Any] = {
+_CUSTOM_DEFINITION: dict[str, Any] = {
     "models": [
         {
             "name": "custom-model",
             "service": {
                 "health_check": {
+                    "enable": False,
                     "path": "/health",
                     "interval": 10.0,
                     "max_retries": 10,
@@ -50,30 +49,26 @@ _EMPTY_DEFINITION: dict[str, Any] = {"models": None}
 
 
 def upgrade() -> None:
-    # Seed only the rows still holding the original empty definition, so an
-    # operator-customised custom variant is left untouched.
-    op.execute(
+    op.get_bind().execute(
         sa.text(
             "UPDATE runtime_variants "
-            "SET default_model_definition = CAST(:custom_definition_with_health_check AS JSONB) "
-            "WHERE name = 'custom' AND default_model_definition = CAST(:empty_definition AS JSONB)"
+            "SET default_model_definition = CAST(:seed AS JSONB) "
+            "WHERE name = 'custom' AND default_model_definition = CAST(:empty AS JSONB)"
         ).bindparams(
-            custom_definition_with_health_check=json.dumps(_CUSTOM_DEFINITION_WITH_HEALTH_CHECK),
-            empty_definition=json.dumps(_EMPTY_DEFINITION),
+            seed=json.dumps(_CUSTOM_DEFINITION),
+            empty=json.dumps(_EMPTY_DEFINITION),
         )
     )
 
 
 def downgrade() -> None:
-    # Revert only the value this migration set; leave later operator edits intact.
-    op.execute(
+    op.get_bind().execute(
         sa.text(
             "UPDATE runtime_variants "
-            "SET default_model_definition = CAST(:empty_definition AS JSONB) "
-            "WHERE name = 'custom' "
-            "AND default_model_definition = CAST(:custom_definition_with_health_check AS JSONB)"
+            "SET default_model_definition = CAST(:empty AS JSONB) "
+            "WHERE name = 'custom' AND default_model_definition = CAST(:seed AS JSONB)"
         ).bindparams(
-            custom_definition_with_health_check=json.dumps(_CUSTOM_DEFINITION_WITH_HEALTH_CHECK),
-            empty_definition=json.dumps(_EMPTY_DEFINITION),
+            seed=json.dumps(_CUSTOM_DEFINITION),
+            empty=json.dumps(_EMPTY_DEFINITION),
         )
     )

--- a/src/ai/backend/manager/models/alembic/versions/ed42bc179b91_set_custom_runtime_variant_default_definition.py
+++ b/src/ai/backend/manager/models/alembic/versions/ed42bc179b91_set_custom_runtime_variant_default_definition.py
@@ -1,11 +1,14 @@
-"""seed the custom runtime_variant default model definition
+"""seed health-check opt-in defaults for runtime variants
 
 ``ModelHealthCheck`` gained an ``enable`` flag (default ``False``), so health
-checks are now opt-in. The ``custom`` runtime variant shipped with an empty
-definition (``{"models": null}``); seed it with a default model definition whose
-health check is present but disabled, so a custom deployment can opt in later by
-flipping ``enable``. Pre-existing health_check blocks need no backfill: without
-the ``enable`` key they read back as disabled, matching the new opt-in default.
+checks are now opt-in. Set up the default model definitions accordingly:
+
+- ``custom`` shipped with an empty definition (``{"models": null}``); seed it
+  with a default model whose health check is present but disabled, so a custom
+  deployment can opt in later by flipping ``enable``.
+- Built-in variants ship a known health_check endpoint and should be checked by
+  default; backfill ``enable = true`` on their first model's health check
+  (variants without a health_check block, e.g. ``cmd``, are left untouched).
 
 Revision ID: ed42bc179b91
 Revises: eb9d9c018e85
@@ -49,26 +52,39 @@ _EMPTY_DEFINITION: dict[str, Any] = {"models": None}
 
 
 def upgrade() -> None:
-    op.get_bind().execute(
+    bind = op.get_bind()
+    # Seed the empty custom definition with a disabled health check (opt-in baseline).
+    bind.execute(
+        sa.text(
+            "UPDATE runtime_variants SET default_model_definition = CAST(:seed AS JSONB) "
+            "WHERE name = 'custom' AND default_model_definition = CAST(:empty AS JSONB)"
+        ).bindparams(seed=json.dumps(_CUSTOM_DEFINITION), empty=json.dumps(_EMPTY_DEFINITION))
+    )
+    # Enable health checks for built-in variants (custom stays opt-in; cmd ships no health check).
+    # jsonb_set writes models[0].service.health_check.enable = true, adding the key when absent.
+    bind.execute(
         sa.text(
             "UPDATE runtime_variants "
-            "SET default_model_definition = CAST(:seed AS JSONB) "
-            "WHERE name = 'custom' AND default_model_definition = CAST(:empty AS JSONB)"
-        ).bindparams(
-            seed=json.dumps(_CUSTOM_DEFINITION),
-            empty=json.dumps(_EMPTY_DEFINITION),
+            "SET default_model_definition = jsonb_set("
+            "default_model_definition, '{models,0,service,health_check,enable}', 'true') "
+            "WHERE name NOT IN ('custom', 'cmd')"
         )
     )
 
 
 def downgrade() -> None:
-    op.get_bind().execute(
+    bind = op.get_bind()
+    bind.execute(
         sa.text(
             "UPDATE runtime_variants "
-            "SET default_model_definition = CAST(:empty AS JSONB) "
-            "WHERE name = 'custom' AND default_model_definition = CAST(:seed AS JSONB)"
-        ).bindparams(
-            seed=json.dumps(_CUSTOM_DEFINITION),
-            empty=json.dumps(_EMPTY_DEFINITION),
+            "SET default_model_definition = jsonb_set("
+            "default_model_definition, '{models,0,service,health_check,enable}', 'false') "
+            "WHERE name NOT IN ('custom', 'cmd')"
         )
+    )
+    bind.execute(
+        sa.text(
+            "UPDATE runtime_variants SET default_model_definition = CAST(:empty AS JSONB) "
+            "WHERE name = 'custom' AND default_model_definition = CAST(:seed AS JSONB)"
+        ).bindparams(seed=json.dumps(_CUSTOM_DEFINITION), empty=json.dumps(_EMPTY_DEFINITION))
     )

--- a/src/ai/backend/manager/models/alembic/versions/ed42bc179b91_set_custom_runtime_variant_default_definition.py
+++ b/src/ai/backend/manager/models/alembic/versions/ed42bc179b91_set_custom_runtime_variant_default_definition.py
@@ -1,0 +1,79 @@
+"""seed custom runtime_variant default_model_definition
+
+The ``custom`` variant previously held an empty Draft ({"models": null}),
+so a deployment that omitted ``health_check`` in its model-definition.yaml
+fell back to the schema default ``initial_delay`` of 60s — too short for
+large models that take minutes to load, causing premature unhealthy
+routes. Seed a baseline ``health_check`` (path ``/health``,
+``initial_delay`` 1800s) matching the prebuilt variants. The user's
+model-definition.yaml / request still override it field-by-field, so this
+acts purely as a fallback layer. Operator-customised rows are left as-is.
+
+Revision ID: ed42bc179b91
+Revises: 0113c63f3261
+Create Date: 2026-05-29
+
+"""
+
+# Part of: 26.6.0
+
+import json
+from typing import Any
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "ed42bc179b91"
+down_revision = "0113c63f3261"
+branch_labels = None
+depends_on = None
+
+
+_CUSTOM_DEFINITION_WITH_HEALTH_CHECK: dict[str, Any] = {
+    "models": [
+        {
+            "name": "custom-model",
+            "service": {
+                "health_check": {
+                    "path": "/health",
+                    "interval": 10.0,
+                    "max_retries": 10,
+                    "initial_delay": 1800.0,
+                },
+            },
+        }
+    ]
+}
+
+_EMPTY_DEFINITION: dict[str, Any] = {"models": None}
+
+
+def upgrade() -> None:
+    # Seed only the rows still holding the original empty definition, so an
+    # operator-customised custom variant is left untouched.
+    op.execute(
+        sa.text(
+            "UPDATE runtime_variants "
+            "SET default_model_definition = CAST(:custom_definition_with_health_check AS JSONB) "
+            "WHERE name = 'custom' AND default_model_definition = CAST(:empty_definition AS JSONB)"
+        ).bindparams(
+            custom_definition_with_health_check=json.dumps(_CUSTOM_DEFINITION_WITH_HEALTH_CHECK),
+            empty_definition=json.dumps(_EMPTY_DEFINITION),
+        )
+    )
+
+
+def downgrade() -> None:
+    # Revert only the value this migration set; leave later operator edits intact.
+    op.execute(
+        sa.text(
+            "UPDATE runtime_variants "
+            "SET default_model_definition = CAST(:empty_definition AS JSONB) "
+            "WHERE name = 'custom' "
+            "AND default_model_definition = CAST(:custom_definition_with_health_check AS JSONB)"
+        ).bindparams(
+            custom_definition_with_health_check=json.dumps(_CUSTOM_DEFINITION_WITH_HEALTH_CHECK),
+            empty_definition=json.dumps(_EMPTY_DEFINITION),
+        )
+    )

--- a/src/ai/backend/manager/repositories/deployment/storage_source/storage_source.py
+++ b/src/ai/backend/manager/repositories/deployment/storage_source/storage_source.py
@@ -87,7 +87,7 @@ class DeploymentStorageSource:
             return None
         return FetchedModelDefinition(
             path=raw.filename,
-            model_definition=ModelDefinitionDraft.model_validate(dict(raw.payload)),
+            model_definition=ModelDefinitionDraft.from_file_payload(raw.payload),
         )
 
     async def _fetch_config_file_in_candidates(

--- a/tests/unit/common/test_config.py
+++ b/tests/unit/common/test_config.py
@@ -13,6 +13,7 @@ from ai.backend.common.config import (
     ModelMetadata,
     ModelServiceConfig,
     _merge_config,
+    _merge_config_draft,
     _merge_definition,
     _merge_metadata,
     _merge_service_config,
@@ -252,6 +253,54 @@ class TestHealthCheckEnable:
         service = normalized.models[0].service
         assert service is not None
         assert service.health_check is None
+
+    def test_file_normalization_null_health_check_becomes_disabled(self) -> None:
+        """An empty ``health_check:`` (null) normalizes to an explicit disabled override."""
+        normalized = ModelDefinitionDraft.from_file_payload({
+            "models": [
+                {"name": "m", "service": {"port": 8080, "health_check": None}},
+            ]
+        })
+        assert normalized.models is not None
+        service = normalized.models[0].service
+        assert service is not None
+        assert service.health_check is not None
+        assert service.health_check.enable is False
+
+    def test_file_normalization_empty_dict_health_check_becomes_disabled(self) -> None:
+        """An empty ``health_check: {}`` block carries no values; disable it like null."""
+        normalized = ModelDefinitionDraft.from_file_payload({
+            "models": [
+                {"name": "m", "service": {"port": 8080, "health_check": {}}},
+            ]
+        })
+        assert normalized.models is not None
+        service = normalized.models[0].service
+        assert service is not None
+        assert service.health_check is not None
+        assert service.health_check.enable is False
+
+    def test_file_normalization_empty_health_check_overrides_enabled_baseline(self) -> None:
+        """An empty ``health_check:`` overlay turns off an enabled baseline (higher priority wins)."""
+        baseline = ModelDefinitionDraft.model_validate({
+            "models": [
+                {
+                    "name": "custom-model",
+                    "service": {"health_check": {"enable": True, "path": "/health"}},
+                }
+            ]
+        })
+        overlay = ModelDefinitionDraft.from_file_payload({
+            "models": [
+                {"name": "m", "model_path": "/m", "service": {"port": 8080, "health_check": None}},
+            ]
+        })
+        assert baseline.models is not None and overlay.models is not None
+        merged = _merge_config_draft(baseline.models[0], overlay.models[0])
+        service = merged.to_resolved().service
+        assert service is not None
+        assert service.health_check is not None
+        assert service.health_check.enable is False
 
     def test_merge_override_enables_from_request(self) -> None:
         """A disabled baseline is opted in when a higher-priority draft sets enable=True."""

--- a/tests/unit/common/test_config.py
+++ b/tests/unit/common/test_config.py
@@ -9,6 +9,7 @@ from ai.backend.common.config import (
     ModelDefinition,
     ModelDefinitionDraft,
     ModelHealthCheck,
+    ModelHealthCheckDraft,
     ModelMetadata,
     ModelServiceConfig,
     _merge_config,
@@ -177,6 +178,100 @@ class TestMergeFieldCoverage:
         result = _merge_definition(base, override)
         missing = set(ModelDefinition.model_fields) - result.model_fields_set
         assert not missing, f"_merge_definition() does not handle: {missing}"
+
+
+class TestHealthCheckEnable:
+    """Tests for the ``enable`` flag on ModelHealthCheck."""
+
+    def test_health_check_config_returns_none_when_disabled(self) -> None:
+        definition = ModelDefinition.model_validate({
+            "models": [
+                {
+                    "name": "m",
+                    "model_path": "/m",
+                    "service": {"port": 8080, "health_check": {"path": "/health", "enable": False}},
+                }
+            ]
+        })
+        assert definition.health_check_config() is None
+
+    def test_health_check_config_returns_check_when_enabled(self) -> None:
+        definition = ModelDefinition.model_validate({
+            "models": [
+                {
+                    "name": "m",
+                    "model_path": "/m",
+                    "service": {"port": 8080, "health_check": {"path": "/health", "enable": True}},
+                }
+            ]
+        })
+        check = definition.health_check_config()
+        assert check is not None
+        assert check.path == "/health"
+
+    def test_enable_defaults_to_false(self) -> None:
+        check = ModelHealthCheck.model_validate({"path": "/health"})
+        assert check.enable is False
+
+    def test_to_resolved_without_path_uses_default(self) -> None:
+        resolved = ModelHealthCheckDraft(enable=True).to_resolved()
+        assert resolved.enable is True
+        assert resolved.path == "/health"
+
+    def test_file_normalization_enables_present_health_check(self) -> None:
+        normalized = ModelDefinitionDraft.from_file_payload({
+            "models": [
+                {"name": "m", "service": {"health_check": {"path": "/health"}}},
+            ]
+        })
+        assert normalized.models is not None
+        service = normalized.models[0].service
+        assert service is not None
+        hc = service.health_check
+        assert hc is not None
+        assert hc.enable is True
+
+    def test_file_normalization_respects_explicit_enable_false(self) -> None:
+        normalized = ModelDefinitionDraft.from_file_payload({
+            "models": [
+                {"name": "m", "service": {"health_check": {"path": "/health", "enable": False}}},
+            ]
+        })
+        assert normalized.models is not None
+        service = normalized.models[0].service
+        assert service is not None
+        hc = service.health_check
+        assert hc is not None
+        assert hc.enable is False
+
+    def test_file_normalization_no_health_check_unchanged(self) -> None:
+        normalized = ModelDefinitionDraft.from_file_payload({
+            "models": [{"name": "m", "service": {"port": 8080}}]
+        })
+        assert normalized.models is not None
+        service = normalized.models[0].service
+        assert service is not None
+        assert service.health_check is None
+
+    def test_merge_override_enables_from_request(self) -> None:
+        """A disabled baseline is opted in when a higher-priority draft sets enable=True."""
+        base = ModelServiceConfig.model_construct(
+            _fields_set={"health_check"},
+            start_command=[],
+            port=2,
+            health_check=ModelHealthCheck.model_construct(
+                _fields_set=set(ModelHealthCheck.model_fields), enable=False, path="/health"
+            ),
+        )
+        override = ModelServiceConfig.model_construct(
+            _fields_set={"health_check"},
+            start_command=[],
+            port=2,
+            health_check=ModelHealthCheck.model_construct(_fields_set={"enable"}, enable=True),
+        )
+        result = _merge_service_config(base, override)
+        assert result.health_check is not None
+        assert result.health_check.enable is True
 
 
 class TestModelConfigs:

--- a/tests/unit/manager/test_registry.py
+++ b/tests/unit/manager/test_registry.py
@@ -209,6 +209,7 @@ class TestResolveHealthCheck:
                             start_command=["run"],
                             port=8000,
                             health_check=ModelHealthCheck(
+                                enable=True,
                                 path="/custom",
                                 interval=5.0,
                                 max_retries=3,


### PR DESCRIPTION
## Summary
- Seed the `custom` runtime variant's `default_model_definition` with a baseline `health_check` (path `/health`, `interval` 10s, `max_retries` 10, `initial_delay` 1800s) via alembic migration `ed42bc179b91`.
- Previously `custom` held `{"models": null}`, so deployments that omitted `health_check` fell back to the 60s schema default and could be marked unhealthy while large models load (up to ~30 min). 1800s matches the prebuilt variants.
- Merge stays field-wise: a user's `model-definition.yaml` / request still overrides each field, so this is purely a fallback layer. Operator-customised rows are left untouched (WHERE-guarded UPDATE, idempotent).
- Kept both fixtures (`fixtures/manager/` and `src/ai/backend/install/fixtures/`) in sync with the migration.

## Test plan
- [x] `pants fmt/lint/check` on the migration
- [x] Real alembic run on a throwaway DB: `0113c63f3261 → ed42bc179b91` seeds the def; `downgrade -1` reverts to `{"models": null}`; re-`upgrade head` is idempotent
- [x] Both fixtures parse as valid JSON
- [ ] CI

Resolves BA-6242

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11863.org.readthedocs.build/en/11863/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11863.org.readthedocs.build/ko/11863/

<!-- readthedocs-preview sorna-ko end -->