### PR TITLE
feat(BA-6279): add auto_assign and role preset sections to RBAC fixtures

### DIFF
--- a/changes/11930.misc.md
+++ b/changes/11930.misc.md
@@ -1,0 +1,1 @@
+Add `auto_assign` and role preset sections to the default RBAC role fixtures and remove `grant:*` operation permissions.

--- a/fixtures/manager/example-roles.json
+++ b/fixtures/manager/example-roles.json
@@ -6,6 +6,7 @@
             "description": "",
             "source": "system",
             "status": "active",
+            "auto_assign": false,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00",
             "deleted_at": null
@@ -16,6 +17,7 @@
             "description": "",
             "source": "system",
             "status": "active",
+            "auto_assign": false,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00",
             "deleted_at": null
@@ -26,6 +28,7 @@
             "description": "",
             "source": "system",
             "status": "active",
+            "auto_assign": false,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00",
             "deleted_at": null
@@ -36,6 +39,7 @@
             "description": "",
             "source": "system",
             "status": "active",
+            "auto_assign": false,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00",
             "deleted_at": null
@@ -46,6 +50,7 @@
             "description": "",
             "source": "system",
             "status": "active",
+            "auto_assign": false,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00",
             "deleted_at": null
@@ -56,6 +61,7 @@
             "description": "",
             "source": "system",
             "status": "active",
+            "auto_assign": false,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00",
             "deleted_at": null
@@ -66,6 +72,7 @@
             "description": "",
             "source": "system",
             "status": "active",
+            "auto_assign": false,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00",
             "deleted_at": null
@@ -76,6 +83,7 @@
             "description": "",
             "source": "system",
             "status": "active",
+            "auto_assign": false,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00",
             "deleted_at": null
@@ -86,6 +94,7 @@
             "description": "",
             "source": "system",
             "status": "active",
+            "auto_assign": false,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00",
             "deleted_at": null
@@ -96,6 +105,7 @@
             "description": "",
             "source": "custom",
             "status": "active",
+            "auto_assign": true,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00",
             "deleted_at": null
@@ -106,6 +116,7 @@
             "description": "",
             "source": "custom",
             "status": "active",
+            "auto_assign": true,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00",
             "deleted_at": null
@@ -116,6 +127,7 @@
             "description": "",
             "source": "system",
             "status": "active",
+            "auto_assign": false,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00",
             "deleted_at": null
@@ -126,6 +138,7 @@
             "description": "",
             "source": "custom",
             "status": "active",
+            "auto_assign": true,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00",
             "deleted_at": null
