### PR TITLE
fix(BA-6287): prevent garbage collection of fire-and-forget asyncio tasks

### DIFF
--- a/changes/11953.fix.md
+++ b/changes/11953.fix.md
@@ -1,0 +1,1 @@
+Prevent fire-and-forget background tasks from being garbage collected mid-execution by retaining strong references to them.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,6 @@ ignore = [
     # RUF
     "RUF003", # ambiguous-unicode-character-comment - intentional use of special characters (e.g., × for multiplication)
     "RUF005", # collection-literal-concatenation - explicit concatenation is sometimes clearer
-    "RUF006", # asyncio-dangling-task - fire-and-forget tasks are intentional in some cases
     "RUF009", # function-call-in-dataclass-default - cast() in dataclass defaults is intentional
     "RUF012", # mutable-class-default - existing codebase uses mutable defaults intentionally
     "RUF015", # unnecessary-iterable-allocation-for-first-element - [0] is clearer than next(iter())

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -845,7 +845,6 @@ class AbstractAgent[
     # Health monitoring tracking
     _active_pulls: dict[str, PullTaskInfo]  # key: image canonical name
     _active_creates: dict[KernelId, CreateTaskInfo]
-    _model_service_health_tasks: set[asyncio.Task[Any]]
 
     @contextmanager
     def track_pull(self, image: str) -> Generator[bool, None, None]:
@@ -929,7 +928,6 @@ class AbstractAgent[
         # Initialize health monitoring tracking maps
         self._active_pulls = {}
         self._active_creates = {}
-        self._model_service_health_tasks = set()
         self._sync_container_lifecycle_observer = SyncContainerLifecycleObserver.instance()
         self._clean_kernel_registry_task = asyncio.create_task(self._clean_kernel_registry_loop())
 
@@ -990,7 +988,7 @@ class AbstractAgent[
             human_readable_name="agent.kernel_presence",
             db_id=REDIS_LIVE_DB,
         )
-        self.background_task_manager = await BackgroundTaskManager.create(
+        self.background_task_manager = BackgroundTaskManager(
             BackgroundTaskManagerArgs(
                 event_producer=self.event_producer,
                 valkey_client=self.valkey_bgtask_client,
@@ -998,6 +996,7 @@ class AbstractAgent[
                 bgtask_observer=self._metric_registry.bgtask,
             )
         )
+        await self.background_task_manager.init()
 
         log.info("Resource slots: {!r}", self.slots)
         log.info("Slot types: {!r}", known_slot_types)
@@ -3195,11 +3194,6 @@ class AbstractAgent[
                                     ctx.image_ref.canonical,
                                 )
                                 continue
-                            health_task = asyncio.create_task(
-                                self.start_and_monitor_model_service_health(kernel_obj, model)
-                            )
-                            self._model_service_health_tasks.add(health_task)
-                            health_task.add_done_callback(self._model_service_health_tasks.discard)
                             log.info(
                                 "create_kernel(kernel:{}, session:{}, container:{}) start monitoring model service: {}",
                                 kernel_id,
@@ -3244,26 +3238,6 @@ class AbstractAgent[
                 except Exception:
                     await self.reconstruct_resource_usage()
                     raise
-
-    async def start_and_monitor_model_service_health(
-        self,
-        kernel_obj: KernelObjectType,
-        model: ModelConfig,
-    ) -> None:
-        log.debug("starting model service of model {}", model.name)
-        result = await kernel_obj.start_model_service(model.model_dump(mode="json"))
-        if result["status"] == "failed":
-            log.error(
-                "Model service failed to start for kernel {} (session {}). Destroying kernel.",
-                kernel_obj.kernel_id,
-                kernel_obj.session_id,
-            )
-            await self.inject_container_lifecycle_event(
-                kernel_obj.kernel_id,
-                kernel_obj.session_id,
-                LifecycleEvent.DESTROY,
-                KernelLifecycleEventReason.FAILED_TO_START,
-            )
 
     async def _load_model_definition(
         self,

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -83,7 +83,7 @@ from ai.backend.agent.tasks import (
 )
 from ai.backend.common import msgpack
 from ai.backend.common.asyncio import cancel_tasks, current_loop
-from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
+from ai.backend.common.bgtask.bgtask import BackgroundTaskManager, BackgroundTaskManagerArgs
 from ai.backend.common.clients.valkey_client.valkey_bgtask.client import ValkeyBgtaskClient
 from ai.backend.common.clients.valkey_client.valkey_container_log.client import (
     ValkeyContainerLogClient,
@@ -845,6 +845,7 @@ class AbstractAgent[
     # Health monitoring tracking
     _active_pulls: dict[str, PullTaskInfo]  # key: image canonical name
     _active_creates: dict[KernelId, CreateTaskInfo]
+    _model_service_health_tasks: set[asyncio.Task[Any]]
 
     @contextmanager
     def track_pull(self, image: str) -> Generator[bool, None, None]:
@@ -928,6 +929,7 @@ class AbstractAgent[
         # Initialize health monitoring tracking maps
         self._active_pulls = {}
         self._active_creates = {}
+        self._model_service_health_tasks = set()
         self._sync_container_lifecycle_observer = SyncContainerLifecycleObserver.instance()
         self._clean_kernel_registry_task = asyncio.create_task(self._clean_kernel_registry_loop())
 
@@ -988,11 +990,13 @@ class AbstractAgent[
             human_readable_name="agent.kernel_presence",
             db_id=REDIS_LIVE_DB,
         )
-        self.background_task_manager = BackgroundTaskManager(
-            self.event_producer,
-            valkey_client=self.valkey_bgtask_client,
-            server_id=self.id,
-            bgtask_observer=self._metric_registry.bgtask,
+        self.background_task_manager = await BackgroundTaskManager.create(
+            BackgroundTaskManagerArgs(
+                event_producer=self.event_producer,
+                valkey_client=self.valkey_bgtask_client,
+                server_id=self.id,
+                bgtask_observer=self._metric_registry.bgtask,
+            )
         )
 
         log.info("Resource slots: {!r}", self.slots)
@@ -1536,6 +1540,7 @@ class AbstractAgent[
 
     async def _clean_kernel_registry_loop(self) -> None:
         # TODO: After reducing `kernel_registry` dependencies and roles, this kind of tasks should be deprecated
+        cleanup_tasks: set[asyncio.Task[None]] = set()
         while True:
             try:
                 alive_containers = await self.enumerate_containers()
@@ -1551,11 +1556,13 @@ class AbstractAgent[
                         "cleaning up dangling kernel objects (kernel ids): {}",
                         ", ".join(map(str, dangling_kernel_ids)),
                     )
-                    asyncio.create_task(
+                    cleanup_task = asyncio.create_task(
                         asyncio.wait_for(
                             self.clean_kernel_objects(dangling_kernel_ids), timeout=30.0
                         )
                     )
+                    cleanup_tasks.add(cleanup_task)
+                    cleanup_task.add_done_callback(cleanup_tasks.discard)
             except Exception as e:
                 log.exception("unexpected error in _clean_kernel_registry_loop: {0}", repr(e))
             finally:
@@ -3188,9 +3195,11 @@ class AbstractAgent[
                                     ctx.image_ref.canonical,
                                 )
                                 continue
-                            asyncio.create_task(
+                            health_task = asyncio.create_task(
                                 self.start_and_monitor_model_service_health(kernel_obj, model)
                             )
+                            self._model_service_health_tasks.add(health_task)
+                            health_task.add_done_callback(self._model_service_health_tasks.discard)
                             log.info(
                                 "create_kernel(kernel:{}, session:{}, container:{}) start monitoring model service: {}",
                                 kernel_id,

--- a/src/ai/backend/common/bgtask/bgtask.py
+++ b/src/ai/backend/common/bgtask/bgtask.py
@@ -257,6 +257,16 @@ def _exception_to_task_result[**P](
     return wrapper
 
 
+@dataclass
+class BackgroundTaskManagerArgs:
+    event_producer: EventProducer
+    valkey_client: ValkeyBgtaskClient
+    server_id: str
+    tags: Iterable[str] | None = None
+    bgtask_observer: BackgroundTaskObserver | None = None
+    task_registry: BackgroundTaskHandlerRegistry | None = None
+
+
 class BackgroundTaskManager:
     _event_producer: EventProducer
     _ongoing_tasks: MutableMapping[TaskID, BackgroundTaskMeta]
@@ -266,39 +276,38 @@ class BackgroundTaskManager:
     _task_set_key: TaskSetKey
     _task_registry: BackgroundTaskHandlerRegistry
 
-    _local_cron: LocalCron
+    _local_cron: LocalCron | None
 
-    def __init__(
-        self,
-        event_producer: EventProducer,
-        *,
-        valkey_client: ValkeyBgtaskClient,
-        server_id: str,
-        tags: Iterable[str] | None = None,
-        bgtask_observer: BackgroundTaskObserver | None = None,
-        task_registry: BackgroundTaskHandlerRegistry | None = None,
-    ) -> None:
-        self._event_producer = event_producer
+    def __init__(self, args: BackgroundTaskManagerArgs) -> None:
+        self._event_producer = args.event_producer
         self._ongoing_tasks = {}
 
-        self._valkey_client = valkey_client
+        self._valkey_client = args.valkey_client
         self._task_set_key = TaskSetKey(
-            server_id=server_id, tags=set(tags) if tags is not None else set()
+            server_id=args.server_id, tags=set(args.tags) if args.tags is not None else set()
         )
-        if bgtask_observer is None:
-            bgtask_observer = NopBackgroundTaskObserver()
+        bgtask_observer = args.bgtask_observer or NopBackgroundTaskObserver()
         self._metric_observer = bgtask_observer
         self._hook = CompositeTaskHook([
             MetricObserverHook(bgtask_observer),
-            EventProducerHook(event_producer),
-            ValkeyUnregisterHook(valkey_client, self._task_set_key),
+            EventProducerHook(args.event_producer),
+            ValkeyUnregisterHook(args.valkey_client, self._task_set_key),
         ])
-        self._task_registry = task_registry or BackgroundTaskHandlerRegistry()
-        self._local_cron = LocalCron([
-            BgtaskHeartbeatTask(self),
-            BgtaskRetryTask(self),
+        self._task_registry = args.task_registry or BackgroundTaskHandlerRegistry()
+        self._local_cron = None
+
+    @classmethod
+    async def create(cls, args: BackgroundTaskManagerArgs) -> Self:
+        """Construct a manager and start its local cron in an async context."""
+        instance = cls(args)
+        local_cron = LocalCron([
+            BgtaskHeartbeatTask(instance),
+            BgtaskRetryTask(instance),
         ])
-        asyncio.create_task(self._local_cron.start())
+        await local_cron.start()
+        # No setter because we don't want this to be changed after initialization
+        instance._local_cron = local_cron
+        return instance
 
     def set_registry(self, registry: BackgroundTaskHandlerRegistry) -> None:
         self._task_registry = registry
@@ -335,7 +344,8 @@ class BackgroundTaskManager:
                     await async_task
                 except asyncio.CancelledError:
                     pass
-        await self._local_cron.stop()
+        if self._local_cron is not None:
+            await self._local_cron.stop()
 
     def _convert_bgtask_to_event(
         self, task_id: uuid.UUID, bgtask_result: DispatchResult[Any] | str | None

--- a/src/ai/backend/common/bgtask/bgtask.py
+++ b/src/ai/backend/common/bgtask/bgtask.py
@@ -276,7 +276,7 @@ class BackgroundTaskManager:
     _task_set_key: TaskSetKey
     _task_registry: BackgroundTaskHandlerRegistry
 
-    _local_cron: LocalCron | None
+    _local_cron: LocalCron
 
     def __init__(self, args: BackgroundTaskManagerArgs) -> None:
         self._event_producer = args.event_producer
@@ -294,20 +294,13 @@ class BackgroundTaskManager:
             ValkeyUnregisterHook(args.valkey_client, self._task_set_key),
         ])
         self._task_registry = args.task_registry or BackgroundTaskHandlerRegistry()
-        self._local_cron = None
-
-    @classmethod
-    async def create(cls, args: BackgroundTaskManagerArgs) -> Self:
-        """Construct a manager and start its local cron in an async context."""
-        instance = cls(args)
-        local_cron = LocalCron([
-            BgtaskHeartbeatTask(instance),
-            BgtaskRetryTask(instance),
+        self._local_cron = LocalCron([
+            BgtaskHeartbeatTask(self),
+            BgtaskRetryTask(self),
         ])
-        await local_cron.start()
-        # No setter because we don't want this to be changed after initialization
-        instance._local_cron = local_cron
-        return instance
+
+    async def init(self) -> None:
+        await self._local_cron.start()
 
     def set_registry(self, registry: BackgroundTaskHandlerRegistry) -> None:
         self._task_registry = registry
@@ -344,8 +337,7 @@ class BackgroundTaskManager:
                     await async_task
                 except asyncio.CancelledError:
                     pass
-        if self._local_cron is not None:
-            await self._local_cron.stop()
+        await self._local_cron.stop()
 
     def _convert_bgtask_to_event(
         self, task_id: uuid.UUID, bgtask_result: DispatchResult[Any] | str | None

--- a/src/ai/backend/common/runner/types.py
+++ b/src/ai/backend/common/runner/types.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
-from collections.abc import Sequence
+from collections.abc import Coroutine, Sequence
+from typing import Any
 
 from ai.backend.common.observer.types import AbstractObserver
 from ai.backend.common.resource.types import AbstractResource
@@ -28,10 +29,21 @@ class Runner:
 
     _resources: Sequence[AbstractResource]
     _closed_event: asyncio.Event
+    _tasks: set[asyncio.Task[None]]
 
     def __init__(self, resources: Sequence[AbstractResource]) -> None:
         self._resources = resources
         self._closed_event = asyncio.Event()
+        self._tasks = set()
+
+    def _track(self, coro: Coroutine[Any, Any, None]) -> asyncio.Task[None]:
+        # The event loop only keeps weak references to tasks, so a fire-and-forget
+        # task may be garbage collected mid-execution. Hold a strong reference until
+        # it completes, then drop it via the done callback.
+        task = asyncio.create_task(coro)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        return task
 
     async def register_observer(self, observer: AbstractObserver) -> None:
         """
@@ -41,7 +53,7 @@ class Runner:
         if self._closed_event.is_set():
             raise RuntimeError("Runner is already closed.")
         log.info("Starting observer: {}", observer.name)
-        asyncio.create_task(self._run_observer(observer))
+        self._track(self._run_observer(observer))
 
     async def _run_observer(self, observer: AbstractObserver) -> None:
         while not self._closed_event.is_set():
@@ -113,7 +125,7 @@ class Runner:
             )
             await self._cleanup()
             raise
-        asyncio.create_task(self._run())
+        self._track(self._run())
         log.info("Runner started.")
 
     async def _run(self) -> None:

--- a/src/ai/backend/common/runner/types.py
+++ b/src/ai/backend/common/runner/types.py
@@ -36,14 +36,13 @@ class Runner:
         self._closed_event = asyncio.Event()
         self._tasks = set()
 
-    def _track(self, coro: Coroutine[Any, Any, None]) -> asyncio.Task[None]:
+    def _track(self, coro: Coroutine[Any, Any, None]) -> None:
         # The event loop only keeps weak references to tasks, so a fire-and-forget
         # task may be garbage collected mid-execution. Hold a strong reference until
         # it completes, then drop it via the done callback.
         task = asyncio.create_task(coro)
         self._tasks.add(task)
         task.add_done_callback(self._tasks.discard)
-        return task
 
     async def register_observer(self, observer: AbstractObserver) -> None:
         """

--- a/src/ai/backend/manager/dependencies/system/background_task_manager.py
+++ b/src/ai/backend/manager/dependencies/system/background_task_manager.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
-from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
+from ai.backend.common.bgtask.bgtask import BackgroundTaskManager, BackgroundTaskManagerArgs
 from ai.backend.common.bgtask.hooks.metric_hook import BackgroundTaskObserver
 from ai.backend.common.clients.valkey_client.valkey_bgtask.client import ValkeyBgtaskClient
 from ai.backend.common.dependencies import NonMonitorableDependencyProvider
@@ -34,11 +34,13 @@ class BackgroundTaskManagerDependency(
     async def provide(
         self, setup_input: BackgroundTaskManagerInput
     ) -> AsyncIterator[BackgroundTaskManager]:
-        manager = BackgroundTaskManager(
-            setup_input.event_producer,
-            valkey_client=setup_input.valkey_bgtask,
-            server_id=setup_input.server_id,
-            bgtask_observer=setup_input.bgtask_observer,
+        manager = await BackgroundTaskManager.create(
+            BackgroundTaskManagerArgs(
+                event_producer=setup_input.event_producer,
+                valkey_client=setup_input.valkey_bgtask,
+                server_id=setup_input.server_id,
+                bgtask_observer=setup_input.bgtask_observer,
+            )
         )
         try:
             yield manager

--- a/src/ai/backend/manager/dependencies/system/background_task_manager.py
+++ b/src/ai/backend/manager/dependencies/system/background_task_manager.py
@@ -34,7 +34,7 @@ class BackgroundTaskManagerDependency(
     async def provide(
         self, setup_input: BackgroundTaskManagerInput
     ) -> AsyncIterator[BackgroundTaskManager]:
-        manager = await BackgroundTaskManager.create(
+        manager = BackgroundTaskManager(
             BackgroundTaskManagerArgs(
                 event_producer=setup_input.event_producer,
                 valkey_client=setup_input.valkey_bgtask,
@@ -42,6 +42,7 @@ class BackgroundTaskManagerDependency(
                 bgtask_observer=setup_input.bgtask_observer,
             )
         )
+        await manager.init()
         try:
             yield manager
         finally:

--- a/src/ai/backend/storage/server.py
+++ b/src/ai/backend/storage/server.py
@@ -225,7 +225,7 @@ async def bgtask_ctx(
     )
     bgtask_registry_creator = BgtaskHandlerRegistryCreator(volume_pool, event_producer)
     registry = bgtask_registry_creator.create()
-    bgtask_mgr = await BackgroundTaskManager.create(
+    bgtask_mgr = BackgroundTaskManager(
         BackgroundTaskManagerArgs(
             event_producer=event_producer,
             task_registry=registry,
@@ -233,6 +233,7 @@ async def bgtask_ctx(
             server_id=local_config.storage_proxy.node_id,
         )
     )
+    await bgtask_mgr.init()
 
     try:
         yield bgtask_mgr

--- a/src/ai/backend/storage/server.py
+++ b/src/ai/backend/storage/server.py
@@ -26,7 +26,7 @@ from aiohttp import web
 from aiohttp.typedefs import Middleware
 from setproctitle import setproctitle
 
-from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
+from ai.backend.common.bgtask.bgtask import BackgroundTaskManager, BackgroundTaskManagerArgs
 from ai.backend.common.clients.valkey_client.valkey_artifact.client import (
     ValkeyArtifactDownloadTrackingClient,
 )
@@ -225,16 +225,19 @@ async def bgtask_ctx(
     )
     bgtask_registry_creator = BgtaskHandlerRegistryCreator(volume_pool, event_producer)
     registry = bgtask_registry_creator.create()
-    bgtask_mgr = BackgroundTaskManager(
-        event_producer=event_producer,
-        task_registry=registry,
-        valkey_client=valkey_client,
-        server_id=local_config.storage_proxy.node_id,
+    bgtask_mgr = await BackgroundTaskManager.create(
+        BackgroundTaskManagerArgs(
+            event_producer=event_producer,
+            task_registry=registry,
+            valkey_client=valkey_client,
+            server_id=local_config.storage_proxy.node_id,
+        )
     )
 
     try:
         yield bgtask_mgr
     finally:
+        await bgtask_mgr.shutdown()
         await valkey_client.close()
 
 

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -26,7 +26,7 @@ from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.registry import BackendAIClientRegistry
-from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
+from ai.backend.common.bgtask.bgtask import BackgroundTaskManager, BackgroundTaskManagerArgs
 from ai.backend.common.clients.valkey_client.valkey_artifact.client import (
     ValkeyArtifactDownloadTrackingClient,
 )
@@ -1130,10 +1130,12 @@ async def background_task_manager(
     valkey_clients: ValkeyClients,
 ) -> AsyncIterator[BackgroundTaskManager]:
     """Real BackgroundTaskManager backed by Valkey."""
-    mgr = BackgroundTaskManager(
-        event_producer,
-        valkey_client=valkey_clients.bgtask,
-        server_id=f"test-server-{uuid4()}",
+    mgr = await BackgroundTaskManager.create(
+        BackgroundTaskManagerArgs(
+            event_producer=event_producer,
+            valkey_client=valkey_clients.bgtask,
+            server_id=f"test-server-{uuid4()}",
+        )
     )
     yield mgr
     await mgr.shutdown()

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -1130,13 +1130,14 @@ async def background_task_manager(
     valkey_clients: ValkeyClients,
 ) -> AsyncIterator[BackgroundTaskManager]:
     """Real BackgroundTaskManager backed by Valkey."""
-    mgr = await BackgroundTaskManager.create(
+    mgr = BackgroundTaskManager(
         BackgroundTaskManagerArgs(
             event_producer=event_producer,
             valkey_client=valkey_clients.bgtask,
             server_id=f"test-server-{uuid4()}",
         )
     )
+    await mgr.init()
     yield mgr
     await mgr.shutdown()
 

--- a/tests/unit/common/bgtask/test_background_task.py
+++ b/tests/unit/common/bgtask/test_background_task.py
@@ -133,13 +133,14 @@ async def background_task_manager(
     event_producer: EventProducer,
     valkey_bgtask_client: ValkeyBgtaskClient,
 ) -> AsyncIterator[BackgroundTaskManager]:
-    bgtask_manager = await BackgroundTaskManager.create(
+    bgtask_manager = BackgroundTaskManager(
         BackgroundTaskManagerArgs(
             event_producer=event_producer,
             valkey_client=valkey_bgtask_client,
             server_id=f"test-server-{uuid4()}",
         )
     )
+    await bgtask_manager.init()
 
     yield bgtask_manager
 

--- a/tests/unit/common/bgtask/test_background_task.py
+++ b/tests/unit/common/bgtask/test_background_task.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 import pytest
 
 from ai.backend.common import redis_helper
-from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
+from ai.backend.common.bgtask.bgtask import BackgroundTaskManager, BackgroundTaskManagerArgs
 from ai.backend.common.clients.valkey_client.valkey_bgtask.client import ValkeyBgtaskClient
 from ai.backend.common.defs import REDIS_BGTASK_DB, REDIS_STREAM_DB
 from ai.backend.common.events.dispatcher import (
@@ -133,10 +133,12 @@ async def background_task_manager(
     event_producer: EventProducer,
     valkey_bgtask_client: ValkeyBgtaskClient,
 ) -> AsyncIterator[BackgroundTaskManager]:
-    bgtask_manager = BackgroundTaskManager(
-        event_producer,
-        valkey_client=valkey_bgtask_client,
-        server_id=f"test-server-{uuid4()}",
+    bgtask_manager = await BackgroundTaskManager.create(
+        BackgroundTaskManagerArgs(
+            event_producer=event_producer,
+            valkey_client=valkey_bgtask_client,
+            server_id=f"test-server-{uuid4()}",
+        )
     )
 
     yield bgtask_manager

--- a/tests/unit/manager/dependencies/system/test_composer.py
+++ b/tests/unit/manager/dependencies/system/test_composer.py
@@ -139,8 +139,9 @@ class TestSystemComposer:
             "ai.backend.manager.dependencies.system.background_task_manager.BackgroundTaskManager"
         ) as mock_bgtask_class:
             mock_bgtask_manager = MagicMock()
+            mock_bgtask_manager.init = AsyncMock()
             mock_bgtask_manager.shutdown = AsyncMock()
-            mock_bgtask_class.create = AsyncMock(return_value=mock_bgtask_manager)
+            mock_bgtask_class.return_value = mock_bgtask_manager
 
             setup_input = SystemInput(
                 config=mock_config,

--- a/tests/unit/manager/dependencies/system/test_composer.py
+++ b/tests/unit/manager/dependencies/system/test_composer.py
@@ -140,7 +140,7 @@ class TestSystemComposer:
         ) as mock_bgtask_class:
             mock_bgtask_manager = MagicMock()
             mock_bgtask_manager.shutdown = AsyncMock()
-            mock_bgtask_class.return_value = mock_bgtask_manager
+            mock_bgtask_class.create = AsyncMock(return_value=mock_bgtask_manager)
 
             setup_input = SystemInput(
                 config=mock_config,


### PR DESCRIPTION
## Summary
- The event loop only keeps weak references to tasks, so a fire-and-forget `asyncio.create_task()` whose return value is not retained may be garbage collected mid-execution.
- `runner.types.Runner`: track observer/run tasks in a `set` and discard them on completion, keeping a strong reference while they run.
- `bgtask.BackgroundTaskManager`: move local cron startup out of `__init__` into an async `create()` factory and accept a `BackgroundTaskManagerArgs` dataclass; the cron's task runners already hold strong references internally, so no dangling wrapper task remains.
- Re-enable the `RUF006` (asyncio-dangling-task) lint rule.

## Test plan
- [x] `pants test tests/unit/common/bgtask::`
- [x] `pants test tests/component::` (background_task_manager fixture)
- [x] CI lint/check passes with RUF006 enabled


Resolves BA-6287