### PR TITLE
feat(BA-6245): exclude unenforced grant operations from RBAC permission matrix

### DIFF
--- a/changes/11870.enhance.md
+++ b/changes/11870.enhance.md
@@ -1,0 +1,1 @@
+Exclude unenforced grant operations from the RBAC permission matrix so it only exposes (scope, entity, operation) combinations that are actually checked at runtime.

--- a/src/ai/backend/manager/services/permission_contoller/service.py
+++ b/src/ai/backend/manager/services/permission_contoller/service.py
@@ -2,7 +2,7 @@ import logging
 from collections.abc import Sequence
 from typing import cast
 
-from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.common.data.permission.types import OperationType, RBACElementType
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.actions.action.rbac import (
     BaseRBACAction,
@@ -153,6 +153,18 @@ from ai.backend.manager.services.permission_contoller.actions.update_role_permis
 )
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+# Grant operations are declared in the RBAC action registry as placeholders for a future
+# entity-delegation feature, but no executable action can request them yet
+# (``ActionOperationType`` has no GRANT member). Exclude them from the permission matrix so
+# it only exposes (scope, entity, operation) combinations that are actually enforced.
+_GRANT_OPERATIONS: frozenset[OperationType] = frozenset({
+    OperationType.GRANT_ALL,
+    OperationType.GRANT_READ,
+    OperationType.GRANT_UPDATE,
+    OperationType.GRANT_SOFT_DELETE,
+    OperationType.GRANT_HARD_DELETE,
+})
 
 
 class PermissionControllerService:
@@ -404,14 +416,17 @@ class PermissionControllerService:
         Build the RBAC permission matrix: scope -> entity -> action_name -> permission.
 
         Reads ``permission_scope()`` from each registered RBAC action to produce
-        the full (scope, entity, operation) mapping.
+        the (scope, entity, operation) mapping. Grant operations are skipped because
+        they are not yet enforceable at runtime (see ``_GRANT_OPERATIONS``).
         """
         result: dict[
             RBACElementType, dict[RBACElementType, dict[RBACActionName, RBACRequiredPermission]]
         ] = {}
         for action_cls in self._rbac_action_registry:
-            scope = action_cls.permission_scope()
             perm = action_cls.required_permission()
+            if perm.operation in _GRANT_OPERATIONS:
+                continue
+            scope = action_cls.permission_scope()
             entity_map = result.setdefault(scope, {})
             actions = entity_map.setdefault(perm.element_type, {})
             actions[action_cls.action_name()] = perm

--- a/tests/unit/manager/services/permission_controller/test_permission_controller_service.py
+++ b/tests/unit/manager/services/permission_controller/test_permission_controller_service.py
@@ -20,6 +20,8 @@ from ai.backend.common.data.permission.types import (
     RoleSource,
     ScopeType,
 )
+from ai.backend.manager.actions.action import RBAC_ACTION_REGISTRY
+from ai.backend.manager.actions.action.rbac import RBACActionName
 from ai.backend.manager.data.common.types import SearchResult
 from ai.backend.manager.data.permission.association_scopes_entities import (
     AssociationScopesEntitiesData,
@@ -49,6 +51,9 @@ from ai.backend.manager.services.permission_contoller.actions.create_role import
 from ai.backend.manager.services.permission_contoller.actions.delete_role import DeleteRoleAction
 from ai.backend.manager.services.permission_contoller.actions.get_entity_types import (
     GetEntityTypesAction,
+)
+from ai.backend.manager.services.permission_contoller.actions.get_permission_matrix import (
+    GetPermissionMatrixAction,
 )
 from ai.backend.manager.services.permission_contoller.actions.get_role_detail import (
     GetRoleDetailAction,
@@ -1010,3 +1015,67 @@ class TestSearchElementAssociations:
 
         assert result.result.total_count == 30
         assert result.result.has_next_page is True
+
+
+class TestGetPermissionMatrix:
+    _GRANT_OPERATIONS = {
+        OperationType.GRANT_ALL,
+        OperationType.GRANT_READ,
+        OperationType.GRANT_UPDATE,
+        OperationType.GRANT_SOFT_DELETE,
+        OperationType.GRANT_HARD_DELETE,
+    }
+    _GRANT_ACTION_NAMES = {
+        RBACActionName.GRANT_ALL,
+        RBACActionName.GRANT_READ,
+        RBACActionName.GRANT_UPDATE,
+        RBACActionName.GRANT_SOFT_DELETE,
+        RBACActionName.GRANT_HARD_DELETE,
+    }
+
+    @pytest.fixture
+    def service(self) -> PermissionControllerService:
+        return PermissionControllerService(
+            repository=MagicMock(),
+            group_repository=MagicMock(),
+            rbac_action_registry=RBAC_ACTION_REGISTRY,
+        )
+
+    async def test_matrix_excludes_grant_operations(
+        self,
+        service: PermissionControllerService,
+    ) -> None:
+        result = await service.get_permission_matrix(GetPermissionMatrixAction())
+
+        for entity_map in result.matrix.values():
+            for actions in entity_map.values():
+                for action_name, perm in actions.items():
+                    assert perm.operation not in self._GRANT_OPERATIONS
+                    assert action_name not in self._GRANT_ACTION_NAMES
+
+    async def test_matrix_keeps_non_grant_registry_entries(
+        self,
+        service: PermissionControllerService,
+    ) -> None:
+        result = await service.get_permission_matrix(GetPermissionMatrixAction())
+
+        # Flatten matrix into (scope, entity, action_name) triples.
+        result_triples: set[tuple[RBACElementType, RBACElementType, RBACActionName]] = set()
+        for scope, entity_map in result.matrix.items():
+            for entity, actions in entity_map.items():
+                for action_name in actions:
+                    result_triples.add((scope, entity, action_name))
+
+        expected_non_grant = {
+            (
+                action_cls.permission_scope(),
+                action_cls.required_permission().element_type,
+                action_cls.action_name(),
+            )
+            for action_cls in RBAC_ACTION_REGISTRY
+            if action_cls.required_permission().operation not in self._GRANT_OPERATIONS
+        }
+
+        # Every non-grant registry entry is present, and nothing extra leaked in.
+        assert result_triples == expected_non_grant
+        assert len(result_triples) > 0


### PR DESCRIPTION
## Summary
- The RBAC permission matrix (`rbac_permission_matrix` GraphQL query / `GET /v2/rbac/permission-matrix`) is built from `RBAC_ACTION_REGISTRY`, which includes `SessionGrant*` / `VFolderGrant*` placeholder actions.
- These grant operations (`OperationType.GRANT_*`) are never enforceable at runtime — `ActionOperationType` has no GRANT member, so no executable action can request them. They were leaking into the matrix as unused (scope, entity, operation) combinations.
- `get_permission_matrix()` now skips grant operations so the matrix only exposes combinations that are actually enforced. The action classes, enums, and DB role seeding are left untouched (kept as placeholders for a future delegation feature).

## Test plan
- [x] `pants fmt / fix / lint` pass
- [x] New `TestGetPermissionMatrix` asserts grant operations are excluded and all non-grant registry entries are preserved
- [x] Existing `rbac_entity_operation_combinations` tests still pass (that endpoint intentionally unchanged)

Resolves BA-6245

🤖 Generated with [Claude Code](https://claude.com/claude-code)