### PR TITLE
docs: clarify single/batch/bulk CRUD target semantics

### DIFF
--- a/.claude/skills/api-guide/SKILL.md
+++ b/.claude/skills/api-guide/SKILL.md
@@ -28,7 +28,7 @@ APIs implement 6 standard operations:
 5. **delete** - Delete entity (soft)
 6. **purge** - Permanently remove entity (hard)
 
-**Batch operations:** `batch_update`, `batch_delete`, `batch_purge`
+**Multi-target:** `batch_*` (atomic, one statement) vs `bulk_*` (per-row, partial failures). See `/repository-guide`.
 
 ## Scope Prefix Rules
 

--- a/.claude/skills/repository-guide/SKILL.md
+++ b/.claude/skills/repository-guide/SKILL.md
@@ -21,10 +21,10 @@ Repositories implement 6 standard operations:
 5. **delete** - Soft delete (status change)
 6. **purge** - Hard delete (permanent removal)
 
-**Batch operations:**
-- `batch_update` - Update multiple entities
-- `batch_delete` - Soft delete multiple entities
-- `batch_purge` - Hard delete multiple entities
+**Target semantics:**
+- **Single** (`create`/`get`/`update`/`delete`/`purge`) — one row by PK.
+- **Batch** (`batch_*`) — many rows in one SQL statement, **atomic** (all-or-nothing); returns only the affected-row count.
+- **Bulk** (`bulk_*`) — rows processed individually, **partial failures allowed** (returns successes + errors).
 
 **Method naming (no prefix):**
 ```python
@@ -34,9 +34,11 @@ await repository.search(scope, filters, pagination)
 await repository.update(id, data)
 await repository.delete(id)
 await repository.purge(id)
-await repository.batch_update(ids, data)
+await repository.batch_update(ids, data)   # atomic
 await repository.batch_delete(ids)
 await repository.batch_purge(ids)
+await repository.bulk_create(specs)         # partial failures allowed
+await repository.bulk_upsert(specs)
 ```
 
 ## Base Utilities
@@ -64,7 +66,8 @@ Multi-tenant access control for queries.
 - `BatchQuerier[TRow]` - Search with filters and pagination
 - `Updater[TRow]` - Update with OptionalState pattern
 - `Purger[TRow]` - Hard delete operations
-- `BatchUpdater[TRow]`, `BatchPurger[TRow]` - Batch operations
+- `BatchUpdater[TRow]`, `BatchPurger[TRow]` - atomic multi-row (single statement)
+- `BulkCreator[TRow]`, `BulkUpserter[TRow]` - per-row with partial failures (`execute_bulk_*_partial`)
 
 **See implementations:**
 - `repositories/base/` - Base utility source code

--- a/.claude/skills/service-guide/SKILL.md
+++ b/.claude/skills/service-guide/SKILL.md
@@ -27,7 +27,7 @@ Services implement 6 standard operations:
 5. **delete** - Delete entity
 6. **purge** - Permanently remove entity
 
-**Batch operations:** `batch_update`, `batch_delete`, `batch_purge`
+**Multi-target:** `batch_*` (atomic, one statement) vs `bulk_*` (per-row, partial failures). See `/repository-guide`.
 
 **Method naming (no prefix):**
 ```python

--- a/changes/11937.doc.md
+++ b/changes/11937.doc.md
@@ -1,0 +1,1 @@
+Document single/batch/bulk CRUD target semantics across skill guides and component READMEs

--- a/src/ai/backend/manager/api/README.md
+++ b/src/ai/backend/manager/api/README.md
@@ -34,8 +34,9 @@ APIs implement 6 standard operations:
 5. **delete** - Delete entity (soft)
 6. **purge** - Permanently remove entity (hard)
 
-**Batch operations:**
-- `batch_update`, `batch_delete`, `batch_purge`
+**Multi-target operations** — two semantics:
+- **Batch** (`batch_*`): many rows in one SQL statement, **atomic** (all-or-nothing); returns only the affected-row count. e.g. `batch_update`, `batch_delete`, `batch_purge`.
+- **Bulk** (`bulk_*`): rows processed individually, **partial failures allowed** (returns successes + errors). e.g. `bulk_create`, `bulk_upsert`.
 
 ## Scope Prefix Rules
 

--- a/src/ai/backend/manager/repositories/README.md
+++ b/src/ai/backend/manager/repositories/README.md
@@ -29,10 +29,9 @@ Repositories implement 6 standard operations:
 5. **delete** - Soft delete (status change)
 6. **purge** - Hard delete (permanent removal)
 
-**Batch operations:**
-- `batch_update` - Update multiple entities
-- `batch_delete` - Soft delete multiple entities
-- `batch_purge` - Hard delete multiple entities
+**Multi-target operations** — two semantics:
+- **Batch** (`batch_*`): many rows in one SQL statement, **atomic** (all-or-nothing); returns only the affected-row count. e.g. `batch_update`, `batch_delete`, `batch_purge`.
+- **Bulk** (`bulk_*`): rows processed individually, **partial failures allowed** (returns successes + errors). e.g. `bulk_create`, `bulk_upsert`.
 
 **Method naming (no prefix):**
 ```python
@@ -42,9 +41,11 @@ await repository.search(scope, filters, pagination)
 await repository.update(id, data)
 await repository.delete(id)
 await repository.purge(id)
-await repository.batch_update(ids, data)
+await repository.batch_update(ids, data)   # atomic
 await repository.batch_delete(ids)
 await repository.batch_purge(ids)
+await repository.bulk_create(specs)         # partial failures allowed
+await repository.bulk_upsert(specs)
 ```
 
 **Note:** Getter methods use entity name (e.g., `user(id)`, `session(id)`) instead of `get_entity(id)`.

--- a/src/ai/backend/manager/services/README.md
+++ b/src/ai/backend/manager/services/README.md
@@ -31,10 +31,9 @@ Services implement 6 standard operations:
 5. **delete** - Delete entity
 6. **purge** - Permanently remove entity
 
-**Batch operations:**
-- `batch_update` - Update multiple entities
-- `batch_delete` - Delete multiple entities
-- `batch_purge` - Permanently remove multiple entities
+**Multi-target operations** — two semantics:
+- **Batch** (`batch_*`): many rows in one SQL statement, **atomic** (all-or-nothing); returns only the affected-row count. e.g. `batch_update`, `batch_delete`, `batch_purge`.
+- **Bulk** (`bulk_*`): rows processed individually, **partial failures allowed** (returns successes + errors). e.g. `bulk_create`, `bulk_upsert`.
 
 **Method naming (no prefix):**
 ```python


### PR DESCRIPTION
## Summary
- Define the three multi-target CRUD operation semantics consistently across skill guides and component READMEs
- **Single**: one row by PK; **Batch** (`batch_*`): one SQL statement, atomic (all-or-nothing), returns only the affected-row count; **Bulk** (`bulk_*`): per-row processing, partial failures allowed (returns successes + errors)
- Previously only `batch_*` was documented and the batch-vs-bulk distinction lived only in code docstrings

## Test plan
- [x] Docs-only change; no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)