### PR TITLE
feat(BA-6177): add role permission preset search read-path

### DIFF
--- a/changes/11913.feature.md
+++ b/changes/11913.feature.md
@@ -1,0 +1,1 @@
+Add a search read-path for role permission presets so the permission entries of a role preset can be queried with filtering and pagination.

--- a/src/ai/backend/manager/data/role_preset/types.py
+++ b/src/ai/backend/manager/data/role_preset/types.py
@@ -51,6 +51,14 @@ class RolePresetSearchResult:
 
 
 @dataclass(frozen=True)
+class RolePermissionPresetSearchResult:
+    items: list[RolePermissionPresetData]
+    total_count: int
+    has_next_page: bool
+    has_previous_page: bool
+
+
+@dataclass(frozen=True)
 class RolePresetBulkPurgeResult:
     successes: list[RolePresetData] = field(default_factory=list)
     failures: list[BulkPurgerError[RolePresetRow]] = field(default_factory=list)

--- a/src/ai/backend/manager/repositories/role_preset/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/role_preset/db_source/db_source.py
@@ -17,6 +17,7 @@ from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.data.role_preset.types import (
     RolePermissionPresetBulkAddResult,
     RolePermissionPresetBulkRemoveResult,
+    RolePermissionPresetSearchResult,
     RolePresetBulkPurgeResult,
     RolePresetBulkUpdateResult,
     RolePresetData,
@@ -77,6 +78,20 @@ class RolePresetDBSource:
             result = await r.batch_query_in_global(sa.select(RolePresetRow), querier)
             items = [row.RolePresetRow.to_data() for row in result.rows]
             return RolePresetSearchResult(
+                items=items,
+                total_count=result.total_count,
+                has_next_page=result.has_next_page,
+                has_previous_page=result.has_previous_page,
+            )
+
+    async def search_permission_presets(
+        self,
+        querier: BatchQuerier,
+    ) -> RolePermissionPresetSearchResult:
+        async with self._ops.read_ops() as r:
+            result = await r.batch_query_in_global(sa.select(RolePermissionPresetRow), querier)
+            items = [row.RolePermissionPresetRow.to_data() for row in result.rows]
+            return RolePermissionPresetSearchResult(
                 items=items,
                 total_count=result.total_count,
                 has_next_page=result.has_next_page,

--- a/src/ai/backend/manager/repositories/role_preset/repository.py
+++ b/src/ai/backend/manager/repositories/role_preset/repository.py
@@ -9,6 +9,7 @@ from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.role_preset.types import (
     RolePermissionPresetBulkAddResult,
     RolePermissionPresetBulkRemoveResult,
+    RolePermissionPresetSearchResult,
     RolePresetBulkPurgeResult,
     RolePresetBulkUpdateResult,
     RolePresetData,
@@ -56,6 +57,12 @@ class RolePresetRepository:
         querier: BatchQuerier,
     ) -> RolePresetSearchResult:
         return await self._db_source.search(querier)
+
+    async def search_permission_presets(
+        self,
+        querier: BatchQuerier,
+    ) -> RolePermissionPresetSearchResult:
+        return await self._db_source.search_permission_presets(querier)
 
     async def update(self, updater: Updater[RolePresetRow]) -> RolePresetData:
         return await self._db_source.update(updater)

--- a/src/ai/backend/manager/services/role_preset/actions/base.py
+++ b/src/ai/backend/manager/services/role_preset/actions/base.py
@@ -64,3 +64,16 @@ class RolePermissionPresetBulkAction(RolePermissionPresetAction):
     @override
     def entity_id(self) -> str | None:
         return None
+
+
+@dataclass
+class RolePermissionPresetScopeAction(RolePermissionPresetAction):
+    """Base for actions scoped to a collection of role permission presets (e.g. search).
+
+    Scope operations query within an RBAC scope rather than acting on one
+    entity, so there is no single entity id to report.
+    """
+
+    @override
+    def entity_id(self) -> str | None:
+        return None

--- a/src/ai/backend/manager/services/role_preset/actions/search_permission_presets.py
+++ b/src/ai/backend/manager/services/role_preset/actions/search_permission_presets.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.role_preset.types import RolePermissionPresetData
+from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.services.role_preset.actions.base import RolePermissionPresetScopeAction
+
+
+@dataclass
+class SearchRolePermissionPresetsAction(RolePermissionPresetScopeAction):
+    querier: BatchQuerier
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.SEARCH
+
+
+@dataclass
+class SearchRolePermissionPresetsActionResult(BaseActionResult):
+    items: list[RolePermissionPresetData]
+    total_count: int
+    has_next_page: bool
+    has_previous_page: bool
+
+    @override
+    def entity_id(self) -> str | None:
+        return None

--- a/src/ai/backend/manager/services/role_preset/processors.py
+++ b/src/ai/backend/manager/services/role_preset/processors.py
@@ -40,6 +40,10 @@ from ai.backend.manager.services.role_preset.actions.search import (
     SearchRolePresetsAction,
     SearchRolePresetsActionResult,
 )
+from ai.backend.manager.services.role_preset.actions.search_permission_presets import (
+    SearchRolePermissionPresetsAction,
+    SearchRolePermissionPresetsActionResult,
+)
 from ai.backend.manager.services.role_preset.actions.update import (
     UpdateRolePresetAction,
     UpdateRolePresetActionResult,
@@ -51,6 +55,9 @@ class RolePresetProcessors(AbstractProcessorPackage):
     create: ActionProcessor[CreateRolePresetAction, CreateRolePresetActionResult]
     get: ActionProcessor[GetRolePresetAction, GetRolePresetActionResult]
     search: ActionProcessor[SearchRolePresetsAction, SearchRolePresetsActionResult]
+    search_permission_presets: ActionProcessor[
+        SearchRolePermissionPresetsAction, SearchRolePermissionPresetsActionResult
+    ]
     update: ActionProcessor[UpdateRolePresetAction, UpdateRolePresetActionResult]
     bulk_delete: ActionProcessor[BulkDeleteRolePresetsAction, BulkDeleteRolePresetsActionResult]
     bulk_restore: ActionProcessor[BulkRestoreRolePresetsAction, BulkRestoreRolePresetsActionResult]
@@ -72,6 +79,9 @@ class RolePresetProcessors(AbstractProcessorPackage):
         self.create = ActionProcessor(service.create, action_monitors)
         self.get = ActionProcessor(service.get, action_monitors)
         self.search = ActionProcessor(service.search, action_monitors)
+        self.search_permission_presets = ActionProcessor(
+            service.search_permission_presets, action_monitors
+        )
         self.update = ActionProcessor(service.update, action_monitors)
         self.bulk_delete = ActionProcessor(service.bulk_delete, action_monitors)
         self.bulk_restore = ActionProcessor(service.bulk_restore, action_monitors)
@@ -88,6 +98,7 @@ class RolePresetProcessors(AbstractProcessorPackage):
             CreateRolePresetAction.spec(),
             GetRolePresetAction.spec(),
             SearchRolePresetsAction.spec(),
+            SearchRolePermissionPresetsAction.spec(),
             UpdateRolePresetAction.spec(),
             BulkDeleteRolePresetsAction.spec(),
             BulkRestoreRolePresetsAction.spec(),

--- a/src/ai/backend/manager/services/role_preset/service.py
+++ b/src/ai/backend/manager/services/role_preset/service.py
@@ -38,6 +38,10 @@ from ai.backend.manager.services.role_preset.actions.search import (
     SearchRolePresetsAction,
     SearchRolePresetsActionResult,
 )
+from ai.backend.manager.services.role_preset.actions.search_permission_presets import (
+    SearchRolePermissionPresetsAction,
+    SearchRolePermissionPresetsActionResult,
+)
 from ai.backend.manager.services.role_preset.actions.update import (
     UpdateRolePresetAction,
     UpdateRolePresetActionResult,
@@ -63,6 +67,17 @@ class RolePresetService:
     async def search(self, action: SearchRolePresetsAction) -> SearchRolePresetsActionResult:
         result = await self._repository.search(action.querier)
         return SearchRolePresetsActionResult(
+            items=result.items,
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    async def search_permission_presets(
+        self, action: SearchRolePermissionPresetsAction
+    ) -> SearchRolePermissionPresetsActionResult:
+        result = await self._repository.search_permission_presets(action.querier)
+        return SearchRolePermissionPresetsActionResult(
             items=result.items,
             total_count=result.total_count,
             has_next_page=result.has_next_page,

--- a/tests/unit/manager/repositories/role_preset/test_repository.py
+++ b/tests/unit/manager/repositories/role_preset/test_repository.py
@@ -33,7 +33,9 @@ from ai.backend.manager.repositories.base import (
     BatchQuerier,
     BulkCreator,
     NoPagination,
+    OffsetPagination,
 )
+from ai.backend.manager.repositories.base.types import QueryCondition
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.manager.repositories.role_preset.creators import (
@@ -75,6 +77,27 @@ async def _count_permissions(
             .where(RolePermissionPresetRow.role_preset_id == preset_id)
         )
         return result.scalar_one()
+
+
+async def _create_preset_with_permissions(
+    repository: RolePresetRepository,
+    name: str,
+    permissions: list[tuple[EntityType, OperationType]],
+) -> RolePresetID:
+    created = await repository.create(
+        RolePresetCreatorSpec(name=name, scope_type=ScopeType.DOMAIN),
+        [
+            RolePermissionPresetDependentCreatorSpec(entity_type=entity_type, operation=operation)
+            for entity_type, operation in permissions
+        ],
+    )
+    return created.id
+
+
+def _by_preset(preset_id: RolePresetID) -> QueryCondition:
+    # The model layer has no role-permission-preset conditions yet, so the
+    # preset-scoping predicate is built inline here.
+    return lambda: RolePermissionPresetRow.role_preset_id == preset_id
 
 
 class TestCreate:
@@ -287,3 +310,96 @@ class TestPermissions:
         assert {perm.id for perm in result.successes} == set(permission_ids)
         assert result.failures == []
         assert await _count_permissions(database_connection, preset.id) == 0
+
+
+class TestSearchPermissionPresets:
+    @pytest.fixture
+    async def preset_with_permissions(self, repository: RolePresetRepository) -> RolePresetID:
+        """A single preset carrying three permission entries with distinct operations."""
+        return await _create_preset_with_permissions(
+            repository,
+            "p1",
+            [
+                (EntityType.VFOLDER, OperationType.CREATE),
+                (EntityType.VFOLDER, OperationType.READ),
+                (EntityType.VFOLDER, OperationType.UPDATE),
+            ],
+        )
+
+    @pytest.fixture
+    async def target_among_other_presets(self, repository: RolePresetRepository) -> RolePresetID:
+        """A target preset (three entries) alongside an unrelated preset (one entry)."""
+        target = await _create_preset_with_permissions(
+            repository,
+            "target",
+            [
+                (EntityType.VFOLDER, OperationType.READ),
+                (EntityType.VFOLDER, OperationType.UPDATE),
+                (EntityType.SESSION, OperationType.READ),
+            ],
+        )
+        await _create_preset_with_permissions(
+            repository, "other", [(EntityType.IMAGE, OperationType.READ)]
+        )
+        return target
+
+    async def test_scopes_to_role_preset(
+        self,
+        repository: RolePresetRepository,
+        target_among_other_presets: RolePresetID,
+    ) -> None:
+        result = await repository.search_permission_presets(
+            BatchQuerier(
+                pagination=NoPagination(),
+                conditions=[_by_preset(target_among_other_presets)],
+            )
+        )
+
+        assert result.total_count == 3
+        assert all(item.role_preset_id == target_among_other_presets for item in result.items)
+
+    @pytest.mark.parametrize(
+        ("limit", "offset", "expected_len", "expected_next", "expected_prev"),
+        [
+            (2, 0, 2, True, False),  # first page of three
+            (2, 2, 1, False, True),  # last page
+            (10, 0, 3, False, False),  # whole set in one page
+        ],
+    )
+    async def test_paginates(
+        self,
+        repository: RolePresetRepository,
+        preset_with_permissions: RolePresetID,
+        limit: int,
+        offset: int,
+        expected_len: int,
+        expected_next: bool,
+        expected_prev: bool,
+    ) -> None:
+        result = await repository.search_permission_presets(
+            BatchQuerier(
+                pagination=OffsetPagination(limit=limit, offset=offset),
+                conditions=[_by_preset(preset_with_permissions)],
+            )
+        )
+
+        assert len(result.items) == expected_len
+        assert result.total_count == 3
+        assert result.has_next_page is expected_next
+        assert result.has_previous_page is expected_prev
+
+    async def test_orders_by_operation(
+        self,
+        repository: RolePresetRepository,
+        preset_with_permissions: RolePresetID,
+    ) -> None:
+        result = await repository.search_permission_presets(
+            BatchQuerier(
+                pagination=NoPagination(),
+                conditions=[_by_preset(preset_with_permissions)],
+                orders=[RolePermissionPresetRow.operation.asc()],
+            )
+        )
+
+        operations = [item.operation for item in result.items]
+        assert operations == sorted(operations, key=lambda op: op.value)


### PR DESCRIPTION
## Summary
- Add the `search_permission_presets` read-path across the data, repository, and service layers so permission entries belonging to a role preset can be queried with filtering and pagination.
- Mirrors the existing role preset `search` path (BatchQuerier-based, `batch_query_in_global`).
- Fills the gap that previously left the GraphQL `permission_presets` field unbacked — the lower layers now exist for the adapter/resolver wiring to call.

## Changes
- **data**: `RolePermissionPresetSearchResult` value object
- **repository**: `search_permission_presets` on `RolePresetRepository` and `RolePresetDBSource`
- **service**: `SearchRolePermissionPresetsAction`/`Result`, service method, processor registration, and `RolePermissionPresetScopeAction` base

## Test plan
- [x] CI: lint, type-check, tests pass

Resolves BA-6177