### PR TITLE
feat(BA-6515): merged-view scoped/admin backend + DTO + adapter

### DIFF
--- a/changes/12229.feature.md
+++ b/changes/12229.feature.md
@@ -1,0 +1,1 @@
+Add the merged-view AppConfig scoped/admin search backend, DTOs, and adapter.

--- a/src/ai/backend/common/data/permission/types.py
+++ b/src/ai/backend/common/data/permission/types.py
@@ -268,6 +268,7 @@ class EntityType(enum.StrEnum):
             cls.ARTIFACT,
             cls.ARTIFACT_REGISTRY,
             cls.APP_CONFIG,
+            cls.APP_CONFIG_FRAGMENT,
             cls.NOTIFICATION_CHANNEL,
             cls.NOTIFICATION_RULE,
             cls.MODEL_DEPLOYMENT,
@@ -405,6 +406,7 @@ class RBACElementType(enum.StrEnum):
     ARTIFACT_REGISTRY = "artifact_registry"
     SESSION_TEMPLATE = "session_template"
     APP_CONFIG = "app_config"
+    APP_CONFIG_FRAGMENT = "app_config_fragment"
     MODEL_CARD = "model_card"
 
     # === Root-query-enabled entities (superadmin-only) ===

--- a/src/ai/backend/common/data/permission/types.py
+++ b/src/ai/backend/common/data/permission/types.py
@@ -268,7 +268,6 @@ class EntityType(enum.StrEnum):
             cls.ARTIFACT,
             cls.ARTIFACT_REGISTRY,
             cls.APP_CONFIG,
-            cls.APP_CONFIG_FRAGMENT,
             cls.NOTIFICATION_CHANNEL,
             cls.NOTIFICATION_RULE,
             cls.MODEL_DEPLOYMENT,
@@ -406,7 +405,6 @@ class RBACElementType(enum.StrEnum):
     ARTIFACT_REGISTRY = "artifact_registry"
     SESSION_TEMPLATE = "session_template"
     APP_CONFIG = "app_config"
-    APP_CONFIG_FRAGMENT = "app_config_fragment"
     MODEL_CARD = "model_card"
 
     # === Root-query-enabled entities (superadmin-only) ===

--- a/src/ai/backend/common/dto/manager/v2/app_config/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/__init__.py
@@ -1,0 +1,41 @@
+"""
+AppConfig (merged view) DTOs v2 for Manager API.
+"""
+
+from .request import (
+    AppConfigFilter,
+    AppConfigOrder,
+    AppConfigScope,
+    GetUserAppConfigInput,
+    ScopedSearchAppConfigsInput,
+    SearchAppConfigsInput,
+)
+from .response import (
+    AppConfigNode,
+    GetUserAppConfigPayload,
+    MyBulkCreateAppConfigFragmentsPayload,
+    MyBulkUpdateAppConfigFragmentsPayload,
+    SearchAppConfigsPayload,
+)
+from .types import (
+    AppConfigOrderField,
+    AppConfigScopeType,
+    OrderDirection,
+)
+
+__all__ = (
+    "AppConfigFilter",
+    "AppConfigNode",
+    "AppConfigOrder",
+    "AppConfigOrderField",
+    "AppConfigScope",
+    "AppConfigScopeType",
+    "MyBulkCreateAppConfigFragmentsPayload",
+    "MyBulkUpdateAppConfigFragmentsPayload",
+    "GetUserAppConfigInput",
+    "GetUserAppConfigPayload",
+    "OrderDirection",
+    "ScopedSearchAppConfigsInput",
+    "SearchAppConfigsInput",
+    "SearchAppConfigsPayload",
+)

--- a/src/ai/backend/common/dto/manager/v2/app_config/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/request.py
@@ -1,0 +1,106 @@
+"""
+Request DTOs for AppConfig (merged view) DTO v2.
+"""
+
+from __future__ import annotations
+
+from typing import Self
+from uuid import UUID
+
+from pydantic import Field, model_validator
+
+from ai.backend.common.api_handlers import BaseRequestModel
+from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter, UUIDFilter
+
+from .types import AppConfigOrderField, OrderDirection
+
+__all__ = (
+    "AppConfigFilter",
+    "AppConfigOrder",
+    "AppConfigScope",
+    "GetUserAppConfigInput",
+    "ScopedSearchAppConfigsInput",
+    "SearchAppConfigsInput",
+)
+
+
+class GetUserAppConfigInput(BaseRequestModel):
+    """Input for reading a single merged AppConfig for a target user
+    (admin path — the `my` variant resolves the user internally)."""
+
+    user_id: UUID = Field(description="Target user's UUID.")
+    name: str = Field(description="Policy / config name.")
+
+
+class AppConfigFilter(BaseRequestModel):
+    """Filter for AppConfig merged-view search.
+
+    `created_at` / `updated_at` filter against the **oldest** /
+    **latest** timestamp across the contributing fragments — the
+    natural projection of "when was this config first created" and
+    "when was it last touched".
+    """
+
+    name: StringFilter | None = Field(default=None, description="Filter by policy name.")
+    user_id: UUIDFilter | None = Field(
+        default=None,
+        description="Filter by target user id (admin cross-user search only).",
+    )
+    created_at: DateTimeFilter | None = Field(
+        default=None,
+        description=("Filter by the oldest contributing fragment's creation timestamp."),
+    )
+    updated_at: DateTimeFilter | None = Field(
+        default=None,
+        description=("Filter by the latest contributing fragment's update timestamp."),
+    )
+
+
+class AppConfigOrder(BaseRequestModel):
+    """Order specification for AppConfig merged-view results."""
+
+    field: AppConfigOrderField = Field(description="Field to order by.")
+    direction: OrderDirection = Field(default=OrderDirection.ASC, description="Order direction.")
+
+
+class _AppConfigSearchInputBase(BaseRequestModel):
+    filter: AppConfigFilter | None = Field(default=None, description="Filter conditions.")
+    order: list[AppConfigOrder] | None = Field(default=None, description="Order specifications.")
+    first: int | None = Field(default=None, ge=1, description="Number of items from the start.")
+    after: str | None = Field(default=None, description="Cursor to paginate forward from.")
+    last: int | None = Field(default=None, ge=1, description="Number of items from the end.")
+    before: str | None = Field(default=None, description="Cursor to paginate backward from.")
+    limit: int | None = Field(default=None, ge=1, le=1000, description="Maximum items to return.")
+    offset: int | None = Field(default=None, ge=0, description="Number of items to skip.")
+
+
+class AppConfigScope(BaseRequestModel):
+    """Scope for the scoped merged-view AppConfig query (user_ids are OR'd)."""
+
+    user_ids: list[UUID] = Field(
+        description="Target user UUIDs to scope the merged-view search to.",
+    )
+
+    @model_validator(mode="after")
+    def validate_non_empty(self) -> Self:
+        if not self.user_ids:
+            raise ValueError("AppConfigScope requires a non-empty 'user_ids'")
+        return self
+
+
+class ScopedSearchAppConfigsInput(_AppConfigSearchInputBase):
+    """Input for scoped (user-restricted) merged-view AppConfig search.
+
+    `scope.user_ids` are OR'd; non-admin callers are restricted to their
+    own user by RBAC at the adapter / processor boundary. Replaces the
+    former `my` variant — self-service is just a USER-scoped search.
+    """
+
+    scope: AppConfigScope = Field(description="Scope (OR across all user_ids).")
+
+
+class SearchAppConfigsInput(_AppConfigSearchInputBase):
+    """Input for admin cross-user merged-view search.
+
+    Optional `filter.user_id` pins the search to a single user.
+    """

