### PR TITLE
chore(BA-6467): enforce component isolation via allow-list visibility rules

### DIFF
--- a/changes/12166.enhance.md
+++ b/changes/12166.enhance.md
@@ -1,0 +1,1 @@
+Enforce strict component isolation in pants BUILD files by switching from deny-list to explicit allow-list visibility rules; add isolation rules to appproxy sub-packages for the first time.

--- a/src/ai/backend/account_manager/BUILD
+++ b/src/ai/backend/account_manager/BUILD
@@ -12,12 +12,9 @@ visibility_private_component(
         "//src/ai/backend/testutils/**",
     ],
     allowed_dependencies=[
-        "//src/ai/backend/**",
-        "!//src/ai/backend/web/**",
-        "!//src/ai/backend/manager/**",
-        "!//src/ai/backend/storage/**",
-        "!//src/ai/backend/wsproxy/**",
-        "!//src/ai/backend/client/**",
+        "//src/ai/backend/common/**",
+        "//src/ai/backend/cli/**",
+        "//src/ai/backend/logging/**",
     ],
 )
 

--- a/src/ai/backend/agent/BUILD
+++ b/src/ai/backend/agent/BUILD
@@ -28,13 +28,14 @@ visibility_private_component(
         "//src/ai/backend/testutils/**",
     ],
     allowed_dependencies=[
-        "//src/ai/backend/**",
-        "!//src/ai/backend/account_manager/**",
-        "!//src/ai/backend/web/**",
-        "!//src/ai/backend/manager/**",
-        "!//src/ai/backend/storage/**",
-        "!//src/ai/backend/wsproxy/**",
-        "!//src/ai/backend/client/**",
+        "//src/ai/backend/common/**",
+        "//src/ai/backend/cli/**",
+        "//src/ai/backend/logging/**",
+        "//src/ai/backend/plugin/**",
+        "//src/ai/backend/runner/**",
+        "//src/ai/backend/helpers/**",
+        "//src/ai/backend/kernel/**",
+        "//src/ai/backend/accelerator/**",
     ],
 )
 

--- a/src/ai/backend/appproxy/common/BUILD
+++ b/src/ai/backend/appproxy/common/BUILD
@@ -6,6 +6,16 @@ python_sources(
     ],
 )
 
+visibility_private_component(
+    allowed_dependents=[
+        "//src/ai/backend/appproxy/**",
+    ],
+    allowed_dependencies=[
+        "//src/ai/backend/common/**",
+        "//src/ai/backend/logging/**",
+    ],
+)
+
 resources(
     name="resources",
     dependencies=[

--- a/src/ai/backend/appproxy/coordinator/BUILD
+++ b/src/ai/backend/appproxy/coordinator/BUILD
@@ -10,6 +10,16 @@ python_sources(
     ],
 )
 
+visibility_private_component(
+    allowed_dependents=[],
+    allowed_dependencies=[
+        "//src/ai/backend/common/**",
+        "//src/ai/backend/cli/**",
+        "//src/ai/backend/logging/**",
+        "//src/ai/backend/appproxy/common/**",
+    ],
+)
+
 resources(
     name="resources",
     dependencies=[

--- a/src/ai/backend/appproxy/worker/BUILD
+++ b/src/ai/backend/appproxy/worker/BUILD
@@ -7,6 +7,16 @@ python_sources(
     ],
 )
 
+visibility_private_component(
+    allowed_dependents=[],
+    allowed_dependencies=[
+        "//src/ai/backend/common/**",
+        "//src/ai/backend/cli/**",
+        "//src/ai/backend/logging/**",
+        "//src/ai/backend/appproxy/common/**",
+    ],
+)
+
 python_distribution(
     name="dist",
     dependencies=[

--- a/src/ai/backend/cli/BUILD
+++ b/src/ai/backend/cli/BUILD
@@ -11,14 +11,7 @@ visibility_private_component(
         "//src/ai/backend/**",
     ],
     allowed_dependencies=[
-        "//src/ai/backend/**",
-        "!//src/ai/backend/account_manager/**",
-        "!//src/ai/backend/web/**",
-        "!//src/ai/backend/manager/**",
-        "!//src/ai/backend/agent/**",
-        "!//src/ai/backend/storage/**",
-        "!//src/ai/backend/wsproxy/**",
-        "!//src/ai/backend/client/**",
+        "//src/ai/backend/plugin/**",
     ],
 )
 

--- a/src/ai/backend/client/BUILD
+++ b/src/ai/backend/client/BUILD
@@ -13,13 +13,8 @@ visibility_private_component(
         "//src/ai/backend/test/**",
     ],
     allowed_dependencies=[
-        "//src/ai/backend/**",
-        "!//src/ai/backend/account_manager/**",
-        "!//src/ai/backend/web/**",
-        "!//src/ai/backend/manager/**",
-        "!//src/ai/backend/agent/**",
-        "!//src/ai/backend/storage/**",
-        "!//src/ai/backend/wsproxy/**",
+        "//src/ai/backend/common/**",
+        "//src/ai/backend/cli/**",
     ],
 )
 

--- a/src/ai/backend/common/BUILD
+++ b/src/ai/backend/common/BUILD
@@ -13,13 +13,8 @@ visibility_private_component(
         "//src/ai/backend/**",
     ],
     allowed_dependencies=[
-        "//src/ai/backend/**",
-        "!//src/ai/backend/account_manager/**",
-        "!//src/ai/backend/web/**",
-        "!//src/ai/backend/manager/**",
-        "!//src/ai/backend/agent/**",
-        "!//src/ai/backend/storage/**",
-        "!//src/ai/backend/wsproxy/**",
+        "//src/ai/backend/logging/**",
+        "//src/ai/backend/plugin/**",
     ],
 )
 

--- a/src/ai/backend/install/BUILD
+++ b/src/ai/backend/install/BUILD
@@ -9,13 +9,9 @@ python_sources(
 visibility_private_component(
     allowed_dependents=[],
     allowed_dependencies=[
-        "//src/ai/backend/**",
-        "!//src/ai/backend/web/**",
-        "!//src/ai/backend/account_manager/**",
-        "!//src/ai/backend/manager/**",
-        "!//src/ai/backend/agent/**",
-        "!//src/ai/backend/storage/**",
-        "!//src/ai/backend/wsproxy/**",
+        "//src/ai/backend/common/**",
+        "//src/ai/backend/cli/**",
+        "//src/ai/backend/plugin/**",
     ],
 )
 

--- a/src/ai/backend/manager/BUILD
+++ b/src/ai/backend/manager/BUILD
@@ -14,13 +14,9 @@ visibility_private_component(
         "//src/ai/backend/testutils/**",
     ],
     allowed_dependencies=[
-        "//src/ai/backend/**",
-        "!//src/ai/backend/account_manager/**",
-        "!//src/ai/backend/web/**",
-        "!//src/ai/backend/agent/**",
-        "!//src/ai/backend/storage/**",
-        "!//src/ai/backend/wsproxy/**",
-        "!//src/ai/backend/client/**",
+        "//src/ai/backend/common/**",
+        "//src/ai/backend/cli/**",
+        "//src/ai/backend/logging/**",
     ],
 )
 

--- a/src/ai/backend/plugin/BUILD
+++ b/src/ai/backend/plugin/BUILD
@@ -11,14 +11,8 @@ visibility_private_component(
         "//src/ai/backend/**",
     ],
     allowed_dependencies=[
-        "//src/ai/backend/**",
-        "!//src/ai/backend/web/**",
-        "!//src/ai/backend/account_manager/**",
-        "!//src/ai/backend/manager/**",
-        "!//src/ai/backend/agent/**",
-        "!//src/ai/backend/storage/**",
-        "!//src/ai/backend/wsproxy/**",
-        "!//src/ai/backend/client/**",
+        "//src/ai/backend/cli/**",
+        "//src/ai/backend/logging/**",
     ],
 )
 

