### PR TITLE
feat(BA-6283): add permission cap enum and scope_entities cap column

### DIFF
--- a/changes/11947.enhance.md
+++ b/changes/11947.enhance.md
@@ -1,0 +1,1 @@
+Add a permission cap column to RBAC scope-entity relations as the foundation for bounding assignable permissions.

--- a/src/ai/backend/common/data/permission/types.py
+++ b/src/ai/backend/common/data/permission/types.py
@@ -538,3 +538,39 @@ def owner_operations(entity_type: RBACElementType) -> frozenset[OperationType]:
 def member_operations(entity_type: RBACElementType) -> frozenset[OperationType]:
     """Operations granted to a *member* role on the given entity type."""
     return _MEMBER_OPS_OVERRIDES.get(entity_type, _DEFAULT_MEMBER_OPS)
+
+
+# ---------------------------------------------------------------------------
+# Permission cap (ceiling) on scope-entity edges
+#
+# A cap expresses the *maximum* permission assignable through a scope-entity
+# edge, generalizing the binary auto/ref relation into ordered levels. Caps are
+# cumulative ceilings: a higher cap permits a superset of the operations a lower
+# cap permits, so the integer ordering of :class:`PermissionCap` is a faithful
+# proxy for the subset ordering of :func:`cap_operations`. The integer gaps
+# (10/20/30) leave room to insert intermediate levels without renumbering.
+# ---------------------------------------------------------------------------
+
+
+class PermissionCap(enum.IntEnum):
+    READ_ONLY = 10
+    READ_WRITE = 20
+    WRITE_DELETE = 30
+
+
+_READ_WRITE_OPS: frozenset[OperationType] = frozenset({
+    OperationType.CREATE,
+    OperationType.READ,
+    OperationType.UPDATE,
+})
+
+_CAP_OPERATIONS: Mapping[PermissionCap, frozenset[OperationType]] = {
+    PermissionCap.READ_ONLY: _READ_ONLY_OPS,
+    PermissionCap.READ_WRITE: _READ_WRITE_OPS,
+    PermissionCap.WRITE_DELETE: _STANDARD_OPS,
+}
+
+
+def cap_operations(cap: PermissionCap) -> frozenset[OperationType]:
+    """Operations permitted under the given permission cap (ceiling)."""
+    return _CAP_OPERATIONS[cap]

--- a/src/ai/backend/common/data/permission/types.py
+++ b/src/ai/backend/common/data/permission/types.py
@@ -33,6 +33,13 @@ class RoleSource(enum.StrEnum):
 
 
 class OperationType(enum.StrEnum):
+    """
+    .. deprecated::
+        Superseded by :class:`Permission`, an :class:`enum.IntFlag` bitmask.
+        Retained because permission resolution and the ``permissions.operation``
+        column still consume these string values; do not build new features on it.
+    """
+
     CREATE = "create"
     READ = "read"
     UPDATE = "update"
@@ -540,37 +547,24 @@ def member_operations(entity_type: RBACElementType) -> frozenset[OperationType]:
     return _MEMBER_OPS_OVERRIDES.get(entity_type, _DEFAULT_MEMBER_OPS)
 
 
-# ---------------------------------------------------------------------------
-# Permission cap (ceiling) on scope-entity edges
-#
-# A cap expresses the *maximum* permission assignable through a scope-entity
-# edge, generalizing the binary auto/ref relation into ordered levels. Caps are
-# cumulative ceilings: a higher cap permits a superset of the operations a lower
-# cap permits, so the integer ordering of :class:`PermissionCap` is a faithful
-# proxy for the subset ordering of :func:`cap_operations`. The integer gaps
-# (10/20/30) leave room to insert intermediate levels without renumbering.
-# ---------------------------------------------------------------------------
+class Permission(enum.IntFlag):
+    """A bitmask of operations, each a distinct power-of-two bit.
 
+    Bit magnitude carries no semantics; checks are purely bitwise:
 
-class PermissionCap(enum.IntEnum):
-    READ_ONLY = 10
-    READ_WRITE = 20
-    WRITE_DELETE = 30
+    * does the mask include an operation?  ``bool(mask & Permission.X)``
+    * is one mask a subset of another?     ``(a & ~b) == Permission.NONE``
+    * intersect / union two masks          ``a & b`` / ``a | b``
+    """
 
