### PR TITLE
fix: merge diverged alembic heads on manager migrations

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/711635faccbe_merge_replica_id_and_deploy_rollout_.py
+++ b/src/ai/backend/manager/models/alembic/versions/711635faccbe_merge_replica_id_and_deploy_rollout_.py
@@ -1,0 +1,21 @@
+"""merge replica_id and deploy_rollout heads
+
+Revision ID: 711635faccbe
+Revises: 169cb5f48658, e1f7a3c9d524
+Create Date: 2026-06-09 18:00:17.385448
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "711635faccbe"
+down_revision = ("169cb5f48658", "e1f7a3c9d524")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- Two manager migration heads diverged from a common ancestor (`eb9d9c018e85`): `169cb5f48658` (add_session_replica_id) and `e1f7a3c9d524` (raise_deploy_rollout_timeout_default), which broke `alembic upgrade head` with a "Multiple head revisions are present" error.
- Add merge revision `711635faccbe` reconciling both heads into a single head. No schema changes.

## Test plan
- [x] `./py -m alembic -c alembic.ini heads` reports a single head
- [x] `./py -m alembic -c alembic.ini upgrade head` succeeds
