### PR TITLE
fix(BA-6454): propagate session commit bgtask failures to clients

### DIFF
--- a/changes/12168.fix.md
+++ b/changes/12168.fix.md
@@ -1,0 +1,1 @@
+Fix image commit background task failures being reported to clients as successful, and allow committing sessions whose base image has been deleted.

--- a/src/ai/backend/common/bgtask/bgtask.py
+++ b/src/ai/backend/common/bgtask/bgtask.py
@@ -503,7 +503,7 @@ class BackgroundTaskManager:
                 task_result = await self._try_to_execute_new_task(task_name, manifest)
                 context.result = task_result
                 task_status = task_result.status().to_task_status()
-                last_message = task_result.last_message()
+                last_message = task_result.result_message()
             except Exception as e:
                 task_status = TaskStatus.FAILURE
                 last_message = f"Task failed with exception: {e}"
@@ -532,7 +532,7 @@ class BackgroundTaskManager:
                 task_result = await self._try_to_revive_task(task_name, task_info)
                 context.result = task_result
                 task_status = task_result.status().to_task_status()
-                last_message = task_result.last_message()
+                last_message = task_result.result_message()
             except Exception as e:
                 task_status = TaskStatus.FAILURE
                 last_message = f"Task failed with exception: {e}"

--- a/src/ai/backend/common/bgtask/bgtask.py
+++ b/src/ai/backend/common/bgtask/bgtask.py
@@ -502,6 +502,8 @@ class BackgroundTaskManager:
             try:
                 task_result = await self._try_to_execute_new_task(task_name, manifest)
                 context.result = task_result
+                task_status = task_result.status().to_task_status()
+                last_message = task_result.last_message()
             except Exception as e:
                 task_status = TaskStatus.FAILURE
                 last_message = f"Task failed with exception: {e}"
@@ -529,6 +531,8 @@ class BackgroundTaskManager:
             try:
                 task_result = await self._try_to_revive_task(task_name, task_info)
                 context.result = task_result
+                task_status = task_result.status().to_task_status()
+                last_message = task_result.last_message()
             except Exception as e:
                 task_status = TaskStatus.FAILURE
                 last_message = f"Task failed with exception: {e}"

--- a/src/ai/backend/common/bgtask/task_result.py
+++ b/src/ai/backend/common/bgtask/task_result.py
@@ -43,6 +43,11 @@ class TaskResult(ABC):
         """Get the error code if applicable."""
         raise NotImplementedError
 
+    @abstractmethod
+    def last_message(self) -> str:
+        """Get the last message describing the task result."""
+        raise NotImplementedError
+
 
 @dataclass
 class TaskSuccessResult[R: BaseBackgroundTaskResult | None](TaskResult):
@@ -66,6 +71,9 @@ class TaskSuccessResult[R: BaseBackgroundTaskResult | None](TaskResult):
     def error_code(self) -> ErrorCode | None:
         return None
 
+    def last_message(self) -> str:
+        return "Task completed successfully"
+
 
 @dataclass
 class TaskCancelledResult(TaskResult):
@@ -85,6 +93,9 @@ class TaskCancelledResult(TaskResult):
             operation=ErrorOperation.EXECUTE,
             error_detail=ErrorDetail.CANCELED,
         )
+
+    def last_message(self) -> str:
+        return self.message
 
 
 @dataclass
@@ -107,3 +118,6 @@ class TaskFailedResult(TaskResult):
             operation=ErrorOperation.EXECUTE,
             error_detail=ErrorDetail.INTERNAL_ERROR,
         )
+
+    def last_message(self) -> str:
+        return f"Task failed with exception: {self.exception}"

