### PR TITLE
fix(BA-6342): retire replica groups on endpoint destroy

### DIFF
--- a/changes/12012.fix.md
+++ b/changes/12012.fix.md
@@ -1,0 +1,1 @@
+Retire a model service's replica groups when its endpoint is destroyed, so the reconciler stops provisioning replicas for the gone endpoint instead of accumulating `failed_to_start` routes.

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -74,6 +74,8 @@ from ai.backend.manager.data.deployment.types import (
     ModelDeploymentAccessTokenData,
     ModelDeploymentAutoScalingRuleData,
     ModelRevisionData,
+    ReplicaGroupLifecycle,
+    ReplicaGroupScalingStatus,
     RevisionSearchResult,
     RouteHandlerCategory,
     RouteHealthStatus,
@@ -3278,6 +3280,41 @@ class DeploymentDBSource:
             )
         )
         return swapped
+
+    async def retire_replica_groups_on_destroy(
+        self,
+        deployment_ids: set[DeploymentID],
+    ) -> None:
+        """Drain the deployments' replica groups and clear their deploying-revision pointer atomically.
+
+        Marking the live (non-DRAINED) groups DRAINING with zeroed desired counts stops the
+        reconcile from provisioning replicas for the destroyed endpoint; the group draining
+        reconcile then retires them to DRAINED. Done in one transaction so the destroy cleanup
+        cannot leave a group requesting replicas while its endpoint is gone.
+        """
+        if not deployment_ids:
+            return
+        async with self._begin_session_read_committed() as db_sess:
+            await db_sess.execute(
+                sa.update(ReplicaGroupRow)
+                .where(ReplicaGroupRow.deployment_id.in_(deployment_ids))
+                .where(ReplicaGroupRow.lifecycle != ReplicaGroupLifecycle.DRAINED)
+                .values(
+                    lifecycle=ReplicaGroupLifecycle.DRAINING,
+                    desired_current_replica_count=0,
+                    desired_target_replica_count=0,
+                    scaling_status=ReplicaGroupScalingStatus.SCALING,
+                )
+            )
+            await db_sess.execute(
+                sa.update(EndpointRow)
+                .where(EndpointRow.id.in_(deployment_ids))
+                .values(
+                    deploying_revision_id=None,
+                    target_replica_group_id=None,
+                    sub_step=None,
+                )
+            )
 
     async def clear_deploying_revision(
         self,

--- a/src/ai/backend/manager/repositories/deployment/repository.py
+++ b/src/ai/backend/manager/repositories/deployment/repository.py
@@ -1619,6 +1619,15 @@ class DeploymentRepository:
         )
 
     @deployment_repository_resilience.apply()
