### PR TITLE
feat(BA-6482): AppConfigPolicy repository layer

### DIFF
--- a/changes/12179.feature.md
+++ b/changes/12179.feature.md
@@ -1,0 +1,1 @@
+Add the AppConfigPolicy repository layer (DBOpsProvider-based db_source with repository / admin_repository).

--- a/src/ai/backend/common/metrics/metric.py
+++ b/src/ai/backend/common/metrics/metric.py
@@ -417,6 +417,8 @@ class DomainType(enum.StrEnum):
 class LayerType(enum.StrEnum):
     # Repository layers with _REPOSITORY suffix
     AGENT_REPOSITORY = "agent_repository"
+    APP_CONFIG_POLICY_ADMIN_REPOSITORY = "app_config_policy_admin_repository"
+    APP_CONFIG_POLICY_REPOSITORY = "app_config_policy_repository"
     AUTH_REPOSITORY = "auth_repository"
     ARTIFACT_REPOSITORY = "artifact_repository"
     ARTIFACT_REGISTRY_REPOSITORY = "artifact_registry_repository"
@@ -459,6 +461,7 @@ class LayerType(enum.StrEnum):
     REPLICA_GROUP_REPOSITORY = "replica_group_repository"
 
     # DB Source layers
+    APP_CONFIG_POLICY_DB_SOURCE = "app_config_policy_db_source"
     AUDIT_LOG_DB_SOURCE = "audit_log_db_source"
     AUTH_DB_SOURCE = "auth_db_source"
     AGENT_DB_SOURCE = "agent_db_source"