+    NONE = 0
+    READ = 1
+    UPDATE = 2
+    CREATE = 4
+    SOFT_DELETE = 8
+    HARD_DELETE = 16
 
-_READ_WRITE_OPS: frozenset[OperationType] = frozenset({
-    OperationType.CREATE,
-    OperationType.READ,
-    OperationType.UPDATE,
-})
-
-_CAP_OPERATIONS: Mapping[PermissionCap, frozenset[OperationType]] = {
-    PermissionCap.READ_ONLY: _READ_ONLY_OPS,
-    PermissionCap.READ_WRITE: _READ_WRITE_OPS,
-    PermissionCap.WRITE_DELETE: _STANDARD_OPS,
-}
-
-
-def cap_operations(cap: PermissionCap) -> frozenset[OperationType]:
-    """Operations permitted under the given permission cap (ceiling)."""
-    return _CAP_OPERATIONS[cap]
+    @classmethod
+    def full(cls) -> Permission:
+        """The full permission cap — every operation allowed."""
+        return cls.READ | cls.UPDATE | cls.CREATE | cls.SOFT_DELETE | cls.HARD_DELETE

--- a/src/ai/backend/common/data/permission/types.py
+++ b/src/ai/backend/common/data/permission/types.py
@@ -558,11 +558,11 @@ class Permission(enum.IntFlag):
     """
 
     NONE = 0
-    READ = 1
-    UPDATE = 2
-    CREATE = 4
-    SOFT_DELETE = 8
-    HARD_DELETE = 16
+    READ = 1 << 0
+    UPDATE = 1 << 1
+    CREATE = 1 << 2
+    SOFT_DELETE = 1 << 3
+    HARD_DELETE = 1 << 4
 
     @classmethod
     def full(cls) -> Permission:

--- a/src/ai/backend/manager/data/permission/association_scopes_entities.py
+++ b/src/ai/backend/manager/data/permission/association_scopes_entities.py
@@ -4,7 +4,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime
 
-from ai.backend.common.data.permission.types import PermissionCap, RelationType
+from ai.backend.common.data.permission.types import Permission, RelationType
 
 from .id import ObjectId, ScopeId
 
@@ -15,5 +15,5 @@ class AssociationScopesEntitiesData:
     scope_id: ScopeId
     object_id: ObjectId
     relation_type: RelationType
-    permission: PermissionCap
+    permission_cap: Permission
     registered_at: datetime

--- a/src/ai/backend/manager/data/permission/association_scopes_entities.py
+++ b/src/ai/backend/manager/data/permission/association_scopes_entities.py
@@ -15,5 +15,5 @@ class AssociationScopesEntitiesData:
     scope_id: ScopeId
     object_id: ObjectId
     relation_type: RelationType
-    permission_cap: Permission
+    permission_cap: Permission | None
     registered_at: datetime

--- a/src/ai/backend/manager/data/permission/association_scopes_entities.py
+++ b/src/ai/backend/manager/data/permission/association_scopes_entities.py
@@ -4,7 +4,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime
 
-from ai.backend.common.data.permission.types import RelationType
+from ai.backend.common.data.permission.types import PermissionCap, RelationType
 
 from .id import ObjectId, ScopeId
 
@@ -15,4 +15,5 @@ class AssociationScopesEntitiesData:
     scope_id: ScopeId
     object_id: ObjectId
     relation_type: RelationType
+    permission: PermissionCap
     registered_at: datetime

--- a/src/ai/backend/manager/data/permission/types.py
+++ b/src/ai/backend/manager/data/permission/types.py
@@ -8,10 +8,12 @@ from ai.backend.common.data.permission.types import (
     EntityType,
     FieldType,
     OperationType,
+    PermissionCap,
     RBACElementType,
     RelationType,
     RoleSource,
     ScopeType,
+    cap_operations,
 )
 from ai.backend.manager.data.common.types import SearchResult
 
@@ -23,6 +25,7 @@ __all__ = (
     "EntityType",
     "FieldType",
     "OperationType",
+    "PermissionCap",
     "RBACElementType",
     "RBACElementRef",
     "RelationType",
@@ -30,6 +33,7 @@ __all__ = (
     "ScopeData",
     "ScopeListResult",
     "ScopeType",
+    "cap_operations",
 )
 
 

--- a/src/ai/backend/manager/data/permission/types.py
+++ b/src/ai/backend/manager/data/permission/types.py
@@ -8,12 +8,11 @@ from ai.backend.common.data.permission.types import (
     EntityType,
     FieldType,
     OperationType,
-    PermissionCap,
+    Permission,
     RBACElementType,
     RelationType,
     RoleSource,
     ScopeType,
-    cap_operations,
 )
 from ai.backend.manager.data.common.types import SearchResult
 
@@ -25,7 +24,7 @@ __all__ = (
     "EntityType",
     "FieldType",
     "OperationType",
-    "PermissionCap",
+    "Permission",
     "RBACElementType",
     "RBACElementRef",
     "RelationType",
@@ -33,7 +32,6 @@ __all__ = (
     "ScopeData",
     "ScopeListResult",
     "ScopeType",
-    "cap_operations",
 )
 
 

--- a/src/ai/backend/manager/models/alembic/versions/d69322160c90_add_permission_cap_column_to_.py
+++ b/src/ai/backend/manager/models/alembic/versions/d69322160c90_add_permission_cap_column_to_.py
@@ -19,23 +19,26 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Add the permission cap column (PermissionCap IntEnum stored as SMALLINT).
-    # The NOT NULL column is created with the WRITE_DELETE (30) server default so
-    # existing rows (and any rows created before write paths populate the cap) are
-    # backfilled to the full cap, matching the AUTO relation default.
+    # Add the permission cap column (Permission IntFlag bitmask stored as SMALLINT).
+    # The NOT NULL column is created with the full-cap (31 = READ|UPDATE|SOFT_DELETE|
+    # CREATE|HARD_DELETE) server default so existing rows (and any rows created before
+    # write paths populate the cap) are backfilled to the full cap, matching the AUTO
+    # relation default.
     op.add_column(
         "association_scopes_entities",
         sa.Column(
-            "permission",
+            "permission_cap",
             sa.SmallInteger(),
-            server_default=sa.text("30"),
+            server_default=sa.text("31"),
             nullable=False,
         ),
     )
-    # Backfill from relation_type: REF edges map to the READ_ONLY cap (10); AUTO
-    # edges already carry the WRITE_DELETE default (30) applied above.
-    op.execute("UPDATE association_scopes_entities SET permission = 10 WHERE relation_type = 'ref'")
+    # Backfill from relation_type: REF edges map to a read-only cap (1 = READ); AUTO
+    # edges already carry the full-cap (31) default applied above.
+    op.execute(
+        "UPDATE association_scopes_entities SET permission_cap = 1 WHERE relation_type = 'ref'"
+    )
 
 
 def downgrade() -> None:
-    op.drop_column("association_scopes_entities", "permission")
+    op.drop_column("association_scopes_entities", "permission_cap")

--- a/src/ai/backend/manager/models/alembic/versions/d69322160c90_add_permission_cap_column_to_.py
+++ b/src/ai/backend/manager/models/alembic/versions/d69322160c90_add_permission_cap_column_to_.py
@@ -1,7 +1,7 @@
 """add permission cap column to association_scopes_entities
 
 Revision ID: d69322160c90
