### PR TITLE
fix(BA-6452): sync deployment replicas to AppProxy by traffic-ACTIVE, not health

### DIFF
--- a/changes/12131.fix.md
+++ b/changes/12131.fix.md
@@ -1,0 +1,1 @@
+Sync deployment replicas to AppProxy by traffic-ACTIVE state instead of health, so that health-check-disabled routes are no longer dropped from the proxy pool on each fallback cycle.

--- a/src/ai/backend/manager/sokovan/deployment/route/executor.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/executor.py
@@ -615,17 +615,25 @@ class RouteExecutor:
         return RouteExecutionResult(successes=[], errors=[])
 
     async def sync_appproxy(self, routes: Sequence[RouteData]) -> RouteExecutionResult:
-        """Push the current HEALTHY routing tables for affected endpoints to AppProxy.
+        """Push the current ACTIVE routing tables for affected endpoints to AppProxy.
+
+        Sync mirrors AppProxy to the manager's routing intent (traffic
+        ACTIVE), not to live health. Evicting an UNHEALTHY backend from
+        the pool is AppProxy's own health-check responsibility; on the
+        manager side a confirmed-unhealthy route is removed via the
+        route-eviction → terminate → unregister path per the scaling
+        group's ``cleanup_target_statuses`` policy. Filtering by HEALTHY
+        here would double-manage that and drop health-check-disabled
+        (NOT_CHECKED) routes that should keep serving.
 
         Steps:
         1. Group the input routes by endpoint (the AppProxy contract is
            endpoint-scoped: one ``circuit.route_info`` per deployment).
         2. Resolve each endpoint's proxy target (wsproxy_addr / token)
            via the deployment repository in two batched calls.
-        3. Re-read the authoritative RUNNING + HEALTHY route set per
+        3. Re-read the authoritative RUNNING + ACTIVE route set per
            endpoint with a caller-composed ``BatchQuerier`` so the same
-           plumbing works for sync, debug, and reporting paths — no
-           ``only_healthy`` flag and no Row-side query method.
+           plumbing works for sync, debug, and reporting paths.
         4. Group endpoints by proxy target and issue one
            ``bulk_update_routes`` HTTP call per target instead of one
            event per endpoint, which previously meant one DB connection
@@ -659,7 +667,6 @@ class RouteExecutor:
             conditions=[
                 RouteConditions.by_endpoint_ids(endpoint_ids),
                 RouteConditions.by_lifecycle_statuses([RouteStatus.RUNNING]),
-                RouteConditions.by_health_statuses([RouteHealthStatus.HEALTHY]),
                 RouteConditions.by_traffic_status_equals(RouteTrafficStatus.ACTIVE),
             ],
         )

--- a/src/ai/backend/manager/sokovan/deployment/route/handlers/appproxy_sync.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/handlers/appproxy_sync.py
@@ -1,4 +1,4 @@
-"""Handler for synchronizing healthy routes to AppProxy."""
+"""Handler for synchronizing ACTIVE routes to AppProxy."""
 
 import logging
 from collections.abc import Sequence
@@ -23,7 +23,11 @@ log = BraceStyleAdapter(logging.getLogger(__name__))
 
 
 class AppProxySyncRouteHandler(RouteHandler):
-    """Handler for syncing healthy routes to the AppProxy.
+    """Handler for syncing ACTIVE routes to the AppProxy.
+
+    Targets RUNNING + traffic-ACTIVE routes regardless of health: sync
+    reflects the manager's routing intent, while pruning unhealthy
+    backends from the pool is AppProxy's own health-check responsibility.
 
     Single push-side entry point: API handlers and session lifecycle hooks
     no longer push directly. They mark APPPROXY_SYNC needed via

--- a/tests/unit/manager/sokovan/deployment/route/executor/test_route_executor.py
+++ b/tests/unit/manager/sokovan/deployment/route/executor/test_route_executor.py
@@ -1131,3 +1131,62 @@ class TestSyncAppproxy:
         assert len(result.successes) == 2
         assert len(result.errors) == 1
         assert result.errors[0].route_info.deployment_id == endpoint_ids[0]
