### PR TITLE
fix(BA-6144): route provisioner scheduling failures into handler failures

### DIFF
--- a/changes/12165.fix.md
+++ b/changes/12165.fix.md
@@ -1,0 +1,1 @@
+Fix scheduling failures being reported as skipped, which bypassed the retry/timeout-based give-up and expiration handling for pending sessions

--- a/changes/12165.fix.md
+++ b/changes/12165.fix.md
@@ -1,1 +1,1 @@
-Fix scheduling failures being reported as skipped, which bypassed the retry/timeout-based give-up and expiration handling for pending sessions
+Fix the scheduler failure pipeline for pending sessions so repeated scheduling failures are retried, deprioritized, and recorded in the scheduling history with human-readable failure messages, including cancellation records

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -919,6 +919,15 @@ class ScheduleDBSource:
         """Cancel PENDING sessions and their kernels, and free the kernels'
         ``resource_allocations`` rows in the same transaction.
         """
+        # Capture from_statuses before update for history recording
+        status_query = sa.select(SessionRow.id, SessionRow.status).where(
+            sa.and_(SessionRow.id.in_(session_ids), SessionRow.status == SessionStatus.PENDING)
+        )
+        status_result = await db_sess.execute(status_query)
+        from_statuses: dict[SessionId, SessionStatus] = {
+            cast(SessionId, row.id): SessionStatus(row.status) for row in status_result
+        }
+
         cancel_stmt = (
             sa.update(SessionRow)
             .values(
@@ -958,6 +967,20 @@ class ScheduleDBSource:
             )
             cancelled_kernel_ids = [row.id for row in kernel_update_result]
             await self._free_kernel_allocations(db_sess, cancelled_kernel_ids, now)
+
+            # Record scheduling history for cancel transition
+            history_specs = [
+                SessionSchedulingHistoryCreatorSpec(
+                    session_id=sid,
+                    phase="cancel",
+                    result=SchedulingResult.SUCCESS,
+                    message=reason,
+                    from_status=from_statuses.get(sid),
+                    to_status=SessionStatus.CANCELLED,
+                )
+                for sid in cancelled_sessions
+            ]
+            await self._record_scheduling_history(db_sess, BulkCreator(specs=history_specs))
 
         return cancelled_sessions
 

--- a/src/ai/backend/manager/sokovan/scheduler/coordinator.py
+++ b/src/ai/backend/manager/sokovan/scheduler/coordinator.py
@@ -1144,46 +1144,64 @@ class ScheduleCoordinator:
                     result.successes, transitions.success.session
                 )
 
-        # FAILURE transitions - Coordinator classifies failures into give_up/expired/need_retry
+        # FAILURE transitions - Coordinator classifies failures into give_up/expired/need_retry.
+        # A classification without a declared transition keeps the current status but
+        # still records history so the phase attempt counter keeps incrementing.
         if result.failures:
             classified = self._classify_failures(
                 result.failures, sessions, current_time, handler_name
             )
 
-            # Apply transitions for each classification
-            if classified.give_up and transitions.give_up:
-                await self._apply_transition(
-                    handler_name,
-                    classified.give_up,
-                    transitions.give_up,
-                    SchedulingResult.GIVE_UP,
-                    records,
-                    current_time,
-                )
+            if classified.give_up:
+                if transitions.give_up:
+                    await self._apply_transition(
+                        handler_name,
+                        classified.give_up,
+                        transitions.give_up,
+                        SchedulingResult.GIVE_UP,
+                        records,
+                        current_time,
+                    )
+                else:
+                    await self._record_history_without_transition(
+                        handler_name, classified.give_up, records, SchedulingResult.GIVE_UP
+                    )
 
-            if classified.expired and transitions.expired:
-                await self._apply_transition(
-                    handler_name,
-                    classified.expired,
-                    transitions.expired,
-                    SchedulingResult.EXPIRED,
-                    records,
-                    current_time,
-                )
+            if classified.expired:
+                if transitions.expired:
+                    await self._apply_transition(
+                        handler_name,
+                        classified.expired,
+                        transitions.expired,
+                        SchedulingResult.EXPIRED,
+                        records,
+                        current_time,
+                    )
+                else:
+                    await self._record_history_without_transition(
+                        handler_name, classified.expired, records, SchedulingResult.EXPIRED
+                    )
 