--- a/src/ai/backend/common/bgtask/task_result.py
+++ b/src/ai/backend/common/bgtask/task_result.py
@@ -44,8 +44,8 @@ class TaskResult(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def last_message(self) -> str:
-        """Get the last message describing the task result."""
+    def result_message(self) -> str:
+        """Get the message describing the task result."""
         raise NotImplementedError
 
 
@@ -71,7 +71,7 @@ class TaskSuccessResult[R: BaseBackgroundTaskResult | None](TaskResult):
     def error_code(self) -> ErrorCode | None:
         return None
 
-    def last_message(self) -> str:
+    def result_message(self) -> str:
         return "Task completed successfully"
 
 
@@ -94,7 +94,7 @@ class TaskCancelledResult(TaskResult):
             error_detail=ErrorDetail.CANCELED,
         )
 
-    def last_message(self) -> str:
+    def result_message(self) -> str:
         return self.message
 
 
@@ -119,5 +119,5 @@ class TaskFailedResult(TaskResult):
             error_detail=ErrorDetail.INTERNAL_ERROR,
         )
 
-    def last_message(self) -> str:
+    def result_message(self) -> str:
         return f"Task failed with exception: {self.exception}"

--- a/src/ai/backend/common/bgtask/task_result.py
+++ b/src/ai/backend/common/bgtask/task_result.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TypeVar
+from typing import TypeVar, override
 
 from ai.backend.common.bgtask.task.base import BaseBackgroundTaskResult
 from ai.backend.common.events.event_types.bgtask.broadcast import (
@@ -55,6 +55,7 @@ class TaskSuccessResult[R: BaseBackgroundTaskResult | None](TaskResult):
 
     result: R
 
+    @override
     def to_broadcast_event(self, task_id: uuid.UUID) -> BaseBgtaskDoneEvent:
         # For now, convert the result to string for the message
         # This assumes the result has a meaningful string representation
@@ -65,12 +66,15 @@ class TaskSuccessResult[R: BaseBackgroundTaskResult | None](TaskResult):
         )
         return BgtaskDoneEvent(task_id=task_id, message=message)
 
+    @override
     def status(self) -> BgtaskStatus:
         return BgtaskStatus.DONE
 
+    @override
     def error_code(self) -> ErrorCode | None:
         return None
 
+    @override
     def result_message(self) -> str:
         return "Task completed successfully"
 
@@ -81,12 +85,15 @@ class TaskCancelledResult(TaskResult):
 
     message: str = "Task cancelled"
 
+    @override
     def to_broadcast_event(self, task_id: uuid.UUID) -> BaseBgtaskDoneEvent:
         return BgtaskCancelledEvent(task_id, self.message)
 
+    @override
     def status(self) -> BgtaskStatus:
         return BgtaskStatus.CANCELLED
 
+    @override
     def error_code(self) -> ErrorCode | None:
         return ErrorCode(
             domain=ErrorDomain.BGTASK,
@@ -94,6 +101,7 @@ class TaskCancelledResult(TaskResult):
             error_detail=ErrorDetail.CANCELED,
         )
 
+    @override
     def result_message(self) -> str:
         return self.message
 
@@ -104,12 +112,15 @@ class TaskFailedResult(TaskResult):
 
     exception: BaseException
 
+    @override
     def to_broadcast_event(self, task_id: uuid.UUID) -> BaseBgtaskDoneEvent:
         return BgtaskFailedEvent(task_id, repr(self.exception))
 
+    @override
     def status(self) -> BgtaskStatus:
         return BgtaskStatus.FAILED
 
+    @override
     def error_code(self) -> ErrorCode | None:
         if isinstance(self.exception, BackendAIError):
             return self.exception.error_code()
@@ -119,5 +130,6 @@ class TaskFailedResult(TaskResult):
             error_detail=ErrorDetail.INTERNAL_ERROR,
         )
 
+    @override
     def result_message(self) -> str:
         return f"Task failed with exception: {self.exception}"

