### PR TITLE
feat(BA-6511): AppConfigFragment repository (CRUD + rank-based merge)

### DIFF
--- a/changes/12225.feature.md
+++ b/changes/12225.feature.md
@@ -1,0 +1,1 @@
+Add the AppConfigFragment repository with rank-ordered merged-view reads.

--- a/src/ai/backend/manager/repositories/app_config_fragment/admin_repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/admin_repository.py
@@ -29,6 +29,7 @@ from ai.backend.manager.repositories.app_config_fragment.updaters import (
 from ai.backend.manager.repositories.base.purger import Purger
 from ai.backend.manager.repositories.base.querier import BatchQuerier
 from ai.backend.manager.repositories.base.updater import Updater
+from ai.backend.manager.repositories.ops import DBOpsProvider
 
 app_config_fragment_admin_repository_resilience = Resilience(
     policies=[
@@ -66,8 +67,8 @@ class AppConfigFragmentAdminRepository:
 
     _db_source: AppConfigFragmentDBSource
 
-    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
-        self._db_source = AppConfigFragmentDBSource(db)
+    def __init__(self, db: ExtendedAsyncSAEngine, ops_provider: DBOpsProvider) -> None:
+        self._db_source = AppConfigFragmentDBSource(db, ops_provider)
 
     # ── Mutations ─────────────────────────────────────────────────
 

--- a/src/ai/backend/manager/repositories/app_config_fragment/admin_repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/admin_repository.py
@@ -8,11 +8,11 @@ from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
 from ai.backend.common.resilience.resilience import Resilience
-from ai.backend.manager.data.app_config.types import AppConfigSearchResult
 from ai.backend.manager.data.app_config_fragment.types import (
     AppConfigFragmentData,
     AppConfigFragmentKey,
     AppConfigFragmentSearchResult,
+    ScopedAppConfigSearchResult,
 )
 from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
@@ -139,5 +139,5 @@ class AppConfigFragmentAdminRepository:
     async def admin_search_app_configs(
         self,
         querier: BatchQuerier,
-    ) -> AppConfigSearchResult:
+    ) -> ScopedAppConfigSearchResult:
         return await self._db_source.admin_search_app_configs(querier)

--- a/src/ai/backend/manager/repositories/app_config_fragment/admin_repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/admin_repository.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ai.backend.common.exception import BackendAIError
+from ai.backend.common.metrics.metric import DomainType, LayerType
+from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
+from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
+from ai.backend.common.resilience.resilience import Resilience
+from ai.backend.manager.data.app_config.types import AppConfigSearchResult
+from ai.backend.manager.data.app_config_fragment.types import (
+    AppConfigFragmentData,
+    AppConfigFragmentKey,
+    AppConfigFragmentSearchResult,
+)
+from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
+from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.app_config_fragment.creators import (
+    AppConfigFragmentCreatorSpec,
+)
+from ai.backend.manager.repositories.app_config_fragment.db_source import (
+    AppConfigFragmentDBSource,
+)
+from ai.backend.manager.repositories.app_config_fragment.updaters import (
+    AppConfigFragmentUpdaterSpec,
+)
+from ai.backend.manager.repositories.base.creator import Creator
+from ai.backend.manager.repositories.base.purger import Purger
+from ai.backend.manager.repositories.base.querier import BatchQuerier
+from ai.backend.manager.repositories.base.updater import Updater
+
+app_config_fragment_admin_repository_resilience = Resilience(
+    policies=[
+        MetricPolicy(
+            MetricArgs(
+                domain=DomainType.REPOSITORY,
+                layer=LayerType.APP_CONFIG_FRAGMENT_ADMIN_REPOSITORY,
+            )
+        ),
+        RetryPolicy(
+            RetryArgs(
+                max_retries=5,
+                retry_delay=0.1,
+                backoff_strategy=BackoffStrategy.FIXED,
+                non_retryable_exceptions=(BackendAIError,),
+            )
+        ),
+    ]
+)
+
+
+class AppConfigFragmentAdminRepository:
+    """Admin-only operations on AppConfigFragment.
+
+    All mutations (`create` / `update` / `purge`) and cross-scope
+    reads (`admin_search` raw, `admin_search_app_configs` merged)
+    live here — read-side scope-bound operations are on
+    `AppConfigFragmentRepository`. Authorization is enforced at the
+    service layer before reaching either repository. The required-
+    policy invariant is enforced upstream by the service layer; the
+    DB-level FK on ``app_config_fragments.name`` is the defense-in-
+    depth backstop and surfaces as a generic integrity error.
+
+    Mutations are routed through the shared Creator / Updater / Purger
+    helpers so the same execution / resilience plumbing applies as in
+    sister repositories.
+    """
+
+    _db_source: AppConfigFragmentDBSource
+
+    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
+        self._db_source = AppConfigFragmentDBSource(db)
+
+    # ── Mutations ─────────────────────────────────────────────────
+
+    @app_config_fragment_admin_repository_resilience.apply()
+    async def create(
+        self,
+        key: AppConfigFragmentKey,
+        config: Mapping[str, Any],
+    ) -> AppConfigFragmentData:
+        creator: Creator[AppConfigFragmentRow] = Creator(
+            spec=AppConfigFragmentCreatorSpec(
+                scope_type=key.scope_type,
+                scope_id=key.scope_id,
+                name=key.name,
+                config=config,
+            ),
+        )
+        return await self._db_source.create(creator)
+
+    @app_config_fragment_admin_repository_resilience.apply()
+    async def update(
+        self,
+        key: AppConfigFragmentKey,
+        config: Mapping[str, Any],
+    ) -> AppConfigFragmentData:
+        """Update a fragment by natural key. Resolves the natural key
+        to the row's UUID, builds an ``Updater``, and delegates to the
+        DB source. Raises :class:`AppConfigFragmentNotFound` when the
+        row is missing (or vanishes between resolve and write)."""
+        pk_value = await self._db_source.resolve_pk_by_key(key)
+        if pk_value is None:
+            raise AppConfigFragmentNotFound(
+                extra_msg=(
+                    f"scope_type={key.scope_type.value!r}, "
+                    f"scope_id={key.scope_id!r}, name={key.name!r}"
+                ),
+            )
+        updater: Updater[AppConfigFragmentRow] = Updater(
+            spec=AppConfigFragmentUpdaterSpec(config=config),
+            pk_value=pk_value,
+        )
+        result = await self._db_source.update(updater)
+        if result is None:
+            raise AppConfigFragmentNotFound(
+                extra_msg=(
+                    f"scope_type={key.scope_type.value!r}, "
+                    f"scope_id={key.scope_id!r}, name={key.name!r}"
+                ),
+            )
+        return result
+
+    @app_config_fragment_admin_repository_resilience.apply()
+    async def purge(self, key: AppConfigFragmentKey) -> bool:
+        """Delete a fragment by natural key. Resolves the natural key,
+        builds a ``Purger``, and delegates to the DB source. Returns
+        ``True`` only when a row was actually removed."""
+        pk_value = await self._db_source.resolve_pk_by_key(key)
+        if pk_value is None:
+            return False
+        purger: Purger[AppConfigFragmentRow] = Purger(
+            row_class=AppConfigFragmentRow,
+            pk_value=pk_value,
+        )
+        return await self._db_source.purge(purger)
+
+    # ── Cross-scope reads ────────────────────────────────────────
+
+    @app_config_fragment_admin_repository_resilience.apply()
+    async def admin_search(
+        self,
+        querier: BatchQuerier,
+    ) -> AppConfigFragmentSearchResult:
+        return await self._db_source.admin_search(querier)
+
+    @app_config_fragment_admin_repository_resilience.apply()
+    async def admin_search_app_configs(
+        self,
+        querier: BatchQuerier,
+    ) -> AppConfigSearchResult:
+        return await self._db_source.admin_search_app_configs(querier)

--- a/src/ai/backend/manager/repositories/app_config_fragment/admin_repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/admin_repository.py
@@ -26,7 +26,6 @@ from ai.backend.manager.repositories.app_config_fragment.db_source import (
 from ai.backend.manager.repositories.app_config_fragment.updaters import (
     AppConfigFragmentUpdaterSpec,
 )
-from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.purger import Purger
 from ai.backend.manager.repositories.base.querier import BatchQuerier
 from ai.backend.manager.repositories.base.updater import Updater
@@ -58,14 +57,11 @@ class AppConfigFragmentAdminRepository:
     reads (`admin_search` raw, `admin_search_app_configs` merged)
     live here — read-side scope-bound operations are on
     `AppConfigFragmentRepository`. Authorization is enforced at the
-    service layer before reaching either repository. The required-
-    policy invariant is enforced upstream by the service layer; the
-    DB-level FK on ``app_config_fragments.name`` is the defense-in-
-    depth backstop and surfaces as a generic integrity error.
+    service layer before reaching either repository.
 
-    Mutations are routed through the shared Creator / Updater / Purger
-    helpers so the same execution / resilience plumbing applies as in
-    sister repositories.
+    Mutations are routed through the shared ops helpers (next-value
+    creator / Updater / Purger) so the same execution / resilience
+    plumbing applies as in sister repositories.
     """
 
     _db_source: AppConfigFragmentDBSource
@@ -81,15 +77,15 @@ class AppConfigFragmentAdminRepository:
         key: AppConfigFragmentKey,
         config: Mapping[str, Any],
     ) -> AppConfigFragmentData:
-        creator: Creator[AppConfigFragmentRow] = Creator(
-            spec=AppConfigFragmentCreatorSpec(
-                scope_type=key.scope_type,
-                scope_id=key.scope_id,
-                name=key.name,
-                config=config,
-            ),
+        """Insert a fragment; its `rank` is assigned by next-value
+        (``MAX(rank) + gap`` within the `name`) in the DB source."""
+        spec = AppConfigFragmentCreatorSpec(
+            scope_type=key.scope_type,
+            scope_id=key.scope_id,
+            name=key.name,
+            config=config,
         )
-        return await self._db_source.create(creator)
+        return await self._db_source.create(spec)
 
     @app_config_fragment_admin_repository_resilience.apply()
     async def update(

--- a/src/ai/backend/manager/repositories/app_config_fragment/admin_repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/admin_repository.py
@@ -109,15 +109,7 @@ class AppConfigFragmentAdminRepository:
             spec=AppConfigFragmentUpdaterSpec(config=config),
             pk_value=pk_value,
         )
-        result = await self._db_source.update(updater)
-        if result is None:
-            raise AppConfigFragmentNotFound(
-                extra_msg=(
-                    f"scope_type={key.scope_type.value!r}, "
-                    f"scope_id={key.scope_id!r}, name={key.name!r}"
-                ),
-            )
-        return result
+        return await self._db_source.update(updater)
 
     @app_config_fragment_admin_repository_resilience.apply()
     async def purge(self, key: AppConfigFragmentKey) -> bool:

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/__init__.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/__init__.py
@@ -1,0 +1,3 @@
+from .db_source import AppConfigFragmentDBSource
+
+__all__ = ("AppConfigFragmentDBSource",)

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -15,12 +15,13 @@ from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPoli
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
 from ai.backend.common.resilience.resilience import Resilience
 from ai.backend.common.utils import deep_merge
-from ai.backend.manager.data.app_config.types import AppConfigData, AppConfigSearchResult
 from ai.backend.manager.data.app_config_fragment.types import (
+    AppConfigData,
     AppConfigFragmentData,
     AppConfigFragmentKey,
     AppConfigFragmentSearchResult,
     AppConfigScopeType,
+    ScopedAppConfigSearchResult,
 )
 from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
@@ -301,7 +302,7 @@ class AppConfigFragmentDBSource:
         self,
         querier: BatchQuerier,
         scopes: Sequence[SearchScope] | None,
-    ) -> AppConfigSearchResult:
+    ) -> ScopedAppConfigSearchResult:
         """Cross-user merged search shared by the scoped and admin paths.
 
         Joins `users` so each `(user_id, name)` view is produced, then
@@ -369,7 +370,7 @@ class AppConfigFragmentDBSource:
                 )
             )
 
-        return AppConfigSearchResult(
+        return ScopedAppConfigSearchResult(
             items=items,
             total_count=result.total_count,
             has_next_page=result.has_next_page,
@@ -381,7 +382,7 @@ class AppConfigFragmentDBSource:
         self,
         querier: BatchQuerier,
         scopes: Sequence[SearchScope],
-    ) -> AppConfigSearchResult:
+    ) -> ScopedAppConfigSearchResult:
         """Merged-view search restricted to `scopes` (OR across users)."""
         return await self._search_merged_app_configs(querier, scopes)
 
@@ -389,6 +390,6 @@ class AppConfigFragmentDBSource:
     async def admin_search_app_configs(
         self,
         querier: BatchQuerier,
-    ) -> AppConfigSearchResult:
+    ) -> ScopedAppConfigSearchResult:
         """Cross-user merged search (admin only) — no scope restriction."""
         return await self._search_merged_app_configs(querier, None)

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -363,7 +363,7 @@ class AppConfigFragmentDBSource:
             merged = self._merge_chain(rows)
             items.append(
                 AppConfigData(
-                    user_id=user_id,
+                    user_id=UserID(user_id),
                     name=name,
                     fragments=merged.fragments,
                     config=merged.config,

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -84,9 +84,9 @@ class AppConfigFragmentDBSource:
     _db: ExtendedAsyncSAEngine
     _ops: DBOpsProvider
 
-    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
+    def __init__(self, db: ExtendedAsyncSAEngine, ops_provider: DBOpsProvider) -> None:
         self._db = db
-        self._ops = DBOpsProvider(db)
+        self._ops = ops_provider
 
     # ── Raw fragment CRUD ──────────────────────────────────────────
 

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -25,14 +25,18 @@ from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
 from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.app_config_fragment.creators import (
+    AppConfigFragmentCreatorSpec,
+)
 from ai.backend.manager.repositories.app_config_fragment.types import (
     UserAppConfigSearchScope,
 )
-from ai.backend.manager.repositories.base.creator import Creator, execute_creator
+from ai.backend.manager.repositories.base.creator import NextValuePolicy
 from ai.backend.manager.repositories.base.purger import Purger, execute_purger
 from ai.backend.manager.repositories.base.querier import BatchQuerier, execute_batch_querier
 from ai.backend.manager.repositories.base.types import SearchScope
 from ai.backend.manager.repositories.base.updater import Updater, execute_updater
+from ai.backend.manager.repositories.ops import DBOpsProvider
 
 app_config_fragment_db_source_resilience = Resilience(
     policies=[
@@ -52,6 +56,8 @@ app_config_fragment_db_source_resilience = Resilience(
         ),
     ]
 )
+
+RANK_GAP = 100
 
 
 @dataclass(frozen=True, slots=True)
@@ -78,9 +84,11 @@ class AppConfigFragmentDBSource:
     """
 
     _db: ExtendedAsyncSAEngine
+    _ops: DBOpsProvider
 
     def __init__(self, db: ExtendedAsyncSAEngine) -> None:
         self._db = db
+        self._ops = DBOpsProvider(db)
 
     # ── Raw fragment CRUD ──────────────────────────────────────────
 
@@ -114,18 +122,27 @@ class AppConfigFragmentDBSource:
             return row.to_data() if row is not None else None
 
     @app_config_fragment_db_source_resilience.apply()
-    async def create(self, creator: Creator[AppConfigFragmentRow]) -> AppConfigFragmentData:
-        """Insert a new fragment via the shared Creator helper.
+    async def create(self, spec: AppConfigFragmentCreatorSpec) -> AppConfigFragmentData:
+        """Insert a fragment, assigning the next-value `rank`
+        (``MAX(rank) + gap`` within the `name`) race-free — the same
+        pattern as DeploymentRevisionPreset.
 
-        The natural-key UNIQUE violation translates to
-        :class:`AppConfigFragmentConflict` via the spec's
-        ``integrity_error_checks``. The required-policy invariant
-        (FK on ``name``) is enforced upstream by the service layer;
-        a bypass here surfaces as a generic integrity error.
+        Concurrent inserts for an existing `name` are serialized by
+        locking that name's rows. The natural-key UNIQUE violation
+        translates to :class:`AppConfigFragmentConflict` via the spec's
+        ``integrity_error_checks``.
         """
-        async with self._db.begin_session() as db_sess:
-            result = await execute_creator(db_sess, creator)
-            return result.row.to_data()
+        policy = NextValuePolicy(
+            column=AppConfigFragmentRow.rank,
+            scope_condition=lambda: AppConfigFragmentRow.name == spec.name,
+            lock_selector=sa.select(AppConfigFragmentRow).where(
+                AppConfigFragmentRow.name == spec.name
+            ),
+            gap=RANK_GAP,
+        )
+        async with self._ops.write_ops() as w:
+            created = await w.create_with_next_value(policy, spec)
+            return created.row.to_data()
 
     @app_config_fragment_db_source_resilience.apply()
     async def resolve_pk_by_key(

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import sqlalchemy as sa
+
+from ai.backend.common.exception import BackendAIError
+from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+from ai.backend.common.metrics.metric import DomainType, LayerType
+from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
+from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
+from ai.backend.common.resilience.resilience import Resilience
+from ai.backend.common.utils import deep_merge
+from ai.backend.manager.data.app_config.types import AppConfigData, AppConfigSearchResult
+from ai.backend.manager.data.app_config_fragment.types import (
+    AppConfigFragmentData,
+    AppConfigFragmentKey,
+    AppConfigFragmentSearchResult,
+    AppConfigScopeType,
+)
+from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
+from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.models.user import UserRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.app_config_fragment.types import (
+    UserAppConfigSearchScope,
+)
+from ai.backend.manager.repositories.base.creator import Creator, execute_creator
+from ai.backend.manager.repositories.base.purger import Purger, execute_purger
+from ai.backend.manager.repositories.base.querier import BatchQuerier, execute_batch_querier
+from ai.backend.manager.repositories.base.types import SearchScope
+from ai.backend.manager.repositories.base.updater import Updater, execute_updater
+
+app_config_fragment_db_source_resilience = Resilience(
+    policies=[
+        MetricPolicy(
+            MetricArgs(
+                domain=DomainType.DB_SOURCE,
+                layer=LayerType.APP_CONFIG_FRAGMENT_DB_SOURCE,
+            )
+        ),
+        RetryPolicy(
+            RetryArgs(
+                max_retries=5,
+                retry_delay=0.1,
+                backoff_strategy=BackoffStrategy.FIXED,
+                non_retryable_exceptions=(BackendAIError,),
+            )
+        ),
+    ]
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _MergedChain:
+    """Internal return type of `_merge_chain` — the ordered fragments
+    that contributed to the merge plus the deep-merged config (or
+    `None` when every contributing fragment is empty).
+
+    Re-shaped into `AppConfigData` by callers that also know the
+    `(user_id, name)` they were resolving for.
+    """
+
+    fragments: list[AppConfigFragmentData]
+    config: Mapping[str, Any] | None
+
+
+class AppConfigFragmentDBSource:
+    """Database operations for `app_config_fragments`.
+
+    Two roles:
+    1. Raw CRUD on `(scope_type, scope_id, name)` rows.
+    2. Merge-side reads that resolve a user's `AppConfig` view by ordering
+       the applicable fragments by `rank` (low → high) and deep-merging.
+    """
+
+    _db: ExtendedAsyncSAEngine
+
+    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
+        self._db = db
+
+    # ── Raw fragment CRUD ──────────────────────────────────────────
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def get_by_key(self, key: AppConfigFragmentKey) -> AppConfigFragmentData:
+        """Look up a fragment by natural key. Raises
+        :class:`AppConfigFragmentNotFound` when no row matches."""
+        async with self._db.begin_readonly_session() as db_sess:
+            row = await db_sess.scalar(
+                sa.select(AppConfigFragmentRow).where(
+                    AppConfigFragmentRow.scope_type == key.scope_type,
+                    AppConfigFragmentRow.scope_id == key.scope_id,
+                    AppConfigFragmentRow.name == key.name,
+                )
+            )
+            if row is None:
+                raise AppConfigFragmentNotFound(
+                    extra_msg=(
+                        f"scope_type={key.scope_type.value!r}, "
+                        f"scope_id={key.scope_id!r}, name={key.name!r}"
+                    ),
+                )
+            return row.to_data()
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def get_by_id(self, id: AppConfigFragmentID) -> AppConfigFragmentData | None:
+        async with self._db.begin_readonly_session() as db_sess:
+            row = await db_sess.scalar(
+                sa.select(AppConfigFragmentRow).where(AppConfigFragmentRow.id == id)
+            )
+            return row.to_data() if row is not None else None
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def create(self, creator: Creator[AppConfigFragmentRow]) -> AppConfigFragmentData:
+        """Insert a new fragment via the shared Creator helper.
+
+        The natural-key UNIQUE violation translates to
+        :class:`AppConfigFragmentConflict` via the spec's
+        ``integrity_error_checks``. The required-policy invariant
+        (FK on ``name``) is enforced upstream by the service layer;
+        a bypass here surfaces as a generic integrity error.
+        """
+        async with self._db.begin_session() as db_sess:
+            result = await execute_creator(db_sess, creator)
+            return result.row.to_data()
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def resolve_pk_by_key(
+        self,
+        key: AppConfigFragmentKey,
+    ) -> AppConfigFragmentID | None:
+        """Resolve the natural key ``(scope_type, scope_id, name)`` to
+        the row's ``id``. Returns ``None`` when no row matches —
+        callers translate to a domain-appropriate response."""
+        async with self._db.begin_readonly_session() as db_sess:
+            pk: AppConfigFragmentID | None = await db_sess.scalar(
+                sa.select(AppConfigFragmentRow.id).where(
+                    AppConfigFragmentRow.scope_type == key.scope_type,
+                    AppConfigFragmentRow.scope_id == key.scope_id,
+                    AppConfigFragmentRow.name == key.name,
+                )
+            )
+            return pk
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def update(self, updater: Updater[AppConfigFragmentRow]) -> AppConfigFragmentData | None:
+        """Apply a pre-built Updater. Returns ``None`` when the row
+        vanished between PK resolution and write; the caller maps this
+        to :class:`AppConfigFragmentNotFound`."""
+        async with self._db.begin_session() as db_sess:
+            result = await execute_updater(db_sess, updater)
+            return result.row.to_data() if result is not None else None
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def purge(self, purger: Purger[AppConfigFragmentRow]) -> bool:
+        """Apply a pre-built Purger. Returns ``True`` when a row was
+        actually removed (``False`` if the row vanished concurrently)."""
+        async with self._db.begin_session() as db_sess:
+            result = await execute_purger(db_sess, purger)
+            return result is not None
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def scoped_search(
+        self,
+        querier: BatchQuerier,
+        scopes: Sequence[SearchScope],
+    ) -> AppConfigFragmentSearchResult:
+        """Paginated search over fragment rows matching any of ``scopes`` (OR),
+        narrowed by ``querier``."""
+        async with self._db.begin_readonly_session() as db_sess:
+            query = sa.select(AppConfigFragmentRow)
+            result = await execute_batch_querier(db_sess, query, querier, scopes=scopes)
+            items = [row.AppConfigFragmentRow.to_data() for row in result.rows]
+            return AppConfigFragmentSearchResult(
+                items=items,
+                total_count=result.total_count,
+                has_next_page=result.has_next_page,
+                has_previous_page=result.has_previous_page,
+            )
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def admin_search(
+        self,
+        querier: BatchQuerier,
+    ) -> AppConfigFragmentSearchResult:
+        """Cross-scope admin search — no scope binding. Authorization
+        is enforced at the service layer before this is reached."""
+        async with self._db.begin_readonly_session() as db_sess:
+            query = sa.select(AppConfigFragmentRow)
+            result = await execute_batch_querier(db_sess, query, querier)
+            items = [row.AppConfigFragmentRow.to_data() for row in result.rows]
+            return AppConfigFragmentSearchResult(
+                items=items,
+                total_count=result.total_count,
+                has_next_page=result.has_next_page,
+                has_previous_page=result.has_previous_page,
+            )
+
+    # ── Merged-view reads (AppConfig) ─────────────────────────────
+
+    @staticmethod
+    def _merge_chain(rows: Sequence[AppConfigFragmentRow]) -> _MergedChain:
+        """Order `rows` by `rank` (low → high) and deep-merge their
+        `config` in that order. Empty result projects to `None`.
+
+        Shared by the single-doc and search merge methods so both paths
+        produce the same shape.
+        """
+        ordered = sorted(rows, key=lambda row: row.rank)
+        merged: Mapping[str, Any] = {}
+        for row in ordered:
+            if row.config is None:
+                continue
+            merged = deep_merge(merged, row.config)
+        return _MergedChain(
+            fragments=[row.to_data() for row in ordered],
+            config=(merged or None),
+        )
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def get_user_app_config(
+        self,
+        user_id: uuid.UUID,
+        config_name: str,
+    ) -> AppConfigData:
+        """Resolve a single AppConfig view for `(user_id, config_name)`.
+
+        One SQL: resolves `domain_name` via a `users` subquery and fetches
+        the fragments applicable to the caller (`scope_id_match` gates
+        PUBLIC / the user's DOMAIN / the user's USER rows). Ordering and
+        deep-merge happen by `rank` in `_merge_chain`.
+        """
+        user_domain_sq = (
+            sa.select(UserRow.domain_name).where(UserRow.uuid == user_id).scalar_subquery()
+        )
+        scope_id_match = sa.case(
+            (
+                AppConfigFragmentRow.scope_type == AppConfigScopeType.PUBLIC,
+                sa.literal("public"),
+            ),
+            (
+                AppConfigFragmentRow.scope_type.in_([
+                    AppConfigScopeType.DOMAIN,
+                    AppConfigScopeType.DOMAIN_USER_DEFAULTS,
+                ]),
+                user_domain_sq,
+            ),
+            (
+                AppConfigFragmentRow.scope_type == AppConfigScopeType.USER,
+                sa.literal(str(user_id)),
+            ),
+        )
+        query = sa.select(AppConfigFragmentRow).where(
+            AppConfigFragmentRow.name == config_name,
+            AppConfigFragmentRow.scope_id == scope_id_match,
+        )
+        async with self._db.begin_readonly_session() as db_sess:
+            rows = (await db_sess.execute(query)).scalars().all()
+
+        if not rows:
+            return AppConfigData(
+                user_id=user_id,
+                name=config_name,
+                fragments=[],
+                config=None,
+            )
+
+        merged = self._merge_chain(rows)
+        return AppConfigData(
+            user_id=user_id,
+            name=config_name,
+            fragments=merged.fragments,
+            config=merged.config,
+        )
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def search_user_app_configs(
+        self,
+        scope: UserAppConfigSearchScope,
+        querier: BatchQuerier,
+    ) -> AppConfigSearchResult:
+        """Connection counterpart of `get_user_app_config`. Groups the
+        scoped page of applicable fragments by `name` and feeds each group
+        through `_merge_chain` (rank-ordered) to produce one `AppConfigData`.
+
+        Filtering / ordering / pagination run through the shared
+        scoped-search helper (`execute_batch_querier`); the per-user
+        restriction lives in the `scope_id_match` predicate while
+        `UserAppConfigSearchScope` stays a passthrough so it composes
+        with the `BatchQuerier` without double-filtering.
+        """
+        user_id = scope.user_id
+        user_domain_sq = (
+            sa.select(UserRow.domain_name).where(UserRow.uuid == user_id).scalar_subquery()
+        )
+        scope_id_match = sa.case(
+            (
+                AppConfigFragmentRow.scope_type == AppConfigScopeType.PUBLIC,
+                sa.literal("public"),
+            ),
+            (
+                AppConfigFragmentRow.scope_type.in_([
+                    AppConfigScopeType.DOMAIN,
+                    AppConfigScopeType.DOMAIN_USER_DEFAULTS,
+                ]),
+                user_domain_sq,
+            ),
+            (
+                AppConfigFragmentRow.scope_type == AppConfigScopeType.USER,
+                sa.literal(str(user_id)),
+            ),
+        )
+        query = sa.select(AppConfigFragmentRow).where(
+            AppConfigFragmentRow.scope_id == scope_id_match,
+        )
+        async with self._db.begin_readonly_session() as db_sess:
+            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
+
+        groups: dict[str, list[AppConfigFragmentRow]] = {}
+        for row in result.rows:
+            fragment_row = row.AppConfigFragmentRow
+            groups.setdefault(fragment_row.name, []).append(fragment_row)
+
+        items: list[AppConfigData] = []
+        for name, rows in groups.items():
+            merged = self._merge_chain(rows)
+            items.append(
+                AppConfigData(
+                    user_id=user_id,
+                    name=name,
+                    fragments=merged.fragments,
+                    config=merged.config,
+                )
+            )
+
+        return AppConfigSearchResult(
+            items=items,
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def admin_search_app_configs(
+        self,
+        querier: BatchQuerier,
+    ) -> AppConfigSearchResult:
+        """Cross-user merged search (admin only). Joins `users` so each
+        `(user_id, name)` combination is produced; the scoped page of rows
+        is grouped and rank-merged the same way as `search_user_app_configs`.
+
+        Filtering / ordering / pagination run through the shared
+        scoped-search helper (`execute_batch_querier`) on the global
+        (unscoped) admin path.
+        """
+        scope_id_match = sa.case(
+            (
+                AppConfigFragmentRow.scope_type == AppConfigScopeType.PUBLIC,
+                sa.literal("public"),
+            ),
+            (
+                AppConfigFragmentRow.scope_type.in_([
+                    AppConfigScopeType.DOMAIN,
+                    AppConfigScopeType.DOMAIN_USER_DEFAULTS,
+                ]),
+                UserRow.domain_name,
+            ),
+            (
+                AppConfigFragmentRow.scope_type == AppConfigScopeType.USER,
+                sa.cast(UserRow.uuid, sa.Text),
+            ),
+        )
+        query = (
+            sa.select(
+                UserRow.uuid.label("user_id"),
+                AppConfigFragmentRow,
+            )
+            .select_from(UserRow)
+            .join(
+                AppConfigFragmentRow,
+                AppConfigFragmentRow.scope_id == scope_id_match,
+            )
+        )
+        async with self._db.begin_readonly_session() as db_sess:
+            result = await execute_batch_querier(db_sess, query, querier)
+
+        groups: dict[tuple[uuid.UUID, str], list[AppConfigFragmentRow]] = {}
+        for row in result.rows:
+            fragment_row = row.AppConfigFragmentRow
+            groups.setdefault((row.user_id, fragment_row.name), []).append(fragment_row)
+
+        items: list[AppConfigData] = []
+        for (user_id, name), rows in groups.items():
+            merged = self._merge_chain(rows)
+            items.append(
+                AppConfigData(
+                    user_id=user_id,
+                    name=name,
+                    fragments=merged.fragments,
+                    config=merged.config,
+                )
+            )
+
+        return AppConfigSearchResult(
+            items=items,
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -9,6 +9,7 @@ import sqlalchemy as sa
 
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
@@ -27,9 +28,6 @@ from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.app_config_fragment.creators import (
     AppConfigFragmentCreatorSpec,
-)
-from ai.backend.manager.repositories.app_config_fragment.types import (
-    UserAppConfigSearchScope,
 )
 from ai.backend.manager.repositories.base.creator import NextValuePolicy
 from ai.backend.manager.repositories.base.purger import Purger, execute_purger
@@ -57,7 +55,7 @@ app_config_fragment_db_source_resilience = Resilience(
     ]
 )
 
-RANK_GAP = 100
+_RANK_GAP = 100
 
 
 @dataclass(frozen=True, slots=True)
@@ -114,12 +112,16 @@ class AppConfigFragmentDBSource:
             return row.to_data()
 
     @app_config_fragment_db_source_resilience.apply()
-    async def get_by_id(self, id: AppConfigFragmentID) -> AppConfigFragmentData | None:
+    async def get_by_id(self, id: AppConfigFragmentID) -> AppConfigFragmentData:
+        """Look up a fragment by id. Raises
+        :class:`AppConfigFragmentNotFound` when no row matches."""
         async with self._db.begin_readonly_session() as db_sess:
             row = await db_sess.scalar(
                 sa.select(AppConfigFragmentRow).where(AppConfigFragmentRow.id == id)
             )
-            return row.to_data() if row is not None else None
+            if row is None:
+                raise AppConfigFragmentNotFound(extra_msg=f"id={id!r}")
+            return row.to_data()
 
     @app_config_fragment_db_source_resilience.apply()
     async def create(self, spec: AppConfigFragmentCreatorSpec) -> AppConfigFragmentData:
@@ -138,7 +140,7 @@ class AppConfigFragmentDBSource:
             lock_selector=sa.select(AppConfigFragmentRow).where(
                 AppConfigFragmentRow.name == spec.name
             ),
-            gap=RANK_GAP,
+            gap=_RANK_GAP,
         )
         async with self._ops.write_ops() as w:
             created = await w.create_with_next_value(policy, spec)
@@ -163,13 +165,15 @@ class AppConfigFragmentDBSource:
             return pk
 
     @app_config_fragment_db_source_resilience.apply()
-    async def update(self, updater: Updater[AppConfigFragmentRow]) -> AppConfigFragmentData | None:
-        """Apply a pre-built Updater. Returns ``None`` when the row
-        vanished between PK resolution and write; the caller maps this
-        to :class:`AppConfigFragmentNotFound`."""
+    async def update(self, updater: Updater[AppConfigFragmentRow]) -> AppConfigFragmentData:
+        """Apply a pre-built Updater. Raises
+        :class:`AppConfigFragmentNotFound` when the row vanished between
+        PK resolution and write."""
         async with self._db.begin_session() as db_sess:
             result = await execute_updater(db_sess, updater)
-            return result.row.to_data() if result is not None else None
+            if result is None:
+                raise AppConfigFragmentNotFound(extra_msg=f"id={updater.pk_value!r}")
+            return result.row.to_data()
 
     @app_config_fragment_db_source_resilience.apply()
     async def purge(self, purger: Purger[AppConfigFragmentRow]) -> bool:
@@ -240,7 +244,7 @@ class AppConfigFragmentDBSource:
     @app_config_fragment_db_source_resilience.apply()
     async def get_user_app_config(
         self,
-        user_id: uuid.UUID,
+        user_id: UserID,
         config_name: str,
     ) -> AppConfigData:
         """Resolve a single AppConfig view for `(user_id, config_name)`.
@@ -293,85 +297,26 @@ class AppConfigFragmentDBSource:
             config=merged.config,
         )
 
-    @app_config_fragment_db_source_resilience.apply()
-    async def search_user_app_configs(
-        self,
-        scope: UserAppConfigSearchScope,
-        querier: BatchQuerier,
-    ) -> AppConfigSearchResult:
-        """Connection counterpart of `get_user_app_config`. Groups the
-        scoped page of applicable fragments by `name` and feeds each group
-        through `_merge_chain` (rank-ordered) to produce one `AppConfigData`.
-
-        Filtering / ordering / pagination run through the shared
-        scoped-search helper (`execute_batch_querier`); the per-user
-        restriction lives in the `scope_id_match` predicate while
-        `UserAppConfigSearchScope` stays a passthrough so it composes
-        with the `BatchQuerier` without double-filtering.
-        """
-        user_id = scope.user_id
-        user_domain_sq = (
-            sa.select(UserRow.domain_name).where(UserRow.uuid == user_id).scalar_subquery()
-        )
-        scope_id_match = sa.case(
-            (
-                AppConfigFragmentRow.scope_type == AppConfigScopeType.PUBLIC,
-                sa.literal("public"),
-            ),
-            (
-                AppConfigFragmentRow.scope_type.in_([
-                    AppConfigScopeType.DOMAIN,
-                    AppConfigScopeType.DOMAIN_USER_DEFAULTS,
-                ]),
-                user_domain_sq,
-            ),
-            (
-                AppConfigFragmentRow.scope_type == AppConfigScopeType.USER,
-                sa.literal(str(user_id)),
-            ),
-        )
-        query = sa.select(AppConfigFragmentRow).where(
-            AppConfigFragmentRow.scope_id == scope_id_match,
-        )
-        async with self._db.begin_readonly_session() as db_sess:
-            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
-
-        groups: dict[str, list[AppConfigFragmentRow]] = {}
-        for row in result.rows:
-            fragment_row = row.AppConfigFragmentRow
-            groups.setdefault(fragment_row.name, []).append(fragment_row)
-
-        items: list[AppConfigData] = []
-        for name, rows in groups.items():
-            merged = self._merge_chain(rows)
-            items.append(
-                AppConfigData(
-                    user_id=user_id,
-                    name=name,
-                    fragments=merged.fragments,
-                    config=merged.config,
-                )
-            )
-
-        return AppConfigSearchResult(
-            items=items,
-            total_count=result.total_count,
-            has_next_page=result.has_next_page,
-            has_previous_page=result.has_previous_page,
-        )
-
-    @app_config_fragment_db_source_resilience.apply()
-    async def admin_search_app_configs(
+    async def _search_merged_app_configs(
         self,
         querier: BatchQuerier,
+        scopes: Sequence[SearchScope] | None,
     ) -> AppConfigSearchResult:
-        """Cross-user merged search (admin only). Joins `users` so each
-        `(user_id, name)` combination is produced; the scoped page of rows
-        is grouped and rank-merged the same way as `search_user_app_configs`.
+        """Cross-user merged search shared by the scoped and admin paths.
+
+        Joins `users` so each `(user_id, name)` view is produced, then
+        groups the scoped page of applicable fragments by `(user_id, name)`
+        and feeds each group through `_merge_chain` (rank-ordered) to
+        produce one `AppConfigData`.
+
+        When `scopes` is given the user set is the OR-union of those scopes
+        (each `UserAppConfigSearchScope` matches `UserRow.uuid`); `None` is
+        the global admin path. `execute_batch_querier` ORs the scopes and
+        the `(user_id, name)` grouping deduplicates any overlap — a user
+        reached via two scopes still yields exactly one AppConfig.
 
         Filtering / ordering / pagination run through the shared
-        scoped-search helper (`execute_batch_querier`) on the global
-        (unscoped) admin path.
+        scoped-search helper (`execute_batch_querier`).
         """
         scope_id_match = sa.case(
             (
@@ -402,7 +347,10 @@ class AppConfigFragmentDBSource:
             )
         )
         async with self._db.begin_readonly_session() as db_sess:
-            result = await execute_batch_querier(db_sess, query, querier)
+            if scopes is not None:
+                result = await execute_batch_querier(db_sess, query, querier, scopes=scopes)
+            else:
+                result = await execute_batch_querier(db_sess, query, querier)
 
         groups: dict[tuple[uuid.UUID, str], list[AppConfigFragmentRow]] = {}
         for row in result.rows:
@@ -427,3 +375,20 @@ class AppConfigFragmentDBSource:
             has_next_page=result.has_next_page,
             has_previous_page=result.has_previous_page,
         )
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def scoped_search_app_configs(
+        self,
+        querier: BatchQuerier,
+        scopes: Sequence[SearchScope],
+    ) -> AppConfigSearchResult:
+        """Merged-view search restricted to `scopes` (OR across users)."""
+        return await self._search_merged_app_configs(querier, scopes)
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def admin_search_app_configs(
+        self,
+        querier: BatchQuerier,
+    ) -> AppConfigSearchResult:
+        """Cross-user merged search (admin only) — no scope restriction."""
+        return await self._search_merged_app_configs(querier, None)

--- a/src/ai/backend/manager/repositories/app_config_fragment/repositories.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repositories.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from typing import Self
+
+from ai.backend.manager.repositories.app_config_fragment.admin_repository import (
+    AppConfigFragmentAdminRepository,
+)
+from ai.backend.manager.repositories.app_config_fragment.repository import (
+    AppConfigFragmentRepository,
+)
+from ai.backend.manager.repositories.types import RepositoryArgs
+
+
+@dataclass
+class AppConfigFragmentRepositories:
+    repository: AppConfigFragmentRepository
+    admin_repository: AppConfigFragmentAdminRepository
+
+    @classmethod
+    def create(cls, args: RepositoryArgs) -> Self:
+        return cls(
+            repository=AppConfigFragmentRepository(args.db),
+            admin_repository=AppConfigFragmentAdminRepository(args.db),
+        )

--- a/src/ai/backend/manager/repositories/app_config_fragment/repositories.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repositories.py
@@ -18,6 +18,6 @@ class AppConfigFragmentRepositories:
     @classmethod
     def create(cls, args: RepositoryArgs) -> Self:
         return cls(
-            repository=AppConfigFragmentRepository(args.db),
-            admin_repository=AppConfigFragmentAdminRepository(args.db),
+            repository=AppConfigFragmentRepository(args.db, args.ops_provider),
+            admin_repository=AppConfigFragmentAdminRepository(args.db, args.ops_provider),
         )

--- a/src/ai/backend/manager/repositories/app_config_fragment/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repository.py
@@ -9,11 +9,12 @@ from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
 from ai.backend.common.resilience.resilience import Resilience
-from ai.backend.manager.data.app_config.types import AppConfigData, AppConfigSearchResult
 from ai.backend.manager.data.app_config_fragment.types import (
+    AppConfigData,
     AppConfigFragmentData,
     AppConfigFragmentKey,
     AppConfigFragmentSearchResult,
+    ScopedAppConfigSearchResult,
 )
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.app_config_fragment.db_source import (
@@ -88,5 +89,5 @@ class AppConfigFragmentRepository:
         self,
         querier: BatchQuerier,
         scopes: Sequence[SearchScope],
-    ) -> AppConfigSearchResult:
+    ) -> ScopedAppConfigSearchResult:
         return await self._db_source.scoped_search_app_configs(querier, scopes)

--- a/src/ai/backend/manager/repositories/app_config_fragment/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repository.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import uuid
 from collections.abc import Sequence
 
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
@@ -18,9 +18,6 @@ from ai.backend.manager.data.app_config_fragment.types import (
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.app_config_fragment.db_source import (
     AppConfigFragmentDBSource,
-)
-from ai.backend.manager.repositories.app_config_fragment.types import (
-    UserAppConfigSearchScope,
 )
 from ai.backend.manager.repositories.base.querier import BatchQuerier
 from ai.backend.manager.repositories.base.types import SearchScope
@@ -64,7 +61,7 @@ class AppConfigFragmentRepository:
         return await self._db_source.get_by_key(key)
 
     @app_config_fragment_repository_resilience.apply()
-    async def get_by_id(self, id: AppConfigFragmentID) -> AppConfigFragmentData | None:
+    async def get_by_id(self, id: AppConfigFragmentID) -> AppConfigFragmentData:
         return await self._db_source.get_by_id(id)
 
     @app_config_fragment_repository_resilience.apply()
@@ -80,15 +77,15 @@ class AppConfigFragmentRepository:
     @app_config_fragment_repository_resilience.apply()
     async def app_config(
         self,
-        user_id: uuid.UUID,
+        user_id: UserID,
         config_name: str,
     ) -> AppConfigData:
         return await self._db_source.get_user_app_config(user_id, config_name)
 
     @app_config_fragment_repository_resilience.apply()
-    async def search_app_configs(
+    async def scoped_search_app_configs(
         self,
-        scope: UserAppConfigSearchScope,
         querier: BatchQuerier,
+        scopes: Sequence[SearchScope],
     ) -> AppConfigSearchResult:
-        return await self._db_source.search_user_app_configs(scope, querier)
+        return await self._db_source.scoped_search_app_configs(querier, scopes)

--- a/src/ai/backend/manager/repositories/app_config_fragment/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repository.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+
+from ai.backend.common.exception import BackendAIError
+from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+from ai.backend.common.metrics.metric import DomainType, LayerType
+from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
+from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
+from ai.backend.common.resilience.resilience import Resilience
+from ai.backend.manager.data.app_config.types import AppConfigData, AppConfigSearchResult
+from ai.backend.manager.data.app_config_fragment.types import (
+    AppConfigFragmentData,
+    AppConfigFragmentKey,
+    AppConfigFragmentSearchResult,
+)
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.app_config_fragment.db_source import (
+    AppConfigFragmentDBSource,
+)
+from ai.backend.manager.repositories.app_config_fragment.types import (
+    UserAppConfigSearchScope,
+)
+from ai.backend.manager.repositories.base.querier import BatchQuerier
+from ai.backend.manager.repositories.base.types import SearchScope
+
+app_config_fragment_repository_resilience = Resilience(
+    policies=[
+        MetricPolicy(
+            MetricArgs(
+                domain=DomainType.REPOSITORY,
+                layer=LayerType.APP_CONFIG_FRAGMENT_REPOSITORY,
+            )
+        ),
+        RetryPolicy(
+            RetryArgs(
+                max_retries=5,
+                retry_delay=0.1,
+                backoff_strategy=BackoffStrategy.FIXED,
+                non_retryable_exceptions=(BackendAIError,),
+            )
+        ),
+    ]
+)
+
+
+class AppConfigFragmentRepository:
+    """Non-admin repository for AppConfigFragment.
+
+    Holds operations available to any authenticated user: scope-bound
+    reads on raw fragments plus the per-user merged `AppConfig` view.
+    """
+
+    _db_source: AppConfigFragmentDBSource
+
+    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
+        self._db_source = AppConfigFragmentDBSource(db)
+
+    # ── Raw fragment reads ────────────────────────────────────────
+
+    @app_config_fragment_repository_resilience.apply()
+    async def get_by_key(self, key: AppConfigFragmentKey) -> AppConfigFragmentData:
+        return await self._db_source.get_by_key(key)
+
+    @app_config_fragment_repository_resilience.apply()
+    async def get_by_id(self, id: AppConfigFragmentID) -> AppConfigFragmentData | None:
+        return await self._db_source.get_by_id(id)
+
+    @app_config_fragment_repository_resilience.apply()
+    async def scoped_search(
+        self,
+        querier: BatchQuerier,
+        scopes: Sequence[SearchScope],
+    ) -> AppConfigFragmentSearchResult:
+        return await self._db_source.scoped_search(querier, scopes)
+
+    # ── Merged view (AppConfig) ───────────────────────────────────
+
+    @app_config_fragment_repository_resilience.apply()
+    async def app_config(
+        self,
+        user_id: uuid.UUID,
+        config_name: str,
+    ) -> AppConfigData:
+        return await self._db_source.get_user_app_config(user_id, config_name)
+
+    @app_config_fragment_repository_resilience.apply()
+    async def search_app_configs(
+        self,
+        scope: UserAppConfigSearchScope,
+        querier: BatchQuerier,
+    ) -> AppConfigSearchResult:
+        return await self._db_source.search_user_app_configs(scope, querier)

--- a/src/ai/backend/manager/repositories/app_config_fragment/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repository.py
@@ -21,6 +21,7 @@ from ai.backend.manager.repositories.app_config_fragment.db_source import (
 )
 from ai.backend.manager.repositories.base.querier import BatchQuerier
 from ai.backend.manager.repositories.base.types import SearchScope
+from ai.backend.manager.repositories.ops import DBOpsProvider
 
 app_config_fragment_repository_resilience = Resilience(
     policies=[
@@ -51,8 +52,8 @@ class AppConfigFragmentRepository:
 
     _db_source: AppConfigFragmentDBSource
 
-    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
-        self._db_source = AppConfigFragmentDBSource(db)
+    def __init__(self, db: ExtendedAsyncSAEngine, ops_provider: DBOpsProvider) -> None:
+        self._db_source = AppConfigFragmentDBSource(db, ops_provider)
 
     # ── Raw fragment reads ────────────────────────────────────────
 

--- a/src/ai/backend/manager/repositories/app_config_fragment/types.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
 
@@ -9,6 +10,7 @@ import sqlalchemy as sa
 
 from ai.backend.manager.data.app_config_fragment.types import AppConfigScopeType
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.repositories.base import ExistenceCheck, QueryCondition, SearchScope
 
 
@@ -34,4 +36,30 @@ class AppConfigFragmentSearchScope(SearchScope):
     @property
     def existence_checks(self) -> Sequence[ExistenceCheck[str]]:
         # Scope existence (domain / user) is validated upstream by RBAC.
+        return []
+
+
+@dataclass(frozen=True)
+class UserAppConfigSearchScope(SearchScope):
+    """Pin merged-view search to a target `user_id`.
+
+    The merged-view query joins `users`, so this matches `UserRow.uuid`.
+    `execute_batch_querier` ORs multiple scopes together and the
+    `(user_id, name)` grouping downstream deduplicates any overlap
+    between scopes — a user reached via two scopes yields one AppConfig.
+    """
+
+    user_id: uuid.UUID
+
+    def to_condition(self) -> QueryCondition:
+        user_id = self.user_id
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return UserRow.uuid == user_id
+
+        return inner
+
+    @property
+    def existence_checks(self) -> Sequence[ExistenceCheck[uuid.UUID]]:
+        # User existence is guaranteed by RBAC authentication upstream.
         return []

--- a/src/ai/backend/manager/repositories/repositories.py
+++ b/src/ai/backend/manager/repositories/repositories.py
@@ -2,6 +2,9 @@ from dataclasses import dataclass
 from typing import Self
 
 from ai.backend.manager.repositories.agent.repositories import AgentRepositories
+from ai.backend.manager.repositories.app_config_fragment.repositories import (
+    AppConfigFragmentRepositories,
+)
 from ai.backend.manager.repositories.artifact.repositories import ArtifactRepositories
 from ai.backend.manager.repositories.artifact_registry.repositories import (
     ArtifactRegistryRepositories,
@@ -85,6 +88,7 @@ from ai.backend.manager.repositories.vfs_storage.repositories import VFSStorageR
 @dataclass
 class Repositories:
     agent: AgentRepositories
+    app_config_fragment: AppConfigFragmentRepositories
     auth: AuthRepositories
     container_registry: ContainerRegistryRepositories
     deployment: DeploymentRepositories
@@ -136,6 +140,7 @@ class Repositories:
     @classmethod
     def create(cls, args: RepositoryArgs) -> Self:
         agent_repositories = AgentRepositories.create(args)
+        app_config_fragment_repositories = AppConfigFragmentRepositories.create(args)
         auth_repositories = AuthRepositories.create(args)
         container_registry_repositories = ContainerRegistryRepositories.create(args)
         deployment_repositories = DeploymentRepositories.create(args)
@@ -188,6 +193,7 @@ class Repositories:
 
         return cls(
             agent=agent_repositories,
+            app_config_fragment=app_config_fragment_repositories,
             auth=auth_repositories,
             container_registry=container_registry_repositories,
             deployment=deployment_repositories,

--- a/tests/unit/manager/repositories/app_config_fragment/BUILD
+++ b/tests/unit/manager/repositories/app_config_fragment/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/tests/unit/manager/repositories/app_config_fragment/test_app_config_fragment.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_app_config_fragment.py
@@ -63,12 +63,12 @@ class TestAppConfigFragmentRepository:
         assert created.scope_type == AppConfigScopeType.DOMAIN
         assert created.scope_id == "default"
         assert created.name == "theme"
-        # rank defaults to the DOMAIN tier when not explicitly provided.
-        assert created.rank == 200
+        # First fragment for `theme` gets the base next-value rank.
+        assert created.rank == 100
         assert created.config is not None
         assert dict(created.config) == {"color": "blue"}
 
-        fetched = await repository.get(key)
+        fetched = await repository.get_by_key(key)
         assert fetched is not None
         assert fetched.id == created.id
         assert fetched.config is not None
@@ -87,7 +87,7 @@ class TestAppConfigFragmentRepository:
             ),
             config={"density": "comfortable"},
         )
-        # rank defaults to the PUBLIC tier.
+        # First fragment for `theme` gets the base next-value rank.
         assert created.rank == 100
 
         fetched = await repository.get_by_id(created.id)
@@ -101,7 +101,7 @@ class TestAppConfigFragmentRepository:
         repository: AppConfigFragmentRepository,
     ) -> None:
         with pytest.raises(AppConfigFragmentNotFound):
-            await repository.get(
+            await repository.get_by_key(
                 AppConfigFragmentKey(
                     scope_type=AppConfigScopeType.DOMAIN,
                     scope_id="missing",
@@ -187,3 +187,29 @@ class TestAppConfigFragmentAdminRepository:
             )
             is False
         )
+
+    async def test_rank_assigned_by_next_value(
+        self,
+        admin_repository: AppConfigFragmentAdminRepository,
+    ) -> None:
+        # Fragments sharing a `name` get a monotonic next-value rank
+        # (MAX + gap within the name), like DeploymentRevisionPreset —
+        # not a per-scope_type tier.
+        first = await admin_repository.create(
+            key=AppConfigFragmentKey(
+                scope_type=AppConfigScopeType.PUBLIC,
+                scope_id="public",
+                name="theme",
+            ),
+            config={"density": "comfortable"},
+        )
+        second = await admin_repository.create(
+            key=AppConfigFragmentKey(
+                scope_type=AppConfigScopeType.DOMAIN,
+                scope_id="default",
+                name="theme",
+            ),
+            config={"color": "blue"},
+        )
+        assert first.rank == 100
+        assert second.rank == 200

--- a/tests/unit/manager/repositories/app_config_fragment/test_app_config_fragment.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_app_config_fragment.py
@@ -19,6 +19,7 @@ from ai.backend.manager.repositories.app_config_fragment.admin_repository import
 from ai.backend.manager.repositories.app_config_fragment.repository import (
     AppConfigFragmentRepository,
 )
+from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.testutils.db import with_tables
 
 
@@ -40,11 +41,11 @@ class TestAppConfigFragmentRepository:
 
     @pytest.fixture
     def repository(self, db: ExtendedAsyncSAEngine) -> AppConfigFragmentRepository:
-        return AppConfigFragmentRepository(db)
+        return AppConfigFragmentRepository(db, DBOpsProvider(db))
 
     @pytest.fixture
     def admin_repository(self, db: ExtendedAsyncSAEngine) -> AppConfigFragmentAdminRepository:
-        return AppConfigFragmentAdminRepository(db)
+        return AppConfigFragmentAdminRepository(db, DBOpsProvider(db))
 
     async def test_create_and_get_by_key(
         self,
@@ -128,7 +129,7 @@ class TestAppConfigFragmentAdminRepository:
 
     @pytest.fixture
     def admin_repository(self, db: ExtendedAsyncSAEngine) -> AppConfigFragmentAdminRepository:
-        return AppConfigFragmentAdminRepository(db)
+        return AppConfigFragmentAdminRepository(db, DBOpsProvider(db))
 
     async def test_update_replaces_config(
         self,

--- a/tests/unit/manager/repositories/app_config_fragment/test_app_config_fragment.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_app_config_fragment.py
@@ -1,0 +1,189 @@
+"""Repository tests for AppConfigFragment with real database."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from ai.backend.manager.data.app_config_fragment.types import (
+    AppConfigFragmentKey,
+    AppConfigScopeType,
+)
+from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
+from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.app_config_fragment.admin_repository import (
+    AppConfigFragmentAdminRepository,
+)
+from ai.backend.manager.repositories.app_config_fragment.repository import (
+    AppConfigFragmentRepository,
+)
+from ai.backend.testutils.db import with_tables
+
+
+class TestAppConfigFragmentRepository:
+    """Read-side tests for AppConfigFragmentRepository."""
+
+    @pytest.fixture
+    async def db(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                AppConfigFragmentRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    def repository(self, db: ExtendedAsyncSAEngine) -> AppConfigFragmentRepository:
+        return AppConfigFragmentRepository(db)
+
+    @pytest.fixture
+    def admin_repository(self, db: ExtendedAsyncSAEngine) -> AppConfigFragmentAdminRepository:
+        return AppConfigFragmentAdminRepository(db)
+
+    async def test_create_and_get_by_key(
+        self,
+        repository: AppConfigFragmentRepository,
+        admin_repository: AppConfigFragmentAdminRepository,
+    ) -> None:
+        key = AppConfigFragmentKey(
+            scope_type=AppConfigScopeType.DOMAIN,
+            scope_id="default",
+            name="theme",
+        )
+        created = await admin_repository.create(
+            key=key,
+            config={"color": "blue"},
+        )
+        assert created.scope_type == AppConfigScopeType.DOMAIN
+        assert created.scope_id == "default"
+        assert created.name == "theme"
+        # rank defaults to the DOMAIN tier when not explicitly provided.
+        assert created.rank == 200
+        assert created.config is not None
+        assert dict(created.config) == {"color": "blue"}
+
+        fetched = await repository.get(key)
+        assert fetched is not None
+        assert fetched.id == created.id
+        assert fetched.config is not None
+        assert dict(fetched.config) == {"color": "blue"}
+
+    async def test_get_by_id(
+        self,
+        repository: AppConfigFragmentRepository,
+        admin_repository: AppConfigFragmentAdminRepository,
+    ) -> None:
+        created = await admin_repository.create(
+            key=AppConfigFragmentKey(
+                scope_type=AppConfigScopeType.PUBLIC,
+                scope_id="public",
+                name="theme",
+            ),
+            config={"density": "comfortable"},
+        )
+        # rank defaults to the PUBLIC tier.
+        assert created.rank == 100
+
+        fetched = await repository.get_by_id(created.id)
+        assert fetched is not None
+        assert fetched.scope_type == AppConfigScopeType.PUBLIC
+        assert fetched.config is not None
+        assert dict(fetched.config) == {"density": "comfortable"}
+
+    async def test_get_raises_for_missing_key(
+        self,
+        repository: AppConfigFragmentRepository,
+    ) -> None:
+        with pytest.raises(AppConfigFragmentNotFound):
+            await repository.get(
+                AppConfigFragmentKey(
+                    scope_type=AppConfigScopeType.DOMAIN,
+                    scope_id="missing",
+                    name="theme",
+                )
+            )
+
+
+class TestAppConfigFragmentAdminRepository:
+    """Mutation-side tests for AppConfigFragmentAdminRepository."""
+
+    @pytest.fixture
+    async def db(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                AppConfigFragmentRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    def admin_repository(self, db: ExtendedAsyncSAEngine) -> AppConfigFragmentAdminRepository:
+        return AppConfigFragmentAdminRepository(db)
+
+    async def test_update_replaces_config(
+        self,
+        admin_repository: AppConfigFragmentAdminRepository,
+    ) -> None:
+        key = AppConfigFragmentKey(
+            scope_type=AppConfigScopeType.DOMAIN,
+            scope_id="default",
+            name="theme",
+        )
+        await admin_repository.create(key=key, config={"color": "blue"})
+        updated = await admin_repository.update(
+            key=key, config={"color": "red", "density": "compact"}
+        )
+        assert updated is not None
+        assert updated.config is not None
+        assert dict(updated.config) == {"color": "red", "density": "compact"}
+
+    async def test_update_raises_for_missing_key(
+        self,
+        admin_repository: AppConfigFragmentAdminRepository,
+    ) -> None:
+        with pytest.raises(AppConfigFragmentNotFound):
+            await admin_repository.update(
+                key=AppConfigFragmentKey(
+                    scope_type=AppConfigScopeType.DOMAIN,
+                    scope_id="missing",
+                    name="theme",
+                ),
+                config={"color": "blue"},
+            )
+
+    async def test_purge_existing_fragment_returns_true(
+        self,
+        admin_repository: AppConfigFragmentAdminRepository,
+    ) -> None:
+        key = AppConfigFragmentKey(
+            scope_type=AppConfigScopeType.DOMAIN,
+            scope_id="default",
+            name="theme",
+        )
+        await admin_repository.create(key=key, config={})
+        assert await admin_repository.purge(key) is True
+
+    async def test_purge_missing_fragment_returns_false(
+        self,
+        admin_repository: AppConfigFragmentAdminRepository,
+    ) -> None:
+        assert (
+            await admin_repository.purge(
+                AppConfigFragmentKey(
+                    scope_type=AppConfigScopeType.DOMAIN,
+                    scope_id="missing",
+                    name="theme",
+                )
+            )
+            is False
+        )


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 12-PR stack delivering BEP-1052 (rank-based AppConfig). **Merge in order:**

1. ⬇️ **#12224** — `feat(BA-6510): AppConfigFragment schema, value types & repo specs`
2. 👉 **#12225** — `feat(BA-6511): AppConfigFragment repository (CRUD + rank merge)` ← you are here
3. ⬇️ **#12226** — `feat(BA-6512): AppConfigFragment v2 DTOs + conditions/orders`
4. ⬇️ **#12244** — `feat(BA-6513): AppConfigFragment service layer (actions, processors)`
5. ⬇️ **#12228** — `feat(BA-6514): AppConfigFragment adapter`
6. ⬇️ **#12229** — `feat(BA-6515): merged-view scoped/admin backend + DTO + adapter`
7. ⬇️ **#12230** — `feat(BA-6516): AppConfigFragment GraphQL`
8. ⬇️ **#12231** — `feat(BA-6517): merged AppConfig GraphQL`
9. ⬇️ **#11286** — `feat(BA-5830): AppConfig/Fragment REST v2`
10. ⬇️ **#12232** — `feat(BA-6518): AppConfig v2 SDK`
11. ⬇️ **#12233** — `feat(BA-6519): AppConfig v2 CLI`
12. ⬇️ **#11298** — `feat(BA-5837): ValkeyCache for merged-view reads`

## Summary

Read/admin repositories over the shared DB source: raw CRUD + merged-view reads ordered by `rank` (no AppConfigPolicy). Repository tests.

