### PR TITLE
feat(BA-6349): add Permission bitmask column to permissions table with backfill

### DIFF
--- a/changes/12128.feature.md
+++ b/changes/12128.feature.md
@@ -1,0 +1,1 @@
+Add a `Permission` bitmask column to the RBAC `permissions` table, backfilled from the legacy per-operation column, as the grant-side foundation for cap-based permission resolution.

--- a/fixtures/manager/example-roles.json
+++ b/fixtures/manager/example-roles.json
@@ -265,7 +265,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "user",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "dc96e05d-29e7-4a90-ba50-2e3e7ea4a65b",
@@ -273,7 +274,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "user",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "a70798b6-aad2-448e-b438-c82930444252",
@@ -281,7 +283,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "user",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "1da58bf7-1852-4abe-9a54-fdc482d427e4",
@@ -289,7 +292,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "user",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "a5449786-2761-4e18-8c7c-1d3bc11c3431",
@@ -297,7 +301,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "user",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "6dfe3d65-f785-4c26-8ac6-6738f28734a0",
@@ -305,7 +310,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "user",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "3be1e328-a1da-44fd-8dd5-842afb267ae5",
@@ -313,7 +319,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "user",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "00642d3d-1b2e-436f-af49-71d6b0612f07",
@@ -321,7 +328,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "user",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "d0086ec5-0163-4b61-9ab8-e807dda8a9d2",
@@ -329,7 +337,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "user",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "ac635c17-ef30-44c5-a209-feceb115f72f",
@@ -337,7 +346,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "user",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "26fa9200-a13c-41ca-832e-1a615a798610",
@@ -345,7 +355,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "user",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "1d8f17b6-0c47-40a7-b96d-4ac6b267d5c7",
@@ -353,7 +364,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "user",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "00a17135-6c91-4345-aff8-650e73a9cdc1",
@@ -361,7 +373,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "user",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "46b449b4-18c1-4a43-8336-dad2597373b1",
@@ -369,7 +382,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "user",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "12622918-ef39-438c-aec8-f5bf2e8f3309",
@@ -377,7 +391,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "user",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "69a4ac81-a174-40e0-8a59-1af4d26cab14",
@@ -385,7 +400,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "user",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "373a6341-0ae8-4ead-8ce6-9f1bd16687e6",
@@ -393,7 +409,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "user",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "1790e1a6-6289-4617-ae59-e75409a29209",
@@ -401,7 +418,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "user",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "fe1313a8-fe1b-4709-99b9-0348d15bd329",
@@ -409,7 +427,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "user",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "89a564c5-48d5-4bf5-b35e-70d838746c72",
@@ -417,7 +436,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "user",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "6e013c73-491c-47ba-abed-6b9fa4224926",
@@ -425,7 +445,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "user",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "81695568-375a-4a6a-aa0f-4fa1e07bc78c",
@@ -433,7 +454,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "user",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "c1c44f4a-774f-4e60-8968-d48d499f231f",
@@ -441,7 +463,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "user",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "d56c152e-2d20-4870-90bf-65e5df4baa72",
@@ -449,7 +472,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "user",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "ce345c7e-d436-41fe-a257-ab178eeb310f",
@@ -457,7 +481,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "user",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "c42fde9e-7480-4108-8583-de8289f7c139",
@@ -465,7 +490,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "user",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "b908f4c6-f9c9-4674-adf5-50a8a6b8c763",
@@ -473,7 +499,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "user",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "79c7cbc8-3dc0-4100-9b02-a331a7d02563",
@@ -481,7 +508,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "user",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "9e56aaa7-b23e-45a2-80eb-afdf77651d30",
@@ -489,7 +517,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "user",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "f8889e4b-2943-49a6-b8da-3019f6129573",
@@ -497,7 +526,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "user",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "3373279c-4cc4-4642-99d1-e2ea48c1f70d",
@@ -505,7 +535,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "user",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "0dc97e33-c0ee-4dea-b8e5-a1ce0fc94ed4",
@@ -513,7 +544,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "user",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "0c430c56-8dca-45b6-af6a-e748f6b0c708",
@@ -521,7 +553,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "user",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "bf9f5480-1e47-4124-b5a9-cc77b4a61e18",
@@ -529,7 +562,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "user",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "9df6c9af-7eaa-4f87-a707-ddba417b48f2",
@@ -537,7 +571,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "user",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "074d7567-1a87-4486-88f1-6e88872b88ad",
@@ -545,7 +580,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "user",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "5647a521-ca91-4c57-974e-bdae6069a605",
@@ -553,7 +589,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "user",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "2ea152ff-5e28-4e96-9908-3ee1e0b99718",
@@ -561,7 +598,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "user",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "7f15717c-e918-4673-9307-5f26c84ff95f",
@@ -569,7 +607,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "user",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "d6c2fe69-619d-4ccd-a559-e04cc1667f34",
@@ -577,7 +616,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "vfolder",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "91853331-3c42-4190-aa4c-d58772323c04",
@@ -585,7 +625,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "vfolder",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "7f049c55-39b7-4dbe-a72f-98dd5d57198d",
@@ -593,7 +634,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "vfolder",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "184508d8-1d7f-4343-994b-b25354423da7",
@@ -601,7 +643,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "vfolder",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "b44e4f5d-3bc4-45b8-b8b4-3dbf7382a363",
@@ -609,7 +652,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "vfolder",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "769a6025-e3dc-416e-8916-e7a42c52e179",
@@ -617,7 +661,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "vfolder",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "5e1110d5-894c-4fef-9785-b4874730088a",
@@ -625,7 +670,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "vfolder",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "9c618332-3ce0-43d2-8b6f-6d30cb07aac0",
@@ -633,7 +679,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "vfolder",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "59eda701-e9b1-4551-a266-4d049eed6815",
@@ -641,7 +688,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "vfolder",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "c05ee039-6735-4a5f-b417-6a94c07a63d7",
@@ -649,7 +697,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "vfolder",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "a3f179f7-00a7-4b24-9e38-612ead26c7e9",
@@ -657,7 +706,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "vfolder",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "6643f5b8-260a-497f-92a5-4fb105b8b209",
@@ -665,7 +715,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "vfolder",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "87bd823f-2d49-4455-821a-d45637318018",
@@ -673,7 +724,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "vfolder",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "73fc448d-aa7f-4796-87c8-24ca14791c2b",
@@ -681,7 +733,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "vfolder",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "489fc4ba-e879-499c-8553-49a11249e170",
@@ -689,7 +742,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "vfolder",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "2b7f8ce0-a12b-450d-86e6-a9f305914a5c",
@@ -697,7 +751,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "vfolder",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "caf9cdf1-259e-4d25-a28b-378b105502d1",
@@ -705,7 +760,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "vfolder",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "83e8cc68-dcf5-414f-bbb1-da4d58cd1ddc",
@@ -713,7 +769,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "vfolder",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "90ed51fa-662d-464f-9004-bf54c5127b5b",
@@ -721,7 +778,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "vfolder",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "531283f1-cb9c-4302-91a9-52a165feffc9",
@@ -729,7 +787,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "vfolder",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "6d1507ca-7897-495e-96c4-153fbd965df2",
@@ -737,7 +796,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "vfolder",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "ab19dedf-0f82-45c1-919e-ebf7d712fc64",
@@ -745,7 +805,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "vfolder",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "87db7417-6cab-4168-8772-c0bbb374521f",
@@ -753,7 +814,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "vfolder",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "4dc03cda-716d-4af9-b011-50e4ef7a7b5e",
@@ -761,7 +823,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "vfolder",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "3011b432-3636-4c67-8311-19ccbf437982",
@@ -769,7 +832,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "vfolder",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "302da7f1-c134-4c58-a885-a486533ec180",
@@ -777,7 +841,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "vfolder",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "ebdd4a33-4c36-417c-8566-3d27f259d4d0",
@@ -785,7 +850,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "vfolder",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "9db1ba31-982d-4923-844d-25e395041112",
@@ -793,7 +859,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "vfolder",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "8b2e5c19-d887-412a-a7de-1cb67b38fd55",
@@ -801,7 +868,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "vfolder",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "0c768941-9b7b-470f-ab4c-6efa26fca2bf",
@@ -809,7 +877,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "vfolder",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "f13aaafd-b727-4530-a15a-a1f2312f180a",
@@ -817,7 +886,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "vfolder",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "ce3af414-a03d-46c1-8e54-fba9a7c78181",
@@ -825,7 +895,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "vfolder",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "9769f2cb-561e-4039-9c5d-11bfaa6596e2",
@@ -833,7 +904,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "vfolder",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "a36ec117-3293-4905-b5d6-2271e6b36055",
@@ -841,7 +913,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "vfolder",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "617982a3-b098-41a2-be1a-5d15bbac8829",
@@ -849,7 +922,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "vfolder",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "fcb9ba33-7c01-489b-89bd-33b9c83ef768",
@@ -857,7 +931,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "vfolder",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "e9fb43a0-ec50-4c66-b97d-2332c50d382d",
@@ -865,7 +940,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "vfolder",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "04c50bfc-6570-4883-ac81-cab6a6348d83",
@@ -873,7 +949,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "vfolder",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "20eb9455-f65e-487b-817c-192cef93d710",
@@ -881,7 +958,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "vfolder",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "ed453470-2008-437d-acee-acdc073b0b0a",
@@ -889,7 +967,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "vfolder",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "65716be9-c1f1-46d8-ab7d-35bf8147f62d",
@@ -897,7 +976,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "vfolder",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "5b20802f-8eb2-4dbe-a81b-eaf8c127cac3",
@@ -905,7 +985,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "vfolder",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "8c37a121-bc1d-4b64-b0bd-8ccaba358516",
@@ -913,7 +994,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "vfolder",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "8195f4f0-aae5-5323-95f1-ae6c72ae7650",
@@ -921,7 +1003,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "session",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "788f39b2-c66b-5b3a-8068-bbe7aa6e8250",
@@ -929,7 +1012,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "agent",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "43c77185-2c07-5373-af93-46ffbab9060d",
@@ -937,7 +1021,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "image",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "0e49e0f8-3cd9-577a-9d44-2c8324eee462",
@@ -945,7 +1030,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "keypair",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "426d4507-4586-5639-8541-6bbe7311c968",
@@ -953,7 +1039,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "container_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "fa6a43d3-dd49-5325-83b3-f3f5810c2204",
@@ -961,7 +1048,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "resource_group",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "cd46c6bd-9a88-5758-ad22-1e1e65cc20ed",
@@ -969,7 +1057,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "da3cdb5e-0489-507a-b3a0-a1f469fea2c1",
@@ -977,7 +1066,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "1f2926bc-7120-5bc0-8529-02f07948b246",
@@ -985,7 +1075,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "app_config",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "fa173baa-9075-5a2b-a890-7673a01aff90",
@@ -993,7 +1084,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_channel",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "12a57c40-b36d-5201-b38d-0dddbd303b98",
@@ -1001,7 +1093,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_rule",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "d3ed2c2c-9173-5993-8a3c-1f6b49d6ce4b",
@@ -1009,7 +1102,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_deployment",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "c8cd71ad-52f0-5fc9-9d3d-ecbb2d162c2a",
@@ -1017,7 +1111,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_card",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "6dfe769a-dabe-5264-b711-84a4b8b47d9e",
@@ -1025,7 +1120,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "session",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "7c34f745-babe-5e7d-b996-ad11ffd2ec35",
@@ -1033,7 +1129,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "agent",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "236ca859-84b4-5595-8f88-90a5dc24741b",
@@ -1041,7 +1138,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "image",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "c121d88e-6794-5664-baba-fef4535a5d41",
@@ -1049,7 +1147,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "keypair",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "265648e2-b8a4-5fe0-a6fd-83df1ad4aba1",
@@ -1057,7 +1156,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "container_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "efe23f2e-684d-520f-99c8-d903f51953df",
@@ -1065,7 +1165,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "resource_group",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "861700c2-0950-5767-9d57-4a6543476f41",
@@ -1073,7 +1174,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "23db3fae-a585-5928-bfed-750ca1b14675",
@@ -1081,7 +1183,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "6f17623b-dd19-5a39-b784-735c354f8e83",
@@ -1089,7 +1192,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "app_config",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "5e63be4a-94cb-5b03-be2b-9de2ea705af2",
@@ -1097,7 +1201,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_channel",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "d8f79e0b-2ebf-5ddb-a307-6e52f8ae1ad7",
@@ -1105,7 +1210,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_rule",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "204f5e07-e4d5-5806-a274-2ca0d1066b6f",
@@ -1113,7 +1219,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_deployment",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "27e5cd57-f28d-5bea-bd8c-bed48dc3f4b4",
@@ -1121,7 +1228,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_card",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "5eff7a9f-cfd5-5caf-8a8d-198c0ca558bc",
@@ -1129,7 +1237,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "session",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "3a2658cd-f38b-5795-9134-31b2da1abf91",
@@ -1137,7 +1246,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "session",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "4d5adefc-1eff-5116-9ea0-2a16d402320d",
@@ -1145,7 +1255,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "session",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "840f8834-204e-5854-9487-027d9a525689",
@@ -1153,7 +1264,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "session",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "6d4dad0a-6e6b-5351-afe9-4cb4c00348d4",
@@ -1161,7 +1273,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "session",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "e6994081-56b4-5493-b79f-e5a3f16220bd",
@@ -1169,7 +1282,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "agent",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "203b11b9-50b2-5543-8d3b-7a045846ddc6",
@@ -1177,7 +1291,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "agent",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "90e7cde1-0d86-5380-96df-270ad7364d97",
@@ -1185,7 +1300,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "agent",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "f5cb8156-364e-50b9-b2ca-1aa5249afa01",
@@ -1193,7 +1309,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "agent",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "1e6310a7-5cdf-5d60-8604-7e3d5b680f9e",
@@ -1201,7 +1318,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "agent",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "db699e36-04f3-57c7-8faa-38ac57cce839",
@@ -1209,7 +1327,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "image",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "c4b29302-e0f2-5f6b-8204-1f1107fcf008",
@@ -1217,7 +1336,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "image",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "8e2fc8df-b194-5b01-94ff-391ff92f467f",
@@ -1225,7 +1345,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "image",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "3560ad21-0caf-5ffb-968d-b132a4b6767d",
@@ -1233,7 +1354,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "image",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "8182c126-239a-5743-9231-b116e286139e",
@@ -1241,7 +1363,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "image",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "4fd86a7c-3721-531c-83a6-904a8d188956",
@@ -1249,7 +1372,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "keypair",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "f746b913-d8b8-55e7-92a7-32a487668c78",
@@ -1257,7 +1381,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "keypair",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "607929e4-e87a-5c6a-b9a4-172389190e6b",
@@ -1265,7 +1390,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "keypair",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "34a1158c-48a0-5a22-b6e6-0e3851ef8f70",
@@ -1273,7 +1399,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "keypair",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "030b9550-e851-5f49-9ebe-a7f357d0f810",
@@ -1281,7 +1408,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "keypair",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "ee8ed54f-c717-5115-a257-eec88586b2de",
@@ -1289,7 +1417,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "container_registry",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "706a55b3-2f4f-5291-9115-acc394f9bdbc",
@@ -1297,7 +1426,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "container_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "ee48768a-91c2-5d07-8aed-ef80a9f1a774",
@@ -1305,7 +1435,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "container_registry",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "f9cd1078-40e6-500c-b08b-b3a4d8cd96a2",
@@ -1313,7 +1444,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "container_registry",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "0fd5998c-0eff-5c45-b489-2da17fecec3c",
@@ -1321,7 +1453,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "container_registry",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "34ba2e04-0547-5481-9ed5-a64b1c86a3c5",
@@ -1329,7 +1462,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "resource_group",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "f2bab7ea-c6fe-5b76-ac37-9f0543625805",
@@ -1337,7 +1471,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "resource_group",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "0577b87d-de55-56cb-ba7f-c0818b913e71",
@@ -1345,7 +1480,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "resource_group",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "86062bdd-6a74-5658-bed1-24c71c6c8dee",
@@ -1353,7 +1489,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "resource_group",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "10ca73e5-051b-591f-8dbf-8b57ad1290f5",
@@ -1361,7 +1498,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "resource_group",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "8baddd58-62fc-50ef-8355-17b96727931f",
@@ -1369,7 +1507,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "artifact",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "80276c2a-adb7-5547-96bc-264970790c2e",
@@ -1377,7 +1516,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "artifact",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "0a2802f7-bf9e-583d-b8f9-abe466113e77",
@@ -1385,7 +1525,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "artifact",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "94ff98b4-0d07-51f1-9dd2-416c4edf6952",
@@ -1393,7 +1534,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "artifact",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "12a09ad2-ac50-54fb-b805-d6cc229126ba",
@@ -1401,7 +1543,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "artifact",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "82f70efc-ba04-5d98-8807-228f8fce8097",
@@ -1409,7 +1552,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "artifact_registry",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "39add42f-fe50-5c05-a225-029214ca7f18",
@@ -1417,7 +1561,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "artifact_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "689e92d8-6427-5a65-9d52-8a731ae89ee0",
@@ -1425,7 +1570,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "artifact_registry",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "738a998c-fdd5-5c98-b83c-21b2aab4ac60",
@@ -1433,7 +1579,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "artifact_registry",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "eaed6411-6e89-568b-8c11-e74465014d9c",
@@ -1441,7 +1588,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "artifact_registry",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "4ff12040-0307-591c-b556-d520d1406a05",
@@ -1449,7 +1597,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "app_config",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "b3fa7699-5a2d-50e7-9199-a7d1f5fbdb63",
@@ -1457,7 +1606,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "app_config",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "fb5e1852-69c8-51ba-ba36-7394ea840c8e",
@@ -1465,7 +1615,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "app_config",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "b5cd5be8-b14d-51e1-b1a5-689d55fe7c03",
@@ -1473,7 +1624,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "app_config",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "9daa3004-237f-5309-8df2-1d567747df1a",
@@ -1481,7 +1633,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "app_config",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "9a56f83e-18a0-52ae-9ffa-c087bf5f968d",
@@ -1489,7 +1642,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "notification_channel",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "022c13f9-02ca-5804-9b6e-6f028cd9c821",
@@ -1497,7 +1651,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "notification_channel",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "173cde5d-4032-5c6e-bc99-cd110b757d88",
@@ -1505,7 +1660,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "notification_channel",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "f257a46b-eae0-5040-9dd8-75822e3dad69",
@@ -1513,7 +1669,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "notification_channel",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "7596db80-bd74-5183-ad62-197a7eb6d481",
@@ -1521,7 +1678,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "notification_channel",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "2aef75ac-2282-53d7-a6e1-3ce3d2f06298",
@@ -1529,7 +1687,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "notification_rule",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "4d19d8d8-ac57-5536-9917-bbd2cbd00294",
@@ -1537,7 +1696,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "notification_rule",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "e0cf3208-dab0-538e-81a3-5fc6def3ab3c",
@@ -1545,7 +1705,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "notification_rule",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "35a8f272-4807-5555-a67a-ba4ec782074e",
@@ -1553,7 +1714,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "notification_rule",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "31a5318d-00ea-5a82-bf47-3829328d86e3",
@@ -1561,7 +1723,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "notification_rule",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "ec9e220c-5e3a-5609-9bff-cec27bc75e8b",
@@ -1569,7 +1732,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "model_deployment",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "a4bc0102-4377-502f-a69b-a466ed432c15",
@@ -1577,7 +1741,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "model_deployment",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "c86b9f3f-ff00-53c7-bfbd-d627d03c332a",
@@ -1585,7 +1750,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "model_deployment",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "bf7e7652-c542-518f-b368-cb5373cfe0b1",
@@ -1593,7 +1759,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "model_deployment",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "e57061c9-4730-5fcb-b01d-708cd01593fc",
@@ -1601,7 +1768,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "model_deployment",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "61bed1bb-f569-5a85-b884-29d9fa7deca0",
@@ -1609,7 +1777,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "model_card",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "39ba718f-18f5-543c-aa17-d74ce188a669",
@@ -1617,7 +1786,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "model_card",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "fa36f0bd-6972-5f10-ad36-7cff96b29958",
@@ -1625,7 +1795,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "model_card",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "dba01b6e-c89b-52ae-92a5-62e7e0759ba7",
@@ -1633,7 +1804,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "model_card",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "6d752868-d6dd-58fa-93f8-ebfab806a077",
@@ -1641,7 +1813,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "model_card",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "92eee125-b32b-5797-8f6d-9704eae14310",
@@ -1649,7 +1822,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "session",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "9299d244-fd8f-5da9-8e5e-81612a53ee0f",
@@ -1657,7 +1831,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "session",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "5a05f5b5-95ed-5df0-a4f0-fc96371d81f6",
@@ -1665,7 +1840,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "session",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "9fa7d13b-7cec-5d36-ab2d-6eadcb97cec0",
@@ -1673,7 +1849,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "session",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "6ded0c6b-020f-5c8c-8983-9909fcc30f78",
@@ -1681,7 +1858,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "session",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "f05ed002-9279-5998-aa83-b207f29c567b",
@@ -1689,7 +1867,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "agent",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "bbd4ab09-0df5-53d1-adb7-661284ff9a4a",
@@ -1697,7 +1876,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "agent",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "3098001c-5a77-510f-b696-b5664da899ff",
@@ -1705,7 +1885,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "agent",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "b02df841-6fa5-5572-a149-9b7dba09c266",
@@ -1713,7 +1894,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "agent",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "98316001-4e7f-55e7-b51f-da1e4d4b9d06",
@@ -1721,7 +1903,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "agent",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "f1f8379b-d243-5628-b292-25f436e398f0",
@@ -1729,7 +1912,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "image",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "694823ea-90ea-58c3-a526-fff8afd45ce2",
@@ -1737,7 +1921,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "image",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "59d3d9b0-9d46-5c12-9e30-6fceb2cd5e24",
@@ -1745,7 +1930,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "image",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "b6efaa04-40ec-54d7-99d3-02411046d73c",
@@ -1753,7 +1939,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "image",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "8c154211-6d9c-57f5-aead-254b3a099266",
@@ -1761,7 +1948,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "image",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "66ed82ec-8584-5e32-a756-83fe4883e85b",
@@ -1769,7 +1957,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "keypair",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "9108b0ec-395f-5708-853c-13cae9cb0b5c",
@@ -1777,7 +1966,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "keypair",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "c9c482ca-2cc6-5f4d-9333-bb16b9bf8267",
@@ -1785,7 +1975,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "keypair",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "61007ef7-5727-5219-ae80-3200e6b399a3",
@@ -1793,7 +1984,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "keypair",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "968d599f-5662-5b4c-9ea0-29eb45f951c1",
@@ -1801,7 +1993,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "keypair",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "31ad0203-a202-56e0-af2c-d3e0d23a3c86",
@@ -1809,7 +2002,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "container_registry",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "e1cb2d39-8bc7-5ce9-bc7d-7c90bbeff8cd",
@@ -1817,7 +2011,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "container_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "151cb0cc-a5bc-58a8-9b9f-0c309dcae6b7",
@@ -1825,7 +2020,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "container_registry",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "bb6ed296-b69c-5468-ac73-99c32c3408cd",
@@ -1833,7 +2029,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "container_registry",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "d25da0a2-52c2-520d-9963-0762c0a37d5c",
@@ -1841,7 +2038,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "container_registry",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "19cfbd57-0872-5cb8-92ac-597a6251fdaf",
@@ -1849,7 +2047,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "resource_group",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "4e9f5fd0-76bb-55bc-acad-7bf63686fa71",
@@ -1857,7 +2056,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "resource_group",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "3b2bde11-b12a-5828-8a43-e8a84074b779",
@@ -1865,7 +2065,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "resource_group",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "7b8e27b3-65e1-5b47-96fa-40707092d651",
@@ -1873,7 +2074,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "resource_group",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "e2646799-5869-5d32-bde7-03322459acde",
@@ -1881,7 +2083,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "resource_group",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "37333a3d-2a50-559b-92bf-6b0c23ab6ed3",
@@ -1889,7 +2092,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "artifact",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "8a22cbd0-bb08-504b-9942-e870de20f11f",
@@ -1897,7 +2101,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "artifact",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "9ea66696-c29e-5658-a302-1264a98b4fac",
@@ -1905,7 +2110,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "artifact",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "f3eca518-b5c2-519c-b558-a7bcfd7d49b6",
@@ -1913,7 +2119,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "artifact",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "032d72b4-f0d6-53f7-9389-5f892204276c",
@@ -1921,7 +2128,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "artifact",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "3e6b4c3e-f490-50f8-a387-03f795e574f3",
@@ -1929,7 +2137,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "artifact_registry",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "e12c10d9-a89e-530e-9e20-f4e81a754c89",
@@ -1937,7 +2146,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "artifact_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "88ed32de-0664-531d-a615-72b260bc9ff1",
@@ -1945,7 +2155,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "artifact_registry",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "36e20812-4acb-582a-bc44-1427171e05db",
@@ -1953,7 +2164,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "artifact_registry",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "ded411ba-1cc6-56e5-bb1f-939c582389b1",
@@ -1961,7 +2173,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "artifact_registry",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "db6c5b62-4853-5784-946a-b8a4397dcb9e",
@@ -1969,7 +2182,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "app_config",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "395a86bd-1ec2-5567-a6ec-4959c7017a62",
@@ -1977,7 +2191,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "app_config",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "4fe29c8c-babd-54ec-896f-f878560c874e",
@@ -1985,7 +2200,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "app_config",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "36014579-0e5e-5b8e-9c82-0eed196bb83f",
@@ -1993,7 +2209,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "app_config",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "219e0d45-7ada-5c2d-94a7-a5f68f2e3992",
@@ -2001,7 +2218,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "app_config",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "53471358-e2b6-55be-818c-0d756ecc7cf3",
@@ -2009,7 +2227,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "notification_channel",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "e3996c16-1ffc-568e-8b5d-88faeda35f8d",
@@ -2017,7 +2236,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "notification_channel",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "46f2bb0e-f3b9-5ec3-94bb-cdf8e5dce8b5",
@@ -2025,7 +2245,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "notification_channel",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "3c7cf377-0839-5667-8aa9-caf228290d9c",
@@ -2033,7 +2254,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "notification_channel",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "552eaee6-abcc-5fd4-8afc-82cb8ecbf6d6",
@@ -2041,7 +2263,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "notification_channel",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "63675456-0253-5f8c-872b-d2749899de50",
@@ -2049,7 +2272,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "notification_rule",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "29789b28-e799-5a05-9c13-293ebd3e1c00",
@@ -2057,7 +2281,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "notification_rule",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "c0b4c9c2-1bd5-5bff-9541-3531a3c068bc",
@@ -2065,7 +2290,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "notification_rule",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "4348c2d1-82ac-5ed5-8be5-f6557328665d",
@@ -2073,7 +2299,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "notification_rule",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "62fb9c9c-3027-51fe-806c-d4216891e965",
@@ -2081,7 +2308,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "notification_rule",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "6bd59b5b-6143-5a62-aca2-ffbfe07951b0",
@@ -2089,7 +2317,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "model_deployment",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "970d3a01-69a1-506b-8ec1-d14fa768ca35",
@@ -2097,7 +2326,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "model_deployment",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "ef507289-edca-5e1b-a25f-f4bd9da5e0bc",
@@ -2105,7 +2335,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "model_deployment",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "097f63c1-13f0-53d9-a46b-e89970672e31",
@@ -2113,7 +2344,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "model_deployment",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "8b707942-599c-52cf-b8b3-119aadefb100",
@@ -2121,7 +2353,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "model_deployment",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "f67361f9-aac6-5e75-9f64-09ca2bf701dd",
@@ -2129,7 +2362,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "model_card",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "a0c1c816-3153-5f1c-b0c8-d3abd4a1f21f",
@@ -2137,7 +2371,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "model_card",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "ca0a21ef-5db5-50ed-8749-0508a128dd0c",
@@ -2145,7 +2380,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "model_card",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "4fbe83a9-8099-560d-b617-5ba8c5f08b58",
@@ -2153,7 +2389,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "model_card",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "e87befd4-13a0-51fd-97ad-893c53d43899",
@@ -2161,7 +2398,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "model_card",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "4b877a54-8f7f-5a40-87d6-83ba5ac18a29",
@@ -2169,7 +2407,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "session",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "3ce0988e-f386-50ae-83b1-05d06c8361fa",
@@ -2177,7 +2416,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "session",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "34c68c19-4e5b-5b7f-a58e-f533ea57e536",
@@ -2185,7 +2425,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "session",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "96012f55-1daf-59a2-a818-dd3a53ca0742",
@@ -2193,7 +2434,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "session",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "902478d8-5ee0-5533-a7ed-0725ba77aacd",
@@ -2201,7 +2443,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "session",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "021ef3fe-085d-5d9d-86b7-060a630e15f2",
@@ -2209,7 +2452,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "agent",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "498acebf-5399-505a-b649-ec0d618fb4ed",
@@ -2217,7 +2461,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "agent",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "13a48d25-ca0e-559c-b06a-ff33f20b11d8",
@@ -2225,7 +2470,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "agent",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "7faf2e87-123f-5845-92d2-6cac36213381",
@@ -2233,7 +2479,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "agent",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "32613252-a857-5bee-ad3d-eca386273e7f",
@@ -2241,7 +2488,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "agent",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "5219cbe1-2bae-53df-b052-778d33f17317",
@@ -2249,7 +2497,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "image",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "b8eb101b-fc35-5747-adeb-c8269b1937a7",
@@ -2257,7 +2506,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "image",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "9d49b40f-44af-5b75-a010-b1eb18845040",
@@ -2265,7 +2515,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "image",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "51e39965-645e-5707-b897-8db6954021c8",
@@ -2273,7 +2524,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "image",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "cb401dd5-8967-5bd5-8f24-2f340af7c631",
@@ -2281,7 +2533,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "image",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "d09fb2eb-dfa6-5f91-919a-94741382015e",
@@ -2289,7 +2542,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "keypair",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "61152f8e-3a19-5c90-b26b-d074e54ed751",
@@ -2297,7 +2551,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "keypair",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "85d73848-a4ef-5e6f-8547-2f095312b58f",
@@ -2305,7 +2560,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "keypair",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "edc2ef49-180d-5bdc-8baf-ab190b902b4b",
@@ -2313,7 +2569,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "keypair",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "cbccb2ac-16a3-5502-806f-291afda7752f",
@@ -2321,7 +2578,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "keypair",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "d2f18ce4-3868-5611-b123-41584272e057",
@@ -2329,7 +2587,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "container_registry",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "7eb202ba-b4e4-56fb-b941-c77005144c02",
@@ -2337,7 +2596,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "container_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "c4d0435a-6fb0-5e5a-960a-f5dd0086dae9",
@@ -2345,7 +2605,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "container_registry",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "24577c96-3d99-560b-9f55-59894a89beba",
@@ -2353,7 +2614,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "container_registry",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "46ecdde7-8403-5abf-879d-f3b57f0061b1",
@@ -2361,7 +2623,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "container_registry",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "f369cba1-bbaf-53d9-af86-828053e78f1f",
@@ -2369,7 +2632,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "resource_group",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "88e955a1-2df1-5d01-a35f-10f8d12adc6a",
@@ -2377,7 +2641,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "resource_group",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "a68d399a-389a-5094-b90e-11142ade53f2",
@@ -2385,7 +2650,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "resource_group",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "c0b6a04c-2665-5bd1-a543-3c9d672606ae",
@@ -2393,7 +2659,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "resource_group",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "26334054-00f1-5f3e-96bc-fa257998cffd",
@@ -2401,7 +2668,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "resource_group",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "38701ada-00fd-5167-b23d-18a64463cd58",
@@ -2409,7 +2677,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "artifact",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "51f89371-6f01-5c20-bc26-5b643f826ffa",
@@ -2417,7 +2686,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "artifact",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "6e8ec8b3-c723-51ed-81d2-88ef22300fec",
@@ -2425,7 +2695,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "artifact",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "f048fa17-7db8-5e51-8047-fcb2ecd9463c",
@@ -2433,7 +2704,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "artifact",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "b968016b-687b-5f15-a9c7-770434b3beb0",
@@ -2441,7 +2713,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "artifact",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "71d44ad8-d29f-586c-98e6-9a9e29d6fbb0",
@@ -2449,7 +2722,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "artifact_registry",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "3f7dea14-c1d3-546b-bb64-8d8ca3649b7d",
@@ -2457,7 +2731,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "artifact_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "614738c2-4d55-5a9c-97ea-ea9dc6857cec",
@@ -2465,7 +2740,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "artifact_registry",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "c3deab23-86ab-5f1f-9235-932f5b88e8cf",
@@ -2473,7 +2749,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "artifact_registry",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "1cc51a4d-c299-5cbe-b824-9cfbf8c101c8",
@@ -2481,7 +2758,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "artifact_registry",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "592a1565-6762-597d-9c8b-911543f90de0",
@@ -2489,7 +2767,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "app_config",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "43469f73-0b71-5b78-9dd8-83afbc327765",
@@ -2497,7 +2776,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "app_config",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "66cc1aef-9dba-5ace-92b4-3753f6ecc76f",
@@ -2505,7 +2785,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "app_config",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "b9c75121-b4bb-57a2-bdcc-9619003d2df2",
@@ -2513,7 +2794,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "app_config",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "71bf79e3-32b7-56df-936c-4c5042c3ad96",
@@ -2521,7 +2803,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "app_config",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "b522dac3-0039-50c0-80cb-7e509e6fa307",
@@ -2529,7 +2812,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "notification_channel",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "8d33cb68-8b1c-5be8-9a41-c1a55a485c24",
@@ -2537,7 +2821,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "notification_channel",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "8224a853-105b-52f8-93c9-67bb1e7bdecd",
@@ -2545,7 +2830,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "notification_channel",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "c47568e3-82d8-5267-a552-ae186175c74d",
@@ -2553,7 +2839,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "notification_channel",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "443de5f8-6a5d-53ed-9f88-bb525278337f",
@@ -2561,7 +2848,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "notification_channel",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "b7711cc1-d33c-57e8-ab93-c6b298da17f7",
@@ -2569,7 +2857,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "notification_rule",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "4c3e562b-b7fc-5f7b-8f9c-4dd83c117862",
@@ -2577,7 +2866,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "notification_rule",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "d932c992-5d09-5c18-bc67-0ac730dc1dbb",
@@ -2585,7 +2875,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "notification_rule",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "60ee5d57-161e-586e-b085-bfc490f9c0b7",
@@ -2593,7 +2884,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "notification_rule",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "c22623fe-de68-54f9-a8fc-94298835b583",
@@ -2601,7 +2893,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "notification_rule",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "8b4a5fc4-e94b-57c7-81f7-116a60a3b2eb",
@@ -2609,7 +2902,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "model_deployment",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "8fa658d3-f711-59dc-b976-c83fa0b089a8",
@@ -2617,7 +2911,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "model_deployment",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "daf88852-f9bd-5cc5-a23c-e0b7bdaf62ac",
@@ -2625,7 +2920,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "model_deployment",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "cf3687bd-7b1d-5da0-8cd4-6ef46c5700ac",
@@ -2633,7 +2929,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "model_deployment",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "0d2bcd11-42e9-5e17-a243-4edddf59720a",
@@ -2641,7 +2938,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "model_deployment",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "0131fba5-7712-561d-86cc-5cc965701dce",
@@ -2649,7 +2947,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "model_card",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "91e26d04-0ddb-51de-a66a-60b591046cd1",
@@ -2657,7 +2956,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "model_card",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "ea246365-4221-5a99-aa0f-543a3c4e101e",
@@ -2665,7 +2965,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "model_card",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "9cfe29e7-1e71-5fa3-a9cb-799c8773cdcc",
@@ -2673,7 +2974,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "model_card",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "1f37213f-5802-5864-bf95-72b720b201fd",
@@ -2681,7 +2983,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "model_card",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "700af57f-bc53-58b0-b5d7-936c27244d9f",
@@ -2689,7 +2992,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "session",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "dd0f4891-a0ae-5169-82dd-4238b0cb4c2e",
@@ -2697,7 +3001,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "session",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "0087831c-9c88-5acc-8335-ca18b4fb75b4",
@@ -2705,7 +3010,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "session",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "f7753612-8420-5a21-a4ed-a50b45011968",
@@ -2713,7 +3019,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "session",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "3b83d315-abf4-5772-98c8-926642c8e4dd",
@@ -2721,7 +3028,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "session",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "0f101d7f-a5cf-52fb-8834-da286b8776bf",
@@ -2729,7 +3037,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "agent",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "e91a3980-c651-5154-b9f0-c205ebbc56fb",
@@ -2737,7 +3046,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "agent",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "78c159cb-404f-58d4-8b9e-c3f370ebd7d1",
@@ -2745,7 +3055,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "agent",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "cbb2205f-d5a0-5e83-bfcb-37dc383747ed",
@@ -2753,7 +3064,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "agent",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "1df180df-ada7-5790-bf74-f83dd419bc8f",
@@ -2761,7 +3073,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "agent",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "3133d01f-36b6-5772-a232-e44f78846b02",
@@ -2769,7 +3082,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "image",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "a0ea2697-8643-5ac4-9a79-75c4948783a7",
@@ -2777,7 +3091,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "image",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "b2859dde-3188-531e-8c91-6d51b3d44a9a",
@@ -2785,7 +3100,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "image",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "c2e29fdd-d578-5598-824d-7460c0ab1fed",
@@ -2793,7 +3109,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "image",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "01b05be3-5f81-5245-b154-329b6033f0ad",
@@ -2801,7 +3118,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "image",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "1f790880-4d3e-53e5-b643-aa0d5f0baa45",
@@ -2809,7 +3127,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "keypair",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "5ece69ec-809a-5857-9bef-aef5e2200b9d",
@@ -2817,7 +3136,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "keypair",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "4fccd263-ca86-52c4-bbb8-6446fd01dc38",
@@ -2825,7 +3145,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "keypair",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "80def686-bfe3-5561-8813-2db7b83aadf4",
@@ -2833,7 +3154,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "keypair",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "956bc6b9-8fe2-57c3-b677-851da5d518ba",
@@ -2841,7 +3163,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "keypair",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "f6297d68-a8d7-57f0-8fde-4e151c1ccdd2",
@@ -2849,7 +3172,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "container_registry",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "3ce954fe-e1a1-54b4-8802-bfab907eda5a",
@@ -2857,7 +3181,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "container_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "a8f077da-892a-5304-90d0-7bd32cb123c1",
@@ -2865,7 +3190,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "container_registry",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "2a6cc0f3-b927-5d94-b713-f4a87fbaa529",
@@ -2873,7 +3199,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "container_registry",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "8f9fc376-fdfc-57b6-a892-0277712c797a",
@@ -2881,7 +3208,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "container_registry",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "dad3985e-322a-5404-8512-a9c2fff91b58",
@@ -2889,7 +3217,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "resource_group",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "619a5533-a51a-5abc-8860-1ed823750d37",
@@ -2897,7 +3226,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "resource_group",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "8278cb73-2756-577d-b655-c884b5fd70ae",
@@ -2905,7 +3235,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "resource_group",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "25db0a08-f468-5f10-b3dd-01bcb605a583",
@@ -2913,7 +3244,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "resource_group",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "b06af513-0664-5c93-87d2-c8a81141a0fc",
@@ -2921,7 +3253,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "resource_group",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "fe01f863-aa7f-5412-a274-f42b3ae5ca4a",
@@ -2929,7 +3262,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "artifact",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "f6659bda-3b70-5554-a7ef-f0036ac8de4d",
@@ -2937,7 +3271,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "artifact",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "a5e7a1c7-159e-5b18-8fd5-79083268abaf",
@@ -2945,7 +3280,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "artifact",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "684995a4-fbc0-5f95-85e0-f71f656c3f46",
@@ -2953,7 +3289,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "artifact",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "91396353-0ff6-5a8e-999f-5f208a5d9b31",
@@ -2961,7 +3298,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "artifact",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "1e745938-da0d-52da-aaa7-5b24d393c4e4",
@@ -2969,7 +3307,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "artifact_registry",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "fca16df8-dc53-5921-8ef4-9c12634e6790",
@@ -2977,7 +3316,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "artifact_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "c6dcd98f-fa23-59ac-9c8d-aff970b87325",
@@ -2985,7 +3325,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "artifact_registry",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "b646f6b0-c1c1-53c5-9667-23ec292bc338",
@@ -2993,7 +3334,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "artifact_registry",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "cce9ebba-7e09-55fd-9226-ac1cdece1471",
@@ -3001,7 +3343,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "artifact_registry",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "96642679-7cf4-5b84-9435-66a8a7607337",
@@ -3009,7 +3352,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "app_config",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "bf274123-15e7-5e39-a0ce-944e940c460a",
@@ -3017,7 +3361,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "app_config",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "236ccf74-5878-5e8a-aa8b-d2e080507d1c",
@@ -3025,7 +3370,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "app_config",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "d5fd6b28-73ba-5fd8-80e1-902412563c1b",
@@ -3033,7 +3379,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "app_config",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "1f664262-f3d6-5591-9848-ad92615c26ab",
@@ -3041,7 +3388,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "app_config",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "c1b9dfd2-4370-5461-9bf0-81bcec40cc91",
@@ -3049,7 +3397,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "notification_channel",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "06090d5e-d05a-5b2c-9862-e83add7f7965",
@@ -3057,7 +3406,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "notification_channel",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "66205230-0284-5613-a25d-f1aa28881288",
@@ -3065,7 +3415,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "notification_channel",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "8adfb830-2109-52a1-af91-cf396d7ae33c",
@@ -3073,7 +3424,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "notification_channel",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "5a41d7c4-cf48-5627-803e-7fdf4fa60556",
@@ -3081,7 +3433,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "notification_channel",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "a929df68-83ee-5ff6-a748-b0c70785d721",
@@ -3089,7 +3442,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "notification_rule",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "ad25496b-c04b-5ba7-8701-edc4de62f9d5",
@@ -3097,7 +3451,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "notification_rule",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "2b8a91e4-0dcc-5aa8-a2d8-bdd05189e923",
@@ -3105,7 +3460,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "notification_rule",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "4b1f9f3b-2204-5b3b-80c8-b85910d8162d",
@@ -3113,7 +3469,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "notification_rule",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "704cda3b-8bba-5032-8a9b-f7236d2a8582",
@@ -3121,7 +3478,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "notification_rule",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "9807b9c9-cf54-5b06-a70c-5774de353e00",
@@ -3129,7 +3487,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "model_deployment",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "6fd9a767-801c-5681-b22f-c823d455ce35",
@@ -3137,7 +3496,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "model_deployment",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "6c10a1d4-0cfd-580b-b70a-2c91c57045d6",
@@ -3145,7 +3505,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "model_deployment",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "274c0634-4abd-5649-9a38-abe6afef5512",
@@ -3153,7 +3514,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "model_deployment",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "44155216-5dd7-5355-8287-3999d8fedd19",
@@ -3161,7 +3523,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "model_deployment",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "cdb36eea-259d-58a6-b900-4284d5dd25a8",
@@ -3169,7 +3532,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "model_card",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "dcf56e44-2e55-5f9c-bb39-d7429d6afb29",
@@ -3177,7 +3541,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "model_card",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "c214bba7-7e84-510e-98b4-6f8512dad34c",
@@ -3185,7 +3550,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "model_card",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "f4eab700-011f-5648-baf3-db052c7087e1",
@@ -3193,7 +3559,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "model_card",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "1cfc8f97-b783-5698-9d5a-3cdc13d08723",
@@ -3201,7 +3568,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "model_card",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "42a3ce9c-02c0-5ca6-9ae1-44e5da9eca7f",
@@ -3209,7 +3577,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "session",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "34a75001-220f-562a-a06e-e00cb1540808",
@@ -3217,7 +3586,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "session",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "97c5ae11-9c3f-50d8-ae02-ca7843c37e01",
@@ -3225,7 +3595,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "session",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "50b20ff3-7f3c-564b-8ecb-7046978645ad",
@@ -3233,7 +3604,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "session",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "f8d3bd3d-6657-5926-9174-dd84ba918145",
@@ -3241,7 +3613,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "session",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "3293bf07-3593-5a4e-b804-3e32cb149773",
@@ -3249,7 +3622,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "agent",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "1f5ff4d0-7414-5848-a0f5-4c5bc6c2fcae",
@@ -3257,7 +3631,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "agent",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "84f2bea9-1a2f-5116-99ca-8f9005de41c5",
@@ -3265,7 +3640,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "agent",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "f78b6b5a-6c40-598f-8cae-2b5af62f1211",
@@ -3273,7 +3649,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "agent",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "f6d68526-04bd-56c8-837f-18812c763639",
@@ -3281,7 +3658,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "agent",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "5aa1007f-9cba-5938-811e-9b1fcde4f093",
@@ -3289,7 +3667,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "image",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "1d3e4ea0-b26b-5600-88cb-d3547c6664d0",
@@ -3297,7 +3676,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "image",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "fe5efd89-487a-59ed-9033-cdb2e9f01d2c",
@@ -3305,7 +3685,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "image",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "56183a09-6fa8-5a1a-a5a8-37ec04558487",
@@ -3313,7 +3694,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "image",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "83b369c4-8c80-5f2a-ac59-351995bd0452",
@@ -3321,7 +3703,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "image",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "fb2733ec-ce05-57d2-982f-a8da78eba9c2",
@@ -3329,7 +3712,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "keypair",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "d9eb60ad-2d58-5658-934c-5206373005bb",
@@ -3337,7 +3721,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "keypair",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "687ce798-2dec-50b3-b6d8-9a93c0dd92d5",
@@ -3345,7 +3730,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "keypair",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "b0aacc78-b3bf-548d-b43a-e63455e46ff6",
@@ -3353,7 +3739,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "keypair",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "12065361-27d4-57aa-bc54-9fb48e4185a3",
@@ -3361,7 +3748,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "keypair",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "c1339151-31ea-561b-8e3a-b7482f130c4d",
@@ -3369,7 +3757,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "container_registry",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "eac4aa3b-f6bd-54a1-a8b9-aaf72373d2dc",
@@ -3377,7 +3766,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "container_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "028e1aee-7349-58d8-86c3-a4d6ceac1cdd",
@@ -3385,7 +3775,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "container_registry",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "876c6f8d-4232-5969-8c12-0841dc6a263c",
@@ -3393,7 +3784,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "container_registry",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "2cb7abae-d38c-556b-bea9-9c904f30f790",
@@ -3401,7 +3793,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "container_registry",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "0f3a940c-da97-5aa2-82c0-29ac55a26f9a",
@@ -3409,7 +3802,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "resource_group",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "38001f0e-8999-5d12-86d1-0ae9c37dddd2",
@@ -3417,7 +3811,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "resource_group",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "fed2e7f6-bb58-5c7e-9890-f385aaa273a1",
@@ -3425,7 +3820,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "resource_group",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "b5f828aa-a66c-55d4-ba16-162e0ff0a72e",
@@ -3433,7 +3829,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "resource_group",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "2ff68c53-e93d-55f1-aafb-8d6eead77bcb",
@@ -3441,7 +3838,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "resource_group",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "c5fa597a-4d5c-5fe2-81da-59b74fbd9e0a",
@@ -3449,7 +3847,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "artifact",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "5a9ffcab-914e-515f-b632-faf2951a4a1d",
@@ -3457,7 +3856,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "artifact",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "379d2c6d-736a-5e5b-931e-f770a0073db3",
@@ -3465,7 +3865,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "artifact",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "31c95177-a0b1-51e3-a4b1-4d6a1c8b536e",
@@ -3473,7 +3874,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "artifact",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "f1648390-c30d-5523-ad52-22948eea2f24",
@@ -3481,7 +3883,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "artifact",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "663ac9c9-b665-525e-90d6-e1b9fae00b77",
@@ -3489,7 +3892,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "artifact_registry",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "a22deeaf-beef-5eef-af90-69d0f8fb5a68",
@@ -3497,7 +3901,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "artifact_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "0671f668-8788-5231-9130-80d2bea8ebd7",
@@ -3505,7 +3910,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "artifact_registry",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "df567479-44e8-5099-ab9d-8d3401c94856",
@@ -3513,7 +3919,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "artifact_registry",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "e803ed07-31d9-50db-abb5-0ffc1d3ca1ca",
@@ -3521,7 +3928,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "artifact_registry",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "80bfbe3c-063e-5b7a-8902-82e571810ce2",
@@ -3529,7 +3937,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "app_config",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "5096b179-7cb8-55f6-9cfa-7ab8d00db807",
@@ -3537,7 +3946,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "app_config",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "6b69ec4a-a47f-5198-af4a-50cccc37fe49",
@@ -3545,7 +3955,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "app_config",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "fb5a1ad0-3224-5362-a870-24b9372ee599",
@@ -3553,7 +3964,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "app_config",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "d9b27a74-fcf8-574f-a349-59f5ff4af4bb",
@@ -3561,7 +3973,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "app_config",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "5384dd38-f2ce-582f-bae0-6b54119d6560",
@@ -3569,7 +3982,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "notification_channel",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "44ffb295-6fe4-5b3e-b40a-0dbd41f91e36",
@@ -3577,7 +3991,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "notification_channel",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "e9b1bb2b-59d2-502d-875b-ac10e7e6c34e",
@@ -3585,7 +4000,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "notification_channel",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "0bf38527-a555-5671-8dda-6197c50c74a2",
@@ -3593,7 +4009,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "notification_channel",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "4b487fa3-c23d-5fa6-a996-b6f7d18af565",
@@ -3601,7 +4018,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "notification_channel",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "4aa22199-dc29-5e79-9927-170644164536",
@@ -3609,7 +4027,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "notification_rule",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "084fbcde-6e02-542d-903d-9bf3ec691bf7",
@@ -3617,7 +4036,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "notification_rule",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "9014e023-0888-5b2b-8995-d713b218c969",
@@ -3625,7 +4045,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "notification_rule",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "87517bf8-b4e6-5118-b3e4-a5c3d3d3ab9b",
@@ -3633,7 +4054,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "notification_rule",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "727a5ad9-77be-5793-a76c-944386d27c11",
@@ -3641,7 +4063,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "notification_rule",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "f01ca483-d98b-58fc-a98c-51c05e55bf7c",
@@ -3649,7 +4072,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "model_deployment",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "0e681b47-5de6-5e26-b2f0-350c5a5853f5",
@@ -3657,7 +4081,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "model_deployment",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "f1078c7c-9750-5dd5-bc48-81c701dbbf7a",
@@ -3665,7 +4090,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "model_deployment",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "63c2e4b2-3f09-5f88-8a4c-99935cb27435",
@@ -3673,7 +4099,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "model_deployment",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "e2cbc22d-7704-5c3d-bc2b-c1650778f0dd",
@@ -3681,7 +4108,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "model_deployment",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "a477d8df-0030-5138-85d1-7d8f6748a182",
@@ -3689,7 +4117,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "model_card",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "ddf879b7-d585-5ed0-8150-b38c3d9001aa",
@@ -3697,7 +4126,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "model_card",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "88956f15-2939-59a6-a7df-fa4d61382afa",
@@ -3705,7 +4135,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "model_card",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "082c0d04-d83d-5f03-a76b-6f1a09125421",
@@ -3713,7 +4144,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "model_card",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "ff788cf2-4e33-518c-bde1-0d349736df26",
@@ -3721,7 +4153,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "model_card",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "5348fb48-a127-5f23-b6ad-6254bc40a47a",
@@ -3729,7 +4162,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "session",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "93ebc88c-ac0b-5977-ba7c-7369d7a01751",
@@ -3737,7 +4171,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "session",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "74beda5d-0df2-5fca-aabc-62cf7b0d0ea9",
@@ -3745,7 +4180,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "session",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "3038915a-9f2b-5ffb-8fa9-4aff23893220",
@@ -3753,7 +4189,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "session",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "57d781f4-b508-5703-a39f-679a1302ccca",
@@ -3761,7 +4198,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "session",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "d9b7a961-f513-5fc8-ac07-1069700c02b2",
@@ -3769,7 +4207,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "agent",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "f3a378dd-d468-5604-becb-2baf1c2b3343",
@@ -3777,7 +4216,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "agent",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "17a3958b-fbf9-54a0-b189-cf3f2cd8aa33",
@@ -3785,7 +4225,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "agent",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "76ed7a84-28d2-5a2a-a882-51b4614d33fe",
@@ -3793,7 +4234,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "agent",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "45f344b5-f868-57be-ae16-7cbf6f36beb9",
@@ -3801,7 +4243,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "agent",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "aa453daa-f237-5db1-b1cc-030e393ca10d",
@@ -3809,7 +4252,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "image",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "66f018f2-ec1d-5d50-9a45-cbb123972a14",
@@ -3817,7 +4261,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "image",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "780fd7d8-f43f-5ca3-baa7-0388544cf5df",
@@ -3825,7 +4270,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "image",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "74197b05-d05d-5e3e-b729-51a1a9c9a14d",
@@ -3833,7 +4279,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "image",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "60813b65-28d6-5e13-b0ea-20c17d6094ef",
@@ -3841,7 +4288,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "image",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "ab68225a-c532-509e-8d93-0e87ad53ad05",
@@ -3849,7 +4297,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "keypair",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "018629dd-27e6-5cd2-a1e6-a7cb74b5f25d",
@@ -3857,7 +4306,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "keypair",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "9c993040-0fa1-53c9-8809-e98567f90fce",
@@ -3865,7 +4315,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "keypair",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "92ff8085-02ca-529a-b8e9-509806ab90eb",
@@ -3873,7 +4324,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "keypair",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "03ab9b99-4617-5c17-a80f-444f3531bafa",
@@ -3881,7 +4333,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "keypair",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "ac214a9f-5766-5d56-a4c8-78b4108c56cf",
@@ -3889,7 +4342,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "container_registry",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "d44806fb-c4b5-5f8e-b7f2-c7cf5145486d",
@@ -3897,7 +4351,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "container_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "44d6f606-ad2b-588e-972e-d4f1688370ff",
@@ -3905,7 +4360,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "container_registry",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "46da113c-0a02-5025-92cf-89c47ba7ea82",
@@ -3913,7 +4369,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "container_registry",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "4ce3aff8-dc64-5041-9d11-157ba6e915f9",
@@ -3921,7 +4378,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "container_registry",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "a69bff92-3ffd-5407-9ba0-532ecee89e81",
@@ -3929,7 +4387,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "resource_group",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "7b75f0d3-d1e3-5890-8e96-1022d172bdad",
@@ -3937,7 +4396,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "resource_group",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "cb705979-805d-5047-9b2d-8122aa580f4c",
@@ -3945,7 +4405,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "resource_group",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "80db25d8-b129-5e3d-8d8d-4cbada9ebaea",
@@ -3953,7 +4414,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "resource_group",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "83ea0b7f-17c4-584a-aaed-8ce21953a9c2",
@@ -3961,7 +4423,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "resource_group",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "f1b41304-7964-5454-9ea6-e7cd102c14ab",
@@ -3969,7 +4432,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "f1f23aa1-eca5-5faa-b17e-266ac4295c27",
@@ -3977,7 +4441,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "2f7b3d6f-09fb-5c49-b091-258b7bf1bce4",
@@ -3985,7 +4450,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "7dd88386-8ee2-5d44-8349-4018b8161608",
@@ -3993,7 +4459,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "f62c54a0-d9bb-59f6-9d03-7cd2ce8c6ba3",
@@ -4001,7 +4468,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "fde64781-7870-52ea-9dc1-e942dedd2ed3",
@@ -4009,7 +4477,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact_registry",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "7f7f7e6d-8339-5f73-8267-bd419b6179dd",
@@ -4017,7 +4486,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "95dd46bf-7c4b-505f-81db-62c83c6daa53",
@@ -4025,7 +4495,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact_registry",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "59c28ef4-8f76-5481-a24e-f5be3db02daf",
@@ -4033,7 +4504,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact_registry",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "89e35e41-d691-589c-a0c8-30880df3684c",
@@ -4041,7 +4513,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact_registry",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "fb428ec7-142d-5a2f-896d-9c028fdc4e29",
@@ -4049,7 +4522,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "app_config",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "58cd2453-beae-578a-a31f-f9298dd44046",
@@ -4057,7 +4531,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "app_config",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "37df2b67-f083-542b-958c-5a6924206735",
@@ -4065,7 +4540,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "app_config",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "65b54896-6196-5454-b472-f9c48466194a",
@@ -4073,7 +4549,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "app_config",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "232c4de3-a4d7-5d6e-a3fa-eb04b8bc468b",
@@ -4081,7 +4558,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "app_config",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "9300f918-b75a-5f19-becd-312da897690a",
@@ -4089,7 +4567,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_channel",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "e6f52c7a-133c-5ca5-9f0d-955755bebfdf",
@@ -4097,7 +4576,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_channel",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "e5e91bb7-665b-57c8-921e-35d2ffd58a64",
@@ -4105,7 +4585,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_channel",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "867a86e9-bc52-54a0-921a-c6ca7fe1453d",
@@ -4113,7 +4594,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_channel",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "0c3d613d-a555-5cbc-b6f9-b1e1d2f2e5e0",
@@ -4121,7 +4603,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_channel",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "5eb2fbf6-071d-5c90-b7ff-e928120aad5a",
@@ -4129,7 +4612,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_rule",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "46811835-82ab-5d50-bd8d-fb07fbc09af0",
@@ -4137,7 +4621,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_rule",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "851381fd-f01c-5db8-8f2b-3bcdb2af3776",
@@ -4145,7 +4630,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_rule",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "93ba0577-5817-5a84-985f-54749ed87a4e",
@@ -4153,7 +4639,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_rule",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "3df6d5a3-0fc4-55a5-a762-b1e34ab410e3",
@@ -4161,7 +4648,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_rule",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "72d9314c-5ed6-57dc-ba88-4eedd44c09f9",
@@ -4169,7 +4657,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_deployment",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "1b4ca410-5687-50db-9e6a-cc1682e9df93",
@@ -4177,7 +4666,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_deployment",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "11050099-bea8-5670-900d-05d4bd0eb120",
@@ -4185,7 +4675,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_deployment",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "84608314-4900-552d-8355-f3c152df6985",
@@ -4193,7 +4684,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_deployment",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "c51dc120-d3f0-5877-ade2-20bc5c45545d",
@@ -4201,7 +4693,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_deployment",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "e9902cad-8023-5c10-bb54-b8e9986eba81",
@@ -4209,7 +4702,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_card",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "b42174c6-b1f4-577e-a328-4383af1fec86",
@@ -4217,7 +4711,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_card",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "7067e55d-1602-5a93-90f1-3513abf6a68a",
@@ -4225,7 +4720,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_card",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "db954365-4601-5a9e-98d5-a6b0024ba776",
@@ -4233,7 +4729,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_card",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "97b21ca0-f4a0-5446-b9a2-be2bcbf3b333",
@@ -4241,7 +4738,8 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_card",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "8d28ac4f-02d8-5e63-947e-a58b301432f4",
@@ -4249,7 +4747,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "session",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "b2fb6f96-358a-5aa8-b9ba-ead6575c2b15",
@@ -4257,7 +4756,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "session",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "cf97bb95-338b-5679-8e01-c7220c61d6d2",
@@ -4265,7 +4765,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "session",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "5b2f05c3-8fc2-5bff-8b60-edb019a8a5d8",
@@ -4273,7 +4774,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "session",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "13f7ba25-014d-5c21-8583-f7865b8a4ef1",
@@ -4281,7 +4783,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "session",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "801219ba-5c20-5aa4-a4ee-b471bde8fc3f",
@@ -4289,7 +4792,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "agent",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "a92da5d2-635c-5d4c-bc70-3cdd1e46b8a3",
@@ -4297,7 +4801,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "agent",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "2771c50e-dde6-5f3a-9900-267b710b50fe",
@@ -4305,7 +4810,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "agent",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "303781b5-8c6f-5c07-86c1-1fc3ebad2d92",
@@ -4313,7 +4819,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "agent",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "6c1e4c11-ef02-56f3-9022-0d621be1d7c9",
@@ -4321,7 +4828,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "agent",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "59177db2-d6dc-5992-99dc-fe3c8f112ae6",
@@ -4329,7 +4837,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "image",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "0b106133-b32c-5e4f-9eb9-82a28b27896c",
@@ -4337,7 +4846,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "image",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "87c8eac2-48ad-50a7-9f4c-fd6bc37fab90",
@@ -4345,7 +4855,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "image",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "8486cd57-d1ea-545a-8942-c13be745df74",
@@ -4353,7 +4864,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "image",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "d952f6e7-1f68-5339-b522-7ceaaf40f033",
@@ -4361,7 +4873,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "image",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "9da0f4ee-5821-566b-9b2c-1907c2ce7665",
@@ -4369,7 +4882,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "keypair",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "4b2f2c6a-08dc-5d1c-a040-fec38e524c79",
@@ -4377,7 +4891,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "keypair",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "5e5ec8b7-d69d-5444-8d9c-8e0a6c128571",
@@ -4385,7 +4900,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "keypair",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "41fbb993-c5fd-5b73-93c9-a81f741af96d",
@@ -4393,7 +4909,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "keypair",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "6f191c6c-15c6-53a6-b17f-e78560190b91",
@@ -4401,7 +4918,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "keypair",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "386b0dc9-6009-5659-8a17-fcf1251c5a73",
@@ -4409,7 +4927,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "container_registry",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "99ecf3ce-c08c-5a7d-9b1a-10085a22d950",
@@ -4417,7 +4936,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "container_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "7d1f4349-73fb-57e5-8225-fbc938b730d2",
@@ -4425,7 +4945,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "container_registry",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "0ae9168c-6161-5d84-82bc-41f4dc6756d0",
@@ -4433,7 +4954,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "container_registry",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "bbc4a770-787c-5375-926a-a99a6d4c8a9a",
@@ -4441,7 +4963,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "container_registry",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "92509289-cbf9-5ad3-9477-e3465a94a50f",
@@ -4449,7 +4972,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "resource_group",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "a8107ec9-7ce1-5d11-aa2f-133500d36e1b",
@@ -4457,7 +4981,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "resource_group",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "9d57c722-40cb-506e-b75c-218a0b6d74b5",
@@ -4465,7 +4990,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "resource_group",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "d0711007-43d9-502b-9d7a-bcafd0108bba",
@@ -4473,7 +4999,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "resource_group",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "6ceadb22-9a1e-5753-9eca-291e72a65ced",
@@ -4481,7 +5008,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "resource_group",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "cafd6453-d578-5ea0-880c-dbb1ee7da4d5",
@@ -4489,7 +5017,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "80865f9c-41ef-5a12-9da5-a5175b111e10",
@@ -4497,7 +5026,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "584ecde4-ced8-5302-bfa9-98158916c601",
@@ -4505,7 +5035,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "c8bdc896-1168-5b51-8afa-e34f81521b6a",
@@ -4513,7 +5044,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "417d0598-704b-5a2b-b0d6-185166d8317c",
@@ -4521,7 +5053,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "b025239a-aa40-59e2-8b2c-39179841555d",
@@ -4529,7 +5062,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact_registry",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "8abafc53-9717-5abd-b512-ae9f4730e563",
@@ -4537,7 +5071,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "1586e964-4a24-51a1-af89-49e2035bb4e9",
@@ -4545,7 +5080,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact_registry",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "aea6f2ac-978e-56c3-aa2f-123a569ba843",
@@ -4553,7 +5089,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact_registry",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "0e498127-f26a-5624-9209-40ee93e8e1c1",
@@ -4561,7 +5098,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact_registry",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "f12d5539-4499-58bd-834b-1c9a16a6eba4",
@@ -4569,7 +5107,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "app_config",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "b2108708-9869-50e5-9e58-bb9b06f8f5d1",
@@ -4577,7 +5116,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "app_config",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "9994dc41-2cf6-574e-b524-213430cf7da8",
@@ -4585,7 +5125,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "app_config",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "ed9f9aa4-ea8e-5c21-83ec-028e11910ddd",
@@ -4593,7 +5134,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "app_config",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "689404a2-d736-5d01-9ae6-b255b776a6d8",
@@ -4601,7 +5143,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "app_config",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "bea067ea-326f-5c53-922f-b208feaefce1",
@@ -4609,7 +5152,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_channel",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "08e6376b-1b2c-538c-9648-135e6498d8da",
@@ -4617,7 +5161,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_channel",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "e6f8b31b-ae32-5023-8df2-ac2624217266",
@@ -4625,7 +5170,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_channel",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "3d32c850-9213-5783-94a7-4fb055349ece",
@@ -4633,7 +5179,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_channel",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "a1e3032f-2afd-5f3d-aff5-b6f281511e7e",
@@ -4641,7 +5188,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_channel",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "0066001f-44d7-59a3-8cdf-82310d37a975",
@@ -4649,7 +5197,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_rule",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "07673017-92ae-5e0c-825f-12b88fdbcada",
@@ -4657,7 +5206,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_rule",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "d3fe2b33-3568-5a50-952b-dce72ca7de1d",
@@ -4665,7 +5215,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_rule",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "896152d0-95ba-5eb6-9a3b-f08246713d9d",
@@ -4673,7 +5224,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_rule",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "f0f4204c-09a7-58ad-86e4-3bc582524acb",
@@ -4681,7 +5233,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_rule",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "f22a133c-e78b-521f-8742-8c52ab40f9a5",
@@ -4689,7 +5242,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_deployment",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "8ed2a8ab-180c-5d1d-953a-8175e0ba814e",
@@ -4697,7 +5251,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_deployment",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "267db2e7-f199-5022-a648-6adff55d938d",
@@ -4705,7 +5260,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_deployment",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "fc1f174e-79ad-5c39-bcf6-14840665f7a1",
@@ -4713,7 +5269,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_deployment",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "52e1b34a-e91a-56a8-93ca-9b59168545f2",
@@ -4721,7 +5278,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_deployment",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "44ec7da3-e10c-518b-9325-93cc387e6d6e",
@@ -4729,7 +5287,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_card",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "1e99e378-d7d2-51d4-a0ea-50304af4cde2",
@@ -4737,7 +5296,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_card",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "0f48c79b-4e47-5f4f-86df-4dd02188bdd6",
@@ -4745,7 +5305,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_card",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "f0c98d7b-ca03-536a-891a-6634d75a3ffd",
@@ -4753,7 +5314,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_card",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "0adbb855-de56-5dba-9d6e-1ce319fde553",
@@ -4761,7 +5323,8 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_card",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "f05e5283-2c47-5a61-93a2-24639d155499",
@@ -4769,7 +5332,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "session",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "e4285d8b-9018-59d3-a426-8d75ad9d39ee",
@@ -4777,7 +5341,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "session",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "028cf31d-3631-5189-925f-2d57f4540278",
@@ -4785,7 +5350,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "session",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "4b084aca-eb7b-556d-8823-58d4973a00e7",
@@ -4793,7 +5359,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "session",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "b48f7975-3517-593f-9350-ced170379fc3",
@@ -4801,7 +5368,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "session",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "35d2a889-d528-5da8-853f-63682ae4939d",
@@ -4809,7 +5377,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "agent",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "8bf06976-9233-57a8-8fba-e6dff8d66b2a",
@@ -4817,7 +5386,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "agent",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "f19e4171-b787-5c50-90b8-db1e2fbe412c",
@@ -4825,7 +5395,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "agent",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "0746528b-4829-51fe-8cb5-a10f738470e2",
@@ -4833,7 +5404,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "agent",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "3a0625a8-eca7-5a39-a07c-beb8b542a817",
@@ -4841,7 +5413,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "agent",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "59c81578-75d5-5c1a-bce2-b9e4915a8f35",
@@ -4849,7 +5422,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "image",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "ebad5eca-0cff-5fbb-8bd5-314a669598ae",
@@ -4857,7 +5431,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "image",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "9034d4b3-1824-5141-80ec-cf00c3699216",
@@ -4865,7 +5440,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "image",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "d7795bf9-5ff8-568e-adc0-97cefaea609a",
@@ -4873,7 +5449,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "image",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "5faf5674-44cc-531a-9701-016e4fec26ae",
@@ -4881,7 +5458,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "image",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "0df6eb48-724d-5a88-a35b-3a701d99049b",
@@ -4889,7 +5467,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "keypair",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "b3f7afe7-e88d-5e8a-b1ec-4060e1638200",
@@ -4897,7 +5476,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "keypair",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "fd8ec22f-397b-5415-9ff6-fff2617a1113",
@@ -4905,7 +5485,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "keypair",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "8728d3f2-bc75-5aa0-ac11-d4d4982599b2",
@@ -4913,7 +5494,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "keypair",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "0c668e91-097d-51f6-b83c-f490d2de33bc",
@@ -4921,7 +5503,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "keypair",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "89578103-1d42-580e-b02b-317e2401fce8",
@@ -4929,7 +5512,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "container_registry",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "cb984c72-8f85-58e1-a2cc-0d825717ddf9",
@@ -4937,7 +5521,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "container_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "d078049d-c58c-5be2-8d5a-557b80ceafd7",
@@ -4945,7 +5530,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "container_registry",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "be7efc4a-18f0-52ff-adbc-963b20946ad0",
@@ -4953,7 +5539,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "container_registry",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "ed18217c-ddb5-5c45-95c6-993be49b24fc",
@@ -4961,7 +5548,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "container_registry",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "09ebbfab-ddda-557e-8074-eff59b054b29",
@@ -4969,7 +5557,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "resource_group",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "cd3aac9b-4a12-573b-8fde-78c34abc461a",
@@ -4977,7 +5566,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "resource_group",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "7240cfba-809e-5e4a-ad27-327b295dbad5",
@@ -4985,7 +5575,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "resource_group",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "8c3f0ad4-93b8-5606-b74b-a18376f9f525",
@@ -4993,7 +5584,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "resource_group",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "473f0344-44e7-521e-96dc-948322cda5ac",
@@ -5001,7 +5593,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "resource_group",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "bc88578c-97f1-56e2-bdba-dd1b241ac3d6",
@@ -5009,7 +5602,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "artifact",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "00029515-9350-56a5-966d-5ab7ed30c6cd",
@@ -5017,7 +5611,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "artifact",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "59ee5ad5-567c-55f9-abf7-00b3922cc66e",
@@ -5025,7 +5620,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "artifact",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "2b4e39d4-253c-5cc8-b193-cd7f926b0b5b",
@@ -5033,7 +5629,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "artifact",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "5b25ba85-5611-59b1-9a94-6dbe9a9553f0",
@@ -5041,7 +5638,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "artifact",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "f0a9c9d6-0029-5568-8ecc-5f05a50999ec",
@@ -5049,7 +5647,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "artifact_registry",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "ea17d556-f478-5d75-87e1-8174ec086776",
@@ -5057,7 +5656,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "artifact_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "13780b58-f2df-5942-acb2-c653db205705",
@@ -5065,7 +5665,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "artifact_registry",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "13fd82d6-6ecc-5ed5-a6ac-e7306890a7a2",
@@ -5073,7 +5674,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "artifact_registry",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "bd54c651-b908-5c42-93a3-e07cefb69dd5",
@@ -5081,7 +5683,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "artifact_registry",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "d460edb8-0a8a-5c3b-99e8-3cc65c8cdee8",
@@ -5089,7 +5692,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "app_config",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "e89a0bf6-f276-55e7-a800-d75337db652f",
@@ -5097,7 +5701,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "app_config",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "020fc616-aff6-5de6-a59d-18abf6b3a28a",
@@ -5105,7 +5710,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "app_config",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "b38bc0bc-2196-5c48-84b0-a0d8d7d3bfd1",
@@ -5113,7 +5719,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "app_config",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "c8876446-80bd-5deb-97a9-483617aad1ff",
@@ -5121,7 +5728,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "app_config",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "81d0fe6b-bb22-516a-9256-e0574aba5767",
@@ -5129,7 +5737,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "notification_channel",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "1faf7461-e9ba-5ffe-8890-b0234528fd23",
@@ -5137,7 +5746,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "notification_channel",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "ec3aea19-3a00-5a92-9ae0-5e2c77cbdf4a",
@@ -5145,7 +5755,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "notification_channel",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "913a4ed1-df89-560f-aec5-6acea1a6e6dd",
@@ -5153,7 +5764,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "notification_channel",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "65c0aab6-5818-503f-8c80-ea6d81c6d1a5",
@@ -5161,7 +5773,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "notification_channel",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "4eb2fdda-045d-58b8-afeb-c954e76cab43",
@@ -5169,7 +5782,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "notification_rule",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "4a55b202-e681-53bd-9402-a72353a158d9",
@@ -5177,7 +5791,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "notification_rule",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "4643dc6c-670e-5fc4-9a91-f61b56ce1f52",
@@ -5185,7 +5800,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "notification_rule",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "b4d71c65-e96d-5d47-92c7-f9a1a3db0808",
@@ -5193,7 +5809,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "notification_rule",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "8aa9cc9c-ec1a-54a8-9fe9-aef6b4ae7194",
@@ -5201,7 +5818,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "notification_rule",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "1c3b70ed-bd40-5900-83e8-c5a227d9c10d",
@@ -5209,7 +5827,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "model_deployment",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "b7270699-d2a8-5fb7-80ee-624d44c96064",
@@ -5217,7 +5836,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "model_deployment",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "23daae9f-d9e2-50b8-bdf6-6de25faeb199",
@@ -5225,7 +5845,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "model_deployment",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "1307ba4d-2f20-5b90-a44f-ad793cd357a3",
@@ -5233,7 +5854,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "model_deployment",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "ea58afc5-b1b6-5863-8103-86170897399d",
@@ -5241,7 +5863,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "model_deployment",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "85d7e2c8-c49b-5a58-b6ac-29fa2325a524",
@@ -5249,7 +5872,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "model_card",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "f78f01ab-d7bb-537b-888d-de2a361ff4bc",
@@ -5257,7 +5881,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "model_card",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "e537ec44-972a-5bc2-a4eb-9aa11a3d9139",
@@ -5265,7 +5890,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "model_card",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "ba6979db-4b2a-5bdb-b11c-e76d95348202",
@@ -5273,7 +5899,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "model_card",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "9cb8e16e-5c3c-5d7d-b00e-ae5c9c5ac78c",
@@ -5281,7 +5908,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "model_card",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "42928b17-47a8-5104-9d31-777876b73e17",
@@ -5289,7 +5917,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "vfolder:data",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "298d7a45-7241-5b05-8704-4c49085b49c2",
@@ -5297,7 +5926,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "vfolder:data",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "f1c340e5-730d-58e9-af76-30f14db63c70",
@@ -5305,7 +5935,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "vfolder:data",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "258a9bae-2932-52ae-b93a-81240f0ad50b",
@@ -5313,7 +5944,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "vfolder:data",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "a29a386e-4552-52d5-9f28-d1cf7d2e757b",
@@ -5321,7 +5953,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "vfolder:data",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "fdb1b976-e998-5767-998a-4889d7b03bb3",
@@ -5329,7 +5962,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "vfolder:data",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "082685f6-b886-5bfd-8d61-462325ae63b9",
@@ -5337,7 +5971,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "vfolder:data",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "26f01d75-8ff9-5093-aae4-bd9606d71c37",
@@ -5345,7 +5980,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "vfolder:data",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "8a9a1171-99f4-5e6f-9eea-cf475bb63578",
@@ -5353,7 +5989,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "vfolder:data",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "38e9d60b-b7ab-5237-a098-7b6d1be2bc13",
@@ -5361,7 +5998,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "vfolder:data",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "4a370c27-02f3-5628-a4a7-03427f60a00d",
@@ -5369,7 +6007,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "vfolder:data",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "70a25037-e38a-5625-9bdf-f11882848093",
@@ -5377,7 +6016,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "vfolder:data",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "48351095-c95f-5d26-a33e-cbe5236660e8",
@@ -5385,7 +6025,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "vfolder:data",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "0f38fd3b-138c-5192-8089-40210da1a137",
@@ -5393,7 +6034,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "vfolder:data",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "de08c1e4-c29e-5e64-91ce-0f797bf4a0d9",
@@ -5401,7 +6043,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "vfolder:data",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "b51c9fd6-77a0-5db3-a011-b005b005bab8",
@@ -5409,7 +6052,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "vfolder:data",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "924a0737-208e-56ee-a408-d5761e0afd05",
@@ -5417,7 +6061,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "vfolder:data",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "8f24e0d6-f716-5248-8822-e9bd50bc60ed",
@@ -5425,7 +6070,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "vfolder:data",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "ebae171c-3bdc-5007-944d-9ef3c11b1436",
@@ -5433,7 +6079,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "vfolder:data",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "e0d7b8de-9335-5efa-951c-3da25007b8dc",
@@ -5441,7 +6088,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "vfolder:data",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "444a9916-e4be-5659-b9b8-23229d134236",
@@ -5449,7 +6097,8 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "session:app_service",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "1a0a057e-2225-54c8-b1e0-2973d025b621",
@@ -5457,7 +6106,8 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "session:app_service",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "2505e7eb-95ea-5c29-816f-82fea3eceb54",
@@ -5465,7 +6115,8 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "session:app_service",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "a1a9a02f-3a48-5e88-8765-ad778a02ba3d",
@@ -5473,7 +6124,8 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "session:app_service",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "8daeb1ab-977d-5612-86f9-c43607379f3b",
@@ -5481,7 +6133,8 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "session:app_service",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "31927715-a2ca-5da6-a21e-a111fd334762",
@@ -5489,7 +6142,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "user",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "455356be-1de9-5c3c-8f2d-4cbfcff772f0",
@@ -5497,7 +6151,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "user",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "d3392bc0-2f12-5e30-b821-214f7393f668",
@@ -5505,7 +6160,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "user",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "e1c99929-afd8-5a69-938f-991168a086cd",
@@ -5513,7 +6169,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "user",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "3dc133ad-cc63-5cb6-abfb-e2aa18352069",
@@ -5521,7 +6178,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "vfolder",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "569f9089-01a1-50b0-b223-b4e0ff4606aa",
@@ -5529,7 +6187,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "vfolder",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "a4b9448c-8af5-5faf-8a69-8708584edd30",
@@ -5537,7 +6196,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "vfolder",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "f12dd6f5-20d3-5f7b-9aba-11ab44751edd",
@@ -5545,7 +6205,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "vfolder",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "9b95a1ac-f217-5af2-b459-25d3b12bd4e0",
@@ -5553,7 +6214,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "vfolder",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "1a05ffb9-1e3d-5803-acf8-b6d8defbbc74",
@@ -5561,7 +6223,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "vfolder:data",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "65da87ba-0cc1-5c89-90f2-29a75fb55d27",
@@ -5569,7 +6232,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "vfolder:data",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "d7fa4cc0-7ca6-52c4-8d4d-e0fa8589e1b8",
@@ -5577,7 +6241,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "vfolder:data",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "fd7fcbf5-acd8-5108-944a-8ff7da795408",
@@ -5585,7 +6250,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "vfolder:data",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "72c740cd-6263-580e-9e60-cda739fbe0ef",
@@ -5593,7 +6259,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "session:app_service",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "c7866a53-7add-55c4-8cbe-00c811c3c9b0",
@@ -5601,7 +6268,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "session",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "3ff40770-5c93-5d04-813c-68f52feb32cc",
@@ -5609,7 +6277,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "session",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "c5cd6b90-8612-5c8b-829c-8aa8ccb672a2",
@@ -5617,7 +6286,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "session",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "a888c4af-cec1-5e81-8ee7-eb0b63cb2625",
@@ -5625,7 +6295,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "session",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "95ba13f4-5532-5597-9ae6-7103eb80092d",
@@ -5633,7 +6304,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "session",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "2cc73f04-cf71-51ff-9131-0b74bc75744d",
@@ -5641,7 +6313,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "agent",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "35297349-afbc-51d8-942f-5c230c33471e",
@@ -5649,7 +6322,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "agent",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "fc7af773-5d59-5c94-b37c-f6d7a46a410b",
@@ -5657,7 +6331,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "agent",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "fb7e5cce-68c6-5ea5-a241-cd600b25fc31",
@@ -5665,7 +6340,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "agent",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "cd0b7d2a-31a9-58c5-a5b2-bb19be2150f2",
@@ -5673,7 +6349,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "agent",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "6bc93b35-4e0c-5018-a433-5811b4c5f35a",
@@ -5681,7 +6358,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "image",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "93e69747-f158-5da2-8687-a9a35588e767",
@@ -5689,7 +6367,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "image",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "6789fe6d-f3d0-5376-b4f0-5abbd30ba820",
@@ -5697,7 +6376,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "image",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "f3706f47-33d6-5749-b550-93e2995ebf81",
@@ -5705,7 +6385,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "image",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "f5f819c6-682d-5946-9731-9e65d198c59d",
@@ -5713,7 +6394,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "image",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "2b061163-6284-5137-910b-9fb1ccb10df3",
@@ -5721,7 +6403,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "keypair",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "bfdda20e-5cb3-5cd7-87e2-53c3ca856fef",
@@ -5729,7 +6412,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "keypair",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "a8c8e2d0-3ec1-5e2f-b26c-80b6e8509359",
@@ -5737,7 +6421,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "keypair",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "df44e719-9cd6-507f-b8a4-488116e1dbae",
@@ -5745,7 +6430,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "keypair",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "5b3fa8e3-30a1-56ac-a44c-dc03b07b4ea9",
@@ -5753,7 +6439,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "keypair",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "b1a0a5e6-105f-5d7d-b30e-ba22fd9e52c9",
@@ -5761,7 +6448,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "container_registry",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "7549b664-553e-5b38-80c2-323347e22e00",
@@ -5769,7 +6457,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "container_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "4f5718d4-9267-544d-bf11-c6fcd5d2607f",
@@ -5777,7 +6466,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "container_registry",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "37dda0c7-c688-5eac-86cb-36e2780c1b1b",
@@ -5785,7 +6475,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "container_registry",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "41c0dfb5-24c9-5e22-99eb-840978adf00f",
@@ -5793,7 +6484,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "container_registry",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "74e17cdc-cc43-574a-92d3-6198bd3ab03a",
@@ -5801,7 +6493,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "resource_group",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "d17c9973-00d5-5e4a-b0f0-78915f8102a8",
@@ -5809,7 +6502,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "resource_group",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "23fbeb8d-95be-5347-b852-2199851a28db",
@@ -5817,7 +6511,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "resource_group",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "4164a0bb-dea2-57ac-92fe-15a76933d80f",
@@ -5825,7 +6520,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "resource_group",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "d64f983f-62a9-5af6-95ed-6eb4f7a10acb",
@@ -5833,7 +6529,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "resource_group",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "a80cb8a6-5ee9-5d09-ad65-51e0920e386e",
@@ -5841,7 +6538,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "artifact",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "37021183-7644-5e0d-af25-7f8e17e6183a",
@@ -5849,7 +6547,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "artifact",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "ecb99d28-e0bb-5a31-a34b-859a9a923d48",
@@ -5857,7 +6556,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "artifact",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "d497d46a-f820-5867-a840-89e4394ccd61",
@@ -5865,7 +6565,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "artifact",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "4fe93953-7e84-5e7b-926c-3139df76a8de",
@@ -5873,7 +6574,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "artifact",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "cdea66fa-3572-5c00-b7ea-bf6d65e28b5f",
@@ -5881,7 +6583,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "artifact_registry",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "25c6e555-aa53-5a5d-a86c-4fc4db659e6b",
@@ -5889,7 +6592,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "artifact_registry",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "f1bc0d7d-195e-5af9-b647-bb7cd449f4c7",
@@ -5897,7 +6601,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "artifact_registry",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "15bc2a01-9ba0-590e-8637-87f0f5d7f45c",
@@ -5905,7 +6610,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "artifact_registry",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "6cb00558-253c-57d4-8e07-4d842a69ddd9",
@@ -5913,7 +6619,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "artifact_registry",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "6dcbe929-3093-5cb9-a071-f3d30ff76f6f",
@@ -5921,7 +6628,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "app_config",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "a2967ed3-087a-50de-bf09-7e960a8df26e",
@@ -5929,7 +6637,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "app_config",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "ba7f34f6-9b23-5b2b-a105-34b32aa639f2",
@@ -5937,7 +6646,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "app_config",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "614db176-d022-56fc-ac2b-e8e650359c7b",
@@ -5945,7 +6655,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "app_config",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "86841463-32b3-52a2-872c-e7a93ac2ac6f",
@@ -5953,7 +6664,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "app_config",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "f4e13f1f-682b-5ee2-a094-5db36e7abe49",
@@ -5961,7 +6673,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "notification_channel",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "2deb1550-68fe-538e-b9c0-810b88a1efaa",
@@ -5969,7 +6682,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "notification_channel",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "5b3f1eed-78da-5023-b304-cee45ef5caba",
@@ -5977,7 +6691,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "notification_channel",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "4829b7f1-7c72-52b3-8e82-ec79bc838b78",
@@ -5985,7 +6700,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "notification_channel",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "214a549e-01b0-564d-8f8d-523e281ae189",
@@ -5993,7 +6709,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "notification_channel",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "37d566b4-9834-52a1-97f3-a71c2118d8a0",
@@ -6001,7 +6718,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "notification_rule",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "62fde6d2-d483-512e-9c5e-2c2b5f2f8cbc",
@@ -6009,7 +6727,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "notification_rule",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "fd6457c4-49d0-5720-b9c8-2325931fb30d",
@@ -6017,7 +6736,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "notification_rule",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "fafc1704-5b7c-51d5-8989-1b40066eafeb",
@@ -6025,7 +6745,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "notification_rule",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "2b519128-94e7-5fe0-a010-54d6a75f1440",
@@ -6033,7 +6754,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "notification_rule",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "cc1716d4-7219-597e-af25-85a93bc2c11f",
@@ -6041,7 +6763,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "model_deployment",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "6e9e57d4-b7d2-56bb-bd71-338c87f28cfe",
@@ -6049,7 +6772,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "model_deployment",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "3605f65b-8f45-5e7f-b7be-22fa037a180f",
@@ -6057,7 +6781,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "model_deployment",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "a76c9de0-2cd8-520a-a25e-e259a847b20b",
@@ -6065,7 +6790,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "model_deployment",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "bd25c346-10aa-5d91-ace2-a2a90cdd86d8",
@@ -6073,7 +6799,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "model_deployment",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         },
         {
             "id": "e75bf5ba-794e-57fe-adb5-176dcf185543",
@@ -6081,7 +6808,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "model_card",
-            "operation": "create"
+            "operation": "create",
+            "permission": 4
         },
         {
             "id": "0555e310-f2ef-544f-9b87-f997d4a73cd0",
@@ -6089,7 +6817,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "model_card",
-            "operation": "read"
+            "operation": "read",
+            "permission": 1
         },
         {
             "id": "9b690095-3f08-53da-8335-743d75272acf",
@@ -6097,7 +6826,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "model_card",
-            "operation": "update"
+            "operation": "update",
+            "permission": 2
         },
         {
             "id": "7dcfdfee-94bd-5ab9-b9e1-4bd072f31cf3",
@@ -6105,7 +6835,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "model_card",
-            "operation": "soft-delete"
+            "operation": "soft-delete",
+            "permission": 8
         },
         {
             "id": "cd61d2c5-2455-5459-940e-297a3d5a69ad",
@@ -6113,7 +6844,8 @@
             "scope_type": "domain",
             "scope_id": "default",
             "entity_type": "model_card",
-            "operation": "hard-delete"
+            "operation": "hard-delete",
+            "permission": 16
         }
     ],
     "association_scopes_entities": [

--- a/scripts/generate-rbac-fixture-permissions.py
+++ b/scripts/generate-rbac-fixture-permissions.py
@@ -47,6 +47,21 @@ OWNER_OPS: tuple[str, ...] = (
 )
 MEMBER_OPS: tuple[str, ...] = ("read",)
 
+# Bit values mirror ai.backend.common.data.permission.types.Permission (IntFlag).
+# Grant operations (grant:*) have no dedicated bit and map to 0 (NONE);
+# grant authority remains carried by the legacy `operation` column.
+OPERATION_PERMISSION_BIT: dict[str, int] = {
+    "read": 1,
+    "update": 2,
+    "create": 4,
+    "soft-delete": 8,
+    "hard-delete": 16,
+}
+
+
+def permission_bit(operation: str) -> int:
+    return OPERATION_PERMISSION_BIT.get(operation, 0)
+
 RESOURCE_ENTITY_TYPES: tuple[str, ...] = (
     "session",
     "agent",
@@ -94,11 +109,16 @@ def main() -> int:
     ]
     stripped = len(data["permissions"]) - len(base_permissions)
 
+    # Backfill the bitmask column on pass-through (base) rows so every emitted
+    # permission row carries `permission` derived from its `operation`.
+    for p in base_permissions:
+        p["permission"] = permission_bit(p["operation"])
+
     role_scopes: set[tuple[str, str, str]] = {
         (p["role_id"], p["scope_type"], p["scope_id"]) for p in base_permissions
     }
 
-    new_rows: list[dict[str, str]] = []
+    new_rows: list[dict[str, str | int]] = []
     for role_id, scope_type, scope_id in sorted(role_scopes):
         role = roles_by_id.get(role_id)
         if role is None:
@@ -116,6 +136,7 @@ def main() -> int:
                     "scope_id": scope_id,
                     "entity_type": entity_type,
                     "operation": op,
+                    "permission": permission_bit(op),
                 })
 
     data["permissions"] = base_permissions + new_rows

