### PR TITLE
feat(BA-6484): AppConfigPolicy v2 DTO and API adapter

### DIFF
--- a/changes/12181.feature.md
+++ b/changes/12181.feature.md
@@ -1,0 +1,1 @@
+Add the AppConfigPolicy v2 API (get, admin/scoped search, and bulk create / update / purge).

--- a/src/ai/backend/common/dto/manager/v2/app_config_policy/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_policy/__init__.py
@@ -1,9 +1,9 @@
 from .request import (
-    AdminAppConfigPolicyCreateItemInput,
-    AdminAppConfigPolicyUpdateItemInput,
     AdminBulkCreateAppConfigPoliciesInput,
+    AdminBulkCreateAppConfigPolicyItemInput,
     AdminBulkPurgeAppConfigPoliciesInput,
     AdminBulkUpdateAppConfigPoliciesInput,
+    AdminBulkUpdateAppConfigPolicyItemInput,
     AdminSearchAppConfigPoliciesInput,
     AppConfigPolicyFilter,
     AppConfigPolicyOrder,
@@ -22,8 +22,8 @@ from .response import (
 from .types import AppConfigPolicyOrderField, OrderDirection
 
 __all__ = (
-    "AdminAppConfigPolicyCreateItemInput",
-    "AdminAppConfigPolicyUpdateItemInput",
+    "AdminBulkCreateAppConfigPolicyItemInput",
+    "AdminBulkUpdateAppConfigPolicyItemInput",
     "AdminBulkCreateAppConfigPoliciesInput",
     "AdminBulkCreateAppConfigPoliciesPayload",
     "AdminBulkPurgeAppConfigPoliciesInput",

--- a/src/ai/backend/common/dto/manager/v2/app_config_policy/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_policy/__init__.py
@@ -1,0 +1,44 @@
+from .request import (
+    AdminAppConfigPolicyCreateItemInput,
+    AdminAppConfigPolicyUpdateItemInput,
+    AdminBulkCreateAppConfigPoliciesInput,
+    AdminBulkPurgeAppConfigPoliciesInput,
+    AdminBulkUpdateAppConfigPoliciesInput,
+    AdminSearchAppConfigPoliciesInput,
+    AppConfigPolicyFilter,
+    AppConfigPolicyOrder,
+    AppConfigPolicyScope,
+    ScopedSearchAppConfigPoliciesInput,
+)
+from .response import (
+    AdminBulkCreateAppConfigPoliciesPayload,
+    AdminBulkPurgeAppConfigPoliciesPayload,
+    AdminBulkUpdateAppConfigPoliciesPayload,
+    AppConfigPolicyBulkError,
+    AppConfigPolicyNode,
+    GetAppConfigPolicyPayload,
+    SearchAppConfigPoliciesPayload,
+)
+from .types import AppConfigPolicyOrderField, OrderDirection
+
+__all__ = (
+    "AdminAppConfigPolicyCreateItemInput",
+    "AdminAppConfigPolicyUpdateItemInput",
+    "AdminBulkCreateAppConfigPoliciesInput",
+    "AdminBulkCreateAppConfigPoliciesPayload",
+    "AdminBulkPurgeAppConfigPoliciesInput",
+    "AdminBulkPurgeAppConfigPoliciesPayload",
+    "AdminBulkUpdateAppConfigPoliciesInput",
+    "AdminBulkUpdateAppConfigPoliciesPayload",
+    "AdminSearchAppConfigPoliciesInput",
+    "AppConfigPolicyBulkError",
+    "AppConfigPolicyFilter",
+    "AppConfigPolicyNode",
+    "AppConfigPolicyOrder",
+    "AppConfigPolicyOrderField",
+    "AppConfigPolicyScope",
+    "GetAppConfigPolicyPayload",
+    "OrderDirection",
+    "ScopedSearchAppConfigPoliciesInput",
+    "SearchAppConfigPoliciesPayload",
+)

--- a/src/ai/backend/common/dto/manager/v2/app_config_policy/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_policy/request.py
@@ -1,0 +1,149 @@
+"""
+Request DTOs for app_config_policy DTO v2.
+"""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, field_validator, model_validator
+
+from ai.backend.common.api_handlers import BaseRequestModel
+from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter
+from ai.backend.common.identifier.app_config_policy import AppConfigPolicyID
+
+from .types import AppConfigPolicyOrderField, OrderDirection
+
+__all__ = (
+    "AdminAppConfigPolicyCreateItemInput",
+    "AdminAppConfigPolicyUpdateItemInput",
+    "AdminBulkCreateAppConfigPoliciesInput",
+    "AdminBulkPurgeAppConfigPoliciesInput",
+    "AdminBulkUpdateAppConfigPoliciesInput",
+    "AdminSearchAppConfigPoliciesInput",
+    "AppConfigPolicyFilter",
+    "AppConfigPolicyOrder",
+    "AppConfigPolicyScope",
+    "ScopedSearchAppConfigPoliciesInput",
+)
+
+
+class AppConfigPolicyFilter(BaseRequestModel):
+    """Filter for app-config policy search."""
+
+    config_name: StringFilter | None = Field(default=None, description="Filter by config_name")
+    created_at: DateTimeFilter | None = Field(default=None, description="Filter by created_at")
+    updated_at: DateTimeFilter | None = Field(default=None, description="Filter by updated_at")
+
+
+class AppConfigPolicyOrder(BaseRequestModel):
+    """Order specification for app-config policies."""
+
+    field: AppConfigPolicyOrderField = Field(description="Field to order by")
+    direction: OrderDirection = Field(default=OrderDirection.ASC, description="Order direction")
+
+
+# ── Bulk mutation inputs (bulk-only writes) ──────────────────────
+
+
+class AdminAppConfigPolicyCreateItemInput(BaseRequestModel):
+    """Per-item input for `adminBulkCreateAppConfigPolicies` —
+    immutable `config_name` + initial `scope_sources`."""
+
+    config_name: str = Field(
+        min_length=1,
+        max_length=128,
+        description="Unique, immutable policy name.",
+    )
+    scope_sources: list[str] = Field(
+        description="Ordered scope chain (low → high merge priority).",
+    )
+
+    @field_validator("config_name", mode="before")
+    @classmethod
+    def strip_and_validate_name(cls, v: str) -> str:
+        """Strip whitespace and ensure config_name is non-blank."""
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("config_name must not be blank after stripping whitespace")
+        return stripped
+
+
+class AdminAppConfigPolicyUpdateItemInput(BaseRequestModel):
+    """Per-item input for `adminBulkUpdateAppConfigPolicies` — target
+    row id + new `scope_sources`. `config_name` is immutable so it's
+    not part of the update payload."""
+
+    id: AppConfigPolicyID = Field(description="Policy row id.")
+    scope_sources: list[str] = Field(
+        description="Ordered scope chain (low → high merge priority).",
+    )
+
+
+class AdminBulkCreateAppConfigPoliciesInput(BaseRequestModel):
+    items: list[AdminAppConfigPolicyCreateItemInput] = Field(description="Policies to create.")
+
+
+class AdminBulkUpdateAppConfigPoliciesInput(BaseRequestModel):
+    items: list[AdminAppConfigPolicyUpdateItemInput] = Field(description="Policies to update.")
+
+
+class AdminBulkPurgeAppConfigPoliciesInput(BaseRequestModel):
+    ids: list[AppConfigPolicyID] = Field(description="Policy row ids to purge.")
+
+
+class AdminSearchAppConfigPoliciesInput(BaseRequestModel):
+    """Input for searching app-config policies system-wide (admin, no scope).
+
+    Supports two pagination modes (mutually exclusive):
+    - Cursor-based: first/after (forward) or last/before (backward)
+    - Offset-based: limit/offset
+    """
+
+    filter: AppConfigPolicyFilter | None = Field(default=None, description="Filter conditions")
+    order: list[AppConfigPolicyOrder] | None = Field(
+        default=None, description="Order specifications"
+    )
+    first: int | None = Field(default=None, ge=1, description="Number of items from the start.")
+    after: str | None = Field(default=None, description="Cursor to paginate forward from.")
+    last: int | None = Field(default=None, ge=1, description="Number of items from the end.")
+    before: str | None = Field(default=None, description="Cursor to paginate backward from.")
+    limit: int | None = Field(default=None, ge=1, le=1000, description="Maximum items to return")
+    offset: int | None = Field(default=None, ge=0, description="Number of items to skip")
+
+
+class AppConfigPolicyScope(BaseRequestModel):
+    """Scope for the scoped app-config-policy query.
+
+    Items are OR'd together; at least one ``config_name`` is required.
+    """
+
+    config_names: list[str] = Field(description="Policy config_names to scope the query to.")
+
+    @model_validator(mode="after")
+    def validate_non_empty(self) -> Self:
+        if not self.config_names:
+            raise ValueError("AppConfigPolicyScope requires a non-empty 'config_names'")
+        return self
+
+
+class ScopedSearchAppConfigPoliciesInput(BaseRequestModel):
+    """Input for searching app-config policies under a scope, with
+    filter / order / pagination.
+
+    Supports two pagination modes (mutually exclusive):
+    - Cursor-based: first/after (forward) or last/before (backward)
+    - Offset-based: limit/offset
+    """
+
+    scope: AppConfigPolicyScope = Field(description="Scope (OR across all config_names).")
+    filter: AppConfigPolicyFilter | None = Field(default=None, description="Filter conditions")
+    order: list[AppConfigPolicyOrder] | None = Field(
+        default=None, description="Order specifications"
+    )
+    first: int | None = Field(default=None, ge=1, description="Number of items from the start.")
+    after: str | None = Field(default=None, description="Cursor to paginate forward from.")
+    last: int | None = Field(default=None, ge=1, description="Number of items from the end.")
+    before: str | None = Field(default=None, description="Cursor to paginate backward from.")
+    limit: int | None = Field(default=None, ge=1, le=1000, description="Maximum items to return")
+    offset: int | None = Field(default=None, ge=0, description="Number of items to skip")

--- a/src/ai/backend/common/dto/manager/v2/app_config_policy/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_policy/request.py
@@ -12,7 +12,7 @@ from ai.backend.common.api_handlers import BaseRequestModel
 from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter
 from ai.backend.common.identifier.app_config_policy import AppConfigPolicyID
 
-from .types import AppConfigPolicyOrderField, OrderDirection
+from .types import AppConfigPolicyOrderField, AppConfigScopeType, OrderDirection
 
 __all__ = (
     "AdminAppConfigPolicyCreateItemInput",
@@ -55,7 +55,7 @@ class AdminAppConfigPolicyCreateItemInput(BaseRequestModel):
         max_length=128,
         description="Unique, immutable policy name.",
     )
-    scope_sources: list[str] = Field(
+    scope_sources: list[AppConfigScopeType] = Field(
         description="Ordered scope chain (low → high merge priority).",
     )
 
@@ -75,7 +75,7 @@ class AdminAppConfigPolicyUpdateItemInput(BaseRequestModel):
     not part of the update payload."""
 
     id: AppConfigPolicyID = Field(description="Policy row id.")
-    scope_sources: list[str] = Field(
+    scope_sources: list[AppConfigScopeType] = Field(
         description="Ordered scope chain (low → high merge priority).",
     )
 

--- a/src/ai/backend/common/dto/manager/v2/app_config_policy/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_policy/request.py
@@ -47,8 +47,7 @@ class AppConfigPolicyOrder(BaseRequestModel):
 
 
 class AdminBulkCreateAppConfigPolicyItemInput(BaseRequestModel):
-    """Per-item input for `adminBulkCreateAppConfigPolicies` —
-    immutable `config_name` + initial `scope_sources`."""
+    """Per-item input for `adminBulkCreateAppConfigPolicies`."""
 
     config_name: str = Field(
         min_length=1,
@@ -70,9 +69,7 @@ class AdminBulkCreateAppConfigPolicyItemInput(BaseRequestModel):
 
 
 class AdminBulkUpdateAppConfigPolicyItemInput(BaseRequestModel):
-    """Per-item input for `adminBulkUpdateAppConfigPolicies` — target
-    row id + new `scope_sources`. `config_name` is immutable so it's
-    not part of the update payload."""
+    """Per-item input for `adminBulkUpdateAppConfigPolicies` (config_name is immutable)."""
 
     id: AppConfigPolicyID = Field(description="Policy row id.")
     scope_sources: list[AppConfigScopeType] = Field(
@@ -93,12 +90,7 @@ class AdminBulkPurgeAppConfigPoliciesInput(BaseRequestModel):
 
 
 class AdminSearchAppConfigPoliciesInput(BaseRequestModel):
-    """Input for searching app-config policies system-wide (admin, no scope).
-
-    Supports two pagination modes (mutually exclusive):
-    - Cursor-based: first/after (forward) or last/before (backward)
-    - Offset-based: limit/offset
-    """
+    """Input for searching app-config policies system-wide (admin, no scope)."""
 
     filter: AppConfigPolicyFilter | None = Field(default=None, description="Filter conditions")
     order: list[AppConfigPolicyOrder] | None = Field(
@@ -113,10 +105,7 @@ class AdminSearchAppConfigPoliciesInput(BaseRequestModel):
 
 
 class AppConfigPolicyScope(BaseRequestModel):
-    """Scope for the scoped app-config-policy query.
-
-    Items are OR'd together; at least one ``config_name`` is required.
-    """
+    """Scope for the scoped app-config-policy query (config_names are OR'd)."""
 
     config_names: list[str] = Field(description="Policy config_names to scope the query to.")
 
@@ -128,13 +117,7 @@ class AppConfigPolicyScope(BaseRequestModel):
 
 
 class ScopedSearchAppConfigPoliciesInput(BaseRequestModel):
-    """Input for searching app-config policies under a scope, with
-    filter / order / pagination.
-
-    Supports two pagination modes (mutually exclusive):
-    - Cursor-based: first/after (forward) or last/before (backward)
-    - Offset-based: limit/offset
-    """
+    """Input for searching app-config policies under a scope."""
 
     scope: AppConfigPolicyScope = Field(description="Scope (OR across all config_names).")
     filter: AppConfigPolicyFilter | None = Field(default=None, description="Filter conditions")

--- a/src/ai/backend/common/dto/manager/v2/app_config_policy/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_policy/request.py
@@ -15,8 +15,8 @@ from ai.backend.common.identifier.app_config_policy import AppConfigPolicyID
 from .types import AppConfigPolicyOrderField, AppConfigScopeType, OrderDirection
 
 __all__ = (
-    "AdminAppConfigPolicyCreateItemInput",
-    "AdminAppConfigPolicyUpdateItemInput",
+    "AdminBulkCreateAppConfigPolicyItemInput",
+    "AdminBulkUpdateAppConfigPolicyItemInput",
     "AdminBulkCreateAppConfigPoliciesInput",
     "AdminBulkPurgeAppConfigPoliciesInput",
     "AdminBulkUpdateAppConfigPoliciesInput",
@@ -46,7 +46,7 @@ class AppConfigPolicyOrder(BaseRequestModel):
 # ── Bulk mutation inputs (bulk-only writes) ──────────────────────
 
 
-class AdminAppConfigPolicyCreateItemInput(BaseRequestModel):
+class AdminBulkCreateAppConfigPolicyItemInput(BaseRequestModel):
     """Per-item input for `adminBulkCreateAppConfigPolicies` —
     immutable `config_name` + initial `scope_sources`."""
 
@@ -69,7 +69,7 @@ class AdminAppConfigPolicyCreateItemInput(BaseRequestModel):
         return stripped
 
 
-class AdminAppConfigPolicyUpdateItemInput(BaseRequestModel):
+class AdminBulkUpdateAppConfigPolicyItemInput(BaseRequestModel):
     """Per-item input for `adminBulkUpdateAppConfigPolicies` — target
     row id + new `scope_sources`. `config_name` is immutable so it's
     not part of the update payload."""
@@ -81,11 +81,11 @@ class AdminAppConfigPolicyUpdateItemInput(BaseRequestModel):
 
 
 class AdminBulkCreateAppConfigPoliciesInput(BaseRequestModel):
-    items: list[AdminAppConfigPolicyCreateItemInput] = Field(description="Policies to create.")
+    items: list[AdminBulkCreateAppConfigPolicyItemInput] = Field(description="Policies to create.")
 
 
 class AdminBulkUpdateAppConfigPoliciesInput(BaseRequestModel):
-    items: list[AdminAppConfigPolicyUpdateItemInput] = Field(description="Policies to update.")
+    items: list[AdminBulkUpdateAppConfigPolicyItemInput] = Field(description="Policies to update.")
 
 
 class AdminBulkPurgeAppConfigPoliciesInput(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/app_config_policy/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_policy/response.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.identifier.app_config_policy import AppConfigPolicyID
 
 __all__ = (
@@ -27,7 +28,7 @@ class AppConfigPolicyNode(BaseResponseModel):
 
     id: AppConfigPolicyID = Field(description="Policy row ID")
     config_name: str = Field(description="Unique, immutable policy name.")
-    scope_sources: list[str] = Field(
+    scope_sources: list[AppConfigScopeType] = Field(
         description="Ordered scope chain (low → high merge priority).",
     )
     created_at: datetime = Field(description="Creation timestamp")

--- a/src/ai/backend/common/dto/manager/v2/app_config_policy/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_policy/response.py
@@ -1,0 +1,82 @@
+"""
+Response DTOs for app_config_policy DTO v2.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import Field
+
+from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.identifier.app_config_policy import AppConfigPolicyID
+
+__all__ = (
+    "AdminBulkCreateAppConfigPoliciesPayload",
+    "AdminBulkPurgeAppConfigPoliciesPayload",
+    "AdminBulkUpdateAppConfigPoliciesPayload",
+    "AppConfigPolicyBulkError",
+    "AppConfigPolicyNode",
+    "GetAppConfigPolicyPayload",
+    "SearchAppConfigPoliciesPayload",
+)
+
+
+class AppConfigPolicyNode(BaseResponseModel):
+    """Node representing a single app-config policy."""
+
+    id: AppConfigPolicyID = Field(description="Policy row ID")
+    config_name: str = Field(description="Unique, immutable policy name.")
+    scope_sources: list[str] = Field(
+        description="Ordered scope chain (low → high merge priority).",
+    )
+    created_at: datetime = Field(description="Creation timestamp")
+    updated_at: datetime | None = Field(default=None, description="Last update timestamp")
+
+
+class GetAppConfigPolicyPayload(BaseResponseModel):
+    """Payload returned after reading a single app-config policy by config_name."""
+
+    item: AppConfigPolicyNode | None = Field(default=None, description="Policy data, or null.")
+
+
+class SearchAppConfigPoliciesPayload(BaseResponseModel):
+    """Payload for paginated app-config policy search results."""
+
+    items: list[AppConfigPolicyNode] = Field(description="Policies matching the filter.")
+    total_count: int = Field(description="Total number of policies matching the filter.")
+    has_next_page: bool = Field(default=False, description="Whether there is a next page.")
+    has_previous_page: bool = Field(default=False, description="Whether there is a previous page.")
+
+
+# ── Bulk mutation payloads (bulk-only writes) ────────────────────
+
+
+class AppConfigPolicyBulkError(BaseResponseModel):
+    """Per-item failure info for bulk Policy mutations."""
+
+    index: int = Field(description="Original position in the input list.")
+    message: str = Field(description="Reason for the failure.")
+
+
+class AdminBulkCreateAppConfigPoliciesPayload(BaseResponseModel):
+    """Payload for `adminBulkCreateAppConfigPolicies`."""
+
+    created: list[AppConfigPolicyNode] = Field(description="Created policies.")
+    failed: list[AppConfigPolicyBulkError] = Field(description="Per-item failures.")
+
+
+class AdminBulkUpdateAppConfigPoliciesPayload(BaseResponseModel):
+    """Payload for `adminBulkUpdateAppConfigPolicies`."""
+
+    updated: list[AppConfigPolicyNode] = Field(description="Updated policies.")
+    failed: list[AppConfigPolicyBulkError] = Field(description="Per-item failures.")
+
+
+class AdminBulkPurgeAppConfigPoliciesPayload(BaseResponseModel):
+    """Payload for `adminBulkPurgeAppConfigPolicies`."""
+
+    purged_ids: list[AppConfigPolicyID] = Field(
+        description="Ids of policies actually removed (absent ids no-oped).",
+    )
+    failed: list[AppConfigPolicyBulkError] = Field(description="Per-item failures.")

--- a/src/ai/backend/common/dto/manager/v2/app_config_policy/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_policy/response.py
@@ -32,13 +32,13 @@ class AppConfigPolicyNode(BaseResponseModel):
         description="Ordered scope chain (low → high merge priority).",
     )
     created_at: datetime = Field(description="Creation timestamp")
-    updated_at: datetime | None = Field(default=None, description="Last update timestamp")
+    updated_at: datetime = Field(description="Last update timestamp")
 
 
 class GetAppConfigPolicyPayload(BaseResponseModel):
     """Payload returned after reading a single app-config policy by config_name."""
 
-    item: AppConfigPolicyNode | None = Field(default=None, description="Policy data, or null.")
+    item: AppConfigPolicyNode = Field(description="Policy data.")
 
 
 class SearchAppConfigPoliciesPayload(BaseResponseModel):

--- a/src/ai/backend/common/dto/manager/v2/app_config_policy/types.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_policy/types.py
@@ -6,11 +6,13 @@ from __future__ import annotations
 
 from enum import StrEnum
 
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.dto.manager.v2.common import OrderDirection
 
 __all__ = (
-    "OrderDirection",
     "AppConfigPolicyOrderField",
+    "AppConfigScopeType",
+    "OrderDirection",
 )
 
 

--- a/src/ai/backend/common/dto/manager/v2/app_config_policy/types.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_policy/types.py
@@ -1,0 +1,22 @@
+"""
+Common types for app_config_policy DTO v2.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from ai.backend.common.dto.manager.v2.common import OrderDirection
+
+__all__ = (
+    "OrderDirection",
+    "AppConfigPolicyOrderField",
+)
+
+
+class AppConfigPolicyOrderField(StrEnum):
+    """Fields available for ordering app config policies."""
+
+    CONFIG_NAME = "config_name"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"

--- a/src/ai/backend/manager/api/adapters/app_config_policy.py
+++ b/src/ai/backend/manager/api/adapters/app_config_policy.py
@@ -57,6 +57,14 @@ from ai.backend.manager.services.app_config_policy.actions.scoped_search import 
 
 from .base import BaseAdapter
 
+_APP_CONFIG_POLICY_PAGINATION_SPEC = PaginationSpec(
+    forward_order=AppConfigPolicyOrders.created_at(ascending=False),
+    backward_order=AppConfigPolicyOrders.created_at(ascending=True),
+    forward_condition_factory=AppConfigPolicyConditions.by_cursor_forward,
+    backward_condition_factory=AppConfigPolicyConditions.by_cursor_backward,
+    tiebreaker_order=AppConfigPolicyRow.id.asc(),
+)
+
 
 class AppConfigPolicyAdapter(BaseAdapter):
     """Adapter for AppConfigPolicy domain operations.
@@ -64,14 +72,6 @@ class AppConfigPolicyAdapter(BaseAdapter):
     Writes are bulk-only; single-item create / update / purge entry
     points are intentionally absent.
     """
-
-    _PAGINATION_SPEC = PaginationSpec(
-        forward_order=AppConfigPolicyOrders.created_at(ascending=False),
-        backward_order=AppConfigPolicyOrders.created_at(ascending=True),
-        forward_condition_factory=AppConfigPolicyConditions.by_cursor_forward,
-        backward_condition_factory=AppConfigPolicyConditions.by_cursor_backward,
-        tiebreaker_order=AppConfigPolicyRow.id.asc(),
-    )
 
     # ── Public surface ─────────────────────────────────────────────
 
@@ -173,7 +173,7 @@ class AppConfigPolicyAdapter(BaseAdapter):
         return self._build_querier(
             conditions=conditions,
             orders=orders,
-            pagination_spec=self._PAGINATION_SPEC,
+            pagination_spec=_APP_CONFIG_POLICY_PAGINATION_SPEC,
             first=input.first,
             after=input.after,
             last=input.last,

--- a/src/ai/backend/manager/api/adapters/app_config_policy.py
+++ b/src/ai/backend/manager/api/adapters/app_config_policy.py
@@ -72,7 +72,7 @@ class AppConfigPolicyAdapter(BaseAdapter):
             GetAppConfigPolicyAction(id=id)
         )
         return GetAppConfigPolicyPayload(
-            item=self._data_to_dto(result.policy) if result.policy is not None else None,
+            item=self._data_to_dto(result.policy),
         )
 
     async def admin_search(

--- a/src/ai/backend/manager/api/adapters/app_config_policy.py
+++ b/src/ai/backend/manager/api/adapters/app_config_policy.py
@@ -65,6 +65,14 @@ class AppConfigPolicyAdapter(BaseAdapter):
     points are intentionally absent.
     """
 
+    _PAGINATION_SPEC = PaginationSpec(
+        forward_order=AppConfigPolicyOrders.created_at(ascending=False),
+        backward_order=AppConfigPolicyOrders.created_at(ascending=True),
+        forward_condition_factory=AppConfigPolicyConditions.by_cursor_forward,
+        backward_condition_factory=AppConfigPolicyConditions.by_cursor_backward,
+        tiebreaker_order=AppConfigPolicyRow.id.asc(),
+    )
+
     # ── Public surface ─────────────────────────────────────────────
 
     async def get(self, id: AppConfigPolicyID) -> GetAppConfigPolicyPayload:
@@ -155,14 +163,6 @@ class AppConfigPolicyAdapter(BaseAdapter):
         )
 
     # ── Private helpers ────────────────────────────────────────────
-
-    _PAGINATION_SPEC = PaginationSpec(
-        forward_order=AppConfigPolicyOrders.created_at(ascending=False),
-        backward_order=AppConfigPolicyOrders.created_at(ascending=True),
-        forward_condition_factory=AppConfigPolicyConditions.by_cursor_forward,
-        backward_condition_factory=AppConfigPolicyConditions.by_cursor_backward,
-        tiebreaker_order=AppConfigPolicyRow.id.asc(),
-    )
 
     def _build_querier_from_input(
         self,

--- a/src/ai/backend/manager/api/adapters/app_config_policy.py
+++ b/src/ai/backend/manager/api/adapters/app_config_policy.py
@@ -79,7 +79,7 @@ class AppConfigPolicyAdapter(BaseAdapter):
         self, input: AdminSearchAppConfigPoliciesInput
     ) -> SearchAppConfigPoliciesPayload:
         querier = self._build_querier_from_input(input)
-        result = await self._processors.app_config_policy.admin_search.wait_for_complete(
+        result = await self._processors.app_config_policy_admin.admin_search.wait_for_complete(
             AdminSearchAppConfigPoliciesAction(querier=querier)
         )
         return SearchAppConfigPoliciesPayload(
@@ -117,7 +117,7 @@ class AppConfigPolicyAdapter(BaseAdapter):
             )
             for item in input.items
         ]
-        result = await self._processors.app_config_policy.admin_bulk_create.wait_for_complete(
+        result = await self._processors.app_config_policy_admin.admin_bulk_create.wait_for_complete(
             AdminBulkCreateAppConfigPoliciesAction(items=items)
         )
         return AdminBulkCreateAppConfigPoliciesPayload(
@@ -135,7 +135,7 @@ class AppConfigPolicyAdapter(BaseAdapter):
             )
             for item in input.items
         ]
-        result = await self._processors.app_config_policy.admin_bulk_update.wait_for_complete(
+        result = await self._processors.app_config_policy_admin.admin_bulk_update.wait_for_complete(
             AdminBulkUpdateAppConfigPoliciesAction(items=items)
         )
         return AdminBulkUpdateAppConfigPoliciesPayload(
@@ -146,7 +146,7 @@ class AppConfigPolicyAdapter(BaseAdapter):
     async def admin_bulk_purge(
         self, input: AdminBulkPurgeAppConfigPoliciesInput
     ) -> AdminBulkPurgeAppConfigPoliciesPayload:
-        result = await self._processors.app_config_policy.admin_bulk_purge.wait_for_complete(
+        result = await self._processors.app_config_policy_admin.admin_bulk_purge.wait_for_complete(
             AdminBulkPurgeAppConfigPoliciesAction(ids=list(input.ids))
         )
         return AdminBulkPurgeAppConfigPoliciesPayload(

--- a/src/ai/backend/manager/api/adapters/app_config_policy.py
+++ b/src/ai/backend/manager/api/adapters/app_config_policy.py
@@ -1,0 +1,245 @@
+"""AppConfigPolicy domain adapter — Pydantic-in / Pydantic-out transport layer."""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.app_config_policy.request import (
+    AdminBulkCreateAppConfigPoliciesInput,
+    AdminBulkPurgeAppConfigPoliciesInput,
+    AdminBulkUpdateAppConfigPoliciesInput,
+    AdminSearchAppConfigPoliciesInput,
+    AppConfigPolicyFilter,
+    AppConfigPolicyOrder,
+    ScopedSearchAppConfigPoliciesInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_policy.response import (
+    AdminBulkCreateAppConfigPoliciesPayload,
+    AdminBulkPurgeAppConfigPoliciesPayload,
+    AdminBulkUpdateAppConfigPoliciesPayload,
+    AppConfigPolicyBulkError,
+    AppConfigPolicyNode,
+    GetAppConfigPolicyPayload,
+    SearchAppConfigPoliciesPayload,
+)
+from ai.backend.common.dto.manager.v2.app_config_policy.types import (
+    AppConfigPolicyOrderField,
+    OrderDirection,
+)
+from ai.backend.common.identifier.app_config_policy import AppConfigPolicyID
+from ai.backend.manager.actions.action.types import SearchableActionTarget
+from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
+from ai.backend.manager.data.app_config_policy.types import (
+    AppConfigPolicyBulkCreateItem,
+    AppConfigPolicyBulkItemError,
+    AppConfigPolicyBulkUpdateItem,
+    AppConfigPolicyData,
+)
+from ai.backend.manager.models.app_config_policy.conditions import AppConfigPolicyConditions
+from ai.backend.manager.models.app_config_policy.orders import AppConfigPolicyOrders
+from ai.backend.manager.models.app_config_policy.row import AppConfigPolicyRow
+from ai.backend.manager.repositories.base import BatchQuerier, QueryCondition, QueryOrder
+from ai.backend.manager.services.app_config_policy.actions.admin_bulk_create import (
+    AdminBulkCreateAppConfigPoliciesAction,
+)
+from ai.backend.manager.services.app_config_policy.actions.admin_bulk_purge import (
+    AdminBulkPurgeAppConfigPoliciesAction,
+)
+from ai.backend.manager.services.app_config_policy.actions.admin_bulk_update import (
+    AdminBulkUpdateAppConfigPoliciesAction,
+)
+from ai.backend.manager.services.app_config_policy.actions.admin_search import (
+    AdminSearchAppConfigPoliciesAction,
+)
+from ai.backend.manager.services.app_config_policy.actions.get import GetAppConfigPolicyAction
+from ai.backend.manager.services.app_config_policy.actions.scoped_search import (
+    ConfigNameAppConfigPolicyTarget,
+    ScopedSearchAppConfigPoliciesAction,
+)
+
+from .base import BaseAdapter
+
+
+class AppConfigPolicyAdapter(BaseAdapter):
+    """Adapter for AppConfigPolicy domain operations.
+
+    Writes are bulk-only; single-item create / update / purge entry
+    points are intentionally absent.
+    """
+
+    # ── Public surface ─────────────────────────────────────────────
+
+    async def get(self, id: AppConfigPolicyID) -> GetAppConfigPolicyPayload:
+        result = await self._processors.app_config_policy.get.wait_for_complete(
+            GetAppConfigPolicyAction(id=id)
+        )
+        return GetAppConfigPolicyPayload(
+            item=self._data_to_dto(result.policy) if result.policy is not None else None,
+        )
+
+    async def admin_search(
+        self, input: AdminSearchAppConfigPoliciesInput
+    ) -> SearchAppConfigPoliciesPayload:
+        querier = self._build_querier_from_input(input)
+        result = await self._processors.app_config_policy.admin_search.wait_for_complete(
+            AdminSearchAppConfigPoliciesAction(querier=querier)
+        )
+        return SearchAppConfigPoliciesPayload(
+            items=[self._data_to_dto(item) for item in result.items],
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    async def scoped_search(
+        self, input: ScopedSearchAppConfigPoliciesInput
+    ) -> SearchAppConfigPoliciesPayload:
+        querier = self._build_querier_from_input(input)
+        targets: list[SearchableActionTarget] = [
+            ConfigNameAppConfigPolicyTarget(config_name=config_name)
+            for config_name in input.scope.config_names
+        ]
+        result = await self._processors.app_config_policy.scoped_search.wait_for_complete(
+            ScopedSearchAppConfigPoliciesAction(items=targets, querier=querier)
+        )
+        return SearchAppConfigPoliciesPayload(
+            items=[self._data_to_dto(item) for item in result.items],
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    async def admin_bulk_create(
+        self, input: AdminBulkCreateAppConfigPoliciesInput
+    ) -> AdminBulkCreateAppConfigPoliciesPayload:
+        items = [
+            AppConfigPolicyBulkCreateItem(
+                config_name=item.config_name,
+                scope_sources=list(item.scope_sources),
+            )
+            for item in input.items
+        ]
+        result = await self._processors.app_config_policy.admin_bulk_create.wait_for_complete(
+            AdminBulkCreateAppConfigPoliciesAction(items=items)
+        )
+        return AdminBulkCreateAppConfigPoliciesPayload(
+            created=[self._data_to_dto(policy) for policy in result.created],
+            failed=[self._bulk_error_to_dto(err) for err in result.failed],
+        )
+
+    async def admin_bulk_update(
+        self, input: AdminBulkUpdateAppConfigPoliciesInput
+    ) -> AdminBulkUpdateAppConfigPoliciesPayload:
+        items = [
+            AppConfigPolicyBulkUpdateItem(
+                id=item.id,
+                scope_sources=list(item.scope_sources),
+            )
+            for item in input.items
+        ]
+        result = await self._processors.app_config_policy.admin_bulk_update.wait_for_complete(
+            AdminBulkUpdateAppConfigPoliciesAction(items=items)
+        )
+        return AdminBulkUpdateAppConfigPoliciesPayload(
+            updated=[self._data_to_dto(policy) for policy in result.updated],
+            failed=[self._bulk_error_to_dto(err) for err in result.failed],
+        )
+
+    async def admin_bulk_purge(
+        self, input: AdminBulkPurgeAppConfigPoliciesInput
+    ) -> AdminBulkPurgeAppConfigPoliciesPayload:
+        result = await self._processors.app_config_policy.admin_bulk_purge.wait_for_complete(
+            AdminBulkPurgeAppConfigPoliciesAction(ids=list(input.ids))
+        )
+        return AdminBulkPurgeAppConfigPoliciesPayload(
+            purged_ids=list(result.purged_ids),
+            failed=[self._bulk_error_to_dto(err) for err in result.failed],
+        )
+
+    # ── Private helpers ────────────────────────────────────────────
+
+    _PAGINATION_SPEC = PaginationSpec(
+        forward_order=AppConfigPolicyOrders.created_at(ascending=False),
+        backward_order=AppConfigPolicyOrders.created_at(ascending=True),
+        forward_condition_factory=AppConfigPolicyConditions.by_cursor_forward,
+        backward_condition_factory=AppConfigPolicyConditions.by_cursor_backward,
+        tiebreaker_order=AppConfigPolicyRow.id.asc(),
+    )
+
+    def _build_querier_from_input(
+        self,
+        input: AdminSearchAppConfigPoliciesInput | ScopedSearchAppConfigPoliciesInput,
+    ) -> BatchQuerier:
+        conditions = self._convert_filter(input.filter) if input.filter else []
+        orders = self._convert_orders(input.order) if input.order else []
+        return self._build_querier(
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=self._PAGINATION_SPEC,
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+        )
+
+    def _convert_filter(self, filter: AppConfigPolicyFilter) -> list[QueryCondition]:
+        conditions: list[QueryCondition] = []
+        if filter.config_name is not None:
+            condition = self.convert_string_filter(
+                filter.config_name,
+                contains_factory=AppConfigPolicyConditions.by_config_name_contains,
+                equals_factory=AppConfigPolicyConditions.by_config_name_equals,
+                starts_with_factory=AppConfigPolicyConditions.by_config_name_starts_with,
+                ends_with_factory=AppConfigPolicyConditions.by_config_name_ends_with,
+                in_factory=AppConfigPolicyConditions.by_config_name_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if filter.created_at is not None:
+            condition = filter.created_at.build_query_condition(
+                before_factory=AppConfigPolicyConditions.by_created_at_before,
+                after_factory=AppConfigPolicyConditions.by_created_at_after,
+                equals_factory=AppConfigPolicyConditions.by_created_at_equals,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if filter.updated_at is not None:
+            condition = filter.updated_at.build_query_condition(
+                before_factory=AppConfigPolicyConditions.by_updated_at_before,
+                after_factory=AppConfigPolicyConditions.by_updated_at_after,
+                equals_factory=AppConfigPolicyConditions.by_updated_at_equals,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        return conditions
+
+    @staticmethod
+    def _convert_orders(orders: list[AppConfigPolicyOrder]) -> list[QueryOrder]:
+        result: list[QueryOrder] = []
+        for order in orders:
+            ascending = order.direction == OrderDirection.ASC
+            match order.field:
+                case AppConfigPolicyOrderField.CONFIG_NAME:
+                    result.append(AppConfigPolicyOrders.config_name(ascending))
+                case AppConfigPolicyOrderField.CREATED_AT:
+                    result.append(AppConfigPolicyOrders.created_at(ascending))
+                case AppConfigPolicyOrderField.UPDATED_AT:
+                    result.append(AppConfigPolicyOrders.updated_at(ascending))
+        return result
+
+    @staticmethod
+    def _data_to_dto(data: AppConfigPolicyData) -> AppConfigPolicyNode:
+        return AppConfigPolicyNode(
+            id=data.id,
+            config_name=data.config_name,
+            scope_sources=list(data.scope_sources),
+            created_at=data.created_at,
+            updated_at=data.updated_at,
+        )
+
+    @staticmethod
+    def _bulk_error_to_dto(err: AppConfigPolicyBulkItemError) -> AppConfigPolicyBulkError:
+        return AppConfigPolicyBulkError(
+            index=err.index,
+            message=err.message,
+        )

--- a/src/ai/backend/manager/api/adapters/registry.py
+++ b/src/ai/backend/manager/api/adapters/registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ai.backend.manager.api.adapters.agent.adapter import AgentAdapter
+from ai.backend.manager.api.adapters.app_config_policy import AppConfigPolicyAdapter
 from ai.backend.manager.api.adapters.artifact.adapter import ArtifactAdapter
 from ai.backend.manager.api.adapters.artifact_registry.adapter import ArtifactRegistryAdapter
 from ai.backend.manager.api.adapters.audit_log.adapter import AuditLogAdapter
@@ -72,6 +73,7 @@ class Adapters:
     def __init__(
         self,
         agent: AgentAdapter,
+        app_config_policy: AppConfigPolicyAdapter,
         artifact: ArtifactAdapter,
         artifact_registry: ArtifactRegistryAdapter,
         audit_log: AuditLogAdapter,
@@ -113,6 +115,7 @@ class Adapters:
         vfs_storage: VFSStorageAdapter,
     ) -> None:
         self.agent = agent
+        self.app_config_policy = app_config_policy
         self.artifact = artifact
         self.artifact_registry = artifact_registry
         self.audit_log = audit_log
@@ -173,6 +176,7 @@ class Adapters:
         """
         return cls(
             agent=AgentAdapter(processors),
+            app_config_policy=AppConfigPolicyAdapter(processors),
             artifact=ArtifactAdapter(processors),
             artifact_registry=ArtifactRegistryAdapter(processors),
             audit_log=AuditLogAdapter(processors),


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 14-PR stack delivering BEP-1052. **Merge in order:**

1. ⬇️ **#11265** — `chore(BA-5822): drop legacy AppConfig layer`
2. ⬇️ **#12178** — `feat(BA-6481): AppConfigPolicy foundation`
3. ⬇️ **#12179** — `feat(BA-6482): AppConfigPolicy repository layer`
4. ⬇️ **#12180** — `feat(BA-6483): AppConfigPolicy service layer`
5. 👉 **#12181** — `feat(BA-6484): AppConfigPolicy v2 DTO and API adapter` ← you are here
6. ⬇️ **#12182** — `test(BA-6485): AppConfigPolicy repository tests`
7. ⬇️ **#11269** — `feat(BA-5815): AppConfigPolicy GraphQL`
8. ⬇️ **#11312** — `feat(BA-5844): AppConfigPolicy REST v2`
9. ⬇️ **#11282** — `feat(BA-5827): AppConfigFragment foundation`
10. ⬇️ **#11296** — `feat(BA-5836): AppConfigFragment service vertical`
11. ⬇️ **#11285** — `feat(BA-5829): AppConfigFragment + AppConfig GraphQL`
12. ⬇️ **#11286** — `feat(BA-5830): AppConfigFragment + AppConfig REST v2`
13. ⬇️ **#11295** — `feat(BA-5832): AppConfig v2 SDK + CLI`
14. ⬇️ **#11298** — `feat(BA-5837): ValkeyCache for AppConfigFragment merged-view reads`

## Summary
- Adds the AppConfigPolicy v2 DTOs under `common/dto/manager/v2/app_config_policy/` (`request`, `response`, `types`), shared across GQL and REST v2:
  - Read: `AppConfigPolicyFilter` (config_name / created_at / updated_at), `AppConfigPolicyOrder` over `AppConfigPolicyOrderField`, plus `AdminSearchAppConfigPoliciesInput` (system-wide) and `ScopedSearchAppConfigPoliciesInput` (scoped by an OR-set of `config_names`), both with cursor + limit/offset pagination.
  - Write inputs are bulk-only: `AdminBulkCreate/Update/PurgeAppConfigPoliciesInput`. `config_name` is validated (stripped, non-blank, 1–128 chars) on create and is immutable on update (update takes `id` + `scope_sources`).
  - Response payloads: `AppConfigPolicyNode`, `GetAppConfigPolicyPayload`, `SearchAppConfigPoliciesPayload`, and bulk payloads that return successes alongside per-item `AppConfigPolicyBulkError` (`index` + `message`); purge reports `purged_ids` (absent ids no-op).
- Adds `AppConfigPolicyAdapter` (`api/adapters/app_config_policy.py`): a Pydantic-in / Pydantic-out transport layer mapping DTOs to service actions via processors and back to DTOs. It exposes `get`, `admin_search`, `scoped_search`, and `admin_bulk_create/update/purge`; single-item writes are intentionally absent.
  - Builds queriers from the search inputs (filter → `QueryCondition`s, order → `QueryOrder`s) using a shared `PaginationSpec` keyed on `created_at` with an `id` tiebreaker.
- Wires the adapter into the `Adapters` registry (`api/adapters/registry.py`).
