### PR TITLE
feat(BA-6514): AppConfigFragment domain adapter

### DIFF
--- a/changes/12228.feature.md
+++ b/changes/12228.feature.md
@@ -1,0 +1,1 @@
+Add the AppConfigFragment domain adapter.

--- a/src/ai/backend/manager/api/adapters/app_config_fragment.py
+++ b/src/ai/backend/manager/api/adapters/app_config_fragment.py
@@ -1,0 +1,297 @@
+"""AppConfigFragment domain adapter — Pydantic-in / Pydantic-out transport layer."""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AdminBulkCreateAppConfigFragmentsInput,
+    AdminBulkPurgeAppConfigFragmentsInput,
+    AdminBulkUpdateAppConfigFragmentsInput,
+    AppConfigFragmentFilter,
+    AppConfigFragmentKeyInput,
+    AppConfigFragmentOrder,
+    SearchAppConfigFragmentsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AdminBulkCreateAppConfigFragmentsPayload,
+    AdminBulkPurgeAppConfigFragmentsPayload,
+    AdminBulkUpdateAppConfigFragmentsPayload,
+    AppConfigFragmentBulkError,
+    AppConfigFragmentNode,
+    GetAppConfigFragmentPayload,
+    PurgeAppConfigFragmentKey,
+    SearchAppConfigFragmentsPayload,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
+    AppConfigFragmentOrderField,
+    OrderDirection,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
+    AppConfigScopeType as AppConfigScopeTypeDTO,
+)
+from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
+from ai.backend.manager.data.app_config_fragment.bulk_types import (
+    AppConfigFragmentBulkItem,
+    AppConfigFragmentBulkItemError,
+)
+from ai.backend.manager.data.app_config_fragment.types import (
+    AppConfigFragmentData,
+    AppConfigFragmentKey,
+    AppConfigScopeType,
+)
+from ai.backend.manager.models.app_config_fragment.conditions import AppConfigFragmentConditions
+from ai.backend.manager.models.app_config_fragment.orders import AppConfigFragmentOrders
+from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.repositories.app_config_fragment.types import (
+    AppConfigFragmentSearchScope,
+)
+from ai.backend.manager.repositories.base import BatchQuerier, QueryCondition, QueryOrder
+from ai.backend.manager.services.app_config_fragment.actions.admin_bulk_create import (
+    AdminBulkCreateAppConfigFragmentsAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.admin_bulk_purge import (
+    AdminBulkPurgeAppConfigFragmentsAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.admin_bulk_update import (
+    AdminBulkUpdateAppConfigFragmentsAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.admin_search import (
+    AdminSearchAppConfigFragmentsAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.get import GetAppConfigFragmentAction
+from ai.backend.manager.services.app_config_fragment.actions.search import (
+    SearchAppConfigFragmentsAction,
+)
+
+from .base import BaseAdapter
+
+_PAGINATION_SPEC = PaginationSpec(
+    forward_order=AppConfigFragmentOrders.created_at(ascending=False),
+    backward_order=AppConfigFragmentOrders.created_at(ascending=True),
+    forward_condition_factory=AppConfigFragmentConditions.by_cursor_forward,
+    backward_condition_factory=AppConfigFragmentConditions.by_cursor_backward,
+    tiebreaker_order=AppConfigFragmentRow.id.asc(),
+)
+
+
+class AppConfigFragmentAdapter(BaseAdapter):
+    """Adapter for AppConfigFragment domain operations.
+
+    Writes are bulk-only; single-item create / update / purge entry
+    points are intentionally absent. Self-service my_bulk methods are
+    added with the merged-view DTOs in BA-5829.
+    """
+
+    async def get(self, key_input: AppConfigFragmentKeyInput) -> GetAppConfigFragmentPayload:
+        key = self._input_to_key(key_input)
+        result = await self._processors.app_config_fragment.get.wait_for_complete(
+            GetAppConfigFragmentAction(key=key)
+        )
+        return GetAppConfigFragmentPayload(
+            item=self._data_to_dto(result.fragment),
+        )
+
+    async def search(
+        self,
+        scope_type: AppConfigScopeType,
+        scope_id: str,
+        input: SearchAppConfigFragmentsInput,
+    ) -> SearchAppConfigFragmentsPayload:
+        """Scope-bound search — caller pins `(scope_type, scope_id)` so
+        non-admin users only see fragments within their own scope.
+        """
+        querier = self._build_querier_from_input(input)
+        result = await self._processors.app_config_fragment.search.wait_for_complete(
+            SearchAppConfigFragmentsAction(
+                scope=AppConfigFragmentSearchScope(
+                    scope_type=scope_type,
+                    scope_id=scope_id,
+                ),
+                querier=querier,
+            )
+        )
+        return SearchAppConfigFragmentsPayload(
+            items=[self._data_to_dto(item) for item in result.items],
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    async def admin_search(
+        self, input: SearchAppConfigFragmentsInput
+    ) -> SearchAppConfigFragmentsPayload:
+        """Cross-scope admin search — authorization is enforced upstream."""
+        querier = self._build_querier_from_input(input)
+        result = await self._processors.app_config_fragment_admin.admin_search.wait_for_complete(
+            AdminSearchAppConfigFragmentsAction(querier=querier)
+        )
+        return SearchAppConfigFragmentsPayload(
+            items=[self._data_to_dto(item) for item in result.items],
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    def _build_querier_from_input(self, input: SearchAppConfigFragmentsInput) -> BatchQuerier:
+        conditions = self._convert_filter(input.filter) if input.filter else []
+        orders = self._convert_orders(input.order) if input.order else []
+        return self._build_querier(
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=_PAGINATION_SPEC,
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+        )
+
+    def _convert_filter(self, filter: AppConfigFragmentFilter) -> list[QueryCondition]:
+        conditions: list[QueryCondition] = []
+        if filter.id is not None:
+            condition = self.convert_uuid_filter(
+                filter.id,
+                equals_factory=AppConfigFragmentConditions.by_id_equals,
+                in_factory=AppConfigFragmentConditions.by_id_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if filter.name is not None:
+            condition = self.convert_string_filter(
+                filter.name,
+                contains_factory=AppConfigFragmentConditions.by_name_contains,
+                equals_factory=AppConfigFragmentConditions.by_name_equals,
+                starts_with_factory=AppConfigFragmentConditions.by_name_starts_with,
+                ends_with_factory=AppConfigFragmentConditions.by_name_ends_with,
+                in_factory=AppConfigFragmentConditions.by_name_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if filter.scope_type is not None:
+            conditions.append(
+                AppConfigFragmentConditions.by_scope_type_equals(filter.scope_type.value)
+            )
+        if filter.scope_id is not None:
+            condition = self.convert_string_filter(
+                filter.scope_id,
+                contains_factory=AppConfigFragmentConditions.by_scope_id_contains,
+                equals_factory=AppConfigFragmentConditions.by_scope_id_equals,
+                starts_with_factory=AppConfigFragmentConditions.by_scope_id_starts_with,
+                ends_with_factory=AppConfigFragmentConditions.by_scope_id_ends_with,
+                in_factory=AppConfigFragmentConditions.by_scope_id_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        return conditions
+
+    @staticmethod
+    def _convert_orders(orders: list[AppConfigFragmentOrder]) -> list[QueryOrder]:
+        result: list[QueryOrder] = []
+        for order in orders:
+            ascending = order.direction == OrderDirection.ASC
+            match order.field:
+                case AppConfigFragmentOrderField.SCOPE_TYPE:
+                    result.append(AppConfigFragmentOrders.scope_type(ascending))
+                case AppConfigFragmentOrderField.SCOPE_ID:
+                    result.append(AppConfigFragmentOrders.scope_id(ascending))
+                case AppConfigFragmentOrderField.NAME:
+                    result.append(AppConfigFragmentOrders.name(ascending))
+                case AppConfigFragmentOrderField.CREATED_AT:
+                    result.append(AppConfigFragmentOrders.created_at(ascending))
+                case AppConfigFragmentOrderField.UPDATED_AT:
+                    result.append(AppConfigFragmentOrders.updated_at(ascending))
+        return result
+
+    @staticmethod
+    def _input_to_key(key_input: AppConfigFragmentKeyInput) -> AppConfigFragmentKey:
+        return AppConfigFragmentKey(
+            scope_type=AppConfigScopeType(key_input.scope_type.value),
+            scope_id=key_input.scope_id,
+            name=key_input.name,
+        )
+
+    @staticmethod
+    def _data_to_dto(data: AppConfigFragmentData) -> AppConfigFragmentNode:
+        return AppConfigFragmentNode(
+            id=data.id,
+            scope_type=AppConfigScopeTypeDTO(data.scope_type.value),
+            scope_id=data.scope_id,
+            name=data.name,
+            rank=data.rank,
+            config=dict(data.config) if data.config is not None else None,
+            created_at=data.created_at,
+            updated_at=data.updated_at,
+        )
+
+    # ── Bulk mutations ─────────────────────────────────────────────
+
+    async def admin_bulk_create(
+        self, input: AdminBulkCreateAppConfigFragmentsInput
+    ) -> AdminBulkCreateAppConfigFragmentsPayload:
+        items = [
+            AppConfigFragmentBulkItem(
+                key=self._input_to_key(item.key),
+                config=dict(item.config),
+            )
+            for item in input.items
+        ]
+        result = (
+            await self._processors.app_config_fragment_admin.admin_bulk_create.wait_for_complete(
+                AdminBulkCreateAppConfigFragmentsAction(items=items)
+            )
+        )
+        return AdminBulkCreateAppConfigFragmentsPayload(
+            created=[self._data_to_dto(fragment) for fragment in result.created],
+            failed=[self._bulk_error_to_dto(err) for err in result.failed],
+        )
+
+    async def admin_bulk_update(
+        self, input: AdminBulkUpdateAppConfigFragmentsInput
+    ) -> AdminBulkUpdateAppConfigFragmentsPayload:
+        items = [
+            AppConfigFragmentBulkItem(
+                key=self._input_to_key(item.key),
+                config=dict(item.config),
+            )
+            for item in input.items
+        ]
+        result = (
+            await self._processors.app_config_fragment_admin.admin_bulk_update.wait_for_complete(
+                AdminBulkUpdateAppConfigFragmentsAction(items=items)
+            )
+        )
+        return AdminBulkUpdateAppConfigFragmentsPayload(
+            updated=[self._data_to_dto(fragment) for fragment in result.updated],
+            failed=[self._bulk_error_to_dto(err) for err in result.failed],
+        )
+
+    async def admin_bulk_purge(
+        self, input: AdminBulkPurgeAppConfigFragmentsInput
+    ) -> AdminBulkPurgeAppConfigFragmentsPayload:
+        keys = [self._input_to_key(key) for key in input.keys]
+        result = (
+            await self._processors.app_config_fragment_admin.admin_bulk_purge.wait_for_complete(
+                AdminBulkPurgeAppConfigFragmentsAction(keys=keys)
+            )
+        )
+        return AdminBulkPurgeAppConfigFragmentsPayload(
+            purged=[
+                PurgeAppConfigFragmentKey(
+                    scope_type=AppConfigScopeTypeDTO(key.scope_type.value),
+                    scope_id=key.scope_id,
+                    name=key.name,
+                )
+                for key in result.purged
+            ],
+            failed=[self._bulk_error_to_dto(err) for err in result.failed],
+        )
+
+    @staticmethod
+    def _bulk_error_to_dto(err: AppConfigFragmentBulkItemError) -> AppConfigFragmentBulkError:
+        return AppConfigFragmentBulkError(
+            index=err.index,
+            scope_type=AppConfigScopeTypeDTO(err.scope_type),
+            scope_id=err.scope_id,
+            name=err.name,
+            message=err.message,
+        )

--- a/src/ai/backend/manager/api/adapters/registry.py
+++ b/src/ai/backend/manager/api/adapters/registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ai.backend.manager.api.adapters.agent.adapter import AgentAdapter
+from ai.backend.manager.api.adapters.app_config_fragment import AppConfigFragmentAdapter
 from ai.backend.manager.api.adapters.artifact.adapter import ArtifactAdapter
 from ai.backend.manager.api.adapters.artifact_registry.adapter import ArtifactRegistryAdapter
 from ai.backend.manager.api.adapters.audit_log.adapter import AuditLogAdapter
@@ -72,6 +73,7 @@ class Adapters:
     def __init__(
         self,
         agent: AgentAdapter,
+        app_config_fragment: AppConfigFragmentAdapter,
         artifact: ArtifactAdapter,
         artifact_registry: ArtifactRegistryAdapter,
         audit_log: AuditLogAdapter,
@@ -113,6 +115,7 @@ class Adapters:
         vfs_storage: VFSStorageAdapter,
     ) -> None:
         self.agent = agent
+        self.app_config_fragment = app_config_fragment
         self.artifact = artifact
         self.artifact_registry = artifact_registry
         self.audit_log = audit_log
@@ -173,6 +176,7 @@ class Adapters:
         """
         return cls(
             agent=AgentAdapter(processors),
+            app_config_fragment=AppConfigFragmentAdapter(processors),
             artifact=ArtifactAdapter(processors),
             artifact_registry=ArtifactRegistryAdapter(processors),
             audit_log=AuditLogAdapter(processors),


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 12-PR stack delivering BEP-1052 (rank-based AppConfig). **Merge in order:**

1. ⬇️ **#12224** — `feat(BA-6510): AppConfigFragment schema, value types & repo specs`
2. ⬇️ **#12225** — `feat(BA-6511): AppConfigFragment repository (CRUD + rank merge)`
3. ⬇️ **#12226** — `feat(BA-6512): AppConfigFragment v2 DTOs + conditions/orders`
4. ⬇️ **#12244** — `feat(BA-6513): AppConfigFragment service layer (actions, processors)`
5. 👉 **#12228** — `feat(BA-6514): AppConfigFragment adapter` ← you are here
6. ⬇️ **#12229** — `feat(BA-6515): merged-view scoped/admin backend + DTO + adapter`
7. ⬇️ **#12230** — `feat(BA-6516): AppConfigFragment GraphQL`
8. ⬇️ **#12231** — `feat(BA-6517): merged AppConfig GraphQL`
9. ⬇️ **#11286** — `feat(BA-5830): AppConfig/Fragment REST v2`
10. ⬇️ **#12232** — `feat(BA-6518): AppConfig v2 SDK`
11. ⬇️ **#12233** — `feat(BA-6519): AppConfig v2 CLI`
12. ⬇️ **#11298** — `feat(BA-5837): ValkeyCache for merged-view reads`

## Summary

Pydantic-in/out transport adapter shared by GraphQL and REST v2.


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12228.org.readthedocs.build/en/12228/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12228.org.readthedocs.build/ko/12228/

<!-- readthedocs-preview sorna-ko end -->