--- a/src/ai/backend/common/data/permission/types.py
+++ b/src/ai/backend/common/data/permission/types.py
@@ -571,3 +571,25 @@ class Permission(enum.IntFlag):
     def full(cls) -> Permission:
         """The full permission cap — every operation allowed."""
         return cls.READ | cls.UPDATE | cls.CREATE | cls.SOFT_DELETE | cls.HARD_DELETE
+
+    @classmethod
+    def from_operation(cls, operation: OperationType) -> Permission:
+        """Map a single :class:`OperationType` to its corresponding bit.
+
+        Grant operations (``GRANT_*``) have no dedicated bit and map to
+        :attr:`NONE`; grant authority is still carried by the legacy
+        ``permissions.operation`` column during the transition.
+        """
+        match operation:
+            case OperationType.READ:
+                return cls.READ
+            case OperationType.UPDATE:
+                return cls.UPDATE
+            case OperationType.CREATE:
+                return cls.CREATE
+            case OperationType.SOFT_DELETE:
+                return cls.SOFT_DELETE
+            case OperationType.HARD_DELETE:
+                return cls.HARD_DELETE
+            case _:
+                return cls.NONE

--- a/src/ai/backend/manager/data/permission/permission.py
+++ b/src/ai/backend/manager/data/permission/permission.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from ai.backend.manager.data.common.types import SearchResult
 
 from .id import ScopeId
