### PR TITLE
fix(BA-6462): re-arm scaling when live replicas drift in stable groups

### DIFF
--- a/changes/12161.fix.md
+++ b/changes/12161.fix.md
@@ -1,0 +1,1 @@
+Recover a stable replica group whose live routes dropped below the desired count (e.g. forced session termination or container crash) by re-arming the scaling reconcile from the group autoscale stage.

--- a/src/ai/backend/manager/repositories/replica_group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/replica_group/db_source/db_source.py
@@ -62,6 +62,7 @@ from ai.backend.manager.repositories.ops.sokovan.provider import SokovanOpsProvi
 from ai.backend.manager.repositories.replica_group.creators import ReplicaGroupCreatorSpec
 from ai.backend.manager.repositories.replica_group.types import (
     ApplyWritesResult,
+    AutoscaleReconcileFetch,
     GroupRolloutSetup,
     GroupRouteCreateInstruction,
     GroupRouteDrainInstruction,
@@ -74,6 +75,7 @@ from ai.backend.manager.repositories.replica_group.types import (
 )
 from ai.backend.manager.types import OptionalState, TriState
 from ai.backend.manager.views.replica_group import (
+    ReplicaGroupAutoscaleReconcileView,
     ReplicaGroupDeploySchedulingView,
     ReplicaGroupLifecycleReconcileView,
     ReplicaGroupScalingReconcileView,
@@ -197,6 +199,51 @@ class ReplicaGroupDBSource:
                 for group_row in group_rows
             ]
             return LifecycleReconcileFetch(views=views, now=now)
+
+    async def fetch_autoscale_reconcile_views(
+        self,
+        querier: BatchQuerier,
+        category: ReplicaGroupHandlerCategory,
+    ) -> AutoscaleReconcileFetch:
+        async with self._db.begin_readonly_session_read_committed() as db_sess:
+            now = (await db_sess.execute(sa.select(sa.func.now()))).scalar_one()
+            group_result = await execute_batch_querier(db_sess, sa.select(ReplicaGroupRow), querier)
+            group_rows: list[ReplicaGroupRow] = [row.ReplicaGroupRow for row in group_result.rows]
+            group_ids = [group_row.id for group_row in group_rows]
+            deployment_ids = [group_row.deployment_id for group_row in group_rows]
+            counts = await self._count_live_serving_by_revision(db_sess, group_ids)
+            last_histories = await self._latest_history_by_group(db_sess, group_ids, category)
+            handler_options = await self._handler_options_by_deployment(db_sess, deployment_ids)
+            deployment_desired = await self._replicas_by_deployment(db_sess, deployment_ids)
+            empty = RevisionReplicaCount(live=0, serving=0)
+            views: list[ReplicaGroupAutoscaleReconcileView] = []
+            for group_row in group_rows:
+                group_counts = counts.get(group_row.id, {})
+                current_counts = (
+                    group_counts.get(group_row.current_revision_id, empty)
+                    if group_row.current_revision_id is not None
+                    else empty
+                )
+                views.append(
+                    ReplicaGroupAutoscaleReconcileView(
+                        group_id=group_row.id,
+                        deployment_id=group_row.deployment_id,
+                        current_revision_id=group_row.current_revision_id,
+                        lifecycle=group_row.lifecycle,
+                        scaling_status=group_row.scaling_status,
+                        desired_current_replica_count=group_row.desired_current_replica_count,
+                        deployment_desired_replica_count=deployment_desired.get(
+                            group_row.deployment_id, 0
+                        ),
+                        current_live_replica_count=current_counts.live,
+                        current_serving_replica_count=current_counts.serving,
+                        last_history=self._to_last_history(last_histories.get(group_row.id)),
+                        handler_options=handler_options.get(
+                            group_row.deployment_id, DeploymentHandlerOptions()
+                        ),
+                    )
+                )
+            return AutoscaleReconcileFetch(views=views, now=now)
 
     @staticmethod
     def _to_last_history(row: ReplicaGroupHistoryRow | None) -> LastHistory | None:

--- a/src/ai/backend/manager/repositories/replica_group/repository.py
+++ b/src/ai/backend/manager/repositories/replica_group/repository.py
@@ -21,6 +21,7 @@ from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.base.updater import BulkUpdaterResult, Updater
 from ai.backend.manager.repositories.replica_group.types import (
     ApplyWritesResult,
+    AutoscaleReconcileFetch,
     GroupRolloutSetup,
     LifecycleReconcileFetch,
     ReplicaGroupLifecycleReconcileApply,
@@ -91,6 +92,14 @@ class ReplicaGroupRepository:
         category: ReplicaGroupHandlerCategory,
     ) -> LifecycleReconcileFetch:
         return await self._db_source.fetch_lifecycle_reconcile_views(querier, category)
+
+    @replica_group_repository_resilience.apply()
+    async def fetch_autoscale_reconcile_views(
+        self,
+        querier: BatchQuerier,
+        category: ReplicaGroupHandlerCategory,
+    ) -> AutoscaleReconcileFetch:
+        return await self._db_source.fetch_autoscale_reconcile_views(querier, category)
 
     @replica_group_repository_resilience.apply()
     async def update_replica_groups(

--- a/src/ai/backend/manager/repositories/replica_group/types.py
+++ b/src/ai/backend/manager/repositories/replica_group/types.py
@@ -16,6 +16,7 @@ from ai.backend.manager.repositories.scheduling_history.creators import (
     ReplicaGroupHistoryCreatorSpec,
 )
 from ai.backend.manager.views.replica_group import (
+    ReplicaGroupAutoscaleReconcileView,
     ReplicaGroupLifecycleReconcileView,
     ReplicaGroupScalingReconcileView,
 )
@@ -35,6 +36,14 @@ class LifecycleReconcileFetch:
     """One lifecycle-reconcile fetch: per-group views plus the DB-sourced current time."""
 
     views: list[ReplicaGroupLifecycleReconcileView]
+    now: datetime
+
+
+@dataclass
+class AutoscaleReconcileFetch:
+    """One autoscale-reconcile fetch: per-group views plus the DB-sourced current time."""
+
+    views: list[ReplicaGroupAutoscaleReconcileView]
     now: datetime
 
 

--- a/src/ai/backend/manager/sokovan/deployment/group/lifecycle/handlers/autoscale.py
+++ b/src/ai/backend/manager/sokovan/deployment/group/lifecycle/handlers/autoscale.py
@@ -1,6 +1,7 @@
-"""Group autoscale handler: keep a STABLE serving group's current-revision replica count synced
-to the deployment's desired count (steady-state scaling). The autoscaling rule only updates the
-deployment desired count; this reflects it onto the serving group's desired_current."""
+"""Group autoscale handler: keep a STABLE serving group converged on the deployment's desired
+count (steady-state keeper). It syncs the group's desired_current to the deployment goal AND
+checks the actual live/serving counts, so a route death (or any drift from desired) re-arms
+scaling — this stage is the only trigger that moves a STABLE group back to SCALING."""
 
 from __future__ import annotations
 
@@ -9,8 +10,8 @@ from uuid import UUID
 
 from ai.backend.manager.data.reconciler.types import HandlerOutcome
 from ai.backend.manager.sokovan.deployment.group.lifecycle.types import (
+    GroupAutoscaleReconcileInfo,
     GroupLifecycleDecision,
-    GroupLifecycleReconcileInfo,
     GroupLifecycleReconcileResult,
 )
 from ai.backend.manager.sokovan.reconciler.base import ReconcilerHandler
@@ -18,11 +19,11 @@ from ai.backend.manager.sokovan.recorder.context import RecorderContext
 
 
 class GroupAutoscaleHandler(
-    ReconcilerHandler[GroupLifecycleReconcileInfo, GroupLifecycleReconcileResult]
+    ReconcilerHandler[GroupAutoscaleReconcileInfo, GroupLifecycleReconcileResult]
 ):
     @override
     async def execute(
-        self, reconcile_info: GroupLifecycleReconcileInfo
+        self, reconcile_info: GroupAutoscaleReconcileInfo
     ) -> GroupLifecycleReconcileResult:
         decisions: list[GroupLifecycleDecision] = []
         pool = RecorderContext[UUID].current_pool()
@@ -32,13 +33,22 @@ class GroupAutoscaleHandler(
             with recorder.phase("group_autoscale"):
                 with recorder.step("evaluate"):
                     goal = view.deployment_desired_replica_count
-                    if view.desired_current_replica_count == goal:
-                        outcome = HandlerOutcome.SUCCESS
-                        message = "current revision at desired count"
-                    else:
-                        # Re-arms scaling so the scaling reconcile fills routes to the new count.
+                    # Same convergence criteria as the scaling reconcile; a group with no
+                    # current revision has nothing the scaling reconcile could fill.
+                    converged = view.current_revision_id is None or (
+                        view.current_live_replica_count == goal
+                        and view.current_serving_replica_count == goal
+                    )
+                    # FAILURE re-arms scaling so the scaling reconcile fills/drains routes.
+                    if view.desired_current_replica_count != goal:
                         outcome = HandlerOutcome.FAILURE
                         message = "scaling current revision toward desired count"
+                    elif not converged:
+                        outcome = HandlerOutcome.FAILURE
+                        message = "live replicas drifted from desired; re-arming scaling"
+                    else:
+                        outcome = HandlerOutcome.SUCCESS
+                        message = "current revision at desired count"
             decisions.append(
                 GroupLifecycleDecision(
                     replica_group_id=view.group_id,

--- a/src/ai/backend/manager/sokovan/deployment/group/lifecycle/source.py
+++ b/src/ai/backend/manager/sokovan/deployment/group/lifecycle/source.py
@@ -7,6 +7,7 @@ from ai.backend.manager.models.replica_group.conditions import ReplicaGroupCondi
 from ai.backend.manager.repositories.base import BatchQuerier, NoPagination
 from ai.backend.manager.repositories.replica_group.repository import ReplicaGroupRepository
 from ai.backend.manager.sokovan.deployment.group.lifecycle.types import (
+    GroupAutoscaleReconcileInfo,
     GroupLifecycleReconcileInfo,
     GroupLifecycleTargetStatuses,
 )
@@ -41,3 +42,36 @@ class GroupLifecycleSource(
             querier, category
         )
         return GroupLifecycleReconcileInfo(views=fetch.views, current_time=fetch.now)
+
+
+class GroupAutoscaleSource(
+    ReconcilerSource[
+        GroupAutoscaleReconcileInfo,
+        ReplicaGroupHandlerCategory,
+        GroupLifecycleTargetStatuses,
+    ]
+):
+    """Like the lifecycle source, but also fetches actual live/serving counts so the
+    autoscale handler can detect drift between desired and reality."""
+
+    _replica_group_repository: ReplicaGroupRepository
+
+    def __init__(self, replica_group_repository: ReplicaGroupRepository) -> None:
+        self._replica_group_repository = replica_group_repository
+
+    async def fetch_reconcile_info(
+        self,
+        category: ReplicaGroupHandlerCategory,
+        target_statuses: GroupLifecycleTargetStatuses,
+    ) -> GroupAutoscaleReconcileInfo:
+        querier = BatchQuerier(
+            pagination=NoPagination(),
+            conditions=[
+                ReplicaGroupConditions.by_lifecycles(target_statuses.lifecycles),
+                ReplicaGroupConditions.by_scaling_statuses(target_statuses.scaling_statuses),
+            ],
+        )
+        fetch = await self._replica_group_repository.fetch_autoscale_reconcile_views(
+            querier, category
+        )
+        return GroupAutoscaleReconcileInfo(views=fetch.views, current_time=fetch.now)

--- a/src/ai/backend/manager/sokovan/deployment/group/lifecycle/types.py
+++ b/src/ai/backend/manager/sokovan/deployment/group/lifecycle/types.py
@@ -25,7 +25,10 @@ from ai.backend.manager.sokovan.reconciler.base import (
     ReconcilerDecision,
 )
 from ai.backend.manager.types import TriState
-from ai.backend.manager.views.replica_group import ReplicaGroupLifecycleReconcileView
+from ai.backend.manager.views.replica_group import (
+    ReplicaGroupAutoscaleReconcileView,
+    ReplicaGroupLifecycleReconcileView,
+)
 
 
 @dataclass(frozen=True)
@@ -51,6 +54,20 @@ class GroupLifecycleReconcileInfo(BaseReconcilerInfo):
     """One fetch's worth of lifecycle-reconcile decision state (per-group views + DB now)."""
 
     views: list[ReplicaGroupLifecycleReconcileView]
+    current_time: datetime
+
+    def entity_ids(self) -> Sequence[UUID]:
+        return [view.group_id for view in self.views]
+
+    def now(self) -> datetime:
+        return self.current_time
+
+
+@dataclass
+class GroupAutoscaleReconcileInfo(BaseReconcilerInfo):
+    """One fetch's worth of autoscale-reconcile decision state (per-group views + DB now)."""
+
+    views: list[ReplicaGroupAutoscaleReconcileView]
     current_time: datetime
 
     def entity_ids(self) -> Sequence[UUID]:

--- a/src/ai/backend/manager/sokovan/stages/group_autoscale.py
+++ b/src/ai/backend/manager/sokovan/stages/group_autoscale.py
@@ -20,7 +20,7 @@ from ai.backend.manager.sokovan.deployment.group.lifecycle.applier import GroupL
 from ai.backend.manager.sokovan.deployment.group.lifecycle.handlers.autoscale import (
     GroupAutoscaleHandler,
 )
-from ai.backend.manager.sokovan.deployment.group.lifecycle.source import GroupLifecycleSource
+from ai.backend.manager.sokovan.deployment.group.lifecycle.source import GroupAutoscaleSource
 from ai.backend.manager.sokovan.deployment.group.lifecycle.types import (
     GroupLifecycleTargetStatuses,
     GroupReconcileStatus,
@@ -40,7 +40,8 @@ def build_group_autoscale_stage(
     metadata = ReconcilerStageMetadata(
         category=ReplicaGroupHandlerCategory.LIFECYCLE,
         kind=GroupReconcileKind.GROUP,
-        # Steady-state group at rest (scaling STABLE): sync its count to the deployment goal.
+        # Steady-state group at rest (scaling STABLE): sync its count to the deployment goal
+        # and re-arm scaling when the actual live routes drift from it (e.g. a route died).
         target_statuses=GroupLifecycleTargetStatuses(
             lifecycles=frozenset({ReplicaGroupLifecycle.STABLE}),
             scaling_statuses=frozenset({ReplicaGroupScalingStatus.STABLE}),
@@ -70,7 +71,7 @@ def build_group_autoscale_stage(
     )
     stage = ReconcilerStage(
         handler=GroupAutoscaleHandler(),
-        source=GroupLifecycleSource(replica_group_repository),
+        source=GroupAutoscaleSource(replica_group_repository),
         applier=GroupLifecycleApplier(replica_group_repository),
         metadata=metadata,
     )

--- a/src/ai/backend/manager/views/replica_group.py
+++ b/src/ai/backend/manager/views/replica_group.py
@@ -65,6 +65,28 @@ class ReplicaGroupScalingReconcileView:
 
 
 @dataclass
+class ReplicaGroupAutoscaleReconcileView:
+    """Autoscale-reconcile decision slice for one STABLE group: the desired count, the
+    deployment's desired replica count (the goal), and the actual live/serving counts of
+    the current revision so the handler can detect drift between desired and reality.
+    A STABLE group never holds a target revision (rollout promotion clears it), so only
+    the current revision is projected."""
+
+    group_id: ReplicaGroupID
+    deployment_id: DeploymentID
+    current_revision_id: DeploymentRevisionID | None
+    lifecycle: ReplicaGroupLifecycle
+    scaling_status: ReplicaGroupScalingStatus
+    desired_current_replica_count: int
+    deployment_desired_replica_count: int
+    # live = warming (PROVISIONING) or serving (RUNNING & ACTIVE); serving = RUNNING & ACTIVE.
+    current_live_replica_count: int
+    current_serving_replica_count: int
+    last_history: LastHistory | None
+    handler_options: DeploymentHandlerOptions
+
+
+@dataclass
 class ReplicaGroupLifecycleReconcileView:
     """Lifecycle-reconcile decision slice for one group: revision pointers, the current
     desired counts, the rollout step config, the deployment's desired replica count (the

--- a/tests/unit/manager/repositories/replica_group/test_replica_group_repository.py
+++ b/tests/unit/manager/repositories/replica_group/test_replica_group_repository.py
@@ -6,15 +6,20 @@ import uuid
 from collections.abc import AsyncGenerator
 
 import pytest
+import sqlalchemy as sa
 
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.identifier.deployment import DeploymentID
+from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
 from ai.backend.common.identifier.replica_group import ReplicaGroupID
 from ai.backend.common.types import BinarySize, ResourceSlot
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.deployment.types import (
+    ReplicaGroupHandlerCategory,
     ReplicaGroupLifecycle,
     ReplicaGroupScalingStatus,
+    RouteStatus,
+    RouteTrafficStatus,
 )
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
@@ -24,13 +29,16 @@ from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac_models import RoleRow, UserRoleRow
 from ai.backend.manager.models.replica_group import ReplicaGroupRow
 from ai.backend.manager.models.replica_group.conditions import ReplicaGroupConditions
+from ai.backend.manager.models.replica_group_history import ReplicaGroupHistoryRow
 from ai.backend.manager.models.resource_policy import (
     KeyPairResourcePolicyRow,
     ProjectResourcePolicyRow,
     UserResourcePolicyRow,
 )
 from ai.backend.manager.models.resource_preset import ResourcePresetRow
+from ai.backend.manager.models.routing import RoutingRow
 from ai.backend.manager.models.scaling_group import ScalingGroupOpts, ScalingGroupRow
+from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base.pagination import OffsetPagination
@@ -76,6 +84,9 @@ class TestReplicaGroupRepository:
                 GroupRow,
                 EndpointRow,
                 ReplicaGroupRow,
+                ReplicaGroupHistoryRow,
+                SessionRow,
+                RoutingRow,
             ],
         ):
             yield database_connection
@@ -285,6 +296,76 @@ class TestReplicaGroupRepository:
         lifecycle_by_id = {group.group_id: group.lifecycle for group in groups}
         assert lifecycle_by_id[first_id] is ReplicaGroupLifecycle.DRAINING
         assert lifecycle_by_id[second_id] is ReplicaGroupLifecycle.DRAINED
+
+    async def test_fetch_autoscale_reconcile_views_counts_live_and_serving_routes(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        replica_group_repository: ReplicaGroupRepository,
+        test_endpoint_id: DeploymentID,
+    ) -> None:
+        group_id = ReplicaGroupID(uuid.uuid4())
+        current_revision_id = DeploymentRevisionID(uuid.uuid4())
+        other_revision_id = DeploymentRevisionID(uuid.uuid4())
+        route_specs = [
+            (current_revision_id, RouteStatus.RUNNING, RouteTrafficStatus.ACTIVE),
+            (current_revision_id, RouteStatus.RUNNING, RouteTrafficStatus.ACTIVE),
+            (current_revision_id, RouteStatus.PROVISIONING, RouteTrafficStatus.INACTIVE),
+            (current_revision_id, RouteStatus.RUNNING, RouteTrafficStatus.INACTIVE),
+            (current_revision_id, RouteStatus.TERMINATED, RouteTrafficStatus.INACTIVE),
+            (other_revision_id, RouteStatus.RUNNING, RouteTrafficStatus.ACTIVE),
+        ]
+        async with db_with_cleanup.begin_session() as db_sess:
+            endpoint_row = (
+                await db_sess.execute(
+                    sa.select(EndpointRow).where(EndpointRow.id == test_endpoint_id)
+                )
+            ).scalar_one()
+            db_sess.add(
+                ReplicaGroupRow(
+                    id=group_id,
+                    deployment_id=test_endpoint_id,
+                    current_revision_id=current_revision_id,
+                    desired_current_replica_count=3,
+                    desired_target_replica_count=0,
+                    lifecycle=ReplicaGroupLifecycle.STABLE,
+                    scaling_status=ReplicaGroupScalingStatus.STABLE,
+                )
+            )
+            for revision_id, route_status, route_traffic_status in route_specs:
+                db_sess.add(
+                    RoutingRow(
+                        id=uuid.uuid4(),
+                        endpoint=test_endpoint_id,
+                        session=None,
+                        session_owner=endpoint_row.session_owner,
+                        domain=endpoint_row.domain,
+                        project=endpoint_row.project,
+                        traffic_ratio=1.0,
+                        revision=revision_id,
+                        replica_group_id=group_id,
+                        status=route_status,
+                        traffic_status=route_traffic_status,
+                    )
+                )
+            await db_sess.commit()
+
+        querier = BatchQuerier(
+            pagination=OffsetPagination(limit=10),
+            conditions=[ReplicaGroupConditions.by_ids([group_id])],
+        )
+        fetch = await replica_group_repository.fetch_autoscale_reconcile_views(
+            querier, ReplicaGroupHandlerCategory.LIFECYCLE
+        )
+
+        assert len(fetch.views) == 1
+        view = fetch.views[0]
+        assert view.group_id == group_id
+        assert view.desired_current_replica_count == 3
+        assert view.deployment_desired_replica_count == 1
+        # live = PROVISIONING or (RUNNING & ACTIVE); RUNNING+INACTIVE and TERMINATED are
+        # excluded, and so are routes of revisions other than the group's current one.
+        assert view.current_live_replica_count == 3
+        assert view.current_serving_replica_count == 2
 
     async def test_update_replica_groups_applies_per_id_scaling_values(
         self,

--- a/tests/unit/manager/sokovan/deployment/group/lifecycle/test_lifecycle_handlers.py
+++ b/tests/unit/manager/sokovan/deployment/group/lifecycle/test_lifecycle_handlers.py
@@ -13,6 +13,9 @@ from ai.backend.manager.data.deployment.types import (
     ReplicaGroupScalingStatus,
 )
 from ai.backend.manager.data.reconciler.types import HandlerOutcome
+from ai.backend.manager.sokovan.deployment.group.lifecycle.handlers.autoscale import (
+    GroupAutoscaleHandler,
+)
 from ai.backend.manager.sokovan.deployment.group.lifecycle.handlers.draining import (
     GroupDrainingHandler,
 )
@@ -20,10 +23,15 @@ from ai.backend.manager.sokovan.deployment.group.lifecycle.handlers.rolling impo
     GroupRollingHandler,
 )
 from ai.backend.manager.sokovan.deployment.group.lifecycle.types import (
+    GroupAutoscaleReconcileInfo,
+    GroupLifecycleDecision,
     GroupLifecycleReconcileInfo,
 )
 from ai.backend.manager.sokovan.recorder.context import RecorderContext
-from ai.backend.manager.views.replica_group import ReplicaGroupLifecycleReconcileView
+from ai.backend.manager.views.replica_group import (
+    ReplicaGroupAutoscaleReconcileView,
+    ReplicaGroupLifecycleReconcileView,
+)
 
 
 def _view(
@@ -58,6 +66,85 @@ def _view(
 
 def _info(view: ReplicaGroupLifecycleReconcileView) -> GroupLifecycleReconcileInfo:
     return GroupLifecycleReconcileInfo(views=[view], current_time=datetime(2026, 1, 1, tzinfo=UTC))
+
+
+def _autoscale_view(
+    *,
+    goal: int = 4,
+    desired_current: int = 4,
+    current_live: int = 4,
+    current_serving: int = 4,
+    current_revision_id: DeploymentRevisionID | None = None,
+) -> ReplicaGroupAutoscaleReconcileView:
+    return ReplicaGroupAutoscaleReconcileView(
+        group_id=ReplicaGroupID(uuid.uuid4()),
+        deployment_id=DeploymentID(uuid.uuid4()),
+        current_revision_id=current_revision_id,
+        lifecycle=ReplicaGroupLifecycle.STABLE,
+        scaling_status=ReplicaGroupScalingStatus.STABLE,
+        desired_current_replica_count=desired_current,
+        deployment_desired_replica_count=goal,
+        current_live_replica_count=current_live,
+        current_serving_replica_count=current_serving,
+        last_history=None,
+        handler_options=DeploymentHandlerOptions(),
+    )
+
+
+async def _autoscale_decision(view: ReplicaGroupAutoscaleReconcileView) -> GroupLifecycleDecision:
+    info = GroupAutoscaleReconcileInfo(views=[view], current_time=datetime(2026, 1, 1, tzinfo=UTC))
+    with RecorderContext[UUID].scope("group_autoscale", [view.group_id]):
+        result = await GroupAutoscaleHandler().execute(info)
+    return result.lifecycle_decisions[0]
+
+
+async def test_autoscale_steady_state_converged() -> None:
+    view = _autoscale_view(current_revision_id=DeploymentRevisionID(uuid.uuid4()))
+    decision = await _autoscale_decision(view)
+    assert decision.outcome() is HandlerOutcome.SUCCESS
+    assert decision.next_desired_current_replica_count == 4
+    assert decision.next_desired_target_replica_count == 0
+
+
+async def test_autoscale_rearms_scaling_when_live_routes_drop() -> None:
+    # A route died: desired still matches the goal but only 3 of 4 are actually live.
+    view = _autoscale_view(
+        current_live=3,
+        current_serving=3,
+        current_revision_id=DeploymentRevisionID(uuid.uuid4()),
+    )
+    decision = await _autoscale_decision(view)
+    assert decision.outcome() is HandlerOutcome.FAILURE
+    assert decision.next_desired_current_replica_count == 4
+
+
+async def test_autoscale_rearms_scaling_when_serving_short_of_live() -> None:
+    # A leftover PROVISIONING route counts as live but not serving yet.
+    view = _autoscale_view(
+        current_live=4,
+        current_serving=3,
+        current_revision_id=DeploymentRevisionID(uuid.uuid4()),
+    )
+    decision = await _autoscale_decision(view)
+    assert decision.outcome() is HandlerOutcome.FAILURE
+
+
+async def test_autoscale_rearms_scaling_when_goal_changes() -> None:
+    # The autoscaling rule moved the deployment goal; desired counts lag behind.
+    view = _autoscale_view(
+        goal=6,
+        current_revision_id=DeploymentRevisionID(uuid.uuid4()),
+    )
+    decision = await _autoscale_decision(view)
+    assert decision.outcome() is HandlerOutcome.FAILURE
+    assert decision.next_desired_current_replica_count == 6
+
+
+async def test_autoscale_skips_drift_check_without_current_revision() -> None:
+    # No current revision means the scaling reconcile has nothing to fill; do not re-arm.
+    view = _autoscale_view(current_live=0, current_serving=0, current_revision_id=None)
+    decision = await _autoscale_decision(view)
+    assert decision.outcome() is HandlerOutcome.SUCCESS
 
 
 async def test_rolling_steps_target_up_and_current_down() -> None:


### PR DESCRIPTION
## Summary
- A STABLE replica group whose routes died (forced session termination, container crash) was never recovered: `GroupAutoscaleHandler` only compared the group's desired count against the deployment goal, so a live-route drop kept reporting SUCCESS and the group stayed STABLE with fewer replicas than desired.
- Redefine the autoscale stage as the steady-state keeper: it now also checks the current revision's actual live/serving counts (same convergence criteria as the scaling reconcile) and re-arms scaling on drift, letting the existing scaling reconcile fill the deficit.
- The stage gets a dedicated fetch/view (`ReplicaGroupAutoscaleReconcileView`) carrying the live counts so the rolling/draining ticks do not pay the extra count query. Target-side checks are omitted on purpose: a STABLE group never holds a target revision (rollout promotion clears it), and mid-rollout route deaths are already healed by the rolling → scaling loop.

## Test plan
- [x] Unit tests for `GroupAutoscaleHandler` drift decisions (route death, serving shortfall, goal change, no current revision)
- [x] DB-backed test for `fetch_autoscale_reconcile_views` live/serving counting per route status and revision scoping
- [x] Live verification: terminating a serving route's session re-armed scaling within one tick and the group converged back to STABLE with a fresh serving route

Resolves BA-6462

🤖 Generated with [Claude Code](https://claude.com/claude-code)