### PR TITLE
fix(BA-6461): make RBAC permission grants idempotent

### DIFF
--- a/changes/12146.fix.md
+++ b/changes/12146.fix.md
@@ -1,0 +1,1 @@
+Fix internal server error when accepting a VFolder invitation for an entity the invitee already has access to

--- a/src/ai/backend/manager/repositories/base/rbac/entity_creator.py
+++ b/src/ai/backend/manager/repositories/base/rbac/entity_creator.py
@@ -22,6 +22,7 @@ from ai.backend.manager.repositories.base.integrity import (
     match_integrity_error,
     parse_integrity_error,
 )
+from ai.backend.manager.repositories.base.rbac.utils import bulk_insert_on_conflict_do_nothing
 
 TRow = TypeVar("TRow", bound=Base)
 
@@ -106,16 +107,17 @@ async def execute_rbac_entity_creator[TRow: Base](
     pk_value = instance_state.identity[0]
     entity_type = creator.element_type.to_entity_type()
     all_scope_refs = [creator.scope_ref, *creator.additional_scope_refs]
-    for scope_ref in all_scope_refs:
-        db_sess.add(
-            AssociationScopesEntitiesRow(
-                scope_type=scope_ref.element_type.to_scope_type(),
-                scope_id=scope_ref.element_id,
-                entity_type=entity_type,
-                entity_id=str(pk_value),
-                relation_type=creator.relation_type,
-            ),
+    associations = [
+        AssociationScopesEntitiesRow(
+            scope_type=scope_ref.element_type.to_scope_type(),
+            scope_id=scope_ref.element_id,
+            entity_type=entity_type,
+            entity_id=str(pk_value),
+            relation_type=creator.relation_type,
         )
+        for scope_ref in all_scope_refs
+    ]
+    await bulk_insert_on_conflict_do_nothing(db_sess, associations)
 
     return RBACEntityCreatorResult(row=row)
 
@@ -201,7 +203,7 @@ async def execute_rbac_bulk_entity_creator[TRow: Base](
         )
         for row in rows
     ]
-    db_sess.add_all(associations)
+    await bulk_insert_on_conflict_do_nothing(db_sess, associations)
 
     return RBACBulkEntityCreatorResult(rows=rows)
 
@@ -268,6 +270,6 @@ async def execute_rbac_entity_creators[TRow: Base](
                     relation_type=creator.relation_type,
                 ),
             )
-    db_sess.add_all(associations)
+    await bulk_insert_on_conflict_do_nothing(db_sess, associations)
 
     return RBACBulkEntityCreatorResult(rows=rows)

