### PR TITLE
feat(BA-6455): add single-entity action processor, validator, monitor framework

### DIFF
--- a/changes/12137.enhance.md
+++ b/changes/12137.enhance.md
@@ -1,0 +1,1 @@
+Add a self-contained per-type execution framework (processor, validator, monitor, result) for single-entity actions, independent of the legacy `BaseAction` hierarchy.

--- a/src/ai/backend/manager/actions/single_entity/__init__.py
+++ b/src/ai/backend/manager/actions/single_entity/__init__.py
@@ -1,5 +1,19 @@
 from .base import (
     BaseSingleEntityAction,
 )
+from .monitor import SingleEntityActionMonitor
+from .processor import SingleEntityActionProcessor
+from .result import (
+    SingleEntityActionProcessResult,
+    SingleEntityActionResultMeta,
+)
+from .validator import SingleEntityActionValidator
 
-__all__ = ("BaseSingleEntityAction",)
+__all__ = (
+    "BaseSingleEntityAction",
+    "SingleEntityActionMonitor",
+    "SingleEntityActionProcessor",
+    "SingleEntityActionProcessResult",
+    "SingleEntityActionResultMeta",
+    "SingleEntityActionValidator",
+)

--- a/src/ai/backend/manager/actions/single_entity/monitor/__init__.py
+++ b/src/ai/backend/manager/actions/single_entity/monitor/__init__.py
@@ -1,0 +1,3 @@
+from .base import SingleEntityActionMonitor
+
+__all__ = ("SingleEntityActionMonitor",)

--- a/src/ai/backend/manager/actions/single_entity/monitor/base.py
+++ b/src/ai/backend/manager/actions/single_entity/monitor/base.py
@@ -1,0 +1,24 @@
+from abc import ABC
+
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.single_entity.base import BaseSingleEntityAction
+from ai.backend.manager.actions.single_entity.result import SingleEntityActionProcessResult
+
+__all__ = ("SingleEntityActionMonitor",)
+
+
+class SingleEntityActionMonitor(ABC):
+    """Observes the lifecycle of a single-entity action.
+
+    Bound to the self-contained :class:`BaseSingleEntityAction` (pure ABC). ``prepare``
+    runs before the action function; ``done`` runs after it completes (or fails), with
+    the outcome carried in :class:`SingleEntityActionProcessResult`.
+    """
+
+    async def prepare(self, action: BaseSingleEntityAction, meta: BaseActionTriggerMeta) -> None:
+        raise NotImplementedError("Subclasses must implement the prepare method")
+
+    async def done(
+        self, action: BaseSingleEntityAction, result: SingleEntityActionProcessResult
+    ) -> None:
+        raise NotImplementedError("Subclasses must implement the done method")

--- a/src/ai/backend/manager/actions/single_entity/processor.py
+++ b/src/ai/backend/manager/actions/single_entity/processor.py
@@ -1,0 +1,105 @@
+import logging
+import uuid
+from collections.abc import Awaitable, Callable, Sequence
+from datetime import UTC, datetime
+
+from ai.backend.common.exception import BackendAIError, ErrorCode
+from ai.backend.logging.utils import BraceStyleAdapter
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.single_entity.base import BaseSingleEntityAction
+from ai.backend.manager.actions.single_entity.monitor import SingleEntityActionMonitor
+from ai.backend.manager.actions.single_entity.result import (
+    SingleEntityActionProcessResult,
+    SingleEntityActionResultMeta,
+)
+from ai.backend.manager.actions.single_entity.validator import SingleEntityActionValidator
+from ai.backend.manager.actions.types import OperationStatus
+
+__all__ = ("SingleEntityActionProcessor",)
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class SingleEntityActionProcessor[TAction: BaseSingleEntityAction, TResult]:
+    """Validate, run monitors around, then execute a single-entity action.
+
+    Each registered validator runs first. The action function then executes within a
+    monitor lifecycle: every monitor's ``prepare`` is called before, and ``done`` after
+    (on success or failure), with status / timing / error captured into a
+    :class:`ProcessResult`. This path depends only on the pure-ABC
+    :class:`BaseSingleEntityAction`, never on the legacy ``BaseAction`` framework.
+    """
+
+    _func: Callable[[TAction], Awaitable[TResult]]
+    _monitors: Sequence[SingleEntityActionMonitor]
+    _validators: Sequence[SingleEntityActionValidator]
+
+    def __init__(
+        self,
+        func: Callable[[TAction], Awaitable[TResult]],
+        monitors: Sequence[SingleEntityActionMonitor] | None = None,
+        validators: Sequence[SingleEntityActionValidator] | None = None,
+    ) -> None:
+        self._func = func
+        self._monitors = monitors or []
+        self._validators = validators or []
+
+    async def _prepare_monitors(self, action: TAction, trigger_meta: BaseActionTriggerMeta) -> None:
+        for monitor in self._monitors:
+            try:
+                await monitor.prepare(action, trigger_meta)
+            except Exception as e:
+                log.warning("Error in monitor prepare method: {}", e)
+
+    async def _finalize_monitors(self, action: TAction, meta: SingleEntityActionResultMeta) -> None:
+        process_result = SingleEntityActionProcessResult(meta=meta)
+        for monitor in reversed(self._monitors):
+            try:
+                await monitor.done(action, process_result)
+            except Exception as e:
+                log.warning("Error in monitor done method: {}", e)
+
+    async def run(self, action: TAction) -> TResult:
+        started_at = datetime.now(UTC)
+        action_id = uuid.uuid4()
+        trigger_meta = BaseActionTriggerMeta(action_id=action_id, started_at=started_at)
+
+        for validator in self._validators:
+            await validator.validate(action, trigger_meta)
+
+        status = OperationStatus.UNKNOWN
+        description = "unknown"
+        error_code: ErrorCode | None = None
+
+        await self._prepare_monitors(action, trigger_meta)
+        try:
+            result = await self._func(action)
+        except BackendAIError as e:
+            log.exception("Action processing error: {}", e)
+            status = OperationStatus.ERROR
+            description = str(e)
+            error_code = e.error_code()
+            raise
+        except BaseException as e:
+            log.exception("Unexpected error during action processing: {}", e)
+            status = OperationStatus.ERROR
+            description = str(e)
+            error_code = ErrorCode.default()
+            raise
+        else:
+            status = OperationStatus.SUCCESS
+            description = "Success"
+            return result
+        finally:
+            ended_at = datetime.now(UTC)
+            meta = SingleEntityActionResultMeta(
+                action_id=action_id,
+                entity_id=action.entity_id(),
+                status=status,
+                description=description,
+                started_at=started_at,
+                ended_at=ended_at,
+                duration=ended_at - started_at,
+                error_code=error_code,
+            )
+            await self._finalize_monitors(action, meta)

