### PR TITLE
test: remove stale xfail markers on infra usage stats tests

### DIFF
--- a/changes/12021.test.md
+++ b/changes/12021.test.md
@@ -1,0 +1,1 @@
+Remove stale xfail markers on infra usage stats component tests now that v2 InfraClient GET params are routed through the query string.

--- a/tests/component/infra/test_infra.py
+++ b/tests/component/infra/test_infra.py
@@ -30,12 +30,6 @@ from ai.backend.common.dto.manager.infra import (
     UsagePerPeriodResponse,
 )
 
-_GET_JSON_BODY_XFAIL_REASON = (
-    "Client SDK v2 sends JSON body on GET requests, but the server's "
-    "check_api_params reads from request.query for GET/HEAD methods, "
-    "ignoring the body entirely.  Params are never seen by the server."
-)
-
 
 class TestEtcdConfigRead:
     """Tests for read-only etcd config endpoints (no auth required)."""
@@ -246,7 +240,6 @@ class TestResourcePresets:
 class TestUsageStats:
     """Tests for usage statistics endpoints."""
 
-    @pytest.mark.xfail(reason=_GET_JSON_BODY_XFAIL_REASON, strict=True)
     async def test_admin_gets_usage_per_month(
         self,
         admin_registry: BackendAIClientRegistry,
@@ -258,7 +251,6 @@ class TestUsageStats:
         assert isinstance(result, UsagePerMonthResponse)
         assert isinstance(result.root, list)
 
-    @pytest.mark.xfail(reason=_GET_JSON_BODY_XFAIL_REASON, strict=True)
     async def test_admin_gets_usage_per_period(
         self,
         admin_registry: BackendAIClientRegistry,


### PR DESCRIPTION
## Summary
- `test_admin_gets_usage_per_month` and `test_admin_gets_usage_per_period` carried `@pytest.mark.xfail(strict=True)` guarding a bug where v2 `InfraClient` sent GET params as a JSON body that the server ignored.
- PR #11968 fixed this by routing those params through the query string, so the tests now pass — and `strict=True` turns the unexpected XPASS into a suite failure.
- Remove the obsolete xfail markers and the now-unused `_GET_JSON_BODY_XFAIL_REASON` constant.

## Test plan
- [ ] `pants test tests/component/infra/test_infra.py` passes (24 passed)