### PR TITLE
fix(BA-6454): propagate session commit bgtask failures to clients (#12168)

### DIFF
--- a/changes/12168.fix.md
+++ b/changes/12168.fix.md
@@ -1,0 +1,1 @@
+Fix image commit background task failures being reported to clients as successful, and allow committing sessions whose base image has been deleted.

--- a/src/ai/backend/common/bgtask/bgtask.py
+++ b/src/ai/backend/common/bgtask/bgtask.py
@@ -509,6 +509,8 @@ class BackgroundTaskManager:
             try:
                 task_result = await self._try_to_execute_new_task(task_name, manifest)
                 context.result = task_result
+                task_status = task_result.status().to_task_status()
+                last_message = task_result.result_message()
             except Exception as e:
                 task_status = TaskStatus.FAILURE
                 last_message = f"Task failed with exception: {e}"
@@ -536,6 +538,8 @@ class BackgroundTaskManager:
             try:
                 task_result = await self._try_to_revive_task(task_name, task_info)
                 context.result = task_result
+                task_status = task_result.status().to_task_status()
+                last_message = task_result.result_message()
             except Exception as e:
                 task_status = TaskStatus.FAILURE
                 last_message = f"Task failed with exception: {e}"

--- a/src/ai/backend/common/bgtask/task_result.py
+++ b/src/ai/backend/common/bgtask/task_result.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TypeVar
+from typing import TypeVar, override
 
 from ai.backend.common.bgtask.task.base import BaseBackgroundTaskResult
 from ai.backend.common.events.event_types.bgtask.broadcast import (
@@ -43,6 +43,11 @@ class TaskResult(ABC):
         """Get the error code if applicable."""
         raise NotImplementedError
 
+    @abstractmethod
+    def result_message(self) -> str:
+        """Get the message describing the task result."""
+        raise NotImplementedError
+
 
 @dataclass
 class TaskSuccessResult[R: BaseBackgroundTaskResult | None](TaskResult):
@@ -50,6 +55,7 @@ class TaskSuccessResult[R: BaseBackgroundTaskResult | None](TaskResult):
 
     result: R
 
+    @override
     def to_broadcast_event(self, task_id: uuid.UUID) -> BaseBgtaskDoneEvent:
         # For now, convert the result to string for the message
         # This assumes the result has a meaningful string representation
@@ -60,11 +66,17 @@ class TaskSuccessResult[R: BaseBackgroundTaskResult | None](TaskResult):
         )
         return BgtaskDoneEvent(task_id=task_id, message=message)
 
+    @override
     def status(self) -> BgtaskStatus:
         return BgtaskStatus.DONE
 
+    @override
     def error_code(self) -> ErrorCode | None:
         return None
+
+    @override
+    def result_message(self) -> str:
+        return "Task completed successfully"
 
 
 @dataclass
@@ -73,18 +85,25 @@ class TaskCancelledResult(TaskResult):
 
     message: str = "Task cancelled"
 
+    @override
     def to_broadcast_event(self, task_id: uuid.UUID) -> BaseBgtaskDoneEvent:
         return BgtaskCancelledEvent(task_id, self.message)
 
+    @override
     def status(self) -> BgtaskStatus:
         return BgtaskStatus.CANCELLED
 
+    @override
     def error_code(self) -> ErrorCode | None:
         return ErrorCode(
             domain=ErrorDomain.BGTASK,
             operation=ErrorOperation.EXECUTE,
             error_detail=ErrorDetail.CANCELED,
         )
+
+    @override
+    def result_message(self) -> str:
+        return self.message
 
 
 @dataclass
@@ -93,12 +112,15 @@ class TaskFailedResult(TaskResult):
 
     exception: BaseException
 
+    @override
     def to_broadcast_event(self, task_id: uuid.UUID) -> BaseBgtaskDoneEvent:
         return BgtaskFailedEvent(task_id, repr(self.exception))
 
+    @override
     def status(self) -> BgtaskStatus:
         return BgtaskStatus.FAILED
 
+    @override
     def error_code(self) -> ErrorCode | None:
         if isinstance(self.exception, BackendAIError):
             return self.exception.error_code()
@@ -107,3 +129,7 @@ class TaskFailedResult(TaskResult):
             operation=ErrorOperation.EXECUTE,
             error_detail=ErrorDetail.INTERNAL_ERROR,
         )
+
+    @override
+    def result_message(self) -> str:
+        return f"Task failed with exception: {self.exception}"

