### PR TITLE
fix: Parse list-typed query parameters in manager `QueryParam` (#11970)

### DIFF
--- a/changes/11970.fix.md
+++ b/changes/11970.fix.md
@@ -1,0 +1,1 @@
+Make the manager's `QueryParam` request parser collect repeated query keys into list-typed fields (e.g. `?group_ids=a&group_ids=b`), which previously failed schema validation because the aiohttp multi-dict collapsed to a single value. Scalar fields keep their existing single-value behavior.

--- a/src/ai/backend/common/api_handlers.py
+++ b/src/ai/backend/common/api_handlers.py
@@ -7,10 +7,12 @@ from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable, Coroutine, Mapping
 from dataclasses import dataclass, field
 from inspect import Signature
+from types import UnionType
 from typing import (
     Any,
     Self,
     TypeVar,
+    Union,
     cast,
     get_args,
     get_origin,
@@ -19,7 +21,8 @@ from typing import (
 from aiohttp import web
 from aiohttp.web_urldispatcher import UrlMappingMatchInfo
 from multidict import CIMultiDictProxy, MultiMapping
-from pydantic import BaseModel, ConfigDict, RootModel
+from pydantic import AliasChoices, BaseModel, ConfigDict, RootModel
+from pydantic.fields import FieldInfo
 from pydantic_core._pydantic_core import ValidationError
 
 from ai.backend.common.types import StreamReader
@@ -129,8 +132,44 @@ class QueryParam[TRequestModel: BaseRequestModel]:
 
     @convert_validation_error
     def from_query(self, query: MultiMapping[str]) -> Self:
-        self._parsed = self._model.model_validate(query)
+        self._parsed = self._model.model_validate(self._to_mapping(query))
         return self
+
+    def _to_mapping(self, query: MultiMapping[str]) -> dict[str, Any]:
+        """Convert an aiohttp multi-dict query into a mapping for pydantic validation.
+
+        Scalars keep their single (first) value, preserving prior behavior. For
+        list-typed fields, all values of the matching key are collected via
+        ``getall`` so repeated query params (``?k=a&k=b``) validate as a list
+        instead of silently collapsing to a single value.
+        """
+
+        def is_sequence_annotation(annotation: Any) -> bool:
+            origin = get_origin(annotation)
+            if origin in (list, tuple, set, frozenset):
+                return True
+            if origin is Union or origin is UnionType:
+                return any(is_sequence_annotation(arg) for arg in get_args(annotation))
+            return False
+
+        def candidate_query_keys(name: str, field_info: FieldInfo) -> list[str]:
+            """Query-string keys a field accepts, honoring validation aliases."""
+            alias = field_info.validation_alias
+            if isinstance(alias, str):
+                return [alias]
+            if isinstance(alias, AliasChoices):
+                return [choice for choice in alias.choices if isinstance(choice, str)]
+            return [name]
+
+        data: dict[str, Any] = {key: query[key] for key in query}
+        for name, field_info in self._model.model_fields.items():
+            if not is_sequence_annotation(field_info.annotation):
+                continue
+            for key in candidate_query_keys(name, field_info):
+                if key in query:
+                    data[key] = query.getall(key)
+                    break
+        return data
 
 
 class HeaderParam[TRequestModel: BaseRequestModel]:

--- a/tests/component/infra/test_infra.py
+++ b/tests/component/infra/test_infra.py
@@ -30,12 +30,6 @@ from ai.backend.common.dto.manager.infra import (
     UsagePerPeriodResponse,
 )
 
-_GET_JSON_BODY_XFAIL_REASON = (
-    "Client SDK v2 sends JSON body on GET requests, but the server's "
-    "check_api_params reads from request.query for GET/HEAD methods, "
-    "ignoring the body entirely.  Params are never seen by the server."
-)
-
 
 class TestEtcdConfigRead:
     """Tests for read-only etcd config endpoints (no auth required)."""
@@ -246,7 +240,6 @@ class TestResourcePresets:
 class TestUsageStats:
     """Tests for usage statistics endpoints."""
 
-    @pytest.mark.xfail(reason=_GET_JSON_BODY_XFAIL_REASON, strict=True)
     async def test_admin_gets_usage_per_month(
         self,
         admin_registry: BackendAIClientRegistry,
@@ -258,7 +251,6 @@ class TestUsageStats:
         assert isinstance(result, UsagePerMonthResponse)
         assert isinstance(result.root, list)
 
-    @pytest.mark.xfail(reason=_GET_JSON_BODY_XFAIL_REASON, strict=True)
     async def test_admin_gets_usage_per_period(
         self,
         admin_registry: BackendAIClientRegistry,

--- a/tests/unit/common/test_api_handlers.py
+++ b/tests/unit/common/test_api_handlers.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import uuid
 from collections.abc import Awaitable, Callable
 from http import HTTPStatus
 from typing import Any, Self
 
 from aiohttp import web
-from pydantic import Field
+from pydantic import AliasChoices, Field
 
 from ai.backend.common.api_handlers import (
     APIResponse,
@@ -480,3 +481,94 @@ async def test_invalid_query_parameter(aiohttp_client: Any) -> None:
     # request with no query parameter
     error_response = await client.get("/test")
     assert error_response.status == HTTPStatus.BAD_REQUEST  # InvalidAPIParameters Error raised
+
+
+class TestListQueryModel(BaseRequestModel):
+    ids: list[str] | None = Field(default=None)
+    name: str
+
+
+class TestListQueryResponse(BaseResponseModel):
+    ids: list[str]
+    name: str
+
+
+class TestListQueryHandler:
+    @api_handler
+    async def handle_list_query(self, query: QueryParam[TestListQueryModel]) -> APIResponse:
+        parsed = query.parsed
+        return APIResponse.build(
+            status_code=HTTPStatus.OK,
+            response_model=TestListQueryResponse(ids=parsed.ids or [], name=parsed.name),
+        )
+
+
+async def test_repeated_query_parameter_parses_as_list(aiohttp_client: Any) -> None:
+    handler = TestListQueryHandler()
+    app = web.Application()
+    app.router.add_get("/test", handler.handle_list_query)
+
+    client = await aiohttp_client(app)
+    resp = await client.get("/test?ids=a&ids=b&ids=c&name=foo")
+
+    assert resp.status == HTTPStatus.OK
+    data = await resp.json()
+    assert data["ids"] == ["a", "b", "c"]
+    assert data["name"] == "foo"
+
+
+async def test_single_value_list_query_parameter_parses_as_one_element_list(
+    aiohttp_client: Any,
+) -> None:
+    handler = TestListQueryHandler()
+    app = web.Application()
+    app.router.add_get("/test", handler.handle_list_query)
+
+    client = await aiohttp_client(app)
+    resp = await client.get("/test?ids=only&name=foo")
+
+    assert resp.status == HTTPStatus.OK
+    data = await resp.json()
+    assert data["ids"] == ["only"]
+    assert data["name"] == "foo"
+
+
+class TestAliasedUuidListQueryModel(BaseRequestModel):
+    """Mirrors the motivating ``UsagePerMonthQuery.group_ids: list[uuid.UUID]`` case."""
+
+    group_ids: list[uuid.UUID] | None = Field(
+        default=None,
+        validation_alias=AliasChoices("group_ids", "group_id"),
+    )
+
+
+class TestAliasedUuidListResponse(BaseResponseModel):
+    group_ids: list[str]
+
+
+class TestAliasedUuidListHandler:
+    @api_handler
+    async def handle(self, query: QueryParam[TestAliasedUuidListQueryModel]) -> APIResponse:
+        parsed = query.parsed
+        return APIResponse.build(
+            status_code=HTTPStatus.OK,
+            response_model=TestAliasedUuidListResponse(
+                group_ids=[str(gid) for gid in (parsed.group_ids or [])],
+            ),
+        )
+
+
+async def test_repeated_uuid_list_query_parameter_via_alias(aiohttp_client: Any) -> None:
+    handler = TestAliasedUuidListHandler()
+    app = web.Application()
+    app.router.add_get("/test", handler.handle)
+
+    g1 = str(uuid.uuid4())
+    g2 = str(uuid.uuid4())
+    client = await aiohttp_client(app)
+    # Provided via the alias key ("group_id") and as repeated keys -> parsed as a UUID list.
+    resp = await client.get(f"/test?group_id={g1}&group_id={g2}")
+
+    assert resp.status == HTTPStatus.OK
+    data = await resp.json()
+    assert data["group_ids"] == [g1, g2]


### PR DESCRIPTION
This is an auto-generated backport PR of #11970 to the 26.4 release.