--- a/src/ai/backend/common/dto/manager/v2/app_config/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/response.py
@@ -1,0 +1,83 @@
+"""
+Response DTOs for AppConfig (merged view) DTO v2.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from pydantic import Field
+
+from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AppConfigFragmentBulkError,
+    AppConfigFragmentNode,
+)
+
+__all__ = (
+    "AppConfigNode",
+    "MyBulkCreateAppConfigFragmentsPayload",
+    "MyBulkUpdateAppConfigFragmentsPayload",
+    "GetUserAppConfigPayload",
+    "SearchAppConfigsPayload",
+)
+
+
+class AppConfigNode(BaseResponseModel):
+    """Merged per-user AppConfig view.
+
+    `fragments` are ordered low → high merge priority (by fragment
+    `rank`). `config` is the deep-merged result, projected to `None`
+    when every contributing fragment is empty (§3 null projection).
+    """
+
+    user_id: UUID = Field(description="Target user's UUID.")
+    name: str = Field(description="Policy / config name.")
+    fragments: list[AppConfigFragmentNode] = Field(
+        description="Contributing fragments in merge order (low → high).",
+    )
+    config: dict[str, Any] | None = Field(
+        default=None,
+        description="Deep-merged configuration, or null when every fragment is empty.",
+    )
+
+
+class GetUserAppConfigPayload(BaseResponseModel):
+    """Payload for reading a single merged AppConfig."""
+
+    item: AppConfigNode | None = Field(
+        default=None,
+        description="Merged AppConfig, or null when no fragments exist for the user.",
+    )
+
+
+class SearchAppConfigsPayload(BaseResponseModel):
+    """Payload for paginated merged-view AppConfig search."""
+
+    items: list[AppConfigNode] = Field(description="AppConfigs matching the filter.")
+    total_count: int = Field(description="Total number of AppConfigs matching the filter.")
+    has_next_page: bool = Field(default=False, description="Whether there is a next page.")
+    has_previous_page: bool = Field(default=False, description="Whether there is a previous page.")
+
+
+class MyBulkCreateAppConfigFragmentsPayload(BaseResponseModel):
+    """Payload for `bulkCreateMyAppConfigFragments`.
+
+    Each successfully created row produces a recomputed merged
+    `AppConfigNode`; failures are collected per-item.
+    """
+
+    created: list[AppConfigNode] = Field(
+        description="Recomputed merged AppConfig views for each created USER fragment.",
+    )
+    failed: list[AppConfigFragmentBulkError] = Field(description="Per-item failures.")
+
+
+class MyBulkUpdateAppConfigFragmentsPayload(BaseResponseModel):
+    """Payload for `bulkUpdateMyAppConfigFragments`."""
+
+    updated: list[AppConfigNode] = Field(
+        description="Recomputed merged AppConfig views for each updated USER fragment.",
+    )
+    failed: list[AppConfigFragmentBulkError] = Field(description="Per-item failures.")

--- a/src/ai/backend/common/dto/manager/v2/app_config/types.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/types.py
@@ -1,0 +1,25 @@
+"""
+Common types for AppConfig (merged view) DTO v2.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import AppConfigScopeType
+from ai.backend.common.dto.manager.v2.common import OrderDirection
+
+__all__ = (
+    "AppConfigOrderField",
+    "AppConfigScopeType",
+    "OrderDirection",
+)
+
+
+class AppConfigOrderField(StrEnum):
+    """Fields available for ordering AppConfig merged-view results."""
+
+    USER_ID = "user_id"
+    NAME = "name"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/types.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/types.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.dto.manager.v2.common import OrderDirection
 
 __all__ = (
@@ -13,15 +14,6 @@ __all__ = (
     "AppConfigScopeType",
     "OrderDirection",
 )
-
-
-class AppConfigScopeType(StrEnum):
-    """Scope types for app-config fragments."""
-
-    PUBLIC = "public"
-    DOMAIN = "domain"
-    DOMAIN_USER_DEFAULTS = "domain_user_defaults"
-    USER = "user"
 
 
 class AppConfigFragmentOrderField(StrEnum):

--- a/src/ai/backend/manager/api/adapters/app_config.py
+++ b/src/ai/backend/manager/api/adapters/app_config.py
@@ -37,6 +37,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
     AppConfigScopeType as DTOAppConfigScopeType,
 )
 from ai.backend.common.exception import UnreachableError
