### PR TITLE
feat(BA-6516): AppConfigFragment GraphQL

### DIFF
--- a/changes/12230.feature.md
+++ b/changes/12230.feature.md
@@ -1,0 +1,1 @@
+Add the AppConfigFragment GraphQL surface.

--- a/src/ai/backend/manager/api/gql/app_config_fragment/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/__init__.py
@@ -1,0 +1,9 @@
+"""AppConfigFragment GraphQL API package.
+
+Resolver and type names are re-exported by ``schema.py`` directly via
+their submodules to keep this package's ``__init__`` import-light: a
+top-level ``from app_config_fragment import ...`` would otherwise drag
+in the mutation resolvers, which back-import from
+``app_config.types.bulk_payloads`` and form an import cycle when
+``AppConfigGQL`` is loading.
+"""

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver/__init__.py
@@ -2,8 +2,6 @@ from .mutation import (
     admin_bulk_create_app_config_fragments,
     admin_bulk_purge_app_config_fragments,
     admin_bulk_update_app_config_fragments,
-    my_bulk_create_app_config_fragments,
-    my_bulk_update_app_config_fragments,
 )
 from .query import (
     admin_app_config_fragments,
@@ -16,6 +14,4 @@ __all__ = [
     "admin_bulk_purge_app_config_fragments",
     "admin_bulk_update_app_config_fragments",
     "app_config_fragment",
-    "my_bulk_create_app_config_fragments",
-    "my_bulk_update_app_config_fragments",
 ]

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver/__init__.py
@@ -1,0 +1,21 @@
+from .mutation import (
+    admin_bulk_create_app_config_fragments,
+    admin_bulk_purge_app_config_fragments,
+    admin_bulk_update_app_config_fragments,
+    my_bulk_create_app_config_fragments,
+    my_bulk_update_app_config_fragments,
+)
+from .query import (
+    admin_app_config_fragments,
+    app_config_fragment,
+)
+
+__all__ = [
+    "admin_app_config_fragments",
+    "admin_bulk_create_app_config_fragments",
+    "admin_bulk_purge_app_config_fragments",
+    "admin_bulk_update_app_config_fragments",
+    "app_config_fragment",
+    "my_bulk_create_app_config_fragments",
+    "my_bulk_update_app_config_fragments",
+]

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver/mutation.py
@@ -1,0 +1,112 @@
+"""AppConfigFragment GQL mutation resolvers (bulk-only)."""
+
+from __future__ import annotations
+
+from strawberry import Info
+
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.app_config.types.bulk_payloads import (
+    MyBulkCreateAppConfigFragmentsPayloadGQL,
+    MyBulkUpdateAppConfigFragmentsPayloadGQL,
+)
+from ai.backend.manager.api.gql.app_config_fragment.types import (
+    AdminBulkCreateAppConfigFragmentInputGQL,
+    AdminBulkCreateAppConfigFragmentsPayloadGQL,
+    AdminBulkPurgeAppConfigFragmentInputGQL,
+    AdminBulkPurgeAppConfigFragmentsPayloadGQL,
+    AdminBulkUpdateAppConfigFragmentInputGQL,
+    AdminBulkUpdateAppConfigFragmentsPayloadGQL,
+    MyBulkCreateAppConfigFragmentInputGQL,
+    MyBulkUpdateAppConfigFragmentInputGQL,
+)
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_mutation,
+)
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+from ai.backend.manager.api.gql.utils import check_admin_only
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Strict insert across any scope; each item runs in its own transaction "
+            "and failures are collected per-item (admin only)."
+        ),
+    )
+)
+async def admin_bulk_create_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    input: AdminBulkCreateAppConfigFragmentInputGQL,
+) -> AdminBulkCreateAppConfigFragmentsPayloadGQL:
+    check_admin_only()
+    result = await info.context.adapters.app_config_fragment.admin_bulk_create(input.to_pydantic())
+    return AdminBulkCreateAppConfigFragmentsPayloadGQL.from_pydantic(result)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Wholesale JSON replacement; items with no existing row are returned as failures "
+            "(admin only)."
+        ),
+    )
+)
+async def admin_bulk_update_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    input: AdminBulkUpdateAppConfigFragmentInputGQL,
+) -> AdminBulkUpdateAppConfigFragmentsPayloadGQL:
+    check_admin_only()
+    result = await info.context.adapters.app_config_fragment.admin_bulk_update(input.to_pydantic())
+    return AdminBulkUpdateAppConfigFragmentsPayloadGQL.from_pydantic(result)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Cleanup-only deletion; absent keys are no-oped (admin only).",
+    )
+)
+async def admin_bulk_purge_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    input: AdminBulkPurgeAppConfigFragmentInputGQL,
+) -> AdminBulkPurgeAppConfigFragmentsPayloadGQL:
+    check_admin_only()
+    result = await info.context.adapters.app_config_fragment.admin_bulk_purge(input.to_pydantic())
+    return AdminBulkPurgeAppConfigFragmentsPayloadGQL.from_pydantic(result)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Strict insert on the caller's USER row; duplicates fail per-item. "
+            "Returns recomputed merged `AppConfig` views."
+        ),
+    )
+)
+async def my_bulk_create_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    input: MyBulkCreateAppConfigFragmentInputGQL,
+) -> MyBulkCreateAppConfigFragmentsPayloadGQL:
+    result = await info.context.adapters.app_config.my_bulk_create(input.to_pydantic())
+    return MyBulkCreateAppConfigFragmentsPayloadGQL.from_pydantic(result)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Wholesale replacement on the caller's USER row; missing rows are returned as "
+            "failures. Returns recomputed merged `AppConfig` views."
+        ),
+    )
+)
+async def my_bulk_update_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    input: MyBulkUpdateAppConfigFragmentInputGQL,
+) -> MyBulkUpdateAppConfigFragmentsPayloadGQL:
+    result = await info.context.adapters.app_config.my_bulk_update(input.to_pydantic())
+    return MyBulkUpdateAppConfigFragmentsPayloadGQL.from_pydantic(result)

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver/mutation.py
@@ -5,10 +5,6 @@ from __future__ import annotations
 from strawberry import Info
 
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
-from ai.backend.manager.api.gql.app_config.types.bulk_payloads import (
-    MyBulkCreateAppConfigFragmentsPayloadGQL,
-    MyBulkUpdateAppConfigFragmentsPayloadGQL,
-)
 from ai.backend.manager.api.gql.app_config_fragment.types import (
     AdminBulkCreateAppConfigFragmentInputGQL,
     AdminBulkCreateAppConfigFragmentsPayloadGQL,
@@ -16,8 +12,6 @@ from ai.backend.manager.api.gql.app_config_fragment.types import (
     AdminBulkPurgeAppConfigFragmentsPayloadGQL,
     AdminBulkUpdateAppConfigFragmentInputGQL,
     AdminBulkUpdateAppConfigFragmentsPayloadGQL,
-    MyBulkCreateAppConfigFragmentInputGQL,
-    MyBulkUpdateAppConfigFragmentInputGQL,
 )
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -76,37 +70,3 @@ async def admin_bulk_purge_app_config_fragments(
     check_admin_only()
     result = await info.context.adapters.app_config_fragment.admin_bulk_purge(input.to_pydantic())
     return AdminBulkPurgeAppConfigFragmentsPayloadGQL.from_pydantic(result)
-
-
-@gql_mutation(
-    BackendAIGQLMeta(
-        added_version=NEXT_RELEASE_VERSION,
-        description=(
-            "Strict insert on the caller's USER row; duplicates fail per-item. "
-            "Returns recomputed merged `AppConfig` views."
-        ),
-    )
-)
-async def my_bulk_create_app_config_fragments(
-    info: Info[StrawberryGQLContext],
-    input: MyBulkCreateAppConfigFragmentInputGQL,
-) -> MyBulkCreateAppConfigFragmentsPayloadGQL:
-    result = await info.context.adapters.app_config.my_bulk_create(input.to_pydantic())
-    return MyBulkCreateAppConfigFragmentsPayloadGQL.from_pydantic(result)
-
-
-@gql_mutation(
-    BackendAIGQLMeta(
-        added_version=NEXT_RELEASE_VERSION,
-        description=(
-            "Wholesale replacement on the caller's USER row; missing rows are returned as "
-            "failures. Returns recomputed merged `AppConfig` views."
-        ),
-    )
-)
-async def my_bulk_update_app_config_fragments(
-    info: Info[StrawberryGQLContext],
-    input: MyBulkUpdateAppConfigFragmentInputGQL,
-) -> MyBulkUpdateAppConfigFragmentsPayloadGQL:
-    result = await info.context.adapters.app_config.my_bulk_update(input.to_pydantic())
-    return MyBulkUpdateAppConfigFragmentsPayloadGQL.from_pydantic(result)

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver/query.py
@@ -1,0 +1,103 @@
+"""AppConfigFragment GQL query resolvers.
+
+Per the scope-bound list is exposed via child fields on
+`DomainV2.appConfigFragments` / `UserV2.appConfigFragments`, not as a
+root resolver. Only the single-row read and the cross-scope admin
+search live here. The scope-bound REST endpoint
+`POST /v2/app-config-fragments/{scope_type}/{scope_id}/search`
+continues to use the adapter's `search()` method directly.
+"""
+
+from __future__ import annotations
+
+import strawberry
+from strawberry import Info
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AppConfigFragmentKeyInput,
+    SearchAppConfigFragmentsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import AppConfigScopeType
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.app_config_fragment.types import (
+    AppConfigFragmentConnectionGQL,
+    AppConfigFragmentEdgeGQL,
+    AppConfigFragmentFilterGQL,
+    AppConfigFragmentGQL,
+    AppConfigFragmentOrderByGQL,
+)
+from ai.backend.manager.api.gql.base import encode_cursor
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_root_field,
+)
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+from ai.backend.manager.api.gql.utils import check_admin_only
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Get a single app-config fragment by natural key "
+            "`(scope_type, scope_id, name)`. Available to any authenticated user "
+            "— service-layer authorization gates cross-scope reads."
+        ),
+    )
+)  # type: ignore[misc]
+async def app_config_fragment(
+    info: Info[StrawberryGQLContext],
+    scope_type: AppConfigScopeType,
+    scope_id: str,
+    name: str,
+) -> AppConfigFragmentGQL | None:
+    payload = await info.context.adapters.app_config_fragment.get(
+        AppConfigFragmentKeyInput(scope_type=scope_type, scope_id=scope_id, name=name)
+    )
+    if payload.item is None:
+        return None
+    return AppConfigFragmentGQL.from_pydantic(payload.item)
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Cross-scope admin search across all app-config fragments (admin only).",
+    )
+)  # type: ignore[misc]
+async def admin_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    filter: AppConfigFragmentFilterGQL | None = None,
+    order_by: list[AppConfigFragmentOrderByGQL] | None = None,
+    first: int | None = None,
+    after: str | None = None,
+    last: int | None = None,
+    before: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> AppConfigFragmentConnectionGQL:
+    check_admin_only()
+    payload = await info.context.adapters.app_config_fragment.admin_search(
+        SearchAppConfigFragmentsInput(
+            filter=filter.to_pydantic() if filter else None,
+            order=[o.to_pydantic() for o in order_by] if order_by else None,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        )
+    )
+    nodes = [AppConfigFragmentGQL.from_pydantic(node) for node in payload.items]
+    edges = [AppConfigFragmentEdgeGQL(node=node, cursor=encode_cursor(node.id)) for node in nodes]
+    return AppConfigFragmentConnectionGQL(
+        edges=edges,
+        page_info=strawberry.relay.PageInfo(
+            has_next_page=payload.has_next_page,
+            has_previous_page=payload.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        ),
+        count=payload.total_count,
+    )

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types/__init__.py
@@ -1,0 +1,51 @@
+from .bulk_inputs import (
+    AdminAppConfigFragmentItemInputGQL,
+    AdminBulkCreateAppConfigFragmentInputGQL,
+    AdminBulkPurgeAppConfigFragmentInputGQL,
+    AdminBulkUpdateAppConfigFragmentInputGQL,
+    MyAppConfigFragmentItemInputGQL,
+    MyBulkCreateAppConfigFragmentInputGQL,
+    MyBulkUpdateAppConfigFragmentInputGQL,
+)
+from .bulk_payloads import (
+    AdminBulkCreateAppConfigFragmentsPayloadGQL,
+    AdminBulkPurgeAppConfigFragmentsPayloadGQL,
+    AdminBulkUpdateAppConfigFragmentsPayloadGQL,
+    AppConfigFragmentBulkErrorGQL,
+    PurgeAppConfigFragmentKeyGQL,
+)
+from .filters import (
+    AppConfigFragmentFilterGQL,
+    AppConfigFragmentOrderByGQL,
+    AppConfigFragmentOrderFieldGQL,
+)
+from .inputs import AppConfigFragmentKeyInputGQL
+from .node import (
+    AppConfigFragmentConnectionGQL,
+    AppConfigFragmentEdgeGQL,
+    AppConfigFragmentGQL,
+    AppConfigScopeTypeGQL,
+)
+
+__all__ = [
+    "AdminAppConfigFragmentItemInputGQL",
+    "AdminBulkCreateAppConfigFragmentInputGQL",
+    "AdminBulkCreateAppConfigFragmentsPayloadGQL",
+    "AdminBulkPurgeAppConfigFragmentInputGQL",
+    "AdminBulkPurgeAppConfigFragmentsPayloadGQL",
+    "AdminBulkUpdateAppConfigFragmentInputGQL",
+    "AdminBulkUpdateAppConfigFragmentsPayloadGQL",
+    "AppConfigFragmentBulkErrorGQL",
+    "AppConfigFragmentConnectionGQL",
+    "AppConfigFragmentEdgeGQL",
+    "AppConfigFragmentFilterGQL",
+    "AppConfigFragmentGQL",
+    "AppConfigFragmentKeyInputGQL",
+    "AppConfigFragmentOrderByGQL",
+    "AppConfigFragmentOrderFieldGQL",
+    "AppConfigScopeTypeGQL",
+    "MyBulkCreateAppConfigFragmentInputGQL",
+    "MyBulkUpdateAppConfigFragmentInputGQL",
+    "MyAppConfigFragmentItemInputGQL",
+    "PurgeAppConfigFragmentKeyGQL",
+]

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types/bulk_inputs.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types/bulk_inputs.py
@@ -1,0 +1,120 @@
+"""AppConfigFragment bulk-mutation GQL input types."""
+
+from __future__ import annotations
+
+from strawberry.scalars import JSON
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AdminAppConfigFragmentItemInput as AdminItemInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AdminBulkCreateAppConfigFragmentsInput as AdminBulkCreateInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AdminBulkPurgeAppConfigFragmentsInput as AdminBulkPurgeInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AdminBulkUpdateAppConfigFragmentsInput as AdminBulkUpdateInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    MyAppConfigFragmentItemInput as MyItemInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    MyBulkCreateAppConfigFragmentsInput as MyBulkCreateInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    MyBulkUpdateAppConfigFragmentsInput as MyBulkUpdateInputDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.app_config_fragment.types.inputs import (
+    AppConfigFragmentKeyInputGQL,
+)
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_input,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Per-item input for admin bulk create / update.",
+    ),
+    name="AdminAppConfigFragmentItemInput",
+)
+class AdminAppConfigFragmentItemInputGQL(PydanticInputMixin[AdminItemInputDTO]):
+    key: AppConfigFragmentKeyInputGQL = gql_field(description="Natural-key identifier.")
+    config: JSON = gql_field(description="Raw configuration payload.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Admin bulk create input — items carry any scope.",
+    ),
+    name="AdminBulkCreateAppConfigFragmentInput",
+)
+class AdminBulkCreateAppConfigFragmentInputGQL(PydanticInputMixin[AdminBulkCreateInputDTO]):
+    items: list[AdminAppConfigFragmentItemInputGQL] = gql_field(description="Rows to create.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Admin bulk update input.",
+    ),
+    name="AdminBulkUpdateAppConfigFragmentInput",
+)
+class AdminBulkUpdateAppConfigFragmentInputGQL(PydanticInputMixin[AdminBulkUpdateInputDTO]):
+    items: list[AdminAppConfigFragmentItemInputGQL] = gql_field(description="Rows to update.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Admin bulk purge input — keyed on `AppConfigFragmentKey`.",
+    ),
+    name="AdminBulkPurgeAppConfigFragmentInput",
+)
+class AdminBulkPurgeAppConfigFragmentInputGQL(PydanticInputMixin[AdminBulkPurgeInputDTO]):
+    keys: list[AppConfigFragmentKeyInputGQL] = gql_field(description="Natural keys to purge.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Per-item input for self-service (`my`) bulk.",
+    ),
+    name="MyAppConfigFragmentItemInput",
+)
+class MyAppConfigFragmentItemInputGQL(PydanticInputMixin[MyItemInputDTO]):
+    name: str = gql_field(description="Policy name.")
+    config: JSON = gql_field(description="Raw configuration payload.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Self-service bulk create — scope is `USER` / `current_user`.",
+    ),
+    name="MyBulkCreateAppConfigFragmentInput",
+)
+class MyBulkCreateAppConfigFragmentInputGQL(PydanticInputMixin[MyBulkCreateInputDTO]):
+    items: list[MyAppConfigFragmentItemInputGQL] = gql_field(
+        description="USER-scope rows to create.",
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Self-service bulk update — scope is `USER` / `current_user`.",
+    ),
+    name="MyBulkUpdateAppConfigFragmentInput",
+)
+class MyBulkUpdateAppConfigFragmentInputGQL(PydanticInputMixin[MyBulkUpdateInputDTO]):
+    items: list[MyAppConfigFragmentItemInputGQL] = gql_field(
+        description="USER-scope rows to update.",
+    )

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types/bulk_payloads.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types/bulk_payloads.py
@@ -1,0 +1,105 @@
+"""AppConfigFragment bulk-mutation GQL payload types (admin only).
+
+Self-service `my_*` bulk payloads return recomputed merged AppConfig
+views, so they live in `app_config/types/bulk_payloads.py` to keep the
+import direction `app_config -> app_config_fragment` (one-way) and
+avoid a circular import.
+"""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AdminBulkCreateAppConfigFragmentsPayload as AdminBulkCreatePayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AdminBulkPurgeAppConfigFragmentsPayload as AdminBulkPurgePayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AdminBulkUpdateAppConfigFragmentsPayload as AdminBulkUpdatePayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AppConfigFragmentBulkError as AppConfigFragmentBulkErrorDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    PurgeAppConfigFragmentKey as PurgeAppConfigFragmentKeyDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import AppConfigScopeType
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.app_config_fragment.types.node import AppConfigFragmentGQL
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticOutputMixin
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Per-item failure info for bulk Fragment mutations.",
+    ),
+    model=AppConfigFragmentBulkErrorDTO,
+    name="AppConfigFragmentBulkError",
+)
+class AppConfigFragmentBulkErrorGQL(PydanticOutputMixin[AppConfigFragmentBulkErrorDTO]):
+    index: int = gql_field(description="Original position in the input list.")
+    scope_type: AppConfigScopeType = gql_field(description="Scope type of the failed row.")
+    scope_id: str = gql_field(description="Scope id of the failed row.")
+    name: str = gql_field(description="Policy name of the failed row.")
+    message: str = gql_field(description="Reason for the failure.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Natural key of a purged fragment row.",
+    ),
+    model=PurgeAppConfigFragmentKeyDTO,
+    name="PurgeAppConfigFragmentKey",
+)
+class PurgeAppConfigFragmentKeyGQL(PydanticOutputMixin[PurgeAppConfigFragmentKeyDTO]):
+    scope_type: AppConfigScopeType = gql_field(description="Scope type.")
+    scope_id: str = gql_field(description="Scope id.")
+    name: str = gql_field(description="Policy name.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for `adminBulkCreateAppConfigFragments`.",
+    ),
+    model=AdminBulkCreatePayloadDTO,
+    name="AdminBulkCreateAppConfigFragmentsPayload",
+)
+class AdminBulkCreateAppConfigFragmentsPayloadGQL(PydanticOutputMixin[AdminBulkCreatePayloadDTO]):
+    created: list[AppConfigFragmentGQL] = gql_field(description="Created fragments.")
+    failed: list[AppConfigFragmentBulkErrorGQL] = gql_field(description="Per-item failures.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for `adminBulkUpdateAppConfigFragments`.",
+    ),
+    model=AdminBulkUpdatePayloadDTO,
+    name="AdminBulkUpdateAppConfigFragmentsPayload",
+)
+class AdminBulkUpdateAppConfigFragmentsPayloadGQL(PydanticOutputMixin[AdminBulkUpdatePayloadDTO]):
+    updated: list[AppConfigFragmentGQL] = gql_field(description="Updated fragments.")
+    failed: list[AppConfigFragmentBulkErrorGQL] = gql_field(description="Per-item failures.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for `adminBulkPurgeAppConfigFragments`.",
+    ),
+    model=AdminBulkPurgePayloadDTO,
+    name="AdminBulkPurgeAppConfigFragmentsPayload",
+)
+class AdminBulkPurgeAppConfigFragmentsPayloadGQL(PydanticOutputMixin[AdminBulkPurgePayloadDTO]):
+    purged: list[PurgeAppConfigFragmentKeyGQL] = gql_field(
+        description="Keys of rows actually removed (absent keys are no-oped).",
+    )
+    failed: list[AppConfigFragmentBulkErrorGQL] = gql_field(description="Per-item failures.")

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types/filters.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types/filters.py
@@ -1,0 +1,63 @@
+"""AppConfigFragment GQL filter / order types."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AppConfigFragmentFilter as AppConfigFragmentFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AppConfigFragmentOrder as AppConfigFragmentOrderDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.base import OrderDirection, StringFilter
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_enum,
+    gql_field,
+    gql_pydantic_input,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Filter input for querying app-config fragments.",
+    ),
+    name="AppConfigFragmentFilter",
+)
+class AppConfigFragmentFilterGQL(PydanticInputMixin[AppConfigFragmentFilterDTO]):
+    name: StringFilter | None = gql_field(description="Filter by policy name.", default=None)
+    scope_id: StringFilter | None = gql_field(description="Filter by scope_id.", default=None)
+
+
+@gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Fields available for ordering app-config fragments.",
+    ),
+    name="AppConfigFragmentOrderField",
+)
+class AppConfigFragmentOrderFieldGQL(StrEnum):
+    SCOPE_TYPE = "scope_type"
+    SCOPE_ID = "scope_id"
+    NAME = "name"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Specifies ordering for app-config fragment results.",
+    ),
+    name="AppConfigFragmentOrderBy",
+)
+class AppConfigFragmentOrderByGQL(PydanticInputMixin[AppConfigFragmentOrderDTO]):
+    field: AppConfigFragmentOrderFieldGQL = gql_field(description="The field to order by.")
+    direction: OrderDirection = gql_field(
+        description="Sort direction.",
+        default=OrderDirection.DESC,
+    )

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types/inputs.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types/inputs.py
@@ -1,0 +1,28 @@
+"""AppConfigFragment GQL natural-key input shared by bulk types."""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AppConfigFragmentKeyInput as AppConfigFragmentKeyInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import AppConfigScopeType
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_input,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Natural key for an app-config fragment row.",
+    ),
+    name="AppConfigFragmentKeyInput",
+)
+class AppConfigFragmentKeyInputGQL(PydanticInputMixin[AppConfigFragmentKeyInputDTO]):
+    scope_type: AppConfigScopeType = gql_field(description="Scope type.")
+    scope_id: str = gql_field(description="Scope id.")
+    name: str = gql_field(description="Policy name.")

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types/node.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types/node.py
@@ -1,0 +1,63 @@
+"""AppConfigFragment GQL Node, Edge, and Connection types."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from strawberry.relay import Connection, Edge, NodeID
+from strawberry.scalars import JSON
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import AppConfigFragmentNode
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import AppConfigScopeType
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_connection_type,
+    gql_field,
+    gql_node_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
+
+# The shared DTO enum is auto-registered by Strawberry the first time it
+# is referenced as a typed field. Re-export under the ``GQL`` suffix so
+# other modules can write `from ... import AppConfigScopeTypeGQL`. Calling
+# `strawberry.enum(...)` here would clash with that auto-registration
+# under the same `"AppConfigScopeType"` name.
+AppConfigScopeTypeGQL = AppConfigScopeType
+
+
+@gql_node_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Raw per-scope app-config fragment.",
+    ),
+    name="AppConfigFragment",
+)
+class AppConfigFragmentGQL(PydanticNodeMixin[AppConfigFragmentNode]):
+    id: NodeID[str] = gql_field(description="Fragment row UUID.")
+    scope_type: AppConfigScopeType = gql_field(description="Scope type.")
+    scope_id: str = gql_field(description="Scope id.")
+    name: str = gql_field(description="Config name.")
+    rank: int = gql_field(description="Merge priority within `name` (low → high).")
+    config: JSON | None = gql_field(description="Raw configuration payload, or null.")
+    created_at: datetime = gql_field(description="Creation timestamp.")
+    updated_at: datetime | None = gql_field(description="Last update timestamp.")
+
+
+AppConfigFragmentEdgeGQL = Edge[AppConfigFragmentGQL]
+
+
+@gql_connection_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Connection type for paginated app-config fragment results.",
+    ),
+    name="AppConfigFragmentConnection",
+)
+class AppConfigFragmentConnectionGQL(Connection[AppConfigFragmentGQL]):
+    count: int = gql_field(description="Total number of fragments matching the query.")
+
+    def __init__(self, *args: Any, count: int, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.count = count

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -14,6 +14,9 @@ if TYPE_CHECKING:
     from ai.backend.common.dto.manager.v2.rbac.response import EntityNode  # pants: no-infer-dep
     from ai.backend.manager.api.adapters.registry import Adapters  # pants: no-infer-dep
     from ai.backend.manager.api.gql.agent.types import AgentV2GQL  # pants: no-infer-dep
+    from ai.backend.manager.api.gql.app_config_fragment.types import (  # pants: no-infer-dep
+        AppConfigFragmentGQL,
+    )
     from ai.backend.manager.api.gql.artifact.types import (  # pants: no-infer-dep
         ArtifactRevision,
     )
@@ -118,6 +121,38 @@ class DataLoaders:
 
     def __init__(self, adapters: Adapters) -> None:
         self._adapters = adapters
+
+    @cached_property
+    def app_config_fragment_loader(
+        self,
+    ) -> DataLoader[uuid.UUID, AppConfigFragmentGQL | None]:
+        adapter = self._adapters.app_config_fragment
+
+        async def load_fn(ids: list[uuid.UUID]) -> list[AppConfigFragmentGQL | None]:
+            from ai.backend.common.dto.manager.query import UUIDFilter  # pants: no-infer-dep
+            from ai.backend.common.dto.manager.v2.app_config_fragment.request import (  # pants: no-infer-dep
+                AppConfigFragmentFilter,
+                SearchAppConfigFragmentsInput,
+            )
+            from ai.backend.common.identifier.app_config_fragment import (  # pants: no-infer-dep
+                AppConfigFragmentID,
+            )
+            from ai.backend.manager.api.gql.app_config_fragment.types import (  # pants: no-infer-dep
+                AppConfigFragmentGQL as F,
+            )
+
+            if not ids:
+                return []
+            payload = await adapter.admin_search(
+                SearchAppConfigFragmentsInput(
+                    filter=AppConfigFragmentFilter(id=UUIDFilter.model_validate({"in": list(ids)})),
+                    limit=len(ids),
+                ),
+            )
+            by_id = {dto.id: F.from_pydantic(dto) for dto in payload.items}
+            return [by_id.get(AppConfigFragmentID(fragment_id)) for fragment_id in ids]
+
+        return DataLoader(load_fn=load_fn)
 
     @cached_property
     def audit_log_loader(


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 12-PR stack delivering BEP-1052 (rank-based AppConfig). **Merge in order:**

1. ⬇️ **#12224** — `feat(BA-6510): AppConfigFragment schema, value types & repo specs`
2. ⬇️ **#12225** — `feat(BA-6511): AppConfigFragment repository (CRUD + rank merge)`
3. ⬇️ **#12226** — `feat(BA-6512): AppConfigFragment v2 DTOs + conditions/orders`
4. ⬇️ **#12244** — `feat(BA-6513): AppConfigFragment service layer (actions, processors)`
5. ⬇️ **#12228** — `feat(BA-6514): AppConfigFragment adapter`
6. ⬇️ **#12229** — `feat(BA-6515): merged-view scoped/admin backend + DTO + adapter`
7. 👉 **#12230** — `feat(BA-6516): AppConfigFragment GraphQL` ← you are here
8. ⬇️ **#12231** — `feat(BA-6517): merged AppConfig GraphQL`
9. ⬇️ **#11286** — `feat(BA-5830): AppConfig/Fragment REST v2`
10. ⬇️ **#12232** — `feat(BA-6518): AppConfig v2 SDK`
11. ⬇️ **#12233** — `feat(BA-6519): AppConfig v2 CLI`
12. ⬇️ **#11298** — `feat(BA-5837): ValkeyCache for merged-view reads`

## Summary

Strawberry Node/Connection/filters/resolvers + bulk mutations for raw fragments, exposing rank.


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12230.org.readthedocs.build/en/12230/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12230.org.readthedocs.build/ko/12230/

<!-- readthedocs-preview sorna-ko end -->
