### PR TITLE
feat(BA-6252): identify session by session_id for the start-service action

### DIFF
--- a/changes/11884.enhance.md
+++ b/changes/11884.enhance.md
@@ -1,0 +1,1 @@
+Identify the session by `session_id` (instead of `session_name` + `access_key`) for the start-service action across the legacy and v2 session APIs, and enforce session-access authorization via RBAC.

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -65,6 +65,7 @@ from ai.backend.common.dto.manager.v2.session.response import (
     UpdateSessionPayload,
 )
 from ai.backend.common.dto.manager.v2.session.types import ClusterModeEnum, SessionStatusFilter
+from ai.backend.common.identifier.session import SessionID
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import (
     AccessKey,
@@ -819,14 +820,12 @@ class SessionAdapter(BaseAdapter):
 
     async def start_service(
         self,
-        session_id: UUID,
+        session_id: SessionID,
         input: StartSessionServiceInput,
-        access_key: str,
     ) -> StartSessionServicePayload:
         """Start an app service in a session."""
         action = StartServiceAction(
-            session_name=str(session_id),
-            access_key=AccessKey(access_key),
+            session_id=session_id,
             service=input.service,
             login_session_token=input.login_session_token,
             port=input.port,

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -80,9 +80,9 @@ from ai.backend.common.dto.manager.session.types import (
     CreationConfigV6Template,
     CreationConfigV7,
 )
-from ai.backend.common.exception import BackendAIError
+from ai.backend.common.exception import BackendAIError, UnreachableError
+from ai.backend.common.identifier.session import SessionID
 from ai.backend.common.types import (
-    AccessKey,
     AgentId,
     KernelId,
 )
@@ -162,6 +162,9 @@ from ai.backend.manager.services.session.actions.match_sessions import (
 )
 from ai.backend.manager.services.session.actions.rename_session import (
     RenameSessionAction,
+)
+from ai.backend.manager.services.session.actions.resolve_session import (
+    ResolveSessionAction,
 )
 from ai.backend.manager.services.session.actions.shutdown_service import (
     ShutdownServiceAction,
@@ -417,6 +420,16 @@ class SessionHandler:
         self._agent = agent
         self._vfolder = vfolder
         self._config_provider = config_provider
+
+    def _require_user_id(self) -> UUID:
+        """Return the authenticated user's id from the request context.
+
+        The route requires authentication, so a missing user is unreachable.
+        """
+        user = current_user()
+        if user is None:
+            raise UnreachableError("authenticated user missing from request context")
+        return user.user_id
 
     async def _normalize_legacy_mounts(self, validated_config: dict[str, Any]) -> dict[str, Any]:
         """One-stop processor for the legacy ``mounts`` / ``mount_map`` /
@@ -1072,14 +1085,16 @@ class SessionHandler:
         request = ctx.request
         params = body.parsed
         session_name: str = request.match_info["session_name"]
-        access_key: AccessKey = request["keypair"]["access_key"]
         myself = asyncio.current_task()
         if myself is None:
             raise NoCurrentTaskContext("No current task context")
+        user_id = self._require_user_id()
+        resolved = await self._session.resolve_session.wait_for_complete(
+            ResolveSessionAction(session_name=session_name, user_id=user_id)
+        )
         result = await self._session.start_service.wait_for_complete(
             StartServiceAction(
-                session_name=session_name,
-                access_key=access_key,
+                session_id=SessionID(resolved.session_id),
                 service=params.app,
                 login_session_token=params.login_session_token,
                 port=params.port,

--- a/src/ai/backend/manager/api/rest/v2/session/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/session/handler.py
@@ -20,6 +20,7 @@ from ai.backend.common.dto.manager.v2.session.request import (
 from ai.backend.common.dto.manager.v2.session.request import (
     SessionIdPathParam as SessionIdPathParamDTO,
 )
+from ai.backend.common.identifier.session import SessionID
 from ai.backend.common.types import AgentId, SessionId
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.api.rest.v2.path_params import (
@@ -141,14 +142,11 @@ class V2SessionHandler:
 
     async def start_service(
         self,
-        user_ctx: UserContext,
         path: PathParam[SessionIdPathParamDTO],
         body: BodyParam[StartSessionServiceInput],
     ) -> APIResponse:
         """Start a service in a session."""
-        result = await self._adapter.start_service(
-            path.parsed.session_id, body.parsed, access_key=user_ctx.access_key
-        )
+        result = await self._adapter.start_service(SessionID(path.parsed.session_id), body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
     async def shutdown_service(

--- a/src/ai/backend/manager/data/session/types.py
+++ b/src/ai/backend/manager/data/session/types.py
@@ -11,9 +11,11 @@ from uuid import UUID
 from ai.backend.common.data.vfolder.types import VFolderMountData
 from ai.backend.common.types import (
     AccessKey,
+    AgentId,
     BackendAISchema,
     CIStrEnum,
     ClusterMode,
+    KernelId,
     ResourceSlot,
     SessionId,
     SessionResult,
@@ -191,6 +193,22 @@ class SessionData:
 
     # Loaded from relationship
     service_ports: str | None
+
+
+@dataclass(frozen=True)
+class SessionRoutingInfo:
+    """Minimal session data needed to start an app service in a session.
+
+    Carries the session metadata (for the action result) together with the main
+    kernel's routing fields, so the repository never exposes a SessionRow to callers.
+    """
+
+    session: SessionData
+    main_kernel_id: KernelId
+    agent_id: AgentId | None
+    kernel_host: str | None
+    agent_addr: str | None
+    service_ports: list[dict[str, Any]]
 
 
 @dataclass

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1625,16 +1625,14 @@ class AgentRegistry:
 
     async def start_service(
         self,
-        session: SessionRow,
+        main_kernel_id: KernelId,
+        agent_id: AgentId,
         service: str,
         opts: Mapping[str, Any],
     ) -> Mapping[str, Any]:
         async with handle_session_exception("execute"):
-            agent_id = session.main_kernel.agent
-            if agent_id is None:
-                raise AgentNotAllocated(f"Session {session.id} main kernel has no agent allocated")
-            async with self._agent_client_pool.acquire(AgentId(agent_id)) as client:
-                return await client.start_service(session.main_kernel.id, service, opts)
+            async with self._agent_client_pool.acquire(agent_id) as client:
+                return await client.start_service(main_kernel_id, service, opts)
 
     async def shutdown_service(
         self,
@@ -1718,13 +1716,6 @@ class AgentRegistry:
             async with self._agent_client_pool.acquire(AgentId(kernel.agent)) as client:
                 reply = await client.get_logs(kernel.id)
             return reply["logs"]
-
-    async def increment_session_usage(
-        self,
-        session: SessionRow,
-    ) -> None:
-        # noop for performance reasons
-        pass
 
     async def sync_agent_kernel_registry(self, agent_id: AgentId) -> None:
         """

--- a/src/ai/backend/manager/repositories/session/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/session/db_source/db_source.py
@@ -7,15 +7,21 @@ from typing import Any, cast
 
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import load_only, noload, selectinload
+from sqlalchemy.orm import joinedload, load_only, noload, selectinload
 from sqlalchemy.orm.strategy_options import _AbstractLoad
 
 from ai.backend.common.docker import ImageRef
-from ai.backend.common.types import AccessKey, ImageAlias, SessionId
+from ai.backend.common.identifier.session import SessionID
+from ai.backend.common.types import AccessKey, AgentId, ImageAlias, SessionId
 from ai.backend.manager.data.image.types import ImageIdentifier, ImageStatus
 from ai.backend.manager.data.kernel.types import KernelListResult
-from ai.backend.manager.data.session.types import SessionData, SessionListResult
+from ai.backend.manager.data.session.types import (
+    SessionData,
+    SessionListResult,
+    SessionRoutingInfo,
+)
 from ai.backend.manager.data.user.types import SessionOwnerContext, UserData
+from ai.backend.manager.defs import DEFAULT_ROLE
 from ai.backend.manager.errors.common import GenericBadRequest
 from ai.backend.manager.errors.image import ImageNotFound
 from ai.backend.manager.errors.kernel import (
@@ -31,6 +37,7 @@ from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.resource_policy import KeyPairResourcePolicyRow
 from ai.backend.manager.models.scaling_group import scaling_groups
 from ai.backend.manager.models.session import (
+    DEAD_SESSION_STATUSES,
     TERMINAL_SESSION_STATUSES,
     KernelLoadingStrategy,
     SessionDependencyRow,
@@ -536,20 +543,43 @@ class SessionDBSource:
 
     async def get_session_with_routing_minimal(
         self,
-        session_name_or_id: str | SessionId,
-        owner_access_key: AccessKey,
-    ) -> SessionRow:
-        """Get session with minimal routing information"""
-        async with self._db.begin_readonly_session_read_committed() as db_sess:
-            return await SessionRow.get_session(
-                db_sess,
-                session_name_or_id,
-                owner_access_key,
-                kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
-                eager_loading_op=[
-                    selectinload(SessionRow.routing).options(noload("*")),
-                ],
+        session_id: SessionID,
+    ) -> SessionRoutingInfo:
+        """Resolve a live session by ``session_id`` into its routing info.
+
+        This is a pure lookup; session access authorization is the caller's
+        responsibility. Dead (terminated/cancelled) sessions are excluded. Returns a
+        data type rather than a SessionRow so the repository never exposes an ORM row.
+        """
+        query = (
+            sa.select(SessionRow)
+            .where((SessionRow.id == session_id) & (~SessionRow.status.in_(DEAD_SESSION_STATUSES)))
+            .options(
+                noload("*"),
+                selectinload(
+                    SessionRow.kernels.and_(KernelRow.cluster_role == DEFAULT_ROLE)
+                ).options(
+                    noload("*"),
+                    selectinload(KernelRow.agent_row).noload("*"),
+                ),
+                joinedload(SessionRow.user),
             )
+        )
+        async with self._ops.read_ops() as r:
+            result = await r.batch_query_in_global(query, BatchQuerier(pagination=NoPagination()))
+        rows: list[SessionRow] = [row.SessionRow for row in result.rows]
+        if not rows:
+            raise SessionNotFound(f"Session (id={session_id}) does not exist.")
+        session_row = rows[0]
+        main_kernel = session_row.main_kernel
+        return SessionRoutingInfo(
+            session=session_row.to_dataclass(),
+            main_kernel_id=main_kernel.id,
+            agent_id=AgentId(main_kernel.agent) if main_kernel.agent is not None else None,
+            kernel_host=main_kernel.kernel_host,
+            agent_addr=main_kernel.agent_addr,
+            service_ports=main_kernel.service_ports or [],
+        )
 
     async def search(
         self,

--- a/src/ai/backend/manager/repositories/session/repository.py
+++ b/src/ai/backend/manager/repositories/session/repository.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm.strategy_options import _AbstractLoad
 
 from ai.backend.common.docker import ImageRef
 from ai.backend.common.exception import BackendAIError
+from ai.backend.common.identifier.session import SessionID
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
@@ -16,7 +17,11 @@ from ai.backend.common.resilience.resilience import Resilience
 from ai.backend.common.types import AccessKey, ImageAlias, SessionId
 from ai.backend.manager.data.image.types import ImageIdentifier
 from ai.backend.manager.data.kernel.types import KernelListResult
-from ai.backend.manager.data.session.types import SessionData, SessionListResult
+from ai.backend.manager.data.session.types import (
+    SessionData,
+    SessionListResult,
+    SessionRoutingInfo,
+)
 from ai.backend.manager.data.user.types import SessionOwnerContext, UserData
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.image import ImageRow
@@ -263,13 +268,13 @@ class SessionRepository:
     @session_repository_resilience.apply()
     async def get_session_with_routing_minimal(
         self,
-        session_name_or_id: str | SessionId,
-        owner_access_key: AccessKey,
-    ) -> SessionRow:
-        """Get session with minimal routing information"""
-        return await self._db_source.get_session_with_routing_minimal(
-            session_name_or_id, owner_access_key
-        )
+        session_id: SessionID,
+    ) -> SessionRoutingInfo:
+        """Resolve a live session by ``session_id`` into its routing info.
+
+        Pure lookup; session access authorization is the caller's responsibility.
+        """
+        return await self._db_source.get_session_with_routing_minimal(session_id)
 
     @session_repository_resilience.apply()
     async def search(

--- a/src/ai/backend/manager/services/session/actions/start_service.py
+++ b/src/ai/backend/manager/services/session/actions/start_service.py
@@ -1,17 +1,20 @@
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.types import AccessKey
-from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.common.identifier.session import SessionID
 from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.data.session.types import SessionData
-from ai.backend.manager.services.session.actions.app_service_base import SessionAppServiceAction
+from ai.backend.manager.services.session.base import (
+    SessionSingleEntityAction,
+    SessionSingleEntityActionResult,
+)
 
 
 @dataclass
-class StartServiceAction(SessionAppServiceAction):
-    session_name: str
-    access_key: AccessKey
+class StartServiceAction(SessionSingleEntityAction):
+    session_id: SessionID
     service: str
     login_session_token: Any
     port: int | None
@@ -19,17 +22,21 @@ class StartServiceAction(SessionAppServiceAction):
     envs: str | None  # json_string
 
     @override
-    def entity_id(self) -> str | None:
-        return None
-
-    @override
     @classmethod
     def operation_type(cls) -> ActionOperationType:
         return ActionOperationType.CREATE
 
+    @override
+    def target_entity_id(self) -> str:
+        return str(self.session_id)
+
+    @override
+    def target_element(self) -> RBACElementRef:
+        return RBACElementRef(RBACElementType.SESSION, str(self.session_id))
+
 
 @dataclass
-class StartServiceActionResult(BaseActionResult):
+class StartServiceActionResult(SessionSingleEntityActionResult):
     # TODO: Add proper type
     result: Any
     session_data: SessionData
@@ -37,5 +44,5 @@ class StartServiceActionResult(BaseActionResult):
     wsproxy_addr: str
 
     @override
-    def entity_id(self) -> str | None:
+    def target_entity_id(self) -> str:
         return str(self.session_data.id)

--- a/src/ai/backend/manager/services/session/processors.py
+++ b/src/ai/backend/manager/services/session/processors.py
@@ -178,7 +178,7 @@ class SessionProcessors(AbstractProcessorPackage):
         SearchSessionsInProjectAction, SearchSessionsInProjectActionResult
     ]
     shutdown_service: ActionProcessor[ShutdownServiceAction, ShutdownServiceActionResult]
-    start_service: ActionProcessor[StartServiceAction, StartServiceActionResult]
+    start_service: SingleEntityActionProcessor[StartServiceAction, StartServiceActionResult]
     terminate_sessions: BulkActionProcessor[TerminateSessionsAction, TerminateSessionsActionResult]
     upload_files: ActionProcessor[UploadFilesAction, UploadFilesActionResult]
     get_session: SingleEntityActionProcessor[GetSessionAction, GetSessionActionResult]
@@ -214,7 +214,6 @@ class SessionProcessors(AbstractProcessorPackage):
         self.rename_session = ActionProcessor(service.rename_session, action_monitors)
         self.resolve_session = ActionProcessor(service.resolve_session, action_monitors)
         self.shutdown_service = ActionProcessor(service.shutdown_service, action_monitors)
-        self.start_service = ActionProcessor(service.start_service, action_monitors)
         self.upload_files = ActionProcessor(service.upload_files, action_monitors)
 
         # Scope actions with RBAC validation
@@ -276,6 +275,11 @@ class SessionProcessors(AbstractProcessorPackage):
         )
         self.modify_session = SingleEntityActionProcessor(
             service.modify_session,
+            action_monitors,
+            validators=rbac_single_entity_validators,
+        )
+        self.start_service = SingleEntityActionProcessor(
+            service.start_service,
             action_monitors,
             validators=rbac_single_entity_validators,
         )

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -83,6 +83,7 @@ from ai.backend.manager.errors.kernel import (
     TooManySessionsMatched,
 )
 from ai.backend.manager.errors.resource import (
+    AgentNotAllocated,
     AppNotFound,
     NoCurrentTaskContext,
     TaskTemplateNotFound,
@@ -340,7 +341,6 @@ class SessionService:
             kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         )
         try:
-            await self._agent_registry.increment_session_usage(session)
             resp = await self._agent_registry.get_completions(session, code, opts=options)
         except AssertionError as e:
             raise InvalidAPIParameters from e
@@ -862,7 +862,6 @@ class SessionService:
                 owner_access_key,
                 kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
             )
-            await self._agent_registry.increment_session_usage(session)
             result = await self._agent_registry.download_single(session, owner_access_key, file)
         except (ValueError, FileNotFoundError) as e:
             raise InvalidAPIParameters("The file is not found.") from e
@@ -890,7 +889,6 @@ class SessionService:
         try:
             if len(files) > 5:
                 raise VFolderBadRequest("Too many files (maximum 5 files allowed)")
-            await self._agent_registry.increment_session_usage(session)
             # TODO: Read all download file contents. Need to fix by using chuncking, etc.
             results = await asyncio.gather(
                 *map(
@@ -932,8 +930,6 @@ class SessionService:
             kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         )
         try:
-            await self._agent_registry.increment_session_usage(session)
-
             run_id: str | None
             mode: str | None
 
@@ -1072,7 +1068,6 @@ class SessionService:
                 )
 
         registry = self._agent_registry
-        await registry.increment_session_usage(compute_session)
         resp["result"]["logs"] = await registry.get_logs_from_agent(
             session=compute_session, kernel_id=kernel_id
         )
@@ -1156,7 +1151,6 @@ class SessionService:
             owner_access_key,
             kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         )
-        await self._agent_registry.increment_session_usage(sess)
 
         created_at = sess.created_at or datetime.now(tzutc())
         age = datetime.now(tzutc()) - created_at
@@ -1219,7 +1213,6 @@ class SessionService:
             owner_access_key,
             kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         )
-        await self._agent_registry.increment_session_usage(session)
         await self._agent_registry.interrupt_session(session)
 
         return InterruptSessionActionResult(result=None, session_data=session.to_dataclass())
@@ -1238,7 +1231,6 @@ class SessionService:
 
         resp: MutableMapping[str, Any] = {}
         try:
-            await self._agent_registry.increment_session_usage(session)
             result = await self._agent_registry.list_files(session, path)
             resp.update(result)
             log.debug("container file list for {0} retrieved", path)
@@ -1305,8 +1297,7 @@ class SessionService:
         return ShutdownServiceActionResult(result=None, session_data=session.to_dataclass())
 
     async def start_service(self, action: StartServiceAction) -> StartServiceActionResult:
-        session_name = action.session_name
-        access_key = action.access_key
+        session_id = action.session_id
         service = action.service
         port = action.port
 
@@ -1314,19 +1305,13 @@ class SessionService:
         envs = action.envs
         login_session_token = action.login_session_token
 
-        session = await asyncio.shield(
-            self._database_ptask_group.create_task(
-                self._session_repository.get_session_with_routing_minimal(
-                    session_name,
-                    access_key,
-                )
-            )
-        )
+        info = await self._session_repository.get_session_with_routing_minimal(session_id)
+        session_data = info.session
 
-        if session.scaling_group_name is None:
+        if session_data.scaling_group_name is None:
             raise ServiceUnavailable("Session has no scaling group assigned")
         wsproxy_addr = await self._session_repository.get_scaling_group_wsproxy_addr(
-            session.scaling_group_name
+            session_data.scaling_group_name
         )
         if not wsproxy_addr:
             raise ServiceUnavailable("No coordinator configured for this resource group")
@@ -1337,11 +1322,11 @@ class SessionService:
         else:
             wsproxy_advertise_addr = wsproxy_addr
 
-        if session.main_kernel.kernel_host is None:
-            kernel_host = urlparse(session.main_kernel.agent_addr).hostname
+        if info.kernel_host is None:
+            kernel_host = urlparse(info.agent_addr).hostname
         else:
-            kernel_host = session.main_kernel.kernel_host
-        service_ports: list[dict[str, Any]] = session.main_kernel.service_ports or []
+            kernel_host = info.kernel_host
+        service_ports: list[dict[str, Any]] = info.service_ports
         sport: dict[str, Any] = {}
         host_port: int
         for sport in service_ports:
@@ -1368,13 +1353,7 @@ class SessionService:
                         host_port = sport["host_ports"][0]
                 break
         else:
-            raise AppNotFound(f"{session_name}:{service}")
-
-        await asyncio.shield(
-            self._database_ptask_group.create_task(
-                self._agent_registry.increment_session_usage(session),
-            )
-        )
+            raise AppNotFound(f"{session_data.name}:{service}")
 
         opts: MutableMapping[str, None | str | list[str]] = {}
         if arguments is not None:
@@ -1382,9 +1361,13 @@ class SessionService:
         if envs is not None:
             opts["envs"] = load_json(envs)
 
+        if info.agent_id is None:
+            raise AgentNotAllocated(f"Session {session_id} main kernel has no agent allocated")
         result = await asyncio.shield(
             self._rpc_ptask_group.create_task(
-                self._agent_registry.start_service(session, service, opts),
+                self._agent_registry.start_service(
+                    info.main_kernel_id, info.agent_id, service, opts
+                ),
             ),
         )
         if result["status"] == "failed":
@@ -1397,11 +1380,11 @@ class SessionService:
             "kernel_host": kernel_host,
             "kernel_port": host_port,
             "session": {
-                "id": str(session.id),
-                "user_uuid": str(session.user_uuid),
-                "group_id": str(session.group_id),
-                "access_key": session.access_key,
-                "domain_name": session.domain_name,
+                "id": str(session_data.id),
+                "user_uuid": str(session_data.user_uuid),
+                "group_id": str(session_data.group_id),
+                "access_key": session_data.access_key,
+                "domain_name": session_data.domain_name,
             },
         }
 