--- a/src/ai/backend/storage/BUILD
+++ b/src/ai/backend/storage/BUILD
@@ -12,13 +12,9 @@ visibility_private_component(
         "//src/ai/backend/testutils/**",
     ],
     allowed_dependencies=[
-        "//src/ai/backend/**",
-        "!//src/ai/backend/web/**",
-        "!//src/ai/backend/account_manager/**",
-        "!//src/ai/backend/manager/**",
-        "!//src/ai/backend/agent/**",
-        "!//src/ai/backend/wsproxy/**",
-        "!//src/ai/backend/client/**",
+        "//src/ai/backend/common/**",
+        "//src/ai/backend/cli/**",
+        "//src/ai/backend/logging/**",
     ],
 )
 

--- a/src/ai/backend/test/BUILD
+++ b/src/ai/backend/test/BUILD
@@ -12,12 +12,9 @@ python_sources(
 visibility_private_component(
     allowed_dependents=[],
     allowed_dependencies=[
-        "//src/ai/backend/**",
-        "!//src/ai/backend/web/**",
-        "!//src/ai/backend/manager/**",
-        "!//src/ai/backend/agent/**",
-        "!//src/ai/backend/storage/**",
-        "!//src/ai/backend/wsproxy/**",
+        "//src/ai/backend/common/**",
+        "//src/ai/backend/client/**",
+        "//src/ai/backend/plugin/**",
     ],
 )
 

--- a/src/ai/backend/web/BUILD
+++ b/src/ai/backend/web/BUILD
@@ -12,12 +12,10 @@ visibility_private_component(
         "//src/ai/backend/testutils/**",
     ],
     allowed_dependencies=[
-        "//src/ai/backend/**",
-        "!//src/ai/backend/account_manager/**",
-        "!//src/ai/backend/manager/**",
-        "!//src/ai/backend/agent/**",
-        "!//src/ai/backend/storage/**",
-        "!//src/ai/backend/wsproxy/**",
+        "//src/ai/backend/common/**",
+        "//src/ai/backend/cli/**",
+        "//src/ai/backend/client/**",
+        "//src/ai/backend/logging/**",
     ],
 )
 


### PR DESCRIPTION
## Summary
- Switch all service components from deny-list to explicit allow-list in `visibility_private_component()`, so new components are isolated by default without requiring manual deny entries in every existing BUILD file
- Add `visibility_private_component()` to `appproxy/{common,coordinator,worker}` for the first time — these had no isolation rules, which allowed any component to freely import from them (the root cause of BA-6466)
- Verified with `pants lint`, `build-wheels.sh`, and `build-scies.sh` — all pass clean

## Test plan
- [x] `pants lint --changed-since=origin/main` — visibility succeeded
- [x] `scripts/build-wheels.sh` — all wheels built successfully
- [x] `scripts/build-scies.sh` — all scie binaries built successfully

Resolves BA-6467