### PR TITLE
feat(BA-6183): add role.auto_assign column and backfill system roles

### DIFF
--- a/changes/11905.feature.md
+++ b/changes/11905.feature.md
@@ -1,0 +1,1 @@
+Add `auto_assign` column to roles so system-sourced roles are automatically granted when a user joins the owning scope.

--- a/src/ai/backend/manager/models/alembic/versions/eb9d9c018e85_add_auto_assign_column_to_roles.py
+++ b/src/ai/backend/manager/models/alembic/versions/eb9d9c018e85_add_auto_assign_column_to_roles.py
@@ -1,0 +1,42 @@
+"""add auto_assign column to roles
+
+Revision ID: eb9d9c018e85
+Revises: 1a2b3c4d5e6f
+Create Date: 2026-06-02 19:03:39.764771
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "eb9d9c018e85"
+down_revision = "1a2b3c4d5e6f"
+# Part of: 26.6.0
+branch_labels = None
+depends_on = None
+
+SYSTEM_ROLE_SOURCE = "system"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "roles",
+        sa.Column(
+            "auto_assign",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    # Backfill: system-sourced roles are auto-assigned when a user joins the
+    # owning scope.
+    op.execute(
+        sa.text("UPDATE roles SET auto_assign = true WHERE source = :source").bindparams(
+            source=SYSTEM_ROLE_SOURCE
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("roles", "auto_assign")

--- a/src/ai/backend/manager/models/rbac_models/role.py
+++ b/src/ai/backend/manager/models/rbac_models/role.py
@@ -68,6 +68,13 @@ class RoleRow(Base):  # type: ignore[misc]
         default=RoleStatus.ACTIVE,
         server_default=RoleStatus.ACTIVE,
     )
+    auto_assign: Mapped[bool] = mapped_column(
+        "auto_assign",
+        sa.Boolean,
+        nullable=False,
+        default=False,
+        server_default=sa.false(),
+    )
     created_at: Mapped[datetime] = mapped_column(
         "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
     )


### PR DESCRIPTION
## Summary
- Add a boolean `auto_assign` column to the `roles` table (default `false`) via Alembic migration `eb9d9c018e85`, and map it on `RoleRow`.
- Backfill sets `auto_assign = true` for all system-sourced roles (`source = 'system'`), so they are auto-granted when a user joins the owning scope.
- No new column on domain/groups; no FK/RESTRICT constraint — auto-assign is intrinsic to the role and its scope owner.

## Test plan
- [x] `alembic upgrade` adds the column; `downgrade` drops it
- [x] Backfill verified on local DB: all `system` roles → `true`, all `custom` roles → `false`
- [x] `pants fmt / lint` pass

Resolves BA-6183