### PR TITLE
fix(BA-6473): serve agent metrics from process-local registry to allow series removal

### DIFF
--- a/changes/12160.fix.md
+++ b/changes/12160.fix.md
@@ -1,0 +1,1 @@
+Fix terminated kernels' utilization metric series remaining in the agent's Prometheus `/metrics` output forever, which inflated capacity/usage values in dashboards summing per-kernel metrics across replaced deployment replicas.

--- a/src/ai/backend/agent/cli/start_server.py
+++ b/src/ai/backend/agent/cli/start_server.py
@@ -47,12 +47,12 @@ def main(
 
     This is a thin wrapper that defers the heavy import of server module.
     """
-    from ai.backend.common.metrics.multiprocess_setup import setup_prometheus_multiprocess_dir
-    from ai.backend.logging import LogLevel
-
-    setup_prometheus_multiprocess_dir("agent")
-
+    # Do NOT set up the prometheus multiprocess dir here: the agent runs a
+    # single worker, and multiprocess mode stores gauge samples in per-process
+    # mmap files where individual series cannot be removed — terminated
+    # kernels' utilization metrics would be exported forever.
     from ai.backend.agent.server import main as server_main
+    from ai.backend.logging import LogLevel
 
     ctx.invoke(
         server_main,

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -39,6 +39,7 @@ import aiotools
 import click
 import tomlkit
 from aiohttp import web
+from aiohttp.typedefs import Handler
 from aiotools import aclosing
 from callosum.lower.zeromq import ZeroMQAddress, ZeroMQRPCTransport
 from callosum.ordering import ExitOrderedAsyncScheduler
@@ -98,10 +99,8 @@ from ai.backend.common.health_checker.types import ComponentId
 from ai.backend.common.json import pretty_json
 from ai.backend.common.metrics.http import (
     build_api_metric_middleware,
-    build_prometheus_metrics_handler,
 )
 from ai.backend.common.metrics.metric import CommonMetricRegistry
-from ai.backend.common.metrics.multiprocess_setup import cleanup_prometheus_multiprocess_dir
 from ai.backend.common.metrics.profiler import Profiler, PyroscopeArgs
 from ai.backend.common.service_discovery.etcd_discovery.service_discovery import (
     ETCDServiceDiscovery,
@@ -1362,6 +1361,24 @@ async def check_readyz(request: web.Request) -> web.Response:
     return _build_agent_probe_response(connectivity)
 
 
+def build_singleprocess_prometheus_metrics_handler(
+    metric_registry: CommonMetricRegistry,
+) -> Handler:
+    async def prometheus_metrics_handler(_request: web.Request) -> web.Response:
+        """
+        Returns the Prometheus metrics from the process-local registry.
+
+        The agent runs a single worker and must NOT use the multiprocess
+        exposition: gauge series stored in multiprocess mmap files cannot be
+        removed individually, so terminated kernels' utilization metrics
+        would be exported forever.
+        """
+        metrics = metric_registry.to_prometheus_singleprocess()
+        return web.Response(text=metrics, content_type="text/plain")
+
+    return prometheus_metrics_handler
+
+
 def build_root_server() -> web.Application:
     metric_registry = CommonMetricRegistry.instance()
     app = web.Application(
@@ -1381,7 +1398,9 @@ def build_root_server() -> web.Application:
     cors.add(app.router.add_route("GET", r"/livez", check_livez))
     cors.add(app.router.add_route("GET", r"/readyz", check_readyz))
     cors.add(
-        app.router.add_route("GET", r"/metrics", build_prometheus_metrics_handler(metric_registry))
+        app.router.add_route(
+            "GET", r"/metrics", build_singleprocess_prometheus_metrics_handler(metric_registry)
+        )
     )
     return app
 
@@ -1793,16 +1812,13 @@ def main(
                         log.info("Using uvloop as the event loop backend")
                     case EventLoopType.ASYNCIO:
                         runner = asyncio.run
-                try:
-                    aiotools.start_server(
-                        server_main_logwrapper,
-                        num_workers=1,
-                        args=(server_config, log_endpoint),
-                        wait_timeout=5.0,
-                        runner=runner,
-                    )
-                finally:
-                    cleanup_prometheus_multiprocess_dir()
+                aiotools.start_server(
+                    server_main_logwrapper,
+                    num_workers=1,
+                    args=(server_config, log_endpoint),
+                    wait_timeout=5.0,
+                    runner=runner,
+                )
                 log.info("exit.")
         finally:
             if server_config.agent_common.pid_file.is_file():

--- a/src/ai/backend/common/metrics/metric.py
+++ b/src/ai/backend/common/metrics/metric.py
@@ -7,7 +7,10 @@ import psutil
 
 from ai.backend.common.data.permission.types import EntityType
 from ai.backend.common.exception import BackendAIError, ErrorCode
-from ai.backend.common.metrics.multiprocess import generate_latest_multiprocess
+from ai.backend.common.metrics.multiprocess import (
+    generate_latest_multiprocess,
+    generate_latest_singleprocess,
+)
 from ai.backend.common.metrics.safe import (
     SafeCounter as Counter,
 )
@@ -764,6 +767,15 @@ class CommonMetricRegistry:
     def to_prometheus(self) -> str:
         self.system.observe()
         return generate_latest_multiprocess().decode("utf-8")
+
+    def to_prometheus_singleprocess(self) -> str:
+        """
+        For single-worker components that do not set up the prometheus
+        multiprocess dir (e.g., the agent, which needs per-series removal
+        that multiprocess mmap storage cannot provide).
+        """
+        self.system.observe()
+        return generate_latest_singleprocess().decode("utf-8")
 
 
 class StageObserver:

--- a/tests/unit/agent/test_utilization_metric_observer.py
+++ b/tests/unit/agent/test_utilization_metric_observer.py
@@ -1,0 +1,79 @@
+import asyncio
+import uuid
+
+import pytest
+from prometheus_client import REGISTRY, generate_latest
+
+from ai.backend.agent.metrics.metric import UtilizationMetricObserver
+from ai.backend.agent.metrics.types import (
+    CAPACITY_METRIC_KEY,
+    CURRENT_METRIC_KEY,
+    FlattenedKernelMetric,
+)
+from ai.backend.agent.stats import Metric
+from ai.backend.common.types import AgentId, KernelId, MetricKey, SessionId
+
+
+@pytest.fixture
+def observer() -> UtilizationMetricObserver:
+    return UtilizationMetricObserver.instance()
+
+
+@pytest.fixture
+def kernel_metric() -> FlattenedKernelMetric:
+    return FlattenedKernelMetric(
+        agent_id=AgentId("agent-1"),
+        kernel_id=KernelId(uuid.UUID("08ff18f9-e263-47b6-a0aa-d97f8ddfbd5b")),
+        session_id=SessionId(uuid.UUID("889e0d78-75a2-4c81-950e-159431e84c52")),
+        owner_user_id=uuid.UUID("f38dea23-50fa-42a0-b5ae-338f5f4693f4"),
+        project_id=None,
+        key=MetricKey("mem"),
+        value_pairs=[
+            (CURRENT_METRIC_KEY, "1073741824"),
+            (CAPACITY_METRIC_KEY, "8589934592"),
+        ],
+    )
+
+
+def test_observe_container_metric_exports_series(
+    observer: UtilizationMetricObserver,
+    kernel_metric: FlattenedKernelMetric,
+) -> None:
+    observer.observe_container_metric(metric=kernel_metric)
+
+    exposition = generate_latest(REGISTRY).decode("utf-8")
+    assert 'kernel_id="08ff18f9-e263-47b6-a0aa-d97f8ddfbd5b"' in exposition
+    assert 'value_type="capacity"' in exposition
+    assert "8.589934592e+09" in exposition
+    # None ownership labels are exported as "undefined"
+    assert 'project_id="undefined"' in exposition
+
+
+async def test_lazy_remove_container_metric_removes_series(
+    observer: UtilizationMetricObserver,
+    kernel_metric: FlattenedKernelMetric,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "ai.backend.agent.metrics.metric.UTILIZATION_METRIC_DETENTION",
+        0.0,
+    )
+    observer.observe_container_metric(metric=kernel_metric)
+    kernel_metrics: dict[KernelId, dict[MetricKey, Metric]] = {kernel_metric.kernel_id: {}}
+
+    await observer.lazy_remove_container_metric(
+        kernel_metrics,
+        agent_id=kernel_metric.agent_id,
+        kernel_id=kernel_metric.kernel_id,
+        session_id=kernel_metric.session_id,
+        owner_user_id=kernel_metric.owner_user_id,
+        project_id=kernel_metric.project_id,
+        keys=[kernel_metric.key],
+    )
+    await observer._removal_kernel_tasks[kernel_metric.kernel_id]
+    # Let the task's done-callback (which prunes the local caches) run.
+    await asyncio.sleep(0)
+
+    exposition = generate_latest(REGISTRY).decode("utf-8")
+    assert 'kernel_id="08ff18f9-e263-47b6-a0aa-d97f8ddfbd5b"' not in exposition
+    assert kernel_metric.kernel_id not in kernel_metrics

--- a/tests/unit/agent/test_utilization_metric_observer.py
+++ b/tests/unit/agent/test_utilization_metric_observer.py
@@ -35,45 +35,47 @@ def kernel_metric() -> FlattenedKernelMetric:
     )
 
 
-def test_observe_container_metric_exports_series(
-    observer: UtilizationMetricObserver,
-    kernel_metric: FlattenedKernelMetric,
-) -> None:
-    observer.observe_container_metric(metric=kernel_metric)
+class TestUtilizationMetricObserver:
+    def test_observe_container_metric_exports_series(
+        self,
+        observer: UtilizationMetricObserver,
+        kernel_metric: FlattenedKernelMetric,
+    ) -> None:
+        observer.observe_container_metric(metric=kernel_metric)
 
-    exposition = generate_latest(REGISTRY).decode("utf-8")
-    assert 'kernel_id="08ff18f9-e263-47b6-a0aa-d97f8ddfbd5b"' in exposition
-    assert 'value_type="capacity"' in exposition
-    assert "8.589934592e+09" in exposition
-    # None ownership labels are exported as "undefined"
-    assert 'project_id="undefined"' in exposition
+        exposition = generate_latest(REGISTRY).decode("utf-8")
+        assert 'kernel_id="08ff18f9-e263-47b6-a0aa-d97f8ddfbd5b"' in exposition
+        assert 'value_type="capacity"' in exposition
+        assert "8.589934592e+09" in exposition
+        # None ownership labels are exported as "undefined"
+        assert 'project_id="undefined"' in exposition
 
+    async def test_lazy_remove_container_metric_removes_series(
+        self,
+        observer: UtilizationMetricObserver,
+        kernel_metric: FlattenedKernelMetric,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "ai.backend.agent.metrics.metric.UTILIZATION_METRIC_DETENTION",
+            0.0,
+        )
+        observer.observe_container_metric(metric=kernel_metric)
+        kernel_metrics: dict[KernelId, dict[MetricKey, Metric]] = {kernel_metric.kernel_id: {}}
 
-async def test_lazy_remove_container_metric_removes_series(
-    observer: UtilizationMetricObserver,
-    kernel_metric: FlattenedKernelMetric,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        "ai.backend.agent.metrics.metric.UTILIZATION_METRIC_DETENTION",
-        0.0,
-    )
-    observer.observe_container_metric(metric=kernel_metric)
-    kernel_metrics: dict[KernelId, dict[MetricKey, Metric]] = {kernel_metric.kernel_id: {}}
+        await observer.lazy_remove_container_metric(
+            kernel_metrics,
+            agent_id=kernel_metric.agent_id,
+            kernel_id=kernel_metric.kernel_id,
+            session_id=kernel_metric.session_id,
+            owner_user_id=kernel_metric.owner_user_id,
+            project_id=kernel_metric.project_id,
+            keys=[kernel_metric.key],
+        )
+        await observer._removal_kernel_tasks[kernel_metric.kernel_id]
+        # Let the task's done-callback (which prunes the local caches) run.
+        await asyncio.sleep(0)
 
-    await observer.lazy_remove_container_metric(
-        kernel_metrics,
-        agent_id=kernel_metric.agent_id,
-        kernel_id=kernel_metric.kernel_id,
-        session_id=kernel_metric.session_id,
-        owner_user_id=kernel_metric.owner_user_id,
-        project_id=kernel_metric.project_id,
-        keys=[kernel_metric.key],
-    )
-    await observer._removal_kernel_tasks[kernel_metric.kernel_id]
-    # Let the task's done-callback (which prunes the local caches) run.
-    await asyncio.sleep(0)
-
-    exposition = generate_latest(REGISTRY).decode("utf-8")
-    assert 'kernel_id="08ff18f9-e263-47b6-a0aa-d97f8ddfbd5b"' not in exposition
-    assert kernel_metric.kernel_id not in kernel_metrics
+        exposition = generate_latest(REGISTRY).decode("utf-8")
+        assert 'kernel_id="08ff18f9-e263-47b6-a0aa-d97f8ddfbd5b"' not in exposition
+        assert kernel_metric.kernel_id not in kernel_metrics


### PR DESCRIPTION
## Summary
- The agent enabled prometheus_client multiprocess mode like every other component, but `Gauge.remove()` is a no-op in multiprocess mode (samples persist in the per-process mmap files), so `UtilizationMetricObserver.lazy_remove_container_metric()` silently failed and terminated kernels' `backendai_container_utilization` series were exported forever. Dashboards summing these series inflated capacity/usage by the number of replaced replicas (reported as "1 CPU shown as 300%, 8 GiB as 24 GiB" on a deployment whose replica had been replaced twice).
- The agent is hardcoded to `num_workers=1`, so multiprocess aggregation is unnecessary: drop `setup_prometheus_multiprocess_dir()` from the agent entry point and serve `/metrics` from the process-local registry via a new `CommonMetricRegistry.to_prometheus_singleprocess()`, which makes the existing detention-based series removal actually work.
- Verified locally: with the unpatched agent a terminated kernel still had 10 series after the detention period (plus `UserWarning: Removal of labels has not been implemented in multi-process mode yet` in the log); with this fix the same scenario removes all series.

Resolves BA-6473.

🤖 Generated with [Claude Code](https://claude.com/claude-code)