@@ -1416,7 +1399,7 @@ class SessionService:
 
             return StartServiceActionResult(
                 result=None,
-                session_data=session.to_dataclass(),
+                session_data=session_data,
                 token=token_json["token"],
                 wsproxy_addr=wsproxy_advertise_addr,
             )
@@ -1432,7 +1415,6 @@ class SessionService:
             kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         )
 
-        await self._agent_registry.increment_session_usage(session)
         file_count = 0
 
         async with aiotools.TaskScope() as ts:

--- a/src/ai/backend/manager/services/stream/service.py
+++ b/src/ai/backend/manager/services/stream/service.py
@@ -8,9 +8,10 @@ from typing import Final
 from ai.backend.common import validators as tx
 from ai.backend.common.clients.valkey_client.valkey_live.client import ValkeyLiveClient
 from ai.backend.common.etcd import AsyncEtcd
-from ai.backend.common.types import KernelId, SessionId
+from ai.backend.common.types import AgentId, KernelId, SessionId
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.errors.api import NotImplementedAPI
+from ai.backend.manager.errors.resource import AgentNotAllocated
 from ai.backend.manager.idle import AppStreamingStatus, IdleCheckerHost
 from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.repositories.stream.repository import StreamRepository
@@ -126,7 +127,12 @@ class StreamService:
         session = await self._repository.get_streaming_session(
             action.session_name, action.user_uuid
         )
