### PR TITLE
chore: regenerate GraphQL v2 schema to fix stale KeyPairGQL reference

### DIFF
--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -3600,7 +3600,7 @@ type CreateKeypairPayload
   @join__type(graph: STRAWBERRY)
 {
   """The newly created keypair."""
-  keypair: KeyPairGQL!
+  keypair: KeyPairV2!
 
   """
   The secret key of the generated keypair. Only returned at creation time.

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -2285,7 +2285,7 @@ Added in UNRELEASED. A keypair returned at creation time, including its one-time
 """
 type CreateKeypairPayload {
   """The newly created keypair."""
-  keypair: KeyPairGQL!
+  keypair: KeyPairV2!
 
   """
   The secret key of the generated keypair. Only returned at creation time.


### PR DESCRIPTION
## Summary

While reviewing remaining `GQL`-suffixed names in the v2 GraphQL schema, found that #11906 (which stripped the `GQL` suffix via `name=` overrides) edited the generated schema docs by find/replace and **missed one occurrence**: the `CreateKeypairPayload.keypair` field still referenced `KeyPairGQL!`, a type that no longer exists (it was renamed to `KeyPairV2`). This left a dangling type reference in the docs.

Regenerating the schema via `scripts/generate-graphql-schema.sh` corrects it to `KeyPairV2!`.

## Changes

- `docs/manager/graphql-reference/v2-schema.graphql`: `keypair: KeyPairGQL!` → `keypair: KeyPairV2!`
- `docs/manager/graphql-reference/supergraph.graphql`: same fix

## Notes

- **No Python source changes** — the source already sets `name="KeyPairV2"` (done in #11906); only the generated docs were stale.
- The only remaining `GQL`-suffixed schema type is `SubStepResultGQL`, intentionally left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)