### PR TITLE
fix(BA-6328): add backend.ai-cli dependency to storage-proxy and app-proxy-worker

### DIFF
--- a/changes/11992.fix.md
+++ b/changes/11992.fix.md
@@ -1,0 +1,1 @@
+Add the missing `backend.ai-cli` dependency to the Storage Proxy and App Proxy Worker distributions so their virtualenvs install the `backend.ai` console script and can be started via `backend.ai <component> start-server`.

--- a/src/ai/backend/appproxy/coordinator/BUILD
+++ b/src/ai/backend/appproxy/coordinator/BUILD
@@ -5,6 +5,7 @@ python_sources(
     name="src",
     sources=["**/*.py"],
     dependencies=[
+        "src/ai/backend/cli:src",  # explicit: provides the `backend.ai` console script
         ":resources",
     ],
 )

--- a/src/ai/backend/appproxy/worker/BUILD
+++ b/src/ai/backend/appproxy/worker/BUILD
@@ -2,6 +2,7 @@ python_sources(
     name="src",
     sources=["**/*.py"],
     dependencies=[
+        "src/ai/backend/cli:src",  # not auto-inferred
         ":resources",
     ],
 )

--- a/src/ai/backend/storage/BUILD
+++ b/src/ai/backend/storage/BUILD
@@ -2,6 +2,7 @@ python_sources(
     name="src",
     sources=["**/*.py"],
     dependencies=[
+        "src/ai/backend/cli:src",  # not auto-inferred
         ":resources",
     ],
 )


### PR DESCRIPTION
## Problem

On the 26.4.3 release, **Storage Proxy** and **App Proxy Worker** cannot be started via `backend.ai <component> start-server` in a clean per-component virtualenv: the `backend.ai` command is simply *not found* (see BA-6328).

The `backend.ai` console script is provided **only** by the `backend.ai-cli` package (`src/ai/backend/cli/BUILD` → `console_scripts`). Each component distribution must therefore depend on `backend.ai-cli` to ship that entry point. How they currently get it:

| Component | How it depended on `backend.ai-cli` | In Requires-Dist (before) |
|---|---|---|
| manager | explicit BUILD dep (also imports `ai.backend.cli`) | ✅ |
| app-proxy-coordinator | **only** Pants import inference (`ai.backend.cli.types`) | ✅ (fragile) |
| agent | explicit `src/ai/backend/cli:src  # not auto-inferred` | ✅ |
| **storage-proxy** | neither imports nor declares it | ❌ **bug** |
| **app-proxy-worker** | neither imports nor declares it | ❌ **bug** |

Storage Proxy and App Proxy Worker only reference `ai.backend.cli` in a comment, so Pants infers nothing and — unlike agent — they never declared it explicitly. Their wheels omit `backend.ai-cli`, and a venv built from them has no `backend.ai` entry point.

## Fix

Declare `src/ai/backend/cli:src` **explicitly** in every component distribution, so the `backend.ai-cli` dependency is guaranteed and never depends on import inference:

- **storage-proxy**, **app-proxy-worker**: add the missing dependency (the actual bug).
- **app-proxy-coordinator**: make the (previously inference-only) dependency explicit, so a future refactor that drops the `ai.backend.cli` import cannot silently reintroduce this bug.

This matches the established `# not auto-inferred` pattern already used by agent/manager/account_manager.

## Verification (local)

Built the wheels before/after and confirmed via a clean Python 3.13.7 venv install:

- **Before**: `backend.ai-storage-proxy` / `-appproxy-worker` Requires-Dist had no `backend.ai-cli`; `backend.ai` command absent → reproduces `command not found`.
- **After**: `Requires-Dist: backend.ai-cli` present in storage-proxy, app-proxy-worker and app-proxy-coordinator wheels; installing into a clean venv creates the `backend.ai` console script.

## Notes

- Likely needs backporting to the `26.4` branch (the release where this surfaced).
- Resolves BA-6328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)