### PR TITLE
feat(BA-6464): enforce strict model_definition on revision preset create

### DIFF
--- a/changes/12152.feature.md
+++ b/changes/12152.feature.md
@@ -1,0 +1,1 @@
+Validate the model definition when creating a deployment revision preset, requiring a fully-populated definition (exactly one model with name, model path, service, port, and start command)

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -3426,9 +3426,9 @@ input CreateDeploymentRevisionPresetInput
   description: String = null
 
   """
-  Added in UNRELEASED. Parsed model definition specifying health checks, ports, and service configuration for the inference endpoint.
+  Added in UNRELEASED. Parsed model definition specifying health checks, ports, and service configuration for the inference endpoint. Optional, but when provided it must be fully populated with at least one model.
   """
-  modelDefinition: ModelDefinitionInput = null
+  modelDefinition: PresetModelDefinitionInput = null
 
   """
   Added in UNRELEASED. Resource slot allocations (e.g. cpu, mem, cuda.device).
@@ -12571,6 +12571,135 @@ type PresetExecutionSpec
 
   """Environment variables."""
   environ: [DeploymentRevisionPresetEnvironEntry!]!
+}
+
+"""
+Added in UNRELEASED. Strict configuration for a single model within a preset model definition.
+"""
+input PresetModelConfigInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Name of the model."""
+  name: String!
+
+  """Path to the model file."""
+  modelPath: String!
+
+  """Configuration for the model service."""
+  service: PresetModelServiceConfigInput!
+
+  """Metadata about the model."""
+  metadata: PresetModelMetadataInput = null
+}
+
+"""
+Added in UNRELEASED. Strict model definition for a preset. When provided on create it must be fully populated with at least one model.
+"""
+input PresetModelDefinitionInput
+  @join__type(graph: STRAWBERRY)
+{
+  """
+  List of models in the model definition. Must contain at least one model.
+  """
+  models: [PresetModelConfigInput!]!
+}
+
+"""
+Added in UNRELEASED. Strict health check configuration for a preset model service.
+"""
+input PresetModelHealthCheckInput
+  @join__type(graph: STRAWBERRY)
+{
+  """
+  Whether the route should be health-checked. When false the route activates immediately and the remaining fields are ignored.
+  """
+  enable: Boolean! = false
+
+  """Interval in seconds between health checks."""
+  interval: Float! = 10
+
+  """Path to check for health status."""
+  path: String! = "/health"
+
+  """Maximum number of retries for health check."""
+  maxRetries: Int! = 10
+
+  """Maximum time in seconds to wait for a health check response."""
+  maxWaitTime: Float! = 15
+
+  """Expected HTTP status code for a healthy response."""
+  expectedStatusCode: Int! = 200
+
+  """Initial delay in seconds before the first health check."""
+  initialDelay: Float! = 1800
+}
+
+"""Added in UNRELEASED. Strict metadata describing a preset model entry."""
+input PresetModelMetadataInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Author of the model."""
+  author: String = null
+
+  """Title of the model."""
+  title: String = null
+
+  """Version of the model."""
+  version: String = null
+
+  """Creation date of the model."""
+  created: String = null
+
+  """Last modified date of the model."""
+  lastModified: String = null
+
+  """Description of the model."""
+  description: String = null
+
+  """Task type of the model."""
+  task: String = null
+
+  """Category of the model."""
+  category: String = null
+
+  """Architecture of the model."""
+  architecture: String = null
+
+  """Frameworks used by the model."""
+  framework: [String!] = null
+
+  """Labels for the model."""
+  label: [String!] = null
+
+  """License of the model."""
+  license: String = null
+
+  """Minimum resource requirements for the model."""
+  minResource: JSON = null
+}
+
+"""
+Added in UNRELEASED. Strict service configuration for a preset model entry.
+"""
+input PresetModelServiceConfigInput
+  @join__type(graph: STRAWBERRY)
+{
+  """
+  Pre-start actions to execute before starting the model service. Provide an empty list when no pre-start actions are needed.
+  """
+  preStartActions: [PreStartActionInput!]!
+
+  """Command to start the model service."""
+  startCommand: [String!]!
+
+  """Shell configured for the model service."""
+  shell: String! = "/bin/bash"
+
+  """Port number for the model service. Must be greater than 1."""
+  port: Int!
+
+  """Health check configuration for the model service."""
+  healthCheck: PresetModelHealthCheckInput = null
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -2182,9 +2182,9 @@ input CreateDeploymentRevisionPresetInput {
   description: String = null
 
   """
