### PR TITLE
fix(BA-6291): wire app-proxy and webserver Redis to Sentinel in HA dev halfstack

### DIFF
--- a/changes/11974.fix.md
+++ b/changes/11974.fix.md
@@ -1,0 +1,1 @@
+Fix the HA (Sentinel) development halfstack so app-proxy and the webserver start: `install-dev.sh --configure-ha` now wires their Redis to the Sentinel cluster instead of leaving them pointed at a non-existent standalone Redis port.

--- a/configs/app-proxy-coordinator/halfstack.toml
+++ b/configs/app-proxy-coordinator/halfstack.toml
@@ -9,6 +9,11 @@ addr = { host = "127.0.0.1", port = 8100 }
 
 [redis]
 addr = { host = "127.0.0.1", port = 8110 }
+# For HA (Sentinel) mode, install-dev.sh --configure-ha comments out `addr` above
+# and enables the three lines below.
+# sentinel = [{ host = "127.0.0.1", port = 9503 }, { host = "127.0.0.1", port = 9504 }, { host = "127.0.0.1", port = 9505 }]
+# service_name = "mymaster"
+# password = "develove"
 
 [proxy_coordinator]
 tls_listen = false

--- a/configs/app-proxy-worker/halfstack.toml
+++ b/configs/app-proxy-worker/halfstack.toml
@@ -1,5 +1,10 @@
 [redis]
 addr = { host = "127.0.0.1", port = 8110 }
