### PR TITLE
feat(BA-6343): honor max_retries and interval in route health checks

### DIFF
--- a/changes/12016.fix.md
+++ b/changes/12016.fix.md
@@ -1,0 +1,1 @@
+Honor `max_retries`, `interval`, `max_wait_time`, and `expected_status_code` in model service health checks so a running route is only marked unhealthy after the configured number of consecutive failed probes.

--- a/src/ai/backend/common/clients/valkey_client/valkey_schedule/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_schedule/client.py
@@ -223,6 +223,7 @@ class ValkeyScheduleClient:
         seconds_bytes, _ = result
         return int(seconds_bytes)
 
+    @valkey_schedule_resilience.apply()
     async def get_redis_time(self) -> int:
         """
         Get current Unix timestamp from Redis server using TIME command.
@@ -778,9 +779,11 @@ class ValkeyScheduleClient:
                 "replica_id": str(result.replica_id),
                 "healthy": "1" if result.healthy else "0",
                 "last_check": current_time,
+                "consecutive_failures": str(result.consecutive_failures),
             }
             batch.hset(key, data)
-            batch.expire(key, ROUTE_HEALTH_STATUS_TTL_SEC)
+            ttl_sec = result.ttl_sec if result.ttl_sec is not None else ROUTE_HEALTH_STATUS_TTL_SEC
+            batch.expire(key, ttl_sec)
 
         async with self._client.client() as conn:
             await conn.exec(batch, raise_on_error=True)

--- a/src/ai/backend/common/clients/valkey_client/valkey_schedule/types.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_schedule/types.py
@@ -47,10 +47,18 @@ class ReplicaHealthResult:
 
     Passed to ``record_route_health_statuses_batch``; ``last_check`` is
     assigned by the client using the current Redis time.
+
+    ``consecutive_failures`` is the running count of consecutive failed
+    probes (0 when the latest probe passed); the consuming handler compares
+    it against ``ModelHealthCheck.max_retries``. ``ttl_sec`` is the per-route
+    key TTL derived from the route's ``interval`` (``None`` falls back to the
+    module default); key expiry signals DEGRADED.
     """
 
     replica_id: ReplicaID
     healthy: bool
+    consecutive_failures: int = 0
+    ttl_sec: int | None = None
 
 
 @dataclass
@@ -65,12 +73,14 @@ class ReplicaHealthStatus:
     replica_id: ReplicaID
     healthy: bool
     last_check: int  # Unix timestamp (Redis time)
+    consecutive_failures: int = 0
 
     def to_valkey_hash(self) -> Mapping[str, str]:
         return {
             "replica_id": str(self.replica_id),
             "healthy": "1" if self.healthy else "0",
             "last_check": str(self.last_check),
+            "consecutive_failures": str(self.consecutive_failures),
         }
 
     @classmethod
@@ -79,4 +89,5 @@ class ReplicaHealthStatus:
             replica_id=ReplicaID(UUID(data["replica_id"])),
             healthy=data.get("healthy", "0") == "1",
             last_check=int(data.get("last_check", "0")),
+            consecutive_failures=int(data.get("consecutive_failures", "0")),
         )

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -211,6 +211,32 @@ class ModelHealthCheck(BaseConfigModel):
         ge=0,
     )
 