-            if classified.need_retry and transitions.need_retry:
-                await self._apply_transition(
-                    handler_name,
-                    classified.need_retry,
-                    transitions.need_retry,
-                    SchedulingResult.NEED_RETRY,
-                    records,
-                    current_time,
-                )
+            if classified.need_retry:
+                if transitions.need_retry:
+                    await self._apply_transition(
+                        handler_name,
+                        classified.need_retry,
+                        transitions.need_retry,
+                        SchedulingResult.NEED_RETRY,
+                        records,
+                        current_time,
+                    )
+                else:
+                    await self._record_history_without_transition(
+                        handler_name, classified.need_retry, records, SchedulingResult.NEED_RETRY
+                    )
 
         # SKIPPED - Record history without status change
         if result.skipped:
-            await self._record_skipped_history(handler_name, result.skipped, records)
+            await self._record_history_without_transition(
+                handler_name, result.skipped, records, SchedulingResult.SKIPPED
+            )
 
         return classified
 
@@ -1368,21 +1386,25 @@ class ScheduleCoordinator:
             len(session_ids),
         )
 
-    async def _record_skipped_history(
+    async def _record_history_without_transition(
         self,
         handler_name: str,
         session_infos: list[SessionTransitionInfo],
         records: Mapping[SessionId, ExecutionRecord],
+        scheduling_result: SchedulingResult,
     ) -> None:
-        """Record history for skipped sessions without status change.
+        """Record history for sessions that stay in their current status.
 
-        Skipped sessions are those that were not processed due to being blocked
-        by other sessions (e.g., scheduling attempt blocked by higher priority sessions).
+        Used for skipped sessions and for classified failures whose handler
+        declares no target transition (e.g., need_retry staying PENDING).
+        Recording keeps the merged ``attempts`` counter incrementing so
+        retry-based classification (give_up) can eventually fire.
 
         Args:
             handler_name: Name of the handler for history recording
-            session_infos: List of skipped session information
+            session_infos: List of session information to record
             records: Mapping of session IDs to their execution records for sub_steps
+            scheduling_result: Result type to record in history
         """
         if not session_infos:
             return
@@ -1391,8 +1413,8 @@ class ScheduleCoordinator:
             SessionSchedulingHistoryCreatorSpec(
                 session_id=info.session_id,
                 phase=handler_name,
-                result=SchedulingResult.SKIPPED,
-                message=info.reason or f"{handler_name} skipped",
+                result=scheduling_result,
+                message=info.reason or f"{handler_name} {scheduling_result.value.lower()}",
                 from_status=info.from_status,
                 to_status=info.from_status,  # No status change
                 error_code=info.error_code,
@@ -1402,9 +1424,10 @@ class ScheduleCoordinator:
         ]
         await self._repository.create_scheduling_history(BulkCreator(specs=history_specs))
         log.debug(
-            "{}: Recorded {} skipped sessions in history",
+            "{}: Recorded {} sessions in history as {} without status change",
             handler_name,
             len(session_infos),
+            scheduling_result.value,
         )
 
     def _collect_target_statuses(

--- a/src/ai/backend/manager/sokovan/scheduler/coordinator.py
+++ b/src/ai/backend/manager/sokovan/scheduler/coordinator.py
@@ -1704,6 +1704,12 @@ class ScheduleCoordinator:
                 long_interval=60.0,
                 initial_delay=30.0,
             ),
+            SchedulerTaskSpec(
+                ScheduleType.DEPRIORITIZE,
+                short_interval=2.0,
+                long_interval=60.0,
+                initial_delay=30.0,
+            ),
             # Sweep is a maintenance task - only needs long cycle task
             SchedulerTaskSpec(
                 ScheduleType.SWEEP,

--- a/src/ai/backend/manager/sokovan/scheduler/handlers/lifecycle/schedule_sessions.py
+++ b/src/ai/backend/manager/sokovan/scheduler/handlers/lifecycle/schedule_sessions.py
@@ -103,6 +103,7 @@ class ScheduleSessionsLifecycleHandler(SessionLifecycleHandler):
 
         Returns:
         - successes: Sessions that were scheduled
+        - failures: Sessions whose scheduling attempt failed in the Provisioner
         - skipped: Sessions that were not attempted (priority-based, resource constraints)
         """
         result = SessionExecutionResult()
@@ -129,13 +130,22 @@ class ScheduleSessionsLifecycleHandler(SessionLifecycleHandler):
             scaling_group, scheduling_data, provision_time
         )
         scheduled_ids = set(schedule_result.scheduled_session_ids)