@@ -271,30 +284,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "eaf477fd-2600-4bf9-b5e2-65ff7e086efa",
-            "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
-            "scope_type": "user",
-            "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
-            "entity_type": "user",
-            "operation": "grant:all"
-        },
-        {
-            "id": "38cb0b72-a6ee-4c5e-b445-5c032f31b0ec",
-            "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
-            "scope_type": "user",
-            "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
-            "entity_type": "user",
-            "operation": "grant:read"
-        },
-        {
-            "id": "b3ce632d-6b1c-4f5a-be91-0798f9c6f70e",
-            "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
-            "scope_type": "user",
-            "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
-            "entity_type": "user",
-            "operation": "grant:update"
-        },
-        {
             "id": "1da58bf7-1852-4abe-9a54-fdc482d427e4",
             "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
             "scope_type": "user",
@@ -325,30 +314,6 @@
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "user",
             "operation": "hard-delete"
-        },
-        {
-            "id": "30c7952b-4ef5-4d85-b8ca-66609f1bfdb9",
-            "role_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
-            "scope_type": "user",
-            "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
-            "entity_type": "user",
-            "operation": "grant:all"
-        },
-        {
-            "id": "511741cd-528d-43b0-88a0-4def512129b7",
-            "role_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
-            "scope_type": "user",
-            "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
-            "entity_type": "user",
-            "operation": "grant:read"
-        },
-        {
-            "id": "5816b995-05b4-4a37-ac53-f69a5fcc544a",
-            "role_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
-            "scope_type": "user",
-            "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
-            "entity_type": "user",
-            "operation": "grant:update"
         },
         {
             "id": "00642d3d-1b2e-436f-af49-71d6b0612f07",
@@ -383,30 +348,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "f0d0134c-3b26-48e3-b122-7251e1da0d25",
-            "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
-            "scope_type": "user",
-            "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
-            "entity_type": "user",
-            "operation": "grant:all"
-        },
-        {
-            "id": "01cb967b-66aa-4e7b-917b-139a3eeacb05",
-            "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
-            "scope_type": "user",
-            "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
-            "entity_type": "user",
-            "operation": "grant:read"
-        },
-        {
-            "id": "d531c88f-3a49-4526-a817-c70b6f4bae0e",
-            "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
-            "scope_type": "user",
-            "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
-            "entity_type": "user",
-            "operation": "grant:update"
-        },
-        {
             "id": "1d8f17b6-0c47-40a7-b96d-4ac6b267d5c7",
             "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
             "scope_type": "user",
@@ -437,30 +378,6 @@
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "user",
             "operation": "hard-delete"
-        },
-        {
-            "id": "c721492f-cb04-437a-ae31-4161f5a98258",
-            "role_id": "fe53e90e-f619-43d8-99c8-574487485bab",
-            "scope_type": "user",
-            "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
-            "entity_type": "user",
-            "operation": "grant:all"
-        },
-        {
-            "id": "25995814-eea6-480c-9c1a-0e1c4e3b181a",
-            "role_id": "fe53e90e-f619-43d8-99c8-574487485bab",
-            "scope_type": "user",
-            "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
-            "entity_type": "user",
-            "operation": "grant:read"
-        },
-        {
-            "id": "f8030c74-601f-4471-a5de-bb8054f1ea5f",
-            "role_id": "fe53e90e-f619-43d8-99c8-574487485bab",
-            "scope_type": "user",
-            "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
-            "entity_type": "user",
-            "operation": "grant:update"
         },
         {
             "id": "69a4ac81-a174-40e0-8a59-1af4d26cab14",
@@ -495,30 +412,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "3bb26ff5-8546-4475-b772-3fe47326e89b",
-            "role_id": "72293d83-1849-4bb5-a555-80e561515428",
-            "scope_type": "user",
-            "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
-            "entity_type": "user",
-            "operation": "grant:all"
-        },
-        {
-            "id": "c7981ebd-2893-4b5c-8562-61464ed35bc4",
-            "role_id": "72293d83-1849-4bb5-a555-80e561515428",
-            "scope_type": "user",
-            "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
-            "entity_type": "user",
-            "operation": "grant:read"
-        },
-        {
-            "id": "295e890d-e0d4-46bf-8cec-505dcc9c82b5",
-            "role_id": "72293d83-1849-4bb5-a555-80e561515428",
-            "scope_type": "user",
-            "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
-            "entity_type": "user",
-            "operation": "grant:update"
-        },
-        {
             "id": "89a564c5-48d5-4bf5-b35e-70d838746c72",
             "role_id": "72293d83-1849-4bb5-a555-80e561515428",
             "scope_type": "user",
@@ -551,30 +444,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "67505ea3-33f5-441c-89b7-411afca443c5",
-            "role_id": "e79d7074-076d-4629-953d-55286b26490c",
-            "scope_type": "project",
-            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
-            "entity_type": "user",
-            "operation": "grant:all"
-        },
-        {
-            "id": "3e184eac-570e-4408-98e1-e303887d10c6",
-            "role_id": "e79d7074-076d-4629-953d-55286b26490c",
-            "scope_type": "project",
-            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
-            "entity_type": "user",
-            "operation": "grant:read"
-        },
-        {
-            "id": "498579ba-5deb-4b6d-a37e-8c788caeba2d",
-            "role_id": "e79d7074-076d-4629-953d-55286b26490c",
-            "scope_type": "project",
-            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
-            "entity_type": "user",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "d56c152e-2d20-4870-90bf-65e5df4baa72",
             "role_id": "e79d7074-076d-4629-953d-55286b26490c",
             "scope_type": "project",
@@ -583,28 +452,12 @@
             "operation": "create"
         },
         {
-            "id": "fbf85b23-caad-487f-af43-a2319b0db0a8",
-            "role_id": "e79d7074-076d-4629-953d-55286b26490c",
-            "scope_type": "project",
-            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
-            "entity_type": "user",
-            "operation": "grant:update"
-        },
-        {
             "id": "ce345c7e-d436-41fe-a257-ab178eeb310f",
             "role_id": "e79d7074-076d-4629-953d-55286b26490c",
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "user",
             "operation": "update"
-        },
-        {
-            "id": "f108a953-8c87-4392-b71d-3fe4cfb51e2b",
-            "role_id": "e79d7074-076d-4629-953d-55286b26490c",
-            "scope_type": "project",
-            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
-            "entity_type": "user",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "c42fde9e-7480-4108-8583-de8289f7c139",
@@ -631,30 +484,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "96a1fbb7-8c0e-4041-9216-96eb4e9484c7",
-            "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
-            "scope_type": "project",
-            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
-            "entity_type": "user",
-            "operation": "grant:all"
-        },
-        {
-            "id": "1f72c6e4-aec9-472d-9c3d-eacd7b0bbe9a",
-            "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
-            "scope_type": "project",
-            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
-            "entity_type": "user",
-            "operation": "grant:read"
-        },
-        {
-            "id": "e09fbd1e-91e0-4037-913d-95e87b9aa4e5",
-            "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
-            "scope_type": "project",
-            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
-            "entity_type": "user",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "9e56aaa7-b23e-45a2-80eb-afdf77651d30",
             "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
             "scope_type": "project",
@@ -663,28 +492,12 @@
             "operation": "create"
         },
         {
-            "id": "9f67a7c0-826d-4bb1-80b4-7511dd26c3ec",
-            "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
-            "scope_type": "project",
-            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
-            "entity_type": "user",
-            "operation": "grant:update"
-        },
-        {
             "id": "f8889e4b-2943-49a6-b8da-3019f6129573",
             "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "user",
             "operation": "update"
-        },
-        {
-            "id": "9354dc64-36eb-4bc5-8479-fc6c8babe724",
-            "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
-            "scope_type": "project",
-            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
-            "entity_type": "user",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "3373279c-4cc4-4642-99d1-e2ea48c1f70d",
@@ -743,30 +556,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "d33e5824-47ba-4c5e-bc43-10446766bc21",
-            "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
-            "scope_type": "domain",
-            "scope_id": "default",
-            "entity_type": "user",
-            "operation": "grant:all"
-        },
-        {
-            "id": "4673f9f9-e8d1-4048-aaf0-8eb83f455be4",
-            "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
-            "scope_type": "domain",
-            "scope_id": "default",
-            "entity_type": "user",
-            "operation": "grant:read"
-        },
-        {
-            "id": "13bc38dd-2aba-4903-8848-5b0440726dac",
-            "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
-            "scope_type": "domain",
-            "scope_id": "default",
-            "entity_type": "user",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "2ea152ff-5e28-4e96-9908-3ee1e0b99718",
             "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
             "scope_type": "domain",
@@ -775,28 +564,12 @@
             "operation": "create"
         },
         {
-            "id": "afb84a96-3382-49cc-b4f6-b98ee525757a",
-            "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
-            "scope_type": "domain",
-            "scope_id": "default",
-            "entity_type": "user",
-            "operation": "grant:update"
-        },
-        {
             "id": "7f15717c-e918-4673-9307-5f26c84ff95f",
             "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "user",
             "operation": "update"
-        },
-        {
-            "id": "89781589-69a7-486d-b270-1d358de43813",
-            "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
-            "scope_type": "domain",
-            "scope_id": "default",
-            "entity_type": "user",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "d6c2fe69-619d-4ccd-a559-e04cc1667f34",
@@ -839,30 +612,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "3b3b8aee-27d8-410e-991b-d08a82e43c20",
-            "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
-            "scope_type": "user",
-            "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
-            "entity_type": "vfolder",
-            "operation": "grant:all"
-        },
-        {
-            "id": "31556a94-4673-44a1-90b4-1e9e63d76e43",
-            "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
-            "scope_type": "user",
-            "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
-            "entity_type": "vfolder",
-            "operation": "grant:read"
-        },
-        {
-            "id": "0c2bea28-ac10-41a5-8a25-23ee0d952bbd",
-            "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
-            "scope_type": "user",
-            "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
-            "entity_type": "vfolder",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "769a6025-e3dc-416e-8916-e7a42c52e179",
             "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
             "scope_type": "user",
@@ -871,28 +620,12 @@
             "operation": "create"
         },
         {
-            "id": "e885ef78-53e3-4a15-b18e-b4020d47cb08",
-            "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
-            "scope_type": "user",
-            "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
-            "entity_type": "vfolder",
-            "operation": "grant:update"
-        },
-        {
             "id": "5e1110d5-894c-4fef-9785-b4874730088a",
             "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "vfolder",
             "operation": "update"
-        },
-        {
-            "id": "e78c0613-ee99-4a98-87d3-74227a826c62",
-            "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
-            "scope_type": "user",
-            "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
-            "entity_type": "vfolder",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "9c618332-3ce0-43d2-8b6f-6d30cb07aac0",
@@ -919,30 +652,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "69770d2a-dc0c-4889-8e90-8f625c884c1b",
-            "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
-            "scope_type": "domain",
-            "scope_id": "default",
-            "entity_type": "vfolder",
-            "operation": "grant:all"
-        },
-        {
-            "id": "7da00b30-0f35-483e-8aec-e4ebad3d1f28",
-            "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
-            "scope_type": "domain",
-            "scope_id": "default",
-            "entity_type": "vfolder",
-            "operation": "grant:read"
-        },
-        {
-            "id": "c80430aa-1fa4-42d4-8c14-26eacfb4a4cf",
-            "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
-            "scope_type": "domain",
-            "scope_id": "default",
-            "entity_type": "vfolder",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "a3f179f7-00a7-4b24-9e38-612ead26c7e9",
             "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
             "scope_type": "domain",
@@ -951,28 +660,12 @@
             "operation": "create"
         },
         {
-            "id": "6c623ec8-6ee6-4aae-9a88-9f5945133d69",
-            "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
-            "scope_type": "domain",
-            "scope_id": "default",
-            "entity_type": "vfolder",
-            "operation": "grant:update"
-        },
-        {
             "id": "6643f5b8-260a-497f-92a5-4fb105b8b209",
             "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "vfolder",
             "operation": "update"
-        },
-        {
-            "id": "2214f12f-6061-45a3-9b71-004ef49bbc2b",
-            "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
-            "scope_type": "domain",
-            "scope_id": "default",
-            "entity_type": "vfolder",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "87bd823f-2d49-4455-821a-d45637318018",
@@ -999,30 +692,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "2ee949d0-07dd-4ed4-8e73-a3b088d27b54",
-            "role_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
-            "scope_type": "user",
-            "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
-            "entity_type": "vfolder",
-            "operation": "grant:all"
-        },
-        {
-            "id": "c0f03d31-fb44-4dac-bd4e-928241e90b76",
-            "role_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
-            "scope_type": "user",
-            "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
-            "entity_type": "vfolder",
-            "operation": "grant:read"
-        },
-        {
-            "id": "6533c51b-aa0e-4c0c-994d-0bfe3b2b3d61",
-            "role_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
-            "scope_type": "user",
-            "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
-            "entity_type": "vfolder",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "2b7f8ce0-a12b-450d-86e6-a9f305914a5c",
             "role_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
             "scope_type": "user",
@@ -1031,28 +700,12 @@
             "operation": "create"
         },
         {
-            "id": "906f3c11-f575-4575-aa5c-b75f7388df76",
-            "role_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
-            "scope_type": "user",
-            "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
-            "entity_type": "vfolder",
-            "operation": "grant:update"
-        },
-        {
             "id": "caf9cdf1-259e-4d25-a28b-378b105502d1",
             "role_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "vfolder",
             "operation": "update"
-        },
-        {
-            "id": "882353e4-ebda-496e-9886-c21381071545",
-            "role_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
-            "scope_type": "user",
-            "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
-            "entity_type": "vfolder",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "83e8cc68-dcf5-414f-bbb1-da4d58cd1ddc",
@@ -1079,30 +732,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "cd36930c-6664-4d1e-80ee-b5c96fe2b50b",
-            "role_id": "72293d83-1849-4bb5-a555-80e561515428",
-            "scope_type": "user",
-            "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
-            "entity_type": "vfolder",
-            "operation": "grant:all"
-        },
-        {
-            "id": "6ce45c57-16bb-4225-856c-1d9681919ce5",
-            "role_id": "72293d83-1849-4bb5-a555-80e561515428",
-            "scope_type": "user",
-            "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
-            "entity_type": "vfolder",
-            "operation": "grant:read"
-        },
-        {
-            "id": "e18c8dd0-5d2e-4d07-a672-ce88ab148674",
-            "role_id": "72293d83-1849-4bb5-a555-80e561515428",
-            "scope_type": "user",
-            "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
-            "entity_type": "vfolder",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "6d1507ca-7897-495e-96c4-153fbd965df2",
             "role_id": "72293d83-1849-4bb5-a555-80e561515428",
             "scope_type": "user",
@@ -1111,28 +740,12 @@
             "operation": "create"
         },
         {
-            "id": "5fc39ce9-a3f4-4b50-a2ac-20baa3957a67",
-            "role_id": "72293d83-1849-4bb5-a555-80e561515428",
-            "scope_type": "user",
-            "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
-            "entity_type": "vfolder",
-            "operation": "grant:update"
-        },
-        {
             "id": "ab19dedf-0f82-45c1-919e-ebf7d712fc64",
             "role_id": "72293d83-1849-4bb5-a555-80e561515428",
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "vfolder",
             "operation": "update"
-        },
-        {
-            "id": "d0395b7a-b072-4d01-995b-0ac015b3cfe0",
-            "role_id": "72293d83-1849-4bb5-a555-80e561515428",
-            "scope_type": "user",
-            "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
-            "entity_type": "vfolder",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "87db7417-6cab-4168-8772-c0bbb374521f",
@@ -1167,30 +780,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "eafd220f-c1b3-4d63-8aeb-9db6dae1e43f",
-            "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
-            "scope_type": "user",
-            "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
-            "entity_type": "vfolder",
-            "operation": "grant:all"
-        },
-        {
-            "id": "dbcd2029-bb8e-49c7-817c-207b894eef6b",
-            "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
-            "scope_type": "user",
-            "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
-            "entity_type": "vfolder",
-            "operation": "grant:read"
-        },
-        {
-            "id": "955d2eea-f9f7-4283-afc8-27a0b70cab2b",
-            "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
-            "scope_type": "user",
-            "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
-            "entity_type": "vfolder",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "ebdd4a33-4c36-417c-8566-3d27f259d4d0",
             "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
             "scope_type": "user",
@@ -1199,28 +788,12 @@
             "operation": "create"
         },
         {
-            "id": "b6cd3798-5fd4-4ea6-9c49-9c8413a3a5f9",
-            "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
-            "scope_type": "user",
-            "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
-            "entity_type": "vfolder",
-            "operation": "grant:update"
-        },
-        {
             "id": "9db1ba31-982d-4923-844d-25e395041112",
             "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "vfolder",
             "operation": "update"
-        },
-        {
-            "id": "ecdddec8-2b11-4e99-a524-9d8c9c1935bb",
-            "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
-            "scope_type": "user",
-            "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
-            "entity_type": "vfolder",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "8b2e5c19-d887-412a-a7de-1cb67b38fd55",
@@ -1247,30 +820,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "96cb3c4e-da0c-4a30-b5af-82139d5bd47d",
-            "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
-            "scope_type": "project",
-            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
-            "entity_type": "vfolder",
-            "operation": "grant:all"
-        },
-        {
-            "id": "f5a7b8cc-da37-4e4f-b368-f737fb85cd18",
-            "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
-            "scope_type": "project",
-            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
-            "entity_type": "vfolder",
-            "operation": "grant:read"
-        },
-        {
-            "id": "7a0a5dcb-ee92-418b-bfee-5bfd5dc01a47",
-            "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
-            "scope_type": "project",
-            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
-            "entity_type": "vfolder",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "ce3af414-a03d-46c1-8e54-fba9a7c78181",
             "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
             "scope_type": "project",
@@ -1279,28 +828,12 @@
             "operation": "create"
         },
         {
-            "id": "e90dcf63-808a-4496-b358-110282de031d",
-            "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
-            "scope_type": "project",
-            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
-            "entity_type": "vfolder",
-            "operation": "grant:update"
-        },
-        {
             "id": "9769f2cb-561e-4039-9c5d-11bfaa6596e2",
             "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "vfolder",
             "operation": "update"
-        },
-        {
-            "id": "e7da6862-a786-4354-a450-bf043345e985",
-            "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
-            "scope_type": "project",
-            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
-            "entity_type": "vfolder",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "a36ec117-3293-4905-b5d6-2271e6b36055",
@@ -1327,30 +860,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "f7088480-c5be-434d-b6a0-1c52a94b3a37",
-            "role_id": "e79d7074-076d-4629-953d-55286b26490c",
-            "scope_type": "project",
-            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
-            "entity_type": "vfolder",
-            "operation": "grant:all"
-        },
-        {
-            "id": "36c2fb37-e7d1-4bee-8ae0-2a1a163674ab",
-            "role_id": "e79d7074-076d-4629-953d-55286b26490c",
-            "scope_type": "project",
-            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
-            "entity_type": "vfolder",
-            "operation": "grant:read"
-        },
-        {
-            "id": "6429cbe3-61b5-4fb3-9c78-b6ffc98520f5",
-            "role_id": "e79d7074-076d-4629-953d-55286b26490c",
-            "scope_type": "project",
-            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
-            "entity_type": "vfolder",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "e9fb43a0-ec50-4c66-b97d-2332c50d382d",
             "role_id": "e79d7074-076d-4629-953d-55286b26490c",
             "scope_type": "project",
@@ -1359,28 +868,12 @@
             "operation": "create"
         },
         {
-            "id": "c14d9b7e-9ea4-4470-a5a8-cc7d89994512",
-            "role_id": "e79d7074-076d-4629-953d-55286b26490c",
-            "scope_type": "project",
-            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
-            "entity_type": "vfolder",
-            "operation": "grant:update"
-        },
-        {
             "id": "04c50bfc-6570-4883-ac81-cab6a6348d83",
             "role_id": "e79d7074-076d-4629-953d-55286b26490c",
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "vfolder",
             "operation": "update"
-        },
-        {
-            "id": "ee4b9397-00a1-4859-a39b-4b2c8a4b1735",
-            "role_id": "e79d7074-076d-4629-953d-55286b26490c",
-            "scope_type": "project",
-            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
-            "entity_type": "vfolder",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "20eb9455-f65e-487b-817c-192cef93d710",
@@ -1407,30 +900,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "870a7e6b-c34d-446b-9515-a6b312598c1c",
-            "role_id": "fe53e90e-f619-43d8-99c8-574487485bab",
-            "scope_type": "user",
-            "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
-            "entity_type": "vfolder",
-            "operation": "grant:all"
-        },
-        {
-            "id": "c2341f98-d604-4a83-8ae4-eba5407670c0",
-            "role_id": "fe53e90e-f619-43d8-99c8-574487485bab",
-            "scope_type": "user",
-            "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
-            "entity_type": "vfolder",
-            "operation": "grant:read"
-        },
-        {
-            "id": "27f86cd0-8d19-452a-8a3d-db66fba4d291",
-            "role_id": "fe53e90e-f619-43d8-99c8-574487485bab",
-            "scope_type": "user",
-            "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
-            "entity_type": "vfolder",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "5b20802f-8eb2-4dbe-a81b-eaf8c127cac3",
             "role_id": "fe53e90e-f619-43d8-99c8-574487485bab",
             "scope_type": "user",
@@ -1439,28 +908,12 @@
             "operation": "create"
         },
         {
-            "id": "613e0cf9-b855-49d1-bb02-7f4c53127e43",
-            "role_id": "fe53e90e-f619-43d8-99c8-574487485bab",
-            "scope_type": "user",
-            "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
-            "entity_type": "vfolder",
-            "operation": "grant:update"
-        },
-        {
             "id": "8c37a121-bc1d-4b64-b0bd-8ccaba358516",
             "role_id": "fe53e90e-f619-43d8-99c8-574487485bab",
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "vfolder",
             "operation": "update"
-        },
-        {
-            "id": "90172aa9-231f-4691-aae5-68b67106f43b",
-            "role_id": "fe53e90e-f619-43d8-99c8-574487485bab",
-            "scope_type": "user",
-            "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
-            "entity_type": "vfolder",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "8195f4f0-aae5-5323-95f1-ae6c72ae7650",
@@ -6130,6 +5583,179 @@
             "entity_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "registered_at": "2025-09-12 09:51:58.265582+00",
             "relation_type": "auto"
+        }
+    ],
+    "role_presets": [
+        {
+            "id": "9ebf4f57-9e67-5631-997a-d2d79cc3815f",
+            "name": "preset_domain_admin",
+            "scope_type": "domain",
+            "auto_assign": false,
+            "deleted": false,
+            "created_at": "2025-09-12 09:51:58.265582+00",
+            "updated_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "22c4db03-24aa-5ff8-b5a9-64b2a2182413",
+            "name": "preset_project_admin",
+            "scope_type": "project",
+            "auto_assign": false,
+            "deleted": false,
+            "created_at": "2025-09-12 09:51:58.265582+00",
+            "updated_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "06057849-3534-546f-b74c-b79d5d3ecf5e",
+            "name": "preset_project_member",
+            "scope_type": "project",
+            "auto_assign": true,
+            "deleted": false,
+            "created_at": "2025-09-12 09:51:58.265582+00",
+            "updated_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "name": "preset_user",
+            "scope_type": "user",
+            "auto_assign": false,
+            "deleted": false,
+            "created_at": "2025-09-12 09:51:58.265582+00",
+            "updated_at": "2025-09-12 09:51:58.265582+00"
+        }
+    ],
+    "role_permission_presets": [
+        {
+            "id": "bb0a5027-216d-5dae-831e-d479611eaed7",
+            "role_preset_id": "9ebf4f57-9e67-5631-997a-d2d79cc3815f",
+            "entity_type": "user",
+            "operation": "create",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "e1b152ed-941c-5610-8aa2-0bfd7b0d338d",
+            "role_preset_id": "9ebf4f57-9e67-5631-997a-d2d79cc3815f",
+            "entity_type": "user",
+            "operation": "hard-delete",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "049ee953-61ea-5605-ac9e-e6a4e4a40f8a",
+            "role_preset_id": "9ebf4f57-9e67-5631-997a-d2d79cc3815f",
+            "entity_type": "user",
+            "operation": "read",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "83ecd0ae-33ba-5516-8394-f8eaa5fbb09d",
+            "role_preset_id": "9ebf4f57-9e67-5631-997a-d2d79cc3815f",
+            "entity_type": "user",
+            "operation": "soft-delete",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "9849cf3c-b40f-55ab-8cad-1578cec97e02",
+            "role_preset_id": "9ebf4f57-9e67-5631-997a-d2d79cc3815f",
+            "entity_type": "user",
+            "operation": "update",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "6cc53d82-7299-50a5-b199-0371e1f7b68b",
+            "role_preset_id": "22c4db03-24aa-5ff8-b5a9-64b2a2182413",
+            "entity_type": "model_deployment",
+            "operation": "create",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "35317d5f-2a28-51ba-845b-77f48a127168",
+            "role_preset_id": "22c4db03-24aa-5ff8-b5a9-64b2a2182413",
+            "entity_type": "model_deployment",
+            "operation": "hard-delete",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "12e1b41d-828c-5e1f-a75c-b115b93cf49f",
+            "role_preset_id": "22c4db03-24aa-5ff8-b5a9-64b2a2182413",
+            "entity_type": "model_deployment",
+            "operation": "read",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "9436c6de-cafe-5842-a1ac-56321a6dd8a1",
+            "role_preset_id": "22c4db03-24aa-5ff8-b5a9-64b2a2182413",
+            "entity_type": "model_deployment",
+            "operation": "update",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "059c527e-e0e6-5d5a-9fd4-3b28f93c7b96",
+            "role_preset_id": "06057849-3534-546f-b74c-b79d5d3ecf5e",
+            "entity_type": "model_deployment",
+            "operation": "read",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "28f11661-be65-5c35-a2a9-cb5494c61737",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "session",
+            "operation": "create",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "13f55c40-9029-56cb-883f-c8b72366c3d9",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "session",
+            "operation": "hard-delete",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "7872c11e-59c2-5e6b-a6d2-bc5c8377503c",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "session",
+            "operation": "read",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "9715fa7e-f837-5de6-8656-88a218a85382",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "session",
+            "operation": "update",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "4ce57936-2f5f-5a7e-ac4a-0ac2438333c6",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "vfolder",
+            "operation": "create",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "1d3eadd8-42cc-5810-b408-784cf045e0e1",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "vfolder",
+            "operation": "hard-delete",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "537dbceb-08c4-586a-896a-de1779b383b5",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "vfolder",
+            "operation": "read",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "03dfd892-f8e6-5993-a3a4-73718a4b9728",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "vfolder",
+            "operation": "soft-delete",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "0ad556c3-c091-5fc4-864b-3573546e55ad",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "vfolder",
+            "operation": "update",
+            "created_at": "2025-09-12 09:51:58.265582+00"
         }
     ]
 }

