### PR TITLE
fix(BA-6479): apply scope-level auto-assign roles on user creation

### DIFF
--- a/changes/12194.fix.md
+++ b/changes/12194.fix.md
@@ -1,0 +1,1 @@
+Apply a scope's auto-assign roles to a newly created user that is assigned to a project or domain (including the model-store project) at creation time, matching the existing-user join behavior.

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import uuid
 from collections.abc import AsyncIterator, Collection, Sequence
 from contextlib import asynccontextmanager
 
@@ -10,6 +9,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
 from ai.backend.common.data.permission.types import RelationType
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.data.permission.id import ScopeId
 from ai.backend.manager.data.permission.types import EntityType
 from ai.backend.manager.models.base import Base
@@ -44,7 +44,7 @@ class RBACWriteOps(WriteOps):
     async def add_users_to_scope(
         self,
         scope_id: ScopeId,
-        user_ids: Collection[uuid.UUID],
+        user_ids: Collection[UserID],
     ) -> None:
         """Bind users to a scope and grant the scope's ``auto_assign`` roles.
 

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -2,20 +2,37 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Sequence
+import uuid
+from collections.abc import AsyncIterator, Collection, Sequence
 from contextlib import asynccontextmanager
 
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession as SASession
+
+from ai.backend.common.data.permission.types import RelationType
+from ai.backend.manager.data.permission.id import ScopeId
+from ai.backend.manager.data.permission.types import EntityType
 from ai.backend.manager.models.base import Base
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
 from ai.backend.manager.repositories.base.rbac.entity_creator import (
     RBACBulkEntityCreatorResult,
     RBACEntityCreator,
     execute_rbac_entity_creators,
 )
 from ai.backend.manager.repositories.ops.base.provider import DBOpsProvider, WriteOps
+from ai.backend.manager.repositories.permission_controller.role_manager import RoleManager
 
 
 class RBACWriteOps(WriteOps):
     """Base write ops plus RBAC scope-associated creation."""
+
+    _role_manager: RoleManager
+
+    def __init__(self, sess: SASession) -> None:
+        super().__init__(sess)
+        self._role_manager = RoleManager()
 
     async def bulk_create_scoped[TRow: Base](
         self,
@@ -23,6 +40,36 @@ class RBACWriteOps(WriteOps):
     ) -> RBACBulkEntityCreatorResult[TRow]:
         """Insert rows with their RBAC scope associations (each creator carries its scope)."""
         return await execute_rbac_entity_creators(self._sess, creators)
+
+    async def add_users_to_scope(
+        self,
+        scope_id: ScopeId,
+        user_ids: Collection[uuid.UUID],
+    ) -> None:
+        """Bind users to a scope and grant the scope's ``auto_assign`` roles.
+
+        Inserts the user-scope associations (``association_scopes_entities``,
+        ON CONFLICT DO NOTHING) and maps every user to each active
+        ``auto_assign`` role bound to the scope. Idempotent: re-binding an
+        existing membership is a no-op and already-granted roles are skipped,
+        so it is safe to call even when the scope association already exists.
+        """
+        if not user_ids:
+            return
+        values = [
+            {
+                "scope_type": scope_id.scope_type,
+                "scope_id": scope_id.scope_id,
+                "entity_type": EntityType.USER,
+                "entity_id": str(user_id),
+                "relation_type": RelationType.AUTO,
+                "permission_cap": None,
+            }
+            for user_id in user_ids
+        ]
+        stmt = pg_insert(AssociationScopesEntitiesRow).values(values).on_conflict_do_nothing()
+        await self._sess.execute(stmt)
+        await self._role_manager.assign_auto_assign_roles(self._sess, user_ids, scope_id)
 
 
 class RBACOpsProvider(DBOpsProvider):

--- a/src/ai/backend/manager/repositories/permission_controller/role_manager.py
+++ b/src/ai/backend/manager/repositories/permission_controller/role_manager.py
@@ -90,6 +90,14 @@ class UserSystemRoleSpec:
 
 
 class RoleManager:
+    """Deprecated. Use :class:`ai.backend.manager.repositories.ops.rbac.provider.RBACWriteOps`
+    instead.
+
+    RBAC role and scope-association management is migrating to the ops-provider
+    layer (``RBACWriteOps``), which performs these writes through the shared
+    ``DBOpsProvider`` transaction.
+    """
+
     def __init__(self) -> None:
         pass
 

--- a/src/ai/backend/manager/repositories/user/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/user/db_source/db_source.py
@@ -18,6 +18,7 @@ from sqlalchemy.sql.expression import bindparam
 from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.identifier.project import ProjectID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import AccessKey, VFolderID
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.data.common.types import SearchResult
@@ -372,7 +373,7 @@ class UserDBSource:
 
     async def assign_users_to_scope(
         self,
-        user_uuid: UUID,
+        user_uuid: UserID,
         domain_name: str | None,
         project_ids: Collection[ProjectID],
     ) -> None:
@@ -395,7 +396,7 @@ class UserDBSource:
                     [user_uuid],
                 )
 
-    async def assign_user_to_model_store(self, user_uuid: UUID, domain_name: str | None) -> None:
+    async def assign_user_to_model_store(self, user_uuid: UserID, domain_name: str | None) -> None:
         """Add a user to its domain's model-store project scope and grant its roles.
 
         Resolves the model-store project(s) of the domain and maps the user to