+from ai.backend.manager.actions.action.types import SearchableActionTarget
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.data.app_config.types import AppConfigData
 from ai.backend.manager.data.app_config_fragment.bulk_types import (
@@ -46,7 +47,6 @@ from ai.backend.manager.data.app_config_fragment.bulk_types import (
 from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
 from ai.backend.manager.models.app_config_fragment.conditions import AppConfigFragmentConditions
 from ai.backend.manager.models.app_config_fragment.orders import AppConfigFragmentOrders
-from ai.backend.manager.actions.action.types import SearchableActionTarget
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
 from ai.backend.manager.repositories.base import BatchQuerier, QueryCondition, QueryOrder
 from ai.backend.manager.services.app_config_fragment.actions.admin_search_app_configs import (
@@ -260,6 +260,7 @@ class AppConfigAdapter(BaseAdapter):
             scope_type=DTOAppConfigScopeType(data.scope_type.value),
             scope_id=data.scope_id,
             name=data.name,
+            rank=data.rank,
             config=dict(data.config) if data.config is not None else None,
             created_at=data.created_at,
             updated_at=data.updated_at,

--- a/src/ai/backend/manager/api/adapters/app_config.py
+++ b/src/ai/backend/manager/api/adapters/app_config.py
@@ -1,0 +1,278 @@
+"""AppConfig (merged view) domain adapter
+
+Reads the per-user merged AppConfig view and writes the underlying USER
+fragments via the same `app_config_fragment` service processors. The
+merged-view surface lives on its own adapter (separate from
+`AppConfigFragmentAdapter`) so each adapter handles a single domain
+DTO surface — convention in this repo.
+"""
+
+from __future__ import annotations
+
+from ai.backend.common.contexts.user import current_user
+from ai.backend.common.dto.manager.v2.app_config.request import (
+    AppConfigFilter,
+    AppConfigOrder,
+    GetUserAppConfigInput,
+    ScopedSearchAppConfigsInput,
+    SearchAppConfigsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config.response import (
+    AppConfigNode,
+    GetUserAppConfigPayload,
+    MyBulkCreateAppConfigFragmentsPayload,
+    MyBulkUpdateAppConfigFragmentsPayload,
+    SearchAppConfigsPayload,
+)
+from ai.backend.common.dto.manager.v2.app_config.types import AppConfigOrderField, OrderDirection
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    MyBulkCreateAppConfigFragmentsInput,
+    MyBulkUpdateAppConfigFragmentsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AppConfigFragmentBulkError,
+    AppConfigFragmentNode,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
+    AppConfigScopeType as DTOAppConfigScopeType,
+)
+from ai.backend.common.exception import UnreachableError
+from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
+from ai.backend.manager.data.app_config.types import AppConfigData
+from ai.backend.manager.data.app_config_fragment.bulk_types import (
+    AppConfigFragmentBulkItemError,
+    MyAppConfigFragmentBulkItem,
+)
+from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
+from ai.backend.manager.models.app_config_fragment.conditions import AppConfigFragmentConditions
+from ai.backend.manager.models.app_config_fragment.orders import AppConfigFragmentOrders
+from ai.backend.manager.actions.action.types import SearchableActionTarget
+from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.repositories.base import BatchQuerier, QueryCondition, QueryOrder
+from ai.backend.manager.services.app_config_fragment.actions.admin_search_app_configs import (
+    AdminSearchAppConfigsAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.get_user_app_config import (
+    GetUserAppConfigAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.my_bulk_create import (
+    MyBulkCreateAppConfigFragmentsAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.my_bulk_update import (
+    MyBulkUpdateAppConfigFragmentsAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.scoped_search_app_configs import (
+    ScopedSearchAppConfigsAction,
+    UserAppConfigTarget,
+)
+
+from .base import BaseAdapter
+
+
+class AppConfigAdapter(BaseAdapter):
+    """Adapter for the merged AppConfig view.
+
+    Backed by the `app_config_fragment` service processors — the merged
+    view is computed from raw fragments — but exposed as a separate
+    transport-layer surface so the Fragment adapter stays focused on
+    raw-row operations.
+    """
+
+    # ── Reads ────────────────────────────────────────────────────────
+
+    async def my_app_config(self, name: str) -> GetUserAppConfigPayload:
+        """Read the caller's own merged AppConfig for `name`.
+
+        Resolves the current user from the context; there is no way to
+        target another user through this method.
+        """
+        me = current_user()
+        if me is None:
+            raise UnreachableError("User context is not available")
+        result = await self._processors.app_config_fragment.get_user_app_config.wait_for_complete(
+            GetUserAppConfigAction(user_id=me.user_id, config_name=name)
+        )
+        return GetUserAppConfigPayload(item=self._data_to_dto(result.app_config))
+
+    async def admin_get_user_app_config(
+        self, input: GetUserAppConfigInput
+    ) -> GetUserAppConfigPayload:
+        """Read a specific user's merged AppConfig (admin only)."""
+        result = await self._processors.app_config_fragment.get_user_app_config.wait_for_complete(
+            GetUserAppConfigAction(user_id=input.user_id, config_name=input.name)
+        )
+        return GetUserAppConfigPayload(item=self._data_to_dto(result.app_config))
+
+    async def scoped_search_app_configs(
+        self, input: ScopedSearchAppConfigsInput
+    ) -> SearchAppConfigsPayload:
+        """Scoped merged-view search; `scope.user_ids` are OR'd and each
+        target is RBAC-gated per item before the service runs. Self-service
+        is just a USER-scoped search over the caller's own user_id.
+        """
+        querier = self._build_querier_from_input(input)
+        targets: list[SearchableActionTarget] = [
+            UserAppConfigTarget(user_id=user_id) for user_id in input.scope.user_ids
+        ]
+        result = (
+            await self._processors.app_config_fragment.scoped_search_app_configs.wait_for_complete(
+                ScopedSearchAppConfigsAction(items=targets, querier=querier)
+            )
+        )
+        return SearchAppConfigsPayload(
+            items=[self._data_to_dto(item) for item in result.items],
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    async def admin_search_app_configs(
+        self, input: SearchAppConfigsInput
+    ) -> SearchAppConfigsPayload:
+        """Cross-user merged-view search (admin only).
+
+        `filter.user_id` pins the query to a single user; otherwise
+        pagination walks across every user.
+        """
+        querier = self._build_querier_from_input(input)
+        result = await self._processors.app_config_fragment_admin.admin_search_app_configs.wait_for_complete(
+            AdminSearchAppConfigsAction(querier=querier)
+        )
+        return SearchAppConfigsPayload(
+            items=[self._data_to_dto(item) for item in result.items],
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    # ── Self-service bulk writes ───────────────────────
+
+    async def my_bulk_create(
+        self, input: MyBulkCreateAppConfigFragmentsInput
+    ) -> MyBulkCreateAppConfigFragmentsPayload:
+        items = [
+            MyAppConfigFragmentBulkItem(name=item.name, config=dict(item.config))
+            for item in input.items
+        ]
+        result = await self._processors.app_config_fragment.my_bulk_create.wait_for_complete(
+            MyBulkCreateAppConfigFragmentsAction(items=items)
+        )
+        return MyBulkCreateAppConfigFragmentsPayload(
+            created=[self._data_to_dto(item) for item in result.created],
+            failed=[self._bulk_error_to_dto(err) for err in result.failed],
+        )
+
+    async def my_bulk_update(
+        self, input: MyBulkUpdateAppConfigFragmentsInput
+    ) -> MyBulkUpdateAppConfigFragmentsPayload:
+        items = [
+            MyAppConfigFragmentBulkItem(name=item.name, config=dict(item.config))
+            for item in input.items
+        ]
+        result = await self._processors.app_config_fragment.my_bulk_update.wait_for_complete(
+            MyBulkUpdateAppConfigFragmentsAction(items=items)
+        )
+        return MyBulkUpdateAppConfigFragmentsPayload(
+            updated=[self._data_to_dto(item) for item in result.updated],
+            failed=[self._bulk_error_to_dto(err) for err in result.failed],
+        )
+
+    # ── Querier / DTO helpers ────────────────────────────────────────
+
+    _PAGINATION_SPEC = PaginationSpec(
+        forward_order=AppConfigFragmentOrders.created_at(ascending=False),
+        backward_order=AppConfigFragmentOrders.created_at(ascending=True),
+        forward_condition_factory=AppConfigFragmentConditions.by_cursor_forward,
+        backward_condition_factory=AppConfigFragmentConditions.by_cursor_backward,
+        tiebreaker_order=AppConfigFragmentRow.id.asc(),
+    )
+
+    def _build_querier_from_input(
+        self,
+        input: ScopedSearchAppConfigsInput | SearchAppConfigsInput,
+    ) -> BatchQuerier:
+        """Querier builder for the merged-view searches.
+
+        The merged-view SQL resolves cursor / order internally via the
+        repository layer; this helper forwards only the filter / order /
+        pagination fields so cursor tiebreakers stay consistent with
+        the raw-fragment querier.
+        """
+        conditions = self._convert_filter(input.filter) if input.filter else []
+        orders = self._convert_orders(input.order) if input.order else []
+        return self._build_querier(
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=self._PAGINATION_SPEC,
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+        )
+
+    def _convert_filter(self, filter: AppConfigFilter) -> list[QueryCondition]:
+        conditions: list[QueryCondition] = []
+        if filter.name is not None:
+            condition = self.convert_string_filter(
+                filter.name,
+                contains_factory=AppConfigFragmentConditions.by_name_contains,
+                equals_factory=AppConfigFragmentConditions.by_name_equals,
+                starts_with_factory=AppConfigFragmentConditions.by_name_starts_with,
+                ends_with_factory=AppConfigFragmentConditions.by_name_ends_with,
+                in_factory=AppConfigFragmentConditions.by_name_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        # `filter.user_id` handling lives inside the merged-view SQL
+        # (repository layer) rather than in a BatchQuerier condition —
+        # see `AppConfigFragmentDBSource.admin_search_app_configs`.
+        return conditions
+
+    @staticmethod
+    def _convert_orders(orders: list[AppConfigOrder]) -> list[QueryOrder]:
+        result: list[QueryOrder] = []
+        for order in orders:
+            ascending = order.direction == OrderDirection.ASC
+            match order.field:
+                case AppConfigOrderField.NAME:
+                    result.append(AppConfigFragmentOrders.name(ascending))
+                case AppConfigOrderField.USER_ID:
+                    # USER_ID ordering is applied inside the merged-view SQL
+                    # because the raw `app_config_fragments` row does not
+                    # carry a user_id column directly.
+                    continue
+        return result
+
+    def _data_to_dto(self, data: AppConfigData) -> AppConfigNode:
+        return AppConfigNode(
+            user_id=data.user_id,
+            name=data.name,
+            fragments=[self._fragment_data_to_dto(fragment) for fragment in data.fragments],
+            config=dict(data.config) if data.config is not None else None,
+        )
+
+    @staticmethod
+    def _fragment_data_to_dto(data: AppConfigFragmentData) -> AppConfigFragmentNode:
+        return AppConfigFragmentNode(
+            id=data.id,
+            scope_type=DTOAppConfigScopeType(data.scope_type.value),
+            scope_id=data.scope_id,
+            name=data.name,
+            config=dict(data.config) if data.config is not None else None,
+            created_at=data.created_at,
+            updated_at=data.updated_at,
+        )
+
+    @staticmethod
+    def _bulk_error_to_dto(
+        err: AppConfigFragmentBulkItemError,
+    ) -> AppConfigFragmentBulkError:
+        return AppConfigFragmentBulkError(
+            index=err.index,
+            scope_type=DTOAppConfigScopeType(err.scope_type),
+            scope_id=err.scope_id,
+            name=err.name,
+            message=err.message,
+        )

--- a/src/ai/backend/manager/api/adapters/app_config.py
+++ b/src/ai/backend/manager/api/adapters/app_config.py
@@ -39,12 +39,11 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
 from ai.backend.common.exception import UnreachableError
 from ai.backend.manager.actions.action.types import SearchableActionTarget
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
-from ai.backend.manager.data.app_config.types import AppConfigData
 from ai.backend.manager.data.app_config_fragment.bulk_types import (
     AppConfigFragmentBulkItemError,
     MyAppConfigFragmentBulkItem,
 )
-from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
+from ai.backend.manager.data.app_config_fragment.types import AppConfigData, AppConfigFragmentData
 from ai.backend.manager.models.app_config_fragment.conditions import AppConfigFragmentConditions
 from ai.backend.manager.models.app_config_fragment.orders import AppConfigFragmentOrders
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow

--- a/src/ai/backend/manager/api/adapters/app_config_fragment.py
+++ b/src/ai/backend/manager/api/adapters/app_config_fragment.py
@@ -1,4 +1,8 @@
-"""AppConfigFragment domain adapter — Pydantic-in / Pydantic-out transport layer."""
+"""AppConfigFragment domain adapter — Pydantic-in / Pydantic-out transport layer.
+
+Raw fragment-row operations only. The merged-view (AppConfig) surface
+and the self-service `my_bulk_*` writes live on `AppConfigAdapter`.
+"""
 
 from __future__ import annotations
 
@@ -26,7 +30,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
     OrderDirection,
 )
 from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
-    AppConfigScopeType as AppConfigScopeTypeDTO,
+    AppConfigScopeType as DTOAppConfigScopeType,
 )
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.data.app_config_fragment.bulk_types import (
@@ -41,9 +45,7 @@ from ai.backend.manager.data.app_config_fragment.types import (
 from ai.backend.manager.models.app_config_fragment.conditions import AppConfigFragmentConditions
 from ai.backend.manager.models.app_config_fragment.orders import AppConfigFragmentOrders
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
-from ai.backend.manager.repositories.app_config_fragment.types import (
-    AppConfigFragmentSearchScope,
-)
+from ai.backend.manager.repositories.app_config_fragment.types import AppConfigFragmentSearchScope
 from ai.backend.manager.repositories.base import BatchQuerier, QueryCondition, QueryOrder
 from ai.backend.manager.services.app_config_fragment.actions.admin_bulk_create import (
     AdminBulkCreateAppConfigFragmentsAction,
@@ -64,21 +66,14 @@ from ai.backend.manager.services.app_config_fragment.actions.search import (
 
 from .base import BaseAdapter
 
-_PAGINATION_SPEC = PaginationSpec(
-    forward_order=AppConfigFragmentOrders.created_at(ascending=False),
-    backward_order=AppConfigFragmentOrders.created_at(ascending=True),
-    forward_condition_factory=AppConfigFragmentConditions.by_cursor_forward,
-    backward_condition_factory=AppConfigFragmentConditions.by_cursor_backward,
-    tiebreaker_order=AppConfigFragmentRow.id.asc(),
-)
-
 
 class AppConfigFragmentAdapter(BaseAdapter):
-    """Adapter for AppConfigFragment domain operations.
+    """Adapter for AppConfigFragment raw-row operations.
 
-    Writes are bulk-only; single-item create / update / purge entry
-    points are intentionally absent. Self-service my_bulk methods are
-    added with the merged-view DTOs in BA-5829.
+    Writes are bulk-only; single-item create / update /
+    purge entry points are intentionally absent. Self-service my_bulk
+    writes (which return the recomputed merged view) live on
+    `AppConfigAdapter` alongside the merged-view reads.
     """
 
     async def get(self, key_input: AppConfigFragmentKeyInput) -> GetAppConfigFragmentPayload:
@@ -131,13 +126,21 @@ class AppConfigFragmentAdapter(BaseAdapter):
             has_previous_page=result.has_previous_page,
         )
 
+    _PAGINATION_SPEC = PaginationSpec(
+        forward_order=AppConfigFragmentOrders.created_at(ascending=False),
+        backward_order=AppConfigFragmentOrders.created_at(ascending=True),
+        forward_condition_factory=AppConfigFragmentConditions.by_cursor_forward,
+        backward_condition_factory=AppConfigFragmentConditions.by_cursor_backward,
+        tiebreaker_order=AppConfigFragmentRow.id.asc(),
+    )
+
     def _build_querier_from_input(self, input: SearchAppConfigFragmentsInput) -> BatchQuerier:
         conditions = self._convert_filter(input.filter) if input.filter else []
         orders = self._convert_orders(input.order) if input.order else []
         return self._build_querier(
             conditions=conditions,
             orders=orders,
-            pagination_spec=_PAGINATION_SPEC,
+            pagination_spec=self._PAGINATION_SPEC,
             first=input.first,
             after=input.after,
             last=input.last,
@@ -214,7 +217,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
     def _data_to_dto(data: AppConfigFragmentData) -> AppConfigFragmentNode:
         return AppConfigFragmentNode(
             id=data.id,
-            scope_type=AppConfigScopeTypeDTO(data.scope_type.value),
+            scope_type=DTOAppConfigScopeType(data.scope_type.value),
             scope_id=data.scope_id,
             name=data.name,
             rank=data.rank,
@@ -223,7 +226,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
             updated_at=data.updated_at,
         )
 
-    # ── Bulk mutations ─────────────────────────────────────────────
+    # ── Bulk mutations ───────────────────────────────
 
     async def admin_bulk_create(
         self, input: AdminBulkCreateAppConfigFragmentsInput
@@ -268,7 +271,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
     async def admin_bulk_purge(
         self, input: AdminBulkPurgeAppConfigFragmentsInput
     ) -> AdminBulkPurgeAppConfigFragmentsPayload:
-        keys = [self._input_to_key(key) for key in input.keys]
+        keys = [self._input_to_key(key_input) for key_input in input.keys]
         result = (
             await self._processors.app_config_fragment_admin.admin_bulk_purge.wait_for_complete(
                 AdminBulkPurgeAppConfigFragmentsAction(keys=keys)
@@ -277,7 +280,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
         return AdminBulkPurgeAppConfigFragmentsPayload(
             purged=[
                 PurgeAppConfigFragmentKey(
-                    scope_type=AppConfigScopeTypeDTO(key.scope_type.value),
+                    scope_type=DTOAppConfigScopeType(key.scope_type.value),
                     scope_id=key.scope_id,
                     name=key.name,
                 )
@@ -287,10 +290,13 @@ class AppConfigFragmentAdapter(BaseAdapter):
         )
 
     @staticmethod
-    def _bulk_error_to_dto(err: AppConfigFragmentBulkItemError) -> AppConfigFragmentBulkError:
+    def _bulk_error_to_dto(
+        err: AppConfigFragmentBulkItemError,
+    ) -> AppConfigFragmentBulkError:
+        """Convert the service-layer error dataclass to its DTO mirror."""
         return AppConfigFragmentBulkError(
             index=err.index,
-            scope_type=AppConfigScopeTypeDTO(err.scope_type),
+            scope_type=DTOAppConfigScopeType(err.scope_type),
             scope_id=err.scope_id,
             name=err.name,
             message=err.message,

--- a/src/ai/backend/manager/api/adapters/registry.py
+++ b/src/ai/backend/manager/api/adapters/registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ai.backend.manager.api.adapters.agent.adapter import AgentAdapter
+from ai.backend.manager.api.adapters.app_config import AppConfigAdapter
 from ai.backend.manager.api.adapters.app_config_fragment import AppConfigFragmentAdapter
 from ai.backend.manager.api.adapters.artifact.adapter import ArtifactAdapter
 from ai.backend.manager.api.adapters.artifact_registry.adapter import ArtifactRegistryAdapter
@@ -73,6 +74,7 @@ class Adapters:
     def __init__(
         self,
         agent: AgentAdapter,
+        app_config: AppConfigAdapter,
         app_config_fragment: AppConfigFragmentAdapter,
         artifact: ArtifactAdapter,
         artifact_registry: ArtifactRegistryAdapter,
@@ -115,6 +117,7 @@ class Adapters:
         vfs_storage: VFSStorageAdapter,
     ) -> None:
         self.agent = agent
+        self.app_config = app_config
         self.app_config_fragment = app_config_fragment
         self.artifact = artifact
         self.artifact_registry = artifact_registry
@@ -176,6 +179,7 @@ class Adapters:
         """
         return cls(
             agent=AgentAdapter(processors),
+            app_config=AppConfigAdapter(processors),
             app_config_fragment=AppConfigFragmentAdapter(processors),
             artifact=ArtifactAdapter(processors),
             artifact_registry=ArtifactRegistryAdapter(processors),

--- a/src/ai/backend/manager/services/app_config_fragment/actions/admin_search_app_configs.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/admin_search_app_configs.py
@@ -5,7 +5,7 @@ from typing import override
 
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.data.app_config.types import AppConfigData
+from ai.backend.manager.data.app_config_fragment.types import AppConfigData
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.services.app_config_fragment.actions.base import AppConfigFragmentAction
 

--- a/src/ai/backend/manager/services/app_config_fragment/actions/admin_search_app_configs.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/admin_search_app_configs.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.app_config.types import AppConfigData
+from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.services.app_config_fragment.actions.base import AppConfigFragmentAction
+
+
+@dataclass
+class AdminSearchAppConfigsAction(AppConfigFragmentAction):
+    """Cross-user merged-view search(admin only)."""
+
+    querier: BatchQuerier
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.SEARCH
+
+
+@dataclass
+class AdminSearchAppConfigsActionResult(BaseActionResult):
+    items: list[AppConfigData]
+    total_count: int
+    has_next_page: bool
+    has_previous_page: bool
+
+    @override
+    def entity_id(self) -> str | None:
+        return None

--- a/src/ai/backend/manager/services/app_config_fragment/actions/base.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/base.py
@@ -13,7 +13,7 @@ class AppConfigFragmentAction(BaseAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EntityType.APP_CONFIG_FRAGMENT
+        return EntityType.APP_CONFIG
 
 
 @dataclass(frozen=True)
@@ -25,7 +25,7 @@ class AppConfigFragmentTarget(ActionTarget):
     @override
     def to_rbac_element_ref(self) -> RBACElementRef:
         return RBACElementRef(
-            element_type=RBACElementType.APP_CONFIG_FRAGMENT,
+            element_type=RBACElementType.APP_CONFIG,
             element_id=f"{self.key.scope_type}:{self.key.scope_id}:{self.key.name}",
         )
 
@@ -40,6 +40,6 @@ class MyAppConfigFragmentTarget(ActionTarget):
     @override
     def to_rbac_element_ref(self) -> RBACElementRef:
         return RBACElementRef(
-            element_type=RBACElementType.APP_CONFIG_FRAGMENT,
+            element_type=RBACElementType.APP_CONFIG,
             element_id=self.name,
         )

--- a/src/ai/backend/manager/services/app_config_fragment/actions/get_user_app_config.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/get_user_app_config.py
@@ -1,0 +1,34 @@
+import uuid
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.app_config.types import AppConfigData
+from ai.backend.manager.services.app_config_fragment.actions.base import AppConfigFragmentAction
+
+
+@dataclass
+class GetUserAppConfigAction(AppConfigFragmentAction):
+    """Resolve a single per-user merged AppConfig."""
+
+    user_id: uuid.UUID
+    config_name: str
+
+    @override
+    def entity_id(self) -> str | None:
+        return f"{self.user_id}:{self.config_name}"
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+
+@dataclass
+class GetUserAppConfigActionResult(BaseActionResult):
+    app_config: AppConfigData
+
+    @override
+    def entity_id(self) -> str | None:
+        return f"{self.app_config.user_id}:{self.app_config.name}"

--- a/src/ai/backend/manager/services/app_config_fragment/actions/get_user_app_config.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/get_user_app_config.py
@@ -4,7 +4,7 @@ from typing import override
 
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.data.app_config.types import AppConfigData
+from ai.backend.manager.data.app_config_fragment.types import AppConfigData
 from ai.backend.manager.services.app_config_fragment.actions.base import AppConfigFragmentAction
 
 

--- a/src/ai/backend/manager/services/app_config_fragment/actions/scoped_search_app_configs.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/scoped_search_app_configs.py
@@ -1,0 +1,74 @@
+"""Scoped merged-view (AppConfig) search action and its searchable targets."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import EntityType, RBACElementType
+from ai.backend.manager.actions.action.bulk import BaseBulkAction, BaseBulkActionResult
+from ai.backend.manager.actions.action.types import SearchableActionTarget
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.app_config.types import AppConfigData
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.repositories.app_config_fragment.types import UserAppConfigSearchScope
+from ai.backend.manager.repositories.base import BatchQuerier, SearchScope
+
+
+@dataclass(frozen=True)
+class UserAppConfigTarget(SearchableActionTarget):
+    """Scope item keyed by a target ``user_id`` in the merged view."""
+
+    user_id: uuid.UUID
+
+    @override
+    def to_rbac_element_ref(self) -> RBACElementRef:
+        return RBACElementRef(
+            element_type=RBACElementType.USER,
+            element_id=str(self.user_id),
+        )
+
+    @override
+    def to_search_scope(self) -> SearchScope:
+        return UserAppConfigSearchScope(user_id=self.user_id)
+
+
+@dataclass
+class ScopedSearchAppConfigsAction(BaseBulkAction[SearchableActionTarget]):
+    """Scoped merged-view search; targets are OR'd and RBAC-gated per target."""
+
+    items: list[SearchableActionTarget]
+    querier: BatchQuerier
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.APP_CONFIG
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.SEARCH
+
+    @override
+    def targets(self) -> Sequence[SearchableActionTarget]:
+        return list(self.items)
+
+
+@dataclass
+class ScopedSearchAppConfigsActionResult(BaseBulkActionResult):
+    items: list[AppConfigData]
+    total_count: int
+    has_next_page: bool
+    has_previous_page: bool
+    queried_refs: list[RBACElementRef]
+
+    @override
+    def element_refs(self) -> list[RBACElementRef]:
+        return list(self.queried_refs)

--- a/src/ai/backend/manager/services/app_config_fragment/actions/scoped_search_app_configs.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/scoped_search_app_configs.py
@@ -11,7 +11,7 @@ from ai.backend.common.data.permission.types import EntityType, RBACElementType
 from ai.backend.manager.actions.action.bulk import BaseBulkAction, BaseBulkActionResult
 from ai.backend.manager.actions.action.types import SearchableActionTarget
 from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.data.app_config.types import AppConfigData
+from ai.backend.manager.data.app_config_fragment.types import AppConfigData
 from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.repositories.app_config_fragment.types import UserAppConfigSearchScope
 from ai.backend.manager.repositories.base import BatchQuerier, SearchScope

--- a/src/ai/backend/manager/services/app_config_fragment/admin_processors.py
+++ b/src/ai/backend/manager/services/app_config_fragment/admin_processors.py
@@ -21,6 +21,10 @@ from ai.backend.manager.services.app_config_fragment.actions.admin_search import
     AdminSearchAppConfigFragmentsAction,
     AdminSearchAppConfigFragmentsActionResult,
 )
+from ai.backend.manager.services.app_config_fragment.actions.admin_search_app_configs import (
+    AdminSearchAppConfigsAction,
+    AdminSearchAppConfigsActionResult,
+)
 from ai.backend.manager.services.app_config_fragment.admin_service import (
     AppConfigFragmentAdminService,
 )
@@ -29,6 +33,9 @@ from ai.backend.manager.services.app_config_fragment.admin_service import (
 class AppConfigFragmentAdminProcessors(AbstractProcessorPackage):
     admin_search: ActionProcessor[
         AdminSearchAppConfigFragmentsAction, AdminSearchAppConfigFragmentsActionResult
+    ]
+    admin_search_app_configs: ActionProcessor[
+        AdminSearchAppConfigsAction, AdminSearchAppConfigsActionResult
     ]
     # Bulk mutations — wrapped by BulkActionProcessor so validators
     # (RBAC, etc.) can filter entity_ids per-item before the service
@@ -51,6 +58,9 @@ class AppConfigFragmentAdminProcessors(AbstractProcessorPackage):
         validators: ActionValidators,
     ) -> None:
         self.admin_search = ActionProcessor(service.admin_search, action_monitors)
+        self.admin_search_app_configs = ActionProcessor(
+            service.admin_search_app_configs, action_monitors
+        )
         self.admin_bulk_create = BulkActionProcessor(service.admin_bulk_create, action_monitors)
         self.admin_bulk_update = BulkActionProcessor(service.admin_bulk_update, action_monitors)
         self.admin_bulk_purge = BulkActionProcessor(service.admin_bulk_purge, action_monitors)
@@ -59,6 +69,7 @@ class AppConfigFragmentAdminProcessors(AbstractProcessorPackage):
     def supported_actions(self) -> list[ActionSpec]:
         return [
             AdminSearchAppConfigFragmentsAction.spec(),
+            AdminSearchAppConfigsAction.spec(),
             AdminBulkCreateAppConfigFragmentsAction.spec(),
             AdminBulkUpdateAppConfigFragmentsAction.spec(),
             AdminBulkPurgeAppConfigFragmentsAction.spec(),

--- a/src/ai/backend/manager/services/app_config_fragment/admin_service.py
+++ b/src/ai/backend/manager/services/app_config_fragment/admin_service.py
@@ -24,6 +24,10 @@ from ai.backend.manager.services.app_config_fragment.actions.admin_search import
     AdminSearchAppConfigFragmentsAction,
     AdminSearchAppConfigFragmentsActionResult,
 )
+from ai.backend.manager.services.app_config_fragment.actions.admin_search_app_configs import (
+    AdminSearchAppConfigsAction,
+    AdminSearchAppConfigsActionResult,
+)
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -41,6 +45,17 @@ class AppConfigFragmentAdminService:
     ) -> AdminSearchAppConfigFragmentsActionResult:
         result = await self._admin_repository.admin_search(action.querier)
         return AdminSearchAppConfigFragmentsActionResult(
+            items=result.items,
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    async def admin_search_app_configs(
+        self, action: AdminSearchAppConfigsAction
+    ) -> AdminSearchAppConfigsActionResult:
+        result = await self._admin_repository.admin_search_app_configs(action.querier)
+        return AdminSearchAppConfigsActionResult(
             items=result.items,
             total_count=result.total_count,
             has_next_page=result.has_next_page,

--- a/src/ai/backend/manager/services/app_config_fragment/processors.py
+++ b/src/ai/backend/manager/services/app_config_fragment/processors.py
@@ -9,6 +9,10 @@ from ai.backend.manager.services.app_config_fragment.actions.get import (
     GetAppConfigFragmentAction,
     GetAppConfigFragmentActionResult,
 )
+from ai.backend.manager.services.app_config_fragment.actions.get_user_app_config import (
+    GetUserAppConfigAction,
+    GetUserAppConfigActionResult,
+)
 from ai.backend.manager.services.app_config_fragment.actions.my_bulk_create import (
     MyBulkCreateAppConfigFragmentsAction,
     MyBulkCreateAppConfigFragmentsActionResult,
@@ -21,12 +25,20 @@ from ai.backend.manager.services.app_config_fragment.actions.search import (
     SearchAppConfigFragmentsAction,
     SearchAppConfigFragmentsActionResult,
 )
+from ai.backend.manager.services.app_config_fragment.actions.scoped_search_app_configs import (
+    ScopedSearchAppConfigsAction,
+    ScopedSearchAppConfigsActionResult,
+)
 from ai.backend.manager.services.app_config_fragment.service import AppConfigFragmentService
 
 
 class AppConfigFragmentProcessors(AbstractProcessorPackage):
     get: ActionProcessor[GetAppConfigFragmentAction, GetAppConfigFragmentActionResult]
     search: ActionProcessor[SearchAppConfigFragmentsAction, SearchAppConfigFragmentsActionResult]
+    get_user_app_config: ActionProcessor[GetUserAppConfigAction, GetUserAppConfigActionResult]
+    scoped_search_app_configs: BulkActionProcessor[
+        ScopedSearchAppConfigsAction, ScopedSearchAppConfigsActionResult
+    ]
     # Bulk mutations — wrapped by BulkActionProcessor so validators
     # (RBAC, etc.) can filter entity_ids per-item before the service
     # runs. No bulk validators are wired today; the processor simply
@@ -46,6 +58,10 @@ class AppConfigFragmentProcessors(AbstractProcessorPackage):
     ) -> None:
         self.get = ActionProcessor(service.get, action_monitors)
         self.search = ActionProcessor(service.search, action_monitors)
+        self.get_user_app_config = ActionProcessor(service.get_user_app_config, action_monitors)
+        self.scoped_search_app_configs = BulkActionProcessor(
+            service.scoped_search_app_configs, action_monitors
+        )
         self.my_bulk_create = BulkActionProcessor(service.my_bulk_create, action_monitors)
         self.my_bulk_update = BulkActionProcessor(service.my_bulk_update, action_monitors)
 
@@ -54,6 +70,8 @@ class AppConfigFragmentProcessors(AbstractProcessorPackage):
         return [
             GetAppConfigFragmentAction.spec(),
             SearchAppConfigFragmentsAction.spec(),
+            GetUserAppConfigAction.spec(),
+            ScopedSearchAppConfigsAction.spec(),
             MyBulkCreateAppConfigFragmentsAction.spec(),
             MyBulkUpdateAppConfigFragmentsAction.spec(),
         ]

--- a/src/ai/backend/manager/services/app_config_fragment/processors.py
+++ b/src/ai/backend/manager/services/app_config_fragment/processors.py
@@ -21,13 +21,13 @@ from ai.backend.manager.services.app_config_fragment.actions.my_bulk_update impo
     MyBulkUpdateAppConfigFragmentsAction,
     MyBulkUpdateAppConfigFragmentsActionResult,
 )
-from ai.backend.manager.services.app_config_fragment.actions.search import (
-    SearchAppConfigFragmentsAction,
-    SearchAppConfigFragmentsActionResult,
-)
 from ai.backend.manager.services.app_config_fragment.actions.scoped_search_app_configs import (
     ScopedSearchAppConfigsAction,
     ScopedSearchAppConfigsActionResult,
+)
+from ai.backend.manager.services.app_config_fragment.actions.search import (
+    SearchAppConfigFragmentsAction,
+    SearchAppConfigFragmentsActionResult,
 )
 from ai.backend.manager.services.app_config_fragment.service import AppConfigFragmentService
 

--- a/src/ai/backend/manager/services/app_config_fragment/service.py
+++ b/src/ai/backend/manager/services/app_config_fragment/service.py
@@ -33,13 +33,13 @@ from ai.backend.manager.services.app_config_fragment.actions.my_bulk_update impo
     MyBulkUpdateAppConfigFragmentsAction,
     MyBulkUpdateAppConfigFragmentsActionResult,
 )
-from ai.backend.manager.services.app_config_fragment.actions.search import (
-    SearchAppConfigFragmentsAction,
-    SearchAppConfigFragmentsActionResult,
-)
 from ai.backend.manager.services.app_config_fragment.actions.scoped_search_app_configs import (
     ScopedSearchAppConfigsAction,
     ScopedSearchAppConfigsActionResult,
+)
+from ai.backend.manager.services.app_config_fragment.actions.search import (
+    SearchAppConfigFragmentsAction,
+    SearchAppConfigFragmentsActionResult,
 )
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))

--- a/src/ai/backend/manager/services/app_config_fragment/service.py
+++ b/src/ai/backend/manager/services/app_config_fragment/service.py
@@ -85,9 +85,7 @@ class AppConfigFragmentService:
     async def get_user_app_config(
         self, action: GetUserAppConfigAction
     ) -> GetUserAppConfigActionResult:
-        app_config = await self._repository.app_config(
-            UserID(action.user_id), action.config_name
-        )
+        app_config = await self._repository.app_config(UserID(action.user_id), action.config_name)
         return GetUserAppConfigActionResult(app_config=app_config)
 
     async def scoped_search_app_configs(

--- a/src/ai/backend/manager/services/app_config_fragment/service.py
+++ b/src/ai/backend/manager/services/app_config_fragment/service.py
@@ -21,6 +21,10 @@ from ai.backend.manager.services.app_config_fragment.actions.get import (
     GetAppConfigFragmentAction,
     GetAppConfigFragmentActionResult,
 )
+from ai.backend.manager.services.app_config_fragment.actions.get_user_app_config import (
+    GetUserAppConfigAction,
+    GetUserAppConfigActionResult,
+)
 from ai.backend.manager.services.app_config_fragment.actions.my_bulk_create import (
     MyBulkCreateAppConfigFragmentsAction,
     MyBulkCreateAppConfigFragmentsActionResult,
@@ -33,6 +37,10 @@ from ai.backend.manager.services.app_config_fragment.actions.search import (
     SearchAppConfigFragmentsAction,
     SearchAppConfigFragmentsActionResult,
 )
+from ai.backend.manager.services.app_config_fragment.actions.scoped_search_app_configs import (
+    ScopedSearchAppConfigsAction,
+    ScopedSearchAppConfigsActionResult,
+)
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -40,8 +48,9 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 class AppConfigFragmentService:
     """Non-admin operations available to any authenticated user.
 
-    Self-service writes (`my_bulk_*`) target the caller's own `USER`
-    scope; the actual row write goes through the shared admin repository
+    Covers raw-fragment reads, the per-user merged `AppConfig` views,
+    and self-service writes (`my_bulk_*`) on the caller's own `USER`
+    scope. The actual row write goes through the shared admin repository
     while reads use the non-admin repository.
     """
 
@@ -70,6 +79,30 @@ class AppConfigFragmentService:
             has_next_page=result.has_next_page,
             has_previous_page=result.has_previous_page,
         )
+
+    # ── Merged-view reads (AppConfig) ─────────────────────────────
+
+    async def get_user_app_config(
+        self, action: GetUserAppConfigAction
+    ) -> GetUserAppConfigActionResult:
+        app_config = await self._repository.app_config(action.user_id, action.config_name)
+        return GetUserAppConfigActionResult(app_config=app_config)
+
+    async def scoped_search_app_configs(
+        self, action: ScopedSearchAppConfigsAction
+    ) -> ScopedSearchAppConfigsActionResult:
+        targets = list(action.targets())
+        scopes = [t.to_search_scope() for t in targets]
+        result = await self._repository.scoped_search_app_configs(action.querier, scopes)
+        return ScopedSearchAppConfigsActionResult(
+            items=result.items,
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+            queried_refs=[t.to_rbac_element_ref() for t in targets],
+        )
+
+    # ── Self-service bulk mutations (per-item transaction) ────────
 
     async def my_bulk_create(
         self, action: MyBulkCreateAppConfigFragmentsAction

--- a/src/ai/backend/manager/services/app_config_fragment/service.py
+++ b/src/ai/backend/manager/services/app_config_fragment/service.py
@@ -85,7 +85,9 @@ class AppConfigFragmentService:
     async def get_user_app_config(
         self, action: GetUserAppConfigAction
     ) -> GetUserAppConfigActionResult:
-        app_config = await self._repository.app_config(action.user_id, action.config_name)
+        app_config = await self._repository.app_config(
+            UserID(action.user_id), action.config_name
+        )
         return GetUserAppConfigActionResult(app_config=app_config)
 
     async def scoped_search_app_configs(


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 12-PR stack delivering BEP-1052 (rank-based AppConfig). **Merge in order:**

1. ⬇️ **#12224** — `feat(BA-6510): AppConfigFragment schema, value types & repo specs`
2. ⬇️ **#12225** — `feat(BA-6511): AppConfigFragment repository (CRUD + rank merge)`
3. ⬇️ **#12226** — `feat(BA-6512): AppConfigFragment v2 DTOs + conditions/orders`
4. ⬇️ **#12244** — `feat(BA-6513): AppConfigFragment service layer (actions, processors)`
5. ⬇️ **#12228** — `feat(BA-6514): AppConfigFragment adapter`
6. 👉 **#12229** — `feat(BA-6515): merged-view scoped/admin backend + DTO + adapter` ← you are here
7. ⬇️ **#12230** — `feat(BA-6516): AppConfigFragment GraphQL`
8. ⬇️ **#12231** — `feat(BA-6517): merged AppConfig GraphQL`
9. ⬇️ **#11286** — `feat(BA-5830): AppConfig/Fragment REST v2`
10. ⬇️ **#12232** — `feat(BA-6518): AppConfig v2 SDK`
11. ⬇️ **#12233** — `feat(BA-6519): AppConfig v2 CLI`
12. ⬇️ **#11298** — `feat(BA-5837): ValkeyCache for merged-view reads`

## Summary

Merged-view scoped_search (multi-scope OR + (user_id,name) dedup) / admin search across db_source/service/actions, merged-view v2 DTOs, and the AppConfig adapter.


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12229.org.readthedocs.build/en/12229/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12229.org.readthedocs.build/ko/12229/

<!-- readthedocs-preview sorna-ko end -->