+# For HA (Sentinel) mode, install-dev.sh --configure-ha comments out `addr` above
+# and enables the three lines below.
+# sentinel = [{ host = "127.0.0.1", port = 9503 }, { host = "127.0.0.1", port = 9504 }, { host = "127.0.0.1", port = 9505 }]
+# service_name = "mymaster"
+# password = "develove"
 
 [proxy_worker]
 coordinator_endpoint = "http://127.0.0.1:10200"

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -1151,6 +1151,18 @@ configure_backendai() {
   sed_inplace "s/jwt_secret = \"some_jwt_secret\"/jwt_secret = \"${APPPROXY_JWT_SECRET}\"/" ./app-proxy-worker.toml
   sed_inplace "s/secret = \"some_permit_hash_secret\"/secret = \"${APPPROXY_PERMIT_HASH_SECRET}\"/" ./app-proxy-worker.toml
 
+  # In HA mode the app-proxy components must reach Redis through Sentinel (nothing
+  # listens on the standalone REDIS_PORT). Comment out the standalone `addr` and
+  # enable the Sentinel lines carried (commented) in the halfstack templates.
+  if [ $CONFIGURE_HA -eq 1 ]; then
+    for f in ./app-proxy-coordinator.toml ./app-proxy-worker.toml; do
+      sed_inplace "s/^addr = { host = \"127.0.0.1\", port = ${REDIS_PORT} }/# addr = { host = \"127.0.0.1\", port = ${REDIS_PORT} }/" "$f"
+      sed_inplace "s/# sentinel = \[/sentinel = [/" "$f"
+      sed_inplace "s/# service_name = \"mymaster\"/service_name = \"mymaster\"/" "$f"
+      sed_inplace "s/# password = \"develove\"/password = \"develove\"/" "$f"
+    done
+  fi
+
   # configure agent
   cp configs/agent/halfstack.toml ./agent.toml
   mkdir -p "$VAR_BASE_PATH"
@@ -1214,12 +1226,12 @@ configure_backendai() {
   sed_inplace "s/https:\/\/api.backend.ai/http:\/\/127.0.0.1:${MANAGER_PORT}/" ./webserver.conf
 
   if [ $CONFIGURE_HA -eq 1 ]; then
-    sed_inplace "s/redis.addr = \"localhost:6379\"/# redis.addr = \"localhost:6379\"/" ./webserver.conf
-    sed_inplace "s/# redis.password = \"mysecret\"/redis.password = \"develove\"/" ./webserver.conf
-    sed_inplace "s/# redis.service_name = \"mymaster\"/redis.service_name = \"mymaster\"/" ./webserver.conf
-    sed_inplace "s/# redis.sentinel = \"127.0.0.1:9503,127.0.0.1:9504,127.0.0.1:9505\"/redis.sentinel = \"127.0.0.1:9503,127.0.0.1:9504,127.0.0.1:9505\"/ " ./webserver.conf
+    sed_inplace "s/addr = \"localhost:8111\"/# addr = \"localhost:8111\"/" ./webserver.conf
+    sed_inplace "s/# password = \"mysecret\"/password = \"develove\"/" ./webserver.conf
+    sed_inplace "s/# service_name = \"mymaster\"/service_name = \"mymaster\"/" ./webserver.conf
+    sed_inplace "s/# sentinel = \"127.0.0.1:9503,127.0.0.1:9504,127.0.0.1:9505\"/sentinel = \"127.0.0.1:9503,127.0.0.1:9504,127.0.0.1:9505\"/" ./webserver.conf
   else
-    sed_inplace "s/redis.addr = \"localhost:6379\"/redis.addr = \"localhost:${REDIS_PORT}\"/" ./webserver.conf
+    sed_inplace "s/addr = \"localhost:8111\"/addr = \"localhost:${REDIS_PORT}\"/" ./webserver.conf
   fi
 
   # install and configure webui


### PR DESCRIPTION
Resolves BA-6291

## Summary

In `--configure-ha` (Sentinel) mode, only manager/agent were wired to the Sentinel Redis (via etcd `config/redis/sentinel`). The other three components could not reach Redis and failed to start:

```
glide_shared.exceptions.ClosingError: Standalone(Received error for address `127.0.0.1:8210`: timed out)   # app-proxy
glide_shared.exceptions.ClosingError: Standalone(Received error for address `localhost:8111`: timed out)    # webserver
```

**Root cause**
- **app-proxy-coordinator/worker**: their `[redis]` is a standalone `addr` on `REDIS_PORT` (8210 in HA), and nothing listens there — Redis is the 3-node cluster (9500-9502) fronted by Sentinels (9503-9505). There was no HA handling for app-proxy at all.
- **webserver**: install-dev's HA Sentinel substitutions targeted a stale `redis.addr = "localhost:6379"` key, but the template now uses a `[session.redis]` section with `addr = "localhost:8111"`, so every substitution silently no-op'd and the webserver kept pointing at the (non-existent) standalone port.

## Changes

- `configs/app-proxy-coordinator/halfstack.toml`, `configs/app-proxy-worker/halfstack.toml`: carry commented `sentinel` / `service_name` / `password` lines under `[redis]`.
- `scripts/install-dev.sh`:
  - app-proxy: in `--configure-ha`, comment the standalone `addr` and enable the Sentinel lines (Sentinels 9503-9505, `service_name = mymaster`).
  - webserver: fix the stale Sentinel substitutions to match the `[session.redis]` template (comment `addr`, enable `password`/`service_name`/`sentinel`).

Sentinel address format differs by component and both were verified: webserver uses the string form `sentinel = "h:p,h:p,h"`; app-proxy uses an array of `HostPortPair` tables.

## Test plan

- [x] Simulated install-dev's `--configure-ha` substitutions on the templates; the generated `[redis]` / `[session.redis]` sections match the manually-verified working config.
- [x] With the resulting config, app-proxy-coordinator, app-proxy-worker, and webserver all start and connect to the master via Sentinel (`Created ValkeyClient for master at node0x:950x`, "Started ... service", "Worker ... joined").
- [x] All six components (manager, agent, storage-proxy, webserver, app-proxy-coordinator, app-proxy-worker) run together against the Sentinel cluster.

Note: `configs/redis/haproxy.cfg` (the former single-endpoint front for port 8210) is now orphaned and a candidate for removal in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
