### PR TITLE
refactor(BA-6330): import BraceStyleAdapter from ai.backend.logging in accelerator plugins (#11988)

### DIFF
--- a/changes/11988.enhance.md
+++ b/changes/11988.enhance.md
@@ -1,0 +1,1 @@
+Import BraceStyleAdapter from ai.backend.logging instead of the deprecated ai.backend.common.logging shim in accelerator plugins

--- a/src/ai/backend/accelerator/furiosa/rngd/plugin.py
+++ b/src/ai/backend/accelerator/furiosa/rngd/plugin.py
@@ -36,7 +36,6 @@ from ai.backend.agent.stats import (
     StatContext,
 )
 from ai.backend.agent.types import Container, MountInfo
-from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import (
     AcceleratorMetadata,
     BinarySize,
@@ -46,6 +45,7 @@ from ai.backend.common.types import (
     SlotName,
     SlotTypes,
 )
+from ai.backend.logging import BraceStyleAdapter
 
 PREFIX = "rngd"
 _NPU_INDEX_RE = re.compile(r"/dev/rngd/npu(\d+)")

--- a/src/ai/backend/accelerator/furiosa/rngd/rngd_api.py
+++ b/src/ai/backend/accelerator/furiosa/rngd/rngd_api.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import ClassVar
 
-from ai.backend.common.logging import BraceStyleAdapter
+from ai.backend.logging import BraceStyleAdapter
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 

--- a/src/ai/backend/accelerator/furiosa/warboy/plugin.py
+++ b/src/ai/backend/accelerator/furiosa/warboy/plugin.py
@@ -32,7 +32,6 @@ from ai.backend.agent.stats import (
     StatContext,
 )
 from ai.backend.agent.types import Container, MountInfo
-from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import (
     AcceleratorMetadata,
     BinarySize,
@@ -42,6 +41,7 @@ from ai.backend.common.types import (
     SlotName,
     SlotTypes,
 )
+from ai.backend.logging import BraceStyleAdapter
 
 PREFIX = "warboy"
 

--- a/src/ai/backend/accelerator/habana/plugin.py
+++ b/src/ai/backend/accelerator/habana/plugin.py
@@ -36,7 +36,6 @@ from ai.backend.agent.stats import (
 )
 from ai.backend.agent.types import Container, MountInfo
 from ai.backend.common import config
-from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import (
     AcceleratorMetadata,
     BinarySize,
@@ -47,6 +46,7 @@ from ai.backend.common.types import (
     SlotName,
     SlotTypes,
 )
+from ai.backend.logging import BraceStyleAdapter
 
 __all__ = (
     "PREFIX",

--- a/src/ai/backend/accelerator/hyperaccel/lpu/plugin.py
+++ b/src/ai/backend/accelerator/hyperaccel/lpu/plugin.py
@@ -30,7 +30,6 @@ from ai.backend.agent.stats import (
     StatContext,
 )
 from ai.backend.agent.types import Container, MountInfo
-from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import (
     AcceleratorMetadata,
     BinarySize,
@@ -41,6 +40,7 @@ from ai.backend.common.types import (
     SlotName,
     SlotTypes,
 )
+from ai.backend.logging import BraceStyleAdapter
 
 PREFIX = "hyperaccel-lpu"
 SLOT_NAME = "hyperaccel-lpu.device"

--- a/src/ai/backend/accelerator/ipu/plugin.py
+++ b/src/ai/backend/accelerator/ipu/plugin.py
@@ -30,7 +30,6 @@ from ai.backend.agent.stats import (
 )
 from ai.backend.agent.types import Container, MountInfo
 from ai.backend.common import config
-from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import (
     AcceleratorMetadata,
     BinarySize,
@@ -42,6 +41,7 @@ from ai.backend.common.types import (
     SlotName,
     SlotTypes,
 )
+from ai.backend.logging import BraceStyleAdapter
 
 from . import __version__
 from .exception import DockerNetworkError, NoIPUoFConfError

--- a/src/ai/backend/accelerator/rebellions/atom/plugin.py
+++ b/src/ai/backend/accelerator/rebellions/atom/plugin.py
@@ -3,11 +3,11 @@ from collections.abc import Iterable
 
 from ai.backend.accelerator.rebellions.common.atom_api import ATOMAPI
 from ai.backend.accelerator.rebellions.common.plugin import AbstractATOMPlugin
-from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import (
     AcceleratorMetadata,
     DeviceId,
 )
+from ai.backend.logging import BraceStyleAdapter
 
 from .types import ATOMDevice
 

--- a/src/ai/backend/accelerator/rebellions/atom_max/plugin.py
+++ b/src/ai/backend/accelerator/rebellions/atom_max/plugin.py
@@ -11,7 +11,6 @@ from ai.backend.agent.stats import (
     NodeMeasurement,
     StatContext,
 )
-from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import (
     AcceleratorMetadata,
     DeviceId,
@@ -20,6 +19,7 @@ from ai.backend.common.types import (
     SlotName,
     SlotTypes,
 )
+from ai.backend.logging import BraceStyleAdapter
 
 from .types import ATOMMaxChildDevice, ATOMMaxDevice
 

--- a/src/ai/backend/accelerator/rebellions/atom_plus/plugin.py
+++ b/src/ai/backend/accelerator/rebellions/atom_plus/plugin.py
@@ -3,7 +3,6 @@ from collections.abc import Iterable, Sequence
 
 from ai.backend.accelerator.rebellions.common.atom_api import ATOMAPI
 from ai.backend.accelerator.rebellions.common.plugin import AbstractATOMPlugin
-from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import (
     AcceleratorMetadata,
     DeviceId,
@@ -11,6 +10,7 @@ from ai.backend.common.types import (
     SlotName,
     SlotTypes,
 )
+from ai.backend.logging import BraceStyleAdapter
 
 from .types import ATOMPlusDevice
 

--- a/src/ai/backend/accelerator/rocm/hip.py
+++ b/src/ai/backend/accelerator/rocm/hip.py
@@ -7,7 +7,7 @@ from abc import ABCMeta, abstractmethod
 from collections.abc import MutableMapping
 from typing import Any
 
-from ai.backend.common.logging import BraceStyleAdapter
+from ai.backend.logging import BraceStyleAdapter
 
 from .exception import LibraryError
 

--- a/src/ai/backend/accelerator/rocm/plugin.py
+++ b/src/ai/backend/accelerator/rocm/plugin.py
@@ -39,7 +39,6 @@ from ai.backend.agent.stats import (
     StatContext,
 )
 from ai.backend.agent.types import Container, MountInfo
-from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import (
     AcceleratorMetadata,
     BinarySize,
@@ -50,6 +49,7 @@ from ai.backend.common.types import (
     SlotName,
     SlotTypes,
 )
+from ai.backend.logging import BraceStyleAdapter
 
 __all__ = (
     "PREFIX",

--- a/src/ai/backend/accelerator/tenstorrent/n300/plugin.py
+++ b/src/ai/backend/accelerator/tenstorrent/n300/plugin.py
@@ -41,7 +41,6 @@ from ai.backend.agent.stats import (
     StatContext,
 )
 from ai.backend.agent.types import Container, MountInfo
-from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import (
     AcceleratorMetadata,
     BinarySize,
@@ -52,6 +51,7 @@ from ai.backend.common.types import (
     SlotName,
     SlotTypes,
 )
+from ai.backend.logging import BraceStyleAdapter
 
 PREFIX = "tt-n300"
 VALID_CARD_TYPE = "n300"

--- a/src/ai/backend/accelerator/tpu/plugin.py
+++ b/src/ai/backend/accelerator/tpu/plugin.py
@@ -18,7 +18,6 @@ from ai.backend.agent.resources import (
 )
 from ai.backend.agent.stats import ContainerMeasurement, NodeMeasurement, StatContext
 from ai.backend.agent.types import Container
-from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import (
     BinarySize,
     DeviceId,
@@ -27,6 +26,7 @@ from ai.backend.common.types import (
     SlotName,
     SlotTypes,
 )
+from ai.backend.logging import BraceStyleAdapter
 
 from . import __version__
 from .tpu import libtpu


### PR DESCRIPTION
This is an auto-generated backport PR of #11988 to the 26.4 release.