-  Added in UNRELEASED. Parsed model definition specifying health checks, ports, and service configuration for the inference endpoint.
+  Added in UNRELEASED. Parsed model definition specifying health checks, ports, and service configuration for the inference endpoint. Optional, but when provided it must be fully populated with at least one model.
   """
-  modelDefinition: ModelDefinitionInput = null
+  modelDefinition: PresetModelDefinitionInput = null
 
   """
   Added in UNRELEASED. Resource slot allocations (e.g. cpu, mem, cuda.device).
@@ -8295,6 +8295,125 @@ type PresetExecutionSpec {
 
   """Environment variables."""
   environ: [DeploymentRevisionPresetEnvironEntry!]!
+}
+
+"""
+Added in UNRELEASED. Strict configuration for a single model within a preset model definition.
+"""
+input PresetModelConfigInput {
+  """Name of the model."""
+  name: String!
+
+  """Path to the model file."""
+  modelPath: String!
+
+  """Configuration for the model service."""
+  service: PresetModelServiceConfigInput!
+
+  """Metadata about the model."""
+  metadata: PresetModelMetadataInput = null
+}
+
+"""
+Added in UNRELEASED. Strict model definition for a preset. When provided on create it must be fully populated with at least one model.
+"""
+input PresetModelDefinitionInput {
+  """
+  List of models in the model definition. Must contain at least one model.
+  """
+  models: [PresetModelConfigInput!]!
+}
+
+"""
+Added in UNRELEASED. Strict health check configuration for a preset model service.
+"""
+input PresetModelHealthCheckInput {
+  """
+  Whether the route should be health-checked. When false the route activates immediately and the remaining fields are ignored.
+  """
+  enable: Boolean! = false
+
+  """Interval in seconds between health checks."""
+  interval: Float! = 10
+
+  """Path to check for health status."""
+  path: String! = "/health"
+
+  """Maximum number of retries for health check."""
+  maxRetries: Int! = 10
+
+  """Maximum time in seconds to wait for a health check response."""
+  maxWaitTime: Float! = 15
+
+  """Expected HTTP status code for a healthy response."""
+  expectedStatusCode: Int! = 200
+
+  """Initial delay in seconds before the first health check."""
+  initialDelay: Float! = 1800
+}
+
+"""Added in UNRELEASED. Strict metadata describing a preset model entry."""
+input PresetModelMetadataInput {
+  """Author of the model."""
+  author: String = null
+
+  """Title of the model."""
+  title: String = null
+
+  """Version of the model."""
+  version: String = null
+
+  """Creation date of the model."""
+  created: String = null
+
+  """Last modified date of the model."""
+  lastModified: String = null
+
+  """Description of the model."""
+  description: String = null
+
+  """Task type of the model."""
+  task: String = null
+
+  """Category of the model."""
+  category: String = null
+
+  """Architecture of the model."""
+  architecture: String = null
+
+  """Frameworks used by the model."""
+  framework: [String!] = null
+
+  """Labels for the model."""
+  label: [String!] = null
+
+  """License of the model."""
+  license: String = null
+
+  """Minimum resource requirements for the model."""
+  minResource: JSON = null
+}
+
+"""
+Added in UNRELEASED. Strict service configuration for a preset model entry.
+"""
+input PresetModelServiceConfigInput {
+  """
+  Pre-start actions to execute before starting the model service. Provide an empty list when no pre-start actions are needed.
+  """
+  preStartActions: [PreStartActionInput!]!
+
+  """Command to start the model service."""
+  startCommand: [String!]!
+
+  """Shell configured for the model service."""
+  shell: String! = "/bin/bash"
+
+  """Port number for the model service. Must be greater than 1."""
+  port: Int!
+
+  """Health check configuration for the model service."""
+  healthCheck: PresetModelHealthCheckInput = null
 }
 
 """

--- a/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from typing import Any
 from uuid import UUID
 
 from pydantic import Field
 
 from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
-from ai.backend.common.config import ModelDefinition
+from ai.backend.common.config import DEFAULT_SHELL, ModelDefinition, PreStartAction
 from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
 from ai.backend.common.dto.manager.v2.common import (
     EnvironmentVariableEntryInput,
@@ -26,6 +27,78 @@ class PresetValueInput(BaseRequestModel):
     value: str = Field(description="Value for this preset.")
 
 
+class PresetModelHealthCheckInput(BaseRequestModel):
+    enable: bool = Field(
+        default=False,
+        description="Whether the route is health-checked. When false the route activates "
+        "immediately and the remaining fields are ignored.",
+    )
+    interval: float = Field(default=10.0, description="Interval in seconds between health checks.")
+    path: str = Field(default="/health", description="Path to check for health status.")
+    max_retries: int = Field(default=10, description="Maximum number of retries for health check.")
+    max_wait_time: float = Field(
+        default=15.0, description="Maximum time in seconds to wait for a health check response."
+    )
+    expected_status_code: int = Field(
+        default=200, gt=100, description="Expected HTTP status code for a healthy response."
+    )
+    initial_delay: float = Field(
+        default=1800.0, ge=0, description="Initial delay in seconds before the first health check."
+    )
+
+
+class PresetModelMetadataInput(BaseRequestModel):
+    author: str | None = Field(default=None, description="Author of the model.")
+    title: str | None = Field(default=None, description="Title of the model.")
+    version: str | None = Field(default=None, description="Version of the model.")
+    created: str | None = Field(default=None, description="Creation date of the model.")
+    last_modified: str | None = Field(default=None, description="Last modified date of the model.")
+    description: str | None = Field(default=None, description="Description of the model.")
+    task: str | None = Field(default=None, description="Task type of the model.")
+    category: str | None = Field(default=None, description="Category of the model.")
+    architecture: str | None = Field(default=None, description="Architecture of the model.")
+    framework: list[str] | None = Field(default=None, description="Frameworks used by the model.")
+    label: list[str] | None = Field(default=None, description="Labels for the model.")
+    license: str | None = Field(default=None, description="License of the model.")
+    min_resource: dict[str, Any] | None = Field(
+        default=None, description="Minimum resource requirements for the model."
+    )
+
+
+class PresetModelServiceConfigInput(BaseRequestModel):
+    pre_start_actions: list[PreStartAction] = Field(
+        default_factory=list,
+        description="Pre-start actions to execute before starting the model service. May be empty.",
+    )
+    start_command: list[str] = Field(description="Command to start the model service.")
+    shell: str = Field(default=DEFAULT_SHELL, description="Shell configured for the model service.")
+    port: int = Field(
+        gt=1, description="Port number for the model service. Must be greater than 1."
+    )
+    health_check: PresetModelHealthCheckInput | None = Field(
+        default=None, description="Health check configuration for the model service."
+    )
+
+
+class PresetModelConfigInput(BaseRequestModel):
+    name: str = Field(min_length=1, description="Name of the model.")
+    model_path: str = Field(min_length=1, description="Path to the model file.")
+    service: PresetModelServiceConfigInput = Field(
+        description="Configuration for the model service."
+    )
+    metadata: PresetModelMetadataInput | None = Field(
+        default=None, description="Metadata about the model."
+    )
+
+
+class PresetModelDefinitionInput(BaseRequestModel):
+    models: list[PresetModelConfigInput] = Field(
+        min_length=1,
+        max_length=1,
+        description="List of models in the model definition. Exactly one model is supported.",
+    )
+
+
 class CreateDeploymentRevisionPresetInput(BaseRequestModel):
     runtime_variant_id: RuntimeVariantID = Field(
         description="ID of the runtime variant this preset belongs to."
@@ -33,8 +106,10 @@ class CreateDeploymentRevisionPresetInput(BaseRequestModel):
     name: str = Field(min_length=1, max_length=256, description="Preset name.")
     description: str | None = Field(default=None, description="Description.")
     image_id: ImageID = Field(description="Container image UUID.")
-    model_definition: ModelDefinition | None = Field(
-        default=None, description="Model definition configuration."
+    model_definition: PresetModelDefinitionInput | None = Field(
+        default=None,
+        description="Model definition configuration. Optional, but when provided it must be "
+        "fully populated (non-empty models, each with name/model_path/service).",
     )
     resource_slots: list[ResourceSlotEntryInput] | None = Field(
         default=None, description="Resource slot allocations."

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -252,7 +252,11 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
         resource_opts = self._convert_resource_opts_input(input.resource_opts)
         environ = self._convert_environ_input(input.environ)
         preset_values = self._convert_preset_values_input(input.preset_values)
-        model_def = input.model_definition
+        model_def = (
+            ModelDefinition.model_validate(input.model_definition.model_dump())
+            if input.model_definition is not None
+            else None
+        )
         strategy, strategy_spec = self._convert_required_strategy_input(input.deployment_strategy)
 
         spec = DeploymentRevisionPresetCreatorSpec(

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -12,6 +12,7 @@ from strawberry import UNSET, Info
 from strawberry.relay import Connection, Edge, NodeID
 from strawberry.scalars import JSON
 
+from ai.backend.common.config import DEFAULT_SHELL
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.dto.manager.v2.deployment.request import (
     DeploymentStrategyInput as DeploymentStrategyInputDTO,
@@ -24,6 +25,21 @@ from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import 
 )
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
     DeploymentRevisionPresetOrder as OrderDTO,
+)
+from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
+    PresetModelConfigInput as PresetModelConfigInputDTO,
+)
+from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
+    PresetModelDefinitionInput as PresetModelDefinitionInputDTO,
+)
+from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
+    PresetModelHealthCheckInput as PresetModelHealthCheckInputDTO,
+)
+from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
+    PresetModelMetadataInput as PresetModelMetadataInputDTO,
+)
+from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
+    PresetModelServiceConfigInput as PresetModelServiceConfigInputDTO,
 )
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
     PresetValueInput as PresetValueInputDTO,
@@ -96,6 +112,7 @@ from ai.backend.manager.api.gql.deployment.types.resource_slot import (
 from ai.backend.manager.api.gql.deployment.types.revision import (
     ModelDefinitionGQL,
     ModelDefinitionInputGQL,
+    PreStartActionInputGQL,
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
@@ -434,6 +451,124 @@ class PresetDeploymentStrategyInputGQL(PydanticInputMixin[DeploymentStrategyInpu
 
 @gql_pydantic_input(
     BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Strict health check configuration for a preset model service.",
+    ),
+    name="PresetModelHealthCheckInput",
+)
+class PresetModelHealthCheckInputGQL(PydanticInputMixin[PresetModelHealthCheckInputDTO]):
+    enable: bool = gql_field(
+        description=(
+            "Whether the route should be health-checked. When false the route activates "
+            "immediately and the remaining fields are ignored."
+        ),
+        default=False,
+    )
+    interval: float = gql_field(
+        description="Interval in seconds between health checks.", default=10.0
+    )
+    path: str = gql_field(description="Path to check for health status.", default="/health")
+    max_retries: int = gql_field(
+        description="Maximum number of retries for health check.", default=10
+    )
+    max_wait_time: float = gql_field(
+        description="Maximum time in seconds to wait for a health check response.", default=15.0
+    )
+    expected_status_code: int = gql_field(
+        description="Expected HTTP status code for a healthy response.", default=200
+    )
+    initial_delay: float = gql_field(
+        description="Initial delay in seconds before the first health check.", default=1800.0
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Strict metadata describing a preset model entry.",
+    ),
+    name="PresetModelMetadataInput",
+)
+class PresetModelMetadataInputGQL(PydanticInputMixin[PresetModelMetadataInputDTO]):
+    author: str | None = gql_field(description="Author of the model.", default=None)
+    title: str | None = gql_field(description="Title of the model.", default=None)
+    version: str | None = gql_field(description="Version of the model.", default=None)
+    created: str | None = gql_field(description="Creation date of the model.", default=None)
+    last_modified: str | None = gql_field(
+        description="Last modified date of the model.", default=None
+    )
+    description: str | None = gql_field(description="Description of the model.", default=None)
+    task: str | None = gql_field(description="Task type of the model.", default=None)
+    category: str | None = gql_field(description="Category of the model.", default=None)
+    architecture: str | None = gql_field(description="Architecture of the model.", default=None)
+    framework: list[str] | None = gql_field(
+        description="Frameworks used by the model.", default=None
+    )
+    label: list[str] | None = gql_field(description="Labels for the model.", default=None)
+    license: str | None = gql_field(description="License of the model.", default=None)
+    min_resource: JSON | None = gql_field(
+        description="Minimum resource requirements for the model.", default=None
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Strict service configuration for a preset model entry.",
+    ),
+    name="PresetModelServiceConfigInput",
+)
+class PresetModelServiceConfigInputGQL(PydanticInputMixin[PresetModelServiceConfigInputDTO]):
+    pre_start_actions: list[PreStartActionInputGQL] = gql_field(
+        description="Pre-start actions to execute before starting the model service. "
+        "Provide an empty list when no pre-start actions are needed.",
+    )
+    start_command: list[str] = gql_field(description="Command to start the model service.")
+    shell: str = gql_field(
+        description="Shell configured for the model service.", default=DEFAULT_SHELL
+    )
+    port: int = gql_field(
+        description="Port number for the model service. Must be greater than 1.",
+    )
+    health_check: PresetModelHealthCheckInputGQL | None = gql_field(
+        description="Health check configuration for the model service.", default=None
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Strict configuration for a single model within a preset model definition.",
+    ),
+    name="PresetModelConfigInput",
+)
+class PresetModelConfigInputGQL(PydanticInputMixin[PresetModelConfigInputDTO]):
+    name: str = gql_field(description="Name of the model.")
+    model_path: str = gql_field(description="Path to the model file.")
+    service: PresetModelServiceConfigInputGQL = gql_field(
+        description="Configuration for the model service.",
+    )
+    metadata: PresetModelMetadataInputGQL | None = gql_field(
+        description="Metadata about the model.", default=None
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Strict model definition for a preset. When provided on create it must be "
+        "fully populated with at least one model.",
+    ),
+    name="PresetModelDefinitionInput",
+)
+class PresetModelDefinitionInputGQL(PydanticInputMixin[PresetModelDefinitionInputDTO]):
+    models: list[PresetModelConfigInputGQL] = gql_field(
+        description="List of models in the model definition. Must contain at least one model.",
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
         added_version="26.4.2",
         description="Create deployment revision preset input.",
     ),
@@ -469,10 +604,12 @@ class CreateDeploymentRevisionPresetInputGQL(PydanticInputMixin[CreateInputDTO])
         ),
         default=None,
     )
-    model_definition: ModelDefinitionInputGQL | None = gql_added_field(
+    model_definition: PresetModelDefinitionInputGQL | None = gql_added_field(
         BackendAIGQLMeta(
             added_version=NEXT_RELEASE_VERSION,
-            description="Parsed model definition specifying health checks, ports, and service configuration for the inference endpoint.",
+            description="Parsed model definition specifying health checks, ports, and service "
+            "configuration for the inference endpoint. Optional, but when provided it must be "
+            "fully populated with at least one model.",
         ),
         default=None,
     )

--- a/tests/component/deployment_revision_preset/test_deployment_revision_preset_crud.py
+++ b/tests/component/deployment_revision_preset/test_deployment_revision_preset_crud.py
@@ -16,11 +16,11 @@ from collections.abc import AsyncIterator
 
 import pytest
 import sqlalchemy as sa
+from pydantic import ValidationError
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.client.exceptions import BackendAPIError
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
-from ai.backend.common.config import ModelConfig, ModelDefinition
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.dto.manager.query import UUIDFilter
 from ai.backend.common.dto.manager.v2.common import ResourceSlotEntryInput
@@ -28,6 +28,9 @@ from ai.backend.common.dto.manager.v2.deployment.request import DeploymentStrate
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
     CreateDeploymentRevisionPresetInput,
     DeploymentRevisionPresetFilter,
+    PresetModelConfigInput,
+    PresetModelDefinitionInput,
+    PresetModelServiceConfigInput,
     SearchDeploymentRevisionPresetsInput,
     UpdateDeploymentRevisionPresetInput,
 )
@@ -106,8 +109,17 @@ class TestDeploymentRevisionPresetCRUD:
         runtime_variant_id: RuntimeVariantID,
     ) -> None:
         image_id = ImageID(uuid.uuid4())
-        model_definition = ModelDefinition(
-            models=[ModelConfig(name="llama", model_path="/models/llama")],
+        model_definition = PresetModelDefinitionInput(
+            models=[
+                PresetModelConfigInput(
+                    name="llama",
+                    model_path="/models/llama",
+                    service=PresetModelServiceConfigInput(
+                        port=8080,
+                        start_command=["python", "server.py"],
+                    ),
+                ),
+            ],
         )
         create_result = await admin_v2_registry.deployment_revision_preset.create(
             CreateDeploymentRevisionPresetInput(
@@ -144,6 +156,25 @@ class TestDeploymentRevisionPresetCRUD:
         assert preset.model_definition.models[0].model_path == "/models/llama"
 
         await admin_v2_registry.deployment_revision_preset.delete(preset_id)
+
+    async def test_create_with_empty_model_definition_models_rejected(
+        self,
+        runtime_variant_id: RuntimeVariantID,
+    ) -> None:
+        # An empty models list is rejected at the strict request-DTO boundary
+        # (CREATE only) before any request is sent.
+        with pytest.raises(ValidationError):
+            CreateDeploymentRevisionPresetInput(
+                runtime_variant_id=runtime_variant_id,
+                name="md-empty-preset",
+                image_id=ImageID(uuid.uuid4()),
+                model_definition=PresetModelDefinitionInput(models=[]),
+                resource_slots=[ResourceSlotEntryInput(resource_type="cpu", quantity="1")],
+                cluster_mode="single-node",
+                cluster_size=1,
+                replica_count=1,
+                deployment_strategy=DeploymentStrategyInput(type=DeploymentStrategy.ROLLING),
+            )
 
     async def test_update(
         self,

--- a/tests/unit/manager/api/gql/deployment/test_revision_preset_types.py
+++ b/tests/unit/manager/api/gql/deployment/test_revision_preset_types.py
@@ -2,11 +2,25 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime
+from typing import Any
 
-from ai.backend.common.config import ModelConfig, ModelDefinition
+import pytest
+from pydantic import ValidationError
+
+from ai.backend.common.config import DEFAULT_SHELL, ModelConfig, ModelDefinition
+from ai.backend.common.data.model_deployment.types import DeploymentStrategy
+from ai.backend.common.dto.manager.v2.deployment.request import DeploymentStrategyInput
 from ai.backend.common.dto.manager.v2.deployment.types import (
     ModelConfigInfoDTO,
     ModelDefinitionInfoDTO,
+    ModelServiceConfigInfoDTO,
+)
+from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
+    CreateDeploymentRevisionPresetInput,
+    PresetModelConfigInput,
+    PresetModelDefinitionInput,
+    PresetModelHealthCheckInput,
+    PresetModelServiceConfigInput,
 )
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.response import (
     DeploymentRevisionPresetNode,
@@ -22,6 +36,10 @@ from ai.backend.manager.api.adapters.deployment_revision_preset.adapter import (
 )
 from ai.backend.manager.api.gql.deployment.types.revision_preset import (
     DeploymentRevisionPresetGQL,
+    PresetModelConfigInputGQL,
+    PresetModelDefinitionInputGQL,
+    PresetModelHealthCheckInputGQL,
+    PresetModelServiceConfigInputGQL,
 )
 
 
@@ -53,46 +71,195 @@ def _make_preset_node(
     )
 
 
-def test_deployment_revision_preset_gql_from_pydantic() -> None:
-    image_id = ImageID(uuid.uuid4())
-    model_def = ModelDefinitionInfoDTO(
-        models=[
-            ModelConfigInfoDTO(
-                name="llama",
-                model_path="/models/llama",
-                service=None,
-                metadata=None,
+class TestDeploymentRevisionPresetGQL:
+    """Tests for ``DeploymentRevisionPresetGQL.from_pydantic`` output conversion."""
+
+    def test_from_pydantic_populates_execution_and_model_definition(self) -> None:
+        image_id = ImageID(uuid.uuid4())
+        model_def = ModelDefinitionInfoDTO(
+            models=[
+                ModelConfigInfoDTO(
+                    name="llama",
+                    model_path="/models/llama",
+                    service=ModelServiceConfigInfoDTO(port=8080),
+                    metadata=None,
+                ),
+            ],
+        )
+
+        populated = DeploymentRevisionPresetGQL.from_pydantic(
+            _make_preset_node(image_id=image_id, model_definition=model_def),
+        )
+
+        assert populated.execution.image_id == uuid.UUID(str(image_id))
+        assert populated.execution.startup_command == "serve"
+        assert populated.execution.bootstrap_script == "setup.sh"
+        assert populated.model_definition is not None
+        assert len(populated.model_definition.models) == 1
+        assert populated.model_definition.models[0].name == "llama"
+        assert populated.model_definition.models[0].model_path == "/models/llama"
+
+    def test_from_pydantic_handles_empty_execution_and_model_definition(self) -> None:
+        empty = DeploymentRevisionPresetGQL.from_pydantic(_make_preset_node())
+
+        assert empty.execution.image_id is None
+        assert empty.model_definition is None
+
+
+class TestModelDefinitionToDTO:
+    """Tests for the adapter helper ``_model_definition_to_dto``."""
+
+    def test_converts_config_to_info_dto(self) -> None:
+        config_model_def = ModelDefinition(
+            models=[ModelConfig(name="llama", model_path="/models/llama")],
+        )
+
+        info_dto = _model_definition_to_dto(config_model_def)
+
+        assert info_dto is not None
+        assert len(info_dto.models) == 1
+        assert info_dto.models[0].name == "llama"
+        assert info_dto.models[0].model_path == "/models/llama"
+
+    def test_returns_none_for_none(self) -> None:
+        assert _model_definition_to_dto(None) is None
+
+
+class TestPresetModelDefinitionInputGQL:
+    """Tests for the strict CREATE-only model_definition GQL input → request DTO conversion."""
+
+    def test_to_pydantic_produces_strict_request_dto(self) -> None:
+        gql_input = PresetModelDefinitionInputGQL(
+            models=[
+                PresetModelConfigInputGQL(
+                    name="llama",
+                    model_path="/models/llama",
+                    service=PresetModelServiceConfigInputGQL(
+                        port=8080,
+                        start_command=["python", "server.py"],
+                    ),
+                ),
+            ],
+        )
+
+        dto = gql_input.to_pydantic()
+
+        assert isinstance(dto, PresetModelDefinitionInput)
+        assert len(dto.models) == 1
+        config = dto.models[0]
+        assert isinstance(config, PresetModelConfigInput)
+        assert config.name == "llama"
+        assert config.model_path == "/models/llama"
+        assert isinstance(config.service, PresetModelServiceConfigInput)
+        assert config.service.port == 8080
+        assert config.service.start_command == ["python", "server.py"]
+        # request-DTO defaults mirror the strict config defaults
+        assert config.service.shell == DEFAULT_SHELL
+        assert config.service.pre_start_actions == []
+        assert config.service.health_check is None
+        assert config.metadata is None
+
+    def test_service_config_carries_health_check_defaults(self) -> None:
+        with_hc = PresetModelServiceConfigInputGQL(
+            port=9000,
+            start_command=["python", "server.py"],
+            health_check=PresetModelHealthCheckInputGQL(enable=True),
+        ).to_pydantic()
+
+        assert isinstance(with_hc.health_check, PresetModelHealthCheckInput)
+        assert with_hc.health_check.enable is True
+        # omitted health-check fields fall back to the request-DTO defaults
+        assert with_hc.health_check.interval == 10.0
+        assert with_hc.health_check.path == "/health"
+        assert with_hc.health_check.initial_delay == 1800.0
+
+
+class TestPresetModelDefinitionInput:
+    """Tests for the strict request DTO's field-level enforcement."""
+
+    def test_rejects_empty_models(self) -> None:
+        with pytest.raises(ValidationError):
+            PresetModelDefinitionInput(models=[])
+
+    def test_rejects_multiple_models(self) -> None:
+        # Exactly one model is supported (max_length=1).
+        config = PresetModelConfigInput(
+            name="llama",
+            model_path="/models/llama",
+            service=PresetModelServiceConfigInput(port=8080, start_command=["python", "s.py"]),
+        )
+        with pytest.raises(ValidationError):
+            PresetModelDefinitionInput(models=[config, config])
+
+    def test_rejects_model_without_service(self) -> None:
+        # ``service`` is a required field; omitting it must be rejected.
+        payload: dict[str, Any] = {"name": "llama", "model_path": "/models/llama"}
+        with pytest.raises(ValidationError):
+            PresetModelConfigInput(**payload)
+
+    def test_rejects_service_without_start_command(self) -> None:
+        # ``start_command`` is a required field; omitting it must be rejected.
+        payload: dict[str, Any] = {"port": 8080}
+        with pytest.raises(ValidationError):
+            PresetModelServiceConfigInput(**payload)
+
+    def test_accepts_fully_populated(self) -> None:
+        dto = PresetModelDefinitionInput(
+            models=[
+                PresetModelConfigInput(
+                    name="llama",
+                    model_path="/models/llama",
+                    service=PresetModelServiceConfigInput(
+                        port=8080,
+                        start_command=["python", "server.py"],
+                    ),
+                ),
+            ],
+        )
+
+        assert len(dto.models) == 1
+        assert dto.models[0].service.port == 8080
+
+
+class TestCreateDeploymentRevisionPresetInput:
+    """Tests for the CREATE input's optional model_definition handling."""
+
+    def test_accepts_populated_model_definition(self) -> None:
+        dto = CreateDeploymentRevisionPresetInput(
+            runtime_variant_id=RuntimeVariantID(uuid.uuid4()),
+            name="populated-models",
+            image_id=ImageID(uuid.uuid4()),
+            model_definition=PresetModelDefinitionInput(
+                models=[
+                    PresetModelConfigInput(
+                        name="llama",
+                        model_path="/models/llama",
+                        service=PresetModelServiceConfigInput(
+                            port=8080,
+                            start_command=["python", "server.py"],
+                        ),
+                    ),
+                ],
             ),
-        ],
-    )
+            cluster_mode="single-node",
+            cluster_size=1,
+            replica_count=1,
+            deployment_strategy=DeploymentStrategyInput(type=DeploymentStrategy.ROLLING),
+        )
 
