### PR TITLE
fix(BA-6333): retain strong refs for remaining fire-and-forget asyncio tasks (RUF006)

### DIFF
--- a/changes/11995.fix.md
+++ b/changes/11995.fix.md
@@ -1,0 +1,1 @@
+Keep strong references to fire-and-forget `asyncio` tasks across the WebSocket proxies (client CLI, web, manager) and the kernel runner/terminal so they are not garbage-collected mid-flight, clearing the remaining `RUF006` violations left after BA-6287.

--- a/src/ai/backend/client/cli/proxy.py
+++ b/src/ai/backend/client/cli/proxy.py
@@ -21,12 +21,14 @@ from .pretty import print_error, print_fail, print_info
 class WebSocketProxy:
     __slots__ = (
         "down_conn",
+        "downstream_task",
         "up_conn",
         "upstream_buffer",
         "upstream_buffer_task",
     )
 
     upstream_buffer: asyncio.Queue[tuple[str | bytes, aiohttp.WSMsgType]]
+    downstream_task: asyncio.Future[None] | None
 
     def __init__(
         self, up_conn: aiohttp.ClientWebSocketResponse, down_conn: web.WebSocketResponse
@@ -35,9 +37,10 @@ class WebSocketProxy:
         self.down_conn = down_conn
         self.upstream_buffer = asyncio.Queue()
         self.upstream_buffer_task = None
+        self.downstream_task = None
 
     async def proxy(self) -> None:
-        asyncio.ensure_future(self.downstream())
+        self.downstream_task = asyncio.ensure_future(self.downstream())
         await self.upstream()
 
     async def upstream(self) -> None:

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -171,10 +171,12 @@ class BaseRunner(metaclass=ABCMeta):
     _main_task: asyncio.Task[Any]
     _run_task: asyncio.Task[Any]
     _health_check_task: asyncio.Task[Any] | None
+    _background_tasks: set[asyncio.Task[Any]]
 
     def __init__(self, runtime_path: Path) -> None:
         setup_logger_basic(self.log_prefix, False)
         self.subproc = None
+        self._background_tasks = set()
         self.runtime_path = runtime_path
         self.child_env = {**os.environ, **self.default_child_env}
         # set some defaults only when they are missing from the image
@@ -940,7 +942,11 @@ class BaseRunner(metaclass=ABCMeta):
                             cwd=_cwd,
                         )
                         self.services_running[service_info["name"]] = proc
-                        asyncio.create_task(self._wait_service_proc(service_info["name"], proc))
+                        wait_task = asyncio.create_task(
+                            self._wait_service_proc(service_info["name"], proc)
+                        )
+                        self._background_tasks.add(wait_task)
+                        wait_task.add_done_callback(self._background_tasks.discard)
                         if launch_timeout is not None:
                             async with asyncio.timeout(launch_timeout):
                                 await wait_local_port_open(service_info["port"])
@@ -1229,13 +1235,19 @@ class BaseRunner(metaclass=ABCMeta):
                     await self._send_status()
                 elif op_type == "event":
                     data = json.loads(text)
-                    asyncio.create_task(self.log_event(data))
+                    event_task = asyncio.create_task(self.log_event(data))
+                    self._background_tasks.add(event_task)
+                    event_task.add_done_callback(self._background_tasks.discard)
                 elif op_type == "start-model-service":  # activate a service port
                     data = json.loads(text)
-                    asyncio.create_task(self.start_model_service(data))
+                    model_service_task = asyncio.create_task(self.start_model_service(data))
+                    self._background_tasks.add(model_service_task)
+                    model_service_task.add_done_callback(self._background_tasks.discard)
                 elif op_type == "start-service":  # activate a service port
                     data = json.loads(text)
-                    asyncio.create_task(self._start_service_and_feed_result(data))
+                    service_task = asyncio.create_task(self._start_service_and_feed_result(data))
+                    self._background_tasks.add(service_task)
+                    service_task.add_done_callback(self._background_tasks.discard)
                 elif op_type == "shutdown-service":  # shutdown the service by its name
                     data = json.loads(text)
                     await self._shutdown_service(data)

--- a/src/ai/backend/kernel/terminal.py
+++ b/src/ai/backend/kernel/terminal.py
@@ -41,6 +41,7 @@ class Terminal:
         loop: AbstractEventLoop | None = None,
     ) -> None:
         self._sorna_media: list[Any] = []
+        self._background_tasks: set[asyncio.Task[Any]] = set()
         self.zctx = sock_out.context
 
         self.ev_term = ev_term
@@ -203,7 +204,9 @@ class Terminal:
                 await self.sock_term_out.send_multipart([b"Terminated.\r\n"])
                 return
             if not self.ev_term.is_set() and self.accept_term_input:
-                asyncio.create_task(self.restart())
+                restart_task = asyncio.create_task(self.restart())
+                self._background_tasks.add(restart_task)
+                restart_task.add_done_callback(self._background_tasks.discard)
         except asyncio.CancelledError:
             pass
         except Exception:

--- a/src/ai/backend/manager/api/wsproxy.py
+++ b/src/ai/backend/manager/api/wsproxy.py
@@ -177,6 +177,7 @@ class WebSocketProxy:
         self.downstream_cb = downstream_callback
         self.upstream_cb = upstream_callback
         self.ping_cb = ping_callback
+        self.downstream_task = None
 
     async def proxy(self) -> None:
         self.downstream_task = asyncio.create_task(self.downstream())

--- a/src/ai/backend/storage/services/artifacts/huggingface.py
+++ b/src/ai/backend/storage/services/artifacts/huggingface.py
@@ -339,6 +339,7 @@ class HuggingFaceService:
     _transfer_manager: StorageTransferManager
     _artifact_verifier_ctx: ArtifactVerifierContext
     _redis_client: ValkeyArtifactDownloadTrackingClient
