### PR TITLE
fix(BA-6241): pick deterministic active keypair for sokovan deployment sessions

### DIFF
--- a/changes/11868.fix.md
+++ b/changes/11868.fix.md
@@ -1,0 +1,1 @@
+Make sokovan deployment pick a deterministic, currently-active keypair when resolving `sessions.access_key`, so INFERENCE sessions no longer get pinned to an arbitrary or already-inactive access key.

--- a/src/ai/backend/manager/errors/deployment.py
+++ b/src/ai/backend/manager/errors/deployment.py
@@ -59,7 +59,7 @@ class NoActiveKeypairForDeployment(ObjectNotFound):
 
     def error_code(self) -> ErrorCode:
         return ErrorCode(
-            domain=ErrorDomain.MODEL_SERVICE,
+            domain=ErrorDomain.MODEL_DEPLOYMENT,
             operation=ErrorOperation.READ,
             error_detail=ErrorDetail.NOT_FOUND,
         )

--- a/src/ai/backend/manager/errors/deployment.py
+++ b/src/ai/backend/manager/errors/deployment.py
@@ -54,6 +54,17 @@ class UserNotFoundInDeployment(ObjectNotFound):
         )
 
 
+class NoActiveKeypairForDeployment(ObjectNotFound):
+    object_name = "active keypair for deployment user"
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.MODEL_SERVICE,
+            operation=ErrorOperation.READ,
+            error_detail=ErrorDetail.NOT_FOUND,
+        )
+
+
 class DeploymentHasNoTargetRevision(BackendAIError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/deployment-has-no-target-revision"
     error_title = "Deployment has no target revision."

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -92,6 +92,7 @@ from ai.backend.manager.data.vfolder.types import VFolderLocation
 from ai.backend.manager.errors.deployment import (
     DeploymentHasNoTargetRevision,
     DeploymentRevisionNotFound,
+    NoActiveKeypairForDeployment,
     UserNotFoundInDeployment,
 )
 from ai.backend.manager.errors.resource import (
@@ -2105,7 +2106,7 @@ class DeploymentDBSource:
         ).scalar_one_or_none()
         if user_row is None:
             raise UserNotFoundInDeployment(f"{user_uuid} not found")
-        raise UserNotFoundInDeployment(f"{user_uuid} has no active keypair")
+        raise NoActiveKeypairForDeployment(f"{user_uuid} has no active keypair")
 
     async def fetch_deployment_context(
         self,
@@ -2144,7 +2145,7 @@ class DeploymentDBSource:
                 created.user.uuid,
                 created.access_key,
                 created.user.role or UserRole.USER,
-                deployment_info.metadata.domain,
+                created.user.domain_name or deployment_info.metadata.domain,
                 None,  # No keypair_resource_policy
                 deployment_info.metadata.domain,
                 deployment_info.metadata.project,

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import aliased, selectinload
 from ai.backend.common.config import ModelHealthCheck
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.dto.manager.v2.runtime_variant_preset.types import (
     PresetTarget,
     PresetValueType,
@@ -204,6 +205,14 @@ class EndpointWithRoutesRawData:
 
     endpoint_row: EndpointRow
     route_rows: list[RoutingRow]
+
+
+@dataclass(frozen=True)
+class _DeploymentUserResolution:
+    """Pairs a deployment user with the active keypair chosen for it."""
+
+    user: UserRow
+    access_key: AccessKey
 
 
 log = BraceStyleAdapter(logging.getLogger(__name__))
@@ -2060,6 +2069,44 @@ class DeploymentDBSource:
             )
             await db_sess.execute(query)
 
+    async def _resolve_user_and_active_access_key(
+        self,
+        db_sess: SASession,
+        user_uuid: uuid.UUID,
+    ) -> _DeploymentUserResolution:
+        # Pick a deterministic, currently-active keypair for the given user.
+        # Preference order: main_access_key match, then latest created_at,
+        # then access_key lexicographic order as a final stable tie-break.
+        is_main_access_key = sa.case(
+            (UserRow.main_access_key == keypairs.c.access_key, 1),
+            else_=0,
+        )
+        active_stmt = (
+            sa.select(UserRow, keypairs.c.access_key)
+            .select_from(sa.join(UserRow, keypairs, UserRow.uuid == keypairs.c.user))
+            .where(UserRow.uuid == user_uuid)
+            .where(keypairs.c.is_active.is_(True))
+            .order_by(
+                is_main_access_key.desc(),
+                keypairs.c.created_at.desc(),
+                keypairs.c.access_key.asc(),
+            )
+            .limit(1)
+        )
+        row = (await db_sess.execute(active_stmt)).first()
+        if row is not None:
+            return _DeploymentUserResolution(
+                user=row.UserRow,
+                access_key=AccessKey(row.access_key),
+            )
+        # No active keypair — distinguish a missing user from an inactive-only user.
+        user_row = (
+            await db_sess.execute(sa.select(UserRow).where(UserRow.uuid == user_uuid))
+        ).scalar_one_or_none()
+        if user_row is None:
+            raise UserNotFoundInDeployment(f"{user_uuid} not found")
+        raise UserNotFoundInDeployment(f"{user_uuid} has no active keypair")
+
     async def fetch_deployment_context(
         self,
         deployment_info: DeploymentInfo,
@@ -2076,47 +2123,33 @@ class DeploymentDBSource:
         """
         async with self._begin_readonly_session_read_committed() as db_sess:
             # Fetch created user info
-            created_user_query = (
-                sa.select(UserRow, keypairs.c.access_key)
-                .select_from(sa.join(UserRow, keypairs, UserRow.uuid == keypairs.c.user))
-                .where(UserRow.uuid == deployment_info.metadata.created_user)
+            created = await self._resolve_user_and_active_access_key(
+                db_sess,
+                deployment_info.metadata.created_user,
             )
-            created_user_result = await db_sess.execute(created_user_query)
-            created_user_row = created_user_result.first()
-            if not created_user_row:
-                raise UserNotFoundInDeployment(
-                    f"Created user {deployment_info.metadata.created_user} not found"
-                )
 
             # Fetch session owner info if different
             if deployment_info.metadata.session_owner != deployment_info.metadata.created_user:
-                session_owner_query = (
-                    sa.select(UserRow, keypairs.c.access_key)
-                    .select_from(sa.join(UserRow, keypairs, UserRow.uuid == keypairs.c.user))
-                    .where(UserRow.uuid == deployment_info.metadata.session_owner)
+                session_owner_resolution = await self._resolve_user_and_active_access_key(
+                    db_sess,
+                    deployment_info.metadata.session_owner,
                 )
-                session_owner_result = await db_sess.execute(session_owner_query)
-                session_owner_row = session_owner_result.first()
-                if not session_owner_row:
-                    raise UserNotFoundInDeployment(
-                        f"Session owner {deployment_info.metadata.session_owner} not found"
-                    )
             else:
-                session_owner_row = created_user_row
+                session_owner_resolution = created
 
             # Use query_userinfo_from_session to get group_id and resource_policy
             # This also validates domain, group access permissions
             user_info = await query_userinfo_from_session(
                 db_sess,
-                created_user_row.UserRow.uuid,
-                AccessKey(created_user_row.access_key),
-                created_user_row.UserRow.role,
-                created_user_row.UserRow.domain_name,
+                created.user.uuid,
+                created.access_key,
+                created.user.role or UserRole.USER,
+                deployment_info.metadata.domain,
                 None,  # No keypair_resource_policy
                 deployment_info.metadata.domain,
                 deployment_info.metadata.project,
-                query_on_behalf_of=AccessKey(session_owner_row.access_key)
-                if session_owner_row != created_user_row
+                query_on_behalf_of=session_owner_resolution.access_key
+                if session_owner_resolution.user.uuid != created.user.uuid
                 else None,
             )
             group_id = user_info.group_id
@@ -2168,23 +2201,24 @@ class DeploymentDBSource:
                 )
 
             # Build DeploymentContext
+            session_owner_user = session_owner_resolution.user
             return DeploymentContext(
                 created_user=UserContext(
-                    uuid=created_user_row.UserRow.uuid,
-                    access_key=AccessKey(created_user_row.access_key),
-                    role=str(created_user_row.UserRow.role),
-                    sudo_session_enabled=created_user_row.UserRow.sudo_session_enabled or False,
+                    uuid=created.user.uuid,
+                    access_key=created.access_key,
+                    role=str(created.user.role),
+                    sudo_session_enabled=created.user.sudo_session_enabled or False,
                 ),
                 session_owner=UserContext(
-                    uuid=session_owner_row.UserRow.uuid,
-                    access_key=AccessKey(session_owner_row.access_key),
-                    role=str(session_owner_row.UserRow.role),
-                    sudo_session_enabled=session_owner_row.UserRow.sudo_session_enabled or False,
+                    uuid=session_owner_user.uuid,
+                    access_key=session_owner_resolution.access_key,
+                    role=str(session_owner_user.role),
+                    sudo_session_enabled=session_owner_user.sudo_session_enabled or False,
                 ),
                 container_user=ContainerUserContext(
-                    uid=session_owner_row.UserRow.container_uid,
-                    main_gid=session_owner_row.UserRow.container_main_gid,
-                    supplementary_gids=session_owner_row.UserRow.container_gids or [],
+                    uid=session_owner_user.container_uid,
+                    main_gid=session_owner_user.container_main_gid,
+                    supplementary_gids=session_owner_user.container_gids or [],
                 ),
                 group_id=group_id,
                 resource_policy=dict(resource_policy),

--- a/tests/unit/manager/repositories/deployment/test_active_access_key_resolution.py
+++ b/tests/unit/manager/repositories/deployment/test_active_access_key_resolution.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+import sqlalchemy as sa
+
+from ai.backend.common.types import AccessKey, ResourceSlot
+from ai.backend.manager.errors.deployment import (
+    NoActiveKeypairForDeployment,
+    UserNotFoundInDeployment,
+)
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.storage import StorageSessionManager
+from ai.backend.manager.models.user import UserRole, UserRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.deployment.db_source.db_source import DeploymentDBSource
+from ai.backend.testutils.db import with_tables
+
+
+@dataclass
+class KeypairSpec:
+    access_key: str
+    is_active: bool
+    created_at: datetime
+    is_main: bool = False
+
+
+@dataclass
+class UserSeed:
+    user_uuid: uuid.UUID
+    domain_name: str
+    main_access_key: str | None
+    keypairs: list[KeypairSpec]
+
+
+class TestResolveUserAndActiveAccessKey:
+    """Tests for DeploymentDBSource._resolve_user_and_active_access_key.
+
+    The resolver is the load-bearing piece of BA-6241: sokovan deployment
+    replicas were persisting non-deterministic and potentially inactive
+    access keys into sessions.access_key. The contract under test is:
+
+    1. Only active keypairs may be selected.
+    2. A keypair matching users.main_access_key wins when active.
+    3. Tie-break is deterministic: created_at DESC then access_key ASC.
+    4. Missing user vs no-active-keypair raise different exceptions.
+    """
+
+    @pytest.fixture
+    async def db(
+        self, database_connection: ExtendedAsyncSAEngine
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                DomainRow,
+                UserResourcePolicyRow,
+                KeyPairResourcePolicyRow,
+                UserRow,
+                KeyPairRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    def db_source(self, db: ExtendedAsyncSAEngine) -> DeploymentDBSource:
+        return DeploymentDBSource(
+            db=db,
+            storage_manager=MagicMock(spec=StorageSessionManager),
+        )
+
+    async def _seed(self, db: ExtendedAsyncSAEngine, spec: UserSeed) -> None:
+        domain_name = spec.domain_name
+        user_policy = f"user-policy-{uuid.uuid4().hex[:8]}"
+        kp_policy = f"kp-policy-{uuid.uuid4().hex[:8]}"
+
+        async with db.begin_session() as sess:
+            sess.add(
+                DomainRow(
+                    name=domain_name,
+                    is_active=True,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts={},
+                    allowed_docker_registries=[],
+                )
+            )
+            sess.add(
+                UserResourcePolicyRow(
+                    name=user_policy,
+                    max_vfolder_count=10,
+                    max_quota_scope_size=-1,
+                    max_session_count_per_model_session=10,
+                    max_customized_image_count=10,
+                )
+            )
+            sess.add(
+                KeyPairResourcePolicyRow(
+                    name=kp_policy,
+                    max_concurrent_sessions=10,
+                    max_concurrent_sftp_sessions=2,
+                    max_containers_per_session=10,
+                    idle_timeout=3600,
+                )
+            )
+            await sess.flush()
+            sess.add(
+                UserRow(
+                    uuid=spec.user_uuid,
+                    username=f"user-{spec.user_uuid.hex[:8]}",
+                    email=f"{spec.user_uuid.hex[:8]}@test.io",
+                    domain_name=domain_name,
+                    role=UserRole.USER,
+                    resource_policy=user_policy,
+                )
+            )
+            await sess.flush()
+            for kp in spec.keypairs:
+                sess.add(
+                    KeyPairRow(
+                        access_key=kp.access_key,
+                        secret_key="secret",
+                        user=spec.user_uuid,
+                        is_active=kp.is_active,
+                        resource_policy=kp_policy,
+                        created_at=kp.created_at,
+                    )
+                )
+            await sess.flush()
+            if spec.main_access_key is not None:
+                await sess.execute(
+                    sa.update(UserRow)
+                    .where(UserRow.uuid == spec.user_uuid)
+                    .values(main_access_key=spec.main_access_key)
+                )
+            await sess.commit()
+
+    async def _resolve(
+        self, db_source: DeploymentDBSource, user_uuid: uuid.UUID
+    ) -> AccessKey | type[Exception]:
+        async with db_source._begin_readonly_session_read_committed() as sess:
+            result = await db_source._resolve_user_and_active_access_key(sess, user_uuid)
+        return result.access_key
+
+    async def test_picks_main_access_key_when_active(
+        self,
+        db: ExtendedAsyncSAEngine,
+        db_source: DeploymentDBSource,
+    ) -> None:
+        # main_access_key wins over a newer active key.
+        user_uuid = uuid.uuid4()
+        now = datetime.now(tz=UTC)
+        main_key = "AK" + "M" * 18
+        other_active = "AK" + "O" * 18
+        await self._seed(
+            db,
+            UserSeed(
+                user_uuid=user_uuid,
+                domain_name=f"d-{uuid.uuid4().hex[:8]}",
+                main_access_key=main_key,
+                keypairs=[
+                    KeypairSpec(main_key, is_active=True, created_at=now - timedelta(days=10)),
+                    KeypairSpec(other_active, is_active=True, created_at=now),
+                ],
+            ),
+        )
+
+        chosen = await self._resolve(db_source, user_uuid)
+
+        assert chosen == AccessKey(main_key)
+
+    async def test_skips_inactive_main_access_key(
+        self,
+        db: ExtendedAsyncSAEngine,
+        db_source: DeploymentDBSource,
+    ) -> None:
+        # If users.main_access_key points at an inactive keypair, the
+        # resolver MUST NOT return it — this is the exact failure mode
+        # BA-6241 surfaced in production.
+        user_uuid = uuid.uuid4()
+        now = datetime.now(tz=UTC)
+        inactive_main = "AK" + "I" * 18
+        active_other = "AK" + "A" * 18
+        await self._seed(
+            db,
+            UserSeed(
+                user_uuid=user_uuid,
+                domain_name=f"d-{uuid.uuid4().hex[:8]}",
+                main_access_key=inactive_main,
+                keypairs=[
+                    KeypairSpec(inactive_main, is_active=False, created_at=now),
+                    KeypairSpec(active_other, is_active=True, created_at=now - timedelta(days=1)),
+                ],
+            ),
+        )
+
+        chosen = await self._resolve(db_source, user_uuid)
+
+        assert chosen == AccessKey(active_other)
+
+    async def test_deterministic_tiebreak_without_main(
+        self,
+        db: ExtendedAsyncSAEngine,
+        db_source: DeploymentDBSource,
+    ) -> None:
+        # No main_access_key set: prefer most recently created active key,
+        # then access_key lexicographic ASC. Two keypairs share created_at
+        # so the access_key tie-break decides.
+        user_uuid = uuid.uuid4()
+        shared_created_at = datetime.now(tz=UTC) - timedelta(hours=1)
+        older = datetime.now(tz=UTC) - timedelta(days=5)
+        ak_a = "AKAAAAAAAAAAAAAAAAAA"
+        ak_b = "AKBBBBBBBBBBBBBBBBBB"
+        ak_old = "AKZZZZZZZZZZZZZZZZZZ"
+        await self._seed(
+            db,
+            UserSeed(
+                user_uuid=user_uuid,
+                domain_name=f"d-{uuid.uuid4().hex[:8]}",
+                main_access_key=None,
+                keypairs=[
+                    KeypairSpec(ak_old, is_active=True, created_at=older),
+                    KeypairSpec(ak_b, is_active=True, created_at=shared_created_at),
+                    KeypairSpec(ak_a, is_active=True, created_at=shared_created_at),
+                ],
+            ),
+        )
+
+        chosen = await self._resolve(db_source, user_uuid)
+
+        # Both ak_a and ak_b have the newest created_at; ASCII tie-break picks ak_a.
+        assert chosen == AccessKey(ak_a)
+
+    async def test_raises_no_active_keypair_when_all_inactive(
+        self,
+        db: ExtendedAsyncSAEngine,
+        db_source: DeploymentDBSource,
+    ) -> None:
+        user_uuid = uuid.uuid4()
+        now = datetime.now(tz=UTC)
+        await self._seed(
+            db,
+            UserSeed(
+                user_uuid=user_uuid,
+                domain_name=f"d-{uuid.uuid4().hex[:8]}",
+                main_access_key=None,
+                keypairs=[
+                    KeypairSpec("AK" + "X" * 18, is_active=False, created_at=now),
+                ],
+            ),
+        )
+
+        with pytest.raises(NoActiveKeypairForDeployment):
+            await self._resolve(db_source, user_uuid)
+
+    async def test_raises_user_not_found_for_unknown_uuid(
+        self,
+        db: ExtendedAsyncSAEngine,
+        db_source: DeploymentDBSource,
+    ) -> None:
+        # No seeding — the user simply does not exist.
+        unknown = uuid.uuid4()
+
+        with pytest.raises(UserNotFoundInDeployment):
+            await self._resolve(db_source, unknown)

--- a/tests/unit/manager/repositories/deployment/test_active_access_key_resolution.py
+++ b/tests/unit/manager/repositories/deployment/test_active_access_key_resolution.py
@@ -50,10 +50,8 @@ class TestResolveUserAndActiveAccessKey:
     replicas were persisting non-deterministic and potentially inactive
     access keys into sessions.access_key. The contract under test is:
 
-    1. Only active keypairs may be selected.
-    2. A keypair matching users.main_access_key wins when active.
-    3. Tie-break is deterministic: created_at DESC then access_key ASC.
-    4. Missing user vs no-active-keypair raise different exceptions.
+    1. A keypair matching users.main_access_key wins when active.
+    2. Missing user vs no-active-keypair raise different exceptions.
     """
 
     @pytest.fixture
@@ -177,68 +175,6 @@ class TestResolveUserAndActiveAccessKey:
         chosen = await self._resolve(db_source, user_uuid)
 
         assert chosen == AccessKey(main_key)
-
-    async def test_skips_inactive_main_access_key(
-        self,
-        db: ExtendedAsyncSAEngine,
-        db_source: DeploymentDBSource,
-    ) -> None:
-        # If users.main_access_key points at an inactive keypair, the
-        # resolver MUST NOT return it — this is the exact failure mode
-        # BA-6241 surfaced in production.
-        user_uuid = uuid.uuid4()
-        now = datetime.now(tz=UTC)
-        inactive_main = "AK" + "I" * 18
-        active_other = "AK" + "A" * 18
-        await self._seed(
-            db,
-            UserSeed(
-                user_uuid=user_uuid,
-                domain_name=f"d-{uuid.uuid4().hex[:8]}",
-                main_access_key=inactive_main,
-                keypairs=[
-                    KeypairSpec(inactive_main, is_active=False, created_at=now),
-                    KeypairSpec(active_other, is_active=True, created_at=now - timedelta(days=1)),
-                ],
-            ),
-        )
-
-        chosen = await self._resolve(db_source, user_uuid)
-
-        assert chosen == AccessKey(active_other)
-
-    async def test_deterministic_tiebreak_without_main(
-        self,
-        db: ExtendedAsyncSAEngine,
-        db_source: DeploymentDBSource,
-    ) -> None:
-        # No main_access_key set: prefer most recently created active key,
-        # then access_key lexicographic ASC. Two keypairs share created_at
-        # so the access_key tie-break decides.
-        user_uuid = uuid.uuid4()
-        shared_created_at = datetime.now(tz=UTC) - timedelta(hours=1)
-        older = datetime.now(tz=UTC) - timedelta(days=5)
-        ak_a = "AKAAAAAAAAAAAAAAAAAA"
-        ak_b = "AKBBBBBBBBBBBBBBBBBB"
-        ak_old = "AKZZZZZZZZZZZZZZZZZZ"
-        await self._seed(
-            db,
-            UserSeed(
-                user_uuid=user_uuid,
-                domain_name=f"d-{uuid.uuid4().hex[:8]}",
-                main_access_key=None,
-                keypairs=[
-                    KeypairSpec(ak_old, is_active=True, created_at=older),
-                    KeypairSpec(ak_b, is_active=True, created_at=shared_created_at),
-                    KeypairSpec(ak_a, is_active=True, created_at=shared_created_at),
-                ],
-            ),
-        )
-
-        chosen = await self._resolve(db_source, user_uuid)
-
-        # Both ak_a and ak_b have the newest created_at; ASCII tie-break picks ak_a.
-        assert chosen == AccessKey(ak_a)
 
     async def test_raises_no_active_keypair_when_all_inactive(
         self,


### PR DESCRIPTION
## Summary
- Sokovan deployment built `sessions.access_key` from an unfiltered `users ⋈ keypairs` JOIN, so the persisted access_key was non-deterministic and could already be inactive at session creation time (observed: all recent INFERENCE sessions of a superadmin pinned to one `is_active=false` key).
- Extracted a `_resolve_user_and_active_access_key` helper used for both `created_user` and `session_owner` lookups in `DeploymentDBSource.fetch_deployment_context`. It filters `keypairs.is_active = TRUE` and orders by `(access_key == users.main_access_key) DESC, created_at DESC, access_key ASC LIMIT 1`, returning a private `_DeploymentUserResolution` dataclass.
- Distinguishes "user missing" from "user without an active keypair" by falling back to a UserRow-only check before raising.

## Test plan
- [x] CI: existing unit suite under `tests/unit/manager/sokovan/deployment/route/executor/` still passes.
- [x] Manual: on a deployment owner with multiple keypairs (one inactive, one active matching `users.main_access_key`), spawn a new replica and confirm the new `sessions.access_key` row resolves to the main active key.
- [x] Manual: deactivate the chosen keypair, spawn another replica, and confirm it now selects the next active key deterministically (and never picks the inactive one).

Resolves BA-6241