### PR TITLE
feat(BA-6184): add auto_assign field to roles and wire it through to the adapter

### DIFF
--- a/changes/11911.feature.md
+++ b/changes/11911.feature.md
@@ -1,0 +1,1 @@
+Add an `auto_assign` field to the Role create/update inputs and role response, allowing a role to be marked for automatic assignment when a user is added to a scope the role is registered in.

--- a/src/ai/backend/common/dto/manager/v2/rbac/request.py
+++ b/src/ai/backend/common/dto/manager/v2/rbac/request.py
@@ -61,6 +61,13 @@ class CreateRoleInput(BaseRequestModel):
     name: str = Field(min_length=1, max_length=256, description="Role name")
     description: str | None = Field(default=None, description="Role description")
     source: RoleSource = Field(default=RoleSource.CUSTOM, description="Role source")
+    auto_assign: bool = Field(
+        default=False,
+        description=(
+            "When true, the role is automatically granted to a user when the user is added "
+            "to a scope this role is registered in."
+        ),
+    )
     scopes: list[ScopeInputDTO] | None = Field(
         default=None, description="Scopes to register the role in"
     )
@@ -82,6 +89,13 @@ class UpdateRoleInput(BaseRequestModel):
         default=SENTINEL, description="Updated role description. Use SENTINEL to clear."
     )
     status: RoleStatus | None = Field(default=None, description="Updated role status")
+    auto_assign: bool | None = Field(
+        default=None,
+        description=(
+            "Updated value for the `auto_assign` flag. When true, the role is automatically "
+            "granted to a user when the user is added to a scope this role is registered in."
+        ),
+    )
 
     @field_validator("name")
     @classmethod

--- a/src/ai/backend/common/dto/manager/v2/rbac/response.py
+++ b/src/ai/backend/common/dto/manager/v2/rbac/response.py
@@ -59,6 +59,13 @@ class RoleNode(BaseResponseModel):
     description: str | None = Field(default=None, description="Role description")
     source: RoleSourceDTO = Field(description="Role source")
     status: RoleStatusDTO = Field(description="Role status")
+    auto_assign: bool = Field(
+        default=False,
+        description=(
+            "When true, the role is automatically granted to a user when the user is added "
+            "to a scope this role is registered in."
+        ),
+    )
     created_at: datetime = Field(description="Creation timestamp")
     updated_at: datetime = Field(description="Last update timestamp")
     deleted_at: datetime | None = Field(default=None, description="Deletion timestamp")

--- a/src/ai/backend/manager/api/adapters/rbac/adapter.py
+++ b/src/ai/backend/manager/api/adapters/rbac/adapter.py
@@ -657,6 +657,7 @@ class RBACAdapter(BaseAdapter):
                 source=InternalRoleSource(input.source.value),
                 status=InternalRoleStatus.ACTIVE,
                 description=input.description,
+                auto_assign=input.auto_assign,
             )
         )
         action_result = await self._processors.permission_controller.create_role.wait_for_complete(
@@ -1719,6 +1720,7 @@ class RBACAdapter(BaseAdapter):
         name: OptionalState[str] = OptionalState.nop()
         status: OptionalState[InternalRoleStatus] = OptionalState.nop()
         description: TriState[str] = TriState.nop()
+        auto_assign: OptionalState[bool] = OptionalState.nop()
 
         if input.name is not None:
             name = OptionalState.update(input.name)
@@ -1729,8 +1731,12 @@ class RBACAdapter(BaseAdapter):
                 description = TriState.nullify()
             else:
                 description = TriState.update(str(input.description))
+        if input.auto_assign is not None:
+            auto_assign = OptionalState.update(input.auto_assign)
 
-        spec = RoleUpdaterSpec(name=name, status=status, description=description)
+        spec = RoleUpdaterSpec(
+            name=name, status=status, description=description, auto_assign=auto_assign
+        )
         return Updater(spec=spec, pk_value=role_id)
 
     @staticmethod
@@ -1741,6 +1747,7 @@ class RBACAdapter(BaseAdapter):
             description=data.description,
             source=RoleSourceDTO(data.source.value),
             status=RoleStatusDTO(data.status.value),
+            auto_assign=data.auto_assign,
             created_at=data.created_at,
             updated_at=data.updated_at,
             deleted_at=data.deleted_at,
@@ -1754,6 +1761,7 @@ class RBACAdapter(BaseAdapter):
             description=data.description,
             source=RoleSourceDTO(data.source.value),
             status=RoleStatusDTO(data.status.value),
+            auto_assign=data.auto_assign,
             created_at=data.created_at,
             updated_at=data.updated_at,
             deleted_at=data.deleted_at,

--- a/src/ai/backend/manager/data/permission/role.py
+++ b/src/ai/backend/manager/data/permission/role.py
@@ -36,6 +36,7 @@ class RoleData:
     created_at: datetime
     updated_at: datetime
     deleted_at: datetime | None
+    auto_assign: bool = False
     description: str | None = None
 
 
@@ -67,6 +68,7 @@ class RoleDetailData:
     created_at: datetime
     updated_at: datetime
     deleted_at: datetime | None
+    auto_assign: bool = False
     description: str | None = None
 
 

--- a/src/ai/backend/manager/models/rbac_models/role.py
+++ b/src/ai/backend/manager/models/rbac_models/role.py
@@ -110,6 +110,7 @@ class RoleRow(Base):  # type: ignore[misc]
             created_at=self.created_at,
             updated_at=self.updated_at,
             deleted_at=self.deleted_at,
+            auto_assign=self.auto_assign,
             description=self.description,
         )
 
