### PR TITLE
feat(BA-6190): grant auto-assign roles when a user joins a project

### DIFF
--- a/changes/11927.feature.md
+++ b/changes/11927.feature.md
@@ -1,0 +1,1 @@
+Grant every auto-assign role bound to a project scope when a user is added to the project, instead of only the project's member role.

--- a/src/ai/backend/manager/repositories/group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/group/db_source/db_source.py
@@ -29,6 +29,7 @@ from ai.backend.manager.data.group.types import (
     UnassignUserFailure,
     UnassignUsersResult,
 )
+from ai.backend.manager.data.permission.id import ScopeId
 from ai.backend.manager.data.permission.types import EntityType, RBACElementRef, ScopeType
 from ai.backend.manager.data.user.types import UserData
 from ai.backend.manager.errors.resource import (
@@ -222,11 +223,9 @@ class GroupDBSource:
         """Add users to a project within an existing session.
 
         Creates the RBAC scope binding (association_scopes_entities) via
-        ``RBACScopeBinder`` and a user-role mapping to the project's member
-        role. Admin roles are intentionally NOT granted here; the modifyGroup
-        add path represents "make this user a project member", not "make this
-        user a project admin". Already-assigned users are filtered out to
-        avoid unique-constraint conflicts.
+        ``RBACScopeBinder`` and maps each new user to every active
+        ``auto_assign`` role bound to the project scope. Already-assigned
+        users are filtered out to avoid unique-constraint conflicts.
         """
         project_domain_subq = (
             sa.select(GroupRow.domain_name).where(GroupRow.id == project_id).scalar_subquery()
@@ -264,38 +263,11 @@ class GroupDBSource:
         ]
         await execute_rbac_scope_binder(session, RBACScopeBinder(pairs=pairs))
 
-        # Locate the project's member role. Two naming conventions coexist:
-        # the runtime name `project-{id8}-member` used by GroupDBSource.create
-        # since BA-5746, and the legacy name `role_project_{id8}_member`
-        # created by alembic migration 430b1631804d for pre-existing projects.
-        runtime_member_name = f"project-{str(project_id)[:8]}-member"
-        legacy_member_name = f"role_project_{str(project_id)[:8]}_member"
-        member_role_id = await session.scalar(
-            sa.select(RoleRow.id)
-            .join(
-                AssociationScopesEntitiesRow,
-                sa.cast(AssociationScopesEntitiesRow.entity_id, sa.String)
-                == sa.cast(RoleRow.id, sa.String),
-            )
-            .where(
-                AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
-                AssociationScopesEntitiesRow.scope_id == str(project_id),
-                AssociationScopesEntitiesRow.entity_type == EntityType.ROLE,
-                RoleRow.name.in_([runtime_member_name, legacy_member_name]),
-            )
+        await self._role_manager.assign_auto_assign_roles(
+            session,
+            [row.uuid for row in new_user_rows],
+            ScopeId(scope_type=ScopeType.PROJECT, scope_id=str(project_id)),
         )
-        if member_role_id is None:
-            log.warning(
-                "project {} has no member role bound at its scope; "
-                "skipping user-role mapping for modifyGroup add",
-                project_id,
-            )
-            return
-
-        user_role_specs = [
-            UserRoleCreatorSpec(user_id=row.uuid, role_id=member_role_id) for row in new_user_rows
-        ]
-        await execute_bulk_creator(session, BulkCreator(specs=user_role_specs))
 
     async def _remove_users_from_project_in_session(
         self,

--- a/src/ai/backend/manager/repositories/permission_controller/role_manager.py
+++ b/src/ai/backend/manager/repositories/permission_controller/role_manager.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
 from collections import defaultdict
-from collections.abc import Iterable, Mapping
+from collections.abc import Collection, Iterable, Mapping
 from dataclasses import dataclass
 from typing import Protocol, cast
 
@@ -37,7 +37,12 @@ from ai.backend.manager.models.rbac_models.role_permission_preset.row import (
 )
 from ai.backend.manager.models.rbac_models.role_preset.row import RolePresetRow
 from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
-from ai.backend.manager.repositories.base.creator import Creator, execute_creator
+from ai.backend.manager.repositories.base.creator import (
+    BulkCreator,
+    Creator,
+    execute_bulk_creator,
+    execute_creator,
+)
 from ai.backend.manager.repositories.base.rbac.entity_creator import (
     RBACEntityCreator,
     execute_rbac_entity_creator,
@@ -250,6 +255,89 @@ class RoleManager:
 
     async def map_user_to_role(self, db_session: SASession, creator: Creator[UserRoleRow]) -> None:
         await execute_creator(db_session, creator)
+
+    async def _query_auto_assign_role_ids_for_scope(
+        self, db_session: SASession, scope_id: ScopeId
+    ) -> list[uuid.UUID]:
+        return list(
+            await db_session.scalars(
+                sa.select(RoleRow.id)
+                .join(
+                    AssociationScopesEntitiesRow,
+                    sa.cast(AssociationScopesEntitiesRow.entity_id, sa.String)
+                    == sa.cast(RoleRow.id, sa.String),
+                )
+                .where(
+                    AssociationScopesEntitiesRow.scope_type == scope_id.scope_type,
+                    AssociationScopesEntitiesRow.scope_id == scope_id.scope_id,
+                    AssociationScopesEntitiesRow.entity_type == EntityType.ROLE,
+                    RoleRow.auto_assign.is_(True),
+                    RoleRow.status == RoleStatus.ACTIVE,
+                )
+            )
+        )
+
+    async def _query_existing_user_role_mappings(
+        self,
+        db_session: SASession,
+        role_ids: Collection[uuid.UUID],
+        user_ids: Collection[uuid.UUID],
+    ) -> dict[uuid.UUID, set[uuid.UUID]]:
+        user_role_rows = (
+            await db_session.scalars(
+                sa.select(UserRoleRow).where(
+                    sa.and_(UserRoleRow.role_id.in_(role_ids), UserRoleRow.user_id.in_(user_ids))
+                )
+            )
+        ).all()
+        existing_role_user_maps = defaultdict(set)
+        for user_role in user_role_rows:
+            existing_role_user_maps[user_role.role_id].add(user_role.user_id)
+        return existing_role_user_maps
+
+    async def assign_auto_assign_roles(
+        self,
+        db_session: SASession,
+        user_ids: Collection[uuid.UUID],
+        scope_id: ScopeId,
+    ) -> None:
+        """Map the given users to every active ``auto_assign`` role bound to ``scope_id``.
+
+        Roles bound to the scope are located via the scope-entity association
+        (``association_scopes_entities`` with ``entity_type == ROLE``). Only
+        active roles flagged ``auto_assign`` are granted. Already-mapped
+        (user, role) pairs are filtered out to avoid unique-constraint conflicts.
+        """
+        if not user_ids:
+            return
+
+        user_id_set: set[uuid.UUID] = set(user_ids)
+        role_ids = await self._query_auto_assign_role_ids_for_scope(db_session, scope_id)
+        if not role_ids:
+            return
+
+        existing_role_user_maps = await self._query_existing_user_role_mappings(
+            db_session, role_ids, user_ids
+        )
+        specs: list[UserRoleCreatorSpec] = []
+        for role_id in role_ids:
+            if role_id not in existing_role_user_maps:
+                # No users mapped to this role yet, so all user_ids are new mappings
+                specs.extend(
+                    UserRoleCreatorSpec(user_id=user_id, role_id=role_id) for user_id in user_id_set
+                )
+            else:
+                # Some users already mapped to this role, filter them out
+                existing_user_ids = existing_role_user_maps[role_id]
+                new_user_ids = user_id_set - existing_user_ids
+                specs.extend(
+                    UserRoleCreatorSpec(user_id=user_id, role_id=role_id)
+                    for user_id in new_user_ids
+                )
+
+        if not specs:
+            return
+        await execute_bulk_creator(db_session, BulkCreator(specs=specs))
 
     async def map_entity_to_scope(
         self,

--- a/src/ai/backend/manager/repositories/user/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/user/db_source/db_source.py
@@ -26,6 +26,7 @@ from ai.backend.manager.data.keypair.types import (
     KeyPairCreator,
     KeyPairData,
 )
+from ai.backend.manager.data.permission.id import ScopeId
 from ai.backend.manager.data.permission.types import EntityType, RBACElementRef, ScopeType
 from ai.backend.manager.data.user.types import (
     BulkUserCreateResultData,
@@ -64,7 +65,6 @@ from ai.backend.manager.models.keypair import (
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
 )
-from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
 from ai.backend.manager.models.resource_policy import UserResourcePolicyRow
 from ai.backend.manager.models.session import (
@@ -90,10 +90,8 @@ from ai.backend.manager.models.vfolder import (
     vfolders,
 )
 from ai.backend.manager.repositories.base.creator import (
-    BulkCreator,
     BulkCreatorError,
     Creator,
-    execute_bulk_creator,
     execute_creator,
 )
 from ai.backend.manager.repositories.base.purger import execute_batch_purger
@@ -1054,8 +1052,8 @@ class UserDBSource:
 
         Mirrors GroupDBSource._add_users_to_project_in_session for the
         single-user case: inserts the RBAC scope binding (ASE) via
-        ``RBACScopeBinder`` and maps the user to the project's member role
-        (only).
+        ``RBACScopeBinder`` and maps the user to every active ``auto_assign``
+        role bound to the project scope.
         """
         project_scope_ref = RBACElementRef(RBACElementType.PROJECT, str(project_id))
         pair = RBACScopeBindingPair(
@@ -1065,37 +1063,10 @@ class UserDBSource:
         )
         await execute_rbac_scope_binder(session, RBACScopeBinder(pairs=[pair]))
 
-        # Locate the project's member role. Two naming conventions coexist:
-        # the runtime name `project-{id8}-member` used by GroupDBSource.create
-        # since BA-5746, and the legacy name `role_project_{id8}_member`
-        # created by alembic migration 430b1631804d for pre-existing projects.
-        runtime_member_name = f"project-{str(project_id)[:8]}-member"
-        legacy_member_name = f"role_project_{str(project_id)[:8]}_member"
-        member_role_id = await session.scalar(
-            sa.select(RoleRow.id)
-            .join(
-                AssociationScopesEntitiesRow,
-                sa.cast(AssociationScopesEntitiesRow.entity_id, sa.String)
-                == sa.cast(RoleRow.id, sa.String),
-            )
-            .where(
-                AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
-                AssociationScopesEntitiesRow.scope_id == str(project_id),
-                AssociationScopesEntitiesRow.entity_type == EntityType.ROLE,
-                RoleRow.name.in_([runtime_member_name, legacy_member_name]),
-            )
-        )
-        if member_role_id is None:
-            log.warning(
-                "project {} has no member role bound at its scope; "
-                "skipping user-role mapping for modify_user group assignment",
-                project_id,
-            )
-            return
-
-        await execute_bulk_creator(
+        await self._role_manager.assign_auto_assign_roles(
             session,
-            BulkCreator(specs=[UserRoleCreatorSpec(user_id=user_uuid, role_id=member_role_id)]),
+            [user_uuid],
+            ScopeId(scope_type=ScopeType.PROJECT, scope_id=str(project_id)),
         )
 
     async def _remove_user_from_project_in_session(

--- a/tests/unit/manager/repositories/group/test_group_repository.py
+++ b/tests/unit/manager/repositories/group/test_group_repository.py
@@ -418,6 +418,10 @@ class TestGroupRepository:
         """Create test group together with both an admin role and a member
         role bound at the project scope, matching the runtime state produced
         by GroupDBSource.create() after BA-5746.
+
+        The member role is flagged ``auto_assign=True`` so that joining users
+        are granted it, while the admin role keeps ``auto_assign=False`` so it
+        is never granted on join.
         """
         group_id = uuid.uuid4()
         admin_role_id = uuid.uuid4()
@@ -445,6 +449,7 @@ class TestGroupRepository:
             member_role = RoleRow(
                 id=member_role_id,
                 name=f"project-{str(group_id)[:8]}-member",
+                auto_assign=True,
             )
             session.add(member_role)
             session.add(

--- a/tests/unit/manager/repositories/permission_controller/test_role_assignment.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_assignment.py
@@ -11,10 +11,12 @@ import sqlalchemy as sa
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.group.types import ProjectType
+from ai.backend.manager.data.permission.id import ScopeId
 from ai.backend.manager.data.permission.role import (
     UserRoleAssignmentInput,
     UserRoleRevocationInput,
 )
+from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import EntityType, ScopeType
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
@@ -45,6 +47,7 @@ from ai.backend.manager.repositories.group.db_source import GroupDBSource
 from ai.backend.manager.repositories.permission_controller.db_source.db_source import (
     PermissionDBSource,
 )
+from ai.backend.manager.repositories.permission_controller.role_manager import RoleManager
 from ai.backend.testutils.db import with_tables
 
 
@@ -380,3 +383,157 @@ class TestRoleAssignment:
                 )
             )
             assert len(assoc.fetchall()) == 0
+
+    # --- RoleManager.assign_auto_assign_roles ---
+
+    @pytest.fixture
+    def role_manager(self) -> RoleManager:
+        return RoleManager()
+
+    @pytest.fixture
+    def project_scope(self, test_project: uuid.UUID) -> ScopeId:
+        return ScopeId(scope_type=ScopeType.PROJECT, scope_id=str(test_project))
+
+    async def _bind_auto_assign_role(
+        self,
+        db: ExtendedAsyncSAEngine,
+        scope_id: ScopeId,
+        *,
+        auto_assign: bool = True,
+        status: RoleStatus = RoleStatus.ACTIVE,
+    ) -> uuid.UUID:
+        role_id = uuid.uuid4()
+        async with db.begin_session() as session:
+            session.add(
+                RoleRow(
+                    id=role_id,
+                    name=f"auto-role-{role_id.hex[:8]}",
+                    auto_assign=auto_assign,
+                    status=status,
+                )
+            )
+            session.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=scope_id.scope_type,
+                    scope_id=scope_id.scope_id,
+                    entity_type=EntityType.ROLE,
+                    entity_id=str(role_id),
+                )
+            )
+            await session.commit()
+        return role_id
+
+    async def _user_ids_for_role(
+        self, db: ExtendedAsyncSAEngine, role_id: uuid.UUID
+    ) -> list[uuid.UUID]:
+        async with db.begin_readonly_session() as session:
+            return list(
+                await session.scalars(
+                    sa.select(UserRoleRow.user_id).where(UserRoleRow.role_id == role_id)
+                )
+            )
+
+    @pytest.fixture
+    async def joined_users(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain: str,
+        user_resource_policy: str,
+        test_password_info: PasswordInfo,
+    ) -> list[uuid.UUID]:
+        return [
+            await self._create_user(
+                db_with_cleanup, test_domain, user_resource_policy, test_password_info
+            )
+            for _ in range(3)
+        ]
+
+    @pytest.fixture
+    async def auto_assign_role(
+        self, db_with_cleanup: ExtendedAsyncSAEngine, project_scope: ScopeId
+    ) -> uuid.UUID:
+        """An active, auto_assign role bound to the target scope."""
+        return await self._bind_auto_assign_role(db_with_cleanup, project_scope)
+
+    @pytest.fixture
+    async def role_with_one_existing_member(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        auto_assign_role: uuid.UUID,
+        joined_users: list[uuid.UUID],
+    ) -> uuid.UUID:
+        """The auto_assign role with its first joined user already mapped."""
+        async with db_with_cleanup.begin_session() as session:
+            session.add(UserRoleRow(user_id=joined_users[0], role_id=auto_assign_role))
+            await session.commit()
+        return auto_assign_role
+
+    @pytest.fixture
+    async def ineligible_roles(
+        self, db_with_cleanup: ExtendedAsyncSAEngine, project_scope: ScopeId
+    ) -> list[uuid.UUID]:
+        """Roles that must NOT be granted: not auto_assign, inactive, or bound elsewhere."""
+        not_auto_assign = await self._bind_auto_assign_role(
+            db_with_cleanup, project_scope, auto_assign=False
+        )
+        inactive = await self._bind_auto_assign_role(
+            db_with_cleanup, project_scope, status=RoleStatus.INACTIVE
+        )
+        other_scope = ScopeId(scope_type=ScopeType.PROJECT, scope_id=str(uuid.uuid4()))
+        bound_to_other_scope = await self._bind_auto_assign_role(db_with_cleanup, other_scope)
+        return [not_auto_assign, inactive, bound_to_other_scope]
+
+    async def test_assign_auto_assign_roles_grants_to_all_users_when_none_mapped(
+        self,
+        role_manager: RoleManager,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        project_scope: ScopeId,
+        auto_assign_role: uuid.UUID,
+        joined_users: list[uuid.UUID],
+    ) -> None:
+        """Every joining user is mapped to an active auto_assign role bound to the scope."""
+        async with db_with_cleanup.begin_session() as session:
+            await role_manager.assign_auto_assign_roles(session, joined_users, project_scope)
+
+        mapped_user_ids = await self._user_ids_for_role(db_with_cleanup, auto_assign_role)
+        assert set(mapped_user_ids) == set(joined_users)
+
+    async def test_assign_auto_assign_roles_skips_already_mapped_users(
+        self,
+        role_manager: RoleManager,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        project_scope: ScopeId,
+        role_with_one_existing_member: uuid.UUID,
+        joined_users: list[uuid.UUID],
+    ) -> None:
+        """A pre-mapped (user, role) pair is not re-inserted; only new users are added."""
+        async with db_with_cleanup.begin_session() as session:
+            await role_manager.assign_auto_assign_roles(session, joined_users, project_scope)
+
+        mapped_user_ids = await self._user_ids_for_role(
+            db_with_cleanup, role_with_one_existing_member
+        )
+        # Exactly one row per user: the pre-mapped user is neither duplicated nor dropped.
+        assert sorted(mapped_user_ids) == sorted(joined_users)
+
+    async def test_assign_auto_assign_roles_skips_non_eligible_roles(
+        self,
+        role_manager: RoleManager,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        project_scope: ScopeId,
+        auto_assign_role: uuid.UUID,
+        ineligible_roles: list[uuid.UUID],
+        user_1: uuid.UUID,
+    ) -> None:
+        """Only active, auto_assign roles bound to the target scope are granted."""
+        async with db_with_cleanup.begin_session() as session:
+            await role_manager.assign_auto_assign_roles(session, [user_1], project_scope)
+
+        async with db_with_cleanup.begin_readonly_session() as session:
+            granted_role_ids = list(
+                await session.scalars(
+                    sa.select(UserRoleRow.role_id).where(UserRoleRow.user_id == user_1)
+                )
+            )
+        # Only the eligible role is granted; none of the ineligible roles appear.
+        assert granted_role_ids == [auto_assign_role]

--- a/tests/unit/manager/repositories/user/test_user_repository.py
+++ b/tests/unit/manager/repositories/user/test_user_repository.py
@@ -263,6 +263,10 @@ class TestUserRepository:
         """Create a test group with both admin and member roles bound at
         project scope, matching the runtime state produced by
         ``GroupDBSource.create()`` after BA-5746.
+
+        The member role is flagged ``auto_assign=True`` so that joining users
+        are granted it, while the admin role keeps ``auto_assign=False`` so it
+        is never granted on join.
         """
         group_id = uuid.uuid4()
         admin_role_id = uuid.uuid4()
@@ -282,7 +286,13 @@ class TestUserRepository:
             )
             session.add(group)
             session.add(RoleRow(id=admin_role_id, name=f"project-{str(group_id)[:8]}-admin"))
-            session.add(RoleRow(id=member_role_id, name=f"project-{str(group_id)[:8]}-member"))
+            session.add(
+                RoleRow(
+                    id=member_role_id,
+                    name=f"project-{str(group_id)[:8]}-member",
+                    auto_assign=True,
+                )
+            )
             session.add(
                 AssociationScopesEntitiesRow(
                     scope_type=ScopeType.PROJECT,


### PR DESCRIPTION
## Summary
- When a user is added to a **project** scope, map them to every active role bound to that scope with `auto_assign=true`, instead of locating a single member role by name.
- Add `RoleManager.assign_auto_assign_roles` as the shared implementation, used by both the single-user (`modify_user`) and multi-user (`modifyGroup`) add paths.
- The role-creation `auto_assign` flag is managed separately (via the role create/update API, BA-6189); this PR only changes the join-time read logic. `role_option` (explicit `role_ids`/`overwrite`) is out of scope.

## Manual verification (bai-cli)
Verified end-to-end against a live local server on this branch:

1. Created a project and a user (`default` domain).
2. Flagged the project's member role `auto_assign=true`, left the admin role `auto_assign=false`.
3. Joined the user to the project via the add path (`modify_group` with `user_update_mode="add"`).

Results:
- [x] Member role (`auto_assign=true`) → automatically granted to the joining user
- [x] Admin role (`auto_assign=false`) → not granted
- [x] Baseline before join: the user held neither role; `user_roles` after join contained only the member role

Confirms only active `auto_assign` roles bound to the project scope are granted on join.

Resolves BA-6190