-    populated = DeploymentRevisionPresetGQL.from_pydantic(
-        _make_preset_node(image_id=image_id, model_definition=model_def),
-    )
+        assert dto.model_definition is not None
+        assert len(dto.model_definition.models) == 1
 
-    assert populated.execution.image_id == uuid.UUID(str(image_id))
-    assert populated.execution.startup_command == "serve"
-    assert populated.execution.bootstrap_script == "setup.sh"
-    assert populated.model_definition is not None
-    assert len(populated.model_definition.models) == 1
-    assert populated.model_definition.models[0].name == "llama"
-    assert populated.model_definition.models[0].model_path == "/models/llama"
+    def test_allows_null_model_definition(self) -> None:
+        dto = CreateDeploymentRevisionPresetInput(
+            runtime_variant_id=RuntimeVariantID(uuid.uuid4()),
+            name="no-models",
+            image_id=ImageID(uuid.uuid4()),
+            model_definition=None,
+            cluster_mode="single-node",
+            cluster_size=1,
+            replica_count=1,
+            deployment_strategy=DeploymentStrategyInput(type=DeploymentStrategy.ROLLING),
+        )
 
-    empty = DeploymentRevisionPresetGQL.from_pydantic(_make_preset_node())
-
-    assert empty.execution.image_id is None
-    assert empty.model_definition is None
-
-
-def test_model_definition_to_dto_converts_config_to_info_dto() -> None:
-    config_model_def = ModelDefinition(
-        models=[ModelConfig(name="llama", model_path="/models/llama")],
-    )
-
-    info_dto = _model_definition_to_dto(config_model_def)
-
-    assert info_dto is not None
-    assert len(info_dto.models) == 1
-    assert info_dto.models[0].name == "llama"
-    assert info_dto.models[0].model_path == "/models/llama"
-    assert _model_definition_to_dto(None) is None
+        assert dto.model_definition is None


