### PR TITLE
feat(BA-6181): add Role Preset SDK v2 + CLI v2

### DIFF
--- a/changes/11916.feature.md
+++ b/changes/11916.feature.md
@@ -1,0 +1,1 @@
+Add Role Preset client SDK v2 and `admin role-preset` CLI v2 commands.

--- a/src/ai/backend/client/cli/v2/admin/__init__.py
+++ b/src/ai/backend/client/cli/v2/admin/__init__.py
@@ -203,3 +203,12 @@ def scheduling_handler() -> None:
 )
 def invitation() -> None:
     """Admin role invitation commands."""
+
+
+@admin.group(
+    cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.admin.role_preset:role_preset",
+    name="role-preset",
+)
+def role_preset() -> None:
+    """Admin role preset commands."""

--- a/src/ai/backend/client/cli/v2/admin/role_preset.py
+++ b/src/ai/backend/client/cli/v2/admin/role_preset.py
@@ -80,15 +80,40 @@ def create(
 
 @role_preset.command()
 @click.argument("role_preset_id", type=click.UUID)
-def get(role_preset_id: uuid.UUID) -> None:
+@click.option(
+    "-d",
+    "--detail",
+    is_flag=True,
+    default=False,
+    help=(
+        "Also include the preset's permission entries. Only the first page is shown "
+        "(server default, up to 10); use `permission-search` to page through all entries."
+    ),
+)
+def get(role_preset_id: uuid.UUID, detail: bool) -> None:
     """Get a single role preset by ID."""
+    from ai.backend.common.dto.manager.v2.role_permission_preset.request import (
+        SearchRolePermissionPresetsInput,
+    )
     from ai.backend.common.identifier.role_preset import RolePresetID
+
+    preset_id = RolePresetID(role_preset_id)
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            result = await registry.role_preset.get(RolePresetID(role_preset_id))
-            print_result(result)
+            node = await registry.role_preset.get(preset_id)
+            if not detail:
+                print_result(node)
+                return
+            permissions = await registry.role_preset.search_permissions(
+                preset_id,
+                SearchRolePermissionPresetsInput(),
+            )
+            print_result({
+                "role_preset": node.model_dump(mode="json"),
+                "permissions": [item.model_dump(mode="json") for item in permissions.items],
+            })
         finally:
             await registry.close()
 

--- a/src/ai/backend/client/cli/v2/admin/role_preset.py
+++ b/src/ai/backend/client/cli/v2/admin/role_preset.py
@@ -1,0 +1,399 @@
+"""Admin CLI commands for the v2 role preset resource (superadmin only).
+
+Delete is a soft-delete, Restore inverts it, and Purge is the hard delete.
+Every active preset is auto-applied at scope creation, so there is no
+``auto_apply`` argument on this surface.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_model,
+    load_v2_config,
+    parse_order_options,
+    print_result,
+    run_async,
+)
+
+
+@click.group()
+def role_preset() -> None:
+    """Admin role preset commands (superadmin only)."""
+
+
+@role_preset.command()
+@click.option("--name", required=True, help="Role preset name.")
+@click.option(
+    "--scope-type",
+    required=True,
+    help="Scope type this preset targets (e.g., domain, project).",
+)
+@click.option(
+    "--auto-assign/--no-auto-assign",
+    default=False,
+    help="Default auto-assign flag for roles instantiated from this preset.",
+)
+@click.option(
+    "--permissions",
+    default=None,
+    help='Permission entries as JSON or @file: [{"entity_type": "...", "operation": "..."}].',
+)
+def create(
+    name: str,
+    scope_type: str,
+    auto_assign: bool,
+    permissions: str | None,
+) -> None:
+    """Create a new role preset."""
+    from ai.backend.common.dto.manager.v2.rbac.types import RBACElementTypeDTO
+    from ai.backend.common.dto.manager.v2.role_permission_preset.types import (
+        RolePermissionPresetEntry,
+    )
+    from ai.backend.common.dto.manager.v2.role_preset.request import CreateRolePresetInput
+
+    entries = (
+        load_model(permissions, list[RolePermissionPresetEntry]) if permissions is not None else []
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.role_preset.create(
+                CreateRolePresetInput(
+                    name=name,
+                    scope_type=RBACElementTypeDTO(scope_type),
+                    auto_assign=auto_assign,
+                    permissions=entries,
+                ),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
+@role_preset.command()
+@click.argument("role_preset_id", type=click.UUID)
+def get(role_preset_id: uuid.UUID) -> None:
+    """Get a single role preset by ID."""
+    from ai.backend.common.identifier.role_preset import RolePresetID
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.role_preset.get(RolePresetID(role_preset_id))
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
+@role_preset.command()
+@click.option("--limit", type=int, default=None, help="Maximum items to return.")
+@click.option("--offset", type=int, default=None, help="Number of items to skip.")
+@click.option(
+    "--name-contains",
+    default=None,
+    help="Filter presets whose name contains this substring.",
+)
+@click.option("--scope-type", default=None, help="Filter by scope type.")
+@click.option(
+    "--auto-assign/--no-auto-assign",
+    default=None,
+    help="Filter by auto-assign flag.",
+)
+@click.option(
+    "--deleted/--no-deleted",
+    default=None,
+    help="Filter by soft-delete flag (defaults to excluding soft-deleted rows).",
+)
+@click.option(
+    "--order-by",
+    multiple=True,
+    help="Order by field:direction (e.g., name:asc, created_at:desc).",
+)
+def search(
+    limit: int | None,
+    offset: int | None,
+    name_contains: str | None,
+    scope_type: str | None,
+    auto_assign: bool | None,
+    deleted: bool | None,
+    order_by: tuple[str, ...],
+) -> None:
+    """Search role presets across the system."""
+    from ai.backend.common.dto.manager.query import StringFilter
+    from ai.backend.common.dto.manager.v2.rbac.types import RBACElementTypeDTO
+    from ai.backend.common.dto.manager.v2.role_preset.request import (
+        RolePresetFilter,
+        RolePresetOrder,
+        SearchRolePresetsInput,
+    )
+    from ai.backend.common.dto.manager.v2.role_preset.types import RolePresetOrderField
+
+    filter_dto: RolePresetFilter | None = None
+    if any(v is not None for v in (name_contains, scope_type, auto_assign, deleted)):
+        filter_dto = RolePresetFilter(
+            name=StringFilter(contains=name_contains) if name_contains is not None else None,
+            scope_type=RBACElementTypeDTO(scope_type) if scope_type is not None else None,
+            auto_assign=auto_assign,
+            deleted=deleted,
+        )
+
+    orders = (
+        parse_order_options(order_by, RolePresetOrderField, RolePresetOrder) if order_by else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.role_preset.search(
+                SearchRolePresetsInput(
+                    filter=filter_dto,
+                    order=orders,
+                    limit=limit,
+                    offset=offset,
+                ),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
+@role_preset.command()
+@click.argument("role_preset_id", type=click.UUID)
+@click.option("--name", default=None, help="Updated name.")
+@click.option(
+    "--auto-assign/--no-auto-assign",
+    default=None,
+    help="Updated default auto-assign flag for instantiated roles.",
+)
+def update(
+    role_preset_id: uuid.UUID,
+    name: str | None,
+    auto_assign: bool | None,
+) -> None:
+    """Update a role preset's mutable metadata."""
+    from ai.backend.common.dto.manager.v2.role_preset.request import UpdateRolePresetBody
+    from ai.backend.common.identifier.role_preset import RolePresetID
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.role_preset.update(
+                RolePresetID(role_preset_id),
+                UpdateRolePresetBody(name=name, auto_assign=auto_assign),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
+@role_preset.command()
+@click.argument("role_preset_ids", type=click.UUID, nargs=-1, required=True)
+def delete(role_preset_ids: tuple[uuid.UUID, ...]) -> None:
+    """Soft-delete one or more role presets (sets ``deleted = true``)."""
+    from ai.backend.common.dto.manager.v2.role_preset.request import BulkDeleteRolePresetsInput
+    from ai.backend.common.identifier.role_preset import RolePresetID
+
+    ids = [RolePresetID(rid) for rid in role_preset_ids]
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.role_preset.delete(
+                BulkDeleteRolePresetsInput(role_preset_ids=ids),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
+@role_preset.command()
+@click.argument("role_preset_ids", type=click.UUID, nargs=-1, required=True)
+def restore(role_preset_ids: tuple[uuid.UUID, ...]) -> None:
+    """Restore one or more soft-deleted role presets (sets ``deleted = false``)."""
+    from ai.backend.common.dto.manager.v2.role_preset.request import BulkRestoreRolePresetsInput
+    from ai.backend.common.identifier.role_preset import RolePresetID
+
+    ids = [RolePresetID(rid) for rid in role_preset_ids]
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.role_preset.restore(
+                BulkRestoreRolePresetsInput(role_preset_ids=ids),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
+@role_preset.command()
+@click.argument("role_preset_ids", type=click.UUID, nargs=-1, required=True)
+def purge(role_preset_ids: tuple[uuid.UUID, ...]) -> None:
+    """Hard-delete one or more role presets, cascading to their permission entries."""
+    from ai.backend.common.dto.manager.v2.role_preset.request import BulkPurgeRolePresetsInput
+    from ai.backend.common.identifier.role_preset import RolePresetID
+
+    ids = [RolePresetID(rid) for rid in role_preset_ids]
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.role_preset.purge(
+                BulkPurgeRolePresetsInput(role_preset_ids=ids),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
+@role_preset.command(name="permission-search")
+@click.argument("role_preset_id", type=click.UUID)
+@click.option("--limit", type=int, default=None, help="Maximum items to return.")
+@click.option("--offset", type=int, default=None, help="Number of items to skip.")
+@click.option("--entity-type", default=None, help="Filter by entity type.")
+@click.option("--operation", default=None, help="Filter by granted operation.")
+@click.option(
+    "--order-by",
+    multiple=True,
+    help="Order by field:direction (e.g., entity_type:asc, created_at:desc).",
+)
+def permission_search(
+    role_preset_id: uuid.UUID,
+    limit: int | None,
+    offset: int | None,
+    entity_type: str | None,
+    operation: str | None,
+    order_by: tuple[str, ...],
+) -> None:
+    """Search the permission entries belonging to a single role preset."""
+    from ai.backend.common.dto.manager.v2.rbac.types import (
+        OperationTypeDTO,
+        OperationTypeFilter,
+        RBACElementTypeDTO,
+        RBACElementTypeFilter,
+    )
+    from ai.backend.common.dto.manager.v2.role_permission_preset.request import (
+        RolePermissionPresetFilter,
+        RolePermissionPresetOrder,
+        SearchRolePermissionPresetsInput,
+    )
+    from ai.backend.common.dto.manager.v2.role_permission_preset.types import (
+        RolePermissionPresetOrderField,
+    )
+    from ai.backend.common.identifier.role_preset import RolePresetID
+
+    filter_dto: RolePermissionPresetFilter | None = None
+    if entity_type is not None or operation is not None:
+        filter_dto = RolePermissionPresetFilter(
+            entity_type=(
+                RBACElementTypeFilter(equals=RBACElementTypeDTO(entity_type))
+                if entity_type is not None
+                else None
+            ),
+            operation=(
+                OperationTypeFilter(equals=OperationTypeDTO(operation))
+                if operation is not None
+                else None
+            ),
+        )
+
+    orders = (
+        parse_order_options(order_by, RolePermissionPresetOrderField, RolePermissionPresetOrder)
+        if order_by
+        else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.role_preset.search_permissions(
+                RolePresetID(role_preset_id),
+                SearchRolePermissionPresetsInput(
+                    filter=filter_dto,
+                    order=orders,
+                    limit=limit,
+                    offset=offset,
+                ),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
+@role_preset.command(name="permission-add")
+@click.argument("role_preset_id", type=click.UUID)
+@click.option(
+    "--permissions",
+    required=True,
+    help='Permission entries as JSON or @file: [{"entity_type": "...", "operation": "..."}].',
+)
+def permission_add(role_preset_id: uuid.UUID, permissions: str) -> None:
+    """Bulk-add permission entries to an existing role preset."""
+    from ai.backend.common.dto.manager.v2.role_permission_preset.request import (
+        BulkAddRolePermissionPresetsInput,
+    )
+    from ai.backend.common.dto.manager.v2.role_permission_preset.types import (
+        RolePermissionPresetEntry,
+    )
+    from ai.backend.common.identifier.role_preset import RolePresetID
+
+    entries = load_model(permissions, list[RolePermissionPresetEntry])
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.role_preset.add_permissions(
+                RolePresetID(role_preset_id),
+                BulkAddRolePermissionPresetsInput(permissions=entries),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
+@role_preset.command(name="permission-remove")
+@click.argument("permission_preset_ids", type=click.UUID, nargs=-1, required=True)
+def permission_remove(permission_preset_ids: tuple[uuid.UUID, ...]) -> None:
+    """Bulk-remove permission entries by their row IDs."""
+    from ai.backend.common.dto.manager.v2.role_permission_preset.request import (
+        BulkRemoveRolePermissionPresetsInput,
+    )
+    from ai.backend.common.identifier.role_permission_preset import RolePermissionPresetID
+
+    ids = [RolePermissionPresetID(pid) for pid in permission_preset_ids]
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.role_preset.remove_permissions(
+                BulkRemoveRolePermissionPresetsInput(permission_preset_ids=ids),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)

--- a/src/ai/backend/client/cli/v2/helpers.py
+++ b/src/ai/backend/client/cli/v2/helpers.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import sys
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import aiohttp
+import click
+from pydantic import TypeAdapter, ValidationError
 from yarl import URL
 
 if TYPE_CHECKING:
@@ -154,6 +158,57 @@ def parse_order_options(
             )
         )
     return orders
+
+
+def load_model[T](payload: str, model: type[T]) -> T:
+    """Parse a JSON string or ``@file`` path and validate it against *model*.
+
+    *payload* is either a raw JSON string or ``@<path>`` pointing to a JSON file.
+    *model* is any type usable with Pydantic ``TypeAdapter`` — a model class or a
+    parametrized form such as ``list[Entry]``. Exits with an error message on
+    malformed JSON or validation failure.
+    """
+    if payload.startswith("@"):
+        path = payload[1:]
+        try:
+            raw = Path(path).read_text()
+        except OSError as e:
+            click.echo(f"Cannot read file {path}: {e}", err=True)
+            sys.exit(1)
+    else:
+        raw = payload
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        click.echo(f"Invalid JSON: {e}", err=True)
+        sys.exit(1)
+
+    try:
+        return TypeAdapter(model).validate_python(data)
+    except ValidationError as e:
+        click.echo(f"Invalid input: {e}", err=True)
+        sys.exit(1)
+
+
+def run_async(coro_fn: Callable[[], Awaitable[None]]) -> None:
+    """Run an async function, translating SDK errors into clean CLI output.
+
+    On ``BackendAPIError`` the gateway's error detail is printed to stderr and
+    the process exits with code 1, instead of leaking a traceback.
+    """
+    from ai.backend.client.exceptions import BackendAPIError
+
+    try:
+        asyncio.run(coro_fn())
+    except BackendAPIError as e:
+        data = e.args[2] if len(e.args) > 2 else {}
+        title = data.get("title", "") if isinstance(data, dict) else ""
+        msg = data.get("msg", "") if isinstance(data, dict) else ""
+        status = e.args[0] if e.args else "?"
+        detail = title or msg or str(e)
+        click.echo(f"Error ({status}): {detail}", err=True)
+        sys.exit(1)
 
 
 def print_result(data: Any) -> None:

--- a/src/ai/backend/client/v2/domains_v2/role_preset.py
+++ b/src/ai/backend/client/v2/domains_v2/role_preset.py
@@ -1,0 +1,141 @@
+"""V2 SDK client for the role preset domain."""
+
+from __future__ import annotations
+
+from ai.backend.client.v2.base_domain import BaseDomainClient
+from ai.backend.common.dto.manager.v2.role_permission_preset.request import (
+    BulkAddRolePermissionPresetsInput,
+    BulkRemoveRolePermissionPresetsInput,
+    SearchRolePermissionPresetsInput,
+)
+from ai.backend.common.dto.manager.v2.role_permission_preset.response import (
+    BulkAddRolePermissionPresetsPayload,
+    BulkRemoveRolePermissionPresetsPayload,
+    SearchRolePermissionPresetsPayload,
+)
+from ai.backend.common.dto.manager.v2.role_preset.request import (
+    BulkDeleteRolePresetsInput,
+    BulkPurgeRolePresetsInput,
+    BulkRestoreRolePresetsInput,
+    CreateRolePresetInput,
+    SearchRolePresetsInput,
+    UpdateRolePresetBody,
+)
+from ai.backend.common.dto.manager.v2.role_preset.response import (
+    BulkDeleteRolePresetsPayload,
+    BulkPurgeRolePresetsPayload,
+    BulkRestoreRolePresetsPayload,
+    CreateRolePresetPayload,
+    RolePresetNode,
+    SearchRolePresetsPayload,
+    UpdateRolePresetPayload,
+)
+from ai.backend.common.identifier.role_preset import RolePresetID
+
+_PATH = "/v2/role-presets"
+
+
+class V2RolePresetClient(BaseDomainClient):
+    """SDK client for ``/v2/role-presets`` endpoints (superadmin only).
+
+    Delete is a soft-delete; Restore inverts it; Purge is the hard delete.
+    Every active preset is auto-applied at scope creation, so there is no
+    ``auto_apply`` argument on this surface.
+    """
+
+    async def create(self, request: CreateRolePresetInput) -> CreateRolePresetPayload:
+        """Create a new role preset."""
+        return await self._client.typed_request(
+            "POST",
+            _PATH,
+            request=request,
+            response_model=CreateRolePresetPayload,
+        )
+
+    async def get(self, role_preset_id: RolePresetID) -> RolePresetNode:
+        """Get a single role preset by ID."""
+        return await self._client.typed_request(
+            "GET",
+            f"{_PATH}/{role_preset_id}",
+            response_model=RolePresetNode,
+        )
+
+    async def search(self, request: SearchRolePresetsInput) -> SearchRolePresetsPayload:
+        """Search role presets across the system."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/search",
+            request=request,
+            response_model=SearchRolePresetsPayload,
+        )
+
+    async def update(
+        self, role_preset_id: RolePresetID, request: UpdateRolePresetBody
+    ) -> UpdateRolePresetPayload:
+        """Update a role preset's mutable metadata."""
+        return await self._client.typed_request(
+            "PATCH",
+            f"{_PATH}/{role_preset_id}",
+            request=request,
+            response_model=UpdateRolePresetPayload,
+        )
+
+    async def delete(self, request: BulkDeleteRolePresetsInput) -> BulkDeleteRolePresetsPayload:
+        """Soft-delete role presets (sets ``deleted = true``)."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/bulk-delete",
+            request=request,
+            response_model=BulkDeleteRolePresetsPayload,
+        )
+
+    async def restore(self, request: BulkRestoreRolePresetsInput) -> BulkRestoreRolePresetsPayload:
+        """Restore soft-deleted role presets (sets ``deleted = false``)."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/bulk-restore",
+            request=request,
+            response_model=BulkRestoreRolePresetsPayload,
+        )
+
+    async def purge(self, request: BulkPurgeRolePresetsInput) -> BulkPurgeRolePresetsPayload:
+        """Hard-delete role presets, cascading to their permission entries."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/bulk-purge",
+            request=request,
+            response_model=BulkPurgeRolePresetsPayload,
+        )
+
+    async def search_permissions(
+        self, role_preset_id: RolePresetID, request: SearchRolePermissionPresetsInput
+    ) -> SearchRolePermissionPresetsPayload:
+        """Search the permission entries belonging to a single role preset."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/{role_preset_id}/permissions/search",
+            request=request,
+            response_model=SearchRolePermissionPresetsPayload,
+        )
+
+    async def add_permissions(
+        self, role_preset_id: RolePresetID, request: BulkAddRolePermissionPresetsInput
+    ) -> BulkAddRolePermissionPresetsPayload:
+        """Bulk-add permission entries to an existing role preset."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/{role_preset_id}/permissions/add",
+            request=request,
+            response_model=BulkAddRolePermissionPresetsPayload,
+        )
+
+    async def remove_permissions(
+        self, request: BulkRemoveRolePermissionPresetsInput
+    ) -> BulkRemoveRolePermissionPresetsPayload:
+        """Bulk-remove permission entries by their row IDs."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/permissions/remove",
+            request=request,
+            response_model=BulkRemoveRolePermissionPresetsPayload,
+        )

--- a/src/ai/backend/client/v2/v2_registry.py
+++ b/src/ai/backend/client/v2/v2_registry.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
     from .domains_v2.resource_slot import V2ResourceSlotClient
     from .domains_v2.resource_usage import V2ResourceUsageClient
     from .domains_v2.role_invitation import V2RoleInvitationClient
+    from .domains_v2.role_preset import V2RolePresetClient
     from .domains_v2.runtime_variant import V2RuntimeVariantClient
     from .domains_v2.runtime_variant_preset import V2RuntimeVariantPresetClient
     from .domains_v2.scheduling_handler import V2SchedulingHandlerClient
@@ -214,6 +215,12 @@ class V2ClientRegistry:
         from .domains_v2.role_invitation import V2RoleInvitationClient
 
         return V2RoleInvitationClient(self._client)
+
+    @cached_property
+    def role_preset(self) -> V2RolePresetClient:
+        from .domains_v2.role_preset import V2RolePresetClient
+
+        return V2RolePresetClient(self._client)
 
     @cached_property
     def prometheus_query_preset(self) -> V2PrometheusQueryPresetClient:

--- a/tests/unit/client/cli/test_v2_helpers.py
+++ b/tests/unit/client/cli/test_v2_helpers.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+
+from ai.backend.client.cli.v2.helpers import load_model, run_async
+from ai.backend.client.exceptions import BackendAPIError
+
+
+class _Entry(BaseModel):
+    name: str
+    count: int
+
+
+class TestLoadModel:
+    """Tests for the ``load_model`` JSON/``@file`` loader."""
+
+    def test_raw_json_single_model(self) -> None:
+        result = load_model('{"name": "a", "count": 1}', _Entry)
+
+        assert result == _Entry(name="a", count=1)
+
+    def test_raw_json_list(self) -> None:
+        result = load_model('[{"name": "a", "count": 1}, {"name": "b", "count": 2}]', list[_Entry])
+
+        assert result == [_Entry(name="a", count=1), _Entry(name="b", count=2)]
+
+    def test_raw_json_empty_list(self) -> None:
+        result = load_model("[]", list[_Entry])
+
+        assert result == []
+
+    def test_file_payload(self, tmp_path: Path) -> None:
+        path = tmp_path / "entries.json"
+        path.write_text('[{"name": "a", "count": 1}]')
+
+        result = load_model(f"@{path}", list[_Entry])
+
+        assert result == [_Entry(name="a", count=1)]
+
+    def test_invalid_json_exits(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            load_model("[{bad", list[_Entry])
+
+        assert exc_info.value.code == 1
+
+    def test_validation_error_exits(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            load_model('[{"name": "a", "count": "not-an-int"}]', list[_Entry])
+
+        assert exc_info.value.code == 1
+
+    def test_missing_file_exits(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            load_model("@/tmp/role_preset_does_not_exist.json", list[_Entry])
+
+        assert exc_info.value.code == 1
+
+
+class TestRunAsync:
+    """Tests for the ``run_async`` coroutine runner."""
+
+    def test_success_runs_coroutine(self) -> None:
+        ran = []
+
+        async def _coro() -> None:
+            ran.append(True)
+
+        run_async(_coro)
+
+        assert ran == [True]
+
+    def test_api_error_exits_with_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        async def _coro() -> None:
+            raise BackendAPIError(404, "Not Found", {"title": "No such role_preset."})
+
+        with pytest.raises(SystemExit) as exc_info:
+            run_async(_coro)
+
+        assert exc_info.value.code == 1
+        assert "No such role_preset." in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- Add `V2RolePresetClient` (create / get / search / update, bulk delete / restore / purge, permission search / add / remove) and register it in the v2 client registry.
- Add the superadmin `admin role-preset` CLI group mirroring that surface, with `--option` flags per field and a `--permissions` JSON/`@file` argument for nested permission entries.
- Add a generic `load_model()` CLI helper that parses a JSON string or `@file` path and validates it via Pydantic `TypeAdapter`, reused for `--permissions`, with clean errors for malformed JSON / validation / unreadable files.

## Test plan
- [x] `pants test tests/unit/client/cli/test_v2_helpers.py` (load_model: raw JSON, @file, list/empty, error exit paths)
- [x] Live CLI against local server: create (raw JSON & @file), get / search / update / delete / restore / purge, permission add / search / remove

Resolves BA-6181

🤖 Generated with [Claude Code](https://claude.com/claude-code)