### PR TITLE
feat(BA-6284): record network cleanup as scheduling sub-step on terminate

### DIFF
--- a/changes/11946.feature.md
+++ b/changes/11946.feature.md
@@ -1,0 +1,1 @@
+Record inter-container network cleanup as a sub-step in session scheduling history on termination

--- a/src/ai/backend/manager/sokovan/scheduler/hooks/status.py
+++ b/src/ai/backend/manager/sokovan/scheduler/hooks/status.py
@@ -161,10 +161,20 @@ class TerminatedTransitionHook(StatusTransitionHook):
         session_id = session.session_info.identity.id
         cluster_mode = ClusterMode(session.session_info.resource.cluster_mode)
 
-        if cluster_mode == ClusterMode.SINGLE_NODE:
-            await self._destroy_local_network(session, network_id)
-        elif cluster_mode == ClusterMode.MULTI_NODE:
-            await self._destroy_overlay_network(session_id, network_id)
+        pool = RecorderContext[SessionId].current_pool()
+        recorder = pool.recorder(session_id)
+        with recorder.phase(
+            "terminate_cleanup",
+            success_detail="Volatile inter-container network destroyed",
+        ):
+            with recorder.step(
+                "destroy_network",
+                success_detail=f"Destroyed {cluster_mode.value} network {network_id}",
+            ):
+                if cluster_mode == ClusterMode.SINGLE_NODE:
+                    await self._destroy_local_network(session, network_id)
+                elif cluster_mode == ClusterMode.MULTI_NODE:
+                    await self._destroy_overlay_network(session_id, network_id)
 
     async def _destroy_local_network(self, session: SessionWithKernels, network_id: str) -> None:
         session_id = session.session_info.identity.id

--- a/tests/unit/manager/sokovan/scheduler/hooks/test_status_hooks.py
+++ b/tests/unit/manager/sokovan/scheduler/hooks/test_status_hooks.py
@@ -1,13 +1,14 @@
 """Regression tests for status-based transition hooks.
 
 Covers the volatile inter-container network cleanup performed by
-``TerminatedTransitionHook`` (BA-6273). The cleanup was lost in a series
+``TerminatedTransitionHook``. The cleanup was lost in a series
 of refactors, leaking Docker overlay (MULTI_NODE) and agent-local
 (SINGLE_NODE) networks after sessions terminated.
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -16,14 +17,17 @@ import pytest
 from ai.backend.common.types import AgentId, ClusterMode, SessionId
 from ai.backend.manager.errors.common import ServerMisconfiguredError
 from ai.backend.manager.models.network import NetworkType
+from ai.backend.manager.sokovan.recorder.pool import RecordPool
+from ai.backend.manager.sokovan.recorder.types import StepStatus
 from ai.backend.manager.sokovan.scheduler.hooks.status import (
     TerminatedHookDependencies,
     TerminatedTransitionHook,
 )
+from ai.backend.manager.sokovan.scheduler.recorder import SessionRecorderContext
 
 
 class TestTerminatedTransitionHookNetworkCleanup:
-    """Volatile network cleanup on session TERMINATED transition (BA-6273)."""
+    """Volatile network cleanup on session TERMINATED transition."""
 
     @pytest.fixture
     def agent_client(self) -> AsyncMock:
@@ -78,6 +82,13 @@ class TestTerminatedTransitionHookNetworkCleanup:
     @pytest.fixture
     def session_id(self) -> SessionId:
         return SessionId(uuid4())
+
+    @pytest.fixture(autouse=True)
+    def recorder_pool(self, session_id: SessionId) -> Iterator[RecordPool[SessionId]]:
+        """Ambient recorder scope, mirroring the coordinator scope the hook always
+        runs within in production. Tests assert on the pool by requesting it by name."""
+        with SessionRecorderContext.scope("terminate", entity_ids=[session_id]) as pool:
+            yield pool
 
     @pytest.fixture
     def network_id(self, request: pytest.FixtureRequest) -> str | None:
@@ -202,3 +213,42 @@ class TestTerminatedTransitionHookNetworkCleanup:
 
         with pytest.raises(RuntimeError, match="docker unreachable"):
             await hook.execute(multi_node_session)
+
+    async def test_records_terminate_cleanup_into_pool(
+        self,
+        hook: TerminatedTransitionHook,
+        recorder_pool: RecordPool[SessionId],
+        multi_node_session: MagicMock,
+        session_id: SessionId,
+    ) -> None:
+        """The hook records a terminate_cleanup phase/step into the scope's pool
+        so the coordinator can persist it as session scheduling sub_steps."""
+        await hook.execute(multi_node_session)
+
+        record = recorder_pool.build_all_records()[session_id]
+        cleanup = next(p for p in record.phases if p.name == "terminate_cleanup")
+        assert cleanup.status == StepStatus.SUCCESS
+        step = next(s for s in cleanup.steps if s.name == "destroy_network")
+        assert step.status == StepStatus.SUCCESS
+
+    async def test_records_terminate_cleanup_failure_with_error_code(
+        self,
+        hook: TerminatedTransitionHook,
+        recorder_pool: RecordPool[SessionId],
+        config_provider: MagicMock,
+        multi_node_session: MagicMock,
+        session_id: SessionId,
+    ) -> None:
+        """A failed cleanup is recorded as FAILED with an error_code, since the
+        hook raises BackendAIError subclasses (ServerMisconfiguredError)."""
+        config_provider.config.network.inter_container.default_driver = None
+
+        with pytest.raises(ServerMisconfiguredError):
+            await hook.execute(multi_node_session)
+
+        record = recorder_pool.build_all_records()[session_id]
+        cleanup = next(p for p in record.phases if p.name == "terminate_cleanup")
+        assert cleanup.status == StepStatus.FAILED
+        step = next(s for s in cleanup.steps if s.name == "destroy_network")
+        assert step.status == StepStatus.FAILED
+        assert step.error_code is not None


### PR DESCRIPTION
## Summary
- Wrap `TerminatedTransitionHook._destroy_network` in a `terminate_cleanup` / `destroy_network` recorder phase/step so the volatile inter-container network cleanup is persisted in the session scheduling history.
- Covers both cluster modes: SINGLE_NODE (local bridge via `_destroy_local_network`) and MULTI_NODE (overlay via `_destroy_overlay_network`); the step message records the cluster mode and network id.
- A failed cleanup is recorded as FAILED with a non-null `error_code` (the hook raises `BackendAIError` subclasses), keeping the blocking cleanup / self-healing retry path visible in history.

**Single Node**
<img width="921" height="233" alt="스크린샷 2026-06-05 오후 7 12 28" src="https://github.com/user-attachments/assets/5d9de18f-3870-4833-b977-24279a6a4070" />


**Multi Node**
<img width="1004" height="214" alt="스크린샷 2026-06-05 오후 7 11 47" src="https://github.com/user-attachments/assets/06c82690-9b19-4882-b25c-51bd8f3ebdd4" />


## Test plan
- [x] Unit: `tests/unit/manager/sokovan/scheduler/hooks/test_status_hooks.py` (records terminate_cleanup into pool; failure recorded with error code)
- [x] Live MULTI_NODE (size 2): `promote-to-terminated` sub_steps include `destroy_network` (SUCCESS, "multi-node"); overlay network removed
- [x] Live SINGLE_NODE (size 2): `promote-to-terminated` sub_steps include `destroy_network` (SUCCESS, "single-node"); local bridge removed

Resolves #11945 (BA-6284)