--- a/src/ai/backend/manager/repositories/user/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/user/db_source/db_source.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable, Sequence
+from collections.abc import Collection, Iterable, Sequence
 from datetime import datetime, timedelta
 from typing import Any, cast
 from uuid import UUID, uuid4
@@ -120,6 +120,7 @@ from ai.backend.manager.repositories.keypair.types import (
     KeypairResourcePolicyKeypairSearchScope,
     UserKeypairSearchScope,
 )
+from ai.backend.manager.repositories.ops.rbac.provider import RBACOpsProvider
 from ai.backend.manager.repositories.permission_controller.creators import UserRoleCreatorSpec
 from ai.backend.manager.repositories.permission_controller.role_manager import RoleManager
 from ai.backend.manager.repositories.user.creators import UserCreatorSpec
@@ -149,6 +150,7 @@ class UserDBSource:
 
     def __init__(self, db: ExtendedAsyncSAEngine) -> None:
         self._db = db
+        self._rbac_ops_provider = RBACOpsProvider(db)
         self._role_manager = RoleManager()
 
     async def get_user_by_uuid(self, user_uuid: UUID) -> UserData:
@@ -367,6 +369,62 @@ class UserDBSource:
         await self._role_manager.create_preset_roles_for_user(db_session, created_user.uuid)
 
         return UserCreateResultData(created_user, kp_data)
