### PR TITLE
feat(BA-6504): accept runtime variant preset values on revision input

### DIFF
--- a/changes/12200.feature.md
+++ b/changes/12200.feature.md
@@ -1,0 +1,1 @@
+Allow binding runtime variant presets to concrete values directly on a deployment revision via runtime_variant_preset_values

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -10077,6 +10077,11 @@ input ModelRuntimeConfigInput
 
   """Environment variables for the service."""
   environ: EnvironmentVariablesInput = null
+
+  """
+  Added in 26.4.4. Concrete values for the runtime variant's configurable presets, each keyed by the runtime variant preset ID. Overrides matching presets from a revision_preset_id template (merged by preset_id).
+  """
+  runtimeVariantPresetValues: [RuntimeVariantPresetValueInput!] = null
 }
 
 """Added in 26.4.2. Service configuration for a model entry."""
@@ -17144,6 +17149,23 @@ enum RuntimeVariantPresetOrderField
   NAME @join__enumValue(graph: STRAWBERRY)
   RANK @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
+"""
+Added in 26.4.4. A concrete value for one of a runtime variant's configurable presets, keyed by the runtime variant preset ID (from the runtimeVariantPresets query). Distinct from a DeploymentRevisionPreset, which is a saved template selected via revision_preset_id.
+"""
+input RuntimeVariantPresetValueInput
+  @join__type(graph: STRAWBERRY)
+{
+  """
+  The runtime variant preset (from runtimeVariantPresets) this value applies to.
+  """
+  presetId: UUID!
+
+  """
+  The concrete value to set for the referenced runtime variant preset parameter.
+  """
+  value: String!
 }
 
 type ScalingGroup

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -6801,6 +6801,11 @@ input ModelRuntimeConfigInput {
 
   """Environment variables for the service."""
   environ: EnvironmentVariablesInput = null
+
+  """
+  Added in 26.4.4. Concrete values for the runtime variant's configurable presets, each keyed by the runtime variant preset ID. Overrides matching presets from a revision_preset_id template (merged by preset_id).
+  """
+  runtimeVariantPresetValues: [RuntimeVariantPresetValueInput!] = null
 }
 
 """Added in 26.4.2. Service configuration for a model entry."""
@@ -11781,6 +11786,21 @@ enum RuntimeVariantPresetOrderField {
   NAME
   RANK
   CREATED_AT
+}
+
+"""
+Added in 26.4.4. A concrete value for one of a runtime variant's configurable presets, keyed by the runtime variant preset ID (from the runtimeVariantPresets query). Distinct from a DeploymentRevisionPreset, which is a saved template selected via revision_preset_id.
+"""
+input RuntimeVariantPresetValueInput {
+  """
+  The runtime variant preset (from runtimeVariantPresets) this value applies to.
+  """
+  presetId: UUID!
+
+  """
+  The concrete value to set for the referenced runtime variant preset parameter.
+  """
+  value: String!
 }
 
 """Added in 24.09.0. Input for SMTP authentication credentials"""

--- a/src/ai/backend/common/dto/manager/v2/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/request.py
@@ -91,6 +91,7 @@ __all__ = (
     "ModelMountConfigInput",
     "ModelRuntimeConfigInput",
     "ModelServiceConfigInput",
+    "PresetValueInput",
     "ReplicaFilter",
     "ReplicaOrder",
     "ReplicaStatusFilter",
@@ -245,6 +246,18 @@ class EnvironmentVariablesInput(BaseRequestModel):
     )
 
 
+class PresetValueInput(BaseRequestModel):
+    """A concrete value bound to a runtime variant preset (by ``preset_id``).
+
+    Shared by the deployment-revision flow (``ModelRuntimeConfigInput``) and the
+    DeploymentRevisionPreset template flow. Defined here, the lower-level module,
+    so ``deployment_revision_preset.request`` can import it without a cycle.
+    """
+
+    preset_id: UUID = Field(description="Runtime variant preset ID.")
+    value: str = Field(description="Value for this preset.")
+
+
 class ModelRuntimeConfigInput(BaseRequestModel):
     """Runtime configuration input for a revision."""
 
@@ -257,6 +270,13 @@ class ModelRuntimeConfigInput(BaseRequestModel):
     )
     environ: EnvironmentVariablesInput | None = Field(
         default=None, description="Environment variables for the service"
+    )
+    runtime_variant_preset_values: list[PresetValueInput] | None = Field(
+        default=None,
+        description=(
+            "Concrete values for the runtime variant's configurable presets, each keyed by the"
+            " runtime variant preset ID. Distinct from 'revision_preset_id' which selects a saved DeploymentRevisionPreset template, "
+        ),
     )
 
 

--- a/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
@@ -13,18 +13,16 @@ from ai.backend.common.dto.manager.v2.common import (
     OrderDirection,
     ResourceSlotEntryInput,
 )
-from ai.backend.common.dto.manager.v2.deployment.request import DeploymentStrategyInput
+from ai.backend.common.dto.manager.v2.deployment.request import (
+    DeploymentStrategyInput,
+    PresetValueInput,
+)
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.types import (
     DeploymentRevisionPresetOrderField,
 )
 from ai.backend.common.dto.manager.v2.resource_slot.types import ResourceOptsEntryDTO
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
-
-
-class PresetValueInput(BaseRequestModel):
-    preset_id: UUID = Field(description="Runtime variant preset ID.")
-    value: str = Field(description="Value for this preset.")
 
 
 class PresetModelHealthCheckInput(BaseRequestModel):

