### PR TITLE
feat(BA-6233): introduce replica groups owning deployment revision pointers

### DIFF
--- a/changes/11871.feature.md
+++ b/changes/11871.feature.md
@@ -1,0 +1,1 @@
+Introduce replica groups that own deployment revision pointers and per-revision replica counts, moving revision ownership off the endpoint and splitting the v1 (full revision) and v2 (id-only) deployment read paths.

--- a/src/ai/backend/common/identifier/replica_group.py
+++ b/src/ai/backend/common/identifier/replica_group.py
@@ -1,0 +1,6 @@
+from typing import NewType
+from uuid import UUID
+
+__all__ = ("ReplicaGroupID",)
+
+ReplicaGroupID = NewType("ReplicaGroupID", UUID)

--- a/src/ai/backend/manager/api/gql_legacy/endpoint.py
+++ b/src/ai/backend/manager/api/gql_legacy/endpoint.py
@@ -808,7 +808,12 @@ class Endpoint(graphene.ObjectType):  # type: ignore[misc]
             .limit(limit)
             .offset(offset)
             .options(
-                selectinload(EndpointRow.revisions).selectinload(DeploymentRevisionRow.image_row)
+                selectinload(EndpointRow.current_revision_row).selectinload(
+                    DeploymentRevisionRow.image_row
+                ),
+                selectinload(EndpointRow.deploying_revision_row).selectinload(
+                    DeploymentRevisionRow.image_row
+                ),
             )
             .options(selectinload(EndpointRow.routings))
             .options(selectinload(EndpointRow.session_owner_row))

