### PR TITLE
feat(BA-6339): render CSP nonce in webserver responses

### DIFF
--- a/changes/12007.feature.md
+++ b/changes/12007.feature.md
@@ -1,0 +1,1 @@
+Render a per-request CSP nonce in the webserver, injecting it into the `script-src`/`style-src` directives and into `index.html` so nonce-based Content-Security-Policy works end-to-end.

--- a/configs/CLAUDE.md
+++ b/configs/CLAUDE.md
@@ -1,0 +1,22 @@
+# Configuration Samples — Guidelines
+
+## `sample.toml` files are generated, not hand-edited
+
+Each component's `sample.toml` (e.g. `configs/webserver/sample.toml`) is a **generated
+view** of its config schema, not a hand-maintained file. The block/field comments,
+defaults, and example values all come from each field's `BackendAIConfigMeta` annotation
+in that component's `config/unified.py`.
+
+**Do NOT edit `sample.toml` directly** — changes are overwritten on regeneration and
+diverge from the schema source of truth.
+
+To change a `sample.toml`:
+1. Edit the field's `description=` (and default/example) in the component's
+   `config/unified.py`.
+2. Regenerate via the component's `generate-sample` CLI command (implemented in
+   `src/ai/backend/{component}/cli/config.py`), e.g. for the web server:
+   `./backend.ai web generate-sample --overwrite`.
+
+Note: the older `.conf` sample files (e.g. `configs/webserver/sample.conf`) are
+hand-maintained with real local example values and are separate from the generated
+`.toml` files.

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -115,6 +115,10 @@ response_policies = ["set_content_type_nosniff_policy"]
 [security.csp]
 # Content Security Policy (CSP) settings.
 # See https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP for more details.
+# When script-src/style-src are set, the webserver appends a per-request
+# "'nonce-<random>'" to them and renders the same value into index.html. Keep
+# "'self'" in script-src (do NOT use "'strict-dynamic'") so the bundled module
+# script keeps loading.
 default-src = ["'self'"]
 style-src = ["'self'", "'unsafe-inline'"]
 font-src = ["'self'", "data:"]

--- a/configs/webserver/sample.toml
+++ b/configs/webserver/sample.toml
@@ -217,7 +217,10 @@
 
   # Content Security Policy configuration. When set, adds CSP headers to
   # responses to protect against XSS and other injection attacks. Leave unset
-  # (None) to skip CSP headers entirely.
+  # (None) to skip CSP headers entirely. When script-src and/or style-src are
+  # set, the webserver appends a per-request "'nonce-<random>'" to those
+  # directives and renders the same value into index.html (the {{nonce}}
+  # placeholders / globalThis.baiNonce).
   # Added in 25.12.0
   [security.csp]
     # CSP default-src directive. Serves as the fallback for other resource types
@@ -247,12 +250,16 @@
     ## font-src = []
     # CSP script-src directive. Specifies valid sources for JavaScript.
     # "'unsafe-inline'" allows inline scripts (less secure but often required).
-    # "'strict-dynamic'" can be used with nonces for better security.
+    # When set, the webserver appends a per-request "'nonce-<random>'" so inline
+    # scripts in index.html are allowed; keep "'self'" and avoid "'strict-
+    # dynamic'" so the bundled module script keeps loading.
     # Added in 25.12.0
     ## script-src = []
     # CSP style-src directive. Specifies valid sources for stylesheets.
     # "'unsafe-inline'" is often needed for frameworks that inject styles
-    # dynamically. Consider using hashes or nonces for stricter security.
+    # dynamically. When set, the webserver appends a per-request
+    # "'nonce-<random>'" so nonce-aware style injectors (e.g. antd via
+    # globalThis.baiNonce) are allowed.
     # Added in 25.12.0
     ## style-src = []
     # CSP frame-src directive. Specifies valid sources for nested browsing

