### PR TITLE
feat(BA-6465): allow updating runtime_variant on deployment revision preset

### DIFF
--- a/changes/12145.feature.md
+++ b/changes/12145.feature.md
@@ -1,0 +1,1 @@
+Allow updating runtime_variant on a deployment revision preset

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -18829,6 +18829,11 @@ input UpdateDeploymentRevisionPresetInput
   """Preset ID."""
   id: UUID!
 
+  """
+  Added in UNRELEASED. New runtime variant for the preset. Omit to leave unchanged.
+  """
+  runtimeVariantId: UUID = null
+
   """New name."""
   name: String = null
 

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -13025,6 +13025,11 @@ input UpdateDeploymentRevisionPresetInput {
   """Preset ID."""
   id: UUID!
 
+  """
+  Added in UNRELEASED. New runtime variant for the preset. Omit to leave unchanged.
+  """
+  runtimeVariantId: UUID = null
+
   """New name."""
   name: String = null
 

--- a/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
@@ -73,6 +73,7 @@ class CreateDeploymentRevisionPresetInput(BaseRequestModel):
 
 class UpdateDeploymentRevisionPresetInput(BaseRequestModel):
     id: UUID = Field(description="Preset ID.")
+    runtime_variant_id: RuntimeVariantID | None = Field(default=None)
     name: str | None = Field(default=None, min_length=1, max_length=256)
     description: str | Sentinel | None = Field(default=SENTINEL)
     rank: int | None = Field(default=None, ge=0)

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -306,6 +306,11 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
         )
 
         spec = DeploymentRevisionPresetUpdaterSpec(
+            runtime_variant=(
+                OptionalState.update(input.runtime_variant_id)
+                if input.runtime_variant_id is not None
+                else OptionalState.nop()
+            ),
             name=(
                 OptionalState.update(input.name) if input.name is not None else OptionalState.nop()
             ),

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -541,6 +541,13 @@ class CreateDeploymentRevisionPresetInputGQL(PydanticInputMixin[CreateInputDTO])
 )
 class UpdateDeploymentRevisionPresetInputGQL(PydanticInputMixin[UpdateInputDTO]):
     id: UUID = gql_field(description="Preset ID.")
+    runtime_variant_id: UUID | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="New runtime variant for the preset. Omit to leave unchanged.",
+        ),
+        default=None,
+    )
     name: str | None = gql_field(default=None, description="New name.")
     description: str | None = gql_field(default=None, description="New description.")
     rank: int | None = gql_field(default=None, description="New rank.")

--- a/src/ai/backend/manager/repositories/deployment_revision_preset/updaters.py
+++ b/src/ai/backend/manager/repositories/deployment_revision_preset/updaters.py
@@ -6,6 +6,7 @@ from typing import Any, override
 
 from ai.backend.common.config import ModelDefinition
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
+from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.manager.models.base import ResourceOptsEntry
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
 from ai.backend.manager.models.deployment_revision_preset.types import PresetValueEntry
@@ -15,6 +16,9 @@ from ai.backend.manager.types import OptionalState, TriState
 
 @dataclass
 class DeploymentRevisionPresetUpdaterSpec(UpdaterSpec[DeploymentRevisionPresetRow]):
+    runtime_variant: OptionalState[RuntimeVariantID] = field(
+        default_factory=OptionalState[RuntimeVariantID].nop
+    )
     name: OptionalState[str] = field(default_factory=OptionalState[str].nop)
     description: TriState[str] = field(default_factory=TriState[str].nop)
     rank: OptionalState[int] = field(default_factory=OptionalState[int].nop)