--- a/src/ai/backend/common/bgtask/types.py
+++ b/src/ai/backend/common/bgtask/types.py
@@ -27,6 +27,15 @@ class BgtaskStatus(enum.StrEnum):
     def finished(self) -> bool:
         return self in {self.DONE, self.CANCELLED, self.FAILED, self.PARTIAL_SUCCESS}
 
+    def to_task_status(self) -> TaskStatus:
+        match self:
+            case BgtaskStatus.DONE | BgtaskStatus.PARTIAL_SUCCESS:
+                return TaskStatus.SUCCESS
+            case BgtaskStatus.CANCELLED | BgtaskStatus.FAILED:
+                return TaskStatus.FAILURE
+            case _:
+                return TaskStatus.ONGOING
+
 
 class BgtaskNameBase(Protocol):
     """

--- a/src/ai/backend/manager/bgtask/tasks/commit_session.py
+++ b/src/ai/backend/manager/bgtask/tasks/commit_session.py
@@ -30,6 +30,8 @@ from ai.backend.common.types import AgentId, ImageRegistry, SessionId
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.bgtask.types import ManagerBgtaskName
 from ai.backend.manager.data.image.types import ImageIdentifier
+from ai.backend.manager.errors.image import ContainerRegistryNotFound
+from ai.backend.manager.errors.kernel import SessionNotFound
 
 if TYPE_CHECKING:
     from ai.backend.common.events.fetcher import EventFetcher
@@ -111,29 +113,28 @@ class CommitSessionHandler(BaseBackgroundTaskHandler[CommitSessionManifest, Comm
             # Get session and validate
             session = await self._session_repository.get_session_by_id(manifest.session_id)
             if not session:
-                error_msg = f"Session {manifest.session_id} not found"
-                log.error(error_msg)
-                return CommitSessionResult(error_message=error_msg)
+                raise SessionNotFound(f"Session {manifest.session_id} not found")
 
             # Get registry configuration
             registry_conf = await self._session_repository.get_container_registry(
                 manifest.registry_hostname, manifest.registry_project
             )
             if not registry_conf:
-                error_msg = f"Project {manifest.registry_project} not found in registry {manifest.registry_hostname}"
-                log.error(error_msg)
-                return CommitSessionResult(error_message=error_msg)
+                raise ContainerRegistryNotFound(
+                    f"Project {manifest.registry_project} not found in registry {manifest.registry_hostname}"
+                )
 
             # Resolve base image
             if not session.main_kernel.image or not session.main_kernel.architecture:
-                error_msg = (
-                    f"Session {manifest.session_id} main kernel has no image or architecture"
+                raise BgtaskFailedError(
+                    extra_msg=f"Session {manifest.session_id} main kernel has no image or architecture"
                 )
-                log.error(error_msg)
-                return CommitSessionResult(error_message=error_msg)
-            image_row = await self._session_repository.resolve_image([
-                ImageIdentifier(session.main_kernel.image, session.main_kernel.architecture)
-            ])
+            # The base image may have been deleted while the session is still
+            # running, so include non-alive images when resolving it.
+            image_row = await self._session_repository.resolve_image(
+                [ImageIdentifier(session.main_kernel.image, session.main_kernel.architecture)],
+                alive_only=False,
+            )
             base_image_ref = image_row.image_ref
 
             # Build new image canonical name
@@ -218,9 +219,9 @@ class CommitSessionHandler(BaseBackgroundTaskHandler[CommitSessionManifest, Comm
                     password=registry_conf.password,
                 )
                 if not session.main_kernel.agent:
-                    error_msg = f"Session {manifest.session_id} main kernel has no agent assigned"
-                    log.error(error_msg)
-                    return CommitSessionResult(error_message=error_msg)
+                    raise BgtaskFailedError(
+                        extra_msg=f"Session {manifest.session_id} main kernel has no agent assigned"
+                    )
                 resp = await self._agent_registry.push_image(
                     AgentId(session.main_kernel.agent),
                     new_image_ref,
@@ -239,11 +240,9 @@ class CommitSessionHandler(BaseBackgroundTaskHandler[CommitSessionManifest, Comm
 
             if len(rescan_result.images) == 0:
                 rescan_errors = ",".join(rescan_result.errors)
-                error_msg = (
-                    f"Session commit succeeded, but no image was rescanned, Error: {rescan_errors}"
+                raise BgtaskFailedError(
+                    extra_msg=f"Session commit succeeded, but no image was rescanned, Error: {rescan_errors}"
                 )
-                log.error(error_msg)
-                return CommitSessionResult(error_message=error_msg)
             if len(rescan_result.images) > 1:
                 log.warning(
                     "More than two images were rescanned unexpectedly. Rescanned Images: {}",
@@ -254,9 +253,9 @@ class CommitSessionHandler(BaseBackgroundTaskHandler[CommitSessionManifest, Comm
             log.info("Session commit completed successfully. Image ID: {}", result_image_id)
             return CommitSessionResult(image_id=result_image_id)
 
-        except Exception as e:
+        except Exception:
             log.exception("Failed to commit session {}", manifest.session_id)
-            return CommitSessionResult(error_message=str(e))
+            raise
 
     async def _wait_for_agent_bgtask(self, bgtask_id: uuid.UUID, operation_name: str) -> None:
         """Wait for an agent background task to complete."""

--- a/src/ai/backend/manager/bgtask/tasks/commit_session.py
+++ b/src/ai/backend/manager/bgtask/tasks/commit_session.py
@@ -46,14 +46,15 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 class CommitSessionResult(BaseBackgroundTaskResult):
     """