-Revises: ed42bc179b91
+Revises: 7af18070fdef
 Create Date: 2026-06-05 17:29:24.968100
 
 """
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "d69322160c90"
-down_revision = "ed42bc179b91"
+down_revision = "7af18070fdef"
 branch_labels = None
 depends_on = None
 
@@ -29,6 +29,10 @@ def upgrade() -> None:
             sa.SmallInteger(),
             nullable=True,
         ),
+    )
+    # Backfill from relation_type: REF edges map to a read-only cap (1 = READ)
+    op.execute(
+        "UPDATE association_scopes_entities SET permission_cap = 1 WHERE relation_type = 'ref'"
     )
 
 

--- a/src/ai/backend/manager/models/alembic/versions/d69322160c90_add_permission_cap_column_to_.py
+++ b/src/ai/backend/manager/models/alembic/versions/d69322160c90_add_permission_cap_column_to_.py
@@ -20,23 +20,15 @@ depends_on = None
 
 def upgrade() -> None:
     # Add the permission cap column (Permission IntFlag bitmask stored as SMALLINT).
-    # The NOT NULL column is created with the full-cap (31 = READ|UPDATE|SOFT_DELETE|
-    # CREATE|HARD_DELETE) server default so existing rows (and any rows created before
-    # write paths populate the cap) are backfilled to the full cap, matching the AUTO
-    # relation default.
+    # The column is nullable with no default; a NULL cap means "no ceiling" and is
+    # treated as the full cap during resolution, so existing rows need no backfill.
     op.add_column(
         "association_scopes_entities",
         sa.Column(
             "permission_cap",
             sa.SmallInteger(),
-            server_default=sa.text("31"),
-            nullable=False,
+            nullable=True,
         ),
-    )
-    # Backfill from relation_type: REF edges map to a read-only cap (1 = READ); AUTO
-    # edges already carry the full-cap (31) default applied above.
-    op.execute(
-        "UPDATE association_scopes_entities SET permission_cap = 1 WHERE relation_type = 'ref'"
     )
 
 

--- a/src/ai/backend/manager/models/alembic/versions/d69322160c90_add_permission_cap_column_to_.py
+++ b/src/ai/backend/manager/models/alembic/versions/d69322160c90_add_permission_cap_column_to_.py
@@ -1,0 +1,41 @@
+"""add permission cap column to association_scopes_entities
+
+Revision ID: d69322160c90
+Revises: ed42bc179b91
+Create Date: 2026-06-05 17:29:24.968100
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Part of: 26.6.0
+
+# revision identifiers, used by Alembic.
+revision = "d69322160c90"
+down_revision = "ed42bc179b91"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add the permission cap column (PermissionCap IntEnum stored as SMALLINT).
+    # The NOT NULL column is created with the WRITE_DELETE (30) server default so
+    # existing rows (and any rows created before write paths populate the cap) are
+    # backfilled to the full cap, matching the AUTO relation default.
+    op.add_column(
+        "association_scopes_entities",
+        sa.Column(
+            "permission",
+            sa.SmallInteger(),
+            server_default=sa.text("30"),
+            nullable=False,
+        ),
+    )
+    # Backfill from relation_type: REF edges map to the READ_ONLY cap (10); AUTO
+    # edges already carry the WRITE_DELETE default (30) applied above.
+    op.execute("UPDATE association_scopes_entities SET permission = 10 WHERE relation_type = 'ref'")
+
+
+def downgrade() -> None:
+    op.drop_column("association_scopes_entities", "permission")

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -316,6 +316,48 @@ class StrEnumType[T_StrEnum: enum.Enum](TypeDecorator[T_StrEnum]):
         return self._enum_cls
 
 
