### PR TITLE
feat(BA-6182): wire up Role Preset GraphQL resolvers and adapter

### DIFF
--- a/changes/11908.feature.md
+++ b/changes/11908.feature.md
@@ -1,0 +1,1 @@
+Wire up the Role Preset GraphQL resolvers and adapter so role presets can be created, queried, updated, soft-deleted/restored/purged, and have their permission entries managed.

--- a/src/ai/backend/common/dto/manager/v2/role_permission_preset/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/role_permission_preset/__init__.py
@@ -7,12 +7,14 @@ from ai.backend.common.dto.manager.v2.role_permission_preset.request import (
     BulkRemoveRolePermissionPresetsInput,
     RolePermissionPresetFilter,
     RolePermissionPresetOrder,
+    SearchRolePermissionPresetsInput,
 )
 from ai.backend.common.dto.manager.v2.role_permission_preset.response import (
     BulkAddRolePermissionPresetsPayload,
     BulkRemoveRolePermissionPresetsPayload,
     BulkRolePermissionPresetFailureInfo,
     RolePermissionPresetNode,
+    SearchRolePermissionPresetsPayload,
 )
 from ai.backend.common.dto.manager.v2.role_permission_preset.types import (
     RolePermissionPresetEntry,
@@ -28,9 +30,11 @@ __all__ = (
     "BulkRemoveRolePermissionPresetsInput",
     "RolePermissionPresetFilter",
     "RolePermissionPresetOrder",
+    "SearchRolePermissionPresetsInput",
     # Response DTOs
     "BulkAddRolePermissionPresetsPayload",
     "BulkRemoveRolePermissionPresetsPayload",
     "BulkRolePermissionPresetFailureInfo",
     "RolePermissionPresetNode",
+    "SearchRolePermissionPresetsPayload",
 )

--- a/src/ai/backend/common/dto/manager/v2/role_permission_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/role_permission_preset/request.py
@@ -22,6 +22,7 @@ __all__ = (
     "BulkRemoveRolePermissionPresetsInput",
     "RolePermissionPresetFilter",
     "RolePermissionPresetOrder",
+    "SearchRolePermissionPresetsInput",
 )
 
 
@@ -76,3 +77,20 @@ class RolePermissionPresetOrder(BaseRequestModel):
 
     field: RolePermissionPresetOrderField = Field(description="Field to order by.")
     direction: OrderDirection = Field(default=OrderDirection.ASC, description="Order direction.")
+
+
+class SearchRolePermissionPresetsInput(BaseRequestModel):
+    """Input for paginated search of the permission entries under a role preset."""
+
+    filter: RolePermissionPresetFilter | None = Field(
+        default=None, description="Filter conditions."
+    )
+    order: list[RolePermissionPresetOrder] | None = Field(
+        default=None, description="Order specifications."
+    )
+    first: int | None = Field(default=None, description="Cursor pagination: number of items.")
+    after: str | None = Field(default=None, description="Cursor pagination: after cursor.")
+    last: int | None = Field(default=None, description="Cursor pagination: last N items.")
+    before: str | None = Field(default=None, description="Cursor pagination: before cursor.")
+    limit: int | None = Field(default=None, description="Offset pagination: maximum items.")
+    offset: int | None = Field(default=None, description="Offset pagination: number to skip.")

--- a/src/ai/backend/common/dto/manager/v2/role_permission_preset/response.py
+++ b/src/ai/backend/common/dto/manager/v2/role_permission_preset/response.py
@@ -17,6 +17,7 @@ __all__ = (
     "BulkRemoveRolePermissionPresetsPayload",
     "BulkRolePermissionPresetFailureInfo",
     "RolePermissionPresetNode",
+    "SearchRolePermissionPresetsPayload",
 )
 
 
@@ -30,6 +31,17 @@ class RolePermissionPresetNode(BaseResponseModel):
     )
     operation: OperationTypeDTO = Field(description="Operation granted by the permission.")
     created_at: datetime = Field(description="Creation timestamp.")
+
+
+class SearchRolePermissionPresetsPayload(BaseResponseModel):
+    """Payload for paginated permission-entry search under a role preset."""
+
+    items: list[RolePermissionPresetNode] = Field(
+        description="Permission entry nodes matching the filter."
+    )
+    total_count: int = Field(description="Total number matching the filter.")
+    has_next_page: bool = Field(description="Whether there is a next page.")
+    has_previous_page: bool = Field(description="Whether there is a previous page.")
 
 
 class BulkRolePermissionPresetFailureInfo(BaseResponseModel):

--- a/src/ai/backend/manager/api/adapters/role_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/role_preset/adapter.py
@@ -1,20 +1,27 @@
 """Role preset domain adapter - Pydantic-in/Pydantic-out transport layer.
 
-Shared between the GraphQL resolvers and REST v2 handlers. Method bodies raise
-``NotImplementedError``; wire-up to the Processor/Service layer happens in a
-follow-up task.
+Shared between the GraphQL resolvers and REST v2 handlers. Translates v2 DTOs
+into Processor actions and converts the action results back into v2 DTOs.
 """
 
 from __future__ import annotations
 
