### PR TITLE
fix(BA-6273): Destroy volatile inter-container network on session termination

### DIFF
--- a/changes/11922.fix.md
+++ b/changes/11922.fix.md
@@ -1,0 +1,1 @@
+Fix volatile inter-container networks leaking after session termination by restoring overlay/local network cleanup in the TERMINATED hook

--- a/src/ai/backend/manager/sokovan/scheduler/factory.py
+++ b/src/ai/backend/manager/sokovan/scheduler/factory.py
@@ -184,6 +184,7 @@ def create_default_scheduler_components(
         repository=repository,
         config_provider=config_provider,
         agent_client_pool=agent_client_pool,
+        network_plugin_ctx=network_plugin_ctx,
     )
 
 

--- a/src/ai/backend/manager/sokovan/scheduler/hooks/registry.py
+++ b/src/ai/backend/manager/sokovan/scheduler/hooks/registry.py
@@ -10,7 +10,9 @@ from dataclasses import dataclass
 
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.clients.agent.pool import AgentClientPool
+from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.plugin.network import NetworkPluginContext
 
 from .status import (
     RunningHookDependencies,
@@ -28,6 +30,8 @@ class HookRegistryArgs:
     """Arguments for creating HookRegistry."""
 
     agent_client_pool: AgentClientPool
+    network_plugin_ctx: NetworkPluginContext
+    config_provider: ManagerConfigProvider
 
 
 class HookRegistry:
@@ -52,7 +56,11 @@ class HookRegistry:
         self._status_hooks[SessionStatus.RUNNING] = RunningTransitionHook(running_deps)
 
         # TERMINATED transition hook
-        terminated_deps = TerminatedHookDependencies()
+        terminated_deps = TerminatedHookDependencies(
+            agent_client_pool=args.agent_client_pool,
+            network_plugin_ctx=args.network_plugin_ctx,
+            config_provider=args.config_provider,
+        )
         self._status_hooks[SessionStatus.TERMINATED] = TerminatedTransitionHook(terminated_deps)
 
     def get_hook(self, status: SessionStatus) -> StatusTransitionHook | None:

--- a/src/ai/backend/manager/sokovan/scheduler/hooks/status.py
+++ b/src/ai/backend/manager/sokovan/scheduler/hooks/status.py
@@ -19,6 +19,7 @@ from ai.backend.common.types import (
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.clients.agent.pool import AgentClientPool
 from ai.backend.manager.config.provider import ManagerConfigProvider
+from ai.backend.manager.errors.common import ServerMisconfiguredError
 from ai.backend.manager.errors.resource import AgentNotAllocated
 from ai.backend.manager.models.network import NetworkType
 from ai.backend.manager.plugin.network import NetworkPluginContext
@@ -183,10 +184,10 @@ class TerminatedTransitionHook(StatusTransitionHook):
                 self._deps.config_provider.config.network.inter_container.default_driver
             )
             if default_driver is None:
-                raise ValueError("No inter-container network driver is configured.")
+                raise ServerMisconfiguredError("No inter-container network driver is configured.")
             if default_driver not in self._deps.network_plugin_ctx.plugins:
                 available = list(self._deps.network_plugin_ctx.plugins.keys())
-                raise KeyError(
+                raise ServerMisconfiguredError(
                     f"Network plugin '{default_driver}' not found. Available plugins: {available}. "
                     f"For overlay networks, ensure Docker Swarm is initialized with 'docker swarm init'."
                 )

--- a/src/ai/backend/manager/sokovan/scheduler/hooks/status.py
+++ b/src/ai/backend/manager/sokovan/scheduler/hooks/status.py
@@ -12,11 +12,16 @@ from dataclasses import dataclass
 
 from ai.backend.common.types import (
     AgentId,
+    ClusterMode,
     SessionId,
     SessionTypes,
 )
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.clients.agent.pool import AgentClientPool
+from ai.backend.manager.config.provider import ManagerConfigProvider
+from ai.backend.manager.errors.resource import AgentNotAllocated
+from ai.backend.manager.models.network import NetworkType
+from ai.backend.manager.plugin.network import NetworkPluginContext
 from ai.backend.manager.sokovan.data import SessionWithKernels
 from ai.backend.manager.sokovan.recorder.context import RecorderContext
 
@@ -121,22 +126,21 @@ class RunningTransitionHook(StatusTransitionHook):
 
 @dataclass
 class TerminatedHookDependencies:
-    """Dependencies for TerminatedTransitionHook (currently empty).
+    """Dependencies for TerminatedTransitionHook."""
 
-    Kept as a placeholder so adding new TERMINATED-specific hooks does
-    not require re-threading dependency injection wiring.
-    """
+    agent_client_pool: AgentClientPool
+    network_plugin_ctx: NetworkPluginContext
+    config_provider: ManagerConfigProvider
 
 
 class TerminatedTransitionHook(StatusTransitionHook):
     """Hook executed when sessions transition to TERMINATED status.
 
-    Currently a no-op for every session type. Inference termination
-    used to mark APPPROXY_SYNC needed; that is no longer required
-    because :class:`TerminatingRouteHandler` unregisters routes from
-    AppProxy synchronously before destroying kernels, and the long-
-    cycle ``AppProxySyncRouteHandler`` keeps state convergent as a
-    fallback.
+    Destroys the session's volatile inter-container network so that
+    overlay (MULTI_NODE) and agent-local (SINGLE_NODE) networks do not
+    leak after the session terminates. The hook is blocking: on failure
+    it propagates so the coordinator keeps the session in TERMINATING and
+    the self-healing loop retries the cleanup on the next tick.
     """
 
     _deps: TerminatedHookDependencies
@@ -146,7 +150,45 @@ class TerminatedTransitionHook(StatusTransitionHook):
 
     async def execute(self, session: SessionWithKernels) -> None:
         """Execute TERMINATED transition hook."""
-        log.debug(
-            "TERMINATED transition hook is currently a no-op for session type {}",
-            session.session_info.metadata.session_type,
-        )
+        await self._destroy_network(session)
+
+    async def _destroy_network(self, session: SessionWithKernels) -> None:
+        network = session.session_info.network
+        if network.network_type != NetworkType.VOLATILE or network.network_id is None:
+            return
+        network_id = network.network_id
+        cluster_mode = session.session_info.resource.cluster_mode
+
+        if cluster_mode == ClusterMode.SINGLE_NODE:
+            agent_id = session.main_kernel.resource.agent
+            if agent_id is None:
+                session_id = session.session_info.identity.id
+                raise AgentNotAllocated(
+                    f"Main kernel has no agent assigned for session {session_id}"
+                )
+            async with self._deps.agent_client_pool.acquire(AgentId(agent_id)) as client:
+                try:
+                    await client.destroy_local_network(network_id)
+                except Exception as e:
+                    log.exception(
+                        "Failed to destroy local network on agent for session. Session ID: {}, Network ID: {}, Agent ID: {}. Error: {}",
+                        session.session_info.identity.id,
+                        network_id,
+                        agent_id,
+                        e,
+                    )
+                    raise
+        elif cluster_mode == ClusterMode.MULTI_NODE:
+            default_driver = (
+                self._deps.config_provider.config.network.inter_container.default_driver
+            )
+            if default_driver is None:
+                raise ValueError("No inter-container network driver is configured.")
+            network_plugin = self._deps.network_plugin_ctx.plugins[default_driver]
+            try:
+                await network_plugin.destroy_network(network_id=network_id)
+            except Exception as e:
+                log.exception(
+                    f"Failed to destroy overlay network for session: Session ID: {session.session_info.identity.id}, Network ID: {network_id}, Driver: {default_driver}. Error: {e!s}"
+                )
+                raise

--- a/src/ai/backend/manager/sokovan/scheduler/hooks/status.py
+++ b/src/ai/backend/manager/sokovan/scheduler/hooks/status.py
@@ -157,25 +157,25 @@ class TerminatedTransitionHook(StatusTransitionHook):
         if network.network_type != NetworkType.VOLATILE or network.network_id is None:
             return
         network_id = network.network_id
-        cluster_mode = session.session_info.resource.cluster_mode
+        session_id = session.session_info.identity.id
+        cluster_mode = ClusterMode(session.session_info.resource.cluster_mode)
 
         if cluster_mode == ClusterMode.SINGLE_NODE:
             agent_id = session.main_kernel.resource.agent
             if agent_id is None:
-                session_id = session.session_info.identity.id
                 raise AgentNotAllocated(
                     f"Main kernel has no agent assigned for session {session_id}"
                 )
             async with self._deps.agent_client_pool.acquire(AgentId(agent_id)) as client:
                 try:
                     await client.destroy_local_network(network_id)
-                except Exception as e:
+                except Exception:
                     log.exception(
-                        "Failed to destroy local network on agent for session. Session ID: {}, Network ID: {}, Agent ID: {}. Error: {}",
-                        session.session_info.identity.id,
+                        "Failed to destroy local network on agent for session. "
+                        "Session ID: {}, Network ID: {}, Agent ID: {}",
+                        session_id,
                         network_id,
                         agent_id,
-                        e,
                     )
                     raise
         elif cluster_mode == ClusterMode.MULTI_NODE:
@@ -184,11 +184,21 @@ class TerminatedTransitionHook(StatusTransitionHook):
             )
             if default_driver is None:
                 raise ValueError("No inter-container network driver is configured.")
+            if default_driver not in self._deps.network_plugin_ctx.plugins:
+                available = list(self._deps.network_plugin_ctx.plugins.keys())
+                raise KeyError(
+                    f"Network plugin '{default_driver}' not found. Available plugins: {available}. "
+                    f"For overlay networks, ensure Docker Swarm is initialized with 'docker swarm init'."
+                )
             network_plugin = self._deps.network_plugin_ctx.plugins[default_driver]
             try:
                 await network_plugin.destroy_network(network_id=network_id)
-            except Exception as e:
+            except Exception:
                 log.exception(
-                    f"Failed to destroy overlay network for session: Session ID: {session.session_info.identity.id}, Network ID: {network_id}, Driver: {default_driver}. Error: {e!s}"
+                    "Failed to destroy overlay network for session. "
+                    "Session ID: {}, Network ID: {}, Driver: {}",
+                    session_id,
+                    network_id,
+                    default_driver,
                 )
                 raise

--- a/src/ai/backend/manager/sokovan/scheduler/hooks/status.py
+++ b/src/ai/backend/manager/sokovan/scheduler/hooks/status.py
@@ -161,20 +161,10 @@ class TerminatedTransitionHook(StatusTransitionHook):
         session_id = session.session_info.identity.id
         cluster_mode = ClusterMode(session.session_info.resource.cluster_mode)
 
-        pool = RecorderContext[SessionId].current_pool()
-        recorder = pool.recorder(session_id)
-        with recorder.phase(
-            "terminate_cleanup",
-            success_detail="Volatile inter-container network destroyed",
-        ):
-            with recorder.step(
-                "destroy_network",
-                success_detail=f"Destroyed volatile network {network_id}",
-            ):
-                if cluster_mode == ClusterMode.SINGLE_NODE:
-                    await self._destroy_local_network(session, network_id)
-                elif cluster_mode == ClusterMode.MULTI_NODE:
-                    await self._destroy_overlay_network(session_id, network_id)
+        if cluster_mode == ClusterMode.SINGLE_NODE:
+            await self._destroy_local_network(session, network_id)
+        elif cluster_mode == ClusterMode.MULTI_NODE:
+            await self._destroy_overlay_network(session_id, network_id)
 
     async def _destroy_local_network(self, session: SessionWithKernels, network_id: str) -> None:
         session_id = session.session_info.identity.id

--- a/src/ai/backend/manager/sokovan/scheduler/hooks/status.py
+++ b/src/ai/backend/manager/sokovan/scheduler/hooks/status.py
@@ -161,45 +161,58 @@ class TerminatedTransitionHook(StatusTransitionHook):
         session_id = session.session_info.identity.id
         cluster_mode = ClusterMode(session.session_info.resource.cluster_mode)
 
-        if cluster_mode == ClusterMode.SINGLE_NODE:
-            agent_id = session.main_kernel.resource.agent
-            if agent_id is None:
-                raise AgentNotAllocated(
-                    f"Main kernel has no agent assigned for session {session_id}"
-                )
-            async with self._deps.agent_client_pool.acquire(AgentId(agent_id)) as client:
-                try:
-                    await client.destroy_local_network(network_id)
-                except Exception:
-                    log.exception(
-                        "Failed to destroy local network on agent for session. "
-                        "Session ID: {}, Network ID: {}, Agent ID: {}",
-                        session_id,
-                        network_id,
-                        agent_id,
-                    )
-                    raise
-        elif cluster_mode == ClusterMode.MULTI_NODE:
-            default_driver = (
-                self._deps.config_provider.config.network.inter_container.default_driver
-            )
-            if default_driver is None:
-                raise ServerMisconfiguredError("No inter-container network driver is configured.")
-            if default_driver not in self._deps.network_plugin_ctx.plugins:
-                available = list(self._deps.network_plugin_ctx.plugins.keys())
-                raise ServerMisconfiguredError(
-                    f"Network plugin '{default_driver}' not found. Available plugins: {available}. "
-                    f"For overlay networks, ensure Docker Swarm is initialized with 'docker swarm init'."
-                )
-            network_plugin = self._deps.network_plugin_ctx.plugins[default_driver]
+        pool = RecorderContext[SessionId].current_pool()
+        recorder = pool.recorder(session_id)
+        with recorder.phase(
+            "terminate_cleanup",
+            success_detail="Volatile inter-container network destroyed",
+        ):
+            with recorder.step(
+                "destroy_network",
+                success_detail=f"Destroyed volatile network {network_id}",
+            ):
+                if cluster_mode == ClusterMode.SINGLE_NODE:
+                    await self._destroy_local_network(session, network_id)
+                elif cluster_mode == ClusterMode.MULTI_NODE:
+                    await self._destroy_overlay_network(session_id, network_id)
+
+    async def _destroy_local_network(self, session: SessionWithKernels, network_id: str) -> None:
+        session_id = session.session_info.identity.id
+        agent_id = session.main_kernel.resource.agent
+        if agent_id is None:
+            raise AgentNotAllocated(f"Main kernel has no agent assigned for session {session_id}")
+        async with self._deps.agent_client_pool.acquire(AgentId(agent_id)) as client:
             try:
-                await network_plugin.destroy_network(network_id=network_id)
+                await client.destroy_local_network(network_id)
             except Exception:
                 log.exception(
-                    "Failed to destroy overlay network for session. "
-                    "Session ID: {}, Network ID: {}, Driver: {}",
+                    "Failed to destroy local network on agent for session. "
+                    "Session ID: {}, Network ID: {}, Agent ID: {}",
                     session_id,
                     network_id,
-                    default_driver,
+                    agent_id,
                 )
                 raise
+
+    async def _destroy_overlay_network(self, session_id: SessionId, network_id: str) -> None:
+        default_driver = self._deps.config_provider.config.network.inter_container.default_driver
+        if default_driver is None:
+            raise ServerMisconfiguredError("No inter-container network driver is configured.")
+        if default_driver not in self._deps.network_plugin_ctx.plugins:
+            available = list(self._deps.network_plugin_ctx.plugins.keys())
+            raise ServerMisconfiguredError(
+                f"Network plugin '{default_driver}' not found. Available plugins: {available}. "
+                f"For overlay networks, ensure Docker Swarm is initialized with 'docker swarm init'."
+            )
+        network_plugin = self._deps.network_plugin_ctx.plugins[default_driver]
+        try:
+            await network_plugin.destroy_network(network_id=network_id)
+        except Exception:
+            log.exception(
+                "Failed to destroy overlay network for session. "
+                "Session ID: {}, Network ID: {}, Driver: {}",
+                session_id,
+                network_id,
+                default_driver,
+            )
+            raise

--- a/src/ai/backend/manager/sokovan/scheduler/scheduler.py
+++ b/src/ai/backend/manager/sokovan/scheduler/scheduler.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from ai.backend.manager.clients.agent import AgentClientPool
 from ai.backend.manager.config.provider import ManagerConfigProvider
+from ai.backend.manager.plugin.network import NetworkPluginContext
 from ai.backend.manager.repositories.scheduler import SchedulerRepository
 
 from .hooks.registry import HookRegistry, HookRegistryArgs
@@ -36,11 +37,14 @@ def create_scheduler_components(
     repository: SchedulerRepository,
     config_provider: ManagerConfigProvider,
     agent_client_pool: AgentClientPool,
+    network_plugin_ctx: NetworkPluginContext,
 ) -> SchedulerComponents:
     """Create SchedulerComponents with all required dependencies."""
     hook_registry = HookRegistry(
         HookRegistryArgs(
             agent_client_pool=agent_client_pool,
+            network_plugin_ctx=network_plugin_ctx,
+            config_provider=config_provider,
         )
     )
     return SchedulerComponents(

--- a/tests/unit/manager/sokovan/scheduler/hooks/BUILD
+++ b/tests/unit/manager/sokovan/scheduler/hooks/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests")

--- a/tests/unit/manager/sokovan/scheduler/hooks/test_status_hooks.py
+++ b/tests/unit/manager/sokovan/scheduler/hooks/test_status_hooks.py
@@ -8,6 +8,7 @@ of refactors, leaking Docker overlay (MULTI_NODE) and agent-local
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -20,6 +21,7 @@ from ai.backend.manager.sokovan.scheduler.hooks.status import (
     TerminatedHookDependencies,
     TerminatedTransitionHook,
 )
+from ai.backend.manager.sokovan.scheduler.recorder import SessionRecorderContext
 
 
 class TestTerminatedTransitionHookNetworkCleanup:
@@ -76,6 +78,15 @@ class TestTerminatedTransitionHookNetworkCleanup:
         return "agent-1"
 
     @pytest.fixture
+    def session_id(self) -> SessionId:
+        return SessionId(uuid4())
+
+    @pytest.fixture(autouse=True)
+    def recorder_scope(self, session_id: SessionId) -> Iterator[None]:
+        with SessionRecorderContext.scope("test_terminate", entity_ids=[session_id]):
+            yield
+
+    @pytest.fixture
     def network_id(self, request: pytest.FixtureRequest) -> str | None:
         value: str | None = getattr(request, "param", "net-123")
         return value
@@ -87,10 +98,13 @@ class TestTerminatedTransitionHookNetworkCleanup:
 
     @pytest.fixture
     def multi_node_session(
-        self, network_type: NetworkType | None, network_id: str | None
+        self,
+        network_type: NetworkType | None,
+        network_id: str | None,
+        session_id: SessionId,
     ) -> MagicMock:
         session = MagicMock()
-        session.session_info.identity.id = SessionId(uuid4())
+        session.session_info.identity.id = session_id
         session.session_info.network.network_type = network_type
         session.session_info.network.network_id = network_id
         session.session_info.resource.cluster_mode = ClusterMode.MULTI_NODE.name
@@ -103,9 +117,10 @@ class TestTerminatedTransitionHookNetworkCleanup:
         network_type: NetworkType | None,
         network_id: str | None,
         agent_id: str,
+        session_id: SessionId,
     ) -> MagicMock:
         session = MagicMock()
-        session.session_info.identity.id = SessionId(uuid4())
+        session.session_info.identity.id = session_id
         session.session_info.network.network_type = network_type
         session.session_info.network.network_id = network_id
         session.session_info.resource.cluster_mode = ClusterMode.SINGLE_NODE.name

--- a/tests/unit/manager/sokovan/scheduler/hooks/test_status_hooks.py
+++ b/tests/unit/manager/sokovan/scheduler/hooks/test_status_hooks.py
@@ -8,7 +8,6 @@ of refactors, leaking Docker overlay (MULTI_NODE) and agent-local
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -21,7 +20,6 @@ from ai.backend.manager.sokovan.scheduler.hooks.status import (
     TerminatedHookDependencies,
     TerminatedTransitionHook,
 )
-from ai.backend.manager.sokovan.scheduler.recorder import SessionRecorderContext
 
 
 class TestTerminatedTransitionHookNetworkCleanup:
@@ -80,11 +78,6 @@ class TestTerminatedTransitionHookNetworkCleanup:
     @pytest.fixture
     def session_id(self) -> SessionId:
         return SessionId(uuid4())
-
-    @pytest.fixture(autouse=True)
-    def recorder_scope(self, session_id: SessionId) -> Iterator[None]:
-        with SessionRecorderContext.scope("test_terminate", entity_ids=[session_id]):
-            yield
 
     @pytest.fixture
     def network_id(self, request: pytest.FixtureRequest) -> str | None:

--- a/tests/unit/manager/sokovan/scheduler/hooks/test_status_hooks.py
+++ b/tests/unit/manager/sokovan/scheduler/hooks/test_status_hooks.py
@@ -1,0 +1,195 @@
+"""Regression tests for status-based transition hooks.
+
+Covers the volatile inter-container network cleanup performed by
+``TerminatedTransitionHook`` (BA-6273). The cleanup was lost in a series
+of refactors, leaking Docker overlay (MULTI_NODE) and agent-local
+(SINGLE_NODE) networks after sessions terminated.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from ai.backend.common.types import AgentId, ClusterMode, SessionId
+from ai.backend.manager.models.network import NetworkType
+from ai.backend.manager.sokovan.scheduler.hooks.status import (
+    TerminatedHookDependencies,
+    TerminatedTransitionHook,
+)
+
+
+class TestTerminatedTransitionHookNetworkCleanup:
+    """Volatile network cleanup on session TERMINATED transition (BA-6273)."""
+
+    @pytest.fixture
+    def agent_client(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def agent_client_pool(self, agent_client: AsyncMock) -> MagicMock:
+        acquire_cm = MagicMock()
+        acquire_cm.__aenter__ = AsyncMock(return_value=agent_client)
+        acquire_cm.__aexit__ = AsyncMock(return_value=None)
+        pool = MagicMock()
+        pool.acquire = MagicMock(return_value=acquire_cm)
+        return pool
+
+    @pytest.fixture
+    def network_plugin(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def network_plugin_ctx(self, network_plugin: AsyncMock) -> MagicMock:
+        ctx = MagicMock()
+        ctx.plugins = {"overlay": network_plugin}
+        return ctx
+
+    @pytest.fixture
+    def config_provider(self) -> MagicMock:
+        cp = MagicMock()
+        cp.config.network.inter_container.default_driver = "overlay"
+        return cp
+
+    @pytest.fixture
+    def deps(
+        self,
+        agent_client_pool: MagicMock,
+        network_plugin_ctx: MagicMock,
+        config_provider: MagicMock,
+    ) -> TerminatedHookDependencies:
+        return TerminatedHookDependencies(
+            agent_client_pool=agent_client_pool,
+            network_plugin_ctx=network_plugin_ctx,
+            config_provider=config_provider,
+        )
+
+    @pytest.fixture
+    def hook(self, deps: TerminatedHookDependencies) -> TerminatedTransitionHook:
+        return TerminatedTransitionHook(deps)
+
+    @pytest.fixture
+    def agent_id(self) -> str:
+        return "agent-1"
+
+    @pytest.fixture
+    def network_id(self, request: pytest.FixtureRequest) -> str | None:
+        value: str | None = getattr(request, "param", "net-123")
+        return value
+
+    @pytest.fixture
+    def network_type(self, request: pytest.FixtureRequest) -> NetworkType | None:
+        value: NetworkType | None = getattr(request, "param", NetworkType.VOLATILE)
+        return value
+
+    @pytest.fixture
+    def multi_node_session(
+        self, network_type: NetworkType | None, network_id: str | None
+    ) -> MagicMock:
+        session = MagicMock()
+        session.session_info.identity.id = SessionId(uuid4())
+        session.session_info.network.network_type = network_type
+        session.session_info.network.network_id = network_id
+        session.session_info.resource.cluster_mode = ClusterMode.MULTI_NODE
+        session.main_kernel.resource.agent = None
+        return session
+
+    @pytest.fixture
+    def single_node_session(
+        self,
+        network_type: NetworkType | None,
+        network_id: str | None,
+        agent_id: str,
+    ) -> MagicMock:
+        session = MagicMock()
+        session.session_info.identity.id = SessionId(uuid4())
+        session.session_info.network.network_type = network_type
+        session.session_info.network.network_id = network_id
+        session.session_info.resource.cluster_mode = ClusterMode.SINGLE_NODE
+        session.main_kernel.resource.agent = agent_id
+        return session
+
+    async def test_multinode_volatile_destroys_overlay_network(
+        self,
+        hook: TerminatedTransitionHook,
+        multi_node_session: MagicMock,
+        network_plugin: AsyncMock,
+        agent_client: AsyncMock,
+    ) -> None:
+        await hook.execute(multi_node_session)
+
+        network_plugin.destroy_network.assert_awaited_once_with(network_id="net-123")
+        agent_client.destroy_local_network.assert_not_awaited()
+
+    async def test_singlenode_volatile_destroys_local_network(
+        self,
+        hook: TerminatedTransitionHook,
+        single_node_session: MagicMock,
+        agent_client_pool: MagicMock,
+        agent_client: AsyncMock,
+        network_plugin: AsyncMock,
+    ) -> None:
+        await hook.execute(single_node_session)
+
+        agent_client_pool.acquire.assert_called_once_with(AgentId("agent-1"))
+        agent_client.destroy_local_network.assert_awaited_once_with("net-123")
+        network_plugin.destroy_network.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        "network_type",
+        [NetworkType.PERSISTENT, NetworkType.HOST, None],
+        indirect=True,
+    )
+    async def test_non_volatile_network_skips_destroy(
+        self,
+        hook: TerminatedTransitionHook,
+        multi_node_session: MagicMock,
+        network_plugin: AsyncMock,
+        agent_client: AsyncMock,
+    ) -> None:
+        await hook.execute(multi_node_session)
+
+        network_plugin.destroy_network.assert_not_awaited()
+        agent_client.destroy_local_network.assert_not_awaited()
+
+    @pytest.mark.parametrize("network_id", [None], indirect=True)
+    async def test_missing_network_id_skips_destroy(
+        self,
+        hook: TerminatedTransitionHook,
+        multi_node_session: MagicMock,
+        network_plugin: AsyncMock,
+        agent_client: AsyncMock,
+    ) -> None:
+        await hook.execute(multi_node_session)
+
+        network_plugin.destroy_network.assert_not_awaited()
+        agent_client.destroy_local_network.assert_not_awaited()
+
+    async def test_multinode_without_driver_raises(
+        self,
+        hook: TerminatedTransitionHook,
+        config_provider: MagicMock,
+        multi_node_session: MagicMock,
+        network_plugin: AsyncMock,
+    ) -> None:
+        config_provider.config.network.inter_container.default_driver = None
+
+        with pytest.raises(ValueError):
+            await hook.execute(multi_node_session)
+
+        network_plugin.destroy_network.assert_not_awaited()
+
+    async def test_destroy_failure_propagates(
+        self,
+        hook: TerminatedTransitionHook,
+        multi_node_session: MagicMock,
+        network_plugin: AsyncMock,
+    ) -> None:
+        """Blocking hook: destroy failures must propagate so the coordinator
+        keeps the session in TERMINATING and the self-healing loop retries."""
+        network_plugin.destroy_network.side_effect = RuntimeError("docker unreachable")
+
+        with pytest.raises(RuntimeError, match="docker unreachable"):
+            await hook.execute(multi_node_session)

--- a/tests/unit/manager/sokovan/scheduler/hooks/test_status_hooks.py
+++ b/tests/unit/manager/sokovan/scheduler/hooks/test_status_hooks.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 import pytest
 
 from ai.backend.common.types import AgentId, ClusterMode, SessionId
+from ai.backend.manager.errors.common import ServerMisconfiguredError
 from ai.backend.manager.models.network import NetworkType
 from ai.backend.manager.sokovan.scheduler.hooks.status import (
     TerminatedHookDependencies,
@@ -176,7 +177,7 @@ class TestTerminatedTransitionHookNetworkCleanup:
     ) -> None:
         config_provider.config.network.inter_container.default_driver = None
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ServerMisconfiguredError):
             await hook.execute(multi_node_session)
 
         network_plugin.destroy_network.assert_not_awaited()

--- a/tests/unit/manager/sokovan/scheduler/hooks/test_status_hooks.py
+++ b/tests/unit/manager/sokovan/scheduler/hooks/test_status_hooks.py
@@ -92,7 +92,7 @@ class TestTerminatedTransitionHookNetworkCleanup:
         session.session_info.identity.id = SessionId(uuid4())
         session.session_info.network.network_type = network_type
         session.session_info.network.network_id = network_id
-        session.session_info.resource.cluster_mode = ClusterMode.MULTI_NODE
+        session.session_info.resource.cluster_mode = ClusterMode.MULTI_NODE.name
         session.main_kernel.resource.agent = None
         return session
 
@@ -107,7 +107,7 @@ class TestTerminatedTransitionHookNetworkCleanup:
         session.session_info.identity.id = SessionId(uuid4())
         session.session_info.network.network_type = network_type
         session.session_info.network.network_id = network_id
-        session.session_info.resource.cluster_mode = ClusterMode.SINGLE_NODE
+        session.session_info.resource.cluster_mode = ClusterMode.SINGLE_NODE.name
         session.main_kernel.resource.agent = agent_id
         return session
 


### PR DESCRIPTION
## Summary
- Restore volatile inter-container network cleanup in `TerminatedTransitionHook`, which was lost across refactors and leaked Docker overlay (MULTI_NODE) and agent-local (SINGLE_NODE) networks after sessions terminated.
- Thread `network_plugin_ctx` and `config_provider` through the hook registry / scheduler factory wiring.
- Blocking hook: destroy failures propagate so the coordinator keeps the session in TERMINATING and the self-healing loop retries. Not-found is already handled idempotently by the overlay plugin and the agent.

## Test plan
- [ ] `pants test tests/unit/manager/sokovan/scheduler/hooks/test_status_hooks.py` (6 regression tests pass)
- [ ] Verify on a live cluster that overlay networks no longer linger in `docker network ls` after MULTI_NODE session termination

Resolves BA-6273