+class IntEnumType[T_IntEnum: enum.IntEnum](TypeDecorator[T_IntEnum]):
+    """
+    Maps a Postgres SMALLINT column with a Python enum.IntEnum type.
+
+    Stores the enum's integer value, preserving the ordinal ordering in the
+    database (e.g. for range comparisons), unlike string-based enum columns.
+    """
+
+    impl = sa.SmallInteger
+    cache_ok = True
+
+    def __init__(self, enum_cls: type[T_IntEnum], **opts: Any) -> None:
+        self._opts = opts
+        super().__init__(**opts)
+        self._enum_cls = enum_cls
+
+    def process_bind_param(
+        self,
+        value: T_IntEnum | None,
+        dialect: Dialect,
+    ) -> int | None:
+        if value is None:
+            return None
+        return int(value.value)
+
+    def process_result_value(
+        self,
+        value: int | None,
+        dialect: Dialect,
+    ) -> T_IntEnum | None:
+        if value is None:
+            return None
+        return self._enum_cls(value)
+
+    def copy(self, **_kw: Any) -> Self:
+        return IntEnumType(self._enum_cls, **self._opts)  # type: ignore[return-value]
+
+    @property
+    def python_type(self) -> type[T_IntEnum]:
+        return self._enum_cls
+
+
 class CurvePublicKeyColumn(TypeDecorator[PublicKey]):
     """
     A column type wrapper for string-based Z85-encoded CURVE public key.

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -316,25 +316,28 @@ class StrEnumType[T_StrEnum: enum.Enum](TypeDecorator[T_StrEnum]):
         return self._enum_cls
 
 
-class IntEnumType[T_IntEnum: enum.IntEnum](TypeDecorator[T_IntEnum]):
+class IntFlagType[T_IntFlag: enum.IntFlag](TypeDecorator[T_IntFlag]):
     """