@@ -123,6 +124,7 @@ class RoleRow(Base):  # type: ignore[misc]
             created_at=self.created_at,
             updated_at=self.updated_at,
             deleted_at=self.deleted_at,
+            auto_assign=self.auto_assign,
             description=self.description,
             object_permissions=[op_row.to_data() for op_row in self.object_permission_rows],
         )

--- a/src/ai/backend/manager/repositories/permission_controller/creators.py
+++ b/src/ai/backend/manager/repositories/permission_controller/creators.py
@@ -39,6 +39,7 @@ class RoleCreatorSpec(CreatorSpec[RoleRow]):
     source: RoleSource
     status: RoleStatus
     description: str | None = None
+    auto_assign: bool = False
 
     @override
     def build_row(self) -> RoleRow:
@@ -47,6 +48,7 @@ class RoleCreatorSpec(CreatorSpec[RoleRow]):
             source=self.source,
             status=self.status,
             description=self.description,
+            auto_assign=self.auto_assign,
         )
 
 

--- a/src/ai/backend/manager/repositories/permission_controller/updaters.py
+++ b/src/ai/backend/manager/repositories/permission_controller/updaters.py
@@ -23,6 +23,7 @@ class RoleUpdaterSpec(UpdaterSpec[RoleRow]):
     source: OptionalState[RoleSource] = field(default_factory=OptionalState.nop)
     status: OptionalState[RoleStatus] = field(default_factory=OptionalState.nop)
     description: TriState[str] = field(default_factory=TriState.nop)
+    auto_assign: OptionalState[bool] = field(default_factory=OptionalState.nop)
 
     @property
     @override
@@ -36,6 +37,7 @@ class RoleUpdaterSpec(UpdaterSpec[RoleRow]):
         self.source.update_dict(to_update, "source")
         self.status.update_dict(to_update, "status")
         self.description.update_dict(to_update, "description")
+        self.auto_assign.update_dict(to_update, "auto_assign")
         return to_update
 
 


### PR DESCRIPTION
## Summary
- Add `auto_assign` to the v2 RBAC DTOs: `CreateRoleInput`, `UpdateRoleInput`, and `RoleNode`.
- Wire the flag end-to-end up to the adapter so it is actually persisted and returned:
  - `RoleData` / `RoleDetailData` carry `auto_assign`; `RoleRow.to_data()` populates it.
  - `RoleCreatorSpec` writes it on create; `RoleUpdaterSpec` updates it when provided.
  - The RBAC adapter passes `auto_assign` on create/update and maps it onto `RoleNode`.
- Builds on the `roles.auto_assign` column added in BA-6183. The Service/Action layer is unchanged (it forwards the Creator/Updater opaquely).

Through the REST v2 path, a role's `auto_assign` can now be set on create, changed on update, and read on get/search.

### Out of scope (follow-up)
- GraphQL `RoleGQL` does not expose `auto_assign` yet, so it is not observable via GraphQL.
- The legacy (non-v2) `RoleDTO` used by the admin search REST response is left unchanged.
- The actual "auto-grant on scope join" behavior lives in the user-join path and is not included here.

## Test plan
- [x] `pants fmt :: / fix :: / lint` pass
- [x] `pants check` passes across the touched layers (7 files)
- [x] RBAC unit tests pass (`tests/unit/manager/repositories/permission_controller`, `tests/unit/manager/services/permission_controller`)

Resolves BA-6184

🤖 Generated with [Claude Code](https://claude.com/claude-code)