-    Result of commit session background task.
-    Contains the rescanned image ID or error message.
+    Result of a successful commit session background task.
+
+    Failures are propagated by raising from ``execute()``, so this result only
+    carries success payload.
     """
 
     image_id: uuid.UUID | None = Field(
         default=None, description="ID of the rescanned image after commit"
     )
-    error_message: str | None = Field(default=None, description="Error message if task failed")
 
 
 class CommitSessionManifest(BaseBackgroundTaskManifest):

--- a/tests/unit/common/bgtask/test_task_result.py
+++ b/tests/unit/common/bgtask/test_task_result.py
@@ -35,11 +35,6 @@ class TestBgtaskStatusToTaskStatus:
     ) -> None:
         assert bgtask_status.to_task_status() == expected
 
-    def test_failed_status_is_not_recorded_as_success(self) -> None:
-        # The core regression: a FAILED bgtask must never be recorded as SUCCESS.
-        assert BgtaskStatus.FAILED.to_task_status() != TaskStatus.SUCCESS
-        assert BgtaskStatus.CANCELLED.to_task_status() != TaskStatus.SUCCESS
-
 
 class TestTaskResultMessage:
     """Regression tests for TaskResult.result_message().

--- a/tests/unit/common/bgtask/test_task_result.py
+++ b/tests/unit/common/bgtask/test_task_result.py
@@ -41,23 +41,23 @@ class TestBgtaskStatusToTaskStatus:
         assert BgtaskStatus.CANCELLED.to_task_status() != TaskStatus.SUCCESS
 
 