-from .types import EntityType, OperationType, ScopeType
+from .types import EntityType, OperationType, Permission, ScopeType
 
 
 @dataclass
@@ -17,6 +17,7 @@ class PermissionCreator:
     scope_id: str
     entity_type: EntityType
     operation: OperationType
+    permission: Permission
 
 
 @dataclass
@@ -27,6 +28,7 @@ class PermissionData:
     scope_id: str
     entity_type: EntityType
     operation: OperationType
+    permission: Permission
     created_at: datetime
 
 

--- a/src/ai/backend/manager/models/alembic/versions/c6648c039bd4_add_permission_bitmask_column_to_.py
+++ b/src/ai/backend/manager/models/alembic/versions/c6648c039bd4_add_permission_bitmask_column_to_.py
@@ -1,7 +1,7 @@
 """add permission bitmask column to permissions
 
 Revision ID: c6648c039bd4
-Revises: a3f1c7e2b9d4
+Revises: e7b3a1f9c2d4
 Create Date: 2026-06-11 01:51:27.442017
 
 """
@@ -11,8 +11,8 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "c6648c039bd4"
-down_revision = "a3f1c7e2b9d4"
-# Part of: 26.6.0
+down_revision = "e7b3a1f9c2d4"
+
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/c6648c039bd4_add_permission_bitmask_column_to_.py
+++ b/src/ai/backend/manager/models/alembic/versions/c6648c039bd4_add_permission_bitmask_column_to_.py
@@ -1,0 +1,44 @@
+"""add permission bitmask column to permissions
+
+Revision ID: c6648c039bd4
+Revises: a3f1c7e2b9d4
+Create Date: 2026-06-11 01:51:27.442017
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c6648c039bd4"
+down_revision = "a3f1c7e2b9d4"
+# Part of: 26.6.0
+branch_labels = None
+depends_on = None
+
+# Bit values mirror ai.backend.common.data.permission.types.Permission (IntFlag).
+# Grant operations (grant:*) have no dedicated bit and backfill to 0 (NONE);
+# grant authority remains carried by the legacy `operation` column.
+_BACKFILL_PERMISSION_FROM_OPERATION = sa.text("""
+    UPDATE permissions SET permission = CASE operation
+        WHEN 'read' THEN 1
+        WHEN 'update' THEN 2
+        WHEN 'create' THEN 4
+        WHEN 'soft-delete' THEN 8
+        WHEN 'hard-delete' THEN 16
+        ELSE 0
+    END
+""")
+
+
+def upgrade() -> None:
+    op.add_column(
+        "permissions",
+        sa.Column("permission", sa.SmallInteger(), nullable=True),
+    )
+    op.execute(_BACKFILL_PERMISSION_FROM_OPERATION)
+    op.alter_column("permissions", "permission", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("permissions", "permission")

--- a/src/ai/backend/manager/models/rbac_models/permission/permission.py
+++ b/src/ai/backend/manager/models/rbac_models/permission/permission.py
@@ -11,11 +11,13 @@ from ai.backend.manager.data.permission.permission import PermissionCreator, Per
 from ai.backend.manager.data.permission.types import (
     EntityType,
     OperationType,
+    Permission,
     ScopeType,
 )
 from ai.backend.manager.models.base import (
     GUID,
     Base,
+    IntFlagType,
     StrEnumType,
 )
 
@@ -54,6 +56,9 @@ class PermissionRow(Base):  # type: ignore[misc]
     operation: Mapped[OperationType] = mapped_column(
         "operation", StrEnumType(OperationType, length=32), nullable=False
     )
+    permission: Mapped[Permission] = mapped_column(
+        "permission", IntFlagType(Permission), nullable=False
+    )
     created_at: Mapped[datetime] = mapped_column(
         "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
     )
@@ -66,6 +71,7 @@ class PermissionRow(Base):  # type: ignore[misc]
             scope_id=input.scope_id,
             entity_type=input.entity_type,
             operation=input.operation,
+            permission=input.permission,
         )
 
     def to_data(self) -> PermissionData:
@@ -76,5 +82,6 @@ class PermissionRow(Base):  # type: ignore[misc]
             scope_id=self.scope_id,
             entity_type=self.entity_type,
             operation=self.operation,
+            permission=self.permission,
             created_at=self.created_at,
         )

--- a/src/ai/backend/manager/repositories/base/rbac/granter.py
+++ b/src/ai/backend/manager/repositories/base/rbac/granter.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
 from ai.backend.common.data.permission.types import (
     OperationType,
+    Permission,
     RBACElementType,
     RelationType,
 )
@@ -104,6 +105,7 @@ async def execute_rbac_granter(
             "scope_id": entity_id.entity_id,
             "entity_type": entity_id.entity_type,
             "operation": operation,
+            "permission": Permission.from_operation(operation),
         }
         for role_id in role_ids
         for operation in granter.operations

--- a/src/ai/backend/manager/repositories/permission_controller/creators.py
+++ b/src/ai/backend/manager/repositories/permission_controller/creators.py
@@ -12,6 +12,7 @@ from ai.backend.manager.data.permission.id import ObjectId, ScopeId
 from ai.backend.manager.data.permission.status import PermissionStatus, RoleStatus
 from ai.backend.manager.data.permission.types import (
     OperationType,
+    Permission,
     RoleSource,
 )
 from ai.backend.manager.errors.permission import RoleAlreadyAssigned
@@ -70,6 +71,7 @@ class PermissionCreatorSpec(CreatorSpec[PermissionRow]):
             scope_id=self.scope_id,
             entity_type=self.entity_type.to_entity_type(),
             operation=self.operation,
+            permission=Permission.from_operation(self.operation),
         )
 
 

--- a/src/ai/backend/manager/repositories/permission_controller/role_manager.py
+++ b/src/ai/backend/manager/repositories/permission_controller/role_manager.py
@@ -21,6 +21,7 @@ from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import (
     EntityType,
     OperationType,
+    Permission,
     RBACElementRef,
     RoleSource,
     ScopeType,
@@ -133,6 +134,7 @@ class RoleManager:
                     scope_id=data.scope_id().scope_id,
                     entity_type=element_type.to_entity_type(),
                     operation=operation,
+                    permission=Permission.from_operation(operation),
                 )
                 permission_rows.append(PermissionRow.from_input(creator))
         db_session.add_all(permission_rows)
@@ -226,6 +228,7 @@ class RoleManager:
                     scope_id=scope_id.scope_id,
                     entity_type=preset_permission.entity_type,
                     operation=preset_permission.operation,
+                    permission=Permission.from_operation(preset_permission.operation),
                 )
             )
             for preset_permission in permission_presets

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -31,6 +31,7 @@ from ai.backend.manager.data.permission.id import ObjectId, ScopeId
 from ai.backend.manager.data.permission.types import (
     EntityType,
     OperationType,
+    Permission,
     RBACElementRef,
     RBACElementType,
     RelationType,
@@ -2270,6 +2271,7 @@ class VfolderRepository:
                         scope_id=str(vfolder_id),
                         entity_type=EntityType.VFOLDER,
                         operation=OperationType.READ,
+                        permission=Permission.READ,
                     )
                     .on_conflict_do_nothing(
                         constraint="uq_permissions_role_scope_entity_op",

--- a/tests/component/model_card/conftest.py
+++ b/tests/component/model_card/conftest.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
-from ai.backend.common.data.permission.types import EntityType, OperationType, ScopeType
+from ai.backend.common.data.permission.types import EntityType, OperationType, Permission, ScopeType
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import QuotaScopeID, QuotaScopeType, VFolderUsageMode
 from ai.backend.manager.actions.validators import ActionValidators
@@ -335,6 +335,7 @@ async def _grant_model_card_read_permission(
                 scope_id=str(model_store_project_fixture),
                 entity_type=EntityType.MODEL_CARD,
                 operation=OperationType.READ,
+                permission=Permission.READ,
             )
         )
     yield

--- a/tests/component/project/conftest.py
+++ b/tests/component/project/conftest.py
@@ -44,7 +44,12 @@ from ai.backend.manager.api.rest.v2.user.registry import register_v2_user_routes
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.permission.status import RoleStatus
-from ai.backend.manager.data.permission.types import EntityType, OperationType, ScopeType
+from ai.backend.manager.data.permission.types import (
+    EntityType,
+    OperationType,
+    Permission,
+    ScopeType,
+)
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.dependencies.infrastructure.redis import ValkeyClients
 from ai.backend.manager.models.group.row import GroupRow
@@ -235,6 +240,7 @@ async def rbac_permission_fixture(
                 scope_id=str(group_fixture),
                 entity_type=EntityType.PROJECT,
                 operation=OperationType.UPDATE,
+                permission=Permission.UPDATE,
             )
         )
 
@@ -288,6 +294,7 @@ async def admin_target_project_permission(
                 scope_id=str(target_project_fixture),
                 entity_type=EntityType.PROJECT,
                 operation=OperationType.UPDATE,
+                permission=Permission.UPDATE,
             )
         )
     yield role_id
@@ -391,6 +398,7 @@ async def member_role_fixture(
                 scope_id=str(target_project_fixture),
                 entity_type=EntityType.USER,
                 operation=OperationType.READ,
+                permission=Permission.READ,
             )
         )
     yield role_id

--- a/tests/component/project/test_project_purge.py
+++ b/tests/component/project/test_project_purge.py
@@ -17,7 +17,12 @@ from ai.backend.client.v2.v2_registry import V2ClientRegistry
 from ai.backend.common.data.permission.types import RBACElementType, RelationType
 from ai.backend.common.dto.manager.v2.group.request import PurgeProjectInput
 from ai.backend.manager.data.permission.status import RoleStatus
-from ai.backend.manager.data.permission.types import EntityType, OperationType, ScopeType
+from ai.backend.manager.data.permission.types import (
+    EntityType,
+    OperationType,
+    Permission,
+    ScopeType,
+)
 from ai.backend.manager.models.group.row import GroupRow
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
@@ -104,6 +109,7 @@ async def project_with_rbac_rows(
                     "scope_id": scope_id,
                     "entity_type": EntityType.PROJECT,
                     "operation": OperationType.UPDATE,
+                    "permission": Permission.UPDATE,
                 },
                 {
                     "role_id": member_role_id,
@@ -111,6 +117,7 @@ async def project_with_rbac_rows(
                     "scope_id": scope_id,
                     "entity_type": EntityType.PROJECT,
                     "operation": OperationType.READ,
+                    "permission": Permission.READ,
                 },
             ])
         )

--- a/tests/component/session_v2/conftest.py
+++ b/tests/component/session_v2/conftest.py
@@ -22,6 +22,7 @@ from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
 from ai.backend.common.data.permission.types import (
     EntityType,
     OperationType,
+    Permission,
     RelationType,
     RoleStatus,
     ScopeType,
@@ -245,6 +246,7 @@ async def user_system_role(
                         scope_id=str(user_uuid),
                         entity_type=entity_type,
                         operation=operation,
+                        permission=Permission.from_operation(operation),
                     )
                 )
         # USER entity type permissions (excluding CREATE)
@@ -258,6 +260,7 @@ async def user_system_role(
                     scope_id=str(user_uuid),
                     entity_type=EntityType.USER,
                     operation=operation,
+                    permission=Permission.from_operation(operation),
                 )
             )
 

--- a/tests/component/user/test_user.py
+++ b/tests/component/user/test_user.py
@@ -40,7 +40,12 @@ from ai.backend.common.dto.manager.v2.user.request import (
 )
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.permission.status import RoleStatus
-from ai.backend.manager.data.permission.types import EntityType, OperationType, ScopeType
+from ai.backend.manager.data.permission.types import (
+    EntityType,
+    OperationType,
+    Permission,
+    ScopeType,
+)
 from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
@@ -442,6 +447,7 @@ async def user_with_rbac_rows(
                 scope_id=scope_id,
                 entity_type=EntityType.USER,
                 operation=OperationType.READ,
+                permission=Permission.READ,
             )
         )
 

--- a/tests/component/vfolder/conftest.py
+++ b/tests/component/vfolder/conftest.py
@@ -14,6 +14,7 @@ from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
 from ai.backend.common.data.permission.types import (
     EntityType,
     OperationType,
+    Permission,
     RelationType,
     RoleStatus,
     ScopeType,
@@ -433,6 +434,7 @@ async def user_system_role(
                         scope_id=str(user_uuid),
                         entity_type=entity_type,
                         operation=operation,
+                        permission=Permission.from_operation(operation),
                     )
                 )
 

--- a/tests/component/vfolder_v2/test_vfolder_mutation.py
+++ b/tests/component/vfolder_v2/test_vfolder_mutation.py
@@ -43,7 +43,12 @@ from ai.backend.manager.api.rest.types import RouteDeps
 from ai.backend.manager.api.rest.v2.vfolder.handler import V2VFolderHandler
 from ai.backend.manager.api.rest.v2.vfolder.registry import register_v2_vfolder_routes
 from ai.backend.manager.data.permission.status import RoleStatus
-from ai.backend.manager.data.permission.types import EntityType, OperationType, ScopeType
+from ai.backend.manager.data.permission.types import (
+    EntityType,
+    OperationType,
+    Permission,
+    ScopeType,
+)
 from ai.backend.manager.data.vfolder.types import (
     VFolderMountPermission,
     VFolderOperationStatus,
@@ -238,6 +243,7 @@ async def regular_user_vfolder_create_permission(
                 scope_id=str(group_fixture),
                 entity_type=EntityType.VFOLDER,
                 operation=OperationType.CREATE,
+                permission=Permission.CREATE,
             )
         )
     yield

--- a/tests/unit/manager/actions/validators/test_rbac_validators.py
+++ b/tests/unit/manager/actions/validators/test_rbac_validators.py
@@ -24,6 +24,7 @@ from ai.backend.common.contexts.user import with_user
 from ai.backend.common.data.permission.types import (
     EntityType,
     OperationType,
+    Permission,
     RBACElementType,
     ScopeType,
 )
@@ -240,6 +241,7 @@ async def _grant_permission(
                 scope_id=scope_id,
                 entity_type=entity_type,
                 operation=operation,
+                permission=Permission.from_operation(operation),
             )
         )
         await db_sess.flush()

--- a/tests/unit/manager/repositories/base/rbac/test_entity_purger.py
+++ b/tests/unit/manager/repositories/base/rbac/test_entity_purger.py
@@ -427,7 +427,7 @@ class TestRBACEntityPurgerWithPermissions:
                     scope_id=str(entity_uuid),
                     entity_type=EntityType.VFOLDER,
                     operation=OperationType.READ,
-                    permission=Permission.from_operation(OperationType.READ),
+                    permission=Permission.READ,
                 )
                 db_sess.add(perm)
             await db_sess.flush()
@@ -765,7 +765,7 @@ class TestRBACEntityBatchPurger:
                     scope_id=str(entity_uuid),
                     entity_type=EntityType.VFOLDER,
                     operation=OperationType.READ,
-                    permission=Permission.from_operation(OperationType.READ),
+                    permission=Permission.READ,
                 )
                 db_sess.add(perm)
             await db_sess.flush()
@@ -1056,7 +1056,7 @@ class TestRBACEntityPurgerTransactionRollback:
                     scope_id=str(entity_uuid),
                     entity_type=EntityType.VFOLDER,
                     operation=OperationType.READ,
-                    permission=Permission.from_operation(OperationType.READ),
+                    permission=Permission.READ,
                 )
             )
             db_sess.add(

--- a/tests/unit/manager/repositories/base/rbac/test_entity_purger.py
+++ b/tests/unit/manager/repositories/base/rbac/test_entity_purger.py
@@ -12,7 +12,12 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
-from ai.backend.common.data.permission.types import OperationType, RBACElementType, ScopeType
+from ai.backend.common.data.permission.types import (
+    OperationType,
+    Permission,
+    RBACElementType,
+    ScopeType,
+)
 from ai.backend.manager.data.permission.id import ObjectId, ScopeId
 from ai.backend.manager.data.permission.types import (
     EntityType,
@@ -364,6 +369,7 @@ class TestRBACEntityPurgerWithPermissions:
                     scope_id=str(entity_uuid),
                     entity_type=EntityType.VFOLDER,
                     operation=op,
+                    permission=Permission.from_operation(op),
                 )
                 db_sess.add(perm)
             await db_sess.flush()
@@ -421,6 +427,7 @@ class TestRBACEntityPurgerWithPermissions:
                     scope_id=str(entity_uuid),
                     entity_type=EntityType.VFOLDER,
                     operation=OperationType.READ,
+                    permission=Permission.from_operation(OperationType.READ),
                 )
                 db_sess.add(perm)
             await db_sess.flush()
@@ -758,6 +765,7 @@ class TestRBACEntityBatchPurger:
                     scope_id=str(entity_uuid),
                     entity_type=EntityType.VFOLDER,
                     operation=OperationType.READ,
+                    permission=Permission.from_operation(OperationType.READ),
                 )
                 db_sess.add(perm)
             await db_sess.flush()
@@ -1048,6 +1056,7 @@ class TestRBACEntityPurgerTransactionRollback:
                     scope_id=str(entity_uuid),
                     entity_type=EntityType.VFOLDER,
                     operation=OperationType.READ,
+                    permission=Permission.from_operation(OperationType.READ),
                 )
             )
             db_sess.add(

--- a/tests/unit/manager/repositories/base/rbac/test_revoker.py
+++ b/tests/unit/manager/repositories/base/rbac/test_revoker.py
@@ -266,7 +266,7 @@ class TestRevokerMultipleRoles:
                     scope_id=entity_id.entity_id,
                     entity_type=entity_id.entity_type,
                     operation=OperationType.READ,
-                    permission=Permission.from_operation(OperationType.READ),
+                    permission=Permission.READ,
                 )
                 db_sess.add(perm)
             await db_sess.flush()
@@ -357,7 +357,7 @@ class TestRevokerIdempotent:
                 scope_id=entity_id.entity_id,
                 entity_type=entity_id.entity_type,
                 operation=OperationType.READ,
-                permission=Permission.from_operation(OperationType.READ),
+                permission=Permission.READ,
             )
             db_sess.add(perm)
             await db_sess.flush()

--- a/tests/unit/manager/repositories/base/rbac/test_revoker.py
+++ b/tests/unit/manager/repositories/base/rbac/test_revoker.py
@@ -14,6 +14,7 @@ import sqlalchemy as sa
 from ai.backend.common.data.permission.types import (
     EntityType,
     OperationType,
+    Permission,
     RBACElementType,
 )
 from ai.backend.manager.data.permission.id import ObjectId
@@ -116,6 +117,7 @@ class TestRevokerBasic:
                     scope_id=entity_id.entity_id,
                     entity_type=entity_id.entity_type,
                     operation=op,
+                    permission=Permission.from_operation(op),
                 )
                 db_sess.add(perm)
             await db_sess.flush()
@@ -264,6 +266,7 @@ class TestRevokerMultipleRoles:
                     scope_id=entity_id.entity_id,
                     entity_type=entity_id.entity_type,
                     operation=OperationType.READ,
+                    permission=Permission.from_operation(OperationType.READ),
                 )
                 db_sess.add(perm)
             await db_sess.flush()
@@ -354,6 +357,7 @@ class TestRevokerIdempotent:
                 scope_id=entity_id.entity_id,
                 entity_type=entity_id.entity_type,
                 operation=OperationType.READ,
+                permission=Permission.from_operation(OperationType.READ),
             )
             db_sess.add(perm)
             await db_sess.flush()

--- a/tests/unit/manager/repositories/permission_controller/test_check_bulk_permission_with_scope_chain.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_bulk_permission_with_scope_chain.py
@@ -412,7 +412,7 @@ class TestCheckBulkPermissionWithScopeChain:
                     scope_id=fixture_ids.project_id,
                     entity_type=EntityType.VFOLDER,
                     operation=OperationType.READ,
-                    permission=Permission.from_operation(OperationType.READ),
+                    permission=Permission.READ,
                 )
             )
             await db_sess.flush()

--- a/tests/unit/manager/repositories/permission_controller/test_check_bulk_permission_with_scope_chain.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_bulk_permission_with_scope_chain.py
@@ -23,6 +23,7 @@ from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import (
     EntityType,
     OperationType,
+    Permission,
     ScopeType,
 )
 from ai.backend.manager.data.user.types import UserStatus
@@ -371,6 +372,7 @@ class TestCheckBulkPermissionWithScopeChain:
                         scope_id=scope_id,
                         entity_type=entry.entity_type,
                         operation=entry.operation,
+                        permission=Permission.from_operation(entry.operation),
                     )
                 )
                 await db_sess.flush()
@@ -410,6 +412,7 @@ class TestCheckBulkPermissionWithScopeChain:
                     scope_id=fixture_ids.project_id,
                     entity_type=EntityType.VFOLDER,
                     operation=OperationType.READ,
+                    permission=Permission.from_operation(OperationType.READ),
                 )
             )
             await db_sess.flush()

--- a/tests/unit/manager/repositories/permission_controller/test_check_permission_with_scope_chain.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_permission_with_scope_chain.py
@@ -23,6 +23,7 @@ from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import (
     EntityType,
     OperationType,
+    Permission,
     ScopeType,
 )
 from ai.backend.manager.data.user.types import UserStatus
@@ -229,6 +230,7 @@ class TestCheckPermissionWithScopeChain:
                     scope_id=scope_id,
                     entity_type=entry.entity_type,
                     operation=entry.operation,
+                    permission=Permission.from_operation(entry.operation),
                 )
                 db_sess.add(perm)
                 await db_sess.flush()
@@ -647,6 +649,7 @@ class TestCheckPermissionWithScopeChain:
                 scope_id=fixture_ids.project_id,
                 entity_type=EntityType.VFOLDER,
                 operation=OperationType.READ,
+                permission=Permission.from_operation(OperationType.READ),
             )
             db_sess.add(perm)
             await db_sess.flush()
@@ -748,6 +751,7 @@ class TestCheckPermissionWithScopeChain:
                     scope_id=scope_id,
                     entity_type=EntityType.VFOLDER,
                     operation=operation,
+                    permission=Permission.from_operation(operation),
                 )
                 db_sess.add(perm)
                 await db_sess.flush()
@@ -999,6 +1003,7 @@ class TestCheckPermissionWithScopeChain:
                 scope_id=fixture_ids.project_id,
                 entity_type=EntityType.VFOLDER,
                 operation=OperationType.READ,
+                permission=Permission.from_operation(OperationType.READ),
             )
             db_sess.add(perm)
             await db_sess.flush()

--- a/tests/unit/manager/repositories/permission_controller/test_check_permission_with_scope_chain.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_permission_with_scope_chain.py
@@ -649,7 +649,7 @@ class TestCheckPermissionWithScopeChain:
                 scope_id=fixture_ids.project_id,
                 entity_type=EntityType.VFOLDER,
                 operation=OperationType.READ,
-                permission=Permission.from_operation(OperationType.READ),
+                permission=Permission.READ,
             )
             db_sess.add(perm)
             await db_sess.flush()
@@ -1003,7 +1003,7 @@ class TestCheckPermissionWithScopeChain:
                 scope_id=fixture_ids.project_id,
                 entity_type=EntityType.VFOLDER,
                 operation=OperationType.READ,
-                permission=Permission.from_operation(OperationType.READ),
+                permission=Permission.READ,
             )
             db_sess.add(perm)
             await db_sess.flush()

--- a/tests/unit/manager/repositories/permission_controller/test_resolve_effective_permissions.py
+++ b/tests/unit/manager/repositories/permission_controller/test_resolve_effective_permissions.py
@@ -760,7 +760,7 @@ class TestResolveEffectivePermissions:
                     scope_id=fixture.project_id,
                     entity_type=EntityType.VFOLDER,
                     operation=OperationType.READ,
-                    permission=Permission.from_operation(OperationType.READ),
+                    permission=Permission.READ,
                 )
             )
             await db_sess.flush()
@@ -791,7 +791,7 @@ class TestResolveEffectivePermissions:
                     scope_id=fixture.project_id,
                     entity_type=EntityType.VFOLDER,
                     operation=OperationType.READ,
-                    permission=Permission.from_operation(OperationType.READ),
+                    permission=Permission.READ,
                 )
             )
             # role_b grants UPDATE at project scope
@@ -802,7 +802,7 @@ class TestResolveEffectivePermissions:
                     scope_id=fixture.project_id,
                     entity_type=EntityType.VFOLDER,
                     operation=OperationType.UPDATE,
-                    permission=Permission.from_operation(OperationType.UPDATE),
+                    permission=Permission.UPDATE,
                 )
             )
             await db_sess.flush()

--- a/tests/unit/manager/repositories/permission_controller/test_resolve_effective_permissions.py
+++ b/tests/unit/manager/repositories/permission_controller/test_resolve_effective_permissions.py
@@ -20,6 +20,7 @@ from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import (
     EntityType,
     OperationType,
+    Permission,
     ScopeType,
 )
 from ai.backend.manager.data.user.types import UserStatus
@@ -415,6 +416,7 @@ class TestResolveEffectivePermissions:
                         scope_id=scope_id,
                         entity_type=entry.entity_type,
                         operation=entry.operation,
+                        permission=Permission.from_operation(entry.operation),
                     )
                 )
                 await db_sess.flush()
@@ -758,6 +760,7 @@ class TestResolveEffectivePermissions:
                     scope_id=fixture.project_id,
                     entity_type=EntityType.VFOLDER,
                     operation=OperationType.READ,
+                    permission=Permission.from_operation(OperationType.READ),
                 )
             )
             await db_sess.flush()
@@ -788,6 +791,7 @@ class TestResolveEffectivePermissions:
                     scope_id=fixture.project_id,
                     entity_type=EntityType.VFOLDER,
                     operation=OperationType.READ,
+                    permission=Permission.from_operation(OperationType.READ),
                 )
             )
             # role_b grants UPDATE at project scope
@@ -798,6 +802,7 @@ class TestResolveEffectivePermissions:
                     scope_id=fixture.project_id,
                     entity_type=EntityType.VFOLDER,
                     operation=OperationType.UPDATE,
+                    permission=Permission.from_operation(OperationType.UPDATE),
                 )
             )
             await db_sess.flush()

--- a/tests/unit/manager/repositories/permission_controller/test_role_permissions_bulk.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_permissions_bulk.py
@@ -13,7 +13,12 @@ import pytest
 import sqlalchemy as sa
 
 from ai.backend.common.data.permission.types import RBACElementType
-from ai.backend.manager.data.permission.types import EntityType, OperationType, ScopeType
+from ai.backend.manager.data.permission.types import (
+    EntityType,
+    OperationType,
+    Permission,
+    ScopeType,
+)
 from ai.backend.manager.errors.permission import RoleNotFound
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 from ai.backend.manager.models.rbac_models.role import RoleRow
@@ -100,6 +105,7 @@ class TestBulkRolePermissions:
                         scope_id=seed_permission.scope_id,
                         entity_type=EntityType(seed_permission.entity_type.value),
                         operation=seed_permission.operation,
+                        permission=Permission.from_operation(seed_permission.operation),
                     )
                 )
             await session.commit()
@@ -120,6 +126,7 @@ class TestBulkRolePermissions:
                     scope_id=spec.scope_id,
                     entity_type=EntityType(spec.entity_type.value),
                     operation=spec.operation,
+                    permission=Permission.from_operation(spec.operation),
                 )
             )
             await session.commit()

--- a/tests/unit/manager/repositories/permission_controller/test_search_permissions.py
+++ b/tests/unit/manager/repositories/permission_controller/test_search_permissions.py
@@ -14,6 +14,7 @@ import pytest
 from ai.backend.manager.data.permission.types import (
     EntityType,
     OperationType,
+    Permission,
     RBACElementType,
     ScopeType,
 )
@@ -109,6 +110,7 @@ class TestSearchPermissions:
                     scope_id="test-domain",
                     entity_type=entity_type,
                     operation=operation,
+                    permission=Permission.from_operation(operation),
                 )
                 db_sess.add(perm)
                 await db_sess.flush()

--- a/tests/unit/manager/services/permission_controller/test_permission_controller_service.py
+++ b/tests/unit/manager/services/permission_controller/test_permission_controller_service.py
@@ -687,6 +687,7 @@ class TestCreatePermission:
             scope_id="test-domain",
             entity_type=EntityType.USER,
             operation=OperationType.READ,
+            permission=Permission.from_operation(OperationType.READ),
             created_at=datetime.now(UTC),
         )
         mock_repository.create_permission.return_value = perm_data
@@ -710,6 +711,7 @@ class TestCreatePermission:
             scope_id="global",
             entity_type=EntityType.USER,
             operation=OperationType.CREATE,
+            permission=Permission.from_operation(OperationType.CREATE),
             created_at=datetime.now(UTC),
         )
         mock_repository.create_permission.return_value = perm_data
@@ -749,6 +751,7 @@ class TestDeletePermission:
             scope_id="test-domain",
             entity_type=EntityType.USER,
             operation=OperationType.READ,
+            permission=Permission.from_operation(OperationType.READ),
             created_at=datetime.now(UTC),
         )
         mock_repository.delete_permission.return_value = perm_data
@@ -790,6 +793,7 @@ class TestSearchPermissions:
             scope_id="test-domain",
             entity_type=EntityType.USER,
             operation=OperationType.READ,
+            permission=Permission.from_operation(OperationType.READ),
             created_at=datetime.now(UTC),
         )
         mock_result = SearchResult(

--- a/tests/unit/manager/services/permission_controller/test_permission_controller_service.py
+++ b/tests/unit/manager/services/permission_controller/test_permission_controller_service.py
@@ -687,7 +687,7 @@ class TestCreatePermission:
             scope_id="test-domain",
             entity_type=EntityType.USER,
             operation=OperationType.READ,
-            permission=Permission.from_operation(OperationType.READ),
+            permission=Permission.READ,
             created_at=datetime.now(UTC),
         )
         mock_repository.create_permission.return_value = perm_data
@@ -711,7 +711,7 @@ class TestCreatePermission:
             scope_id="global",
             entity_type=EntityType.USER,
             operation=OperationType.CREATE,
-            permission=Permission.from_operation(OperationType.CREATE),
+            permission=Permission.CREATE,
             created_at=datetime.now(UTC),
         )
         mock_repository.create_permission.return_value = perm_data
@@ -751,7 +751,7 @@ class TestDeletePermission:
             scope_id="test-domain",
             entity_type=EntityType.USER,
             operation=OperationType.READ,
-            permission=Permission.from_operation(OperationType.READ),
+            permission=Permission.READ,
             created_at=datetime.now(UTC),
         )
         mock_repository.delete_permission.return_value = perm_data
@@ -793,7 +793,7 @@ class TestSearchPermissions:
             scope_id="test-domain",
             entity_type=EntityType.USER,
             operation=OperationType.READ,
-            permission=Permission.from_operation(OperationType.READ),
+            permission=Permission.READ,
             created_at=datetime.now(UTC),
         )
         mock_result = SearchResult(


### PR DESCRIPTION
## Summary
- Add a `Permission` IntFlag bitmask column to the `permissions` table, coexisting with the legacy per-operation `operation` StrEnum column (grant-side analog of the cap column added to `scope_entities`).
- Introduce `Permission.from_operation()`: CRUD operations map to their bit; `GRANT_*` operations have no dedicated bit and map to `NONE` (grant authority stays on the `operation` column during the transition).
- Wire the new field through `PermissionRow` / `PermissionData` / `PermissionCreator` and every write path (`PermissionCreatorSpec`, role manager, RBAC granter, vfolder owner-grant insert).
- Alembic migration adds the column, backfills each row's single `operation` into the corresponding bit, then sets `NOT NULL`; downgrade drops the column.

Switching permission resolution to the new column, API exposure, and row de-duplication / `operation` removal are separate follow-ups.

## Test plan
- [x] `pants fmt / fix / lint / check` (mypy) pass for affected packages
- [x] Affected permission_controller / base.rbac / service unit suites pass; updated 25 inline `PermissionRow`/`PermissionData` test constructions
- [x] Migration verified against local DB (2,427 rows): backfill maps create→4, read→1, update→2, soft-delete→8, hard-delete→16, `grant:*`→0; no NULLs; column is `smallint NOT NULL`
- [x] `downgrade` drops the column cleanly and re-`upgrade` succeeds

Resolves BA-6349

🤖 Generated with [Claude Code](https://claude.com/claude-code)