--- a/src/ai/backend/manager/api/rest/deployment/adapter.py
+++ b/src/ai/backend/manager/api/rest/deployment/adapter.py
@@ -61,7 +61,7 @@ from ai.backend.manager.data.deployment.types import (
     DeploymentNetworkSpec,
     DeploymentPolicyData,
     ExecutionSpec,
-    ModelDeploymentData,
+    LegacyDeploymentData,
     ModelRevisionData,
     MountInfo,
     ReplicaSpec,
@@ -124,10 +124,10 @@ class DeploymentAdapter(BaseFilterAdapter):
 
     def convert_to_dto(
         self,
-        data: ModelDeploymentData,
+        data: LegacyDeploymentData,
         runtime_variant_name: RuntimeVariant,
     ) -> DeploymentDTO:
-        """Convert ModelDeploymentData to DTO.
+        """Convert LegacyDeploymentData to DTO.
 
         ``runtime_variant_name`` is resolved by the caller (REST handler)
         from ``data.revision.model_runtime_config.runtime_variant_id``

--- a/src/ai/backend/manager/api/rest/deployment/handler.py
+++ b/src/ai/backend/manager/api/rest/deployment/handler.py
@@ -48,7 +48,7 @@ from ai.backend.common.identifier.deployment_revision import DeploymentRevisionI
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.common.types import RuntimeVariant
 from ai.backend.manager.api.adapters.runtime_variant.adapter import RuntimeVariantAdapter
-from ai.backend.manager.data.deployment.types import ModelDeploymentData, ModelRevisionData
+from ai.backend.manager.data.deployment.types import LegacyDeploymentData, ModelRevisionData
 from ai.backend.manager.data.deployment.types import RouteTrafficStatus as ManagerRouteTrafficStatus
 from ai.backend.manager.dto.context import UserContext
 from ai.backend.manager.models.endpoint import EndpointRow
@@ -70,8 +70,8 @@ from ai.backend.manager.services.deployment.actions.deployment_policy.upsert_dep
 from ai.backend.manager.services.deployment.actions.destroy_deployment import (
     DestroyDeploymentAction,
 )
-from ai.backend.manager.services.deployment.actions.get_deployment_by_id import (
-    GetDeploymentByIdAction,
+from ai.backend.manager.services.deployment.actions.get_legacy_deployment_by_id import (
+    GetLegacyDeploymentByIdAction,
 )
 from ai.backend.manager.services.deployment.actions.model_revision.add_model_revision import (
     AddModelRevisionAction,
@@ -89,8 +89,8 @@ from ai.backend.manager.services.deployment.actions.route import (
     SearchRoutesAction,
     UpdateRouteTrafficStatusAction,
 )
-from ai.backend.manager.services.deployment.actions.search_deployments import (
-    SearchDeploymentsAction,
+from ai.backend.manager.services.deployment.actions.search_legacy_deployments import (
+    SearchLegacyDeploymentsAction,
 )
 from ai.backend.manager.services.deployment.actions.update_deployment import (
     UpdateDeploymentAction,
@@ -152,7 +152,7 @@ class DeploymentAPIHandler:
         )
         return RuntimeVariant(variant_node.name)
 
-    async def _deployment_dto(self, data: ModelDeploymentData) -> DeploymentDTO:
+    async def _deployment_dto(self, data: LegacyDeploymentData) -> DeploymentDTO:
         """Render a deployment DTO with runtime-variant name pre-resolved.
 
         ``DeploymentAdapter.convert_to_dto`` expects the caller to provide
@@ -165,6 +165,16 @@ class DeploymentAPIHandler:
         else:
             variant_name = await self._resolve_revision_variant_name(data.revision)
         return self._deployment_adapter.convert_to_dto(data, variant_name)
+
+    async def _legacy_deployment_dto(self, deployment_id: DeploymentID) -> DeploymentDTO:
+        """Fetch a deployment via the legacy (full-revision) read path and render
+        its DTO. The REST v1 response embeds the full current revision, which the
+        modern (v2) read path does not load.
+        """
+        result = await self._deployment.get_legacy_deployment_by_id.wait_for_complete(
+            GetLegacyDeploymentByIdAction(deployment_id=deployment_id)
+        )
+        return await self._deployment_dto(result.data)
 
     # Deployment Endpoints
 
@@ -188,8 +198,10 @@ class DeploymentAPIHandler:
             CreateDeploymentAction(creator=creator, auto_activate=True)
         )
 
-        # Build response
-        resp = CreateDeploymentResponse(deployment=await self._deployment_dto(action_result.data))
+        # Build response (re-read via the legacy full-revision path for v1)
+        resp = CreateDeploymentResponse(
+            deployment=await self._legacy_deployment_dto(DeploymentID(action_result.data.id))
+        )
         return APIResponse.build(status_code=HTTPStatus.CREATED, response_model=resp)
 
     async def search_deployments(
@@ -200,9 +212,9 @@ class DeploymentAPIHandler:
         # Build querier using adapter
         querier = self._deployment_adapter.build_querier(body.parsed)
 
-        # Call service action
-        action_result = await self._deployment.search_deployments.wait_for_complete(
-            SearchDeploymentsAction(querier=querier)
+        # Call service action (legacy full-revision read path for v1)
+        action_result = await self._deployment.search_legacy_deployments.wait_for_complete(
+            SearchLegacyDeploymentsAction(querier=querier)
         )
 
         # Build response
@@ -222,13 +234,10 @@ class DeploymentAPIHandler:
         path: PathParam[DeploymentPathParam],
     ) -> APIResponse:
         """Get a specific deployment."""
-        # Call service action - raises EndpointNotFound if not found
-        action_result = await self._deployment.get_deployment_by_id.wait_for_complete(
-            GetDeploymentByIdAction(deployment_id=DeploymentID(path.parsed.deployment_id))
+        # Legacy full-revision read path for v1; raises EndpointNotFound if absent
+        resp = GetDeploymentResponse(
+            deployment=await self._legacy_deployment_dto(DeploymentID(path.parsed.deployment_id))
         )
-
-        # Build response
-        resp = GetDeploymentResponse(deployment=await self._deployment_dto(action_result.data))
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=resp)
 
     async def update_deployment(
@@ -264,8 +273,10 @@ class DeploymentAPIHandler:
             UpdateDeploymentAction(updater=updater)
         )
 
-        # Build response
-        resp = UpdateDeploymentResponse(deployment=await self._deployment_dto(action_result.data))
+        # Build response (re-read via the legacy full-revision path for v1)
+        resp = UpdateDeploymentResponse(
+            deployment=await self._legacy_deployment_dto(DeploymentID(action_result.data.id))
+        )
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=resp)
 
     async def destroy_deployment(

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -753,6 +753,13 @@ class DeploymentInfo:
     replica: ReplicaData
     network: DeploymentNetworkData
     options: DeploymentOptions
+    # Revision ids, always populated cheaply from the replica groups (no
+    # revision-row load). The modern (v2) read path fills only these.
+    current_revision_id: DeploymentRevisionID | None = None
+    deploying_revision_id: DeploymentRevisionID | None = None
+    # Full revision data, populated only by the legacy (REST v1) / engine
+    # read paths that eagerly load the revision rows. ``None`` on the modern
+    # read path even when ``current_revision_id`` is set.
     current_revision: ModelRevisionData | None = None
     policy: DeploymentPolicyData | None = None
     deploying_revision: ModelRevisionData | None = None
@@ -1078,10 +1085,17 @@ class ReplicaStateData:
 
 @dataclass
 class ModelDeploymentData:
+    """Modern (v2 / GraphQL) deployment projection.
+
+    Carries revisions as ids only (``current_revision_id`` /
+    ``deploying_revision_id``); the full revision is resolved on demand by
+    the GraphQL DataLoader. The REST v1 surface, which embeds the full
+    revision, uses :class:`LegacyDeploymentData` instead.
+    """
+
     id: DeploymentID
     metadata: ModelDeploymentMetadataInfo
     network_access: DeploymentNetworkData
-    revision: ModelRevisionData | None
     current_revision_id: DeploymentRevisionID | None
     deploying_revision_id: DeploymentRevisionID | None
     revision_history_ids: list[DeploymentRevisionID]
@@ -1096,6 +1110,27 @@ class ModelDeploymentData:
     scaling_state: ScalingState
     policy: DeploymentPolicyData | None = None
     access_token_ids: list[UUID] | None = None
+    sub_step: DeploymentLifecycleSubStep | None = None
+
+
+@dataclass
+class LegacyDeploymentData:
+    """Legacy v1 deployment projection — DO NOT USE in new code.
+
+    Backs the REST v1 ``DeploymentDTO`` response only, which embeds the full
+    current ``revision``. v2 / GraphQL use :class:`ModelDeploymentData`
+    (revision ids only). Built independently from ``DeploymentInfo``; it is
+    never converted to or from :class:`ModelDeploymentData`.
+    """
+
+    id: DeploymentID
+    metadata: ModelDeploymentMetadataInfo
+    network_access: DeploymentNetworkData
+    revision: ModelRevisionData | None
+    replica_state: ReplicaStateData
+    default_deployment_strategy: DeploymentStrategy
+    created_user_id: UUID
+    policy: DeploymentPolicyData | None = None
     sub_step: DeploymentLifecycleSubStep | None = None
 
 

--- a/src/ai/backend/manager/data/model_serving/types.py
+++ b/src/ai/backend/manager/data/model_serving/types.py
@@ -58,6 +58,14 @@ class EndpointAccessValidationData:
 
 @dataclass
 class EndpointData:
+    """Legacy model-serving endpoint projection — DO NOT USE in new code.
+
+    Backs the legacy ``/services`` (model-serving) responses, which flatten
+    the active revision's fields (image, model, resources, mounts, …) onto
+    the endpoint and carry no separate revision object. New deployment code
+    uses ``ModelDeploymentData`` (v2) / ``LegacyDeploymentData`` (REST v1).
+    """
+
     id: uuid.UUID
     name: str
     image: ImageData | None

--- a/src/ai/backend/manager/models/alembic/versions/1a2b3c4d5e6f_drop_endpoint_revision_pointers.py
+++ b/src/ai/backend/manager/models/alembic/versions/1a2b3c4d5e6f_drop_endpoint_revision_pointers.py
@@ -1,0 +1,47 @@
+"""drop current_revision / deploying_revision from endpoints
+
+The revision pointers now live on the replica groups:
+
+- current revision  = primary group's ``current_revision_id``
+- deploying revision = target group's ``target_revision_id``
+
+The ``endpoints.current_revision`` / ``deploying_revision`` columns are no
+longer read or written, so drop them. ``downgrade`` re-adds the columns and
+back-fills them from the replica groups.
+
+Create Date: 2026-05-30
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.base import GUID
+
+revision = "1a2b3c4d5e6f"
+down_revision = "c0ffee5a91d3"
+# Part of: 26.6.0
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("endpoints", "current_revision")
+    op.drop_column("endpoints", "deploying_revision")
+
+
+def downgrade() -> None:
+    op.add_column("endpoints", sa.Column("current_revision", GUID(), nullable=True))
+    op.add_column("endpoints", sa.Column("deploying_revision", GUID(), nullable=True))
+    # Back-fill from the replica groups.
+    op.execute("""
+        UPDATE endpoints e
+        SET current_revision = rg.current_revision_id
+        FROM replica_groups rg
+        WHERE e.primary_replica_group_id = rg.id
+    """)
+    op.execute("""
+        UPDATE endpoints e
+        SET deploying_revision = rg.target_revision_id
+        FROM replica_groups rg
+        WHERE e.target_replica_group_id = rg.id
+    """)

--- a/src/ai/backend/manager/models/alembic/versions/c0ffee5a91d3_add_replica_groups.py
+++ b/src/ai/backend/manager/models/alembic/versions/c0ffee5a91d3_add_replica_groups.py
@@ -1,0 +1,137 @@
+"""add replica_groups table and replica group references
+
+Introduce the ReplicaGroup concept for deployments:
+
+- ``replica_groups`` — one row per group within a deployment. Owns the
+  revision pointers (``current_revision_id`` / ``target_revision_id``)
+  and the per-revision desired replica counts, plus a ``traffic_weight``.
+- ``endpoints.primary_replica_group_id`` / ``target_replica_group_id`` —
+  references to the serving group and the group being rolled out
+  (no FK; avoids a circular FK with ``replica_groups.deployment_id``).
+- ``routings.replica_group_id`` — the group a replica belongs to
+  (no FK; relationship only, mirrors ``routings.revision``).
+
+Backfill: create one replica group per existing endpoint (reusing the
+endpoint id as the group id for a deterministic 1:1 mapping), migrate the
+endpoint's revision pointers and replica count into it, point the
+endpoint's ``primary_replica_group_id`` at it, and attach every existing
+routing to it.
+
+Create Date: 2026-05-29
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.base import GUID
+
+revision = "c0ffee5a91d3"
+down_revision = "0113c63f3261"
+# Part of: 26.6.0
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "replica_groups",
+        sa.Column(
+            "id",
+            GUID(),
+            server_default=sa.text("uuid_generate_v4()"),
+            nullable=False,
+        ),
+        sa.Column("deployment_id", GUID(), nullable=False),
+        sa.Column("current_revision_id", GUID(), nullable=True),
+        sa.Column("target_revision_id", GUID(), nullable=True),
+        sa.Column(
+            "desired_current_replica_count",
+            sa.Integer(),
+            server_default=sa.text("0"),
+            nullable=False,
+        ),
+        sa.Column(
+            "desired_target_replica_count",
+            sa.Integer(),
+            server_default=sa.text("0"),
+            nullable=False,
+        ),
+        sa.Column(
+            "traffic_weight",
+            sa.Integer(),
+            server_default=sa.text("100"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["deployment_id"],
+            ["endpoints.id"],
+            name=op.f("fk_replica_groups_deployment_id_endpoints"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_replica_groups")),
+    )
+    op.create_index(
+        "ix_replica_groups_deployment_id",
+        "replica_groups",
+        ["deployment_id"],
+    )
+
+    op.add_column(
+        "endpoints",
+        sa.Column("primary_replica_group_id", GUID(), nullable=True),
+    )
+    op.add_column(
+        "endpoints",
+        sa.Column("target_replica_group_id", GUID(), nullable=True),
+    )
+
+    op.add_column(
+        "routings",
+        sa.Column("replica_group_id", GUID(), nullable=True),
+    )
+    op.create_index(
+        "ix_routings_replica_group_id",
+        "routings",
+        ["replica_group_id"],
+    )
+
+    # Backfill: one replica group per endpoint, reusing the endpoint id as
+    # the group id for a deterministic 1:1 mapping. Active endpoints get the
+    # default traffic weight (100) so their lone group keeps serving traffic;
+    # destroyed endpoints are left at weight 0 since they no longer route.
+    op.execute("""
+        INSERT INTO replica_groups (
+            id, deployment_id, current_revision_id, target_revision_id,
+            desired_current_replica_count, desired_target_replica_count,
+            traffic_weight, created_at, updated_at
+        )
+        SELECT
+            e.id, e.id, e.current_revision, e.deploying_revision,
+            COALESCE(e.desired_replicas, e.replicas), 0,
+            CASE WHEN e.lifecycle_stage = 'destroyed' THEN 0 ELSE 100 END,
+            now(), now()
+        FROM endpoints e
+    """)
+    op.execute("UPDATE endpoints SET primary_replica_group_id = id")
+    op.execute("UPDATE routings SET replica_group_id = endpoint")
+
+
+def downgrade() -> None:
+    op.drop_index("ix_routings_replica_group_id", table_name="routings")
+    op.drop_column("routings", "replica_group_id")
+    op.drop_column("endpoints", "target_replica_group_id")
+    op.drop_column("endpoints", "primary_replica_group_id")
+    op.drop_index("ix_replica_groups_deployment_id", table_name="replica_groups")
+    op.drop_table("replica_groups")

--- a/src/ai/backend/manager/models/endpoint/row.py
+++ b/src/ai/backend/manager/models/endpoint/row.py
@@ -260,13 +260,10 @@ class EndpointRow(Base):  # type: ignore[misc]
         nullable=True,
     )
 
-    # Revision management columns
-    current_revision: Mapped[DeploymentRevisionID | None] = mapped_column(
-        "current_revision", GUID(DeploymentRevisionID), nullable=True
-    )
-    deploying_revision: Mapped[DeploymentRevisionID | None] = mapped_column(
-        "deploying_revision", GUID(DeploymentRevisionID), nullable=True
-    )
+    # Revision pointers live on the replica groups (see
+    # ``primary_replica_group_id`` / ``target_replica_group_id`` below): the
+    # current revision is the primary group's ``current_revision_id`` and the
+    # deploying revision is the target group's ``target_revision_id``.
 
     # Replica group references (no FK; mirrors ``RoutingRow.revision`` and
     # avoids a circular FK with ``replica_groups.deployment_id``).

--- a/src/ai/backend/manager/models/endpoint/row.py
+++ b/src/ai/backend/manager/models/endpoint/row.py
@@ -845,24 +845,47 @@ class EndpointRow(Base):  # type: ignore[misc]
         )
 
     def to_deployment_info(self) -> DeploymentInfo:
-        """Convert EndpointRow to DeploymentInfo dataclass using revision data."""
+        """Full DeploymentInfo including the resolved current/deploying revision
+        rows. Requires the revision-row relationships to be eagerly loaded
+        (legacy REST v1 / engine read paths). The revision ids are derived from
+        those rows, so no separate replica-group load is needed.
+        """
+        current_row = self.current_revision_row
+        deploying_row = self.deploying_revision_row
         return self._build_deployment_info(
-            current_revision=(
-                self.current_revision_row.to_data() if self.current_revision_row else None
-            ),
-            deploying_revision=(
-                self.deploying_revision_row.to_data() if self.deploying_revision_row else None
-            ),
+            current_revision_id=DeploymentRevisionID(current_row.id) if current_row else None,
+            deploying_revision_id=DeploymentRevisionID(deploying_row.id) if deploying_row else None,
+            current_revision=current_row.to_data() if current_row else None,
+            deploying_revision=deploying_row.to_data() if deploying_row else None,
+            policy=self.deployment_policy.to_data() if self.deployment_policy is not None else None,
+        )
+
+    def to_modern_deployment_info(self) -> DeploymentInfo:
+        """Lightweight DeploymentInfo carrying only the revision *ids* (sourced
+        from the replica groups), without loading the full revision rows. Used
+        by the modern (v2) read path, which only needs the ids. Requires the
+        replica-group relationships to be eagerly loaded.
+        """
+        return self._build_deployment_info(
+            current_revision_id=self.current_revision_id,
+            deploying_revision_id=self.deploying_revision_id,
+            current_revision=None,
+            deploying_revision=None,
             policy=self.deployment_policy.to_data() if self.deployment_policy is not None else None,
         )
 
     def _build_deployment_info(
         self,
+        current_revision_id: DeploymentRevisionID | None,
+        deploying_revision_id: DeploymentRevisionID | None,
         current_revision: ModelRevisionData | None,
         deploying_revision: ModelRevisionData | None,
         policy: DeploymentPolicyData | None = None,
     ) -> DeploymentInfo:
-        """Build DeploymentInfo with current and deploying revision data."""
+        """Build DeploymentInfo. The revision *ids* and the full
+        ``current_revision`` / ``deploying_revision`` data are supplied by the
+        caller (the full data is ``None`` on the modern read path).
+        """
         return DeploymentInfo(
             id=self.id,
             metadata=DeploymentMetadata(
@@ -892,6 +915,8 @@ class EndpointRow(Base):  # type: ignore[misc]
                 preferred_domain_name=None,
             ),
             options=self.options,
+            current_revision_id=current_revision_id,
+            deploying_revision_id=deploying_revision_id,
             current_revision=current_revision,
             deploying_revision=deploying_revision,
             sub_step=self.sub_step,

--- a/src/ai/backend/manager/models/endpoint/row.py
+++ b/src/ai/backend/manager/models/endpoint/row.py
@@ -32,6 +32,7 @@ from sqlalchemy.orm import (
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
 from ai.backend.common.identifier.project import ProjectID
+from ai.backend.common.identifier.replica_group import ReplicaGroupID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.common.types import (
     AccessKey,
@@ -250,6 +251,18 @@ class EndpointRow(Base):  # type: ignore[misc]
     )
     deploying_revision: Mapped[DeploymentRevisionID | None] = mapped_column(
         "deploying_revision", GUID(DeploymentRevisionID), nullable=True
+    )
+
+    # Replica group references (no FK; mirrors ``RoutingRow.revision`` and
+    # avoids a circular FK with ``replica_groups.deployment_id``).
+    # ``primary_replica_group_id`` is the group serving traffic;
+    # ``target_replica_group_id`` is the group being rolled out (``NULL``
+    # in the steady state).
+    primary_replica_group_id: Mapped[ReplicaGroupID | None] = mapped_column(
+        "primary_replica_group_id", GUID(ReplicaGroupID), nullable=True
+    )
+    target_replica_group_id: Mapped[ReplicaGroupID | None] = mapped_column(
+        "target_replica_group_id", GUID(ReplicaGroupID), nullable=True
     )
     sub_step: Mapped[DeploymentLifecycleSubStep | None] = mapped_column(
         "sub_step",

--- a/src/ai/backend/manager/models/endpoint/row.py
+++ b/src/ai/backend/manager/models/endpoint/row.py
@@ -101,6 +101,7 @@ if TYPE_CHECKING:
     )
     from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
     from ai.backend.manager.models.deployment_revision.row import DeploymentRevisionRow
+    from ai.backend.manager.models.replica_group import ReplicaGroupRow
     from ai.backend.manager.models.routing import RoutingRow
     from ai.backend.manager.models.user import UserRow
 
@@ -128,16 +129,30 @@ def _get_endpoint_revisions_join_condition() -> Any:
     return EndpointRow.id == foreign(DeploymentRevisionRow.endpoint)
 
 
-def _get_current_revision_row_join_condition() -> sa.ColumnElement[bool]:
+def _get_primary_replica_group_join_condition() -> sa.ColumnElement[bool]:
+    from ai.backend.manager.models.replica_group import ReplicaGroupRow
+
+    return foreign(EndpointRow.primary_replica_group_id) == ReplicaGroupRow.id
+
+
+def _get_target_replica_group_join_condition() -> sa.ColumnElement[bool]:
+    from ai.backend.manager.models.replica_group import ReplicaGroupRow
+
+    return foreign(EndpointRow.target_replica_group_id) == ReplicaGroupRow.id
+
+
+def _get_current_revision_secondaryjoin() -> sa.ColumnElement[bool]:
     from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+    from ai.backend.manager.models.replica_group import ReplicaGroupRow
 
-    return EndpointRow.current_revision == DeploymentRevisionRow.id
+    return foreign(ReplicaGroupRow.current_revision_id) == DeploymentRevisionRow.id
 
 
-def _get_deploying_revision_row_join_condition() -> sa.ColumnElement[bool]:
+def _get_deploying_revision_secondaryjoin() -> sa.ColumnElement[bool]:
     from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+    from ai.backend.manager.models.replica_group import ReplicaGroupRow
 
-    return EndpointRow.deploying_revision == DeploymentRevisionRow.id
+    return foreign(ReplicaGroupRow.target_revision_id) == DeploymentRevisionRow.id
 
 
 def _get_endpoint_auto_scaling_policy_join_condition() -> Any:
@@ -313,17 +328,36 @@ class EndpointRow(Base):  # type: ignore[misc]
         primaryjoin=_get_endpoint_revisions_join_condition,
         order_by="DeploymentRevisionRow.revision_number.desc()",
     )
+    primary_replica_group_row: Mapped[ReplicaGroupRow | None] = relationship(
+        "ReplicaGroupRow",
+        primaryjoin=_get_primary_replica_group_join_condition,
+        viewonly=True,
+        uselist=False,
+    )
+    target_replica_group_row: Mapped[ReplicaGroupRow | None] = relationship(
+        "ReplicaGroupRow",
+        primaryjoin=_get_target_replica_group_join_condition,
+        viewonly=True,
+        uselist=False,
+    )
+    # Sourced from the replica groups: the current revision is the primary
+    # group's ``current_revision_id`` and the deploying revision is the
+    # target group's ``target_revision_id`` (``None`` when no rollout is in
+    # progress). Joined through ``replica_groups`` so existing consumers
+    # (``to_deployment_info`` and the ``selectinload`` paths) are unchanged.
     current_revision_row: Mapped[DeploymentRevisionRow | None] = relationship(
         "DeploymentRevisionRow",
-        primaryjoin=_get_current_revision_row_join_condition,
-        foreign_keys="EndpointRow.current_revision",
+        secondary="replica_groups",
+        primaryjoin=_get_primary_replica_group_join_condition,
+        secondaryjoin=_get_current_revision_secondaryjoin,
         viewonly=True,
         uselist=False,
     )
     deploying_revision_row: Mapped[DeploymentRevisionRow | None] = relationship(
         "DeploymentRevisionRow",
-        primaryjoin=_get_deploying_revision_row_join_condition,
-        foreign_keys="EndpointRow.deploying_revision",
+        secondary="replica_groups",
+        primaryjoin=_get_target_replica_group_join_condition,
+        secondaryjoin=_get_deploying_revision_secondaryjoin,
         viewonly=True,
         uselist=False,
     )
@@ -372,7 +406,16 @@ class EndpointRow(Base):  # type: ignore[misc]
             query = query.options(selectinload(EndpointRow.session_owner_row))
         if load_revisions:
             query = query.options(
-                selectinload(EndpointRow.revisions).selectinload(DeploymentRevisionRow.image_row)
+                # Revision-resolution helpers (``_find_current_revision`` /
+                # ``_find_active_revision``) read the group-sourced
+                # current/deploying revision relationships, so load only those
+                # two revision rows — not the full revision history.
+                selectinload(EndpointRow.current_revision_row).selectinload(
+                    DeploymentRevisionRow.image_row
+                ),
+                selectinload(EndpointRow.deploying_revision_row).selectinload(
+                    DeploymentRevisionRow.image_row
+                ),
             )
         if project:
             query = query.filter(EndpointRow.project == project)
@@ -417,7 +460,16 @@ class EndpointRow(Base):  # type: ignore[misc]
             query = query.options(selectinload(EndpointRow.session_owner_row))
         if load_revisions:
             query = query.options(
-                selectinload(EndpointRow.revisions).selectinload(DeploymentRevisionRow.image_row)
+                # Revision-resolution helpers (``_find_current_revision`` /
+                # ``_find_active_revision``) read the group-sourced
+                # current/deploying revision relationships, so load only those
+                # two revision rows — not the full revision history.
+                selectinload(EndpointRow.current_revision_row).selectinload(
+                    DeploymentRevisionRow.image_row
+                ),
+                selectinload(EndpointRow.deploying_revision_row).selectinload(
+                    DeploymentRevisionRow.image_row
+                ),
             )
         if project:
             query = query.filter(EndpointRow.project == project)
@@ -462,7 +514,16 @@ class EndpointRow(Base):  # type: ignore[misc]
             query = query.options(selectinload(EndpointRow.session_owner_row))
         if load_revisions:
             query = query.options(
-                selectinload(EndpointRow.revisions).selectinload(DeploymentRevisionRow.image_row)
+                # Revision-resolution helpers (``_find_current_revision`` /
+                # ``_find_active_revision``) read the group-sourced
+                # current/deploying revision relationships, so load only those
+                # two revision rows — not the full revision history.
+                selectinload(EndpointRow.current_revision_row).selectinload(
+                    DeploymentRevisionRow.image_row
+                ),
+                selectinload(EndpointRow.deploying_revision_row).selectinload(
+                    DeploymentRevisionRow.image_row
+                ),
             )
         if project:
             query = query.filter(EndpointRow.project == project)
@@ -489,13 +550,19 @@ class EndpointRow(Base):  # type: ignore[misc]
         status_filter: Iterable[EndpointLifecycle] = frozenset([EndpointLifecycle.CREATED]),
     ) -> Sequence[Self]:
         from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+        from ai.backend.manager.models.replica_group import ReplicaGroupRow
 
-        # Join through current revision to find endpoints by model
+        # Join through the primary replica group's current revision to find
+        # endpoints by model.
         query = (
             sa.select(EndpointRow)
             .join(
+                ReplicaGroupRow,
+                EndpointRow.primary_replica_group_id == ReplicaGroupRow.id,
+            )
+            .join(
                 DeploymentRevisionRow,
-                EndpointRow.current_revision == DeploymentRevisionRow.id,
+                ReplicaGroupRow.current_revision_id == DeploymentRevisionRow.id,
             )
             .where(
                 EndpointRow.lifecycle_stage.in_(status_filter)
@@ -513,7 +580,16 @@ class EndpointRow(Base):  # type: ignore[misc]
             query = query.options(selectinload(EndpointRow.session_owner_row))
         if load_revisions:
             query = query.options(
-                selectinload(EndpointRow.revisions).selectinload(DeploymentRevisionRow.image_row)
+                # Revision-resolution helpers (``_find_current_revision`` /
+                # ``_find_active_revision``) read the group-sourced
+                # current/deploying revision relationships, so load only those
+                # two revision rows — not the full revision history.
+                selectinload(EndpointRow.current_revision_row).selectinload(
+                    DeploymentRevisionRow.image_row
+                ),
+                selectinload(EndpointRow.deploying_revision_row).selectinload(
+                    DeploymentRevisionRow.image_row
+                ),
             )
         if project:
             query = query.filter(EndpointRow.project == project)
@@ -595,38 +671,45 @@ class EndpointRow(Base):  # type: ignore[misc]
         for session_row in session_rows:
             session_row.delegate_ownership(target_user_uuid, target_access_key)
 
-    def _find_current_revision(self) -> DeploymentRevisionRow | None:
-        """Find the current revision row from eagerly loaded revisions.
+    @property
+    def current_revision_id(self) -> DeploymentRevisionID | None:
+        """Active revision id, sourced from the primary replica group.
 
-        Requires revisions to be eagerly loaded via selectinload.
-
-        Raises:
-            RuntimeError: If revisions are not loaded (programming error).
+        Requires ``primary_replica_group_row`` to be eagerly loaded.
         """
-        if not self.current_revision:
-            return None
-        for rev in self.revisions:
-            if rev.id == self.current_revision:
-                return rev
-        return None
+        group = self.primary_replica_group_row
+        return group.current_revision_id if group is not None else None
+
+    @property
+    def deploying_revision_id(self) -> DeploymentRevisionID | None:
+        """Revision being rolled out, sourced from the target replica group's
+        ``target_revision_id`` (``None`` when no rollout is in progress).
+
+        Requires ``target_replica_group_row`` to be eagerly loaded.
+        """
+        group = self.target_replica_group_row
+        return group.target_revision_id if group is not None else None
+
+    def _find_current_revision(self) -> DeploymentRevisionRow | None:
+        """Active revision row, sourced from the primary replica group.
+
+        Requires ``current_revision_row`` to be eagerly loaded.
+        """
+        return self.current_revision_row
 
     def _find_active_revision(self) -> DeploymentRevisionRow | None:
         """Return the revision representing the deployment's active spec.
 
-        Falls back to ``deploying_revision`` when ``current_revision`` is
-        unset (e.g. during the initial DEPLOYING phase before strategy
-        completion). Used by display/serialization paths that should reflect
-        the spec being deployed rather than rendering empty fields.
+        Falls back to the deploying revision (the target group's
+        ``target_revision_id``) when the current revision is unset (e.g.
+        during the initial DEPLOYING phase before strategy completion).
+        Used by display/serialization paths that should reflect the spec
+        being deployed rather than rendering empty fields.
+
+        Requires ``current_revision_row`` and ``deploying_revision_row`` to
+        be eagerly loaded.
         """
-        current = self._find_current_revision()
-        if current is not None:
-            return current
-        if not self.deploying_revision:
-            return None
-        for rev in self.revisions:
-            if rev.id == self.deploying_revision:
-                return rev
-        return None
+        return self.current_revision_row or self.deploying_revision_row
 
     def to_summary_data(self) -> DeploymentSummaryData:
         return DeploymentSummaryData(
@@ -641,8 +724,8 @@ class EndpointRow(Base):  # type: ignore[misc]
             tag=self.tag,
             open_to_public=self.open_to_public or False,
             url=self.url,
-            current_revision=self.current_revision,
-            deploying_revision=self.deploying_revision,
+            current_revision=self.current_revision_id,
+            deploying_revision=self.deploying_revision_id,
             replicas=self.replicas,
             desired_replicas=self.desired_replicas,
             created_at=self.created_at,

--- a/src/ai/backend/manager/models/replica_group/__init__.py
+++ b/src/ai/backend/manager/models/replica_group/__init__.py
@@ -1,0 +1,3 @@
+from .row import ReplicaGroupRow
+
+__all__ = ("ReplicaGroupRow",)

--- a/src/ai/backend/manager/models/replica_group/row.py
+++ b/src/ai/backend/manager/models/replica_group/row.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
+
+from ai.backend.common.identifier.deployment import DeploymentID
+from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
+from ai.backend.common.identifier.replica_group import ReplicaGroupID
+from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.models.base import GUID, Base
+
+if TYPE_CHECKING:
+    from ai.backend.manager.models.endpoint import EndpointRow
+
+__all__ = ("ReplicaGroupRow",)
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+def _get_deployment_join_condition() -> sa.sql.elements.ColumnElement[Any]:
+    from ai.backend.manager.models.endpoint import EndpointRow
+
+    return foreign(ReplicaGroupRow.deployment_id) == EndpointRow.id
+
+
+class ReplicaGroupRow(Base):  # type: ignore[misc]
+    """
+    A group of replicas (routes) within a single deployment.
+
+    A replica group owns the revision pointers and per-revision desired
+    replica counts so a deployment can run several groups, each rolling
+    out its own revision and receiving a share of the traffic.
+    """
+
+    __tablename__ = "replica_groups"
+
+    __table_args__ = (sa.Index("ix_replica_groups_deployment_id", "deployment_id"),)
+
+    id: Mapped[ReplicaGroupID] = mapped_column(
+        "id",
+        GUID(ReplicaGroupID),
+        primary_key=True,
+        server_default=sa.text("uuid_generate_v4()"),
+    )
+    deployment_id: Mapped[DeploymentID] = mapped_column(
+        "deployment_id",
+        GUID,
+        sa.ForeignKey("endpoints.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    # Revision pointers (no FK; mirrors ``RoutingRow.revision``).
+    # ``current_revision_id`` is the revision actively serving traffic in
+    # this group; ``target_revision_id`` is the revision being rolled out
+    # within the group (``NULL`` when no rollout is in progress).
+    current_revision_id: Mapped[DeploymentRevisionID | None] = mapped_column(
+        "current_revision_id", GUID(DeploymentRevisionID), nullable=True
+    )
+    target_revision_id: Mapped[DeploymentRevisionID | None] = mapped_column(
+        "target_revision_id", GUID(DeploymentRevisionID), nullable=True
+    )
+
+    # Desired replica counts split by revision within the group.
+    desired_current_replica_count: Mapped[int] = mapped_column(
+        "desired_current_replica_count",
+        sa.Integer,
+        nullable=False,
+        default=0,
+        server_default=sa.text("0"),
+    )
+    desired_target_replica_count: Mapped[int] = mapped_column(
+        "desired_target_replica_count",
+        sa.Integer,
+        nullable=False,
+        default=0,
+        server_default=sa.text("0"),
+    )
+
+    # Relative weight of this group when distributing traffic across the
+    # deployment's replica groups.
+    traffic_weight: Mapped[int] = mapped_column(
+        "traffic_weight",
+        sa.Integer,
+        nullable=False,
+        default=0,
+        server_default=sa.text("0"),
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        "created_at",
+        sa.DateTime(timezone=True),
+        server_default=sa.func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        "updated_at",
+        sa.DateTime(timezone=True),
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+        nullable=False,
+    )
+
+    endpoint_row: Mapped[EndpointRow] = relationship(
+        "EndpointRow",
+        primaryjoin=_get_deployment_join_condition,
+        viewonly=True,
+    )

--- a/src/ai/backend/manager/models/replica_group/row.py
+++ b/src/ai/backend/manager/models/replica_group/row.py
@@ -88,13 +88,14 @@ class ReplicaGroupRow(Base):  # type: ignore[misc]
     )
 
     # Relative weight of this group when distributing traffic across the
-    # deployment's replica groups.
+    # deployment's replica groups. Defaults to 100 so a lone group receives
+    # the full share and percentage-style splits are intuitive.
     traffic_weight: Mapped[int] = mapped_column(
         "traffic_weight",
         sa.Integer,
         nullable=False,
-        default=0,
-        server_default=sa.text("0"),
+        default=100,
+        server_default=sa.text("100"),
     )
 
     created_at: Mapped[datetime] = mapped_column(

--- a/src/ai/backend/manager/models/replica_group/row.py
+++ b/src/ai/backend/manager/models/replica_group/row.py
@@ -14,6 +14,7 @@ from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.models.base import GUID, Base
 
 if TYPE_CHECKING:
+    from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
     from ai.backend.manager.models.endpoint import EndpointRow
     from ai.backend.manager.models.routing import RoutingRow
 
@@ -32,6 +33,18 @@ def _get_replicas_join_condition() -> sa.sql.elements.ColumnElement[Any]:
     from ai.backend.manager.models.routing import RoutingRow
 
     return ReplicaGroupRow.id == foreign(RoutingRow.replica_group_id)
+
+
+def _get_current_revision_join_condition() -> sa.sql.elements.ColumnElement[Any]:
+    from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+
+    return foreign(ReplicaGroupRow.current_revision_id) == DeploymentRevisionRow.id
+
+
+def _get_target_revision_join_condition() -> sa.sql.elements.ColumnElement[Any]:
+    from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+
+    return foreign(ReplicaGroupRow.target_revision_id) == DeploymentRevisionRow.id
 
 
 class ReplicaGroupRow(Base):  # type: ignore[misc]
@@ -121,4 +134,16 @@ class ReplicaGroupRow(Base):  # type: ignore[misc]
         "RoutingRow",
         primaryjoin=_get_replicas_join_condition,
         viewonly=True,
+    )
+    current_revision_row: Mapped[DeploymentRevisionRow | None] = relationship(
+        "DeploymentRevisionRow",
+        primaryjoin=_get_current_revision_join_condition,
+        viewonly=True,
+        uselist=False,
+    )
+    target_revision_row: Mapped[DeploymentRevisionRow | None] = relationship(
+        "DeploymentRevisionRow",
+        primaryjoin=_get_target_revision_join_condition,
+        viewonly=True,
+        uselist=False,
     )

--- a/src/ai/backend/manager/models/replica_group/row.py
+++ b/src/ai/backend/manager/models/replica_group/row.py
@@ -15,6 +15,7 @@ from ai.backend.manager.models.base import GUID, Base
 
 if TYPE_CHECKING:
     from ai.backend.manager.models.endpoint import EndpointRow
+    from ai.backend.manager.models.routing import RoutingRow
 
 __all__ = ("ReplicaGroupRow",)
 
@@ -25,6 +26,12 @@ def _get_deployment_join_condition() -> sa.sql.elements.ColumnElement[Any]:
     from ai.backend.manager.models.endpoint import EndpointRow
 
     return foreign(ReplicaGroupRow.deployment_id) == EndpointRow.id
+
+
+def _get_replicas_join_condition() -> sa.sql.elements.ColumnElement[Any]:
+    from ai.backend.manager.models.routing import RoutingRow
+
+    return ReplicaGroupRow.id == foreign(RoutingRow.replica_group_id)
 
 
 class ReplicaGroupRow(Base):  # type: ignore[misc]
@@ -107,5 +114,10 @@ class ReplicaGroupRow(Base):  # type: ignore[misc]
     endpoint_row: Mapped[EndpointRow] = relationship(
         "EndpointRow",
         primaryjoin=_get_deployment_join_condition,
+        viewonly=True,
+    )
+    replicas: Mapped[list[RoutingRow]] = relationship(
+        "RoutingRow",
+        primaryjoin=_get_replicas_join_condition,
         viewonly=True,
     )

--- a/src/ai/backend/manager/models/routing/row.py
+++ b/src/ai/backend/manager/models/routing/row.py
@@ -10,11 +10,12 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pgsql
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import Mapped, mapped_column, relationship, selectinload
+from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship, selectinload
 
 from ai.backend.common.config import ModelHealthCheck
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.replica import ReplicaID
+from ai.backend.common.identifier.replica_group import ReplicaGroupID
 from ai.backend.common.types import SessionId
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.deployment.types import (
@@ -35,6 +36,7 @@ from ai.backend.manager.models.base import (
 if TYPE_CHECKING:
     from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
     from ai.backend.manager.models.endpoint import EndpointRow
+    from ai.backend.manager.models.replica_group import ReplicaGroupRow
     from ai.backend.manager.models.session import SessionRow
 
 
@@ -48,6 +50,12 @@ def _get_deployment_revision_join_condition() -> sa.ColumnElement[bool]:
     from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
 
     return RoutingRow.revision == DeploymentRevisionRow.id
+
+
+def _get_replica_group_join_condition() -> sa.ColumnElement[bool]:
+    from ai.backend.manager.models.replica_group import ReplicaGroupRow
+
+    return foreign(RoutingRow.replica_group_id) == ReplicaGroupRow.id
 
 
 class RoutingRow(Base):  # type: ignore[misc]
@@ -119,6 +127,14 @@ class RoutingRow(Base):  # type: ignore[misc]
 
     # Revision reference without FK (relationship only)
     revision: Mapped[uuid.UUID] = mapped_column("revision", GUID, nullable=False)
+    # Replica group this replica belongs to (``NULL`` until assigned).
+    # No FK (relationship only); mirrors ``revision`` above.
+    replica_group_id: Mapped[ReplicaGroupID | None] = mapped_column(
+        "replica_group_id",
+        GUID(ReplicaGroupID),
+        nullable=True,
+        index=True,
+    )
     traffic_status: Mapped[RouteTrafficStatus] = mapped_column(
         "traffic_status",
         StrEnumType(RouteTrafficStatus, use_name=False),
@@ -147,6 +163,11 @@ class RoutingRow(Base):  # type: ignore[misc]
         "DeploymentRevisionRow",
         primaryjoin=_get_deployment_revision_join_condition,
         foreign_keys="RoutingRow.revision",
+        viewonly=True,
+    )
+    replica_group_row: Mapped[ReplicaGroupRow | None] = relationship(
+        "ReplicaGroupRow",
+        primaryjoin=_get_replica_group_join_condition,
         viewonly=True,
     )
 

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -16,7 +16,7 @@ from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 from sqlalchemy.ext.asyncio import async_sessionmaker
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import aliased, selectinload
 
 from ai.backend.common.config import ModelHealthCheck
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
@@ -30,6 +30,7 @@ from ai.backend.common.identifier.deployment_preset import DeploymentPresetID
 from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.replica import ReplicaID
+from ai.backend.common.identifier.replica_group import ReplicaGroupID
 from ai.backend.common.identifier.resource_group import ResourceGroupName
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.common.identifier.vfolder import VFolderUUID
@@ -126,6 +127,7 @@ from ai.backend.manager.models.group import GroupRow, groups
 from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.keypair import keypairs
+from ai.backend.manager.models.replica_group import ReplicaGroupRow
 from ai.backend.manager.models.resource_slot.row import (
     DeploymentRevisionResourceSlotRow,
     PresetResourceSlotRow,
@@ -326,6 +328,19 @@ class DeploymentDBSource:
                 ),
             )
             await execute_rbac_entity_creator(db_sess, policy_creator)
+            await db_sess.flush()
+
+            # Every deployment owns a primary replica group that holds its
+            # revision pointers and per-revision desired replica counts. The
+            # revision pointers start empty; the first rollout populates them
+            # via ``set_deploying_revision`` / the deployment swap.
+            primary_replica_group = ReplicaGroupRow(
+                deployment_id=endpoint.id,
+                desired_current_replica_count=endpoint.replicas,
+            )
+            db_sess.add(primary_replica_group)
+            await db_sess.flush()
+            endpoint.primary_replica_group_id = ReplicaGroupID(primary_replica_group.id)
             await db_sess.flush()
 
             stmt = (
@@ -1149,12 +1164,15 @@ class DeploymentDBSource:
     ) -> DeploymentSummarySearchResult:
         """Search endpoints within a project scope with pagination and filtering.
 
-        Returns lightweight DeploymentSummaryData built from EndpointRow scalar
-        columns only (no eager-loaded relationships). Revision and policy
-        details are not included.
+        Returns lightweight DeploymentSummaryData. Only the replica group
+        rows are eagerly loaded — ``to_summary_data`` reads the current /
+        deploying revision *ids* from them (not the full revision rows).
         """
         async with self._begin_readonly_session_read_committed() as db_sess:
-            query = sa.select(EndpointRow)
+            query = sa.select(EndpointRow).options(
+                selectinload(EndpointRow.primary_replica_group_row),
+                selectinload(EndpointRow.target_replica_group_row),
+            )
 
             result = await execute_batch_querier(
                 db_sess,
@@ -1224,8 +1242,12 @@ class DeploymentDBSource:
                 .select_from(RoutingRow)
                 .join(EndpointRow, RoutingRow.endpoint == EndpointRow.id)
                 .join(
+                    ReplicaGroupRow,
+                    EndpointRow.primary_replica_group_id == ReplicaGroupRow.id,
+                )
+                .join(
                     DeploymentRevisionRow,
-                    EndpointRow.current_revision == DeploymentRevisionRow.id,
+                    ReplicaGroupRow.current_revision_id == DeploymentRevisionRow.id,
                 )
                 .join(
                     RuntimeVariantRow,
@@ -2627,8 +2649,15 @@ class DeploymentDBSource:
             DeploymentRevisionNotFound: If the endpoint has no current revision.
         """
         async with self._db.begin_readonly_session() as db_sess:
-            endpoint_query = sa.select(EndpointRow.current_revision).where(
-                EndpointRow.id == endpoint_id
+            # Current revision lives on the primary replica group.
+            endpoint_query = (
+                sa.select(ReplicaGroupRow.current_revision_id)
+                .select_from(EndpointRow)
+                .join(
+                    ReplicaGroupRow,
+                    EndpointRow.primary_replica_group_id == ReplicaGroupRow.id,
+                )
+                .where(EndpointRow.id == endpoint_id)
             )
             result = await db_sess.execute(endpoint_query)
             current_revision_id = result.scalar_one_or_none()
@@ -2767,21 +2796,39 @@ class DeploymentDBSource:
             ``updated=False`` means the endpoint row was not found.
         """
         async with self._begin_session_read_committed() as db_sess:
-            update_query = (
+            # Revision pointers live on the primary replica group. Resolve it
+            # (and its current revision, returned as the "previous") first.
+            group_query = (
+                sa.select(ReplicaGroupRow.id, ReplicaGroupRow.current_revision_id)
+                .select_from(EndpointRow)
+                .join(
+                    ReplicaGroupRow,
+                    EndpointRow.primary_replica_group_id == ReplicaGroupRow.id,
+                )
+                .where(EndpointRow.id == endpoint_id)
+            )
+            group_row = (await db_sess.execute(group_query)).one_or_none()
+            if group_row is None:
+                return None, False
+            primary_group_id, previous_current_revision_id = group_row
+
+            # Set the rollout target on the primary group and point the
+            # deployment's target group at it (rolling within the same group).
+            await db_sess.execute(
+                sa.update(ReplicaGroupRow)
+                .where(ReplicaGroupRow.id == primary_group_id)
+                .values(target_revision_id=revision_id)
+            )
+            await db_sess.execute(
                 sa.update(EndpointRow)
                 .where(EndpointRow.id == endpoint_id)
                 .values(
-                    deploying_revision=revision_id,
+                    target_replica_group_id=primary_group_id,
                     lifecycle_stage=EndpointLifecycle.DEPLOYING,
                     sub_step=DeploymentLifecycleSubStep.DEPLOYING_PROVISIONING,
                 )
-                .returning(EndpointRow.current_revision)
             )
-            result = await db_sess.execute(update_query)
-            row = result.one_or_none()
-            if row is None:
-                return None, False
-            return cast(DeploymentRevisionID | None, row[0]), True
+            return cast(DeploymentRevisionID | None, previous_current_revision_id), True
 
     async def prune_old_revisions(
         self,
@@ -2801,11 +2848,26 @@ class DeploymentDBSource:
         Returns the number of deleted revisions.
         """
         async with self._begin_session_read_committed() as db_sess:
-            # Fetch protected revision IDs
-            endpoint_query = sa.select(
-                EndpointRow.current_revision,
-                EndpointRow.deploying_revision,
-            ).where(EndpointRow.id == endpoint_id)
+            # Fetch protected revision IDs: the primary group's current
+            # revision and the target group's deploying revision.
+            primary_group = aliased(ReplicaGroupRow)
+            target_group = aliased(ReplicaGroupRow)
+            endpoint_query = (
+                sa.select(
+                    primary_group.current_revision_id,
+                    target_group.target_revision_id,
+                )
+                .select_from(EndpointRow)
+                .outerjoin(
+                    primary_group,
+                    EndpointRow.primary_replica_group_id == primary_group.id,
+                )
+                .outerjoin(
+                    target_group,
+                    EndpointRow.target_replica_group_id == target_group.id,
+                )
+                .where(EndpointRow.id == endpoint_id)
+            )
             ep_result = await db_sess.execute(endpoint_query)
             ep_row = ep_result.one_or_none()
             if ep_row is None:
@@ -3178,23 +3240,36 @@ class DeploymentDBSource:
         db_sess: SASession,
         completed_ids: set[DeploymentID],
     ) -> int:
-        """Swap deploying_revision → current_revision for completed deployments."""
+        """Roll each completed deployment's primary group forward: the group's
+        ``target_revision_id`` becomes its ``current_revision_id`` and the
+        deployment's rollout pointer (``target_replica_group_id``) is cleared."""
         if not completed_ids:
             return 0
-        query = (
-            sa.update(EndpointRow)
+        primary_group_ids = sa.select(EndpointRow.primary_replica_group_id).where(
+            EndpointRow.id.in_(completed_ids)
+        )
+        group_update = (
+            sa.update(ReplicaGroupRow)
             .where(
-                EndpointRow.id.in_(completed_ids),
-                EndpointRow.deploying_revision.is_not(None),
+                ReplicaGroupRow.id.in_(primary_group_ids),
+                ReplicaGroupRow.target_revision_id.is_not(None),
             )
             .values(
-                current_revision=EndpointRow.deploying_revision,
-                deploying_revision=None,
+                current_revision_id=ReplicaGroupRow.target_revision_id,
+                target_revision_id=None,
+            )
+        )
+        result = await db_sess.execute(group_update)
+        swapped = cast(CursorResult[Any], result).rowcount
+        await db_sess.execute(
+            sa.update(EndpointRow)
+            .where(EndpointRow.id.in_(completed_ids))
+            .values(
+                target_replica_group_id=None,
                 sub_step=None,
             )
         )
-        result = await db_sess.execute(query)
-        return cast(CursorResult[Any], result).rowcount
+        return swapped
 
     async def clear_deploying_revision(
         self,
@@ -3208,15 +3283,24 @@ class DeploymentDBSource:
         if not deployment_ids:
             return
         async with self._begin_session_read_committed() as db_sess:
-            query = (
+            # Drop the rollout target on each primary group, then clear the
+            # deployment's rollout pointer and sub-step.
+            primary_group_ids = sa.select(EndpointRow.primary_replica_group_id).where(
+                EndpointRow.id.in_(deployment_ids)
+            )
+            await db_sess.execute(
+                sa.update(ReplicaGroupRow)
+                .where(ReplicaGroupRow.id.in_(primary_group_ids))
+                .values(target_revision_id=None)
+            )
+            await db_sess.execute(
                 sa.update(EndpointRow)
                 .where(EndpointRow.id.in_(deployment_ids))
                 .values(
-                    deploying_revision=None,
+                    target_replica_group_id=None,
                     sub_step=None,
                 )
             )
-            await db_sess.execute(query)
 
     async def search_revision_resource_slots(
         self,

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -394,7 +394,40 @@ class DeploymentDBSource:
         self,
         endpoint_id: DeploymentID,
     ) -> DeploymentInfo:
-        """Get endpoint by ID.
+        """Get endpoint by ID (modern, light: revision *ids* only).
+
+        Loads the replica groups for the revision ids but not the full
+        revision rows. For the full revision data (REST v1) use
+        :meth:`get_legacy_endpoint`.
+
+        Raises:
+            EndpointNotFound: If the endpoint does not exist
+        """
+        async with self._begin_readonly_session_read_committed() as db_sess:
+            query = (
+                sa.select(EndpointRow)
+                .where(EndpointRow.id == endpoint_id)
+                .options(
+                    selectinload(EndpointRow.primary_replica_group_row),
+                    selectinload(EndpointRow.target_replica_group_row),
+                    selectinload(EndpointRow.deployment_policy),
+                )
+            )
+            result = await db_sess.execute(query)
+            row: EndpointRow | None = result.scalar_one_or_none()
+
+            if not row:
+                raise EndpointNotFound(f"Endpoint {endpoint_id} not found")
+
+            return row.to_modern_deployment_info()
+
+    async def get_legacy_endpoint(
+        self,
+        endpoint_id: DeploymentID,
+    ) -> DeploymentInfo:
+        """Get endpoint by ID (legacy, full: includes the current/deploying
+        revision rows). DO NOT USE in new code — the REST v1 surface needs the
+        embedded revision; v2 uses :meth:`get_endpoint`.
 
         Raises:
             EndpointNotFound: If the endpoint does not exist
@@ -1127,13 +1160,41 @@ class DeploymentDBSource:
         self,
         querier: BatchQuerier,
     ) -> DeploymentInfoSearchResult:
-        """Search endpoints with pagination and filtering.
+        """Search endpoints (modern, light: revision *ids* only).
 
-        Args:
-            querier: BatchQuerier containing conditions, orders, and pagination
+        Loads the replica groups for the revision ids but not the full
+        revision rows. For the full revision data (REST v1) use
+        :meth:`search_legacy_endpoints`.
+        """
+        async with self._begin_readonly_session_read_committed() as db_sess:
+            query = sa.select(EndpointRow).options(
+                selectinload(EndpointRow.primary_replica_group_row),
+                selectinload(EndpointRow.target_replica_group_row),
+                selectinload(EndpointRow.deployment_policy),
+            )
 
-        Returns:
-            DeploymentInfoSearchResult with items, total_count, and pagination info
+            result = await execute_batch_querier(
+                db_sess,
+                query,
+                querier,
+            )
+
+            items = [row.EndpointRow.to_modern_deployment_info() for row in result.rows]
+
+            return DeploymentInfoSearchResult(
+                items=items,
+                total_count=result.total_count,
+                has_next_page=result.has_next_page,
+                has_previous_page=result.has_previous_page,
+            )
+
+    async def search_legacy_endpoints(
+        self,
+        querier: BatchQuerier,
+    ) -> DeploymentInfoSearchResult:
+        """Search endpoints (legacy, full: includes the current/deploying
+        revision rows). DO NOT USE in new code — the REST v1 surface needs the
+        embedded revision; v2 uses :meth:`search_endpoints`.
         """
         async with self._begin_readonly_session_read_committed() as db_sess:
             query = sa.select(EndpointRow).options(

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -2742,9 +2742,9 @@ class DeploymentDBSource:
     ) -> ModelRevisionData:
         """Get the latest revision (highest ``revision_number``) of a deployment.
 
-        Unlike :meth:`get_current_revision`, this does not consult
-        ``EndpointRow.current_revision``: it returns the most recently
-        created revision for the endpoint regardless of activation state.
+        Unlike :meth:`get_current_revision`, this does not consult the primary
+        group's ``current_revision_id``: it returns the most recently created
+        revision for the endpoint regardless of activation state.
 
         Args:
             endpoint_id: ID of the deployment endpoint

--- a/src/ai/backend/manager/repositories/deployment/repository.py
+++ b/src/ai/backend/manager/repositories/deployment/repository.py
@@ -345,12 +345,25 @@ class DeploymentRepository:
         self,
         endpoint_id: DeploymentID,
     ) -> DeploymentInfo:
-        """Get endpoint information.
+        """Get endpoint information (modern, light: revision *ids* only).
 
         Raises:
             EndpointNotFound: If the endpoint does not exist
         """
         return await self._db_source.get_endpoint(endpoint_id)
+
+    @deployment_repository_resilience.apply()
+    async def get_legacy_endpoint_info(
+        self,
+        endpoint_id: DeploymentID,
+    ) -> DeploymentInfo:
+        """Get endpoint information (legacy, full: includes the current/deploying
+        revision data). DO NOT USE in new code — for the REST v1 surface only.
+
+        Raises:
+            EndpointNotFound: If the endpoint does not exist
+        """
+        return await self._db_source.get_legacy_endpoint(endpoint_id)
 
     @deployment_repository_resilience.apply()
     async def destroy_endpoint(
@@ -1528,15 +1541,18 @@ class DeploymentRepository:
         self,
         querier: BatchQuerier,
     ) -> DeploymentInfoSearchResult:
-        """Search endpoints with pagination and filtering.
-
-        Args:
-            querier: BatchQuerier containing conditions, orders, and pagination
-
-        Returns:
-            DeploymentInfoSearchResult with items, total_count, and pagination info
-        """
+        """Search endpoints (modern, light: revision *ids* only)."""
         return await self._db_source.search_endpoints(querier)
+
+    @deployment_repository_resilience.apply()
+    async def search_legacy_endpoints(
+        self,
+        querier: BatchQuerier,
+    ) -> DeploymentInfoSearchResult:
+        """Search endpoints (legacy, full: includes the current/deploying
+        revision data). DO NOT USE in new code — for the REST v1 surface only.
+        """
+        return await self._db_source.search_legacy_endpoints(querier)
 
     @deployment_repository_resilience.apply()
     async def search_deployments_in_project(

--- a/src/ai/backend/manager/repositories/deployment/repository.py
+++ b/src/ai/backend/manager/repositories/deployment/repository.py
@@ -1305,9 +1305,9 @@ class DeploymentRepository:
     ) -> ModelRevisionData:
         """Get the latest revision (highest ``revision_number``) of a deployment.
 
-        Unlike :meth:`get_current_revision`, this does not consult
-        ``EndpointRow.current_revision``: it returns the most recently
-        created revision for the endpoint regardless of activation state.
+        Unlike :meth:`get_current_revision`, this does not consult the primary
+        group's ``current_revision_id``: it returns the most recently created
+        revision for the endpoint regardless of activation state.
 
         Raises:
             DeploymentRevisionNotFound: If no revisions exist for the endpoint.

--- a/src/ai/backend/manager/repositories/model_serving/repository.py
+++ b/src/ai/backend/manager/repositories/model_serving/repository.py
@@ -187,7 +187,10 @@ class ModelServingRepository:
                     selectinload(EndpointRow.routings),
                     selectinload(EndpointRow.session_owner_row),
                     selectinload(EndpointRow.created_user_row),
-                    selectinload(EndpointRow.revisions).selectinload(
+                    selectinload(EndpointRow.current_revision_row).selectinload(
+                        DeploymentRevisionRow.image_row
+                    ),
+                    selectinload(EndpointRow.deploying_revision_row).selectinload(
                         DeploymentRevisionRow.image_row
                     ),
                 )
@@ -874,7 +877,7 @@ class ModelServingRepository:
                 .where(EndpointRow.session_owner == session_owner_id)
                 .where(EndpointRow.lifecycle_stage == EndpointLifecycle.CREATED)
                 .options(selectinload(EndpointRow.routings))
-                .options(selectinload(EndpointRow.revisions))
+                .options(selectinload(EndpointRow.current_revision_row))
             )
 
             result = await execute_batch_querier(session, query, querier)

--- a/src/ai/backend/manager/services/deployment/actions/get_legacy_deployment_by_id.py
+++ b/src/ai/backend/manager/services/deployment/actions/get_legacy_deployment_by_id.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.common.identifier.deployment import DeploymentID
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.deployment.types import LegacyDeploymentData
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.services.deployment.actions.base import (
+    DeploymentSingleEntityAction,
+    DeploymentSingleEntityActionResult,
+)
+
+
+@dataclass
+class GetLegacyDeploymentByIdAction(DeploymentSingleEntityAction):
+    """Legacy (REST v1) get-by-id. Returns the full current revision. DO NOT
+    USE in new code — v2 / GraphQL use ``GetDeploymentByIdAction``.
+    """
+
+    deployment_id: DeploymentID
+
+    @override
+    def target_entity_id(self) -> str:
+        return str(self.deployment_id)
+
+    @override
+    def target_element(self) -> RBACElementRef:
+        return RBACElementRef(RBACElementType.MODEL_DEPLOYMENT, str(self.deployment_id))
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+
+@dataclass
+class GetLegacyDeploymentByIdActionResult(DeploymentSingleEntityActionResult):
+    data: LegacyDeploymentData
+
+    @override
+    def target_entity_id(self) -> str:
+        return str(self.data.id)

--- a/src/ai/backend/manager/services/deployment/actions/search_legacy_deployments.py
+++ b/src/ai/backend/manager/services/deployment/actions/search_legacy_deployments.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.deployment.types import LegacyDeploymentData
+from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.services.deployment.actions.base import DeploymentBaseAction
+
+
+@dataclass
+class SearchLegacyDeploymentsAction(DeploymentBaseAction):
+    """Legacy (REST v1) search. Returns the full current revision per item. DO
+    NOT USE in new code — v2 / GraphQL use ``SearchDeploymentsAction``.
+    """
+
+    querier: BatchQuerier
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.SEARCH
+
+
+@dataclass
+class SearchLegacyDeploymentsActionResult(BaseActionResult):
+    data: list[LegacyDeploymentData]
+    total_count: int
+    has_next_page: bool
+    has_previous_page: bool
+
+    @override
+    def entity_id(self) -> str | None:
+        return None

--- a/src/ai/backend/manager/services/deployment/processors.py
+++ b/src/ai/backend/manager/services/deployment/processors.py
@@ -78,6 +78,10 @@ from ai.backend.manager.services.deployment.actions.get_deployment_by_id import 
     GetDeploymentByIdAction,
     GetDeploymentByIdActionResult,
 )
+from ai.backend.manager.services.deployment.actions.get_legacy_deployment_by_id import (
+    GetLegacyDeploymentByIdAction,
+    GetLegacyDeploymentByIdActionResult,
+)
 from ai.backend.manager.services.deployment.actions.get_replica_by_id import (
     GetReplicaByIdAction,
     GetReplicaByIdActionResult,
@@ -124,6 +128,10 @@ from ai.backend.manager.services.deployment.actions.search_deployments_in_projec
     SearchDeploymentsInProjectAction,
     SearchDeploymentsInProjectActionResult,
 )
+from ai.backend.manager.services.deployment.actions.search_legacy_deployments import (
+    SearchLegacyDeploymentsAction,
+    SearchLegacyDeploymentsActionResult,
+)
 from ai.backend.manager.services.deployment.actions.search_replicas import (
     SearchReplicasAction,
     SearchReplicasActionResult,
@@ -159,11 +167,18 @@ class DeploymentProcessors(AbstractProcessorPackage):
         DestroyDeploymentAction, DestroyDeploymentActionResult
     ]
     search_deployments: ActionProcessor[SearchDeploymentsAction, SearchDeploymentsActionResult]
+    # Legacy (REST v1) read variants — full revision. DO NOT USE in new code.
+    search_legacy_deployments: ActionProcessor[
+        SearchLegacyDeploymentsAction, SearchLegacyDeploymentsActionResult
+    ]
     search_deployments_in_project: ActionProcessor[
         SearchDeploymentsInProjectAction, SearchDeploymentsInProjectActionResult
     ]
     get_deployment_by_id: SingleEntityActionProcessor[
         GetDeploymentByIdAction, GetDeploymentByIdActionResult
+    ]
+    get_legacy_deployment_by_id: SingleEntityActionProcessor[
+        GetLegacyDeploymentByIdAction, GetLegacyDeploymentByIdActionResult
     ]
     get_deployment_policy: ActionProcessor[
         GetDeploymentPolicyAction, GetDeploymentPolicyActionResult
@@ -249,6 +264,9 @@ class DeploymentProcessors(AbstractProcessorPackage):
             service.destroy_deployment, action_monitors, validators=rbac_single_entity_validators
         )
         self.search_deployments = ActionProcessor(service.search_deployments, action_monitors)
+        self.search_legacy_deployments = ActionProcessor(
+            service.search_legacy_deployments, action_monitors
+        )
         self.search_deployments_in_project = ActionProcessor(
             service.search_deployments_in_project,
             action_monitors,
@@ -256,6 +274,11 @@ class DeploymentProcessors(AbstractProcessorPackage):
         )
         self.get_deployment_by_id = SingleEntityActionProcessor(
             service.get_deployment_by_id, action_monitors, validators=rbac_single_entity_validators
+        )
+        self.get_legacy_deployment_by_id = SingleEntityActionProcessor(
+            service.get_legacy_deployment_by_id,
+            action_monitors,
+            validators=rbac_single_entity_validators,
         )
         self.get_deployment_policy = ActionProcessor(service.get_deployment_policy, action_monitors)
         self.search_deployment_policies = ActionProcessor(
@@ -325,8 +348,10 @@ class DeploymentProcessors(AbstractProcessorPackage):
             ReplaceDeploymentOptionsAction.spec(),
             DestroyDeploymentAction.spec(),
             SearchDeploymentsAction.spec(),
+            SearchLegacyDeploymentsAction.spec(),
             SearchDeploymentsInProjectAction.spec(),
             GetDeploymentByIdAction.spec(),
+            GetLegacyDeploymentByIdAction.spec(),
             GetDeploymentPolicyAction.spec(),
             SearchDeploymentPoliciesAction.spec(),
             UpsertDeploymentPolicyAction.spec(),

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -27,6 +27,7 @@ from ai.backend.manager.data.deployment.creator import (
 from ai.backend.manager.data.deployment.types import (
     DeploymentInfo,
     ExecutionSpec,
+    LegacyDeploymentData,
     ModelDeploymentAccessTokenData,
     ModelDeploymentData,
     ModelDeploymentMetadataInfo,
@@ -132,6 +133,10 @@ from ai.backend.manager.services.deployment.actions.get_deployment_by_id import 
     GetDeploymentByIdAction,
     GetDeploymentByIdActionResult,
 )
+from ai.backend.manager.services.deployment.actions.get_legacy_deployment_by_id import (
+    GetLegacyDeploymentByIdAction,
+    GetLegacyDeploymentByIdActionResult,
+)
 from ai.backend.manager.services.deployment.actions.get_replica_by_id import (
     GetReplicaByIdAction,
     GetReplicaByIdActionResult,
@@ -178,6 +183,10 @@ from ai.backend.manager.services.deployment.actions.search_deployments_in_projec
     SearchDeploymentsInProjectAction,
     SearchDeploymentsInProjectActionResult,
 )
+from ai.backend.manager.services.deployment.actions.search_legacy_deployments import (
+    SearchLegacyDeploymentsAction,
+    SearchLegacyDeploymentsActionResult,
+)
 from ai.backend.manager.services.deployment.actions.search_replicas import (
     SearchReplicasAction,
     SearchReplicasActionResult,
@@ -220,17 +229,19 @@ def _map_lifecycle_to_status(lifecycle: EndpointLifecycle) -> ModelDeploymentSta
             return ModelDeploymentStatus.STOPPED
 
 
-def _convert_deployment_info_to_data(info: DeploymentInfo) -> ModelDeploymentData:
-    """Convert DeploymentInfo to ModelDeploymentData.
-
-    Note: Some fields are set to defaults as DeploymentInfo doesn't have all the data.
-    """
-    revision: ModelRevisionData | None = info.current_revision
-
+def _deployment_desired_replica_count(info: DeploymentInfo) -> int:
     desired_count = info.replica.desired_replica_count
     if desired_count is None:
         desired_count = info.replica.replica_count
+    return desired_count
 
+
+def _convert_deployment_info_to_data(info: DeploymentInfo) -> ModelDeploymentData:
+    """Convert DeploymentInfo to the modern (v2 / GraphQL) ModelDeploymentData.
+
+    Uses the revision *ids* only — the modern read path does not load the full
+    revision rows. Note: some fields default as DeploymentInfo lacks the data.
+    """
     return ModelDeploymentData(
         id=info.id,
         metadata=ModelDeploymentMetadataInfo(
@@ -244,23 +255,52 @@ def _convert_deployment_info_to_data(info: DeploymentInfo) -> ModelDeploymentDat
             updated_at=info.metadata.created_at or datetime.now(UTC),
         ),
         network_access=info.network,
-        revision_history_ids=[info.current_revision.id]
-        if info.current_revision is not None
+        revision_history_ids=[info.current_revision_id]
+        if info.current_revision_id is not None
         else [],
-        revision=revision,
-        current_revision_id=info.current_revision.id if info.current_revision is not None else None,
-        deploying_revision_id=info.deploying_revision.id
-        if info.deploying_revision is not None
-        else None,
+        current_revision_id=info.current_revision_id,
+        deploying_revision_id=info.deploying_revision_id,
         scaling_rule_ids=[],  # Not available in DeploymentInfo
         replica_state=ReplicaStateData(
-            desired_replica_count=desired_count,
+            desired_replica_count=_deployment_desired_replica_count(info),
             replica_ids=[],  # Not available in DeploymentInfo
         ),
         default_deployment_strategy=DeploymentStrategy.ROLLING,
         created_user_id=info.metadata.created_user,
         options=info.options,
         scaling_state=info.state.scaling_state,
+        policy=info.policy,
+        sub_step=info.sub_step,
+    )
+
+
+def _convert_deployment_info_to_legacy_data(info: DeploymentInfo) -> LegacyDeploymentData:
+    """Convert DeploymentInfo to the legacy (REST v1) LegacyDeploymentData.
+
+    Built independently from the same ``DeploymentInfo`` — never derived from
+    ``ModelDeploymentData``. Carries the full current ``revision`` that the
+    legacy ``DeploymentDTO`` embeds, so it requires a full (legacy) read.
+    """
+    return LegacyDeploymentData(
+        id=info.id,
+        metadata=ModelDeploymentMetadataInfo(
+            name=info.metadata.name,
+            status=_map_lifecycle_to_status(info.state.lifecycle),
+            tags=[info.metadata.tag] if info.metadata.tag else [],
+            project_id=info.metadata.project,
+            domain_name=info.metadata.domain,
+            resource_group_name=info.metadata.resource_group,
+            created_at=info.metadata.created_at or datetime.now(UTC),
+            updated_at=info.metadata.created_at or datetime.now(UTC),
+        ),
+        network_access=info.network,
+        revision=info.current_revision,
+        replica_state=ReplicaStateData(
+            desired_replica_count=_deployment_desired_replica_count(info),
+            replica_ids=[],  # Not available in DeploymentInfo
+        ),
+        default_deployment_strategy=DeploymentStrategy.ROLLING,
+        created_user_id=info.metadata.created_user,
         policy=info.policy,
         sub_step=info.sub_step,
     )
@@ -526,6 +566,21 @@ class DeploymentService:
             has_previous_page=result.has_previous_page,
         )
 
+    async def search_legacy_deployments(
+        self, action: SearchLegacyDeploymentsAction
+    ) -> SearchLegacyDeploymentsActionResult:
+        """Legacy (REST v1) search — full revision per item. DO NOT USE in new
+        code; v2 uses :meth:`search_deployments`.
+        """
+        result = await self._deployment_repository.search_legacy_endpoints(action.querier)
+        deployments = [_convert_deployment_info_to_legacy_data(info) for info in result.items]
+        return SearchLegacyDeploymentsActionResult(
+            data=deployments,
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
     async def search_deployments_in_project(
         self, action: SearchDeploymentsInProjectAction
     ) -> SearchDeploymentsInProjectActionResult:
@@ -556,6 +611,19 @@ class DeploymentService:
         """
         deployment_info = await self._deployment_repository.get_endpoint_info(action.deployment_id)
         return GetDeploymentByIdActionResult(data=_convert_deployment_info_to_data(deployment_info))
+
+    async def get_legacy_deployment_by_id(
+        self, action: GetLegacyDeploymentByIdAction
+    ) -> GetLegacyDeploymentByIdActionResult:
+        """Legacy (REST v1) get-by-id — full revision. DO NOT USE in new code;
+        v2 uses :meth:`get_deployment_by_id`.
+        """
+        deployment_info = await self._deployment_repository.get_legacy_endpoint_info(
+            action.deployment_id
+        )
+        return GetLegacyDeploymentByIdActionResult(
+            data=_convert_deployment_info_to_legacy_data(deployment_info)
+        )
 
     async def get_deployment_policy(
         self, action: GetDeploymentPolicyAction

--- a/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
@@ -544,10 +544,7 @@ class DeploymentController:
 
         # 2. Validate deployment state
         deployment_info = await self._deployment_repository.get_endpoint_info(deployment_id)
-        if (
-            deployment_info.current_revision is not None
-            and deployment_info.current_revision.id == revision_id
-        ):
+        if deployment_info.current_revision_id == revision_id:
             raise InvalidEndpointState(
                 f"Revision {revision_id} is already the current revision "
                 f"of deployment {deployment_id}."

--- a/tests/unit/manager/models/test_deployment_auto_scaling_policy.py
+++ b/tests/unit/manager/models/test_deployment_auto_scaling_policy.py
@@ -301,7 +301,6 @@ class TestDeploymentAutoScalingPolicyRow:
                 resource_group=test_scaling_group.name,
                 url=f"https://test-{uuid.uuid4().hex[:8]}.example.com",
                 lifecycle_stage=EndpointLifecycle.CREATED,
-                current_revision=uuid.uuid4(),
             )
             db_sess.add(endpoint)
             await db_sess.flush()

--- a/tests/unit/manager/repositories/deployment/test_deployment_repository.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_repository.py
@@ -677,7 +677,6 @@ class TestDeploymentRepositoryFetchRouteServiceDiscoveryInfo:
                 url="http://test.example.com",
                 open_to_public=False,
                 lifecycle_stage=EndpointLifecycle.READY,
-                current_revision=revision_id,
             )
             db_sess.add(endpoint)
             attach_primary_replica_group(db_sess, endpoint, current_revision_id=revision_id)
@@ -915,7 +914,6 @@ class TestDeploymentRepositoryFetchRouteServiceDiscoveryInfo:
                     url=f"http://test{i}.example.com",
                     open_to_public=False,
                     lifecycle_stage=EndpointLifecycle.READY,
-                    current_revision=revision_id,
                 )
                 db_sess.add(endpoint)
                 attach_primary_replica_group(db_sess, endpoint, current_revision_id=revision_id)
@@ -2271,7 +2269,6 @@ class TestDeploymentAutoScalingPolicyOperations:
                 url=f"http://test-{uuid.uuid4().hex[:8]}.example.com",
                 open_to_public=False,
                 lifecycle_stage=EndpointLifecycle.DESTROYED,
-                current_revision=uuid.uuid4(),
             )
             db_sess.add(endpoint)
             await db_sess.commit()
@@ -2648,7 +2645,6 @@ class TestDeploymentPolicyOperations:
                 url=f"http://test-{uuid.uuid4().hex[:8]}.example.com",
                 open_to_public=False,
                 lifecycle_stage=EndpointLifecycle.DESTROYED,
-                current_revision=uuid.uuid4(),
             )
             db_sess.add(endpoint)
             await db_sess.commit()
@@ -2969,7 +2965,6 @@ class TestSearchDeploymentPolicies:
                     url=f"http://test-{eid.hex[:8]}.example.com",
                     open_to_public=False,
                     lifecycle_stage=EndpointLifecycle.DESTROYED,
-                    current_revision=uuid.uuid4(),
                 )
                 db_sess.add(endpoint)
                 endpoint_ids.append(eid)
@@ -3371,7 +3366,6 @@ class TestRouteOperations:
                 url=f"http://test-{uuid.uuid4().hex[:8]}.example.com",
                 open_to_public=False,
                 lifecycle_stage=EndpointLifecycle.DESTROYED,
-                current_revision=uuid.uuid4(),
             )
             db_sess.add(endpoint)
             await db_sess.commit()

--- a/tests/unit/manager/repositories/deployment/test_deployment_repository.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_repository.py
@@ -6,6 +6,7 @@ import uuid
 from collections.abc import AsyncGenerator
 from datetime import datetime
 from decimal import Decimal
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -22,6 +23,7 @@ from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.replica import ReplicaID
+from ai.backend.common.identifier.replica_group import ReplicaGroupID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import (
@@ -74,6 +76,7 @@ from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
 )
 from ai.backend.manager.models.rbac_models.entity_field import EntityFieldRow
+from ai.backend.manager.models.replica_group import ReplicaGroupRow
 from ai.backend.manager.models.resource_policy import (
     KeyPairResourcePolicyRow,
     ProjectResourcePolicyRow,
@@ -136,6 +139,34 @@ def create_test_password_info(password: str) -> PasswordInfo:
     )
 
 
+def attach_primary_replica_group(
+    db_sess: Any,
+    endpoint: EndpointRow,
+    *,
+    current_revision_id: uuid.UUID | None = None,
+    target_revision_id: uuid.UUID | None = None,
+) -> ReplicaGroupRow:
+    """Create the primary replica group for a hand-built endpoint and wire its
+    revision pointers, mirroring what ``create_endpoint`` does at runtime.
+
+    Revision pointers now live on the replica group, so tests that construct
+    ``EndpointRow`` directly must attach a group for the revision-resolution
+    paths to see ``current``/``deploying`` revisions.
+    """
+    group_id = uuid.uuid4()
+    group = ReplicaGroupRow(
+        id=ReplicaGroupID(group_id),
+        deployment_id=endpoint.id,
+        current_revision_id=current_revision_id,
+        target_revision_id=target_revision_id,
+    )
+    db_sess.add(group)
+    endpoint.primary_replica_group_id = ReplicaGroupID(group_id)
+    if target_revision_id is not None:
+        endpoint.target_replica_group_id = ReplicaGroupID(group_id)
+    return group
+
+
 class TestDeploymentRepositoryFetchRouteServiceDiscoveryInfo:
     """Test cases for fetch_route_service_discovery_info method."""
 
@@ -167,6 +198,7 @@ class TestDeploymentRepositoryFetchRouteServiceDiscoveryInfo:
                 SessionRow,
                 KernelRow,
                 EndpointRow,
+                ReplicaGroupRow,
                 RuntimeVariantRow,
                 DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
@@ -648,6 +680,7 @@ class TestDeploymentRepositoryFetchRouteServiceDiscoveryInfo:
                 current_revision=revision_id,
             )
             db_sess.add(endpoint)
+            attach_primary_replica_group(db_sess, endpoint, current_revision_id=revision_id)
             await db_sess.flush()
 
             # Create revision for endpoint
@@ -885,6 +918,7 @@ class TestDeploymentRepositoryFetchRouteServiceDiscoveryInfo:
                     current_revision=revision_id,
                 )
                 db_sess.add(endpoint)
+                attach_primary_replica_group(db_sess, endpoint, current_revision_id=revision_id)
                 revision = DeploymentRevisionRow(
                     id=revision_id,
                     endpoint=endpoint_id,
@@ -1371,6 +1405,7 @@ class TestDeploymentRevisionOperations:
                 ImageRow,
                 ResourceSlotTypeRow,
                 EndpointRow,
+                ReplicaGroupRow,
                 EntityFieldRow,  # DeploymentRevisionRow relationship dependency
                 AssociationScopesEntitiesRow,  # RBACEntityCreator dependency
                 RuntimeVariantRow,
@@ -1590,9 +1625,9 @@ class TestDeploymentRevisionOperations:
                 url=f"http://test-{uuid.uuid4().hex[:8]}.example.com",
                 open_to_public=False,
                 lifecycle_stage=EndpointLifecycle.CREATED,
-                current_revision=uuid.uuid4(),
             )
             db_sess.add(endpoint)
+            attach_primary_replica_group(db_sess, endpoint)
             await db_sess.commit()
 
         return endpoint_id
@@ -1916,10 +1951,11 @@ class TestDeploymentRevisionOperations:
         latest_revision = test_multiple_revisions[-1]
 
         async with db_with_cleanup.begin_session() as db_sess:
+            # Current revision now lives on the primary replica group.
             await db_sess.execute(
-                sa.update(EndpointRow)
-                .where(EndpointRow.id == test_endpoint_id)
-                .values(current_revision=first_revision.id)
+                sa.update(ReplicaGroupRow)
+                .where(ReplicaGroupRow.deployment_id == test_endpoint_id)
+                .values(current_revision_id=first_revision.id)
             )
             await db_sess.commit()
 
@@ -2068,6 +2104,7 @@ class TestDeploymentAutoScalingPolicyOperations:
                 GroupRow,
                 VFolderRow,
                 EndpointRow,
+                ReplicaGroupRow,
                 DeploymentAutoScalingPolicyRow,
             ],
         ):
@@ -2444,6 +2481,7 @@ class TestDeploymentPolicyOperations:
                 GroupRow,
                 VFolderRow,
                 EndpointRow,
+                ReplicaGroupRow,
                 DeploymentPolicyRow,
             ],
         ):
@@ -2781,6 +2819,7 @@ class TestSearchDeploymentPolicies:
                 GroupRow,
                 VFolderRow,
                 EndpointRow,
+                ReplicaGroupRow,
                 DeploymentPolicyRow,
             ],
         ):
@@ -3164,6 +3203,7 @@ class TestRouteOperations:
                 GroupRow,
                 VFolderRow,
                 EndpointRow,
+                ReplicaGroupRow,
                 RoutingRow,
                 AssociationScopesEntitiesRow,
             ],
@@ -3537,6 +3577,7 @@ class TestDeploymentRepositoryDuplicateName:
                 ImageRow,
                 ResourceSlotTypeRow,
                 EndpointRow,
+                ReplicaGroupRow,
                 EndpointTokenRow,
                 RuntimeVariantRow,
                 DeploymentRevisionPresetRow,
@@ -3950,23 +3991,24 @@ class TestDeploymentRepositoryDuplicateName:
         user_id = uuid.uuid4()
 
         async with db_with_cleanup.begin_session() as db_sess:
-            db_sess.add(
-                EndpointRow(
-                    id=endpoint_id,
-                    name=f"override-{uuid.uuid4().hex[:8]}",
-                    created_user=user_id,
-                    session_owner=user_id,
-                    domain=test_domain.name,
-                    project=test_group.id,
-                    resource_group=test_scaling_group.name,
-                    replicas=1,
-                    desired_replicas=1,
-                    url=None,
-                    open_to_public=False,
-                    lifecycle_stage=EndpointLifecycle.DEPLOYING,
-                    deploying_revision=previous_deploying,
-                )
+            endpoint = EndpointRow(
+                id=endpoint_id,
+                name=f"override-{uuid.uuid4().hex[:8]}",
+                created_user=user_id,
+                session_owner=user_id,
+                domain=test_domain.name,
+                project=test_group.id,
+                resource_group=test_scaling_group.name,
+                replicas=1,
+                desired_replicas=1,
+                url=None,
+                open_to_public=False,
+                lifecycle_stage=EndpointLifecycle.DEPLOYING,
             )
+            db_sess.add(endpoint)
+            # A previous rollout's deploying revision lives on the primary
+            # group's ``target_revision_id``.
+            attach_primary_replica_group(db_sess, endpoint, target_revision_id=previous_deploying)
             await db_sess.commit()
 
         previous_current, updated = await deployment_repository.set_deploying_revision(
@@ -3979,12 +4021,19 @@ class TestDeploymentRepositoryDuplicateName:
         async with db_with_cleanup.begin_readonly_session() as db_sess:
             row = (
                 await db_sess.execute(
-                    sa.select(EndpointRow.deploying_revision, EndpointRow.lifecycle_stage).where(
-                        EndpointRow.id == endpoint_id
+                    sa.select(
+                        ReplicaGroupRow.target_revision_id,
+                        EndpointRow.lifecycle_stage,
                     )
+                    .select_from(EndpointRow)
+                    .join(
+                        ReplicaGroupRow,
+                        EndpointRow.primary_replica_group_id == ReplicaGroupRow.id,
+                    )
+                    .where(EndpointRow.id == endpoint_id)
                 )
             ).one()
-            assert row.deploying_revision == new_deploying
+            assert row.target_revision_id == new_deploying
             assert row.lifecycle_stage == EndpointLifecycle.DEPLOYING
 
     async def test_set_deploying_revision_returns_false_for_missing_endpoint(

--- a/tests/unit/manager/repositories/deployment/test_deployment_repository_history.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_repository_history.py
@@ -394,7 +394,6 @@ class TestUpdateEndpointLifecycleBulkWithHistory:
                 url="http://test.example.com",
                 open_to_public=False,
                 lifecycle_stage=EndpointLifecycle.PENDING,
-                current_revision=uuid.uuid4(),
             )
             db_sess.add(endpoint)
             await db_sess.commit()
@@ -809,7 +808,6 @@ class TestUpdateRouteStatusBulkWithHistory:
                 url="http://test.example.com",
                 open_to_public=False,
                 lifecycle_stage=EndpointLifecycle.READY,
-                current_revision=uuid.uuid4(),
             )
             db_sess.add(endpoint)
             await db_sess.commit()
@@ -1116,7 +1114,6 @@ class TestDeploymentHistoryMergeLogic:
                     url="http://test.example.com",
                     open_to_public=False,
                     lifecycle_stage=EndpointLifecycle.PENDING,
-                    current_revision=uuid.uuid4(),
                 )
             )
 
@@ -1432,7 +1429,6 @@ class TestRouteHistoryMergeLogic:
                     url="http://test.example.com",
                     open_to_public=False,
                     lifecycle_stage=EndpointLifecycle.READY,
-                    current_revision=uuid.uuid4(),
                 )
             )
 

--- a/tests/unit/manager/repositories/deployment/test_deployment_search_in_project.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_search_in_project.py
@@ -235,7 +235,6 @@ class TestEndpointSearchInProject:
                         project=project_a_id,
                         resource_group=sgroup_name,
                         lifecycle_stage=EndpointLifecycle.CREATED,
-                        current_revision=uuid.uuid4(),
                         replicas=1,
                     )
                 )
@@ -253,7 +252,6 @@ class TestEndpointSearchInProject:
                     project=project_b_id,
                     resource_group=sgroup_name,
                     lifecycle_stage=EndpointLifecycle.CREATED,
-                    current_revision=uuid.uuid4(),
                     replicas=1,
                 )
             )

--- a/tests/unit/manager/repositories/deployment/test_legacy_extra_mounts_hydration.py
+++ b/tests/unit/manager/repositories/deployment/test_legacy_extra_mounts_hydration.py
@@ -12,6 +12,7 @@ from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.image import ImageID
+from ai.backend.common.identifier.replica_group import ReplicaGroupID
 from ai.backend.common.types import ClusterMode, MountPermission, ResourceSlot
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.image.types import ImageType
@@ -29,6 +30,7 @@ from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac_models import RoleRow, UserRoleRow
+from ai.backend.manager.models.replica_group import ReplicaGroupRow
 from ai.backend.manager.models.resource_policy import (
     KeyPairResourcePolicyRow,
     ProjectResourcePolicyRow,
@@ -68,6 +70,7 @@ _REQUIRED_TABLES = [
     DeploymentRevisionRow,
     DeploymentRevisionResourceSlotRow,
     EndpointRow,
+    ReplicaGroupRow,
 ]
 
 
@@ -257,21 +260,30 @@ class TestLegacyExtraMountsHydration:
         endpoint_id = DeploymentID(uuid.uuid4())
         revision_id = uuid.uuid4()
         async with db_with_cleanup.begin_session() as db_sess:
+            endpoint = EndpointRow(
+                id=endpoint_id,
+                name=f"ep-{suffix}",
+                created_user=user_id,
+                session_owner=user_id,
+                domain=domain_name,
+                project=project_id,
+                resource_group=scaling_group_name,
+                url="http://test.example.com",
+                open_to_public=False,
+                lifecycle_stage=EndpointLifecycle.READY,
+            )
+            db_sess.add(endpoint)
+            await db_sess.flush()
+            # Current revision lives on the primary replica group.
+            group_id = uuid.uuid4()
             db_sess.add(
-                EndpointRow(
-                    id=endpoint_id,
-                    name=f"ep-{suffix}",
-                    created_user=user_id,
-                    session_owner=user_id,
-                    domain=domain_name,
-                    project=project_id,
-                    resource_group=scaling_group_name,
-                    url="http://test.example.com",
-                    open_to_public=False,
-                    lifecycle_stage=EndpointLifecycle.READY,
-                    current_revision=revision_id,
+                ReplicaGroupRow(
+                    id=ReplicaGroupID(group_id),
+                    deployment_id=endpoint_id,
+                    current_revision_id=revision_id,
                 )
             )
+            endpoint.primary_replica_group_id = ReplicaGroupID(group_id)
             await db_sess.flush()
             db_sess.add(
                 DeploymentRevisionRow(

--- a/tests/unit/manager/repositories/deployment/test_observer_route_scope.py
+++ b/tests/unit/manager/repositories/deployment/test_observer_route_scope.py
@@ -274,7 +274,6 @@ class TestObserverCycleRouteScope:
                     project=project,
                     resource_group=scaling_group,
                     lifecycle_stage=EndpointLifecycle.CREATED,
-                    current_revision=revision_id,
                     replicas=4,
                 )
             )

--- a/tests/unit/manager/repositories/group/test_group_db_source.py
+++ b/tests/unit/manager/repositories/group/test_group_db_source.py
@@ -262,7 +262,6 @@ class TestGroupDBSourceDeleteEndpoints:
                     project=test_group,
                     resource_group=sgroup_name,
                     lifecycle_stage=EndpointLifecycle.DESTROYED,
-                    current_revision=uuid.uuid4(),
                 )
                 session.add(endpoint)
                 endpoint_ids.append(endpoint_id)
@@ -323,7 +322,6 @@ class TestGroupDBSourceDeleteEndpoints:
                 project=test_group,
                 resource_group=sgroup_name,
                 lifecycle_stage=EndpointLifecycle.DESTROYED,
-                current_revision=uuid.uuid4(),
             )
             session.add(endpoint)
 
@@ -401,7 +399,6 @@ class TestGroupDBSourceDeleteEndpoints:
                 project=test_group,
                 resource_group=sgroup_name,
                 lifecycle_stage=EndpointLifecycle.CREATED,
-                current_revision=uuid.uuid4(),
             )
             session.add(endpoint)
             await session.commit()
@@ -450,7 +447,6 @@ class TestGroupDBSourceDeleteEndpoints:
                     project=test_group,
                     resource_group=sgroup_name,
                     lifecycle_stage=EndpointLifecycle.DESTROYED,
-                    current_revision=uuid.uuid4(),
                 )
                 session.add(endpoint)
                 endpoint_ids.append(endpoint_id)

--- a/tests/unit/manager/repositories/group/test_group_purgers.py
+++ b/tests/unit/manager/repositories/group/test_group_purgers.py
@@ -288,7 +288,6 @@ class TestGroupPurgersIntegration:
                     project=sample_group.id,
                     resource_group=sample_scaling_group,
                     lifecycle_stage=EndpointLifecycle.DESTROYED,
-                    current_revision=uuid.uuid4(),
                     replicas=0,
                 )
                 session.add(endpoint)

--- a/tests/unit/manager/repositories/group/test_group_repository.py
+++ b/tests/unit/manager/repositories/group/test_group_repository.py
@@ -673,7 +673,6 @@ class TestGroupRepository:
                 project=group_id,
                 resource_group=test_scaling_group,
                 lifecycle_stage=EndpointLifecycle.CREATED,
-                current_revision=uuid.uuid4(),
             )
             session.add(endpoint)
             await session.commit()

--- a/tests/unit/manager/repositories/model_serving/conftest.py
+++ b/tests/unit/manager/repositories/model_serving/conftest.py
@@ -453,7 +453,6 @@ def create_full_featured_endpoint(
         cluster_size=3,
         extra_mounts=[],
         created_user=sample_user.uuid,
-        current_revision=uuid.uuid4(),
     )
 
     # Set attributes normally set by database

--- a/tests/unit/manager/repositories/model_serving/test_list_endpoints_by_owner_validated.py
+++ b/tests/unit/manager/repositories/model_serving/test_list_endpoints_by_owner_validated.py
@@ -25,6 +25,7 @@ from ai.backend.common.config import ModelDefinition
 from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.image import ImageID
+from ai.backend.common.identifier.replica_group import ReplicaGroupID
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.image.types import ImageType
@@ -38,6 +39,7 @@ from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.replica_group import ReplicaGroupRow
 from ai.backend.manager.models.resource_policy import (
     KeyPairResourcePolicyRow,
     ProjectResourcePolicyRow,
@@ -78,6 +80,7 @@ async def db_with_cleanup(
             ImageRow,
             VFolderRow,
             EndpointRow,
+            ReplicaGroupRow,
             RuntimeVariantRow,
             DeploymentRevisionPresetRow,
             DeploymentRevisionRow,
@@ -326,10 +329,20 @@ async def listed_endpoint(
         )
         await sess.flush()
 
+        # Current revision lives on the primary replica group.
+        group_id = uuid.uuid4()
+        sess.add(
+            ReplicaGroupRow(
+                id=ReplicaGroupID(group_id),
+                deployment_id=DeploymentID(endpoint_id),
+                current_revision_id=revision_id,
+            )
+        )
+        await sess.flush()
         await sess.execute(
             sa.update(EndpointRow)
             .where(EndpointRow.id == endpoint_id)
-            .values(current_revision=revision_id)
+            .values(primary_replica_group_id=group_id)
         )
         await sess.flush()
 

--- a/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
+++ b/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
@@ -19,6 +19,7 @@ from ai.backend.common.contexts.user import with_user
 from ai.backend.common.data.user.types import UserData
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.image import ImageID
+from ai.backend.common.identifier.replica_group import ReplicaGroupID
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.image.types import ImageType
@@ -328,10 +329,20 @@ class TestModifyEndpointModelDefinitionRefresh:
             )
             await sess.flush()
 
+            # Current revision lives on the primary replica group.
+            group_id = uuid.uuid4()
+            sess.add(
+                ReplicaGroupRow(
+                    id=ReplicaGroupID(group_id),
+                    deployment_id=DeploymentID(endpoint_id),
+                    current_revision_id=revision_id,
+                )
+            )
+            await sess.flush()
             await sess.execute(
                 sa.update(EndpointRow)
                 .where(EndpointRow.id == endpoint_id)
-                .values(current_revision=revision_id)
+                .values(primary_replica_group_id=group_id)
             )
             await sess.flush()
         return endpoint_id, revision_id

--- a/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
+++ b/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
@@ -32,6 +32,7 @@ from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.replica_group import ReplicaGroupRow
 from ai.backend.manager.models.resource_policy import (
     KeyPairResourcePolicyRow,
     ProjectResourcePolicyRow,
@@ -89,6 +90,7 @@ class TestModifyEndpointModelDefinitionRefresh:
                 VFolderRow,
                 SessionRow,
                 EndpointRow,
+                ReplicaGroupRow,
                 RoutingRow,
                 RuntimeVariantRow,
                 DeploymentRevisionPresetRow,

--- a/tests/unit/manager/repositories/model_serving/test_update_route_traffic.py
+++ b/tests/unit/manager/repositories/model_serving/test_update_route_traffic.py
@@ -23,6 +23,7 @@ from ai.backend.common.config import ModelDefinition
 from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.image import ImageID
+from ai.backend.common.identifier.replica_group import ReplicaGroupID
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.image.types import ImageType
@@ -36,6 +37,7 @@ from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.replica_group import ReplicaGroupRow
 from ai.backend.manager.models.resource_policy import (
     KeyPairResourcePolicyRow,
     ProjectResourcePolicyRow,
@@ -76,6 +78,7 @@ async def db_with_cleanup(
             ImageRow,
             VFolderRow,
             EndpointRow,
+            ReplicaGroupRow,
             RuntimeVariantRow,
             DeploymentRevisionPresetRow,
             DeploymentRevisionRow,
@@ -317,10 +320,20 @@ async def endpoint_with_revision_and_route(
         )
         await sess.flush()
 
+        # Current revision lives on the primary replica group.
+        group_id = uuid.uuid4()
+        sess.add(
+            ReplicaGroupRow(
+                id=ReplicaGroupID(group_id),
+                deployment_id=DeploymentID(endpoint_id),
+                current_revision_id=revision_id,
+            )
+        )
+        await sess.flush()
         await sess.execute(
             sa.update(EndpointRow)
             .where(EndpointRow.id == endpoint_id)
-            .values(current_revision=revision_id)
+            .values(primary_replica_group_id=group_id)
         )
         await sess.flush()
 

--- a/tests/unit/manager/repositories/scaling_group/test_scaling_group_repository.py
+++ b/tests/unit/manager/repositories/scaling_group/test_scaling_group_repository.py
@@ -441,7 +441,6 @@ class TestScalingGroupRepositoryDB:
                     project=test_group_id,
                     resource_group=sgroup_name,
                     lifecycle_stage=EndpointLifecycle.DESTROYED,
-                    current_revision=uuid.uuid4(),
                     session_owner=test_user_uuid,
                     created_user=test_user_uuid,
                 )
@@ -1336,7 +1335,6 @@ class TestScalingGroupRepositoryDB:
                     project=test_group_id,
                     resource_group=sample_scaling_group_for_hierarchy,
                     lifecycle_stage=EndpointLifecycle.DESTROYED,
-                    current_revision=uuid.uuid4(),
                     session_owner=test_user_uuid,
                     created_user=test_user_uuid,
                 )

--- a/tests/unit/manager/services/deployment/test_deployment_service.py
+++ b/tests/unit/manager/services/deployment/test_deployment_service.py
@@ -84,6 +84,7 @@ from ai.backend.manager.services.deployment.processors import DeploymentProcesso
 from ai.backend.manager.services.deployment.service import (
     DeploymentService,
     _convert_deployment_info_to_data,
+    _convert_deployment_info_to_legacy_data,
 )
 from ai.backend.manager.sokovan.deployment import DeploymentController
 
@@ -727,6 +728,8 @@ class TestConvertDeploymentInfoToData:
                 open_to_public=False, access_token_ids=None, url=None, preferred_domain_name=None
             ),
             options=DeploymentOptions(),
+            current_revision_id=current_data.id,
+            deploying_revision_id=deploying_data.id,
             current_revision=current_data,
             deploying_revision=deploying_data,
         )
@@ -736,5 +739,8 @@ class TestConvertDeploymentInfoToData:
         assert deployment_data.current_revision_id == current_data.id
         assert deployment_data.deploying_revision_id == deploying_data.id
         assert deployment_data.current_revision_id != deployment_data.deploying_revision_id
-        assert deployment_data.revision is not None
-        assert deployment_data.revision.id == current_data.id
+
+        # The full current revision now lives on the legacy (REST v1) projection.
+        legacy_data = _convert_deployment_info_to_legacy_data(deployment_info)
+        assert legacy_data.revision is not None
+        assert legacy_data.revision.id == current_data.id


### PR DESCRIPTION
## Summary
- Introduce a **Replica Group** concept for deployments: a new `replica_groups` table where each group owns its revision pointers (`current_revision_id` / `target_revision_id`) and per-revision desired replica counts (`desired_current/target_replica_count`) plus a `traffic_weight`. Deployments reference a `primary_replica_group_id` / `target_replica_group_id`; each replica (`RoutingRow`) belongs to a group.
- Move the **source of truth** for a deployment's current/deploying revision from `endpoints.current_revision` / `deploying_revision` onto the replica groups (current = primary group's `current_revision_id`, deploying = target group's `target_revision_id`), then drop the now-dead endpoint columns. Migration backfills one group per existing endpoint (active endpoints get traffic weight 100).
- Split the deployment read stack so the **v2 (modern) path loads revision ids only** while the **v1 (legacy) REST path keeps the full embedded revision** — `get_endpoint_info`/`search_endpoints` are light; new `get_legacy_endpoint_info`/`search_legacy_endpoints` + `GetLegacyDeploymentByIdAction`/`SearchLegacyDeploymentsAction` serve v1. New `ModelDeploymentData` (id-only) / `LegacyDeploymentData` (full) data types; `EndpointData` annotated as legacy.

## Test plan
- [x] Unit tests: deployment & model_serving repositories, deployment service, sokovan deployment engine
- [x] Component tests: deployment CRUD + lifecycle (real aiohttp + DB)
- [x] Alembic upgrade/downgrade round-trip; backfill integrity (mismatch 0); single head, current == head
- [x] Live verification: v2 GraphQL resolves `currentRevision` from the group-sourced id; v1 REST `GET /deployments/{id}` embeds the full revision — both consistent after the column drop
- [ ] CI: full `pants check` / `pants test`

## Follow-ups (out of scope)
- Group-level traffic distribution via `traffic_weight`
- In-group rollout count splitting via `desired_target_replica_count` (executor/strategy behavior)
- Multi-group blue-green flow using `target_replica_group_id`

Resolves BA-6233