+
+    async def test_sync_targets_traffic_not_health(
+        self,
+        route_executor: RouteExecutor,
+        mock_deployment_repo: AsyncMock,
+        mock_appproxy_client_pool: MagicMock,
+    ) -> None:
+        """AP-005: Regression — the routing-table re-read filters by traffic
+        ACTIVE only, never by health.
+
+        Sync mirrors the manager's routing intent; pruning unhealthy
+        backends from the pool is AppProxy's own responsibility. A health
+        filter here would silently drop health-check-disabled
+        (NOT_CHECKED) routes that should keep serving.
+        """
+        endpoint_id = DeploymentID(uuid4())
+        routes = [_route_for_endpoint(endpoint_id)]
+        _wire_proxy_target(mock_deployment_repo, [endpoint_id])
+        client = mock_appproxy_client_pool.load_client.return_value
+        client.bulk_update_routes.return_value = _bulk_response([
+            UpdatedRoutesItem(deployment_id=endpoint_id, success=True)
+        ])
+
+        await route_executor.sync_appproxy(routes)
+
+        querier = mock_deployment_repo.fetch_route_connection_infos.await_args.kwargs[
+            "route_querier"
+        ]
+        compiled = [str(condition()) for condition in querier.conditions]
+        assert not any("health_status" in clause for clause in compiled), (
+            f"sync_appproxy must not filter by health; got {compiled}"
+        )
+        assert any("traffic_status" in clause for clause in compiled)
+
+    async def test_not_checked_route_is_synced(
+        self,
+        route_executor: RouteExecutor,
+        mock_deployment_repo: AsyncMock,
+        mock_appproxy_client_pool: MagicMock,
+    ) -> None:
+        """AP-006: A RUNNING + ACTIVE route whose health is NOT_CHECKED
+        (health check disabled) is still pushed to AppProxy."""
+        endpoint_id = DeploymentID(uuid4())
+        route = dataclasses.replace(
+            _route_for_endpoint(endpoint_id),
+            health_status=RouteHealthStatus.NOT_CHECKED,
+        )
+        _wire_proxy_target(mock_deployment_repo, [endpoint_id])
+        client = mock_appproxy_client_pool.load_client.return_value
+        client.bulk_update_routes.return_value = _bulk_response([
+            UpdatedRoutesItem(deployment_id=endpoint_id, success=True)
+        ])
+
+        result = await route_executor.sync_appproxy([route])
+
+        assert len(result.successes) == 1
+        client.bulk_update_routes.assert_awaited_once()
+        request = client.bulk_update_routes.await_args.args[0]
+        assert [item.deployment_id for item in request.endpoints] == [endpoint_id]


### PR DESCRIPTION
## Summary
- The fallback `sync_appproxy` re-read filtered the routing table by `HEALTHY`, so on every long cycle it dropped health-check-disabled (`NOT_CHECKED`) routes from the AppProxy pool — even though they should keep serving.
- Sync now mirrors the manager's routing **intent** (`RUNNING` + traffic-`ACTIVE`) and no longer filters by health. Evicting an unhealthy backend stays the responsibility of the route-eviction → terminate → unregister path (per scaling group `cleanup_target_statuses`) and AppProxy's own health check.
- Register/unregister hot paths are unchanged; only the fallback reconcile criteria changed.

## Test plan
- [x] `test_sync_targets_traffic_not_health` — asserts the sync querier filters by `traffic_status`, never by `health_status` (verified it FAILs when the HEALTHY filter is reintroduced).
- [x] `test_not_checked_route_is_synced` — a `RUNNING` + `ACTIVE` route with `NOT_CHECKED` health is still pushed to AppProxy.
- [x] `pants test tests/unit/manager/sokovan/deployment/route/executor::` — all green.
- [x] `pants lint` / `mypy` — pass.

Resolves BA-6452