-class TestTaskResultLastMessage:
-    """Regression tests for TaskResult.last_message().
+class TestTaskResultMessage:
+    """Regression tests for TaskResult.result_message().
 
     The failure reason must be carried into the recorded task message instead of
     being discarded (see PR #12168).
     """
 
-    def test_success_result_last_message(self) -> None:
+    def test_success_result_message(self) -> None:
         result = TaskSuccessResult(result=None)
-        assert result.last_message() == "Task completed successfully"
+        assert result.result_message() == "Task completed successfully"
 
-    def test_cancelled_result_last_message(self) -> None:
+    def test_cancelled_result_message(self) -> None:
         result = TaskCancelledResult(message="cancelled by user")
-        assert result.last_message() == "cancelled by user"
+        assert result.result_message() == "cancelled by user"
 
-    def test_failed_result_last_message_includes_exception(self) -> None:
+    def test_failed_result_message_includes_exception(self) -> None:
         result = TaskFailedResult(exception=ZeroDivisionError("boom"))
-        message = result.last_message()
+        message = result.result_message()
         assert "boom" in message
         assert message != "Task completed successfully"

--- a/tests/unit/common/bgtask/test_task_result.py
+++ b/tests/unit/common/bgtask/test_task_result.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+
+from ai.backend.common.bgtask.task_result import (
+    TaskCancelledResult,
+    TaskFailedResult,
+    TaskSuccessResult,
+)
+from ai.backend.common.bgtask.types import BgtaskStatus, TaskStatus
+
+
+class TestBgtaskStatusToTaskStatus:
+    """Regression tests for BgtaskStatus.to_task_status().
+
+    A finished bgtask must map onto the *actual* TaskStatus recorded in the task
+    store. Previously every finished subtask was unconditionally marked SUCCESS,
+    so failed/cancelled commits were stored as SUCCESS (see PR #12168).
+    """
+
+    @pytest.mark.parametrize(
+        ("bgtask_status", "expected"),
+        [
+            (BgtaskStatus.DONE, TaskStatus.SUCCESS),
+            (BgtaskStatus.PARTIAL_SUCCESS, TaskStatus.SUCCESS),
+            (BgtaskStatus.CANCELLED, TaskStatus.FAILURE),
+            (BgtaskStatus.FAILED, TaskStatus.FAILURE),
+            (BgtaskStatus.STARTED, TaskStatus.ONGOING),
+            (BgtaskStatus.UPDATED, TaskStatus.ONGOING),
+            (BgtaskStatus.UNKNOWN, TaskStatus.ONGOING),
+        ],
+    )
+    def test_to_task_status_mapping(
+        self, bgtask_status: BgtaskStatus, expected: TaskStatus
+    ) -> None:
+        assert bgtask_status.to_task_status() == expected
+
+    def test_failed_status_is_not_recorded_as_success(self) -> None:
+        # The core regression: a FAILED bgtask must never be recorded as SUCCESS.
+        assert BgtaskStatus.FAILED.to_task_status() != TaskStatus.SUCCESS
+        assert BgtaskStatus.CANCELLED.to_task_status() != TaskStatus.SUCCESS
+
+
+class TestTaskResultLastMessage:
+    """Regression tests for TaskResult.last_message().
+
+    The failure reason must be carried into the recorded task message instead of
+    being discarded (see PR #12168).
+    """
+
+    def test_success_result_last_message(self) -> None:
+        result = TaskSuccessResult(result=None)
+        assert result.last_message() == "Task completed successfully"
+
+    def test_cancelled_result_last_message(self) -> None:
+        result = TaskCancelledResult(message="cancelled by user")
+        assert result.last_message() == "cancelled by user"
+
+    def test_failed_result_last_message_includes_exception(self) -> None:
+        result = TaskFailedResult(exception=ZeroDivisionError("boom"))
+        message = result.last_message()
+        assert "boom" in message
+        assert message != "Task completed successfully"

--- a/tests/unit/manager/bgtask/tasks/test_commit_session.py
+++ b/tests/unit/manager/bgtask/tasks/test_commit_session.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -12,6 +13,8 @@ from ai.backend.manager.bgtask.tasks.commit_session import (
     CommitSessionResult,
 )
 from ai.backend.manager.bgtask.types import ManagerBgtaskName
+from ai.backend.manager.errors.image import ContainerRegistryNotFound
+from ai.backend.manager.errors.kernel import SessionNotFound
 
 
 class TestCommitSessionHandler:
@@ -112,3 +115,80 @@ class TestCommitSessionHandler:
         restored = CommitSessionResult.model_validate(data)
         assert restored.image_id is None
         assert restored.error_message == error_msg
+
+
+class TestCommitSessionExecute:
+    """Regression tests for CommitSessionHandler.execute() failure propagation.
+
+    Previously execute() swallowed every failure into a success-typed
+    CommitSessionResult carrying an error_message, so the bgtask framework
+    emitted bgtask_done and the WebUI reported a failed commit as successful.
+    Failures must now raise domain exceptions so bgtask_failed is emitted
+    (see PR #12168).
+    """
+
+    @pytest.fixture
+    def sample_manifest(self) -> CommitSessionManifest:
+        return CommitSessionManifest(
+            session_id=SessionId(uuid.uuid4()),
+            registry_hostname="registry.example.com",
+            registry_project="test-project",
+            image_name="test-image",
+            image_visibility=CustomizedImageVisibilityScope.USER,
+            image_owner_id="user-123",
+            user_email="test@example.com",
+        )
+
+    def _make_handler(self, session_repository: AsyncMock) -> CommitSessionHandler:
+        return CommitSessionHandler(
+            session_repository=session_repository,
+            image_repository=AsyncMock(),
+            agent_registry=AsyncMock(),
+            event_hub=MagicMock(),
+            event_fetcher=MagicMock(),
+        )
+
+    async def test_missing_session_raises_session_not_found(
+        self, sample_manifest: CommitSessionManifest
+    ) -> None:
+        session_repository = AsyncMock()
+        session_repository.get_session_by_id.return_value = None
+        handler = self._make_handler(session_repository)
+
+        with pytest.raises(SessionNotFound):
+            await handler.execute(sample_manifest)
+
+    async def test_missing_registry_raises_container_registry_not_found(
+        self, sample_manifest: CommitSessionManifest
+    ) -> None:
+        session_repository = AsyncMock()
+        session_repository.get_session_by_id.return_value = MagicMock()
+        session_repository.get_container_registry.return_value = None
+        handler = self._make_handler(session_repository)
+
+        with pytest.raises(ContainerRegistryNotFound):
+            await handler.execute(sample_manifest)
+
+    async def test_base_image_resolved_including_deleted(
+        self, sample_manifest: CommitSessionManifest
+    ) -> None:
+        # A running session's base image may have been deleted, so the base
+        # image must be resolved with alive_only=False (see PR #12168).
+        session = MagicMock()
+        session.main_kernel.image = "registry.example.com/base:latest"
+        session.main_kernel.architecture = "x86_64"
+
+        session_repository = AsyncMock()
+        session_repository.get_session_by_id.return_value = session
+        session_repository.get_container_registry.return_value = MagicMock()
+        # Stop execution right after resolve_image so the test stays focused on
+        # how the base image is resolved.
+        session_repository.resolve_image.side_effect = RuntimeError("stop here")
+        handler = self._make_handler(session_repository)
+
+        with pytest.raises(RuntimeError):
+            await handler.execute(sample_manifest)
+
+        session_repository.resolve_image.assert_awaited_once()
+        _, kwargs = session_repository.resolve_image.call_args
+        assert kwargs["alive_only"] is False

--- a/tests/unit/manager/bgtask/tasks/test_commit_session.py
+++ b/tests/unit/manager/bgtask/tasks/test_commit_session.py
@@ -84,45 +84,27 @@ class TestCommitSessionHandler:
         """Test result default values are None."""
         result = CommitSessionResult()
         assert result.image_id is None
-        assert result.error_message is None
 
     def test_result_success_serialization(self) -> None:
         """Test result can be serialized and deserialized with success case."""
         image_id = uuid.uuid4()
-        result = CommitSessionResult(image_id=image_id, error_message=None)
+        result = CommitSessionResult(image_id=image_id)
 
         # Serialize to dict
         data = result.model_dump(mode="json")
         assert data["image_id"] == str(image_id)
-        assert data["error_message"] is None
 
         # Deserialize back
         restored = CommitSessionResult.model_validate(data)
         assert restored.image_id == image_id
-        assert restored.error_message is None
-
-    def test_result_error_serialization(self) -> None:
-        """Test result can be serialized and deserialized with error case."""
-        error_msg = "Session not found"
-        result = CommitSessionResult(image_id=None, error_message=error_msg)
-
-        # Serialize to dict
-        data = result.model_dump(mode="json")
-        assert data["image_id"] is None
-        assert data["error_message"] == error_msg
-
-        # Deserialize back
-        restored = CommitSessionResult.model_validate(data)
-        assert restored.image_id is None
-        assert restored.error_message == error_msg
 
 
 class TestCommitSessionExecute:
     """Regression tests for CommitSessionHandler.execute() failure propagation.
 
     Previously execute() swallowed every failure into a success-typed
-    CommitSessionResult carrying an error_message, so the bgtask framework
-    emitted bgtask_done and the WebUI reported a failed commit as successful.
+    CommitSessionResult, so the bgtask framework emitted bgtask_done and the
+    WebUI reported a failed commit as successful.
     Failures must now raise domain exceptions so bgtask_failed is emitted
     (see PR #12168).
     """

--- a/tests/unit/manager/bgtask/tasks/test_commit_session.py
+++ b/tests/unit/manager/bgtask/tasks/test_commit_session.py
@@ -13,8 +13,20 @@ from ai.backend.manager.bgtask.tasks.commit_session import (
     CommitSessionResult,
 )
 from ai.backend.manager.bgtask.types import ManagerBgtaskName
-from ai.backend.manager.errors.image import ContainerRegistryNotFound
 from ai.backend.manager.errors.kernel import SessionNotFound
+
+
+@pytest.fixture
+def sample_manifest() -> CommitSessionManifest:
+    return CommitSessionManifest(
+        session_id=SessionId(uuid.uuid4()),
+        registry_hostname="registry.example.com",
+        registry_project="test-project",
+        image_name="test-image",
+        image_visibility=CustomizedImageVisibilityScope.USER,
+        image_owner_id="user-123",
+        user_email="test@example.com",
+    )
 
 
 class TestCommitSessionHandler:
@@ -24,19 +36,6 @@ class TestCommitSessionHandler:
     def sample_session_id(self) -> SessionId:
         """Sample session ID for testing."""
         return SessionId(uuid.uuid4())
-
-    @pytest.fixture
-    def sample_manifest(self, sample_session_id: SessionId) -> CommitSessionManifest:
-        """Sample manifest for testing."""
-        return CommitSessionManifest(
-            session_id=sample_session_id,
-            registry_hostname="registry.example.com",
-            registry_project="test-project",
-            image_name="test-image",
-            image_visibility=CustomizedImageVisibilityScope.USER,
-            image_owner_id="user-123",
-            user_email="test@example.com",
-        )
 
     def test_handler_name(self) -> None:
         """Test handler returns correct name."""
@@ -100,26 +99,7 @@ class TestCommitSessionHandler:
 
 
 class TestCommitSessionExecute:
-    """Regression tests for CommitSessionHandler.execute() failure propagation.
-
-    Previously execute() swallowed every failure into a success-typed
-    CommitSessionResult, so the bgtask framework emitted bgtask_done and the
-    WebUI reported a failed commit as successful.
-    Failures must now raise domain exceptions so bgtask_failed is emitted
-    (see PR #12168).
-    """
-
-    @pytest.fixture
-    def sample_manifest(self) -> CommitSessionManifest:
-        return CommitSessionManifest(
-            session_id=SessionId(uuid.uuid4()),
-            registry_hostname="registry.example.com",
-            registry_project="test-project",
-            image_name="test-image",
-            image_visibility=CustomizedImageVisibilityScope.USER,
-            image_owner_id="user-123",
-            user_email="test@example.com",
-        )
+    """Regression tests for CommitSessionHandler.execute() (PR #12168)."""
 
     def _make_handler(self, session_repository: AsyncMock) -> CommitSessionHandler:
         return CommitSessionHandler(
@@ -130,9 +110,11 @@ class TestCommitSessionExecute:
             event_fetcher=MagicMock(),
         )
 
-    async def test_missing_session_raises_session_not_found(
+    async def test_failure_raises_instead_of_returning_result(
         self, sample_manifest: CommitSessionManifest
     ) -> None:
+        # Failures must propagate as exceptions (-> bgtask_failed) instead of
+        # being swallowed into a success-typed CommitSessionResult.
         session_repository = AsyncMock()
         session_repository.get_session_by_id.return_value = None
         handler = self._make_handler(session_repository)
@@ -140,22 +122,11 @@ class TestCommitSessionExecute:
         with pytest.raises(SessionNotFound):
             await handler.execute(sample_manifest)
 
-    async def test_missing_registry_raises_container_registry_not_found(
-        self, sample_manifest: CommitSessionManifest
-    ) -> None:
-        session_repository = AsyncMock()
-        session_repository.get_session_by_id.return_value = MagicMock()
-        session_repository.get_container_registry.return_value = None
-        handler = self._make_handler(session_repository)
-
-        with pytest.raises(ContainerRegistryNotFound):
-            await handler.execute(sample_manifest)
-
     async def test_base_image_resolved_including_deleted(
         self, sample_manifest: CommitSessionManifest
     ) -> None:
-        # A running session's base image may have been deleted, so the base
-        # image must be resolved with alive_only=False (see PR #12168).
+        # A running session's base image may have been deleted, so it must be
+        # resolved with alive_only=False.
         session = MagicMock()
         session.main_kernel.image = "registry.example.com/base:latest"
         session.main_kernel.architecture = "x86_64"
@@ -163,14 +134,12 @@ class TestCommitSessionExecute:
         session_repository = AsyncMock()
         session_repository.get_session_by_id.return_value = session
         session_repository.get_container_registry.return_value = MagicMock()
-        # Stop execution right after resolve_image so the test stays focused on
-        # how the base image is resolved.
+        # Stop right after resolve_image to keep the test focused.
         session_repository.resolve_image.side_effect = RuntimeError("stop here")
         handler = self._make_handler(session_repository)
 
         with pytest.raises(RuntimeError):
             await handler.execute(sample_manifest)
 
-        session_repository.resolve_image.assert_awaited_once()
         _, kwargs = session_repository.resolve_image.call_args
         assert kwargs["alive_only"] is False


### PR DESCRIPTION
## Summary
- Raise domain exceptions (`SessionNotFound`, `ContainerRegistryNotFound`, `BgtaskFailedError`) from `CommitSessionHandler.execute()` instead of returning a success-typed result carrying an `error_message`, so the bgtask framework emits `bgtask_failed` to clients instead of `bgtask_done`. Previously the WebUI showed image commit as successful even when it had failed.
- Resolve the base image with `alive_only=False` inside the background task, matching the service-layer pre-validation, so committing a session whose base image was deleted no longer fails with `ImageNotFound` mid-task.
- Record the actual task result status and message in the task store (`finish_subtask`): failed/cancelled results are now recorded as `FAILURE` with the failure reason instead of being unconditionally marked `SUCCESS`. Added `BgtaskStatus.to_task_status()` and `TaskResult.last_message()` to support this.

## Test plan
- [ ] Existing bgtask unit tests pass (`tests/unit/manager/bgtask`, `tests/unit/common/bgtask`)
- [ ] Live verification: commit a session whose base (customized) image row is deleted → task succeeds
- [ ] Live verification: force a commit failure → client SSE stream receives `bgtask_failed` and WebUI shows the failure

Resolves BA-6454 ([Jira](https://lablup.atlassian.net/browse/BA-6454))

🤖 Generated with [Claude Code](https://claude.com/claude-code)