@@ -53,6 +57,7 @@ class DeploymentRevisionPresetUpdaterSpec(UpdaterSpec[DeploymentRevisionPresetRo
     @override
     def build_values(self) -> dict[str, Any]:
         to_update: dict[str, Any] = {}
+        self.runtime_variant.update_dict(to_update, "runtime_variant")
         self.name.update_dict(to_update, "name")
         self.description.update_dict(to_update, "description")
         self.rank.update_dict(to_update, "rank")

--- a/tests/component/deployment_revision_preset/test_deployment_revision_preset_crud.py
+++ b/tests/component/deployment_revision_preset/test_deployment_revision_preset_crud.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 import pytest
 import sqlalchemy as sa
@@ -36,11 +37,9 @@ from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 
 
-@pytest.fixture()
-async def runtime_variant_id(
-    db_engine: SAEngine, database_fixture: None
-) -> AsyncIterator[RuntimeVariantID]:
-    """Create a runtime variant for testing."""
+@asynccontextmanager
+async def _runtime_variant(db_engine: SAEngine) -> AsyncIterator[RuntimeVariantID]:
+    """Insert a runtime variant and clean up its presets and itself on exit."""
     variant_id = RuntimeVariantID(uuid.uuid4())
     async with db_engine.begin() as conn:
         await conn.execute(
@@ -54,16 +53,36 @@ async def runtime_variant_id(
                 default_model_definition="{}",
             )
         )
-    yield variant_id
-    async with db_engine.begin() as conn:
-        await conn.execute(
-            sa.text(
-                "DELETE FROM deployment_revision_presets WHERE runtime_variant = :id"
-            ).bindparams(id=variant_id)
-        )
-        await conn.execute(
-            sa.text("DELETE FROM runtime_variants WHERE id = :id").bindparams(id=variant_id)
-        )
+    try:
+        yield variant_id
+    finally:
+        async with db_engine.begin() as conn:
+            await conn.execute(
+                sa.text(
+                    "DELETE FROM deployment_revision_presets WHERE runtime_variant = :id"
+                ).bindparams(id=variant_id)
+            )
+            await conn.execute(
+                sa.text("DELETE FROM runtime_variants WHERE id = :id").bindparams(id=variant_id)
+            )
+
+
+@pytest.fixture()
+async def runtime_variant_id(
+    db_engine: SAEngine, database_fixture: None
+) -> AsyncIterator[RuntimeVariantID]:
+    """Create a runtime variant for testing."""
+    async with _runtime_variant(db_engine) as variant_id:
+        yield variant_id
+
+
+@pytest.fixture()
+async def other_runtime_variant_id(
+    db_engine: SAEngine, database_fixture: None
+) -> AsyncIterator[RuntimeVariantID]:
+    """Create a second runtime variant to move a preset into."""
+    async with _runtime_variant(db_engine) as variant_id:
+        yield variant_id
 
 
 class TestDeploymentRevisionPresetCRUD:
@@ -177,6 +196,39 @@ class TestDeploymentRevisionPresetCRUD:
         assert update_result.preset.rank == 50
 
         await admin_v2_registry.deployment_revision_preset.delete(preset_id)
+
+    async def test_update_runtime_variant(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        runtime_variant_id: RuntimeVariantID,
+        other_runtime_variant_id: RuntimeVariantID,
+    ) -> None:
+        create_result = await admin_v2_registry.deployment_revision_preset.create(
+            CreateDeploymentRevisionPresetInput(
+                runtime_variant_id=runtime_variant_id,
+                name="variant-move-preset",
+                image_id=ImageID(uuid.uuid4()),
+                resource_slots=[ResourceSlotEntryInput(resource_type="cpu", quantity="1")],
+                cluster_mode="single-node",
+                cluster_size=1,
+                replica_count=1,
+                deployment_strategy=DeploymentStrategyInput(type=DeploymentStrategy.ROLLING),
+            )
+        )
+        preset_id = create_result.preset.id
+        assert create_result.preset.runtime_variant_id == runtime_variant_id
+
+        update_result = await admin_v2_registry.deployment_revision_preset.update(
+            preset_id,
+            UpdateDeploymentRevisionPresetInput(
+                id=preset_id,
+                runtime_variant_id=other_runtime_variant_id,
+            ),
+        )
+        assert update_result.preset.runtime_variant_id == other_runtime_variant_id
+
+        get_result = await admin_v2_registry.deployment_revision_preset.get(preset_id)
+        assert get_result.runtime_variant_id == other_runtime_variant_id
 
     async def test_delete(
         self,


### PR DESCRIPTION
## Summary
- Enable updating the deployment revision preset's `runtime_variant` — previously the only `DeploymentRevisionPresetRow` column with no update path. Adds `runtime_variant_id` to the update DTO, the GQL update input, the updater spec (`build_values`), and the adapter wiring.
- `None`/omitted is a no-op; the column is `NOT NULL` so it cannot be cleared. Rank recomputation across variants is intentionally out of scope — only the column update is enabled. A `(runtime_variant, name)` collision surfaces as the existing `DeploymentRevisionPresetConflict`.

## Test plan
- [x] Component `test_update_runtime_variant` (real DB, full REST path): create on variant A → update to B → mutation response and re-`get` both reflect B
- [x] Existing preset CRUD component tests still pass (variant fixture refactored into a reusable context manager to add a second variant)
- [x] Regenerated GraphQL v2 + supergraph schema dumps; supergraph composition succeeds
- [x] `pants lint check` (ruff + mypy) clean on changed files
- [ ] CI green

Resolves BA-6465

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12145.org.readthedocs.build/en/12145/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12145.org.readthedocs.build/ko/12145/

<!-- readthedocs-preview sorna-ko end -->