### PR TITLE
feat(BA-6058): add llama-cpp runtime variant to example fixtures

### DIFF
--- a/changes/11940.feature.md
+++ b/changes/11940.feature.md
@@ -1,0 +1,1 @@
+Add a llama-cpp runtime variant to the model-service example fixtures

--- a/fixtures/manager/example-runtime-variants.json
+++ b/fixtures/manager/example-runtime-variants.json
@@ -131,6 +131,33 @@
       }
     },
     {
+      "name": "llama-cpp",
+      "description": "llama.cpp",
+      "reads_vfolder_config_files": false,
+      "default_model_definition": {
+        "models": [
+          {
+            "name": "llamacpp-model",
+            "service": {
+              "start_command": [
+                "sh",
+                "-c",
+                "llama-server -m \"$(ls /models/*.gguf | head -n1)\" \"$@\"",
+                "llama-cpp"
+              ],
+              "port": 8080,
+              "health_check": {
+                "path": "/health",
+                "interval": 10.0,
+                "max_retries": 30,
+                "initial_delay": 60.0
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "custom",
       "description": "Custom (Default)",
       "reads_vfolder_config_files": true,

--- a/src/ai/backend/install/fixtures/example-runtime-variants.json
+++ b/src/ai/backend/install/fixtures/example-runtime-variants.json
@@ -131,6 +131,33 @@
       }
     },
     {
+      "name": "llama-cpp",
+      "description": "llama.cpp",
+      "reads_vfolder_config_files": false,
+      "default_model_definition": {
+        "models": [
+          {
+            "name": "llamacpp-model",
+            "service": {
+              "start_command": [
+                "sh",
+                "-c",
+                "llama-server -m \"$(ls /models/*.gguf | head -n1)\" \"$@\"",
+                "llama-cpp"
+              ],
+              "port": 8080,
+              "health_check": {
+                "path": "/health",
+                "interval": 10.0,
+                "max_retries": 30,
+                "initial_delay": 60.0
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "custom",
       "description": "Custom (Default)",
       "reads_vfolder_config_files": true,


### PR DESCRIPTION
## Summary
- Add a `llama-cpp` runtime variant to the manager and installer `example-runtime-variants` fixtures.
- `start_command` selects the first `.gguf` under the model mount (`/models`) and forwards preset args to `llama-server` via `"$@"`; the service listens on port 8080.

## Notes
- The variant assumes a Backend.AI `llama.cpp` image where `llama-server` is on `PATH` and `LD_LIBRARY_PATH=/app` (the stock `ghcr.io/ggml-org/llama.cpp` binary relies on `WORKINGDIR /app`, which Backend.AI bypasses), mirroring how the `vllm` variant assumes `vllm` is on `PATH`.
- Fixtures seed fresh installs only; exposing the variant on an existing deployment needs a separate alembic seed migration.

## Test plan
- [ ] Runtime-variant fixture loads / seeds without error.
- [ ] Create a model service with `runtime_variant=llama-cpp` + a llama.cpp image and a `.gguf` vfolder → `llama-server` boots and `/health` returns 200.

Resolves BA-6058 #11634 