### PR TITLE
chore: strip GQL suffix from v2 GraphQL schema type names

### DIFF
--- a/changes/11906.breaking.md
+++ b/changes/11906.breaking.md
@@ -1,0 +1,1 @@
+Remove the unintended `GQL` suffix from v2 GraphQL schema type names (e.g. `CreateDomainInputGQL` → `CreateDomainInput`); types whose name would collide with v1 schema types use a `V2` suffix instead (e.g. `KeyPairV2`).

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -231,7 +231,7 @@ type AdminCreateKeypairPayload
   @join__type(graph: STRAWBERRY)
 {
   """The newly created keypair."""
-  keypair: KeyPairGQL!
+  keypair: KeyPairV2!
 
   """The secret key. Only returned at creation time."""
   secretKey: String!
@@ -340,7 +340,7 @@ type AdminUpdateKeypairPayload
   @join__type(graph: STRAWBERRY)
 {
   """The updated keypair."""
-  keypair: KeyPairGQL!
+  keypair: KeyPairV2!
 }
 
 type Agent implements Item
@@ -3105,7 +3105,7 @@ input CreateContainerRegistryInput
 }
 
 """Added in 26.4.2. Input for creating a container registry."""
-input CreateContainerRegistryInputGQL
+input CreateContainerRegistryInputV2
   @join__type(graph: STRAWBERRY)
 {
   """URL of the container registry."""
@@ -3188,7 +3188,7 @@ type CreateContainerRegistryNodeV2
 """
 Added in 26.4.2. Payload for container registry create/update mutations.
 """
-type CreateContainerRegistryPayloadGQL
+type CreateContainerRegistryPayload
   @join__type(graph: STRAWBERRY)
 {
   """Created container registry."""
@@ -3299,7 +3299,7 @@ input CreateDeploymentRevisionPresetInput
 }
 
 """Added in 26.4.2. Create deployment revision preset payload."""
-type CreateDeploymentRevisionPresetPayloadGQL
+type CreateDeploymentRevisionPresetPayload
   @join__type(graph: STRAWBERRY)
 {
   """The created preset."""
@@ -3315,7 +3315,7 @@ type CreateDomain
 }
 
 """Added in 26.4.2. Input for creating a new domain."""
-input CreateDomainInputGQL
+input CreateDomainInput
   @join__type(graph: STRAWBERRY)
 {
   """Domain name. Must be unique across the system."""
@@ -3430,30 +3430,8 @@ type CreateKeyPairResourcePolicy
   resource_policy: KeyPairResourcePolicy
 }
 
-input CreateKeyPairResourcePolicyInput
-  @join__type(graph: GRAPHENE)
-{
-  default_for_unspecified: String!
-  total_resource_slots: JSONString = "{}"
-  max_session_lifetime: Int = 0
-  max_concurrent_sessions: Int!
-  max_concurrent_sftp_sessions: Int = 1
-  max_containers_per_session: Int!
-  idle_timeout: BigInt!
-  allowed_vfolder_hosts: JSONString
-  max_vfolder_count: Int @deprecated(reason: "Deprecated since 23.09.4.")
-  max_vfolder_size: BigInt @deprecated(reason: "Deprecated since 23.09.4.")
-  max_quota_scope_size: BigInt @deprecated(reason: "Deprecated since 23.09.6.")
-
-  """Added in 24.03.4."""
-  max_pending_session_count: Int
-
-  """Added in 24.03.4."""
-  max_pending_session_resource_slots: JSONString
-}
-
 """Added in 26.4.2. Input for creating a keypair resource policy."""
-input CreateKeypairResourcePolicyInputGQL
+input CreateKeypairResourcePolicyInput
   @join__type(graph: STRAWBERRY)
 {
   """Policy name. Must be unique."""
@@ -3490,10 +3468,32 @@ input CreateKeypairResourcePolicyInputGQL
   allowedVfolderHosts: [VFolderHostPermissionEntryInput!]!
 }
 
+input CreateKeyPairResourcePolicyInput
+  @join__type(graph: GRAPHENE)
+{
+  default_for_unspecified: String!
+  total_resource_slots: JSONString = "{}"
+  max_session_lifetime: Int = 0
+  max_concurrent_sessions: Int!
+  max_concurrent_sftp_sessions: Int = 1
+  max_containers_per_session: Int!
+  idle_timeout: BigInt!
+  allowed_vfolder_hosts: JSONString
+  max_vfolder_count: Int @deprecated(reason: "Deprecated since 23.09.4.")
+  max_vfolder_size: BigInt @deprecated(reason: "Deprecated since 23.09.4.")
+  max_quota_scope_size: BigInt @deprecated(reason: "Deprecated since 23.09.6.")
+
+  """Added in 24.03.4."""
+  max_pending_session_count: Int
+
+  """Added in 24.03.4."""
+  max_pending_session_resource_slots: JSONString
+}
+
 """
 Added in 26.4.2. Payload for keypair resource policy create/update mutations.
 """
-type CreateKeypairResourcePolicyPayloadGQL
+type CreateKeypairResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
   """Created keypair resource policy."""
@@ -3520,7 +3520,7 @@ type CreateLoginClientTypePayload
 }
 
 """Added in 26.4.2. Create model card payload."""
-type CreateModelCardPayloadGQL
+type CreateModelCardPayload
   @join__type(graph: STRAWBERRY)
 {
   """The created model card."""
@@ -3662,7 +3662,7 @@ input CreatePermissionInput
 }
 
 """Added in 26.4.2. Input for creating a new project."""
-input CreateProjectInputGQL
+input CreateProjectInput
   @join__type(graph: STRAWBERRY)
 {
   """Project name. Must be unique within the domain."""
@@ -3710,7 +3710,7 @@ input CreateProjectResourcePolicyInput
 }
 
 """Added in 26.4.2. Input for creating a project resource policy."""
-input CreateProjectResourcePolicyInputGQL
+input CreateProjectResourcePolicyInputV2
   @join__type(graph: STRAWBERRY)
 {
   """Policy name. Must be unique."""
@@ -3729,7 +3729,7 @@ input CreateProjectResourcePolicyInputGQL
 """
 Added in 26.4.2. Payload for project resource policy create/update mutations.
 """
-type CreateProjectResourcePolicyPayloadGQL
+type CreateProjectResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
   """Created project resource policy."""
@@ -3807,7 +3807,7 @@ input CreateResourceGroupInput
 }
 
 """Added in 26.4.2. Payload for resource group creation."""
-type CreateResourceGroupPayloadGQL
+type CreateResourceGroupPayload
   @join__type(graph: STRAWBERRY)
 {
   """Created resource group."""
@@ -3835,7 +3835,7 @@ input CreateResourcePresetInput
 }
 
 """Added in 26.4.2. Payload for resource preset creation."""
-type CreateResourcePresetPayloadGQL
+type CreateResourcePresetPayload
   @join__type(graph: STRAWBERRY)
 {
   """Created resource preset."""
@@ -3924,7 +3924,7 @@ input CreateRuntimeVariantInput
 }
 
 """Added in 26.4.2. Payload for runtime variant creation."""
-type CreateRuntimeVariantPayloadGQL
+type CreateRuntimeVariantPayload
   @join__type(graph: STRAWBERRY)
 {
   """The created runtime variant."""
@@ -3964,7 +3964,7 @@ input CreateRuntimeVariantPresetInput
 }
 
 """Added in 26.4.2. Create preset payload."""
-type CreateRuntimeVariantPresetPayloadGQL
+type CreateRuntimeVariantPresetPayload
   @join__type(graph: STRAWBERRY)
 {
   """The created preset."""
@@ -4069,7 +4069,7 @@ input CreateUserResourcePolicyInput
 }
 
 """Added in 26.4.2. Input for creating a user resource policy."""
-input CreateUserResourcePolicyInputGQL
+input CreateUserResourcePolicyInputV2
   @join__type(graph: STRAWBERRY)
 {
   """Policy name. Must be unique."""
@@ -4096,7 +4096,7 @@ input CreateUserResourcePolicyInputGQL
 """
 Added in 26.4.2. Payload for user resource policy create/update mutations.
 """
-type CreateUserResourcePolicyPayloadGQL
+type CreateUserResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
   """Created user resource policy."""
@@ -4500,7 +4500,7 @@ input DelegateImportArtifactsInput
   """
   Added in 26.1.0. Options controlling import behavior such as forcing re-download.
   """
-  options: ImportArtifactsOptionsGQL = null
+  options: ImportArtifactsOptions = null
 }
 
 """
@@ -4635,7 +4635,7 @@ type DeleteContainerRegistryNodeV2
 }
 
 """Added in 26.4.2. Payload for container registry deletion."""
-type DeleteContainerRegistryPayloadGQL
+type DeleteContainerRegistryPayload
   @join__type(graph: STRAWBERRY)
 {
   """ID of the deleted container registry."""
@@ -4666,7 +4666,7 @@ type DeleteDeploymentPayload
 }
 
 """Added in 26.4.2. Delete deployment revision preset payload."""
-type DeleteDeploymentRevisionPresetPayloadGQL
+type DeleteDeploymentRevisionPresetPayload
   @join__type(graph: STRAWBERRY)
 {
   """ID of the deleted preset."""
@@ -4699,7 +4699,7 @@ type DeleteDomainConfigPayload
 }
 
 """Added in 26.4.2. Payload for domain deletion mutation."""
-type DeleteDomainPayloadGQL
+type DeleteDomainPayload
   @join__type(graph: STRAWBERRY)
 {
   """Whether the deletion was successful."""
@@ -4773,7 +4773,7 @@ type DeleteKeyPairResourcePolicy
 }
 
 """Added in 26.4.2. Payload for keypair resource policy deletion."""
-type DeleteKeypairResourcePolicyPayloadGQL
+type DeleteKeypairResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
   """Name of the deleted keypair resource policy."""
@@ -4789,7 +4789,7 @@ type DeleteLoginClientTypePayload
 }
 
 """Added in 26.4.2. Delete model card payload."""
-type DeleteModelCardPayloadGQL
+type DeleteModelCardPayload
   @join__type(graph: STRAWBERRY)
 {
   """ID of the deleted model card."""
@@ -4875,7 +4875,7 @@ type DeletePermissionPayload
 }
 
 """Added in 26.4.2. Payload for project deletion mutation."""
-type DeleteProjectPayloadGQL
+type DeleteProjectPayload
   @join__type(graph: STRAWBERRY)
 {
   """Whether the deletion was successful."""
@@ -4890,7 +4890,7 @@ type DeleteProjectResourcePolicy
 }
 
 """Added in 26.4.2. Payload for project resource policy deletion."""
-type DeleteProjectResourcePolicyPayloadGQL
+type DeleteProjectResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
   """Name of the deleted project resource policy."""
@@ -4921,7 +4921,7 @@ type DeleteReservoirRegistryPayload
 }
 
 """Added in 26.4.2. Payload for resource group deletion."""
-type DeleteResourceGroupPayloadGQL
+type DeleteResourceGroupPayload
   @join__type(graph: STRAWBERRY)
 {
   """Name of the deleted resource group."""
@@ -4936,7 +4936,7 @@ type DeleteResourcePreset
 }
 
 """Added in 26.4.2. Payload for resource preset deletion."""
-type DeleteResourcePresetPayloadGQL
+type DeleteResourcePresetPayload
   @join__type(graph: STRAWBERRY)
 {
   """UUID of the deleted resource preset."""
@@ -4959,7 +4959,7 @@ type DeleteRolePayload
 }
 
 """Added in 26.4.2. Payload for runtime variant deletion."""
-type DeleteRuntimeVariantPayloadGQL
+type DeleteRuntimeVariantPayload
   @join__type(graph: STRAWBERRY)
 {
   """ID of the deleted runtime variant."""
@@ -4967,7 +4967,7 @@ type DeleteRuntimeVariantPayloadGQL
 }
 
 """Added in 26.4.2. Delete preset payload."""
-type DeleteRuntimeVariantPresetPayloadGQL
+type DeleteRuntimeVariantPresetPayload
   @join__type(graph: STRAWBERRY)
 {
   """ID of the deleted preset."""
@@ -4983,7 +4983,7 @@ input DeleteRuntimeVariantsInput
 }
 
 """Added in 26.4.2. Payload for bulk runtime variant deletion."""
-type DeleteRuntimeVariantsPayloadGQL
+type DeleteRuntimeVariantsPayload
   @join__type(graph: STRAWBERRY)
 {
   """Number of runtime variants successfully deleted."""
@@ -5037,7 +5037,7 @@ type DeleteUserResourcePolicy
 }
 
 """Added in 26.4.2. Payload for user resource policy deletion."""
-type DeleteUserResourcePolicyPayloadGQL
+type DeleteUserResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
   """Name of the deleted user resource policy."""
@@ -5130,14 +5130,14 @@ input DeploymentFilter
 }
 
 """Added in UNRELEASED. Deployment handler-options policy response."""
-type DeploymentHandlerOptionsInfoGQL
+type DeploymentHandlerOptionsInfo
   @join__type(graph: STRAWBERRY)
 {
   """Fallback per-handler policy."""
-  default: HandlerOptionsInfoGQL!
+  default: HandlerOptionsInfo!
 
   """Per-handler overrides."""
-  byHandler: [HandlerOptionsEntryInfoGQL!]!
+  byHandler: [HandlerOptionsEntryInfo!]!
 }
 
 """Added in UNRELEASED. Deployment handler-options policy input."""
@@ -5235,11 +5235,11 @@ enum DeploymentHistoryOrderField
 }
 
 """Added in UNRELEASED. Deployment options payload response."""
-type DeploymentOptionsInfoGQL
+type DeploymentOptionsInfo
   @join__type(graph: STRAWBERRY)
 {
   """Handler-keyed scheduler policy (timeout + retry)."""
-  handlerOptions: DeploymentHandlerOptionsInfoGQL!
+  handlerOptions: DeploymentHandlerOptionsInfo!
 }
 
 """Added in UNRELEASED. Deployment options payload input."""
@@ -5490,7 +5490,7 @@ input DeploymentStatusFilter
 """
 Added in 25.19.0. Represents the deployment strategy configuration that determines how updates are rolled out to replicas (e.g., rolling update, blue-green).
 """
-type DeploymentStrategyGQL
+type DeploymentStrategy
   @join__type(graph: STRAWBERRY)
 {
   type: DeploymentStrategyType!
@@ -5930,7 +5930,7 @@ type DomainNode implements Node
 }
 
 """Added in 26.4.2. Payload for domain mutation responses."""
-type DomainPayloadGQL
+type DomainPayload
   @join__type(graph: STRAWBERRY)
 {
   """The domain entity."""
@@ -6793,7 +6793,7 @@ input ExtraMountInput
 """
 Added in 25.19.0. An extra virtual folder mount attached to a model revision.
 """
-type ExtraVFolderMountInfoGQL
+type ExtraVFolderMountInfo
   @join__type(graph: STRAWBERRY)
 {
   """The vfolder of this entity."""
@@ -7085,7 +7085,7 @@ scalar GroupPermissionField
 """
 Added in UNRELEASED. A single (handler_name, options) entry response for deployment handler options.
 """
-type HandlerOptionsEntryInfoGQL
+type HandlerOptionsEntryInfo
   @join__type(graph: STRAWBERRY)
 {
   """Phase timeout in seconds; `null` means unbounded for this entry."""
@@ -7114,7 +7114,7 @@ input HandlerOptionsEntryInput
 """
 Added in UNRELEASED. Per-handler scheduler policy snapshot for deployment handler options.
 """
-type HandlerOptionsInfoGQL
+type HandlerOptionsInfo
   @join__type(graph: STRAWBERRY)
 {
   """Phase timeout in seconds; `null` means unbounded for this entry."""
@@ -7375,7 +7375,7 @@ type ImageV2 implements Node
   lastUsed: DateTime
 
   """Added in 26.2.0. Aliases for this image."""
-  aliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null): ImageV2AliasConnection
+  aliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null): ImageV2AliasConnection
 }
 
 """
