### PR TITLE
fix(BA-6487): prune dead-PID process metrics each collection cycle

### DIFF
--- a/changes/12203.fix.md
+++ b/changes/12203.fix.md
@@ -1,0 +1,1 @@
+Prune per-process utilization metrics for dead PIDs each collection cycle so the per-container metric blob no longer grows unbounded and saturates Redis.

--- a/configs/agent/sample.toml
+++ b/configs/agent/sample.toml
@@ -237,15 +237,47 @@
     # Added in 25.12.0
     interval = 30.0
 
-  # Configuration for utilization metric collection. Controls the collection
-  # interval and, derived from it, the Valkey expiration of stored utilization
-  # values.
+  # Configuration for utilization metric collection. Holds per-node, per-
+  # container, and per-process settings, each with its own enable flag and
+  # collection interval.
   # Added in 26.4.4
   [agent.utilization-metric]
-    # Time interval in seconds between utilization metric collection cycles
-    # (per-node, per-container, and per-process statistics).
+
+    # Per-node and per-device utilization metric collection settings.
     # Added in 26.4.4
-    interval = 30.0
+    [agent.utilization-metric.node]
+      # Whether to collect per-node and per-device utilization metrics.
+      # Added in 26.4.4
+      enable = true
+      # Time interval in seconds between per-node utilization metric collection
+      # cycles.
+      # Added in 26.4.4
+      interval = 30.0
+
+    # Per-container utilization metric collection settings.
+    # Added in 26.4.4
+    [agent.utilization-metric.container]
+      # Whether to collect per-container utilization metrics.
+      # Added in 26.4.4
+      enable = true
+      # Time interval in seconds between per-container utilization metric
+      # collection cycles.
+      # Added in 26.4.4
+      interval = 30.0
+
+    # Per-process utilization metric collection settings.
+    # Added in 26.4.4
+    [agent.utilization-metric.process]
+      # Whether to collect per-process utilization metrics for each container.
+      # When disabled, the agent skips listing container processes and reporting
+      # per-process statistics, while per-node and per-container metrics are
+      # still collected.
+      # Added in 26.4.4
+      enable = true
+      # Time interval in seconds between per-process utilization metric
+      # collection cycles.
+      # Added in 26.4.4
+      interval = 30.0
 
 # Container runtime configuration including execution modes, user settings, and
 # networking. In multi-agent mode (when 'agents' field is populated), this

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1349,6 +1349,9 @@ class AbstractAgent[
 
     @_observe_stat_task(stat_scope=StatScope.NODE)
     async def collect_node_stat(self, resource_scaling_factors: Mapping[SlotName, Decimal]) -> None:
+        if not self.local_config.agent.utilization_metric.node.enable:
+            log.debug("skipping node stat collection as it's disabled in config")
+            return
         if self.local_config.debug.log_stats:
             log.debug("collecting node statistics")
         async with asyncio.timeout(STAT_COLLECTION_TIMEOUT):
@@ -1356,6 +1359,9 @@ class AbstractAgent[
 
     @_observe_stat_task(stat_scope=StatScope.CONTAINER)
     async def collect_container_stat(self) -> None:
+        if not self.local_config.agent.utilization_metric.container.enable:
+            log.debug("skipping container stat collection as it's disabled in config")
+            return
         if self.local_config.debug.log_stats:
             log.debug("collecting container statistics")
         container_ids: set[ContainerId] = set()
@@ -1368,7 +1374,7 @@ class AbstractAgent[
 
     @_observe_stat_task(stat_scope=StatScope.PROCESS)
     async def collect_process_stat(self) -> None:
-        if not self.local_config.agent.utilization_metric.enable_process_metric:
+        if not self.local_config.agent.utilization_metric.process.enable:
             log.debug("skipping process stat collection as it's disabled in config")
             return
         if self.local_config.debug.log_stats:

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1368,6 +1368,9 @@ class AbstractAgent[
 
     @_observe_stat_task(stat_scope=StatScope.PROCESS)
     async def collect_process_stat(self) -> None:
+        if not self.local_config.agent.utilization_metric.enable_process_metric:
+            log.debug("skipping process stat collection as it's disabled in config")
+            return
         if self.local_config.debug.log_stats:
             log.debug("collecting process statistics in container")
         container_ids: set[ContainerId] = set()

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -8,6 +8,7 @@ import pickle
 import re
 import signal
 import sys
+import time
 import traceback
 import weakref
 import zlib
@@ -776,6 +777,7 @@ def _observe_stat_task(
     ) -> Callable[Concatenate[AbstractAgent[Any, Any], P], Coroutine[Any, Any, None]]:
         async def wrapper(self: AbstractAgent[Any, Any], *args: P.args, **kwargs: P.kwargs) -> None:
             stat_task_observer.observe_stat_task_triggered(agent_id=self.id, stat_scope=stat_scope)
+            start = time.perf_counter()
             try:
                 await func(self, *args, **kwargs)
             except asyncio.CancelledError:
@@ -801,6 +803,12 @@ def _observe_stat_task(
             else:
                 stat_task_observer.observe_stat_task_success(
                     agent_id=self.id, stat_scope=stat_scope
+                )
+            finally:
+                stat_task_observer.observe_stat_task_duration(
+                    agent_id=self.id,
+                    stat_scope=stat_scope,
+                    elapsed=time.perf_counter() - start,
                 )
 
         return wrapper  # type: ignore[return-value]

--- a/src/ai/backend/agent/config/unified.py
+++ b/src/ai/backend/agent/config/unified.py
@@ -122,26 +122,57 @@ class SyncContainerLifecyclesConfig(BaseConfigSchema):
     ]
 
 
-class UtilizationMetricConfig(BaseConfigSchema):
+class NodeMetricConfig(BaseConfigSchema):
+    enable: Annotated[
+        bool,
+        Field(default=True),
+        BackendAIConfigMeta(
+            description="Whether to collect per-node and per-device utilization metrics.",
+            added_version="26.4.4",
+            example=ConfigExample(local="true", prod="true"),
+        ),
+    ]
     interval: Annotated[
         float,
         Field(default=30.0, gt=0),
         BackendAIConfigMeta(
             description=(
-                "Time interval in seconds between utilization metric collection cycles "
-                "(per-node, per-container, and per-process statistics)."
+                "Time interval in seconds between per-node utilization metric collection cycles."
             ),
             added_version="26.4.4",
             example=ConfigExample(local="30.0", prod="30.0"),
         ),
     ]
-    enable_process_metric: Annotated[
+
+
+class ContainerMetricConfig(BaseConfigSchema):
+    enable: Annotated[
         bool,
-        Field(
-            default=True,
-            validation_alias=AliasChoices("enable-process-metric", "enable_process_metric"),
-            serialization_alias="enable-process-metric",
+        Field(default=True),
+        BackendAIConfigMeta(
+            description="Whether to collect per-container utilization metrics.",
+            added_version="26.4.4",
+            example=ConfigExample(local="true", prod="true"),
         ),
+    ]
+    interval: Annotated[
+        float,
+        Field(default=30.0, gt=0),
+        BackendAIConfigMeta(
+            description=(
+                "Time interval in seconds between per-container utilization metric collection "
+                "cycles."
+            ),
+            added_version="26.4.4",
+            example=ConfigExample(local="30.0", prod="30.0"),
+        ),
+    ]
+
+
+class ProcessMetricConfig(BaseConfigSchema):
+    enable: Annotated[
+        bool,
+        Field(default=True),
         BackendAIConfigMeta(
             description=(
                 "Whether to collect per-process utilization metrics for each container. "
@@ -151,6 +182,47 @@ class UtilizationMetricConfig(BaseConfigSchema):
             ),
             added_version="26.4.4",
             example=ConfigExample(local="true", prod="true"),
+        ),
+    ]
+    interval: Annotated[
+        float,
+        Field(default=30.0, gt=0),
+        BackendAIConfigMeta(
+            description=(
+                "Time interval in seconds between per-process utilization metric collection cycles."
+            ),
+            added_version="26.4.4",
+            example=ConfigExample(local="30.0", prod="30.0"),
+        ),
+    ]
+
+
+class UtilizationMetricConfig(BaseConfigSchema):
+    node: Annotated[
+        NodeMetricConfig,
+        Field(default_factory=NodeMetricConfig),
+        BackendAIConfigMeta(
+            description="Per-node and per-device utilization metric collection settings.",
+            added_version="26.4.4",
+            composite=CompositeType.FIELD,
+        ),
+    ]
+    container: Annotated[
+        ContainerMetricConfig,
+        Field(default_factory=ContainerMetricConfig),
+        BackendAIConfigMeta(
+            description="Per-container utilization metric collection settings.",
+            added_version="26.4.4",
+            composite=CompositeType.FIELD,
+        ),
+    ]
+    process: Annotated[
+        ProcessMetricConfig,
+        Field(default_factory=ProcessMetricConfig),
+        BackendAIConfigMeta(
+            description="Per-process utilization metric collection settings.",
+            added_version="26.4.4",
+            composite=CompositeType.FIELD,
         ),
     ]
 
@@ -1234,8 +1306,8 @@ class OverridableAgentConfig(BaseConfigSchema):
         ),
         BackendAIConfigMeta(
             description=(
-                "Configuration for utilization metric collection. Controls the collection "
-                "interval and, derived from it, the Valkey expiration of stored utilization values."
+                "Configuration for utilization metric collection. Holds per-node, per-container, "
+                "and per-process settings, each with its own enable flag and collection interval."
             ),
             added_version="26.4.4",
             composite=CompositeType.FIELD,

--- a/src/ai/backend/agent/config/unified.py
+++ b/src/ai/backend/agent/config/unified.py
@@ -135,6 +135,24 @@ class UtilizationMetricConfig(BaseConfigSchema):
             example=ConfigExample(local="30.0", prod="30.0"),
         ),
     ]
+    enable_process_metric: Annotated[
+        bool,
+        Field(
+            default=True,
+            validation_alias=AliasChoices("enable-process-metric", "enable_process_metric"),
+            serialization_alias="enable-process-metric",
+        ),
+        BackendAIConfigMeta(
+            description=(
+                "Whether to collect per-process utilization metrics for each container. "
+                "When disabled, the agent skips listing container processes and reporting "
+                "per-process statistics, while per-node and per-container metrics are "
+                "still collected."
+            ),
+            added_version="26.4.4",
+            example=ConfigExample(local="true", prod="true"),
+        ),
+    ]
 
 
 class CoreDumpConfig(BaseConfigSchema):

--- a/src/ai/backend/agent/metrics/metric.py
+++ b/src/ai/backend/agent/metrics/metric.py
@@ -340,6 +340,7 @@ class StatTaskObserver:
     _task_trigger_count: Counter
     _task_success_count: Counter
     _task_failure_count: Counter
+    _task_duration_sec: Histogram
 
     def __init__(self) -> None:
         self._task_trigger_count = Counter(
@@ -356,6 +357,12 @@ class StatTaskObserver:
             name="backendai_stat_task_failure_count",
             documentation="Number of stat() task failed",
             labelnames=["agent_id", "stat_scope", "exception"],
+        )
+        self._task_duration_sec = Histogram(
+            name="backendai_stat_task_duration_sec",
+            documentation="Total elapsed time of a stat() collection cycle in seconds",
+            labelnames=["agent_id", "stat_scope"],
+            buckets=[0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600],
         )
 
     @classmethod
@@ -391,3 +398,12 @@ class StatTaskObserver:
         self._task_failure_count.labels(
             agent_id=agent_id, stat_scope=stat_scope, exception=exception_name
         ).inc()
+
+    def observe_stat_task_duration(
+        self,
+        *,
+        agent_id: AgentId,
+        stat_scope: StatScope,
+        elapsed: float,
+    ) -> None:
+        self._task_duration_sec.labels(agent_id=agent_id, stat_scope=stat_scope).observe(elapsed)

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -348,20 +348,6 @@ class Metric:
         }
 
 
-async def _packb_many_in_executor(
-    loop: asyncio.AbstractEventLoop,
-    mapping: dict[str, Any],
-) -> dict[str, bytes]:
-    """
-    msgpack-pack each value of ``mapping`` off the event loop in a single hop.
-    """
-
-    def _pack(m: dict[str, Any]) -> dict[str, bytes]:
-        return {key: msgpack.packb(value) for key, value in m.items()}
-
-    return await loop.run_in_executor(None, _pack, mapping)
-
-
 class StatContext:
     agent: AbstractAgent[Any, Any]
     mode: StatModes
@@ -884,11 +870,13 @@ class StatContext:
         )
 
         # Use ValkeyStatClient set_multiple_keys for batch operations
-        loop = asyncio.get_running_loop()
         with self._stage_observer.stage_timer(
             stage=CollectionStage.SERIALIZE, upper_layer=CollectionLayer.CONTAINER
         ):
-            key_value_map = await _packb_many_in_executor(loop, serializable_by_kernel)
+            key_value_map = {
+                kernel_id: msgpack.packb(metrics)
+                for kernel_id, metrics in serializable_by_kernel.items()
+            }
         if key_value_map:
             with self._stage_observer.stage_timer(
                 stage=CollectionStage.REDIS_WRITE, upper_layer=CollectionLayer.CONTAINER
@@ -1080,11 +1068,12 @@ class StatContext:
             serializable_by_cid[str(cid)] = serializable_table
 
         # Use ValkeyStatClient set_multiple_keys for batch operations.
-        loop = asyncio.get_running_loop()
         with self._stage_observer.stage_timer(
             stage=CollectionStage.SERIALIZE, upper_layer=CollectionLayer.PROCESS
         ):
-            key_value_map = await _packb_many_in_executor(loop, serializable_by_cid)
+            key_value_map = {
+                cid: msgpack.packb(table) for cid, table in serializable_by_cid.items()
+            }
         if key_value_map:
             with self._stage_observer.stage_timer(
                 stage=CollectionStage.REDIS_WRITE, upper_layer=CollectionLayer.PROCESS

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -12,6 +12,7 @@ import logging
 import sys
 import time
 import uuid
+from collections import defaultdict
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from decimal import Decimal, DecimalException
 from typing import (
@@ -979,9 +980,9 @@ class StatContext:
         )
 
         # Prune metrics for PIDs that are no longer alive.
-        active_pids_by_cid: dict[ContainerId, set[PID]] = {}
+        active_pids_by_cid: defaultdict[ContainerId, set[PID]] = defaultdict(set)
         for live_pid, live_cid in pid_map.items():
-            active_pids_by_cid.setdefault(live_cid, set()).add(live_pid)
+            active_pids_by_cid[live_cid].add(live_pid)
         agent_id = self.agent.id
         for tracked_cid, metrics_per_pid in self.process_metrics.items():
             active_pids_set = active_pids_by_cid[tracked_cid]

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -978,6 +978,35 @@ class StatContext:
             upper_layer="collect_per_container_process_stat",
         )
 
+        # Prune metrics for PIDs that are no longer alive.
+        active_pids_by_cid: dict[ContainerId, set[PID]] = {}
+        for live_pid, live_cid in pid_map.items():
+            active_pids_by_cid.setdefault(live_cid, set()).add(live_pid)
+        agent_id = self.agent.id
+        for tracked_cid, metrics_per_pid in self.process_metrics.items():
+            active_pids_set = active_pids_by_cid[tracked_cid]
+            tracked_kid = kernel_id_map.get(tracked_cid)
+            if tracked_kid is None:
+                continue
+            dead_pids = [pid for pid in metrics_per_pid if pid not in active_pids_set]
+            if not dead_pids:
+                continue
+            session_id, owner_user_id, project_id = self._get_ownership_info_from_kernel(
+                tracked_kid
+            )
+            for dead_pid in dead_pids:
+                await self._utilization_metric_observer.lazy_remove_process_metric(
+                    self.process_metrics,
+                    agent_id=agent_id,
+                    kernel_id=tracked_kid,
+                    session_id=session_id,
+                    owner_user_id=owner_user_id,
+                    project_id=project_id,
+                    container_id=tracked_cid,
+                    pid=dead_pid,
+                    keys=list(metrics_per_pid.get(dead_pid, {}).keys()),
+                )
+
         # Use ValkeyStatClient set_multiple_keys for batch operations
         key_value_map: dict[str, bytes] = {}
         for cid in updated_cids:

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -29,7 +29,6 @@ from ai.backend.common import msgpack
 from ai.backend.common.identity import is_containerized
 from ai.backend.common.metrics.metric import (
     CollectionLayer,
-    CollectionMarker,
     CollectionStage,
     StageObserver,
 )
@@ -519,18 +518,10 @@ class StatContext:
             asyncio.create_task(gather_node_measures_with_slots(computer.instance))
             for computer in self.agent.computers.values()
         ]
-        self._stage_observer.observe_stage(
-            stage=CollectionMarker.BEFORE_GATHER_MEASURES,
-            upper_layer=CollectionLayer.NODE,
-        )
-        with self._stage_observer.stage_timer(
+        with self._stage_observer.measure_stage(
             stage=CollectionStage.GATHER_MEASURES, upper_layer=CollectionLayer.NODE
         ):
             results = await asyncio.gather(*_tasks, return_exceptions=True)
-        self._stage_observer.observe_stage(
-            stage=CollectionMarker.BEFORE_OBSERVE,
-            upper_layer=CollectionLayer.NODE,
-        )
         for res in results:
             if isinstance(res, BaseException):
                 log.error("collect_node_stat(): gather_node_measures() error", exc_info=res)
@@ -630,19 +621,14 @@ class StatContext:
                 self.agent.id,
                 redis_agent_updates["node"],
             )
-        with self._stage_observer.stage_timer(
+        with self._stage_observer.measure_stage(
             stage=CollectionStage.SERIALIZE, upper_layer=CollectionLayer.NODE
         ):
             serialized_agent_updates = msgpack.packb(redis_agent_updates)
 
-        self._stage_observer.observe_stage(
-            stage=CollectionMarker.BEFORE_REPORT_TO_REDIS,
-            upper_layer=CollectionLayer.NODE,
-        )
-
         # Use ValkeyStatClient set method with expiration
         agent_id = self.agent.id
-        with self._stage_observer.stage_timer(
+        with self._stage_observer.measure_stage(
             stage=CollectionStage.REDIS_WRITE, upper_layer=CollectionLayer.NODE
         ):
             await self.agent.valkey_stat_client.set(
@@ -772,19 +758,11 @@ class StatContext:
                     ),
                 )
             )
-        self._stage_observer.observe_stage(
-            stage=CollectionMarker.BEFORE_GATHER_MEASURES,
-            upper_layer=CollectionLayer.CONTAINER,
-        )
-        with self._stage_observer.stage_timer(
+        with self._stage_observer.measure_stage(
             stage=CollectionStage.GATHER_MEASURES, upper_layer=CollectionLayer.CONTAINER
         ):
             results = await asyncio.gather(*_tasks, return_exceptions=True)
         updated_kernel_ids: set[KernelId] = set()
-        self._stage_observer.observe_stage(
-            stage=CollectionMarker.BEFORE_OBSERVE,
-            upper_layer=CollectionLayer.CONTAINER,
-        )
         for result in results:
             if isinstance(result, BaseException):
                 log.error(
@@ -864,13 +842,8 @@ class StatContext:
 
             serializable_by_kernel[str(kernel_id)] = serializable_metrics
 
-        self._stage_observer.observe_stage(
-            stage=CollectionMarker.BEFORE_REPORT_TO_REDIS,
-            upper_layer=CollectionLayer.CONTAINER,
-        )
-
         # Use ValkeyStatClient set_multiple_keys for batch operations
-        with self._stage_observer.stage_timer(
+        with self._stage_observer.measure_stage(
             stage=CollectionStage.SERIALIZE, upper_layer=CollectionLayer.CONTAINER
         ):
             key_value_map = {
@@ -878,7 +851,7 @@ class StatContext:
                 for kernel_id, metrics in serializable_by_kernel.items()
             }
         if key_value_map:
-            with self._stage_observer.stage_timer(
+            with self._stage_observer.measure_stage(
                 stage=CollectionStage.REDIS_WRITE, upper_layer=CollectionLayer.CONTAINER
             ):
                 await self.agent.valkey_stat_client.set_multiple_keys(key_value_map)
@@ -936,7 +909,7 @@ class StatContext:
                 kernel_id_map[ContainerId(cid)] = kid
 
         pid_map: dict[PID, ContainerId] = {}
-        with self._stage_observer.stage_timer(
+        with self._stage_observer.measure_stage(
             stage=CollectionStage.DOCKER_TOP, upper_layer=CollectionLayer.PROCESS
         ):
             async with aiodocker.Docker() as docker:
@@ -956,18 +929,10 @@ class StatContext:
                     ),
                 )
             )
-        self._stage_observer.observe_stage(
-            stage=CollectionMarker.BEFORE_GATHER_MEASURES,
-            upper_layer=CollectionLayer.PROCESS,
-        )
-        with self._stage_observer.stage_timer(
+        with self._stage_observer.measure_stage(
             stage=CollectionStage.GATHER_MEASURES, upper_layer=CollectionLayer.PROCESS
         ):
             results = await asyncio.gather(*_tasks, return_exceptions=True)
-        self._stage_observer.observe_stage(
-            stage=CollectionMarker.BEFORE_OBSERVE,
-            upper_layer=CollectionLayer.PROCESS,
-        )
         updated_cids: set[ContainerId] = set()
         for result in results:
             if isinstance(result, BaseException):
@@ -1011,11 +976,6 @@ class StatContext:
                         )
                     else:
                         self.process_metrics[cid][pid][metric_key].update(measure)
-
-        self._stage_observer.observe_stage(
-            stage=CollectionMarker.BEFORE_REPORT_TO_REDIS,
-            upper_layer=CollectionLayer.PROCESS,
-        )
 
         # Prune metrics for PIDs that are no longer alive.
         active_pids_by_cid: defaultdict[ContainerId, set[PID]] = defaultdict(set)
@@ -1068,14 +1028,14 @@ class StatContext:
             serializable_by_cid[str(cid)] = serializable_table
 
         # Use ValkeyStatClient set_multiple_keys for batch operations.
-        with self._stage_observer.stage_timer(
+        with self._stage_observer.measure_stage(
             stage=CollectionStage.SERIALIZE, upper_layer=CollectionLayer.PROCESS
         ):
             key_value_map = {
                 cid: msgpack.packb(table) for cid, table in serializable_by_cid.items()
             }
         if key_value_map:
-            with self._stage_observer.stage_timer(
+            with self._stage_observer.measure_stage(
                 stage=CollectionStage.REDIS_WRITE, upper_layer=CollectionLayer.PROCESS
             ):
                 await self.agent.valkey_stat_client.set_multiple_keys(

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -27,7 +27,12 @@ import attrs
 
 from ai.backend.common import msgpack
 from ai.backend.common.identity import is_containerized
-from ai.backend.common.metrics.metric import StageObserver
+from ai.backend.common.metrics.metric import (
+    CollectionLayer,
+    CollectionMarker,
+    CollectionStage,
+    StageObserver,
+)
 from ai.backend.common.types import (
     PID,
     ContainerId,
@@ -529,13 +534,16 @@ class StatContext:
             for computer in self.agent.computers.values()
         ]
         self._stage_observer.observe_stage(
-            stage="before_gather_measures",
-            upper_layer="collect_node_stat",
+            stage=CollectionMarker.BEFORE_GATHER_MEASURES,
+            upper_layer=CollectionLayer.NODE,
         )
-        results = await asyncio.gather(*_tasks, return_exceptions=True)
+        with self._stage_observer.stage_timer(
+            stage=CollectionStage.GATHER_MEASURES, upper_layer=CollectionLayer.NODE
+        ):
+            results = await asyncio.gather(*_tasks, return_exceptions=True)
         self._stage_observer.observe_stage(
-            stage="before_observe",
-            upper_layer="collect_node_stat",
+            stage=CollectionMarker.BEFORE_OBSERVE,
+            upper_layer=CollectionLayer.NODE,
         )
         for res in results:
             if isinstance(res, BaseException):
@@ -636,20 +644,28 @@ class StatContext:
                 self.agent.id,
                 redis_agent_updates["node"],
             )
-        serialized_agent_updates = msgpack.packb(redis_agent_updates)
+        with self._stage_observer.stage_timer(
+            stage=CollectionStage.SERIALIZE, upper_layer=CollectionLayer.NODE
+        ):
+            serialized_agent_updates = msgpack.packb(redis_agent_updates)
 
         self._stage_observer.observe_stage(
-            stage="before_report_to_redis",
-            upper_layer="collect_node_stat",
+            stage=CollectionMarker.BEFORE_REPORT_TO_REDIS,
+            upper_layer=CollectionLayer.NODE,
         )
 
         # Use ValkeyStatClient set method with expiration
         agent_id = self.agent.id
-        await self.agent.valkey_stat_client.set(
-            agent_id,
-            serialized_agent_updates,
-            expire_sec=self._metric_ttl(self._local_config.agent.utilization_metric.node.interval),
-        )
+        with self._stage_observer.stage_timer(
+            stage=CollectionStage.REDIS_WRITE, upper_layer=CollectionLayer.NODE
+        ):
+            await self.agent.valkey_stat_client.set(
+                agent_id,
+                serialized_agent_updates,
+                expire_sec=self._metric_ttl(
+                    self._local_config.agent.utilization_metric.node.interval
+                ),
+            )
 
     def _extract_slot_measurement_scale_factor(
         self,
@@ -771,14 +787,17 @@ class StatContext:
                 )
             )
         self._stage_observer.observe_stage(
-            stage="before_gather_measures",
-            upper_layer="collect_container_stat",
+            stage=CollectionMarker.BEFORE_GATHER_MEASURES,
+            upper_layer=CollectionLayer.CONTAINER,
         )
-        results = await asyncio.gather(*_tasks, return_exceptions=True)
+        with self._stage_observer.stage_timer(
+            stage=CollectionStage.GATHER_MEASURES, upper_layer=CollectionLayer.CONTAINER
+        ):
+            results = await asyncio.gather(*_tasks, return_exceptions=True)
         updated_kernel_ids: set[KernelId] = set()
         self._stage_observer.observe_stage(
-            stage="before_observe",
-            upper_layer="collect_container_stat",
+            stage=CollectionMarker.BEFORE_OBSERVE,
+            upper_layer=CollectionLayer.CONTAINER,
         )
         for result in results:
             if isinstance(result, BaseException):
@@ -860,15 +879,21 @@ class StatContext:
             serializable_by_kernel[str(kernel_id)] = serializable_metrics
 
         self._stage_observer.observe_stage(
-            stage="before_report_to_redis",
-            upper_layer="collect_container_stat",
+            stage=CollectionMarker.BEFORE_REPORT_TO_REDIS,
+            upper_layer=CollectionLayer.CONTAINER,
         )
 
         # Use ValkeyStatClient set_multiple_keys for batch operations
         loop = asyncio.get_running_loop()
-        key_value_map = await _packb_many_in_executor(loop, serializable_by_kernel)
+        with self._stage_observer.stage_timer(
+            stage=CollectionStage.SERIALIZE, upper_layer=CollectionLayer.CONTAINER
+        ):
+            key_value_map = await _packb_many_in_executor(loop, serializable_by_kernel)
         if key_value_map:
-            await self.agent.valkey_stat_client.set_multiple_keys(key_value_map)
+            with self._stage_observer.stage_timer(
+                stage=CollectionStage.REDIS_WRITE, upper_layer=CollectionLayer.CONTAINER
+            ):
+                await self.agent.valkey_stat_client.set_multiple_keys(key_value_map)
 
     async def _get_processes(
         self, container_id: ContainerId, docker: aiodocker.Docker
@@ -923,11 +948,14 @@ class StatContext:
                 kernel_id_map[ContainerId(cid)] = kid
 
         pid_map: dict[PID, ContainerId] = {}
-        async with aiodocker.Docker() as docker:
-            for cid in container_ids:
-                active_pids = await self._get_processes(cid, docker)
-                for pid_ in active_pids:
-                    pid_map[pid_] = cid
+        with self._stage_observer.stage_timer(
+            stage=CollectionStage.DOCKER_TOP, upper_layer=CollectionLayer.PROCESS
+        ):
+            async with aiodocker.Docker() as docker:
+                for cid in container_ids:
+                    active_pids = await self._get_processes(cid, docker)
+                    for pid_ in active_pids:
+                        pid_map[pid_] = cid
         # Here we use asyncio.gather() instead of aiotools.TaskGroup
         # to keep methods of other plugins running when a plugin raises an error
         # instead of cancelling them.
@@ -941,13 +969,16 @@ class StatContext:
                 )
             )
         self._stage_observer.observe_stage(
-            stage="before_gather_measures",
-            upper_layer="collect_per_container_process_stat",
+            stage=CollectionMarker.BEFORE_GATHER_MEASURES,
+            upper_layer=CollectionLayer.PROCESS,
         )
-        results = await asyncio.gather(*_tasks, return_exceptions=True)
+        with self._stage_observer.stage_timer(
+            stage=CollectionStage.GATHER_MEASURES, upper_layer=CollectionLayer.PROCESS
+        ):
+            results = await asyncio.gather(*_tasks, return_exceptions=True)
         self._stage_observer.observe_stage(
-            stage="before_observe",
-            upper_layer="collect_per_container_process_stat",
+            stage=CollectionMarker.BEFORE_OBSERVE,
+            upper_layer=CollectionLayer.PROCESS,
         )
         updated_cids: set[ContainerId] = set()
         for result in results:
@@ -994,8 +1025,8 @@ class StatContext:
                         self.process_metrics[cid][pid][metric_key].update(measure)
 
         self._stage_observer.observe_stage(
-            stage="before_report_to_redis",
-            upper_layer="collect_per_container_process_stat",
+            stage=CollectionMarker.BEFORE_REPORT_TO_REDIS,
+            upper_layer=CollectionLayer.PROCESS,
         )
 
         # Prune metrics for PIDs that are no longer alive.
@@ -1050,11 +1081,17 @@ class StatContext:
 
         # Use ValkeyStatClient set_multiple_keys for batch operations.
         loop = asyncio.get_running_loop()
-        key_value_map = await _packb_many_in_executor(loop, serializable_by_cid)
+        with self._stage_observer.stage_timer(
+            stage=CollectionStage.SERIALIZE, upper_layer=CollectionLayer.PROCESS
+        ):
+            key_value_map = await _packb_many_in_executor(loop, serializable_by_cid)
         if key_value_map:
-            await self.agent.valkey_stat_client.set_multiple_keys(
-                key_value_map,
-                expire_sec=self._metric_ttl(
-                    self._local_config.agent.utilization_metric.process.interval
-                ),
-            )
+            with self._stage_observer.stage_timer(
+                stage=CollectionStage.REDIS_WRITE, upper_layer=CollectionLayer.PROCESS
+            ):
+                await self.agent.valkey_stat_client.set_multiple_keys(
+                    key_value_map,
+                    expire_sec=self._metric_ttl(
+                        self._local_config.agent.utilization_metric.process.interval
+                    ),
+                )

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -387,8 +387,8 @@ class StatContext:
         self._utilization_metric_observer = UtilizationMetricObserver.instance()
         self._stage_observer = StageObserver.instance()
 
-    def _metric_ttl(self) -> int:
-        return int(self._local_config.agent.utilization_metric.interval * _METRIC_TTL_FACTOR)
+    def _metric_ttl(self, interval: float) -> int:
+        return int(interval * _METRIC_TTL_FACTOR)
 
     def update_timestamp(self, timestamp_key: str) -> tuple[float, float]:
         """
@@ -646,7 +646,9 @@ class StatContext:
         # Use ValkeyStatClient set method with expiration
         agent_id = self.agent.id
         await self.agent.valkey_stat_client.set(
-            agent_id, serialized_agent_updates, expire_sec=self._metric_ttl()
+            agent_id,
+            serialized_agent_updates,
+            expire_sec=self._metric_ttl(self._local_config.agent.utilization_metric.node.interval),
         )
 
     def _extract_slot_measurement_scale_factor(
@@ -762,7 +764,9 @@ class StatContext:
                 asyncio.create_task(
                     asyncio.wait_for(
                         computer.instance.gather_container_measures(self, container_ids),
-                        timeout=self._metric_ttl(),
+                        timeout=self._metric_ttl(
+                            self._local_config.agent.utilization_metric.container.interval
+                        ),
                     ),
                 )
             )
@@ -1049,5 +1053,8 @@ class StatContext:
         key_value_map = await _packb_many_in_executor(loop, serializable_by_cid)
         if key_value_map:
             await self.agent.valkey_stat_client.set_multiple_keys(
-                key_value_map, expire_sec=self._metric_ttl()
+                key_value_map,
+                expire_sec=self._metric_ttl(
+                    self._local_config.agent.utilization_metric.process.interval
+                ),
             )

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -343,6 +343,20 @@ class Metric:
         }
 
 
+async def _packb_many_in_executor(
+    loop: asyncio.AbstractEventLoop,
+    mapping: dict[str, Any],
+) -> dict[str, bytes]:
+    """
+    msgpack-pack each value of ``mapping`` off the event loop in a single hop.
+    """
+
+    def _pack(m: dict[str, Any]) -> dict[str, bytes]:
+        return {key: msgpack.packb(value) for key, value in m.items()}
+
+    return await loop.run_in_executor(None, _pack, mapping)
+
+
 class StatContext:
     agent: AbstractAgent[Any, Any]
     mode: StatModes
@@ -804,7 +818,7 @@ class StatContext:
                         self.kernel_metrics[kernel_id][metric_key].update(measure)
 
         kernel_updates: list[FlattenedKernelMetric] = []
-        kernel_serialized_updates: list[tuple[KernelId, bytes]] = []
+        serializable_by_kernel: dict[str, dict[MetricKey, MetricValue]] = {}
         agent_id = self.agent.id
         for kernel_id in updated_kernel_ids:
             session_id, owner_user_id, project_id = self._get_ownership_info_from_kernel(kernel_id)
@@ -839,7 +853,7 @@ class StatContext:
             if self.agent.local_config.debug.log_stats:
                 log.debug("kernel_updates: {0}: {1}", kernel_id, serializable_metrics)
 
-            kernel_serialized_updates.append((kernel_id, msgpack.packb(serializable_metrics)))
+            serializable_by_kernel[str(kernel_id)] = serializable_metrics
 
         self._stage_observer.observe_stage(
             stage="before_report_to_redis",
@@ -847,7 +861,8 @@ class StatContext:
         )
 
         # Use ValkeyStatClient set_multiple_keys for batch operations
-        key_value_map = {str(kernel_id): update for kernel_id, update in kernel_serialized_updates}
+        loop = asyncio.get_running_loop()
+        key_value_map = await _packb_many_in_executor(loop, serializable_by_kernel)
         if key_value_map:
             await self.agent.valkey_stat_client.set_multiple_keys(key_value_map)
 
@@ -1009,12 +1024,11 @@ class StatContext:
                 )
 
         # Use ValkeyStatClient set_multiple_keys for batch operations
-        key_value_map: dict[str, bytes] = {}
+        serializable_by_cid: dict[str, dict[PID, dict[str, MetricValue]]] = {}
         for cid in updated_cids:
-            serializable_table = {}
-            for pid in self.process_metrics[cid].keys():
-                metrics = self.process_metrics[cid][pid]
-                serializable_metrics = {}
+            serializable_table: dict[PID, dict[str, MetricValue]] = {}
+            for pid, metrics in self.process_metrics[cid].items():
+                serializable_metrics: dict[str, MetricValue] = {}
                 for key, obj in metrics.items():
                     try:
                         serializable_metrics[str(key)] = obj.to_serializable_dict()
@@ -1028,9 +1042,11 @@ class StatContext:
                     cid,
                     serializable_table,
                 )
-            serialized_metrics = msgpack.packb(serializable_table)
-            key_value_map[str(cid)] = serialized_metrics
+            serializable_by_cid[str(cid)] = serializable_table
 
+        # Use ValkeyStatClient set_multiple_keys for batch operations.
+        loop = asyncio.get_running_loop()
+        key_value_map = await _packb_many_in_executor(loop, serializable_by_cid)
         if key_value_map:
             await self.agent.valkey_stat_client.set_multiple_keys(
                 key_value_map, expire_sec=self._metric_ttl()

--- a/src/ai/backend/agent/tasks/collect_container_stat.py
+++ b/src/ai/backend/agent/tasks/collect_container_stat.py
@@ -27,7 +27,7 @@ class CollectContainerStatTask(PeriodicTask):
 
     @property
     def interval(self) -> float:
-        return self._local_config.agent.utilization_metric.interval
+        return self._local_config.agent.utilization_metric.container.interval
 
     @property
     def initial_delay(self) -> float:

--- a/src/ai/backend/agent/tasks/collect_node_stat.py
+++ b/src/ai/backend/agent/tasks/collect_node_stat.py
@@ -27,7 +27,7 @@ class CollectNodeStatTask(PeriodicTask):
 
     @property
     def interval(self) -> float:
-        return self._local_config.agent.utilization_metric.interval
+        return self._local_config.agent.utilization_metric.node.interval
 
     @property
     def initial_delay(self) -> float:

--- a/src/ai/backend/agent/tasks/collect_process_stat.py
+++ b/src/ai/backend/agent/tasks/collect_process_stat.py
@@ -27,7 +27,7 @@ class CollectProcessStatTask(PeriodicTask):
 
     @property
     def interval(self) -> float:
-        return self._local_config.agent.utilization_metric.interval
+        return self._local_config.agent.utilization_metric.process.interval
 
     @property
     def initial_delay(self) -> float:

--- a/src/ai/backend/common/metrics/metric.py
+++ b/src/ai/backend/common/metrics/metric.py
@@ -23,6 +23,7 @@ from ai.backend.common.metrics.safe import (
 from ai.backend.common.metrics.safe import (
     SafeHistogram as Histogram,
 )
+from ai.backend.common.metrics.types import SUCCESS_LABEL_FALSE, SUCCESS_LABEL_TRUE
 
 
 class APIMetricObserver:
@@ -781,16 +782,8 @@ class CommonMetricRegistry:
         return generate_latest_singleprocess().decode("utf-8")
 
 
-class CollectionMarker(enum.StrEnum):
-    """Checkpoint markers within a stat collection cycle (counted via observe_stage)."""
-
-    BEFORE_GATHER_MEASURES = "before_gather_measures"
-    BEFORE_OBSERVE = "before_observe"
-    BEFORE_REPORT_TO_REDIS = "before_report_to_redis"
-
-
 class CollectionStage(enum.StrEnum):
-    """Named timed segments of a stat collection cycle (measured via stage_timer)."""
+    """Named timed segments of a stat collection cycle (measured via measure_stage)."""
 
     DOCKER_TOP = "docker_top"
     GATHER_MEASURES = "gather_measures"
@@ -816,7 +809,7 @@ class StageObserver:
         self._stage_count = Counter(
             name="backendai_stage_count",
             documentation="Count stage occurrences",
-            labelnames=["stage", "upper_layer"],
+            labelnames=["stage", "upper_layer", "success"],
         )
         self._stage_duration_sec = Histogram(
             name="backendai_stage_duration_sec",
@@ -831,26 +824,36 @@ class StageObserver:
             cls._instance = cls()
         return cls._instance
 
-    def observe_stage(self, *, stage: CollectionMarker, upper_layer: CollectionLayer) -> None:
-        self._stage_count.labels(stage=stage.value, upper_layer=upper_layer.value).inc()
-
     @contextmanager
-    def stage_timer(
+    def measure_stage(
         self, *, stage: CollectionStage, upper_layer: CollectionLayer
     ) -> Iterator[None]:
         """
-        Measure the wall-clock duration of the wrapped block and record it into
-        the stage-duration histogram. Usable around ``await`` expressions:
+        Measure the wrapped block: record its wall-clock duration into the
+        stage-duration histogram and count its occurrence (with a ``success``
+        label) into the stage counter. Usable around ``await`` expressions:
 
-            with observer.stage_timer(
+            with observer.measure_stage(
                 stage=CollectionStage.DOCKER_TOP, upper_layer=CollectionLayer.PROCESS
             ):
                 await do_docker_call()
+
+        A block that raises (including ``CancelledError``) is counted as
+        ``success="False"`` and the exception is re-raised.
         """
-        start = time.perf_counter()
+        start_time = time.perf_counter()
+        success = SUCCESS_LABEL_TRUE
         try:
             yield
+        except BaseException:
+            success = SUCCESS_LABEL_FALSE
+            raise
         finally:
             self._stage_duration_sec.labels(
                 stage=stage.value, upper_layer=upper_layer.value
-            ).observe(time.perf_counter() - start)
+            ).observe(time.perf_counter() - start_time)
+            self._stage_count.labels(
+                stage=stage.value,
+                upper_layer=upper_layer.value,
+                success=success,
+            ).inc()

--- a/src/ai/backend/common/metrics/metric.py
+++ b/src/ai/backend/common/metrics/metric.py
@@ -1,6 +1,9 @@
 import asyncio
 import enum
 import os
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Self
 
 import psutil
@@ -778,16 +781,48 @@ class CommonMetricRegistry:
         return generate_latest_singleprocess().decode("utf-8")
 
 
+class CollectionMarker(enum.StrEnum):
+    """Checkpoint markers within a stat collection cycle (counted via observe_stage)."""
+
+    BEFORE_GATHER_MEASURES = "before_gather_measures"
+    BEFORE_OBSERVE = "before_observe"
+    BEFORE_REPORT_TO_REDIS = "before_report_to_redis"
+
+
+class CollectionStage(enum.StrEnum):
+    """Named timed segments of a stat collection cycle (measured via stage_timer)."""
+
+    DOCKER_TOP = "docker_top"
+    GATHER_MEASURES = "gather_measures"
+    SERIALIZE = "serialize"
+    REDIS_WRITE = "redis_write"
+
+
+class CollectionLayer(enum.StrEnum):
+    """The collection task a stage belongs to (the ``upper_layer`` label)."""
+
+    NODE = "collect_node_stat"
+    CONTAINER = "collect_container_stat"
+    PROCESS = "collect_per_container_process_stat"
+
+
 class StageObserver:
     _instance: Self | None = None
 
     _stage_count: Counter
+    _stage_duration_sec: Histogram
 
     def __init__(self) -> None:
         self._stage_count = Counter(
             name="backendai_stage_count",
             documentation="Count stage occurrences",
             labelnames=["stage", "upper_layer"],
+        )
+        self._stage_duration_sec = Histogram(
+            name="backendai_stage_duration_sec",
+            documentation="Elapsed wall-clock time spent in each stage in seconds",
+            labelnames=["stage", "upper_layer"],
+            buckets=[0.001, 0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300],
         )
 
     @classmethod
@@ -796,5 +831,26 @@ class StageObserver:
             cls._instance = cls()
         return cls._instance
 
-    def observe_stage(self, *, stage: str, upper_layer: str) -> None:
-        self._stage_count.labels(stage=stage, upper_layer=upper_layer).inc()
+    def observe_stage(self, *, stage: CollectionMarker, upper_layer: CollectionLayer) -> None:
+        self._stage_count.labels(stage=stage.value, upper_layer=upper_layer.value).inc()
+
+    @contextmanager
+    def stage_timer(
+        self, *, stage: CollectionStage, upper_layer: CollectionLayer
+    ) -> Iterator[None]:
+        """
+        Measure the wall-clock duration of the wrapped block and record it into
+        the stage-duration histogram. Usable around ``await`` expressions:
+
+            with observer.stage_timer(
+                stage=CollectionStage.DOCKER_TOP, upper_layer=CollectionLayer.PROCESS
+            ):
+                await do_docker_call()
+        """
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            self._stage_duration_sec.labels(
+                stage=stage.value, upper_layer=upper_layer.value
+            ).observe(time.perf_counter() - start)

--- a/src/ai/backend/common/metrics/types.py
+++ b/src/ai/backend/common/metrics/types.py
@@ -2,6 +2,10 @@ from typing import Final
 
 UNDEFINED: Final[str] = "undefined"
 
+# Label values for the boolean "success" metric label (matching ``str(bool)``).
+SUCCESS_LABEL_TRUE: Final[str] = "True"
+SUCCESS_LABEL_FALSE: Final[str] = "False"
+
 UTILIZATION_METRIC_DETENTION: Final[float] = 600.0  # 10 minutes
 
 CONTAINER_UTILIZATION_METRIC_NAME: Final[str] = "backendai_container_utilization"


### PR DESCRIPTION
## Summary
  - Prune per-process utilization metrics for PIDs no longer alive on each collection cycle, routed through lazy_remove_process_metric (the same cleanup path used at container destroy), so the in-memory map / per-container Redis blob / exported Prometheus series
  stay bounded instead of growing for the container's lifetime. A container with no live-process listing in a cycle has all its tracked PIDs pruned.
  - Add an config flag (default true) to turn off node/container/per-process metric collection entirely.
  - Add Prometheus duration histograms for stat collection: `backendai_stage_duration_sec` (per-segment: docker_top/gather/serialize/redis_write) and `backendai_stat_task_duration_sec` (whole-cycle, by scope).

## Test plan
  - [x] Per-process Prometheus series for dead PIDs are removed after UTILIZATION_METRIC_DETENTION.
  - [x] Disabling enable_process_metric skips per-process collection while node/container metrics keep flowing.

Resolves BA-6487