+        failure_map = {
+            failure.session_id: failure for failure in schedule_result.scheduling_failures
+        }
 
-        # Allocated sessions transition to SCHEDULED; the rest are skipped this
-        # cycle (priority/resource constraints). The coordinator owns the actual
-        # session status transition based on these reports.
+        # Allocated sessions transition to SCHEDULED; failed attempts are reported
+        # as failures so the coordinator can classify them (need_retry/expired/
+        # give_up); the rest were not attempted this cycle (priority/resource
+        # constraints) and are skipped. The coordinator owns the actual session
+        # status transition based on these reports.
         for session in sessions:
-            if session.session_info.identity.id in scheduled_ids:
+            session_id = session.session_info.identity.id
+            if session_id in scheduled_ids:
                 result.successes.append(self._to_transition_info(session, "triggered-by-scheduler"))
+            elif session_id in failure_map:
+                reason = failure_map[session_id].msg or "scheduling-failed"
+                result.failures.append(self._to_transition_info(session, reason))
             else:
                 result.skipped.append(self._to_transition_info(session, "not-scheduled-this-cycle"))
 

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/provisioner.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/provisioner.py
@@ -180,7 +180,7 @@ class SessionProvisioner:
 
         if not scheduling_data.snapshot_data:
             log.warning("Missing snapshot data for scaling group {}", scaling_group)
-            return ScheduleResult()
+            return ScheduleResult(scheduled_session_ids=[], scheduling_failures=[])
 
         # Load per-session failed agents from Valkey for retry deprioritization.
         # Uses a single pipelined Batch request instead of N parallel round-trips.