@@ -7437,7 +7437,7 @@ input ImageV2AliasFilter
 """
 Added in 26.2.0. Specifies the field and direction for ordering image aliases in queries.
 """
-input ImageV2AliasOrderByGQL
+input ImageV2AliasOrderBy
   @join__type(graph: STRAWBERRY)
 {
   field: ImageV2AliasOrderField!
@@ -7561,7 +7561,7 @@ type ImageV2MetadataInfo
 """
 Added in 26.2.0. Specifies the field and direction for ordering images in queries.
 """
-input ImageV2OrderByGQL
+input ImageV2OrderBy
   @join__type(graph: STRAWBERRY)
 {
   field: ImageV2OrderField!
@@ -7683,7 +7683,7 @@ input ImportArtifactsInput
   """
   Added in 26.1.0. Options controlling import behavior such as forcing re-download.
   """
-  options: ImportArtifactsOptionsGQL = null
+  options: ImportArtifactsOptions = null
 }
 
 """
@@ -7691,7 +7691,7 @@ Added in 24.09.0. Options for importing artifact revisions.
 
 Controls import behavior such as forcing re-download regardless of digest freshness.
 """
-input ImportArtifactsOptionsGQL
+input ImportArtifactsOptions
   @join__type(graph: STRAWBERRY)
 {
   """Force re-download regardless of digest freshness check."""
@@ -7769,7 +7769,7 @@ type IssueMyKeypairPayload
   @join__type(graph: STRAWBERRY)
 {
   """The newly created keypair."""
-  keypair: KeyPairGQL!
+  keypair: KeyPairV2!
 
   """
   The newly generated secret key. This value is only returned at creation time.
@@ -8241,7 +8241,7 @@ type KeyPairConnection
   pageInfo: PageInfo!
 
   """Contains the nodes in this connection"""
-  edges: [KeyPairGQLEdge!]!
+  edges: [KeyPairV2Edge!]!
 
   """Total number of keypair records matching the query criteria."""
   count: Int!
@@ -8262,64 +8262,6 @@ input KeypairFilter
   AND: [KeypairFilter!] = null
   OR: [KeypairFilter!] = null
   NOT: [KeypairFilter!] = null
-}
-
-"""
-Added in 26.4.2. Keypair entity representing an API access key. The access_key field serves as the unique identifier. Secret key and private SSH key are excluded for security reasons.
-"""
-type KeyPairGQL implements Node
-  @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
-  id: ID!
-
-  """The access key string."""
-  accessKey: String!
-
-  """Whether the keypair is currently active."""
-  isActive: Boolean
-
-  """Whether the keypair has admin privileges."""
-  isAdmin: Boolean
-
-  """Timestamp when the keypair was created."""
-  createdAt: DateTime
-
-  """Timestamp when the keypair was last modified."""
-  modifiedAt: DateTime
-
-  """Timestamp when the keypair was last used for an API call."""
-  lastUsed: DateTime
-
-  """API rate limit (requests per minute)."""
-  rateLimit: Int!
-
-  """Total number of API queries made with this keypair."""
-  numQueries: Int!
-
-  """Name of the resource policy assigned to this keypair."""
-  resourcePolicy: String!
-
-  """The SSH public key associated with this keypair."""
-  sshPublicKey: String
-
-  """UUID of the user who owns this keypair."""
-  userId: UUID!
-
-  """Added in 26.4.3. The user who owns this keypair."""
-  user: UserV2
-}
-
-"""An edge in a connection."""
-type KeyPairGQLEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
-  cursor: String!
-
-  """The item at the end of the edge"""
-  node: KeyPairGQL!
 }
 
 input KeyPairInput
@@ -8527,6 +8469,64 @@ enum KeypairResourcePolicyV2OrderField
   IDLE_TIMEOUT @join__enumValue(graph: STRAWBERRY)
   MAX_CONCURRENT_SFTP_SESSIONS @join__enumValue(graph: STRAWBERRY)
   MAX_PENDING_SESSION_COUNT @join__enumValue(graph: STRAWBERRY)
+}
+
+"""
+Added in 26.4.2. Keypair entity representing an API access key. The access_key field serves as the unique identifier. Secret key and private SSH key are excluded for security reasons.
+"""
+type KeyPairV2 implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """The access key string."""
+  accessKey: String!
+
+  """Whether the keypair is currently active."""
+  isActive: Boolean
+
+  """Whether the keypair has admin privileges."""
+  isAdmin: Boolean
+
+  """Timestamp when the keypair was created."""
+  createdAt: DateTime
+
+  """Timestamp when the keypair was last modified."""
+  modifiedAt: DateTime
+
+  """Timestamp when the keypair was last used for an API call."""
+  lastUsed: DateTime
+
+  """API rate limit (requests per minute)."""
+  rateLimit: Int!
+
+  """Total number of API queries made with this keypair."""
+  numQueries: Int!
+
+  """Name of the resource policy assigned to this keypair."""
+  resourcePolicy: String!
+
+  """The SSH public key associated with this keypair."""
+  sshPublicKey: String
+
+  """UUID of the user who owns this keypair."""
+  userId: UUID!
+
+  """Added in 26.4.3. The user who owns this keypair."""
+  user: UserV2
+}
+
+"""An edge in a connection."""
+type KeyPairV2Edge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: KeyPairV2!
 }
 
 type KVPair
@@ -9351,10 +9351,10 @@ type ModelDeployment implements Node
   networkAccess: ModelDeploymentNetworkAccess!
   currentRevisionId: ID
   deployingRevisionId: ID
-  defaultDeploymentStrategy: DeploymentStrategyGQL!
+  defaultDeploymentStrategy: DeploymentStrategy!
   replicaState: ReplicaState!
   createdUserId: ID!
-  options: DeploymentOptionsInfoGQL!
+  options: DeploymentOptionsInfo!
 
   """
   Added in UNRELEASED. Replica scaling axis, orthogonal to ``metadata.status`` (lifecycle). ``SCALING`` while the replica reconciler is adjusting replica count; ``STABLE`` once holding at the desired count.
@@ -9755,7 +9755,7 @@ type ModelRevision implements Node
   modelDefinition: ModelDefinition
 
   """Additional volume folder mounts."""
-  extraMounts: [ExtraVFolderMountInfoGQL!]!
+  extraMounts: [ExtraVFolderMountInfo!]!
 
   """
   Added in UNRELEASED. ID of the deployment-level preset that produced this revision. ``None`` when the revision was created without a preset, when the originating preset row has since been deleted (SET NULL FK), or for legacy rows that predate this field.
@@ -10911,13 +10911,13 @@ type Mutation
   cancelImportArtifact(input: CancelArtifactInput!): CancelImportArtifactPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new container registry (admin only)."""
-  adminCreateContainerRegistryV2(input: CreateContainerRegistryInputGQL!): CreateContainerRegistryPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateContainerRegistryV2(input: CreateContainerRegistryInputV2!): CreateContainerRegistryPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a container registry (admin only)."""
-  adminUpdateContainerRegistryV2(input: UpdateContainerRegistryInputGQL!): UpdateContainerRegistryPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateContainerRegistryV2(input: UpdateContainerRegistryInput!): UpdateContainerRegistryPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a container registry (admin only)."""
-  adminDeleteContainerRegistryV2(id: String!): DeleteContainerRegistryPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteContainerRegistryV2(id: String!): DeleteContainerRegistryPayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.16.0. Create model deployment."""
   createModelDeployment(input: CreateDeploymentInput!): CreateDeploymentPayload @join__field(graph: STRAWBERRY)
@@ -11166,10 +11166,10 @@ type Mutation
   adminUpdateResourceGroup(input: UpdateResourceGroupInput!): UpdateResourceGroupPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new resource group (admin only)."""
-  adminCreateResourceGroupV2(input: CreateResourceGroupInput!): CreateResourceGroupPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateResourceGroupV2(input: CreateResourceGroupInput!): CreateResourceGroupPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a resource group (admin only)."""
-  adminDeleteResourceGroupV2(name: String!): DeleteResourceGroupPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteResourceGroupV2(name: String!): DeleteResourceGroupPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update allowed resource groups for a domain (admin only).
@@ -11209,42 +11209,42 @@ type Mutation
   """
   Added in 26.4.2. Create a new domain (admin only). Requires superadmin privileges.
   """
-  adminCreateDomainV2(input: CreateDomainInputGQL!): DomainPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateDomainV2(input: CreateDomainInput!): DomainPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update a domain (admin only). Requires superadmin privileges. Only provided fields will be updated.
   """
-  adminUpdateDomainV2(domainName: String!, input: UpdateDomainInputGQL!): DomainPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateDomainV2(domainName: String!, input: UpdateDomainInput!): DomainPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Soft-delete a domain (admin only). Requires superadmin privileges.
   """
-  adminDeleteDomainV2(domainName: String!): DeleteDomainPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteDomainV2(domainName: String!): DeleteDomainPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Permanently purge a domain and all associated data (admin only). Requires superadmin privileges.
   """
-  adminPurgeDomainV2(domainName: String!): PurgeDomainPayloadGQL @join__field(graph: STRAWBERRY)
+  adminPurgeDomainV2(domainName: String!): PurgeDomainPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Create a new project (admin only). Requires superadmin privileges.
   """
-  adminCreateProjectV2(input: CreateProjectInputGQL!): ProjectPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateProjectV2(input: CreateProjectInput!): ProjectPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update a project (admin only). Requires superadmin privileges. Only provided fields will be updated.
   """
-  adminUpdateProjectV2(projectId: UUID!, input: UpdateProjectInputGQL!): ProjectPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateProjectV2(projectId: UUID!, input: UpdateProjectInput!): ProjectPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Soft-delete a project (admin only). Requires superadmin privileges.
   """
-  adminDeleteProjectV2(projectId: UUID!): DeleteProjectPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteProjectV2(projectId: UUID!): DeleteProjectPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Permanently purge a project and all associated data (admin only). Requires superadmin privileges.
   """
-  adminPurgeProjectV2(projectId: UUID!): PurgeProjectPayloadGQL @join__field(graph: STRAWBERRY)
+  adminPurgeProjectV2(projectId: UUID!): PurgeProjectPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Unassign users from a project. RBAC validates project admin permission.
@@ -11429,46 +11429,46 @@ type Mutation
   adminCancelRoleInvitation(input: CancelRoleInvitationInput!): RoleInvitation @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new keypair resource policy (admin only)."""
-  adminCreateKeypairResourcePolicyV2(input: CreateKeypairResourcePolicyInputGQL!): CreateKeypairResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateKeypairResourcePolicyV2(input: CreateKeypairResourcePolicyInput!): CreateKeypairResourcePolicyPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update a keypair resource policy (admin only). Only provided fields will be updated.
   """
-  adminUpdateKeypairResourcePolicyV2(name: String!, input: UpdateKeypairResourcePolicyInputGQL!): UpdateKeypairResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateKeypairResourcePolicyV2(name: String!, input: UpdateKeypairResourcePolicyInput!): UpdateKeypairResourcePolicyPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a keypair resource policy (admin only)."""
-  adminDeleteKeypairResourcePolicyV2(name: String!): DeleteKeypairResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteKeypairResourcePolicyV2(name: String!): DeleteKeypairResourcePolicyPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new user resource policy (admin only)."""
-  adminCreateUserResourcePolicyV2(input: CreateUserResourcePolicyInputGQL!): CreateUserResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateUserResourcePolicyV2(input: CreateUserResourcePolicyInputV2!): CreateUserResourcePolicyPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update a user resource policy (admin only). Only provided fields will be updated.
   """
-  adminUpdateUserResourcePolicyV2(name: String!, input: UpdateUserResourcePolicyInputGQL!): UpdateUserResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateUserResourcePolicyV2(name: String!, input: UpdateUserResourcePolicyInput!): UpdateUserResourcePolicyPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a user resource policy (admin only)."""
-  adminDeleteUserResourcePolicyV2(name: String!): DeleteUserResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteUserResourcePolicyV2(name: String!): DeleteUserResourcePolicyPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new project resource policy (admin only)."""
-  adminCreateProjectResourcePolicyV2(input: CreateProjectResourcePolicyInputGQL!): CreateProjectResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateProjectResourcePolicyV2(input: CreateProjectResourcePolicyInputV2!): CreateProjectResourcePolicyPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update a project resource policy (admin only). Only provided fields will be updated.
   """
-  adminUpdateProjectResourcePolicyV2(name: String!, input: UpdateProjectResourcePolicyInputGQL!): UpdateProjectResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateProjectResourcePolicyV2(name: String!, input: UpdateProjectResourcePolicyInput!): UpdateProjectResourcePolicyPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a project resource policy (admin only)."""
-  adminDeleteProjectResourcePolicyV2(name: String!): DeleteProjectResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteProjectResourcePolicyV2(name: String!): DeleteProjectResourcePolicyPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new resource preset (admin only)."""
-  adminCreateResourcePresetV2(input: CreateResourcePresetV2Input!): CreateResourcePresetPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateResourcePresetV2(input: CreateResourcePresetV2Input!): CreateResourcePresetPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a resource preset (admin only)."""
-  adminUpdateResourcePresetV2(input: UpdateResourcePresetV2Input!): UpdateResourcePresetPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateResourcePresetV2(input: UpdateResourcePresetV2Input!): UpdateResourcePresetPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a resource preset (admin only)."""
-  adminDeleteResourcePresetV2(id: UUID!): DeleteResourcePresetPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteResourcePresetV2(id: UUID!): DeleteResourcePresetPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new login client type (super admin only)."""
   adminCreateLoginClientType(input: CreateLoginClientTypeInput!): CreateLoginClientTypePayload @join__field(graph: STRAWBERRY)
@@ -11480,43 +11480,43 @@ type Mutation
   adminDeleteLoginClientType(id: UUID!): DeleteLoginClientTypePayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new runtime variant (superadmin only)."""
-  adminCreateRuntimeVariant(input: CreateRuntimeVariantInput!): CreateRuntimeVariantPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateRuntimeVariant(input: CreateRuntimeVariantInput!): CreateRuntimeVariantPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a runtime variant (superadmin only)."""
-  adminUpdateRuntimeVariant(input: UpdateRuntimeVariantInput!): UpdateRuntimeVariantPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateRuntimeVariant(input: UpdateRuntimeVariantInput!): UpdateRuntimeVariantPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a runtime variant (superadmin only)."""
-  adminDeleteRuntimeVariant(id: UUID!): DeleteRuntimeVariantPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteRuntimeVariant(id: UUID!): DeleteRuntimeVariantPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete multiple runtime variants (superadmin only)."""
-  adminDeleteRuntimeVariants(input: DeleteRuntimeVariantsInput!): DeleteRuntimeVariantsPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteRuntimeVariants(input: DeleteRuntimeVariantsInput!): DeleteRuntimeVariantsPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a runtime variant preset (superadmin only)."""
-  adminCreateRuntimeVariantPreset(input: CreateRuntimeVariantPresetInput!): CreateRuntimeVariantPresetPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateRuntimeVariantPreset(input: CreateRuntimeVariantPresetInput!): CreateRuntimeVariantPresetPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a runtime variant preset (superadmin only)."""
-  adminUpdateRuntimeVariantPreset(input: UpdateRuntimeVariantPresetInput!): UpdateRuntimeVariantPresetPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateRuntimeVariantPreset(input: UpdateRuntimeVariantPresetInput!): UpdateRuntimeVariantPresetPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a runtime variant preset (superadmin only)."""
-  adminDeleteRuntimeVariantPreset(id: UUID!): DeleteRuntimeVariantPresetPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteRuntimeVariantPreset(id: UUID!): DeleteRuntimeVariantPresetPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a deployment revision preset (admin only)."""
-  adminCreateDeploymentRevisionPreset(input: CreateDeploymentRevisionPresetInput!): CreateDeploymentRevisionPresetPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateDeploymentRevisionPreset(input: CreateDeploymentRevisionPresetInput!): CreateDeploymentRevisionPresetPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a deployment revision preset (admin only)."""
-  adminUpdateDeploymentRevisionPreset(input: UpdateDeploymentRevisionPresetInput!): UpdateDeploymentRevisionPresetPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateDeploymentRevisionPreset(input: UpdateDeploymentRevisionPresetInput!): UpdateDeploymentRevisionPresetPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a deployment revision preset (admin only)."""
-  adminDeleteDeploymentRevisionPreset(id: UUID!): DeleteDeploymentRevisionPresetPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteDeploymentRevisionPreset(id: UUID!): DeleteDeploymentRevisionPresetPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a model card (admin only)."""
-  adminCreateModelCardV2(input: CreateModelCardV2Input!): CreateModelCardPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateModelCardV2(input: CreateModelCardV2Input!): CreateModelCardPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a model card (admin only)."""
-  adminUpdateModelCardV2(input: UpdateModelCardV2Input!): UpdateModelCardPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateModelCardV2(input: UpdateModelCardV2Input!): UpdateModelCardPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a model card (admin only)."""
-  adminDeleteModelCardV2(id: UUID!, options: DeleteModelCardV2Options = null): DeleteModelCardPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteModelCardV2(id: UUID!, options: DeleteModelCardV2Options = null): DeleteModelCardPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Bulk-delete model cards (admin only) with per-card partial-failure reporting.
@@ -12648,7 +12648,7 @@ type ProjectOrganizationInfo
 }
 
 """Added in 26.4.2. Payload for project mutation responses."""
-type ProjectPayloadGQL
+type ProjectPayload
   @join__type(graph: STRAWBERRY)
 {
   """The project entity."""
@@ -13137,7 +13137,7 @@ type PurgeDomain
 }
 
 """Added in 26.4.2. Payload for domain permanent deletion mutation."""
-type PurgeDomainPayloadGQL
+type PurgeDomainPayload
   @join__type(graph: STRAWBERRY)
 {
   """Whether the purge was successful."""
@@ -13204,7 +13204,7 @@ type PurgeImagesPayload
 }
 
 """Added in 26.4.2. Payload for project permanent deletion mutation."""
-type PurgeProjectPayloadGQL
+type PurgeProjectPayload
   @join__type(graph: STRAWBERRY)
 {
   """Whether the purge was successful."""
@@ -13881,7 +13881,7 @@ type Query
   """
   Added in 26.2.0. Query images with optional filtering, ordering, and pagination (admin only). Returns container images available in the system. Images are container specifications that define runtime environments for compute sessions. Use filters to narrow down results by status, name, or architecture. Supports both cursor-based and offset-based pagination.
   """
-  adminImagesV2(filter: ImageV2Filter = null, orderBy: [ImageV2OrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2Connection @join__field(graph: STRAWBERRY)
+  adminImagesV2(filter: ImageV2Filter = null, orderBy: [ImageV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Query kernels with pagination and filtering. (admin only)
@@ -13947,7 +13947,7 @@ type Query
   """
   Added in 26.2.0. Query image aliases with optional filtering, ordering, and pagination. Returns image aliases that provide alternative names for container images. Use filters to search by alias string. Supports both cursor-based and offset-based pagination.
   """
-  adminImageAliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection @join__field(graph: STRAWBERRY)
+  adminImageAliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Get a single prometheus query preset by ID. Available to any authenticated user since presets are a shared catalog of metric query templates.
@@ -14010,7 +14010,7 @@ type Query
   """
   Added in 26.4.2. Get a single keypair by access key (admin only). Requires superadmin privileges.
   """
-  adminKeypairV2(accessKey: String!): KeyPairGQL @join__field(graph: STRAWBERRY)
+  adminKeypairV2(accessKey: String!): KeyPairV2 @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. List all keypairs with filtering and pagination (admin only). Requires superadmin privileges.
@@ -14093,12 +14093,12 @@ type Query
   """
   Added in 26.2.0. Query images within a specific container registry with optional filtering, ordering, and pagination. Returns container images that belong to the specified registry. Use filters to narrow down results by status, name, or architecture. Supports both cursor-based and offset-based pagination.
   """
-  containerRegistryImagesV2(scope: ContainerRegistryScope!, filter: ImageV2Filter = null, orderBy: [ImageV2OrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2Connection @join__field(graph: STRAWBERRY)
+  containerRegistryImagesV2(scope: ContainerRegistryScope!, filter: ImageV2Filter = null, orderBy: [ImageV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Query image aliases within a specific image with optional filtering, ordering, and pagination. Returns image aliases that belong to the specified image. Supports both cursor-based and offset-based pagination.
   """
-  imageScopedAliases(scope: ImageV2Scope!, filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection @join__field(graph: STRAWBERRY)
+  imageScopedAliases(scope: ImageV2Scope!, filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection @join__field(graph: STRAWBERRY)
 
   """Added in 26.2.0. Get scheduling history for a specific session."""
   sessionScopedSchedulingHistories(scope: SessionScope!, filter: SessionSchedulingHistoryFilter = null, orderBy: [SessionSchedulingHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionSchedulingHistoryConnection @join__field(graph: STRAWBERRY)
@@ -14756,7 +14756,7 @@ type ReplaceResourceGroupDefaultDeploymentOptionsPayload
   resourceGroupName: String!
 
   """The newly persisted ``default_deployment_options`` surface."""
-  defaultDeploymentOptions: DeploymentOptionsInfoGQL!
+  defaultDeploymentOptions: DeploymentOptionsInfo!
 }
 
 """
@@ -15061,7 +15061,7 @@ type ResourceGroup implements Node
   """
   Added in UNRELEASED. Default deployment options (timeouts, etc.) snapshot-copied onto each new deployment created in this resource group.
   """
-  defaultDeploymentOptions: DeploymentOptionsInfoGQL!
+  defaultDeploymentOptions: DeploymentOptionsInfo!
 
   """
   Added in UNRELEASED. Default session options used as the fallback layer for the scheduling controller's options resolver at session enqueue time.
@@ -18180,7 +18180,7 @@ type UpdateAutoScalingRulePayload
 """
 Added in 26.4.2. Input for updating a container registry. All fields optional except id.
 """
-input UpdateContainerRegistryInputGQL
+input UpdateContainerRegistryInput
   @join__type(graph: STRAWBERRY)
 {
   """ID of the registry to update."""
@@ -18215,7 +18215,7 @@ input UpdateContainerRegistryInputGQL
 }
 
 """Added in 26.4.2. Payload for container registry update mutation."""
-type UpdateContainerRegistryPayloadGQL
+type UpdateContainerRegistryPayload
   @join__type(graph: STRAWBERRY)
 {
   """Updated container registry."""
@@ -18359,7 +18359,7 @@ input UpdateDeploymentRevisionPresetInput
 }
 
 """Added in 26.4.2. Update deployment revision preset payload."""
-type UpdateDeploymentRevisionPresetPayloadGQL
+type UpdateDeploymentRevisionPresetPayload
   @join__type(graph: STRAWBERRY)
 {
   """The updated preset."""
@@ -18369,7 +18369,7 @@ type UpdateDeploymentRevisionPresetPayloadGQL
 """
 Added in 26.4.2. Input for updating domain information. All fields optional.
 """
-input UpdateDomainInputGQL
+input UpdateDomainInput
   @join__type(graph: STRAWBERRY)
 {
   """New domain name."""
@@ -18409,7 +18409,7 @@ type UpdateHuggingFaceRegistryPayload
 """
 Added in 26.4.2. Input for updating a keypair resource policy. All fields optional.
 """
-input UpdateKeypairResourcePolicyInputGQL
+input UpdateKeypairResourcePolicyInput
   @join__type(graph: STRAWBERRY)
 {
   """Updated default for unspecified."""
@@ -18444,7 +18444,7 @@ input UpdateKeypairResourcePolicyInputGQL
 }
 
 """Added in 26.4.2. Payload for keypair resource policy update mutation."""
-type UpdateKeypairResourcePolicyPayloadGQL
+type UpdateKeypairResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
   """Updated keypair resource policy."""
@@ -18473,7 +18473,7 @@ type UpdateLoginClientTypePayload
 }
 
 """Added in 26.4.2. Update model card payload."""
-type UpdateModelCardPayloadGQL
+type UpdateModelCardPayload
   @join__type(graph: STRAWBERRY)
 {
   """The updated model card."""
@@ -18574,7 +18574,7 @@ type UpdateMyKeypairPayload
   @join__type(graph: STRAWBERRY)
 {
   """The updated keypair."""
-  keypair: KeyPairGQL!
+  keypair: KeyPairV2!
 }
 
 """Added in 24.09.0. Input for updating a notification channel"""
@@ -18650,7 +18650,7 @@ input UpdatePermissionInput
 """
 Added in 26.4.2. Input for updating project information. All fields optional.
 """
-input UpdateProjectInputGQL
+input UpdateProjectInput
   @join__type(graph: STRAWBERRY)
 {
   """New project name."""
@@ -18672,7 +18672,7 @@ input UpdateProjectInputGQL
 """
 Added in 26.4.2. Input for updating a project resource policy. All fields optional.
 """
-input UpdateProjectResourcePolicyInputGQL
+input UpdateProjectResourcePolicyInput
   @join__type(graph: STRAWBERRY)
 {
   """Updated max vfolder count."""
@@ -18686,7 +18686,7 @@ input UpdateProjectResourcePolicyInputGQL
 }
 
 """Added in 26.4.2. Payload for project resource policy update mutation."""
-type UpdateProjectResourcePolicyPayloadGQL
+type UpdateProjectResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
   """Updated project resource policy."""
@@ -18805,7 +18805,7 @@ type UpdateResourceGroupPayload
 }
 
 """Added in 26.4.2. Payload for resource preset update."""
-type UpdateResourcePresetPayloadGQL
+type UpdateResourcePresetPayload
   @join__type(graph: STRAWBERRY)
 {
   """Updated resource preset."""
@@ -18878,7 +18878,7 @@ input UpdateRuntimeVariantInput
 }
 
 """Added in 26.4.2. Payload for runtime variant update."""
-type UpdateRuntimeVariantPayloadGQL
+type UpdateRuntimeVariantPayload
   @join__type(graph: STRAWBERRY)
 {
   """The updated runtime variant."""
@@ -18915,7 +18915,7 @@ input UpdateRuntimeVariantPresetInput
 }
 
 """Added in 26.4.2. Update preset payload."""
-type UpdateRuntimeVariantPresetPayloadGQL
+type UpdateRuntimeVariantPresetPayload
   @join__type(graph: STRAWBERRY)
 {
   """The updated preset."""
@@ -18925,7 +18925,7 @@ type UpdateRuntimeVariantPresetPayloadGQL
 """
 Added in 26.4.2. Input for updating a user resource policy. All fields optional.
 """
-input UpdateUserResourcePolicyInputGQL
+input UpdateUserResourcePolicyInput
   @join__type(graph: STRAWBERRY)
 {
   """Updated max vfolder count."""
@@ -18947,7 +18947,7 @@ input UpdateUserResourcePolicyInputGQL
 }
 
 """Added in 26.4.2. Payload for user resource policy update mutation."""
-type UpdateUserResourcePolicyPayloadGQL
+type UpdateUserResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
   """Updated user resource policy."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -181,7 +181,7 @@ Added in 26.4.2. Payload returned after admin creates a keypair. The secret_key 
 """
 type AdminCreateKeypairPayload {
   """The newly created keypair."""
-  keypair: KeyPairGQL!
+  keypair: KeyPairV2!
 
   """The secret key. Only returned at creation time."""
   secretKey: String!
@@ -272,7 +272,7 @@ input AdminUpdateKeypairInput {
 """Added in 26.4.2. Payload returned after admin updates a keypair."""
 type AdminUpdateKeypairPayload {
   """The updated keypair."""
-  keypair: KeyPairGQL!
+  keypair: KeyPairV2!
 }
 
 """Added in 26.1.0. Filter options for querying agents"""
@@ -1956,7 +1956,7 @@ type CreateCategoryPayload {
 }
 
 """Added in 26.4.2. Input for creating a container registry."""
-input CreateContainerRegistryInputGQL {
+input CreateContainerRegistryInputV2 {
   """URL of the container registry."""
   url: String!
 
@@ -1988,7 +1988,7 @@ input CreateContainerRegistryInputGQL {
 """
 Added in 26.4.2. Payload for container registry create/update mutations.
 """
-type CreateContainerRegistryPayloadGQL {
+type CreateContainerRegistryPayload {
   """Created container registry."""
   registry: ContainerRegistryV2!
 }
@@ -2083,13 +2083,13 @@ input CreateDeploymentRevisionPresetInput {
 }
 
 """Added in 26.4.2. Create deployment revision preset payload."""
-type CreateDeploymentRevisionPresetPayloadGQL {
+type CreateDeploymentRevisionPresetPayload {
   """The created preset."""
   preset: DeploymentRevisionPreset!
 }
 
 """Added in 26.4.2. Input for creating a new domain."""
-input CreateDomainInputGQL {
+input CreateDomainInput {
   """Domain name. Must be unique across the system."""
   name: String!
 
@@ -2138,7 +2138,7 @@ type CreateHuggingFaceRegistryPayload {
 }
 
 """Added in 26.4.2. Input for creating a keypair resource policy."""
-input CreateKeypairResourcePolicyInputGQL {
+input CreateKeypairResourcePolicyInput {
   """Policy name. Must be unique."""
   name: String!
 
@@ -2176,7 +2176,7 @@ input CreateKeypairResourcePolicyInputGQL {
 """
 Added in 26.4.2. Payload for keypair resource policy create/update mutations.
 """
-type CreateKeypairResourcePolicyPayloadGQL {
+type CreateKeypairResourcePolicyPayload {
   """Created keypair resource policy."""
   keypairResourcePolicy: KeypairResourcePolicyV2!
 }
@@ -2197,7 +2197,7 @@ type CreateLoginClientTypePayload {
 }
 
 """Added in 26.4.2. Create model card payload."""
-type CreateModelCardPayloadGQL {
+type CreateModelCardPayload {
   """The created model card."""
   modelCard: ModelCardV2!
 }
@@ -2312,7 +2312,7 @@ input CreatePermissionInput {
 }
 
 """Added in 26.4.2. Input for creating a new project."""
-input CreateProjectInputGQL {
+input CreateProjectInput {
   """Project name. Must be unique within the domain."""
   name: String!
 
@@ -2330,7 +2330,7 @@ input CreateProjectInputGQL {
 }
 
 """Added in 26.4.2. Input for creating a project resource policy."""
-input CreateProjectResourcePolicyInputGQL {
+input CreateProjectResourcePolicyInputV2 {
   """Policy name. Must be unique."""
   name: String!
 
@@ -2347,7 +2347,7 @@ input CreateProjectResourcePolicyInputGQL {
 """
 Added in 26.4.2. Payload for project resource policy create/update mutations.
 """
-type CreateProjectResourcePolicyPayloadGQL {
+type CreateProjectResourcePolicyPayload {
   """Created project resource policy."""
   projectResourcePolicy: ProjectResourcePolicyV2!
 }
@@ -2413,13 +2413,13 @@ input CreateResourceGroupInput {
 }
 
 """Added in 26.4.2. Payload for resource group creation."""
-type CreateResourceGroupPayloadGQL {
+type CreateResourceGroupPayload {
   """Created resource group."""
   resourceGroup: ResourceGroup!
 }
 
 """Added in 26.4.2. Payload for resource preset creation."""
-type CreateResourcePresetPayloadGQL {
+type CreateResourcePresetPayload {
   """Created resource preset."""
   resourcePreset: ResourcePresetV2!
 }
@@ -2494,7 +2494,7 @@ input CreateRuntimeVariantInput {
 }
 
 """Added in 26.4.2. Payload for runtime variant creation."""
-type CreateRuntimeVariantPayloadGQL {
+type CreateRuntimeVariantPayload {
   """The created runtime variant."""
   runtimeVariant: RuntimeVariant!
 }
@@ -2530,7 +2530,7 @@ input CreateRuntimeVariantPresetInput {
 }
 
 """Added in 26.4.2. Create preset payload."""
-type CreateRuntimeVariantPresetPayloadGQL {
+type CreateRuntimeVariantPresetPayload {
   """The created preset."""
   preset: RuntimeVariantPreset!
 }
@@ -2560,7 +2560,7 @@ type CreateUploadSessionV2Payload {
 }
 
 """Added in 26.4.2. Input for creating a user resource policy."""
-input CreateUserResourcePolicyInputGQL {
+input CreateUserResourcePolicyInputV2 {
   """Policy name. Must be unique."""
   name: String!
 
@@ -2585,7 +2585,7 @@ input CreateUserResourcePolicyInputGQL {
 """
 Added in 26.4.2. Payload for user resource policy create/update mutations.
 """
-type CreateUserResourcePolicyPayloadGQL {
+type CreateUserResourcePolicyPayload {
   """Created user resource policy."""
   userResourcePolicy: UserResourcePolicyV2!
 }
@@ -2920,7 +2920,7 @@ input DelegateImportArtifactsInput {
   """
   Added in 26.1.0. Options controlling import behavior such as forcing re-download.
   """
-  options: ImportArtifactsOptionsGQL = null
+  options: ImportArtifactsOptions = null
 }
 
 """
@@ -3020,7 +3020,7 @@ type DeleteCategoryPayload {
 }
 
 """Added in 26.4.2. Payload for container registry deletion."""
-type DeleteContainerRegistryPayloadGQL {
+type DeleteContainerRegistryPayload {
   """ID of the deleted container registry."""
   id: String!
 }
@@ -3037,7 +3037,7 @@ type DeleteDeploymentPayload {
 }
 
 """Added in 26.4.2. Delete deployment revision preset payload."""
-type DeleteDeploymentRevisionPresetPayloadGQL {
+type DeleteDeploymentRevisionPresetPayload {
   """ID of the deleted preset."""
   id: UUID!
 }
@@ -3056,7 +3056,7 @@ type DeleteDomainConfigPayload {
 }
 
 """Added in 26.4.2. Payload for domain deletion mutation."""
-type DeleteDomainPayloadGQL {
+type DeleteDomainPayload {
   """Whether the deletion was successful."""
   deleted: Boolean!
 }
@@ -3090,7 +3090,7 @@ type DeleteHuggingFaceRegistryPayload {
 }
 
 """Added in 26.4.2. Payload for keypair resource policy deletion."""
-type DeleteKeypairResourcePolicyPayloadGQL {
+type DeleteKeypairResourcePolicyPayload {
   """Name of the deleted keypair resource policy."""
   name: String!
 }
@@ -3102,7 +3102,7 @@ type DeleteLoginClientTypePayload {
 }
 
 """Added in 26.4.2. Delete model card payload."""
-type DeleteModelCardPayloadGQL {
+type DeleteModelCardPayload {
   """ID of the deleted model card."""
   id: UUID!
 }
@@ -3160,13 +3160,13 @@ type DeletePermissionPayload {
 }
 
 """Added in 26.4.2. Payload for project deletion mutation."""
-type DeleteProjectPayloadGQL {
+type DeleteProjectPayload {
   """Whether the deletion was successful."""
   deleted: Boolean!
 }
 
 """Added in 26.4.2. Payload for project resource policy deletion."""
-type DeleteProjectResourcePolicyPayloadGQL {
+type DeleteProjectResourcePolicyPayload {
   """Name of the deleted project resource policy."""
   name: String!
 }
@@ -3189,13 +3189,13 @@ type DeleteReservoirRegistryPayload {
 }
 
 """Added in 26.4.2. Payload for resource group deletion."""
-type DeleteResourceGroupPayloadGQL {
+type DeleteResourceGroupPayload {
   """Name of the deleted resource group."""
   id: String!
 }
 
 """Added in 26.4.2. Payload for resource preset deletion."""
-type DeleteResourcePresetPayloadGQL {
+type DeleteResourcePresetPayload {
   """UUID of the deleted resource preset."""
   id: String!
 }
@@ -3212,13 +3212,13 @@ type DeleteRolePayload {
 }
 
 """Added in 26.4.2. Payload for runtime variant deletion."""
-type DeleteRuntimeVariantPayloadGQL {
+type DeleteRuntimeVariantPayload {
   """ID of the deleted runtime variant."""
   id: UUID!
 }
 
 """Added in 26.4.2. Delete preset payload."""
-type DeleteRuntimeVariantPresetPayloadGQL {
+type DeleteRuntimeVariantPresetPayload {
   """ID of the deleted preset."""
   id: UUID!
 }
@@ -3230,7 +3230,7 @@ input DeleteRuntimeVariantsInput {
 }
 
 """Added in 26.4.2. Payload for bulk runtime variant deletion."""
-type DeleteRuntimeVariantsPayloadGQL {
+type DeleteRuntimeVariantsPayload {
   """Number of runtime variants successfully deleted."""
   deletedCount: Int!
 }
@@ -3252,7 +3252,7 @@ type DeleteUserConfigPayload {
 }
 
 """Added in 26.4.2. Payload for user resource policy deletion."""
-type DeleteUserResourcePolicyPayloadGQL {
+type DeleteUserResourcePolicyPayload {
   """Name of the deleted user resource policy."""
   name: String!
 }
@@ -3411,12 +3411,12 @@ input DeploymentFilter {
 }
 
 """Added in UNRELEASED. Deployment handler-options policy response."""
-type DeploymentHandlerOptionsInfoGQL {
+type DeploymentHandlerOptionsInfo {
   """Fallback per-handler policy."""
-  default: HandlerOptionsInfoGQL!
+  default: HandlerOptionsInfo!
 
   """Per-handler overrides."""
-  byHandler: [HandlerOptionsEntryInfoGQL!]!
+  byHandler: [HandlerOptionsEntryInfo!]!
 }
 
 """Added in UNRELEASED. Deployment handler-options policy input."""
@@ -3499,9 +3499,9 @@ enum DeploymentHistoryOrderField {
 }
 
 """Added in UNRELEASED. Deployment options payload response."""
-type DeploymentOptionsInfoGQL {
+type DeploymentOptionsInfo {
   """Handler-keyed scheduler policy (timeout + retry)."""
-  handlerOptions: DeploymentHandlerOptionsInfoGQL!
+  handlerOptions: DeploymentHandlerOptionsInfo!
 }
 
 """Added in UNRELEASED. Deployment options payload input."""
@@ -3716,7 +3716,7 @@ input DeploymentStatusFilter {
 """
 Added in 25.19.0. Represents the deployment strategy configuration that determines how updates are rolled out to replicas (e.g., rolling update, blue-green).
 """
-type DeploymentStrategyGQL {
+type DeploymentStrategy {
   type: DeploymentStrategyType!
 }
 
@@ -3910,7 +3910,7 @@ extend type DomainNode @key(fields: "id") {
 }
 
 """Added in 26.4.2. Payload for domain mutation responses."""
-type DomainPayloadGQL {
+type DomainPayload {
   """The domain entity."""
   domain: DomainV2!
 }
@@ -4480,7 +4480,7 @@ input ExecuteQueryDefinitionOptionsInput {
 """
 Added in 25.19.0. An extra virtual folder mount attached to a model revision.
 """
-type ExtraVFolderMountInfoGQL {
+type ExtraVFolderMountInfo {
   """The vfolder of this entity."""
   vfolder: VirtualFolderNode
   vfolderId: ID!
@@ -4620,7 +4620,7 @@ extend type GroupNode @key(fields: "id") {
 """
 Added in UNRELEASED. A single (handler_name, options) entry response for deployment handler options.
 """
-type HandlerOptionsEntryInfoGQL {
+type HandlerOptionsEntryInfo {
   """Phase timeout in seconds; `null` means unbounded for this entry."""
   timeoutSec: Int
 
@@ -4645,7 +4645,7 @@ input HandlerOptionsEntryInput {
 """
 Added in UNRELEASED. Per-handler scheduler policy snapshot for deployment handler options.
 """
-type HandlerOptionsInfoGQL {
+type HandlerOptionsInfo {
   """Phase timeout in seconds; `null` means unbounded for this entry."""
   timeoutSec: Int
 
@@ -4742,7 +4742,7 @@ type ImageV2 implements Node {
   lastUsed: DateTime
 
   """Added in 26.2.0. Aliases for this image."""
-  aliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null): ImageV2AliasConnection
+  aliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null): ImageV2AliasConnection
 }
 
 """
@@ -4795,7 +4795,7 @@ input ImageV2AliasFilter {
 """
 Added in 26.2.0. Specifies the field and direction for ordering image aliases in queries.
 """
-input ImageV2AliasOrderByGQL {
+input ImageV2AliasOrderBy {
   field: ImageV2AliasOrderField!
   direction: OrderDirection! = ASC
 }
@@ -4903,7 +4903,7 @@ type ImageV2MetadataInfo {
 """
 Added in 26.2.0. Specifies the field and direction for ordering images in queries.
 """
-input ImageV2OrderByGQL {
+input ImageV2OrderBy {
   field: ImageV2OrderField!
   direction: OrderDirection! = ASC
 }
@@ -5003,7 +5003,7 @@ input ImportArtifactsInput {
   """
   Added in 26.1.0. Options controlling import behavior such as forcing re-download.
   """
-  options: ImportArtifactsOptionsGQL = null
+  options: ImportArtifactsOptions = null
 }
 
 """
@@ -5011,7 +5011,7 @@ Added in 24.09.0. Options for importing artifact revisions.
 
 Controls import behavior such as forcing re-download regardless of digest freshness.
 """
-input ImportArtifactsOptionsGQL {
+input ImportArtifactsOptions {
   """Force re-download regardless of digest freshness check."""
   force: Boolean! = false
 }
@@ -5062,7 +5062,7 @@ Added in 26.2.0. Payload returned after issuing a new keypair. The secret_key is
 """
 type IssueMyKeypairPayload {
   """The newly created keypair."""
-  keypair: KeyPairGQL!
+  keypair: KeyPairV2!
 
   """
   The newly generated secret key. This value is only returned at creation time.
@@ -5370,7 +5370,7 @@ type KeyPairConnection {
   pageInfo: PageInfo!
 
   """Contains the nodes in this connection"""
-  edges: [KeyPairGQLEdge!]!
+  edges: [KeyPairV2Edge!]!
 
   """Total number of keypair records matching the query criteria."""
   count: Int!
@@ -5379,7 +5379,7 @@ type KeyPairConnection {
 """
 Added in 26.4.2. Keypair entity representing an API access key. The access_key field serves as the unique identifier. Secret key and private SSH key are excluded for security reasons.
 """
-type KeyPairGQL implements Node {
+type KeyPairV2 implements Node {
   """The Globally Unique ID of this object"""
   id: ID!
 
@@ -5421,12 +5421,12 @@ type KeyPairGQL implements Node {
 }
 
 """An edge in a connection."""
-type KeyPairGQLEdge {
+type KeyPairV2Edge {
   """A cursor for use in pagination"""
   cursor: String!
 
   """The item at the end of the edge"""
-  node: KeyPairGQL!
+  node: KeyPairV2!
 }
 
 """
@@ -6146,10 +6146,10 @@ type ModelDeployment implements Node {
   networkAccess: ModelDeploymentNetworkAccess!
   currentRevisionId: ID
   deployingRevisionId: ID
-  defaultDeploymentStrategy: DeploymentStrategyGQL!
+  defaultDeploymentStrategy: DeploymentStrategy!
   replicaState: ReplicaState!
   createdUserId: ID!
-  options: DeploymentOptionsInfoGQL!
+  options: DeploymentOptionsInfo!
 
   """
   Added in UNRELEASED. Replica scaling axis, orthogonal to ``metadata.status`` (lifecycle). ``SCALING`` while the replica reconciler is adjusting replica count; ``STABLE`` once holding at the desired count.
@@ -6516,7 +6516,7 @@ type ModelRevision implements Node {
   modelDefinition: ModelDefinition
 
   """Additional volume folder mounts."""
-  extraMounts: [ExtraVFolderMountInfoGQL!]!
+  extraMounts: [ExtraVFolderMountInfo!]!
 
   """
   Added in UNRELEASED. ID of the deployment-level preset that produced this revision. ``None`` when the revision was created without a preset, when the originating preset row has since been deleted (SET NULL FK), or for legacy rows that predate this field.
@@ -6818,13 +6818,13 @@ type Mutation {
   cancelImportArtifact(input: CancelArtifactInput!): CancelImportArtifactPayload
 
   """Added in 26.4.2. Create a new container registry (admin only)."""
-  adminCreateContainerRegistryV2(input: CreateContainerRegistryInputGQL!): CreateContainerRegistryPayloadGQL
+  adminCreateContainerRegistryV2(input: CreateContainerRegistryInputV2!): CreateContainerRegistryPayload
 
   """Added in 26.4.2. Update a container registry (admin only)."""
-  adminUpdateContainerRegistryV2(input: UpdateContainerRegistryInputGQL!): UpdateContainerRegistryPayloadGQL
+  adminUpdateContainerRegistryV2(input: UpdateContainerRegistryInput!): UpdateContainerRegistryPayload
 
   """Added in 26.4.2. Delete a container registry (admin only)."""
-  adminDeleteContainerRegistryV2(id: String!): DeleteContainerRegistryPayloadGQL
+  adminDeleteContainerRegistryV2(id: String!): DeleteContainerRegistryPayload
 
   """Added in 25.16.0. Create model deployment."""
   createModelDeployment(input: CreateDeploymentInput!): CreateDeploymentPayload
@@ -7073,10 +7073,10 @@ type Mutation {
   adminUpdateResourceGroup(input: UpdateResourceGroupInput!): UpdateResourceGroupPayload
 
   """Added in 26.4.2. Create a new resource group (admin only)."""
-  adminCreateResourceGroupV2(input: CreateResourceGroupInput!): CreateResourceGroupPayloadGQL
+  adminCreateResourceGroupV2(input: CreateResourceGroupInput!): CreateResourceGroupPayload
 
   """Added in 26.4.2. Delete a resource group (admin only)."""
-  adminDeleteResourceGroupV2(name: String!): DeleteResourceGroupPayloadGQL
+  adminDeleteResourceGroupV2(name: String!): DeleteResourceGroupPayload
 
   """
   Added in 26.4.2. Update allowed resource groups for a domain (admin only).
@@ -7116,42 +7116,42 @@ type Mutation {
   """
   Added in 26.4.2. Create a new domain (admin only). Requires superadmin privileges.
   """
-  adminCreateDomainV2(input: CreateDomainInputGQL!): DomainPayloadGQL
+  adminCreateDomainV2(input: CreateDomainInput!): DomainPayload
 
   """
   Added in 26.4.2. Update a domain (admin only). Requires superadmin privileges. Only provided fields will be updated.
   """
-  adminUpdateDomainV2(domainName: String!, input: UpdateDomainInputGQL!): DomainPayloadGQL
+  adminUpdateDomainV2(domainName: String!, input: UpdateDomainInput!): DomainPayload
 
   """
   Added in 26.4.2. Soft-delete a domain (admin only). Requires superadmin privileges.
   """
-  adminDeleteDomainV2(domainName: String!): DeleteDomainPayloadGQL
+  adminDeleteDomainV2(domainName: String!): DeleteDomainPayload
 
   """
   Added in 26.4.2. Permanently purge a domain and all associated data (admin only). Requires superadmin privileges.
   """
-  adminPurgeDomainV2(domainName: String!): PurgeDomainPayloadGQL
+  adminPurgeDomainV2(domainName: String!): PurgeDomainPayload
 
   """
   Added in 26.4.2. Create a new project (admin only). Requires superadmin privileges.
   """
-  adminCreateProjectV2(input: CreateProjectInputGQL!): ProjectPayloadGQL
+  adminCreateProjectV2(input: CreateProjectInput!): ProjectPayload
 
   """
   Added in 26.4.2. Update a project (admin only). Requires superadmin privileges. Only provided fields will be updated.
   """
-  adminUpdateProjectV2(projectId: UUID!, input: UpdateProjectInputGQL!): ProjectPayloadGQL
+  adminUpdateProjectV2(projectId: UUID!, input: UpdateProjectInput!): ProjectPayload
 
   """
   Added in 26.4.2. Soft-delete a project (admin only). Requires superadmin privileges.
   """
-  adminDeleteProjectV2(projectId: UUID!): DeleteProjectPayloadGQL
+  adminDeleteProjectV2(projectId: UUID!): DeleteProjectPayload
 
   """
   Added in 26.4.2. Permanently purge a project and all associated data (admin only). Requires superadmin privileges.
   """
-  adminPurgeProjectV2(projectId: UUID!): PurgeProjectPayloadGQL
+  adminPurgeProjectV2(projectId: UUID!): PurgeProjectPayload
 
   """
   Added in 26.4.2. Unassign users from a project. RBAC validates project admin permission.
@@ -7336,46 +7336,46 @@ type Mutation {
   adminCancelRoleInvitation(input: CancelRoleInvitationInput!): RoleInvitation
 
   """Added in 26.4.2. Create a new keypair resource policy (admin only)."""
-  adminCreateKeypairResourcePolicyV2(input: CreateKeypairResourcePolicyInputGQL!): CreateKeypairResourcePolicyPayloadGQL
+  adminCreateKeypairResourcePolicyV2(input: CreateKeypairResourcePolicyInput!): CreateKeypairResourcePolicyPayload
 
   """
   Added in 26.4.2. Update a keypair resource policy (admin only). Only provided fields will be updated.
   """
-  adminUpdateKeypairResourcePolicyV2(name: String!, input: UpdateKeypairResourcePolicyInputGQL!): UpdateKeypairResourcePolicyPayloadGQL
+  adminUpdateKeypairResourcePolicyV2(name: String!, input: UpdateKeypairResourcePolicyInput!): UpdateKeypairResourcePolicyPayload
 
   """Added in 26.4.2. Delete a keypair resource policy (admin only)."""
-  adminDeleteKeypairResourcePolicyV2(name: String!): DeleteKeypairResourcePolicyPayloadGQL
+  adminDeleteKeypairResourcePolicyV2(name: String!): DeleteKeypairResourcePolicyPayload
 
   """Added in 26.4.2. Create a new user resource policy (admin only)."""
-  adminCreateUserResourcePolicyV2(input: CreateUserResourcePolicyInputGQL!): CreateUserResourcePolicyPayloadGQL
+  adminCreateUserResourcePolicyV2(input: CreateUserResourcePolicyInputV2!): CreateUserResourcePolicyPayload
 
   """
   Added in 26.4.2. Update a user resource policy (admin only). Only provided fields will be updated.
   """
-  adminUpdateUserResourcePolicyV2(name: String!, input: UpdateUserResourcePolicyInputGQL!): UpdateUserResourcePolicyPayloadGQL
+  adminUpdateUserResourcePolicyV2(name: String!, input: UpdateUserResourcePolicyInput!): UpdateUserResourcePolicyPayload
 
   """Added in 26.4.2. Delete a user resource policy (admin only)."""
-  adminDeleteUserResourcePolicyV2(name: String!): DeleteUserResourcePolicyPayloadGQL
+  adminDeleteUserResourcePolicyV2(name: String!): DeleteUserResourcePolicyPayload
 
   """Added in 26.4.2. Create a new project resource policy (admin only)."""
-  adminCreateProjectResourcePolicyV2(input: CreateProjectResourcePolicyInputGQL!): CreateProjectResourcePolicyPayloadGQL
+  adminCreateProjectResourcePolicyV2(input: CreateProjectResourcePolicyInputV2!): CreateProjectResourcePolicyPayload
 
   """
   Added in 26.4.2. Update a project resource policy (admin only). Only provided fields will be updated.
   """
-  adminUpdateProjectResourcePolicyV2(name: String!, input: UpdateProjectResourcePolicyInputGQL!): UpdateProjectResourcePolicyPayloadGQL
+  adminUpdateProjectResourcePolicyV2(name: String!, input: UpdateProjectResourcePolicyInput!): UpdateProjectResourcePolicyPayload
 
   """Added in 26.4.2. Delete a project resource policy (admin only)."""
-  adminDeleteProjectResourcePolicyV2(name: String!): DeleteProjectResourcePolicyPayloadGQL
+  adminDeleteProjectResourcePolicyV2(name: String!): DeleteProjectResourcePolicyPayload
 
   """Added in 26.4.2. Create a new resource preset (admin only)."""
-  adminCreateResourcePresetV2(input: CreateResourcePresetV2Input!): CreateResourcePresetPayloadGQL
+  adminCreateResourcePresetV2(input: CreateResourcePresetV2Input!): CreateResourcePresetPayload
 
   """Added in 26.4.2. Update a resource preset (admin only)."""
-  adminUpdateResourcePresetV2(input: UpdateResourcePresetV2Input!): UpdateResourcePresetPayloadGQL
+  adminUpdateResourcePresetV2(input: UpdateResourcePresetV2Input!): UpdateResourcePresetPayload
 
   """Added in 26.4.2. Delete a resource preset (admin only)."""
-  adminDeleteResourcePresetV2(id: UUID!): DeleteResourcePresetPayloadGQL
+  adminDeleteResourcePresetV2(id: UUID!): DeleteResourcePresetPayload
 
   """Added in 26.4.2. Create a new login client type (super admin only)."""
   adminCreateLoginClientType(input: CreateLoginClientTypeInput!): CreateLoginClientTypePayload
@@ -7387,43 +7387,43 @@ type Mutation {
   adminDeleteLoginClientType(id: UUID!): DeleteLoginClientTypePayload
 
   """Added in 26.4.2. Create a new runtime variant (superadmin only)."""
-  adminCreateRuntimeVariant(input: CreateRuntimeVariantInput!): CreateRuntimeVariantPayloadGQL
+  adminCreateRuntimeVariant(input: CreateRuntimeVariantInput!): CreateRuntimeVariantPayload
 
   """Added in 26.4.2. Update a runtime variant (superadmin only)."""
-  adminUpdateRuntimeVariant(input: UpdateRuntimeVariantInput!): UpdateRuntimeVariantPayloadGQL
+  adminUpdateRuntimeVariant(input: UpdateRuntimeVariantInput!): UpdateRuntimeVariantPayload
 
   """Added in 26.4.2. Delete a runtime variant (superadmin only)."""
-  adminDeleteRuntimeVariant(id: UUID!): DeleteRuntimeVariantPayloadGQL
+  adminDeleteRuntimeVariant(id: UUID!): DeleteRuntimeVariantPayload
 
   """Added in 26.4.2. Delete multiple runtime variants (superadmin only)."""
-  adminDeleteRuntimeVariants(input: DeleteRuntimeVariantsInput!): DeleteRuntimeVariantsPayloadGQL
+  adminDeleteRuntimeVariants(input: DeleteRuntimeVariantsInput!): DeleteRuntimeVariantsPayload
 
   """Added in 26.4.2. Create a runtime variant preset (superadmin only)."""
-  adminCreateRuntimeVariantPreset(input: CreateRuntimeVariantPresetInput!): CreateRuntimeVariantPresetPayloadGQL
+  adminCreateRuntimeVariantPreset(input: CreateRuntimeVariantPresetInput!): CreateRuntimeVariantPresetPayload
 
   """Added in 26.4.2. Update a runtime variant preset (superadmin only)."""
-  adminUpdateRuntimeVariantPreset(input: UpdateRuntimeVariantPresetInput!): UpdateRuntimeVariantPresetPayloadGQL
+  adminUpdateRuntimeVariantPreset(input: UpdateRuntimeVariantPresetInput!): UpdateRuntimeVariantPresetPayload
 
   """Added in 26.4.2. Delete a runtime variant preset (superadmin only)."""
-  adminDeleteRuntimeVariantPreset(id: UUID!): DeleteRuntimeVariantPresetPayloadGQL
+  adminDeleteRuntimeVariantPreset(id: UUID!): DeleteRuntimeVariantPresetPayload
 
   """Added in 26.4.2. Create a deployment revision preset (admin only)."""
-  adminCreateDeploymentRevisionPreset(input: CreateDeploymentRevisionPresetInput!): CreateDeploymentRevisionPresetPayloadGQL
+  adminCreateDeploymentRevisionPreset(input: CreateDeploymentRevisionPresetInput!): CreateDeploymentRevisionPresetPayload
 
   """Added in 26.4.2. Update a deployment revision preset (admin only)."""
-  adminUpdateDeploymentRevisionPreset(input: UpdateDeploymentRevisionPresetInput!): UpdateDeploymentRevisionPresetPayloadGQL
+  adminUpdateDeploymentRevisionPreset(input: UpdateDeploymentRevisionPresetInput!): UpdateDeploymentRevisionPresetPayload
 
   """Added in 26.4.2. Delete a deployment revision preset (admin only)."""
-  adminDeleteDeploymentRevisionPreset(id: UUID!): DeleteDeploymentRevisionPresetPayloadGQL
+  adminDeleteDeploymentRevisionPreset(id: UUID!): DeleteDeploymentRevisionPresetPayload
 
   """Added in 26.4.2. Create a model card (admin only)."""
-  adminCreateModelCardV2(input: CreateModelCardV2Input!): CreateModelCardPayloadGQL
+  adminCreateModelCardV2(input: CreateModelCardV2Input!): CreateModelCardPayload
 
   """Added in 26.4.2. Update a model card (admin only)."""
-  adminUpdateModelCardV2(input: UpdateModelCardV2Input!): UpdateModelCardPayloadGQL
+  adminUpdateModelCardV2(input: UpdateModelCardV2Input!): UpdateModelCardPayload
 
   """Added in 26.4.2. Delete a model card (admin only)."""
-  adminDeleteModelCardV2(id: UUID!, options: DeleteModelCardV2Options = null): DeleteModelCardPayloadGQL
+  adminDeleteModelCardV2(id: UUID!, options: DeleteModelCardV2Options = null): DeleteModelCardPayload
 
   """
   Added in UNRELEASED. Bulk-delete model cards (admin only) with per-card partial-failure reporting.
@@ -8337,7 +8337,7 @@ type ProjectOrganizationInfo {
 }
 
 """Added in 26.4.2. Payload for project mutation responses."""
-type ProjectPayloadGQL {
+type ProjectPayload {
   """The project entity."""
   project: ProjectV2!
 }
@@ -8732,13 +8732,13 @@ input ProjectWeightInputItem {
 }
 
 """Added in 26.4.2. Payload for domain permanent deletion mutation."""
-type PurgeDomainPayloadGQL {
+type PurgeDomainPayload {
   """Whether the purge was successful."""
   purged: Boolean!
 }
 
 """Added in 26.4.2. Payload for project permanent deletion mutation."""
-type PurgeProjectPayloadGQL {
+type PurgeProjectPayload {
   """Whether the purge was successful."""
   purged: Boolean!
 }
@@ -8997,7 +8997,7 @@ type Query {
   """
   Added in 26.2.0. Query images with optional filtering, ordering, and pagination (admin only). Returns container images available in the system. Images are container specifications that define runtime environments for compute sessions. Use filters to narrow down results by status, name, or architecture. Supports both cursor-based and offset-based pagination.
   """
-  adminImagesV2(filter: ImageV2Filter = null, orderBy: [ImageV2OrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2Connection
+  adminImagesV2(filter: ImageV2Filter = null, orderBy: [ImageV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2Connection
 
   """
   Added in 26.2.0. Query kernels with pagination and filtering. (admin only)
@@ -9063,7 +9063,7 @@ type Query {
   """
   Added in 26.2.0. Query image aliases with optional filtering, ordering, and pagination. Returns image aliases that provide alternative names for container images. Use filters to search by alias string. Supports both cursor-based and offset-based pagination.
   """
-  adminImageAliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection
+  adminImageAliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection
 
   """
   Added in 26.4.2. Get a single prometheus query preset by ID. Available to any authenticated user since presets are a shared catalog of metric query templates.
@@ -9126,7 +9126,7 @@ type Query {
   """
   Added in 26.4.2. Get a single keypair by access key (admin only). Requires superadmin privileges.
   """
-  adminKeypairV2(accessKey: String!): KeyPairGQL
+  adminKeypairV2(accessKey: String!): KeyPairV2
 
   """
   Added in 26.4.2. List all keypairs with filtering and pagination (admin only). Requires superadmin privileges.
@@ -9209,12 +9209,12 @@ type Query {
   """
   Added in 26.2.0. Query images within a specific container registry with optional filtering, ordering, and pagination. Returns container images that belong to the specified registry. Use filters to narrow down results by status, name, or architecture. Supports both cursor-based and offset-based pagination.
   """
-  containerRegistryImagesV2(scope: ContainerRegistryScope!, filter: ImageV2Filter = null, orderBy: [ImageV2OrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2Connection
+  containerRegistryImagesV2(scope: ContainerRegistryScope!, filter: ImageV2Filter = null, orderBy: [ImageV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2Connection
 
   """
   Added in 26.2.0. Query image aliases within a specific image with optional filtering, ordering, and pagination. Returns image aliases that belong to the specified image. Supports both cursor-based and offset-based pagination.
   """
-  imageScopedAliases(scope: ImageV2Scope!, filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection
+  imageScopedAliases(scope: ImageV2Scope!, filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection
 
   """Added in 26.2.0. Get scheduling history for a specific session."""
   sessionScopedSchedulingHistories(scope: SessionScope!, filter: SessionSchedulingHistoryFilter = null, orderBy: [SessionSchedulingHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionSchedulingHistoryConnection
@@ -9879,7 +9879,7 @@ type ReplaceResourceGroupDefaultDeploymentOptionsPayload {
   resourceGroupName: String!
 
   """The newly persisted ``default_deployment_options`` surface."""
-  defaultDeploymentOptions: DeploymentOptionsInfoGQL!
+  defaultDeploymentOptions: DeploymentOptionsInfo!
 }
 
 """
@@ -10125,7 +10125,7 @@ type ResourceGroup implements Node {
   """
   Added in UNRELEASED. Default deployment options (timeouts, etc.) snapshot-copied onto each new deployment created in this resource group.
   """
-  defaultDeploymentOptions: DeploymentOptionsInfoGQL!
+  defaultDeploymentOptions: DeploymentOptionsInfo!
 
   """
   Added in UNRELEASED. Default session options used as the fallback layer for the scheduling controller's options resolver at session enqueue time.
@@ -12460,7 +12460,7 @@ type UpdateAutoScalingRulePayload {
 """
 Added in 26.4.2. Input for updating a container registry. All fields optional except id.
 """
-input UpdateContainerRegistryInputGQL {
+input UpdateContainerRegistryInput {
   """ID of the registry to update."""
   id: String!
 
@@ -12493,7 +12493,7 @@ input UpdateContainerRegistryInputGQL {
 }
 
 """Added in 26.4.2. Payload for container registry update mutation."""
-type UpdateContainerRegistryPayloadGQL {
+type UpdateContainerRegistryPayload {
   """Updated container registry."""
   registry: ContainerRegistryV2!
 }
@@ -12617,7 +12617,7 @@ input UpdateDeploymentRevisionPresetInput {
 }
 
 """Added in 26.4.2. Update deployment revision preset payload."""
-type UpdateDeploymentRevisionPresetPayloadGQL {
+type UpdateDeploymentRevisionPresetPayload {
   """The updated preset."""
   preset: DeploymentRevisionPreset!
 }
@@ -12625,7 +12625,7 @@ type UpdateDeploymentRevisionPresetPayloadGQL {
 """
 Added in 26.4.2. Input for updating domain information. All fields optional.
 """
-input UpdateDomainInputGQL {
+input UpdateDomainInput {
   """New domain name."""
   name: String = null
 
@@ -12659,7 +12659,7 @@ type UpdateHuggingFaceRegistryPayload {
 """
 Added in 26.4.2. Input for updating a keypair resource policy. All fields optional.
 """
-input UpdateKeypairResourcePolicyInputGQL {
+input UpdateKeypairResourcePolicyInput {
   """Updated default for unspecified."""
   defaultForUnspecified: String = null
 
@@ -12692,7 +12692,7 @@ input UpdateKeypairResourcePolicyInputGQL {
 }
 
 """Added in 26.4.2. Payload for keypair resource policy update mutation."""
-type UpdateKeypairResourcePolicyPayloadGQL {
+type UpdateKeypairResourcePolicyPayload {
   """Updated keypair resource policy."""
   keypairResourcePolicy: KeypairResourcePolicyV2!
 }
@@ -12715,7 +12715,7 @@ type UpdateLoginClientTypePayload {
 }
 
 """Added in 26.4.2. Update model card payload."""
-type UpdateModelCardPayloadGQL {
+type UpdateModelCardPayload {
   """The updated model card."""
   modelCard: ModelCardV2!
 }
@@ -12804,7 +12804,7 @@ input UpdateMyKeypairInput {
 """Added in 26.2.0. Payload returned after updating a keypair."""
 type UpdateMyKeypairPayload {
   """The updated keypair."""
-  keypair: KeyPairGQL!
+  keypair: KeyPairV2!
 }
 
 """Added in 24.09.0. Input for updating a notification channel"""
@@ -12866,7 +12866,7 @@ input UpdatePermissionInput {
 """
 Added in 26.4.2. Input for updating project information. All fields optional.
 """
-input UpdateProjectInputGQL {
+input UpdateProjectInput {
   """New project name."""
   name: String = null
 
@@ -12886,7 +12886,7 @@ input UpdateProjectInputGQL {
 """
 Added in 26.4.2. Input for updating a project resource policy. All fields optional.
 """
-input UpdateProjectResourcePolicyInputGQL {
+input UpdateProjectResourcePolicyInput {
   """Updated max vfolder count."""
   maxVfolderCount: Int = null
 
@@ -12898,7 +12898,7 @@ input UpdateProjectResourcePolicyInputGQL {
 }
 
 """Added in 26.4.2. Payload for project resource policy update mutation."""
-type UpdateProjectResourcePolicyPayloadGQL {
+type UpdateProjectResourcePolicyPayload {
   """Updated project resource policy."""
   projectResourcePolicy: ProjectResourcePolicyV2!
 }
@@ -13003,7 +13003,7 @@ type UpdateResourceGroupPayload {
 }
 
 """Added in 26.4.2. Payload for resource preset update."""
-type UpdateResourcePresetPayloadGQL {
+type UpdateResourcePresetPayload {
   """Updated resource preset."""
   resourcePreset: ResourcePresetV2!
 }
@@ -13064,7 +13064,7 @@ input UpdateRuntimeVariantInput {
 }
 
 """Added in 26.4.2. Payload for runtime variant update."""
-type UpdateRuntimeVariantPayloadGQL {
+type UpdateRuntimeVariantPayload {
   """The updated runtime variant."""
   runtimeVariant: RuntimeVariant!
 }
@@ -13097,7 +13097,7 @@ input UpdateRuntimeVariantPresetInput {
 }
 
 """Added in 26.4.2. Update preset payload."""
-type UpdateRuntimeVariantPresetPayloadGQL {
+type UpdateRuntimeVariantPresetPayload {
   """The updated preset."""
   preset: RuntimeVariantPreset!
 }
@@ -13105,7 +13105,7 @@ type UpdateRuntimeVariantPresetPayloadGQL {
 """
 Added in 26.4.2. Input for updating a user resource policy. All fields optional.
 """
-input UpdateUserResourcePolicyInputGQL {
+input UpdateUserResourcePolicyInput {
   """Updated max vfolder count."""
   maxVfolderCount: Int = null
 
@@ -13125,7 +13125,7 @@ input UpdateUserResourcePolicyInputGQL {
 }
 
 """Added in 26.4.2. Payload for user resource policy update mutation."""
-type UpdateUserResourcePolicyPayloadGQL {
+type UpdateUserResourcePolicyPayload {
   """Updated user resource policy."""
   userResourcePolicy: UserResourcePolicyV2!
 }

--- a/src/ai/backend/manager/api/gql/CLAUDE.md
+++ b/src/ai/backend/manager/api/gql/CLAUDE.md
@@ -4,8 +4,18 @@
 
 ## Type Naming
 
-- Every Strawberry type MUST carry a `GQL` suffix: `DomainGQL`, `DomainFilterGQL`, `DomainScopeGQL`.
+- Every Strawberry type MUST carry a `GQL` suffix in its **Python class name**:
+  `DomainGQL`, `DomainFilterGQL`, `DomainScopeGQL`.
 - Applies to all GQL output types, input types, and connection types.
+- The **schema-exposed name** MUST NOT contain `GQL`. Always pass `name=` to the decorator
+  with the class name minus the `GQL` suffix (e.g. `class CreateDomainInputGQL` →
+  `name="CreateDomainInput"`). Omitting `name=` leaks the `GQL` suffix into the SDL.
+- **Federation collision caveat:** the v2 Strawberry schema is composed into a supergraph
+  alongside the v1 Graphene schema. If the stripped name collides with an existing v1
+  Graphene type of a different shape (e.g. `KeyPair`, `CreateContainerRegistryInput`),
+  supergraph composition fails. In that case use a `V2`-suffixed schema name instead
+  (`name="KeyPairV2"`) — matching the existing `DomainV2` / `UserV2` convention.
+  Run `scripts/generate-graphql-schema.sh` to verify composition after naming changes.
 
 ## Decorators
 

--- a/src/ai/backend/manager/api/gql/artifact/types.py
+++ b/src/ai/backend/manager/api/gql/artifact/types.py
@@ -362,6 +362,7 @@ class ScanArtifactsInput(PydanticInputMixin[ScanArtifactsInputDTO]):
         """),
         added_version="24.09.0",
     ),
+    name="ImportArtifactsOptions",
 )
 class ImportArtifactsOptionsGQL(PydanticInputMixin[ImportArtifactsOptionsInputDTO]):
     force: bool = gql_field(

--- a/src/ai/backend/manager/api/gql/container_registry/mutations.py
+++ b/src/ai/backend/manager/api/gql/container_registry/mutations.py
@@ -38,7 +38,8 @@ from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin, Pydan
     BackendAIGQLMeta(
         added_version="26.4.2",
         description="Input for creating a container registry.",
-    )
+    ),
+    name="CreateContainerRegistryInputV2",
 )
 class CreateContainerRegistryInputGQL(PydanticInputMixin[CreateContainerRegistryInputDTO]):
     url: str = gql_field(description="URL of the container registry.")
@@ -56,7 +57,8 @@ class CreateContainerRegistryInputGQL(PydanticInputMixin[CreateContainerRegistry
     BackendAIGQLMeta(
         added_version="26.4.2",
         description="Input for updating a container registry. All fields optional except id.",
-    )
+    ),
+    name="UpdateContainerRegistryInput",
 )
 class UpdateContainerRegistryInputGQL(PydanticInputMixin[UpdateContainerRegistryInputDTO]):
     id: str = gql_field(description="ID of the registry to update.")
@@ -80,6 +82,7 @@ class UpdateContainerRegistryInputGQL(PydanticInputMixin[UpdateContainerRegistry
         description="Payload for container registry create/update mutations.",
     ),
     model=CreateContainerRegistryPayloadDTO,
+    name="CreateContainerRegistryPayload",
 )
 class CreateContainerRegistryPayloadGQL(PydanticOutputMixin[CreateContainerRegistryPayloadDTO]):
     registry: ContainerRegistryGQL = gql_field(description="The container registry.")
@@ -91,6 +94,7 @@ class CreateContainerRegistryPayloadGQL(PydanticOutputMixin[CreateContainerRegis
         description="Payload for container registry update mutation.",
     ),
     model=UpdateContainerRegistryPayloadDTO,
+    name="UpdateContainerRegistryPayload",
 )
 class UpdateContainerRegistryPayloadGQL(PydanticOutputMixin[UpdateContainerRegistryPayloadDTO]):
     registry: ContainerRegistryGQL = gql_field(description="The updated container registry.")
@@ -102,6 +106,7 @@ class UpdateContainerRegistryPayloadGQL(PydanticOutputMixin[UpdateContainerRegis
         description="Payload for container registry deletion.",
     ),
     model=DeleteContainerRegistryPayloadDTO,
+    name="DeleteContainerRegistryPayload",
 )
 class DeleteContainerRegistryPayloadGQL(PydanticOutputMixin[DeleteContainerRegistryPayloadDTO]):
     id: str = gql_field(description="ID of the deleted registry.")

--- a/src/ai/backend/manager/api/gql/deployment/types/deployment.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/deployment.py
@@ -201,6 +201,7 @@ ScalingStateGQL: type[ScalingState] = gql_enum(
         description="Represents the deployment strategy configuration that determines how updates are rolled out to replicas (e.g., rolling update, blue-green).",
     ),
     model=DeploymentStrategyInfoDTO,
+    name="DeploymentStrategy",
 )
 class DeploymentStrategyGQL:
     type: DeploymentStrategyTypeGQL

--- a/src/ai/backend/manager/api/gql/deployment/types/deployment_options.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/deployment_options.py
@@ -94,6 +94,7 @@ class DeploymentOptionsInputGQL(PydanticInputMixin[DeploymentOptionsInputDTO]):
         description="Per-handler scheduler policy snapshot for deployment handler options.",
     ),
     model=HandlerOptionsInfoDTO,
+    name="HandlerOptionsInfo",
 )
 class HandlerOptionsInfoGQL:
     timeout_sec: int | None
@@ -106,6 +107,7 @@ class HandlerOptionsInfoGQL:
         description="A single (handler_name, options) entry response for deployment handler options.",
     ),
     model=HandlerOptionsEntryInfoDTO,
+    name="HandlerOptionsEntryInfo",
 )
 class HandlerOptionsEntryInfoGQL:
     handler_name: str
@@ -119,6 +121,7 @@ class HandlerOptionsEntryInfoGQL:
         description="Deployment handler-options policy response.",
     ),
     model=DeploymentHandlerOptionsInfoDTO,
+    name="DeploymentHandlerOptionsInfo",
 )
 class DeploymentHandlerOptionsInfoGQL:
     default: HandlerOptionsInfoGQL
@@ -131,6 +134,7 @@ class DeploymentHandlerOptionsInfoGQL:
         description="Deployment options payload response.",
     ),
     model=DeploymentOptionsInfoDTO,
+    name="DeploymentOptionsInfo",
 )
 class DeploymentOptionsInfoGQL:
     handler_options: DeploymentHandlerOptionsInfoGQL

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -304,6 +304,7 @@ class ModelMountConfig:
         description="An extra virtual folder mount attached to a model revision.",
     ),
     model=ExtraVFolderMountGQLDTO,
+    name="ExtraVFolderMountInfo",
 )
 class ExtraVFolderMountInfoGQL:
     vfolder_id: ID

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -620,6 +620,7 @@ class UpdateDeploymentRevisionPresetInputGQL(PydanticInputMixin[UpdateInputDTO])
         description="Create deployment revision preset payload.",
     ),
     model=CreatePayloadDTO,
+    name="CreateDeploymentRevisionPresetPayload",
 )
 class CreateDeploymentRevisionPresetPayloadGQL(PydanticOutputMixin[CreatePayloadDTO]):
     preset: DeploymentRevisionPresetGQL = gql_field(description="The created preset.")
@@ -631,6 +632,7 @@ class CreateDeploymentRevisionPresetPayloadGQL(PydanticOutputMixin[CreatePayload
         description="Update deployment revision preset payload.",
     ),
     model=UpdatePayloadDTO,
+    name="UpdateDeploymentRevisionPresetPayload",
 )
 class UpdateDeploymentRevisionPresetPayloadGQL(PydanticOutputMixin[UpdatePayloadDTO]):
     preset: DeploymentRevisionPresetGQL = gql_field(description="The updated preset.")
@@ -642,6 +644,7 @@ class UpdateDeploymentRevisionPresetPayloadGQL(PydanticOutputMixin[UpdatePayload
         description="Delete deployment revision preset payload.",
     ),
     model=DeletePayloadDTO,
+    name="DeleteDeploymentRevisionPresetPayload",
 )
 class DeleteDeploymentRevisionPresetPayloadGQL(PydanticOutputMixin[DeletePayloadDTO]):
     id: UUID = gql_field(description="ID of the deleted preset.")

--- a/src/ai/backend/manager/api/gql/domain_v2/types/mutations.py
+++ b/src/ai/backend/manager/api/gql/domain_v2/types/mutations.py
@@ -36,7 +36,8 @@ UNSET = None
     BackendAIGQLMeta(
         added_version="26.4.2",
         description="Input for creating a new domain.",
-    )
+    ),
+    name="CreateDomainInput",
 )
 class CreateDomainInputGQL(PydanticInputMixin[CreateDomainInputDTO]):
     """Input for creating a new domain."""
@@ -56,7 +57,8 @@ class CreateDomainInputGQL(PydanticInputMixin[CreateDomainInputDTO]):
     BackendAIGQLMeta(
         added_version="26.4.2",
         description="Input for updating domain information. All fields optional.",
-    )
+    ),
+    name="UpdateDomainInput",
 )
 class UpdateDomainInputGQL(PydanticInputMixin[UpdateDomainInputDTO]):
     """Input for updating domain information."""
@@ -81,6 +83,7 @@ class UpdateDomainInputGQL(PydanticInputMixin[UpdateDomainInputDTO]):
         description="Payload for domain mutation responses.",
     ),
     model=DomainPayloadDTO,
+    name="DomainPayload",
 )
 class DomainPayloadGQL(PydanticOutputMixin[DomainPayloadDTO]):
     """Payload for domain create/update mutations."""
@@ -94,6 +97,7 @@ class DomainPayloadGQL(PydanticOutputMixin[DomainPayloadDTO]):
         description="Payload for domain deletion mutation.",
     ),
     model=DeleteDomainPayloadDTO,
+    name="DeleteDomainPayload",
 )
 class DeleteDomainPayloadGQL(PydanticOutputMixin[DeleteDomainPayloadDTO]):
     """Payload for domain soft-delete."""
@@ -107,6 +111,7 @@ class DeleteDomainPayloadGQL(PydanticOutputMixin[DeleteDomainPayloadDTO]):
         description="Payload for domain permanent deletion mutation.",
     ),
     model=PurgeDomainPayloadDTO,
+    name="PurgeDomainPayload",
 )
 class PurgeDomainPayloadGQL(PydanticOutputMixin[PurgeDomainPayloadDTO]):
     """Payload for domain permanent purge."""

--- a/src/ai/backend/manager/api/gql/image/types.py
+++ b/src/ai/backend/manager/api/gql/image/types.py
@@ -487,6 +487,7 @@ class ImageV2OrderFieldGQL(StrEnum):
         description="Specifies the field and direction for ordering images in queries.",
         added_version="26.2.0",
     ),
+    name="ImageV2OrderBy",
 )
 class ImageV2OrderByGQL(PydanticInputMixin[ImageOrderByInputDTO], GQLOrderBy):
     field: ImageV2OrderFieldGQL
@@ -550,6 +551,7 @@ class ImageV2AliasOrderFieldGQL(StrEnum):
         description="Specifies the field and direction for ordering image aliases in queries.",
         added_version="26.2.0",
     ),
+    name="ImageV2AliasOrderBy",
 )
 class ImageV2AliasOrderByGQL(PydanticInputMixin[ImageAliasOrderByInputDTO], GQLOrderBy):
     field: ImageV2AliasOrderFieldGQL

--- a/src/ai/backend/manager/api/gql/keypair/types/node.py
+++ b/src/ai/backend/manager/api/gql/keypair/types/node.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
             "Secret key and private SSH key are excluded for security reasons."
         ),
     ),
-    name="KeyPairGQL",
+    name="KeyPairV2",
 )
 class KeyPairGQL(PydanticNodeMixin[KeypairNode]):
     """Keypair entity accessible via Relay Node interface."""

--- a/src/ai/backend/manager/api/gql/model_card/types.py
+++ b/src/ai/backend/manager/api/gql/model_card/types.py
@@ -464,6 +464,7 @@ class UpdateModelCardInputGQL(PydanticInputMixin[UpdateInputDTO]):
 @gql_pydantic_type(
     BackendAIGQLMeta(added_version="26.4.2", description="Create model card payload."),
     model=CreatePayloadDTO,
+    name="CreateModelCardPayload",
 )
 class CreateModelCardPayloadGQL(PydanticOutputMixin[CreatePayloadDTO]):
     model_card: ModelCardGQL = gql_field(description="The created model card.")
@@ -472,6 +473,7 @@ class CreateModelCardPayloadGQL(PydanticOutputMixin[CreatePayloadDTO]):
 @gql_pydantic_type(
     BackendAIGQLMeta(added_version="26.4.2", description="Update model card payload."),
     model=UpdatePayloadDTO,
+    name="UpdateModelCardPayload",
 )
 class UpdateModelCardPayloadGQL(PydanticOutputMixin[UpdatePayloadDTO]):
     model_card: ModelCardGQL = gql_field(description="The updated model card.")
@@ -480,6 +482,7 @@ class UpdateModelCardPayloadGQL(PydanticOutputMixin[UpdatePayloadDTO]):
 @gql_pydantic_type(
     BackendAIGQLMeta(added_version="26.4.2", description="Delete model card payload."),
     model=DeletePayloadDTO,
+    name="DeleteModelCardPayload",
 )
 class DeleteModelCardPayloadGQL(PydanticOutputMixin[DeletePayloadDTO]):
     id: UUID = gql_field(description="ID of the deleted model card.")

--- a/src/ai/backend/manager/api/gql/project_v2/types/mutations.py
+++ b/src/ai/backend/manager/api/gql/project_v2/types/mutations.py
@@ -48,7 +48,8 @@ UNSET = None
     BackendAIGQLMeta(
         added_version="26.4.2",
         description="Input for creating a new project.",
-    )
+    ),
+    name="CreateProjectInput",
 )
 class CreateProjectInputGQL(PydanticInputMixin[CreateProjectInputDTO]):
     """Input for creating a new project."""
@@ -68,7 +69,8 @@ class CreateProjectInputGQL(PydanticInputMixin[CreateProjectInputDTO]):
     BackendAIGQLMeta(
         added_version="26.4.2",
         description="Input for updating project information. All fields optional.",
-    )
+    ),
+    name="UpdateProjectInput",
 )
 class UpdateProjectInputGQL(PydanticInputMixin[UpdateProjectInputDTO]):
     """Input for updating project information."""
@@ -91,6 +93,7 @@ class UpdateProjectInputGQL(PydanticInputMixin[UpdateProjectInputDTO]):
         description="Payload for project mutation responses.",
     ),
     model=ProjectPayloadDTO,
+    name="ProjectPayload",
 )
 class ProjectPayloadGQL(PydanticOutputMixin[ProjectPayloadDTO]):
     """Payload for project create/update mutations."""
@@ -104,6 +107,7 @@ class ProjectPayloadGQL(PydanticOutputMixin[ProjectPayloadDTO]):
         description="Payload for project deletion mutation.",
     ),
     model=DeleteProjectPayloadDTO,
+    name="DeleteProjectPayload",
 )
 class DeleteProjectPayloadGQL(PydanticOutputMixin[DeleteProjectPayloadDTO]):
     """Payload for project soft-delete."""
@@ -117,6 +121,7 @@ class DeleteProjectPayloadGQL(PydanticOutputMixin[DeleteProjectPayloadDTO]):
         description="Payload for project permanent deletion mutation.",
     ),
     model=PurgeProjectPayloadDTO,
+    name="PurgeProjectPayload",
 )
 class PurgeProjectPayloadGQL(PydanticOutputMixin[PurgeProjectPayloadDTO]):
     """Payload for project permanent purge."""

--- a/src/ai/backend/manager/api/gql/resource_group/types.py
+++ b/src/ai/backend/manager/api/gql/resource_group/types.py
@@ -607,6 +607,7 @@ class CreateResourceGroupInputGQL(PydanticInputMixin[CreateResourceGroupInputDTO
         description="Payload for resource group creation.",
     ),
     model=CreateResourceGroupPayloadDTO,
+    name="CreateResourceGroupPayload",
 )
 class CreateResourceGroupPayloadGQL(PydanticOutputMixin[CreateResourceGroupPayloadDTO]):
     resource_group: ResourceGroupGQL = gql_field(description="The created resource group.")
@@ -618,6 +619,7 @@ class CreateResourceGroupPayloadGQL(PydanticOutputMixin[CreateResourceGroupPaylo
         description="Payload for resource group deletion.",
     ),
     model=DeleteResourceGroupPayloadDTO,
+    name="DeleteResourceGroupPayload",
 )
 class DeleteResourceGroupPayloadGQL(PydanticOutputMixin[DeleteResourceGroupPayloadDTO]):
     id: str = gql_field(description="ID of the deleted resource group.")

--- a/src/ai/backend/manager/api/gql/resource_policy_v2/types/mutations.py
+++ b/src/ai/backend/manager/api/gql/resource_policy_v2/types/mutations.py
@@ -77,7 +77,8 @@ UNSET = None
     BackendAIGQLMeta(
         added_version="26.4.2",
         description="Input for creating a keypair resource policy.",
-    )
+    ),
+    name="CreateKeypairResourcePolicyInput",
 )
 class CreateKeypairResourcePolicyInputGQL(PydanticInputMixin[CreateKeypairResourcePolicyInputDTO]):
     name: str = gql_field(description="Policy name. Must be unique.")
@@ -109,7 +110,8 @@ class CreateKeypairResourcePolicyInputGQL(PydanticInputMixin[CreateKeypairResour
     BackendAIGQLMeta(
         added_version="26.4.2",
         description="Input for updating a keypair resource policy. All fields optional.",
-    )
+    ),
+    name="UpdateKeypairResourcePolicyInput",
 )
 class UpdateKeypairResourcePolicyInputGQL(PydanticInputMixin[UpdateKeypairResourcePolicyInputDTO]):
     default_for_unspecified: str | None = gql_field(
@@ -149,7 +151,8 @@ class UpdateKeypairResourcePolicyInputGQL(PydanticInputMixin[UpdateKeypairResour
     BackendAIGQLMeta(
         added_version="26.4.2",
         description="Input for creating a user resource policy.",
-    )
+    ),
+    name="CreateUserResourcePolicyInputV2",
 )
 class CreateUserResourcePolicyInputGQL(PydanticInputMixin[CreateUserResourcePolicyInputDTO]):
     name: str = gql_field(description="Policy name. Must be unique.")
@@ -181,7 +184,8 @@ class CreateUserResourcePolicyInputGQL(PydanticInputMixin[CreateUserResourcePoli
     BackendAIGQLMeta(
         added_version="26.4.2",
         description="Input for updating a user resource policy. All fields optional.",
-    )
+    ),
+    name="UpdateUserResourcePolicyInput",
 )
 class UpdateUserResourcePolicyInputGQL(PydanticInputMixin[UpdateUserResourcePolicyInputDTO]):
     max_vfolder_count: int | None = gql_field(
@@ -217,7 +221,8 @@ class UpdateUserResourcePolicyInputGQL(PydanticInputMixin[UpdateUserResourcePoli
     BackendAIGQLMeta(
         added_version="26.4.2",
         description="Input for creating a project resource policy.",
-    )
+    ),
+    name="CreateProjectResourcePolicyInputV2",
 )
 class CreateProjectResourcePolicyInputGQL(PydanticInputMixin[CreateProjectResourcePolicyInputDTO]):
     name: str = gql_field(description="Policy name. Must be unique.")
@@ -234,7 +239,8 @@ class CreateProjectResourcePolicyInputGQL(PydanticInputMixin[CreateProjectResour
     BackendAIGQLMeta(
         added_version="26.4.2",
         description="Input for updating a project resource policy. All fields optional.",
-    )
+    ),
+    name="UpdateProjectResourcePolicyInput",
 )
 class UpdateProjectResourcePolicyInputGQL(PydanticInputMixin[UpdateProjectResourcePolicyInputDTO]):
     max_vfolder_count: int | None = gql_field(
@@ -257,6 +263,7 @@ class UpdateProjectResourcePolicyInputGQL(PydanticInputMixin[UpdateProjectResour
         description="Payload for keypair resource policy create/update mutations.",
     ),
     model=CreateKeypairResourcePolicyPayloadDTO,
+    name="CreateKeypairResourcePolicyPayload",
 )
 class CreateKeypairResourcePolicyPayloadGQL(
     PydanticOutputMixin[CreateKeypairResourcePolicyPayloadDTO]
@@ -272,6 +279,7 @@ class CreateKeypairResourcePolicyPayloadGQL(
         description="Payload for keypair resource policy update mutation.",
     ),
     model=UpdateKeypairResourcePolicyPayloadDTO,
+    name="UpdateKeypairResourcePolicyPayload",
 )
 class UpdateKeypairResourcePolicyPayloadGQL(
     PydanticOutputMixin[UpdateKeypairResourcePolicyPayloadDTO]
@@ -287,6 +295,7 @@ class UpdateKeypairResourcePolicyPayloadGQL(
         description="Payload for keypair resource policy deletion.",
     ),
     model=DeleteKeypairResourcePolicyPayloadDTO,
+    name="DeleteKeypairResourcePolicyPayload",
 )
 class DeleteKeypairResourcePolicyPayloadGQL(
     PydanticOutputMixin[DeleteKeypairResourcePolicyPayloadDTO]
@@ -300,6 +309,7 @@ class DeleteKeypairResourcePolicyPayloadGQL(
         description="Payload for user resource policy create/update mutations.",
     ),
     model=CreateUserResourcePolicyPayloadDTO,
+    name="CreateUserResourcePolicyPayload",
 )
 class CreateUserResourcePolicyPayloadGQL(PydanticOutputMixin[CreateUserResourcePolicyPayloadDTO]):
     user_resource_policy: UserResourcePolicyV2GQL = gql_field(
@@ -313,6 +323,7 @@ class CreateUserResourcePolicyPayloadGQL(PydanticOutputMixin[CreateUserResourceP
         description="Payload for user resource policy update mutation.",
     ),
     model=UpdateUserResourcePolicyPayloadDTO,
+    name="UpdateUserResourcePolicyPayload",
 )
 class UpdateUserResourcePolicyPayloadGQL(PydanticOutputMixin[UpdateUserResourcePolicyPayloadDTO]):
     user_resource_policy: UserResourcePolicyV2GQL = gql_field(
@@ -326,6 +337,7 @@ class UpdateUserResourcePolicyPayloadGQL(PydanticOutputMixin[UpdateUserResourceP
         description="Payload for user resource policy deletion.",
     ),
     model=DeleteUserResourcePolicyPayloadDTO,
+    name="DeleteUserResourcePolicyPayload",
 )
 class DeleteUserResourcePolicyPayloadGQL(PydanticOutputMixin[DeleteUserResourcePolicyPayloadDTO]):
     name: str = gql_field(description="Name of the deleted policy.")
@@ -337,6 +349,7 @@ class DeleteUserResourcePolicyPayloadGQL(PydanticOutputMixin[DeleteUserResourceP
         description="Payload for project resource policy create/update mutations.",
     ),
     model=CreateProjectResourcePolicyPayloadDTO,
+    name="CreateProjectResourcePolicyPayload",
 )
 class CreateProjectResourcePolicyPayloadGQL(
     PydanticOutputMixin[CreateProjectResourcePolicyPayloadDTO]
@@ -352,6 +365,7 @@ class CreateProjectResourcePolicyPayloadGQL(
         description="Payload for project resource policy update mutation.",
     ),
     model=UpdateProjectResourcePolicyPayloadDTO,
+    name="UpdateProjectResourcePolicyPayload",
 )
 class UpdateProjectResourcePolicyPayloadGQL(
     PydanticOutputMixin[UpdateProjectResourcePolicyPayloadDTO]
@@ -367,6 +381,7 @@ class UpdateProjectResourcePolicyPayloadGQL(
         description="Payload for project resource policy deletion.",
     ),
     model=DeleteProjectResourcePolicyPayloadDTO,
+    name="DeleteProjectResourcePolicyPayload",
 )
 class DeleteProjectResourcePolicyPayloadGQL(
     PydanticOutputMixin[DeleteProjectResourcePolicyPayloadDTO]

--- a/src/ai/backend/manager/api/gql/resource_preset/types.py
+++ b/src/ai/backend/manager/api/gql/resource_preset/types.py
@@ -187,6 +187,7 @@ class CreateResourcePresetInputGQL(PydanticInputMixin[CreateResourcePresetInputD
         description="Payload for resource preset creation.",
     ),
     model=CreateResourcePresetPayloadDTO,
+    name="CreateResourcePresetPayload",
 )
 class CreateResourcePresetPayloadGQL(PydanticOutputMixin[CreateResourcePresetPayloadDTO]):
     resource_preset: ResourcePresetGQL = gql_field(description="The created resource preset.")
@@ -221,6 +222,7 @@ class UpdateResourcePresetInputGQL(PydanticInputMixin[UpdateResourcePresetInputD
         description="Payload for resource preset update.",
     ),
     model=UpdateResourcePresetPayloadDTO,
+    name="UpdateResourcePresetPayload",
 )
 class UpdateResourcePresetPayloadGQL(PydanticOutputMixin[UpdateResourcePresetPayloadDTO]):
     resource_preset: ResourcePresetGQL = gql_field(description="The updated resource preset.")
@@ -232,6 +234,7 @@ class UpdateResourcePresetPayloadGQL(PydanticOutputMixin[UpdateResourcePresetPay
         description="Payload for resource preset deletion.",
     ),
     model=DeleteResourcePresetPayloadDTO,
+    name="DeleteResourcePresetPayload",
 )
 class DeleteResourcePresetPayloadGQL(PydanticOutputMixin[DeleteResourcePresetPayloadDTO]):
     id: str = gql_field(description="UUID of the deleted resource preset.")

--- a/src/ai/backend/manager/api/gql/runtime_variant/types.py
+++ b/src/ai/backend/manager/api/gql/runtime_variant/types.py
@@ -142,6 +142,7 @@ class UpdateRuntimeVariantInputGQL(PydanticInputMixin[UpdateRuntimeVariantInputD
 @gql_pydantic_type(
     BackendAIGQLMeta(added_version="26.4.2", description="Payload for runtime variant creation."),
     model=CreateRuntimeVariantPayloadDTO,
+    name="CreateRuntimeVariantPayload",
 )
 class CreateRuntimeVariantPayloadGQL(PydanticOutputMixin[CreateRuntimeVariantPayloadDTO]):
     runtime_variant: RuntimeVariantGQL = gql_field(description="The created runtime variant.")
@@ -150,6 +151,7 @@ class CreateRuntimeVariantPayloadGQL(PydanticOutputMixin[CreateRuntimeVariantPay
 @gql_pydantic_type(
     BackendAIGQLMeta(added_version="26.4.2", description="Payload for runtime variant update."),
     model=UpdateRuntimeVariantPayloadDTO,
+    name="UpdateRuntimeVariantPayload",
 )
 class UpdateRuntimeVariantPayloadGQL(PydanticOutputMixin[UpdateRuntimeVariantPayloadDTO]):
     runtime_variant: RuntimeVariantGQL = gql_field(description="The updated runtime variant.")
@@ -158,6 +160,7 @@ class UpdateRuntimeVariantPayloadGQL(PydanticOutputMixin[UpdateRuntimeVariantPay
 @gql_pydantic_type(
     BackendAIGQLMeta(added_version="26.4.2", description="Payload for runtime variant deletion."),
     model=DeleteRuntimeVariantPayloadDTO,
+    name="DeleteRuntimeVariantPayload",
 )
 class DeleteRuntimeVariantPayloadGQL(PydanticOutputMixin[DeleteRuntimeVariantPayloadDTO]):
     id: UUID = gql_field(description="ID of the deleted runtime variant.")
@@ -180,6 +183,7 @@ class DeleteRuntimeVariantsInputGQL(PydanticInputMixin[DeleteRuntimeVariantsInpu
         description="Payload for bulk runtime variant deletion.",
     ),
     model=DeleteRuntimeVariantsPayloadDTO,
+    name="DeleteRuntimeVariantsPayload",
 )
 class DeleteRuntimeVariantsPayloadGQL(PydanticOutputMixin[DeleteRuntimeVariantsPayloadDTO]):
     deleted_count: int = gql_field(description="Number of runtime variants successfully deleted.")

--- a/src/ai/backend/manager/api/gql/runtime_variant_preset/types.py
+++ b/src/ai/backend/manager/api/gql/runtime_variant_preset/types.py
@@ -301,6 +301,7 @@ class UpdateRuntimeVariantPresetInputGQL(PydanticInputMixin[UpdateInputDTO]):
 @gql_pydantic_type(
     BackendAIGQLMeta(added_version="26.4.2", description="Create preset payload."),
     model=CreatePayloadDTO,
+    name="CreateRuntimeVariantPresetPayload",
 )
 class CreateRuntimeVariantPresetPayloadGQL(PydanticOutputMixin[CreatePayloadDTO]):
     preset: RuntimeVariantPresetGQL = gql_field(description="The created preset.")
@@ -309,6 +310,7 @@ class CreateRuntimeVariantPresetPayloadGQL(PydanticOutputMixin[CreatePayloadDTO]
 @gql_pydantic_type(
     BackendAIGQLMeta(added_version="26.4.2", description="Update preset payload."),
     model=UpdatePayloadDTO,
+    name="UpdateRuntimeVariantPresetPayload",
 )
 class UpdateRuntimeVariantPresetPayloadGQL(PydanticOutputMixin[UpdatePayloadDTO]):
     preset: RuntimeVariantPresetGQL = gql_field(description="The updated preset.")
@@ -317,6 +319,7 @@ class UpdateRuntimeVariantPresetPayloadGQL(PydanticOutputMixin[UpdatePayloadDTO]
 @gql_pydantic_type(
     BackendAIGQLMeta(added_version="26.4.2", description="Delete preset payload."),
     model=DeletePayloadDTO,
+    name="DeleteRuntimeVariantPresetPayload",
 )
 class DeleteRuntimeVariantPresetPayloadGQL(PydanticOutputMixin[DeletePayloadDTO]):
     id: UUID = gql_field(description="ID of the deleted preset.")


### PR DESCRIPTION
## Summary
- v2 Strawberry GQL types exposed a `GQL` suffix in the GraphQL schema (e.g. `CreateDomainInputGQL`, `KeyPairGQL`, the auto-derived `KeyPairGQLEdge`). The `GQL` suffix is a Python-class-name convention only — it should never appear in the SDL.
- Added/adjusted `name=` on ~58 v2 decorators so the schema-exposed name drops the `GQL` suffix, while **Python class names keep the `GQL` suffix** per `api/gql/CLAUDE.md`.
- Four types whose stripped name collides with existing v1 Graphene types in the federated supergraph use a `V2` suffix instead (matching the `DomainV2`/`UserV2` convention): `KeyPairV2`, `CreateContainerRegistryInputV2`, `CreateUserResourcePolicyInputV2`, `CreateProjectResourcePolicyInputV2`.
- `SubStepResultGQL` intentionally keeps its suffix for backward compatibility with existing clients (documented in code).
- Regenerated `docs/manager/graphql-reference/v2-schema.graphql` and `supergraph.graphql` (v1 `schema.graphql` unchanged); documented the naming + federation-collision rule in `api/gql/CLAUDE.md`.

## Test plan
- [x] `pants fmt :: && pants fix ::` — no changes
- [x] `pants lint --changed-since=main` — passed (ruff + visibility)
- [x] `pants check --changed-since=HEAD` — mypy passed (16 files)
- [x] `scripts/generate-graphql-schema.sh` — supergraph composition succeeds; only `SubStepResultGQL` remains as a `*GQL` type declaration (intended exception)
- [x] Confirmed the two failing `tests/component/session` cases (`Mock has no attribute 'increment_session_usage'`) are pre-existing on `main` and unrelated to this change

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11906.org.readthedocs.build/en/11906/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11906.org.readthedocs.build/ko/11906/

<!-- readthedocs-preview sorna-ko end -->