--- a/src/ai/backend/common/identifier/runtime_variant_preset.py
+++ b/src/ai/backend/common/identifier/runtime_variant_preset.py
@@ -1,0 +1,7 @@
+from typing import NewType
+from uuid import UUID
+
+__all__ = ("RuntimeVariantPresetID",)
+
+
+RuntimeVariantPresetID = NewType("RuntimeVariantPresetID", UUID)

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -137,6 +137,7 @@ from ai.backend.common.dto.manager.v2.resource_slot.types import (
 )
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
+from ai.backend.common.identifier.runtime_variant_preset import RuntimeVariantPresetID
 from ai.backend.manager.api.adapter_options.deployment.options import (
     deployment_options_from_input,
     deployment_options_to_info,
@@ -184,6 +185,7 @@ from ai.backend.manager.data.deployment.types import (
     RouteTrafficStatus as ManagerRouteTrafficStatus,
 )
 from ai.backend.manager.data.deployment.upserter import DeploymentPolicyUpserter
+from ai.backend.manager.data.runtime_variant_preset.types import RuntimeVariantPresetValueData
 from ai.backend.manager.errors.deployment import DeploymentRevisionNotFound
 from ai.backend.manager.errors.service import EndpointTokenNotFound
 from ai.backend.manager.models.deployment_policy import BlueGreenSpec, RollingUpdateSpec
@@ -554,6 +556,15 @@ class DeploymentAdapter(BaseAdapter):
                     if initial_revision.model_runtime_config.environ
                     else None,
                 ),
+                runtime_variant_preset_values=[
+                    RuntimeVariantPresetValueData(
+                        preset_id=RuntimeVariantPresetID(preset_input.preset_id),
+                        value=preset_input.value,
+                    )
+                    for preset_input in (
+                        initial_revision.model_runtime_config.runtime_variant_preset_values or []
+                    )
+                ],
             )
         strategy = input.default_deployment_strategy
         policy: DeploymentPolicyConfig | None = None
@@ -1173,6 +1184,19 @@ class DeploymentAdapter(BaseAdapter):
             input.model_definition.to_draft() if input.model_definition is not None else None
         )
 
+        runtime_variant_preset_values = (
+            [
+                RuntimeVariantPresetValueData(
+                    preset_id=RuntimeVariantPresetID(preset_value_input.preset_id),
+                    value=preset_value_input.value,
+                )
+                for preset_value_input in (
+                    input.model_runtime_config.runtime_variant_preset_values or []
+                )
+            ]
+            if input.model_runtime_config is not None
+            else []
+        )
         adder = ModelRevisionCreator(
             image_id=image_id,
             resource_spec=resource_spec,
@@ -1180,6 +1204,7 @@ class DeploymentAdapter(BaseAdapter):
             execution=execution,
             model_definition=model_definition,
             revision_preset_id=input.revision_preset_id,
+            runtime_variant_preset_values=runtime_variant_preset_values,
         )
         action_result = await self._processors.deployment.add_model_revision.wait_for_complete(
             AddModelRevisionAction(
@@ -2340,7 +2365,7 @@ class DeploymentAdapter(BaseAdapter):
                 )
                 for m in data.model_mount_config.extra_mounts
             ],
-            revision_preset_id=data.preset.preset_id,
+            revision_preset_id=data.revision_preset.preset_id,
         )
 
     @staticmethod

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -69,7 +69,9 @@ from ai.backend.manager.models.deployment_revision_preset.orders import (
     DeploymentRevisionPresetOrders,
 )
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
-from ai.backend.manager.models.deployment_revision_preset.types import PresetValueEntry
+from ai.backend.manager.models.deployment_revision_preset.types import (
+    DeploymentRevisionPresetValueEntry,
+)
 from ai.backend.manager.models.resource_slot.conditions import PresetResourceSlotConditions
 from ai.backend.manager.models.resource_slot.orders import (
     ALLOCATED_SLOT_DEFAULT_BACKWARD_ORDER,
@@ -300,7 +302,7 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
             if input.environ is not None
             else OptionalState.nop()
         )
-        preset_values_state: OptionalState[list[PresetValueEntry]] = (
+        preset_values_state: OptionalState[list[DeploymentRevisionPresetValueEntry]] = (
             OptionalState.update(self._convert_preset_values_input(input.preset_values))
             if input.preset_values is not None
             else OptionalState.nop()
@@ -548,10 +550,13 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
     @staticmethod
     def _convert_preset_values_input(
         preset_values: list[Any] | None,
-    ) -> list[PresetValueEntry]:
+    ) -> list[DeploymentRevisionPresetValueEntry]:
         if not preset_values:
             return []
-        return [PresetValueEntry(preset_id=pv.preset_id, value=pv.value) for pv in preset_values]
+        return [
+            DeploymentRevisionPresetValueEntry(preset_id=pv.preset_id, value=pv.value)
+            for pv in preset_values
+        ]
 
     @staticmethod
     def _convert_model_definition_state(

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -65,6 +65,9 @@ from ai.backend.common.dto.manager.v2.deployment.request import (
     ModelServiceConfigInput as ModelServiceConfigInputDTO,
 )
 from ai.backend.common.dto.manager.v2.deployment.request import (
+    PresetValueInput as PresetValueInputDTO,
+)
+from ai.backend.common.dto.manager.v2.deployment.request import (
     ResourceConfigInput as ResourceConfigInputDTO,
 )
 from ai.backend.common.dto.manager.v2.deployment.request import (
@@ -808,12 +811,43 @@ class EnvironmentVariablesInputGQL(PydanticInputMixin[EnvironmentVariablesInputD
 
 
 @gql_pydantic_input(
+    BackendAIGQLMeta(
+        description=(
+            "A concrete value for one of a runtime variant's configurable presets, keyed by the "
+            "runtime variant preset ID (from the runtimeVariantPresets query). Distinct from a "
+            "DeploymentRevisionPreset, which is a saved template selected via revision_preset_id."
+        ),
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="RuntimeVariantPresetValueInput",
+)
+class RuntimeVariantPresetValueInputGQL(PydanticInputMixin[PresetValueInputDTO]):
+    preset_id: UUID = gql_field(
+        description="The runtime variant preset (from runtimeVariantPresets) this value applies to."
+    )
+    value: str = gql_field(
+        description="The concrete value to set for the referenced runtime variant preset parameter."
+    )
+
+
+@gql_pydantic_input(
     BackendAIGQLMeta(description="", added_version="25.19.0"),
 )
 class ModelRuntimeConfigInput(PydanticInputMixin[ModelRuntimeConfigInputDTO]):
     runtime_variant_id: UUID
     environ: EnvironmentVariablesInputGQL | None = gql_field(
         description="Environment variables for the service.", default=None
+    )
+    runtime_variant_preset_values: list[RuntimeVariantPresetValueInputGQL] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Concrete values for the runtime variant's configurable presets, each keyed by the "
+                "runtime variant preset ID. Overrides matching presets from a revision_preset_id "
+                "template (merged by preset_id)."
+            ),
+        ),
+        default=None,
     )
 
 

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -17,6 +17,9 @@ from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.dto.manager.v2.deployment.request import (
     DeploymentStrategyInput as DeploymentStrategyInputDTO,
 )
+from ai.backend.common.dto.manager.v2.deployment.request import (
+    PresetValueInput as PresetValueInputDTO,
+)
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
     CreateDeploymentRevisionPresetInput as CreateInputDTO,
 )
@@ -40,9 +43,6 @@ from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import 
 )
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
     PresetModelServiceConfigInput as PresetModelServiceConfigInputDTO,
-)
-from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
-    PresetValueInput as PresetValueInputDTO,
 )
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
     UpdateDeploymentRevisionPresetInput as UpdateInputDTO,