--- a/src/ai/backend/manager/repositories/base/rbac/granter.py
+++ b/src/ai/backend/manager/repositories/base/rbac/granter.py
@@ -94,16 +94,23 @@ async def execute_rbac_granter(
     await db_sess.execute(ref_edge_stmt)
 
     # 2. Insert entity-scope permissions (access control)
-    perms = [
-        PermissionRow(
-            role_id=role_id,
-            scope_type=granter.granted_entity_scope_type.to_scope_type(),
-            scope_id=entity_id.entity_id,
-            entity_type=entity_id.entity_type,
-            operation=operation,
-        )
+    #    Use ON CONFLICT DO NOTHING to safely handle repeated grants for the
+    #    same (role_id, scope_type, scope_id, entity_type, operation) tuple.
+    scope_type = granter.granted_entity_scope_type.to_scope_type()
+    perm_values = [
+        {
+            "role_id": role_id,
+            "scope_type": scope_type,
+            "scope_id": entity_id.entity_id,
+            "entity_type": entity_id.entity_type,
+            "operation": operation,
+        }
         for role_id in role_ids
         for operation in granter.operations
     ]
-    db_sess.add_all(perms)
-    await db_sess.flush()
+    perm_stmt = (
+        pg_insert(PermissionRow)
+        .values(perm_values)
+        .on_conflict_do_nothing(constraint="uq_permissions_role_scope_entity_op")
+    )
+    await db_sess.execute(perm_stmt)

--- a/tests/unit/manager/repositories/base/rbac/test_granter.py
+++ b/tests/unit/manager/repositories/base/rbac/test_granter.py
@@ -359,8 +359,114 @@ class TestGranterMultipleOperations:
             assert assoc_count == 0
 
 
-# TODO(#9411): Re-enable idempotency tests once permissions table has unique constraint.
-# These tests verify:
-# 1. Duplicate grants raise IntegrityError (test_granter_raises_on_duplicate_grant)
-# 2. Same entity can be granted to different scopes (test_granter_grants_to_different_scopes_sequentially)
-# Currently disabled because permissions table lacks the required unique constraint.
+class TestGranterIdempotency:
+    """Tests that repeated grants are idempotent.
+
+    The permissions table has a unique constraint on
+    (role_id, scope_type, scope_id, entity_type, operation), and the granter inserts
+    with ON CONFLICT DO NOTHING. Re-granting an already-held permission (e.g. accepting
+    a VFolder invitation for an entity the invitee's role can already access) must
+    therefore succeed without raising and without duplicating rows.
+    """
+
+    @pytest.fixture
+    async def single_role(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        create_tables: None,
+    ) -> AsyncGenerator[SingleRoleContext, None]:
+        """Create a single role for idempotency testing."""
+        entity_id = ObjectId(entity_type=EntityType.VFOLDER, entity_id=str(uuid.uuid4()))
+        target_scope_id = ScopeId(scope_type=ScopeType.USER, scope_id=str(uuid.uuid4()))
+
+        role_id: UUID
+        async with database_connection.begin_session_read_committed() as db_sess:
+            role = RoleRow(
+                id=uuid.uuid4(),
+                name="test-role",
+                source=RoleSource.SYSTEM,
+            )
+            db_sess.add(role)
+            await db_sess.flush()
+            role_id = role.id
+
+        yield SingleRoleContext(
+            entity_scope_type=RBACElementType.VFOLDER,
+            entity_id=entity_id,
+            target_scope_id=target_scope_id,
+            role_id=role_id,
+        )
+
+    async def test_duplicate_grant_is_idempotent(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        single_role: SingleRoleContext,
+    ) -> None:
+        """Granting the same permissions twice across separate transactions must not
+        raise and must not create duplicate permission or ref-edge rows."""
+        ctx = single_role
+
+        def make_granter() -> RBACGranter:
+            return RBACGranter(
+                granted_entity_id=ctx.entity_id,
+                granted_entity_scope_type=ctx.entity_scope_type,
+                target_scope_id=ctx.target_scope_id,
+                target_role_ids=[ctx.role_id],
+                operations=[OperationType.READ, OperationType.UPDATE],
+            )
+
+        async with database_connection.begin_session_read_committed() as db_sess:
+            await execute_rbac_granter(db_sess, make_granter())
+
+        # Second grant with identical parameters: a no-op, not a UniqueViolationError.
+        async with database_connection.begin_session_read_committed() as db_sess:
+            await execute_rbac_granter(db_sess, make_granter())
+
+        async with database_connection.begin_session_read_committed() as db_sess:
+            perm_count = await db_sess.scalar(sa.select(sa.func.count()).select_from(PermissionRow))
+            assert perm_count == 2  # READ + UPDATE, not duplicated
+            assoc_count = await db_sess.scalar(
+                sa.select(sa.func.count()).select_from(AssociationScopesEntitiesRow)
+            )
+            assert assoc_count == 1  # single ref edge, not duplicated
+
+    async def test_overlapping_grant_adds_only_new_operation(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        single_role: SingleRoleContext,
+    ) -> None:
+        """A second grant overlapping an existing operation grants only the new one and
+        leaves the already-held operation intact."""
+        ctx = single_role
+
+        async with database_connection.begin_session_read_committed() as db_sess:
+            await execute_rbac_granter(
+                db_sess,
+                RBACGranter(
+                    granted_entity_id=ctx.entity_id,
+                    granted_entity_scope_type=ctx.entity_scope_type,
+                    target_scope_id=ctx.target_scope_id,
+                    target_role_ids=[ctx.role_id],
+                    operations=[OperationType.READ],
+                ),
+            )
+
+        async with database_connection.begin_session_read_committed() as db_sess:
+            await execute_rbac_granter(
+                db_sess,
+                RBACGranter(
+                    granted_entity_id=ctx.entity_id,
+                    granted_entity_scope_type=ctx.entity_scope_type,
+                    target_scope_id=ctx.target_scope_id,
+                    target_role_ids=[ctx.role_id],
+                    operations=[OperationType.READ, OperationType.UPDATE],
+                ),
+            )
+
+        async with database_connection.begin_session_read_committed() as db_sess:
+            perms = (await db_sess.scalars(sa.select(PermissionRow))).all()
+            assert len(perms) == 2
+            assert {perm.operation for perm in perms} == {
+                OperationType.READ,
+                OperationType.UPDATE,
+            }


### PR DESCRIPTION
## Summary
- `execute_rbac_granter` inserted permission rows via a plain ORM `add_all`/`flush` with no conflict handling, while the parallel ref-edge insert was already idempotent. Accepting a VFolder invitation for an entity the invitee's role could already access raised `UniqueViolationError` on `uq_permissions_role_scope_entity_op`, surfacing as HTTP 500.
- Insert permission rows with `ON CONFLICT DO NOTHING` so repeated grants are idempotent.
- Route the association inserts in `entity_creator` through the existing `bulk_insert_on_conflict_do_nothing` helper for consistency.

## Test plan
- [x] `pants test tests/unit/manager/repositories/base/rbac/test_granter.py`
- [ ] Manual: accept a VFolder invitation when the invitee's role already holds the permission — no 500.

Resolves BA-6461

🤖 Generated with [Claude Code](https://claude.com/claude-code)