### PR TITLE
refactor(BA-6466): move AppProxyStatusResponse to common DTO

### DIFF
--- a/changes/12164.enhance.md
+++ b/changes/12164.enhance.md
@@ -1,0 +1,1 @@
+Move `AppProxyStatusResponse` to `common/dto/appproxy_coordinator/v2/status/types.py` to remove the direct `manager` → `appproxy` package dependency.

--- a/src/ai/backend/appproxy/coordinator/api/types.py
+++ b/src/ai/backend/appproxy/coordinator/api/types.py
@@ -26,15 +26,6 @@ class StubResponseModel(BackendAISchema):
     success: Annotated[bool, Field(default=True)]
 
 
-class AppProxyStatusResponse(BackendAISchema):
-    """Response from AppProxy /status endpoint."""
-
-    api_version: str = Field(description="AppProxy API version (e.g., 'v1', 'v2')")
-    advertise_address: str | None = Field(
-        default=None, description="Advertised address for AppProxy"
-    )
-
-
 class CircuitListResponseModel(BackendAISchema):
     circuits: list[SerializableCircuit]
 

--- a/src/ai/backend/appproxy/coordinator/server.py
+++ b/src/ai/backend/appproxy/coordinator/server.py
@@ -72,13 +72,13 @@ from ai.backend.appproxy.common.utils import (
     mime_match,
     ping_redis_connection,
 )
-from ai.backend.appproxy.coordinator.api.types import AppProxyStatusResponse
 from ai.backend.appproxy.coordinator.models.worker import WorkerStatus
 from ai.backend.common import redis_helper
 from ai.backend.common.clients.valkey_client.valkey_leader.client import ValkeyLeaderClient
 from ai.backend.common.clients.valkey_client.valkey_live.client import ValkeyLiveClient
 from ai.backend.common.clients.valkey_client.valkey_schedule import ValkeyScheduleClient
 from ai.backend.common.defs import REDIS_LIVE_DB, REDIS_STREAM_DB, REDIS_STREAM_LOCK, RedisRole
+from ai.backend.common.dto.appproxy_coordinator.v2.status.types import AppProxyStatusResponse
 from ai.backend.common.etcd import ConfigScopes
 from ai.backend.common.events.dispatcher import EventDispatcher, EventProducer
 from ai.backend.common.exception import BackendAIError, BackendAISchemaValidationFailed

--- a/src/ai/backend/common/dto/appproxy_coordinator/v2/status/types.py
+++ b/src/ai/backend/common/dto/appproxy_coordinator/v2/status/types.py
@@ -1,0 +1,8 @@
+from ai.backend.common.types import BackendAISchema
+
+
+class AppProxyStatusResponse(BackendAISchema):
+    """Response from AppProxy /status endpoint."""
+
+    api_version: str
+    advertise_address: str | None = None

--- a/src/ai/backend/manager/clients/appproxy/client.py
+++ b/src/ai/backend/manager/clients/appproxy/client.py
@@ -7,7 +7,6 @@ from uuid import UUID
 
 import aiohttp
 
-from ai.backend.appproxy.coordinator.api.types import AppProxyStatusResponse
 from ai.backend.common.clients.http_client.client_pool import (
     ClientKey,
     ClientPool,
@@ -29,6 +28,7 @@ from ai.backend.common.dto.appproxy_coordinator.v2.endpoint.response import (
     BulkUpdateRoutesResponse,
     MintEndpointTokenResponse,
 )
+from ai.backend.common.dto.appproxy_coordinator.v2.status.types import AppProxyStatusResponse
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy


### PR DESCRIPTION
## Summary
- Move `AppProxyStatusResponse` from `appproxy/coordinator/api/types.py` to `common/dto/appproxy_coordinator/v2/status/types.py`
- Update `appproxy/coordinator/server.py` and `manager/clients/appproxy/client.py` to import from the new common location
- Eliminates the direct `manager` → `appproxy` package dependency for this type

## Test plan
- [ ] `pants check --changed-since=origin/main` passes (mypy)
- [ ] `pants lint --changed-since=origin/main` passes

Resolves BA-6466