### PR TITLE
test(BA-6485): AppConfigPolicy repository tests

### DIFF
--- a/changes/12182.feature.md
+++ b/changes/12182.feature.md
@@ -1,0 +1,1 @@
+Add repository-layer tests for AppConfigPolicy.

--- a/tests/unit/manager/repositories/app_config_policy/BUILD
+++ b/tests/unit/manager/repositories/app_config_policy/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/tests/unit/manager/repositories/app_config_policy/test_app_config_policy.py
+++ b/tests/unit/manager/repositories/app_config_policy/test_app_config_policy.py
@@ -76,11 +76,12 @@ class TestAppConfigPolicyRepository:
         assert fetched.config_name == "preferences"
         assert list(fetched.scope_sources) == [AppConfigScopeType.DOMAIN_USER_DEFAULTS, AppConfigScopeType.USER]
 
-    async def test_get_by_id_returns_none_for_missing(
+    async def test_get_by_id_raises_for_missing(
         self,
         repository: AppConfigPolicyRepository,
     ) -> None:
-        assert await repository.get_by_id(AppConfigPolicyID(uuid.uuid4())) is None
+        with pytest.raises(AppConfigPolicyNotFound):
+            await repository.get_by_id(AppConfigPolicyID(uuid.uuid4()))
 
 
 class TestAppConfigPolicyAdminRepository:

--- a/tests/unit/manager/repositories/app_config_policy/test_app_config_policy.py
+++ b/tests/unit/manager/repositories/app_config_policy/test_app_config_policy.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncGenerator
 
 import pytest
 
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.identifier.app_config_policy import AppConfigPolicyID
 from ai.backend.manager.errors.app_config import AppConfigPolicyNotFound
 from ai.backend.manager.models.app_config_policy.row import AppConfigPolicyRow
@@ -50,15 +51,15 @@ class TestAppConfigPolicyRepository:
     ) -> None:
         created = await admin_repository.create(
             config_name="theme",
-            scope_sources=["domain"],
+            scope_sources=[AppConfigScopeType.DOMAIN],
         )
         assert created.config_name == "theme"
-        assert list(created.scope_sources) == ["domain"]
+        assert list(created.scope_sources) == [AppConfigScopeType.DOMAIN]
 
         fetched = await repository.get_by_id(created.id)
         assert fetched is not None
         assert fetched.id == created.id
-        assert list(fetched.scope_sources) == ["domain"]
+        assert list(fetched.scope_sources) == [AppConfigScopeType.DOMAIN]
 
     async def test_get_by_id_returns_full_record(
         self,
@@ -67,13 +68,13 @@ class TestAppConfigPolicyRepository:
     ) -> None:
         created = await admin_repository.create(
             config_name="preferences",
-            scope_sources=["domain_user_defaults", "user"],
+            scope_sources=[AppConfigScopeType.DOMAIN_USER_DEFAULTS, AppConfigScopeType.USER],
         )
 
         fetched = await repository.get_by_id(created.id)
         assert fetched is not None
         assert fetched.config_name == "preferences"
-        assert list(fetched.scope_sources) == ["domain_user_defaults", "user"]
+        assert list(fetched.scope_sources) == [AppConfigScopeType.DOMAIN_USER_DEFAULTS, AppConfigScopeType.USER]
 
     async def test_get_by_id_returns_none_for_missing(
         self,
@@ -106,14 +107,14 @@ class TestAppConfigPolicyAdminRepository:
     ) -> None:
         created = await admin_repository.create(
             config_name="theme",
-            scope_sources=["domain"],
+            scope_sources=[AppConfigScopeType.DOMAIN],
         )
         updated = await admin_repository.update(
             id=created.id,
-            scope_sources=["domain", "user"],
+            scope_sources=[AppConfigScopeType.DOMAIN, AppConfigScopeType.USER],
         )
         assert updated is not None