+from ai.backend.common.data.permission.types import (
+    OperationType,
+    RBACElementType,
+)
+from ai.backend.common.dto.manager.v2.common import OrderDirection
+from ai.backend.common.dto.manager.v2.rbac.types import OperationTypeDTO, RBACElementTypeDTO
 from ai.backend.common.dto.manager.v2.role_permission_preset.request import (
     BulkAddRolePermissionPresetsInput,
     BulkRemoveRolePermissionPresetsInput,
     RolePermissionPresetFilter,
 )
 from ai.backend.common.dto.manager.v2.role_permission_preset.response import (
+    BulkAddRolePermissionPresetFailureInfo,
     BulkAddRolePermissionPresetsPayload,
     BulkRemoveRolePermissionPresetsPayload,
+    BulkRolePermissionPresetFailureInfo,
     RolePermissionPresetNode,
 )
 from ai.backend.common.dto.manager.v2.role_preset.request import (
@@ -22,6 +29,8 @@ from ai.backend.common.dto.manager.v2.role_preset.request import (
     BulkPurgeRolePresetsInput,
     BulkRestoreRolePresetsInput,
     CreateRolePresetInput,
+    RolePresetFilter,
+    RolePresetOrder,
     SearchRolePresetsInput,
     UpdateRolePresetInput,
 )
@@ -29,13 +38,69 @@ from ai.backend.common.dto.manager.v2.role_preset.response import (
     BulkDeleteRolePresetsPayload,
     BulkPurgeRolePresetsPayload,
     BulkRestoreRolePresetsPayload,
+    BulkRolePresetFailureInfo,
     CreateRolePresetPayload,
     RolePresetNode,
     SearchRolePresetsPayload,
     UpdateRolePresetPayload,
 )
+from ai.backend.common.dto.manager.v2.role_preset.types import RolePresetOrderField
 from ai.backend.common.identifier.role_preset import RolePresetID
+from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
+from ai.backend.manager.data.role_preset.types import (
+    RolePermissionPresetData,
+    RolePresetData,
+)
+from ai.backend.manager.models.rbac_models.role_permission_preset.row import (
+    RolePermissionPresetRow,
+)
+from ai.backend.manager.models.rbac_models.role_preset.conditions import RolePresetConditions
+from ai.backend.manager.models.rbac_models.role_preset.orders import RolePresetOrders
+from ai.backend.manager.models.rbac_models.role_preset.row import RolePresetRow
+from ai.backend.manager.repositories.base import (
+    BulkCreator,
+    QueryCondition,
+    QueryOrder,
+    combine_conditions_or,
+    negate_conditions,
+)
+from ai.backend.manager.repositories.base.updater import Updater
+from ai.backend.manager.repositories.role_preset.creators import (
+    RolePermissionPresetCreatorSpec,
+    RolePermissionPresetDependentCreatorSpec,
+    RolePresetCreatorSpec,
+)
+from ai.backend.manager.repositories.role_preset.updaters import (
+    RolePresetDeletedFlagUpdaterSpec,
+    RolePresetUpdaterSpec,
+)
+from ai.backend.manager.services.role_preset.actions.bulk_add_permissions import (
+    BulkAddRolePermissionPresetsAction,
+)
+from ai.backend.manager.services.role_preset.actions.bulk_purge import (
+    BulkPurgeRolePresetsAction,
+)
+from ai.backend.manager.services.role_preset.actions.bulk_remove_permissions import (
+    BulkRemoveRolePermissionPresetsAction,
+)
+from ai.backend.manager.services.role_preset.actions.create import CreateRolePresetAction
+from ai.backend.manager.services.role_preset.actions.delete import BulkDeleteRolePresetsAction
+from ai.backend.manager.services.role_preset.actions.get import GetRolePresetAction
+from ai.backend.manager.services.role_preset.actions.restore import BulkRestoreRolePresetsAction
+from ai.backend.manager.services.role_preset.actions.search import SearchRolePresetsAction
+from ai.backend.manager.services.role_preset.actions.update import UpdateRolePresetAction
+from ai.backend.manager.types import OptionalState
+
+
+def _role_preset_pagination_spec() -> PaginationSpec:
+    return PaginationSpec(
+        forward_order=RolePresetOrders.created_at(ascending=False),
+        backward_order=RolePresetOrders.created_at(ascending=True),
+        forward_condition_factory=RolePresetConditions.by_cursor_forward,
+        backward_condition_factory=RolePresetConditions.by_cursor_backward,
+        tiebreaker_order=RolePresetRow.id.asc(),
+    )
 
 
 class RolePresetAdapter(BaseAdapter):
@@ -43,33 +108,140 @@ class RolePresetAdapter(BaseAdapter):
 
     async def create(self, input: CreateRolePresetInput) -> CreateRolePresetPayload:
         """Create a new role preset."""
-        raise NotImplementedError
+        creator_spec = RolePresetCreatorSpec(
+            name=input.name,
+            scope_type=RBACElementType(input.scope_type.value).to_scope_type(),
+            auto_assign=input.auto_assign,
+        )
+        permission_creator_specs = [
+            RolePermissionPresetDependentCreatorSpec(
+                entity_type=RBACElementType(entry.entity_type.value).to_entity_type(),
+                operation=OperationType(entry.operation.value),
+            )
+            for entry in input.permissions
+        ]
+        result = await self._processors.role_preset.create.wait_for_complete(
+            CreateRolePresetAction(
+                creator_spec=creator_spec,
+                permission_creator_specs=permission_creator_specs,
+            )
+        )
+        return CreateRolePresetPayload(role_preset=self._data_to_node(result.preset))
 
     async def get(self, role_preset_id: RolePresetID) -> RolePresetNode | None:
         """Get a single role preset by ID."""
-        raise NotImplementedError
+        result = await self._processors.role_preset.get.wait_for_complete(
+            GetRolePresetAction(preset_id=role_preset_id)
+        )
+        return self._data_to_node(result.preset)
 
     async def search(self, input: SearchRolePresetsInput) -> SearchRolePresetsPayload:
         """Search role presets with filtering and pagination."""
-        raise NotImplementedError
+        conditions = self._convert_filter(input.filter) if input.filter else []
+        orders = self._convert_orders(input.order) if input.order else []
+        # Soft-deleted rows are excluded unless the caller explicitly sets the
+        # top-level ``deleted`` filter.
+        base_conditions: list[QueryCondition] = []
+        if input.filter is None or input.filter.deleted is None:
+            base_conditions.append(RolePresetConditions.by_deleted(False))
+        querier = self._build_querier(
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=_role_preset_pagination_spec(),
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+            base_conditions=base_conditions,
+        )
+        result = await self._processors.role_preset.search.wait_for_complete(
+            SearchRolePresetsAction(querier=querier)
+        )
+        return SearchRolePresetsPayload(
+            items=[self._data_to_node(d) for d in result.items],
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
 
     async def update(self, input: UpdateRolePresetInput) -> UpdateRolePresetPayload:
         """Update an existing role preset's metadata."""
-        raise NotImplementedError
+        spec = RolePresetUpdaterSpec(
+            name=(
+                OptionalState.update(input.name) if input.name is not None else OptionalState.nop()
+            ),
+            auto_assign=(
+                OptionalState.update(input.auto_assign)
+                if input.auto_assign is not None
+                else OptionalState.nop()
+            ),
+        )
+        updater: Updater[RolePresetRow] = Updater(spec=spec, pk_value=input.role_preset_id)
+        result = await self._processors.role_preset.update.wait_for_complete(
+            UpdateRolePresetAction(updater=updater)
+        )
+        return UpdateRolePresetPayload(role_preset=self._data_to_node(result.preset))
 
     async def bulk_delete(self, input: BulkDeleteRolePresetsInput) -> BulkDeleteRolePresetsPayload:
         """Bulk-soft-delete role presets."""
-        raise NotImplementedError
+        updaters: list[Updater[RolePresetRow]] = [
+            Updater(spec=RolePresetDeletedFlagUpdaterSpec(deleted=True), pk_value=preset_id)
+            for preset_id in input.role_preset_ids
+        ]
+        result = await self._processors.role_preset.bulk_delete.wait_for_complete(
+            BulkDeleteRolePresetsAction(updaters=updaters)
+        )
+        return BulkDeleteRolePresetsPayload(
+            items=[self._data_to_node(d) for d in result.successes],
+            failed=[
+                BulkRolePresetFailureInfo(
+                    role_preset_id=input.role_preset_ids[f.index],
+                    message=str(f.exception),
+                )
+                for f in result.failures
+            ],
+        )
 
     async def bulk_restore(
         self, input: BulkRestoreRolePresetsInput
     ) -> BulkRestoreRolePresetsPayload:
         """Bulk-restore soft-deleted role presets."""
-        raise NotImplementedError
+        updaters: list[Updater[RolePresetRow]] = [
+            Updater(spec=RolePresetDeletedFlagUpdaterSpec(deleted=False), pk_value=preset_id)
+            for preset_id in input.role_preset_ids
+        ]
+        result = await self._processors.role_preset.bulk_restore.wait_for_complete(
+            BulkRestoreRolePresetsAction(updaters=updaters)
+        )
+        return BulkRestoreRolePresetsPayload(
+            items=[self._data_to_node(d) for d in result.successes],
+            failed=[
+                BulkRolePresetFailureInfo(
+                    role_preset_id=input.role_preset_ids[f.index],
+                    message=str(f.exception),
+                )
+                for f in result.failures
+            ],
+        )
 
     async def bulk_purge(self, input: BulkPurgeRolePresetsInput) -> BulkPurgeRolePresetsPayload:
         """Bulk-hard-delete role presets."""
-        raise NotImplementedError
+        result = await self._processors.role_preset.bulk_purge.wait_for_complete(
+            BulkPurgeRolePresetsAction(ids=input.role_preset_ids)
+        )
+        purge_result = result.result
+        return BulkPurgeRolePresetsPayload(
+            items=[self._data_to_node(d) for d in purge_result.successes],
+            failed=[
+                BulkRolePresetFailureInfo(
+                    role_preset_id=input.role_preset_ids[f.index],
+                    message=str(f.exception),
+                )
+                for f in purge_result.failures
+            ],
+        )
 
     async def search_permissions(
         self, input: RolePermissionPresetFilter
@@ -78,6 +250,9 @@ class RolePresetAdapter(BaseAdapter):
 
         Backs the ``permission_presets`` field resolver on ``RolePresetNode``; the caller
         supplies ``role_preset_id`` via the filter.
+
+        Not yet wired: there is no read-path Processor/Service for permission entries.
+        Adding one is tracked under the Role Preset service layer, not this wire-up.
         """
         raise NotImplementedError
 
@@ -87,10 +262,122 @@ class RolePresetAdapter(BaseAdapter):
         input: BulkAddRolePermissionPresetsInput,
     ) -> BulkAddRolePermissionPresetsPayload:
         """Bulk-add permission entries to an existing role preset."""
-        raise NotImplementedError
+        bulk_creator: BulkCreator[RolePermissionPresetRow] = BulkCreator(
+            specs=[
+                RolePermissionPresetCreatorSpec(
+                    role_preset_id=role_preset_id,
+                    entity_type=RBACElementType(entry.entity_type.value).to_entity_type(),
+                    operation=OperationType(entry.operation.value),
+                )
+                for entry in input.permissions
+            ]
+        )
+        result = await self._processors.role_preset.bulk_add_permissions.wait_for_complete(
+            BulkAddRolePermissionPresetsAction(bulk_creator=bulk_creator)
+        )
+        return BulkAddRolePermissionPresetsPayload(
+            items=[self._permission_data_to_node(d) for d in result.successes],
+            failed=[
+                BulkAddRolePermissionPresetFailureInfo(
+                    entity_type=input.permissions[f.index].entity_type,
+                    operation=input.permissions[f.index].operation,
+                    message=str(f.exception),
+                )
+                for f in result.failures
+            ],
+        )
 
     async def bulk_remove_permissions(
         self, input: BulkRemoveRolePermissionPresetsInput
     ) -> BulkRemoveRolePermissionPresetsPayload:
         """Bulk-remove permission entries from a role preset."""
-        raise NotImplementedError
+        result = await self._processors.role_preset.bulk_remove_permissions.wait_for_complete(
+            BulkRemoveRolePermissionPresetsAction(ids=input.permission_preset_ids)
+        )
+        return BulkRemoveRolePermissionPresetsPayload(
+            items=[self._permission_data_to_node(d) for d in result.successes],
+            failed=[
+                BulkRolePermissionPresetFailureInfo(
+                    permission_preset_id=input.permission_preset_ids[f.index],
+                    message=str(f.exception),
+                )
+                for f in result.failures
+            ],
+        )
+
+    def _convert_filter(self, filter_: RolePresetFilter) -> list[QueryCondition]:
+        conditions: list[QueryCondition] = []
+        if filter_.name is not None:
+            cond = self.convert_string_filter(
+                filter_.name,
+                contains_factory=RolePresetConditions.by_name_contains,
+                equals_factory=RolePresetConditions.by_name_equals,
+                starts_with_factory=RolePresetConditions.by_name_starts_with,
+                ends_with_factory=RolePresetConditions.by_name_ends_with,
+                in_factory=RolePresetConditions.by_name_in,
+            )
+            if cond is not None:
+                conditions.append(cond)
+        if filter_.scope_type is not None:
+            conditions.append(
+                RolePresetConditions.by_scope_type(
+                    RBACElementType(filter_.scope_type.value).to_scope_type()
+                )
+            )
+        if filter_.auto_assign is not None:
+            conditions.append(RolePresetConditions.by_auto_assign(filter_.auto_assign))
+        if filter_.deleted is not None:
+            conditions.append(RolePresetConditions.by_deleted(filter_.deleted))
+        if filter_.AND:
+            for sub in filter_.AND:
+                conditions.extend(self._convert_filter(sub))
+        if filter_.OR:
+            or_conds: list[QueryCondition] = []
+            for sub in filter_.OR:
+                or_conds.extend(self._convert_filter(sub))
+            if or_conds:
+                conditions.append(combine_conditions_or(or_conds))
+        if filter_.NOT:
+            not_conds: list[QueryCondition] = []
+            for sub in filter_.NOT:
+                not_conds.extend(self._convert_filter(sub))
+            if not_conds:
+                conditions.append(negate_conditions(not_conds))
+        return conditions
+
+    def _convert_orders(self, orders: list[RolePresetOrder]) -> list[QueryOrder]:
+        result: list[QueryOrder] = []
+        for order in orders:
+            ascending = order.direction == OrderDirection.ASC
+            match order.field:
+                case RolePresetOrderField.NAME:
+                    result.append(RolePresetOrders.name(ascending))
+                case RolePresetOrderField.SCOPE_TYPE:
+                    result.append(RolePresetOrders.scope_type(ascending))
+                case RolePresetOrderField.CREATED_AT:
+                    result.append(RolePresetOrders.created_at(ascending))
+                case RolePresetOrderField.UPDATED_AT:
+                    result.append(RolePresetOrders.updated_at(ascending))
+        return result
+
+    @staticmethod
+    def _data_to_node(data: RolePresetData) -> RolePresetNode:
+        return RolePresetNode(
+            id=data.id,
+            name=data.name,
+            scope_type=RBACElementTypeDTO(data.scope_type.value),
+            auto_assign=data.auto_assign,
+            deleted=data.deleted,
+            created_at=data.created_at,
+            updated_at=data.updated_at,
+        )
+
+    @staticmethod
+    def _permission_data_to_node(data: RolePermissionPresetData) -> RolePermissionPresetNode:
+        return RolePermissionPresetNode(
+            id=data.id,
+            role_preset_id=data.role_preset_id,
+            entity_type=RBACElementTypeDTO(data.entity_type.value),
+            operation=OperationTypeDTO(data.operation.value),
+            created_at=data.created_at,
+        )

--- a/src/ai/backend/manager/api/adapters/role_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/role_preset/adapter.py
@@ -16,6 +16,8 @@ from ai.backend.common.dto.manager.v2.role_permission_preset.request import (
     BulkAddRolePermissionPresetsInput,
     BulkRemoveRolePermissionPresetsInput,
     RolePermissionPresetFilter,
+    RolePermissionPresetOrder,
+    SearchRolePermissionPresetsInput,
 )
 from ai.backend.common.dto.manager.v2.role_permission_preset.response import (
     BulkAddRolePermissionPresetFailureInfo,
@@ -23,6 +25,10 @@ from ai.backend.common.dto.manager.v2.role_permission_preset.response import (
     BulkRemoveRolePermissionPresetsPayload,
     BulkRolePermissionPresetFailureInfo,
     RolePermissionPresetNode,
+    SearchRolePermissionPresetsPayload,
+)
+from ai.backend.common.dto.manager.v2.role_permission_preset.types import (
+    RolePermissionPresetOrderField,
 )
 from ai.backend.common.dto.manager.v2.role_preset.request import (
     BulkDeleteRolePresetsInput,
@@ -51,6 +57,12 @@ from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.role_preset.types import (
     RolePermissionPresetData,
     RolePresetData,
+)
+from ai.backend.manager.models.rbac_models.role_permission_preset.conditions import (
+    RolePermissionPresetConditions,
+)
+from ai.backend.manager.models.rbac_models.role_permission_preset.orders import (
+    RolePermissionPresetOrders,
 )
 from ai.backend.manager.models.rbac_models.role_permission_preset.row import (
     RolePermissionPresetRow,
@@ -89,6 +101,9 @@ from ai.backend.manager.services.role_preset.actions.delete import BulkDeleteRol
 from ai.backend.manager.services.role_preset.actions.get import GetRolePresetAction
 from ai.backend.manager.services.role_preset.actions.restore import BulkRestoreRolePresetsAction
 from ai.backend.manager.services.role_preset.actions.search import SearchRolePresetsAction
+from ai.backend.manager.services.role_preset.actions.search_permission_presets import (
+    SearchRolePermissionPresetsAction,
+)
 from ai.backend.manager.services.role_preset.actions.update import UpdateRolePresetAction
 from ai.backend.manager.types import OptionalState
 
@@ -100,6 +115,16 @@ def _role_preset_pagination_spec() -> PaginationSpec:
         forward_condition_factory=RolePresetConditions.by_cursor_forward,
         backward_condition_factory=RolePresetConditions.by_cursor_backward,
         tiebreaker_order=RolePresetRow.id.asc(),
+    )
+
+
+def _role_permission_preset_pagination_spec() -> PaginationSpec:
+    return PaginationSpec(
+        forward_order=RolePermissionPresetOrders.id(ascending=False),
+        backward_order=RolePermissionPresetOrders.id(ascending=True),
+        forward_condition_factory=RolePermissionPresetConditions.by_cursor_forward,
+        backward_condition_factory=RolePermissionPresetConditions.by_cursor_backward,
+        tiebreaker_order=RolePermissionPresetRow.id.asc(),
     )
 
 
@@ -243,18 +268,43 @@ class RolePresetAdapter(BaseAdapter):
             ],
         )
 
-    async def search_permissions(
-        self, input: RolePermissionPresetFilter
-    ) -> list[RolePermissionPresetNode]:
-        """Resolve the permission entries belonging to a role preset.
+    async def search_permission_presets(
+        self,
+        role_preset_id: RolePresetID,
+        input: SearchRolePermissionPresetsInput,
+    ) -> SearchRolePermissionPresetsPayload:
+        """Search the permission entries belonging to a single role preset.
 
-        Backs the ``permission_presets`` field resolver on ``RolePresetNode``; the caller
-        supplies ``role_preset_id`` via the filter.
-
-        Not yet wired: there is no read-path Processor/Service for permission entries.
-        Adding one is tracked under the Role Preset service layer, not this wire-up.
+        Backs the ``permission_presets`` field resolver on ``RolePresetGQL``. The
+        parent preset id is always enforced as a base condition, so caller-supplied
+        filters can only narrow within that preset, never widen across presets.
         """
-        raise NotImplementedError
+        conditions = self._convert_permission_filter(input.filter) if input.filter else []
+        orders = self._convert_permission_orders(input.order) if input.order else []
+        base_conditions: list[QueryCondition] = [
+            RolePermissionPresetConditions.by_role_preset_id_equals(role_preset_id)
+        ]
+        querier = self._build_querier(
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=_role_permission_preset_pagination_spec(),
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+            base_conditions=base_conditions,
+        )
+        result = await self._processors.role_preset.search_permission_presets.wait_for_complete(
+            SearchRolePermissionPresetsAction(querier=querier)
+        )
+        return SearchRolePermissionPresetsPayload(
+            items=[self._permission_data_to_node(d) for d in result.items],
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
 
     async def bulk_add_permissions(
         self,
@@ -358,6 +408,104 @@ class RolePresetAdapter(BaseAdapter):
                     result.append(RolePresetOrders.created_at(ascending))
                 case RolePresetOrderField.UPDATED_AT:
                     result.append(RolePresetOrders.updated_at(ascending))
+        return result
+
+    def _convert_permission_filter(
+        self, filter_: RolePermissionPresetFilter
+    ) -> list[QueryCondition]:
+        # ``role_preset_id`` is intentionally ignored here: the parent preset scope
+        # is enforced as a base condition by the caller, so it cannot be widened.
+        conditions: list[QueryCondition] = []
+        if filter_.entity_type is not None:
+            f = filter_.entity_type
+            if f.equals is not None:
+                conditions.append(
+                    RolePermissionPresetConditions.by_entity_type_equals(
+                        RBACElementType(f.equals.value).to_entity_type()
+                    )
+                )
+            if f.not_equals is not None:
+                conditions.append(
+                    RolePermissionPresetConditions.by_entity_type_not_equals(
+                        RBACElementType(f.not_equals.value).to_entity_type()
+                    )
+                )
+            if f.in_:
+                conditions.append(
+                    RolePermissionPresetConditions.by_entity_type_in([
+                        RBACElementType(v.value).to_entity_type() for v in f.in_
+                    ])
+                )
+            if f.not_in:
+                conditions.append(
+                    RolePermissionPresetConditions.by_entity_type_not_in([
+                        RBACElementType(v.value).to_entity_type() for v in f.not_in
+                    ])
+                )
+        if filter_.operation is not None:
+            f_op = filter_.operation
+            if f_op.equals is not None:
+                conditions.append(
+                    RolePermissionPresetConditions.by_operation_equals(
+                        OperationType(f_op.equals.value)
+                    )
+                )
+            if f_op.not_equals is not None:
+                conditions.append(
+                    RolePermissionPresetConditions.by_operation_not_equals(
+                        OperationType(f_op.not_equals.value)
+                    )
+                )
+            if f_op.in_:
+                conditions.append(
+                    RolePermissionPresetConditions.by_operation_in([
+                        OperationType(v.value) for v in f_op.in_
+                    ])
+                )
+            if f_op.not_in:
+                conditions.append(
+                    RolePermissionPresetConditions.by_operation_not_in([
+                        OperationType(v.value) for v in f_op.not_in
+                    ])
+                )
+        if filter_.created_at is not None:
+            cond = filter_.created_at.build_query_condition(
+                before_factory=RolePermissionPresetConditions.by_created_at_before,
+                after_factory=RolePermissionPresetConditions.by_created_at_after,
+                equals_factory=RolePermissionPresetConditions.by_created_at_equals,
+            )
+            if cond is not None:
+                conditions.append(cond)
+        if filter_.AND:
+            for sub in filter_.AND:
+                conditions.extend(self._convert_permission_filter(sub))
+        if filter_.OR:
+            or_conds: list[QueryCondition] = []
+            for sub in filter_.OR:
+                or_conds.extend(self._convert_permission_filter(sub))
+            if or_conds:
+                conditions.append(combine_conditions_or(or_conds))
+        if filter_.NOT:
+            not_conds: list[QueryCondition] = []
+            for sub in filter_.NOT:
+                not_conds.extend(self._convert_permission_filter(sub))
+            if not_conds:
+                conditions.append(negate_conditions(not_conds))
+        return conditions
+
+    def _convert_permission_orders(
+        self, orders: list[RolePermissionPresetOrder]
+    ) -> list[QueryOrder]:
+        result: list[QueryOrder] = []
+        for order in orders:
+            ascending = order.direction == OrderDirection.ASC
+            match order.field:
+                case RolePermissionPresetOrderField.ENTITY_TYPE:
+                    result.append(RolePermissionPresetOrders.entity_type(ascending))
+                case RolePermissionPresetOrderField.OPERATION:
+                    result.append(RolePermissionPresetOrders.operation(ascending))
+                case RolePermissionPresetOrderField.CREATED_AT:
+                    result.append(RolePermissionPresetOrders.created_at(ascending))
         return result
 
     @staticmethod

--- a/src/ai/backend/manager/api/gql/role_preset/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/role_preset/resolver/mutation.py
@@ -1,13 +1,12 @@
-"""Role preset GQL mutation resolvers.
-
-Function bodies raise ``NotImplementedError``; wire-up to the adapter/service
-layer happens in a follow-up task.
-"""
+"""Role preset GQL mutation resolvers."""
 
 from __future__ import annotations
 
+from uuid import UUID
+
 from strawberry import Info
 
+from ai.backend.common.identifier.role_preset import RolePresetID
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -44,7 +43,8 @@ async def admin_create_role_preset(
     input: CreateRolePresetInputGQL,
 ) -> CreateRolePresetPayloadGQL | None:
     check_admin_only()
-    raise NotImplementedError
+    payload = await info.context.adapters.role_preset.create(input.to_pydantic())
+    return CreateRolePresetPayloadGQL.from_pydantic(payload)
 
 
 @gql_mutation(
@@ -58,7 +58,8 @@ async def admin_update_role_preset(
     input: UpdateRolePresetInputGQL,
 ) -> UpdateRolePresetPayloadGQL | None:
     check_admin_only()
-    raise NotImplementedError
+    payload = await info.context.adapters.role_preset.update(input.to_pydantic())
+    return UpdateRolePresetPayloadGQL.from_pydantic(payload)
 
 
 @gql_mutation(
@@ -72,7 +73,8 @@ async def admin_delete_role_presets(
     input: BulkDeleteRolePresetsInputGQL,
 ) -> BulkDeleteRolePresetsPayloadGQL | None:
     check_admin_only()
-    raise NotImplementedError
+    payload = await info.context.adapters.role_preset.bulk_delete(input.to_pydantic())
+    return BulkDeleteRolePresetsPayloadGQL.from_pydantic(payload)
 
 
 @gql_mutation(
@@ -86,7 +88,8 @@ async def admin_restore_role_presets(
     input: BulkRestoreRolePresetsInputGQL,
 ) -> BulkRestoreRolePresetsPayloadGQL | None:
     check_admin_only()
-    raise NotImplementedError
+    payload = await info.context.adapters.role_preset.bulk_restore(input.to_pydantic())
+    return BulkRestoreRolePresetsPayloadGQL.from_pydantic(payload)
 
 
 @gql_mutation(
@@ -100,7 +103,8 @@ async def admin_purge_role_presets(
     input: BulkPurgeRolePresetsInputGQL,
 ) -> BulkPurgeRolePresetsPayloadGQL | None:
     check_admin_only()
-    raise NotImplementedError
+    payload = await info.context.adapters.role_preset.bulk_purge(input.to_pydantic())
+    return BulkPurgeRolePresetsPayloadGQL.from_pydantic(payload)
 
 
 @gql_mutation(
@@ -114,7 +118,11 @@ async def admin_bulk_add_role_preset_permissions(
     input: BulkAddRolePermissionPresetsInputGQL,
 ) -> BulkAddRolePermissionPresetsPayloadGQL | None:
     check_admin_only()
-    raise NotImplementedError
+    role_preset_id = RolePresetID(UUID(str(input.role_preset_id)))
+    payload = await info.context.adapters.role_preset.bulk_add_permissions(
+        role_preset_id, input.to_pydantic()
+    )
+    return BulkAddRolePermissionPresetsPayloadGQL.from_pydantic(payload)
 
 
 @gql_mutation(
@@ -128,4 +136,5 @@ async def admin_bulk_remove_role_preset_permissions(
     input: BulkRemoveRolePermissionPresetsInputGQL,
 ) -> BulkRemoveRolePermissionPresetsPayloadGQL | None:
     check_admin_only()
-    raise NotImplementedError
+    payload = await info.context.adapters.role_preset.bulk_remove_permissions(input.to_pydantic())
+    return BulkRemoveRolePermissionPresetsPayloadGQL.from_pydantic(payload)

--- a/src/ai/backend/manager/api/gql/role_preset/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/role_preset/resolver/query.py
@@ -1,13 +1,18 @@
-"""Role preset GQL query resolvers.
-
-Function bodies raise ``NotImplementedError``; wire-up to the adapter/service
-layer happens in a follow-up task.
-"""
+"""Role preset GQL query resolvers."""
 
 from __future__ import annotations
 
-from strawberry import ID, Info
+from uuid import UUID
 
+from strawberry import ID, Info
+from strawberry.relay import PageInfo
+
+from ai.backend.common.dto.manager.v2.role_preset.request import (
+    RolePresetFilter,
+    RolePresetOrder,
+    SearchRolePresetsInput,
+)
+from ai.backend.common.identifier.role_preset import RolePresetID
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -15,6 +20,7 @@ from ai.backend.manager.api.gql.decorators import (
 )
 from ai.backend.manager.api.gql.role_preset.types import (
     RolePresetConnection,
+    RolePresetEdge,
     RolePresetFilterGQL,
     RolePresetGQL,
     RolePresetOrderByGQL,
@@ -34,7 +40,10 @@ async def admin_role_preset(
     id: ID,
 ) -> RolePresetGQL | None:
     check_admin_only()
-    raise NotImplementedError
+    node = await info.context.adapters.role_preset.get(RolePresetID(UUID(str(id))))
+    if node is None:
+        return None
+    return RolePresetGQL.from_pydantic(node)
 
 
 @gql_root_field(
@@ -55,4 +64,35 @@ async def admin_role_presets(
     offset: int | None = None,
 ) -> RolePresetConnection | None:
     check_admin_only()
-    raise NotImplementedError
+    filter_dto: RolePresetFilter | None = filter.to_pydantic() if filter else None
+    orders_dto: list[RolePresetOrder] | None = (
+        [o.to_pydantic() for o in order_by] if order_by else None
+    )
+    search_input = SearchRolePresetsInput(
+        filter=filter_dto,
+        order=orders_dto,
+        first=first,
+        after=after,
+        last=last,
+        before=before,
+        limit=limit,
+        offset=offset,
+    )
+    result = await info.context.adapters.role_preset.search(search_input)
+    edges = [
+        RolePresetEdge(
+            node=RolePresetGQL.from_pydantic(item),
+            cursor=str(item.id),
+        )
+        for item in result.items
+    ]
+    return RolePresetConnection(
+        edges=edges,
+        page_info=PageInfo(
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        ),
+        count=result.total_count,
+    )

--- a/src/ai/backend/manager/api/gql/role_preset/types/node.py
+++ b/src/ai/backend/manager/api/gql/role_preset/types/node.py
@@ -4,11 +4,18 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Any
+from uuid import UUID
 
 from strawberry import Info
-from strawberry.relay import Connection, Edge, NodeID
+from strawberry.relay import Connection, Edge, NodeID, PageInfo
 
+from ai.backend.common.dto.manager.v2.role_permission_preset.request import (
+    RolePermissionPresetFilter,
+    RolePermissionPresetOrder,
+    SearchRolePermissionPresetsInput,
+)
 from ai.backend.common.dto.manager.v2.role_preset.response import RolePresetNode
+from ai.backend.common.identifier.role_preset import RolePresetID
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -23,7 +30,9 @@ from ai.backend.manager.api.gql.types import StrawberryGQLContext
 
 from .permission import (
     RolePermissionPresetConnection,
+    RolePermissionPresetEdge,
     RolePermissionPresetFilterGQL,
+    RolePermissionPresetGQL,
     RolePermissionPresetOrderByGQL,
 )
 
@@ -74,7 +83,40 @@ class RolePresetGQL(PydanticNodeMixin[RolePresetNode]):
         limit: int | None = None,
         offset: int | None = None,
     ) -> RolePermissionPresetConnection | None:
-        raise NotImplementedError
+        filter_dto: RolePermissionPresetFilter | None = filter.to_pydantic() if filter else None
+        orders_dto: list[RolePermissionPresetOrder] | None = (
+            [o.to_pydantic() for o in order_by] if order_by else None
+        )
+        search_input = SearchRolePermissionPresetsInput(
+            filter=filter_dto,
+            order=orders_dto,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        )
+        result = await info.context.adapters.role_preset.search_permission_presets(
+            RolePresetID(UUID(str(self.id))), search_input
+        )
+        edges = [
+            RolePermissionPresetEdge(
+                node=RolePermissionPresetGQL.from_pydantic(item),
+                cursor=str(item.id),
+            )
+            for item in result.items
+        ]
+        return RolePermissionPresetConnection(
+            edges=edges,
+            page_info=PageInfo(
+                has_next_page=result.has_next_page,
+                has_previous_page=result.has_previous_page,
+                start_cursor=edges[0].cursor if edges else None,
+                end_cursor=edges[-1].cursor if edges else None,
+            ),
+            count=result.total_count,
+        )
 
 
 RolePresetEdge = Edge[RolePresetGQL]

--- a/src/ai/backend/manager/api/gql/role_preset/types/payloads.py
+++ b/src/ai/backend/manager/api/gql/role_preset/types/payloads.py
@@ -28,6 +28,7 @@ from ai.backend.manager.api.gql.decorators import (
     gql_field,
     gql_pydantic_type,
 )
+from ai.backend.manager.api.gql.pydantic_compat import PydanticOutputMixin
 
 from .node import RolePresetGQL
 
@@ -40,7 +41,7 @@ from .node import RolePresetGQL
     model=CreateRolePresetPayloadDTO,
     name="CreateRolePresetPayload",
 )
-class CreateRolePresetPayloadGQL:
+class CreateRolePresetPayloadGQL(PydanticOutputMixin[CreateRolePresetPayloadDTO]):
     role_preset: RolePresetGQL = gql_field(description="Created role preset.")
 
 
@@ -52,7 +53,7 @@ class CreateRolePresetPayloadGQL:
     model=UpdateRolePresetPayloadDTO,
     name="UpdateRolePresetPayload",
 )
-class UpdateRolePresetPayloadGQL:
+class UpdateRolePresetPayloadGQL(PydanticOutputMixin[UpdateRolePresetPayloadDTO]):
     role_preset: RolePresetGQL = gql_field(description="Updated role preset.")
 
 
@@ -64,7 +65,7 @@ class UpdateRolePresetPayloadGQL:
     model=BulkRolePresetFailureInfoDTO,
     name="BulkRolePresetFailureInfo",
 )
-class BulkRolePresetFailureInfoGQL:
+class BulkRolePresetFailureInfoGQL(PydanticOutputMixin[BulkRolePresetFailureInfoDTO]):
     role_preset_id: UUID = gql_field(description="Role preset ID that the operation failed on.")
     message: str = gql_field(description="Error message describing the failure.")
 
@@ -77,7 +78,7 @@ class BulkRolePresetFailureInfoGQL:
     model=BulkDeleteRolePresetsPayloadDTO,
     name="BulkDeleteRolePresetsPayload",
 )
-class BulkDeleteRolePresetsPayloadGQL:
+class BulkDeleteRolePresetsPayloadGQL(PydanticOutputMixin[BulkDeleteRolePresetsPayloadDTO]):
     items: list[RolePresetGQL] = gql_field(description="Role presets that were soft-deleted.")
     failed: list[BulkRolePresetFailureInfoGQL] = gql_field(
         description="Role preset IDs that failed to soft-delete."
@@ -92,7 +93,7 @@ class BulkDeleteRolePresetsPayloadGQL:
     model=BulkRestoreRolePresetsPayloadDTO,
     name="BulkRestoreRolePresetsPayload",
 )
-class BulkRestoreRolePresetsPayloadGQL:
+class BulkRestoreRolePresetsPayloadGQL(PydanticOutputMixin[BulkRestoreRolePresetsPayloadDTO]):
     items: list[RolePresetGQL] = gql_field(description="Role presets that were restored.")
     failed: list[BulkRolePresetFailureInfoGQL] = gql_field(
         description="Role preset IDs that failed to restore."
@@ -107,7 +108,7 @@ class BulkRestoreRolePresetsPayloadGQL:
     model=BulkPurgeRolePresetsPayloadDTO,
     name="BulkPurgeRolePresetsPayload",
 )
-class BulkPurgeRolePresetsPayloadGQL:
+class BulkPurgeRolePresetsPayloadGQL(PydanticOutputMixin[BulkPurgeRolePresetsPayloadDTO]):
     items: list[RolePresetGQL] = gql_field(description="Role presets that were purged.")
     failed: list[BulkRolePresetFailureInfoGQL] = gql_field(
         description="Role preset IDs that failed to purge."

--- a/src/ai/backend/manager/api/gql/role_preset/types/permission.py
+++ b/src/ai/backend/manager/api/gql/role_preset/types/permission.py
@@ -50,7 +50,11 @@ from ai.backend.manager.api.gql.decorators import (
     gql_pydantic_input,
     gql_pydantic_type,
 )
-from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin, PydanticNodeMixin
+from ai.backend.manager.api.gql.pydantic_compat import (
+    PydanticInputMixin,
+    PydanticNodeMixin,
+    PydanticOutputMixin,
+)
 from ai.backend.manager.api.gql.rbac.types import (
     OperationTypeFilterGQL,
     OperationTypeGQL,
@@ -174,7 +178,9 @@ class RolePermissionPresetOrderByGQL(PydanticInputMixin[RolePermissionPresetOrde
     model=BulkRolePermissionPresetFailureInfoDTO,
     name="BulkRolePermissionPresetFailureInfo",
 )
-class BulkRolePermissionPresetFailureInfoGQL:
+class BulkRolePermissionPresetFailureInfoGQL(
+    PydanticOutputMixin[BulkRolePermissionPresetFailureInfoDTO]
+):
     permission_preset_id: UUID = gql_field(
         description="Permission entry ID that the operation failed on."
     )
@@ -189,7 +195,9 @@ class BulkRolePermissionPresetFailureInfoGQL:
     model=BulkAddRolePermissionPresetFailureInfoDTO,
     name="BulkAddRolePermissionPresetFailureInfo",
 )
-class BulkAddRolePermissionPresetFailureInfoGQL:
+class BulkAddRolePermissionPresetFailureInfoGQL(
+    PydanticOutputMixin[BulkAddRolePermissionPresetFailureInfoDTO]
+):
     entity_type: RBACElementTypeGQL = gql_field(
         description="Entity type of the permission entry that failed."
     )
@@ -207,7 +215,9 @@ class BulkAddRolePermissionPresetFailureInfoGQL:
     model=BulkAddRolePermissionPresetsPayloadDTO,
     name="BulkAddRolePermissionPresetsPayload",
 )
-class BulkAddRolePermissionPresetsPayloadGQL:
+class BulkAddRolePermissionPresetsPayloadGQL(
+    PydanticOutputMixin[BulkAddRolePermissionPresetsPayloadDTO]
+):
     items: list[RolePermissionPresetGQL] = gql_field(
         description="Permission entries that were added."
     )
@@ -224,7 +234,9 @@ class BulkAddRolePermissionPresetsPayloadGQL:
     model=BulkRemoveRolePermissionPresetsPayloadDTO,
     name="BulkRemoveRolePermissionPresetsPayload",
 )
-class BulkRemoveRolePermissionPresetsPayloadGQL:
+class BulkRemoveRolePermissionPresetsPayloadGQL(
+    PydanticOutputMixin[BulkRemoveRolePermissionPresetsPayloadDTO]
+):
     items: list[RolePermissionPresetGQL] = gql_field(
         description="Permission entries that were removed."
     )

--- a/src/ai/backend/manager/models/rbac_models/role_permission_preset/conditions.py
+++ b/src/ai/backend/manager/models/rbac_models/role_permission_preset/conditions.py
@@ -1,0 +1,128 @@
+"""Query conditions for role permission preset rows."""
+
+from __future__ import annotations
+
+from collections.abc import Collection
+from datetime import datetime
+from uuid import UUID
+
+import sqlalchemy as sa
+
+from ai.backend.common.data.permission.types import EntityType, OperationType
+from ai.backend.manager.models.rbac_models.role_permission_preset.row import (
+    RolePermissionPresetRow,
+)
+from ai.backend.manager.repositories.base import QueryCondition
+
+__all__ = ("RolePermissionPresetConditions",)
+
+
+class RolePermissionPresetConditions:
+    @staticmethod
+    def by_role_preset_id_equals(role_preset_id: UUID) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RolePermissionPresetRow.role_preset_id == role_preset_id
+
+        return inner
+
+    @staticmethod
+    def by_role_preset_id_in(role_preset_ids: Collection[UUID]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RolePermissionPresetRow.role_preset_id.in_(role_preset_ids)
+
+        return inner
+
+    @staticmethod
+    def by_entity_type_equals(entity_type: EntityType) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RolePermissionPresetRow.entity_type == entity_type
+
+        return inner
+
+    @staticmethod
+    def by_entity_type_not_equals(entity_type: EntityType) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RolePermissionPresetRow.entity_type != entity_type
+
+        return inner
+
+    @staticmethod
+    def by_entity_type_in(entity_types: Collection[EntityType]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RolePermissionPresetRow.entity_type.in_(entity_types)
+
+        return inner
+
+    @staticmethod
+    def by_entity_type_not_in(entity_types: Collection[EntityType]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RolePermissionPresetRow.entity_type.notin_(entity_types)
+
+        return inner
+
+    @staticmethod
+    def by_operation_equals(operation: OperationType) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RolePermissionPresetRow.operation == operation
+
+        return inner
+
+    @staticmethod
+    def by_operation_not_equals(operation: OperationType) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RolePermissionPresetRow.operation != operation
+
+        return inner
+
+    @staticmethod
+    def by_operation_in(operations: Collection[OperationType]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RolePermissionPresetRow.operation.in_(operations)
+
+        return inner
+
+    @staticmethod
+    def by_operation_not_in(operations: Collection[OperationType]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RolePermissionPresetRow.operation.notin_(operations)
+
+        return inner
+
+    @staticmethod
+    def by_created_at_equals(value: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RolePermissionPresetRow.created_at == value
+
+        return inner
+
+    @staticmethod
+    def by_created_at_before(value: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RolePermissionPresetRow.created_at <= value
+
+        return inner
+
+    @staticmethod
+    def by_created_at_after(value: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RolePermissionPresetRow.created_at >= value
+
+        return inner
+
+    @staticmethod
+    def by_cursor_forward(cursor_id: str) -> QueryCondition:
+        cursor_uuid = UUID(cursor_id)
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RolePermissionPresetRow.id < cursor_uuid
+
+        return inner
+
+    @staticmethod
+    def by_cursor_backward(cursor_id: str) -> QueryCondition:
+        cursor_uuid = UUID(cursor_id)
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RolePermissionPresetRow.id > cursor_uuid
+
+        return inner

--- a/src/ai/backend/manager/models/rbac_models/role_permission_preset/orders.py
+++ b/src/ai/backend/manager/models/rbac_models/role_permission_preset/orders.py
@@ -1,0 +1,36 @@
+"""Query orders for role permission preset rows."""
+
+from __future__ import annotations
+
+from ai.backend.manager.models.rbac_models.role_permission_preset.row import (
+    RolePermissionPresetRow,
+)
+from ai.backend.manager.repositories.base import QueryOrder
+
+__all__ = ("RolePermissionPresetOrders",)
+
+
+class RolePermissionPresetOrders:
+    @staticmethod
+    def entity_type(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return RolePermissionPresetRow.entity_type.asc()
+        return RolePermissionPresetRow.entity_type.desc()
+
+    @staticmethod
+    def operation(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return RolePermissionPresetRow.operation.asc()
+        return RolePermissionPresetRow.operation.desc()
+
+    @staticmethod
+    def created_at(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return RolePermissionPresetRow.created_at.asc()
+        return RolePermissionPresetRow.created_at.desc()
+
+    @staticmethod
+    def id(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return RolePermissionPresetRow.id.asc()
+        return RolePermissionPresetRow.id.desc()

--- a/src/ai/backend/manager/models/rbac_models/role_preset/conditions.py
+++ b/src/ai/backend/manager/models/rbac_models/role_preset/conditions.py
@@ -1,0 +1,104 @@
+"""Query conditions for role preset rows."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from ai.backend.common.data.filter_specs import StringMatchSpec
+from ai.backend.common.data.permission.types import ScopeType
+from ai.backend.manager.models.condition_utils import make_string_in_factory
+from ai.backend.manager.models.rbac_models.role_preset.row import RolePresetRow
+from ai.backend.manager.repositories.base import QueryCondition
+
+__all__ = ("RolePresetConditions",)
+
+
+class RolePresetConditions:
+    @staticmethod
+    def by_name_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = RolePresetRow.name.ilike(f"%{spec.value}%")
+            else:
+                condition = RolePresetRow.name.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_name_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = sa.func.lower(RolePresetRow.name) == spec.value.lower()
+            else:
+                condition = RolePresetRow.name == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = RolePresetRow.name.ilike(f"{spec.value}%")
+            else:
+                condition = RolePresetRow.name.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = RolePresetRow.name.ilike(f"%{spec.value}")
+            else:
+                condition = RolePresetRow.name.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    by_name_in = staticmethod(make_string_in_factory(RolePresetRow.name))
+
+    @staticmethod
+    def by_scope_type(scope_type: ScopeType) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RolePresetRow.scope_type == scope_type
+
+        return inner
+
+    @staticmethod
+    def by_auto_assign(auto_assign: bool) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RolePresetRow.auto_assign == auto_assign
+
+        return inner
+
+    @staticmethod
+    def by_deleted(deleted: bool) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RolePresetRow.deleted == deleted
+
+        return inner
+
+    @staticmethod
+    def by_cursor_forward(cursor_id: str) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RolePresetRow.id < sa.text(f"'{cursor_id}'::uuid")
+
+        return inner
+
+    @staticmethod
+    def by_cursor_backward(cursor_id: str) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RolePresetRow.id > sa.text(f"'{cursor_id}'::uuid")
+
+        return inner

--- a/src/ai/backend/manager/models/rbac_models/role_preset/orders.py
+++ b/src/ai/backend/manager/models/rbac_models/role_preset/orders.py
@@ -1,0 +1,40 @@
+"""Query orders for role preset rows."""
+
+from __future__ import annotations
+
+from ai.backend.manager.models.rbac_models.role_preset.row import RolePresetRow
+from ai.backend.manager.repositories.base import QueryOrder
+
+__all__ = ("RolePresetOrders",)
+
+
+class RolePresetOrders:
+    @staticmethod
+    def name(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return RolePresetRow.name.asc()
+        return RolePresetRow.name.desc()
+
+    @staticmethod
+    def scope_type(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return RolePresetRow.scope_type.asc()
+        return RolePresetRow.scope_type.desc()
+
+    @staticmethod
+    def created_at(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return RolePresetRow.created_at.asc()
+        return RolePresetRow.created_at.desc()
+
+    @staticmethod
+    def updated_at(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return RolePresetRow.updated_at.asc()
+        return RolePresetRow.updated_at.desc()
+
+    @staticmethod
+    def id(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return RolePresetRow.id.asc()
+        return RolePresetRow.id.desc()


### PR DESCRIPTION
## Summary
- Wire the Role Preset adapter to the Processor layer: `create`/`get`/`search`/`update`/`bulk_delete`/`bulk_restore`/`bulk_purge` and bulk add/remove permissions, replacing the `NotImplementedError` stubs.
- Wire the GraphQL admin query/list and create/update/delete/restore/purge + permission add/remove mutations to call the adapter.
- Search excludes soft-deleted presets by default; the `deleted` filter must be set explicitly to surface archived rows. Bulk errors are mapped to DTO failure infos by index.
- Add `RolePresetConditions`/`RolePresetOrders` query helpers, and the missing `PydanticOutputMixin` base on payload GQL types so `from_pydantic` resolves.

The `permission_presets` field resolver and adapter `search_permissions` remain stubbed pending a permission read-path service.

## Test plan
- [x] `pants fmt / lint / check` pass
- [x] GraphQL schema builds; role preset fields present in SDL
- [x] Live round-trip via `./bai gql --v2`: create (with permissions), get, search, update, bulk add permissions (incl. duplicate → `failed`), bulk remove permissions, soft delete, default search hides deleted, `deleted:true` surfaces them, restore, purge

Resolves BA-6182