### PR TITLE
test(manager): characterize cross-request flaws in shared GraphQL DataLoader

### DIFF
--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -1807,6 +1807,13 @@ type BackgroundTaskEventPayload
   totalProgress: Float
 }
 
+type BatchProbeResult
+  @join__type(graph: STRAWBERRY)
+{
+  batch: [String!]!
+  seenUser: String
+}
+
 """Added in 24.3.0. Type of background task event"""
 enum BgtaskEventType
   @join__type(graph: STRAWBERRY)
@@ -13971,6 +13978,16 @@ type Query
 
   """Added in 26.1.0. List agents with filtering and pagination"""
   agentsV2(filter: AgentFilter = null, orderBy: [AgentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AgentV2Connection @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. Probe: returns the DataLoader batch a single load was coalesced into.
+  """
+  loadedBatchIds(id: ID!): BatchProbeResult! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. Probe: owner-only authz check inside load_fn; demonstrates cache bypass.
+  """
+  authzProbe(id: ID!): String! @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Retrieve a specific artifact by its ID. Returns detailed information about the artifact including its metadata, registry information, and availability status.

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1231,6 +1231,11 @@ type BackgroundTaskEventPayload {
   totalProgress: Float
 }
 
+type BatchProbeResult {
+  batch: [String!]!
+  seenUser: String
+}
+
 """Added in 24.3.0. Type of background task event"""
 enum BgtaskEventType {
   UPDATED
@@ -9053,6 +9058,16 @@ type Query {
 
   """Added in 26.1.0. List agents with filtering and pagination"""
   agentsV2(filter: AgentFilter = null, orderBy: [AgentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AgentV2Connection
+
+  """
+  Added in UNRELEASED. Probe: returns the DataLoader batch a single load was coalesced into.
+  """
+  loadedBatchIds(id: ID!): BatchProbeResult!
+
+  """
+  Added in UNRELEASED. Probe: owner-only authz check inside load_fn; demonstrates cache bypass.
+  """
+  authzProbe(id: ID!): String!
 
   """
   Added in 25.14.0. Retrieve a specific artifact by its ID. Returns detailed information about the artifact including its metadata, registry information, and availability status.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,6 +208,8 @@ split-on-trailing-comma = true
 "src/ai/backend/manager/api/gql/schema.py" = ["TID251"]
 # test_pydantic_compat.py defines fixture types without BackendAIGQLMeta metadata
 "tests/unit/manager/api/gql/test_pydantic_compat.py" = ["TID251"]
+# probe.py defines a test-only probe GQL output type with a raw strawberry decorator
+"src/ai/backend/manager/api/gql/probe.py" = ["TID251"]
 "src/ai/backend/manager/config.py" = ["E402"]
 "src/ai/backend/manager/models/alembic/env.py" = ["E402"]
 "src/ai/backend/logging/otel.py" = ["LOG015"]  # root logger usage is intentional for OTEL initialization

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import asyncio
 import uuid
+from dataclasses import dataclass
 from functools import cached_property
 from typing import TYPE_CHECKING
 
 from strawberry.dataloader import DataLoader
 
+from ai.backend.common.contexts.user import current_user
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.types import AgentId, ImageID, KernelId, SessionId
 from ai.backend.manager.data.permission.id import ObjectId
+from ai.backend.manager.errors.auth import InsufficientPrivilege
 
 if TYPE_CHECKING:
     from ai.backend.common.dto.manager.v2.rbac.response import EntityNode  # pants: no-infer-dep
@@ -102,6 +106,15 @@ if TYPE_CHECKING:
     from ai.backend.manager.api.gql.vfs_storage import VFSStorage  # pants: no-infer-dep
 
 
+@dataclass
+class BatchProbeData:
+    """Snapshot of a single probe ``load_fn`` invocation: the coalesced batch of
+    keys it received and the user observed via the ambient context at dispatch time."""
+
+    batch: list[str]
+    seen_user: str | None
+
+
 class DataLoaders:
     """
     Manages domain-specific DataLoader instances for GraphQL resolvers.
@@ -112,9 +125,44 @@ class DataLoaders:
     """
 
     _adapters: Adapters
+    # Optional rendezvous barrier used only to make cross-request batch coalescing
+    # observable/deterministic in tests; ``None`` disables waiting in production.
+    probe_barrier: asyncio.Barrier | None = None
 
     def __init__(self, adapters: Adapters) -> None:
         self._adapters = adapters
+
+    @cached_property
+    def loaded_batch_ids_loader(self) -> DataLoader[str, BatchProbeData]:
+        """Probe loader: echoes the full coalesced batch (and the user seen at dispatch)
+        back to every caller, so batching behaviour is observable from the API."""
+
+        async def load_fn(ids: list[str]) -> list[BatchProbeData]:
+            user = current_user()
+            snapshot = BatchProbeData(
+                batch=list(ids),
+                seen_user=str(user.user_id) if user is not None else None,
+            )
+            return [snapshot for _ in ids]
+
+        return DataLoader(load_fn=load_fn)
+
+    @cached_property
+    def authz_probe_loader(self) -> DataLoader[str, str]:
+        """Probe loader that performs an owner-only authorization check INSIDE
+        load_fn: a key may be loaded only by the user whose id equals the key.
+        This is the anti-pattern -- a shared cache (or cross-request batch)
+        serves a previously authorized result without re-running this check."""
+
+        async def load_fn(ids: list[str]) -> list[str]:
+            user = current_user()
+            caller = str(user.user_id) if user is not None else None
+            for key in ids:
+                if key != caller:
+                    raise InsufficientPrivilege("caller may only load their own id")
+            return [f"secret-of:{key}" for key in ids]
+
+        return DataLoader(load_fn=load_fn)
 
     @cached_property
     def audit_log_loader(

--- a/src/ai/backend/manager/api/gql/probe.py
+++ b/src/ai/backend/manager/api/gql/probe.py
@@ -1,0 +1,56 @@
+"""Test-only probe query for observing DataLoader batch coalescing.
+
+``loadedBatchIds`` resolves a single id through the shared ``loaded_batch_ids_loader``
+and returns the full batch of ids that load was coalesced into, plus the user observed
+by the batch function. Concurrent requests that share the process-wide ``DataLoaders``
+instance therefore reveal, in their responses, that their loads landed in one batch.
+
+This exists to make the batching/authorization behaviour testable end-to-end; it is not
+intended for production use.
+"""
+
+from __future__ import annotations
+
+import strawberry
+from strawberry import Info
+
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import BackendAIGQLMeta, gql_root_field
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+
+
+@strawberry.type
+class BatchProbeResult:
+    batch: list[str]
+    seen_user: str | None
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Probe: returns the DataLoader batch a single load was coalesced into.",
+    )
+)  # type: ignore[misc]
+async def loaded_batch_ids(
+    info: Info[StrawberryGQLContext],
+    id: strawberry.ID,
+) -> BatchProbeResult:
+    loaders = info.context.data_loaders
+    barrier = loaders.probe_barrier
+    if barrier is not None:
+        await barrier.wait()
+    data = await loaders.loaded_batch_ids_loader.load(str(id))
+    return BatchProbeResult(batch=data.batch, seen_user=data.seen_user)
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Probe: owner-only authz check inside load_fn; demonstrates cache bypass.",
+    )
+)  # type: ignore[misc]
+async def authz_probe(
+    info: Info[StrawberryGQLContext],
+    id: strawberry.ID,
+) -> str:
+    return await info.context.data_loaders.authz_probe_loader.load(str(id))

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -234,6 +234,7 @@ from .object_storage import (
     object_storages,
     update_object_storage,
 )
+from .probe import authz_probe, loaded_batch_ids
 from .project_v2 import (
     admin_create_project_v2,
     admin_delete_project_v2,
@@ -472,6 +473,8 @@ from .vfs_storage import (
 class Query:
     agent_stats = agent_stats
     agents_v2 = agents_v2
+    loaded_batch_ids = loaded_batch_ids
+    authz_probe = authz_probe
     artifact = artifact
     artifacts = artifacts
     artifact_revision = artifact_revision

--- a/tests/component/dataloader/BUILD
+++ b/tests/component/dataloader/BUILD
@@ -1,0 +1,5 @@
+python_test_utils()
+
+python_tests(
+    name="tests",
+)

--- a/tests/component/dataloader/conftest.py
+++ b/tests/component/dataloader/conftest.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from strawberry.federation import Schema as StrawberrySchema
+
+from ai.backend.manager.api.gql.data_loader.data_loaders import DataLoaders
+from ai.backend.manager.api.gql.schema import schema as strawberry_schema
+from ai.backend.manager.api.rest.admin.handler import AdminHandler
+from ai.backend.manager.api.rest.admin.registry import register_admin_routes
+from ai.backend.manager.api.rest.routing import RouteRegistry
+from ai.backend.manager.api.rest.types import RouteDeps
+from ai.backend.manager.config.provider import ManagerConfigProvider
+
+
+@pytest.fixture()
+def gql_schema() -> StrawberrySchema:
+    """The real Strawberry (v2) GraphQL schema served at /admin/gql/strawberry."""
+    return strawberry_schema
+
+
+@pytest.fixture()
+def data_loaders() -> DataLoaders:
+    """The single DataLoaders instance shared across all requests of the test app.
+
+    The probe barrier forces the two concurrent probe requests to issue their loads
+    in the same event-loop tick, so they deterministically coalesce into one batch.
+    Its party count must match the number of concurrent requests per test (2 here).
+    """
+    loaders = DataLoaders(MagicMock())
+    loaders.probe_barrier = asyncio.Barrier(2)
+    return loaders
+
+
+@pytest.fixture()
+def server_module_registries(
+    route_deps: RouteDeps,
+    config_provider: ManagerConfigProvider,
+    gql_schema: StrawberrySchema,
+    data_loaders: DataLoaders,
+) -> list[RouteRegistry]:
+    """Serve the real strawberry schema with a real config provider and DataLoaders."""
+    mock_gql_deps = MagicMock()
+    # GQLValidationExtension reads introspection / max-depth from the config provider.
+    mock_gql_deps.config_provider = config_provider
+    # The probe resolver loads via this shared DataLoaders instance.
+    mock_gql_deps.strawberry_data_loaders = data_loaders
+    return [
+        register_admin_routes(
+            AdminHandler(
+                gql_schema=MagicMock(),
+                gql_deps=mock_gql_deps,
+                strawberry_schema=gql_schema,
+            ),
+            route_deps,
+            sub_registries=[],
+            gql_ws_handler=MagicMock(),
+        ),
+    ]

--- a/tests/component/dataloader/test_dataloader_batching.py
+++ b/tests/component/dataloader/test_dataloader_batching.py
@@ -1,0 +1,116 @@
+"""Component tests for cross-request isolation of the shared ``DataLoaders`` instance.
+
+These tests drive the real ``/admin/gql/strawberry`` endpoint (the ``loadedBatchIds``
+probe backed by ``DataLoaders.loaded_batch_ids_loader``) with two concurrent requests
+and assert the *desired* behavior: a request's load must only see its own key and run
+in its own user context.
+
+They are expected to FAIL against the current implementation, which shares a single
+process-wide ``DataLoaders`` instance: concurrent loads coalesce into one batch that
+runs in a single request's context. The probe ``load_fn`` echoes the coalesced batch
+(and the user seen via ``current_user()``) back to each caller; an ``asyncio.Barrier``
+(set on the shared ``DataLoaders`` in the ``data_loaders`` fixture) makes the coalescing
+deterministic so the failure is reproducible rather than flaky.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+
+from ai.backend.client.v2.registry import BackendAIClientRegistry
+
+_PROBE_QUERY = "query($id: ID!) { loadedBatchIds(id: $id) { batch seenUser } }"
+
+
+# ---------------------------------------------------------------------------
+# GQL HTTP helper
+# ---------------------------------------------------------------------------
+
+
+async def _call_gql(
+    registry: BackendAIClientRegistry,
+    variables: dict[str, Any],
+) -> dict[str, Any]:
+    result = await registry._client._request(
+        "POST",
+        "/admin/gql/strawberry",
+        json={"query": _PROBE_QUERY, "variables": variables},
+    )
+    assert result is not None, "Expected a non-null JSON response from the GQL endpoint"
+    return cast(dict[str, Any], result)
+
+
+def _payload(response: dict[str, Any]) -> dict[str, Any]:
+    assert not response.get("errors"), f"Unexpected GQL errors: {response.get('errors')}"
+    data = response.get("data")
+    assert data is not None
+    return cast(dict[str, Any], data["loadedBatchIds"])
+
+
+# ---------------------------------------------------------------------------
+# Tests (assert the desired isolation; currently FAIL due to the shared loader)
+# ---------------------------------------------------------------------------
+
+
+class TestSharedDataLoaderBatching:
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BA-6340: shared DataLoader coalesces cross-request loads (no per-request isolation)",
+    )
+    async def test_each_request_only_sees_its_own_load(
+        self,
+        admin_registry: BackendAIClientRegistry,
+        user_registry: BackendAIClientRegistry,
+    ) -> None:
+        """Each request's batch should contain only the key it loaded.
+
+        Currently FAILS: the shared loader coalesces both requests' loads into one
+        batch, so each response sees both ids.
+        """
+        id_a = "11111111-1111-1111-1111-111111111111"
+        id_b = "22222222-2222-2222-2222-222222222222"
+
+        resp_a, resp_b = await asyncio.wait_for(
+            asyncio.gather(
+                _call_gql(admin_registry, {"id": id_a}),
+                _call_gql(user_registry, {"id": id_b}),
+            ),
+            timeout=10,
+        )
+
+        assert set(_payload(resp_a)["batch"]) == {id_a}
+        assert set(_payload(resp_b)["batch"]) == {id_b}
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BA-6340: coalesced batch runs in a single request's context",
+    )
+    async def test_each_request_batch_runs_in_its_own_user_context(
+        self,
+        admin_registry: BackendAIClientRegistry,
+        user_registry: BackendAIClientRegistry,
+    ) -> None:
+        """Each request's load should run in its own user context.
+
+        Currently FAILS: the coalesced batch runs in a single request's context, so
+        both responses report the same user.
+        """
+        id_a = "33333333-3333-3333-3333-333333333333"
+        id_b = "44444444-4444-4444-4444-444444444444"
+
+        resp_a, resp_b = await asyncio.wait_for(
+            asyncio.gather(
+                _call_gql(admin_registry, {"id": id_a}),
+                _call_gql(user_registry, {"id": id_b}),
+            ),
+            timeout=10,
+        )
+
+        seen_a = _payload(resp_a)["seenUser"]
+        seen_b = _payload(resp_b)["seenUser"]
+        assert seen_a is not None
+        assert seen_b is not None
+        assert seen_a != seen_b

--- a/tests/component/dataloader/test_dataloader_cache_sharing.py
+++ b/tests/component/dataloader/test_dataloader_cache_sharing.py
@@ -1,0 +1,104 @@
+"""Component test for per-request enforcement of the shared DataLoader cache.
+
+The shared loader keeps ``cache=True`` with a process-global cache that is never
+cleared, so a value loaded by one request is served from cache to any later request
+that loads the same key, without re-invoking ``load_fn``. This test asserts the
+*desired* behavior: an authorization check performed inside ``load_fn`` must be
+enforced for every request.
+
+It is expected to FAIL against the current implementation: a cache hit skips
+``load_fn`` (and its check) entirely, so a different user receives another user's
+previously authorized result. Requests run sequentially, so no probe barrier is used.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from ai.backend.client.v2.registry import BackendAIClientRegistry
+from ai.backend.manager.api.gql.data_loader.data_loaders import DataLoaders
+
+_AUTHZ_QUERY = "query($id: ID!) { authzProbe(id: $id) }"
+
+
+@pytest.fixture()
+def data_loaders() -> DataLoaders:
+    """Shared DataLoaders without a probe barrier (these requests run sequentially)."""
+    return DataLoaders(MagicMock())
+
+
+async def _authz_probe(registry: BackendAIClientRegistry, id_: str) -> dict[str, Any]:
+    """Call authzProbe and return the raw response (so errors are observable)."""
+    result = cast(
+        dict[str, Any],
+        await registry._client._request(
+            "POST",
+            "/admin/gql/strawberry",
+            json={"query": _AUTHZ_QUERY, "variables": {"id": id_}},
+        ),
+    )
+    assert result is not None, "Expected a non-null JSON response from the GQL endpoint"
+    return result
+
+
+class TestSharedDataLoaderCacheSharing:
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BA-6340: shared loader cache serves a foreign authorized result, bypassing load_fn",
+    )
+    async def test_authz_check_in_load_fn_is_enforced_per_request(
+        self,
+        server: Any,
+        admin_registry: BackendAIClientRegistry,
+        user_registry: BackendAIClientRegistry,
+        admin_user_fixture: Any,
+    ) -> None:
+        """An owner-only check inside load_fn must reject every unauthorized request.
+
+        Currently FAILS: the shared cache serves admin's previously authorized result
+        to a different user without re-running load_fn's check.
+        """
+        admin_id = str(admin_user_fixture.user_uuid)
+
+        # admin loads its own id -> owner check passes inside load_fn, result cached.
+        ok = await _authz_probe(admin_registry, admin_id)
+        assert not ok.get("errors")
+        assert ok["data"]["authzProbe"] == f"secret-of:{admin_id}"
+
+        # a different user loads admin's id -> must be forbidden
+        result = await _authz_probe(user_registry, admin_id)
+        assert result.get("errors"), (
+            "owner check must be enforced per request, not bypassed by cache"
+        )
+        data = result.get("data")
+        assert data is None or data.get("authzProbe") is None
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BA-6340: a cached load_fn failure (negative caching) denies a later legitimate request",
+    )
+    async def test_cached_failure_does_not_deny_a_later_legitimate_request(
+        self,
+        server: Any,
+        admin_registry: BackendAIClientRegistry,
+        user_registry: BackendAIClientRegistry,
+        admin_user_fixture: Any,
+    ) -> None:
+        """A failed load must not poison the cache for a later legitimate request.
+
+        Currently FAILS: a non-owner's forbidden load caches the exception, so the
+        owner's own (should-succeed) load for the same id is denied from cache.
+        """
+        admin_id = str(admin_user_fixture.user_uuid)
+
+        # a non-owner loads admin's id first -> correctly forbidden, exception cached.
+        denied = await _authz_probe(user_registry, admin_id)
+        assert denied.get("errors"), "non-owner load should be forbidden"
+
+        # the owner loads its own id -> should succeed, but the cached failure denies it.
+        owner = await _authz_probe(admin_registry, admin_id)
+        assert not owner.get("errors"), "a cached failure must not deny the legitimate owner"
+        assert owner["data"]["authzProbe"] == f"secret-of:{admin_id}"


### PR DESCRIPTION
## Summary

The Strawberry v2 `DataLoaders` instance is created once per worker and shared across all requests. This branch adds a probe loader, probe GraphQL queries, and component tests (driving the real `/admin/gql/strawberry` endpoint) that **characterize cross-request problems** of this shared, long-lived loader state.

Tests assert the *desired* per-request isolation/enforcement and are marked `xfail(strict=True)` — they document the current defect and will flip to failures (alerting) once it is fixed.

Tracking: **BA-6340** (backend.ai-internal).

## Findings

- **Cache reuse (primary):** `cache=True` with a never-cleared process-global `cache_map` serves one request's loaded value to later requests for the same key, without re-invoking `load_fn` — bypassing any authorization performed inside `load_fn`. Deterministic (no tick alignment needed).
  - **Negative caching:** a *failed* load is cached the same way, so the first caller's failure denies later legitimate requests for that key (availability/correctness, order-dependent).
- **Batch coalescing (secondary):** concurrent loads collected per event-loop tick merge into a single `load_fn` that runs in only one request's context. A timing race (rarer), made deterministic in tests via an `asyncio.Barrier`.

## Tests (xfail until fixed)

- `test_each_request_only_sees_its_own_load`
- `test_each_request_batch_runs_in_its_own_user_context`
- `test_authz_check_in_load_fn_is_enforced_per_request`
- `test_cached_failure_does_not_deny_a_later_legitimate_request`

## Note

`src/ai/backend/manager/api/gql/probe.py` and `loaded_batch_ids_loader` / `authz_probe_loader` are test-only diagnostics added to exercise the real schema; this branch is for characterization and is not intended to merge as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
