### PR TITLE
feat(BA-6512): AppConfigFragment v2 DTOs + query conditions/orders

### DIFF
--- a/changes/12226.feature.md
+++ b/changes/12226.feature.md
@@ -1,0 +1,1 @@
+Add AppConfigFragment v2 DTOs and model query conditions/orders.

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/__init__.py
@@ -1,0 +1,53 @@
+from .request import (
+    AdminAppConfigFragmentItemInput,
+    AdminBulkCreateAppConfigFragmentsInput,
+    AdminBulkPurgeAppConfigFragmentsInput,
+    AdminBulkUpdateAppConfigFragmentsInput,
+    AppConfigFragmentFilter,
+    AppConfigFragmentKeyInput,
+    AppConfigFragmentOrder,
+    MyAppConfigFragmentItemInput,
+    MyBulkCreateAppConfigFragmentsInput,
+    MyBulkUpdateAppConfigFragmentsInput,
+    SearchAppConfigFragmentsInput,
+)
+from .response import (
+    AdminBulkCreateAppConfigFragmentsPayload,
+    AdminBulkPurgeAppConfigFragmentsPayload,
+    AdminBulkUpdateAppConfigFragmentsPayload,
+    AppConfigFragmentBulkError,
+    AppConfigFragmentNode,
+    GetAppConfigFragmentPayload,
+    PurgeAppConfigFragmentKey,
+    SearchAppConfigFragmentsPayload,
+)
+from .types import (
+    AppConfigFragmentOrderField,
+    AppConfigScopeType,
+    OrderDirection,
+)
+
+__all__ = (
+    "AdminAppConfigFragmentItemInput",
+    "AdminBulkCreateAppConfigFragmentsInput",
+    "AdminBulkCreateAppConfigFragmentsPayload",
+    "AdminBulkPurgeAppConfigFragmentsInput",
+    "AdminBulkPurgeAppConfigFragmentsPayload",
+    "AdminBulkUpdateAppConfigFragmentsInput",
+    "AdminBulkUpdateAppConfigFragmentsPayload",
+    "AppConfigFragmentBulkError",
+    "AppConfigFragmentFilter",
+    "AppConfigFragmentKeyInput",
+    "AppConfigFragmentNode",
+    "AppConfigFragmentOrder",
+    "AppConfigFragmentOrderField",
+    "AppConfigScopeType",
+    "MyBulkCreateAppConfigFragmentsInput",
+    "MyBulkUpdateAppConfigFragmentsInput",
+    "GetAppConfigFragmentPayload",
+    "MyAppConfigFragmentItemInput",
+    "OrderDirection",
+    "PurgeAppConfigFragmentKey",
+    "SearchAppConfigFragmentsInput",
+    "SearchAppConfigFragmentsPayload",
+)

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/request.py
@@ -1,0 +1,121 @@
+"""
+Request DTOs for app_config_fragment DTO v2.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import Field
+
+from ai.backend.common.api_handlers import BaseRequestModel
+from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
+
+from .types import AppConfigFragmentOrderField, AppConfigScopeType, OrderDirection
+
+__all__ = (
+    "AdminAppConfigFragmentItemInput",
+    "AdminBulkCreateAppConfigFragmentsInput",
+    "AdminBulkPurgeAppConfigFragmentsInput",
+    "AdminBulkUpdateAppConfigFragmentsInput",
+    "AppConfigFragmentFilter",
+    "AppConfigFragmentKeyInput",
+    "AppConfigFragmentOrder",
+    "MyBulkCreateAppConfigFragmentsInput",
+    "MyBulkUpdateAppConfigFragmentsInput",
+    "MyAppConfigFragmentItemInput",
+    "SearchAppConfigFragmentsInput",
+)
+
+
+class AppConfigFragmentKeyInput(BaseRequestModel):
+    """Natural-key identifier for a single fragment row."""
+
+    scope_type: AppConfigScopeType = Field(description="Scope type.")
+    scope_id: str = Field(description="Scope id (e.g., domain name, user id, or `public`).")
+    name: str = Field(
+        min_length=1,
+        max_length=128,
+        description="Policy name.",
+    )
+
+
+class AppConfigFragmentFilter(BaseRequestModel):
+    """Filter for app-config fragment search."""
+
+    id: UUIDFilter | None = Field(default=None, description="Filter by row id.")
+    name: StringFilter | None = Field(default=None, description="Filter by policy name.")
+    scope_type: AppConfigScopeType | None = Field(default=None, description="Filter by scope_type.")
+    scope_id: StringFilter | None = Field(default=None, description="Filter by scope_id.")
+
+
+class AppConfigFragmentOrder(BaseRequestModel):
+    """Order specification for app-config fragments."""
+
+    field: AppConfigFragmentOrderField = Field(description="Field to order by.")
+    direction: OrderDirection = Field(default=OrderDirection.ASC, description="Order direction.")
+
+
+# ── Bulk mutation inputs ─────────────────────────────────────────
+
+
+class AdminAppConfigFragmentItemInput(BaseRequestModel):
+    """Per-item input for admin bulk create / update (natural key + payload)."""
+
+    key: AppConfigFragmentKeyInput = Field(description="Natural-key identifier.")
+    config: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Raw configuration payload (empty dict clears the row).",
+    )
+
+
+class AdminBulkCreateAppConfigFragmentsInput(BaseRequestModel):
+    items: list[AdminAppConfigFragmentItemInput] = Field(description="Rows to create.")
+
+
+class AdminBulkUpdateAppConfigFragmentsInput(BaseRequestModel):
+    items: list[AdminAppConfigFragmentItemInput] = Field(description="Rows to update.")
+
+
+class AdminBulkPurgeAppConfigFragmentsInput(BaseRequestModel):
+    keys: list[AppConfigFragmentKeyInput] = Field(description="Natural keys to purge.")
+
+
+class MyAppConfigFragmentItemInput(BaseRequestModel):
+    """Per-item input for self-service (`my`) bulk — `scope_type`
+    / `scope_id` are server-injected, so `name` is the only identifier.
+    """
+
+    name: str = Field(description="Policy name.")
+    config: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Raw configuration payload (empty dict clears the row).",
+    )
+
+
+class MyBulkCreateAppConfigFragmentsInput(BaseRequestModel):
+    items: list[MyAppConfigFragmentItemInput] = Field(description="USER-scope rows to create.")
+
+
+class MyBulkUpdateAppConfigFragmentsInput(BaseRequestModel):
+    items: list[MyAppConfigFragmentItemInput] = Field(description="USER-scope rows to update.")
+
+
+class SearchAppConfigFragmentsInput(BaseRequestModel):
+    """Input for searching fragments (raw rows) with filter / order / pagination.
+
+    Supports two pagination modes (mutually exclusive):
+    - Cursor-based: first/after (forward) or last/before (backward)
+    - Offset-based: limit/offset
+    """
+
+    filter: AppConfigFragmentFilter | None = Field(default=None, description="Filter conditions.")
+    order: list[AppConfigFragmentOrder] | None = Field(
+        default=None, description="Order specifications."
+    )
+    first: int | None = Field(default=None, ge=1, description="Number of items from the start.")
+    after: str | None = Field(default=None, description="Cursor to paginate forward from.")
+    last: int | None = Field(default=None, ge=1, description="Number of items from the end.")
+    before: str | None = Field(default=None, description="Cursor to paginate backward from.")
+    limit: int | None = Field(default=None, ge=1, le=1000, description="Maximum items to return.")
+    offset: int | None = Field(default=None, ge=0, description="Number of items to skip.")

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
@@ -1,0 +1,100 @@
+"""
+Response DTOs for app_config_fragment DTO v2.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import Field
+
+from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+
+from .types import AppConfigScopeType
+
+__all__ = (
+    "AdminBulkCreateAppConfigFragmentsPayload",
+    "AdminBulkPurgeAppConfigFragmentsPayload",
+    "AdminBulkUpdateAppConfigFragmentsPayload",
+    "AppConfigFragmentBulkError",
+    "AppConfigFragmentNode",
+    "GetAppConfigFragmentPayload",
+    "PurgeAppConfigFragmentKey",
+    "SearchAppConfigFragmentsPayload",
+)
+
+
+class AppConfigFragmentNode(BaseResponseModel):
+    """Node representing a single fragment row (raw per-scope payload)."""
+
+    id: AppConfigFragmentID = Field(description="Row ID.")
+    scope_type: AppConfigScopeType = Field(description="Scope type.")
+    scope_id: str = Field(description="Scope id.")
+    name: str = Field(description="Config name.")
+    rank: int = Field(description="Merge priority within `name` (low → high).")
+    config: dict[str, Any] | None = Field(
+        default=None, description="Raw configuration payload, or null."
+    )
+    created_at: datetime = Field(description="Creation timestamp.")
+    updated_at: datetime = Field(description="Last update timestamp.")
+
+
+class GetAppConfigFragmentPayload(BaseResponseModel):
+    """Payload returned after reading a single fragment by natural key."""
+
+    item: AppConfigFragmentNode | None = Field(default=None, description="Fragment data, or null.")
+
+
+class SearchAppConfigFragmentsPayload(BaseResponseModel):
+    """Payload for paginated fragment search results."""
+
+    items: list[AppConfigFragmentNode] = Field(description="Fragments matching the filter.")
+    total_count: int = Field(description="Total number of fragments matching the filter.")
+    has_next_page: bool = Field(default=False, description="Whether there is a next page.")
+    has_previous_page: bool = Field(default=False, description="Whether there is a previous page.")
+
+
+# ── Bulk mutation payloads (bulk-only writes) ────────────────────
+
+
+class AppConfigFragmentBulkError(BaseResponseModel):
+    """Per-item failure information for bulk Fragment mutations."""
+
+    index: int = Field(description="Original position in the input list.")
+    scope_type: AppConfigScopeType = Field(description="Scope type of the failed row.")
+    scope_id: str = Field(description="Scope id of the failed row.")
+    name: str = Field(description="Policy name of the failed row.")
+    message: str = Field(description="Reason for the failure.")
+
+
+class PurgeAppConfigFragmentKey(BaseResponseModel):
+    """Natural-key identifier returned by bulk purge payloads."""
+
+    scope_type: AppConfigScopeType = Field(description="Scope type.")
+    scope_id: str = Field(description="Scope id.")
+    name: str = Field(description="Policy name.")
+
+
+class AdminBulkCreateAppConfigFragmentsPayload(BaseResponseModel):
+    """Payload for `adminBulkCreateAppConfigFragments`."""
+
+    created: list[AppConfigFragmentNode] = Field(description="Created fragments.")
+    failed: list[AppConfigFragmentBulkError] = Field(description="Per-item failures.")
+
+
+class AdminBulkUpdateAppConfigFragmentsPayload(BaseResponseModel):
+    """Payload for `adminBulkUpdateAppConfigFragments`."""
+
+    updated: list[AppConfigFragmentNode] = Field(description="Updated fragments.")
+    failed: list[AppConfigFragmentBulkError] = Field(description="Per-item failures.")
+
+
+class AdminBulkPurgeAppConfigFragmentsPayload(BaseResponseModel):
+    """Payload for `adminBulkPurgeAppConfigFragments`."""
+
+    purged: list[PurgeAppConfigFragmentKey] = Field(
+        description="Keys of rows actually removed (absent keys are no-oped).",
+    )
+    failed: list[AppConfigFragmentBulkError] = Field(description="Per-item failures.")

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/types.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/types.py
@@ -1,0 +1,34 @@
+"""
+Common types for app_config_fragment DTO v2.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from ai.backend.common.dto.manager.v2.common import OrderDirection
+
+__all__ = (
+    "AppConfigFragmentOrderField",
+    "AppConfigScopeType",
+    "OrderDirection",
+)
+
+
+class AppConfigScopeType(StrEnum):
+    """Scope types for app-config fragments."""
+
+    PUBLIC = "public"
+    DOMAIN = "domain"
+    DOMAIN_USER_DEFAULTS = "domain_user_defaults"
+    USER = "user"
+
+
+class AppConfigFragmentOrderField(StrEnum):
+    """Fields available for ordering app-config fragments."""
+
+    SCOPE_TYPE = "scope_type"
+    SCOPE_ID = "scope_id"
+    NAME = "name"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"

--- a/src/ai/backend/manager/data/app_config_fragment/bulk_types.py
+++ b/src/ai/backend/manager/data/app_config_fragment/bulk_types.py
@@ -1,0 +1,44 @@
+"""Bulk-mutation service-layer dataclasses for app_config_fragments."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentKey
+
+
+@dataclass(frozen=True)
+class AppConfigFragmentBulkItem:
+    """One item for `adminBulkCreate/Update` — natural key + payload."""
+
+    key: AppConfigFragmentKey
+    config: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class MyAppConfigFragmentBulkItem:
+    """One item for `bulkCreate/UpdateMy` — `name` + payload.
+
+    `scope_type` is always `USER` and `scope_id` is resolved from the
+    current user at the adapter layer.
+    """
+
+    name: str
+    config: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class AppConfigFragmentBulkItemError:
+    """Per-item failure carried through bulk action results.
+
+    `scope_type` / `scope_id` / `name` identify which input row failed;
+    `index` preserves the caller's original list position.
+    """
+
+    index: int
+    scope_type: str
+    scope_id: str
+    name: str
+    message: str