--- a/src/ai/backend/common/bgtask/types.py
+++ b/src/ai/backend/common/bgtask/types.py
@@ -26,6 +26,15 @@ class BgtaskStatus(enum.StrEnum):
     def finished(self) -> bool:
         return self in {self.DONE, self.CANCELLED, self.FAILED, self.PARTIAL_SUCCESS}
 
+    def to_task_status(self) -> TaskStatus:
+        match self:
+            case BgtaskStatus.DONE | BgtaskStatus.PARTIAL_SUCCESS:
+                return TaskStatus.SUCCESS
+            case BgtaskStatus.CANCELLED | BgtaskStatus.FAILED:
+                return TaskStatus.FAILURE
+            case _:
+                return TaskStatus.ONGOING
+
 
 class BgtaskNameBase(Protocol):
     """

--- a/src/ai/backend/manager/bgtask/tasks/commit_session.py
+++ b/src/ai/backend/manager/bgtask/tasks/commit_session.py
@@ -30,6 +30,8 @@ from ai.backend.common.types import AgentId, ImageRegistry, SessionId
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.bgtask.types import ManagerBgtaskName
 from ai.backend.manager.data.image.types import ImageIdentifier
+from ai.backend.manager.errors.image import ContainerRegistryNotFound
+from ai.backend.manager.errors.kernel import SessionNotFound
 
 if TYPE_CHECKING:
     from ai.backend.common.events.fetcher import EventFetcher
@@ -44,14 +46,15 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 class CommitSessionResult(BaseBackgroundTaskResult):
     """