--- a/src/ai/backend/install/fixtures/example-roles.json
+++ b/src/ai/backend/install/fixtures/example-roles.json
@@ -6,6 +6,7 @@
             "description": "",
             "source": "system",
             "status": "active",
+            "auto_assign": false,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": null,
             "deleted_at": null
@@ -16,6 +17,7 @@
             "description": "",
             "source": "system",
             "status": "active",
+            "auto_assign": false,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": null,
             "deleted_at": null
@@ -26,6 +28,7 @@
             "description": "",
             "source": "system",
             "status": "active",
+            "auto_assign": false,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": null,
             "deleted_at": null
@@ -36,6 +39,7 @@
             "description": "",
             "source": "system",
             "status": "active",
+            "auto_assign": false,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": null,
             "deleted_at": null
@@ -46,6 +50,7 @@
             "description": "",
             "source": "system",
             "status": "active",
+            "auto_assign": false,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": null,
             "deleted_at": null
@@ -56,6 +61,7 @@
             "description": "",
             "source": "system",
             "status": "active",
+            "auto_assign": false,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": null,
             "deleted_at": null
@@ -66,6 +72,7 @@
             "description": "",
             "source": "system",
             "status": "active",
+            "auto_assign": false,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": null,
             "deleted_at": null
@@ -76,6 +83,7 @@
             "description": "",
             "source": "system",
             "status": "active",