@@ -298,6 +298,7 @@ class SessionProvisioner:
         await self._valkey_schedule.set_pending_queue(scaling_group, failure_ids)
         return ScheduleResult(
             scheduled_session_ids=scheduled_session_ids,
+            scheduling_failures=scheduling_failures,
         )
 
     async def _schedule_workload(

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/exceptions.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/exceptions.py
@@ -116,7 +116,10 @@ class NoAvailableAgentError(AgentSelectionError):
 
     def _format_header(self) -> str:
         kernel_id_list = ", ".join(str(k) for k in self._kernel_ids)
-        slot_str = " ".join(f"{k}={v}" for k, v in self._requested_slots.items() if v)
+        humanized_slots = self._requested_slots.to_humanized({})
+        slot_str = " ".join(
+            f"{k}={humanized_slots[k]}" for k, v in self._requested_slots.items() if v
+        )
         return f"kernels [{kernel_id_list}] (arch={self._required_architecture}, slots={slot_str})"
 
     def _designated_reasons(self) -> list[str]:

--- a/src/ai/backend/manager/sokovan/scheduler/results.py
+++ b/src/ai/backend/manager/sokovan/scheduler/results.py
@@ -17,6 +17,7 @@ from ai.backend.common.types import (
 )
 from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.models.session import SessionStatus
+from ai.backend.manager.sokovan.data.allocation import SchedulingFailure
 
 __all__ = ["ScheduleResult"]
 
@@ -26,7 +27,10 @@ class ScheduleResult:
     """Result of a scheduling operation."""
 
     # Ids of the sessions that were actually allocated this pass.
-    scheduled_session_ids: list[SessionId] = field(default_factory=list)
+    scheduled_session_ids: list[SessionId]
+    # Sessions whose scheduling attempt failed this pass (predicate failure,
+    # no suitable agent, etc.), as reported by the provisioner.
+    scheduling_failures: list[SchedulingFailure]
 
     def success_count(self) -> int:
         """Get the count of successfully scheduled sessions."""

--- a/src/ai/backend/manager/sokovan/scheduler/terminator/terminator.py
+++ b/src/ai/backend/manager/sokovan/scheduler/terminator/terminator.py
@@ -72,7 +72,7 @@ class SessionTerminator:
         """
         if not terminating_sessions:
             log.debug("No sessions to terminate")
-            return ScheduleResult()
+            return ScheduleResult(scheduled_session_ids=[], scheduling_failures=[])
 
         log.info("Processing {} sessions for termination", len(terminating_sessions))
 
@@ -106,7 +106,7 @@ class SessionTerminator:
         # Execute all termination tasks concurrently across all sessions
         if not all_tasks:
             log.debug("No kernels with agents to terminate")
-            return ScheduleResult()
+            return ScheduleResult(scheduled_session_ids=[], scheduling_failures=[])
 
         log.info("Terminating {} kernels in parallel", len(all_tasks))
 
@@ -139,7 +139,7 @@ class SessionTerminator:
             failed_count,
         )
 
-        return ScheduleResult()
+        return ScheduleResult(scheduled_session_ids=[], scheduling_failures=[])
 
     async def _terminate_kernel(
         self,

--- a/tests/unit/manager/repositories/scheduler/test_scheduling_history_recording.py
+++ b/tests/unit/manager/repositories/scheduler/test_scheduling_history_recording.py
@@ -676,6 +676,47 @@ class TestMarkTerminatingSchedulingHistory:
             assert history_record.to_status == str(SessionStatus.TERMINATING)
             assert history_record.message == "mark_terminating success"
 
+    async def test_cancel_pending_creates_scheduling_history(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain_name: str,
+        test_scaling_group_name: str,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_access_key: AccessKey,
+        test_agent_id: str,
+    ) -> None:
+        """Test that mark_sessions_terminating() records history for cancelled PENDING sessions."""
+        db_source = ScheduleDBSource(db_with_cleanup)
+
+        session_id = await self._create_session_with_kernel(
+            db_with_cleanup,
+            session_status=SessionStatus.PENDING,
+            kernel_status=KernelStatus.PENDING,
+            domain_name=test_domain_name,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+            agent_id=test_agent_id,
+        )
+
+        result = await db_source.mark_sessions_terminating([session_id])
+        assert session_id in result.cancelled_sessions
+
+        # Verify scheduling history record was created
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            history_stmt = sa.select(SessionSchedulingHistoryRow).where(
+                SessionSchedulingHistoryRow.session_id == session_id
+            )
+            history_record = await db_sess.scalar(history_stmt)
+            assert history_record is not None
+            assert history_record.phase == "cancel"
+            assert history_record.result == str(SchedulingResult.SUCCESS)
+            assert history_record.from_status == str(SessionStatus.PENDING)
+            assert history_record.to_status == str(SessionStatus.CANCELLED)
+            assert history_record.message == "USER_REQUESTED"
+
     async def test_force_terminate_creates_scheduling_history(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,

--- a/tests/unit/manager/sokovan/scheduler/handlers/conftest.py
+++ b/tests/unit/manager/sokovan/scheduler/handlers/conftest.py
@@ -343,7 +343,7 @@ def mock_provisioner() -> AsyncMock:
     """Mock SessionProvisioner for ScheduleSessionsLifecycleHandler tests."""
     provisioner = AsyncMock()
     provisioner.schedule_scaling_group = AsyncMock(
-        return_value=ScheduleResult(scheduled_session_ids=[])
+        return_value=ScheduleResult(scheduled_session_ids=[], scheduling_failures=[])
     )
     return provisioner
 
@@ -544,7 +544,10 @@ def schedule_result_success_factory() -> Callable[..., ScheduleResult]:
     """Factory for creating successful ScheduleResult from sessions."""
 
     def _create(sessions: list[SessionWithKernels]) -> ScheduleResult:
-        return ScheduleResult(scheduled_session_ids=[s.session_info.identity.id for s in sessions])
+        return ScheduleResult(
+            scheduled_session_ids=[s.session_info.identity.id for s in sessions],
+            scheduling_failures=[],
+        )
 
     return _create
 

--- a/tests/unit/manager/sokovan/scheduler/handlers/test_lifecycle_handlers.py
+++ b/tests/unit/manager/sokovan/scheduler/handlers/test_lifecycle_handlers.py
@@ -25,6 +25,7 @@ from ai.backend.manager.sokovan.data import (
     SessionsForStartWithImages,
     SessionWithKernels,
 )
+from ai.backend.manager.sokovan.data.allocation import SchedulingFailure
 from ai.backend.manager.sokovan.scheduler.handlers.lifecycle.check_precondition import (
     CheckPreconditionLifecycleHandler,
 )
@@ -52,7 +53,7 @@ class TestScheduleSessionsLifecycleHandler:
     """Tests for ScheduleSessionsLifecycleHandler.
 
     Verifies the handler correctly delegates to provisioner and categorizes
-    results into successes and skipped sessions.
+    results into successes, failures, and skipped sessions.
     """
 
     @pytest.fixture
@@ -117,7 +118,8 @@ class TestScheduleSessionsLifecycleHandler:
         first_session = pending_sessions_multiple[0]
         mock_repository.get_scheduling_data.return_value = MagicMock()
         mock_provisioner.schedule_scaling_group.return_value = ScheduleResult(
-            scheduled_session_ids=[first_session.session_info.identity.id]
+            scheduled_session_ids=[first_session.session_info.identity.id],
+            scheduling_failures=[],
         )
 
         # Act
@@ -140,16 +142,18 @@ class TestScheduleSessionsLifecycleHandler:
         mock_repository: AsyncMock,
         pending_sessions_multiple: list[SessionWithKernels],
     ) -> None:
-        """SC-SS-003: Non-scheduled sessions are marked as skipped (not failures).
+        """SC-SS-003: Non-attempted sessions are marked as skipped (not failures).
 
         Given: Multiple PENDING sessions in the scaling group
-        When: Provisioner schedules none of them (resource constraints)
+        When: Provisioner schedules none of them without reporting failures
+              (not attempted this cycle: priority/queue constraints)
         Then: All sessions appear in result.skipped with reason
         """
-        # Arrange - No sessions scheduled
+        # Arrange - No sessions scheduled, no failures reported
         mock_repository.get_scheduling_data.return_value = MagicMock()
         mock_provisioner.schedule_scaling_group.return_value = ScheduleResult(
-            scheduled_session_ids=[]
+            scheduled_session_ids=[],
+            scheduling_failures=[],
         )
 
         # Act
@@ -161,6 +165,85 @@ class TestScheduleSessionsLifecycleHandler:
         assert len(result.failures) == 0
 
         # Verify all sessions are skipped with appropriate reason
+        for skipped in result.skipped:
+            assert skipped.reason == "not-scheduled-this-cycle"
+
+    async def test_failed_sessions_returned_as_failures(
+        self,
+        handler: ScheduleSessionsLifecycleHandler,
+        mock_provisioner: AsyncMock,
+        mock_repository: AsyncMock,
+        pending_sessions_multiple: list[SessionWithKernels],
+    ) -> None:
+        """SC-SS-006: Sessions reported as scheduling failures appear in result.failures.
+
+        Given: Multiple PENDING sessions in the scaling group
+        When: Provisioner reports them as scheduling failures (predicate failure,
+              no suitable agent, etc.)
+        Then: All sessions appear in result.failures with reason from the failure msg
+        """
+        # Arrange - All sessions fail scheduling
+        mock_repository.get_scheduling_data.return_value = MagicMock()
+        mock_provisioner.schedule_scaling_group.return_value = ScheduleResult(
+            scheduled_session_ids=[],
+            scheduling_failures=[
+                SchedulingFailure(
+                    session_id=session.session_info.identity.id,
+                    msg="no suitable agent",
+                )
+                for session in pending_sessions_multiple
+            ],
+        )
+
+        # Act
+        result = await handler.execute("default", pending_sessions_multiple)
+
+        # Assert
+        assert len(result.successes) == 0
+        assert len(result.skipped) == 0
+        assert len(result.failures) == len(pending_sessions_multiple)
+        for failure in result.failures:
+            assert failure.reason == "no suitable agent"
+
+    async def test_mixed_results_categorized_correctly(
+        self,
+        handler: ScheduleSessionsLifecycleHandler,
+        mock_provisioner: AsyncMock,
+        mock_repository: AsyncMock,
+        pending_sessions_multiple: list[SessionWithKernels],
+    ) -> None:
+        """SC-SS-007: Scheduled, failed, and non-attempted sessions are categorized.
+
+        Given: Three PENDING sessions in the scaling group
+        When: Provisioner schedules the first, fails the second, and does not
+              attempt the third
+        Then: Each session lands in successes, failures, and skipped respectively
+        """
+        # Arrange
+        scheduled_session, failed_session, *rest = pending_sessions_multiple
+        mock_repository.get_scheduling_data.return_value = MagicMock()
+        mock_provisioner.schedule_scaling_group.return_value = ScheduleResult(
+            scheduled_session_ids=[scheduled_session.session_info.identity.id],
+            scheduling_failures=[
+                SchedulingFailure(
+                    session_id=failed_session.session_info.identity.id,
+                    msg="resource quota exceeded",
+                )
+            ],
+        )
+
+        # Act
+        result = await handler.execute("default", pending_sessions_multiple)
+
+        # Assert
+        assert [s.session_id for s in result.successes] == [
+            scheduled_session.session_info.identity.id
+        ]
+        assert [f.session_id for f in result.failures] == [failed_session.session_info.identity.id]
+        assert result.failures[0].reason == "resource quota exceeded"
+        assert {s.session_id for s in result.skipped} == {
+            session.session_info.identity.id for session in rest
+        }
         for skipped in result.skipped:
             assert skipped.reason == "not-scheduled-this-cycle"
 

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_failure_message_format.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_failure_message_format.py
@@ -154,6 +154,26 @@ class TestNoAvailableAgentErrorAggregationFormat:
                 assert "x " not in head, f"unexpected count-prefix in: {line!r}"
 
 
+class TestNoAvailableAgentHeaderFormat:
+    """The header's requested-slots summary must be human-readable."""
+
+    def test_header_humanizes_byte_slots(self) -> None:
+        error = NoAvailableAgentError(
+            kernel_ids=[KernelId(uuid.uuid4())],
+            required_architecture="aarch64",
+            requested_slots=ResourceSlot({
+                "cpu": Decimal("1000"),
+                "mem": Decimal("1073741824"),
+            }),
+            agent_errors={},
+        )
+
+        header = (error.extra_msg or "").splitlines()[0]
+        assert "cpu=1000" in header
+        assert "mem=1g" in header
+        assert "1073741824" not in header
+
+
 class TestDesignatedAgentFailureFormat:
     """Designated-agent failure path must list each candidate reason on its own line."""
 

--- a/tests/unit/manager/sokovan/scheduler/test_coordinator.py
+++ b/tests/unit/manager/sokovan/scheduler/test_coordinator.py
@@ -696,6 +696,57 @@ class TestScheduleCoordinatorStatusTransition:
         # Verify _apply_transition was called for give_up
         mock_coordinator._apply_transition.assert_awaited()
 
+    async def test_need_retry_without_transition_records_history(
+        self,
+        mock_coordinator: MagicMock,
+        status_transitions_success_only: StatusTransitions,
+    ) -> None:
+        """SC-CO-015b: need_retry failures without a declared transition record history only.
+
+        Given: Failures classified as need_retry and a handler declaring need_retry=None
+        When: Handle result is called
+        Then: No status transition is applied, and history is recorded as NEED_RETRY
+              so the phase attempt counter keeps incrementing
+        """
+        # Arrange
+        mock_handler = MagicMock()
+        mock_handler.name.return_value = "test_handler"
+        mock_handler.status_transitions.return_value = status_transitions_success_only
+
+        session_id = SessionId(uuid4())
+        failure_info = _create_session_transition_info(session_id=session_id)
+        result = SessionExecutionResult(
+            successes=[],
+            failures=[failure_info],
+            skipped=[],
+        )
+        session = _create_session_with_kernels(session_id=session_id)
+
+        mock_coordinator._classify_failures = MagicMock(
+            return_value=FailureClassificationResult(
+                give_up=[], expired=[], need_retry=[failure_info]
+            )
+        )
+        mock_coordinator._apply_transition = AsyncMock()
+        mock_coordinator._record_history_without_transition = AsyncMock()
+
+        # Act
+        classified = await ScheduleCoordinator._handle_result(
+            mock_coordinator,
+            handler=mock_handler,
+            result=result,
+            records={},
+            sessions=[session],
+        )
+
+        # Assert
+        assert classified is not None
+        assert len(classified.need_retry) == 1
+        mock_coordinator._apply_transition.assert_not_awaited()
+        mock_coordinator._record_history_without_transition.assert_awaited_once_with(
+            "test_handler", [failure_info], {}, SchedulingResult.NEED_RETRY
+        )
+
     async def test_skipped_recorded_without_status_change(
         self,
         mock_coordinator: MagicMock,
@@ -723,7 +774,7 @@ class TestScheduleCoordinatorStatusTransition:
             return_value=FailureClassificationResult(give_up=[], expired=[], need_retry=[])
         )
         mock_coordinator._apply_transition = AsyncMock()
-        mock_coordinator._record_skipped_history = AsyncMock()
+        mock_coordinator._record_history_without_transition = AsyncMock()
 
         # Act
         await ScheduleCoordinator._handle_result(
@@ -735,7 +786,7 @@ class TestScheduleCoordinatorStatusTransition:
         )
 
         # Assert
-        mock_coordinator._record_skipped_history.assert_awaited_once()
+        mock_coordinator._record_history_without_transition.assert_awaited_once()
 
     async def test_empty_result_no_transitions(
         self,
@@ -760,7 +811,7 @@ class TestScheduleCoordinatorStatusTransition:
         )
 
         mock_coordinator._apply_transition = AsyncMock()
-        mock_coordinator._record_skipped_history = AsyncMock()
+        mock_coordinator._record_history_without_transition = AsyncMock()
 
         # Act
         classified = await ScheduleCoordinator._handle_result(
@@ -773,7 +824,7 @@ class TestScheduleCoordinatorStatusTransition:
 
         # Assert
         mock_coordinator._apply_transition.assert_not_awaited()
-        mock_coordinator._record_skipped_history.assert_not_awaited()
+        mock_coordinator._record_history_without_transition.assert_not_awaited()
         assert classified is None
 
     async def test_kernel_reset_on_pending_transition(


### PR DESCRIPTION
## Summary
- The provisioner accumulated `SchedulingFailure` records but only used them to refresh the valkey pending queue, so every failed scheduling attempt (predicate failure, no suitable agent, etc.) was reported as `skipped` and the BEP-1030 failure classification (`give_up`/`expired`/`need_retry`) was completely bypassed for the SCHEDULE phase.
- `ScheduleResult` now carries `scheduling_failures`, and `ScheduleSessionsLifecycleHandler` routes them into `SessionExecutionResult.failures` with the failure message as the reason, keeping `skipped` only for sessions that were not attempted this cycle.
- The coordinator now records scheduling history without a status change for classified failures whose handler declares no transition (e.g. `need_retry` staying PENDING), so the merged `attempts` counter keeps incrementing and `max_retry_count`/`timeout` policies (`give_up` → DEPRIORITIZING, `expired` → TERMINATING) can actually fire.
- Registered the missing `SchedulerTaskSpec` for `ScheduleType.DEPRIORITIZE`: the handler and the post-processor marking existed, but no task consumed the mark, leaving sessions stuck in DEPRIORITIZING forever (previously invisible because give_up never fired).
- Humanized the requested-slots summary in the no-available-agent failure message (`mem=1073741824` → `mem=1g`).
- Recorded scheduling history for the PENDING → CANCELLED path (`cancel` phase with the cancellation reason), matching the existing `mark_terminating`/`force_terminate` records.

## Test plan
- [x] `pants test tests/unit/manager/sokovan/scheduler::` and scheduler repository tests pass
- [x] New handler tests: failures routed with reason from `SchedulingFailure.msg`, mixed success/failure/skipped categorization, non-attempted sessions still skipped
- [x] New coordinator test: `need_retry` without a declared transition records NEED_RETRY history without applying a status transition
- [x] New repository test: cancelling a PENDING session records a `cancel` history entry; new format test pins `mem=1g` in the failure header
- [x] Verified live: a session requesting cpu=1000 goes through NEED_RETRY ×5 → GIVE_UP → DEPRIORITIZING → priority lowered (10 → 0) → back to PENDING; terminating it while PENDING records `cancel | PENDING → CANCELLED`

Resolves BA-6144

🤖 Generated with [Claude Code](https://claude.com/claude-code)
