### PR TITLE
feat(BA-6187): expose Role.auto_assign on GraphQL type and create/update inputs

### DIFF
--- a/changes/11912.feature.md
+++ b/changes/11912.feature.md
@@ -1,0 +1,1 @@
+Expose the `auto_assign` field on the GraphQL `Role` type and accept it in the role create/update mutation inputs.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -4047,6 +4047,11 @@ input CreateRoleInput
   name: String!
   description: String = null
   source: RoleSource! = CUSTOM
+
+  """
+  Added in UNRELEASED. When true, the role is automatically granted to a user when the user is added to a scope this role is registered in.
+  """
+  autoAssign: Boolean! = false
   scopes: [ScopeInput!] = null
 }
 
@@ -16002,6 +16007,11 @@ type Role implements Node
   updatedAt: DateTime!
   deletedAt: DateTime
 
+  """
+  Added in UNRELEASED. When true, the role is automatically granted to a user when the user is added to a scope this role is registered in.
+  """
+  autoAssign: Boolean!
+
   """Added in 26.3.0. Permissions associated with this role."""
   permissions(filter: PermissionFilter = null, orderBy: [PermissionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): PermissionConnection
 
@@ -19291,6 +19301,11 @@ input UpdateRoleInput
   name: String
   description: String
   status: RoleStatus
+
+  """
+  Added in UNRELEASED. Updated value for the `auto_assign` flag. When true, the role is automatically granted to a user when the user is added to a scope this role is registered in.
+  """
+  autoAssign: Boolean
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -2597,6 +2597,11 @@ input CreateRoleInput {
   name: String!
   description: String = null
   source: RoleSource! = CUSTOM
+
+  """
+  Added in UNRELEASED. When true, the role is automatically granted to a user when the user is added to a scope this role is registered in.
+  """
+  autoAssign: Boolean! = false
   scopes: [ScopeInput!] = null
 }
 
@@ -10824,6 +10829,11 @@ type Role implements Node {
   updatedAt: DateTime!
   deletedAt: DateTime
 
+  """
+  Added in UNRELEASED. When true, the role is automatically granted to a user when the user is added to a scope this role is registered in.
+  """
+  autoAssign: Boolean!
+
   """Added in 26.3.0. Permissions associated with this role."""
   permissions(filter: PermissionFilter = null, orderBy: [PermissionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): PermissionConnection
 
@@ -13425,6 +13435,11 @@ input UpdateRoleInput {
   name: String
   description: String
   status: RoleStatus
+
+  """
+  Added in UNRELEASED. Updated value for the `auto_assign` flag. When true, the role is automatically granted to a user when the user is added to a scope this role is registered in.
+  """
+  autoAssign: Boolean
 }
 
 """

--- a/src/ai/backend/manager/api/gql/rbac/types/role.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/role.py
@@ -157,6 +157,15 @@ class RoleGQL(PydanticNodeMixin[Any]):
     created_at: datetime
     updated_at: datetime
     deleted_at: datetime | None
+    auto_assign: bool = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "When true, the role is automatically granted to a user when the user is added "
+                "to a scope this role is registered in."
+            ),
+        )
+    )
 
     @classmethod
     async def resolve_nodes(  # type: ignore[override]
@@ -615,6 +624,16 @@ class CreateRoleInput(PydanticInputMixin[CreateRoleInputDTO]):
     name: str
     description: str | None = None
     source: RoleSourceGQL = RoleSourceGQL.CUSTOM
+    auto_assign: bool = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "When true, the role is automatically granted to a user when the user is added "
+                "to a scope this role is registered in."
+            ),
+        ),
+        default=False,
+    )
     scopes: list[ScopeInputGQL] | None = None
 
 
@@ -626,6 +645,16 @@ class UpdateRoleInput(PydanticInputMixin[UpdateRoleInputDTO]):
     name: str | None = UNSET
     description: str | None = UNSET
     status: RoleStatusGQL | None = UNSET
+    auto_assign: bool | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Updated value for the `auto_assign` flag. When true, the role is automatically "
+                "granted to a user when the user is added to a scope this role is registered in."
+            ),
+        ),
+        default=UNSET,
+    )
 
 
 @gql_pydantic_input(

--- a/tests/unit/manager/api/gql/rbac/test_role_input.py
+++ b/tests/unit/manager/api/gql/rbac/test_role_input.py
@@ -55,12 +55,29 @@ class TestCreateRoleInputToPydantic:
         assert isinstance(dto, CreateRoleInputDTO)
         assert dto.description is None
 
+    def test_auto_assign_omitted_defaults_to_false(self) -> None:
+        """CreateRoleInput with auto_assign omitted → dto.auto_assign is False."""
+        role_input = CreateRoleInput(name="MyRole")
+
+        dto = role_input.to_pydantic()
+        assert isinstance(dto, CreateRoleInputDTO)
+        assert dto.auto_assign is False
+
+    def test_auto_assign_explicit_true(self) -> None:
+        """CreateRoleInput with auto_assign=True → dto.auto_assign is True."""
+        role_input = CreateRoleInput(name="MyRole", auto_assign=True)
+
+        dto = role_input.to_pydantic()
+        assert isinstance(dto, CreateRoleInputDTO)
+        assert dto.auto_assign is True
+
     def test_all_fields_provided(self) -> None:
         """CreateRoleInput with all fields → dto has matching values."""
         role_input = CreateRoleInput(
             name="Admin",
             description="Admin role",
             source=RoleSourceGQL.SYSTEM,
+            auto_assign=True,
         )
 
         dto = role_input.to_pydantic()
@@ -68,6 +85,7 @@ class TestCreateRoleInputToPydantic:
         assert dto.name == "Admin"
         assert dto.description == "Admin role"
         assert dto.source == RoleSource.SYSTEM
+        assert dto.auto_assign is True
 
 
 class TestUpdateRoleInputToPydantic:
@@ -161,6 +179,39 @@ class TestUpdateRoleInputToPydantic:
         assert isinstance(dto, UpdateRoleInputDTO)
         assert dto.status == RoleStatus.INACTIVE
 
+    def test_auto_assign_with_unset_produces_none_in_dto(self) -> None:
+        """UpdateRoleInput with auto_assign=UNSET → dto.auto_assign is None (no change)."""
+        role_input = UpdateRoleInput(
+            id=uuid.uuid4(),
+            # auto_assign is omitted (UNSET by default)
+        )
+
+        dto = role_input.to_pydantic()
+        assert isinstance(dto, UpdateRoleInputDTO)
+        assert dto.auto_assign is None
+
+    def test_auto_assign_with_true_produces_true_in_dto(self) -> None:
+        """UpdateRoleInput with auto_assign=True → dto.auto_assign is True."""
+        role_input = UpdateRoleInput(
+            id=uuid.uuid4(),
+            auto_assign=True,
+        )
+
+        dto = role_input.to_pydantic()
+        assert isinstance(dto, UpdateRoleInputDTO)
+        assert dto.auto_assign is True
+
+    def test_auto_assign_with_false_produces_false_in_dto(self) -> None:
+        """UpdateRoleInput with auto_assign=False → dto.auto_assign is False."""
+        role_input = UpdateRoleInput(
+            id=uuid.uuid4(),
+            auto_assign=False,
+        )
+
+        dto = role_input.to_pydantic()
+        assert isinstance(dto, UpdateRoleInputDTO)
+        assert dto.auto_assign is False
+
     def test_multiple_fields_with_mixed_values(self) -> None:
         """Multiple fields with different values produce correct DTO."""
         role_input = UpdateRoleInput(
@@ -168,6 +219,7 @@ class TestUpdateRoleInputToPydantic:
             name="updated role",
             description=None,
             status=RoleStatusGQL.ACTIVE,
+            auto_assign=True,
         )
 
         dto = role_input.to_pydantic()
@@ -175,6 +227,7 @@ class TestUpdateRoleInputToPydantic:
         assert dto.name == "updated role"
         assert dto.description is None
         assert dto.status == RoleStatus.ACTIVE
+        assert dto.auto_assign is True
 
     def test_all_fields_unset_produces_all_defaults(self) -> None:
         """When all fields are UNSET, all DTO fields use their defaults."""
@@ -188,6 +241,7 @@ class TestUpdateRoleInputToPydantic:
         assert dto.name is None
         assert dto.description is SENTINEL
         assert dto.status is None
+        assert dto.auto_assign is None
 
     def test_id_is_on_gql_input_not_in_dto(self) -> None:
         """id is a GQL input field used for routing but not included in the DTO."""


### PR DESCRIPTION
## Summary
- Expose the `auto_assign` field on the Strawberry `Role` GraphQL type.
- Accept `auto_assign` in the role create (`adminCreateRole`) and update (`adminUpdateRole`) mutation inputs.
- The DTO, adapter, and DB layers were already wired in BA-6184, so this change only completes the GraphQL exposure.

Scope note: this covers the Role type / mutation portion of BA-6187. The user-join `role_option` mutation extension is out of scope for this PR.

## Test plan
- [x] `pants fmt / fix / lint` pass
- [x] `pants test tests/unit/manager/api/gql/rbac::` passes (added `auto_assign` cases to `test_role_input.py`)
- [x] Live server (`./bai gql --v2`): create with `autoAssign: true`/omitted (defaults false), update `true → false`, and `adminRole` read-back all return the expected `autoAssign` value

Resolves BA-6187

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11912.org.readthedocs.build/en/11912/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11912.org.readthedocs.build/ko/11912/

<!-- readthedocs-preview sorna-ko end -->