--- a/src/ai/backend/manager/models/app_config_fragment/conditions.py
+++ b/src/ai/backend/manager/models/app_config_fragment/conditions.py
@@ -1,0 +1,191 @@
+"""Query conditions for the app_config_fragment domain."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Collection
+
+import sqlalchemy as sa
+
+from ai.backend.common.data.filter_specs import (
+    StringMatchSpec,
+    UUIDEqualMatchSpec,
+    UUIDInMatchSpec,
+)
+from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.models.condition_utils import make_string_in_factory
+from ai.backend.manager.repositories.base import QueryCondition
+
+
+class AppConfigFragmentConditions:
+    """QueryCondition factories for app-config fragment filtering."""
+
+    @staticmethod
+    def by_ids(fragment_ids: Collection[uuid.UUID]) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            return AppConfigFragmentRow.id.in_(fragment_ids)
+
+        return inner
+
+    @staticmethod
+    def by_id_equals(spec: UUIDEqualMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            condition = AppConfigFragmentRow.id == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_id_in(spec: UUIDInMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            condition = AppConfigFragmentRow.id.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_name_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AppConfigFragmentRow.name.ilike(f"%{spec.value}%")
+            else:
+                condition = AppConfigFragmentRow.name.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_name_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = sa.func.lower(AppConfigFragmentRow.name) == spec.value.lower()
+            else:
+                condition = AppConfigFragmentRow.name == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AppConfigFragmentRow.name.ilike(f"{spec.value}%")
+            else:
+                condition = AppConfigFragmentRow.name.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AppConfigFragmentRow.name.ilike(f"%{spec.value}")
+            else:
+                condition = AppConfigFragmentRow.name.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    by_name_in = staticmethod(make_string_in_factory(AppConfigFragmentRow.name))
+
+    @staticmethod
+    def by_scope_id_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AppConfigFragmentRow.scope_id.ilike(f"%{spec.value}%")
+            else:
+                condition = AppConfigFragmentRow.scope_id.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_scope_id_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = sa.func.lower(AppConfigFragmentRow.scope_id) == spec.value.lower()
+            else:
+                condition = AppConfigFragmentRow.scope_id == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_scope_id_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AppConfigFragmentRow.scope_id.ilike(f"{spec.value}%")
+            else:
+                condition = AppConfigFragmentRow.scope_id.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_scope_id_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AppConfigFragmentRow.scope_id.ilike(f"%{spec.value}")
+            else:
+                condition = AppConfigFragmentRow.scope_id.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    by_scope_id_in = staticmethod(make_string_in_factory(AppConfigFragmentRow.scope_id))
+
+    @staticmethod
+    def by_scope_type_equals(scope_type: str) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            return AppConfigFragmentRow.scope_type == scope_type
+
+        return inner
+
+    @staticmethod
+    def by_cursor_forward(cursor_id: str) -> QueryCondition:
+        cursor_uuid = uuid.UUID(cursor_id)
+
+        def inner() -> sa.ColumnElement[bool]:
+            subquery = (
+                sa.select(AppConfigFragmentRow.created_at)
+                .where(AppConfigFragmentRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return AppConfigFragmentRow.created_at < subquery
+
+        return inner
+
+    @staticmethod
+    def by_cursor_backward(cursor_id: str) -> QueryCondition:
+        cursor_uuid = uuid.UUID(cursor_id)
+
+        def inner() -> sa.ColumnElement[bool]:
+            subquery = (
+                sa.select(AppConfigFragmentRow.created_at)
+                .where(AppConfigFragmentRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return AppConfigFragmentRow.created_at > subquery
+
+        return inner

--- a/src/ai/backend/manager/models/app_config_fragment/orders.py
+++ b/src/ai/backend/manager/models/app_config_fragment/orders.py
@@ -1,0 +1,40 @@
+"""Query orders for the app_config_fragment domain."""
+
+from __future__ import annotations
+
+from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.repositories.base import QueryOrder
+
+
+class AppConfigFragmentOrders:
+    """QueryOrder factories for app-config fragment sorting."""
+
+    @staticmethod
+    def scope_type(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AppConfigFragmentRow.scope_type.asc()
+        return AppConfigFragmentRow.scope_type.desc()
+
+    @staticmethod
+    def scope_id(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AppConfigFragmentRow.scope_id.asc()
+        return AppConfigFragmentRow.scope_id.desc()
+
+    @staticmethod
+    def name(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AppConfigFragmentRow.name.asc()
+        return AppConfigFragmentRow.name.desc()
+
+    @staticmethod
+    def created_at(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AppConfigFragmentRow.created_at.asc()
+        return AppConfigFragmentRow.created_at.desc()
+
+    @staticmethod
+    def updated_at(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AppConfigFragmentRow.updated_at.asc()
+        return AppConfigFragmentRow.updated_at.desc()


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 12-PR stack delivering BEP-1052 (rank-based AppConfig). **Merge in order:**

1. ⬇️ **#12224** — `feat(BA-6510): AppConfigFragment schema, value types & repo specs`
2. ⬇️ **#12225** — `feat(BA-6511): AppConfigFragment repository (CRUD + rank merge)`
3. 👉 **#12226** — `feat(BA-6512): AppConfigFragment v2 DTOs + conditions/orders` ← you are here
4. ⬇️ **#12244** — `feat(BA-6513): AppConfigFragment service layer (actions, processors)`
5. ⬇️ **#12228** — `feat(BA-6514): AppConfigFragment adapter`
6. ⬇️ **#12229** — `feat(BA-6515): merged-view scoped/admin backend + DTO + adapter`
7. ⬇️ **#12230** — `feat(BA-6516): AppConfigFragment GraphQL`
8. ⬇️ **#12231** — `feat(BA-6517): merged AppConfig GraphQL`
9. ⬇️ **#11286** — `feat(BA-5830): AppConfig/Fragment REST v2`
10. ⬇️ **#12232** — `feat(BA-6518): AppConfig v2 SDK`
11. ⬇️ **#12233** — `feat(BA-6519): AppConfig v2 CLI`
12. ⬇️ **#11298** — `feat(BA-5837): ValkeyCache for merged-view reads`

## Summary

Request/response v2 DTOs (rank exposed), bulk types, and model-level query conditions/orders.

