### PR TITLE
fix(BA-6488): correct broken request format of the imagify (convert-to-image) API

### DIFF
--- a/changes/12185.fix.md
+++ b/changes/12185.fix.md
@@ -1,0 +1,1 @@
+Fix the broken request format of the session `imagify` (convert-to-image) REST endpoint, which required a JSON body and rejected every request with a "Malformed request body" error.

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -1380,11 +1380,11 @@ class SessionHandler:
 
     async def convert_session_to_image(
         self,
-        body: BodyParam[ConvertSessionToImageRequest],
+        query: QueryParam[ConvertSessionToImageRequest],
         ctx: RequestCtx,
     ) -> APIResponse:
         request = ctx.request
-        params = body.parsed
+        params = query.parsed
         session_name: str = request.match_info["session_name"]
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(


### PR DESCRIPTION
## Summary
- The `POST /session/{name}/imagify` (convert-to-image) endpoint had a **broken request format**: BA-5694 (#11009) made the handler require a JSON body (`BodyParam[ConvertSessionToImageRequest]`), but the endpoint's request format is **query parameters** — no client sends a body.
- Every `convert-to-image` request therefore failed with `400 Bad Request: "Malformed request body"`.
- This fixes the endpoint to parse its request as query parameters again (`QueryParam`), the correct request format for this API, consistent with the other session POST handlers (`commit`, `download_single`, `restart`, `destroy`).

## Background
Discovered while live-verifying #12168 (BA-6454, image-commit error propagation): `convert-to-image` returned `Malformed request body` instead of reaching the commit bgtask. Tracked separately as BA-6488.

## Test plan
- [ ] `./backend.ai session convert-to-image <session> <image>` no longer returns `400 Malformed request body` and reaches the commit bgtask.
- [ ] Existing session REST handler tests pass.

Resolves BA-6488 ([Jira](https://lablup.atlassian.net/browse/BA-6488))

🤖 Generated with [Claude Code](https://claude.com/claude-code)