### PR TITLE
feat(BA-6247): add container UID/GID filters to v2 user search API

### DIFF
--- a/changes/11878.feature.md
+++ b/changes/11878.feature.md
@@ -1,0 +1,1 @@
+Add container UID/GID filters (`container_uid`, `container_main_gid`, `container_gids`) to the v2 user search API.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -7727,16 +7727,14 @@ type InferenceSessionErrorInfo
 }
 
 """
-Added in UNRELEASED. Filter for integer array fields. Supports 'all' (column contains all of these values) and 'any' (column contains any of these values).
+Added in UNRELEASED. Filter for integer array fields. Supports 'contains' (column contains this single value), 'contains_any' (column contains any of these values), and 'contains_all' (column contains all of these values).
 """
 input IntArrayFilter
   @join__type(graph: STRAWBERRY)
 {
-  """Column array contains ALL of these values."""
-  all: [Int!] = null
-
-  """Column array contains ANY of these values."""
-  any: [Int!] = null
+  contains: Int = null
+  containsAny: [Int!] = null
+  containsAll: [Int!] = null
 }
 
 """

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -7727,6 +7727,19 @@ type InferenceSessionErrorInfo
 }
 
 """
+Added in UNRELEASED. Filter for integer array fields. Supports 'all' (column contains all of these values) and 'any' (column contains any of these values).
+"""
+input IntArrayFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Column array contains ALL of these values."""
+  all: [Int!] = null
+
+  """Column array contains ANY of these values."""
+  any: [Int!] = null
+}
+
+"""
 Added in 24.09.0. Filter for integer fields supporting equality and comparison operations.
 """
 input IntFilter
@@ -20088,6 +20101,15 @@ input UserV2Filter
 
   """Added in UNRELEASED. Filter by whether sudo sessions are enabled."""
   sudoSessionEnabled: Boolean = null
