### PR TITLE
fix(BA-6280): resolve_session_id accepts session name or id

### DIFF
--- a/changes/11934.fix.md
+++ b/changes/11934.fix.md
@@ -1,0 +1,1 @@
+Fix legacy session resolvers raising `SessionNotFound` (404) for a live session referenced by its session ID, by resolving a session ID or name interchangeably.

--- a/src/ai/backend/manager/repositories/session/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/session/db_source/db_source.py
@@ -69,17 +69,22 @@ class SessionDBSource:
 
     async def resolve_session_id(
         self,
-        session_name: str,
+        session_name_or_id: str,
         user_id: uuid.UUID,
     ) -> SessionId:
-        """Resolve a single live session to its ``session_id`` by name within a user scope.
+        """Infer a session id from ``(session_name_or_id, user_id)`` for legacy callers.
 
-        The ``user_id`` scope spans every keypair access key owned by the user, since the
-        owner is denormalized onto ``SessionRow.user_uuid``. Terminal sessions (ERROR,
-        TERMINATED, CANCELLED) are excluded so a stale namesake does not shadow the live
-        one. This matches the `ix_sessions_unique_name_per_user_nonterminal` partial unique
-        index, which guarantees at most one matching session.
+        The goal is to derive a usable session id when only a name is known, not to return
+        a validated one. A UUID-shaped input is already an id and is returned verbatim;
+        otherwise the live (non-terminal) session owned by the user with that name is
+        resolved, matching the ``ix_sessions_unique_name_per_user_nonterminal`` partial
+        unique index. DO NOT USE FOR NEW DEVELOPMENT.
         """
+        try:
+            return SessionId(uuid.UUID(session_name_or_id))
+        except (ValueError, TypeError):
+            pass
+        session_name = session_name_or_id
         query = sa.select(SessionRow).where(
             (SessionRow.name == session_name)
             & (SessionRow.user_uuid == user_id)

--- a/src/ai/backend/manager/repositories/session/repository.py
+++ b/src/ai/backend/manager/repositories/session/repository.py
@@ -61,16 +61,20 @@ class SessionRepository:
     @session_repository_resilience.apply()
     async def resolve_session_id(
         self,
-        session_name: str,
+        session_name_or_id: str,
         user_id: uuid.UUID,
     ) -> SessionId:
-        """Resolve a live session to its ``session_id`` by ``(session_name, user_id)``.
+        """Infer a session id from ``(session_name_or_id, user_id)`` for legacy callers.
 
-        The ``user_id`` scope covers sessions created with any of the user's keypair
-        access keys. Raises ``SessionNotFound`` when unresolved and
-        ``TooManySessionsMatched`` when more than one live session shares the name.
+        The goal is to derive a usable session id when only a name is known, not to return
+        a validated one — ownership and state checks are the caller's job. A UUID-shaped
+        input is already an id and is returned as-is; otherwise the live session owned by
+        the user with that name is looked up. DO NOT USE FOR NEW DEVELOPMENT.
+
+        Raises ``SessionNotFound`` when a name resolves to no live session and
+        ``TooManySessionsMatched`` when more than one shares the name.
         """
-        return await self._db_source.resolve_session_id(session_name, user_id)
+        return await self._db_source.resolve_session_id(session_name_or_id, user_id)
 
     @session_repository_resilience.apply()
     async def get_session_validated(

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -292,6 +292,7 @@ class SessionService:
 
     async def resolve_session(self, action: ResolveSessionAction) -> ResolveSessionActionResult:
         """Resolve a live session to its ``session_id`` by ``(session_name, user_id)``.
+        DO NOT USE THIS FOR NEW DEVELOPMENT. This is only for backward compatibility with existing resolvers.
 
         Callers go through this resolver before invoking any other session operation, so
         that downstream lookups can rely solely on ``session_id``. The ``user_id`` scope

--- a/tests/unit/manager/repositories/session/test_session_repository.py
+++ b/tests/unit/manager/repositories/session/test_session_repository.py
@@ -505,6 +505,18 @@ class TestSessionRepository:
         resolved = await repository.resolve_session_id("test-session", session_with_kernel.user_id)
         assert resolved == session_with_kernel.session_id
 
+    async def test_resolve_session_id_returns_uuid_input_as_is(
+        self,
+        repository: SessionRepository,
+        session_with_kernel: SessionTestData,
+    ) -> None:
+        """A UUID-shaped input is already a session id, so it is returned verbatim without
+        a name lookup. This resolver only disambiguates name-vs-id for legacy callers, so an
+        arbitrary UUID resolves to itself even when no such session exists."""
+        some_id = uuid.uuid4()
+        resolved = await repository.resolve_session_id(str(some_id), session_with_kernel.user_id)
+        assert resolved == SessionId(some_id)
+
     # =========================================================================
     # Tests - get_session_with_routing_minimal
     # =========================================================================


### PR DESCRIPTION
## Summary
- `resolve_session_id` now accepts either a session name or a session id via the renamed `session_name_or_id` parameter
- When the argument is already a valid UUID, it short-circuits to that session id instead of doing a name-only lookup
- Fixes the case where callers pass a session id into the name field and a live, RUNNING session wrongly returns `SessionNotFound` (404), e.g. `POST /v2/sessions/{id}/start-service`

## Test plan
- [x] `POST /v2/sessions/{id}/start-service` succeeds for a live session referenced by id
- [x] Name-based resolution still works for callers passing an actual session name

Resolves BA-6280