+
+    async def assign_users_to_scope(
+        self,
+        user_uuid: UUID,
+        domain_name: str | None,
+        project_ids: Collection[ProjectID],
+    ) -> None:
+        """Grant the auto_assign roles of a new user's initial domain/project scopes.
+
+        Maps the user to the active auto_assign roles of its domain scope and
+        each given project scope. Model-store membership is handled separately
+        by :meth:`assign_user_to_model_store`. Idempotent, so it is safe to run
+        after user creation.
+        """
+        async with self._rbac_ops_provider.write_ops() as rbac_write_ops:
+            if domain_name is not None:
+                await rbac_write_ops.add_users_to_scope(
+                    ScopeId(scope_type=ScopeType.DOMAIN, scope_id=domain_name),
+                    [user_uuid],
+                )
+            for project_id in project_ids:
+                await rbac_write_ops.add_users_to_scope(
+                    ScopeId(scope_type=ScopeType.PROJECT, scope_id=str(project_id)),
+                    [user_uuid],
+                )
+
+    async def assign_user_to_model_store(self, user_uuid: UUID, domain_name: str | None) -> None:
+        """Add a user to its domain's model-store project scope and grant its roles.
+
+        Resolves the model-store project(s) of the domain and maps the user to
+        each one's active auto_assign roles. Idempotent: the scope binding is a
+        no-op when the membership already exists.
+        """
+        if domain_name is None:
+            return
+        async with self._db.begin_session_read_committed() as db_session:
+            model_store_project_ids = await self._get_model_store_project_ids(
+                db_session, domain_name
+            )
+        await self.assign_users_to_scope(
+            user_uuid,
+            domain_name,
+            [ProjectID(pid) for pid in model_store_project_ids],
+        )
+
+    async def _get_model_store_project_ids(
+        self, db_session: SASession, domain_name: str
+    ) -> list[UUID]:
+        """Return the model-store project ids of the given domain."""
+        rows = await db_session.scalars(
+            sa.select(GroupRow.id).where(
+                GroupRow.domain_name == domain_name,
+                GroupRow.type == ProjectType.MODEL_STORE,
+            )
+        )
+        return list(rows.all())
 
     async def bulk_create_users_validated(
         self,

--- a/src/ai/backend/manager/repositories/user/repository.py
+++ b/src/ai/backend/manager/repositories/user/repository.py
@@ -13,6 +13,7 @@ from dateutil.tz import tzutc
 from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.project import ProjectID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
@@ -108,13 +109,13 @@ class UserRepository:
 
     @user_repository_resilience.apply()
     async def assign_users_to_scope(
-        self, user_uuid: UUID, domain_name: str | None, project_ids: Collection[ProjectID]
+        self, user_uuid: UserID, domain_name: str | None, project_ids: Collection[ProjectID]
     ) -> None:
         """Grant the auto_assign roles of a new user's initial domain/project scopes."""
         await self._db_source.assign_users_to_scope(user_uuid, domain_name, project_ids)
 
     @user_repository_resilience.apply()
-    async def assign_user_to_model_store(self, user_uuid: UUID, domain_name: str | None) -> None:
+    async def assign_user_to_model_store(self, user_uuid: UserID, domain_name: str | None) -> None:
         """Add a user to its domain's model-store project and grant its auto_assign roles."""
         await self._db_source.assign_user_to_model_store(user_uuid, domain_name)
 

--- a/src/ai/backend/manager/repositories/user/repository.py
+++ b/src/ai/backend/manager/repositories/user/repository.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import Any
@@ -105,6 +105,18 @@ class UserRepository:
     async def assign_project_membership(self, user_uuid: UUID, project_id: ProjectID) -> None:
         """Add a user to a project, mapping the user to the project's member role."""
         await self._db_source.assign_project_membership(user_uuid, project_id)
+
+    @user_repository_resilience.apply()
+    async def assign_users_to_scope(
+        self, user_uuid: UUID, domain_name: str | None, project_ids: Collection[ProjectID]
+    ) -> None:
+        """Grant the auto_assign roles of a new user's initial domain/project scopes."""
+        await self._db_source.assign_users_to_scope(user_uuid, domain_name, project_ids)
+
+    @user_repository_resilience.apply()
+    async def assign_user_to_model_store(self, user_uuid: UUID, domain_name: str | None) -> None:
+        """Add a user to its domain's model-store project and grant its auto_assign roles."""
+        await self._db_source.assign_user_to_model_store(user_uuid, domain_name)
 
     @user_repository_resilience.apply()
     async def bulk_create_users_validated(

--- a/src/ai/backend/manager/services/user/service.py
+++ b/src/ai/backend/manager/services/user/service.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
 from ai.backend.common.events.event_types.kernel.types import KernelLifecycleEventReason
+from ai.backend.common.identifier.project import ProjectID
 from ai.backend.common.types import AccessKey
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.data.user.types import (
@@ -138,6 +139,19 @@ class UserService:
     async def create_user(self, action: CreateUserAction) -> CreateUserActionResult:
         user_data_result = await self._user_repository.create_user_validated(
             action.creator, action.group_ids
+        )
+        # Grant the scope-level auto_assign roles for the user's initial domain
+        # and project memberships (user creation only provisions user-scope roles).
+        # action.scope_id() is the user's domain name (the action's DOMAIN scope).
+        await self._user_repository.assign_users_to_scope(
+            user_data_result.user.uuid,
+            user_data_result.user.domain_name,
+            [ProjectID(UUID(gid)) for gid in action.group_ids] if action.group_ids else [],
+        )
+        # The user is also a member of its domain's model-store project at
+        # creation, so grant that project scope's auto_assign roles too.
+        await self._user_repository.assign_user_to_model_store(
+            user_data_result.user.uuid, user_data_result.user.domain_name
         )
         return CreateUserActionResult(
             data=user_data_result,

--- a/src/ai/backend/manager/services/user/service.py
+++ b/src/ai/backend/manager/services/user/service.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
 from ai.backend.common.events.event_types.kernel.types import KernelLifecycleEventReason
 from ai.backend.common.identifier.project import ProjectID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import AccessKey
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.data.user.types import (
@@ -145,14 +146,14 @@ class UserService:
         # and project memberships (user creation only provisions user-scope roles).
         # action.scope_id() is the user's domain name (the action's DOMAIN scope).
         await self._user_repository.assign_users_to_scope(
-            user_data_result.user.uuid,
+            UserID(user_data_result.user.uuid),
             user_data_result.user.domain_name,
             [ProjectID(UUID(gid)) for gid in action.group_ids] if action.group_ids else [],
         )
         # The user is also a member of its domain's model-store project at
         # creation, so grant that project scope's auto_assign roles too.
         await self._user_repository.assign_user_to_model_store(
-            user_data_result.user.uuid, user_data_result.user.domain_name
+            UserID(user_data_result.user.uuid), user_data_result.user.domain_name
         )
         return CreateUserActionResult(
             data=user_data_result,
@@ -169,12 +170,12 @@ class UserService:
         for created in result.successes:
             group_ids = group_ids_by_email.get(created.user.email)
             await self._user_repository.assign_users_to_scope(
-                created.user.uuid,
+                UserID(created.user.uuid),
                 created.user.domain_name,
                 [ProjectID(UUID(gid)) for gid in group_ids] if group_ids else [],
             )
             await self._user_repository.assign_user_to_model_store(
-                created.user.uuid, created.user.domain_name
+                UserID(created.user.uuid), created.user.domain_name
             )
         return BulkCreateUserActionResult(data=result)
 

--- a/src/ai/backend/manager/services/user/service.py
+++ b/src/ai/backend/manager/services/user/service.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
 from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
@@ -16,6 +16,7 @@ from ai.backend.manager.data.user.types import (
 from ai.backend.manager.errors.user import UserPurgeFailure
 from ai.backend.manager.models.storage import StorageSessionManager
 from ai.backend.manager.registry import AgentRegistry
+from ai.backend.manager.repositories.user.creators import UserCreatorSpec
 from ai.backend.manager.repositories.user.repository import UserRepository
 from ai.backend.manager.services.user.actions.admin_month_stats import (
     AdminMonthStatsAction,
@@ -159,6 +160,22 @@ class UserService:
 
     async def bulk_create_users(self, action: BulkCreateUserAction) -> BulkCreateUserActionResult:
         result = await self._user_repository.bulk_create_users_validated(action.items)
+        # Grant the scope-level auto_assign roles for each created user's initial
+        # domain/project memberships, the same as the single-user create path.
+        # group_ids are not carried in the result, so correlate them by email.
+        group_ids_by_email = {
+            cast(UserCreatorSpec, item.creator.spec).email: item.group_ids for item in action.items
+        }
+        for created in result.successes:
+            group_ids = group_ids_by_email.get(created.user.email)
+            await self._user_repository.assign_users_to_scope(
+                created.user.uuid,
+                created.user.domain_name,
+                [ProjectID(UUID(gid)) for gid in group_ids] if group_ids else [],
+            )
+            await self._user_repository.assign_user_to_model_store(
+                created.user.uuid, created.user.domain_name
+            )
         return BulkCreateUserActionResult(data=result)
 
     async def modify_user(self, action: ModifyUserAction) -> ModifyUserActionResult:

--- a/tests/component/user/test_user_crud.py
+++ b/tests/component/user/test_user_crud.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import secrets
 import uuid
+from collections.abc import AsyncIterator
 
 import pytest
 import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncConnection
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.client.v2.exceptions import ConflictError, InvalidRequestError, NotFoundError
 from ai.backend.client.v2.registry import BackendAIClientRegistry
+from ai.backend.common.data.permission.types import RelationType
 from ai.backend.common.dto.manager.user import (
     CreateUserRequest,
     CreateUserResponse,
@@ -16,11 +20,15 @@ from ai.backend.common.dto.manager.user import (
     GetUserResponse,
     UserStatus,
 )
+from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import EntityType, ScopeType
+from ai.backend.manager.models.group import GroupRow, ProjectType
 from ai.backend.manager.models.keypair import keypairs
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
 )
+from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
 from ai.backend.manager.models.user import users
 from ai.backend.testutils.fixtures import DomainFixtureData
 
@@ -326,3 +334,171 @@ class TestUserDeleteCrud:
         # Second delete on already-deleted user is idempotent (UPDATE without status filter)
         result = await admin_registry.user.delete(DeleteUserRequest(user_id=created.user.id))
         assert result.success is True
+
+
+class TestUserCreateAutoAssignRoles:
+    """A new user receives the auto_assign roles of its initial scopes."""
+
+    async def _create_auto_assign_role_for_project(
+        self, conn: AsyncConnection, project_id: uuid.UUID, name: str
+    ) -> uuid.UUID:
+        """Insert an active auto_assign role bound to the given project scope."""
+        role_id = uuid.uuid4()
+        await conn.execute(
+            sa.insert(RoleRow.__table__).values(
+                id=role_id,
+                name=name,
+                status=RoleStatus.ACTIVE,
+                auto_assign=True,
+            )
+        )
+        await conn.execute(
+            sa.insert(AssociationScopesEntitiesRow.__table__).values(
+                scope_type=ScopeType.PROJECT,
+                scope_id=str(project_id),
+                entity_type=EntityType.ROLE,
+                entity_id=str(role_id),
+                relation_type=RelationType.AUTO,
+            )
+        )
+        return role_id
+
+    async def _delete_role(self, conn: AsyncConnection, role_id: uuid.UUID) -> None:
+        """Remove a role together with its user mappings and scope binding."""
+        await conn.execute(
+            UserRoleRow.__table__.delete().where(UserRoleRow.__table__.c.role_id == role_id)
+        )
+        await conn.execute(
+            AssociationScopesEntitiesRow.__table__.delete().where(
+                sa.and_(
+                    AssociationScopesEntitiesRow.__table__.c.entity_type == EntityType.ROLE,
+                    AssociationScopesEntitiesRow.__table__.c.entity_id == str(role_id),
+                )
+            )
+        )
+        await conn.execute(RoleRow.__table__.delete().where(RoleRow.__table__.c.id == role_id))
+
+    @pytest.fixture()
+    async def project_auto_assign_role(
+        self,
+        db_engine: SAEngine,
+        group_fixture: uuid.UUID,
+    ) -> AsyncIterator[uuid.UUID]:
+        """An active auto_assign role bound to the test project (group) scope."""
+        async with db_engine.begin() as conn:
+            role_id = await self._create_auto_assign_role_for_project(
+                conn, group_fixture, f"auto-project-{secrets.token_hex(4)}"
+            )
+        yield role_id
+        async with db_engine.begin() as conn:
+            await self._delete_role(conn, role_id)
+
+    @pytest.fixture()
+    async def model_store_project(
+        self,
+        db_engine: SAEngine,
+        domain_fixture: DomainFixtureData,
+        resource_policy_fixture: str,
+    ) -> AsyncIterator[uuid.UUID]:
+        """A model-store project in the test domain (new users auto-join it)."""
+        project_id = uuid.uuid4()
+        async with db_engine.begin() as conn:
+            await conn.execute(
+                sa.insert(GroupRow.__table__).values(
+                    id=project_id,
+                    name=f"model-store-{secrets.token_hex(4)}",
+                    description="Model Store",
+                    is_active=True,
+                    domain_name=domain_fixture.domain_name,
+                    resource_policy=resource_policy_fixture,
+                    type=ProjectType.MODEL_STORE,
+                )
+            )
+        yield project_id
+        async with db_engine.begin() as conn:
+            await conn.execute(
+                GroupRow.__table__.delete().where(GroupRow.__table__.c.id == project_id)
+            )
+
+    @pytest.fixture()
+    async def model_store_auto_assign_role(
+        self,
+        db_engine: SAEngine,
+        model_store_project: uuid.UUID,
+    ) -> AsyncIterator[uuid.UUID]:
+        """An active auto_assign role bound to the model-store project scope."""
+        async with db_engine.begin() as conn:
+            role_id = await self._create_auto_assign_role_for_project(
+                conn, model_store_project, f"auto-modelstore-{secrets.token_hex(4)}"
+            )
+        yield role_id
+        async with db_engine.begin() as conn:
+            await self._delete_role(conn, role_id)
+
+    async def test_create_grants_project_scope_auto_assign_role(
+        self,
+        user_factory: UserFactory,
+        group_fixture: uuid.UUID,
+        project_auto_assign_role: uuid.UUID,
+        db_engine: SAEngine,
+    ) -> None:
+        """User created into a project is a scope member and gets its auto_assign role."""
+        result = await user_factory(group_ids=[str(group_fixture)])
+
+        async with db_engine.begin() as conn:
+            membership = (
+                await conn.execute(
+                    sa.select(AssociationScopesEntitiesRow).where(
+                        AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                        AssociationScopesEntitiesRow.scope_id == str(group_fixture),
+                        AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                        AssociationScopesEntitiesRow.entity_id == str(result.user.id),
+                    )
+                )
+            ).fetchone()
+            role_mapping = (
+                await conn.execute(
+                    sa.select(UserRoleRow).where(
+                        UserRoleRow.user_id == result.user.id,
+                        UserRoleRow.role_id == project_auto_assign_role,
+                    )
+                )
+            ).fetchone()
+
+        assert membership is not None, "User should be a member of the project scope"
+        assert role_mapping is not None, "User should be mapped to the project's auto_assign role"
+
+    async def test_create_grants_model_store_auto_assign_role(
+        self,
+        user_factory: UserFactory,
+        model_store_project: uuid.UUID,
+        model_store_auto_assign_role: uuid.UUID,
+        db_engine: SAEngine,
+    ) -> None:
+        """A new user auto-joins the domain's model-store project and gets its auto_assign role."""
+        result = await user_factory()
+
+        async with db_engine.begin() as conn:
+            membership = (
+                await conn.execute(
+                    sa.select(AssociationScopesEntitiesRow).where(
+                        AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                        AssociationScopesEntitiesRow.scope_id == str(model_store_project),
+                        AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                        AssociationScopesEntitiesRow.entity_id == str(result.user.id),
+                    )
+                )
+            ).fetchone()
+            role_mapping = (
+                await conn.execute(
+                    sa.select(UserRoleRow).where(
+                        UserRoleRow.user_id == result.user.id,
+                        UserRoleRow.role_id == model_store_auto_assign_role,
+                    )
+                )
+            ).fetchone()
+
+        assert membership is not None, "User should be a member of the model-store project scope"
+        assert role_mapping is not None, (
+            "User should be mapped to the model-store's auto_assign role"
+        )

--- a/tests/unit/manager/services/test_users.py
+++ b/tests/unit/manager/services/test_users.py
@@ -183,7 +183,7 @@ class TestCreateUser:
         assert sample_user_data.username is not None
         assert sample_user_data.need_password_change is not None
         assert sample_user_data.domain_name is not None
-        group_ids = ["group1", "group2"]
+        group_ids = [str(uuid.uuid4()), str(uuid.uuid4())]
         action = CreateUserAction(
             creator=Creator(
                 spec=UserCreatorSpec(


### PR DESCRIPTION
## Summary
- A newly created user assigned to a project/domain at creation time was not granted that scope's `auto_assign` roles — only its own user-scope preset roles were provisioned (project/domain auto-assign worked only on the existing-user join/update path).
- Add `RBACWriteOps.add_users_to_scope()` bundling the user↔scope binding (`association_scopes_entities`, idempotent) with `auto_assign` role mapping.
- Grant the new user's initial domain/project auto-assign roles from the `create_user` service flow via `UserRepository.assign_initial_scope_roles()`, plus a dedicated `assign_user_to_model_store()` path for the domain's model-store project membership and role mapping.

## Test plan
- [x] `pants test tests/component/user/test_user_crud.py` — new `TestUserCreateAutoAssignRoles` verifies project- and model-store-scope auto_assign role mappings end-to-end (real server + DB)
- [x] `pants test tests/unit/manager/services/::` — service-level create_user delegation
- [x] Manual: create a user into a project/domain that has an `auto_assign=true` role; confirm `user_roles` mapping is created

Resolves BA-6479