--- a/src/ai/backend/web/config/unified.py
+++ b/src/ai/backend/web/config/unified.py
@@ -769,7 +769,9 @@ class CSPConfig(BaseConfigSchema):
             description=(
                 "CSP script-src directive. Specifies valid sources for JavaScript. "
                 "\"'unsafe-inline'\" allows inline scripts (less secure but often required). "
-                "\"'strict-dynamic'\" can be used with nonces for better security."
+                "When set, the webserver appends a per-request \"'nonce-<random>'\" so inline "
+                "scripts in index.html are allowed; keep \"'self'\" and avoid \"'strict-dynamic'\" "
+                "so the bundled module script keeps loading."
             ),
             added_version="25.12.0",
         ),
@@ -785,7 +787,8 @@ class CSPConfig(BaseConfigSchema):
             description=(
                 "CSP style-src directive. Specifies valid sources for stylesheets. "
                 "\"'unsafe-inline'\" is often needed for frameworks that inject styles dynamically. "
-                "Consider using hashes or nonces for stricter security."
+                "When set, the webserver appends a per-request \"'nonce-<random>'\" so nonce-aware "
+                "style injectors (e.g. antd via globalThis.baiNonce) are allowed."
             ),
             added_version="25.12.0",
         ),
@@ -920,7 +923,9 @@ class SecurityConfig(BaseConfigSchema):
             description=(
                 "Content Security Policy configuration. When set, adds CSP headers to responses "
                 "to protect against XSS and other injection attacks. Leave unset (None) to skip "
-                "CSP headers entirely."
+                "CSP headers entirely. When script-src and/or style-src are set, the webserver "
+                "appends a per-request \"'nonce-<random>'\" to those directives and renders the "
+                "same value into index.html (the {{nonce}} placeholders / globalThis.baiNonce)."
             ),
             added_version="25.12.0",
             composite=CompositeType.FIELD,

--- a/src/ai/backend/web/security.py
+++ b/src/ai/backend/web/security.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import secrets
 from collections.abc import Callable, Iterable, Mapping
+from contextvars import ContextVar
 from typing import Self
 
 from aiohttp import web
@@ -10,13 +12,23 @@ type RequestPolicy = Callable[[web.Request], None]
 
 type ResponsePolicy = Callable[[web.StreamResponse], web.StreamResponse]
 
+# Per-request CSP nonce shared between the response policies (which set the
+# Content-Security-Policy header) and the handler that renders index.html.
+csp_nonce_var: ContextVar[str] = ContextVar("csp_nonce", default="")
+
+_NONCED_CSP_DIRECTIVES = frozenset({"script-src", "style-src"})
+
 
 @web.middleware
 async def security_policy_middleware(request: web.Request, handler: Handler) -> web.StreamResponse:
     security_policy: SecurityPolicy = request.app["security_policy"]
-    security_policy.check_request_policies(request)
-    response = await handler(request)
-    return security_policy.apply_response_policies(response)
+    token = csp_nonce_var.set(secrets.token_urlsafe(16))
+    try:
+        security_policy.check_request_policies(request)
+        response = await handler(request)
+        return security_policy.apply_response_policies(response)
+    finally:
+        csp_nonce_var.reset(token)
 
 
 class SecurityPolicy:
@@ -104,12 +116,19 @@ def add_self_content_security_policy(response: web.StreamResponse) -> web.Stream
 
 
 def csp_policy_builder(csp_config: Mapping[str, list[str] | None]) -> ResponsePolicy:
-    csp = [key + " " + " ".join(value) for key, value in csp_config.items() if value]
-    csp_str = "; ".join(csp)
-    if csp_str:
-        csp_str = csp_str + ";"
-
     def policy(response: web.StreamResponse) -> web.StreamResponse:
