### PR TITLE
fix: increase utilization metric collection interval to 30s

### DIFF
--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -995,4 +995,4 @@ class StatContext:
             key_value_map[str(cid)] = serialized_metrics
 
         if key_value_map:
-            await self.agent.valkey_stat_client.set_multiple_keys(key_value_map, expire_sec=8)
+            await self.agent.valkey_stat_client.set_multiple_keys(key_value_map, expire_sec=120)

--- a/src/ai/backend/common/metrics/types.py
+++ b/src/ai/backend/common/metrics/types.py
@@ -2,7 +2,7 @@ from typing import Final
 
 UNDEFINED: Final[str] = "undefined"
 
-UTILIZATION_METRIC_INTERVAL: Final[float] = 5.0
+UTILIZATION_METRIC_INTERVAL: Final[float] = 30.0
 UTILIZATION_METRIC_DETENTION: Final[float] = 600.0  # 10 minutes
 
 CONTAINER_UTILIZATION_METRIC_LABEL_NAME: Final[str] = "container_metric_name"


### PR DESCRIPTION
> **Note:** Monkeypatch for sharing — not intended to be merged. No JIRA issue.

## Background

The stat collection timers all use aiotools' `TimerDelayPolicy.CANCEL` with `UTILIZATION_METRIC_INTERVAL` (5s):

- `collect_container_stat` / `collect_process_stat` — `agent.py:1044-1057`
- `_collect_node_stat` — `runtime.py:166-170`

With `CANCEL`, when a collection pass takes longer than the interval, the next tick **cancels the in-flight task before it reports to Redis**, so metrics are silently dropped. `collect_*` is wrapped in `STAT_COLLECTION_TIMEOUT = 10min`, so a slow pass never self-terminates fast enough — it just keeps getting cancelled every 5s.

Node stat is the most exposed: unlike container stat (which caps each plugin at `_PLUGIN_TIMEOUT = max(INTERVAL-1, 1)`), `collect_node_stat` has neither a per-plugin nor an overall timeout, so any single slow plugin cancels the whole pass.

## Changes

- `UTILIZATION_METRIC_INTERVAL`: `5.0 → 30.0` (`common/metrics/types.py`) — 6× more room for a pass to finish before the next tick. Applies to all three timers (shared constant).
- Process-metric Redis expiry: `expire_sec=8 → 120` (`agent/stats.py:998`) — fixed 2-minute TTL so values survive one or two missed collections at the longer interval.

Auto-follows the constant, no edit needed: `_PLUGIN_TIMEOUT` (4s→29s), manager PromQL `/ UTILIZATION_METRIC_INTERVAL` rate divisor.

Left as-is: node `cache_lifespan=120`, kernel/container default 24h TTL (ample margin).

## Notes / follow-up

Out of scope here, but `collect_node_stat` has no plugin/overall timeout — even at 30s, a plugin slower than 30s will still be cancelled. Worth a separate fix to add a per-plugin timeout like container stat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)