### PR TITLE
docs: clarify ModelHealthCheck.initial_delay is a grace period, not a probe delay

### DIFF
--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -206,7 +206,13 @@ class ModelHealthCheck(BaseConfigModel):
     )
     initial_delay: float = Field(
         default=60.0,
-        description="Initial delay in seconds before the first health check.",
+        description=(
+            "Grace period in seconds for a warming-up route to pass its first "
+            "health check. Probing starts immediately; the route stays "
+            "WARMING_UP until a probe passes (then it activates) or this period "
+            "elapses without a passing probe (then it is terminated). This does "
+            "not delay the first probe."
+        ),
         examples=[60.0],
         ge=0,
     )


### PR DESCRIPTION
## Summary

The `ModelHealthCheck.initial_delay` field description in `common/config.py` was misleading. It read:

> Initial delay in seconds before the first health check.

But the implementation does **not** delay the first health check. Health probing starts immediately when a route enters WARMING_UP (the observer probes WARMING_UP routes, throttled only by `interval` — `initial_delay` is never referenced in the probe loop). The field is actually used in `sokovan/deployment/route/executor.py` (`check_warming_up_health`) purely as a **grace period / deadline**: the route stays WARMING_UP until a probe passes (then it activates) or `initial_delay` elapses without a passing probe (then it is terminated).

This PR updates only the field description to match the actual behavior. No functional change.

## Verification

- `pants lint` / `fmt` passed via pre-commit hook.