### PR TITLE
fix(BA-6468): seed default port for custom runtime variant baseline

### DIFF
--- a/changes/12151.fix.md
+++ b/changes/12151.fix.md
@@ -1,0 +1,1 @@
+Fix custom runtime variant deployments failing with 'port: Field required' by seeding a default service port in the variant baseline

--- a/fixtures/manager/example-runtime-variants.json
+++ b/fixtures/manager/example-runtime-variants.json
@@ -144,6 +144,7 @@
           {
             "name": "custom-model",
             "service": {
+              "port": 8080,
               "health_check": {
                 "enable": false,
                 "path": "/health",

--- a/src/ai/backend/install/fixtures/example-runtime-variants.json
+++ b/src/ai/backend/install/fixtures/example-runtime-variants.json
@@ -144,6 +144,7 @@
           {
             "name": "custom-model",
             "service": {
+              "port": 8080,
               "health_check": {
                 "enable": false,
                 "path": "/health",

--- a/src/ai/backend/manager/models/alembic/versions/ed42bc179b91_set_custom_runtime_variant_default_definition.py
+++ b/src/ai/backend/manager/models/alembic/versions/ed42bc179b91_set_custom_runtime_variant_default_definition.py
@@ -36,6 +36,7 @@ _CUSTOM_DEFINITION: dict[str, Any] = {
         {
             "name": "custom-model",
             "service": {
+                "port": 8080,
                 "health_check": {
                     "enable": False,
                     "path": "/health",

--- a/src/ai/backend/manager/models/alembic/versions/f3a8c1d05e64_backfill_custom_variant_default_port.py
+++ b/src/ai/backend/manager/models/alembic/versions/f3a8c1d05e64_backfill_custom_variant_default_port.py
@@ -1,0 +1,55 @@
+"""backfill default service port for custom runtime variant
+
+Backfill the ``port`` that ``ed42bc179b91`` omitted from the ``custom``
+variant's seeded ``service`` block, for databases that already ran it.
+Idempotent: only touches a ``custom`` service block missing a ``port``.
+
+Revision ID: f3a8c1d05e64
+Revises: a3f1c7e2b9d4
+Create Date: 2026-06-12
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f3a8c1d05e64"
+down_revision = "a3f1c7e2b9d4"
+# Part of: 26.6.4
+branch_labels = None
+depends_on = None
+
+_DEFAULT_PORT = 8080
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    # Add models[0].service.port = 8080 only when the custom variant has a
+    # service block but no port yet. Idempotent: re-running is a no-op once
+    # the port is present.
+    bind.execute(
+        sa.text(
+            "UPDATE runtime_variants "
+            "SET default_model_definition = jsonb_set("
+            "default_model_definition, '{models,0,service,port}', to_jsonb(CAST(:port AS integer))) "
+            "WHERE name = 'custom' "
+            "AND default_model_definition #> '{models,0,service}' IS NOT NULL "
+            "AND default_model_definition #> '{models,0,service,port}' IS NULL"
+        ).bindparams(port=_DEFAULT_PORT)
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    # Remove the port only when it still equals the value this migration set,
+    # so a port supplied by other means is left untouched.
+    bind.execute(
+        sa.text(
+            "UPDATE runtime_variants "
+            "SET default_model_definition = "
+            "default_model_definition #- '{models,0,service,port}' "
+            "WHERE name = 'custom' "
+            "AND default_model_definition #> '{models,0,service,port}' = to_jsonb(CAST(:port AS integer))"
+        ).bindparams(port=_DEFAULT_PORT)
+    )


### PR DESCRIPTION
## Summary
- The `custom` runtime variant baseline (`default_model_definition`) seeded by migration `ed42bc179b91` injected a `service` block with a `health_check` but **no `port`**.
- `ModelServiceConfig.port` is a required field, so any custom deployment whose vfolder `model-definition.yaml` did not supply a port failed at `ModelDefinitionDraft.to_resolved()` with `port: Field required` (observed in the `deploy_vfolder_v2` flow).
- Seed `port: 8080` in both the migration seed and the fixture; it stays overridable by the vfolder's `model-definition.yaml`.

## Test plan
- [ ] Fresh install: custom variant baseline resolves with `port: 8080`
- [ ] Deploy a model vfolder (custom variant) whose `model-definition.yaml` omits `service.port` → succeeds instead of `port: Field required`
- [ ] Deploy with a `model-definition.yaml` that sets `service.port` → vfolder value still wins

> Note: environments that already applied `ed42bc179b91` need a one-off data patch (alembic will not re-run an applied revision):
> ```sql
> UPDATE runtime_variants
> SET default_model_definition = jsonb_set(default_model_definition, '{models,0,service,port}', '8080')
> WHERE name = 'custom' AND default_model_definition #> '{models,0,service,port}' IS NULL;
> ```

Resolves BA-6468

🤖 Generated with [Claude Code](https://claude.com/claude-code)