-        result = await self._registry.start_service(session, action.service, action.opts)
+        main_kernel = session.main_kernel
+        if main_kernel.agent is None:
+            raise AgentNotAllocated(f"Session {session.id} main kernel has no agent allocated")
+        result = await self._registry.start_service(
+            main_kernel.id, AgentId(main_kernel.agent), action.service, action.opts
+        )
         return StartServiceInStreamActionResult(result=dict(result))
 
     def create_connection_refresh_callback(

--- a/tests/unit/manager/repositories/session/test_session_repository.py
+++ b/tests/unit/manager/repositories/session/test_session_repository.py
@@ -16,6 +16,7 @@ import sqlalchemy as sa
 from dateutil.tz import tzutc
 from sqlalchemy.orm import selectinload
 
+from ai.backend.common.identifier.session import SessionID
 from ai.backend.common.types import (
     AccessKey,
     ClusterMode,
@@ -503,6 +504,45 @@ class TestSessionRepository:
 
         resolved = await repository.resolve_session_id("test-session", session_with_kernel.user_id)
         assert resolved == session_with_kernel.session_id
+
+    # =========================================================================
+    # Tests - get_session_with_routing_minimal
+    # =========================================================================
+
+    async def test_routing_minimal_returns_info(
+        self,
+        repository: SessionRepository,
+        session_with_kernel: SessionTestData,
+    ) -> None:
+        info = await repository.get_session_with_routing_minimal(
+            SessionID(session_with_kernel.session_id)
+        )
+        assert info.session.id == session_with_kernel.session_id
+        assert info.session.access_key == session_with_kernel.access_key
+        assert info.main_kernel_id == session_with_kernel.kernel_id
+
+    async def test_routing_minimal_not_found_for_unknown_id(
+        self,
+        repository: SessionRepository,
+    ) -> None:
+        with pytest.raises(SessionNotFound):
+            await repository.get_session_with_routing_minimal(SessionID(uuid.uuid4()))
+
+    async def test_routing_minimal_excludes_terminated(
+        self,
+        repository: SessionRepository,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        session_with_kernel: SessionTestData,
+    ) -> None:
+        terminated_id = await self._insert_session(
+            db_with_cleanup,
+            session_with_kernel,
+            name="terminated-session",
+            access_key=session_with_kernel.access_key,
+            status=SessionStatus.TERMINATED,
+        )
+        with pytest.raises(SessionNotFound):
+            await repository.get_session_with_routing_minimal(SessionID(terminated_id))
 
 
 class TestBatchPopulateSessionOccupiedSlots:

--- a/tests/unit/manager/services/session/test_session_lifecycle_service.py
+++ b/tests/unit/manager/services/session/test_session_lifecycle_service.py
@@ -17,9 +17,11 @@ import pytest
 from dateutil.tz import tzutc
 
 from ai.backend.common.exception import InvalidAPIParameters, UnknownImageReference
+from ai.backend.common.identifier.session import SessionID
 from ai.backend.common.types import (
     AbuseReport,
     AccessKey,
+    AgentId,
     ClusterMode,
     KernelId,
     ResourceSlot,
@@ -34,7 +36,11 @@ from ai.backend.manager.api.rest.session.handler import (
     _route_legacy_uuid_mounts,
 )
 from ai.backend.manager.api.utils import undefined
-from ai.backend.manager.data.session.types import SessionData, SessionStatus
+from ai.backend.manager.data.session.types import (
+    SessionData,
+    SessionRoutingInfo,
+    SessionStatus,
+)
 from ai.backend.manager.data.user.types import SessionOwnerContext
 from ai.backend.manager.errors.common import ServiceUnavailable
 from ai.backend.manager.errors.image import UnknownImageReferenceError
@@ -293,6 +299,24 @@ def _make_mock_session(
         session_id, access_key, user_id, group_id, session_type=session_type
     )
     return session
+
+
+def _make_routing_info(
+    session: MagicMock,
+    kernel_id: KernelId,
+    service_ports: list[dict[str, Any]],
+    *,
+    agent_id: str | None = "i-agent",
+) -> SessionRoutingInfo:
+    """Build a SessionRoutingInfo for start_service tests from a mock session."""
+    return SessionRoutingInfo(
+        session=session,
+        main_kernel_id=kernel_id,
+        agent_id=AgentId(agent_id) if agent_id is not None else None,
+        kernel_host=session.main_kernel.kernel_host,
+        agent_addr=session.main_kernel.agent_addr,
+        service_ports=service_ports,
+    )
 
 
 # ==================== CommitSession Tests ====================
@@ -1931,17 +1955,19 @@ class TestStartService:
         mock_session = _make_mock_session(
             sample_session_id, sample_access_key, sample_user_id, sample_group_id, sample_kernel_id
         )
-        mock_session.main_kernel.service_ports = [
-            {
-                "name": "jupyter",
-                "host_ports": [8888],
-                "container_ports": [8888],
-                "is_inference": False,
-            },
-        ]
-        mock_session_repository.get_session_with_routing_minimal = AsyncMock(
-            return_value=mock_session
+        info = _make_routing_info(
+            mock_session,
+            sample_kernel_id,
+            [
+                {
+                    "name": "jupyter",
+                    "host_ports": [8888],
+                    "container_ports": [8888],
+                    "is_inference": False,
+                },
+            ],
         )
+        mock_session_repository.get_session_with_routing_minimal = AsyncMock(return_value=info)
         mock_session_repository.get_scaling_group_wsproxy_addr = AsyncMock(
             return_value="http://wsproxy:10200"
         )
@@ -1958,8 +1984,7 @@ class TestStartService:
         mock_resp.json = AsyncMock(return_value={"token": "test-token-xyz"})
 
         action = StartServiceAction(
-            session_name="test-session",
-            access_key=sample_access_key,
+            session_id=SessionID(sample_session_id),
             service="jupyter",
             login_session_token="login-token",
             port=None,
@@ -1995,17 +2020,19 @@ class TestStartService:
         mock_session = _make_mock_session(
             sample_session_id, sample_access_key, sample_user_id, sample_group_id, sample_kernel_id
         )
-        mock_session.main_kernel.service_ports = [
-            {
-                "name": "jupyter",
-                "host_ports": [8888],
-                "container_ports": [8888],
-                "is_inference": False,
-            },
-        ]
-        mock_session_repository.get_session_with_routing_minimal = AsyncMock(
-            return_value=mock_session
+        info = _make_routing_info(
+            mock_session,
+            sample_kernel_id,
+            [
+                {
+                    "name": "jupyter",
+                    "host_ports": [8888],
+                    "container_ports": [8888],
+                    "is_inference": False,
+                },
+            ],
         )
+        mock_session_repository.get_session_with_routing_minimal = AsyncMock(return_value=info)
         mock_session_repository.get_scaling_group_wsproxy_addr = AsyncMock(
             return_value="http://wsproxy:10200"
         )
@@ -2017,8 +2044,7 @@ class TestStartService:
         mock_appproxy_client_pool.load_client.return_value = mock_client
 
         action = StartServiceAction(
-            session_name="test-session",
-            access_key=sample_access_key,
+            session_id=SessionID(sample_session_id),
             service="nonexistent-service",
             login_session_token="login-token",
             port=None,
@@ -2043,13 +2069,11 @@ class TestStartService:
             sample_session_id, sample_access_key, sample_user_id, sample_group_id, sample_kernel_id
         )
         mock_session.scaling_group_name = None
-        mock_session_repository.get_session_with_routing_minimal = AsyncMock(
-            return_value=mock_session
-        )
+        info = _make_routing_info(mock_session, sample_kernel_id, [])
+        mock_session_repository.get_session_with_routing_minimal = AsyncMock(return_value=info)
 
         action = StartServiceAction(
-            session_name="test-session",
-            access_key=sample_access_key,
+            session_id=SessionID(sample_session_id),
             service="jupyter",
             login_session_token="login-token",
             port=None,
@@ -2074,17 +2098,19 @@ class TestStartService:
         mock_session = _make_mock_session(
             sample_session_id, sample_access_key, sample_user_id, sample_group_id, sample_kernel_id
         )
-        mock_session.main_kernel.service_ports = [
-            {
-                "name": "inference-app",
-                "host_ports": [8080],
-                "container_ports": [8080],
-                "is_inference": True,
-            },
-        ]
-        mock_session_repository.get_session_with_routing_minimal = AsyncMock(
-            return_value=mock_session
+        info = _make_routing_info(
+            mock_session,
+            sample_kernel_id,
+            [
+                {
+                    "name": "inference-app",
+                    "host_ports": [8080],
+                    "container_ports": [8080],
+                    "is_inference": True,
+                },
+            ],
         )
+        mock_session_repository.get_session_with_routing_minimal = AsyncMock(return_value=info)
         mock_session_repository.get_scaling_group_wsproxy_addr = AsyncMock(
             return_value="http://wsproxy:10200"
         )
@@ -2096,8 +2122,7 @@ class TestStartService:
         mock_appproxy_client_pool.load_client.return_value = mock_client
 
         action = StartServiceAction(
-            session_name="test-session",
-            access_key=sample_access_key,
+            session_id=SessionID(sample_session_id),
             service="inference-app",
             login_session_token="login-token",
             port=None,

--- a/tests/unit/manager/services/session/test_session_service.py
+++ b/tests/unit/manager/services/session/test_session_service.py
@@ -123,9 +123,7 @@ def mock_session_repository() -> MagicMock:
 @pytest.fixture
 def mock_agent_registry() -> MagicMock:
     """Create mocked agent registry."""
-    mock = MagicMock()
-    mock.increment_session_usage = AsyncMock()
-    return mock
+    return MagicMock()
 
 
 @pytest.fixture
@@ -701,7 +699,6 @@ class TestComplete:
         assert result.session_data == sample_session_data
         assert result.result == expected_response
         mock_session_repository.get_session_validated.assert_called_once()
-        mock_agent_registry.increment_session_usage.assert_called_once_with(mock_session)
         mock_agent_registry.get_completions.assert_called_once()
 
     async def test_session_not_found(
@@ -795,7 +792,6 @@ class TestGetSessionInfo:
         assert result.session_info.container_id == "a" * 64
         assert result.session_data == sample_session_data
         mock_session_repository.get_session_validated.assert_called_once()
-        mock_agent_registry.increment_session_usage.assert_called_once_with(mock_running_session)
 
     async def test_success_with_no_container_id(
         self,
@@ -871,7 +867,6 @@ class TestDownloadFiles:
         assert result.session_data == sample_session_data
         assert result.result is not None
         mock_session_repository.get_session_validated.assert_called_once()
-        mock_agent_registry.increment_session_usage.assert_called_once_with(mock_session)
         mock_agent_registry.download_file.assert_called_once()
 
     async def test_session_not_found(
@@ -1124,7 +1119,6 @@ class TestUploadFiles:
         assert isinstance(result, UploadFilesActionResult)
         assert result.session_data == sample_session_data
         mock_session_repository.get_session_validated.assert_called_once()
-        mock_agent_registry.increment_session_usage.assert_called_once_with(mock_session)
 
     async def test_session_not_found(
         self,
@@ -1197,7 +1191,6 @@ class TestExecute:
         assert result.result is not None
         assert result.result["result"]["status"] == "finished"
         mock_session_repository.get_session_validated.assert_called_once()
-        mock_agent_registry.increment_session_usage.assert_called_once_with(mock_session)
         mock_agent_registry.execute.assert_called_once()
 
     async def test_session_not_found(
@@ -1257,7 +1250,6 @@ class TestInterrupt:
         assert isinstance(result, InterruptSessionActionResult)
         assert result.session_data == sample_session_data
         mock_session_repository.get_session_validated.assert_called_once()
-        mock_agent_registry.increment_session_usage.assert_called_once_with(mock_session)
         mock_agent_registry.interrupt_session.assert_called_once_with(mock_session)
 
     async def test_session_not_found(

--- a/tests/unit/manager/services/stream/test_stream_service.py
+++ b/tests/unit/manager/services/stream/test_stream_service.py
@@ -264,7 +264,10 @@ class TestStartServiceInStream(TestStreamService):
         assert isinstance(result, StartServiceInStreamActionResult)
         assert result.result == {"status": "started"}
         mock_registry.start_service.assert_awaited_once_with(
-            mock_session, "jupyter", {"port": 8888}
+            mock_session.main_kernel.id,
+            mock_session.main_kernel.agent,
+            "jupyter",
+            {"port": 8888},
         )
 
 


### PR DESCRIPTION
## Summary
- Make the **start-service** operation identify the session by `session_id` (instead of `session_name` + `access_key`) across both the legacy v1 and v2 session APIs. The v2 adapter/handler pass the URL `session_id` directly; the legacy handler resolves `session_name` → `session_id` via the resolver (BA-6251).
- `get_session_with_routing_minimal` becomes a **pure `session_id` lookup** returning a new `SessionRoutingInfo` data type instead of exposing a `SessionRow`.
- `AgentRegistry.start_service` now takes `(main_kernel_id, agent_id: AgentId)` with the None-check at the callers; the no-op `increment_session_usage` is removed entirely.
- Enforce **session-access authorization** on start-service via the RBAC single-entity validator (mirrors `get_session`), so the repository can stay a pure lookup while access control is handled upstream.

## Test plan
- [ ] `pants test tests/unit/manager/repositories/session/test_session_repository.py` — routing-minimal lookup, unknown id / terminated session raise SessionNotFound
- [ ] `pants test tests/unit/manager/services/session/test_session_lifecycle_service.py` — start_service success + AppNotFound / ServiceUnavailable / inference-app paths
- [ ] `pants test tests/unit/manager/services/stream/test_stream_service.py` — stream start_service uses the new registry signature
- [ ] Live: start an app service via both v2 (`/v2/sessions/{id}/services/start`) and legacy (`/session/{name}/start-service`)

Resolves BA-6252

🤖 Generated with [Claude Code](https://claude.com/claude-code)