@@ -389,7 +389,7 @@ class DeploymentRevisionPresetConnection(Connection[DeploymentRevisionPresetGQL]
     ),
     name="DeploymentRevisionPresetValueEntryInput",
 )
-class PresetValueEntryInputGQL(PydanticInputMixin[PresetValueInputDTO]):
+class DeploymentRevisionPresetValueEntryInputGQL(PydanticInputMixin[PresetValueInputDTO]):
     preset_id: UUID = gql_field(
         description="The runtime variant preset that this value applies to."
     )
@@ -660,7 +660,7 @@ class CreateDeploymentRevisionPresetInputGQL(PydanticInputMixin[CreateInputDTO])
         ),
         default=None,
     )
-    preset_values: list[PresetValueEntryInputGQL] | None = gql_added_field(
+    preset_values: list[DeploymentRevisionPresetValueEntryInputGQL] | None = gql_added_field(
         BackendAIGQLMeta(
             added_version=NEXT_RELEASE_VERSION,
             description="Runtime variant preset values applied when using this deployment preset.",
@@ -771,7 +771,7 @@ class UpdateDeploymentRevisionPresetInputGQL(PydanticInputMixin[UpdateInputDTO])
         ),
         default=None,
     )
-    preset_values: list[PresetValueEntryInputGQL] | None = gql_added_field(
+    preset_values: list[DeploymentRevisionPresetValueEntryInputGQL] | None = gql_added_field(
         BackendAIGQLMeta(
             added_version=NEXT_RELEASE_VERSION,
             description="Replace runtime variant preset values. Omit to leave unchanged.",

--- a/src/ai/backend/manager/data/deployment/creator.py
+++ b/src/ai/backend/manager/data/deployment/creator.py
@@ -23,7 +23,7 @@ from ai.backend.manager.data.deployment.types import (
     ResourceSpec,
     RevisionDraft,
 )
-from ai.backend.manager.data.deployment_revision_preset.types import PresetValueData
+from ai.backend.manager.data.runtime_variant_preset.types import RuntimeVariantPresetValueData
 from ai.backend.manager.models.deployment_policy import BlueGreenSpec, RollingUpdateSpec
 
 
@@ -65,7 +65,7 @@ class ModelRevisionCreator:
     execution: ExecutionSpec | None = None
     model_definition: ModelDefinitionDraft | None = None
     revision_preset_id: DeploymentPresetID | None = None
-    preset_values: list[PresetValueData] = field(default_factory=list)
+    runtime_variant_preset_values: list[RuntimeVariantPresetValueData] = field(default_factory=list)
 
     def to_draft_with_extra_mount(self, extra_mounts: list[MountInfoEntry]) -> RevisionDraft:
         """Project this v2 creator onto a ``RevisionDraft`` layer.
@@ -97,6 +97,7 @@ class ModelRevisionCreator:
             callback_url=ex.callback_url if ex is not None else None,
             inference_runtime_config=ex.inference_runtime_config if ex is not None else None,
             model_definition=self.model_definition,
+            runtime_variant_preset_values=self.runtime_variant_preset_values or None,
         )
 
 

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -30,6 +30,7 @@ from ai.backend.common.identifier.deployment_revision import DeploymentRevisionI
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.replica_group import ReplicaGroupID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
+from ai.backend.common.identifier.runtime_variant_preset import RuntimeVariantPresetID
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.manager.data.reconciler.types import BaseReconcilerCategory
 from ai.backend.manager.data.session.options import HandlerOptions
@@ -50,10 +51,11 @@ from ai.backend.common.types import (
 from ai.backend.manager.data.deployment.scale import AutoScalingRule
 from ai.backend.manager.data.deployment_revision_preset.types import (
     DeploymentRevisionPresetData,
-    PresetValueData,
+    DeploymentRevisionPresetValueData,
     ResourceSlotEntryData,
 )
 from ai.backend.manager.data.runtime_variant.types import RuntimeVariantData
+from ai.backend.manager.data.runtime_variant_preset.types import RuntimeVariantPresetValueData
 
 
 class DeploymentConfig(BackendAISchema):
@@ -586,10 +588,10 @@ class ExecutionSpec(ConfiguredModel):
     inference_runtime_config: Mapping[str, Any] | None = None
 
 
-class PresetValueSpec(ConfiguredModel):
+class RuntimeVariantPresetValueSpec(ConfiguredModel):
     """A runtime variant preset value binding stored in a deployment revision."""
 
-    preset_id: DeploymentPresetID
+    preset_id: RuntimeVariantPresetID
     value: str
 
 
@@ -604,7 +606,7 @@ class ModelRevisionSpec(ConfiguredModel):
     mounts: MountMetadata
     execution: ExecutionSpec
     model_definition: ModelDefinition | None = None
-    preset_values: list[PresetValueSpec] = Field(default_factory=list)
+    runtime_variant_preset_values: list[RuntimeVariantPresetValueSpec] = Field(default_factory=list)
     # Original deployment-level preset selection used to build this revision.
     # ``None`` for legacy rows and revisions created without a preset; the
     # materialised effects still live on ``preset_values`` and the resolved
@@ -689,8 +691,8 @@ class RevisionDraft:
     # Model definition (draft form — partial fields allowed; merged then resolved
     # to a strict ``ModelDefinition`` at the persistence boundary).
     model_definition: ModelDefinitionDraft | None = None
-    # Preset values (carried alongside; not field-merged)
-    preset_values: list[PresetValueData] | None = None
+    # Runtime variant preset values (carried alongside; merged by ``preset_id``)
+    runtime_variant_preset_values: list[RuntimeVariantPresetValueData] | None = None
 
     def merge(self, other: RevisionDraft) -> RevisionDraft:
         """Return a new draft with ``other`` layered on top of ``self``."""
@@ -722,9 +724,9 @@ class RevisionDraft:
             if other.inference_runtime_config is not None
             else self.inference_runtime_config,
             model_definition=_merge_model_definition(self.model_definition, other.model_definition),
-            preset_values=list(other.preset_values)
-            if other.preset_values is not None
-            else (list(self.preset_values) if self.preset_values is not None else None),
+            runtime_variant_preset_values=_merge_preset_values(
+                self.runtime_variant_preset_values, other.runtime_variant_preset_values
+            ),
         )
 
     def to_model_revision_spec(self) -> ModelRevisionSpec:
@@ -802,6 +804,28 @@ def _merge_mappings(
     if upper is not None:
         merged.update(upper)
     return merged or None
+
+
+def _merge_preset_values(
+    lower: list[RuntimeVariantPresetValueData] | None,
+    upper: list[RuntimeVariantPresetValueData] | None,
+) -> list[RuntimeVariantPresetValueData] | None:
+    """Merge runtime-variant preset values by ``preset_id``.
+
+    ``upper`` (higher-priority source, e.g. the user request) overrides
+    ``lower`` (e.g. the revision-preset template) per ``preset_id``; preset_ids
+    only present in ``lower`` are preserved. ``None`` on a side means "this
+    source supplied no values" and is skipped. Returns ``None`` only when both
+    sides are ``None``.
+    """
+    if lower is None and upper is None:
+        return None
+    merged: dict[RuntimeVariantPresetID, RuntimeVariantPresetValueData] = {}
+    for pv in lower or []:
+        merged[pv.preset_id] = pv
+    for pv in upper or []:
+        merged[pv.preset_id] = pv
+    return list(merged.values())
 
 
 def _merge_model_definition(
@@ -1054,6 +1078,7 @@ class ModelRuntimeConfigData:
     runtime_variant_id: RuntimeVariantID
     inference_runtime_config: Mapping[str, Any] | None = None
     environ: dict[str, Any] | None = None
+    runtime_variant_preset_values: list[RuntimeVariantPresetValueData] = field(default_factory=list)
 
 
 @dataclass
@@ -1104,7 +1129,8 @@ class PresetAttributionData:
     """
 
     preset_id: DeploymentPresetID | None
-    values: list[PresetValueData]
+    # value fields are not used, currently dead code
+    values: list[DeploymentRevisionPresetValueData]
 
 
 @dataclass
@@ -1127,7 +1153,7 @@ class ModelRevisionData:
     # Mount
     model_mount_config: ModelMountConfigData
     # Preset attribution
-    preset: PresetAttributionData
+    revision_preset: PresetAttributionData
     # Model definition (resolved against the model vfolder at
     # persistence time; ``None`` if the source had none).
     model_definition: ModelDefinition | None = None
@@ -1142,7 +1168,7 @@ class ModelRevisionData:
         ``model_runtime_config`` (runtime variant + environ +
         inference_runtime_config), ``execution`` (startup_command /
         bootstrap_script / callback_url), and ``model_definition`` —
-        flows back into the draft as the baseline; preset /
+        flows back into the draft as the baseline; revision_preset /
         ``deployment-config.yaml`` / ``model-definition.yaml`` / user
         request layers then override on top via ``merge_revision_drafts``.
         """
@@ -1178,6 +1204,10 @@ class ModelRevisionData:
             callback_url=self.execution.callback_url,
             inference_runtime_config=self.model_runtime_config.inference_runtime_config,
             model_definition=model_definition_draft,
+            runtime_variant_preset_values=list(
+                self.model_runtime_config.runtime_variant_preset_values
+            )
+            or None,
         )
 
 

--- a/src/ai/backend/manager/data/deployment_revision_preset/types.py
+++ b/src/ai/backend/manager/data/deployment_revision_preset/types.py
@@ -12,7 +12,7 @@ from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 
 
 @dataclass(frozen=True)
-class PresetValueData:
+class DeploymentRevisionPresetValueData:
     preset_id: DeploymentPresetID
     value: str
 
@@ -50,7 +50,7 @@ class DeploymentRevisionPresetData:
     startup_command: str | None
     bootstrap_script: str | None
     environ: list[EnvironEntryData]
-    preset_values: list[PresetValueData]
+    preset_values: list[DeploymentRevisionPresetValueData]
     replica_count: int
     deployment_strategy: DeploymentStrategy
     deployment_strategy_spec: dict[str, Any]

--- a/src/ai/backend/manager/data/runtime_variant_preset/types.py
+++ b/src/ai/backend/manager/data/runtime_variant_preset/types.py
@@ -8,6 +8,15 @@ from ai.backend.common.dto.manager.v2.runtime_variant_preset.types import (
     PresetTarget,
     PresetValueType,
 )
+from ai.backend.common.identifier.runtime_variant_preset import RuntimeVariantPresetID
+
+
+@dataclass(frozen=True)
+class RuntimeVariantPresetValueData:
+    """A concrete value bound to a runtime variant preset (by 'preset_id')."""
+
+    preset_id: RuntimeVariantPresetID
+    value: str
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/models/deployment_revision/row.py
+++ b/src/ai/backend/manager/models/deployment_revision/row.py
@@ -31,7 +31,7 @@ from ai.backend.manager.data.deployment.types import (
     PresetAttributionData,
     ResourceConfigData,
 )
-from ai.backend.manager.data.deployment_revision_preset.types import PresetValueData
+from ai.backend.manager.data.runtime_variant_preset.types import RuntimeVariantPresetValueData
 from ai.backend.manager.models.base import (
     GUID,
     Base,
@@ -39,7 +39,7 @@ from ai.backend.manager.models.base import (
     PydanticListColumn,
     URLColumn,
 )
-from ai.backend.manager.models.deployment_revision_preset.types import PresetValueEntry
+from ai.backend.manager.models.runtime_variant_preset.types import RuntimeVariantPresetValueEntry
 
 if TYPE_CHECKING:
     from ai.backend.manager.models.endpoint import EndpointRow
@@ -209,9 +209,9 @@ class DeploymentRevisionRow(Base):  # type: ignore[misc]
     )
 
     # Runtime variant preset values (resolved at session creation time)
-    preset_values: Mapped[list[PresetValueEntry]] = mapped_column(
+    preset_values: Mapped[list[RuntimeVariantPresetValueEntry]] = mapped_column(
         "preset_values",
-        PydanticListColumn(PresetValueEntry),
+        PydanticListColumn(RuntimeVariantPresetValueEntry),
         nullable=False,
         default=[],
         server_default="[]",
@@ -288,6 +288,10 @@ class DeploymentRevisionRow(Base):  # type: ignore[misc]
             model_runtime_config=ModelRuntimeConfigData(
                 runtime_variant_id=RuntimeVariantID(self.runtime_variant_id),
                 environ=self.environ,
+                runtime_variant_preset_values=[
+                    RuntimeVariantPresetValueData(preset_id=pv.preset_id, value=pv.value)
+                    for pv in (self.preset_values or [])
+                ],
             ),
             execution=ExecutionData(
                 startup_command=self.startup_command,
@@ -301,12 +305,11 @@ class DeploymentRevisionRow(Base):  # type: ignore[misc]
                 definition_path=self.model_definition_path or "",
                 extra_mounts=list(self.extra_mounts),
             ),
-            preset=PresetAttributionData(
+            revision_preset=PresetAttributionData(
                 preset_id=self.revision_preset_id,
-                values=[
-                    PresetValueData(preset_id=pv.preset_id, value=pv.value)
-                    for pv in (self.preset_values or [])
-                ],
+                # DeploymentRevisionPresetValueData is not stored on the row
+                # value fields are not used, currently dead code
+                values=[],
             ),
             model_definition=self.model_definition,
         )

--- a/src/ai/backend/manager/models/deployment_revision_preset/row.py
+++ b/src/ai/backend/manager/models/deployment_revision_preset/row.py
@@ -14,8 +14,8 @@ from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.manager.data.deployment_revision_preset.types import (
     DeploymentRevisionPresetData,
+    DeploymentRevisionPresetValueData,
     EnvironEntryData,
-    PresetValueData,
     ResourceOptsEntryData,
 )
 from ai.backend.manager.models.base import (
@@ -26,7 +26,9 @@ from ai.backend.manager.models.base import (
     ResourceOptsEntry,
     StrEnumType,
 )
-from ai.backend.manager.models.deployment_revision_preset.types import PresetValueEntry
+from ai.backend.manager.models.deployment_revision_preset.types import (
+    DeploymentRevisionPresetValueEntry,
+)
 
 if TYPE_CHECKING:
     from ai.backend.manager.models.resource_slot.row import PresetResourceSlotRow
@@ -75,8 +77,11 @@ class DeploymentRevisionPresetRow(Base):  # type: ignore[misc]
     environ: Mapped[dict[str, str]] = mapped_column(
         "environ", pgsql.JSONB(), nullable=False, default={}, server_default="{}"
     )
-    preset_values: Mapped[list[PresetValueEntry]] = mapped_column(
-        "preset_values", PydanticListColumn(PresetValueEntry), nullable=False, server_default="[]"
+    preset_values: Mapped[list[DeploymentRevisionPresetValueEntry]] = mapped_column(
+        "preset_values",
+        PydanticListColumn(DeploymentRevisionPresetValueEntry),
+        nullable=False,
+        server_default="[]",
     )
 
     # Deployment-level preset fields. ``open_to_public`` and
@@ -145,7 +150,7 @@ class DeploymentRevisionPresetRow(Base):  # type: ignore[misc]
             bootstrap_script=self.bootstrap_script,
             environ=[EnvironEntryData(key=k, value=v) for k, v in (self.environ or {}).items()],
             preset_values=[
-                PresetValueData(preset_id=pv.preset_id, value=pv.value)
+                DeploymentRevisionPresetValueData(preset_id=pv.preset_id, value=pv.value)
                 for pv in (self.preset_values or [])
             ],
             open_to_public=self.open_to_public,

--- a/src/ai/backend/manager/models/deployment_revision_preset/types.py
+++ b/src/ai/backend/manager/models/deployment_revision_preset/types.py
@@ -6,6 +6,6 @@ from ai.backend.common.identifier.deployment_preset import DeploymentPresetID
 from ai.backend.common.types import BackendAISchema
 
 
-class PresetValueEntry(BackendAISchema):
+class DeploymentRevisionPresetValueEntry(BackendAISchema):
     preset_id: DeploymentPresetID = Field(description="Deployment preset ID.")
     value: str = Field(description="Value for this preset.")

--- a/src/ai/backend/manager/models/runtime_variant_preset/row.py
+++ b/src/ai/backend/manager/models/runtime_variant_preset/row.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
 from ai.backend.common.dto.manager.v2.runtime_variant_preset.types import (
     PresetTarget,
     PresetValueType,
+    UIOption,
 )
 from ai.backend.manager.data.runtime_variant_preset.types import (
     ChoiceItemData,
@@ -21,7 +22,6 @@ from ai.backend.manager.data.runtime_variant_preset.types import (
     UIOptionData,
 )
 from ai.backend.manager.models.base import GUID, Base, PydanticColumn
-from ai.backend.manager.models.runtime_variant_preset.types import UIOption
 
 if TYPE_CHECKING:
     from ai.backend.manager.models.runtime_variant.row import RuntimeVariantRow

--- a/src/ai/backend/manager/models/runtime_variant_preset/types.py
+++ b/src/ai/backend/manager/models/runtime_variant_preset/types.py
@@ -1,5 +1,13 @@
-"""Re-export UIOption from DTO for PydanticColumn usage."""
+from __future__ import annotations
 
-from ai.backend.common.dto.manager.v2.runtime_variant_preset.types import UIOption
+from pydantic import Field
 
-__all__ = ("UIOption",)
+from ai.backend.common.identifier.runtime_variant_preset import RuntimeVariantPresetID
+from ai.backend.common.types import BackendAISchema
+
+
+class RuntimeVariantPresetValueEntry(BackendAISchema):
+    """A concrete value bound to a runtime variant preset, stored as JSONB."""
+
+    preset_id: RuntimeVariantPresetID = Field(description="Runtime variant preset ID.")
+    value: str = Field(description="Value for this preset.")

--- a/src/ai/backend/manager/repositories/deployment/creators/revision.py
+++ b/src/ai/backend/manager/repositories/deployment/creators/revision.py
@@ -18,8 +18,8 @@ from ai.backend.common.types import (
 )
 from ai.backend.manager.errors.common import InternalServerError
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
-from ai.backend.manager.models.deployment_revision_preset.types import PresetValueEntry
 from ai.backend.manager.models.resource_slot.row import DeploymentRevisionResourceSlotRow
+from ai.backend.manager.models.runtime_variant_preset.types import RuntimeVariantPresetValueEntry
 from ai.backend.manager.repositories.base import CreatorSpec
 
 
@@ -51,7 +51,7 @@ class DeploymentRevisionCreatorSpec(CreatorSpec[DeploymentRevisionRow]):
     runtime_variant_id: RuntimeVariantID
     extra_mounts: Sequence[MountInfoEntry]
     termination_grace_period: float = 30.0
-    preset_values: Sequence[PresetValueEntry] = field(default_factory=list)
+    preset_values: Sequence[RuntimeVariantPresetValueEntry] = field(default_factory=list)
     revision_preset_id: DeploymentPresetID | None = None
     revision_number: int | None = None
 

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -2164,7 +2164,7 @@ class DeploymentDBSource:
             )
             image_row = await ImageRow.resolve(db_sess, [image_identifier])
 
-            # Resolve preset_values from revision
+            # Resolve runtime variant preset values from revision
             resolved_presets: ResolvedPresetValues | None = None
             if revision_row.preset_values:
                 preset_ids = [pv.preset_id for pv in revision_row.preset_values]

--- a/src/ai/backend/manager/repositories/deployment_revision_preset/creators.py
+++ b/src/ai/backend/manager/repositories/deployment_revision_preset/creators.py
@@ -16,7 +16,9 @@ from ai.backend.manager.errors.repository import UniqueConstraintViolationError
 from ai.backend.manager.errors.resource import DeploymentRevisionPresetConflict
 from ai.backend.manager.models.base import ResourceOptsEntry
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
-from ai.backend.manager.models.deployment_revision_preset.types import PresetValueEntry
+from ai.backend.manager.models.deployment_revision_preset.types import (
+    DeploymentRevisionPresetValueEntry,
+)
 from ai.backend.manager.models.resource_slot.row import PresetResourceSlotRow
 from ai.backend.manager.repositories.base.creator import DependentCreatorSpec
 from ai.backend.manager.repositories.base.types import IntegrityErrorCheck
@@ -47,7 +49,7 @@ class DeploymentRevisionPresetCreatorSpec(DependentCreatorSpec[int, DeploymentRe
     startup_command: str | None
     bootstrap_script: str | None
     environ: dict[str, str]
-    preset_values: list[PresetValueEntry]
+    preset_values: list[DeploymentRevisionPresetValueEntry]
     replica_count: int
     deployment_strategy: DeploymentStrategy
     deployment_strategy_spec: dict[str, Any]

--- a/src/ai/backend/manager/repositories/deployment_revision_preset/updaters.py
+++ b/src/ai/backend/manager/repositories/deployment_revision_preset/updaters.py
@@ -9,7 +9,9 @@ from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.manager.models.base import ResourceOptsEntry
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
-from ai.backend.manager.models.deployment_revision_preset.types import PresetValueEntry
+from ai.backend.manager.models.deployment_revision_preset.types import (
+    DeploymentRevisionPresetValueEntry,
+)
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -36,8 +38,8 @@ class DeploymentRevisionPresetUpdaterSpec(UpdaterSpec[DeploymentRevisionPresetRo
     environ: OptionalState[dict[str, str]] = field(
         default_factory=OptionalState[dict[str, str]].nop
     )
-    preset_values: OptionalState[list[PresetValueEntry]] = field(
-        default_factory=OptionalState[list[PresetValueEntry]].nop
+    preset_values: OptionalState[list[DeploymentRevisionPresetValueEntry]] = field(
+        default_factory=OptionalState[list[DeploymentRevisionPresetValueEntry]].nop
     )
     open_to_public: TriState[bool] = field(default_factory=TriState[bool].nop)
     replica_count: TriState[int] = field(default_factory=TriState[int].nop)

--- a/src/ai/backend/manager/repositories/runtime_variant_preset/creators.py
+++ b/src/ai/backend/manager/repositories/runtime_variant_preset/creators.py
@@ -8,11 +8,11 @@ from uuid import UUID
 from ai.backend.common.dto.manager.v2.runtime_variant_preset.types import (
     PresetTarget,
     PresetValueType,
+    UIOption,
 )
 from ai.backend.manager.errors.repository import UniqueConstraintViolationError
 from ai.backend.manager.errors.resource import RuntimeVariantPresetConflict
 from ai.backend.manager.models.runtime_variant_preset.row import RuntimeVariantPresetRow
-from ai.backend.manager.models.runtime_variant_preset.types import UIOption
 from ai.backend.manager.repositories.base.creator import CreatorSpec
 from ai.backend.manager.repositories.base.types import IntegrityErrorCheck
 

--- a/src/ai/backend/manager/repositories/runtime_variant_preset/updaters.py
+++ b/src/ai/backend/manager/repositories/runtime_variant_preset/updaters.py
@@ -6,9 +6,9 @@ from typing import Any, override
 from ai.backend.common.dto.manager.v2.runtime_variant_preset.types import (
     PresetTarget,
     PresetValueType,
+    UIOption,
 )
 from ai.backend.manager.models.runtime_variant_preset.row import RuntimeVariantPresetRow
-from ai.backend.manager.models.runtime_variant_preset.types import UIOption
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -410,8 +410,8 @@ def _build_creator_from_revision_data(data: ModelRevisionData) -> ModelRevisionC
             inference_runtime_config=data.model_runtime_config.inference_runtime_config,
         ),
         model_definition=None,
-        revision_preset_id=data.preset.preset_id,
-        preset_values=list(data.preset.values),
+        revision_preset_id=data.revision_preset.preset_id,
+        runtime_variant_preset_values=data.model_runtime_config.runtime_variant_preset_values,
     )
 
 

--- a/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
@@ -53,10 +53,10 @@ from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.errors.api import InvalidAPIParameters
 from ai.backend.manager.errors.deployment import EndpointNotFound
 from ai.backend.manager.models.deployment_policy import BlueGreenSpec, RollingUpdateSpec
-from ai.backend.manager.models.deployment_revision_preset.types import PresetValueEntry
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.routing import RoutingRow
 from ai.backend.manager.models.routing.conditions import RouteConditions
+from ai.backend.manager.models.runtime_variant_preset.types import RuntimeVariantPresetValueEntry
 from ai.backend.manager.models.storage import StorageSessionManager
 from ai.backend.manager.repositories.base import BatchQuerier, OffsetPagination
 from ai.backend.manager.repositories.base.rbac.entity_creator import RBACEntityCreator
@@ -451,8 +451,8 @@ class DeploymentController:
             runtime_variant_id=runtime_variant_id,
             extra_mounts=list(merged.mounts.extra_mounts),
             preset_values=[
-                PresetValueEntry(preset_id=pv.preset_id, value=pv.value)
-                for pv in (merged.preset_values or [])
+                RuntimeVariantPresetValueEntry(preset_id=pv.preset_id, value=pv.value)
+                for pv in (merged.runtime_variant_preset_values or [])
             ],
             revision_preset_id=preset_id,
         )

--- a/src/ai/backend/manager/sokovan/deployment/revision_draft/reader.py
+++ b/src/ai/backend/manager/sokovan/deployment/revision_draft/reader.py
@@ -143,7 +143,6 @@ class RevisionDraftReader:
             bootstrap_script=preset.bootstrap_script,
             environ=environ or None,
             model_definition=model_definition,
-            preset_values=list(preset.preset_values) or None,
         )
 
     def _model_mount_path_default_draft(

--- a/tests/unit/manager/api/adapters/test_deployment_adapter.py
+++ b/tests/unit/manager/api/adapters/test_deployment_adapter.py
@@ -74,7 +74,7 @@ class TestRevisionDataToDTO:
                 bootstrap_script=None,
                 callback_url=None,
             ),
-            preset=PresetAttributionData(preset_id=None, values=[]),
+            revision_preset=PresetAttributionData(preset_id=None, values=[]),
         )
 
         dto = DeploymentAdapter._revision_data_to_dto(revision)

--- a/tests/unit/manager/data/deployment/test_revision_draft_merge.py
+++ b/tests/unit/manager/data/deployment/test_revision_draft_merge.py
@@ -8,13 +8,13 @@ from uuid import uuid4
 import yarl
 
 from ai.backend.common.config import ModelConfigDraft, ModelDefinitionDraft
-from ai.backend.common.identifier.deployment_preset import DeploymentPresetID
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
+from ai.backend.common.identifier.runtime_variant_preset import RuntimeVariantPresetID
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import ClusterMode
 from ai.backend.manager.data.deployment.types import MountMetadata, RevisionDraft
-from ai.backend.manager.data.deployment_revision_preset.types import PresetValueData
+from ai.backend.manager.data.runtime_variant_preset.types import RuntimeVariantPresetValueData
 
 
 def _merge_all(*drafts: RevisionDraft) -> RevisionDraft:
@@ -108,13 +108,37 @@ class TestRevisionDraftMerge:
         merged = earlier.merge(later)
         assert merged.model_definition is override
 
-    def test_preset_values_replaced_by_latest_non_none(self) -> None:
-        first = [PresetValueData(preset_id=DeploymentPresetID(uuid4()), value="a")]
-        second = [PresetValueData(preset_id=DeploymentPresetID(uuid4()), value="b")]
-        earlier = RevisionDraft(preset_values=first)
-        later = RevisionDraft(preset_values=second)
-        merged = earlier.merge(later)
-        assert merged.preset_values == second
+    def test_preset_values_same_id_overridden_by_upper(self) -> None:
+        preset_id = RuntimeVariantPresetID(uuid4())
+        lower = RevisionDraft(
+            runtime_variant_preset_values=[
+                RuntimeVariantPresetValueData(preset_id=preset_id, value="old")
+            ]
+        )
+        upper = RevisionDraft(
+            runtime_variant_preset_values=[
+                RuntimeVariantPresetValueData(preset_id=preset_id, value="new")
+            ]
+        )
+        merged = lower.merge(upper)
+        assert merged.runtime_variant_preset_values == [
+            RuntimeVariantPresetValueData(preset_id=preset_id, value="new")
+        ]
+
+    def test_preset_values_distinct_ids_preserved(self) -> None:
+        # Partial override: ids only on one side survive, so template entries the
+        # request does not touch are kept.
+        template = RuntimeVariantPresetValueData(
+            preset_id=RuntimeVariantPresetID(uuid4()), value="template"
+        )
+        override = RuntimeVariantPresetValueData(
+            preset_id=RuntimeVariantPresetID(uuid4()), value="override"
+        )
+        merged = RevisionDraft(runtime_variant_preset_values=[template]).merge(
+            RevisionDraft(runtime_variant_preset_values=[override])
+        )
+        assert merged.runtime_variant_preset_values is not None
+        assert set(merged.runtime_variant_preset_values) == {template, override}
 
     def test_model_definition_uses_lower_model_path_when_higher_omits_it(self) -> None:
         base = RevisionDraft(

--- a/tests/unit/manager/services/deployment/test_deployment_crud_actions.py
+++ b/tests/unit/manager/services/deployment/test_deployment_crud_actions.py
@@ -632,7 +632,7 @@ class TestGetRevisionById(DeploymentCRUDBaseFixtures):
                 bootstrap_script=None,
                 callback_url=None,
             ),
-            preset=PresetAttributionData(preset_id=None, values=[]),
+            revision_preset=PresetAttributionData(preset_id=None, values=[]),
         )
 
     async def test_existing_revision_returns_data(

--- a/tests/unit/manager/services/deployment/test_deployment_service.py
+++ b/tests/unit/manager/services/deployment/test_deployment_service.py
@@ -449,7 +449,7 @@ class ModelRevisionFixtures(DeploymentServiceBaseFixtures):
                 bootstrap_script=None,
                 callback_url=None,
             ),
-            preset=PresetAttributionData(preset_id=None, values=[]),
+            revision_preset=PresetAttributionData(preset_id=None, values=[]),
             created_at=datetime(2024, 1, 1, tzinfo=UTC),
         )
 
@@ -696,7 +696,7 @@ class TestConvertDeploymentInfoToData:
                     bootstrap_script=None,
                     callback_url=None,
                 ),
-                preset=PresetAttributionData(preset_id=None, values=[]),
+                revision_preset=PresetAttributionData(preset_id=None, values=[]),
             )
 
         return make

--- a/tests/unit/manager/services/deployment/test_refresh_revision_mount_preservation.py
+++ b/tests/unit/manager/services/deployment/test_refresh_revision_mount_preservation.py
@@ -85,7 +85,7 @@ class RefreshRevisionBaseFixtures:
                     extra_mounts=extra_mounts or [],
                     subpath=vfolder_subpath,
                 ),
-                preset=PresetAttributionData(preset_id=None, values=[]),
+                revision_preset=PresetAttributionData(preset_id=None, values=[]),
                 model_definition=None,
             )
 


### PR DESCRIPTION
## Summary
- Add `runtime_variant_preset_values` to `ModelRuntimeConfigInput` (DTO + new GQL wrapper `RuntimeVariantPresetValueInput`) so a client can bind runtime variant presets to concrete values directly on a deployment revision — keyed by `preset_id` from the `runtimeVariantPresets` query, distinct from the `revision_preset_id` template.
- Project the values through `ModelRevisionCreator.to_draft_with_extra_mount` into the `RevisionDraft` (previously dropped) and merge them **by `preset_id`** in `RevisionDraft.merge`, so a partial override preserves untouched template entries.
- Rename the data/domain field `preset_values` → `runtime_variant_preset_values`; the persistence layer (ORM column, `DeploymentRevisionCreatorSpec`) keeps `preset_values` (no migration).
- Introduce `RuntimeVariantPresetID` to correct the value-binding `preset_id` type, which was mistyped as `DeploymentPresetID` (the DeploymentRevisionPreset PK).

## Test plan
- [x] `pants fmt / lint / check` clean (changed files + dependent packages)
- [x] Unit tests: `RevisionDraft.merge` preset_id-keyed merge (same-id override, distinct-id preserve)
- [x] Affected deployment unit suites pass
- [x] Regenerated GraphQL v2 + supergraph schema dumps
- [ ] CI green

Resolves BA-6504

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12200.org.readthedocs.build/en/12200/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12200.org.readthedocs.build/ko/12200/

<!-- readthedocs-preview sorna-ko end -->