### PR TITLE
feat(BA-6274): add execute_bulk_querier with partitioned results and scopes

### DIFF
--- a/changes/11921.feature.md
+++ b/changes/11921.feature.md
@@ -1,0 +1,1 @@
+Add `execute_bulk_querier`, the bulk counterpart of `execute_querier`, which resolves many single-row queriers in one query per lookup-column group and partitions the outcome into successes and typed failures, with optional RBAC scope filtering

--- a/src/ai/backend/manager/repositories/base/__init__.py
+++ b/src/ai/backend/manager/repositories/base/__init__.py
@@ -58,9 +58,13 @@ from .purger import (
 from .querier import (
     BatchQuerier,
     BatchQuerierResult,
+    BulkQuerierFailureReason,
+    BulkQuerierResult,
     Querier,
+    QuerierFailureResult,
     QuerierResult,
     execute_batch_querier,
+    execute_bulk_querier,
     execute_querier,
 )
 from .types import (
@@ -131,6 +135,11 @@ __all__ = [
     "Querier",
     "QuerierResult",
     "execute_querier",
+    # BulkQuerier
+    "BulkQuerierFailureReason",
+    "BulkQuerierResult",
+    "QuerierFailureResult",
+    "execute_bulk_querier",
     # BatchQuerier
     "BatchQuerier",
     "BatchQuerierResult",

--- a/src/ai/backend/manager/repositories/base/querier.py
+++ b/src/ai/backend/manager/repositories/base/querier.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import enum
+from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -18,6 +20,7 @@ from .types import ExistenceCheck, QueryCondition, QueryOrder, SearchScope
 if TYPE_CHECKING:
     from sqlalchemy.engine import Row
     from sqlalchemy.ext.asyncio import AsyncSession as SASession
+    from sqlalchemy.orm import InstrumentedAttribute
 
 TRow = TypeVar("TRow", bound=Base)
 
@@ -29,15 +32,19 @@ TRow = TypeVar("TRow", bound=Base)
 
 @dataclass
 class Querier[TRow: Base]:
-    """Single-row query by primary key.
+    """Single-row query by primary key (or an alternate unique column).
 
     Attributes:
         row_class: ORM class for table access and PK detection.
-        pk_value: Primary key value to identify the target row.
+        pk_value: The value identifying the target row, matched against the
+            primary key by default, or against ``lookup_column`` when set.
+        lookup_column: Optional ORM attribute to match on instead of the
+            primary key (e.g. ``RoutingRow.session`` for a 1:1 alternate key).
     """
 
     row_class: type[TRow]
     pk_value: UUID | str | int
+    lookup_column: InstrumentedAttribute[Any] | None = None
 
 
 @dataclass
@@ -71,14 +78,18 @@ async def execute_querier[TRow: Base](
     """
     row_class = querier.row_class
     table = row_class.__table__
-    pk_columns = list(table.primary_key.columns)
 
-    if len(pk_columns) != 1:
-        raise UnsupportedCompositePrimaryKeyError(
-            f"Querier only supports single-column primary keys (table: {table.name})",
-        )
+    if querier.lookup_column is not None:
+        match_column: Any = querier.lookup_column
+    else:
+        pk_columns = list(table.primary_key.columns)
+        if len(pk_columns) != 1:
+            raise UnsupportedCompositePrimaryKeyError(
+                f"Querier only supports single-column primary keys (table: {table.name})",
+            )
+        match_column = pk_columns[0]
 
-    stmt = sa.select(table).where(pk_columns[0] == querier.pk_value)
+    stmt = sa.select(table).where(match_column == querier.pk_value)
 
     result = await db_sess.execute(stmt)
     row_data = result.fetchone()
@@ -88,6 +99,128 @@ async def execute_querier[TRow: Base](
 
     fetched_row: TRow = row_class(**dict(row_data._mapping))
     return QuerierResult(row=fetched_row)
+
+
+# =============================================================================
+# Bulk single-row Querier (many independent by-key lookups)
+# =============================================================================
+
+
+class BulkQuerierFailureReason(enum.StrEnum):
+    """Reason a single querier failed within a bulk execution."""
+
+    NOT_FOUND = "not_found"
+
+
+@dataclass
+class QuerierFailureResult[TRow: Base]:
+    """A single querier that could not be resolved, with the reason why."""
+
+    querier: Querier[TRow]
+    reason: BulkQuerierFailureReason
+
+
+@dataclass
+class BulkQuerierResult[TRow: Base]:
+    """Partitioned outcome of a bulk querier execution.
+
+    ``successes`` and ``failures`` together cover every input querier; both
+    preserve the input order within their own list.
+    """
+
+    successes: list[QuerierResult[TRow]]
+    failures: list[QuerierFailureResult[TRow]]
+
+
+def _resolve_lookup_attr(querier: Querier[Any]) -> InstrumentedAttribute[Any]:
+    """Resolve the ORM attribute a querier matches on (its lookup column, or PK)."""
+    if querier.lookup_column is not None:
+        return querier.lookup_column
+    mapper = sa.inspect(querier.row_class)
+    pk_columns = list(mapper.primary_key)
+    if len(pk_columns) != 1:
+        raise UnsupportedCompositePrimaryKeyError(
+            f"Querier only supports single-column primary keys "
+            f"(table: {querier.row_class.__tablename__})",
+        )
+    return getattr(querier.row_class, mapper.get_property_by_column(pk_columns[0]).key)
+
+
+async def execute_bulk_querier[TRow: Base](
+    db_sess: SASession,
+    queriers: Sequence[Querier[TRow]],
+    scopes: Sequence[SearchScope] = (),
+) -> BulkQuerierResult[TRow]:
+    """Execute many single-row queriers as a batch, partitioning the outcome.
+
+    Queriers targeting the same ``row_class`` and lookup column are collapsed
+    into one ``WHERE col IN (...)`` query, so the cost is one round-trip per
+    distinct (row_class, column) group instead of one per querier — the bulk
+    counterpart of :func:`execute_querier`. Each querier is then resolved
+    independently: a matched row yields a ``QuerierResult`` (success), an
+    unmatched one a ``QuerierFailureResult`` with ``NOT_FOUND`` (failure).
+
+    ``scopes`` apply RBAC filtering exactly as in :func:`execute_batch_querier`:
+    each scope contributes its existence checks (aggregated and validated once)
+    and its ``to_condition()``; the conditions form a single OR group AND-merged
+    with every group's ``IN`` predicate. A row filtered out by scope is treated
+    as not found, so its querier lands in ``failures`` — no cross-scope leakage.
+
+    Example:
+        queriers = [
+            Querier(row_class=RoutingRow, pk_value=sid, lookup_column=RoutingRow.session)
+            for sid in session_ids
+        ]
+        result = await execute_bulk_querier(db_sess, queriers, scopes=[owned_scope])
+        rows = [r.row for r in result.successes]  # found, in-scope routes
+        missing = [f.querier.pk_value for f in result.failures]  # absent or out-of-scope
+    """
+    if not queriers:
+        return BulkQuerierResult(successes=[], failures=[])
+
+    or_conditions: list[QueryCondition] = []
+    if scopes:
+        aggregated_checks: list[ExistenceCheck[Any]] = []
+        for scope in scopes:
+            aggregated_checks.extend(scope.existence_checks)
+            or_conditions.append(scope.to_condition())
+        await _validate_scope(db_sess, aggregated_checks)
+
+    # Group queriers by (row_class, lookup attribute) so each group is one IN-query.
+    groups: dict[tuple[type[Base], str], list[Querier[TRow]]] = defaultdict(list)
+    group_attr: dict[tuple[type[Base], str], InstrumentedAttribute[Any]] = {}
+    for querier in queriers:
+        attr = _resolve_lookup_attr(querier)
+        key = (querier.row_class, attr.key)
+        groups[key].append(querier)
+        group_attr[key] = attr
+
+    # One IN-query per group, AND-merged with the OR-combined scope predicate;
+    # map lookup value -> fetched row.
+    found: dict[tuple[type[Base], str], dict[Any, TRow]] = {}
+    for key, group in groups.items():
+        row_class, attr_key = key
+        attr = group_attr[key]
+        values = {querier.pk_value for querier in group}
+        stmt = sa.select(row_class).where(attr.in_(values))
+        if or_conditions:
+            stmt = stmt.where(sa.or_(*(condition() for condition in or_conditions)))
+        result = await db_sess.execute(stmt)
+        found[key] = {getattr(row, attr_key): row for row in result.scalars().all()}
+
+    # Resolve each querier in input order, keeping successes and failures apart.
+    successes: list[QuerierResult[TRow]] = []
+    failures: list[QuerierFailureResult[TRow]] = []
+    for querier in queriers:
+        key = (querier.row_class, _resolve_lookup_attr(querier).key)
+        row = found[key].get(querier.pk_value)
+        if row is None:
+            failures.append(
+                QuerierFailureResult(querier=querier, reason=BulkQuerierFailureReason.NOT_FOUND)
+            )
+        else:
+            successes.append(QuerierResult(row=row))
+    return BulkQuerierResult(successes=successes, failures=failures)
 
 
 # =============================================================================

--- a/tests/unit/manager/repositories/base/test_querier.py
+++ b/tests/unit/manager/repositories/base/test_querier.py
@@ -22,13 +22,17 @@ from ai.backend.manager.models.base import Base, IDColumn
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
     BatchQuerierResult,
+    BulkQuerierFailureReason,
+    BulkQuerierResult,
     ExistenceCheck,
     OffsetPagination,
     Querier,
+    QuerierFailureResult,
     QuerierResult,
     QueryCondition,
     SearchScope,
     execute_batch_querier,
+    execute_bulk_querier,
     execute_querier,
 )
 
@@ -220,6 +224,177 @@ class TestQuerierUUIDPK:
             result = await execute_querier(db_sess, querier)
 
             assert result is None
+
+
+# =============================================================================
+# Bulk single-row Querier Tests
+# =============================================================================
+
+
+class BulkQuerierTestRow(Base):  # type: ignore[misc]
+    """ORM model for bulk querier testing, with an alternate lookup column."""
+
+    __tablename__ = "test_bulk_querier_orm"
+    __table_args__ = {"extend_existing": True}
+
+    id = sa.Column(sa.Integer, primary_key=True)
+    ref = sa.Column(sa.Integer, nullable=True)
+    name = sa.Column(sa.String(50), nullable=False)
+
+
+@dataclass(frozen=True)
+class RefAtLeastScope(SearchScope):
+    """Test scope: keep only rows whose ``ref`` is at least ``minimum``."""
+
+    minimum: int
+
+    def to_condition(self) -> QueryCondition:
+        minimum = self.minimum
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return BulkQuerierTestRow.ref >= minimum
+
+        return inner
+
+    @property
+    def existence_checks(self) -> Sequence[ExistenceCheck[Any]]:
+        return []
+
+
+class TestBulkQuerier:
+    """Tests for execute_bulk_querier (many independent by-key lookups)."""
+
+    @pytest.fixture
+    async def bulk_row_class(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[type[BulkQuerierTestRow], None]:
+        async with database_connection.begin() as conn:
+            await conn.run_sync(
+                lambda c: Base.metadata.create_all(c, [BulkQuerierTestRow.__table__])
+            )
+
+        yield BulkQuerierTestRow
+
+        async with database_connection.begin() as conn:
+            await conn.execute(sa.text("DROP TABLE IF EXISTS test_bulk_querier_orm CASCADE"))
+
+    @pytest.fixture
+    async def sample_data(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        bulk_row_class: type[BulkQuerierTestRow],
+    ) -> AsyncGenerator[list[dict[str, int | str]], None]:
+        # id i, ref = i * 10
+        data: list[dict[str, int | str]] = [
+            {"id": i, "ref": i * 10, "name": f"item-{i}"} for i in range(1, 6)
+        ]
+
+        async with database_connection.begin_session() as db_sess:
+            table = bulk_row_class.__table__
+            await db_sess.execute(table.insert(), data)
+
+        yield data
+
+    async def test_empty_input_returns_empty_partitions(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        bulk_row_class: type[BulkQuerierTestRow],
+        sample_data: list[dict[str, int | str]],
+    ) -> None:
+        """No queriers => empty successes and failures, no query issued."""
+        async with database_connection.begin_session() as db_sess:
+            result = await execute_bulk_querier(db_sess, [])
+
+            assert isinstance(result, BulkQuerierResult)
+            assert result.successes == []
+            assert result.failures == []
+
+    async def test_by_pk_partitions_found_and_missing(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        bulk_row_class: type[BulkQuerierTestRow],
+        sample_data: list[dict[str, int | str]],
+    ) -> None:
+        """Found PKs become successes; missing ones become NOT_FOUND failures."""
+        async with database_connection.begin_session() as db_sess:
+            queriers: list[Querier[BulkQuerierTestRow]] = [
+                Querier(row_class=BulkQuerierTestRow, pk_value=1),
+                Querier(row_class=BulkQuerierTestRow, pk_value=999),
+                Querier(row_class=BulkQuerierTestRow, pk_value=2),
+            ]
+
+            result = await execute_bulk_querier(db_sess, queriers)
+
+            assert [s.row.id for s in result.successes] == [1, 2]
+            assert all(isinstance(s, QuerierResult) for s in result.successes)
+            assert len(result.failures) == 1
+            failure = result.failures[0]
+            assert isinstance(failure, QuerierFailureResult)
+            assert failure.querier.pk_value == 999
+            assert failure.reason is BulkQuerierFailureReason.NOT_FOUND
+
+    async def test_by_pk_preserves_input_order(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        bulk_row_class: type[BulkQuerierTestRow],
+        sample_data: list[dict[str, int | str]],
+    ) -> None:
+        """Successes follow the input querier order, not PK order."""
+        async with database_connection.begin_session() as db_sess:
+            queriers: list[Querier[BulkQuerierTestRow]] = [
+                Querier(row_class=BulkQuerierTestRow, pk_value=pk) for pk in (3, 1, 2)
+            ]
+
+            result = await execute_bulk_querier(db_sess, queriers)
+
+            assert [s.row.id for s in result.successes] == [3, 1, 2]
+
+    async def test_by_lookup_column_matches_alternate_key(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        bulk_row_class: type[BulkQuerierTestRow],
+        sample_data: list[dict[str, int | str]],
+    ) -> None:
+        """lookup_column matches on a non-PK column (the 1:1 alternate key case)."""
+        async with database_connection.begin_session() as db_sess:
+            queriers: list[Querier[BulkQuerierTestRow]] = [
+                Querier(
+                    row_class=BulkQuerierTestRow,
+                    pk_value=ref,
+                    lookup_column=BulkQuerierTestRow.ref,
+                )
+                for ref in (10, 999, 30)
+            ]
+
+            result = await execute_bulk_querier(db_sess, queriers)
+
+            assert [s.row.ref for s in result.successes] == [10, 30]
+            assert [s.row.id for s in result.successes] == [1, 3]
+            assert len(result.failures) == 1
+            assert result.failures[0].querier.pk_value == 999
+
+    async def test_scope_filters_out_of_scope_rows_into_failures(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        bulk_row_class: type[BulkQuerierTestRow],
+        sample_data: list[dict[str, int | str]],
+    ) -> None:
+        """A row that exists but is filtered out by scope lands in failures."""
+        async with database_connection.begin_session() as db_sess:
+            queriers: list[Querier[BulkQuerierTestRow]] = [
+                Querier(row_class=BulkQuerierTestRow, pk_value=pk) for pk in (1, 3, 5)
+            ]
+            # ref = id * 10, so minimum=30 keeps ids 3 and 5, drops id 1 (ref 10).
+            scope = RefAtLeastScope(minimum=30)
+
+            result = await execute_bulk_querier(db_sess, queriers, scopes=[scope])
+
+            assert [s.row.id for s in result.successes] == [3, 5]
+            assert {f.querier.pk_value for f in result.failures} == {1}
+            assert all(
+                f.reason is BulkQuerierFailureReason.NOT_FOUND for f in result.failures
+            )
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Adds `execute_bulk_querier` to the repository base layer — the **bulk counterpart of `execute_querier`**. It resolves many single-row queriers in one round-trip per `(row_class, lookup column)` group and **partitions** the outcome into successes and typed failures, with optional RBAC scope filtering.

This is split out of the SessionV2 `replica` work (#11903) as standalone, reusable infrastructure.

## Changes

- **`Querier.lookup_column`** — optional ORM attribute to match a 1:1 alternate key instead of the primary key (e.g. `RoutingRow.session`). `execute_querier` honors it too.
- **`execute_bulk_querier(db_sess, queriers, scopes=())`** — groups queriers by lookup column into one `WHERE col IN (...)` per group; returns `BulkQuerierResult(successes: list[QuerierResult], failures: list[QuerierFailureResult])`, preserving input order.
- **`scopes`** — applied exactly as in `execute_batch_querier` (existence checks validated once; `to_condition()`s OR-combined and AND-merged). An out-of-scope row is treated as not found, so there is no cross-scope leakage.
- New types: `QuerierFailureResult`, `BulkQuerierResult`, `BulkQuerierFailureReason`, exported from `repositories.base`.

## Tests

`test_querier.py` covers PK lookup, alternate-key lookup, partial (found + missing), input ordering, and scope filtering.

Jira: BA-6274

🤖 Generated with [Claude Code](https://claude.com/claude-code)