### PR TITLE
fix(BA-6490): preserve model service fields during draft merge

### DIFF
--- a/changes/12197.fix.md
+++ b/changes/12197.fix.md
@@ -1,0 +1,1 @@
+Fix model revision creation when partial model service overrides include null fields.

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -351,6 +351,18 @@ def _pick(base_val: Any, override_val: Any, override_set: bool) -> Any:
     return override_val
 
 
+def _pick_non_null_override(base_val: Any, override_val: Any, override_set: bool) -> Any:
+    """Return a non-null draft override, otherwise keep the base value.
+
+    Draft model definitions are patch layers from several sources. In that
+    patch context ``None`` means the field was not supplied with a concrete
+    value, even when an input adapter materializes optional fields as null.
+    """
+    if not override_set or override_val is None:
+        return base_val
+    return override_val
+
+
 def _merge_metadata(base: ModelMetadata, override: ModelMetadata) -> ModelMetadata:
     """Merge two ModelMetadata instances. All fields are atomic."""
     s = override.model_fields_set
@@ -592,15 +604,21 @@ def _merge_health_check_draft(
 ) -> ModelHealthCheckDraft:
     s = override.model_fields_set
     return ModelHealthCheckDraft.model_construct(
-        enable=_pick(base.enable, override.enable, "enable" in s),
-        interval=_pick(base.interval, override.interval, "interval" in s),
-        path=_pick(base.path, override.path, "path" in s),
-        max_retries=_pick(base.max_retries, override.max_retries, "max_retries" in s),
-        max_wait_time=_pick(base.max_wait_time, override.max_wait_time, "max_wait_time" in s),
-        expected_status_code=_pick(
+        enable=_pick_non_null_override(base.enable, override.enable, "enable" in s),
+        interval=_pick_non_null_override(base.interval, override.interval, "interval" in s),
+        path=_pick_non_null_override(base.path, override.path, "path" in s),
+        max_retries=_pick_non_null_override(
+            base.max_retries, override.max_retries, "max_retries" in s
+        ),
+        max_wait_time=_pick_non_null_override(
+            base.max_wait_time, override.max_wait_time, "max_wait_time" in s
+        ),
+        expected_status_code=_pick_non_null_override(
             base.expected_status_code, override.expected_status_code, "expected_status_code" in s
         ),
-        initial_delay=_pick(base.initial_delay, override.initial_delay, "initial_delay" in s),
+        initial_delay=_pick_non_null_override(
+            base.initial_delay, override.initial_delay, "initial_delay" in s
+        ),
     )
 
 
@@ -613,14 +631,18 @@ def _merge_service_config_draft(
     if "health_check" in s and base.health_check is not None and override.health_check is not None:
         health_check = _merge_health_check_draft(base.health_check, override.health_check)
     else:
-        health_check = _pick(base.health_check, override.health_check, "health_check" in s)
+        health_check = _pick_non_null_override(
+            base.health_check, override.health_check, "health_check" in s
+        )
     return ModelServiceConfigDraft.model_construct(
-        pre_start_actions=_pick(
+        pre_start_actions=_pick_non_null_override(
             base.pre_start_actions, override.pre_start_actions, "pre_start_actions" in s
         ),
-        start_command=_pick(base.start_command, override.start_command, "start_command" in s),
-        shell=_pick(base.shell, override.shell, "shell" in s),
-        port=_pick(base.port, override.port, "port" in s),
+        start_command=_pick_non_null_override(
+            base.start_command, override.start_command, "start_command" in s
+        ),
+        shell=_pick_non_null_override(base.shell, override.shell, "shell" in s),
+        port=_pick_non_null_override(base.port, override.port, "port" in s),
         health_check=health_check,
     )
 
@@ -634,14 +656,14 @@ def _merge_config_draft(
     if "service" in s and base.service is not None and override.service is not None:
         service = _merge_service_config_draft(base.service, override.service)
     else:
-        service = _pick(base.service, override.service, "service" in s)
+        service = _pick_non_null_override(base.service, override.service, "service" in s)
     metadata: ModelMetadata | None
     if "metadata" in s and base.metadata is not None and override.metadata is not None:
         metadata = _merge_metadata(base.metadata, override.metadata)
     else:
-        metadata = _pick(base.metadata, override.metadata, "metadata" in s)
+        metadata = _pick_non_null_override(base.metadata, override.metadata, "metadata" in s)
     return ModelConfigDraft.model_construct(
-        name=_pick(base.name, override.name, "name" in s),
+        name=_pick_non_null_override(base.name, override.name, "name" in s),
         model_path=override.model_path if override.model_path is not None else base.model_path,
         service=service,
         metadata=metadata,

--- a/tests/unit/common/test_config.py
+++ b/tests/unit/common/test_config.py
@@ -6,12 +6,14 @@ import tomli
 
 from ai.backend.common.config import (
     ModelConfig,
+    ModelConfigDraft,
     ModelDefinition,
     ModelDefinitionDraft,
     ModelHealthCheck,
     ModelHealthCheckDraft,
     ModelMetadata,
     ModelServiceConfig,
+    ModelServiceConfigDraft,
     _merge_config,
     _merge_config_draft,
     _merge_definition,
@@ -338,6 +340,62 @@ class TestHealthCheckEnable:
         result = _merge_service_config(base, override)
         assert result.health_check is not None
         assert result.health_check.enable is True
+
+
+class TestModelDefinitionDraftMerge:
+    """Tests for patch-style draft model-definition merge."""
+
+    def test_null_service_fields_do_not_override_baseline(self) -> None:
+        base = ModelConfigDraft(
+            name="base",
+            model_path="/models",
+            service=ModelServiceConfigDraft(
+                pre_start_actions=[],
+                start_command=["/models/start.sh"],
+                shell="/bin/sh",
+                port=8000,
+                health_check=ModelHealthCheckDraft(
+                    enable=True,
+                    interval=10.0,
+                    path="/health",
+                    max_retries=80,
+                    max_wait_time=30.0,
+                    expected_status_code=200,
+                    initial_delay=300.0,
+                ),
+            ),
+        )
+        override = ModelConfigDraft(
+            name=None,
+            model_path=None,
+            service=ModelServiceConfigDraft(
+                pre_start_actions=None,
+                start_command=None,
+                shell=None,
+                port=None,
+                health_check=ModelHealthCheckDraft(
+                    enable=False,
+                    interval=1.0,
+                    path="/override",
+                    max_retries=1,
+                    max_wait_time=1.0,
+                    expected_status_code=101,
+                    initial_delay=1.0,
+                ),
+            ),
+        )
+
+        merged = _merge_config_draft(base, override).to_resolved()
+
+        assert merged.name == "base"
+        assert merged.model_path == "/models"
+        assert merged.service is not None
+        assert merged.service.port == 8000
+        assert merged.service.start_command == ["/models/start.sh"]
+        assert merged.service.health_check is not None
+        assert merged.service.health_check.enable is False
+        assert merged.service.health_check.path == "/override"
+        assert merged.service.health_check.expected_status_code == 101
 
 
 class TestHealthCheckJudgment:

--- a/tests/unit/manager/api/gql/deployment/test_revision_types.py
+++ b/tests/unit/manager/api/gql/deployment/test_revision_types.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from ai.backend.common.config import ModelDefinitionDraft
+from ai.backend.manager.api.gql.deployment.types.revision import (
+    ModelConfigInputGQL,
+    ModelDefinitionInputGQL,
+    ModelHealthCheckInputGQL,
+    ModelServiceConfigInputGQL,
+)
+
+
+class TestModelDefinitionInputGQL:
+    def test_health_check_patch_preserves_baseline_service_fields(self) -> None:
+        baseline = ModelDefinitionDraft.model_validate({
+            "models": [
+                {
+                    "name": "Sehyo/Qwen3.5-35B-A3B-NVFP4",
+                    "model_path": "/models",
+                    "service": {
+                        "pre_start_actions": [
+                            {
+                                "action": "run_command",
+                                "args": {"command": ["chmod", "+x", "/models/start.sh"]},
+                            }
+                        ],
+                        "start_command": ["/models/start.sh"],
+                        "port": 8000,
+                        "health_check": {
+                            "enable": True,
+                            "interval": 10.0,
+                            "path": "/health",
+                            "max_retries": 80,
+                            "max_wait_time": 30.0,
+                            "expected_status_code": 200,
+                            "initial_delay": 300.0,
+                        },
+                    },
+                }
+            ]
+        })
+        gql_patch = ModelDefinitionInputGQL(
+            models=[
+                ModelConfigInputGQL(
+                    service=ModelServiceConfigInputGQL(
+                        health_check=ModelHealthCheckInputGQL(
+                            enable=True,
+                            interval=1.0,
+                            path="1",
+                            max_retries=1,
+                            max_wait_time=1.0,
+                            expected_status_code=101,
+                            initial_delay=1.0,
+                        )
+                    )
+                )
+            ]
+        )
+
+        patch = gql_patch.to_pydantic().to_draft()
+        assert patch.models is not None
+        assert patch.models[0].service is not None
+        assert "port" in patch.models[0].service.model_fields_set
+        assert patch.models[0].service.port is None
+
+        resolved = baseline.merge(patch).to_resolved()
+
+        service = resolved.models[0].service
+        assert service is not None
+        assert service.port == 8000
+        assert service.start_command == ["/models/start.sh"]
+        assert service.health_check is not None
+        assert service.health_check.path == "1"
+        assert service.health_check.expected_status_code == 101


### PR DESCRIPTION
## Summary
- Preserve baseline model service fields when a draft override provides null values.
- Keep health check field overrides working while preventing null `port` values from erasing the resolved service port.
- Add regression coverage for direct draft merges and the GraphQL add-revision input path.

## Test plan
- [x] pants fmt ::
- [x] pants fix ::
- [x] pants lint --changed-since=origin/main
- [x] pre-push hook: lint/check/test on origin/main..HEAD

Resolves BA-6490