### PR TITLE
fix(BA-6282): persist hook-recorded execution sub-steps to scheduling history (#11942)

### DIFF
--- a/changes/11942.fix.md
+++ b/changes/11942.fix.md
@@ -1,0 +1,1 @@
+Fix hook-recorded execution sub-steps not being persisted to scheduling history

--- a/src/ai/backend/manager/sokovan/scheduler/coordinator.py
+++ b/src/ai/backend/manager/sokovan/scheduler/coordinator.py
@@ -55,6 +55,7 @@ from ai.backend.manager.sokovan.data import (
     PromotionSpec,
     SessionWithKernels,
 )
+from ai.backend.manager.sokovan.recorder.pool import RecordPool
 from ai.backend.manager.sokovan.recorder.types import ExecutionRecord
 from ai.backend.manager.sokovan.recorder.utils import extract_sub_steps_for_entity
 from ai.backend.manager.sokovan.scheduler.scheduler import SchedulerComponents
@@ -844,11 +845,8 @@ class ScheduleCoordinator:
                             )
                         )
 
-            # Get recorded steps for history
-            all_records = pool.build_all_records()
-
             # Phase 2: Apply status transitions (includes hook execution)
-            await self._handle_promotion_status_transitions(spec, result, all_records)
+            await self._handle_promotion_status_transitions(spec, result, pool)
 
             # Emit metrics per scaling group
             self._operation_metrics.observe_success(
@@ -869,6 +867,7 @@ class ScheduleCoordinator:
                     )
 
             # Log recorded steps for this scaling group
+            all_records = pool.get_all_records()
             if all_records:
                 log.debug(
                     "Recorded {} sessions with execution records for {} in scaling group {}",
@@ -881,7 +880,7 @@ class ScheduleCoordinator:
         self,
         spec: PromotionSpec,
         result: SessionExecutionResult,
-        records: Mapping[SessionId, ExecutionRecord],
+        pool: RecordPool[SessionId],
     ) -> None:
         """Apply status transitions for promotion spec results.
 
@@ -900,7 +899,7 @@ class ScheduleCoordinator:
         Args:
             spec: The promotion spec that defines the transition
             result: Execution result containing successes
-            records: Mapping of session IDs to their execution records for sub_steps
+            pool: Recorder pool for the scope; records are built after hooks run
         """
         if not result.successes:
             return
@@ -919,6 +918,10 @@ class ScheduleCoordinator:
                 to_status,
             )
             sessions_to_transition = hook_result.successful_sessions
+
+        # Build records only after hooks have run so hook-recorded sub-steps
+        # (e.g. terminate_cleanup) are captured in the persisted history.
+        records = pool.build_all_records()
 
         # Apply status transition for sessions that passed hooks
         if sessions_to_transition:

--- a/tests/unit/manager/sokovan/scheduler/test_coordinator.py
+++ b/tests/unit/manager/sokovan/scheduler/test_coordinator.py
@@ -32,9 +32,11 @@ from ai.backend.manager.defs import SERVICE_MAX_RETRIES
 from ai.backend.manager.repositories.scheduler.updaters import SessionStatusBatchUpdaterSpec
 from ai.backend.manager.sokovan.scheduler.coordinator import (
     FailureClassificationResult,
+    HookExecutionResult,
     ScheduleCoordinator,
 )
 from ai.backend.manager.sokovan.scheduler.post_processors import PostProcessorContext
+from ai.backend.manager.sokovan.scheduler.recorder import SessionRecorderContext
 from ai.backend.manager.sokovan.scheduler.results import (
     KernelExecutionResult,
     KernelTransitionInfo,
@@ -1104,3 +1106,70 @@ class TestScheduleCoordinatorPostProcessors:
         assert SessionStatus.SCHEDULED in target_statuses  # Success transition
         assert SessionStatus.CANCELLED in target_statuses  # give_up and expired transition
         assert SessionStatus.PENDING in target_statuses  # need_retry transition
+
+
+class TestScheduleCoordinatorPromotionRecordOrdering:
+    """Promotion records must be built AFTER hooks run (BA-6282).
+
+    Transition hooks (e.g. RunningTransitionHook triggering batch execution)
+    record sub-steps into the scope's pool while executing. If the coordinator
+    builds records before the hooks run, those sub-steps are lost from the
+    persisted scheduling history.
+    """
+
+    @pytest.fixture
+    def session_id(self) -> SessionId:
+        return SessionId(uuid4())
+
+    @pytest.fixture
+    def mock_coordinator(self) -> MagicMock:
+        coordinator = MagicMock(spec=ScheduleCoordinator)
+        coordinator._hook_registry = MagicMock()
+        coordinator._repository = AsyncMock()
+        coordinator._repository.get_db_now = AsyncMock(return_value=datetime.now(tzutc()))
+        coordinator._apply_transition = AsyncMock()
+        coordinator._broadcast_transition_events = AsyncMock()
+        return coordinator
+
+    @pytest.fixture
+    def promotion_spec(self) -> MagicMock:
+        spec = MagicMock()
+        spec.success_status = SessionStatus.RUNNING
+        spec.name = "promote-to-running"
+        spec.reason = "started"
+        return spec
+
+    async def test_hook_recorded_substep_reaches_apply_transition(
+        self,
+        mock_coordinator: MagicMock,
+        promotion_spec: MagicMock,
+        session_id: SessionId,
+    ) -> None:
+        # Arrange: hooks record finalize_start into the pool while running,
+        # then report the session as passed (collaborator is mocked, not re-run).
+        async def run_hooks(sessions: list[Any], _status: SessionStatus) -> HookExecutionResult:
+            recorder = SessionRecorderContext.current_pool().recorder(session_id)
+            with recorder.phase("finalize_start"):
+                with recorder.step("trigger_batch_execution"):
+                    pass
+            return HookExecutionResult(successful_sessions=sessions, full_session_data=[])
+
+        mock_coordinator._hook_registry.get_hook.return_value = MagicMock()
+        mock_coordinator._execute_transition_hooks = AsyncMock(side_effect=run_hooks)
+
+        # One success carries the path past the early-return into _apply_transition;
+        # its contents are opaque here since both collaborators are mocked.
+        result = SessionExecutionResult(successes=[_create_session_transition_info()])
+
+        # Act
+        with SessionRecorderContext.scope("promote", entity_ids=[session_id]) as pool:
+            await ScheduleCoordinator._handle_promotion_status_transitions(
+                mock_coordinator, promotion_spec, result, pool
+            )
+
+        # Assert: records passed to _apply_transition include the sub-step recorded
+        # during hook execution, proving the build happened after hooks ran.
+        records = mock_coordinator._apply_transition.await_args.args[4]
+        (finalize,) = records[session_id].phases
+        assert finalize.name == "finalize_start"
+        assert [step.name for step in finalize.steps] == ["trigger_batch_execution"]


### PR DESCRIPTION
This is an auto-generated backport PR of #11942 to the 26.4 release.