--- a/src/ai/backend/manager/repositories/app_config_policy/admin_repository.py
+++ b/src/ai/backend/manager/repositories/app_config_policy/admin_repository.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from ai.backend.common.exception import BackendAIError
+from ai.backend.common.identifier.app_config_policy import AppConfigPolicyID
+from ai.backend.common.metrics.metric import DomainType, LayerType
+from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
+from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
+from ai.backend.common.resilience.resilience import Resilience
+from ai.backend.manager.data.app_config_policy.types import AppConfigPolicyData
+from ai.backend.manager.errors.app_config import AppConfigPolicyNotFound
+from ai.backend.manager.models.app_config_policy.row import AppConfigPolicyRow
+from ai.backend.manager.repositories.app_config_policy.creators import (
+    AppConfigPolicyCreatorSpec,
+)
+from ai.backend.manager.repositories.app_config_policy.db_source import (
+    AppConfigPolicyDBSource,
+)
+from ai.backend.manager.repositories.app_config_policy.types import (
+    AppConfigPolicySearchResult,
+)
+from ai.backend.manager.repositories.app_config_policy.updaters import (
+    AppConfigPolicyUpdaterSpec,
+)
+from ai.backend.manager.repositories.base.creator import Creator
+from ai.backend.manager.repositories.base.purger import Purger
+from ai.backend.manager.repositories.base.querier import BatchQuerier
+from ai.backend.manager.repositories.base.types import SearchScope
+from ai.backend.manager.repositories.base.updater import Updater
+from ai.backend.manager.repositories.ops import DBOpsProvider
+
+app_config_policy_admin_repository_resilience = Resilience(
+    policies=[
+        MetricPolicy(
+            MetricArgs(
+                domain=DomainType.REPOSITORY,
+                layer=LayerType.APP_CONFIG_POLICY_ADMIN_REPOSITORY,
+            )
+        ),
+        RetryPolicy(
+            RetryArgs(
+                max_retries=5,
+                retry_delay=0.1,
+                backoff_strategy=BackoffStrategy.FIXED,
+                non_retryable_exceptions=(BackendAIError,),
+            )
+        ),
+    ]
+)
+
+
+class AppConfigPolicyAdminRepository:
+    """Admin-only operations on AppConfigPolicy.
+
+    Mutations (`create` / `update` / `purge`) and cross-policy
+    `search` live here — read-side single lookups are on
+    `AppConfigPolicyRepository`. Authorization is enforced at the
+    service layer before reaching either repository.
+
+    Update keeps `config_name` immutable; the FK on
+    `app_config_fragments.name` is the defense-in-depth backstop for
+    purge.
+
+    Mutations are routed through the shared Creator / Updater / Purger
+    helpers so DB constraint violations surface as typed domain errors
+    (e.g., :class:`AppConfigPolicyConflict`).
+    """
+
+    _db_source: AppConfigPolicyDBSource
+
+    def __init__(self, ops_provider: DBOpsProvider) -> None:
+        self._db_source = AppConfigPolicyDBSource(ops_provider)
+
+    @app_config_policy_admin_repository_resilience.apply()
+    async def create(
+        self,
+        config_name: str,
+        scope_sources: Sequence[str],
+    ) -> AppConfigPolicyData:
+        creator: Creator[AppConfigPolicyRow] = Creator(
+            spec=AppConfigPolicyCreatorSpec(
+                config_name=config_name,
+                scope_sources=scope_sources,
+            ),
+        )
+        return await self._db_source.create(creator)
+
+    @app_config_policy_admin_repository_resilience.apply()
+    async def update(
+        self,
+        id: AppConfigPolicyID,
+        scope_sources: Sequence[str],
+    ) -> AppConfigPolicyData:
+        """Update a policy by id. Raises :class:`AppConfigPolicyNotFound`
+        when the row is missing."""
+        updater: Updater[AppConfigPolicyRow] = Updater(
+            spec=AppConfigPolicyUpdaterSpec(scope_sources=scope_sources),
+            pk_value=id,
+        )
+        result = await self._db_source.update(updater)
+        if result is None:
+            raise AppConfigPolicyNotFound(extra_msg=f"id={id!s}")
+        return result
+
+    @app_config_policy_admin_repository_resilience.apply()
+    async def purge(self, id: AppConfigPolicyID) -> bool:
+        """Delete a policy by id. Returns ``True`` only when a row was
+        actually removed."""
+        purger: Purger[AppConfigPolicyRow] = Purger(
+            row_class=AppConfigPolicyRow,
+            pk_value=id,
+        )
+        return await self._db_source.purge(purger)
+
+    @app_config_policy_admin_repository_resilience.apply()
+    async def search(self, querier: BatchQuerier) -> AppConfigPolicySearchResult:
+        return await self._db_source.search(querier)
+
+    @app_config_policy_admin_repository_resilience.apply()
+    async def scoped_search(
+        self,
+        querier: BatchQuerier,
+        scopes: Sequence[SearchScope],
+    ) -> AppConfigPolicySearchResult:
+        return await self._db_source.scoped_search(querier, scopes)

