### PR TITLE
feat(BA-6180): add Role Preset REST v2 API

### DIFF
--- a/changes/11914.feature.md
+++ b/changes/11914.feature.md
@@ -1,0 +1,1 @@
+Add Role Preset REST v2 API under `/api/rest/v2/role-presets` with create, search, get, update, soft-delete, restore, purge, and bulk permission-entry management.

--- a/src/ai/backend/common/dto/manager/v2/role_preset/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/role_preset/__init__.py
@@ -10,6 +10,7 @@ from ai.backend.common.dto.manager.v2.role_preset.request import (
     RolePresetFilter,
     RolePresetOrder,
     SearchRolePresetsInput,
+    UpdateRolePresetBody,
     UpdateRolePresetInput,
 )
 from ai.backend.common.dto.manager.v2.role_preset.response import (
@@ -35,6 +36,7 @@ __all__ = (
     "RolePresetFilter",
     "RolePresetOrder",
     "SearchRolePresetsInput",
+    "UpdateRolePresetBody",
     "UpdateRolePresetInput",
     # Response DTOs
     "BulkDeleteRolePresetsPayload",

--- a/src/ai/backend/common/dto/manager/v2/role_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/role_preset/request.py
@@ -22,6 +22,7 @@ __all__ = (
     "RolePresetFilter",
     "RolePresetOrder",
     "SearchRolePresetsInput",
+    "UpdateRolePresetBody",
     "UpdateRolePresetInput",
 )
 
@@ -47,20 +48,31 @@ class CreateRolePresetInput(BaseRequestModel):
     )
 
 
-class UpdateRolePresetInput(BaseRequestModel):
-    """Input for updating a role preset's metadata. All fields optional for partial update.
+class UpdateRolePresetBody(BaseRequestModel):
+    """Mutable metadata of a role preset. All fields optional for partial update.
 
-    Permission entries are managed via the dedicated Add/Remove endpoints. The
-    ``deleted`` flag is managed through the dedicated Delete/Restore endpoints
-    and cannot be mutated here.
+    Used directly as the REST request body, where the preset ID is supplied as a
+    URL path segment instead of a body field. ``UpdateRolePresetInput`` extends
+    this with the ID for the GQL/adapter call path. Permission entries are
+    managed via the dedicated Add/Remove endpoints, and the ``deleted`` flag
+    through the dedicated Delete/Restore endpoints.
     """
 
-    role_preset_id: RolePresetID = Field(description="ID of the role preset to update.")
     name: str | None = Field(default=None, min_length=1, max_length=64, description="Updated name.")
     auto_assign: bool | None = Field(
         default=None,
         description="Updated default value for the `auto_assign` flag of instantiated roles.",
     )
+
+
+class UpdateRolePresetInput(UpdateRolePresetBody):
+    """Input for updating a role preset's metadata, carrying the target preset ID.
+
+    Extends ``UpdateRolePresetBody`` with ``role_preset_id`` for the GQL mutation
+    and adapter call path.
+    """
+
+    role_preset_id: RolePresetID = Field(description="ID of the role preset to update.")
 
 
 class BulkDeleteRolePresetsInput(BaseRequestModel):

--- a/src/ai/backend/manager/api/adapters/role_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/role_preset/adapter.py
@@ -38,6 +38,7 @@ from ai.backend.common.dto.manager.v2.role_preset.request import (
     RolePresetFilter,
     RolePresetOrder,
     SearchRolePresetsInput,
+    UpdateRolePresetBody,
     UpdateRolePresetInput,
 )
 from ai.backend.common.dto.manager.v2.role_preset.response import (
@@ -153,7 +154,7 @@ class RolePresetAdapter(BaseAdapter):
         )
         return CreateRolePresetPayload(role_preset=self._data_to_node(result.preset))
 
-    async def get(self, role_preset_id: RolePresetID) -> RolePresetNode | None:
+    async def get(self, role_preset_id: RolePresetID) -> RolePresetNode:
         """Get a single role preset by ID."""
         result = await self._processors.role_preset.get.wait_for_complete(
             GetRolePresetAction(preset_id=role_preset_id)
@@ -208,6 +209,22 @@ class RolePresetAdapter(BaseAdapter):
             UpdateRolePresetAction(updater=updater)
         )
         return UpdateRolePresetPayload(role_preset=self._data_to_node(result.preset))
+
+    async def update_from_body(
+        self, role_preset_id: RolePresetID, body: UpdateRolePresetBody
+    ) -> UpdateRolePresetPayload:
+        """Update a role preset whose ID is carried separately from the body.
+
+        Used by the REST handler, where the preset ID comes from the URL path
+        while the body only carries the mutable metadata.
+        """
+        return await self.update(
+            UpdateRolePresetInput(
+                role_preset_id=role_preset_id,
+                name=body.name,
+                auto_assign=body.auto_assign,
+            )
+        )
 
     async def bulk_delete(self, input: BulkDeleteRolePresetsInput) -> BulkDeleteRolePresetsPayload:
         """Bulk-soft-delete role presets."""

--- a/src/ai/backend/manager/api/gql/role_preset/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/role_preset/resolver/query.py
@@ -41,8 +41,6 @@ async def admin_role_preset(
 ) -> RolePresetGQL | None:
     check_admin_only()
     node = await info.context.adapters.role_preset.get(RolePresetID(UUID(str(id))))
-    if node is None:
-        return None
     return RolePresetGQL.from_pydantic(node)
 
 

--- a/src/ai/backend/manager/api/rest/v2/path_params.py
+++ b/src/ai/backend/manager/api/rest/v2/path_params.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseRequestModel
+from ai.backend.common.identifier.role_preset import RolePresetID
 
 
 class DomainNamePathParam(BaseRequestModel):
@@ -75,6 +76,10 @@ class RuleIdPathParam(BaseRequestModel):
 
 class PresetIdPathParam(BaseRequestModel):
     preset_id: UUID = Field(description="Preset UUID")
+
+
+class RolePresetIdPathParam(BaseRequestModel):
+    role_preset_id: RolePresetID = Field(description="Role preset UUID")
 
 
 class LoginClientTypeIdPathParam(BaseRequestModel):

--- a/src/ai/backend/manager/api/rest/v2/role_preset/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/role_preset/handler.py
@@ -1,0 +1,132 @@
+"""REST v2 handler for the role preset domain."""
+
+from __future__ import annotations
+
+import logging
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Final
+
+from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam
+from ai.backend.common.dto.manager.v2.role_permission_preset.request import (
+    BulkAddRolePermissionPresetsInput,
+    BulkRemoveRolePermissionPresetsInput,
+    SearchRolePermissionPresetsInput,
+)
+from ai.backend.common.dto.manager.v2.role_preset.request import (
+    BulkDeleteRolePresetsInput,
+    BulkPurgeRolePresetsInput,
+    BulkRestoreRolePresetsInput,
+    CreateRolePresetInput,
+    SearchRolePresetsInput,
+    UpdateRolePresetBody,
+)
+from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.api.rest.v2.path_params import RolePresetIdPathParam
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.adapters.role_preset.adapter import RolePresetAdapter
+
+log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class V2RolePresetHandler:
+    """REST v2 handler for role preset operations.
+
+    Delete is a soft-delete (toggles ``deleted = true``); Restore inverts it;
+    Purge performs the hard delete and cascades to permission entries.
+    """
+
+    def __init__(self, *, adapter: RolePresetAdapter) -> None:
+        self._adapter = adapter
+
+    async def create(
+        self,
+        body: BodyParam[CreateRolePresetInput],
+    ) -> APIResponse:
+        """Create a new role preset."""
+        result = await self._adapter.create(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.CREATED, response_model=result)
+
+    async def search(
+        self,
+        body: BodyParam[SearchRolePresetsInput],
+    ) -> APIResponse:
+        """Search role presets (superadmin only)."""
+        result = await self._adapter.search(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def get(
+        self,
+        path: PathParam[RolePresetIdPathParam],
+    ) -> APIResponse:
+        """Get a single role preset by ID."""
+        result = await self._adapter.get(path.parsed.role_preset_id)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def update(
+        self,
+        path: PathParam[RolePresetIdPathParam],
+        body: BodyParam[UpdateRolePresetBody],
+    ) -> APIResponse:
+        """Update a role preset's metadata. The ``deleted`` flag cannot be mutated here.
+
+        The preset ID comes from the URL path; the adapter merges it with the body.
+        """
+        result = await self._adapter.update_from_body(path.parsed.role_preset_id, body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def bulk_delete(
+        self,
+        body: BodyParam[BulkDeleteRolePresetsInput],
+    ) -> APIResponse:
+        """Soft-delete role presets (sets ``deleted = true``)."""
+        result = await self._adapter.bulk_delete(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def bulk_restore(
+        self,
+        body: BodyParam[BulkRestoreRolePresetsInput],
+    ) -> APIResponse:
+        """Restore soft-deleted role presets (sets ``deleted = false``)."""
+        result = await self._adapter.bulk_restore(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def bulk_purge(
+        self,
+        body: BodyParam[BulkPurgeRolePresetsInput],
+    ) -> APIResponse:
+        """Hard-delete role presets, cascading to their permission entries."""
+        result = await self._adapter.bulk_purge(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def search_permissions(
+        self,
+        path: PathParam[RolePresetIdPathParam],
+        body: BodyParam[SearchRolePermissionPresetsInput],
+    ) -> APIResponse:
+        """Search the permission entries belonging to a single role preset."""
+        result = await self._adapter.search_permission_presets(
+            path.parsed.role_preset_id,
+            body.parsed,
+        )
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def add_permissions(
+        self,
+        path: PathParam[RolePresetIdPathParam],
+        body: BodyParam[BulkAddRolePermissionPresetsInput],
+    ) -> APIResponse:
+        """Bulk-add permission entries to an existing role preset."""
+        result = await self._adapter.bulk_add_permissions(
+            path.parsed.role_preset_id,
+            body.parsed,
+        )
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def remove_permissions(
+        self,
+        body: BodyParam[BulkRemoveRolePermissionPresetsInput],
+    ) -> APIResponse:
+        """Bulk-remove permission entries by their row IDs."""
+        result = await self._adapter.bulk_remove_permissions(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/role_preset/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/role_preset/registry.py
@@ -1,0 +1,50 @@
+"""Route registry for REST v2 role preset endpoints."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ai.backend.manager.api.rest.middleware.auth import superadmin_required
+from ai.backend.manager.api.rest.routing import RouteRegistry
+
+from .handler import V2RolePresetHandler
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.rest.types import RouteDeps
+
+
+def register_v2_role_preset_routes(
+    handler: V2RolePresetHandler,
+    route_deps: RouteDeps,
+) -> RouteRegistry:
+    """Register all v2 role preset routes.
+
+    Delete is a soft-delete, Restore inverts it, and Purge is the hard delete;
+    all three operate on a list of preset IDs supplied in the request body.
+    """
+    registry = RouteRegistry.create("role-presets", route_deps.cors_options)
+
+    registry.add("POST", "", handler.create, middlewares=[superadmin_required])
+    registry.add("POST", "/search", handler.search, middlewares=[superadmin_required])
+    registry.add("POST", "/bulk-delete", handler.bulk_delete, middlewares=[superadmin_required])
+    registry.add("POST", "/bulk-restore", handler.bulk_restore, middlewares=[superadmin_required])
+    registry.add("POST", "/bulk-purge", handler.bulk_purge, middlewares=[superadmin_required])
+    registry.add(
+        "POST", "/permissions/remove", handler.remove_permissions, middlewares=[superadmin_required]
+    )
+    registry.add("GET", "/{role_preset_id}", handler.get, middlewares=[superadmin_required])
+    registry.add("PATCH", "/{role_preset_id}", handler.update, middlewares=[superadmin_required])
+    registry.add(
+        "POST",
+        "/{role_preset_id}/permissions/search",
+        handler.search_permissions,
+        middlewares=[superadmin_required],
+    )
+    registry.add(
+        "POST",
+        "/{role_preset_id}/permissions/add",
+        handler.add_permissions,
+        middlewares=[superadmin_required],
+    )
+
+    return registry

--- a/src/ai/backend/manager/api/rest/v2/tree.py
+++ b/src/ai/backend/manager/api/rest/v2/tree.py
@@ -92,6 +92,8 @@ def build_v2_routes(
     from .resource_usage.registry import register_v2_resource_usage_routes
     from .role_invitation.handler import V2RoleInvitationHandler
     from .role_invitation.registry import register_v2_role_invitation_routes
+    from .role_preset.handler import V2RolePresetHandler
+    from .role_preset.registry import register_v2_role_preset_routes
     from .runtime_variant.handler import V2RuntimeVariantHandler
     from .runtime_variant.registry import register_v2_runtime_variant_routes
     from .runtime_variant_preset.handler import V2RuntimeVariantPresetHandler
@@ -137,6 +139,7 @@ def build_v2_routes(
     object_storage_handler = V2ObjectStorageHandler(adapter=adapters.object_storage)
     project_handler = V2ProjectHandler(adapter=adapters.project)
     role_invitation_handler = V2RoleInvitationHandler(adapter=adapters.rbac)
+    role_preset_handler = V2RolePresetHandler(adapter=adapters.role_preset)
     prometheus_query_preset_handler = V2PrometheusQueryPresetHandler(
         adapter=adapters.prometheus_query_preset
     )
@@ -205,6 +208,7 @@ def build_v2_routes(
     v2_reg.add_subregistry(register_v2_object_storage_routes(object_storage_handler, route_deps))
     v2_reg.add_subregistry(register_v2_project_routes(project_handler, route_deps))
     v2_reg.add_subregistry(register_v2_role_invitation_routes(role_invitation_handler, route_deps))
+    v2_reg.add_subregistry(register_v2_role_preset_routes(role_preset_handler, route_deps))
     v2_reg.add_subregistry(
         register_v2_prometheus_query_preset_routes(prometheus_query_preset_handler, route_deps)
     )


### PR DESCRIPTION
## Summary
Wire up the REST v2 surface for role presets under `/api/rest/v2/role-presets`. The lower layers (DTOs, adapter, GraphQL) already existed, so this PR adds the REST handler/registry and a few supporting refinements.

- **Endpoints** (`V2RolePresetHandler`, all superadmin-only):
  - `POST /role-presets` create, `POST /role-presets/search` search
  - `GET /role-presets/{role_preset_id}` get, `PATCH /role-presets/{role_preset_id}` update
  - `POST /role-presets/bulk-delete` (soft), `/bulk-restore`, `/bulk-purge` (hard)
  - `POST /role-presets/{role_preset_id}/permissions/search` and `/permissions/add`, `POST /role-presets/permissions/remove`
- **Soft-delete semantics**: Delete toggles `deleted = true`, Restore inverts it, Purge hard-deletes and cascades to permission entries.
- **Update body**: add `UpdateRolePresetBody` (mutable metadata only) so clients pass the preset ID via the URL path instead of repeating it in the body. `UpdateRolePresetInput` now extends `UpdateRolePresetBody`, keeping the flat field shape that the GQL input mapping and adapter rely on; the adapter's `update_from_body` merges the path ID with the body.
- **Path param**: add `RolePresetIdPathParam` typed as `RolePresetID`, with `{role_preset_id}` URL placeholders.
- **Bulk naming**: the list-based delete/restore/purge endpoints use `bulk_*` handlers at `/bulk-*`, matching their `Bulk*Input` DTOs and the adapter's `bulk_*` methods, consistent with sibling v2 domains.
- Drop the now-unreachable `None` branch from `adapter.get` and the GQL resolver, since `get` always returns a node.

## Test plan
- [x] `./dev restart mgr`, then exercise each endpoint against the live server
- [x] Verify superadmin-only endpoints reject non-admin callers (403)
- [x] Verify soft-delete → restore → purge lifecycle on a preset
- [x] Verify `PATCH` works with the ID in the path only (no ID in body), and partial updates
- [x] Verify the same update path through the GraphQL `adminUpdateRolePreset` mutation

Resolves BA-6180
