### PR TITLE
chore: raise open-files ulimit for dev-managed services

### DIFF
--- a/changes/12172.misc.md
+++ b/changes/12172.misc.md
@@ -1,0 +1,1 @@
+Raise the soft open-files limit for services started by `./dev` to avoid "Too many open files" errors inherited from the tmux server's low default limit.

--- a/dev
+++ b/dev
@@ -146,7 +146,11 @@ _start_service() {
     return
   fi
   local cmd
-  cmd=$(_service_cmd "$svc")
+  # Raise the soft open-files limit before exec'ing the service. The long-lived
+  # tmux server inherits launchd's low default (256 on macOS), so services
+  # started here would otherwise hit "Too many open files". Best-effort: a
+  # failure on hosts with a low hard limit must not block startup.
+  cmd="ulimit -n 65536 2>/dev/null; $(_service_cmd "$svc")"
   if ! tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
     local winname
     winname=$(_tmux_window_name "$svc")


### PR DESCRIPTION
## Summary
- The long-lived tmux server spawned by `./dev` inherits launchd's low default soft open-files limit (`256` on macOS), so every service started through it shares that cap regardless of the interactive shell's `ulimit`.
- This surfaced as `OSError: [Errno 24] Too many open files` in the manager — the reconcile coordinator failed to acquire its advisory lock because asyncpg could not open a new DB connection.
- Raise the soft FD limit to `65536` before exec'ing each service in `_start_service` (best-effort; `2>/dev/null` so hosts with a low hard limit still start).

## Test plan
- [x] `./dev stop all && tmux kill-server && ./dev start all`
- [x] Verified service-applied limit is `soft=65536` (was `256`)
- [x] All 6 services report `running`; manager reconcile event tasks fire normally
- [x] No `Too many open files` errors in Loki after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)