+            "auto_assign": false,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": null,
             "deleted_at": null
@@ -86,6 +94,7 @@
             "description": "",
             "source": "system",
             "status": "active",
+            "auto_assign": false,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": null,
             "deleted_at": null
@@ -96,6 +105,7 @@
             "description": "",
             "source": "custom",
             "status": "active",
+            "auto_assign": true,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": null,
             "deleted_at": null
@@ -106,6 +116,7 @@
             "description": "",
             "source": "custom",
             "status": "active",
+            "auto_assign": true,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": null,
             "deleted_at": null
@@ -116,6 +127,7 @@
             "description": "",
             "source": "system",
             "status": "active",
+            "auto_assign": false,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": null,
             "deleted_at": null
@@ -126,6 +138,7 @@
             "description": "",
             "source": "custom",
             "status": "active",
+            "auto_assign": true,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": null,
             "deleted_at": null
@@ -271,30 +284,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "eaf477fd-2600-4bf9-b5e2-65ff7e086efa",
-            "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
-            "scope_type": "user",
-            "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
-            "entity_type": "user",
-            "operation": "grant:all"
-        },
-        {
-            "id": "38cb0b72-a6ee-4c5e-b445-5c032f31b0ec",
-            "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
-            "scope_type": "user",
-            "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
-            "entity_type": "user",
-            "operation": "grant:read"
-        },
-        {
-            "id": "b3ce632d-6b1c-4f5a-be91-0798f9c6f70e",
-            "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
-            "scope_type": "user",
-            "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
-            "entity_type": "user",
-            "operation": "grant:update"
-        },
-        {
             "id": "1da58bf7-1852-4abe-9a54-fdc482d427e4",
             "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
             "scope_type": "user",
@@ -325,30 +314,6 @@
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "user",
             "operation": "hard-delete"
-        },
-        {
-            "id": "30c7952b-4ef5-4d85-b8ca-66609f1bfdb9",
-            "role_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
-            "scope_type": "user",
-            "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
-            "entity_type": "user",
-            "operation": "grant:all"
-        },
-        {
-            "id": "511741cd-528d-43b0-88a0-4def512129b7",
-            "role_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
-            "scope_type": "user",
-            "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
-            "entity_type": "user",
-            "operation": "grant:read"
-        },
-        {
-            "id": "5816b995-05b4-4a37-ac53-f69a5fcc544a",
-            "role_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
-            "scope_type": "user",
-            "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
-            "entity_type": "user",
-            "operation": "grant:update"
         },
         {
             "id": "00642d3d-1b2e-436f-af49-71d6b0612f07",
@@ -383,30 +348,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "f0d0134c-3b26-48e3-b122-7251e1da0d25",
-            "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
-            "scope_type": "user",
-            "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
-            "entity_type": "user",
-            "operation": "grant:all"
-        },
-        {
-            "id": "01cb967b-66aa-4e7b-917b-139a3eeacb05",
-            "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
-            "scope_type": "user",
-            "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
-            "entity_type": "user",
-            "operation": "grant:read"
-        },
-        {
-            "id": "d531c88f-3a49-4526-a817-c70b6f4bae0e",
-            "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
-            "scope_type": "user",
-            "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
-            "entity_type": "user",
-            "operation": "grant:update"
-        },
-        {
             "id": "1d8f17b6-0c47-40a7-b96d-4ac6b267d5c7",
             "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
             "scope_type": "user",
@@ -437,30 +378,6 @@
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "user",
             "operation": "hard-delete"
-        },
-        {
-            "id": "c721492f-cb04-437a-ae31-4161f5a98258",
-            "role_id": "fe53e90e-f619-43d8-99c8-574487485bab",
-            "scope_type": "user",
-            "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
-            "entity_type": "user",
-            "operation": "grant:all"
-        },
-        {
-            "id": "25995814-eea6-480c-9c1a-0e1c4e3b181a",
-            "role_id": "fe53e90e-f619-43d8-99c8-574487485bab",
-            "scope_type": "user",
-            "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
-            "entity_type": "user",
-            "operation": "grant:read"
-        },
-        {
-            "id": "f8030c74-601f-4471-a5de-bb8054f1ea5f",
-            "role_id": "fe53e90e-f619-43d8-99c8-574487485bab",
-            "scope_type": "user",
-            "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
-            "entity_type": "user",
-            "operation": "grant:update"
         },
         {
             "id": "69a4ac81-a174-40e0-8a59-1af4d26cab14",
@@ -495,30 +412,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "3bb26ff5-8546-4475-b772-3fe47326e89b",
-            "role_id": "72293d83-1849-4bb5-a555-80e561515428",
-            "scope_type": "user",
-            "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
-            "entity_type": "user",
-            "operation": "grant:all"
-        },
-        {
-            "id": "c7981ebd-2893-4b5c-8562-61464ed35bc4",
-            "role_id": "72293d83-1849-4bb5-a555-80e561515428",
-            "scope_type": "user",
-            "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
-            "entity_type": "user",
-            "operation": "grant:read"
-        },
-        {
-            "id": "295e890d-e0d4-46bf-8cec-505dcc9c82b5",
-            "role_id": "72293d83-1849-4bb5-a555-80e561515428",
-            "scope_type": "user",
-            "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
-            "entity_type": "user",
-            "operation": "grant:update"
-        },
-        {
             "id": "89a564c5-48d5-4bf5-b35e-70d838746c72",
             "role_id": "72293d83-1849-4bb5-a555-80e561515428",
             "scope_type": "user",
@@ -551,30 +444,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "67505ea3-33f5-441c-89b7-411afca443c5",
-            "role_id": "e79d7074-076d-4629-953d-55286b26490c",
-            "scope_type": "project",
-            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
-            "entity_type": "user",
-            "operation": "grant:all"
-        },
-        {
-            "id": "3e184eac-570e-4408-98e1-e303887d10c6",
-            "role_id": "e79d7074-076d-4629-953d-55286b26490c",
-            "scope_type": "project",
-            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
-            "entity_type": "user",
-            "operation": "grant:read"
-        },
-        {
-            "id": "498579ba-5deb-4b6d-a37e-8c788caeba2d",
-            "role_id": "e79d7074-076d-4629-953d-55286b26490c",
-            "scope_type": "project",
-            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
-            "entity_type": "user",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "d56c152e-2d20-4870-90bf-65e5df4baa72",
             "role_id": "e79d7074-076d-4629-953d-55286b26490c",
             "scope_type": "project",
@@ -583,28 +452,12 @@
             "operation": "create"
         },
         {
-            "id": "fbf85b23-caad-487f-af43-a2319b0db0a8",
-            "role_id": "e79d7074-076d-4629-953d-55286b26490c",
-            "scope_type": "project",
-            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
-            "entity_type": "user",
-            "operation": "grant:update"
-        },
-        {
             "id": "ce345c7e-d436-41fe-a257-ab178eeb310f",
             "role_id": "e79d7074-076d-4629-953d-55286b26490c",
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "user",
             "operation": "update"
-        },
-        {
-            "id": "f108a953-8c87-4392-b71d-3fe4cfb51e2b",
-            "role_id": "e79d7074-076d-4629-953d-55286b26490c",
-            "scope_type": "project",
-            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
-            "entity_type": "user",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "c42fde9e-7480-4108-8583-de8289f7c139",
@@ -631,30 +484,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "96a1fbb7-8c0e-4041-9216-96eb4e9484c7",
-            "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
-            "scope_type": "project",
-            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
-            "entity_type": "user",
-            "operation": "grant:all"
-        },
-        {
-            "id": "1f72c6e4-aec9-472d-9c3d-eacd7b0bbe9a",
-            "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
-            "scope_type": "project",
-            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
-            "entity_type": "user",
-            "operation": "grant:read"
-        },
-        {
-            "id": "e09fbd1e-91e0-4037-913d-95e87b9aa4e5",
-            "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
-            "scope_type": "project",
-            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
-            "entity_type": "user",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "9e56aaa7-b23e-45a2-80eb-afdf77651d30",
             "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
             "scope_type": "project",
@@ -663,28 +492,12 @@
             "operation": "create"
         },
         {
-            "id": "9f67a7c0-826d-4bb1-80b4-7511dd26c3ec",
-            "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
-            "scope_type": "project",
-            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
-            "entity_type": "user",
-            "operation": "grant:update"
-        },
-        {
             "id": "f8889e4b-2943-49a6-b8da-3019f6129573",
             "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "user",
             "operation": "update"
-        },
-        {
-            "id": "9354dc64-36eb-4bc5-8479-fc6c8babe724",
-            "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
-            "scope_type": "project",
-            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
-            "entity_type": "user",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "3373279c-4cc4-4642-99d1-e2ea48c1f70d",
@@ -743,30 +556,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "d33e5824-47ba-4c5e-bc43-10446766bc21",
-            "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
-            "scope_type": "domain",
-            "scope_id": "default",
-            "entity_type": "user",
-            "operation": "grant:all"
-        },
-        {
-            "id": "4673f9f9-e8d1-4048-aaf0-8eb83f455be4",
-            "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
-            "scope_type": "domain",
-            "scope_id": "default",
-            "entity_type": "user",
-            "operation": "grant:read"
-        },
-        {
-            "id": "13bc38dd-2aba-4903-8848-5b0440726dac",
-            "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
-            "scope_type": "domain",
-            "scope_id": "default",
-            "entity_type": "user",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "2ea152ff-5e28-4e96-9908-3ee1e0b99718",
             "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
             "scope_type": "domain",
@@ -775,28 +564,12 @@
             "operation": "create"
         },
         {
-            "id": "afb84a96-3382-49cc-b4f6-b98ee525757a",
-            "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
-            "scope_type": "domain",
-            "scope_id": "default",
-            "entity_type": "user",
-            "operation": "grant:update"
-        },
-        {
             "id": "7f15717c-e918-4673-9307-5f26c84ff95f",
             "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "user",
             "operation": "update"
-        },
-        {
-            "id": "89781589-69a7-486d-b270-1d358de43813",
-            "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
-            "scope_type": "domain",
-            "scope_id": "default",
-            "entity_type": "user",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "d6c2fe69-619d-4ccd-a559-e04cc1667f34",
@@ -839,30 +612,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "3b3b8aee-27d8-410e-991b-d08a82e43c20",
-            "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
-            "scope_type": "user",
-            "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
-            "entity_type": "vfolder",
-            "operation": "grant:all"
-        },
-        {
-            "id": "31556a94-4673-44a1-90b4-1e9e63d76e43",
-            "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
-            "scope_type": "user",
-            "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
-            "entity_type": "vfolder",
-            "operation": "grant:read"
-        },
-        {
-            "id": "0c2bea28-ac10-41a5-8a25-23ee0d952bbd",
-            "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
-            "scope_type": "user",
-            "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
-            "entity_type": "vfolder",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "769a6025-e3dc-416e-8916-e7a42c52e179",
             "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
             "scope_type": "user",
@@ -871,28 +620,12 @@
             "operation": "create"
         },
         {
-            "id": "e885ef78-53e3-4a15-b18e-b4020d47cb08",
-            "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
-            "scope_type": "user",
-            "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
-            "entity_type": "vfolder",
-            "operation": "grant:update"
-        },
-        {
             "id": "5e1110d5-894c-4fef-9785-b4874730088a",
             "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "vfolder",
             "operation": "update"
-        },
-        {
-            "id": "e78c0613-ee99-4a98-87d3-74227a826c62",
-            "role_id": "31f74f6d-04f7-418b-b375-ab0c39fa3058",
-            "scope_type": "user",
-            "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
-            "entity_type": "vfolder",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "9c618332-3ce0-43d2-8b6f-6d30cb07aac0",
@@ -919,30 +652,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "69770d2a-dc0c-4889-8e90-8f625c884c1b",
-            "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
-            "scope_type": "domain",
-            "scope_id": "default",
-            "entity_type": "vfolder",
-            "operation": "grant:all"
-        },
-        {
-            "id": "7da00b30-0f35-483e-8aec-e4ebad3d1f28",
-            "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
-            "scope_type": "domain",
-            "scope_id": "default",
-            "entity_type": "vfolder",
-            "operation": "grant:read"
-        },
-        {
-            "id": "c80430aa-1fa4-42d4-8c14-26eacfb4a4cf",
-            "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
-            "scope_type": "domain",
-            "scope_id": "default",
-            "entity_type": "vfolder",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "a3f179f7-00a7-4b24-9e38-612ead26c7e9",
             "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
             "scope_type": "domain",
@@ -951,28 +660,12 @@
             "operation": "create"
         },
         {
-            "id": "6c623ec8-6ee6-4aae-9a88-9f5945133d69",
-            "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
-            "scope_type": "domain",
-            "scope_id": "default",
-            "entity_type": "vfolder",
-            "operation": "grant:update"
-        },
-        {
             "id": "6643f5b8-260a-497f-92a5-4fb105b8b209",
             "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "vfolder",
             "operation": "update"
-        },
-        {
-            "id": "2214f12f-6061-45a3-9b71-004ef49bbc2b",
-            "role_id": "416fca68-f247-457b-ac83-32a0a45bb7d1",
-            "scope_type": "domain",
-            "scope_id": "default",
-            "entity_type": "vfolder",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "87bd823f-2d49-4455-821a-d45637318018",
@@ -999,30 +692,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "2ee949d0-07dd-4ed4-8e73-a3b088d27b54",
-            "role_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
-            "scope_type": "user",
-            "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
-            "entity_type": "vfolder",
-            "operation": "grant:all"
-        },
-        {
-            "id": "c0f03d31-fb44-4dac-bd4e-928241e90b76",
-            "role_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
-            "scope_type": "user",
-            "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
-            "entity_type": "vfolder",
-            "operation": "grant:read"
-        },
-        {
-            "id": "6533c51b-aa0e-4c0c-994d-0bfe3b2b3d61",
-            "role_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
-            "scope_type": "user",
-            "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
-            "entity_type": "vfolder",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "2b7f8ce0-a12b-450d-86e6-a9f305914a5c",
             "role_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
             "scope_type": "user",
@@ -1031,28 +700,12 @@
             "operation": "create"
         },
         {
-            "id": "906f3c11-f575-4575-aa5c-b75f7388df76",
-            "role_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
-            "scope_type": "user",
-            "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
-            "entity_type": "vfolder",
-            "operation": "grant:update"
-        },
-        {
             "id": "caf9cdf1-259e-4d25-a28b-378b105502d1",
             "role_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "vfolder",
             "operation": "update"
-        },
-        {
-            "id": "882353e4-ebda-496e-9886-c21381071545",
-            "role_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
-            "scope_type": "user",
-            "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
-            "entity_type": "vfolder",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "83e8cc68-dcf5-414f-bbb1-da4d58cd1ddc",
@@ -1079,30 +732,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "cd36930c-6664-4d1e-80ee-b5c96fe2b50b",
-            "role_id": "72293d83-1849-4bb5-a555-80e561515428",
-            "scope_type": "user",
-            "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
-            "entity_type": "vfolder",
-            "operation": "grant:all"
-        },
-        {
-            "id": "6ce45c57-16bb-4225-856c-1d9681919ce5",
-            "role_id": "72293d83-1849-4bb5-a555-80e561515428",
-            "scope_type": "user",
-            "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
-            "entity_type": "vfolder",
-            "operation": "grant:read"
-        },
-        {
-            "id": "e18c8dd0-5d2e-4d07-a672-ce88ab148674",
-            "role_id": "72293d83-1849-4bb5-a555-80e561515428",
-            "scope_type": "user",
-            "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
-            "entity_type": "vfolder",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "6d1507ca-7897-495e-96c4-153fbd965df2",
             "role_id": "72293d83-1849-4bb5-a555-80e561515428",
             "scope_type": "user",
@@ -1111,28 +740,12 @@
             "operation": "create"
         },
         {
-            "id": "5fc39ce9-a3f4-4b50-a2ac-20baa3957a67",
-            "role_id": "72293d83-1849-4bb5-a555-80e561515428",
-            "scope_type": "user",
-            "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
-            "entity_type": "vfolder",
-            "operation": "grant:update"
-        },
-        {
             "id": "ab19dedf-0f82-45c1-919e-ebf7d712fc64",
             "role_id": "72293d83-1849-4bb5-a555-80e561515428",
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "vfolder",
             "operation": "update"
-        },
-        {
-            "id": "d0395b7a-b072-4d01-995b-0ac015b3cfe0",
-            "role_id": "72293d83-1849-4bb5-a555-80e561515428",
-            "scope_type": "user",
-            "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
-            "entity_type": "vfolder",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "87db7417-6cab-4168-8772-c0bbb374521f",
@@ -1167,30 +780,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "eafd220f-c1b3-4d63-8aeb-9db6dae1e43f",
-            "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
-            "scope_type": "user",
-            "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
-            "entity_type": "vfolder",
-            "operation": "grant:all"
-        },
-        {
-            "id": "dbcd2029-bb8e-49c7-817c-207b894eef6b",
-            "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
-            "scope_type": "user",
-            "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
-            "entity_type": "vfolder",
-            "operation": "grant:read"
-        },
-        {
-            "id": "955d2eea-f9f7-4283-afc8-27a0b70cab2b",
-            "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
-            "scope_type": "user",
-            "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
-            "entity_type": "vfolder",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "ebdd4a33-4c36-417c-8566-3d27f259d4d0",
             "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
             "scope_type": "user",
@@ -1199,28 +788,12 @@
             "operation": "create"
         },
         {
-            "id": "b6cd3798-5fd4-4ea6-9c49-9c8413a3a5f9",
-            "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
-            "scope_type": "user",
-            "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
-            "entity_type": "vfolder",
-            "operation": "grant:update"
-        },
-        {
             "id": "9db1ba31-982d-4923-844d-25e395041112",
             "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "vfolder",
             "operation": "update"
-        },
-        {
-            "id": "ecdddec8-2b11-4e99-a524-9d8c9c1935bb",
-            "role_id": "cb0768f1-3b35-415d-beef-8916a5c3c88b",
-            "scope_type": "user",
-            "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
-            "entity_type": "vfolder",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "8b2e5c19-d887-412a-a7de-1cb67b38fd55",
@@ -1247,30 +820,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "96cb3c4e-da0c-4a30-b5af-82139d5bd47d",
-            "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
-            "scope_type": "project",
-            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
-            "entity_type": "vfolder",
-            "operation": "grant:all"
-        },
-        {
-            "id": "f5a7b8cc-da37-4e4f-b368-f737fb85cd18",
-            "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
-            "scope_type": "project",
-            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
-            "entity_type": "vfolder",
-            "operation": "grant:read"
-        },
-        {
-            "id": "7a0a5dcb-ee92-418b-bfee-5bfd5dc01a47",
-            "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
-            "scope_type": "project",
-            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
-            "entity_type": "vfolder",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "ce3af414-a03d-46c1-8e54-fba9a7c78181",
             "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
             "scope_type": "project",
@@ -1279,28 +828,12 @@
             "operation": "create"
         },
         {
-            "id": "e90dcf63-808a-4496-b358-110282de031d",
-            "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
-            "scope_type": "project",
-            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
-            "entity_type": "vfolder",
-            "operation": "grant:update"
-        },
-        {
             "id": "9769f2cb-561e-4039-9c5d-11bfaa6596e2",
             "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "vfolder",
             "operation": "update"
-        },
-        {
-            "id": "e7da6862-a786-4354-a450-bf043345e985",
-            "role_id": "d1b9c1af-9b2f-447c-82bc-a5278e01f89e",
-            "scope_type": "project",
-            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
-            "entity_type": "vfolder",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "a36ec117-3293-4905-b5d6-2271e6b36055",
@@ -1327,30 +860,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "f7088480-c5be-434d-b6a0-1c52a94b3a37",
-            "role_id": "e79d7074-076d-4629-953d-55286b26490c",
-            "scope_type": "project",
-            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
-            "entity_type": "vfolder",
-            "operation": "grant:all"
-        },
-        {
-            "id": "36c2fb37-e7d1-4bee-8ae0-2a1a163674ab",
-            "role_id": "e79d7074-076d-4629-953d-55286b26490c",
-            "scope_type": "project",
-            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
-            "entity_type": "vfolder",
-            "operation": "grant:read"
-        },
-        {
-            "id": "6429cbe3-61b5-4fb3-9c78-b6ffc98520f5",
-            "role_id": "e79d7074-076d-4629-953d-55286b26490c",
-            "scope_type": "project",
-            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
-            "entity_type": "vfolder",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "e9fb43a0-ec50-4c66-b97d-2332c50d382d",
             "role_id": "e79d7074-076d-4629-953d-55286b26490c",
             "scope_type": "project",
@@ -1359,28 +868,12 @@
             "operation": "create"
         },
         {
-            "id": "c14d9b7e-9ea4-4470-a5a8-cc7d89994512",
-            "role_id": "e79d7074-076d-4629-953d-55286b26490c",
-            "scope_type": "project",
-            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
-            "entity_type": "vfolder",
-            "operation": "grant:update"
-        },
-        {
             "id": "04c50bfc-6570-4883-ac81-cab6a6348d83",
             "role_id": "e79d7074-076d-4629-953d-55286b26490c",
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "vfolder",
             "operation": "update"
-        },
-        {
-            "id": "ee4b9397-00a1-4859-a39b-4b2c8a4b1735",
-            "role_id": "e79d7074-076d-4629-953d-55286b26490c",
-            "scope_type": "project",
-            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
-            "entity_type": "vfolder",
-            "operation": "grant:soft-delete"
         },
         {
             "id": "20eb9455-f65e-487b-817c-192cef93d710",
@@ -1407,30 +900,6 @@
             "operation": "hard-delete"
         },
         {
-            "id": "870a7e6b-c34d-446b-9515-a6b312598c1c",
-            "role_id": "fe53e90e-f619-43d8-99c8-574487485bab",
-            "scope_type": "user",
-            "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
-            "entity_type": "vfolder",
-            "operation": "grant:all"
-        },
-        {
-            "id": "c2341f98-d604-4a83-8ae4-eba5407670c0",
-            "role_id": "fe53e90e-f619-43d8-99c8-574487485bab",
-            "scope_type": "user",
-            "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
-            "entity_type": "vfolder",
-            "operation": "grant:read"
-        },
-        {
-            "id": "27f86cd0-8d19-452a-8a3d-db66fba4d291",
-            "role_id": "fe53e90e-f619-43d8-99c8-574487485bab",
-            "scope_type": "user",
-            "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
-            "entity_type": "vfolder",
-            "operation": "grant:hard-delete"
-        },
-        {
             "id": "5b20802f-8eb2-4dbe-a81b-eaf8c127cac3",
             "role_id": "fe53e90e-f619-43d8-99c8-574487485bab",
             "scope_type": "user",
@@ -1439,28 +908,12 @@
             "operation": "create"
         },
         {
-            "id": "613e0cf9-b855-49d1-bb02-7f4c53127e43",
-            "role_id": "fe53e90e-f619-43d8-99c8-574487485bab",
-            "scope_type": "user",
-            "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
-            "entity_type": "vfolder",
-            "operation": "grant:update"
-        },
-        {
             "id": "8c37a121-bc1d-4b64-b0bd-8ccaba358516",
             "role_id": "fe53e90e-f619-43d8-99c8-574487485bab",
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "vfolder",
             "operation": "update"
-        },
-        {
-            "id": "90172aa9-231f-4691-aae5-68b67106f43b",
-            "role_id": "fe53e90e-f619-43d8-99c8-574487485bab",
-            "scope_type": "user",
-            "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
-            "entity_type": "vfolder",
-            "operation": "grant:soft-delete"
         }
     ],
     "association_scopes_entities": [
@@ -1562,6 +1015,179 @@
             "entity_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "registered_at": "2025-09-12 09:51:58.265582+00",
             "relation_type": "auto"
+        }
+    ],
+    "role_presets": [
+        {
+            "id": "9ebf4f57-9e67-5631-997a-d2d79cc3815f",
+            "name": "preset_domain_admin",
+            "scope_type": "domain",
+            "auto_assign": false,
+            "deleted": false,
+            "created_at": "2025-09-12 09:51:58.265582+00",
+            "updated_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "22c4db03-24aa-5ff8-b5a9-64b2a2182413",
+            "name": "preset_project_admin",
+            "scope_type": "project",
+            "auto_assign": false,
+            "deleted": false,
+            "created_at": "2025-09-12 09:51:58.265582+00",
+            "updated_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "06057849-3534-546f-b74c-b79d5d3ecf5e",
+            "name": "preset_project_member",
+            "scope_type": "project",
+            "auto_assign": true,
+            "deleted": false,
+            "created_at": "2025-09-12 09:51:58.265582+00",
+            "updated_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "name": "preset_user",
+            "scope_type": "user",
+            "auto_assign": false,
+            "deleted": false,
+            "created_at": "2025-09-12 09:51:58.265582+00",
+            "updated_at": "2025-09-12 09:51:58.265582+00"
+        }
+    ],
+    "role_permission_presets": [
+        {
+            "id": "bb0a5027-216d-5dae-831e-d479611eaed7",
+            "role_preset_id": "9ebf4f57-9e67-5631-997a-d2d79cc3815f",
+            "entity_type": "user",
+            "operation": "create",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "e1b152ed-941c-5610-8aa2-0bfd7b0d338d",
+            "role_preset_id": "9ebf4f57-9e67-5631-997a-d2d79cc3815f",
+            "entity_type": "user",
+            "operation": "hard-delete",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "049ee953-61ea-5605-ac9e-e6a4e4a40f8a",
+            "role_preset_id": "9ebf4f57-9e67-5631-997a-d2d79cc3815f",
+            "entity_type": "user",
+            "operation": "read",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "83ecd0ae-33ba-5516-8394-f8eaa5fbb09d",
+            "role_preset_id": "9ebf4f57-9e67-5631-997a-d2d79cc3815f",
+            "entity_type": "user",
+            "operation": "soft-delete",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "9849cf3c-b40f-55ab-8cad-1578cec97e02",
+            "role_preset_id": "9ebf4f57-9e67-5631-997a-d2d79cc3815f",
+            "entity_type": "user",
+            "operation": "update",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "6cc53d82-7299-50a5-b199-0371e1f7b68b",
+            "role_preset_id": "22c4db03-24aa-5ff8-b5a9-64b2a2182413",
+            "entity_type": "model_deployment",
+            "operation": "create",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "35317d5f-2a28-51ba-845b-77f48a127168",
+            "role_preset_id": "22c4db03-24aa-5ff8-b5a9-64b2a2182413",
+            "entity_type": "model_deployment",
+            "operation": "hard-delete",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "12e1b41d-828c-5e1f-a75c-b115b93cf49f",
+            "role_preset_id": "22c4db03-24aa-5ff8-b5a9-64b2a2182413",
+            "entity_type": "model_deployment",
+            "operation": "read",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "9436c6de-cafe-5842-a1ac-56321a6dd8a1",
+            "role_preset_id": "22c4db03-24aa-5ff8-b5a9-64b2a2182413",
+            "entity_type": "model_deployment",
+            "operation": "update",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "059c527e-e0e6-5d5a-9fd4-3b28f93c7b96",
+            "role_preset_id": "06057849-3534-546f-b74c-b79d5d3ecf5e",
+            "entity_type": "model_deployment",
+            "operation": "read",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "28f11661-be65-5c35-a2a9-cb5494c61737",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "session",
+            "operation": "create",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "13f55c40-9029-56cb-883f-c8b72366c3d9",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "session",
+            "operation": "hard-delete",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "7872c11e-59c2-5e6b-a6d2-bc5c8377503c",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "session",
+            "operation": "read",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "9715fa7e-f837-5de6-8656-88a218a85382",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "session",
+            "operation": "update",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "4ce57936-2f5f-5a7e-ac4a-0ac2438333c6",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "vfolder",
+            "operation": "create",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "1d3eadd8-42cc-5810-b408-784cf045e0e1",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "vfolder",
+            "operation": "hard-delete",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "537dbceb-08c4-586a-896a-de1779b383b5",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "vfolder",
+            "operation": "read",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "03dfd892-f8e6-5993-a3a4-73718a4b9728",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "vfolder",
+            "operation": "soft-delete",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "0ad556c3-c091-5fc4-864b-3573546e55ad",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "vfolder",
+            "operation": "update",
+            "created_at": "2025-09-12 09:51:58.265582+00"
         }
     ]
 }


### PR DESCRIPTION
## Summary
- Add an `auto_assign` field to every role in both `example-roles.json` fixtures (`fixtures/manager/` and `src/ai/backend/install/fixtures/`); set `true` only for `*_member` roles.
- Add `role_presets` and `role_permission_presets` sections. Presets mirror the admin/member/user archetypes per scope_type; each preset's permissions are the archetype role's permissions intersected with the `rbac_permission_matrix` (only enforceable RBAC permissions). The empty domain-member preset is omitted.
- Remove all `grant:*` operation permissions from the `permissions` section.

## Verification
- Both fixtures validate as JSON; enum values check against `ScopeType` / `EntityType` / `OperationType`.
- Loaded the new preset sections via `populate_fixture` against a live DB and queried them with `./bai admin role-preset search` — all 4 presets load with correct `scope_type` and `auto_assign`.

Resolves BA-6279