### PR TITLE
feat(BA-6267): add replica field to SessionV2 GraphQL type

### DIFF
--- a/changes/11903.feature.md
+++ b/changes/11903.feature.md
@@ -1,0 +1,1 @@
+Add a `replica` field to the `SessionV2` GraphQL type that resolves the model deployment replica served by a session via a session-scoped DataLoader, enabling the Session detail page to surface deployment information without N+1 queries

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -17855,6 +17855,11 @@ type SessionV2 implements Node
 
   """Added in 26.3.0. The kernels belonging to this session."""
   kernels: KernelV2Connection
+
+  """
+  Added in UNRELEASED. The model deployment replica served by this session, resolved via DataLoader. Null for non-inference sessions. Follow `replica.revision` or the deployment chain to obtain deployment details.
+  """
+  replica: ModelReplica
 }
 
 """Added in 26.3.0. Connection type for paginated session results."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -12254,6 +12254,11 @@ type SessionV2 implements Node {
 
   """Added in 26.3.0. The kernels belonging to this session."""
   kernels: KernelV2Connection
+
+  """
+  Added in UNRELEASED. The model deployment replica served by this session, resolved via DataLoader. Null for non-inference sessions. Follow `replica.revision` or the deployment chain to obtain deployment details.
+  """
+  replica: ModelReplica
 }
 
 """Added in 26.3.0. Connection type for paginated session results."""

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -221,12 +221,16 @@ from ai.backend.manager.repositories.base import (
     BatchQuerier,
     NoPagination,
     OffsetPagination,
+    Querier,
     QueryCondition,
     QueryOrder,
     Updater,
     combine_conditions_and,
     combine_conditions_or,
     negate_conditions,
+)
+from ai.backend.manager.repositories.deployment.types import (
+    UserRouteSearchScope,
 )
 from ai.backend.manager.repositories.deployment.updaters import (
     DeploymentMetadataUpdaterSpec,
@@ -266,6 +270,9 @@ from ai.backend.manager.services.deployment.actions.auto_scaling_rule.search_aut
 )
 from ai.backend.manager.services.deployment.actions.auto_scaling_rule.update_auto_scaling_rule import (
     UpdateAutoScalingRuleAction,
+)
+from ai.backend.manager.services.deployment.actions.bulk_query_routes import (
+    BulkQueryRoutesAction,
 )
 from ai.backend.manager.services.deployment.actions.create_deployment import CreateDeploymentAction
 from ai.backend.manager.services.deployment.actions.deployment_policy.get_deployment_policy import (
@@ -1409,6 +1416,45 @@ class DeploymentAdapter(BaseAdapter):
         )
         replica_map = {data.id: self._replica_data_to_dto(data) for data in action_result.data}
         return [replica_map.get(replica_id) for replica_id in replica_ids]
+
+    async def batch_load_replicas_by_session_ids(
+        self,
+        session_ids: Sequence[uuid.UUID],
+    ) -> list[ReplicaNode | None]:
+        """Batch load replicas by their owning session ID for DataLoader use.
+
+        Builds one by-session ``Querier`` per session (the route -> session link
+        is 1:1) and resolves them all through the generic bulk-route query under
+        the requester's USER scope (RBAC enforced by the scope processor; routes
+        the requester does not own drop out). Returns ReplicaNode DTOs in the
+        same order as the input session_ids list; an absent or out-of-scope
+        session yields None.
+        """
+        if not session_ids:
+            return []
+        user = current_user()
+        if user is None:
+            raise RuntimeError("No authenticated user in context")
+        queriers = [
+            Querier(
+                row_class=RoutingRow,
+                pk_value=session_id,
+                lookup_column=RoutingRow.session,
+            )
+            for session_id in session_ids
+        ]
+        action_result = await self._processors.deployment.bulk_query_routes.wait_for_complete(
+            BulkQueryRoutesAction(
+                queriers=queriers,
+                scope=UserRouteSearchScope(user_uuid=user.user_id),
+            )
+        )
+        replica_map = {
+            data.session_id: self._replica_data_to_dto(data)
+            for data in action_result.data
+            if data.session_id is not None
+        }
+        return [replica_map.get(session_id) for session_id in session_ids]
 
     async def batch_load_routes_by_ids(
         self,

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -433,6 +433,22 @@ class DataLoaders:
         return DataLoader(load_fn=load_fn)
 
     @cached_property
+    def replica_by_session_loader(
+        self,
+    ) -> DataLoader[SessionId, ModelReplica | None]:
+        adapter = self._adapters.deployment
+
+        async def load_fn(session_ids: list[SessionId]) -> list[ModelReplica | None]:
+            from ai.backend.manager.api.gql.deployment.types.replica import (  # pants: no-infer-dep
+                ModelReplica as MRep,
+            )
+
+            dtos = await adapter.batch_load_replicas_by_session_ids(session_ids)
+            return [MRep.from_pydantic(dto) if dto is not None else None for dto in dtos]
+
+        return DataLoader(load_fn=load_fn)
+
+    @cached_property
     def container_count_loader(
         self,
     ) -> DataLoader[AgentId, int]:

--- a/src/ai/backend/manager/api/gql/session/types.py
+++ b/src/ai/backend/manager/api/gql/session/types.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from datetime import datetime
 from enum import StrEnum
-from typing import Any, Self, cast
+from typing import TYPE_CHECKING, Annotated, Any, Self, cast
 from uuid import UUID
 
 import strawberry
@@ -86,6 +86,9 @@ from ai.backend.manager.api.gql.resource_group.types import ResourceGroupGQL
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.api.gql.user.types.node import UserV2GQL
 from ai.backend.manager.errors.user import UserNotFound
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.deployment.types.replica import ModelReplica
 
 
 @gql_enum(
@@ -432,6 +435,29 @@ class SessionV2GQL(PydanticNodeMixin[SessionNode]):
                 end_cursor=edges[-1].cursor if edges else None,
             ),
             count=payload.total_count,
+        )
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "The model deployment replica served by this session, resolved via DataLoader. "
+                "Null for non-inference sessions. Follow `replica.revision` or the deployment "
+                "chain to obtain deployment details."
+            ),
+        )
+    )  # type: ignore[misc]
+    async def replica(
+        self, info: Info[StrawberryGQLContext]
+    ) -> (
+        Annotated[
+            ModelReplica,
+            strawberry.lazy("ai.backend.manager.api.gql.deployment.types.replica"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.replica_by_session_loader.load(
+            SessionId(UUID(str(self.id)))
         )
 
     # TODO: Add `vfolder_mounts` dynamic field (VFolder connection type needed)

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -151,7 +151,10 @@ from ai.backend.manager.models.vfolder import VFolderRow
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
     Creator,
+    Querier,
+    SearchScope,
     execute_batch_querier,
+    execute_bulk_querier,
     execute_creator,
 )
 from ai.backend.manager.repositories.base.creator import BulkCreator
@@ -1165,6 +1168,25 @@ class DeploymentDBSource:
             if row is None:
                 return None
             return row.to_route_info()
+
+    async def bulk_query_routes(
+        self,
+        queriers: Sequence[Querier[RoutingRow]],
+        scopes: Sequence[SearchScope] = (),
+    ) -> list[RouteInfo]:
+        """Resolve many routes (replicas) at once from independent by-key queriers.
+
+        Queriers sharing a lookup column collapse into one ``WHERE col IN (...)``
+        query via ``execute_bulk_querier``. ``scopes`` apply RBAC row filtering
+        (AND-merged with the IN predicate). Queriers that match no row — or whose
+        row is filtered out by scope — simply drop out (they land in the bulk
+        result's failures, discarded here).
+        """
+        if not queriers:
+            return []
+        async with self._begin_readonly_session_read_committed() as db_sess:
+            result = await execute_bulk_querier(db_sess, queriers, scopes)
+            return [success.row.to_route_info() for success in result.successes]
 
     async def search_endpoints(
         self,

--- a/src/ai/backend/manager/repositories/deployment/repository.py
+++ b/src/ai/backend/manager/repositories/deployment/repository.py
@@ -95,7 +95,7 @@ from ai.backend.manager.models.scheduling_history import (
 from ai.backend.manager.models.storage import StorageSessionManager
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import VFolderOwnershipType
-from ai.backend.manager.repositories.base import BatchQuerier, Creator
+from ai.backend.manager.repositories.base import BatchQuerier, Creator, Querier, SearchScope
 from ai.backend.manager.repositories.base.creator import BulkCreator
 from ai.backend.manager.repositories.base.purger import Purger, PurgerResult
 from ai.backend.manager.repositories.base.rbac.entity_creator import RBACEntityCreator
@@ -1535,6 +1535,23 @@ class DeploymentRepository:
             RouteInfo if found, None otherwise
         """
         return await self._db_source.get_route(route_id)
+
+    @deployment_repository_resilience.apply()
+    async def bulk_query_routes(
+        self,
+        queriers: Sequence[Querier[RoutingRow]],
+        scopes: Sequence[SearchScope] = (),
+    ) -> list[RouteInfo]:
+        """Resolve many routes (replicas) at once from independent by-key queriers.
+
+        Args:
+            queriers: One Querier per route to resolve (by PK or alternate key)
+            scopes: RBAC scopes to constrain which rows are visible
+
+        Returns:
+            A flat list of RouteInfo for the queriers that matched an in-scope row
+        """
+        return await self._db_source.bulk_query_routes(queriers, scopes)
 
     @deployment_repository_resilience.apply()
     async def search_endpoints(

--- a/src/ai/backend/manager/repositories/deployment/types/__init__.py
+++ b/src/ai/backend/manager/repositories/deployment/types/__init__.py
@@ -9,6 +9,7 @@ from .endpoint import (
     RouteServiceDiscoveryInfo,
     RouteSessionInfo,
     RouteSessionKernelInfo,
+    UserRouteSearchScope,
 )
 
 __all__ = [
@@ -20,4 +21,5 @@ __all__ = [
     "RouteServiceDiscoveryInfo",
     "RouteSessionInfo",
     "RouteSessionKernelInfo",
+    "UserRouteSearchScope",
 ]

--- a/src/ai/backend/manager/repositories/deployment/types/endpoint.py
+++ b/src/ai/backend/manager/repositories/deployment/types/endpoint.py
@@ -27,6 +27,7 @@ from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.errors.resource import ProjectNotFound
 from ai.backend.manager.models.endpoint.row import EndpointRow
 from ai.backend.manager.models.group.row import GroupRow
+from ai.backend.manager.models.routing.row import RoutingRow
 from ai.backend.manager.repositories.base.types import ExistenceCheck, QueryCondition, SearchScope
 
 
@@ -144,3 +145,31 @@ class ProjectDeploymentSearchScope(SearchScope):
                 error=ProjectNotFound(str(self.project_id)),
             ),
         ]
+
+
+@dataclass(frozen=True)
+class UserRouteSearchScope(SearchScope):
+    """USER scope for routes owned by a specific user.
+
+    Constrains routes to those whose owning session belongs to ``user_uuid``
+    (``RoutingRow.session_owner == user_uuid``). Mirrors the per-entity
+    ``User*SearchScope`` convention (e.g. ``UserKeypairSearchScope``).
+
+    Existence checks are intentionally empty: this scopes a partial-by-absence
+    batch lookup, so out-of-scope routes drop out via the WHERE predicate
+    rather than raising all-or-nothing.
+    """
+
+    user_uuid: UUID
+
+    def to_condition(self) -> QueryCondition:
+        user_uuid = self.user_uuid
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RoutingRow.session_owner == user_uuid
+
+        return inner
+
+    @property
+    def existence_checks(self) -> Sequence[ExistenceCheck[Any]]:
+        return []

--- a/src/ai/backend/manager/services/deployment/actions/bulk_query_routes.py
+++ b/src/ai/backend/manager/services/deployment/actions/bulk_query_routes.py
@@ -1,0 +1,57 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import EntityType, RBACElementType, ScopeType
+from ai.backend.manager.actions.action.scope import BaseScopeAction, BaseScopeActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.deployment.types import ModelReplicaData
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.models.routing import RoutingRow
+from ai.backend.manager.repositories.base import Querier
+from ai.backend.manager.repositories.deployment.types import UserRouteSearchScope
+
+
+@dataclass
+class BulkQueryRoutesAction(BaseScopeAction):
+    """Resolve many routes (replicas) at once via independent by-key queriers,
+    constrained to the requester's USER scope (routes they own)."""
+
+    queriers: Sequence[Querier[RoutingRow]]
+    scope: UserRouteSearchScope
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.DEPLOYMENT_REPLICA
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+    @override
+    def scope_type(self) -> ScopeType:
+        return ScopeType.USER
+
+    @override
+    def scope_id(self) -> str:
+        return str(self.scope.user_uuid)
+
+    @override
+    def target_element(self) -> RBACElementRef:
+        return RBACElementRef(RBACElementType.USER, str(self.scope.user_uuid))
+
+
+@dataclass
+class BulkQueryRoutesActionResult(BaseScopeActionResult):
+    data: list[ModelReplicaData]
+    _scope_id: str
+
+    @override
+    def scope_type(self) -> ScopeType:
+        return ScopeType.USER
+
+    @override
+    def scope_id(self) -> str:
+        return self._scope_id

--- a/src/ai/backend/manager/services/deployment/processors.py
+++ b/src/ai/backend/manager/services/deployment/processors.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, cast, override
 
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
+from ai.backend.manager.actions.processor.scope import ScopeActionProcessor
 from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
 from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validator.base import ActionValidator
@@ -53,6 +54,10 @@ from ai.backend.manager.services.deployment.actions.auto_scaling_rule.search_aut
 from ai.backend.manager.services.deployment.actions.auto_scaling_rule.update_auto_scaling_rule import (
     UpdateAutoScalingRuleAction,
     UpdateAutoScalingRuleActionResult,
+)
+from ai.backend.manager.services.deployment.actions.bulk_query_routes import (
+    BulkQueryRoutesAction,
+    BulkQueryRoutesActionResult,
 )
 from ai.backend.manager.services.deployment.actions.create_deployment import (
     CreateDeploymentAction,
@@ -211,6 +216,7 @@ class DeploymentProcessors(AbstractProcessorPackage):
 
     # Replica operations
     get_replica_by_id: ActionProcessor[GetReplicaByIdAction, GetReplicaByIdActionResult]
+    bulk_query_routes: ScopeActionProcessor[BulkQueryRoutesAction, BulkQueryRoutesActionResult]
     search_replicas: ActionProcessor[SearchReplicasAction, SearchReplicasActionResult]
 
     # Auto-scaling rules
@@ -248,6 +254,7 @@ class DeploymentProcessors(AbstractProcessorPackage):
     ) -> None:
         # Deployment CRUD
         rbac_single_entity_validators = [validators.rbac.single_entity]
+        rbac_scope_validators = [validators.rbac.scope]
         self.create_deployment = ActionProcessor(service.create_deployment, action_monitors)
         self.create_legacy_deployment = ActionProcessor(
             service.create_legacy_deployment, action_monitors
@@ -309,6 +316,9 @@ class DeploymentProcessors(AbstractProcessorPackage):
 
         # Replica operations
         self.get_replica_by_id = ActionProcessor(service.get_replica_by_id, action_monitors)
+        self.bulk_query_routes = ScopeActionProcessor(
+            service.bulk_query_routes, action_monitors, validators=rbac_scope_validators
+        )
         self.search_replicas = ActionProcessor(service.search_replicas, action_monitors)
 
         # Auto-scaling rules
@@ -368,6 +378,7 @@ class DeploymentProcessors(AbstractProcessorPackage):
             UpdateRouteTrafficStatusAction.spec(),
             # Replica operations
             GetReplicaByIdAction.spec(),
+            BulkQueryRoutesAction.spec(),
             SearchReplicasAction.spec(),
             # Auto-scaling rules
             CreateAutoScalingRuleAction.spec(),

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -109,6 +109,10 @@ from ai.backend.manager.services.deployment.actions.auto_scaling_rule.update_aut
     UpdateAutoScalingRuleAction,
     UpdateAutoScalingRuleActionResult,
 )
+from ai.backend.manager.services.deployment.actions.bulk_query_routes import (
+    BulkQueryRoutesAction,
+    BulkQueryRoutesActionResult,
+)
 from ai.backend.manager.services.deployment.actions.create_deployment import (
     CreateDeploymentAction,
     CreateDeploymentActionResult,
@@ -1079,6 +1083,16 @@ class DeploymentService:
         if route is None:
             return GetReplicaByIdActionResult(data=None)
         return GetReplicaByIdActionResult(data=_convert_route_info_to_replica_data(route))
+
+    async def bulk_query_routes(
+        self, action: BulkQueryRoutesAction
+    ) -> BulkQueryRoutesActionResult:
+        """Resolve many routes at once within the requester's USER scope, as replica data."""
+        routes = await self._deployment_repository.bulk_query_routes(
+            action.queriers, scopes=(action.scope,)
+        )
+        replicas = [_convert_route_info_to_replica_data(route) for route in routes]
+        return BulkQueryRoutesActionResult(data=replicas, _scope_id=action.scope_id())
 
     # ========== Search Operations ==========
 


### PR DESCRIPTION
## Summary

Adds a `replica` field to the `SessionV2` GraphQL type so the Session detail page can surface **Deployment** information for inference sessions. The field resolves to the `ModelReplica` (DB: `RoutingRow`) served by the session; clients follow `replica.revision` / the deployment chain to reach the Deployment.

> **Stacked on #11921** (`execute_bulk_querier`). This PR targets `feat/bulk-querier`; review/merge that first. The bulk-querier infrastructure itself lives there.

## Changes

- **`SessionV2GQL.replica`** — resolves the `ModelReplica` for a session via a session-scoped DataLoader (`replica_by_session_loader`), avoiding N+1 across a session list.
- **Deployment side** — the adapter builds one by-session `Querier` per session and resolves them through a generic `bulk_query_routes` action → service → repository → `execute_bulk_querier`.
- **RBAC** — `BulkQueryRoutesAction` is a USER-scope action run through `ScopeActionProcessor` with the `rbac.scope` validator; `UserRouteSearchScope` filters routes to the requester's own (`RoutingRow.session_owner == user_uuid`).

## Notes

- A session maps to at most one replica → the field returns a single `ModelReplica | None`.
- **USER-scope limitation (follow-up):** a requester only sees replicas for sessions they own; superadmin / project-admin viewing others' sessions would currently get `null`. Deferred pending the scoping decision.

## Verification

- [ ] `./dev restart mgr && ./dev restart web`, then query `session { replica { id revision { id } } }` for an inference session and a plain session.

Jira: BA-6267

🤖 Generated with [Claude Code](https://claude.com/claude-code)