+    def is_retry_exhausted(self, consecutive_failures: int) -> bool:
+        """Whether consecutive failed probes have reached ``max_retries``.
+
+        The health observer accumulates ``consecutive_failures`` (reset to 0
+        on a passing probe); the consuming handler calls this to decide when
+        a route should transition to UNHEALTHY.
+        """
+        return consecutive_failures >= self.max_retries
+
+    def is_probe_due(self, last_check: int, now: int) -> bool:
+        """Whether ``interval`` has elapsed since the last probe.
+
+        ``last_check`` / ``now`` are Unix-second timestamps. Used by the
+        observer to throttle per-route probing to the configured interval.
+        """
+        return now - last_check >= self.interval
+
+    def health_status_ttl_sec(self) -> int:
+        """Per-route TTL for the cached health status in Valkey.
+
+        Key expiry signals DEGRADED (no recent check), so the TTL must stay
+        comfortably above the probe ``interval`` — normal probing refreshes
+        it every ``interval`` with margin for scheduling jitter.
+        """
+        return max(120, int(self.interval * 3))
+
 
 class ModelServiceConfig(BaseConfigModel):
     pre_start_actions: list[PreStartAction] = Field(

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -481,6 +481,18 @@ class ModelDefinition(BaseConfigModel):
                 return model.service.health_check
         return None
 
+    def health_check_setting(self) -> ModelHealthCheck | None:
+        """The configured health check, preserved even when disabled.
+
+        Unlike :meth:`health_check_config`, this does not gate on ``enable``,
+        so a caller that persists the setting keeps the ``enable`` flag intact
+        and consumers decide based on it rather than on presence alone.
+        """
+        for model in self.models:
+            if model.service and model.service.health_check:
+                return model.service.health_check
+        return None
+
     def with_args_appended(self, args: list[str]) -> ModelDefinition:
         """Return a copy with ``args`` appended to each model's
         ``service.start_command`` as separate argv tokens.

--- a/src/ai/backend/manager/repositories/deployment/types/endpoint.py
+++ b/src/ai/backend/manager/repositories/deployment/types/endpoint.py
@@ -87,6 +87,18 @@ class RouteData:
     last_transition_at: datetime | None = None
     error_data: dict[str, Any] = field(default_factory=dict)
 
+    @property
+    def enabled_health_check(self) -> ModelHealthCheck | None:
+        """The health check to enforce, or ``None`` when absent or disabled.
+
+        A ``health_check`` with ``enable=False`` means the route activates
+        immediately and the remaining fields are ignored, so it must be
+        treated the same as no health check at all.
+        """
+        if self.health_check is None or not self.health_check.enable:
+            return None
+        return self.health_check
+
 
 @dataclass(frozen=True)
 class RouteSessionKernelInfo:

--- a/src/ai/backend/manager/repositories/replica_group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/replica_group/db_source/db_source.py
@@ -526,7 +526,7 @@ class ReplicaGroupDBSource:
         result = await db_sess.execute(query)
         return {
             DeploymentRevisionID(revision_id): (
-                model_definition.health_check_config() if model_definition is not None else None
+                model_definition.health_check_setting() if model_definition is not None else None
             )
             for revision_id, model_definition in result.all()
         }

--- a/src/ai/backend/manager/sokovan/deployment/route/coordinator.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/coordinator.py
@@ -524,11 +524,13 @@ class RouteCoordinator:
                 long_interval=30.0,
                 initial_delay=15.0,
             ),
-            # Health observer - manager fallback health check for stale routes
+            # Health observer - drives per-route HTTP probes. Ticks frequently so the
+            # observer can honor each route's configured ``interval`` (it throttles
+            # per route by last_check); intervals shorter than this tick are clamped.
             RouteTaskSpec(
                 RouteLifecycleType.OBSERVE_HEALTH,
                 short_interval=None,
-                long_interval=30.0,
+                long_interval=10.0,
                 initial_delay=15.0,
             ),
             # Probe target sync - refresh ReplicaProbeTarget TTL and recover lost Valkey entries

--- a/src/ai/backend/manager/sokovan/deployment/route/executor.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/executor.py
@@ -344,11 +344,12 @@ class RouteExecutor:
     @staticmethod
     def _build_probe_target(route: RouteData) -> ReplicaProbeTarget | None:
         """Build a ReplicaProbeTarget from a route, or None if any required field is absent."""
-        if route.health_check is None or route.replica_host is None or route.replica_port is None:
+        health_check = route.enabled_health_check
+        if health_check is None or route.replica_host is None or route.replica_port is None:
             return None
         return ReplicaProbeTarget(
             replica_id=route.route_id,
-            health_path=route.health_check.path,
+            health_path=health_check.path,
             inference_port=route.replica_port,
             replica_host=route.replica_host,
         )
@@ -362,12 +363,12 @@ class RouteExecutor:
         targets: list[ReplicaProbeTarget] = [
             ReplicaProbeTarget(
                 replica_id=route.route_id,
-                health_path=route.health_check.path,
+                health_path=health_check.path,
                 inference_port=replica_info[route.route_id].replica_port,
                 replica_host=replica_info[route.route_id].replica_host,
             )
             for route in routes
-            if route.health_check is not None
+            if (health_check := route.enabled_health_check) is not None
         ]
 
         if targets:
@@ -412,7 +413,8 @@ class RouteExecutor:
         errors: list[RouteExecutionError] = []
 
         for route in routes:
-            if route.health_check is None:
+            health_check = route.enabled_health_check
+            if health_check is None:
                 successes.append(route)
                 continue
 
@@ -425,14 +427,14 @@ class RouteExecutor:
                 continue
 
             elapsed = (now - route.last_transition_at).total_seconds()
-            if elapsed > route.health_check.initial_delay:
+            if elapsed > health_check.initial_delay:
                 errors.append(
                     RouteExecutionError(
                         route_info=route,
                         reason="Route warming-up timed out waiting for healthy probe",
                         error_detail=(
                             f"Elapsed {elapsed:.0f}s exceeds "
-                            f"initial_delay {route.health_check.initial_delay}s"
+                            f"initial_delay {health_check.initial_delay}s"
                         ),
                     )
                 )
@@ -443,7 +445,9 @@ class RouteExecutor:
         """
         Check health status of RUNNING routes and push newly-healthy ones to AppProxy.
 
-        Reads RouteHealthStatus from Valkey and classifies:
+        Routes with no active health check (absent or disabled) are skipped —
+        their health is left unmanaged. For the rest, reads RouteHealthStatus
+        from Valkey and classifies:
         - HEALTHY:   latest probe passed, or it failed but consecutive_failures
                      has not yet reached ``max_retries`` (still within retry budget)
         - UNHEALTHY: consecutive_failures reached ``max_retries``
@@ -472,6 +476,12 @@ class RouteExecutor:
 
         # Phase 2: Classify health state (per-route)
         for route in routes:
+            health_check = route.enabled_health_check
+            if health_check is None:
+                # No active health check (absent or disabled) → leave health
+                # unmanaged; do not transition this route.
+                continue
+
             status = statuses.get(route.route_id)
 
             if status is None:
@@ -481,9 +491,7 @@ class RouteExecutor:
 
             if status.healthy:
                 successes.append(route)
-            elif route.health_check is not None and not route.health_check.is_retry_exhausted(
-                status.consecutive_failures
-            ):
+            elif not health_check.is_retry_exhausted(status.consecutive_failures):
                 # Probe failing but still within the retry budget → keep HEALTHY.
                 successes.append(route)
             else:

--- a/src/ai/backend/manager/sokovan/deployment/route/executor.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/executor.py
@@ -444,8 +444,9 @@ class RouteExecutor:
         Check health status of RUNNING routes and push newly-healthy ones to AppProxy.
 
         Reads RouteHealthStatus from Valkey and classifies:
-        - HEALTHY:   status.healthy is True
-        - UNHEALTHY: status.healthy is False
+        - HEALTHY:   latest probe passed, or it failed but consecutive_failures
+                     has not yet reached ``max_retries`` (still within retry budget)
+        - UNHEALTHY: consecutive_failures reached ``max_retries``
         - DEGRADED:  status absent (key missing or TTL expired — no recent check)
 
         Routes whose pre-execute health_status was not HEALTHY but whose
@@ -480,12 +481,20 @@ class RouteExecutor:
 
             if status.healthy:
                 successes.append(route)
+            elif route.health_check is not None and not route.health_check.is_retry_exhausted(
+                status.consecutive_failures
+            ):
+                # Probe failing but still within the retry budget → keep HEALTHY.
+                successes.append(route)
             else:
                 errors.append(
                     RouteExecutionError(
                         route_info=route,
                         reason="Route health check failed",
-                        error_detail="RouteHealthStatus reports unhealthy",
+                        error_detail=(
+                            f"RouteHealthStatus reports unhealthy after "
+                            f"{status.consecutive_failures} consecutive failures"
+                        ),
                         error_code=None,
                     )
                 )

--- a/src/ai/backend/manager/sokovan/deployment/route/handlers/observer/health_check.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/handlers/observer/health_check.py
@@ -10,13 +10,17 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 import aiohttp
 
 from ai.backend.common.clients.valkey_client.valkey_schedule import (
     ReplicaHealthResult,
+    ReplicaProbeTarget,
     ValkeyScheduleClient,
 )
+from ai.backend.common.config import ModelHealthCheck
+from ai.backend.common.identifier.replica import ReplicaID
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.repositories.deployment import DeploymentRepository
 from ai.backend.manager.repositories.deployment.types import RouteData
@@ -25,15 +29,29 @@ from .base import RouteObservationResult, RouteObserver
 
 log = BraceStyleAdapter(logging.getLogger(__name__))
 
-HEALTH_CHECK_TIMEOUT_SEC = 5
+
+@dataclass
+class _ProbePlan:
+    """A route selected for probing this tick, with the prior failure count."""
+
+    route_id: ReplicaID
+    target: ReplicaProbeTarget
+    health_check: ModelHealthCheck
+    prev_failures: int
 
 
 class RouteHealthObserver(RouteObserver):
     """Performs HTTP health checks on routes using ReplicaProbeTarget from Valkey.
 
-    Reads ReplicaProbeTarget (health_path, replica_host, inference_port) from Valkey.
-    HTTP checks run in parallel via asyncio.gather.
-    Writes RouteHealthStatus back to Valkey; TTL expiry signals DEGRADED automatically.
+    Reads ReplicaProbeTarget (health_path, replica_host, inference_port) from Valkey
+    for the endpoint, and per-route policy (interval, max_wait_time,
+    expected_status_code) from ``RouteData.health_check``.
+
+    Per route the observer throttles to the configured ``interval``, runs the HTTP
+    probe with ``max_wait_time`` / ``expected_status_code``, and accumulates a
+    ``consecutive_failures`` counter (reset to 0 on a passing probe) in Valkey.
+    It only counts; the RUNNING health-check handler compares the counter against
+    ``max_retries`` to decide UNHEALTHY. TTL expiry signals DEGRADED automatically.
     """
 
     def __init__(
@@ -53,53 +71,81 @@ class RouteHealthObserver(RouteObserver):
         if not routes:
             return RouteObservationResult(observed_count=0)
 
-        # Load ReplicaProbeTargets from Valkey (keyed by ReplicaID)
+        # Load probe targets (endpoint), prior statuses (count + last_check), and the
+        # current time in one round-trip — the three reads are independent.
         replica_ids = [r.route_id for r in routes]
-        probe_targets = await self._valkey_schedule.get_route_probe_targets_batch(replica_ids)
+        probe_targets, prev_statuses, now = await asyncio.gather(
+            self._valkey_schedule.get_route_probe_targets_batch(replica_ids),
+            self._valkey_schedule.get_route_health_statuses_batch(replica_ids),
+            self._valkey_schedule.get_redis_time(),
+        )
 
-        # Collect routes that have probe targets
-        checkable = [
-            (route, target)
-            for route in routes
-            if (target := probe_targets.get(route.route_id)) is not None
-        ]
-
-        if not checkable:
-            if routes:
-                log.warning(
-                    "Health observer: {} routes but 0 have probe targets in Valkey",
-                    len(routes),
+        # Select routes that have a probe target and are due for a probe (interval throttle).
+        # A probe target only exists when health_check is set (see _build_probe_target),
+        # so health_check is non-None for every selected route.
+        plans: list[_ProbePlan] = []
+        for route in routes:
+            target = probe_targets.get(route.route_id)
+            if target is None or route.health_check is None:
+                continue
+            prev = prev_statuses.get(route.route_id)
+            if prev is not None and not route.health_check.is_probe_due(prev.last_check, now):
+                continue
+            plans.append(
+                _ProbePlan(
+                    route_id=route.route_id,
+                    target=target,
+                    health_check=route.health_check,
+                    prev_failures=prev.consecutive_failures if prev is not None else 0,
                 )
+            )
+
+        if not plans:
             return RouteObservationResult(observed_count=0)
 
-        # Perform HTTP health checks in parallel
-        check_tasks = [
-            self._http_health_check(target.replica_host, target.inference_port, target.health_path)
-            for _, target in checkable
-        ]
-        results = await asyncio.gather(*check_tasks)
+        # Perform HTTP health checks in parallel using per-route policy.
+        results = await asyncio.gather(*[
+            self._http_health_check(
+                plan.target.replica_host,
+                plan.target.inference_port,
+                plan.target.health_path,
+                plan.health_check.max_wait_time,
+                plan.health_check.expected_status_code,
+            )
+            for plan in plans
+        ])
 
-        # Write results to Valkey in a single batch (TTL refreshed on every call)
+        # Increment/reset consecutive_failures; record with per-route interval-based TTL.
         health_results = [
-            ReplicaHealthResult(replica_id=route.route_id, healthy=is_healthy)
-            for (route, _target), is_healthy in zip(checkable, results, strict=False)
+            ReplicaHealthResult(
+                replica_id=plan.route_id,
+                healthy=is_healthy,
+                consecutive_failures=0 if is_healthy else plan.prev_failures + 1,
+                ttl_sec=plan.health_check.health_status_ttl_sec(),
+            )
+            for plan, is_healthy in zip(plans, results, strict=False)
         ]
         await self._valkey_schedule.record_route_health_statuses_batch(health_results)
 
-        if checkable:
-            log.debug("Health observer: checked {} routes", len(checkable))
-        return RouteObservationResult(observed_count=len(checkable))
+        log.debug("Health observer: checked {} routes", len(plans))
+        return RouteObservationResult(observed_count=len(plans))
 
     @staticmethod
-    async def _http_health_check(host: str, port: int, path: str) -> bool:
+    async def _http_health_check(
+        host: str,
+        port: int,
+        path: str,
+        max_wait_time: float,
+        expected_status_code: int,
+    ) -> bool:
         """Perform HTTP GET health check."""
         url = f"http://{host}:{port}{path}"
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.get(
-                    url, timeout=aiohttp.ClientTimeout(total=HEALTH_CHECK_TIMEOUT_SEC)
+                    url, timeout=aiohttp.ClientTimeout(total=max_wait_time)
                 ) as resp:
-                    return resp.status == 200
+                    return resp.status == expected_status_code
         except Exception:
             log.debug("Health check failed for {}", url)
             return False

--- a/src/ai/backend/manager/sokovan/deployment/route/handlers/observer/health_check.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/handlers/observer/health_check.py
@@ -86,16 +86,17 @@ class RouteHealthObserver(RouteObserver):
         plans: list[_ProbePlan] = []
         for route in routes:
             target = probe_targets.get(route.route_id)
-            if target is None or route.health_check is None:
+            health_check = route.enabled_health_check
+            if target is None or health_check is None:
                 continue
             prev = prev_statuses.get(route.route_id)
-            if prev is not None and not route.health_check.is_probe_due(prev.last_check, now):
+            if prev is not None and not health_check.is_probe_due(prev.last_check, now):
                 continue
             plans.append(
                 _ProbePlan(
                     route_id=route.route_id,
                     target=target,
-                    health_check=route.health_check,
+                    health_check=health_check,
                     prev_failures=prev.consecutive_failures if prev is not None else 0,
                 )
             )

--- a/tests/unit/common/clients/valkey_client/test_valkey_schedule_client.py
+++ b/tests/unit/common/clients/valkey_client/test_valkey_schedule_client.py
@@ -1108,3 +1108,30 @@ class TestReplicaHealthStatusClient:
         status = results[replica_id]
         assert status is not None
         assert status.healthy is False
+
+    async def test_record_consecutive_failures_round_trip(
+        self,
+        valkey_schedule_client: ValkeyScheduleClient,
+        replica_id: ReplicaID,
+    ) -> None:
+        await valkey_schedule_client.record_route_health_statuses_batch([
+            ReplicaHealthResult(replica_id=replica_id, healthy=False, consecutive_failures=4)
+        ])
+        results = await valkey_schedule_client.get_route_health_statuses_batch([replica_id])
+        status = results[replica_id]
+        assert status is not None
+        assert status.consecutive_failures == 4
+
+    async def test_record_with_custom_ttl(
+        self,
+        valkey_schedule_client: ValkeyScheduleClient,
+        replica_id: ReplicaID,
+    ) -> None:
+        """Per-route ttl_sec is applied to the health status key."""
+        await valkey_schedule_client.record_route_health_statuses_batch([
+            ReplicaHealthResult(replica_id=replica_id, healthy=True, ttl_sec=7)
+        ])
+        key = valkey_schedule_client._get_route_health_status_key(replica_id)
+        async with valkey_schedule_client._client.client() as conn:
+            ttl = await conn.ttl(key)
+        assert 0 < ttl <= 7

--- a/tests/unit/common/clients/valkey_client/test_valkey_schedule_types.py
+++ b/tests/unit/common/clients/valkey_client/test_valkey_schedule_types.py
@@ -70,31 +70,48 @@ class TestReplicaHealthStatusSerialization:
         assert h["replica_id"] == str(healthy_status.replica_id)
         assert h["healthy"] == "1"
         assert h["last_check"] == "1700000000"
+        assert h["consecutive_failures"] == "0"
 
     def test_to_valkey_hash_unhealthy(self, replica_id: ReplicaID) -> None:
         status = ReplicaHealthStatus(
             replica_id=replica_id,
             healthy=False,
             last_check=1700000000,
+            consecutive_failures=3,
         )
-        assert status.to_valkey_hash()["healthy"] == "0"
+        h = status.to_valkey_hash()
+        assert h["healthy"] == "0"
+        assert h["consecutive_failures"] == "3"
 
     def test_from_valkey_hash(self, replica_id: ReplicaID) -> None:
         data = {
             "replica_id": str(replica_id),
-            "healthy": "1",
+            "healthy": "0",
             "last_check": "1700000000",
+            "consecutive_failures": "5",
         }
         status = ReplicaHealthStatus.from_valkey_hash(data)
         assert status.replica_id == replica_id
-        assert status.healthy is True
+        assert status.healthy is False
         assert status.last_check == 1700000000
+        assert status.consecutive_failures == 5
 
     def test_from_valkey_hash_missing_optional_fields(self, replica_id: ReplicaID) -> None:
-        """Missing healthy/last_check fields default to safe values."""
+        """Missing healthy/last_check/consecutive_failures fields default to safe values."""
         status = ReplicaHealthStatus.from_valkey_hash({"replica_id": str(replica_id)})
         assert status.healthy is False
         assert status.last_check == 0
+        assert status.consecutive_failures == 0
+
+    def test_round_trip_with_failures(self, replica_id: ReplicaID) -> None:
+        status = ReplicaHealthStatus(
+            replica_id=replica_id,
+            healthy=False,
+            last_check=1700000000,
+            consecutive_failures=7,
+        )
+        restored = ReplicaHealthStatus.from_valkey_hash(status.to_valkey_hash())
+        assert restored == status
 
     def test_round_trip(self, healthy_status: ReplicaHealthStatus) -> None:
         restored = ReplicaHealthStatus.from_valkey_hash(healthy_status.to_valkey_hash())

--- a/tests/unit/common/test_config.py
+++ b/tests/unit/common/test_config.py
@@ -323,6 +323,40 @@ class TestHealthCheckEnable:
         assert result.health_check.enable is True
 
 
+class TestHealthCheckJudgment:
+    """Tests for ModelHealthCheck judgment helpers used by the route health loop."""
+
+    def _check(self, **overrides: Any) -> ModelHealthCheck:
+        return ModelHealthCheck.model_validate({"path": "/health", **overrides})
+
+    def test_is_retry_exhausted_below_threshold(self) -> None:
+        check = self._check(max_retries=3)
+        assert check.is_retry_exhausted(0) is False
+        assert check.is_retry_exhausted(2) is False
+
+    def test_is_retry_exhausted_at_and_above_threshold(self) -> None:
+        check = self._check(max_retries=3)
+        assert check.is_retry_exhausted(3) is True
+        assert check.is_retry_exhausted(4) is True
+
+    def test_is_probe_due_before_interval(self) -> None:
+        check = self._check(interval=10.0)
+        assert check.is_probe_due(last_check=1000, now=1005) is False
+
+    def test_is_probe_due_at_and_after_interval(self) -> None:
+        check = self._check(interval=10.0)
+        assert check.is_probe_due(last_check=1000, now=1010) is True
+        assert check.is_probe_due(last_check=1000, now=1030) is True
+
+    def test_health_status_ttl_floor(self) -> None:
+        """Short intervals are clamped to the 120s floor."""
+        assert self._check(interval=10.0).health_status_ttl_sec() == 120
+
+    def test_health_status_ttl_scales_with_interval(self) -> None:
+        """Long intervals stay above the probe cadence (interval * 3)."""
+        assert self._check(interval=60.0).health_status_ttl_sec() == 180
+
+
 class TestModelConfigs:
     def test_sanitize_inline_dicts(self) -> None:
         sample = """

--- a/tests/unit/common/test_config.py
+++ b/tests/unit/common/test_config.py
@@ -210,6 +210,23 @@ class TestHealthCheckEnable:
         assert check is not None
         assert check.path == "/health"
 
+    def test_health_check_setting_preserves_disabled_check(self) -> None:
+        """health_check_setting returns the config (with enable) even when disabled."""
+        definition = ModelDefinition.model_validate({
+            "models": [
+                {
+                    "name": "m",
+                    "model_path": "/m",
+                    "service": {"port": 8080, "health_check": {"path": "/health", "enable": False}},
+                }
+            ]
+        })
+        assert definition.health_check_config() is None
+        setting = definition.health_check_setting()
+        assert setting is not None
+        assert setting.enable is False
+        assert setting.path == "/health"
+
     def test_enable_defaults_to_false(self) -> None:
         check = ModelHealthCheck.model_validate({"path": "/health"})
         assert check.enable is False

--- a/tests/unit/manager/sokovan/deployment/route/executor/test_check_route_health_register.py
+++ b/tests/unit/manager/sokovan/deployment/route/executor/test_check_route_health_register.py
@@ -19,6 +19,7 @@ from dateutil.tz import tzutc
 from ai.backend.common.clients.valkey_client.valkey_schedule import (
     ReplicaHealthStatus as ValkeyReplicaHealthStatus,
 )
+from ai.backend.common.config import ModelHealthCheck
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
 from ai.backend.common.identifier.replica import ReplicaID
@@ -44,7 +45,7 @@ def _route(health_status: RouteHealthStatus) -> RouteData:
         traffic_ratio=1.0,
         revision_id=DeploymentRevisionID(uuid4()),
         traffic_status=RouteTrafficStatus.ACTIVE,
-        health_check=None,
+        health_check=ModelHealthCheck(enable=True, max_retries=1),
         replica_host="10.0.0.1",
         replica_port=8000,
         created_at=datetime.now(tzutc()),
@@ -64,6 +65,7 @@ def _unhealthy_status(route: RouteData) -> ValkeyReplicaHealthStatus:
         replica_id=route.route_id,
         healthy=False,
         last_check=999,
+        consecutive_failures=1,
     )
 
 

--- a/tests/unit/manager/sokovan/deployment/route/executor/test_initial_delay.py
+++ b/tests/unit/manager/sokovan/deployment/route/executor/test_initial_delay.py
@@ -9,7 +9,6 @@ from uuid import uuid4
 from dateutil.tz import tzutc
 
 from ai.backend.common.clients.valkey_client.valkey_schedule.types import (
-    ReplicaHealthResult,
     ReplicaProbeTarget,
 )
 from ai.backend.common.config import ModelHealthCheck
@@ -24,9 +23,6 @@ from ai.backend.manager.data.deployment.types import (
 )
 from ai.backend.manager.repositories.deployment.types import RouteData, RouteSessionKernelInfo
 from ai.backend.manager.sokovan.deployment.route.executor import RouteExecutor
-from ai.backend.manager.sokovan.deployment.route.handlers.observer.health_check import (
-    RouteHealthObserver,
-)
 from ai.backend.manager.sokovan.deployment.route.recorder.context import RouteRecorderContext
 
 
@@ -201,98 +197,3 @@ class TestSyncReplicaProbeTargets:
         mock_valkey_schedule.register_route_probe_targets_batch.assert_not_awaited()
         assert result.successes == []
         assert result.errors == []
-
-
-# =============================================================================
-# RouteHealthObserver: probe target based observation
-# =============================================================================
-
-
-class TestObserverSetsHealthStatus:
-    """Tests for RouteHealthObserver writing RouteHealthStatus to Valkey."""
-
-    async def test_observer_writes_success_result(self) -> None:
-        """ID-005: Observer writes healthy=True on successful probe.
-
-        Given: ReplicaProbeTarget exists in Valkey, HTTP check succeeds
-        When: Observer runs
-        Then: record_route_health_status called with (replica_id, True)
-        """
-        mock_deployment_repo = AsyncMock()
-        mock_valkey = AsyncMock()
-
-        route = _make_route()
-        probe_target = ReplicaProbeTarget(
-            replica_id=route.route_id,
-            health_path="/health",
-            inference_port=8000,
-            replica_host="10.0.0.1",
-        )
-        mock_valkey.get_route_probe_targets_batch.return_value = {route.route_id: probe_target}
-
-        observer = RouteHealthObserver(
-            deployment_repository=mock_deployment_repo,
-            valkey_schedule=mock_valkey,
-        )
-        observer._http_health_check = AsyncMock(return_value=True)  # type: ignore[method-assign]
-
-        await observer.observe([route])
-
-        mock_valkey.record_route_health_statuses_batch.assert_awaited_once_with([
-            ReplicaHealthResult(replica_id=route.route_id, healthy=True)
-        ])
-
-    async def test_observer_writes_failure_result(self) -> None:
-        """ID-006: Observer writes healthy=False on failed probe.
-
-        Given: ReplicaProbeTarget exists in Valkey, HTTP check fails
-        When: Observer runs
-        Then: record_route_health_status called with (replica_id, False)
-        """
-        mock_deployment_repo = AsyncMock()
-        mock_valkey = AsyncMock()
-
-        route = _make_route()
-        probe_target = ReplicaProbeTarget(
-            replica_id=route.route_id,
-            health_path="/health",
-            inference_port=8000,
-            replica_host="10.0.0.1",
-        )
-        mock_valkey.get_route_probe_targets_batch.return_value = {route.route_id: probe_target}
-
-        observer = RouteHealthObserver(
-            deployment_repository=mock_deployment_repo,
-            valkey_schedule=mock_valkey,
-        )
-        observer._http_health_check = AsyncMock(return_value=False)  # type: ignore[method-assign]
-
-        await observer.observe([route])
-
-        mock_valkey.record_route_health_statuses_batch.assert_awaited_once_with([
-            ReplicaHealthResult(replica_id=route.route_id, healthy=False)
-        ])
-
-    async def test_observer_skips_route_without_probe_target(self) -> None:
-        """ID-007: Observer skips route when no probe target in Valkey.
-
-        Given: No ReplicaProbeTarget in Valkey
-        When: Observer runs
-        Then: record_route_health_status NOT called, observed_count=0
-        """
-        mock_deployment_repo = AsyncMock()
-        mock_valkey = AsyncMock()
-
-        route = _make_route()
-        mock_valkey.get_route_probe_targets_batch.return_value = {route.route_id: None}
-
-        observer = RouteHealthObserver(
-            deployment_repository=mock_deployment_repo,
-            valkey_schedule=mock_valkey,
-        )
-        observer._http_health_check = AsyncMock(return_value=True)  # type: ignore[method-assign]
-
-        result = await observer.observe([route])
-
-        mock_valkey.record_route_health_statuses_batch.assert_not_awaited()
-        assert result.observed_count == 0

--- a/tests/unit/manager/sokovan/deployment/route/executor/test_initial_delay.py
+++ b/tests/unit/manager/sokovan/deployment/route/executor/test_initial_delay.py
@@ -61,7 +61,9 @@ class TestRegisterReplicaProbeTargets:
         mock_valkey_schedule: AsyncMock,
     ) -> None:
         """health_path comes from route.health_check when present."""
-        route = _make_route(health_check=ModelHealthCheck(path="/healthz", initial_delay=60.0))
+        route = _make_route(
+            health_check=ModelHealthCheck(enable=True, path="/healthz", initial_delay=60.0)
+        )
         replica_id = ReplicaID(route.route_id)
 
         await route_executor._register_route_probe_targets(
@@ -99,7 +101,7 @@ class TestRegisterReplicaProbeTargets:
         mock_valkey_schedule: AsyncMock,
     ) -> None:
         """Multiple routes with health_check produce multiple ReplicaProbeTarget entries."""
-        health_check = ModelHealthCheck(path="/health", initial_delay=60.0)
+        health_check = ModelHealthCheck(enable=True, path="/health", initial_delay=60.0)
         routes = [_make_route(health_check=health_check) for _ in range(3)]
         replica_infos = {
             ReplicaID(r.route_id): RouteSessionKernelInfo(
@@ -124,7 +126,9 @@ class TestSyncReplicaProbeTargets:
         mock_valkey_schedule: AsyncMock,
     ) -> None:
         """Routes with health_check, replica_host and replica_port are synced."""
-        route = _make_route(health_check=ModelHealthCheck(path="/health", initial_delay=60.0))
+        route = _make_route(
+            health_check=ModelHealthCheck(enable=True, path="/health", initial_delay=60.0)
+        )
 
         with RouteRecorderContext.scope("test", entity_ids=[route.route_id]):
             result = await route_executor.sync_route_probe_targets([route])
@@ -139,7 +143,9 @@ class TestSyncReplicaProbeTargets:
         mock_valkey_schedule: AsyncMock,
     ) -> None:
         """Routes missing health_check or replica info are silently skipped."""
-        route = _make_route(health_check=ModelHealthCheck(path="/health", initial_delay=60.0))
+        route = _make_route(
+            health_check=ModelHealthCheck(enable=True, path="/health", initial_delay=60.0)
+        )
         route_no_health_check = _make_route(health_check=None)
         route_no_replica = RouteData(
             route_id=ReplicaID(uuid4()),
@@ -151,7 +157,7 @@ class TestSyncReplicaProbeTargets:
             created_at=datetime.fromtimestamp(1000, tz=tzutc()),
             revision_id=DeploymentRevisionID(uuid4()),
             traffic_status=RouteTrafficStatus.INACTIVE,
-            health_check=ModelHealthCheck(path="/health", initial_delay=60.0),
+            health_check=ModelHealthCheck(enable=True, path="/health", initial_delay=60.0),
             replica_host=None,
             replica_port=None,
         )

--- a/tests/unit/manager/sokovan/deployment/route/executor/test_route_executor.py
+++ b/tests/unit/manager/sokovan/deployment/route/executor/test_route_executor.py
@@ -25,6 +25,7 @@ from dateutil.tz import tzutc
 from ai.backend.common.clients.valkey_client.valkey_schedule import (
     ReplicaHealthStatus as ValkeyReplicaHealthStatus,
 )
+from ai.backend.common.config import ModelHealthCheck
 from ai.backend.common.dto.appproxy_coordinator.v2.endpoint.response import (
     BulkUpdateRoutesResponse,
 )
@@ -254,6 +255,56 @@ class TestCheckRouteHealth:
         entity_ids = [healthy_route.route_id]
         with RouteRecorderContext.scope("test", entity_ids=entity_ids):
             result = await route_executor.check_route_health([healthy_route])
+
+        assert len(result.successes) == 0
+        assert len(result.errors) == 1
+        assert len(result.stale) == 0
+
+    async def test_failing_route_within_retry_budget_stays_healthy(
+        self,
+        route_executor: RouteExecutor,
+        mock_valkey_schedule: AsyncMock,
+        healthy_route: RouteData,
+    ) -> None:
+        """A failing probe below max_retries keeps the route HEALTHY (within budget)."""
+        route = dataclasses.replace(
+            healthy_route, health_check=ModelHealthCheck(enable=True, max_retries=3)
+        )
+        status = ValkeyReplicaHealthStatus(
+            replica_id=route.route_id,
+            healthy=False,
+            last_check=995,
+            consecutive_failures=2,
+        )
+        mock_valkey_schedule.get_route_health_statuses_batch.return_value = {route.route_id: status}
+
+        with RouteRecorderContext.scope("test", entity_ids=[route.route_id]):
+            result = await route_executor.check_route_health([route])
+
+        assert len(result.successes) == 1
+        assert len(result.errors) == 0
+        assert len(result.stale) == 0
+
+    async def test_failing_route_exhausts_retries_in_errors(
+        self,
+        route_executor: RouteExecutor,
+        mock_valkey_schedule: AsyncMock,
+        healthy_route: RouteData,
+    ) -> None:
+        """Once consecutive_failures reaches max_retries the route is UNHEALTHY."""
+        route = dataclasses.replace(
+            healthy_route, health_check=ModelHealthCheck(enable=True, max_retries=3)
+        )
+        status = ValkeyReplicaHealthStatus(
+            replica_id=route.route_id,
+            healthy=False,
+            last_check=995,
+            consecutive_failures=3,
+        )
+        mock_valkey_schedule.get_route_health_statuses_batch.return_value = {route.route_id: status}
+
+        with RouteRecorderContext.scope("test", entity_ids=[route.route_id]):
+            result = await route_executor.check_route_health([route])
 
         assert len(result.successes) == 0
         assert len(result.errors) == 1

--- a/tests/unit/manager/sokovan/deployment/route/executor/test_route_executor.py
+++ b/tests/unit/manager/sokovan/deployment/route/executor/test_route_executor.py
@@ -214,18 +214,16 @@ class TestCheckRouteHealth:
         When: Check route health
         Then: Route in successes list
         """
+        route = dataclasses.replace(healthy_route, health_check=ModelHealthCheck(enable=True))
         status = ValkeyReplicaHealthStatus(
-            replica_id=healthy_route.route_id,
+            replica_id=route.route_id,
             healthy=True,
             last_check=995,
         )
-        mock_valkey_schedule.get_route_health_statuses_batch.return_value = {
-            healthy_route.route_id: status,
-        }
+        mock_valkey_schedule.get_route_health_statuses_batch.return_value = {route.route_id: status}
 
-        entity_ids = [healthy_route.route_id]
-        with RouteRecorderContext.scope("test", entity_ids=entity_ids):
-            result = await route_executor.check_route_health([healthy_route])
+        with RouteRecorderContext.scope("test", entity_ids=[route.route_id]):
+            result = await route_executor.check_route_health([route])
 
         assert len(result.successes) == 1
         assert len(result.errors) == 0
@@ -237,27 +235,62 @@ class TestCheckRouteHealth:
         mock_valkey_schedule: AsyncMock,
         healthy_route: RouteData,
     ) -> None:
-        """RH-002: Unhealthy route is in errors.
+        """RH-002: Route whose failures exhausted max_retries is in errors.
 
-        Given: Route with RouteHealthStatus(healthy=False) in Valkey
+        Given: Enabled health check with max_retries=1 and a failing status
+               whose consecutive_failures reached the budget
         When: Check route health
         Then: Route in errors list
         """
+        route = dataclasses.replace(
+            healthy_route, health_check=ModelHealthCheck(enable=True, max_retries=1)
+        )
         status = ValkeyReplicaHealthStatus(
-            replica_id=healthy_route.route_id,
+            replica_id=route.route_id,
             healthy=False,
             last_check=995,
+            consecutive_failures=1,
         )
-        mock_valkey_schedule.get_route_health_statuses_batch.return_value = {
-            healthy_route.route_id: status,
-        }
+        mock_valkey_schedule.get_route_health_statuses_batch.return_value = {route.route_id: status}
 
-        entity_ids = [healthy_route.route_id]
-        with RouteRecorderContext.scope("test", entity_ids=entity_ids):
-            result = await route_executor.check_route_health([healthy_route])
+        with RouteRecorderContext.scope("test", entity_ids=[route.route_id]):
+            result = await route_executor.check_route_health([route])
 
         assert len(result.successes) == 0
         assert len(result.errors) == 1
+        assert len(result.stale) == 0
+
+    async def test_disabled_health_check_is_skipped(
+        self,
+        route_executor: RouteExecutor,
+        mock_valkey_schedule: AsyncMock,
+        healthy_route: RouteData,
+    ) -> None:
+        """A route with health_check present but enable=False is skipped (unmanaged)."""
+        route = dataclasses.replace(healthy_route, health_check=ModelHealthCheck(enable=False))
+        mock_valkey_schedule.get_route_health_statuses_batch.return_value = {}
+
+        with RouteRecorderContext.scope("test", entity_ids=[route.route_id]):
+            result = await route_executor.check_route_health([route])
+
+        assert len(result.successes) == 0
+        assert len(result.errors) == 0
+        assert len(result.stale) == 0
+
+    async def test_absent_health_check_is_skipped(
+        self,
+        route_executor: RouteExecutor,
+        mock_valkey_schedule: AsyncMock,
+        healthy_route: RouteData,
+    ) -> None:
+        """A route with no health check is skipped, neither HEALTHY nor DEGRADED."""
+        mock_valkey_schedule.get_route_health_statuses_batch.return_value = {}
+
+        with RouteRecorderContext.scope("test", entity_ids=[healthy_route.route_id]):
+            result = await route_executor.check_route_health([healthy_route])
+
+        assert len(result.successes) == 0
+        assert len(result.errors) == 0
         assert len(result.stale) == 0
 
     async def test_failing_route_within_retry_budget_stays_healthy(
@@ -316,17 +349,18 @@ class TestCheckRouteHealth:
         mock_valkey_schedule: AsyncMock,
         healthy_route: RouteData,
     ) -> None:
-        """RH-003: Route with expired TTL (no key) is in stale list.
+        """RH-003: Enabled-health-check route with expired TTL (no key) is in stale list.
 
-        Given: Route whose RouteHealthStatus TTL has expired (key absent)
+        Given: Route with an active health check whose RouteHealthStatus
+               TTL has expired (key absent)
         When: Check route health
         Then: Route in stale list (DEGRADED)
         """
+        route = dataclasses.replace(healthy_route, health_check=ModelHealthCheck(enable=True))
         mock_valkey_schedule.get_route_health_statuses_batch.return_value = {}
 
-        entity_ids = [healthy_route.route_id]
-        with RouteRecorderContext.scope("test", entity_ids=entity_ids):
-            result = await route_executor.check_route_health([healthy_route])
+        with RouteRecorderContext.scope("test", entity_ids=[route.route_id]):
+            result = await route_executor.check_route_health([route])
 
         assert len(result.successes) == 0
         assert len(result.errors) == 0
@@ -338,17 +372,17 @@ class TestCheckRouteHealth:
         mock_valkey_schedule: AsyncMock,
         healthy_route: RouteData,
     ) -> None:
-        """RH-004: Missing health data is treated as stale.
+        """RH-004: Missing health data for an active health check is treated as stale.
 
-        Given: Route with no RouteHealthStatus in Valkey
+        Given: Route with an active health check and no RouteHealthStatus in Valkey
         When: Check route health
         Then: Route in stale list
         """
+        route = dataclasses.replace(healthy_route, health_check=ModelHealthCheck(enable=True))
         mock_valkey_schedule.get_route_health_statuses_batch.return_value = {}
 
-        entity_ids = [healthy_route.route_id]
-        with RouteRecorderContext.scope("test", entity_ids=entity_ids):
-            result = await route_executor.check_route_health([healthy_route])
+        with RouteRecorderContext.scope("test", entity_ids=[route.route_id]):
+            result = await route_executor.check_route_health([route])
 
         assert len(result.successes) == 0
         assert len(result.errors) == 0

--- a/tests/unit/manager/sokovan/deployment/route/handlers/observer/BUILD
+++ b/tests/unit/manager/sokovan/deployment/route/handlers/observer/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/tests/unit/manager/sokovan/deployment/route/handlers/observer/test_health_check_observer.py
+++ b/tests/unit/manager/sokovan/deployment/route/handlers/observer/test_health_check_observer.py
@@ -1,0 +1,209 @@
+"""Tests for RouteHealthObserver interval throttle and consecutive-failure counting."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from typing import cast
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+from dateutil.tz import tzutc
+
+from ai.backend.common.clients.valkey_client.valkey_schedule.types import (
+    ReplicaHealthResult,
+    ReplicaHealthStatus,
+    ReplicaProbeTarget,
+)
+from ai.backend.common.config import ModelHealthCheck
+from ai.backend.common.identifier.deployment import DeploymentID
+from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
+from ai.backend.common.identifier.replica import ReplicaID
+from ai.backend.common.types import SessionId
+from ai.backend.manager.data.deployment.types import (
+    RouteHealthStatus,
+    RouteStatus,
+    RouteTrafficStatus,
+)
+from ai.backend.manager.repositories.deployment.types import RouteData
+from ai.backend.manager.sokovan.deployment.route.handlers.observer.health_check import (
+    RouteHealthObserver,
+)
+
+_NOW = 1000
+
+
+def _make_route(health_check: ModelHealthCheck | None) -> RouteData:
+    return RouteData(
+        route_id=ReplicaID(uuid4()),
+        deployment_id=DeploymentID(uuid4()),
+        session_id=SessionId(uuid4()),
+        status=RouteStatus.RUNNING,
+        health_status=RouteHealthStatus.HEALTHY,
+        traffic_ratio=1.0,
+        created_at=datetime.fromtimestamp(0, tz=tzutc()),
+        revision_id=DeploymentRevisionID(uuid4()),
+        traffic_status=RouteTrafficStatus.ACTIVE,
+        health_check=health_check,
+        replica_host="10.0.0.1",
+        replica_port=8000,
+    )
+
+
+def _probe_target(route: RouteData) -> ReplicaProbeTarget:
+    assert route.health_check is not None
+    return ReplicaProbeTarget(
+        replica_id=route.route_id,
+        health_path=route.health_check.path,
+        inference_port=route.replica_port or 8000,
+        replica_host=route.replica_host or "10.0.0.1",
+    )
+
+
+def _make_valkey(
+    *,
+    probe_targets: Mapping[ReplicaID, ReplicaProbeTarget],
+    statuses: Mapping[ReplicaID, ReplicaHealthStatus | None],
+    now: int = _NOW,
+) -> AsyncMock:
+    valkey = AsyncMock()
+    valkey.get_route_probe_targets_batch.return_value = probe_targets
+    valkey.get_route_health_statuses_batch.return_value = statuses
+    valkey.get_redis_time.return_value = now
+    valkey.record_route_health_statuses_batch.return_value = None
+    return valkey
+
+
+def _observer(valkey: AsyncMock) -> RouteHealthObserver:
+    return RouteHealthObserver(deployment_repository=AsyncMock(), valkey_schedule=valkey)
+
+
+def _recorded(valkey: AsyncMock) -> list[ReplicaHealthResult]:
+    return cast(
+        "list[ReplicaHealthResult]",
+        valkey.record_route_health_statuses_batch.call_args[0][0],
+    )
+
+
+class TestRouteHealthObserverCounting:
+    async def test_first_probe_success_records_zero_failures(self) -> None:
+        check = ModelHealthCheck(enable=True, interval=10.0)
+        route = _make_route(check)
+        valkey = _make_valkey(
+            probe_targets={route.route_id: _probe_target(route)},
+            statuses={route.route_id: None},
+        )
+        observer = _observer(valkey)
+        observer._http_health_check = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+        result = await observer.observe([route])
+
+        assert result.observed_count == 1
+        recorded = _recorded(valkey)
+        assert recorded[0].healthy is True
+        assert recorded[0].consecutive_failures == 0
+        assert recorded[0].ttl_sec == check.health_status_ttl_sec()
+
+    async def test_failure_increments_previous_count(self) -> None:
+        route = _make_route(ModelHealthCheck(enable=True, interval=10.0))
+        statuses = {
+            route.route_id: ReplicaHealthStatus(
+                replica_id=route.route_id,
+                healthy=False,
+                last_check=_NOW - 20,  # due: 20 >= interval 10
+                consecutive_failures=2,
+            )
+        }
+        valkey = _make_valkey(
+            probe_targets={route.route_id: _probe_target(route)},
+            statuses=statuses,
+        )
+        observer = _observer(valkey)
+        observer._http_health_check = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+        await observer.observe([route])
+
+        recorded = _recorded(valkey)
+        assert recorded[0].healthy is False
+        assert recorded[0].consecutive_failures == 3
+
+    async def test_success_resets_count(self) -> None:
+        route = _make_route(ModelHealthCheck(enable=True, interval=10.0))
+        statuses = {
+            route.route_id: ReplicaHealthStatus(
+                replica_id=route.route_id,
+                healthy=False,
+                last_check=_NOW - 20,
+                consecutive_failures=5,
+            )
+        }
+        valkey = _make_valkey(
+            probe_targets={route.route_id: _probe_target(route)},
+            statuses=statuses,
+        )
+        observer = _observer(valkey)
+        observer._http_health_check = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+        await observer.observe([route])
+
+        assert _recorded(valkey)[0].consecutive_failures == 0
+
+
+class TestRouteHealthObserverThrottle:
+    async def test_skips_probe_within_interval(self) -> None:
+        route = _make_route(ModelHealthCheck(enable=True, interval=10.0))
+        statuses = {
+            route.route_id: ReplicaHealthStatus(
+                replica_id=route.route_id,
+                healthy=True,
+                last_check=_NOW - 5,  # not due: 5 < interval 10
+                consecutive_failures=0,
+            )
+        }
+        valkey = _make_valkey(
+            probe_targets={route.route_id: _probe_target(route)},
+            statuses=statuses,
+        )
+        observer = _observer(valkey)
+        observer._http_health_check = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+        result = await observer.observe([route])
+
+        assert result.observed_count == 0
+        observer._http_health_check.assert_not_called()
+        valkey.record_route_health_statuses_batch.assert_not_called()
+
+    async def test_skips_route_without_probe_target(self) -> None:
+        route = _make_route(ModelHealthCheck(enable=True, interval=10.0))
+        valkey = _make_valkey(probe_targets={}, statuses={route.route_id: None})
+        observer = _observer(valkey)
+        observer._http_health_check = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+        result = await observer.observe([route])
+
+        assert result.observed_count == 0
+        observer._http_health_check.assert_not_called()
+
+
+class TestRouteHealthObserverProbePolicy:
+    async def test_probe_uses_per_route_timeout_and_status_code(self) -> None:
+        route = _make_route(
+            ModelHealthCheck(
+                enable=True,
+                interval=10.0,
+                max_wait_time=42.0,
+                expected_status_code=204,
+                path="/livez",
+            )
+        )
+        valkey = _make_valkey(
+            probe_targets={route.route_id: _probe_target(route)},
+            statuses={route.route_id: None},
+        )
+        observer = _observer(valkey)
+        observer._http_health_check = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+        await observer.observe([route])
+
+        call = observer._http_health_check.call_args
+        assert call.args == ("10.0.0.1", 8000, "/livez", 42.0, 204)

--- a/tests/unit/manager/sokovan/deployment/route/handlers/observer/test_health_check_observer.py
+++ b/tests/unit/manager/sokovan/deployment/route/handlers/observer/test_health_check_observer.py
@@ -184,6 +184,22 @@ class TestRouteHealthObserverThrottle:
         assert result.observed_count == 0
         observer._http_health_check.assert_not_called()
 
+    async def test_skips_disabled_health_check(self) -> None:
+        """A route whose health_check has enable=False is not probed."""
+        route = _make_route(ModelHealthCheck(enable=False, interval=10.0))
+        valkey = _make_valkey(
+            probe_targets={route.route_id: _probe_target(route)},
+            statuses={route.route_id: None},
+        )
+        observer = _observer(valkey)
+        observer._http_health_check = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+        result = await observer.observe([route])
+
+        assert result.observed_count == 0
+        observer._http_health_check.assert_not_called()
+        valkey.record_route_health_statuses_batch.assert_not_called()
+
 
 class TestRouteHealthObserverProbePolicy:
     async def test_probe_uses_per_route_timeout_and_status_code(self) -> None:


### PR DESCRIPTION
## Summary
- The route health-check loop now honors `ModelHealthCheck.max_retries`, `interval`, `max_wait_time`, and `expected_status_code`, which were stored but previously ignored (only `initial_delay` was enforced).
- The health observer accumulates a per-route `consecutive_failures` counter in Valkey (reset on a passing probe) and throttles each route to its configured `interval`; the running-route handler keeps a route HEALTHY until the count reaches `max_retries`, then marks it UNHEALTHY. A missing status stays DEGRADED.
- Warming-up / `initial_delay` behavior is unchanged (already guaranteed by stage separation).

## Test plan
- [x] Unit tests: config judgment methods, observer interval throttle + failure count, RUNNING classification (within-budget HEALTHY / exhausted UNHEALTHY), Valkey round-trip + per-route TTL
- [ ] Live: deploy a model whose health endpoint starts failing after it reaches RUNNING; confirm the route stays HEALTHY for `max_retries` probes then flips to UNHEALTHY

Resolves BA-6343

🤖 Generated with [Claude Code](https://claude.com/claude-code)