### PR TITLE
fix: Wrong flag type column converter

### DIFF
--- a/changes/12223.fix.md
+++ b/changes/12223.fix.md
@@ -1,0 +1,1 @@
+Allow pure int type values for `IntFlagType.column` data

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -337,7 +337,7 @@ class IntFlagType[T_IntFlag: enum.IntFlag](TypeDecorator[T_IntFlag]):
 
     def process_bind_param(
         self,
-        value: T_IntFlag | int | None,
+        value: T_IntFlag | None,
         dialect: Dialect,
     ) -> int | None:
         if value is None:

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -337,12 +337,12 @@ class IntFlagType[T_IntFlag: enum.IntFlag](TypeDecorator[T_IntFlag]):
 
     def process_bind_param(
         self,
-        value: T_IntFlag | None,
+        value: T_IntFlag | int | None,
         dialect: Dialect,
     ) -> int | None:
         if value is None:
             return None
-        return int(value.value)
+        return int(value)
 
     def process_result_value(
         self,


### PR DESCRIPTION
IntFlagType.process_bind_param() does not allow pure int type values - e.g. insert fixture data from JSON files