### PR TITLE
feat(BA-6338): add Grafana MCP for log/metric observability during dev

### DIFF
--- a/.claude/skills/bai-cli/SKILL.md
+++ b/.claude/skills/bai-cli/SKILL.md
@@ -238,6 +238,11 @@ For local development, restart services first — see `/local-dev` skill.
 # Switch to regular user, same command should fail with 403
 ```
 
+After a command, confirm runtime behavior through the Grafana MCP — see `/observability`.
+Query Loki for the service that handled the request (e.g. `{service_name="manager"} |=
+"error"`) to catch errors not surfaced by the CLI response, and Prometheus
+(`backendai_api_request_count`) to confirm the request was counted.
+
 ### Testing as a Regular User
 
 Default accounts in `fixtures/manager/example-users.json`.
@@ -286,4 +291,5 @@ If a CLI command for an entity/operation does not exist in the reference above:
 ## Related Skills
 
 - `/local-dev` — Restart local services before CLI testing
+- `/observability` — Verify logs/metrics via Grafana MCP after CLI testing
 - `/cli-sdk-guide` — Implement new CLI commands

--- a/.claude/skills/cli-executor/SKILL.md
+++ b/.claude/skills/cli-executor/SKILL.md
@@ -307,6 +307,8 @@ Automatic error diagnosis and troubleshooting suggestions.
 - Show expected output
 - Suggest next steps
 - Link to related skills
+- After a component starts, confirm runtime behavior via the Grafana MCP (`/observability`)
+  — query Loki by `service_name` and Prometheus metrics rather than scraping console output
 
 ---
 
@@ -532,6 +534,7 @@ Note: Starting with pending migrations may cause errors
 
 ## Related Skills
 
+- `/observability` - Inspect component logs/metrics via Grafana MCP after start
 - `/db-status` - Check database migration status
 - `/db-migrate` - Apply database migrations
 - `/db-rebase` - Resolve diverged migration heads

--- a/.claude/skills/local-dev/SKILL.md
+++ b/.claude/skills/local-dev/SKILL.md
@@ -10,10 +10,13 @@ Tools for managing Backend.AI services locally via tmux sessions.
 ./dev restart all                    # Restart all services
 ./dev stop <service|all>             # Stop service(s)
 ./dev start <service|all>            # Start service(s)
-./dev log <service>                  # Show recent log output
 ```
 
 **Services:** `mgr`, `agent`, `storage`, `web`, `proxy-coordinator`, `proxy-worker`
+
+**Logs & metrics:** view runtime logs and metrics through the Grafana MCP — see
+`/observability`. Query Loki by `service_name` (e.g. `{service_name="manager"}`) after a
+restart rather than reading console output.
 
 ## Debugging Startup Crashes
 
@@ -58,6 +61,7 @@ docker compose -f docker-compose.halfstack.current.yml restart backendai-half-ap
 
 ## Related Skills
 
+- `/observability` — Inspect logs/metrics via Grafana MCP after a restart
 - `/bai-cli` — Verify changes via CLI after restarting services
 - `/halfstack` — Docker Compose infrastructure (DB, Redis, etcd, Hive Gateway)
 - `/cli-executor` — Run Backend.AI component servers directly