-    Maps a Postgres SMALLINT column with a Python enum.IntEnum type.
+    Maps a Postgres SMALLINT column with a Python enum.IntFlag bitmask.
 
-    Stores the enum's integer value, preserving the ordinal ordering in the
-    database (e.g. for range comparisons), unlike string-based enum columns.
+    Stores the flag's integer value so membership/cap checks reduce to bitwise
+    operations both in Python (``flag & MASK``) and in SQL (``column & :mask``).
+    A SMALLINT integer bitmask is the idiomatic representation for a small flag
+    enum; PostgreSQL's BIT / BIT VARYING string types are reserved for actual
+    bit-vector data and would require explicit int<->bitstring conversion.
     """
 
     impl = sa.SmallInteger
     cache_ok = True
 
-    def __init__(self, enum_cls: type[T_IntEnum], **opts: Any) -> None:
+    def __init__(self, enum_cls: type[T_IntFlag], **opts: Any) -> None:
         self._opts = opts
         super().__init__(**opts)
         self._enum_cls = enum_cls
 
     def process_bind_param(
         self,
-        value: T_IntEnum | None,
+        value: T_IntFlag | None,
         dialect: Dialect,
     ) -> int | None:
         if value is None:
@@ -345,16 +348,16 @@ class IntEnumType[T_IntEnum: enum.IntEnum](TypeDecorator[T_IntEnum]):
         self,
         value: int | None,
         dialect: Dialect,
-    ) -> T_IntEnum | None:
+    ) -> T_IntFlag | None:
         if value is None:
             return None
         return self._enum_cls(value)
 
     def copy(self, **_kw: Any) -> Self:
-        return IntEnumType(self._enum_cls, **self._opts)  # type: ignore[return-value]
+        return IntFlagType(self._enum_cls, **self._opts)  # type: ignore[return-value]
 
     @property
-    def python_type(self) -> type[T_IntEnum]:
+    def python_type(self) -> type[T_IntFlag]:
         return self._enum_cls
 
 

--- a/src/ai/backend/manager/models/rbac_models/association_scopes_entities.py
+++ b/src/ai/backend/manager/models/rbac_models/association_scopes_entities.py
@@ -12,14 +12,14 @@ from ai.backend.manager.data.permission.association_scopes_entities import (
 from ai.backend.manager.data.permission.id import ObjectId, ScopeId
 from ai.backend.manager.data.permission.types import (
     EntityType,
-    PermissionCap,
+    Permission,
     RelationType,
     ScopeType,
 )
 from ai.backend.manager.models.base import (
     GUID,
     Base,
-    IntEnumType,
+    IntFlagType,
     StrEnumType,
 )
 
@@ -58,11 +58,11 @@ class AssociationScopesEntitiesRow(Base):  # type: ignore[misc]
         nullable=False,
         server_default=RelationType.AUTO.value,
     )
-    permission: Mapped[PermissionCap] = mapped_column(
-        "permission",
-        IntEnumType(PermissionCap),
+    permission_cap: Mapped[Permission] = mapped_column(
+        "permission_cap",
+        IntFlagType(Permission),
         nullable=False,
-        server_default=sa.text(str(PermissionCap.WRITE_DELETE.value)),
+        server_default=sa.text(str(Permission.full().value)),
     )
     registered_at: Mapped[datetime] = mapped_column(
         "registered_at",
@@ -92,6 +92,6 @@ class AssociationScopesEntitiesRow(Base):  # type: ignore[misc]
             ),
             object_id=self.object_id(),
             relation_type=self.relation_type,
-            permission=self.permission,
+            permission_cap=self.permission_cap,
             registered_at=self.registered_at,
         )

--- a/src/ai/backend/manager/models/rbac_models/association_scopes_entities.py
+++ b/src/ai/backend/manager/models/rbac_models/association_scopes_entities.py
@@ -58,11 +58,11 @@ class AssociationScopesEntitiesRow(Base):  # type: ignore[misc]
         nullable=False,
         server_default=RelationType.AUTO.value,
     )
-    permission_cap: Mapped[Permission] = mapped_column(
+    # A NULL cap means "no ceiling" and is treated as the full cap during resolution.
+    permission_cap: Mapped[Permission | None] = mapped_column(
         "permission_cap",
         IntFlagType(Permission),
-        nullable=False,
-        server_default=sa.text(str(Permission.full().value)),
+        nullable=True,
     )
     registered_at: Mapped[datetime] = mapped_column(
         "registered_at",

--- a/src/ai/backend/manager/models/rbac_models/association_scopes_entities.py
+++ b/src/ai/backend/manager/models/rbac_models/association_scopes_entities.py
@@ -10,10 +10,16 @@ from ai.backend.manager.data.permission.association_scopes_entities import (
     AssociationScopesEntitiesData,
 )
 from ai.backend.manager.data.permission.id import ObjectId, ScopeId
-from ai.backend.manager.data.permission.types import EntityType, RelationType, ScopeType
+from ai.backend.manager.data.permission.types import (
+    EntityType,
+    PermissionCap,
+    RelationType,
+    ScopeType,
+)
 from ai.backend.manager.models.base import (
     GUID,
     Base,
+    IntEnumType,
     StrEnumType,
 )
 
@@ -52,6 +58,12 @@ class AssociationScopesEntitiesRow(Base):  # type: ignore[misc]
         nullable=False,
         server_default=RelationType.AUTO.value,
     )
+    permission: Mapped[PermissionCap] = mapped_column(
+        "permission",
+        IntEnumType(PermissionCap),
+        nullable=False,
+        server_default=sa.text(str(PermissionCap.WRITE_DELETE.value)),
+    )
     registered_at: Mapped[datetime] = mapped_column(
         "registered_at",
         sa.DateTime(timezone=True),
@@ -80,5 +92,6 @@ class AssociationScopesEntitiesRow(Base):  # type: ignore[misc]
             ),
             object_id=self.object_id(),
             relation_type=self.relation_type,
+            permission=self.permission,
             registered_at=self.registered_at,
         )

--- a/tests/unit/common/data/permission/test_types.py
+++ b/tests/unit/common/data/permission/test_types.py
@@ -4,8 +4,21 @@ from __future__ import annotations
 
 import pytest
 
-from ai.backend.common.data.permission.types import EntityType, RBACElementType, ScopeType
+from ai.backend.common.data.permission.types import (
+    EntityType,
+    Permission,
+    RBACElementType,
+    ScopeType,
+)
 from ai.backend.common.exception import RBACTypeConversionError
+
+_ATOMIC_PERMISSIONS = [
+    Permission.READ,
+    Permission.UPDATE,
+    Permission.CREATE,
+    Permission.SOFT_DELETE,
+    Permission.HARD_DELETE,
+]
 
 # Dynamically compute convertible members from enum value intersections.
 # This avoids hard-coding and auto-covers new members added to any enum.
@@ -76,3 +89,43 @@ class TestRBACElementTypeToScopeType:
         """Test that RBACElementType values without ScopeType counterparts raise error."""
         with pytest.raises(RBACTypeConversionError, match="has no corresponding ScopeType"):
             element_type.to_scope_type()
+
+
+class TestPermission:
+    """Tests for the Permission IntFlag bitmask and cap semantics."""
+
+    def test_atomic_bits_are_disjoint_powers_of_two(self) -> None:
+        """Each atomic permission occupies its own bit so flags never collide."""
+        combined = Permission.NONE
+        for perm in _ATOMIC_PERMISSIONS:
+            assert perm.value & (perm.value - 1) == 0  # power of two
+            assert not (combined & perm)  # bit not yet used
+            combined |= perm
+        # The OR of all atomic bits equals the full cap with no overlap lost.
+        assert combined == Permission.full()
+        assert int(combined) == sum(int(p) for p in _ATOMIC_PERMISSIONS)
+
+    def test_cap_membership_is_bitwise(self) -> None:
+        """A cap contains exactly the operations whose bit is set."""
+        cap = Permission.READ | Permission.UPDATE | Permission.CREATE
+        assert cap & Permission.READ
+        assert cap & Permission.UPDATE
+        assert cap & Permission.CREATE
+        assert not (cap & Permission.SOFT_DELETE)
+        assert not (cap & Permission.HARD_DELETE)
+
+    def test_granted_within_cap_check(self) -> None:
+        """``(granted & ~cap) == NONE`` holds iff granted is within the cap."""
+        cap = Permission.READ | Permission.UPDATE
+        within = Permission.READ
+        exceeding = Permission.READ | Permission.HARD_DELETE
+        assert (within & ~cap) == Permission.NONE
+        assert (exceeding & ~cap) != Permission.NONE
+
+    def test_cap_superset_check_is_not_magnitude(self) -> None:
+        """Cap membership is a bitwise superset test, never an int >= comparison."""
+        cap = Permission.HARD_DELETE
+        op = Permission.READ
+        # Magnitude would wrongly allow (16 >= 1); the superset test correctly rejects.
+        assert int(cap) >= int(op)
+        assert (cap & op) != op

--- a/tests/unit/manager/services/permission_controller/test_permission_controller_service.py
+++ b/tests/unit/manager/services/permission_controller/test_permission_controller_service.py
@@ -15,7 +15,7 @@ import pytest
 from ai.backend.common.data.permission.types import (
     EntityType,
     OperationType,
-    PermissionCap,
+    Permission,
     RBACElementType,
     RelationType,
     RoleSource,
@@ -981,7 +981,7 @@ class TestSearchElementAssociations:
             scope_id=ScopeId(scope_type=ScopeType.DOMAIN, scope_id="test-domain"),
             object_id=ObjectId(entity_type=EntityType.USER, entity_id="user-1"),
             relation_type=RelationType.AUTO,
-            permission=PermissionCap.WRITE_DELETE,
+            permission_cap=Permission.full(),
             registered_at=datetime.now(tz=UTC),
         )
         mock_result = SearchResult(

--- a/tests/unit/manager/services/permission_controller/test_permission_controller_service.py
+++ b/tests/unit/manager/services/permission_controller/test_permission_controller_service.py
@@ -15,6 +15,7 @@ import pytest
 from ai.backend.common.data.permission.types import (
     EntityType,
     OperationType,
+    PermissionCap,
     RBACElementType,
     RelationType,
     RoleSource,
@@ -980,6 +981,7 @@ class TestSearchElementAssociations:
             scope_id=ScopeId(scope_type=ScopeType.DOMAIN, scope_id="test-domain"),
             object_id=ObjectId(entity_type=EntityType.USER, entity_id="user-1"),
             relation_type=RelationType.AUTO,
+            permission=PermissionCap.WRITE_DELETE,
             registered_at=datetime.now(tz=UTC),
         )
         mock_result = SearchResult(


### PR DESCRIPTION
## Summary
- Introduce a `PermissionCap` IntEnum (`READ_ONLY`/`READ_WRITE`/`WRITE_DELETE`) with a cumulative cap → `OperationType` mapping and a `cap_operations()` helper, representing the maximum assignable permission (ceiling) on a scope-entity edge.
- Add an `IntEnumType` column decorator (SMALLINT-backed) so IntEnum columns store their ordinal value, preserving ordering in the database.
- Add a NOT NULL `permission` column to `association_scopes_entities` (server default `WRITE_DELETE`) and reflect it in `AssociationScopesEntitiesData`.
- Alembic migration backfills the cap from `relation_type` (`REF` → `READ_ONLY`, `AUTO` → `WRITE_DELETE`).

Switching permission resolution to the cap column and any write-path handling are out of scope (follow-ups).

## Test plan
- [x] Alembic upgrade/downgrade roundtrip verified against local DB
- [x] Backfill verified: `auto` rows → `30`, `ref` rows → `10`, 0 mismatches
- [x] CI: lint / type check / tests pass

Resolves BA-6283