+    async def retire_replica_groups_on_destroy(self, deployment_ids: set[DeploymentID]) -> None:
+        """Drain the deployments' replica groups and clear their deploying-revision pointer atomically.
+
+        Called from the destroy flow so the reconcile stops provisioning replicas for the gone
+        endpoint and no stale group/revision pointer lingers.
+        """
+        await self._db_source.retire_replica_groups_on_destroy(deployment_ids)
+
+    @deployment_repository_resilience.apply()
     async def clear_deploying_revision(self, deployment_ids: set[DeploymentID]) -> None:
         """Clear deploying_revision and sub_step for rolled-back deployments.
 

--- a/src/ai/backend/manager/sokovan/deployment/executor.py
+++ b/src/ai/backend/manager/sokovan/deployment/executor.py
@@ -366,14 +366,9 @@ class DeploymentExecutor:
     async def destroy_deployment(
         self, deployments: Sequence[DeploymentWithHistory]
     ) -> DeploymentExecutionResult:
-        # Phase 1: Load termination configuration
+        # Phase 1: Load proxy configuration
+        deployment_ids = {dep.deployment_info.id for dep in deployments}
         with DeploymentRecorderContext.shared_phase("load_termination_config"):
-            with DeploymentRecorderContext.shared_step("load_routes"):
-                deployment_ids = {dep.deployment_info.id for dep in deployments}
-                routes = await self._deployment_repo.fetch_active_routes_by_deployment_ids(
-                    deployment_ids
-                )
-
             with DeploymentRecorderContext.shared_step("load_proxy_config"):
                 scaling_groups = {
                     dep.deployment_info.metadata.resource_group for dep in deployments
@@ -382,15 +377,12 @@ class DeploymentExecutor:
                     scaling_groups
                 )
 
-        route_ids: set[UUID] = set()
-        for route_list in routes.values():
-            for route in route_list:
-                route_ids.add(route.route_id)
-
-        # Phase 2: Terminate routes
-        with DeploymentRecorderContext.shared_phase("terminate_routes"):
-            with DeploymentRecorderContext.shared_step("mark_routes_terminating"):
-                await self._deployment_repo.mark_terminating_route_status_bulk(route_ids)
+        # Phase 2: Retire replica groups and clear the deploying-revision pointer in one
+        # transaction. Zeroing desired counts makes the scaling reconcile drain existing routes
+        # (TERMINATING) and stops it provisioning new replicas for the destroyed endpoints.
+        with DeploymentRecorderContext.shared_phase("retire_replica_groups"):
+            with DeploymentRecorderContext.shared_step("drain_replica_groups"):
+                await self._deployment_repo.retire_replica_groups_on_destroy(deployment_ids)
 
         successes: list[DeploymentWithHistory] = []
         errors: list[DeploymentExecutionError] = []

--- a/src/ai/backend/manager/sokovan/deployment/group/lifecycle/handlers/draining.py
+++ b/src/ai/backend/manager/sokovan/deployment/group/lifecycle/handlers/draining.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import override
 from uuid import UUID
 
+from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
 from ai.backend.manager.data.reconciler.types import HandlerOutcome
 from ai.backend.manager.sokovan.deployment.group.lifecycle.types import (
     GroupLifecycleDecision,
@@ -14,6 +15,7 @@ from ai.backend.manager.sokovan.deployment.group.lifecycle.types import (
 )
 from ai.backend.manager.sokovan.reconciler.base import ReconcilerHandler
 from ai.backend.manager.sokovan.recorder.context import RecorderContext
+from ai.backend.manager.types import TriState
 
 
 class GroupDrainingHandler(
@@ -35,9 +37,14 @@ class GroupDrainingHandler(
                         view.desired_current_replica_count == 0
                         and view.desired_target_replica_count == 0
                     )
+                    next_current_revision: TriState[DeploymentRevisionID] = TriState.nop()
+                    next_target_revision: TriState[DeploymentRevisionID] = TriState.nop()
                     if drained:
                         outcome = HandlerOutcome.SUCCESS
                         message = "drain complete; no routes remain"
+                        # Retired group: clear its revision pointers along with the DRAINED transition.
+                        next_current_revision = TriState.nullify()
+                        next_target_revision = TriState.nullify()
                     else:
                         outcome = HandlerOutcome.FAILURE
                         message = "draining routes to zero"
@@ -52,6 +59,8 @@ class GroupDrainingHandler(
                     next_desired_target_replica_count=0,
                     prior_history=view.last_history,
                     handler_options=view.handler_options,
+                    next_current_revision_id=next_current_revision,
+                    next_target_revision_id=next_target_revision,
                 )
             )
 

--- a/tests/unit/manager/repositories/deployment/test_deployment_repository.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_repository.py
@@ -43,6 +43,8 @@ from ai.backend.manager.data.deployment.types import (
     DeploymentOptions,
     DeploymentPolicyData,
     ModelRevisionData,
+    ReplicaGroupLifecycle,
+    ReplicaGroupScalingStatus,
     RouteStatus,
     RouteTrafficStatus,
 )
@@ -2069,6 +2071,74 @@ class TestDeploymentRevisionOperations:
             endpoint = result.scalar_one()
             assert endpoint.name == new_name
             assert endpoint.replicas == new_replica_count
+
+    async def test_retire_replica_groups_on_destroy(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        deployment_repository: DeploymentRepository,
+        test_endpoint_id: DeploymentID,
+    ) -> None:
+        """Drains live groups to DRAINING with zeroed desired counts and clears the endpoint's
+        deploy pointer, leaving already-DRAINED groups untouched."""
+        drained_group_id = ReplicaGroupID(uuid.uuid4())
+        async with db_with_cleanup.begin_session() as db_sess:
+            # The endpoint's primary group is live and still requesting replicas.
+            await db_sess.execute(
+                sa.update(ReplicaGroupRow)
+                .where(ReplicaGroupRow.deployment_id == test_endpoint_id)
+                .values(
+                    lifecycle=ReplicaGroupLifecycle.ROLLING,
+                    desired_current_replica_count=1,
+                    desired_target_replica_count=1,
+                    scaling_status=ReplicaGroupScalingStatus.SCALING,
+                )
+            )
+            # A second group that has already finished draining.
+            db_sess.add(
+                ReplicaGroupRow(
+                    id=drained_group_id,
+                    deployment_id=test_endpoint_id,
+                    lifecycle=ReplicaGroupLifecycle.DRAINED,
+                    desired_current_replica_count=0,
+                    desired_target_replica_count=0,
+                )
+            )
+            await db_sess.execute(
+                sa.update(EndpointRow)
+                .where(EndpointRow.id == test_endpoint_id)
+                .values(sub_step=DeploymentLifecycleSubStep.DEPLOYING_PROVISIONING)
+            )
+
+        await deployment_repository.retire_replica_groups_on_destroy({test_endpoint_id})
+
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            groups = (
+                (
+                    await db_sess.execute(
+                        sa.select(ReplicaGroupRow).where(
+                            ReplicaGroupRow.deployment_id == test_endpoint_id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            by_id = {group.id: group for group in groups}
+            live = next(group for group in groups if group.id != drained_group_id)
+            # Live group is driven to DRAINING with zeroed desired counts.
+            assert live.lifecycle is ReplicaGroupLifecycle.DRAINING
+            assert live.desired_current_replica_count == 0
+            assert live.desired_target_replica_count == 0
+            assert live.scaling_status is ReplicaGroupScalingStatus.SCALING
+            # The already-DRAINED group is left as-is.
+            assert by_id[drained_group_id].lifecycle is ReplicaGroupLifecycle.DRAINED
+            # The endpoint's deploy pointer/sub-step is cleared.
+            endpoint = (
+                await db_sess.execute(
+                    sa.select(EndpointRow).where(EndpointRow.id == test_endpoint_id)
+                )
+            ).scalar_one()
+            assert endpoint.sub_step is None
 
 
 class TestDeploymentPolicyOperations:

--- a/tests/unit/manager/sokovan/deployment/executor/test_deployment_executor.py
+++ b/tests/unit/manager/sokovan/deployment/executor/test_deployment_executor.py
@@ -12,7 +12,6 @@ Test Scenarios:
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import uuid4
 
 import pytest
 
@@ -49,11 +48,6 @@ class TestDestroyDeployment:
         Then: Routes terminated, endpoint unregistered
         """
         # Arrange