### PR DESCRIPTION
## Summary
- Introduce dedicated **strict** GQL input + request DTO types (`Preset*Input`) for the deployment revision preset **create** `model_definition`, instead of reusing the shared partial revision `ModelDefinitionInput` (draft/merge) type.
- When `model_definition` is provided on create it must be **fully populated**: exactly one model, each requiring `name`/`model_path`/`service`, with `service.port` (>1) and `start_command` required. Enforced at the request-DTO boundary (field-level + `min_length`/`max_length`), so REST/SDK and GraphQL reject partial input uniformly.
- The adapter converts the request DTO into the domain `ModelDefinition` (`model_dump()` → `ModelDefinition.model_validate(...)`), keeping the DTO free of domain-type internals.
- **Update** is intentionally unchanged — it keeps the partial/optional override (`ModelDefinitionInput`) semantics.

## Notes
- `health_check` sub-fields currently keep concrete defaults (incl. `initial_delay=1800.0`); the enable/disable required-vs-nullable handling is deferred for discussion on this PR.

## Test plan
- [x] `pants lint check` clean (mypy: no issues)
- [x] Unit tests pass (`tests/unit/.../test_revision_preset_types.py`)
- [x] Component CRUD tests pass against local stack (ran on pre-push)
- [x] GraphQL v2 schema composes (`./backend.ai mgr api dump-gql-schema --v2`)
- [ ] CI green

Resolves BA-6464

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12152.org.readthedocs.build/en/12152/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12152.org.readthedocs.build/ko/12152/

<!-- readthedocs-preview sorna-ko end -->