-        assert list(updated.scope_sources) == ["domain", "user"]
+        assert list(updated.scope_sources) == [AppConfigScopeType.DOMAIN, AppConfigScopeType.USER]
 
     async def test_update_raises_for_missing_id(
         self,
@@ -122,7 +123,7 @@ class TestAppConfigPolicyAdminRepository:
         with pytest.raises(AppConfigPolicyNotFound):
             await admin_repository.update(
                 id=AppConfigPolicyID(uuid.uuid4()),
-                scope_sources=["user"],
+                scope_sources=[AppConfigScopeType.USER],
             )
 
     async def test_purge_existing_policy_returns_true(
@@ -131,7 +132,7 @@ class TestAppConfigPolicyAdminRepository:
     ) -> None:
         created = await admin_repository.create(
             config_name="theme",
-            scope_sources=["domain"],
+            scope_sources=[AppConfigScopeType.DOMAIN],
         )
         assert await admin_repository.purge(created.id) is True
 

--- a/tests/unit/manager/repositories/app_config_policy/test_app_config_policy.py
+++ b/tests/unit/manager/repositories/app_config_policy/test_app_config_policy.py
@@ -1,0 +1,142 @@
+"""Repository tests for AppConfigPolicy with real database."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from ai.backend.common.identifier.app_config_policy import AppConfigPolicyID
+from ai.backend.manager.errors.app_config import AppConfigPolicyNotFound
+from ai.backend.manager.models.app_config_policy.row import AppConfigPolicyRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.app_config_policy.admin_repository import (
+    AppConfigPolicyAdminRepository,
+)
+from ai.backend.manager.repositories.app_config_policy.repository import (
+    AppConfigPolicyRepository,
+)
+from ai.backend.manager.repositories.ops import DBOpsProvider
+from ai.backend.testutils.db import with_tables
+
+
+class TestAppConfigPolicyRepository:
+    """Read-side tests for AppConfigPolicyRepository."""
+
+    @pytest.fixture
+    async def db(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [AppConfigPolicyRow],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    def repository(self, db: ExtendedAsyncSAEngine) -> AppConfigPolicyRepository:
+        return AppConfigPolicyRepository(DBOpsProvider(db))
+
+    @pytest.fixture
+    def admin_repository(self, db: ExtendedAsyncSAEngine) -> AppConfigPolicyAdminRepository:
+        return AppConfigPolicyAdminRepository(DBOpsProvider(db))
+
+    async def test_create_and_get_by_id(
+        self,
+        repository: AppConfigPolicyRepository,
+        admin_repository: AppConfigPolicyAdminRepository,
+    ) -> None:
+        created = await admin_repository.create(
+            config_name="theme",
+            scope_sources=["domain"],
+        )
+        assert created.config_name == "theme"
+        assert list(created.scope_sources) == ["domain"]
+
+        fetched = await repository.get_by_id(created.id)
+        assert fetched is not None
+        assert fetched.id == created.id
+        assert list(fetched.scope_sources) == ["domain"]
+
+    async def test_get_by_id_returns_full_record(
+        self,
+        repository: AppConfigPolicyRepository,
+        admin_repository: AppConfigPolicyAdminRepository,
+    ) -> None:
+        created = await admin_repository.create(
+            config_name="preferences",
+            scope_sources=["domain_user_defaults", "user"],
+        )
+
+        fetched = await repository.get_by_id(created.id)
+        assert fetched is not None
+        assert fetched.config_name == "preferences"
+        assert list(fetched.scope_sources) == ["domain_user_defaults", "user"]
+
+    async def test_get_by_id_returns_none_for_missing(
+        self,
+        repository: AppConfigPolicyRepository,
+    ) -> None:
+        assert await repository.get_by_id(AppConfigPolicyID(uuid.uuid4())) is None
+
+
+class TestAppConfigPolicyAdminRepository:
+    """Mutation-side tests for AppConfigPolicyAdminRepository."""
+
+    @pytest.fixture
+    async def db(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [AppConfigPolicyRow],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    def admin_repository(self, db: ExtendedAsyncSAEngine) -> AppConfigPolicyAdminRepository:
+        return AppConfigPolicyAdminRepository(DBOpsProvider(db))
+
+    async def test_update_replaces_scope_sources(
+        self,
+        admin_repository: AppConfigPolicyAdminRepository,
+    ) -> None:
+        created = await admin_repository.create(
+            config_name="theme",
+            scope_sources=["domain"],
+        )
+        updated = await admin_repository.update(
+            id=created.id,
+            scope_sources=["domain", "user"],
+        )
+        assert updated is not None
+        assert list(updated.scope_sources) == ["domain", "user"]
+
+    async def test_update_raises_for_missing_id(
+        self,
+        admin_repository: AppConfigPolicyAdminRepository,
+    ) -> None:
+        with pytest.raises(AppConfigPolicyNotFound):
+            await admin_repository.update(
+                id=AppConfigPolicyID(uuid.uuid4()),
+                scope_sources=["user"],
+            )
+
+    async def test_purge_existing_policy_returns_true(
+        self,
+        admin_repository: AppConfigPolicyAdminRepository,
+    ) -> None:
+        created = await admin_repository.create(
+            config_name="theme",
+            scope_sources=["domain"],
+        )
+        assert await admin_repository.purge(created.id) is True
+
+    async def test_purge_missing_policy_returns_false(
+        self,
+        admin_repository: AppConfigPolicyAdminRepository,
+    ) -> None:
+        assert await admin_repository.purge(AppConfigPolicyID(uuid.uuid4())) is False


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 14-PR stack delivering BEP-1052. **Merge in order:**

1. ⬇️ **#11265** — `chore(BA-5822): drop legacy AppConfig layer`
2. ⬇️ **#12178** — `feat(BA-6481): AppConfigPolicy foundation`
3. ⬇️ **#12179** — `feat(BA-6482): AppConfigPolicy repository layer`
4. ⬇️ **#12180** — `feat(BA-6483): AppConfigPolicy service layer`
5. ⬇️ **#12181** — `feat(BA-6484): AppConfigPolicy v2 DTO and API adapter`
6. 👉 **#12182** — `test(BA-6485): AppConfigPolicy repository tests` ← you are here
7. ⬇️ **#11269** — `feat(BA-5815): AppConfigPolicy GraphQL`
8. ⬇️ **#11312** — `feat(BA-5844): AppConfigPolicy REST v2`
9. ⬇️ **#11282** — `feat(BA-5827): AppConfigFragment foundation`
10. ⬇️ **#11296** — `feat(BA-5836): AppConfigFragment service vertical`
11. ⬇️ **#11285** — `feat(BA-5829): AppConfigFragment + AppConfig GraphQL`
12. ⬇️ **#11286** — `feat(BA-5830): AppConfigFragment + AppConfig REST v2`
13. ⬇️ **#11295** — `feat(BA-5832): AppConfig v2 SDK + CLI`
14. ⬇️ **#11298** — `feat(BA-5837): ValkeyCache for AppConfigFragment merged-view reads`

## Summary

Adds repository-layer tests for AppConfigPolicy, run against a real database via `with_tables([AppConfigPolicyRow])`.

- `TestAppConfigPolicyRepository` (read side): covers `get_by_id` returning the full record (including `scope_sources`), and asserts it raises `AppConfigPolicyNotFound` for a missing `AppConfigPolicyID`.
- `TestAppConfigPolicyAdminRepository` (mutation side): covers `create`, `update` (replacing `scope_sources`, plus raising `AppConfigPolicyNotFound` for a missing id), and `purge` (returning `True` for an existing policy, `False` for a missing one).
- Repositories are constructed with `DBOpsProvider(db)`, and `scope_sources` are exercised as `AppConfigScopeType` enum values.