--- a/.claude/skills/observability/SKILL.md
+++ b/.claude/skills/observability/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: observability
+description: Observe Backend.AI logs, metrics, and traces during local development via the Grafana MCP (Loki logs, Prometheus metrics, Tempo traces, Pyroscope profiles). Use after restarting a service to verify behavior instead of tailing console output.
+invoke_method: automatic
+auto_execute: false
+enabled: true
+---
+
+# Observability — Logs & Metrics During Development
+
+The local halfstack ships a full observability stack. Services emit logs/traces over
+OTEL (`[otel] enabled = true` in `manager.toml` / `agent.toml` / `storage-proxy.toml`),
+so logs land in Loki and metrics in Prometheus automatically. **Query them through the
+Grafana MCP (`grafana` server in `.mcp.json`)** — this is the single source of truth for
+runtime logs and metrics during development.
+
+## Stack
+
+| Service | URL | Datasource UID | Purpose |
+|---------|-----|----------------|---------|
+| Grafana | http://localhost:3000 (`backend` / `develove`) | — | UI / MCP target |
+| Loki | http://localhost:3100 | `loki_ds_001` | Logs |
+| Prometheus | http://localhost:9090 | `prom_ds_001` | Metrics |
+| Tempo | http://localhost:3200 | `tempo_ds_001` | Traces |
+| Pyroscope | http://localhost:4040 | `pyroscope_ds_001` | Profiles |
+
+If these containers are not running, bring up the observability profile — see `/halfstack`.
+
+Log streams are labelled by `service_name` (`manager`, `agent`, …). Confirm what is
+flowing with the Loki label-values tool before querying.
+
+## Grafana MCP — Common Queries
+
+Use the `grafana` MCP tools (e.g. `list_datasources`, `query_loki_logs`,
+`query_prometheus`, `list_loki_label_values`, `search_dashboards`). Verify exact tool
+names/params from the MCP itself; the queries below are what you pass.
+
+**Logs (Loki / LogQL)** — datasource `loki_ds_001`:
+
+```logql
+{service_name="manager"}                       # recent manager logs
+{service_name="manager"} |= "error"            # errors only
+{service_name="agent"} | json | level="ERROR"  # structured (JSON) filter
+{service_name="manager"} |= "<request-id>"     # trace one request end-to-end
+```
+
+**Metrics (Prometheus / PromQL)** — datasource `prom_ds_001`:
+
+```promql
+up                                                     # which targets are healthy
+backendai_api_request_count                            # REST request counter
+rate(backendai_api_request_count[1m])                  # request rate
+backendai_api_request_duration_sec_bucket              # API latency histogram
+backendai_graphql_request_count                        # GraphQL operation counter
+```
+
+Metric definitions live in `src/ai/backend/common/metrics/metric.py`
+(`backendai_api_request_*`, `backendai_graphql_request_*`); component-specific metrics
+under `src/ai/backend/{manager,agent,storage}/metrics/`.
+
+**Dashboards / traces / profiles:** the pre-built dashboard is provisioned from
+`grafana-dashboards/dashboard.json` (discover via `search_dashboards`). Tempo
+(`tempo_ds_001`) holds distributed traces; Pyroscope (`pyroscope_ds_001`) holds profiles.
+
+## Standard Verification Loop
+
+After a code change:
+
+1. Restart the affected service — `./dev restart mgr` (see `/local-dev`).
+2. Exercise it — e.g. a `./bai` call (see `/bai-cli`).
+3. **Observe via Grafana MCP**: query Loki for that `service_name` to confirm the request
+   ran without errors, and Prometheus to confirm the expected metric moved.
+
+This replaces tailing console output — always confirm runtime behavior through the MCP.
+
+## Related Skills
+
+- `/local-dev` — Restart services before observing.
+- `/bai-cli` — Exercise the API, then verify logs/metrics here.
+- `/halfstack` — Bring up / inspect the observability containers.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,27 @@
+{
+  "mcpServers": {
+    "grafana": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "--add-host=host.docker.internal:host-gateway",
+        "-e",
+        "GRAFANA_URL",
+        "-e",
+        "GRAFANA_USERNAME",
+        "-e",
+        "GRAFANA_PASSWORD",
+        "mcp/grafana",
+        "-t",
+        "stdio"
+      ],
+      "env": {
+        "GRAFANA_URL": "http://host.docker.internal:3000",
+        "GRAFANA_USERNAME": "backend",
+        "GRAFANA_PASSWORD": "develove"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ When to use:
 - Writing tests → `/tdd-guide`
 - Restarting services after code changes → `/local-dev`
 - **Running any `./bai` command → `/bai-cli` (MUST load before executing)**
+- Checking logs/metrics/traces during development → `/observability` (Grafana MCP)
 - Docker/halfstack issues → `/halfstack`
 - Checking/applying DB migrations → `/db-status`, `/db-migrate`
 - Running component servers directly → `/cli-executor`
@@ -59,7 +60,7 @@ pants test --changed-since=HEAD~1
 
 **Fix all lint, type, and test errors — never suppress or skip.**
 
-**After API/CLI changes, verify with live server using `./bai` CLI.**
+**After API/CLI changes, verify with live server using `./bai` CLI, then check runtime logs/metrics via the Grafana MCP (`/observability`).**
 **MUST invoke `/bai-cli` skill before running any `./bai` command.** The skill contains the entity-command reference — without it, you will guess wrong commands.
 For service restarts, see `/local-dev`. For docker service changes, see `/halfstack` skill.
 
@@ -97,6 +98,7 @@ API Handler → Processor → Service → Repository → DB
 1. Restart server: `./dev restart mgr` (invoke `/local-dev`)
 2. Invoke `/bai-cli` skill, then test each operation via `./bai` CLI
 3. Verify both admin and non-admin scenarios
+4. Check logs/metrics via the Grafana MCP (`/observability`) to confirm no runtime errors
 
 ## Development Guidelines
 

--- a/changes/12004.misc.md
+++ b/changes/12004.misc.md
@@ -1,0 +1,1 @@
+Add a project-scope Grafana MCP and an `/observability` skill so AI agents can query Loki logs and Prometheus metrics during local development.


### PR DESCRIPTION
## Summary
- Add a project-scope Grafana MCP server (`.mcp.json`) so logs/metrics can be queried via Loki/Prometheus during local development (the halfstack observability stack already runs; OTEL ships logs to Loki).
- Add an `/observability` skill documenting the stack, datasource UIDs, example LogQL/PromQL queries, and the standard "restart → exercise → observe via MCP" verification loop.
- Thread the MCP observation step through `local-dev`, `bai-cli`, `cli-executor`, and `CLAUDE.md`; drop the `./dev log` reference so the Grafana MCP is the single log source.

## Test plan
- [x] `.mcp.json` valid; `claude mcp list` shows `grafana` connected after approval
- [x] `query_loki_logs {service_name="manager"}` returns live logs via MCP
- [x] `query_prometheus up` returns target health via MCP
- [ ] Team members approve the project MCP on first `claude` launch

Resolves BA-6338