### PR TITLE
chore: merge diverged alembic heads

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/5d08e1164834_merge_heads.py
+++ b/src/ai/backend/manager/models/alembic/versions/5d08e1164834_merge_heads.py
@@ -1,0 +1,22 @@
+"""Merge heads b7fa28e23b29 and 84d5c6daf8cc
+
+Revision ID: 5d08e1164834
+Revises: b7fa28e23b29, 84d5c6daf8cc
+Create Date: 2026-06-15 10:53:07.112232
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "5d08e1164834"
+down_revision = ("b7fa28e23b29", "84d5c6daf8cc")
+# Part of: {NEXT_RELEASE_VERSION}
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary

`check-multiple-alembic-heads.py` reported two heads:

- `b7fa28e23b29` (add_route_termination_grace_period)
- `84d5c6daf8cc` (drop_legacy_app_configs_table)

Both branch directly off the common ancestor `f3a8c1d05e64`. This adds a merge migration (`5d08e1164834`) that collapses them into a single head with no schema changes (`upgrade`/`downgrade` are no-ops).

## Verification

```
$ python scripts/check-multiple-alembic-heads.py
Detected head revisions: 5d08e1164834
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)