### PR TITLE
chore: Promote unmatched glob & unowned dependency warnings into errors

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -30,6 +30,7 @@ pants_ignore = [
     "/wheelhouse/*.whl"
 ]
 build_file_prelude_globs = ["tools/build-macros.py"]
+unmatched_build_file_globs = "error"
 
 [anonymous-telemetry]
 enabled = false
@@ -81,6 +82,7 @@ search_path = ["<PYENV>"]
 
 [python-infer]
 use_rust_parser = true
+unowned_dependency_behavior = "error"
 
 # This slows down `generate-lockfiles` severely. Enable only when strictly needed.
 # [python-repos]

--- a/tests/unit/manager/sokovan/scheduling_controller/validators/BUILD
+++ b/tests/unit/manager/sokovan/scheduling_controller/validators/BUILD
@@ -1,8 +1,3 @@
-python_test_utils(
-    name="test_utils",
-    sources=["conftest.py"],
-)
-
 python_tests(
     name="tests",
 )

--- a/tests/unit/web/clients/BUILD
+++ b/tests/unit/web/clients/BUILD
@@ -1,3 +1,6 @@
-python_tests(
-    name="tests",
+python_test_utils(
+    sources=[
+        "*.py",
+        "!test_*.py",
+    ],
 )


### PR DESCRIPTION
Finally, I found the pants option to promote the unmatched glob warnings into errors.

This PR promotes both unmatched globs of BUILD files and unowned dependencies found in the `python-infer` subsystem into explicit errors.

Example (before):
<img width="1279" height="381" alt="image" src="https://github.com/user-attachments/assets/35dfc313-5401-4d0c-8238-0a63a07803cc" />

Example (after):
<img width="1280" height="660" alt="image" src="https://github.com/user-attachments/assets/a38bd24a-020f-4488-b7dc-f1406394b75a" />