+    _background_tasks: set[asyncio.Task[Any]]
 
     def __init__(self, args: HuggingFaceServiceArgs) -> None:
         self._storage_pool = args.storage_pool
@@ -348,6 +349,7 @@ class HuggingFaceService:
         self._transfer_manager = StorageTransferManager(args.storage_pool)
         self._artifact_verifier_ctx = args.artifact_verifier_ctx
         self._redis_client = args.redis_client
+        self._background_tasks = set()
 
     def _make_scanner(self, registry_name: str) -> HuggingFaceScanner:
         config = self._registry_configs.get(registry_name)
@@ -392,9 +394,11 @@ class HuggingFaceService:
         # Start background task to download metadata and fire event when complete
         if models:
             scanner = self._make_scanner(registry_name)
-            asyncio.create_task(
+            task = asyncio.create_task(
                 scanner.download_metadata_batch(models, registry_name, self._event_producer)
             )
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
 
         return models
 
@@ -475,11 +479,13 @@ class HuggingFaceService:
 
         # Start background metadata processing for multiple models
         if retrieved_models:
-            asyncio.create_task(
+            task = asyncio.create_task(
                 scanner.download_metadata_batch(
                     retrieved_models, registry_name, self._event_producer
                 )
             )
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
 
         log.info("Successfully retrieved {} models", len(retrieved_models))
         return retrieved_models

--- a/src/ai/backend/storage/services/service.py
+++ b/src/ai/backend/storage/services/service.py
@@ -43,6 +43,7 @@ class VolumeService:
     _volume_pool: VolumePool
     _event_producer: EventProducer
     _deletion_tasks: weakref.WeakValueDictionary[VFolderID, asyncio.Task[Any]]
+    _background_tasks: set[asyncio.Task[Any]]
 
     def __init__(
         self,
@@ -52,6 +53,7 @@ class VolumeService:
         self._volume_pool = volume_pool
         self._event_producer = event_producer
         self._deletion_tasks = weakref.WeakValueDictionary[VFolderID, asyncio.Task[Any]]()
+        self._background_tasks = set()
 
     async def _get_capabilities(self, volume_id: VolumeID) -> list[str]:
         async with self._volume_pool.get_volume(volume_id) as volume:
@@ -256,5 +258,7 @@ class VolumeService:
         else:
             ongoing_task = self._deletion_tasks.get(vfolder_id)
             if ongoing_task is not None and ongoing_task.done():
-                asyncio.create_task(self._delete_vfolder(vfolder_key))
+                task = asyncio.create_task(self._delete_vfolder(vfolder_key))
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
         return

--- a/src/ai/backend/web/proxy.py
+++ b/src/ai/backend/web/proxy.py
@@ -56,6 +56,7 @@ HOP_ONLY_HEADERS: Final[CIMultiDict[int]] = CIMultiDict([
 class WebSocketProxy:
     __slots__ = (
         "down_conn",
+        "downstream_task",
         "up_conn",
         "upstream_buffer",
         "upstream_buffer_task",
@@ -65,6 +66,7 @@ class WebSocketProxy:
     down_conn: web.WebSocketResponse
     upstream_buffer: asyncio.Queue[tuple[str | bytes, aiohttp.WSMsgType]]
     upstream_buffer_task: asyncio.Task[Any] | None
+    downstream_task: asyncio.Future[None] | None
 
     def __init__(
         self, up_conn: aiohttp.ClientWebSocketResponse, down_conn: web.WebSocketResponse
@@ -73,9 +75,10 @@ class WebSocketProxy:
         self.down_conn = down_conn
         self.upstream_buffer = asyncio.Queue()
         self.upstream_buffer_task = None
+        self.downstream_task = None
 
     async def proxy(self) -> None:
-        asyncio.ensure_future(self.downstream())
+        self.downstream_task = asyncio.ensure_future(self.downstream())
         await self.upstream()
 
     async def upstream(self) -> None:


### PR DESCRIPTION
## Background

`BA-6287 (#11953)` enabled the **RUF006** ruff rule (`asyncio-dangling-task`) by removing it from the `ignore` list and fixed the violations within its own change scope. But CI lints only changed files (`--changed-since`), so violations in files untouched since then stayed **latent** — they only surface when an unrelated change pulls those files into lint scope (which is exactly what happened in #11992 / BA-6328 for the storage files).

A full-tree scan (`ruff check src/ --select RUF006`) found the remaining violations.

## Changes

Retain a strong reference to each fire-and-forget task so it cannot be garbage-collected mid-flight. **Behavior is unchanged** — references only, no cancellation added.

- `client/cli/proxy.py`, `web/proxy.py`, `manager/api/wsproxy.py` — store the downstream task on the `WebSocketProxy` instance (new slot/attribute, alongside the existing `upstream_buffer_task`).
- `kernel/base.py` — service-proc wait, `log_event`, `start_model_service`, `start_service`: retain in a per-instance `_background_tasks` set with a done-callback that discards them.
- `kernel/terminal.py` — `restart`: same set pattern.
- `storage/services/service.py`, `storage/services/artifacts/huggingface.py` — included here (originally surfaced by BA-6328's lint scope) so all RUF006 fixes live in one cleanup PR.

## Verification

- `ruff check src/ --select RUF006` → **All checks passed!** (0 violations tree-wide)
- `pants --changed-since=origin/main fmt lint check` → ruff ✓, mypy ✓

## Notes

- Pattern matches the fix introduced in BA-6287.
- Resolves BA-6333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)