### PR TITLE
fix(BA-6478): resolve vfolder file download 404 with relative volume path

### DIFF
--- a/changes/12170.fix.md
+++ b/changes/12170.fix.md
@@ -1,0 +1,1 @@
+Fix a spurious 404 when downloading an individual vfolder file on storage-proxy volumes configured with a relative `path`.

--- a/src/ai/backend/storage/api/client.py
+++ b/src/ai/backend/storage/api/client.py
@@ -217,9 +217,9 @@ async def download(request: web.Request) -> web.StreamResponse:
     ):
         token_data = params["token"]
         if token_data["unmanaged_path"] is not None:
-            vfpath = Path(token_data["unmanaged_path"])
+            vfpath = Path(token_data["unmanaged_path"]).resolve()
         else:
-            vfpath = volume.mangle_vfpath(token_data["vfid"])
+            vfpath = volume.mangle_vfpath(token_data["vfid"]).resolve()
         try:
             parent_dir = vfpath
             if (dst_dir := params["dst_dir"]) is not None:


### PR DESCRIPTION
## Summary
- The storage-proxy `download()` handler compared an **unresolved** `vfpath` against `file_path.resolve()`. When a volume's `path` config is a **relative path**, `vfpath` stayed relative while `file_path.resolve()` became absolute, so `relative_to()` raised `ValueError` and returned a spurious **404** even though the file existed on disk.
- File listing (`scandir`) worked because it goes through `sanitize_vfpath()`, which resolves both sides; only `download()` bypassed it — hence "list works, download 404".
- Fix: call `.resolve()` on `vfpath` in both the managed (`mangle_vfpath`) and unmanaged (`unmanaged_path`) branches, matching the canonical pattern in `sanitize_vfpath` / `strip_vfpath`.

## Test plan
- [ ] With a volume configured using a **relative** `path` (e.g. `path = "vfolder/local/volume1"`), download an individual file from a model vfolder → succeeds (previously 404).
- [ ] File listing and archive/directory download still work.
- [ ] Absolute-path volume config unaffected.

## Notes
- A deeper follow-up (normalizing `mount_path` at ingest in `volumes/pool.py`, and reusing `sanitize_vfpath` in the download handler so the same asymmetry can't recur in TUS upload handlers) was identified in review but kept out of this hotfix to keep the backport small.

Resolves BA-6478