### PR TITLE
fix: linearize manager alembic revisions

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/169cb5f48658_add_session_replica_id.py
+++ b/src/ai/backend/manager/models/alembic/versions/169cb5f48658_add_session_replica_id.py
@@ -1,7 +1,7 @@
 """add replica_id to sessions
 
 Revision ID: 169cb5f48658
-Revises: eb9d9c018e85
+Revises: e1f7a3c9d524
 Create Date: 2026-06-04 00:00:00.000000
 
 """
@@ -13,7 +13,7 @@ from ai.backend.manager.models.base import GUID
 
 # revision identifiers, used by Alembic.
 revision = "169cb5f48658"
-down_revision = "eb9d9c018e85"
+down_revision = "e1f7a3c9d524"
 # Part of: 26.6.0
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
## Summary
- Linearize the manager Alembic migration graph by moving `169cb5f48658` after current head `e1f7a3c9d524`.
- Fix the `check-multiple-alembic-heads.py` failure currently reported as heads `169cb5f48658` and `e1f7a3c9d524`.
- Keep the migration body unchanged; this only corrects the revision linkage.

## Test plan
- [x] `./py scripts/check-multiple-alembic-heads.py`
- [x] `pants lint src/ai/backend/manager/models/alembic/versions/169cb5f48658_add_session_replica_id.py`
- [x] push hook lint/typecheck for `origin/main..HEAD`

Related to #12003.