### PR TITLE
fix(BA-6336): guard runtime variant health check migration

### DIFF
--- a/changes/12003.fix.md
+++ b/changes/12003.fix.md
@@ -1,0 +1,1 @@
+Fix runtime variant health-check migration for operator-added definitions.

--- a/src/ai/backend/manager/models/alembic/versions/ed42bc179b91_set_custom_runtime_variant_default_definition.py
+++ b/src/ai/backend/manager/models/alembic/versions/ed42bc179b91_set_custom_runtime_variant_default_definition.py
@@ -67,7 +67,9 @@ def upgrade() -> None:
             "UPDATE runtime_variants "
             "SET default_model_definition = jsonb_set("
             "default_model_definition, '{models,0,service,health_check,enable}', 'true') "
-            "WHERE name NOT IN ('custom', 'cmd')"
+            "WHERE name NOT IN ('custom', 'cmd') "
+            "AND jsonb_typeof(default_model_definition #> "
+            "'{models,0,service,health_check}') = 'object'"
         )
     )
 
@@ -77,9 +79,11 @@ def downgrade() -> None:
     bind.execute(
         sa.text(
             "UPDATE runtime_variants "
-            "SET default_model_definition = jsonb_set("
-            "default_model_definition, '{models,0,service,health_check,enable}', 'false') "
-            "WHERE name NOT IN ('custom', 'cmd')"
+            "SET default_model_definition = "
+            "default_model_definition #- '{models,0,service,health_check,enable}' "
+            "WHERE name NOT IN ('custom', 'cmd') "
+            "AND jsonb_typeof(default_model_definition #> "
+            "'{models,0,service,health_check}') = 'object'"
         )
     )
     bind.execute(


### PR DESCRIPTION
## Summary
- Guard the runtime variant health-check data migration so it only updates rows whose `health_check` path is a JSON object.
- Make downgrade remove the `enable` field instead of forcing it to `false`, restoring the previous definition shape.
- Avoid failures on operator-added runtime variants with scalar or incomplete `default_model_definition` values.

## Test plan
- [x] `pants fmt ::`
- [x] `pants fix ::`
- [x] `pants lint --changed-since=origin/main`
- [x] `./py -m alembic -c /tmp/bai-alembic-cli-edge.XXXXXX.ini upgrade ed42bc179b91` against an isolated PostgreSQL DB with edge-case runtime variants
- [x] `./py -m alembic -c /tmp/bai-alembic-cli-edge.XXXXXX.ini downgrade eb9d9c018e85` against the same isolated PostgreSQL DB

Resolves BA-6336