### PR TITLE
feat(BA-6179): define Role Preset GraphQL create/query/purge/permission schema

### DIFF
--- a/changes/11892.feature.md
+++ b/changes/11892.feature.md
@@ -1,0 +1,1 @@
+Add the Role Preset GraphQL create/get/search/purge mutations and permission-entry management (stub resolvers; service wire-up to follow).

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -1883,6 +1883,45 @@ type BulkAddRolePermissionFailureInfo
 }
 
 """
+Added in UNRELEASED. Failure detail for a single permission entry in a bulk add operation.
+"""
+type BulkAddRolePermissionPresetFailureInfo
+  @join__type(graph: STRAWBERRY)
+{
+  """Entity type of the permission entry that failed."""
+  entityType: RBACElementType!
+
+  """Operation of the permission entry that failed."""
+  operation: OperationType!
+
+  """Error message describing the failure."""
+  message: String!
+}
+
+"""
+Added in UNRELEASED. Input for bulk-adding permission entries to an existing role preset.
+"""
+input BulkAddRolePermissionPresetsInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Permission entries to insert. Duplicates are surfaced as failures."""
+  permissions: [RolePermissionPresetEntryInput!]!
+}
+
+"""
+Added in UNRELEASED. Payload returned after bulk-adding permission entries to a role preset.
+"""
+type BulkAddRolePermissionPresetsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Permission entries that were added."""
+  items: [RolePermissionPreset!]!
+
+  """Permission entries that failed to be added (e.g., duplicates)."""
+  failed: [BulkAddRolePermissionPresetFailureInfo!]!
+}
+
+"""
 Added in UNRELEASED. Input for bulk-inserting scoped permissions across one or more roles
 """
 input BulkAddRolePermissionsInput
@@ -2024,6 +2063,27 @@ type BulkDeleteVFoldersV2Payload
   deletedCount: Int!
 }
 
+"""Added in UNRELEASED. Input for bulk-hard-deleting role presets."""
+input BulkPurgeRolePresetsInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Role preset UUIDs to purge."""
+  rolePresetIds: [ID!]!
+}
+
+"""
+Added in UNRELEASED. Payload returned after bulk-hard-deleting role presets.
+"""
+type BulkPurgeRolePresetsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Role presets that were purged."""
+  items: [RolePreset!]!
+
+  """Role preset IDs that failed to purge."""
+  failed: [BulkRolePresetFailureInfo!]!
+}
+
 """
 Added in 26.3.0. Input for permanently deleting multiple users. This action is irreversible.
 """
@@ -2125,6 +2185,29 @@ type BulkRemoveRolePermissionFailureInfo
 }
 
 """
+Added in UNRELEASED. Input for bulk-removing permission entries from a role preset.
+"""
+input BulkRemoveRolePermissionPresetsInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Permission entry row IDs to delete."""
+  permissionPresetIds: [ID!]!
+}
+
+"""
+Added in UNRELEASED. Payload returned after bulk-removing permission entries from a role preset.
+"""
+type BulkRemoveRolePermissionPresetsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Permission entries that were removed."""
+  items: [RolePermissionPreset!]!
+
+  """Permission entry IDs that failed to delete."""
+  failed: [BulkRolePermissionPresetFailureInfo!]!
+}
+
+"""
 Added in UNRELEASED. Input for bulk-deleting permission rows by primary key
 """
 input BulkRemoveRolePermissionsInput
@@ -2174,6 +2257,32 @@ type BulkRevokeRolePayload
 
   """Users that failed to be revoked"""
   failed: [BulkRevokeRoleError!]!
+}
+
+"""
+Added in UNRELEASED. Failure detail for a single permission entry in a bulk operation.
+"""
+type BulkRolePermissionPresetFailureInfo
+  @join__type(graph: STRAWBERRY)
+{
+  """role_permission_presets row ID that the operation failed on."""
+  permissionPresetId: UUID!
+
+  """Error message describing the failure."""
+  message: String!
+}
+
+"""
+Added in UNRELEASED. Failure detail for a single role preset ID in a bulk operation.
+"""
+type BulkRolePresetFailureInfo
+  @join__type(graph: STRAWBERRY)
+{
+  """Role preset ID that the operation failed on."""
+  rolePresetId: UUID!
+
+  """Error message describing the failure."""
+  message: String!
 }
 
 """Added in 26.3.0. Payload for bulk user update mutation."""
@@ -3908,6 +4017,33 @@ type CreateRoleInvitationPayload
 {
   """List of created role invitations."""
   items: [RoleInvitation!]!
+}
+
+"""Added in UNRELEASED. Input for creating a new role preset."""
+input CreateRolePresetInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Role preset name."""
+  name: String!
+
+  """Scope type this preset targets (e.g., domain, project)."""
+  scopeType: RBACElementType!
+
+  """
+  Default value for the `auto_assign` flag on roles instantiated from this preset.
+  """
+  autoAssign: Boolean! = false
+
+  """Permission entries carried by the preset."""
+  permissions: [RolePermissionPresetEntryInput!]!
+}
+
+"""Added in UNRELEASED. Payload returned after creating a role preset."""
+type CreateRolePresetPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Created role preset."""
+  rolePreset: RolePreset!
 }
 
 """Added in 26.4.2. Input for creating a runtime variant."""
@@ -11368,6 +11504,22 @@ type Mutation
   """Added in 26.3.0. Delete a query preset category (admin only)."""
   adminDeletePrometheusQueryPresetCategory(id: ID!): DeleteCategoryPayload @join__field(graph: STRAWBERRY)
 