-        mock_route = MagicMock()
-        mock_route.route_id = uuid4()
-        mock_deployment_repo.fetch_active_routes_by_deployment_ids.return_value = {
-            destroying_deployment.deployment_info.id: [mock_route]
-        }
         mock_deployment_repo.fetch_scaling_group_proxy_targets.return_value = (
             proxy_targets_by_scaling_group
         )
@@ -78,14 +72,12 @@ class TestDestroyDeployment:
         # Assert
         assert len(result.successes) == 1
         assert len(result.failures) == 0
-        mock_deployment_repo.mark_terminating_route_status_bulk.assert_awaited_once()
         mock_unregister.assert_awaited_once()
 
-        # Verify 1 route marked for termination
-        call_args = mock_deployment_repo.mark_terminating_route_status_bulk.call_args
-        route_ids = call_args[0][0]
-        assert len(route_ids) == 1
-        assert mock_route.route_id in route_ids
+        # The destroyed deployment's replica groups are retired (drained + revision cleared).
+        mock_deployment_repo.retire_replica_groups_on_destroy.assert_awaited_once_with({
+            destroying_deployment.deployment_info.id
+        })
 
     async def test_multiple_deployments_destroyed(
         self,
@@ -101,13 +93,6 @@ class TestDestroyDeployment:
         Then: All destroyed successfully
         """
         # Arrange
-        routes_map = {}
-        for deployment in destroying_deployments_multiple:
-            mock_route = MagicMock()
-            mock_route.route_id = uuid4()
-            routes_map[deployment.deployment_info.id] = [mock_route]
-
-        mock_deployment_repo.fetch_active_routes_by_deployment_ids.return_value = routes_map
         mock_deployment_repo.fetch_scaling_group_proxy_targets.return_value = (
             proxy_targets_by_scaling_group
         )
@@ -149,9 +134,6 @@ class TestDestroyDeployment:
         Then: Error captured in result
         """
         # Arrange
-        mock_deployment_repo.fetch_active_routes_by_deployment_ids.return_value = {
-            destroying_deployment.deployment_info.id: []
-        }
         mock_deployment_repo.fetch_scaling_group_proxy_targets.return_value = (
             proxy_targets_by_scaling_group
         )

--- a/tests/unit/manager/sokovan/deployment/group/lifecycle/test_lifecycle_handlers.py
+++ b/tests/unit/manager/sokovan/deployment/group/lifecycle/test_lifecycle_handlers.py
@@ -115,18 +115,34 @@ async def test_rolling_converges_when_target_full_and_current_drained() -> None:
 
 
 async def test_draining_in_progress_sets_zero_and_keeps_scaling() -> None:
-    view = _view(lifecycle=ReplicaGroupLifecycle.DRAINING, desired_current=2, desired_target=0)
+    view = _view(
+        lifecycle=ReplicaGroupLifecycle.DRAINING,
+        desired_current=2,
+        desired_target=0,
+        current_revision_id=DeploymentRevisionID(uuid.uuid4()),
+    )
     with RecorderContext[UUID].scope("group_draining", [view.group_id]):
         result = await GroupDrainingHandler().execute(_info(view))
     decision = result.lifecycle_decisions[0]
     assert decision.next_desired_current_replica_count == 0
     assert decision.next_desired_target_replica_count == 0
     assert decision.outcome() is HandlerOutcome.FAILURE
+    # Still draining: revision pointers are left untouched until the group is fully retired.
+    assert not decision.next_current_revision_id.is_nullify()
+    assert not decision.next_target_revision_id.is_nullify()
 
 
 async def test_draining_completes_when_desired_is_zero() -> None:
-    view = _view(lifecycle=ReplicaGroupLifecycle.DRAINING, desired_current=0, desired_target=0)
+    view = _view(
+        lifecycle=ReplicaGroupLifecycle.DRAINING,
+        desired_current=0,
+        desired_target=0,
+        current_revision_id=DeploymentRevisionID(uuid.uuid4()),
+    )
     with RecorderContext[UUID].scope("group_draining", [view.group_id]):
         result = await GroupDrainingHandler().execute(_info(view))
     decision = result.lifecycle_decisions[0]
     assert decision.outcome() is HandlerOutcome.SUCCESS
+    # Retired group: its revision pointers are cleared with the DRAINED transition.
+    assert decision.next_current_revision_id.is_nullify()
+    assert decision.next_target_revision_id.is_nullify()


### PR DESCRIPTION
## Summary
- Destroying an endpoint left its `replica_groups` at `lifecycle=rolling` with a non-zero `desired_target_replica_count`, so the reconcile kept provisioning replicas for the gone endpoint and accumulated `failed_to_start` routes indefinitely.
- Add `DeploymentRepository.retire_replica_groups_on_destroy`: in one transaction it drives the deployment's live (non-DRAINED) groups to `DRAINING` with zeroed desired counts and clears the endpoint's deploying-revision pointer. The destroy executor calls it and now relies on the scaling reconcile to drain existing routes, dropping the explicit bulk route-termination step.
- The group draining handler also clears the group's revision pointers when it reaches `DRAINED`.

## Test plan
- [x] Unit: `retire_replica_groups_on_destroy` (real DB) — live groups → DRAINING + 0/0 + SCALING, DRAINED untouched, endpoint deploy pointer cleared
- [x] Unit: executor destroy calls retire + unregister (no bulk route-terminate); group draining handler nullifies revisions on DRAINED
- [x] Live: destroyed an endpoint with a running route+session → group DRAINING→DRAINED, route running→terminating→terminated, session RUNNING→TERMINATED, revision pointers cleared, provisioning loop stopped

Resolves BA-6342