### PR TITLE
feat(BA-5952): add image node v2 to deployment revision preset

### DIFF
--- a/changes/12023.feature.md
+++ b/changes/12023.feature.md
@@ -1,0 +1,1 @@
+Add an `image` field to the `DeploymentRevisionPreset` GraphQL type that resolves the container image as an `ImageV2` node

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -5570,6 +5570,11 @@ type DeploymentRevisionPreset implements Node
   """Added in 26.4.3. The runtime variant this preset is designed for."""
   runtimeVariant: RuntimeVariant
 
+  """
+  Added in UNRELEASED. The container image used to run the inference server, resolved via DataLoader. None when the preset does not specify an image.
+  """
+  image: ImageV2
+
   """Added in 26.4.2. Resource slot allocations for this preset."""
   resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null): [AllocatedResourceSlot!]
 }

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -5571,7 +5571,7 @@ type DeploymentRevisionPreset implements Node
   runtimeVariant: RuntimeVariant
 
   """
-  Added in UNRELEASED. The container image used to run the inference server, resolved via DataLoader. None when the preset does not specify an image.
+  Added in UNRELEASED. The container image used to run the inference server. None when the preset does not specify an image.
   """
   image: ImageV2
 

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -3787,7 +3787,7 @@ type DeploymentRevisionPreset implements Node {
   runtimeVariant: RuntimeVariant
 
   """
-  Added in UNRELEASED. The container image used to run the inference server, resolved via DataLoader. None when the preset does not specify an image.
+  Added in UNRELEASED. The container image used to run the inference server. None when the preset does not specify an image.
   """
   image: ImageV2
 

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -3786,6 +3786,11 @@ type DeploymentRevisionPreset implements Node {
   """Added in 26.4.3. The runtime variant this preset is designed for."""
   runtimeVariant: RuntimeVariant
 
+  """
+  Added in UNRELEASED. The container image used to run the inference server, resolved via DataLoader. None when the preset does not specify an image.
+  """
+  image: ImageV2
+
   """Added in 26.4.2. Resource slot allocations for this preset."""
   resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null): [AllocatedResourceSlot!]
 }

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -304,7 +304,7 @@ class DeploymentRevisionPresetGQL(PydanticNodeMixin[NodeDTO]):
     @gql_added_field(
         BackendAIGQLMeta(
             added_version=NEXT_RELEASE_VERSION,
-            description="The container image used to run the inference server, resolved via DataLoader. None when the preset does not specify an image.",
+            description="The container image used to run the inference server. None when the preset does not specify an image.",
         )
     )  # type: ignore[misc]
     async def image(

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -61,6 +61,7 @@ from ai.backend.common.dto.manager.v2.deployment_revision_preset.response import
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.response import (
     UpdateDeploymentRevisionPresetPayload as UpdatePayloadDTO,
 )
+from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import StringFilter as StringFilterGQL
 from ai.backend.manager.api.gql.base import UUIDFilter as UUIDFilterGQL
@@ -100,6 +101,7 @@ from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, Pydant
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 
 if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.image.types import ImageV2GQL
     from ai.backend.manager.api.gql.runtime_variant.types import RuntimeVariantGQL
 
 
@@ -298,6 +300,26 @@ class DeploymentRevisionPresetGQL(PydanticNodeMixin[NodeDTO]):
         | None
     ):
         return await info.context.data_loaders.runtime_variant_loader.load(self.runtime_variant_id)
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The container image used to run the inference server, resolved via DataLoader. None when the preset does not specify an image.",
+        )
+    )  # type: ignore[misc]
+    async def image(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            ImageV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.image.types"),
+        ]
+        | None
+    ):
+        if self.execution.image_id is None:
+            return None
+        return await info.context.data_loaders.image_loader.load(ImageID(self.execution.image_id))
 
     @gql_added_field(
         BackendAIGQLMeta(


### PR DESCRIPTION
## Summary
- Add an `image` field to the `DeploymentRevisionPreset` GraphQL type that resolves the container image as an `ImageV2` node via the existing image DataLoader (batched, N+1-safe).
- Previously the preset only exposed `execution.imageId`, forcing clients to issue a separate query to render image details in preset tables; the field returns `null` when the preset does not specify an image.
- Regenerate the v2 schema and supergraph artifacts.

## Test plan
- [x] `scripts/generate-graphql-schema.sh` — v2 schema and supergraph composition succeed
- [x] `tests/unit/manager/api/gql/deployment/test_revision_preset_types.py` passes
- [ ] Query `deploymentRevisionPresets { ... image { ... } }` against a live server

Resolves BA-5952

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12023.org.readthedocs.build/en/12023/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12023.org.readthedocs.build/ko/12023/

<!-- readthedocs-preview sorna-ko end -->