### PR TITLE
fix(BA-6270): recalculate appproxy worker available_slots on restart

### DIFF
--- a/changes/11909.fix.md
+++ b/changes/11909.fix.md
@@ -1,0 +1,1 @@
+Fix App Proxy worker's `available_slots` staying pinned to its first-registration value, so restarting a worker with a changed `port_range` now recalculates the slot count instead of blocking new port allocations against the stale quota.

--- a/changes/11909.fix.md
+++ b/changes/11909.fix.md
@@ -1,1 +1,1 @@
-Fix App Proxy worker's `available_slots` staying pinned to its first-registration value, so restarting a worker with a changed `port_range` now recalculates the slot count instead of blocking new port allocations against the stale quota.
+Recalculate App Proxy worker's `available_slots` on restart so a changed `port_range` takes effect.

--- a/src/ai/backend/appproxy/coordinator/api/worker_v2.py
+++ b/src/ai/backend/appproxy/coordinator/api/worker_v2.py
@@ -212,6 +212,14 @@ async def update_worker(
             worker.wildcard_traffic_port = params.wildcard_traffic_port
             worker.filtered_apps_only = params.filtered_apps_only
             worker.traefik_last_used_marker_path = params.traefik_last_used_marker_path
+            # Recalculate available_slots so that a restart with an updated
+            # frontend_mode / port_range is reflected instead of staying pinned
+            # to the value computed at the worker's first registration.
+            worker.available_slots = Worker.calculate_available_slots(
+                params.frontend_mode,
+                port_range=params.port_range,
+                wildcard_domain=params.wildcard_domain,
+            )
             worker.updated_at = datetime.now(UTC)
             worker.nodes += 1
             worker.status = WorkerStatus.ALIVE

--- a/src/ai/backend/appproxy/coordinator/api/worker_v2.py
+++ b/src/ai/backend/appproxy/coordinator/api/worker_v2.py
@@ -212,7 +212,7 @@ async def update_worker(
             worker.wildcard_traffic_port = params.wildcard_traffic_port
             worker.filtered_apps_only = params.filtered_apps_only
             worker.traefik_last_used_marker_path = params.traefik_last_used_marker_path
-            # Reflect port_range / frontend_mode changes on restart (BA-6270).
+            # Reflect port_range / frontend_mode changes on restart.
             worker.refresh_available_slots()
             worker.updated_at = datetime.now(UTC)
             worker.nodes += 1

--- a/src/ai/backend/appproxy/coordinator/api/worker_v2.py
+++ b/src/ai/backend/appproxy/coordinator/api/worker_v2.py
@@ -212,9 +212,7 @@ async def update_worker(
             worker.wildcard_traffic_port = params.wildcard_traffic_port
             worker.filtered_apps_only = params.filtered_apps_only
             worker.traefik_last_used_marker_path = params.traefik_last_used_marker_path
-            # Recalculate available_slots so that a restart with an updated
-            # frontend_mode / port_range is reflected instead of staying pinned
-            # to the value computed at the worker's first registration (BA-6270).
+            # Reflect port_range / frontend_mode changes on restart (BA-6270).
             worker.refresh_available_slots()
             worker.updated_at = datetime.now(UTC)
             worker.nodes += 1

--- a/src/ai/backend/appproxy/coordinator/api/worker_v2.py
+++ b/src/ai/backend/appproxy/coordinator/api/worker_v2.py
@@ -214,12 +214,8 @@ async def update_worker(
             worker.traefik_last_used_marker_path = params.traefik_last_used_marker_path
             # Recalculate available_slots so that a restart with an updated
             # frontend_mode / port_range is reflected instead of staying pinned
-            # to the value computed at the worker's first registration.
-            worker.available_slots = Worker.calculate_available_slots(
-                params.frontend_mode,
-                port_range=params.port_range,
-                wildcard_domain=params.wildcard_domain,
-            )
+            # to the value computed at the worker's first registration (BA-6270).
+            worker.refresh_available_slots()
             worker.updated_at = datetime.now(UTC)
             worker.nodes += 1
             worker.status = WorkerStatus.ALIVE

--- a/src/ai/backend/appproxy/coordinator/models/worker.py
+++ b/src/ai/backend/appproxy/coordinator/models/worker.py
@@ -254,6 +254,20 @@ class Worker(Base, BaseMixin):  # type: ignore[misc]
                 return port_range[1] - port_range[0] + 1
         raise MissingFrontendConfigError(f"Unsupported frontend mode: {frontend_mode}")
 
+    def refresh_available_slots(self) -> None:
+        """
+        Recompute ``available_slots`` from the worker's current frontend
+        configuration. Call this after mutating ``frontend_mode`` / ``port_range``
+        / ``wildcard_domain`` (e.g. when a worker re-registers on restart) so the
+        slot quota tracks the live port range instead of staying pinned to the
+        value computed at the worker's first registration (BA-6270).
+        """
+        self.available_slots = self.calculate_available_slots(
+            self.frontend_mode,
+            port_range=self.port_range,
+            wildcard_domain=self.wildcard_domain,
+        )
+
     @property
     def use_tls(self) -> bool:
         return self.tls_listen or self.tls_advertised

--- a/src/ai/backend/appproxy/coordinator/models/worker.py
+++ b/src/ai/backend/appproxy/coordinator/models/worker.py
@@ -223,36 +223,26 @@ class Worker(Base, BaseMixin):  # type: ignore[misc]
 
         return w
 
-    @staticmethod
-    def _calculate_available_slots(
-        frontend_mode: FrontendMode,
-        *,
-        port_range: tuple[int, int] | None = None,
-        wildcard_domain: str | None = None,
-    ) -> int:
-        """Number of available slots derived from the frontend configuration."""
-        match frontend_mode:
+    def _calculate_available_slots(self) -> int:
+        """Number of available slots derived from the current frontend configuration."""
+        match self.frontend_mode:
             case FrontendMode.WILDCARD_DOMAIN:
-                if not wildcard_domain:
+                if not self.wildcard_domain:
                     raise MissingFrontendConfigError(
                         "Wildcard domain is required for WILDCARD_DOMAIN frontend mode"
                     )
                 return -1
             case FrontendMode.PORT:
-                if not port_range:
+                if not self.port_range:
                     raise MissingFrontendConfigError(
                         "Port range is required for PORT frontend mode"
                     )
-                return port_range[1] - port_range[0] + 1
-        assert_never(frontend_mode)
+                return self.port_range[1] - self.port_range[0] + 1
+        assert_never(self.frontend_mode)
 
     def refresh_available_slots(self) -> None:
         """Recompute available_slots from the current frontend config."""
-        self.available_slots = self._calculate_available_slots(
-            self.frontend_mode,
-            port_range=self.port_range,
-            wildcard_domain=self.wildcard_domain,
-        )
+        self.available_slots = self._calculate_available_slots()
 
     @property
     def use_tls(self) -> bool:

--- a/src/ai/backend/appproxy/coordinator/models/worker.py
+++ b/src/ai/backend/appproxy/coordinator/models/worker.py
@@ -219,21 +219,40 @@ class Worker(Base, BaseMixin):  # type: ignore[misc]
         w.status = status
 
         w.occupied_slots = 0
+        w.available_slots = cls.calculate_available_slots(
+            frontend_mode, port_range=port_range, wildcard_domain=wildcard_domain
+        )
+
+        return w
+
+    @staticmethod
+    def calculate_available_slots(
+        frontend_mode: FrontendMode,
+        *,
+        port_range: tuple[int, int] | None = None,
+        wildcard_domain: str | None = None,
+    ) -> int:
+        """
+        Derives the number of available slots from the frontend configuration.
+
+        This must be re-evaluated whenever the frontend mode or port range changes
+        (e.g. a worker restarts with an updated ``port_range``), otherwise the slot
+        count stays pinned to the value computed at the worker's first registration.
+        """
         match frontend_mode:
             case FrontendMode.WILDCARD_DOMAIN:
                 if not wildcard_domain:
                     raise MissingFrontendConfigError(
                         "Wildcard domain is required for WILDCARD_DOMAIN frontend mode"
                     )
-                w.available_slots = -1
+                return -1
             case FrontendMode.PORT:
                 if not port_range:
                     raise MissingFrontendConfigError(
                         "Port range is required for PORT frontend mode"
                     )
-                w.available_slots = port_range[1] - port_range[0] + 1
-
-        return w
+                return port_range[1] - port_range[0] + 1
+        raise MissingFrontendConfigError(f"Unsupported frontend mode: {frontend_mode}")
 
     @property
     def use_tls(self) -> bool:

--- a/src/ai/backend/appproxy/coordinator/models/worker.py
+++ b/src/ai/backend/appproxy/coordinator/models/worker.py
@@ -3,7 +3,7 @@ import uuid
 from collections.abc import Sequence
 from datetime import datetime
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, assert_never
 from uuid import UUID
 
 if TYPE_CHECKING:
@@ -244,7 +244,7 @@ class Worker(Base, BaseMixin):  # type: ignore[misc]
                         "Port range is required for PORT frontend mode"
                     )
                 return port_range[1] - port_range[0] + 1
-        raise MissingFrontendConfigError(f"Unsupported frontend mode: {frontend_mode}")
+        assert_never(frontend_mode)
 
     def refresh_available_slots(self) -> None:
         """Recompute available_slots from the current frontend config."""

--- a/src/ai/backend/appproxy/coordinator/models/worker.py
+++ b/src/ai/backend/appproxy/coordinator/models/worker.py
@@ -249,7 +249,7 @@ class Worker(Base, BaseMixin):  # type: ignore[misc]
         raise MissingFrontendConfigError(f"Unsupported frontend mode: {frontend_mode}")
 
     def refresh_available_slots(self) -> None:
-        """Recompute available_slots from the current frontend config (BA-6270)."""
+        """Recompute available_slots from the current frontend config."""
         self.available_slots = self.calculate_available_slots(
             self.frontend_mode,
             port_range=self.port_range,

--- a/src/ai/backend/appproxy/coordinator/models/worker.py
+++ b/src/ai/backend/appproxy/coordinator/models/worker.py
@@ -3,7 +3,7 @@ import uuid
 from collections.abc import Sequence
 from datetime import datetime
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, assert_never
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 if TYPE_CHECKING:
@@ -238,7 +238,6 @@ class Worker(Base, BaseMixin):  # type: ignore[misc]
                         "Port range is required for PORT frontend mode"
                     )
                 return self.port_range[1] - self.port_range[0] + 1
-        assert_never(self.frontend_mode)
 
     def refresh_available_slots(self) -> None:
         """Recompute available_slots from the current frontend config."""

--- a/src/ai/backend/appproxy/coordinator/models/worker.py
+++ b/src/ai/backend/appproxy/coordinator/models/worker.py
@@ -232,13 +232,7 @@ class Worker(Base, BaseMixin):  # type: ignore[misc]
         port_range: tuple[int, int] | None = None,
         wildcard_domain: str | None = None,
     ) -> int:
-        """
-        Derives the number of available slots from the frontend configuration.
-
-        This must be re-evaluated whenever the frontend mode or port range changes
-        (e.g. a worker restarts with an updated ``port_range``), otherwise the slot
-        count stays pinned to the value computed at the worker's first registration.
-        """
+        """Number of available slots derived from the frontend configuration."""
         match frontend_mode:
             case FrontendMode.WILDCARD_DOMAIN:
                 if not wildcard_domain:
@@ -255,13 +249,7 @@ class Worker(Base, BaseMixin):  # type: ignore[misc]
         raise MissingFrontendConfigError(f"Unsupported frontend mode: {frontend_mode}")
 
     def refresh_available_slots(self) -> None:
-        """
-        Recompute ``available_slots`` from the worker's current frontend
-        configuration. Call this after mutating ``frontend_mode`` / ``port_range``
-        / ``wildcard_domain`` (e.g. when a worker re-registers on restart) so the
-        slot quota tracks the live port range instead of staying pinned to the
-        value computed at the worker's first registration (BA-6270).
-        """
+        """Recompute available_slots from the current frontend config (BA-6270)."""
         self.available_slots = self.calculate_available_slots(
             self.frontend_mode,
             port_range=self.port_range,

--- a/src/ai/backend/appproxy/coordinator/models/worker.py
+++ b/src/ai/backend/appproxy/coordinator/models/worker.py
@@ -219,14 +219,12 @@ class Worker(Base, BaseMixin):  # type: ignore[misc]
         w.status = status
 
         w.occupied_slots = 0
-        w.available_slots = cls.calculate_available_slots(
-            frontend_mode, port_range=port_range, wildcard_domain=wildcard_domain
-        )
+        w.refresh_available_slots()
 
         return w
 
     @staticmethod
-    def calculate_available_slots(
+    def _calculate_available_slots(
         frontend_mode: FrontendMode,
         *,
         port_range: tuple[int, int] | None = None,
@@ -250,7 +248,7 @@ class Worker(Base, BaseMixin):  # type: ignore[misc]
 
     def refresh_available_slots(self) -> None:
         """Recompute available_slots from the current frontend config."""
-        self.available_slots = self.calculate_available_slots(
+        self.available_slots = self._calculate_available_slots(
             self.frontend_mode,
             port_range=self.port_range,
             wildcard_domain=self.wildcard_domain,

--- a/src/ai/backend/appproxy/coordinator/models/worker.py
+++ b/src/ai/backend/appproxy/coordinator/models/worker.py
@@ -30,6 +30,7 @@ from ai.backend.appproxy.common.types import (
     Slot,
 )
 from ai.backend.appproxy.coordinator.errors import MissingFrontendConfigError
+from ai.backend.common.exception import UnreachableError
 from ai.backend.logging import BraceStyleAdapter
 
 from .base import GUID, Base, BaseMixin, EnumType, StrEnumType
@@ -238,6 +239,7 @@ class Worker(Base, BaseMixin):  # type: ignore[misc]
                         "Port range is required for PORT frontend mode"
                     )
                 return self.port_range[1] - self.port_range[0] + 1
+        raise UnreachableError(f"Unsupported frontend mode: {self.frontend_mode}")
 
     def refresh_available_slots(self) -> None:
         """Recompute available_slots from the current frontend config."""

--- a/tests/unit/appproxy/coordinator/test_worker_available_slots.py
+++ b/tests/unit/appproxy/coordinator/test_worker_available_slots.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from typing import NamedTuple
 
 import pytest
 
@@ -9,10 +10,21 @@ from ai.backend.appproxy.coordinator.errors import MissingFrontendConfigError
 from ai.backend.appproxy.coordinator.models.worker import Worker
 
 
-@pytest.fixture
-def port_worker(request: pytest.FixtureRequest) -> Worker:
-    """A PORT-mode worker created with the port_range given via indirect param."""
-    port_range: tuple[int, int] = request.param
+class PortRange(NamedTuple):
+    start: int
+    end: int
+
+
+class RangeChangeCase(NamedTuple):
+    """A restart that changes a worker's port_range and the slot count it should yield."""
+
+    initial: PortRange
+    updated: PortRange
+    expected_slots: int
+
+
+def make_port_worker(port_range: PortRange) -> Worker:
+    """A PORT-mode worker created with the given port_range."""
     return Worker.create(
         uuid.uuid4(),
         "worker-1",
@@ -27,23 +39,29 @@ def port_worker(request: pytest.FixtureRequest) -> Worker:
     )
 
 
+@pytest.fixture
+def port_worker(request: pytest.FixtureRequest) -> Worker:
+    """A PORT-mode worker created with the port_range given via indirect param."""
+    return make_port_worker(request.param)
+
+
 class TestCalculateAvailableSlots:
     @pytest.mark.parametrize(
         ("port_range", "expected"),
         [
-            ((10501, 10800), 300),
-            ((10501, 10600), 100),
-            ((10501, 10501), 1),
+            (PortRange(10501, 10800), 300),
+            (PortRange(10501, 10600), 100),
+            (PortRange(10501, 10501), 1),
         ],
     )
-    def test_port_mode_span(self, port_range: tuple[int, int], expected: int) -> None:
+    def test_port_mode_span(self, port_range: PortRange, expected: int) -> None:
         assert (
-            Worker.calculate_available_slots(FrontendMode.PORT, port_range=port_range) == expected
+            Worker._calculate_available_slots(FrontendMode.PORT, port_range=port_range) == expected
         )
 
     def test_wildcard_mode_is_unlimited(self) -> None:
         assert (
-            Worker.calculate_available_slots(
+            Worker._calculate_available_slots(
                 FrontendMode.WILDCARD_DOMAIN, wildcard_domain="*.example.com"
             )
             == -1
@@ -56,29 +74,28 @@ class TestCalculateAvailableSlots:
     def test_missing_config_raises(self, frontend_mode: FrontendMode) -> None:
         # PORT without port_range / WILDCARD_DOMAIN without wildcard_domain.
         with pytest.raises(MissingFrontendConfigError):
-            Worker.calculate_available_slots(frontend_mode)
+            Worker._calculate_available_slots(frontend_mode)
 
 
 class TestRefreshAvailableSlots:
     """Regression tests: available_slots must track port_range on restart."""
 
     @pytest.mark.parametrize(
-        ("port_worker", "new_port_range", "expected"),
+        "case",
         [
-            ((10501, 10600), (10501, 10800), 300),  # expand
-            ((10501, 10800), (10501, 10600), 100),  # shrink
-            ((10501, 10600), (10501, 10600), 100),  # unchanged
+            RangeChangeCase(PortRange(10501, 10600), PortRange(10501, 10800), 300),
+            RangeChangeCase(PortRange(10501, 10800), PortRange(10501, 10600), 100),
+            RangeChangeCase(PortRange(10501, 10600), PortRange(10501, 10600), 100),
         ],
-        indirect=["port_worker"],
+        ids=["expand", "shrink", "unchanged"],
     )
-    def test_refresh_after_port_range_change(
-        self, port_worker: Worker, new_port_range: tuple[int, int], expected: int
-    ) -> None:
-        port_worker.port_range = new_port_range
-        port_worker.refresh_available_slots()
-        assert port_worker.available_slots == expected
+    def test_refresh_after_port_range_change(self, case: RangeChangeCase) -> None:
+        worker = make_port_worker(case.initial)
+        worker.port_range = case.updated
+        worker.refresh_available_slots()
+        assert worker.available_slots == case.expected_slots
 
-    @pytest.mark.parametrize("port_worker", [(10501, 10600)], indirect=True)
+    @pytest.mark.parametrize("port_worker", [PortRange(10501, 10600)], indirect=True)
     def test_switch_to_wildcard_mode_sets_unlimited(self, port_worker: Worker) -> None:
         port_worker.frontend_mode = FrontendMode.WILDCARD_DOMAIN
         port_worker.port_range = None
@@ -86,7 +103,7 @@ class TestRefreshAvailableSlots:
         port_worker.refresh_available_slots()
         assert port_worker.available_slots == -1
 
-    @pytest.mark.parametrize("port_worker", [(10501, 10600)], indirect=True)
+    @pytest.mark.parametrize("port_worker", [PortRange(10501, 10600)], indirect=True)
     def test_refresh_without_port_range_raises(self, port_worker: Worker) -> None:
         port_worker.port_range = None
         with pytest.raises(MissingFrontendConfigError):

--- a/tests/unit/appproxy/coordinator/test_worker_available_slots.py
+++ b/tests/unit/appproxy/coordinator/test_worker_available_slots.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
+from typing import NamedTuple
 
 import pytest
 
@@ -10,16 +11,21 @@ from ai.backend.appproxy.coordinator.errors import MissingFrontendConfigError
 from ai.backend.appproxy.coordinator.models.worker import Worker
 
 
+class PortRange(NamedTuple):
+    start: int
+    end: int
+
+
 @dataclass(frozen=True)
 class RangeChangeCase:
     """A restart that changes a worker's port_range and the slot count it should yield."""
 
-    initial: tuple[int, int]
-    updated: tuple[int, int]
-    expected_slots: int
+    initial: PortRange
+    updated: PortRange
+    expected_available_slots: int
 
 
-def make_port_worker(port_range: tuple[int, int]) -> Worker:
+def make_port_worker(port_range: PortRange) -> Worker:
     """A PORT-mode worker created with the given port_range."""
     return Worker.create(
         uuid.uuid4(),
@@ -47,10 +53,26 @@ class TestRefreshAvailableSlots:
     @pytest.mark.parametrize(
         "case",
         [
-            RangeChangeCase(initial=(10501, 10600), updated=(10501, 10800), expected_slots=300),
-            RangeChangeCase(initial=(10501, 10800), updated=(10501, 10600), expected_slots=100),
-            RangeChangeCase(initial=(10501, 10600), updated=(10501, 10600), expected_slots=100),
-            RangeChangeCase(initial=(10501, 10501), updated=(10501, 10501), expected_slots=1),
+            RangeChangeCase(
+                initial=PortRange(start=10501, end=10600),
+                updated=PortRange(start=10501, end=10800),
+                expected_available_slots=300,
+            ),
+            RangeChangeCase(
+                initial=PortRange(start=10501, end=10800),
+                updated=PortRange(start=10501, end=10600),
+                expected_available_slots=100,
+            ),
+            RangeChangeCase(
+                initial=PortRange(start=10501, end=10600),
+                updated=PortRange(start=10501, end=10600),
+                expected_available_slots=100,
+            ),
+            RangeChangeCase(
+                initial=PortRange(start=10501, end=10501),
+                updated=PortRange(start=10501, end=10501),
+                expected_available_slots=1,
+            ),
         ],
         ids=["expand", "shrink", "unchanged", "single-port"],
     )
@@ -58,9 +80,9 @@ class TestRefreshAvailableSlots:
         worker = make_port_worker(case.initial)
         worker.port_range = case.updated
         worker.refresh_available_slots()
-        assert worker.available_slots == case.expected_slots
+        assert worker.available_slots == case.expected_available_slots
 
-    @pytest.mark.parametrize("port_worker", [(10501, 10600)], indirect=True)
+    @pytest.mark.parametrize("port_worker", [PortRange(start=10501, end=10600)], indirect=True)
     def test_switch_to_wildcard_mode_sets_unlimited(self, port_worker: Worker) -> None:
         port_worker.frontend_mode = FrontendMode.WILDCARD_DOMAIN
         port_worker.port_range = None
@@ -68,13 +90,13 @@ class TestRefreshAvailableSlots:
         port_worker.refresh_available_slots()
         assert port_worker.available_slots == -1
 
-    @pytest.mark.parametrize("port_worker", [(10501, 10600)], indirect=True)
+    @pytest.mark.parametrize("port_worker", [PortRange(start=10501, end=10600)], indirect=True)
     def test_refresh_without_port_range_raises(self, port_worker: Worker) -> None:
         port_worker.port_range = None
         with pytest.raises(MissingFrontendConfigError):
             port_worker.refresh_available_slots()
 
-    @pytest.mark.parametrize("port_worker", [(10501, 10600)], indirect=True)
+    @pytest.mark.parametrize("port_worker", [PortRange(start=10501, end=10600)], indirect=True)
     def test_refresh_without_wildcard_domain_raises(self, port_worker: Worker) -> None:
         port_worker.frontend_mode = FrontendMode.WILDCARD_DOMAIN
         port_worker.port_range = None

--- a/tests/unit/appproxy/coordinator/test_worker_available_slots.py
+++ b/tests/unit/appproxy/coordinator/test_worker_available_slots.py
@@ -52,3 +52,71 @@ class TestCalculateAvailableSlots:
             port_range=(10501, 10800),
         )
         assert worker.available_slots == 300
+
+
+def _make_port_worker(port_range: tuple[int, int]) -> Worker:
+    return Worker.create(
+        uuid.uuid4(),
+        "worker-1",
+        FrontendMode.PORT,
+        ProxyProtocol.HTTP,
+        "127.0.0.1",
+        False,
+        False,
+        10200,
+        [AppMode.INTERACTIVE],
+        port_range=port_range,
+    )
+
+
+class TestRefreshAvailableSlots:
+    """
+    Regression tests for BA-6270.
+
+    ``update_worker`` re-registers an existing worker on restart and calls
+    ``worker.refresh_available_slots()`` after applying the new frontend config.
+    Before the fix, ``available_slots`` was only ever set at first registration,
+    so a restart with a changed ``port_range`` left it pinned to the original
+    value and the stale quota blocked new port allocations.
+    """
+
+    def test_expanding_port_range_increases_slots(self) -> None:
+        # Initial registration: 100-port range -> available_slots == 100.
+        worker = _make_port_worker((10501, 10600))
+        assert worker.available_slots == 100
+
+        # Restart with an expanded range; update_worker mutates port_range first...
+        worker.port_range = (10501, 10800)
+        # ...then refreshes the quota.
+        worker.refresh_available_slots()
+
+        # BA-6270: without refresh this stayed 100 and blocked new ports past 100.
+        assert worker.available_slots == 300
+
+    def test_shrinking_port_range_decreases_slots(self) -> None:
+        worker = _make_port_worker((10501, 10800))
+        assert worker.available_slots == 300
+
+        worker.port_range = (10501, 10600)
+        worker.refresh_available_slots()
+
+        assert worker.available_slots == 100
+
+    def test_switch_to_wildcard_mode_sets_unlimited(self) -> None:
+        worker = _make_port_worker((10501, 10600))
+        assert worker.available_slots == 100
+
+        worker.frontend_mode = FrontendMode.WILDCARD_DOMAIN
+        worker.port_range = None
+        worker.wildcard_domain = "*.example.com"
+        worker.refresh_available_slots()
+
+        assert worker.available_slots == -1
+
+    def test_refresh_without_port_range_raises(self) -> None:
+        worker = _make_port_worker((10501, 10600))
+        # A PORT-mode worker that lost its port_range is a misconfiguration and
+        # must fail loudly rather than silently keeping the stale quota.
+        worker.port_range = None
+        with pytest.raises(MissingFrontendConfigError):
+            worker.refresh_available_slots()

--- a/tests/unit/appproxy/coordinator/test_worker_available_slots.py
+++ b/tests/unit/appproxy/coordinator/test_worker_available_slots.py
@@ -60,7 +60,7 @@ class TestCalculateAvailableSlots:
 
 
 class TestRefreshAvailableSlots:
-    """Regression tests for BA-6270: available_slots must track port_range on restart."""
+    """Regression tests: available_slots must track port_range on restart."""
 
     @pytest.mark.parametrize(
         ("port_worker", "new_port_range", "expected"),

--- a/tests/unit/appproxy/coordinator/test_worker_available_slots.py
+++ b/tests/unit/appproxy/coordinator/test_worker_available_slots.py
@@ -70,27 +70,15 @@ def _make_port_worker(port_range: tuple[int, int]) -> Worker:
 
 
 class TestRefreshAvailableSlots:
-    """
-    Regression tests for BA-6270.
-
-    ``update_worker`` re-registers an existing worker on restart and calls
-    ``worker.refresh_available_slots()`` after applying the new frontend config.
-    Before the fix, ``available_slots`` was only ever set at first registration,
-    so a restart with a changed ``port_range`` left it pinned to the original
-    value and the stale quota blocked new port allocations.
-    """
+    """Regression tests for BA-6270: available_slots must track port_range on restart."""
 
     def test_expanding_port_range_increases_slots(self) -> None:
-        # Initial registration: 100-port range -> available_slots == 100.
         worker = _make_port_worker((10501, 10600))
         assert worker.available_slots == 100
 
-        # Restart with an expanded range; update_worker mutates port_range first...
         worker.port_range = (10501, 10800)
-        # ...then refreshes the quota.
         worker.refresh_available_slots()
 
-        # BA-6270: without refresh this stayed 100 and blocked new ports past 100.
         assert worker.available_slots == 300
 
     def test_shrinking_port_range_decreases_slots(self) -> None:
@@ -104,7 +92,6 @@ class TestRefreshAvailableSlots:
 
     def test_switch_to_wildcard_mode_sets_unlimited(self) -> None:
         worker = _make_port_worker((10501, 10600))
-        assert worker.available_slots == 100
 
         worker.frontend_mode = FrontendMode.WILDCARD_DOMAIN
         worker.port_range = None
@@ -115,8 +102,6 @@ class TestRefreshAvailableSlots:
 
     def test_refresh_without_port_range_raises(self) -> None:
         worker = _make_port_worker((10501, 10600))
-        # A PORT-mode worker that lost its port_range is a misconfiguration and
-        # must fail loudly rather than silently keeping the stale quota.
         worker.port_range = None
         with pytest.raises(MissingFrontendConfigError):
             worker.refresh_available_slots()

--- a/tests/unit/appproxy/coordinator/test_worker_available_slots.py
+++ b/tests/unit/appproxy/coordinator/test_worker_available_slots.py
@@ -47,6 +47,12 @@ def port_worker(request: pytest.FixtureRequest) -> Worker:
     return make_port_worker(request.param)
 
 
+class TestCreate:
+    def test_create_initializes_available_slots(self) -> None:
+        worker = make_port_worker(PortRange(start=10501, end=10600))
+        assert worker.available_slots == 100
+
+
 class TestRefreshAvailableSlots:
     """Regression tests: available_slots must track the frontend config on restart."""
 

--- a/tests/unit/appproxy/coordinator/test_worker_available_slots.py
+++ b/tests/unit/appproxy/coordinator/test_worker_available_slots.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from ai.backend.appproxy.common.types import AppMode, FrontendMode, ProxyProtocol
+from ai.backend.appproxy.coordinator.errors import MissingFrontendConfigError
+from ai.backend.appproxy.coordinator.models.worker import Worker
+
+
+class TestCalculateAvailableSlots:
+    def test_port_mode_uses_port_range_span(self) -> None:
+        # span is inclusive on both ends: 10501..10800 -> 300 slots
+        assert Worker.calculate_available_slots(FrontendMode.PORT, port_range=(10501, 10800)) == 300
+
+    def test_port_mode_recomputes_when_range_changes(self) -> None:
+        # BA-6270: a restart with a different port_range must yield a new slot count
+        # instead of staying pinned to the value from the first registration.
+        initial = Worker.calculate_available_slots(FrontendMode.PORT, port_range=(10501, 10600))
+        expanded = Worker.calculate_available_slots(FrontendMode.PORT, port_range=(10501, 10800))
+        assert initial == 100
+        assert expanded == 300
+
+    def test_wildcard_mode_is_unlimited(self) -> None:
+        assert (
+            Worker.calculate_available_slots(
+                FrontendMode.WILDCARD_DOMAIN, wildcard_domain="*.example.com"
+            )
+            == -1
+        )
+
+    def test_port_mode_without_range_raises(self) -> None:
+        with pytest.raises(MissingFrontendConfigError):
+            Worker.calculate_available_slots(FrontendMode.PORT)
+
+    def test_wildcard_mode_without_domain_raises(self) -> None:
+        with pytest.raises(MissingFrontendConfigError):
+            Worker.calculate_available_slots(FrontendMode.WILDCARD_DOMAIN)
+
+    def test_create_uses_calculated_slots(self) -> None:
+        worker = Worker.create(
+            uuid.uuid4(),
+            "worker-1",
+            FrontendMode.PORT,
+            ProxyProtocol.HTTP,
+            "127.0.0.1",
+            False,
+            False,
+            10200,
+            [AppMode.INTERACTIVE],
+            port_range=(10501, 10800),
+        )
+        assert worker.available_slots == 300

--- a/tests/unit/appproxy/coordinator/test_worker_available_slots.py
+++ b/tests/unit/appproxy/coordinator/test_worker_available_slots.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import NamedTuple
+from dataclasses import dataclass
 
 import pytest
 
@@ -10,12 +10,17 @@ from ai.backend.appproxy.coordinator.errors import MissingFrontendConfigError
 from ai.backend.appproxy.coordinator.models.worker import Worker
 
 
-class PortRange(NamedTuple):
+@dataclass(frozen=True)
+class PortRange:
     start: int
     end: int
 
+    def as_tuple(self) -> tuple[int, int]:
+        return (self.start, self.end)
 
-class RangeChangeCase(NamedTuple):
+
+@dataclass(frozen=True)
+class RangeChangeCase:
     """A restart that changes a worker's port_range and the slot count it should yield."""
 
     initial: PortRange
@@ -35,7 +40,7 @@ def make_port_worker(port_range: PortRange) -> Worker:
         False,
         10200,
         [AppMode.INTERACTIVE],
-        port_range=port_range,
+        port_range=port_range.as_tuple(),
     )
 
 
@@ -51,20 +56,36 @@ class TestRefreshAvailableSlots:
     @pytest.mark.parametrize(
         "case",
         [
-            RangeChangeCase(PortRange(10501, 10600), PortRange(10501, 10800), 300),
-            RangeChangeCase(PortRange(10501, 10800), PortRange(10501, 10600), 100),
-            RangeChangeCase(PortRange(10501, 10600), PortRange(10501, 10600), 100),
-            RangeChangeCase(PortRange(10501, 10501), PortRange(10501, 10501), 1),
+            RangeChangeCase(
+                initial=PortRange(start=10501, end=10600),
+                updated=PortRange(start=10501, end=10800),
+                expected_slots=300,
+            ),
+            RangeChangeCase(
+                initial=PortRange(start=10501, end=10800),
+                updated=PortRange(start=10501, end=10600),
+                expected_slots=100,
+            ),
+            RangeChangeCase(
+                initial=PortRange(start=10501, end=10600),
+                updated=PortRange(start=10501, end=10600),
+                expected_slots=100,
+            ),
+            RangeChangeCase(
+                initial=PortRange(start=10501, end=10501),
+                updated=PortRange(start=10501, end=10501),
+                expected_slots=1,
+            ),
         ],
         ids=["expand", "shrink", "unchanged", "single-port"],
     )
     def test_refresh_after_port_range_change(self, case: RangeChangeCase) -> None:
         worker = make_port_worker(case.initial)
-        worker.port_range = case.updated
+        worker.port_range = case.updated.as_tuple()
         worker.refresh_available_slots()
         assert worker.available_slots == case.expected_slots
 
-    @pytest.mark.parametrize("port_worker", [PortRange(10501, 10600)], indirect=True)
+    @pytest.mark.parametrize("port_worker", [PortRange(start=10501, end=10600)], indirect=True)
     def test_switch_to_wildcard_mode_sets_unlimited(self, port_worker: Worker) -> None:
         port_worker.frontend_mode = FrontendMode.WILDCARD_DOMAIN
         port_worker.port_range = None
@@ -72,13 +93,13 @@ class TestRefreshAvailableSlots:
         port_worker.refresh_available_slots()
         assert port_worker.available_slots == -1
 
-    @pytest.mark.parametrize("port_worker", [PortRange(10501, 10600)], indirect=True)
+    @pytest.mark.parametrize("port_worker", [PortRange(start=10501, end=10600)], indirect=True)
     def test_refresh_without_port_range_raises(self, port_worker: Worker) -> None:
         port_worker.port_range = None
         with pytest.raises(MissingFrontendConfigError):
             port_worker.refresh_available_slots()
 
-    @pytest.mark.parametrize("port_worker", [PortRange(10501, 10600)], indirect=True)
+    @pytest.mark.parametrize("port_worker", [PortRange(start=10501, end=10600)], indirect=True)
     def test_refresh_without_wildcard_domain_raises(self, port_worker: Worker) -> None:
         port_worker.frontend_mode = FrontendMode.WILDCARD_DOMAIN
         port_worker.port_range = None

--- a/tests/unit/appproxy/coordinator/test_worker_available_slots.py
+++ b/tests/unit/appproxy/coordinator/test_worker_available_slots.py
@@ -45,40 +45,8 @@ def port_worker(request: pytest.FixtureRequest) -> Worker:
     return make_port_worker(request.param)
 
 
-class TestCalculateAvailableSlots:
-    @pytest.mark.parametrize(
-        ("port_range", "expected"),
-        [
-            (PortRange(10501, 10800), 300),
-            (PortRange(10501, 10600), 100),
-            (PortRange(10501, 10501), 1),
-        ],
-    )
-    def test_port_mode_span(self, port_range: PortRange, expected: int) -> None:
-        assert (
-            Worker._calculate_available_slots(FrontendMode.PORT, port_range=port_range) == expected
-        )
-
-    def test_wildcard_mode_is_unlimited(self) -> None:
-        assert (
-            Worker._calculate_available_slots(
-                FrontendMode.WILDCARD_DOMAIN, wildcard_domain="*.example.com"
-            )
-            == -1
-        )
-
-    @pytest.mark.parametrize(
-        "frontend_mode",
-        [FrontendMode.PORT, FrontendMode.WILDCARD_DOMAIN],
-    )
-    def test_missing_config_raises(self, frontend_mode: FrontendMode) -> None:
-        # PORT without port_range / WILDCARD_DOMAIN without wildcard_domain.
-        with pytest.raises(MissingFrontendConfigError):
-            Worker._calculate_available_slots(frontend_mode)
-
-
 class TestRefreshAvailableSlots:
-    """Regression tests: available_slots must track port_range on restart."""
+    """Regression tests: available_slots must track the frontend config on restart."""
 
     @pytest.mark.parametrize(
         "case",
@@ -86,8 +54,9 @@ class TestRefreshAvailableSlots:
             RangeChangeCase(PortRange(10501, 10600), PortRange(10501, 10800), 300),
             RangeChangeCase(PortRange(10501, 10800), PortRange(10501, 10600), 100),
             RangeChangeCase(PortRange(10501, 10600), PortRange(10501, 10600), 100),
+            RangeChangeCase(PortRange(10501, 10501), PortRange(10501, 10501), 1),
         ],
-        ids=["expand", "shrink", "unchanged"],
+        ids=["expand", "shrink", "unchanged", "single-port"],
     )
     def test_refresh_after_port_range_change(self, case: RangeChangeCase) -> None:
         worker = make_port_worker(case.initial)
@@ -106,5 +75,13 @@ class TestRefreshAvailableSlots:
     @pytest.mark.parametrize("port_worker", [PortRange(10501, 10600)], indirect=True)
     def test_refresh_without_port_range_raises(self, port_worker: Worker) -> None:
         port_worker.port_range = None
+        with pytest.raises(MissingFrontendConfigError):
+            port_worker.refresh_available_slots()
+
+    @pytest.mark.parametrize("port_worker", [PortRange(10501, 10600)], indirect=True)
+    def test_refresh_without_wildcard_domain_raises(self, port_worker: Worker) -> None:
+        port_worker.frontend_mode = FrontendMode.WILDCARD_DOMAIN
+        port_worker.port_range = None
+        port_worker.wildcard_domain = None
         with pytest.raises(MissingFrontendConfigError):
             port_worker.refresh_available_slots()

--- a/tests/unit/appproxy/coordinator/test_worker_available_slots.py
+++ b/tests/unit/appproxy/coordinator/test_worker_available_slots.py
@@ -11,24 +11,15 @@ from ai.backend.appproxy.coordinator.models.worker import Worker
 
 
 @dataclass(frozen=True)
-class PortRange:
-    start: int
-    end: int
-
-    def as_tuple(self) -> tuple[int, int]:
-        return (self.start, self.end)
-
-
-@dataclass(frozen=True)
 class RangeChangeCase:
     """A restart that changes a worker's port_range and the slot count it should yield."""
 
-    initial: PortRange
-    updated: PortRange
+    initial: tuple[int, int]
+    updated: tuple[int, int]
     expected_slots: int
 
 
-def make_port_worker(port_range: PortRange) -> Worker:
+def make_port_worker(port_range: tuple[int, int]) -> Worker:
     """A PORT-mode worker created with the given port_range."""
     return Worker.create(
         uuid.uuid4(),
@@ -40,7 +31,7 @@ def make_port_worker(port_range: PortRange) -> Worker:
         False,
         10200,
         [AppMode.INTERACTIVE],
-        port_range=port_range.as_tuple(),
+        port_range=port_range,
     )
 
 
@@ -56,36 +47,20 @@ class TestRefreshAvailableSlots:
     @pytest.mark.parametrize(
         "case",
         [
-            RangeChangeCase(
-                initial=PortRange(start=10501, end=10600),
-                updated=PortRange(start=10501, end=10800),
-                expected_slots=300,
-            ),
-            RangeChangeCase(
-                initial=PortRange(start=10501, end=10800),
-                updated=PortRange(start=10501, end=10600),
-                expected_slots=100,
-            ),
-            RangeChangeCase(
-                initial=PortRange(start=10501, end=10600),
-                updated=PortRange(start=10501, end=10600),
-                expected_slots=100,
-            ),
-            RangeChangeCase(
-                initial=PortRange(start=10501, end=10501),
-                updated=PortRange(start=10501, end=10501),
-                expected_slots=1,
-            ),
+            RangeChangeCase(initial=(10501, 10600), updated=(10501, 10800), expected_slots=300),
+            RangeChangeCase(initial=(10501, 10800), updated=(10501, 10600), expected_slots=100),
+            RangeChangeCase(initial=(10501, 10600), updated=(10501, 10600), expected_slots=100),
+            RangeChangeCase(initial=(10501, 10501), updated=(10501, 10501), expected_slots=1),
         ],
         ids=["expand", "shrink", "unchanged", "single-port"],
     )
     def test_refresh_after_port_range_change(self, case: RangeChangeCase) -> None:
         worker = make_port_worker(case.initial)
-        worker.port_range = case.updated.as_tuple()
+        worker.port_range = case.updated
         worker.refresh_available_slots()
         assert worker.available_slots == case.expected_slots
 
-    @pytest.mark.parametrize("port_worker", [PortRange(start=10501, end=10600)], indirect=True)
+    @pytest.mark.parametrize("port_worker", [(10501, 10600)], indirect=True)
     def test_switch_to_wildcard_mode_sets_unlimited(self, port_worker: Worker) -> None:
         port_worker.frontend_mode = FrontendMode.WILDCARD_DOMAIN
         port_worker.port_range = None
@@ -93,13 +68,13 @@ class TestRefreshAvailableSlots:
         port_worker.refresh_available_slots()
         assert port_worker.available_slots == -1
 
-    @pytest.mark.parametrize("port_worker", [PortRange(start=10501, end=10600)], indirect=True)
+    @pytest.mark.parametrize("port_worker", [(10501, 10600)], indirect=True)
     def test_refresh_without_port_range_raises(self, port_worker: Worker) -> None:
         port_worker.port_range = None
         with pytest.raises(MissingFrontendConfigError):
             port_worker.refresh_available_slots()
 
-    @pytest.mark.parametrize("port_worker", [PortRange(start=10501, end=10600)], indirect=True)
+    @pytest.mark.parametrize("port_worker", [(10501, 10600)], indirect=True)
     def test_refresh_without_wildcard_domain_raises(self, port_worker: Worker) -> None:
         port_worker.frontend_mode = FrontendMode.WILDCARD_DOMAIN
         port_worker.port_range = None

--- a/tests/unit/appproxy/coordinator/test_worker_available_slots.py
+++ b/tests/unit/appproxy/coordinator/test_worker_available_slots.py
@@ -9,52 +9,10 @@ from ai.backend.appproxy.coordinator.errors import MissingFrontendConfigError
 from ai.backend.appproxy.coordinator.models.worker import Worker
 
 
-class TestCalculateAvailableSlots:
-    def test_port_mode_uses_port_range_span(self) -> None:
-        # span is inclusive on both ends: 10501..10800 -> 300 slots
-        assert Worker.calculate_available_slots(FrontendMode.PORT, port_range=(10501, 10800)) == 300
-
-    def test_port_mode_recomputes_when_range_changes(self) -> None:
-        # BA-6270: a restart with a different port_range must yield a new slot count
-        # instead of staying pinned to the value from the first registration.
-        initial = Worker.calculate_available_slots(FrontendMode.PORT, port_range=(10501, 10600))
-        expanded = Worker.calculate_available_slots(FrontendMode.PORT, port_range=(10501, 10800))
-        assert initial == 100
-        assert expanded == 300
-
-    def test_wildcard_mode_is_unlimited(self) -> None:
-        assert (
-            Worker.calculate_available_slots(
-                FrontendMode.WILDCARD_DOMAIN, wildcard_domain="*.example.com"
-            )
-            == -1
-        )
-
-    def test_port_mode_without_range_raises(self) -> None:
-        with pytest.raises(MissingFrontendConfigError):
-            Worker.calculate_available_slots(FrontendMode.PORT)
-
-    def test_wildcard_mode_without_domain_raises(self) -> None:
-        with pytest.raises(MissingFrontendConfigError):
-            Worker.calculate_available_slots(FrontendMode.WILDCARD_DOMAIN)
-
-    def test_create_uses_calculated_slots(self) -> None:
-        worker = Worker.create(
-            uuid.uuid4(),
-            "worker-1",
-            FrontendMode.PORT,
-            ProxyProtocol.HTTP,
-            "127.0.0.1",
-            False,
-            False,
-            10200,
-            [AppMode.INTERACTIVE],
-            port_range=(10501, 10800),
-        )
-        assert worker.available_slots == 300
-
-
-def _make_port_worker(port_range: tuple[int, int]) -> Worker:
+@pytest.fixture
+def port_worker(request: pytest.FixtureRequest) -> Worker:
+    """A PORT-mode worker created with the port_range given via indirect param."""
+    port_range: tuple[int, int] = request.param
     return Worker.create(
         uuid.uuid4(),
         "worker-1",
@@ -69,39 +27,67 @@ def _make_port_worker(port_range: tuple[int, int]) -> Worker:
     )
 
 
+class TestCalculateAvailableSlots:
+    @pytest.mark.parametrize(
+        ("port_range", "expected"),
+        [
+            ((10501, 10800), 300),
+            ((10501, 10600), 100),
+            ((10501, 10501), 1),
+        ],
+    )
+    def test_port_mode_span(self, port_range: tuple[int, int], expected: int) -> None:
+        assert (
+            Worker.calculate_available_slots(FrontendMode.PORT, port_range=port_range) == expected
+        )
+
+    def test_wildcard_mode_is_unlimited(self) -> None:
+        assert (
+            Worker.calculate_available_slots(
+                FrontendMode.WILDCARD_DOMAIN, wildcard_domain="*.example.com"
+            )
+            == -1
+        )
+
+    @pytest.mark.parametrize(
+        "frontend_mode",
+        [FrontendMode.PORT, FrontendMode.WILDCARD_DOMAIN],
+    )
+    def test_missing_config_raises(self, frontend_mode: FrontendMode) -> None:
+        # PORT without port_range / WILDCARD_DOMAIN without wildcard_domain.
+        with pytest.raises(MissingFrontendConfigError):
+            Worker.calculate_available_slots(frontend_mode)
+
+
 class TestRefreshAvailableSlots:
     """Regression tests for BA-6270: available_slots must track port_range on restart."""
 
-    def test_expanding_port_range_increases_slots(self) -> None:
-        worker = _make_port_worker((10501, 10600))
-        assert worker.available_slots == 100
+    @pytest.mark.parametrize(
+        ("port_worker", "new_port_range", "expected"),
+        [
+            ((10501, 10600), (10501, 10800), 300),  # expand
+            ((10501, 10800), (10501, 10600), 100),  # shrink
+            ((10501, 10600), (10501, 10600), 100),  # unchanged
+        ],
+        indirect=["port_worker"],
+    )
+    def test_refresh_after_port_range_change(
+        self, port_worker: Worker, new_port_range: tuple[int, int], expected: int
+    ) -> None:
+        port_worker.port_range = new_port_range
+        port_worker.refresh_available_slots()
+        assert port_worker.available_slots == expected
 
-        worker.port_range = (10501, 10800)
-        worker.refresh_available_slots()
+    @pytest.mark.parametrize("port_worker", [(10501, 10600)], indirect=True)
+    def test_switch_to_wildcard_mode_sets_unlimited(self, port_worker: Worker) -> None:
+        port_worker.frontend_mode = FrontendMode.WILDCARD_DOMAIN
+        port_worker.port_range = None
+        port_worker.wildcard_domain = "*.example.com"
+        port_worker.refresh_available_slots()
+        assert port_worker.available_slots == -1
 
-        assert worker.available_slots == 300
-
-    def test_shrinking_port_range_decreases_slots(self) -> None:
-        worker = _make_port_worker((10501, 10800))
-        assert worker.available_slots == 300
-
-        worker.port_range = (10501, 10600)
-        worker.refresh_available_slots()
-
-        assert worker.available_slots == 100
-
-    def test_switch_to_wildcard_mode_sets_unlimited(self) -> None:
-        worker = _make_port_worker((10501, 10600))
-
-        worker.frontend_mode = FrontendMode.WILDCARD_DOMAIN
-        worker.port_range = None
-        worker.wildcard_domain = "*.example.com"
-        worker.refresh_available_slots()
-
-        assert worker.available_slots == -1
-
-    def test_refresh_without_port_range_raises(self) -> None:
-        worker = _make_port_worker((10501, 10600))
-        worker.port_range = None
+    @pytest.mark.parametrize("port_worker", [(10501, 10600)], indirect=True)
+    def test_refresh_without_port_range_raises(self, port_worker: Worker) -> None:
+        port_worker.port_range = None
         with pytest.raises(MissingFrontendConfigError):
-            worker.refresh_available_slots()
+            port_worker.refresh_available_slots()


### PR DESCRIPTION
## Summary

- App Proxy Worker computed `available_slots` only at first registration (`Worker.create`). On restart with a changed `port_range`, `update_worker` updated `port_range` but left `available_slots` pinned to the original value.
- `available_slots` is the admission-control quota checked in `pick_worker` and `add_circuit` (`available_slots - occupied_slots`), while the actual port pool is derived from `port_range`. The two diverged: ports were physically free but the stale quota blocked new circuit creation once `occupied_slots` reached the old value (e.g. stuck at 100 while `port_range` 10501–10800 has 300 ports).
- Extracted the slot calculation into the private `Worker._calculate_available_slots()` and exposed `Worker.refresh_available_slots()`, which `update_worker` (and `create`) now call, so a restart with an updated `port_range` / `frontend_mode` is reflected.

## Why the stale value blocked port creation

`available_slots` acts as a cached capacity ceiling. Both admission gates filter/reject workers when `available_slots - occupied_slots <= 0`, so the code never reaches the `port_range`-based pool computation. When `port_range` was expanded but `available_slots` stayed at the old (smaller) value, legitimate allocations were rejected despite free ports.

## Note on shrinking port_range

When `port_range` is reduced such that the new `available_slots < occupied_slots`, the worker is naturally excluded by the capacity gates. Existing circuits whose ports fall outside the new range are **not** force-removed by this PR (cleanup/migration of out-of-range ports is out of scope and tracked separately, as noted in BA-6270). New allocation already uses `port_range` directly, so out-of-range existing ports do not block new allocations.

## Test plan

- [x] `pants check` on changed source files
- [x] New unit tests in `tests/unit/appproxy/coordinator/test_worker_available_slots.py` (port-mode span, recompute on range change, wildcard unlimited, missing-config errors, `create()` integration)
- [ ] CI green
- [ ] Live verification: restart appproxy worker with an expanded `port_range`, confirm DB `available_slots` updates and new ports can be allocated past the previous ceiling

Resolves BA-6270

🤖 Generated with [Claude Code](https://claude.com/claude-code)