### PR TITLE
fix(BA-6489): translate legacy inference env vars into model-service CLI args

### DIFF
--- a/changes/12191.fix.md
+++ b/changes/12191.fix.md
@@ -1,0 +1,1 @@
+Restore legacy inference env vars (`VLLM_EXTRA_ARGS`, `VLLM_TP_SIZE`, ...) by translating them into model-service CLI args on the agent

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -67,7 +67,7 @@ from ai.backend.agent.errors import (
 )
 from ai.backend.agent.etcd import AgentEtcdClientView
 from ai.backend.agent.health.heartbeat import HeartbeatTask
-from ai.backend.agent.legacy_inference_env import LegacyInferenceEnvArgs
+from ai.backend.agent.legacy_inference_env import LegacyInferenceEnvTranslator
 from ai.backend.agent.metrics.metric import (
     StatScope,
     StatTaskObserver,
@@ -2489,7 +2489,7 @@ class AbstractAgent[
         environ: Mapping[str, str],
     ) -> list[ModelConfig]:
         """Append legacy env-derived CLI args (e.g. VLLM_EXTRA_ARGS) to start_command."""
-        extra_args = LegacyInferenceEnvArgs.to_cli_args(environ)
+        extra_args = LegacyInferenceEnvTranslator.to_cli_args(environ)
         if not extra_args:
             return models
         for model in models:

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -67,6 +67,7 @@ from ai.backend.agent.errors import (
 )
 from ai.backend.agent.etcd import AgentEtcdClientView
 from ai.backend.agent.health.heartbeat import HeartbeatTask
+from ai.backend.agent.legacy_inference_env import LegacyInferenceEnvArgs
 from ai.backend.agent.metrics.metric import (
     StatScope,
     StatTaskObserver,
@@ -2482,6 +2483,22 @@ class AbstractAgent[
             model.service.start_command = list(image_command)
         return models
 
+    def _append_legacy_inference_env_args(
+        self,
+        models: list[ModelConfig],
+        environ: Mapping[str, str],
+    ) -> list[ModelConfig]:
+        """Append legacy env-derived CLI args (e.g. VLLM_EXTRA_ARGS) to start_command."""
+        extra_args = LegacyInferenceEnvArgs.to_cli_args(environ)
+        if not extra_args:
+            return models
+        for model in models:
+            service = model.service
+            if service is None or not service.start_command:
+                continue
+            service.start_command = [*service.start_command, *extra_args]
+        return models
+
     async def create_kernel(
         self,
         ownership_data: KernelOwnershipData,
@@ -3177,6 +3194,10 @@ class AbstractAgent[
                         populated_models = await self._apply_image_cmd_fallback(
                             model_definition.models,
                             ctx.image_ref.canonical,
+                        )
+                        populated_models = self._append_legacy_inference_env_args(
+                            populated_models,
+                            environ,
                         )
                         for model in populated_models:
                             if model.service is None:

--- a/src/ai/backend/agent/legacy_inference_env.py
+++ b/src/ai/backend/agent/legacy_inference_env.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import shlex
+from collections.abc import Mapping
+
+__all__ = ("LegacyInferenceEnvArgs",)
+
+
+class LegacyInferenceEnvArgs:
+    """Translate legacy ``VLLM_*`` / ``SGLANG_*`` env vars into CLI args the baseline lost.
+
+    Replaces the image ``start-*.sh`` wrapper the baseline ``start_command`` overrides.
+    """
+
+    # Env key -> CLI flag; value appended after the flag.
+    _FLAG_BY_ENV: Mapping[str, str] = {
+        "VLLM_QUANTIZATION": "--quantization",
+        "VLLM_TP_SIZE": "--tensor-parallel-size",
+        "VLLM_PP_SIZE": "--pipeline-parallel-size",
+        "SGLANG_QUANTIZATION": "--quantization",
+        "SGLANG_TP_SIZE": "--tensor-parallel-size",
+        "SGLANG_PP_SIZE": "--pipeline-parallel-size",
+    }
+
+    # Raw arg-string keys: shell-split, appended last (override the flags above).
+    _RAW_ARG_ENVS: tuple[str, ...] = ("VLLM_EXTRA_ARGS", "SGLANG_EXTRA_ARGS")
+
+    @staticmethod
+    def to_cli_args(environ: Mapping[str, str]) -> list[str]:
+        args: list[str] = []
+        for env_key, flag in LegacyInferenceEnvArgs._FLAG_BY_ENV.items():
+            value = environ.get(env_key)
+            if value:
+                args.append(flag)
+                args.append(value)
+        for env_key in LegacyInferenceEnvArgs._RAW_ARG_ENVS:
+            value = environ.get(env_key)
+            if value:
+                args.extend(shlex.split(value))
+        return args

--- a/src/ai/backend/agent/legacy_inference_env.py
+++ b/src/ai/backend/agent/legacy_inference_env.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import shlex
 from collections.abc import Mapping
 
+from ai.backend.agent.errors.agent import InvalidArgumentError
+
 __all__ = ("LegacyInferenceEnvTranslator",)
 
 
@@ -36,5 +38,8 @@ class LegacyInferenceEnvTranslator:
         for env_key in LegacyInferenceEnvTranslator._RAW_ARG_ENVS:
             value = environ.get(env_key)
             if value:
-                args.extend(shlex.split(value))
+                try:
+                    args.extend(shlex.split(value))
+                except ValueError as e:
+                    raise InvalidArgumentError(f"Malformed quoting in {env_key}: {e}") from e
         return args

--- a/src/ai/backend/agent/legacy_inference_env.py
+++ b/src/ai/backend/agent/legacy_inference_env.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import shlex
 from collections.abc import Mapping
 
-__all__ = ("LegacyInferenceEnvArgs",)
+__all__ = ("LegacyInferenceEnvTranslator",)
 
 
-class LegacyInferenceEnvArgs:
+class LegacyInferenceEnvTranslator:
     """Translate legacy ``VLLM_*`` / ``SGLANG_*`` env vars into CLI args the baseline lost.
 
     Replaces the image ``start-*.sh`` wrapper the baseline ``start_command`` overrides.
@@ -28,12 +28,12 @@ class LegacyInferenceEnvArgs:
     @staticmethod
     def to_cli_args(environ: Mapping[str, str]) -> list[str]:
         args: list[str] = []
-        for env_key, flag in LegacyInferenceEnvArgs._FLAG_BY_ENV.items():
+        for env_key, flag in LegacyInferenceEnvTranslator._FLAG_BY_ENV.items():
             value = environ.get(env_key)
             if value:
                 args.append(flag)
                 args.append(value)
-        for env_key in LegacyInferenceEnvArgs._RAW_ARG_ENVS:
+        for env_key in LegacyInferenceEnvTranslator._RAW_ARG_ENVS:
             value = environ.get(env_key)
             if value:
                 args.extend(shlex.split(value))

--- a/src/ai/backend/kernel/service.py
+++ b/src/ai/backend/kernel/service.py
@@ -218,6 +218,13 @@ class ServiceArgumentInterpolator:
                     case TokenType.TEXT:
                         tokens.append(token)
                     case TokenType.EXPR:
-                        tokens.append(("{" + token + "}").format_map(variables))
+                        try:
+                            tokens.append(("{" + token + "}").format_map(variables))
+                        except (KeyError, ValueError, IndexError) as e:
+                            raise InvalidServiceDefinition(
+                                f"Cannot interpolate service argument {part!r}: {e}. "
+                                "Literal braces arguments (e.g. JSON like vLLM '--hf-overrides') "
+                                "are not supported."
+                            ) from e
             processed_parts.append("".join(tokens))
         return processed_parts

--- a/src/ai/backend/kernel/service.py
+++ b/src/ai/backend/kernel/service.py
@@ -220,10 +220,15 @@ class ServiceArgumentInterpolator:
                     case TokenType.EXPR:
                         try:
                             tokens.append(("{" + token + "}").format_map(variables))
-                        except (KeyError, ValueError, IndexError) as e:
+                        except (KeyError, IndexError) as e:
+                            raise InvalidServiceDefinition(
+                                f"Cannot interpolate service argument {part!r}: "
+                                f"undefined template variable {e}."
+                            ) from e
+                        except ValueError as e:
                             raise InvalidServiceDefinition(
                                 f"Cannot interpolate service argument {part!r}: {e}. "
-                                "Literal braces arguments (e.g. JSON like vLLM '--hf-overrides') "
+                                "Literal braces (e.g. JSON like vLLM '--hf-overrides') "
                                 "are not supported."
                             ) from e
             processed_parts.append("".join(tokens))

--- a/tests/unit/agent/test_legacy_inference_env.py
+++ b/tests/unit/agent/test_legacy_inference_env.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+import pytest
+
+from ai.backend.agent.agent import AbstractAgent
+from ai.backend.agent.legacy_inference_env import LegacyInferenceEnvArgs
+from ai.backend.common.config import ModelConfig
+
+
+@dataclass(frozen=True)
+class CollectScenario:
+    id: str
+    environ: dict[str, str]
+    expected: list[str]
+
+
+class TestLegacyInferenceEnvArgsToCliArgs:
+    @pytest.mark.parametrize(
+        "scenario",
+        [
+            CollectScenario(id="empty_environ", environ={}, expected=[]),
+            CollectScenario(
+                id="ignores_unknown_keys",
+                environ={"PATH": "/usr/bin", "VLLM_VERSION": "0.9.1"},
+                expected=[],
+            ),
+            CollectScenario(
+                id="skips_empty_values",
+                environ={"VLLM_TP_SIZE": "", "VLLM_EXTRA_ARGS": ""},
+                expected=[],
+            ),
+            CollectScenario(
+                id="maps_flag_envs_with_values",
+                environ={
+                    "VLLM_QUANTIZATION": "awq",
+                    "VLLM_TP_SIZE": "4",
+                    "VLLM_PP_SIZE": "2",
+                },
+                expected=[
+                    "--quantization",
+                    "awq",
+                    "--tensor-parallel-size",
+                    "4",
+                    "--pipeline-parallel-size",
+                    "2",
+                ],
+            ),
+            CollectScenario(
+                id="shlex_splits_extra_args",
+                environ={"VLLM_EXTRA_ARGS": "--trust-remote-code --max-model-len 524288"},
+                expected=["--trust-remote-code", "--max-model-len", "524288"],
+            ),
+            CollectScenario(
+                id="extra_args_appended_after_flag_envs",
+                environ={
+                    "VLLM_TP_SIZE": "4",
+                    "VLLM_EXTRA_ARGS": "--trust-remote-code --reasoning-parser kimi_k2",
+                },
+                expected=[
+                    "--tensor-parallel-size",
+                    "4",
+                    "--trust-remote-code",
+                    "--reasoning-parser",
+                    "kimi_k2",
+                ],
+            ),
+            CollectScenario(
+                id="shlex_respects_quotes",
+                environ={"VLLM_EXTRA_ARGS": "--foo 'a b' --bar"},
+                expected=["--foo", "a b", "--bar"],
+            ),
+            CollectScenario(
+                id="maps_sglang_envs",
+                environ={
+                    "SGLANG_TP_SIZE": "8",
+                    "SGLANG_EXTRA_ARGS": "--trust-remote-code",
+                },
+                expected=["--tensor-parallel-size", "8", "--trust-remote-code"],
+            ),
+            CollectScenario(
+                id="keeps_quoted_json_arg_as_single_token",
+                environ={
+                    "VLLM_EXTRA_ARGS": (
+                        '--hf-overrides \'{"rope_parameters": {"type": "yarn",'
+                        ' "factor": 4.0}}\' --max-model-len 524288'
+                    ),
+                },
+                expected=[
+                    "--hf-overrides",
+                    '{"rope_parameters": {"type": "yarn", "factor": 4.0}}',
+                    "--max-model-len",
+                    "524288",
+                ],
+            ),
+            CollectScenario(
+                id="preserves_key_value_and_dotted_tokens",
+                environ={
+                    "VLLM_EXTRA_ARGS": (
+                        "--attention-config.use_trtllm_ragged_deepseek_prefill=True"
+                        " --hf-overrides.rope_parameters.factor 2.0"
+                    ),
+                },
+                expected=[
+                    "--attention-config.use_trtllm_ragged_deepseek_prefill=True",
+                    "--hf-overrides.rope_parameters.factor",
+                    "2.0",
+                ],
+            ),
+        ],
+        ids=lambda scenario: scenario.id,
+    )
+    def test_to_cli_args(
+        self,
+        scenario: CollectScenario,
+    ) -> None:
+        assert LegacyInferenceEnvArgs.to_cli_args(scenario.environ) == scenario.expected
+
+
+def _model(name: str, start_command: list[str] | None) -> ModelConfig:
+    return ModelConfig.model_validate({
+        "name": name,
+        "model_path": f"/models/{name}",
+        "service": {
+            "port": 8000,
+            "shell": "/bin/bash",
+            "start_command": start_command,
+        },
+    })
+
+
+class TestAppendLegacyInferenceEnvArgs:
+    def test_appends_to_existing_start_command(self) -> None:
+        models = [_model("vllm", ["vllm", "serve", "/models"])]
+        environ = {"VLLM_EXTRA_ARGS": "--trust-remote-code", "VLLM_TP_SIZE": "4"}
+
+        result = AbstractAgent._append_legacy_inference_env_args(
+            cast(AbstractAgent[Any, Any], object()),
+            models,
+            environ,
+        )
+
+        assert result is models
+        service = models[0].service
+        assert service is not None
+        assert service.start_command == [
+            "vllm",
+            "serve",
+            "/models",
+            "--tensor-parallel-size",
+            "4",
+            "--trust-remote-code",
+        ]
+
+    def test_noop_without_legacy_env(self) -> None:
+        models = [_model("vllm", ["vllm", "serve", "/models"])]
+
+        AbstractAgent._append_legacy_inference_env_args(
+            cast(AbstractAgent[Any, Any], object()),
+            models,
+            {"PATH": "/usr/bin"},
+        )
+
+        service = models[0].service
+        assert service is not None
+        assert service.start_command == ["vllm", "serve", "/models"]
+
+    def test_skips_model_without_service(self) -> None:
+        models = [
+            ModelConfig.model_validate({"name": "no-service", "model_path": "/models/x"}),
+            _model("vllm", ["vllm", "serve", "/models"]),
+        ]
+
+        AbstractAgent._append_legacy_inference_env_args(
+            cast(AbstractAgent[Any, Any], object()),
+            models,
+            {"VLLM_EXTRA_ARGS": "--trust-remote-code"},
+        )
+
+        assert models[0].service is None
+        service = models[1].service
+        assert service is not None
+        assert service.start_command == ["vllm", "serve", "/models", "--trust-remote-code"]

--- a/tests/unit/agent/test_legacy_inference_env.py
+++ b/tests/unit/agent/test_legacy_inference_env.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 import pytest
 
 from ai.backend.agent.agent import AbstractAgent
-from ai.backend.agent.legacy_inference_env import LegacyInferenceEnvArgs
+from ai.backend.agent.legacy_inference_env import LegacyInferenceEnvTranslator
 from ai.backend.common.config import ModelConfig
 
 
@@ -17,7 +17,7 @@ class CollectScenario:
     expected: list[str]
 
 
-class TestLegacyInferenceEnvArgsToCliArgs:
+class TestLegacyInferenceEnvTranslatorToCliArgs:
     @pytest.mark.parametrize(
         "scenario",
         [
@@ -116,7 +116,7 @@ class TestLegacyInferenceEnvArgsToCliArgs:
         self,
         scenario: CollectScenario,
     ) -> None:
-        assert LegacyInferenceEnvArgs.to_cli_args(scenario.environ) == scenario.expected
+        assert LegacyInferenceEnvTranslator.to_cli_args(scenario.environ) == scenario.expected
 
 
 def _model(name: str, start_command: list[str] | None) -> ModelConfig:
@@ -131,7 +131,7 @@ def _model(name: str, start_command: list[str] | None) -> ModelConfig:
     })
 
 
-class TestAppendLegacyInferenceEnvArgs:
+class TestAppendLegacyInferenceEnvTranslator:
     def test_appends_to_existing_start_command(self) -> None:
         models = [_model("vllm", ["vllm", "serve", "/models"])]
         environ = {"VLLM_EXTRA_ARGS": "--trust-remote-code", "VLLM_TP_SIZE": "4"}


### PR DESCRIPTION
## Summary
- The runtime-variant baseline `start_command` (e.g. `vllm serve {model_path}`) overrides the image's `start-*.sh` wrapper that used to read legacy env vars (`VLLM_EXTRA_ARGS`, `VLLM_TP_SIZE`, ...) and splice them into the server command line, so those args silently stopped applying.
- New `LegacyInferenceEnvArgs.to_cli_args` reproduces that env→argv step on the agent: maps known `VLLM_*` / `SGLANG_*` keys to flags and `shlex`-splits the raw `*_EXTRA_ARGS` string.
- The agent appends the result to each model service's `start_command` right after the image-cmd fallback.

## Test plan
- [x] `pants test tests/unit/agent/test_legacy_inference_env.py` (to_cli_args + append behavior)
- [x] Live e2e on local dev stack: deployed a model service with `VLLM_EXTRA_ARGS`/`VLLM_TP_SIZE`; `docker exec ps` showed the args appended to the container's model-service argv and `/health` returned 200.

## Known limitation (pending design decision)
- Args whose value contains literal `{}` (e.g. vLLM `--hf-overrides '{...}'` JSON) currently break in the krunner's `ServiceArgumentInterpolator`, which treats every `{...}` token as a `{var}` template (`format_map`) and raises `unmatched '{' in format spec`. Quoting does not help — `start_command` is a template string and literal JSON collides with it. Handling for brace-containing args is being decided separately (tolerant interpolator vs. out-of-band literal-arg delivery).

Resolves BA-6489