+        nonce = csp_nonce_var.get()
+        directives = []
+        for key, value in csp_config.items():
+            if not value:
+                continue
+            sources = list(value)
+            if nonce and key in _NONCED_CSP_DIRECTIVES:
+                sources.append(f"'nonce-{nonce}'")
+            directives.append(key + " " + " ".join(sources))
+        csp_str = "; ".join(directives)
+        if csp_str:
+            csp_str = csp_str + ";"
         response.headers["Content-Security-Policy"] = csp_str
         return response
 

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -89,7 +89,7 @@ from ai.backend.web.clients.manager_pool import (
     ManagerPoolGateHealthChecker,
 )
 from ai.backend.web.config.unified import EventLoopType, ServiceMode, WebServerUnifiedConfig
-from ai.backend.web.security import SecurityPolicy, security_policy_middleware
+from ai.backend.web.security import SecurityPolicy, csp_nonce_var, security_policy_middleware
 
 from . import __version__, user_agent
 from .auth import build_forwarding_headers, fill_forwarding_hdrs_to_api_session, get_client_ip
@@ -221,10 +221,16 @@ async def console_handler(request: web.Request) -> web.StreamResponse:
             }),
             content_type="application/problem+json",
         ) from e
-    if file_path.is_file():
+    index_path = (static_path / "index.html").resolve()
+    if file_path.is_file() and file_path != index_path:
         return apply_cache_headers(web.FileResponse(file_path), request_path)
-    # Fallback to index.html to support the URL routing for single-page application.
-    return apply_cache_headers(web.FileResponse(static_path / "index.html"), "index.html")
+    # Serve index.html for both direct requests and the SPA URL-routing fallback.
+    # Render the per-request CSP nonce into the template so it matches the nonce
+    # advertised in the Content-Security-Policy header.
+    index_template: str = request.app["webui_index_template"]
+    rendered = index_template.replace("{{nonce}}", csp_nonce_var.get())
+    response = web.Response(text=rendered, content_type="text/html")
+    return apply_cache_headers(response, "index.html")
 
 
 async def update_password_no_auth(request: web.Request) -> web.Response:
@@ -1078,6 +1084,7 @@ async def webapp_ctx(
     if config.service.mode == ServiceMode.WEBUI:
         cors.add(app.router.add_route("GET", "/config.ini", config_ini_handler))
         cors.add(app.router.add_route("GET", "/config.toml", config_toml_handler))
+        app["webui_index_template"] = (config.service.static_path / "index.html").read_text()
         fallback_handler = console_handler
     elif config.service.mode == ServiceMode.STATIC:
         fallback_handler = static_handler

--- a/tests/unit/webserver/test_security_policy.py
+++ b/tests/unit/webserver/test_security_policy.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import make_mocked_request
@@ -6,11 +8,15 @@ from aiohttp.typedefs import Handler
 from ai.backend.web.security import (
     SecurityPolicy,
     add_self_content_security_policy,
+    csp_nonce_var,
+    csp_policy_builder,
     reject_access_for_unsafe_file_policy,
     reject_metadata_local_link_policy,
     security_policy_middleware,
     set_content_type_nosniff_policy,
 )
+
+_NONCE_RE = re.compile(r"'nonce-([A-Za-z0-9_-]+)'")
 
 
 @pytest.fixture
@@ -91,3 +97,61 @@ async def test_set_content_type_nosniff_policy(async_handler: Handler) -> None:
     request = make_mocked_request("GET", "/", headers={"Host": "localhost"}, app=test_app)
     response = await security_policy_middleware(request, async_handler)
     assert response.headers["X-Content-Type-Options"] == "nosniff"
+
+
+async def test_csp_policy_injects_nonce_into_script_and_style_src(async_handler: Handler) -> None:
+    test_app = web.Application()
+    test_app["security_policy"] = SecurityPolicy(
+        request_policies=[],
+        response_policies=[
+            csp_policy_builder({
+                "default-src": ["'self'"],
+                "script-src": ["'self'"],
+                "style-src": ["'self'", "'unsafe-inline'"],
+            })
+        ],
+    )
+    request = make_mocked_request("GET", "/", headers={"Host": "localhost"}, app=test_app)
+    response = await security_policy_middleware(request, async_handler)
+
+    csp = response.headers["Content-Security-Policy"]
+    script_directive = next(d for d in csp.split(";") if d.strip().startswith("script-src"))
+    style_directive = next(d for d in csp.split(";") if d.strip().startswith("style-src"))
+    default_directive = next(d for d in csp.split(";") if d.strip().startswith("default-src"))
+
+    script_nonce = _NONCE_RE.search(script_directive)
+    style_nonce = _NONCE_RE.search(style_directive)
+    assert script_nonce is not None
+    assert style_nonce is not None
+    # Same nonce is shared across directives within a single request.
+    assert script_nonce.group(1) == style_nonce.group(1)
+    # default-src is not a nonce-able directive, so it stays untouched.
+    assert _NONCE_RE.search(default_directive) is None
+
+
+async def test_csp_policy_uses_new_nonce_per_request(async_handler: Handler) -> None:
+    test_app = web.Application()
+    test_app["security_policy"] = SecurityPolicy(
+        request_policies=[],
+        response_policies=[csp_policy_builder({"script-src": ["'self'"]})],
+    )
+
+    def nonce_of(response: web.StreamResponse) -> str:
+        match = _NONCE_RE.search(response.headers["Content-Security-Policy"])
+        assert match is not None
+        return match.group(1)
+
+    request = make_mocked_request("GET", "/", headers={"Host": "localhost"}, app=test_app)
+    first = nonce_of(await security_policy_middleware(request, async_handler))
+    second = nonce_of(await security_policy_middleware(request, async_handler))
+
+    assert first != second
+    # The context variable is reset once the middleware returns.
+    assert csp_nonce_var.get() == ""
+
+
+def test_csp_policy_without_nonce_keeps_directives_clean() -> None:
+    # Outside of the middleware no nonce is set, so none should be appended.
+    policy = csp_policy_builder({"script-src": ["'self'"]})
+    response = policy(web.Response())
+    assert response.headers["Content-Security-Policy"] == "script-src 'self';"


### PR DESCRIPTION
## Summary
- The webui (`globalThis.baiNonce` / `<script nonce="{{nonce}}">`) expected a server-rendered CSP nonce, but the webserver served `index.html` as a static `FileResponse` (leaving the literal `{{nonce}}`) and never emitted a nonce in the CSP header — so nonce-based CSP could not work.
- The security middleware now generates a per-request nonce (`csp_nonce_var` ContextVar, set/reset per request) and `csp_policy_builder` appends `'nonce-<random>'` to `script-src`/`style-src` when those directives are configured (CSP stays opt-in).
- `console_handler` renders that same nonce into `index.html` (both direct requests and the SPA URL-routing fallback), so the header and document always agree. Other static files keep using `FileResponse`.
- Config schema descriptions document the auto-injection; `sample.toml` is regenerated, and `configs/CLAUDE.md` records that `sample.toml` is generated (not hand-edited).

Note: to use nonces, keep `'self'` in `script-src` and avoid `'strict-dynamic'` so the bundled module script keeps loading.

## Test plan
- [x] Unit tests for nonce injection / per-request rotation / untouched non-nonce directives / contextvar reset (`tests/unit/webserver/test_security_policy.py`)
- [x] Live webserver: CSP header `script-src`/`style-src` carry `'nonce-X'`; `index.html` body substitutes the same `X` (`{{nonce}}` count 0; `nonce="X"` / `baiNonce = "X"` match the header); nonce rotates per request; SPA deep-link and direct `/index.html` both render; `Cache-Control: no-store` preserved
- [ ] webui verification against this server (antd `csp.nonce` path — separate repo, follow-up)

**html response:**

<img width="486" height="208" alt="스크린샷 2026-06-09 오후 6 14 00" src="https://github.com/user-attachments/assets/cf17f91a-b66f-40b8-b312-c52ab87ec4d7" />


Resolves BA-6339