--- a/src/ai/backend/manager/actions/single_entity/result.py
+++ b/src/ai/backend/manager/actions/single_entity/result.py
@@ -1,0 +1,34 @@
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from ai.backend.common.exception import ErrorCode
+from ai.backend.manager.actions.types import OperationStatus
+
+__all__ = (
+    "SingleEntityActionResultMeta",
+    "SingleEntityActionProcessResult",
+)
+
+
+@dataclass
+class SingleEntityActionResultMeta:
+    """Outcome metadata for a single-entity action run.
+
+    Self-contained for the pure-ABC single-entity line; ``entity_id`` is always
+    present because :class:`BaseSingleEntityAction` operates on an identified entity.
+    """
+
+    action_id: uuid.UUID
+    entity_id: str
+    status: OperationStatus
+    description: str
+    started_at: datetime
+    ended_at: datetime
+    duration: timedelta
+    error_code: ErrorCode | None
+
+
+@dataclass
+class SingleEntityActionProcessResult:
+    meta: SingleEntityActionResultMeta

--- a/src/ai/backend/manager/actions/single_entity/validator/__init__.py
+++ b/src/ai/backend/manager/actions/single_entity/validator/__init__.py
@@ -1,0 +1,3 @@
+from .base import SingleEntityActionValidator
+
+__all__ = ("SingleEntityActionValidator",)

--- a/src/ai/backend/manager/actions/single_entity/validator/base.py
+++ b/src/ai/backend/manager/actions/single_entity/validator/base.py
@@ -1,0 +1,18 @@
+from abc import ABC, abstractmethod
+
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.single_entity.base import BaseSingleEntityAction
+
+__all__ = ("SingleEntityActionValidator",)
+
+
+class SingleEntityActionValidator(ABC):
+    """Validates a single-entity action before execution.
+
+    Bound to the self-contained :class:`BaseSingleEntityAction` (pure ABC), so this
+    contract stays independent of the legacy ``BaseAction`` hierarchy.
+    """
+
+    @abstractmethod
+    async def validate(self, action: BaseSingleEntityAction, meta: BaseActionTriggerMeta) -> None:
+        raise NotImplementedError("Subclasses must implement the validate method")


### PR DESCRIPTION
## Summary
- Build the per-type execution framework on the pure-ABC `BaseSingleEntityAction`, independent of the legacy `BaseAction` hierarchy (`src/ai/backend/manager/actions/single_entity/`).
- `SingleEntityActionProcessor` runs validators, then executes the action within a monitor lifecycle (`prepare` → func → `done`), capturing status/timing/error.
- Adds the type-specific ABCs `SingleEntityActionValidator` and `SingleEntityActionMonitor` (as packages) plus self-contained `SingleEntityActionResultMeta` / `SingleEntityActionProcessResult` (non-optional `entity_id`).


Resolves BA-6455