+  """Added in UNRELEASED. Create a new role preset (admin only)."""
+  adminCreateRolePreset(input: CreateRolePresetInput!): CreateRolePresetPayload @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Bulk-hard-delete role presets (admin only)."""
+  adminPurgeRolePresets(input: BulkPurgeRolePresetsInput!): BulkPurgeRolePresetsPayload @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. Bulk-add permission entries to an existing role preset (admin only).
+  """
+  adminBulkAddRolePresetPermissions(rolePresetId: ID!, input: BulkAddRolePermissionPresetsInput!): BulkAddRolePermissionPresetsPayload @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. Bulk-remove permission entries from a role preset (admin only).
+  """
+  adminBulkRemoveRolePresetPermissions(input: BulkRemoveRolePermissionPresetsInput!): BulkRemoveRolePermissionPresetsPayload @join__field(graph: STRAWBERRY)
+
   """Added in 26.3.0. Create a new role (admin only)."""
   adminCreateRole(input: CreateRoleInput!): Role @join__field(graph: STRAWBERRY)
 
@@ -13979,6 +14131,14 @@ type Query
   """
   prometheusQueryPresetCategories(filter: CategoryFilter = null, orderBy: [CategoryOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [QueryPresetCategory!] @join__field(graph: STRAWBERRY)
 
+  """Added in UNRELEASED. Get a single role preset by ID (admin only)."""
+  adminRolePreset(id: ID!): RolePreset @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. List role presets with filtering and pagination (admin only).
+  """
+  adminRolePresets(filter: RolePresetFilter = null, orderBy: [RolePresetOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RolePresetConnection @join__field(graph: STRAWBERRY)
+
   """Added in 26.3.0. Get a single role by ID (admin only)."""
   adminRole(id: UUID!): Role @join__field(graph: STRAWBERRY)
 
@@ -16075,6 +16235,235 @@ enum RoleOrderField
   @join__type(graph: STRAWBERRY)
 {
   NAME @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
+  UPDATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
+"""Added in UNRELEASED. A stored permission entry under a role preset."""
+type RolePermissionPreset implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """UUID of the parent role preset."""
+  rolePresetId: UUID!
+
+  """Entity type the permission applies to."""
+  entityType: RBACElementType!
+
+  """Operation granted by the permission."""
+  operation: OperationType!
+
+  """Creation timestamp."""
+  createdAt: DateTime!
+}
+
+"""
+Added in UNRELEASED. Paginated connection for role permission preset entries.
+"""
+type RolePermissionPresetConnection
+  @join__type(graph: STRAWBERRY)
+{
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [RolePermissionPresetEdge!]!
+
+  """Total number of permission entries matching the query criteria."""
+  count: Int!
+}
+
+"""An edge in a connection."""
+type RolePermissionPresetEdge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: RolePermissionPreset!
+}
+
+"""
+Added in UNRELEASED. A single (entity_type, operation) pair carried by a role preset.
+"""
+input RolePermissionPresetEntryInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Entity type the permission applies to."""
+  entityType: RBACElementType!
+
+  """Operation granted by the permission."""
+  operation: OperationType!
+}
+
+"""
+Added in UNRELEASED. Filter input for role permission preset entries. Also used as the input for the `permission_presets` field resolver on a role preset (the resolver injects `role_preset_id` from its parent).
+"""
+input RolePermissionPresetFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Filter by parent role preset ID."""
+  rolePresetId: UUIDFilter = null
+
+  """Filter by entity type the permission applies to."""
+  entityType: RBACElementTypeFilter = null
+
+  """Filter by granted operation."""
+  operation: OperationTypeFilter = null
+
+  """Filter by creation timestamp."""
+  createdAt: DateTimeFilter = null
+
+  """Combine multiple filters with AND logic. All conditions must match."""
+  AND: [RolePermissionPresetFilter!] = null
+
+  """
+  Combine multiple filters with OR logic. At least one condition must match.
+  """
+  OR: [RolePermissionPresetFilter!] = null
+
+  """Negate the specified filters. Matching records are excluded."""
+  NOT: [RolePermissionPresetFilter!] = null
+}
+
+"""
+Added in UNRELEASED. Specifies ordering for role permission preset entries.
+"""
+input RolePermissionPresetOrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  """The field to order by."""
+  field: RolePermissionPresetOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = ASC
+}
+
+"""
+Added in UNRELEASED. Fields available for ordering role permission preset entries.
+"""
+enum RolePermissionPresetOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  ENTITY_TYPE @join__enumValue(graph: STRAWBERRY)
+  OPERATION @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
+"""
+Added in UNRELEASED. Role preset entity implementing the Relay Node pattern.
+"""
+type RolePreset implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Role preset name."""
+  name: String!
+
+  """Scope type this preset targets (e.g., domain, project)."""
+  scopeType: RBACElementType!
+
+  """
+  Default value for the `auto_assign` flag copied onto roles instantiated from this preset.
+  """
+  autoAssign: Boolean!
+
+  """
+  Soft-delete flag. Set by the delete mutation and cleared by the restore mutation; archived rows are excluded from default searches.
+  """
+  deleted: Boolean!
+
+  """Creation timestamp."""
+  createdAt: DateTime!
+
+  """Last modification timestamp."""
+  updatedAt: DateTime!
+
+  """Added in UNRELEASED. Permission entries carried by this role preset."""
+  permissionPresets(filter: RolePermissionPresetFilter = null, orderBy: [RolePermissionPresetOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RolePermissionPresetConnection
+}
+
+"""Added in UNRELEASED. Paginated connection for role preset records."""
+type RolePresetConnection
+  @join__type(graph: STRAWBERRY)
+{
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [RolePresetEdge!]!
+
+  """Total number of role preset records matching the query criteria."""
+  count: Int!
+}
+
+"""An edge in a connection."""
+type RolePresetEdge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: RolePreset!
+}
+
+"""Added in UNRELEASED. Filter input for querying role presets."""
+input RolePresetFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Filter by name."""
+  name: StringFilter = null
+
+  """Filter by scope type."""
+  scopeType: RBACElementTypeFilter = null
+
+  """Filter by auto-assign flag."""
+  autoAssign: Boolean = null
+
+  """
+  Filter by soft-delete flag. Searches exclude soft-deleted rows by default; set this explicitly to `true` to inspect archived presets.
+  """
+  deleted: Boolean = null
+
+  """Combine multiple filters with AND logic. All conditions must match."""
+  AND: [RolePresetFilter!] = null
+
+  """
+  Combine multiple filters with OR logic. At least one condition must match.
+  """
+  OR: [RolePresetFilter!] = null
+
+  """Negate the specified filters. Matching records are excluded."""
+  NOT: [RolePresetFilter!] = null
+}
+
+"""Added in UNRELEASED. Specifies ordering for role preset results."""
+input RolePresetOrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  """The field to order by."""
+  field: RolePresetOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = ASC
+}
+
+"""
+Added in UNRELEASED. Fields available for ordering role preset results.
+"""
+enum RolePresetOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  NAME @join__enumValue(graph: STRAWBERRY)
+  SCOPE_TYPE @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   UPDATED_AT @join__enumValue(graph: STRAWBERRY)
 }

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -1904,6 +1904,9 @@ Added in UNRELEASED. Input for bulk-adding permission entries to an existing rol
 input BulkAddRolePermissionPresetsInput
   @join__type(graph: STRAWBERRY)
 {
+  """ID of the role preset to add permissions to."""
+  rolePresetId: ID!
+
   """Permission entries to insert. Duplicates are surfaced as failures."""
   permissions: [RolePermissionPresetEntryInput!]!
 }
@@ -11513,7 +11516,7 @@ type Mutation
   """
   Added in UNRELEASED. Bulk-add permission entries to an existing role preset (admin only).
   """
-  adminBulkAddRolePresetPermissions(rolePresetId: ID!, input: BulkAddRolePermissionPresetsInput!): BulkAddRolePermissionPresetsPayload @join__field(graph: STRAWBERRY)
+  adminBulkAddRolePresetPermissions(input: BulkAddRolePermissionPresetsInput!): BulkAddRolePermissionPresetsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Bulk-remove permission entries from a role preset (admin only).

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1290,6 +1290,39 @@ type BulkAddRolePermissionFailureInfo {
 }
 
 """
+Added in UNRELEASED. Failure detail for a single permission entry in a bulk add operation.
+"""
+type BulkAddRolePermissionPresetFailureInfo {
+  """Entity type of the permission entry that failed."""
+  entityType: RBACElementType!
+
+  """Operation of the permission entry that failed."""
+  operation: OperationType!
+
+  """Error message describing the failure."""
+  message: String!
+}
+
+"""
+Added in UNRELEASED. Input for bulk-adding permission entries to an existing role preset.
+"""
+input BulkAddRolePermissionPresetsInput {
+  """Permission entries to insert. Duplicates are surfaced as failures."""
+  permissions: [RolePermissionPresetEntryInput!]!
+}
+
+"""
+Added in UNRELEASED. Payload returned after bulk-adding permission entries to a role preset.
+"""
+type BulkAddRolePermissionPresetsPayload {
+  """Permission entries that were added."""
+  items: [RolePermissionPreset!]!
+
+  """Permission entries that failed to be added (e.g., duplicates)."""
+  failed: [BulkAddRolePermissionPresetFailureInfo!]!
+}
+
+"""
 Added in UNRELEASED. Input for bulk-inserting scoped permissions across one or more roles
 """
 input BulkAddRolePermissionsInput {
@@ -1405,6 +1438,23 @@ type BulkDeleteVFoldersV2Payload {
   deletedCount: Int!
 }
 
+"""Added in UNRELEASED. Input for bulk-hard-deleting role presets."""
+input BulkPurgeRolePresetsInput {
+  """Role preset UUIDs to purge."""
+  rolePresetIds: [ID!]!
+}
+
+"""
+Added in UNRELEASED. Payload returned after bulk-hard-deleting role presets.
+"""
+type BulkPurgeRolePresetsPayload {
+  """Role presets that were purged."""
+  items: [RolePreset!]!
+
+  """Role preset IDs that failed to purge."""
+  failed: [BulkRolePresetFailureInfo!]!
+}
+
 """Added in 26.3.0. Error information for a failed user in bulk purge."""
 type BulkPurgeUserV2Error {
   """UUID of the user that failed to purge."""
@@ -1490,6 +1540,25 @@ type BulkRemoveRolePermissionFailureInfo {
 }
 
 """
+Added in UNRELEASED. Input for bulk-removing permission entries from a role preset.
+"""
+input BulkRemoveRolePermissionPresetsInput {
+  """Permission entry row IDs to delete."""
+  permissionPresetIds: [ID!]!
+}
+
+"""
+Added in UNRELEASED. Payload returned after bulk-removing permission entries from a role preset.
+"""
+type BulkRemoveRolePermissionPresetsPayload {
+  """Permission entries that were removed."""
+  items: [RolePermissionPreset!]!
+
+  """Permission entry IDs that failed to delete."""
+  failed: [BulkRolePermissionPresetFailureInfo!]!
+}
+
+"""
 Added in UNRELEASED. Input for bulk-deleting permission rows by primary key
 """
 input BulkRemoveRolePermissionsInput {
@@ -1529,6 +1598,28 @@ type BulkRevokeRolePayload {
 
   """Users that failed to be revoked"""
   failed: [BulkRevokeRoleError!]!
+}
+
+"""
+Added in UNRELEASED. Failure detail for a single permission entry in a bulk operation.
+"""
+type BulkRolePermissionPresetFailureInfo {
+  """role_permission_presets row ID that the operation failed on."""
+  permissionPresetId: UUID!
+
+  """Error message describing the failure."""
+  message: String!
+}
+
+"""
+Added in UNRELEASED. Failure detail for a single role preset ID in a bulk operation.
+"""
+type BulkRolePresetFailureInfo {
+  """Role preset ID that the operation failed on."""
+  rolePresetId: UUID!
+
+  """Error message describing the failure."""
+  message: String!
 }
 
 """Added in 26.3.0. Error information for a failed user in bulk update."""
@@ -2480,6 +2571,29 @@ input CreateRoleInvitationInput {
 type CreateRoleInvitationPayload {
   """List of created role invitations."""
   items: [RoleInvitation!]!
+}
+
+"""Added in UNRELEASED. Input for creating a new role preset."""
+input CreateRolePresetInput {
+  """Role preset name."""
+  name: String!
+
+  """Scope type this preset targets (e.g., domain, project)."""
+  scopeType: RBACElementType!
+
+  """
+  Default value for the `auto_assign` flag on roles instantiated from this preset.
+  """
+  autoAssign: Boolean! = false
+
+  """Permission entries carried by the preset."""
+  permissions: [RolePermissionPresetEntryInput!]!
+}
+
+"""Added in UNRELEASED. Payload returned after creating a role preset."""
+type CreateRolePresetPayload {
+  """Created role preset."""
+  rolePreset: RolePreset!
 }
 
 """Added in 26.4.2. Input for creating a runtime variant."""
@@ -7275,6 +7389,22 @@ type Mutation {
   """Added in 26.3.0. Delete a query preset category (admin only)."""
   adminDeletePrometheusQueryPresetCategory(id: ID!): DeleteCategoryPayload
 
+  """Added in UNRELEASED. Create a new role preset (admin only)."""
+  adminCreateRolePreset(input: CreateRolePresetInput!): CreateRolePresetPayload
+
+  """Added in UNRELEASED. Bulk-hard-delete role presets (admin only)."""
+  adminPurgeRolePresets(input: BulkPurgeRolePresetsInput!): BulkPurgeRolePresetsPayload
+
+  """
+  Added in UNRELEASED. Bulk-add permission entries to an existing role preset (admin only).
+  """
+  adminBulkAddRolePresetPermissions(rolePresetId: ID!, input: BulkAddRolePermissionPresetsInput!): BulkAddRolePermissionPresetsPayload
+
+  """
+  Added in UNRELEASED. Bulk-remove permission entries from a role preset (admin only).
+  """
+  adminBulkRemoveRolePresetPermissions(input: BulkRemoveRolePermissionPresetsInput!): BulkRemoveRolePermissionPresetsPayload
+
   """Added in 26.3.0. Create a new role (admin only)."""
   adminCreateRole(input: CreateRoleInput!): Role
 
@@ -9095,6 +9225,14 @@ type Query {
   """
   prometheusQueryPresetCategories(filter: CategoryFilter = null, orderBy: [CategoryOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [QueryPresetCategory!]
 
+  """Added in UNRELEASED. Get a single role preset by ID (admin only)."""
+  adminRolePreset(id: ID!): RolePreset
+
+  """
+  Added in UNRELEASED. List role presets with filtering and pagination (admin only).
+  """
+  adminRolePresets(filter: RolePresetFilter = null, orderBy: [RolePresetOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RolePresetConnection
+
   """Added in 26.3.0. Get a single role by ID (admin only)."""
   adminRole(id: UUID!): Role
 
@@ -10881,6 +11019,207 @@ input RoleOrderBy {
 """Added in 26.3.0. Role ordering field"""
 enum RoleOrderField {
   NAME
+  CREATED_AT
+  UPDATED_AT
+}
+
+"""Added in UNRELEASED. A stored permission entry under a role preset."""
+type RolePermissionPreset implements Node {
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """UUID of the parent role preset."""
+  rolePresetId: UUID!
+
+  """Entity type the permission applies to."""
+  entityType: RBACElementType!
+
+  """Operation granted by the permission."""
+  operation: OperationType!
+
+  """Creation timestamp."""
+  createdAt: DateTime!
+}
+
+"""
+Added in UNRELEASED. Paginated connection for role permission preset entries.
+"""
+type RolePermissionPresetConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [RolePermissionPresetEdge!]!
+
+  """Total number of permission entries matching the query criteria."""
+  count: Int!
+}
+
+"""An edge in a connection."""
+type RolePermissionPresetEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: RolePermissionPreset!
+}
+
+"""
+Added in UNRELEASED. A single (entity_type, operation) pair carried by a role preset.
+"""
+input RolePermissionPresetEntryInput {
+  """Entity type the permission applies to."""
+  entityType: RBACElementType!
+
+  """Operation granted by the permission."""
+  operation: OperationType!
+}
+
+"""
+Added in UNRELEASED. Filter input for role permission preset entries. Also used as the input for the `permission_presets` field resolver on a role preset (the resolver injects `role_preset_id` from its parent).
+"""
+input RolePermissionPresetFilter {
+  """Filter by parent role preset ID."""
+  rolePresetId: UUIDFilter = null
+
+  """Filter by entity type the permission applies to."""
+  entityType: RBACElementTypeFilter = null
+
+  """Filter by granted operation."""
+  operation: OperationTypeFilter = null
+
+  """Filter by creation timestamp."""
+  createdAt: DateTimeFilter = null
+
+  """Combine multiple filters with AND logic. All conditions must match."""
+  AND: [RolePermissionPresetFilter!] = null
+
+  """
+  Combine multiple filters with OR logic. At least one condition must match.
+  """
+  OR: [RolePermissionPresetFilter!] = null
+
+  """Negate the specified filters. Matching records are excluded."""
+  NOT: [RolePermissionPresetFilter!] = null
+}
+
+"""
+Added in UNRELEASED. Specifies ordering for role permission preset entries.
+"""
+input RolePermissionPresetOrderBy {
+  """The field to order by."""
+  field: RolePermissionPresetOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = ASC
+}
+
+"""
+Added in UNRELEASED. Fields available for ordering role permission preset entries.
+"""
+enum RolePermissionPresetOrderField {
+  ENTITY_TYPE
+  OPERATION
+  CREATED_AT
+}
+
+"""
+Added in UNRELEASED. Role preset entity implementing the Relay Node pattern.
+"""
+type RolePreset implements Node {
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Role preset name."""
+  name: String!
+
+  """Scope type this preset targets (e.g., domain, project)."""
+  scopeType: RBACElementType!
+
+  """
+  Default value for the `auto_assign` flag copied onto roles instantiated from this preset.
+  """
+  autoAssign: Boolean!
+
+  """
+  Soft-delete flag. Set by the delete mutation and cleared by the restore mutation; archived rows are excluded from default searches.
+  """
+  deleted: Boolean!
+
+  """Creation timestamp."""
+  createdAt: DateTime!
+
+  """Last modification timestamp."""
+  updatedAt: DateTime!
+
+  """Added in UNRELEASED. Permission entries carried by this role preset."""
+  permissionPresets(filter: RolePermissionPresetFilter = null, orderBy: [RolePermissionPresetOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RolePermissionPresetConnection
+}
+
+"""Added in UNRELEASED. Paginated connection for role preset records."""
+type RolePresetConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [RolePresetEdge!]!
+
+  """Total number of role preset records matching the query criteria."""
+  count: Int!
+}
+
+"""An edge in a connection."""
+type RolePresetEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: RolePreset!
+}
+
+"""Added in UNRELEASED. Filter input for querying role presets."""
+input RolePresetFilter {
+  """Filter by name."""
+  name: StringFilter = null
+
+  """Filter by scope type."""
+  scopeType: RBACElementTypeFilter = null
+
+  """Filter by auto-assign flag."""
+  autoAssign: Boolean = null
+
+  """
+  Filter by soft-delete flag. Searches exclude soft-deleted rows by default; set this explicitly to `true` to inspect archived presets.
+  """
+  deleted: Boolean = null
+
+  """Combine multiple filters with AND logic. All conditions must match."""
+  AND: [RolePresetFilter!] = null
+
+  """
+  Combine multiple filters with OR logic. At least one condition must match.
+  """
+  OR: [RolePresetFilter!] = null
+
+  """Negate the specified filters. Matching records are excluded."""
+  NOT: [RolePresetFilter!] = null
+}
+
+"""Added in UNRELEASED. Specifies ordering for role preset results."""
+input RolePresetOrderBy {
+  """The field to order by."""
+  field: RolePresetOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = ASC
+}
+
+"""
+Added in UNRELEASED. Fields available for ordering role preset results.
+"""
+enum RolePresetOrderField {
+  NAME
+  SCOPE_TYPE
   CREATED_AT
   UPDATED_AT
 }

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1307,6 +1307,9 @@ type BulkAddRolePermissionPresetFailureInfo {
 Added in UNRELEASED. Input for bulk-adding permission entries to an existing role preset.
 """
 input BulkAddRolePermissionPresetsInput {
+  """ID of the role preset to add permissions to."""
+  rolePresetId: ID!
+
   """Permission entries to insert. Duplicates are surfaced as failures."""
   permissions: [RolePermissionPresetEntryInput!]!
 }
@@ -7398,7 +7401,7 @@ type Mutation {
   """
   Added in UNRELEASED. Bulk-add permission entries to an existing role preset (admin only).
   """
-  adminBulkAddRolePresetPermissions(rolePresetId: ID!, input: BulkAddRolePermissionPresetsInput!): BulkAddRolePermissionPresetsPayload
+  adminBulkAddRolePresetPermissions(input: BulkAddRolePermissionPresetsInput!): BulkAddRolePermissionPresetsPayload
 
   """
   Added in UNRELEASED. Bulk-remove permission entries from a role preset (admin only).

--- a/src/ai/backend/common/dto/manager/v2/role_permission_preset/response.py
+++ b/src/ai/backend/common/dto/manager/v2/role_permission_preset/response.py
@@ -12,6 +12,7 @@ from ai.backend.common.identifier.role_permission_preset import RolePermissionPr
 from ai.backend.common.identifier.role_preset import RolePresetID
 
 __all__ = (
+    "BulkAddRolePermissionPresetFailureInfo",
     "BulkAddRolePermissionPresetsPayload",
     "BulkRemoveRolePermissionPresetsPayload",
     "BulkRolePermissionPresetFailureInfo",
@@ -40,11 +41,32 @@ class BulkRolePermissionPresetFailureInfo(BaseResponseModel):
     message: str = Field(description="Error message describing the failure.")
 
 
+class BulkAddRolePermissionPresetFailureInfo(BaseResponseModel):
+    """Failure detail for a single permission entry in a bulk add operation.
+
+    Added entries have no row ID yet, so failures are keyed by the
+    ``(entity_type, operation)`` pair that could not be inserted (e.g., a duplicate).
+    """
+
+    entity_type: RBACElementTypeDTO = Field(
+        description="Entity type of the permission entry that failed.",
+    )
+    operation: OperationTypeDTO = Field(
+        description="Operation of the permission entry that failed.",
+    )
+    message: str = Field(description="Error message describing the failure.")
+
+
 class BulkAddRolePermissionPresetsPayload(BaseResponseModel):
     """Payload for bulk-adding permission entries to a role preset."""
 
-    permissions: list[RolePermissionPresetNode] = Field(
+    items: list[RolePermissionPresetNode] = Field(
+        default_factory=list,
         description="Permission entries that were added.",
+    )
+    failed: list[BulkAddRolePermissionPresetFailureInfo] = Field(
+        default_factory=list,
+        description="Permission entries that failed to be added (e.g., duplicates).",
     )
 
 

--- a/src/ai/backend/common/dto/manager/v2/role_preset/response.py
+++ b/src/ai/backend/common/dto/manager/v2/role_preset/response.py
@@ -96,11 +96,16 @@ class BulkRestoreRolePresetsPayload(BaseResponseModel):
 
 
 class BulkPurgeRolePresetsPayload(BaseResponseModel):
-    """Payload for bulk-hard-deleting role presets."""
+    """Payload for bulk-hard-deleting role presets.
+
+    Purge is validated per row (each isolated by a savepoint) so individual presets
+    may fail independently; successes and failures are reported separately. The
+    returned items are snapshots of the rows as they existed just before purge.
+    """
 
     items: list[RolePresetNode] = Field(
         default_factory=list,
-        description="Snapshot of role presets that were purged.",
+        description="Role presets that were purged.",
     )
     failed: list[BulkRolePresetFailureInfo] = Field(
         default_factory=list,

--- a/src/ai/backend/manager/api/adapters/registry.py
+++ b/src/ai/backend/manager/api/adapters/registry.py
@@ -39,6 +39,7 @@ from ai.backend.manager.api.adapters.resource_policy.adapter import ResourcePoli
 from ai.backend.manager.api.adapters.resource_preset.adapter import ResourcePresetAdapter
 from ai.backend.manager.api.adapters.resource_slot.adapter import ResourceSlotAdapter
 from ai.backend.manager.api.adapters.resource_usage.adapter import ResourceUsageAdapter
+from ai.backend.manager.api.adapters.role_preset.adapter import RolePresetAdapter
 from ai.backend.manager.api.adapters.runtime_variant.adapter import RuntimeVariantAdapter
 from ai.backend.manager.api.adapters.runtime_variant_preset.adapter import (
     RuntimeVariantPresetAdapter,
@@ -102,6 +103,7 @@ class Adapters:
         deployment_revision_preset: DeploymentRevisionPresetAdapter,
         model_card: ModelCardAdapter,
         resource_usage: ResourceUsageAdapter,
+        role_preset: RolePresetAdapter,
         scheduling_handler: SchedulingHandlerAdapter,
         scheduling_history: SchedulingHistoryAdapter,
         service_catalog: ServiceCatalogAdapter,
@@ -143,6 +145,7 @@ class Adapters:
         self.deployment_revision_preset = deployment_revision_preset
         self.model_card = model_card
         self.resource_usage = resource_usage
+        self.role_preset = role_preset
         self.scheduling_handler = scheduling_handler
         self.scheduling_history = scheduling_history
         self.service_catalog = service_catalog
@@ -205,6 +208,7 @@ class Adapters:
             deployment_revision_preset=DeploymentRevisionPresetAdapter(processors),
             model_card=ModelCardAdapter(processors),
             resource_usage=ResourceUsageAdapter(processors),
+            role_preset=RolePresetAdapter(processors),
             scheduling_handler=SchedulingHandlerAdapter(deployment_coordinator),
             scheduling_history=SchedulingHistoryAdapter(processors),
             service_catalog=ServiceCatalogAdapter(processors),

--- a/src/ai/backend/manager/api/adapters/role_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/role_preset/adapter.py
@@ -1,0 +1,76 @@
+"""Role preset domain adapter - Pydantic-in/Pydantic-out transport layer.
+
+Shared between the GraphQL resolvers and REST v2 handlers. Method bodies raise
+``NotImplementedError``; wire-up to the Processor/Service layer happens in a
+follow-up task.
+"""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.role_permission_preset.request import (
+    BulkAddRolePermissionPresetsInput,
+    BulkRemoveRolePermissionPresetsInput,
+    RolePermissionPresetFilter,
+)
+from ai.backend.common.dto.manager.v2.role_permission_preset.response import (
+    BulkAddRolePermissionPresetsPayload,
+    BulkRemoveRolePermissionPresetsPayload,
+    RolePermissionPresetNode,
+)
+from ai.backend.common.dto.manager.v2.role_preset.request import (
+    BulkPurgeRolePresetsInput,
+    CreateRolePresetInput,
+    SearchRolePresetsInput,
+)
+from ai.backend.common.dto.manager.v2.role_preset.response import (
+    BulkPurgeRolePresetsPayload,
+    CreateRolePresetPayload,
+    RolePresetNode,
+    SearchRolePresetsPayload,
+)
+from ai.backend.common.identifier.role_preset import RolePresetID
+from ai.backend.manager.api.adapters.base import BaseAdapter
+
+
+class RolePresetAdapter(BaseAdapter):
+    """Adapter for role preset domain operations."""
+
+    async def create(self, input: CreateRolePresetInput) -> CreateRolePresetPayload:
+        """Create a new role preset."""
+        raise NotImplementedError
+
+    async def get(self, role_preset_id: RolePresetID) -> RolePresetNode | None:
+        """Get a single role preset by ID."""
+        raise NotImplementedError
+
+    async def search(self, input: SearchRolePresetsInput) -> SearchRolePresetsPayload:
+        """Search role presets with filtering and pagination."""
+        raise NotImplementedError
+
+    async def bulk_purge(self, input: BulkPurgeRolePresetsInput) -> BulkPurgeRolePresetsPayload:
+        """Bulk-hard-delete role presets."""
+        raise NotImplementedError
+
+    async def search_permissions(
+        self, input: RolePermissionPresetFilter
+    ) -> list[RolePermissionPresetNode]:
+        """Resolve the permission entries belonging to a role preset.
+
+        Backs the ``permission_presets`` field resolver on ``RolePresetNode``; the caller
+        supplies ``role_preset_id`` via the filter.
+        """
+        raise NotImplementedError
+
+    async def bulk_add_permissions(
+        self,
+        role_preset_id: RolePresetID,
+        input: BulkAddRolePermissionPresetsInput,
+    ) -> BulkAddRolePermissionPresetsPayload:
+        """Bulk-add permission entries to an existing role preset."""
+        raise NotImplementedError
+
+    async def bulk_remove_permissions(
+        self, input: BulkRemoveRolePermissionPresetsInput
+    ) -> BulkRemoveRolePermissionPresetsPayload:
+        """Bulk-remove permission entries from a role preset."""
+        raise NotImplementedError

--- a/src/ai/backend/manager/api/gql/role_preset/__init__.py
+++ b/src/ai/backend/manager/api/gql/role_preset/__init__.py
@@ -1,0 +1,75 @@
+"""Role preset GraphQL API package."""
+
+from .resolver import (
+    admin_bulk_add_role_preset_permissions,
+    admin_bulk_remove_role_preset_permissions,
+    admin_create_role_preset,
+    admin_purge_role_presets,
+    admin_role_preset,
+    admin_role_presets,
+)
+from .types import (
+    BulkAddRolePermissionPresetFailureInfoGQL,
+    BulkAddRolePermissionPresetsInputGQL,
+    BulkAddRolePermissionPresetsPayloadGQL,
+    BulkPurgeRolePresetsInputGQL,
+    BulkPurgeRolePresetsPayloadGQL,
+    BulkRemoveRolePermissionPresetsInputGQL,
+    BulkRemoveRolePermissionPresetsPayloadGQL,
+    BulkRolePermissionPresetFailureInfoGQL,
+    BulkRolePresetFailureInfoGQL,
+    CreateRolePresetInputGQL,
+    CreateRolePresetPayloadGQL,
+    RolePermissionPresetConnection,
+    RolePermissionPresetEdge,
+    RolePermissionPresetEntryInputGQL,
+    RolePermissionPresetFilterGQL,
+    RolePermissionPresetGQL,
+    RolePermissionPresetOrderByGQL,
+    RolePermissionPresetOrderFieldGQL,
+    RolePresetConnection,
+    RolePresetEdge,
+    RolePresetFilterGQL,
+    RolePresetGQL,
+    RolePresetOrderByGQL,
+    RolePresetOrderFieldGQL,
+)
+
+__all__ = [
+    # Queries
+    "admin_role_preset",
+    "admin_role_presets",
+    # Mutations
+    "admin_create_role_preset",
+    "admin_purge_role_presets",
+    "admin_bulk_add_role_preset_permissions",
+    "admin_bulk_remove_role_preset_permissions",
+    # Node / Connection types
+    "RolePresetGQL",
+    "RolePresetEdge",
+    "RolePresetConnection",
+    "RolePermissionPresetGQL",
+    "RolePermissionPresetEdge",
+    "RolePermissionPresetConnection",
+    # Filter / OrderBy types
+    "RolePresetFilterGQL",
+    "RolePresetOrderByGQL",
+    "RolePresetOrderFieldGQL",
+    "RolePermissionPresetFilterGQL",
+    "RolePermissionPresetOrderByGQL",
+    "RolePermissionPresetOrderFieldGQL",
+    # Input types
+    "CreateRolePresetInputGQL",
+    "BulkPurgeRolePresetsInputGQL",
+    "RolePermissionPresetEntryInputGQL",
+    "BulkAddRolePermissionPresetsInputGQL",
+    "BulkRemoveRolePermissionPresetsInputGQL",
+    # Payload types
+    "CreateRolePresetPayloadGQL",
+    "BulkRolePresetFailureInfoGQL",
+    "BulkPurgeRolePresetsPayloadGQL",
+    "BulkRolePermissionPresetFailureInfoGQL",
+    "BulkAddRolePermissionPresetFailureInfoGQL",
+    "BulkAddRolePermissionPresetsPayloadGQL",
+    "BulkRemoveRolePermissionPresetsPayloadGQL",
+]

--- a/src/ai/backend/manager/api/gql/role_preset/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/role_preset/resolver/__init__.py
@@ -1,0 +1,23 @@
+"""Role preset GQL resolvers."""
+
+from .mutation import (
+    admin_bulk_add_role_preset_permissions,
+    admin_bulk_remove_role_preset_permissions,
+    admin_create_role_preset,
+    admin_purge_role_presets,
+)
+from .query import (
+    admin_role_preset,
+    admin_role_presets,
+)
+
+__all__ = [
+    # Queries
+    "admin_role_preset",
+    "admin_role_presets",
+    # Mutations
+    "admin_create_role_preset",
+    "admin_purge_role_presets",
+    "admin_bulk_add_role_preset_permissions",
+    "admin_bulk_remove_role_preset_permissions",
+]

--- a/src/ai/backend/manager/api/gql/role_preset/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/role_preset/resolver/mutation.py
@@ -1,0 +1,84 @@
+"""Role preset GQL mutation resolvers.
+
+Function bodies raise ``NotImplementedError``; wire-up to the adapter/service
+layer happens in a follow-up task.
+"""
+
+from __future__ import annotations
+
+from strawberry import ID, Info
+
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_mutation,
+)
+from ai.backend.manager.api.gql.role_preset.types import (
+    BulkAddRolePermissionPresetsInputGQL,
+    BulkAddRolePermissionPresetsPayloadGQL,
+    BulkPurgeRolePresetsInputGQL,
+    BulkPurgeRolePresetsPayloadGQL,
+    BulkRemoveRolePermissionPresetsInputGQL,
+    BulkRemoveRolePermissionPresetsPayloadGQL,
+    CreateRolePresetInputGQL,
+    CreateRolePresetPayloadGQL,
+)
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+from ai.backend.manager.api.gql.utils import check_admin_only
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Create a new role preset (admin only).",
+    )
+)
+async def admin_create_role_preset(
+    info: Info[StrawberryGQLContext],
+    input: CreateRolePresetInputGQL,
+) -> CreateRolePresetPayloadGQL | None:
+    check_admin_only()
+    raise NotImplementedError
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Bulk-hard-delete role presets (admin only).",
+    )
+)
+async def admin_purge_role_presets(
+    info: Info[StrawberryGQLContext],
+    input: BulkPurgeRolePresetsInputGQL,
+) -> BulkPurgeRolePresetsPayloadGQL | None:
+    check_admin_only()
+    raise NotImplementedError
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Bulk-add permission entries to an existing role preset (admin only).",
+    )
+)
+async def admin_bulk_add_role_preset_permissions(
+    info: Info[StrawberryGQLContext],
+    role_preset_id: ID,
+    input: BulkAddRolePermissionPresetsInputGQL,
+) -> BulkAddRolePermissionPresetsPayloadGQL | None:
+    check_admin_only()
+    raise NotImplementedError
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Bulk-remove permission entries from a role preset (admin only).",
+    )
+)
+async def admin_bulk_remove_role_preset_permissions(
+    info: Info[StrawberryGQLContext],
+    input: BulkRemoveRolePermissionPresetsInputGQL,
+) -> BulkRemoveRolePermissionPresetsPayloadGQL | None:
+    check_admin_only()
+    raise NotImplementedError

--- a/src/ai/backend/manager/api/gql/role_preset/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/role_preset/resolver/mutation.py
@@ -6,7 +6,7 @@ layer happens in a follow-up task.
 
 from __future__ import annotations
 
-from strawberry import ID, Info
+from strawberry import Info
 
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
@@ -63,7 +63,6 @@ async def admin_purge_role_presets(
 )
 async def admin_bulk_add_role_preset_permissions(
     info: Info[StrawberryGQLContext],
-    role_preset_id: ID,
     input: BulkAddRolePermissionPresetsInputGQL,
 ) -> BulkAddRolePermissionPresetsPayloadGQL | None:
     check_admin_only()

--- a/src/ai/backend/manager/api/gql/role_preset/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/role_preset/resolver/query.py
@@ -1,0 +1,58 @@
+"""Role preset GQL query resolvers.
+
+Function bodies raise ``NotImplementedError``; wire-up to the adapter/service
+layer happens in a follow-up task.
+"""
+
+from __future__ import annotations
+
+from strawberry import ID, Info
+
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_root_field,
+)
+from ai.backend.manager.api.gql.role_preset.types import (
+    RolePresetConnection,
+    RolePresetFilterGQL,
+    RolePresetGQL,
+    RolePresetOrderByGQL,
+)
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+from ai.backend.manager.api.gql.utils import check_admin_only
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Get a single role preset by ID (admin only).",
+    )
+)  # type: ignore[misc]
+async def admin_role_preset(
+    info: Info[StrawberryGQLContext],
+    id: ID,
+) -> RolePresetGQL | None:
+    check_admin_only()
+    raise NotImplementedError
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="List role presets with filtering and pagination (admin only).",
+    )
+)  # type: ignore[misc]
+async def admin_role_presets(
+    info: Info[StrawberryGQLContext],
+    filter: RolePresetFilterGQL | None = None,
+    order_by: list[RolePresetOrderByGQL] | None = None,
+    before: str | None = None,
+    after: str | None = None,
+    first: int | None = None,
+    last: int | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> RolePresetConnection | None:
+    check_admin_only()
+    raise NotImplementedError

--- a/src/ai/backend/manager/api/gql/role_preset/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/role_preset/types/__init__.py
@@ -1,0 +1,67 @@
+"""Role preset GQL types."""
+
+from .filters import (
+    RolePresetFilterGQL,
+    RolePresetOrderByGQL,
+    RolePresetOrderFieldGQL,
+)
+from .inputs import (
+    BulkAddRolePermissionPresetsInputGQL,
+    BulkPurgeRolePresetsInputGQL,
+    BulkRemoveRolePermissionPresetsInputGQL,
+    CreateRolePresetInputGQL,
+    RolePermissionPresetEntryInputGQL,
+)
+from .node import (
+    RolePresetConnection,
+    RolePresetEdge,
+    RolePresetGQL,
+)
+from .payloads import (
+    BulkPurgeRolePresetsPayloadGQL,
+    BulkRolePresetFailureInfoGQL,
+    CreateRolePresetPayloadGQL,
+)
+from .permission import (
+    BulkAddRolePermissionPresetFailureInfoGQL,
+    BulkAddRolePermissionPresetsPayloadGQL,
+    BulkRemoveRolePermissionPresetsPayloadGQL,
+    BulkRolePermissionPresetFailureInfoGQL,
+    RolePermissionPresetConnection,
+    RolePermissionPresetEdge,
+    RolePermissionPresetFilterGQL,
+    RolePermissionPresetGQL,
+    RolePermissionPresetOrderByGQL,
+    RolePermissionPresetOrderFieldGQL,
+)
+
+__all__ = [
+    # Node / Connection types
+    "RolePresetGQL",
+    "RolePresetEdge",
+    "RolePresetConnection",
+    "RolePermissionPresetGQL",
+    "RolePermissionPresetEdge",
+    "RolePermissionPresetConnection",
+    # Filter / OrderBy types
+    "RolePresetFilterGQL",
+    "RolePresetOrderByGQL",
+    "RolePresetOrderFieldGQL",
+    "RolePermissionPresetFilterGQL",
+    "RolePermissionPresetOrderByGQL",
+    "RolePermissionPresetOrderFieldGQL",
+    # Input types
+    "CreateRolePresetInputGQL",
+    "BulkPurgeRolePresetsInputGQL",
+    "RolePermissionPresetEntryInputGQL",
+    "BulkAddRolePermissionPresetsInputGQL",
+    "BulkRemoveRolePermissionPresetsInputGQL",
+    # Payload types
+    "CreateRolePresetPayloadGQL",
+    "BulkRolePresetFailureInfoGQL",
+    "BulkPurgeRolePresetsPayloadGQL",
+    "BulkRolePermissionPresetFailureInfoGQL",
+    "BulkAddRolePermissionPresetFailureInfoGQL",
+    "BulkAddRolePermissionPresetsPayloadGQL",
+    "BulkRemoveRolePermissionPresetsPayloadGQL",
+]

--- a/src/ai/backend/manager/api/gql/role_preset/types/filters.py
+++ b/src/ai/backend/manager/api/gql/role_preset/types/filters.py
@@ -1,0 +1,83 @@
+"""Role preset GQL filter and order-by types."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Self
+
+from ai.backend.common.dto.manager.v2.role_preset.request import (
+    RolePresetFilter as RolePresetFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.role_preset.request import (
+    RolePresetOrder as RolePresetOrderDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.base import OrderDirection, StringFilter
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_enum,
+    gql_field,
+    gql_pydantic_input,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
+from ai.backend.manager.api.gql.rbac.types import RBACElementTypeFilterGQL
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Filter input for querying role presets.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="RolePresetFilter",
+)
+class RolePresetFilterGQL(PydanticInputMixin[RolePresetFilterDTO]):
+    name: StringFilter | None = gql_field(description="Filter by name.", default=None)
+    scope_type: RBACElementTypeFilterGQL | None = gql_field(
+        description="Filter by scope type.", default=None
+    )
+    auto_assign: bool | None = gql_field(description="Filter by auto-assign flag.", default=None)
+    deleted: bool | None = gql_field(
+        description=(
+            "Filter by soft-delete flag. Searches exclude soft-deleted rows by default; "
+            "set this explicitly to `true` to inspect archived presets."
+        ),
+        default=None,
+    )
+    AND: list[Self] | None = gql_field(
+        description="Combine multiple filters with AND logic. All conditions must match.",
+        default=None,
+    )
+    OR: list[Self] | None = gql_field(
+        description="Combine multiple filters with OR logic. At least one condition must match.",
+        default=None,
+    )
+    NOT: list[Self] | None = gql_field(
+        description="Negate the specified filters. Matching records are excluded.",
+        default=None,
+    )
+
+
+@gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Fields available for ordering role preset results.",
+    ),
+    name="RolePresetOrderField",
+)
+class RolePresetOrderFieldGQL(StrEnum):
+    NAME = "name"
+    SCOPE_TYPE = "scope_type"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Specifies ordering for role preset results.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="RolePresetOrderBy",
+)
+class RolePresetOrderByGQL(PydanticInputMixin[RolePresetOrderDTO]):
+    field: RolePresetOrderFieldGQL = gql_field(description="The field to order by.")
+    direction: OrderDirection = gql_field(description="Sort direction.", default=OrderDirection.ASC)

--- a/src/ai/backend/manager/api/gql/role_preset/types/inputs.py
+++ b/src/ai/backend/manager/api/gql/role_preset/types/inputs.py
@@ -1,0 +1,106 @@
+"""Role preset GQL input types."""
+
+from __future__ import annotations
+
+from strawberry import ID, UNSET
+
+from ai.backend.common.dto.manager.v2.role_permission_preset.request import (
+    BulkAddRolePermissionPresetsInput as BulkAddRolePermissionPresetsInputDTO,
+)
+from ai.backend.common.dto.manager.v2.role_permission_preset.request import (
+    BulkRemoveRolePermissionPresetsInput as BulkRemoveRolePermissionPresetsInputDTO,
+)
+from ai.backend.common.dto.manager.v2.role_permission_preset.types import (
+    RolePermissionPresetEntry as RolePermissionPresetEntryDTO,
+)
+from ai.backend.common.dto.manager.v2.role_preset.request import (
+    BulkPurgeRolePresetsInput as BulkPurgeRolePresetsInputDTO,
+)
+from ai.backend.common.dto.manager.v2.role_preset.request import (
+    CreateRolePresetInput as CreateRolePresetInputDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_input,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
+from ai.backend.manager.api.gql.rbac.types import OperationTypeGQL, RBACElementTypeGQL
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="A single (entity_type, operation) pair carried by a role preset.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="RolePermissionPresetEntryInput",
+)
+class RolePermissionPresetEntryInputGQL(PydanticInputMixin[RolePermissionPresetEntryDTO]):
+    entity_type: RBACElementTypeGQL = gql_field(
+        description="Entity type the permission applies to."
+    )
+    operation: OperationTypeGQL = gql_field(description="Operation granted by the permission.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Input for creating a new role preset.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="CreateRolePresetInput",
+)
+class CreateRolePresetInputGQL(PydanticInputMixin[CreateRolePresetInputDTO]):
+    name: str = gql_field(description="Role preset name.")
+    scope_type: RBACElementTypeGQL = gql_field(
+        description="Scope type this preset targets (e.g., domain, project)."
+    )
+    auto_assign: bool = gql_field(
+        description=(
+            "Default value for the `auto_assign` flag on roles instantiated from this preset."
+        ),
+        default=False,
+    )
+    permissions: list[RolePermissionPresetEntryInputGQL] = gql_field(
+        description="Permission entries carried by the preset.",
+        default=UNSET,
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Input for bulk-hard-deleting role presets.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="BulkPurgeRolePresetsInput",
+)
+class BulkPurgeRolePresetsInputGQL(PydanticInputMixin[BulkPurgeRolePresetsInputDTO]):
+    role_preset_ids: list[ID] = gql_field(description="Role preset UUIDs to purge.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Input for bulk-adding permission entries to an existing role preset.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="BulkAddRolePermissionPresetsInput",
+)
+class BulkAddRolePermissionPresetsInputGQL(
+    PydanticInputMixin[BulkAddRolePermissionPresetsInputDTO]
+):
+    permissions: list[RolePermissionPresetEntryInputGQL] = gql_field(
+        description="Permission entries to insert. Duplicates are surfaced as failures."
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Input for bulk-removing permission entries from a role preset.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="BulkRemoveRolePermissionPresetsInput",
+)
+class BulkRemoveRolePermissionPresetsInputGQL(
+    PydanticInputMixin[BulkRemoveRolePermissionPresetsInputDTO]
+):
+    permission_preset_ids: list[ID] = gql_field(description="Permission entry row IDs to delete.")

--- a/src/ai/backend/manager/api/gql/role_preset/types/inputs.py
+++ b/src/ai/backend/manager/api/gql/role_preset/types/inputs.py
@@ -88,6 +88,7 @@ class BulkPurgeRolePresetsInputGQL(PydanticInputMixin[BulkPurgeRolePresetsInputD
 class BulkAddRolePermissionPresetsInputGQL(
     PydanticInputMixin[BulkAddRolePermissionPresetsInputDTO]
 ):
+    role_preset_id: ID = gql_field(description="ID of the role preset to add permissions to.")
     permissions: list[RolePermissionPresetEntryInputGQL] = gql_field(
         description="Permission entries to insert. Duplicates are surfaced as failures."
     )

--- a/src/ai/backend/manager/api/gql/role_preset/types/node.py
+++ b/src/ai/backend/manager/api/gql/role_preset/types/node.py
@@ -1,0 +1,96 @@
+"""Role preset GQL Node, Edge, and Connection types."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from strawberry import Info
+from strawberry.relay import Connection, Edge, NodeID
+
+from ai.backend.common.dto.manager.v2.role_preset.response import RolePresetNode
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_added_field,
+    gql_connection_type,
+    gql_field,
+    gql_node_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
+from ai.backend.manager.api.gql.rbac.types import RBACElementTypeGQL
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+
+from .permission import (
+    RolePermissionPresetConnection,
+    RolePermissionPresetFilterGQL,
+    RolePermissionPresetOrderByGQL,
+)
+
+
+@gql_node_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Role preset entity implementing the Relay Node pattern.",
+    ),
+    name="RolePreset",
+)
+class RolePresetGQL(PydanticNodeMixin[RolePresetNode]):
+    id: NodeID[str] = gql_field(description="Role preset UUID (primary key).")
+    name: str = gql_field(description="Role preset name.")
+    scope_type: RBACElementTypeGQL = gql_field(
+        description="Scope type this preset targets (e.g., domain, project)."
+    )
+    auto_assign: bool = gql_field(
+        description=(
+            "Default value for the `auto_assign` flag copied onto roles instantiated "
+            "from this preset."
+        )
+    )
+    deleted: bool = gql_field(
+        description=(
+            "Soft-delete flag. Set by the delete mutation and cleared by the restore "
+            "mutation; archived rows are excluded from default searches."
+        )
+    )
+    created_at: datetime = gql_field(description="Creation timestamp.")
+    updated_at: datetime = gql_field(description="Last modification timestamp.")
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Permission entries carried by this role preset.",
+        )
+    )  # type: ignore[misc]
+    async def permission_presets(
+        self,
+        info: Info[StrawberryGQLContext],
+        filter: RolePermissionPresetFilterGQL | None = None,
+        order_by: list[RolePermissionPresetOrderByGQL] | None = None,
+        before: str | None = None,
+        after: str | None = None,
+        first: int | None = None,
+        last: int | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> RolePermissionPresetConnection | None:
+        raise NotImplementedError
+
+
+RolePresetEdge = Edge[RolePresetGQL]
+
+
+@gql_connection_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Paginated connection for role preset records.",
+    ),
+)
+class RolePresetConnection(Connection[RolePresetGQL]):
+    count: int = gql_field(
+        description="Total number of role preset records matching the query criteria."
+    )
+
+    def __init__(self, *args: Any, count: int, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.count = count

--- a/src/ai/backend/manager/api/gql/role_preset/types/payloads.py
+++ b/src/ai/backend/manager/api/gql/role_preset/types/payloads.py
@@ -1,0 +1,63 @@
+"""Role preset GQL mutation payload types."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from ai.backend.common.dto.manager.v2.role_preset.response import (
+    BulkPurgeRolePresetsPayload as BulkPurgeRolePresetsPayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.role_preset.response import (
+    BulkRolePresetFailureInfo as BulkRolePresetFailureInfoDTO,
+)
+from ai.backend.common.dto.manager.v2.role_preset.response import (
+    CreateRolePresetPayload as CreateRolePresetPayloadDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_type,
+)
+
+from .node import RolePresetGQL
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload returned after creating a role preset.",
+    ),
+    model=CreateRolePresetPayloadDTO,
+    name="CreateRolePresetPayload",
+)
+class CreateRolePresetPayloadGQL:
+    role_preset: RolePresetGQL = gql_field(description="Created role preset.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Failure detail for a single role preset ID in a bulk operation.",
+    ),
+    model=BulkRolePresetFailureInfoDTO,
+    name="BulkRolePresetFailureInfo",
+)
+class BulkRolePresetFailureInfoGQL:
+    role_preset_id: UUID = gql_field(description="Role preset ID that the operation failed on.")
+    message: str = gql_field(description="Error message describing the failure.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload returned after bulk-hard-deleting role presets.",
+    ),
+    model=BulkPurgeRolePresetsPayloadDTO,
+    name="BulkPurgeRolePresetsPayload",
+)
+class BulkPurgeRolePresetsPayloadGQL:
+    items: list[RolePresetGQL] = gql_field(description="Role presets that were purged.")
+    failed: list[BulkRolePresetFailureInfoGQL] = gql_field(
+        description="Role preset IDs that failed to purge."
+    )

--- a/src/ai/backend/manager/api/gql/role_preset/types/permission.py
+++ b/src/ai/backend/manager/api/gql/role_preset/types/permission.py
@@ -1,0 +1,233 @@
+"""Role permission preset GQL types (node, filter, order, payloads).
+
+These types describe the permission entries carried by a role preset. They back
+the ``permission_presets`` field resolver on ``RolePresetGQL`` and the bulk add/remove
+permission mutations.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any, Self
+from uuid import UUID
+
+from strawberry.relay import Connection, Edge, NodeID
+
+from ai.backend.common.dto.manager.v2.role_permission_preset.request import (
+    RolePermissionPresetFilter as RolePermissionPresetFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.role_permission_preset.request import (
+    RolePermissionPresetOrder as RolePermissionPresetOrderDTO,
+)
+from ai.backend.common.dto.manager.v2.role_permission_preset.response import (
+    BulkAddRolePermissionPresetFailureInfo as BulkAddRolePermissionPresetFailureInfoDTO,
+)
+from ai.backend.common.dto.manager.v2.role_permission_preset.response import (
+    BulkAddRolePermissionPresetsPayload as BulkAddRolePermissionPresetsPayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.role_permission_preset.response import (
+    BulkRemoveRolePermissionPresetsPayload as BulkRemoveRolePermissionPresetsPayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.role_permission_preset.response import (
+    BulkRolePermissionPresetFailureInfo as BulkRolePermissionPresetFailureInfoDTO,
+)
+from ai.backend.common.dto.manager.v2.role_permission_preset.response import (
+    RolePermissionPresetNode,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.base import (
+    DateTimeFilter,
+    OrderDirection,
+    UUIDFilter,
+)
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_connection_type,
+    gql_enum,
+    gql_field,
+    gql_node_type,
+    gql_pydantic_input,
+    gql_pydantic_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin, PydanticNodeMixin
+from ai.backend.manager.api.gql.rbac.types import (
+    OperationTypeFilterGQL,
+    OperationTypeGQL,
+    RBACElementTypeFilterGQL,
+    RBACElementTypeGQL,
+)
+
+# --- Node / Connection types ---
+
+
+@gql_node_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="A stored permission entry under a role preset.",
+    ),
+    name="RolePermissionPreset",
+)
+class RolePermissionPresetGQL(PydanticNodeMixin[RolePermissionPresetNode]):
+    id: NodeID[str] = gql_field(description="Permission entry UUID.")
+    role_preset_id: UUID = gql_field(description="UUID of the parent role preset.")
+    entity_type: RBACElementTypeGQL = gql_field(
+        description="Entity type the permission applies to."
+    )
+    operation: OperationTypeGQL = gql_field(description="Operation granted by the permission.")
+    created_at: datetime = gql_field(description="Creation timestamp.")
+
+
+RolePermissionPresetEdge = Edge[RolePermissionPresetGQL]
+
+
+@gql_connection_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Paginated connection for role permission preset entries.",
+    ),
+)
+class RolePermissionPresetConnection(Connection[RolePermissionPresetGQL]):
+    count: int = gql_field(
+        description="Total number of permission entries matching the query criteria."
+    )
+
+    def __init__(self, *args: Any, count: int, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.count = count
+
+
+# --- Filter / Order types ---
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description=(
+            "Filter input for role permission preset entries. Also used as the input for the "
+            "`permission_presets` field resolver on a role preset (the resolver injects "
+            "`role_preset_id` from its parent)."
+        ),
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="RolePermissionPresetFilter",
+)
+class RolePermissionPresetFilterGQL(PydanticInputMixin[RolePermissionPresetFilterDTO]):
+    role_preset_id: UUIDFilter | None = gql_field(
+        description="Filter by parent role preset ID.", default=None
+    )
+    entity_type: RBACElementTypeFilterGQL | None = gql_field(
+        description="Filter by entity type the permission applies to.", default=None
+    )
+    operation: OperationTypeFilterGQL | None = gql_field(
+        description="Filter by granted operation.", default=None
+    )
+    created_at: DateTimeFilter | None = gql_field(
+        description="Filter by creation timestamp.", default=None
+    )
+    AND: list[Self] | None = gql_field(
+        description="Combine multiple filters with AND logic. All conditions must match.",
+        default=None,
+    )
+    OR: list[Self] | None = gql_field(
+        description="Combine multiple filters with OR logic. At least one condition must match.",
+        default=None,
+    )
+    NOT: list[Self] | None = gql_field(
+        description="Negate the specified filters. Matching records are excluded.",
+        default=None,
+    )
+
+
+@gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Fields available for ordering role permission preset entries.",
+    ),
+    name="RolePermissionPresetOrderField",
+)
+class RolePermissionPresetOrderFieldGQL(StrEnum):
+    ENTITY_TYPE = "entity_type"
+    OPERATION = "operation"
+    CREATED_AT = "created_at"
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Specifies ordering for role permission preset entries.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="RolePermissionPresetOrderBy",
+)
+class RolePermissionPresetOrderByGQL(PydanticInputMixin[RolePermissionPresetOrderDTO]):
+    field: RolePermissionPresetOrderFieldGQL = gql_field(description="The field to order by.")
+    direction: OrderDirection = gql_field(description="Sort direction.", default=OrderDirection.ASC)
+
+
+# --- Payload types ---
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Failure detail for a single permission entry in a bulk operation.",
+    ),
+    model=BulkRolePermissionPresetFailureInfoDTO,
+    name="BulkRolePermissionPresetFailureInfo",
+)
+class BulkRolePermissionPresetFailureInfoGQL:
+    permission_preset_id: UUID = gql_field(
+        description="Permission entry ID that the operation failed on."
+    )
+    message: str = gql_field(description="Error message describing the failure.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Failure detail for a single permission entry in a bulk add operation.",
+    ),
+    model=BulkAddRolePermissionPresetFailureInfoDTO,
+    name="BulkAddRolePermissionPresetFailureInfo",
+)
+class BulkAddRolePermissionPresetFailureInfoGQL:
+    entity_type: RBACElementTypeGQL = gql_field(
+        description="Entity type of the permission entry that failed."
+    )
+    operation: OperationTypeGQL = gql_field(
+        description="Operation of the permission entry that failed."
+    )
+    message: str = gql_field(description="Error message describing the failure.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload returned after bulk-adding permission entries to a role preset.",
+    ),
+    model=BulkAddRolePermissionPresetsPayloadDTO,
+    name="BulkAddRolePermissionPresetsPayload",
+)
+class BulkAddRolePermissionPresetsPayloadGQL:
+    items: list[RolePermissionPresetGQL] = gql_field(
+        description="Permission entries that were added."
+    )
+    failed: list[BulkAddRolePermissionPresetFailureInfoGQL] = gql_field(
+        description="Permission entries that failed to be added (e.g., duplicates)."
+    )
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload returned after bulk-removing permission entries from a role preset.",
+    ),
+    model=BulkRemoveRolePermissionPresetsPayloadDTO,
+    name="BulkRemoveRolePermissionPresetsPayload",
+)
+class BulkRemoveRolePermissionPresetsPayloadGQL:
+    items: list[RolePermissionPresetGQL] = gql_field(
+        description="Permission entries that were removed."
+    )
+    failed: list[BulkRolePermissionPresetFailureInfoGQL] = gql_field(
+        description="Permission entry IDs that failed to delete."
+    )

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -363,6 +363,14 @@ from .resource_usage import (
     project_usage_buckets,
     user_usage_buckets,
 )
+from .role_preset import (
+    admin_bulk_add_role_preset_permissions,
+    admin_bulk_remove_role_preset_permissions,
+    admin_create_role_preset,
+    admin_purge_role_presets,
+    admin_role_preset,
+    admin_role_presets,
+)
 from .runtime_variant import (
     admin_create_runtime_variant,
     admin_delete_runtime_variant,
@@ -534,6 +542,9 @@ class Query:
     # Prometheus Query Preset Category APIs (read available to any authenticated user)
     prometheus_query_preset_category = prometheus_query_preset_category
     prometheus_query_preset_categories = prometheus_query_preset_categories
+    # Role Preset Admin APIs
+    admin_role_preset = admin_role_preset
+    admin_role_presets = admin_role_presets
     # RBAC Admin APIs
     admin_role = admin_role
     admin_roles = admin_roles
@@ -819,6 +830,11 @@ class Mutation:
     # Prometheus Query Preset Category - Admin APIs
     admin_create_prometheus_query_preset_category = admin_create_prometheus_query_preset_category
     admin_delete_prometheus_query_preset_category = admin_delete_prometheus_query_preset_category
+    # Role Preset - Admin APIs
+    admin_create_role_preset = admin_create_role_preset
+    admin_purge_role_presets = admin_purge_role_presets
+    admin_bulk_add_role_preset_permissions = admin_bulk_add_role_preset_permissions
+    admin_bulk_remove_role_preset_permissions = admin_bulk_remove_role_preset_permissions
     # RBAC Admin APIs
     admin_create_role = admin_create_role
     admin_update_role = admin_update_role


### PR DESCRIPTION
## Summary
- Add the remaining **Role Preset** GraphQL surface, complementing the update/delete/restore mutations in #11872 (parallel split off this work):
  - **Queries**: `adminRolePreset` (get), `adminRolePresets` (search) with filters/ordering and the `RolePreset` Relay connection.
  - **Mutations**: `adminCreateRolePreset`, `adminPurgeRolePresets`, and permission-entry management `adminBulkAddRolePresetPermissions` / `adminBulkRemoveRolePresetPermissions`.
  - The `RolePermissionPreset` node/connection/filter types and the `permissionPresets` sub-field on `RolePreset`.
- Extend the shared `RolePresetAdapter` (`api/adapters/role_preset/`) with the matching method stubs (`create` / `get` / `search` / `bulk_purge` / `search_permissions` / `bulk_add_permissions` / `bulk_remove_permissions`).
- Resolvers and adapter methods raise `NotImplementedError`; service wire-up is deferred to a follow-up task.

Note: this PR shares the `RolePreset` node and `schema.py` wiring with #11872; whichever merges second will rebase to absorb the overlap. The generated GraphQL schema doc is left to CI to regenerate.

Resolves BA-6179


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11892.org.readthedocs.build/en/11892/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11892.org.readthedocs.build/ko/11892/

<!-- readthedocs-preview sorna-ko end -->