-    Result of commit session background task.
-    Contains the rescanned image ID or error message.
+    Result of a successful commit session background task.
+
+    Failures are propagated by raising from ``execute()``, so this result only
+    carries success payload.
     """
 
     image_id: uuid.UUID | None = Field(
         default=None, description="ID of the rescanned image after commit"
     )
-    error_message: str | None = Field(default=None, description="Error message if task failed")
 
 
 class CommitSessionManifest(BaseBackgroundTaskManifest):
@@ -111,29 +114,28 @@ class CommitSessionHandler(BaseBackgroundTaskHandler[CommitSessionManifest, Comm
             # Get session and validate
             session = await self._session_repository.get_session_by_id(manifest.session_id)
             if not session:
-                error_msg = f"Session {manifest.session_id} not found"
-                log.error(error_msg)
-                return CommitSessionResult(error_message=error_msg)
+                raise SessionNotFound(f"Session {manifest.session_id} not found")
 
             # Get registry configuration
             registry_conf = await self._session_repository.get_container_registry(
                 manifest.registry_hostname, manifest.registry_project
             )
             if not registry_conf:
-                error_msg = f"Project {manifest.registry_project} not found in registry {manifest.registry_hostname}"
-                log.error(error_msg)
-                return CommitSessionResult(error_message=error_msg)
+                raise ContainerRegistryNotFound(
+                    f"Project {manifest.registry_project} not found in registry {manifest.registry_hostname}"
+                )
 
             # Resolve base image
             if not session.main_kernel.image or not session.main_kernel.architecture:
-                error_msg = (
-                    f"Session {manifest.session_id} main kernel has no image or architecture"
+                raise BgtaskFailedError(
+                    extra_msg=f"Session {manifest.session_id} main kernel has no image or architecture"
                 )
-                log.error(error_msg)
-                return CommitSessionResult(error_message=error_msg)
-            image_row = await self._session_repository.resolve_image([
-                ImageIdentifier(session.main_kernel.image, session.main_kernel.architecture)
-            ])
+            # The base image may have been deleted while the session is still
+            # running, so include non-alive images when resolving it.
+            image_row = await self._session_repository.resolve_image(
+                [ImageIdentifier(session.main_kernel.image, session.main_kernel.architecture)],
+                alive_only=False,
+            )
             base_image_ref = image_row.image_ref
 
             # Build new image canonical name
@@ -218,9 +220,9 @@ class CommitSessionHandler(BaseBackgroundTaskHandler[CommitSessionManifest, Comm
                     password=registry_conf.password,
                 )
                 if not session.main_kernel.agent:
-                    error_msg = f"Session {manifest.session_id} main kernel has no agent assigned"
-                    log.error(error_msg)
-                    return CommitSessionResult(error_message=error_msg)
+                    raise BgtaskFailedError(
+                        extra_msg=f"Session {manifest.session_id} main kernel has no agent assigned"
+                    )
                 resp = await self._agent_registry.push_image(
                     AgentId(session.main_kernel.agent),
                     new_image_ref,
@@ -239,11 +241,9 @@ class CommitSessionHandler(BaseBackgroundTaskHandler[CommitSessionManifest, Comm
 
             if len(rescan_result.images) == 0:
                 rescan_errors = ",".join(rescan_result.errors)
-                error_msg = (
-                    f"Session commit succeeded, but no image was rescanned, Error: {rescan_errors}"
+                raise BgtaskFailedError(
+                    extra_msg=f"Session commit succeeded, but no image was rescanned, Error: {rescan_errors}"
                 )
-                log.error(error_msg)
-                return CommitSessionResult(error_message=error_msg)
             if len(rescan_result.images) > 1:
                 log.warning(
                     "More than two images were rescanned unexpectedly. Rescanned Images: {}",
@@ -254,9 +254,9 @@ class CommitSessionHandler(BaseBackgroundTaskHandler[CommitSessionManifest, Comm
             log.info("Session commit completed successfully. Image ID: {}", result_image_id)
             return CommitSessionResult(image_id=result_image_id)
 
-        except Exception as e:
+        except Exception:
             log.exception("Failed to commit session {}", manifest.session_id)
-            return CommitSessionResult(error_message=str(e))
+            raise
 
     async def _wait_for_agent_bgtask(self, bgtask_id: uuid.UUID, operation_name: str) -> None:
         """Wait for an agent background task to complete."""

--- a/tests/unit/common/bgtask/test_task_result.py
+++ b/tests/unit/common/bgtask/test_task_result.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+
+from ai.backend.common.bgtask.task_result import (
+    TaskCancelledResult,
+    TaskFailedResult,
+    TaskSuccessResult,
+)
+from ai.backend.common.bgtask.types import BgtaskStatus, TaskStatus
+
+
+class TestBgtaskStatusToTaskStatus:
+    """Regression tests for BgtaskStatus.to_task_status().
+
+    A finished bgtask must map onto the *actual* TaskStatus recorded in the task
+    store. Previously every finished subtask was unconditionally marked SUCCESS,
+    so failed/cancelled commits were stored as SUCCESS (see PR #12168).
+    """
+
+    @pytest.mark.parametrize(
+        ("bgtask_status", "expected"),
+        [
+            (BgtaskStatus.DONE, TaskStatus.SUCCESS),
+            (BgtaskStatus.PARTIAL_SUCCESS, TaskStatus.SUCCESS),
+            (BgtaskStatus.CANCELLED, TaskStatus.FAILURE),
+            (BgtaskStatus.FAILED, TaskStatus.FAILURE),
+            (BgtaskStatus.STARTED, TaskStatus.ONGOING),
+            (BgtaskStatus.UPDATED, TaskStatus.ONGOING),
+            (BgtaskStatus.UNKNOWN, TaskStatus.ONGOING),
+        ],
+    )
+    def test_to_task_status_mapping(
+        self, bgtask_status: BgtaskStatus, expected: TaskStatus
+    ) -> None:
+        assert bgtask_status.to_task_status() == expected
+
+
+class TestTaskResultMessage:
+    """Regression tests for TaskResult.result_message().
+
+    The failure reason must be carried into the recorded task message instead of
+    being discarded (see PR #12168).
+    """
+
+    def test_success_result_message(self) -> None:
+        result = TaskSuccessResult(result=None)
+        assert result.result_message() == "Task completed successfully"
+
+    def test_cancelled_result_message(self) -> None:
+        result = TaskCancelledResult(message="cancelled by user")
+        assert result.result_message() == "cancelled by user"
+
+    def test_failed_result_message_includes_exception(self) -> None:
+        result = TaskFailedResult(exception=ZeroDivisionError("boom"))
+        message = result.result_message()
+        assert "boom" in message
+        assert message != "Task completed successfully"

--- a/tests/unit/manager/bgtask/tasks/test_commit_session.py
+++ b/tests/unit/manager/bgtask/tasks/test_commit_session.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -12,6 +13,20 @@ from ai.backend.manager.bgtask.tasks.commit_session import (
     CommitSessionResult,
 )
 from ai.backend.manager.bgtask.types import ManagerBgtaskName
+from ai.backend.manager.errors.kernel import SessionNotFound
+
+
+@pytest.fixture
+def sample_manifest() -> CommitSessionManifest:
+    return CommitSessionManifest(
+        session_id=SessionId(uuid.uuid4()),
+        registry_hostname="registry.example.com",
+        registry_project="test-project",
+        image_name="test-image",
+        image_visibility=CustomizedImageVisibilityScope.USER,
+        image_owner_id="user-123",
+        user_email="test@example.com",
+    )
 
 
 class TestCommitSessionHandler:
@@ -21,19 +36,6 @@ class TestCommitSessionHandler:
     def sample_session_id(self) -> SessionId:
         """Sample session ID for testing."""
         return SessionId(uuid.uuid4())
-
-    @pytest.fixture
-    def sample_manifest(self, sample_session_id: SessionId) -> CommitSessionManifest:
-        """Sample manifest for testing."""
-        return CommitSessionManifest(
-            session_id=sample_session_id,
-            registry_hostname="registry.example.com",
-            registry_project="test-project",
-            image_name="test-image",
-            image_visibility=CustomizedImageVisibilityScope.USER,
-            image_owner_id="user-123",
-            user_email="test@example.com",
-        )
 
     def test_handler_name(self) -> None:
         """Test handler returns correct name."""
@@ -81,34 +83,63 @@ class TestCommitSessionHandler:
         """Test result default values are None."""
         result = CommitSessionResult()
         assert result.image_id is None
-        assert result.error_message is None
 
     def test_result_success_serialization(self) -> None:
         """Test result can be serialized and deserialized with success case."""
         image_id = uuid.uuid4()
-        result = CommitSessionResult(image_id=image_id, error_message=None)
+        result = CommitSessionResult(image_id=image_id)
 
         # Serialize to dict
         data = result.model_dump(mode="json")
         assert data["image_id"] == str(image_id)
-        assert data["error_message"] is None
 
         # Deserialize back
         restored = CommitSessionResult.model_validate(data)
         assert restored.image_id == image_id
-        assert restored.error_message is None
 
-    def test_result_error_serialization(self) -> None:
-        """Test result can be serialized and deserialized with error case."""
-        error_msg = "Session not found"
-        result = CommitSessionResult(image_id=None, error_message=error_msg)
 
-        # Serialize to dict
-        data = result.model_dump(mode="json")
-        assert data["image_id"] is None
-        assert data["error_message"] == error_msg
+class TestCommitSessionExecute:
+    """Regression tests for CommitSessionHandler.execute() (PR #12168)."""
 
-        # Deserialize back
-        restored = CommitSessionResult.model_validate(data)
-        assert restored.image_id is None
-        assert restored.error_message == error_msg
+    def _make_handler(self, session_repository: AsyncMock) -> CommitSessionHandler:
+        return CommitSessionHandler(
+            session_repository=session_repository,
+            image_repository=AsyncMock(),
+            agent_registry=AsyncMock(),
+            event_hub=MagicMock(),
+            event_fetcher=MagicMock(),
+        )
+
+    async def test_failure_raises_instead_of_returning_result(
+        self, sample_manifest: CommitSessionManifest
+    ) -> None:
+        # Failures must propagate as exceptions (-> bgtask_failed) instead of
+        # being swallowed into a success-typed CommitSessionResult.
+        session_repository = AsyncMock()
+        session_repository.get_session_by_id.return_value = None
+        handler = self._make_handler(session_repository)
+
+        with pytest.raises(SessionNotFound):
+            await handler.execute(sample_manifest)
+
+    async def test_base_image_resolved_including_deleted(
+        self, sample_manifest: CommitSessionManifest
+    ) -> None:
+        # A running session's base image may have been deleted, so it must be
+        # resolved with alive_only=False.
+        session = MagicMock()
+        session.main_kernel.image = "registry.example.com/base:latest"
+        session.main_kernel.architecture = "x86_64"
+
+        session_repository = AsyncMock()
+        session_repository.get_session_by_id.return_value = session
+        session_repository.get_container_registry.return_value = MagicMock()
+        # Stop right after resolve_image to keep the test focused.
+        session_repository.resolve_image.side_effect = RuntimeError("stop here")
+        handler = self._make_handler(session_repository)
+
+        with pytest.raises(RuntimeError):
+            await handler.execute(sample_manifest)
+
+        _, kwargs = session_repository.resolve_image.call_args
+        assert kwargs["alive_only"] is False


### PR DESCRIPTION
This is an auto-generated backport PR of #12168 to the 26.4 release.