+
+  """Added in UNRELEASED. Filter by container UID."""
+  containerUid: IntFilter = null
+
+  """Added in UNRELEASED. Filter by container main GID."""
+  containerMainGid: IntFilter = null
+
+  """Added in UNRELEASED. Filter by container supplementary GIDs."""
+  containerGids: IntArrayFilter = null
   createdAt: DateTimeFilter = null
   domain: UserDomainNestedFilter = null
   project: UserProjectNestedFilter = null

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -5028,6 +5028,17 @@ type ImportArtifactsPayload {
 }
 
 """
+Added in UNRELEASED. Filter for integer array fields. Supports 'all' (column contains all of these values) and 'any' (column contains any of these values).
+"""
+input IntArrayFilter {
+  """Column array contains ALL of these values."""
+  all: [Int!] = null
+
+  """Column array contains ANY of these values."""
+  any: [Int!] = null
+}
+
+"""
 Added in 24.09.0. Filter for integer fields supporting equality and comparison operations.
 """
 input IntFilter {
@@ -13925,6 +13936,15 @@ input UserV2Filter {
 
   """Added in UNRELEASED. Filter by whether sudo sessions are enabled."""
   sudoSessionEnabled: Boolean = null
+
+  """Added in UNRELEASED. Filter by container UID."""
+  containerUid: IntFilter = null
+
+  """Added in UNRELEASED. Filter by container main GID."""
+  containerMainGid: IntFilter = null
+
+  """Added in UNRELEASED. Filter by container supplementary GIDs."""
+  containerGids: IntArrayFilter = null
   createdAt: DateTimeFilter = null
   domain: UserDomainNestedFilter = null
   project: UserProjectNestedFilter = null

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -5028,14 +5028,12 @@ type ImportArtifactsPayload {
 }
 
 """
-Added in UNRELEASED. Filter for integer array fields. Supports 'all' (column contains all of these values) and 'any' (column contains any of these values).
+Added in UNRELEASED. Filter for integer array fields. Supports 'contains' (column contains this single value), 'contains_any' (column contains any of these values), and 'contains_all' (column contains all of these values).
 """
 input IntArrayFilter {
-  """Column array contains ALL of these values."""
-  all: [Int!] = null
-
-  """Column array contains ANY of these values."""
-  any: [Int!] = null
+  contains: Int = null
+  containsAny: [Int!] = null
+  containsAll: [Int!] = null
 }
 
 """

--- a/src/ai/backend/common/dto/manager/query.py
+++ b/src/ai/backend/common/dto/manager/query.py
@@ -78,6 +78,47 @@ class IntFilter(BaseRequestModel):
         return None
 
 
+class ArrayFilter[T](BaseRequestModel):
+    """Filter for array (list) columns of element type ``T``.
+
+    Supports two membership operations against the stored array column:
+
+    * ``all`` — the column array must contain ALL of the given values.
+    * ``any`` — the column array must contain ANY of the given values.
+    """
+
+    all_: list[T] | None = Field(
+        default=None,
+        alias="all",
+        description="Column array contains ALL of these values.",
+    )
+    any_: list[T] | None = Field(
+        default=None,
+        alias="any",
+        description="Column array contains ANY of these values.",
+    )
+
+    def build_query_condition(
+        self,
+        all_factory: Callable[[list[T]], _QC],
+        any_factory: Callable[[list[T]], _QC],
+    ) -> _QC | None:
+        """Build a query condition from this filter using the provided factory callables.
+
+        Args:
+            all_factory: Factory for "contains ALL of these values" operations.
+            any_factory: Factory for "contains ANY of these values" operations.
+
+        Returns:
+            A query condition if any filter field is set, None otherwise.
+        """
+        if self.all_ is not None:
+            return all_factory(self.all_)
+        if self.any_ is not None:
+            return any_factory(self.any_)
+        return None
+
+
 class DateTimeFilter(BaseRequestModel):
     """Filter for datetime fields supporting range and equality operations."""
 

--- a/src/ai/backend/common/dto/manager/query.py
+++ b/src/ai/backend/common/dto/manager/query.py
@@ -90,11 +90,13 @@ class ArrayFilter[T](BaseRequestModel):
     all_: list[T] | None = Field(
         default=None,
         alias="all",
+        min_length=1,
         description="Column array contains ALL of these values.",
     )
     any_: list[T] | None = Field(
         default=None,
         alias="any",
+        min_length=1,
         description="Column array contains ANY of these values.",
     )
 

--- a/src/ai/backend/common/dto/manager/query.py
+++ b/src/ai/backend/common/dto/manager/query.py
@@ -81,43 +81,50 @@ class IntFilter(BaseRequestModel):
 class ArrayFilter[T](BaseRequestModel):
     """Filter for array (list) columns of element type ``T``.
 
-    Supports two membership operations against the stored array column:
+    Supports three membership operations against the stored array column:
 
-    * ``all`` — the column array must contain ALL of the given values.
-    * ``any`` — the column array must contain ANY of the given values.
+    * ``contains`` — the column array must contain this single value.
+    * ``contains_any`` — the column array must contain ANY of the given values.
+    * ``contains_all`` — the column array must contain ALL of the given values.
     """
 
-    all_: list[T] | None = Field(
+    contains: T | None = Field(
         default=None,
-        alias="all",
-        min_length=1,
-        description="Column array contains ALL of these values.",
+        description="Column array contains this value.",
     )
-    any_: list[T] | None = Field(
+    contains_any: list[T] | None = Field(
         default=None,
-        alias="any",
         min_length=1,
         description="Column array contains ANY of these values.",
+    )
+    contains_all: list[T] | None = Field(
+        default=None,
+        min_length=1,
+        description="Column array contains ALL of these values.",
     )
 
     def build_query_condition(
         self,
-        all_factory: Callable[[list[T]], _QC],
-        any_factory: Callable[[list[T]], _QC],
+        contains_factory: Callable[[T], _QC],
+        contains_any_factory: Callable[[list[T]], _QC],
+        contains_all_factory: Callable[[list[T]], _QC],
     ) -> _QC | None:
         """Build a query condition from this filter using the provided factory callables.
 
         Args:
-            all_factory: Factory for "contains ALL of these values" operations.
-            any_factory: Factory for "contains ANY of these values" operations.
+            contains_factory: Factory for "contains this single value" operations.
+            contains_any_factory: Factory for "contains ANY of these values" operations.
+            contains_all_factory: Factory for "contains ALL of these values" operations.
 
         Returns:
             A query condition if any filter field is set, None otherwise.
         """
-        if self.all_ is not None:
-            return all_factory(self.all_)
-        if self.any_ is not None:
-            return any_factory(self.any_)
+        if self.contains is not None:
+            return contains_factory(self.contains)
+        if self.contains_any is not None:
+            return contains_any_factory(self.contains_any)
+        if self.contains_all is not None:
+            return contains_all_factory(self.contains_all)
         return None
 
 

--- a/src/ai/backend/common/dto/manager/v2/user/request.py
+++ b/src/ai/backend/common/dto/manager/v2/user/request.py
@@ -11,7 +11,13 @@ from pydantic import Field, field_validator
 
 from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
 from ai.backend.common.dto.manager.defs import DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT
-from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter, UUIDFilter
+from ai.backend.common.dto.manager.query import (
+    ArrayFilter,
+    DateTimeFilter,
+    IntFilter,
+    StringFilter,
+    UUIDFilter,
+)
 from ai.backend.common.dto.manager.v2.user.types import (
     OrderDirection,
     UserDomainFilter,
@@ -321,6 +327,13 @@ class UserFilter(BaseRequestModel):
     )
     sudo_session_enabled: bool | None = Field(
         default=None, description="Filter by whether sudo sessions are enabled."
+    )
+    container_uid: IntFilter | None = Field(default=None, description="Filter by container UID.")
+    container_main_gid: IntFilter | None = Field(
+        default=None, description="Filter by container main GID."
+    )
+    container_gids: ArrayFilter[int] | None = Field(
+        default=None, description="Filter by container supplementary GIDs."
     )
     created_at: DateTimeFilter | None = Field(
         default=None, description="Filter by creation timestamp."

--- a/src/ai/backend/manager/api/adapters/user/adapter.py
+++ b/src/ai/backend/manager/api/adapters/user/adapter.py
@@ -1127,6 +1127,31 @@ class UserAdapter(BaseAdapter):
                 UserConditions.by_sudo_session_enabled(filter_req.sudo_session_enabled)
             )
 
+        if filter_req.container_uid is not None:
+            condition = self.convert_int_filter(
+                filter_req.container_uid,
+                UserConditions.by_container_uid,
+            )
+            if condition is not None:
+                conditions.append(condition)
+
+        if filter_req.container_main_gid is not None:
+            condition = self.convert_int_filter(
+                filter_req.container_main_gid,
+                UserConditions.by_container_main_gid,
+            )
+            if condition is not None:
+                conditions.append(condition)
+
+        if filter_req.container_gids is not None:
+            condition = self.convert_array_filter(
+                filter_req.container_gids,
+                all_factory=UserConditions.by_container_gids_all,
+                any_factory=UserConditions.by_container_gids_any,
+            )
+            if condition is not None:
+                conditions.append(condition)
+
         if filter_req.created_at is not None:
             condition = filter_req.created_at.build_query_condition(
                 before_factory=UserConditions.by_created_at_before,
@@ -1384,6 +1409,31 @@ class UserAdapter(BaseAdapter):
                         UserConditions.by_role_in([UserRole(r.value) for r in role_f.not_in])
                     ])
                 )
+
+        if filter_req.container_uid is not None:
+            condition = self.convert_int_filter(
+                filter_req.container_uid,
+                UserConditions.by_container_uid,
+            )
+            if condition is not None:
+                conditions.append(condition)
+
+        if filter_req.container_main_gid is not None:
+            condition = self.convert_int_filter(
+                filter_req.container_main_gid,
+                UserConditions.by_container_main_gid,
+            )
+            if condition is not None:
+                conditions.append(condition)
+
+        if filter_req.container_gids is not None:
+            condition = self.convert_array_filter(
+                filter_req.container_gids,
+                all_factory=UserConditions.by_container_gids_all,
+                any_factory=UserConditions.by_container_gids_any,
+            )
+            if condition is not None:
+                conditions.append(condition)
 
         if filter_req.created_at is not None:
             condition = filter_req.created_at.build_query_condition(

--- a/src/ai/backend/manager/api/adapters/user/adapter.py
+++ b/src/ai/backend/manager/api/adapters/user/adapter.py
@@ -1146,8 +1146,9 @@ class UserAdapter(BaseAdapter):
         if filter_req.container_gids is not None:
             condition = self.convert_array_filter(
                 filter_req.container_gids,
-                all_factory=UserConditions.by_container_gids_all,
-                any_factory=UserConditions.by_container_gids_any,
+                contains_factory=UserConditions.by_container_gids_contains,
+                contains_any_factory=UserConditions.by_container_gids_any,
+                contains_all_factory=UserConditions.by_container_gids_all,
             )
             if condition is not None:
                 conditions.append(condition)
@@ -1429,8 +1430,9 @@ class UserAdapter(BaseAdapter):
         if filter_req.container_gids is not None:
             condition = self.convert_array_filter(
                 filter_req.container_gids,
-                all_factory=UserConditions.by_container_gids_all,
-                any_factory=UserConditions.by_container_gids_any,
+                contains_factory=UserConditions.by_container_gids_contains,
+                contains_any_factory=UserConditions.by_container_gids_any,
+                contains_all_factory=UserConditions.by_container_gids_all,
             )
             if condition is not None:
                 conditions.append(condition)

--- a/src/ai/backend/manager/api/gql/base.py
+++ b/src/ai/backend/manager/api/gql/base.py
@@ -266,21 +266,18 @@ class IntFilter(PydanticInputMixin[IntFilterDTO]):
 @gql_pydantic_input(
     BackendAIGQLMeta(
         description=(
-            "Filter for integer array fields. "
-            "Supports 'all' (column contains all of these values) and "
-            "'any' (column contains any of these values)."
+            "Filter for integer array fields. Supports 'contains' (column contains this "
+            "single value), 'contains_any' (column contains any of these values), and "
+            "'contains_all' (column contains all of these values)."
         ),
         added_version=NEXT_RELEASE_VERSION,
     ),
     name="IntArrayFilter",
 )
 class IntArrayFilter(PydanticInputMixin[ArrayFilterDTO[int]]):
-    all_: list[int] | None = gql_field(
-        description="Column array contains ALL of these values.", name="all", default=None
-    )
-    any_: list[int] | None = gql_field(
-        description="Column array contains ANY of these values.", name="any", default=None
-    )
+    contains: int | None = None
+    contains_any: list[int] | None = None
+    contains_all: list[int] | None = None
 
 
 @gql_pydantic_input(

--- a/src/ai/backend/manager/api/gql/base.py
+++ b/src/ai/backend/manager/api/gql/base.py
@@ -21,12 +21,14 @@ from ai.backend.common.data.filter_specs import (
     UUIDEqualMatchSpec,
     UUIDInMatchSpec,
 )
+from ai.backend.common.dto.manager.query import ArrayFilter as ArrayFilterDTO
 from ai.backend.common.dto.manager.query import DateFilter as DateFilterDTO
 from ai.backend.common.dto.manager.query import DateTimeFilter as DateTimeFilterDTO
 from ai.backend.common.dto.manager.query import IntFilter as IntFilterDTO
 from ai.backend.common.dto.manager.query import NullableDateTimeFilter as NullableDateTimeFilterDTO
 from ai.backend.common.dto.manager.query import StringFilter as StringFilterDTO
 from ai.backend.common.dto.manager.query import UUIDFilter as UUIDFilterDTO
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.adapter_options.cursor.cursor import decode_cursor as decode_cursor
 from ai.backend.manager.api.adapter_options.cursor.cursor import encode_cursor as encode_cursor
 from ai.backend.manager.api.gql.decorators import (
@@ -259,6 +261,26 @@ class IntFilter(PydanticInputMixin[IntFilterDTO]):
     greater_than_or_equal: int | None = None
     less_than: int | None = None
     less_than_or_equal: int | None = None
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description=(
+            "Filter for integer array fields. "
+            "Supports 'all' (column contains all of these values) and "
+            "'any' (column contains any of these values)."
+        ),
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="IntArrayFilter",
+)
+class IntArrayFilter(PydanticInputMixin[ArrayFilterDTO[int]]):
+    all_: list[int] | None = gql_field(
+        description="Column array contains ALL of these values.", name="all", default=None
+    )
+    any_: list[int] | None = gql_field(
+        description="Column array contains ANY of these values.", name="any", default=None
+    )
 
 
 @gql_pydantic_input(

--- a/src/ai/backend/manager/api/gql/user/types/filters.py
+++ b/src/ai/backend/manager/api/gql/user/types/filters.py
@@ -15,6 +15,8 @@ from ai.backend.common.dto.manager.v2.user.types import (
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import (
     DateTimeFilter,
+    IntArrayFilter,
+    IntFilter,
     OrderDirection,
     StringFilter,
     UUIDFilter,
@@ -164,6 +166,27 @@ class UserFilterGQL(PydanticInputMixin[UserFilter]):
         BackendAIGQLMeta(
             added_version=NEXT_RELEASE_VERSION,
             description="Filter by whether sudo sessions are enabled.",
+        ),
+        default=None,
+    )
+    container_uid: IntFilter | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Filter by container UID.",
+        ),
+        default=None,
+    )
+    container_main_gid: IntFilter | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Filter by container main GID.",
+        ),
+        default=None,
+    )
+    container_gids: IntArrayFilter | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Filter by container supplementary GIDs.",
         ),
         default=None,
     )

--- a/src/ai/backend/manager/api/rest/adapter.py
+++ b/src/ai/backend/manager/api/rest/adapter.py
@@ -14,7 +14,7 @@ from ai.backend.common.data.filter_specs import (
     UUIDEqualMatchSpec,
     UUIDInMatchSpec,
 )
-from ai.backend.common.dto.manager.query import IntFilter, StringFilter, UUIDFilter
+from ai.backend.common.dto.manager.query import ArrayFilter, IntFilter, StringFilter, UUIDFilter
 from ai.backend.manager.repositories.base import QueryCondition
 
 
@@ -201,4 +201,26 @@ class BaseFilterAdapter:
             greater_than_or_equal_factory=int_conditions.gte,
             less_than_factory=int_conditions.lt,
             less_than_or_equal_factory=int_conditions.lte,
+        )
+
+    @final
+    def convert_array_filter(
+        self,
+        array_filter: ArrayFilter[Any],
+        all_factory: Callable[[list[Any]], QueryCondition],
+        any_factory: Callable[[list[Any]], QueryCondition],
+    ) -> QueryCondition | None:
+        """Convert an ArrayFilter to a QueryCondition.
+
+        Args:
+            array_filter: The array filter to convert.
+            all_factory: Factory for "column contains ALL of these values".
+            any_factory: Factory for "column contains ANY of these values".
+
+        Returns:
+            QueryCondition if any filter field is set, None otherwise.
+        """
+        return array_filter.build_query_condition(
+            all_factory=all_factory,
+            any_factory=any_factory,
         )

--- a/src/ai/backend/manager/api/rest/adapter.py
+++ b/src/ai/backend/manager/api/rest/adapter.py
@@ -207,20 +207,23 @@ class BaseFilterAdapter:
     def convert_array_filter(
         self,
         array_filter: ArrayFilter[Any],
-        all_factory: Callable[[list[Any]], QueryCondition],
-        any_factory: Callable[[list[Any]], QueryCondition],
+        contains_factory: Callable[[Any], QueryCondition],
+        contains_any_factory: Callable[[list[Any]], QueryCondition],
+        contains_all_factory: Callable[[list[Any]], QueryCondition],
     ) -> QueryCondition | None:
         """Convert an ArrayFilter to a QueryCondition.
 
         Args:
             array_filter: The array filter to convert.
-            all_factory: Factory for "column contains ALL of these values".
-            any_factory: Factory for "column contains ANY of these values".
+            contains_factory: Factory for "column contains this single value".
+            contains_any_factory: Factory for "column contains ANY of these values".
+            contains_all_factory: Factory for "column contains ALL of these values".
 
         Returns:
             QueryCondition if any filter field is set, None otherwise.
         """
         return array_filter.build_query_condition(
-            all_factory=all_factory,
-            any_factory=any_factory,
+            contains_factory=contains_factory,
+            contains_any_factory=contains_any_factory,
+            contains_all_factory=contains_all_factory,
         )

--- a/src/ai/backend/manager/models/user/conditions.py
+++ b/src/ai/backend/manager/models/user/conditions.py
@@ -6,11 +6,13 @@ from collections.abc import Collection
 from datetime import datetime
 
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 from ai.backend.common.data.filter_specs import StringMatchSpec, UUIDEqualMatchSpec, UUIDInMatchSpec
 from ai.backend.common.data.user.types import UserRole
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.models.condition_utils import (
+    make_int_conditions,
     make_nested_string_in_factory,
     make_string_in_factory,
 )
@@ -559,6 +561,33 @@ class UserConditions:
             if spec.negated:
                 condition = sa.not_(condition)
             return condition
+
+        return inner
+
+    # ==================== Container UID/GID Filters ====================
+
+    by_container_uid = make_int_conditions(UserRow.container_uid)
+    by_container_main_gid = make_int_conditions(UserRow.container_main_gid)
+
+    @staticmethod
+    def by_container_gids_all(values: list[int]) -> QueryCondition:
+        """Filter rows whose container_gids array contains ALL given values (PG ``@>``)."""
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return UserRow.container_gids.bool_op("@>")(
+                sa.cast(values, postgresql.ARRAY(sa.Integer))
+            )
+
+        return inner
+
+    @staticmethod
+    def by_container_gids_any(values: list[int]) -> QueryCondition:
+        """Filter rows whose container_gids array contains ANY given value (PG ``&&``)."""
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return UserRow.container_gids.bool_op("&&")(
+                sa.cast(values, postgresql.ARRAY(sa.Integer))
+            )
 
         return inner
 

--- a/src/ai/backend/manager/models/user/conditions.py
+++ b/src/ai/backend/manager/models/user/conditions.py
@@ -570,6 +570,17 @@ class UserConditions:
     by_container_main_gid = make_int_conditions(UserRow.container_main_gid)
 
     @staticmethod
+    def by_container_gids_contains(value: int) -> QueryCondition:
+        """Filter rows whose container_gids array contains the given value (PG ``@>``)."""
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return UserRow.container_gids.bool_op("@>")(
+                sa.cast([value], postgresql.ARRAY(sa.Integer))
+            )
+
+        return inner
+
+    @staticmethod
     def by_container_gids_all(values: list[int]) -> QueryCondition:
         """Filter rows whose container_gids array contains ALL given values (PG ``@>``)."""
 

--- a/tests/component/user/conftest.py
+++ b/tests/component/user/conftest.py
@@ -3,13 +3,18 @@ from __future__ import annotations
 import secrets
 import uuid
 from collections.abc import AsyncIterator, Callable, Coroutine
-from typing import Any
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import yarl
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
+from ai.backend.client.v2.auth import HMACAuth
+from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.registry import BackendAIClientRegistry
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
 from ai.backend.common.dto.manager.user import (
     CreateUserRequest,
     CreateUserResponse,
@@ -18,12 +23,15 @@ from ai.backend.common.dto.manager.user import (
 )
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import RBACValidators
+from ai.backend.manager.api.adapters.user.adapter import UserAdapter
 from ai.backend.manager.api.rest.admin.handler import AdminHandler
 from ai.backend.manager.api.rest.admin.registry import register_admin_routes
 from ai.backend.manager.api.rest.routing import RouteRegistry
 from ai.backend.manager.api.rest.types import RouteDeps
 from ai.backend.manager.api.rest.user.handler import UserHandler
 from ai.backend.manager.api.rest.user.registry import register_user_routes
+from ai.backend.manager.api.rest.v2.user.handler import V2UserHandler
+from ai.backend.manager.api.rest.v2.user.registry import register_v2_user_routes
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.models.group import association_groups_users
 from ai.backend.manager.models.keypair import keypairs
@@ -32,9 +40,13 @@ from ai.backend.manager.models.user import users
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.repositories.user.repository import UserRepository
+from ai.backend.manager.services.processors import Processors
 from ai.backend.manager.services.user.processors import UserProcessors
 from ai.backend.manager.services.user.service import UserService
 from ai.backend.testutils.fixtures import DomainFixtureData
+
+if TYPE_CHECKING:
+    from tests.component.conftest import ServerInfo, UserFixtureData
 
 UserFactory = Callable[..., Coroutine[Any, Any, CreateUserResponse]]
 
@@ -79,16 +91,40 @@ def server_module_registries(
         UserHandler(user=user_processors, config_provider=config_provider),
         route_deps,
     )
-    return [
-        register_admin_routes(
-            AdminHandler(
-                gql_schema=MagicMock(), gql_deps=MagicMock(), strawberry_schema=MagicMock()
-            ),
-            route_deps,
-            sub_registries=[user_registry],
-            gql_ws_handler=MagicMock(),
+    admin_registry = register_admin_routes(
+        AdminHandler(gql_schema=MagicMock(), gql_deps=MagicMock(), strawberry_schema=MagicMock()),
+        route_deps,
+        sub_registries=[user_registry],
+        gql_ws_handler=MagicMock(),
+    )
+
+    # v2 user routes (/v2/users) — exercises the api/adapters/user adapter shared with GQL.
+    processors = MagicMock(spec=Processors)
+    processors.user = user_processors
+    v2_handler = V2UserHandler(adapter=UserAdapter(processors, auth_config=MagicMock()))
+    v2_registry = RouteRegistry.create("v2", route_deps.cors_options)
+    v2_registry.add_subregistry(register_v2_user_routes(v2_handler, route_deps))
+
+    return [admin_registry, v2_registry]
+
+
+@pytest.fixture()
+async def admin_v2_registry(
+    server: ServerInfo,
+    admin_user_fixture: UserFixtureData,
+) -> AsyncIterator[V2ClientRegistry]:
+    """V2ClientRegistry authenticated as superadmin, for /v2/users endpoints."""
+    registry = await V2ClientRegistry.create(
+        ClientConfig(endpoint=yarl.URL(server.url)),
+        HMACAuth(
+            access_key=admin_user_fixture.keypair.access_key,
+            secret_key=admin_user_fixture.keypair.secret_key,
         ),
-    ]
+    )
+    try:
+        yield registry
+    finally:
+        await registry.close()
 
 
 @pytest.fixture()
@@ -140,3 +176,83 @@ async def target_user(
 ) -> CreateUserResponse:
     """Pre-created user for tests that need an existing user."""
     return await user_factory()
+
+
+# --------------------------------------------------------------------------- #
+# Data-setup fixtures for v2 container UID/GID filter tests.
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class ScalarMatchUsers:
+    """A user matching a scalar container value (uid / main gid) and one that does not."""
+
+    value: int
+    matching: CreateUserResponse
+    other: CreateUserResponse
+
+
+@dataclass
+class ArrayMatchUsers:
+    """Users for container_gids array filter scenarios."""
+
+    query: list[int]
+    matching: CreateUserResponse
+    other: CreateUserResponse
+
+
+@dataclass
+class SingleGidUsers:
+    """One gid value present as one user's main gid and another user's supplementary gid."""
+
+    gid: int
+    via_main_gid: CreateUserResponse
+    via_gids: CreateUserResponse
+    unrelated: CreateUserResponse
+
+
+@pytest.fixture()
+async def container_uid_users(user_factory: UserFactory) -> ScalarMatchUsers:
+    return ScalarMatchUsers(
+        value=4001,
+        matching=await user_factory(container_uid=4001),
+        other=await user_factory(container_uid=4002),
+    )
+
+
+@pytest.fixture()
+async def container_main_gid_users(user_factory: UserFactory) -> ScalarMatchUsers:
+    return ScalarMatchUsers(
+        value=5001,
+        matching=await user_factory(container_main_gid=5001),
+        other=await user_factory(container_main_gid=5002),
+    )
+
+
+@pytest.fixture()
+async def container_gids_any_users(user_factory: UserFactory) -> ArrayMatchUsers:
+    return ArrayMatchUsers(
+        query=[6020, 6099],
+        matching=await user_factory(container_gids=[6010, 6020]),
+        other=await user_factory(container_gids=[6030]),
+    )
+
+
+@pytest.fixture()
+async def container_gids_all_users(user_factory: UserFactory) -> ArrayMatchUsers:
+    return ArrayMatchUsers(
+        query=[7010, 7020],
+        matching=await user_factory(container_gids=[7010, 7020, 7030]),
+        other=await user_factory(container_gids=[7010]),
+    )
+
+
+@pytest.fixture()
+async def single_gid_users(user_factory: UserFactory) -> SingleGidUsers:
+    gid = 8000
+    return SingleGidUsers(
+        gid=gid,
+        via_main_gid=await user_factory(container_main_gid=gid),
+        via_gids=await user_factory(container_gids=[gid, 8001]),
+        unrelated=await user_factory(container_main_gid=9000, container_gids=[9001]),
+    )

--- a/tests/component/user/test_user.py
+++ b/tests/component/user/test_user.py
@@ -10,8 +10,9 @@ from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.client.v2.exceptions import NotFoundError, PermissionDeniedError
 from ai.backend.client.v2.registry import BackendAIClientRegistry
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
 from ai.backend.common.data.permission.types import RBACElementType, RelationType
-from ai.backend.common.dto.manager.query import StringFilter
+from ai.backend.common.dto.manager.query import ArrayFilter, IntFilter, StringFilter
 from ai.backend.common.dto.manager.user import (
     CreateUserRequest,
     CreateUserResponse,
@@ -31,6 +32,12 @@ from ai.backend.common.dto.manager.user import (
     UserRole,
     UserStatus,
 )
+from ai.backend.common.dto.manager.v2.user.request import (
+    SearchUsersRequest as V2SearchUsersRequest,
+)
+from ai.backend.common.dto.manager.v2.user.request import (
+    UserFilter as V2UserFilter,
+)
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import EntityType, OperationType, ScopeType
@@ -43,7 +50,12 @@ from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.user import users
 from ai.backend.testutils.fixtures import DomainFixtureData
 
-from .conftest import UserFactory
+from .conftest import (
+    ArrayMatchUsers,
+    ScalarMatchUsers,
+    SingleGidUsers,
+    UserFactory,
+)
 
 
 class TestUserCreate:
@@ -554,3 +566,107 @@ class TestUserBulkOperations:
     async def test_failure_index_tracking(self) -> None:
         """Failure index tracking -> each failure has correct index and error message."""
         pytest.fail("Not implemented")
+
+
+class TestV2UserContainerFilter:
+    """Container UID/GID filtering via POST /v2/users/search (v2 API).
+
+    Seeds users with distinct container_uid / container_main_gid / container_gids and
+    asserts the search narrows results. This is the only layer that validates the
+    PostgreSQL array operators (``@>`` / ``&&``) for container_gids against real rows.
+    """
+
+    async def test_filter_by_container_uid(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        container_uid_users: ScalarMatchUsers,
+    ) -> None:
+        result = await admin_v2_registry.user.admin_search(
+            V2SearchUsersRequest(
+                filter=V2UserFilter(container_uid=IntFilter(equals=container_uid_users.value))
+            )
+        )
+
+        ids = {item.id for item in result.items}
+        assert container_uid_users.matching.user.id in ids
+        assert container_uid_users.other.user.id not in ids
+
+    async def test_filter_by_container_main_gid(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        container_main_gid_users: ScalarMatchUsers,
+    ) -> None:
+        result = await admin_v2_registry.user.admin_search(
+            V2SearchUsersRequest(
+                filter=V2UserFilter(
+                    container_main_gid=IntFilter(equals=container_main_gid_users.value)
+                )
+            )
+        )
+
+        ids = {item.id for item in result.items}
+        assert container_main_gid_users.matching.user.id in ids
+        assert container_main_gid_users.other.user.id not in ids
+
+    async def test_filter_container_gids_any(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        container_gids_any_users: ArrayMatchUsers,
+    ) -> None:
+        result = await admin_v2_registry.user.admin_search(
+            V2SearchUsersRequest(
+                filter=V2UserFilter(
+                    container_gids=ArrayFilter[int].model_validate({
+                        "any": container_gids_any_users.query
+                    })
+                )
+            )
+        )
+
+        ids = {item.id for item in result.items}
+        assert container_gids_any_users.matching.user.id in ids
+        assert container_gids_any_users.other.user.id not in ids
+
+    async def test_filter_container_gids_all(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        container_gids_all_users: ArrayMatchUsers,
+    ) -> None:
+        result = await admin_v2_registry.user.admin_search(
+            V2SearchUsersRequest(
+                filter=V2UserFilter(
+                    container_gids=ArrayFilter[int].model_validate({
+                        "all": container_gids_all_users.query
+                    })
+                )
+            )
+        )
+
+        ids = {item.id for item in result.items}
+        assert container_gids_all_users.matching.user.id in ids
+        assert container_gids_all_users.other.user.id not in ids
+
+    async def test_filter_single_gid_across_main_gid_and_gids(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        single_gid_users: SingleGidUsers,
+    ) -> None:
+        """A single gid matches users via container_main_gid OR container_gids.any."""
+        gid = single_gid_users.gid
+        result = await admin_v2_registry.user.admin_search(
+            V2SearchUsersRequest(
+                filter=V2UserFilter(
+                    OR=[
+                        V2UserFilter(container_main_gid=IntFilter(equals=gid)),
+                        V2UserFilter(
+                            container_gids=ArrayFilter[int].model_validate({"any": [gid]})
+                        ),
+                    ]
+                )
+            )
+        )
+
+        ids = {item.id for item in result.items}
+        assert single_gid_users.via_main_gid.user.id in ids
+        assert single_gid_users.via_gids.user.id in ids
+        assert single_gid_users.unrelated.user.id not in ids

--- a/tests/component/user/test_user.py
+++ b/tests/component/user/test_user.py
@@ -617,7 +617,7 @@ class TestV2UserContainerFilter:
             V2SearchUsersRequest(
                 filter=V2UserFilter(
                     container_gids=ArrayFilter[int].model_validate({
-                        "any": container_gids_any_users.query
+                        "contains_any": container_gids_any_users.query
                     })
                 )
             )
@@ -636,7 +636,7 @@ class TestV2UserContainerFilter:
             V2SearchUsersRequest(
                 filter=V2UserFilter(
                     container_gids=ArrayFilter[int].model_validate({
-                        "all": container_gids_all_users.query
+                        "contains_all": container_gids_all_users.query
                     })
                 )
             )
@@ -651,7 +651,7 @@ class TestV2UserContainerFilter:
         admin_v2_registry: V2ClientRegistry,
         single_gid_users: SingleGidUsers,
     ) -> None:
-        """A single gid matches users via container_main_gid OR container_gids.any."""
+        """A single gid matches users via container_main_gid OR container_gids.contains."""
         gid = single_gid_users.gid
         result = await admin_v2_registry.user.admin_search(
             V2SearchUsersRequest(
@@ -659,7 +659,7 @@ class TestV2UserContainerFilter:
                     OR=[
                         V2UserFilter(container_main_gid=IntFilter(equals=gid)),
                         V2UserFilter(
-                            container_gids=ArrayFilter[int].model_validate({"any": [gid]})
+                            container_gids=ArrayFilter[int].model_validate({"contains": gid})
                         ),
                     ]
                 )

--- a/tests/unit/common/dto/manager/v2/user/test_request.py
+++ b/tests/unit/common/dto/manager/v2/user/test_request.py
@@ -504,25 +504,32 @@ class TestUserFilter:
         assert f.container_main_gid is not None
         assert f.container_main_gid.greater_than == 500
 
-    def test_container_gids_all_filter(self) -> None:
-        f = UserFilter.model_validate({"container_gids": {"all": [10, 20]}})
+    def test_container_gids_contains_filter(self) -> None:
+        f = UserFilter.model_validate({"container_gids": {"contains": 42}})
         assert f.container_gids is not None
-        assert f.container_gids.all_ == [10, 20]
-        assert f.container_gids.any_ is None
+        assert f.container_gids.contains == 42
+        assert f.container_gids.contains_any is None
+        assert f.container_gids.contains_all is None
 
-    def test_container_gids_any_filter(self) -> None:
-        f = UserFilter.model_validate({"container_gids": {"any": [30]}})
+    def test_container_gids_contains_all_filter(self) -> None:
+        f = UserFilter.model_validate({"container_gids": {"contains_all": [10, 20]}})
         assert f.container_gids is not None
-        assert f.container_gids.any_ == [30]
-        assert f.container_gids.all_ is None
+        assert f.container_gids.contains_all == [10, 20]
+        assert f.container_gids.contains_any is None
 
-    def test_container_gids_empty_all_rejected(self) -> None:
-        with pytest.raises((BackendAISchemaValidationFailed, ValidationError)):
-            UserFilter.model_validate({"container_gids": {"all": []}})
+    def test_container_gids_contains_any_filter(self) -> None:
+        f = UserFilter.model_validate({"container_gids": {"contains_any": [30]}})
+        assert f.container_gids is not None
+        assert f.container_gids.contains_any == [30]
+        assert f.container_gids.contains_all is None
 
-    def test_container_gids_empty_any_rejected(self) -> None:
+    def test_container_gids_empty_contains_all_rejected(self) -> None:
         with pytest.raises((BackendAISchemaValidationFailed, ValidationError)):
-            UserFilter.model_validate({"container_gids": {"any": []}})
+            UserFilter.model_validate({"container_gids": {"contains_all": []}})
+
+    def test_container_gids_empty_contains_any_rejected(self) -> None:
+        with pytest.raises((BackendAISchemaValidationFailed, ValidationError)):
+            UserFilter.model_validate({"container_gids": {"contains_any": []}})
 
 
 class TestUserOrder:

--- a/tests/unit/common/dto/manager/v2/user/test_request.py
+++ b/tests/unit/common/dto/manager/v2/user/test_request.py
@@ -488,6 +488,34 @@ class TestUserFilter:
         assert f.role is not None
         assert f.role.in_ == [UserRole.ADMIN, UserRole.SUPERADMIN]
 
+    def test_container_filters_default_to_none(self) -> None:
+        f = UserFilter()
+        assert f.container_uid is None
+        assert f.container_main_gid is None
+        assert f.container_gids is None
+
+    def test_container_uid_filter(self) -> None:
+        f = UserFilter.model_validate({"container_uid": {"equals": 1000}})
+        assert f.container_uid is not None
+        assert f.container_uid.equals == 1000
+
+    def test_container_main_gid_filter(self) -> None:
+        f = UserFilter.model_validate({"container_main_gid": {"greater_than": 500}})
+        assert f.container_main_gid is not None
+        assert f.container_main_gid.greater_than == 500
+
+    def test_container_gids_all_filter(self) -> None:
+        f = UserFilter.model_validate({"container_gids": {"all": [10, 20]}})
+        assert f.container_gids is not None
+        assert f.container_gids.all_ == [10, 20]
+        assert f.container_gids.any_ is None
+
+    def test_container_gids_any_filter(self) -> None:
+        f = UserFilter.model_validate({"container_gids": {"any": [30]}})
+        assert f.container_gids is not None
+        assert f.container_gids.any_ == [30]
+        assert f.container_gids.all_ is None
+
 
 class TestUserOrder:
     """Tests for UserOrder model."""

--- a/tests/unit/common/dto/manager/v2/user/test_request.py
+++ b/tests/unit/common/dto/manager/v2/user/test_request.py
@@ -516,6 +516,14 @@ class TestUserFilter:
         assert f.container_gids.any_ == [30]
         assert f.container_gids.all_ is None
 
+    def test_container_gids_empty_all_rejected(self) -> None:
+        with pytest.raises((BackendAISchemaValidationFailed, ValidationError)):
+            UserFilter.model_validate({"container_gids": {"all": []}})
+
+    def test_container_gids_empty_any_rejected(self) -> None:
+        with pytest.raises((BackendAISchemaValidationFailed, ValidationError)):
+            UserFilter.model_validate({"container_gids": {"any": []}})
+
 
 class TestUserOrder:
     """Tests for UserOrder model."""


### PR DESCRIPTION
## Summary
- Add `container_uid`, `container_main_gid` (via `IntFilter`) and `container_gids` (via a new generic `ArrayFilter[T]` with `all`/`any`) to the v2 `UserFilter`.
- Wire them through the GQL `IntArrayFilter` wrapper, the shared `convert_array_filter` adapter helper, **both** adapter converters (REST `_convert_filter` and GQL `_convert_gql_filter`), and `UserConditions` using PostgreSQL `@>` / `&&` array operators.
- SDK/CLI untouched (v2 SDK passes the typed filter through unchanged).

## Test plan
- [x] DTO unit tests for the new `UserFilter` fields (`tests/unit/common/dto/manager/v2/user/test_request.py`)
- [x] Component tests over `POST /v2/users/search` against a real DB, covering `container_uid`, `container_main_gid`, `container_gids` (`any`/`all`), and a single-gid OR query across `container_main_gid` + `container_gids.any` (`tests/component/user/test_user.py::TestV2UserContainerFilter`)
- [x] `pants fmt/fix/lint/check` clean; pre-push `lint/check/test` green

Resolves BA-6247

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11878.org.readthedocs.build/en/11878/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11878.org.readthedocs.build/ko/11878/

<!-- readthedocs-preview sorna-ko end -->