--- a/src/ai/backend/manager/repositories/app_config_policy/admin_repository.py
+++ b/src/ai/backend/manager/repositories/app_config_policy/admin_repository.py
@@ -27,7 +27,6 @@ from ai.backend.manager.repositories.app_config_policy.updaters import (
 from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.purger import Purger
 from ai.backend.manager.repositories.base.querier import BatchQuerier
-from ai.backend.manager.repositories.base.types import SearchScope
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.ops import DBOpsProvider
 
@@ -117,11 +116,3 @@ class AppConfigPolicyAdminRepository:
     @app_config_policy_admin_repository_resilience.apply()
     async def search(self, querier: BatchQuerier) -> AppConfigPolicySearchResult:
         return await self._db_source.search(querier)
-
-    @app_config_policy_admin_repository_resilience.apply()
-    async def scoped_search(
-        self,
-        querier: BatchQuerier,
-        scopes: Sequence[SearchScope],
-    ) -> AppConfigPolicySearchResult:
-        return await self._db_source.scoped_search(querier, scopes)

--- a/src/ai/backend/manager/repositories/app_config_policy/admin_repository.py
+++ b/src/ai/backend/manager/repositories/app_config_policy/admin_repository.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.app_config_policy import AppConfigPolicyID
 from ai.backend.common.metrics.metric import DomainType, LayerType
@@ -76,7 +77,7 @@ class AppConfigPolicyAdminRepository:
     async def create(
         self,
         config_name: str,
-        scope_sources: Sequence[str],
+        scope_sources: Sequence[AppConfigScopeType],
     ) -> AppConfigPolicyData:
         creator: Creator[AppConfigPolicyRow] = Creator(
             spec=AppConfigPolicyCreatorSpec(
@@ -90,7 +91,7 @@ class AppConfigPolicyAdminRepository:
     async def update(
         self,
         id: AppConfigPolicyID,
-        scope_sources: Sequence[str],
+        scope_sources: Sequence[AppConfigScopeType],
     ) -> AppConfigPolicyData:
         """Update a policy by id. Raises :class:`AppConfigPolicyNotFound`
         when the row is missing."""

--- a/src/ai/backend/manager/repositories/app_config_policy/creators.py
+++ b/src/ai/backend/manager/repositories/app_config_policy/creators.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.manager.errors.app_config import AppConfigPolicyConflict
 from ai.backend.manager.errors.repository import UniqueConstraintViolationError
 from ai.backend.manager.models.app_config_policy.row import AppConfigPolicyRow
@@ -22,7 +23,7 @@ class AppConfigPolicyCreatorSpec(CreatorSpec[AppConfigPolicyRow]):
     """
 
     config_name: str
-    scope_sources: Sequence[str]
+    scope_sources: Sequence[AppConfigScopeType]
 
     @property
     @override

--- a/src/ai/backend/manager/repositories/app_config_policy/creators.py
+++ b/src/ai/backend/manager/repositories/app_config_policy/creators.py
@@ -1,0 +1,44 @@
+"""CreatorSpec for AppConfigPolicy rows."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.manager.errors.app_config import AppConfigPolicyConflict
+from ai.backend.manager.errors.repository import UniqueConstraintViolationError
+from ai.backend.manager.models.app_config_policy.row import AppConfigPolicyRow
+from ai.backend.manager.repositories.base.creator import CreatorSpec
+from ai.backend.manager.repositories.base.types import IntegrityErrorCheck
+
+
+@dataclass
+class AppConfigPolicyCreatorSpec(CreatorSpec[AppConfigPolicyRow]):
+    """CreatorSpec for `app_config_policies`.
+
+    `config_name` is UNIQUE and immutable — duplicate inserts surface as
+    :class:`AppConfigPolicyConflict` via ``integrity_error_checks``.
+    """
+
+    config_name: str
+    scope_sources: Sequence[str]
+
+    @property
+    @override
+    def integrity_error_checks(self) -> Sequence[IntegrityErrorCheck]:
+        return (
+            IntegrityErrorCheck(
+                violation_type=UniqueConstraintViolationError,
+                error=AppConfigPolicyConflict(
+                    extra_msg=f"Duplicate config_name: {self.config_name}",
+                ),
+            ),
+        )
+
+    @override
+    def build_row(self) -> AppConfigPolicyRow:
+        return AppConfigPolicyRow(
+            config_name=self.config_name,
+            scope_sources=list(self.scope_sources),
+        )

--- a/src/ai/backend/manager/repositories/app_config_policy/db_source/__init__.py
+++ b/src/ai/backend/manager/repositories/app_config_policy/db_source/__init__.py
@@ -1,0 +1,3 @@
+from .db_source import AppConfigPolicyDBSource
+
+__all__ = ("AppConfigPolicyDBSource",)

--- a/src/ai/backend/manager/repositories/app_config_policy/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_policy/db_source/db_source.py
@@ -1,0 +1,119 @@
+"""Database source for app config policy repository operations.
+
+Each public method only executes the spec/wrapper handed in by the caller —
+no raw sessions or SQLAlchemy statements are touched. All DB access goes
+through the session-bound ops handed out by :class:`DBOpsProvider`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from ai.backend.common.identifier.app_config_policy import AppConfigPolicyID
+from ai.backend.manager.data.app_config_policy.types import AppConfigPolicyData
+from ai.backend.manager.models.app_config_policy.row import AppConfigPolicyRow
+from ai.backend.manager.repositories.app_config_policy.creators import (
+    AppConfigPolicyCreatorSpec,
+)
+from ai.backend.manager.repositories.app_config_policy.types import (
+    AppConfigPolicySearchResult,
+)
+from ai.backend.manager.repositories.app_config_policy.updaters import (
+    AppConfigPolicyUpdaterSpec,
+)
+from ai.backend.manager.repositories.base import (
+    BatchQuerier,
+    Creator,
+    Purger,
+    Querier,
+    SearchScope,
+    Updater,
+)
+from ai.backend.manager.repositories.ops import DBOpsProvider
+
+__all__ = (
+    "AppConfigPolicyCreatorSpec",
+    "AppConfigPolicyDBSource",
+    "AppConfigPolicyUpdaterSpec",
+)
+
+
+class AppConfigPolicyDBSource:
+    """Database operations for `app_config_policies`.
+
+    Mutations go through the shared Creator / Updater / Purger specs so the
+    ``integrity_error_checks`` wired into the specs translate DB constraint
+    violations into typed domain errors (see
+    :mod:`ai.backend.manager.repositories.app_config_policy.creators`).
+    """
+
+    _ops: DBOpsProvider
+
+    def __init__(self, ops_provider: DBOpsProvider) -> None:
+        self._ops = ops_provider
+
+    async def get_by_id(self, id: AppConfigPolicyID) -> AppConfigPolicyData | None:
+        """Look up a policy by row id."""
+        async with self._ops.read_ops() as r:
+            result = await r.query(Querier(row_class=AppConfigPolicyRow, pk_value=id))
+            return result.row.to_data() if result is not None else None
+
+    async def create(self, creator: Creator[AppConfigPolicyRow]) -> AppConfigPolicyData:
+        """Insert a new policy via the shared Creator spec.
+
+        Duplicate `config_name` surfaces as :class:`AppConfigPolicyConflict`
+        via the spec's ``integrity_error_checks``.
+        """
+        async with self._ops.write_ops() as w:
+            result = await w.create(creator)
+            return result.row.to_data()
+
+    async def update(self, updater: Updater[AppConfigPolicyRow]) -> AppConfigPolicyData | None:
+        """Apply a pre-built Updater. Returns ``None`` when the row vanished
+        between PK resolution and write; the caller maps this to
+        :class:`AppConfigPolicyNotFound`."""
+        async with self._ops.write_ops() as w:
+            result = await w.update(updater)
+            return result.row.to_data() if result is not None else None
+
+    async def purge(self, purger: Purger[AppConfigPolicyRow]) -> bool:
+        """Apply a pre-built Purger. The DB-side FK from
+        `app_config_fragments.name` (NO ACTION) blocks the delete while
+        fragments still reference this policy — the service layer is expected
+        to reject earlier with a friendlier error. Returns ``True`` only when
+        a row was actually removed."""
+        async with self._ops.write_ops() as w:
+            result = await w.purge(purger)
+            return result is not None
+
+    async def search(self, querier: BatchQuerier) -> AppConfigPolicySearchResult:
+        """Paginated search across all policies, with no scope filter
+        (superadmin / system-wide path)."""
+        async with self._ops.read_ops() as r:
+            result = await r.batch_query_in_global(sa.select(AppConfigPolicyRow), querier)
+            items = [row.AppConfigPolicyRow.to_data() for row in result.rows]
+            return AppConfigPolicySearchResult(
+                items=items,
+                total_count=result.total_count,
+                has_next_page=result.has_next_page,
+                has_previous_page=result.has_previous_page,
+            )
+
+    async def scoped_search(
+        self,
+        querier: BatchQuerier,
+        scopes: Sequence[SearchScope],
+    ) -> AppConfigPolicySearchResult:
+        """Paginated search over policy rows matching any of ``scopes`` (OR),
+        narrowed by ``querier``."""
+        async with self._ops.read_ops() as r:
+            result = await r.batch_query_with_scopes(sa.select(AppConfigPolicyRow), querier, scopes)
+            items = [row.AppConfigPolicyRow.to_data() for row in result.rows]
+            return AppConfigPolicySearchResult(
+                items=items,
+                total_count=result.total_count,
+                has_next_page=result.has_next_page,
+                has_previous_page=result.has_previous_page,
+            )

--- a/src/ai/backend/manager/repositories/app_config_policy/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_policy/db_source/db_source.py
@@ -13,6 +13,7 @@ import sqlalchemy as sa
 
 from ai.backend.common.identifier.app_config_policy import AppConfigPolicyID
 from ai.backend.manager.data.app_config_policy.types import AppConfigPolicyData
+from ai.backend.manager.errors.app_config import AppConfigPolicyNotFound
 from ai.backend.manager.models.app_config_policy.row import AppConfigPolicyRow
 from ai.backend.manager.repositories.app_config_policy.creators import (
     AppConfigPolicyCreatorSpec,
@@ -54,11 +55,14 @@ class AppConfigPolicyDBSource:
     def __init__(self, ops_provider: DBOpsProvider) -> None:
         self._ops = ops_provider
 
-    async def get_by_id(self, id: AppConfigPolicyID) -> AppConfigPolicyData | None:
-        """Look up a policy by row id."""
+    async def get_by_id(self, id: AppConfigPolicyID) -> AppConfigPolicyData:
+        """Look up a policy by row id. Raises :class:`AppConfigPolicyNotFound`
+        when no row matches."""
         async with self._ops.read_ops() as r:
             result = await r.query(Querier(row_class=AppConfigPolicyRow, pk_value=id))
-            return result.row.to_data() if result is not None else None
+            if result is None:
+                raise AppConfigPolicyNotFound(extra_msg=f"id={id!s}")
+            return result.row.to_data()
 
     async def create(self, creator: Creator[AppConfigPolicyRow]) -> AppConfigPolicyData:
         """Insert a new policy via the shared Creator spec.

--- a/src/ai/backend/manager/repositories/app_config_policy/repositories.py
+++ b/src/ai/backend/manager/repositories/app_config_policy/repositories.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from typing import Self
+
+from ai.backend.manager.repositories.app_config_policy.admin_repository import (
+    AppConfigPolicyAdminRepository,
+)
+from ai.backend.manager.repositories.app_config_policy.repository import (
+    AppConfigPolicyRepository,
+)
+from ai.backend.manager.repositories.types import RepositoryArgs
+
+
+@dataclass
+class AppConfigPolicyRepositories:
+    repository: AppConfigPolicyRepository
+    admin_repository: AppConfigPolicyAdminRepository
+
+    @classmethod
+    def create(cls, args: RepositoryArgs) -> Self:
+        return cls(
+            repository=AppConfigPolicyRepository(args.ops_provider),
+            admin_repository=AppConfigPolicyAdminRepository(args.ops_provider),
+        )

--- a/src/ai/backend/manager/repositories/app_config_policy/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_policy/repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.app_config_policy import AppConfigPolicyID
 from ai.backend.common.metrics.metric import DomainType, LayerType
@@ -10,6 +12,11 @@ from ai.backend.manager.data.app_config_policy.types import AppConfigPolicyData
 from ai.backend.manager.repositories.app_config_policy.db_source import (
     AppConfigPolicyDBSource,
 )
+from ai.backend.manager.repositories.app_config_policy.types import (
+    AppConfigPolicySearchResult,
+)
+from ai.backend.manager.repositories.base.querier import BatchQuerier
+from ai.backend.manager.repositories.base.types import SearchScope
 from ai.backend.manager.repositories.ops import DBOpsProvider
 
 app_config_policy_repository_resilience = Resilience(
@@ -35,9 +42,9 @@ app_config_policy_repository_resilience = Resilience(
 class AppConfigPolicyRepository:
     """Non-admin repository for AppConfigPolicy.
 
-    Holds operations available to any authenticated user (currently a
-    single-policy lookup). Admin-only operations (create / update /
-    purge / search) live on `AppConfigPolicyAdminRepository`.
+    Holds operations available to any authenticated user (single-policy
+    lookup and scoped search). Admin-only operations (create / update /
+    purge / admin search) live on `AppConfigPolicyAdminRepository`.
     """
 
     _db_source: AppConfigPolicyDBSource
@@ -48,3 +55,11 @@ class AppConfigPolicyRepository:
     @app_config_policy_repository_resilience.apply()
     async def get_by_id(self, id: AppConfigPolicyID) -> AppConfigPolicyData:
         return await self._db_source.get_by_id(id)
+
+    @app_config_policy_repository_resilience.apply()
+    async def scoped_search(
+        self,
+        querier: BatchQuerier,
+        scopes: Sequence[SearchScope],
+    ) -> AppConfigPolicySearchResult:
+        return await self._db_source.scoped_search(querier, scopes)

--- a/src/ai/backend/manager/repositories/app_config_policy/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_policy/repository.py
@@ -33,11 +33,11 @@ app_config_policy_repository_resilience = Resilience(
 
 
 class AppConfigPolicyRepository:
-    """Read-side repository for AppConfigPolicy.
+    """Non-admin repository for AppConfigPolicy.
 
-    Any authenticated user may read a policy — admin operations
-    (create / update / purge / search) live on
-    `AppConfigPolicyAdminRepository`.
+    Holds operations available to any authenticated user (currently a
+    single-policy lookup). Admin-only operations (create / update /
+    purge / search) live on `AppConfigPolicyAdminRepository`.
     """
 
     _db_source: AppConfigPolicyDBSource

--- a/src/ai/backend/manager/repositories/app_config_policy/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_policy/repository.py
@@ -46,5 +46,5 @@ class AppConfigPolicyRepository:
         self._db_source = AppConfigPolicyDBSource(ops_provider)
 
     @app_config_policy_repository_resilience.apply()
-    async def get_by_id(self, id: AppConfigPolicyID) -> AppConfigPolicyData | None:
+    async def get_by_id(self, id: AppConfigPolicyID) -> AppConfigPolicyData:
         return await self._db_source.get_by_id(id)

--- a/src/ai/backend/manager/repositories/app_config_policy/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_policy/repository.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from ai.backend.common.exception import BackendAIError
+from ai.backend.common.identifier.app_config_policy import AppConfigPolicyID
+from ai.backend.common.metrics.metric import DomainType, LayerType
+from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
+from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
+from ai.backend.common.resilience.resilience import Resilience
+from ai.backend.manager.data.app_config_policy.types import AppConfigPolicyData
+from ai.backend.manager.repositories.app_config_policy.db_source import (
+    AppConfigPolicyDBSource,
+)
+from ai.backend.manager.repositories.ops import DBOpsProvider
+
+app_config_policy_repository_resilience = Resilience(
+    policies=[
+        MetricPolicy(
+            MetricArgs(
+                domain=DomainType.REPOSITORY,
+                layer=LayerType.APP_CONFIG_POLICY_REPOSITORY,
+            )
+        ),
+        RetryPolicy(
+            RetryArgs(
+                max_retries=5,
+                retry_delay=0.1,
+                backoff_strategy=BackoffStrategy.FIXED,
+                non_retryable_exceptions=(BackendAIError,),
+            )
+        ),
+    ]
+)
+
+
+class AppConfigPolicyRepository:
+    """Read-side repository for AppConfigPolicy.
+
+    Any authenticated user may read a policy — admin operations
+    (create / update / purge / search) live on
+    `AppConfigPolicyAdminRepository`.
+    """
+
+    _db_source: AppConfigPolicyDBSource
+
+    def __init__(self, ops_provider: DBOpsProvider) -> None:
+        self._db_source = AppConfigPolicyDBSource(ops_provider)
+
+    @app_config_policy_repository_resilience.apply()
+    async def get_by_id(self, id: AppConfigPolicyID) -> AppConfigPolicyData | None:
+        return await self._db_source.get_by_id(id)

--- a/src/ai/backend/manager/repositories/app_config_policy/types.py
+++ b/src/ai/backend/manager/repositories/app_config_policy/types.py
@@ -1,0 +1,60 @@
+"""Types for app-config-policy repository operations."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, override
+
+import sqlalchemy as sa
+
+from ai.backend.manager.data.app_config_policy.types import AppConfigPolicyData
+from ai.backend.manager.models.app_config_policy.row import AppConfigPolicyRow
+from ai.backend.manager.repositories.base import (
+    ExistenceCheck,
+    QueryCondition,
+    SearchScope,
+)
+
+__all__ = (
+    "AppConfigPolicySearchResult",
+    "ConfigNameAppConfigPolicySearchScope",
+)
+
+
+@dataclass
+class AppConfigPolicySearchResult:
+    """Result from searching app-config policies."""
+
+    items: list[AppConfigPolicyData]
+    total_count: int
+    has_next_page: bool
+    has_previous_page: bool
+
+
+@dataclass(frozen=True)
+class ConfigNameAppConfigPolicySearchScope(SearchScope):
+    """Policy rows matching a single ``config_name``.
+
+    One scope = one item of a scoped policy query; the repository layer
+    combines multiple scopes with ``OR``.
+
+    ``existence_checks`` is empty by ``SearchableActionTarget`` convention —
+    RBAC validation already gates entity reachability.
+    """
+
+    config_name: str
+
+    @override
+    def to_condition(self) -> QueryCondition:
+        config_name = self.config_name
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigPolicyRow.config_name == config_name
+
+        return inner
+
+    @property
+    @override
+    def existence_checks(self) -> Sequence[ExistenceCheck[Any]]:
+        return ()

--- a/src/ai/backend/manager/repositories/app_config_policy/updaters.py
+++ b/src/ai/backend/manager/repositories/app_config_policy/updaters.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, override
 
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.manager.models.app_config_policy.row import AppConfigPolicyRow
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 
@@ -18,7 +19,7 @@ class AppConfigPolicyUpdaterSpec(UpdaterSpec[AppConfigPolicyRow]):
     therefore never appears in ``build_values()``.
     """
 
-    scope_sources: Sequence[str]
+    scope_sources: Sequence[AppConfigScopeType]
 
     @property
     @override

--- a/src/ai/backend/manager/repositories/app_config_policy/updaters.py
+++ b/src/ai/backend/manager/repositories/app_config_policy/updaters.py
@@ -1,0 +1,30 @@
+"""UpdaterSpec for AppConfigPolicy rows."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, override
+
+from ai.backend.manager.models.app_config_policy.row import AppConfigPolicyRow
+from ai.backend.manager.repositories.base.updater import UpdaterSpec
+
+
+@dataclass
+class AppConfigPolicyUpdaterSpec(UpdaterSpec[AppConfigPolicyRow]):
+    """UpdaterSpec for `app_config_policies`.
+
+    Only `scope_sources` is mutable — `config_name` is immutable and
+    therefore never appears in ``build_values()``.
+    """
+
+    scope_sources: Sequence[str]
+
+    @property
+    @override
+    def row_class(self) -> type[AppConfigPolicyRow]:
+        return AppConfigPolicyRow
+
+    @override
+    def build_values(self) -> dict[str, Any]:
+        return {"scope_sources": list(self.scope_sources)}

--- a/src/ai/backend/manager/repositories/repositories.py
+++ b/src/ai/backend/manager/repositories/repositories.py
@@ -2,6 +2,9 @@ from dataclasses import dataclass
 from typing import Self
 
 from ai.backend.manager.repositories.agent.repositories import AgentRepositories
+from ai.backend.manager.repositories.app_config_policy.repositories import (
+    AppConfigPolicyRepositories,
+)
 from ai.backend.manager.repositories.artifact.repositories import ArtifactRepositories
 from ai.backend.manager.repositories.artifact_registry.repositories import (
     ArtifactRegistryRepositories,
@@ -85,6 +88,7 @@ from ai.backend.manager.repositories.vfs_storage.repositories import VFSStorageR
 @dataclass
 class Repositories:
     agent: AgentRepositories
+    app_config_policy: AppConfigPolicyRepositories
     auth: AuthRepositories
     container_registry: ContainerRegistryRepositories
     deployment: DeploymentRepositories
@@ -136,6 +140,7 @@ class Repositories:
     @classmethod
     def create(cls, args: RepositoryArgs) -> Self:
         agent_repositories = AgentRepositories.create(args)
+        app_config_policy_repositories = AppConfigPolicyRepositories.create(args)
         auth_repositories = AuthRepositories.create(args)
         container_registry_repositories = ContainerRegistryRepositories.create(args)
         deployment_repositories = DeploymentRepositories.create(args)
@@ -188,6 +193,7 @@ class Repositories:
 
         return cls(
             agent=agent_repositories,
+            app_config_policy=app_config_policy_repositories,
             auth=auth_repositories,
             container_registry=container_registry_repositories,
             deployment=deployment_repositories,


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 14-PR stack delivering BEP-1052. **Merge in order:**

1. ⬇️ **#11265** — `chore(BA-5822): drop legacy AppConfig layer`
2. ⬇️ **#12178** — `feat(BA-6481): AppConfigPolicy foundation`
3. 👉 **#12179** — `feat(BA-6482): AppConfigPolicy repository layer` ← you are here
4. ⬇️ **#12180** — `feat(BA-6483): AppConfigPolicy service layer`
5. ⬇️ **#12181** — `feat(BA-6484): AppConfigPolicy v2 DTO and API adapter`
6. ⬇️ **#12182** — `test(BA-6485): AppConfigPolicy repository tests`
7. ⬇️ **#11269** — `feat(BA-5815): AppConfigPolicy GraphQL`
8. ⬇️ **#11312** — `feat(BA-5844): AppConfigPolicy REST v2`
9. ⬇️ **#11282** — `feat(BA-5827): AppConfigFragment foundation`
10. ⬇️ **#11296** — `feat(BA-5836): AppConfigFragment service vertical`
11. ⬇️ **#11285** — `feat(BA-5829): AppConfigFragment + AppConfig GraphQL`
12. ⬇️ **#11286** — `feat(BA-5830): AppConfigFragment + AppConfig REST v2`
13. ⬇️ **#11295** — `feat(BA-5832): AppConfig v2 SDK + CLI`
14. ⬇️ **#11298** — `feat(BA-5837): ValkeyCache for AppConfigFragment merged-view reads`

## Summary

- Adds the `AppConfigPolicy` repository layer, split into a non-admin `AppConfigPolicyRepository` (`get_by_id`, `scoped_search`) and an admin-only `AppConfigPolicyAdminRepository` (`create`, `update`, `purge`, `search`). Authorization is enforced upstream at the service layer.
- Introduces `AppConfigPolicyDBSource`, built on `DBOpsProvider` (`read_ops` / `write_ops`); all DB access goes through session-bound ops, so no raw sessions or SQLAlchemy statements leak into the repository surface.
- Routes mutations through the shared `Creator` / `Updater` / `Purger` specs: `config_name` is UNIQUE and immutable (never in `build_values()`), and duplicate inserts surface as a typed `AppConfigPolicyConflict` via `integrity_error_checks`.
- Get-raise lives in the db_source: `get_by_id` raises `AppConfigPolicyNotFound`, and `update` maps a vanished row to the same error.
- Adds `ConfigNameAppConfigPolicySearchScope` (scopes OR-combined) and the `AppConfigPolicySearchResult` paging type; `search` is global (superadmin) while `scoped_search` filters by scope.
- Wraps both repositories in a `Resilience` (metric + retry, `BackendAIError` non-retryable), wires `AppConfigPolicyRepositories` into the top-level `Repositories` container, and registers the new `LayerType` enum values (admin/non-admin repository + db_source).
