### PR TITLE
refactor(BA-6329): reuse a single Docker client per stats pass in accelerator plugins

### DIFF
--- a/changes/11990.enhance.md
+++ b/changes/11990.enhance.md
@@ -1,0 +1,1 @@
+Reuse a single Docker client per stats-collection pass in accelerator plugins instead of opening one per container

--- a/src/ai/backend/accelerator/furiosa/rngd/plugin.py
+++ b/src/ai/backend/accelerator/furiosa/rngd/plugin.py
@@ -218,33 +218,33 @@ class RngdPlugin(AbstractComputePlugin):
             return []
 
         # Step 2: For each container, find allocated devices via Docker inspection
-        for cid in container_ids:
-            mem_stats[cid] = 0
-            mem_sizes[cid] = 0
-            util_stats[cid] = Decimal("0")
-            num_devices_per_container[cid] = 0
-            try:
-                async with aiodocker.Docker() as docker:
+        async with aiodocker.Docker() as docker:
+            for cid in container_ids:
+                mem_stats[cid] = 0
+                mem_sizes[cid] = 0
+                util_stats[cid] = Decimal("0")
+                num_devices_per_container[cid] = 0
+                try:
                     container_info = await docker.containers.get(cid)
-                seen_indices: set[int] = set()
-                for dev_entry in container_info["HostConfig"].get("Devices", []):
-                    m = _NPU_INDEX_RE.match(dev_entry["PathOnHost"])
-                    if m is None:
-                        continue
-                    dev_idx = int(m.group(1))
-                    if dev_idx in seen_indices:
-                        continue
-                    seen_indices.add(dev_idx)
-                    dev_metric = device_metrics.get(dev_idx)
-                    if dev_metric is None:
-                        continue
-                    mem_used, mem_total, avg_util = dev_metric
-                    mem_stats[cid] += mem_used
-                    mem_sizes[cid] += mem_total
-                    util_stats[cid] += Decimal(str(avg_util))
-                    num_devices_per_container[cid] += 1
-            except Exception:
-                log.warning("failed to inspect container {} for RNGD measures", cid)
+                    seen_indices: set[int] = set()
+                    for dev_entry in container_info["HostConfig"].get("Devices", []):
+                        m = _NPU_INDEX_RE.match(dev_entry["PathOnHost"])
+                        if m is None:
+                            continue
+                        dev_idx = int(m.group(1))
+                        if dev_idx in seen_indices:
+                            continue
+                        seen_indices.add(dev_idx)
+                        dev_metric = device_metrics.get(dev_idx)
+                        if dev_metric is None:
+                            continue
+                        mem_used, mem_total, avg_util = dev_metric
+                        mem_stats[cid] += mem_used
+                        mem_sizes[cid] += mem_total
+                        util_stats[cid] += Decimal(str(avg_util))
+                        num_devices_per_container[cid] += 1
+                except Exception:
+                    log.warning("failed to inspect container {} for RNGD measures", cid)
 
         return [
             ContainerMeasurement(

--- a/src/ai/backend/accelerator/habana/plugin.py
+++ b/src/ai/backend/accelerator/habana/plugin.py
@@ -230,20 +230,20 @@ class AbstractGaudiPlugin[TDevice: AbstractGaudiDevice](AbstractComputePlugin, m
                 self.enabled = False
                 return []
 
-            for cid in container_ids:
-                mem_stats[cid] = 0
-                mem_sizes[cid] = 0
-                util_stats[cid] = Decimal("0")
-                number_of_devices_per_container[cid] = 0
-                async with aiodocker.Docker() as docker:
+            async with aiodocker.Docker() as docker:
+                for cid in container_ids:
+                    mem_stats[cid] = 0
+                    mem_sizes[cid] = 0
+                    util_stats[cid] = Decimal("0")
+                    number_of_devices_per_container[cid] = 0
                     container_info = await docker.containers.get(cid)
-                for device in container_info["HostConfig"]["Devices"]:
-                    if device["PathOnHost"] in device_stats_by_device_filename:
-                        device_stat = device_stats_by_device_filename[device["PathOnHost"]]
-                        mem_stats[cid] += int(device_stat["mem_used"])
-                        mem_sizes[cid] += int(device_stat["mem_total"])
-                        util_stats[cid] += Decimal(device_stat["util"])
-                        number_of_devices_per_container[cid] += 1
+                    for device in container_info["HostConfig"]["Devices"]:
+                        if device["PathOnHost"] in device_stats_by_device_filename:
+                            device_stat = device_stats_by_device_filename[device["PathOnHost"]]
+                            mem_stats[cid] += int(device_stat["mem_used"])
+                            mem_sizes[cid] += int(device_stat["mem_total"])
+                            util_stats[cid] += Decimal(device_stat["util"])
+                            number_of_devices_per_container[cid] += 1
 
         return [
             ContainerMeasurement(

--- a/src/ai/backend/accelerator/ipu/plugin.py
+++ b/src/ai/backend/accelerator/ipu/plugin.py
@@ -261,37 +261,38 @@ class IPUPlugin(AbstractComputePlugin):
             devices_by_hw_id: dict[str, IPUDevice] = {
                 d.hw_location: d for d in await self.list_devices()
             }
-            for cid in container_ids:
-                mem_stats[cid] = 0
-                mem_sizes[cid] = 0
-                util_stats[cid] = Decimal("0")
-                number_of_devices_per_container[cid] = 0
-                async with aiodocker.Docker() as docker:
+            async with aiodocker.Docker() as docker:
+                for cid in container_ids:
+                    mem_stats[cid] = 0
+                    mem_sizes[cid] = 0
+                    util_stats[cid] = Decimal("0")
+                    number_of_devices_per_container[cid] = 0
                     container_info = await docker.containers.get(cid)
-                for mount in container_info["HostConfig"]["Mounts"]:
-                    if mount["Target"] == "/etc/ipuof.conf.d":
-                        ipuof_conf_path = (
-                            Path(mount["Source"]) / Path(self.ipu_config["ipuof-config-path"]).name
-                        )
-                        ipuof_conf = json.loads(
-                            await asyncio.get_running_loop().run_in_executor(
-                                None, ipuof_conf_path.read_text
+                    for mount in container_info["HostConfig"]["Mounts"]:
+                        if mount["Target"] == "/etc/ipuof.conf.d":
+                            ipuof_conf_path = (
+                                Path(mount["Source"])
+                                / Path(self.ipu_config["ipuof-config-path"]).name
                             )
-                        )
-                        for device in ipuof_conf["devices"]:
-                            hw_location = device["ip"] + ":" + str(device["device_id"])
-                            device = devices_by_hw_id[hw_location]
-                            inventory_info = inventory_map[device.device_id]
-                            mem_stats[cid] += int(
-                                inventory_info["hexoatt active size (bytes)"]
-                            ) + int(inventory_info["hexopt active size (bytes)"])
-                            mem_sizes[cid] += int(
-                                inventory_info["hexoatt total size (bytes)"]
-                            ) + int(inventory_info["hexopt total size (bytes)"])
-                            util_stats[cid] += Decimal(
-                                inventory_info["ipu utilisation"].replace("%", "")
+                            ipuof_conf = json.loads(
+                                await asyncio.get_running_loop().run_in_executor(
+                                    None, ipuof_conf_path.read_text
+                                )
                             )
-                            number_of_devices_per_container[cid] += 1
+                            for device in ipuof_conf["devices"]:
+                                hw_location = device["ip"] + ":" + str(device["device_id"])
+                                device = devices_by_hw_id[hw_location]
+                                inventory_info = inventory_map[device.device_id]
+                                mem_stats[cid] += int(
+                                    inventory_info["hexoatt active size (bytes)"]
+                                ) + int(inventory_info["hexopt active size (bytes)"])
+                                mem_sizes[cid] += int(
+                                    inventory_info["hexoatt total size (bytes)"]
+                                ) + int(inventory_info["hexopt total size (bytes)"])
+                                util_stats[cid] += Decimal(
+                                    inventory_info["ipu utilisation"].replace("%", "")
+                                )
+                                number_of_devices_per_container[cid] += 1
         return [
             ContainerMeasurement(
                 MetricKey("ipu_mem"),

--- a/src/ai/backend/accelerator/rebellions/common/plugin.py
+++ b/src/ai/backend/accelerator/rebellions/common/plugin.py
@@ -197,20 +197,20 @@ class AbstractATOMPlugin[TATOMDevice: AbstractATOMDevice](AbstractComputePlugin,
             device_stats_by_device_filename: dict[str, ATOMDeviceStat] = {
                 "/dev/" + device.device: device for device in stats.devices
             }
-            for cid in container_ids:
-                mem_stats[cid] = 0
-                mem_sizes[cid] = 0
-                util_stats[cid] = Decimal("0")
-                number_of_devices_per_container[cid] = 0
-                async with Docker() as docker:
+            async with Docker() as docker:
+                for cid in container_ids:
+                    mem_stats[cid] = 0
+                    mem_sizes[cid] = 0
+                    util_stats[cid] = Decimal("0")
+                    number_of_devices_per_container[cid] = 0
                     container_info = await docker.containers.get(cid)
-                for device in container_info["HostConfig"]["Devices"]:
-                    if device["PathOnHost"] in device_stats_by_device_filename:
-                        device_stat = device_stats_by_device_filename[device["PathOnHost"]]
-                        mem_stats[cid] += int(device_stat.memory.used)
-                        mem_sizes[cid] += int(device_stat.memory.total)
-                        util_stats[cid] += Decimal(device_stat.util)
-                        number_of_devices_per_container[cid] += 1
+                    for device in container_info["HostConfig"]["Devices"]:
+                        if device["PathOnHost"] in device_stats_by_device_filename:
+                            device_stat = device_stats_by_device_filename[device["PathOnHost"]]
+                            mem_stats[cid] += int(device_stat.memory.used)
+                            mem_sizes[cid] += int(device_stat.memory.total)
+                            util_stats[cid] += Decimal(device_stat.util)
+                            number_of_devices_per_container[cid] += 1
         return [
             ContainerMeasurement(
                 MetricKey(f"{stat_prefix}_mem"),

--- a/src/ai/backend/accelerator/rocm/plugin.py
+++ b/src/ai/backend/accelerator/rocm/plugin.py
@@ -279,21 +279,23 @@ class ROCmPlugin(AbstractComputePlugin):
                 return []
 
             log.debug("device_stats_by_device_filename: {}", device_stats_by_device_filename)
-            for cid in container_ids:
-                mem_stats[cid] = 0
-                mem_sizes[cid] = 0
-                util_stats[cid] = Decimal("0")
-                number_of_devices_per_container[cid] = 0
-                async with aiodocker.Docker() as docker:
+            async with aiodocker.Docker() as docker:
+                for cid in container_ids:
+                    mem_stats[cid] = 0
+                    mem_sizes[cid] = 0
+                    util_stats[cid] = Decimal("0")
+                    number_of_devices_per_container[cid] = 0
                     container_info = await docker.containers.get(cid)
-                log.debug("Container {}: Devices: {}", cid, container_info["HostConfig"]["Devices"])
-                for device in container_info["HostConfig"]["Devices"]:
-                    if device["PathOnHost"] in device_stats_by_device_filename:
-                        device_stat = device_stats_by_device_filename[device["PathOnHost"]]
-                        mem_stats[cid] += int(device_stat["mem_used"])
-                        mem_sizes[cid] += int(device_stat["mem_total"])
-                        util_stats[cid] += Decimal(device_stat["util"])
-                        number_of_devices_per_container[cid] += 1
+                    log.debug(
+                        "Container {}: Devices: {}", cid, container_info["HostConfig"]["Devices"]
+                    )
+                    for device in container_info["HostConfig"]["Devices"]:
+                        if device["PathOnHost"] in device_stats_by_device_filename:
+                            device_stat = device_stats_by_device_filename[device["PathOnHost"]]
+                            mem_stats[cid] += int(device_stat["mem_used"])
+                            mem_sizes[cid] += int(device_stat["mem_total"])
+                            util_stats[cid] += Decimal(device_stat["util"])
+                            number_of_devices_per_container[cid] += 1
 
         return [
             ContainerMeasurement(

--- a/src/ai/backend/accelerator/tenstorrent/n300/plugin.py
+++ b/src/ai/backend/accelerator/tenstorrent/n300/plugin.py
@@ -207,19 +207,19 @@ class TTn300Plugin(AbstractComputePlugin):
                 for device in (await self.list_devices())
             }
 
-            for cid in container_ids:
-                power_stats[cid] = Decimal("0")
-                number_of_devices_per_container[cid] = 0
-                async with Docker() as docker:
+            async with Docker() as docker:
+                for cid in container_ids:
+                    power_stats[cid] = Decimal("0")
+                    number_of_devices_per_container[cid] = 0
                     container_info = await docker.containers.get(cid)
-                for device in container_info["HostConfig"]["Devices"]:
-                    if device["PathOnHost"] in device_stats_by_device_filename:
-                        left_stat, right_stat = device_stats_by_device_filename[
-                            device["PathOnHost"]
-                        ]
-                        power_stats[cid] += Decimal(left_stat["power"].strip())
-                        power_stats[cid] += Decimal(right_stat["power"].strip())
-                        number_of_devices_per_container[cid] += 1
+                    for device in container_info["HostConfig"]["Devices"]:
+                        if device["PathOnHost"] in device_stats_by_device_filename:
+                            left_stat, right_stat = device_stats_by_device_filename[
+                                device["PathOnHost"]
+                            ]
+                            power_stats[cid] += Decimal(left_stat["power"].strip())
+                            power_stats[cid] += Decimal(right_stat["power"].strip())
+                            number_of_devices_per_container[cid] += 1
         return [
             ContainerMeasurement(
                 MetricKey(f"{stat_prefix}_power"),


### PR DESCRIPTION
## Summary
- Hoist `aiodocker.Docker()` out of the per-container loop in `gather_container_measures()` across the habana, ipu, rocm, furiosa/rngd, rebellions, and tenstorrent/n300 accelerator plugins.
- Each stats-collection pass now reuses one Docker client instead of opening a new aiohttp session + Docker unix socket for every container, reducing socket/connection churn proportional to (containers × collection frequency).
- Aligns these plugins with the already-correct `cuda_open` and `mock` plugins. No behavior change — same Docker queries, just a reused client.

## Test plan
- [x] `pants fmt` — no changes
- [x] `pants lint` — ruff/visibility passed
- [x] `pants check` — mypy passed
- [ ] Verify GPU/NPU container stats are still collected correctly on a real agent with allocated devices

Resolves BA-6329