### PR TITLE
feat(BA-6517): merged AppConfig GraphQL

### DIFF
--- a/changes/12231.feature.md
+++ b/changes/12231.feature.md
@@ -1,0 +1,1 @@
+Add the merged AppConfig GraphQL surface.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -202,6 +202,76 @@ type AddRevisionPayload
   revision: ModelRevision!
 }
 
+"""Added in 26.4.4. Per-item input for admin bulk create / update."""
+input AdminAppConfigFragmentItemInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Natural-key identifier."""
+  key: AppConfigFragmentKeyInput!
+
+  """Raw configuration payload."""
+  config: JSON!
+}
+
+"""Added in 26.4.4. Admin bulk create input — items carry any scope."""
+input AdminBulkCreateAppConfigFragmentInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Rows to create."""
+  items: [AdminAppConfigFragmentItemInput!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkCreateAppConfigFragments`."""
+type AdminBulkCreateAppConfigFragmentsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Created fragments."""
+  created: [AppConfigFragment!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""
+Added in 26.4.4. Admin bulk purge input — keyed on `AppConfigFragmentKey`.
+"""
+input AdminBulkPurgeAppConfigFragmentInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Natural keys to purge."""
+  keys: [AppConfigFragmentKeyInput!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkPurgeAppConfigFragments`."""
+type AdminBulkPurgeAppConfigFragmentsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Keys of rows actually removed (absent keys are no-oped)."""
+  purged: [PurgeAppConfigFragmentKey!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""Added in 26.4.4. Admin bulk update input."""
+input AdminBulkUpdateAppConfigFragmentInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Rows to update."""
+  items: [AdminAppConfigFragmentItemInput!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkUpdateAppConfigFragments`."""
+type AdminBulkUpdateAppConfigFragmentsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Updated fragments."""
+  updated: [AppConfigFragment!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
 """Added in 26.4.2. Admin input for creating a keypair for a user."""
 input AdminCreateKeypairInput
   @join__type(graph: STRAWBERRY)
@@ -883,6 +953,237 @@ type AllowedResourceGroupsPayload
 {
   """Allowed resource group names."""
   items: [String!]!
+}
+
+"""
+Added in 26.4.4. Merged per-user AppConfig view. `id` is the composite `{userId}:{name}` (the merged view is a derived value, not a table row); `fragments` are ordered low → high merge priority; `config` is the deep-merge result and is null when every contributing fragment is empty.
+"""
+type AppConfig implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Target user's UUID."""
+  userId: UUID!
+
+  """Policy / config name."""
+  name: String!
+
+  """Contributing fragments in merge order (low → high)."""
+  fragments: [AppConfigFragment!]!
+
+  """Deep-merged configuration, or null when every fragment is empty."""
+  config: JSON
+}
+
+"""
+Added in 26.4.4. Connection type for paginated merged AppConfig results.
+"""
+type AppConfigConnection
+  @join__type(graph: STRAWBERRY)
+{
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [AppConfigEdge!]!
+
+  """Total number of AppConfigs matching the query."""
+  count: Int!
+}
+
+"""An edge in a connection."""
+type AppConfigEdge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: AppConfig!
+}
+
+"""Added in 26.4.4. Filter input for querying merged AppConfigs."""
+input AppConfigFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Filter by policy name."""
+  name: StringFilter = null
+
+  """Filter by target user id (admin cross-user search only)."""
+  userId: UUIDFilter = null
+
+  """Filter by the oldest contributing fragment's creation timestamp."""
+  createdAt: DateTimeFilter = null
+
+  """Filter by the latest contributing fragment's update timestamp."""
+  updatedAt: DateTimeFilter = null
+}
+
+"""Added in 26.4.4. Raw per-scope app-config fragment."""
+type AppConfigFragment implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Scope type."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id."""
+  scopeId: String!
+
+  """Config name."""
+  name: String!
+
+  """Merge priority within `name` (low → high)."""
+  rank: Int!
+
+  """Raw configuration payload, or null."""
+  config: JSON
+
+  """Creation timestamp."""
+  createdAt: DateTime!
+
+  """Last update timestamp."""
+  updatedAt: DateTime
+}
+
+"""Added in 26.4.4. Per-item failure info for bulk Fragment mutations."""
+type AppConfigFragmentBulkError
+  @join__type(graph: STRAWBERRY)
+{
+  """Original position in the input list."""
+  index: Int!
+
+  """Scope type of the failed row."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id of the failed row."""
+  scopeId: String!
+
+  """Policy name of the failed row."""
+  name: String!
+
+  """Reason for the failure."""
+  message: String!
+}
+
+"""
+Added in 26.4.4. Connection type for paginated app-config fragment results.
+"""
+type AppConfigFragmentConnection
+  @join__type(graph: STRAWBERRY)
+{
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [AppConfigFragmentEdge!]!
+
+  """Total number of fragments matching the query."""
+  count: Int!
+}
+
+"""An edge in a connection."""
+type AppConfigFragmentEdge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: AppConfigFragment!
+}
+
+"""Added in 26.4.4. Filter input for querying app-config fragments."""
+input AppConfigFragmentFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Filter by policy name."""
+  name: StringFilter = null
+
+  """Filter by scope_id."""
+  scopeId: StringFilter = null
+}
+
+"""Added in 26.4.4. Natural key for an app-config fragment row."""
+input AppConfigFragmentKeyInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Scope type."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id."""
+  scopeId: String!
+
+  """Policy name."""
+  name: String!
+}
+
+"""Added in 26.4.4. Specifies ordering for app-config fragment results."""
+input AppConfigFragmentOrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  """The field to order by."""
+  field: AppConfigFragmentOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = DESC
+}
+
+"""Added in 26.4.4. Fields available for ordering app-config fragments."""
+enum AppConfigFragmentOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  SCOPE_TYPE @join__enumValue(graph: STRAWBERRY)
+  SCOPE_ID @join__enumValue(graph: STRAWBERRY)
+  NAME @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
+  UPDATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
+"""Added in 26.4.4. Specifies ordering for merged AppConfig results."""
+input AppConfigOrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  """The field to order by."""
+  field: AppConfigOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = ASC
+}
+
+"""Added in 26.4.4. Fields available for ordering merged AppConfigs."""
+enum AppConfigOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  USER_ID @join__enumValue(graph: STRAWBERRY)
+  NAME @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
+  UPDATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
+"""
+Added in 26.4.4. Scope for the scoped merged-view AppConfig query. `userIds` are OR'd; raises an error when empty.
+"""
+input AppConfigScope
+  @join__type(graph: STRAWBERRY)
+{
+  """Target user UUIDs to scope the merged-view search to (OR'd)."""
+  userIds: [UUID!]!
+}
+
+enum AppConfigScopeType
+  @join__type(graph: STRAWBERRY)
+{
+  PUBLIC @join__enumValue(graph: STRAWBERRY)
+  DOMAIN @join__enumValue(graph: STRAWBERRY)
+  DOMAIN_USER_DEFAULTS @join__enumValue(graph: STRAWBERRY)
+  USER @join__enumValue(graph: STRAWBERRY)
 }
 
 """
@@ -11530,6 +11831,31 @@ type Mutation
   """
   updateMyAllowedClientIp(input: UpdateMyAllowedClientIPInput!): UpdateMyAllowedClientIPPayload @join__field(graph: STRAWBERRY)
 
+  """
+  Added in 26.4.4. Strict insert across any scope; each item runs in its own transaction and failures are collected per-item (admin only).
+  """
+  adminBulkCreateAppConfigFragments(input: AdminBulkCreateAppConfigFragmentInput!): AdminBulkCreateAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Wholesale JSON replacement; items with no existing row are returned as failures (admin only).
+  """
+  adminBulkUpdateAppConfigFragments(input: AdminBulkUpdateAppConfigFragmentInput!): AdminBulkUpdateAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Cleanup-only deletion; absent keys are no-oped (admin only).
+  """
+  adminBulkPurgeAppConfigFragments(input: AdminBulkPurgeAppConfigFragmentInput!): AdminBulkPurgeAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Strict insert on the caller's USER row; duplicates fail per-item. Returns recomputed merged `AppConfig` views.
+  """
+  myBulkCreateAppConfigFragments(input: MyBulkCreateAppConfigFragmentInput!): MyBulkCreateAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Wholesale replacement on the caller's USER row; missing rows are returned as failures. Returns recomputed merged `AppConfig` views.
+  """
+  myBulkUpdateAppConfigFragments(input: MyBulkUpdateAppConfigFragmentInput!): MyBulkUpdateAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
+
   """Added in 26.3.0. Create a new query definition (admin only)"""
   adminCreatePrometheusQueryPreset(input: CreateQueryDefinitionInput!): CreateQueryDefinitionPayload @join__field(graph: STRAWBERRY)
 
@@ -11793,6 +12119,63 @@ type Mutation
   Added in 26.4.4. Terminate one or more sessions by ID. Per-session RBAC permission is enforced by the bulk validator; any denial fails the whole request.
   """
   terminateSessionsV2(sessionIds: [ID!]!, forced: Boolean! = false): TerminateSessionsPayload @join__field(graph: STRAWBERRY)
+}
+
+"""Added in 26.4.4. Per-item input for self-service (`my`) bulk."""
+input MyAppConfigFragmentItemInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Policy name."""
+  name: String!
+
+  """Raw configuration payload."""
+  config: JSON!
+}
+
+"""
+Added in 26.4.4. Self-service bulk create — scope is `USER` / `current_user`.
+"""
+input MyBulkCreateAppConfigFragmentInput
+  @join__type(graph: STRAWBERRY)
+{
+  """USER-scope rows to create."""
+  items: [MyAppConfigFragmentItemInput!]!
+}
+
+"""
+Added in 26.4.4. Payload for `myBulkCreateAppConfigFragments` (recomputed views).
+"""
+type MyBulkCreateAppConfigFragmentsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Recomputed merged AppConfig views for each created USER fragment."""
+  created: [AppConfig!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""
+Added in 26.4.4. Self-service bulk update — scope is `USER` / `current_user`.
+"""
+input MyBulkUpdateAppConfigFragmentInput
+  @join__type(graph: STRAWBERRY)
+{
+  """USER-scope rows to update."""
+  items: [MyAppConfigFragmentItemInput!]!
+}
+
+"""
+Added in 26.4.4. Payload for `myBulkUpdateAppConfigFragments` (recomputed views).
+"""
+type MyBulkUpdateAppConfigFragmentsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Recomputed merged AppConfig views for each updated USER fragment."""
+  updated: [AppConfig!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
 }
 
 """
@@ -13456,6 +13839,20 @@ input ProjectWeightInputItem
   weight: Decimal = null
 }
 
+"""Added in 26.4.4. Natural key of a purged fragment row."""
+type PurgeAppConfigFragmentKey
+  @join__type(graph: STRAWBERRY)
+{
+  """Scope type."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id."""
+  scopeId: String!
+
+  """Policy name."""
+  name: String!
+}
+
 """
 Completely delete domain from DB.
 
@@ -14264,6 +14661,31 @@ type Query
   Added in 26.2.0. Query image aliases with optional filtering, ordering, and pagination. Returns image aliases that provide alternative names for container images. Use filters to search by alias string. Supports both cursor-based and offset-based pagination.
   """
   adminImageAliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Get a single app-config fragment by natural key `(scope_type, scope_id, name)`. Available to any authenticated user — service-layer authorization gates cross-scope reads.
+  """
+  appConfigFragment(scopeType: AppConfigScopeType!, scopeId: String!, name: String!): AppConfigFragment @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Cross-scope admin search across all app-config fragments (admin only).
+  """
+  adminAppConfigFragments(filter: AppConfigFragmentFilter = null, orderBy: [AppConfigFragmentOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigFragmentConnection! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Public (no-auth) `PUBLIC`-scope app-config fragments — the subset of raw fragments that carry no personally-scoped data.
+  """
+  publicAppConfigFragments(filter: AppConfigFragmentFilter = null, orderBy: [AppConfigFragmentOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [AppConfigFragment!]! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Scoped merged-view AppConfig search (auth required, RBAC-gated). `scope.userIds` are OR'd; non-admin callers are restricted to their own user. Self-service is just a USER-scoped search.
+  """
+  scopedAppConfigs(scope: AppConfigScope!, filter: AppConfigFilter = null, orderBy: [AppConfigOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigConnection! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Cross-user merged-view search (admin only). Resolves any user's AppConfig for audit / support. Pin to a single user with `filter.userId`; otherwise paginates across all users.
+  """
+  adminAppConfigs(filter: AppConfigFilter = null, orderBy: [AppConfigOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigConnection! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Get a single prometheus query preset by ID. Available to any authenticated user since presets are a shared catalog of metric query templates.

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -156,6 +156,62 @@ type AddRevisionPayload {
   revision: ModelRevision!
 }
 
+"""Added in 26.4.4. Per-item input for admin bulk create / update."""
+input AdminAppConfigFragmentItemInput {
+  """Natural-key identifier."""
+  key: AppConfigFragmentKeyInput!
+
+  """Raw configuration payload."""
+  config: JSON!
+}
+
+"""Added in 26.4.4. Admin bulk create input — items carry any scope."""
+input AdminBulkCreateAppConfigFragmentInput {
+  """Rows to create."""
+  items: [AdminAppConfigFragmentItemInput!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkCreateAppConfigFragments`."""
+type AdminBulkCreateAppConfigFragmentsPayload {
+  """Created fragments."""
+  created: [AppConfigFragment!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""
+Added in 26.4.4. Admin bulk purge input — keyed on `AppConfigFragmentKey`.
+"""
+input AdminBulkPurgeAppConfigFragmentInput {
+  """Natural keys to purge."""
+  keys: [AppConfigFragmentKeyInput!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkPurgeAppConfigFragments`."""
+type AdminBulkPurgeAppConfigFragmentsPayload {
+  """Keys of rows actually removed (absent keys are no-oped)."""
+  purged: [PurgeAppConfigFragmentKey!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""Added in 26.4.4. Admin bulk update input."""
+input AdminBulkUpdateAppConfigFragmentInput {
+  """Rows to update."""
+  items: [AdminAppConfigFragmentItemInput!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkUpdateAppConfigFragments`."""
+type AdminBulkUpdateAppConfigFragmentsPayload {
+  """Updated fragments."""
+  updated: [AppConfigFragment!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
 """Added in 26.4.2. Admin input for creating a keypair for a user."""
 input AdminCreateKeypairInput {
   """UUID of the target user."""
@@ -602,6 +658,203 @@ type AllowedProjectsPayload {
 type AllowedResourceGroupsPayload {
   """Allowed resource group names."""
   items: [String!]!
+}
+
+"""
+Added in 26.4.4. Merged per-user AppConfig view. `id` is the composite `{userId}:{name}` (the merged view is a derived value, not a table row); `fragments` are ordered low → high merge priority; `config` is the deep-merge result and is null when every contributing fragment is empty.
+"""
+type AppConfig implements Node {
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Target user's UUID."""
+  userId: UUID!
+
+  """Policy / config name."""
+  name: String!
+
+  """Contributing fragments in merge order (low → high)."""
+  fragments: [AppConfigFragment!]!
+
+  """Deep-merged configuration, or null when every fragment is empty."""
+  config: JSON
+}
+
+"""
+Added in 26.4.4. Connection type for paginated merged AppConfig results.
+"""
+type AppConfigConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [AppConfigEdge!]!
+
+  """Total number of AppConfigs matching the query."""
+  count: Int!
+}
+
+"""An edge in a connection."""
+type AppConfigEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: AppConfig!
+}
+
+"""Added in 26.4.4. Filter input for querying merged AppConfigs."""
+input AppConfigFilter {
+  """Filter by policy name."""
+  name: StringFilter = null
+
+  """Filter by target user id (admin cross-user search only)."""
+  userId: UUIDFilter = null
+
+  """Filter by the oldest contributing fragment's creation timestamp."""
+  createdAt: DateTimeFilter = null
+
+  """Filter by the latest contributing fragment's update timestamp."""
+  updatedAt: DateTimeFilter = null
+}
+
+"""Added in 26.4.4. Raw per-scope app-config fragment."""
+type AppConfigFragment implements Node {
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Scope type."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id."""
+  scopeId: String!
+
+  """Config name."""
+  name: String!
+
+  """Merge priority within `name` (low → high)."""
+  rank: Int!
+
+  """Raw configuration payload, or null."""
+  config: JSON
+
+  """Creation timestamp."""
+  createdAt: DateTime!
+
+  """Last update timestamp."""
+  updatedAt: DateTime
+}
+
+"""Added in 26.4.4. Per-item failure info for bulk Fragment mutations."""
+type AppConfigFragmentBulkError {
+  """Original position in the input list."""
+  index: Int!
+
+  """Scope type of the failed row."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id of the failed row."""
+  scopeId: String!
+
+  """Policy name of the failed row."""
+  name: String!
+
+  """Reason for the failure."""
+  message: String!
+}
+
+"""
+Added in 26.4.4. Connection type for paginated app-config fragment results.
+"""
+type AppConfigFragmentConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [AppConfigFragmentEdge!]!
+
+  """Total number of fragments matching the query."""
+  count: Int!
+}
+
+"""An edge in a connection."""
+type AppConfigFragmentEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: AppConfigFragment!
+}
+
+"""Added in 26.4.4. Filter input for querying app-config fragments."""
+input AppConfigFragmentFilter {
+  """Filter by policy name."""
+  name: StringFilter = null
+
+  """Filter by scope_id."""
+  scopeId: StringFilter = null
+}
+
+"""Added in 26.4.4. Natural key for an app-config fragment row."""
+input AppConfigFragmentKeyInput {
+  """Scope type."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id."""
+  scopeId: String!
+
+  """Policy name."""
+  name: String!
+}
+
+"""Added in 26.4.4. Specifies ordering for app-config fragment results."""
+input AppConfigFragmentOrderBy {
+  """The field to order by."""
+  field: AppConfigFragmentOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = DESC
+}
+
+"""Added in 26.4.4. Fields available for ordering app-config fragments."""
+enum AppConfigFragmentOrderField {
+  SCOPE_TYPE
+  SCOPE_ID
+  NAME
+  CREATED_AT
+  UPDATED_AT
+}
+
+"""Added in 26.4.4. Specifies ordering for merged AppConfig results."""
+input AppConfigOrderBy {
+  """The field to order by."""
+  field: AppConfigOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = ASC
+}
+
+"""Added in 26.4.4. Fields available for ordering merged AppConfigs."""
+enum AppConfigOrderField {
+  USER_ID
+  NAME
+  CREATED_AT
+  UPDATED_AT
+}
+
+"""
+Added in 26.4.4. Scope for the scoped merged-view AppConfig query. `userIds` are OR'd; raises an error when empty.
+"""
+input AppConfigScope {
+  """Target user UUIDs to scope the merged-view search to (OR'd)."""
+  userIds: [UUID!]!
+}
+
+enum AppConfigScopeType {
+  PUBLIC
+  DOMAIN
+  DOMAIN_USER_DEFAULTS
+  USER
 }
 
 """
@@ -7414,6 +7667,31 @@ type Mutation {
   """
   updateMyAllowedClientIp(input: UpdateMyAllowedClientIPInput!): UpdateMyAllowedClientIPPayload
 
+  """
+  Added in 26.4.4. Strict insert across any scope; each item runs in its own transaction and failures are collected per-item (admin only).
+  """
+  adminBulkCreateAppConfigFragments(input: AdminBulkCreateAppConfigFragmentInput!): AdminBulkCreateAppConfigFragmentsPayload!
+
+  """
+  Added in 26.4.4. Wholesale JSON replacement; items with no existing row are returned as failures (admin only).
+  """
+  adminBulkUpdateAppConfigFragments(input: AdminBulkUpdateAppConfigFragmentInput!): AdminBulkUpdateAppConfigFragmentsPayload!
+
+  """
+  Added in 26.4.4. Cleanup-only deletion; absent keys are no-oped (admin only).
+  """
+  adminBulkPurgeAppConfigFragments(input: AdminBulkPurgeAppConfigFragmentInput!): AdminBulkPurgeAppConfigFragmentsPayload!
+
+  """
+  Added in 26.4.4. Strict insert on the caller's USER row; duplicates fail per-item. Returns recomputed merged `AppConfig` views.
+  """
+  myBulkCreateAppConfigFragments(input: MyBulkCreateAppConfigFragmentInput!): MyBulkCreateAppConfigFragmentsPayload!
+
+  """
+  Added in 26.4.4. Wholesale replacement on the caller's USER row; missing rows are returned as failures. Returns recomputed merged `AppConfig` views.
+  """
+  myBulkUpdateAppConfigFragments(input: MyBulkUpdateAppConfigFragmentInput!): MyBulkUpdateAppConfigFragmentsPayload!
+
   """Added in 26.3.0. Create a new query definition (admin only)"""
   adminCreatePrometheusQueryPreset(input: CreateQueryDefinitionInput!): CreateQueryDefinitionPayload
 
@@ -7677,6 +7955,53 @@ type Mutation {
   Added in 26.4.4. Terminate one or more sessions by ID. Per-session RBAC permission is enforced by the bulk validator; any denial fails the whole request.
   """
   terminateSessionsV2(sessionIds: [ID!]!, forced: Boolean! = false): TerminateSessionsPayload
+}
+
+"""Added in 26.4.4. Per-item input for self-service (`my`) bulk."""
+input MyAppConfigFragmentItemInput {
+  """Policy name."""
+  name: String!
+
+  """Raw configuration payload."""
+  config: JSON!
+}
+
+"""
+Added in 26.4.4. Self-service bulk create — scope is `USER` / `current_user`.
+"""
+input MyBulkCreateAppConfigFragmentInput {
+  """USER-scope rows to create."""
+  items: [MyAppConfigFragmentItemInput!]!
+}
+
+"""
+Added in 26.4.4. Payload for `myBulkCreateAppConfigFragments` (recomputed views).
+"""
+type MyBulkCreateAppConfigFragmentsPayload {
+  """Recomputed merged AppConfig views for each created USER fragment."""
+  created: [AppConfig!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""
+Added in 26.4.4. Self-service bulk update — scope is `USER` / `current_user`.
+"""
+input MyBulkUpdateAppConfigFragmentInput {
+  """USER-scope rows to update."""
+  items: [MyAppConfigFragmentItemInput!]!
+}
+
+"""
+Added in 26.4.4. Payload for `myBulkUpdateAppConfigFragments` (recomputed views).
+"""
+type MyBulkUpdateAppConfigFragmentsPayload {
+  """Recomputed merged AppConfig views for each updated USER fragment."""
+  updated: [AppConfig!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
 }
 
 """
@@ -9031,6 +9356,18 @@ input ProjectWeightInputItem {
   weight: Decimal = null
 }
 
+"""Added in 26.4.4. Natural key of a purged fragment row."""
+type PurgeAppConfigFragmentKey {
+  """Scope type."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id."""
+  scopeId: String!
+
+  """Policy name."""
+  name: String!
+}
+
 """Added in 26.4.2. Payload for domain permanent deletion mutation."""
 type PurgeDomainPayload {
   """Whether the purge was successful."""
@@ -9347,6 +9684,31 @@ type Query {
   Added in 26.2.0. Query image aliases with optional filtering, ordering, and pagination. Returns image aliases that provide alternative names for container images. Use filters to search by alias string. Supports both cursor-based and offset-based pagination.
   """
   adminImageAliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection
+
+  """
+  Added in 26.4.4. Get a single app-config fragment by natural key `(scope_type, scope_id, name)`. Available to any authenticated user — service-layer authorization gates cross-scope reads.
+  """
+  appConfigFragment(scopeType: AppConfigScopeType!, scopeId: String!, name: String!): AppConfigFragment
+
+  """
+  Added in 26.4.4. Cross-scope admin search across all app-config fragments (admin only).
+  """
+  adminAppConfigFragments(filter: AppConfigFragmentFilter = null, orderBy: [AppConfigFragmentOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigFragmentConnection!
+
+  """
+  Added in 26.4.4. Public (no-auth) `PUBLIC`-scope app-config fragments — the subset of raw fragments that carry no personally-scoped data.
+  """
+  publicAppConfigFragments(filter: AppConfigFragmentFilter = null, orderBy: [AppConfigFragmentOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [AppConfigFragment!]!
+
+  """
+  Added in 26.4.4. Scoped merged-view AppConfig search (auth required, RBAC-gated). `scope.userIds` are OR'd; non-admin callers are restricted to their own user. Self-service is just a USER-scoped search.
+  """
+  scopedAppConfigs(scope: AppConfigScope!, filter: AppConfigFilter = null, orderBy: [AppConfigOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigConnection!
+
+  """
+  Added in 26.4.4. Cross-user merged-view search (admin only). Resolves any user's AppConfig for audit / support. Pin to a single user with `filter.userId`; otherwise paginates across all users.
+  """
+  adminAppConfigs(filter: AppConfigFilter = null, orderBy: [AppConfigOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigConnection!
 
   """
   Added in 26.4.2. Get a single prometheus query preset by ID. Available to any authenticated user since presets are a shared catalog of metric query templates.

--- a/src/ai/backend/manager/api/gql/app_config/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config/__init__.py
@@ -1,0 +1,29 @@
+"""AppConfig (merged view) GraphQL API package."""
+
+from .resolver import (
+    admin_app_configs,
+    public_app_config_fragments,
+    scoped_app_configs,
+)
+from .types import (
+    AppConfigConnectionGQL,
+    AppConfigFilterGQL,
+    AppConfigGQL,
+    AppConfigOrderByGQL,
+    AppConfigOrderFieldGQL,
+    AppConfigScopeGQL,
+)
+
+__all__ = [
+    # Queries
+    "scoped_app_configs",
+    "admin_app_configs",
+    "public_app_config_fragments",
+    # Types
+    "AppConfigGQL",
+    "AppConfigConnectionGQL",
+    "AppConfigFilterGQL",
+    "AppConfigOrderByGQL",
+    "AppConfigOrderFieldGQL",
+    "AppConfigScopeGQL",
+]

--- a/src/ai/backend/manager/api/gql/app_config/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config/resolver/__init__.py
@@ -1,0 +1,11 @@
+from .query import (
+    admin_app_configs,
+    public_app_config_fragments,
+    scoped_app_configs,
+)
+
+__all__ = [
+    "admin_app_configs",
+    "public_app_config_fragments",
+    "scoped_app_configs",
+]

--- a/src/ai/backend/manager/api/gql/app_config/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/app_config/resolver/query.py
@@ -1,0 +1,181 @@
+"""AppConfig (merged view) GQL query resolvers."""
+
+from __future__ import annotations
+
+import strawberry
+from strawberry import Info
+
+from ai.backend.common.dto.manager.v2.app_config.request import (
+    ScopedSearchAppConfigsInput,
+    SearchAppConfigsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    SearchAppConfigFragmentsInput,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.app_config.types import (
+    AppConfigConnectionGQL,
+    AppConfigEdgeGQL,
+    AppConfigFilterGQL,
+    AppConfigGQL,
+    AppConfigOrderByGQL,
+    AppConfigScopeGQL,
+)
+from ai.backend.manager.api.gql.app_config_fragment.types import (
+    AppConfigFragmentFilterGQL,
+    AppConfigFragmentGQL,
+    AppConfigFragmentOrderByGQL,
+)
+from ai.backend.manager.api.gql.base import encode_cursor
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_root_field,
+)
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+from ai.backend.manager.api.gql.utils import check_admin_only
+from ai.backend.manager.data.app_config_fragment.types import AppConfigScopeType
+
+
+def _app_config_id(user_id: object, name: str) -> str:
+    """Composite Relay id for the merged view (keyed by `(user_id, name)`)."""
+    return f"{user_id}:{name}"
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Scoped merged-view AppConfig search (auth required, RBAC-gated). "
+            "`scope.userIds` are OR'd; non-admin callers are restricted to "
+            "their own user. Self-service is just a USER-scoped search."
+        ),
+    )
+)  # type: ignore[misc]
+async def scoped_app_configs(
+    info: Info[StrawberryGQLContext],
+    scope: AppConfigScopeGQL,
+    filter: AppConfigFilterGQL | None = None,
+    order_by: list[AppConfigOrderByGQL] | None = None,
+    first: int | None = None,
+    after: str | None = None,
+    last: int | None = None,
+    before: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> AppConfigConnectionGQL:
+    payload = await info.context.adapters.app_config.scoped_search_app_configs(
+        ScopedSearchAppConfigsInput(
+            scope=scope.to_pydantic(),
+            filter=filter.to_pydantic() if filter else None,
+            order=[o.to_pydantic() for o in order_by] if order_by else None,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        )
+    )
+    nodes = [
+        AppConfigGQL.from_pydantic(item, extra={"id": _app_config_id(item.user_id, item.name)})
+        for item in payload.items
+    ]
+    edges = [AppConfigEdgeGQL(node=node, cursor=encode_cursor(node.id)) for node in nodes]
+    return AppConfigConnectionGQL(
+        edges=edges,
+        page_info=strawberry.relay.PageInfo(
+            has_next_page=payload.has_next_page,
+            has_previous_page=payload.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        ),
+        count=payload.total_count,
+    )
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Cross-user merged-view search (admin only). Resolves any user's "
+            "AppConfig for audit / support. Pin to a single user with "
+            "`filter.userId`; otherwise paginates across all users."
+        ),
+    )
+)  # type: ignore[misc]
+async def admin_app_configs(
+    info: Info[StrawberryGQLContext],
+    filter: AppConfigFilterGQL | None = None,
+    order_by: list[AppConfigOrderByGQL] | None = None,
+    first: int | None = None,
+    after: str | None = None,
+    last: int | None = None,
+    before: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> AppConfigConnectionGQL:
+    check_admin_only()
+    payload = await info.context.adapters.app_config.admin_search_app_configs(
+        SearchAppConfigsInput(
+            filter=filter.to_pydantic() if filter else None,
+            order=[o.to_pydantic() for o in order_by] if order_by else None,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        )
+    )
+    nodes = [
+        AppConfigGQL.from_pydantic(item, extra={"id": _app_config_id(item.user_id, item.name)})
+        for item in payload.items
+    ]
+    edges = [AppConfigEdgeGQL(node=node, cursor=encode_cursor(node.id)) for node in nodes]
+    return AppConfigConnectionGQL(
+        edges=edges,
+        page_info=strawberry.relay.PageInfo(
+            has_next_page=payload.has_next_page,
+            has_previous_page=payload.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        ),
+        count=payload.total_count,
+    )
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Public (no-auth) `PUBLIC`-scope app-config fragments — the subset of "
+            "raw fragments that carry no personally-scoped data."
+        ),
+    )
+)  # type: ignore[misc]
+async def public_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    filter: AppConfigFragmentFilterGQL | None = None,
+    order_by: list[AppConfigFragmentOrderByGQL] | None = None,
+    first: int | None = None,
+    after: str | None = None,
+    last: int | None = None,
+    before: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> list[AppConfigFragmentGQL]:
+    payload = await info.context.adapters.app_config_fragment.search(
+        scope_type=AppConfigScopeType.PUBLIC,
+        scope_id=AppConfigScopeType.PUBLIC.value,
+        input=SearchAppConfigFragmentsInput(
+            filter=filter.to_pydantic() if filter else None,
+            order=[o.to_pydantic() for o in order_by] if order_by else None,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        ),
+    )
+    return [AppConfigFragmentGQL.from_pydantic(node) for node in payload.items]

--- a/src/ai/backend/manager/api/gql/app_config/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config/types/__init__.py
@@ -1,0 +1,21 @@
+from .filters import (
+    AppConfigFilterGQL,
+    AppConfigOrderByGQL,
+    AppConfigOrderFieldGQL,
+)
+from .node import (
+    AppConfigConnectionGQL,
+    AppConfigEdgeGQL,
+    AppConfigGQL,
+)
+from .scope import AppConfigScopeGQL
+
+__all__ = [
+    "AppConfigConnectionGQL",
+    "AppConfigEdgeGQL",
+    "AppConfigFilterGQL",
+    "AppConfigGQL",
+    "AppConfigOrderByGQL",
+    "AppConfigOrderFieldGQL",
+    "AppConfigScopeGQL",
+]

--- a/src/ai/backend/manager/api/gql/app_config/types/bulk_payloads.py
+++ b/src/ai/backend/manager/api/gql/app_config/types/bulk_payloads.py
@@ -1,0 +1,55 @@
+"""AppConfig (merged-view) GQL payloads for self-service bulk mutations."""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.app_config.response import (
+    MyBulkCreateAppConfigFragmentsPayload as MyBulkCreatePayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config.response import (
+    MyBulkUpdateAppConfigFragmentsPayload as MyBulkUpdatePayloadDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.app_config.types.node import AppConfigGQL
+from ai.backend.manager.api.gql.app_config_fragment.types.bulk_payloads import (
+    AppConfigFragmentBulkErrorGQL,
+)
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticOutputMixin
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for `myBulkCreateAppConfigFragments` (recomputed views).",
+    ),
+    model=MyBulkCreatePayloadDTO,
+    name="MyBulkCreateAppConfigFragmentsPayload",
+)
+class MyBulkCreateAppConfigFragmentsPayloadGQL(PydanticOutputMixin[MyBulkCreatePayloadDTO]):
+    created: list[AppConfigGQL] = gql_field(
+        description="Recomputed merged AppConfig views for each created USER fragment.",
+    )
+    failed: list[AppConfigFragmentBulkErrorGQL] = gql_field(
+        description="Per-item failures.",
+    )
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for `myBulkUpdateAppConfigFragments` (recomputed views).",
+    ),
+    model=MyBulkUpdatePayloadDTO,
+    name="MyBulkUpdateAppConfigFragmentsPayload",
+)
+class MyBulkUpdateAppConfigFragmentsPayloadGQL(PydanticOutputMixin[MyBulkUpdatePayloadDTO]):
+    updated: list[AppConfigGQL] = gql_field(
+        description="Recomputed merged AppConfig views for each updated USER fragment.",
+    )
+    failed: list[AppConfigFragmentBulkErrorGQL] = gql_field(
+        description="Per-item failures.",
+    )

--- a/src/ai/backend/manager/api/gql/app_config/types/filters.py
+++ b/src/ai/backend/manager/api/gql/app_config/types/filters.py
@@ -1,0 +1,78 @@
+"""AppConfig (merged view) GQL filter / order types."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from ai.backend.common.dto.manager.v2.app_config.request import (
+    AppConfigFilter as AppConfigFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config.request import (
+    AppConfigOrder as AppConfigOrderDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.base import (
+    DateTimeFilter,
+    OrderDirection,
+    StringFilter,
+    UUIDFilter,
+)
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_enum,
+    gql_field,
+    gql_pydantic_input,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Filter input for querying merged AppConfigs.",
+    ),
+    name="AppConfigFilter",
+)
+class AppConfigFilterGQL(PydanticInputMixin[AppConfigFilterDTO]):
+    name: StringFilter | None = gql_field(description="Filter by policy name.", default=None)
+    user_id: UUIDFilter | None = gql_field(
+        description="Filter by target user id (admin cross-user search only).",
+        default=None,
+    )
+    created_at: DateTimeFilter | None = gql_field(
+        description="Filter by the oldest contributing fragment's creation timestamp.",
+        default=None,
+    )
+    updated_at: DateTimeFilter | None = gql_field(
+        description="Filter by the latest contributing fragment's update timestamp.",
+        default=None,
+    )
+
+
+@gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Fields available for ordering merged AppConfigs.",
+    ),
+    name="AppConfigOrderField",
+)
+class AppConfigOrderFieldGQL(StrEnum):
+    USER_ID = "user_id"
+    NAME = "name"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Specifies ordering for merged AppConfig results.",
+    ),
+    name="AppConfigOrderBy",
+)
+class AppConfigOrderByGQL(PydanticInputMixin[AppConfigOrderDTO]):
+    field: AppConfigOrderFieldGQL = gql_field(description="The field to order by.")
+    direction: OrderDirection = gql_field(
+        description="Sort direction.",
+        default=OrderDirection.ASC,
+    )

--- a/src/ai/backend/manager/api/gql/app_config/types/node.py
+++ b/src/ai/backend/manager/api/gql/app_config/types/node.py
@@ -1,0 +1,75 @@
+"""AppConfig (merged view) GQL Node, Edge, and Connection types."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated, Any
+from uuid import UUID
+
+import strawberry
+from strawberry.relay import Connection, Edge, NodeID
+from strawberry.scalars import JSON
+
+from ai.backend.common.dto.manager.v2.app_config.response import AppConfigNode
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_connection_type,
+    gql_field,
+    gql_node_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.app_config_fragment.types.node import AppConfigFragmentGQL
+
+
+@gql_node_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Merged per-user AppConfig view. `id` is the composite "
+            "`{userId}:{name}` (the merged view is a derived value, not a "
+            "table row); `fragments` are ordered low → high merge priority; "
+            "`config` is the deep-merge result and is null when every "
+            "contributing fragment is empty."
+        ),
+    ),
+    name="AppConfig",
+)
+class AppConfigGQL(PydanticNodeMixin[AppConfigNode]):
+    id: NodeID[str] = gql_field(description="Composite id `{userId}:{name}`.")
+    user_id: UUID = gql_field(description="Target user's UUID.")
+    name: str = gql_field(description="Policy / config name.")
+    # Use `strawberry.lazy()` to break the import cycle between
+    # `app_config.types.node` and `app_config_fragment.types.node`:
+    # the fragment package's `__init__.py` eagerly loads its resolver,
+    # which imports `MyBulkCreate*` payloads back from `app_config.types`.
+    fragments: list[
+        Annotated[
+            AppConfigFragmentGQL,
+            strawberry.lazy("ai.backend.manager.api.gql.app_config_fragment.types.node"),
+        ]
+    ] = gql_field(
+        description="Contributing fragments in merge order (low → high).",
+    )
+    config: JSON | None = gql_field(
+        description="Deep-merged configuration, or null when every fragment is empty.",
+    )
+
+
+AppConfigEdgeGQL = Edge[AppConfigGQL]
+
+
+@gql_connection_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Connection type for paginated merged AppConfig results.",
+    ),
+    name="AppConfigConnection",
+)
+class AppConfigConnectionGQL(Connection[AppConfigGQL]):
+    count: int = gql_field(description="Total number of AppConfigs matching the query.")
+
+    def __init__(self, *args: Any, count: int, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.count = count

--- a/src/ai/backend/manager/api/gql/app_config/types/scope.py
+++ b/src/ai/backend/manager/api/gql/app_config/types/scope.py
@@ -1,0 +1,30 @@
+"""AppConfig (merged view) GraphQL scope input types."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from ai.backend.common.dto.manager.v2.app_config.request import AppConfigScope
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_input,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description=(
+            "Scope for the scoped merged-view AppConfig query. "
+            "`userIds` are OR'd; raises an error when empty."
+        ),
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="AppConfigScope",
+)
+class AppConfigScopeGQL(PydanticInputMixin[AppConfigScope]):
+    user_ids: list[UUID] = gql_field(
+        description="Target user UUIDs to scope the merged-view search to (OR'd).",
+    )

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver/__init__.py
@@ -2,6 +2,8 @@ from .mutation import (
     admin_bulk_create_app_config_fragments,
     admin_bulk_purge_app_config_fragments,
     admin_bulk_update_app_config_fragments,
+    my_bulk_create_app_config_fragments,
+    my_bulk_update_app_config_fragments,
 )
 from .query import (
     admin_app_config_fragments,
@@ -14,4 +16,6 @@ __all__ = [
     "admin_bulk_purge_app_config_fragments",
     "admin_bulk_update_app_config_fragments",
     "app_config_fragment",
+    "my_bulk_create_app_config_fragments",
+    "my_bulk_update_app_config_fragments",
 ]

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver/mutation.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from strawberry import Info
 
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.app_config.types.bulk_payloads import (
+    MyBulkCreateAppConfigFragmentsPayloadGQL,
+    MyBulkUpdateAppConfigFragmentsPayloadGQL,
+)
 from ai.backend.manager.api.gql.app_config_fragment.types import (
     AdminBulkCreateAppConfigFragmentInputGQL,
     AdminBulkCreateAppConfigFragmentsPayloadGQL,
@@ -12,6 +16,8 @@ from ai.backend.manager.api.gql.app_config_fragment.types import (
     AdminBulkPurgeAppConfigFragmentsPayloadGQL,
     AdminBulkUpdateAppConfigFragmentInputGQL,
     AdminBulkUpdateAppConfigFragmentsPayloadGQL,
+    MyBulkCreateAppConfigFragmentInputGQL,
+    MyBulkUpdateAppConfigFragmentInputGQL,
 )
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -70,3 +76,37 @@ async def admin_bulk_purge_app_config_fragments(
     check_admin_only()
     result = await info.context.adapters.app_config_fragment.admin_bulk_purge(input.to_pydantic())
     return AdminBulkPurgeAppConfigFragmentsPayloadGQL.from_pydantic(result)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Strict insert on the caller's USER row; duplicates fail per-item. "
+            "Returns recomputed merged `AppConfig` views."
+        ),
+    )
+)
+async def my_bulk_create_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    input: MyBulkCreateAppConfigFragmentInputGQL,
+) -> MyBulkCreateAppConfigFragmentsPayloadGQL:
+    result = await info.context.adapters.app_config.my_bulk_create(input.to_pydantic())
+    return MyBulkCreateAppConfigFragmentsPayloadGQL.from_pydantic(result)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Wholesale replacement on the caller's USER row; missing rows are returned as "
+            "failures. Returns recomputed merged `AppConfig` views."
+        ),
+    )
+)
+async def my_bulk_update_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    input: MyBulkUpdateAppConfigFragmentInputGQL,
+) -> MyBulkUpdateAppConfigFragmentsPayloadGQL:
+    result = await info.context.adapters.app_config.my_bulk_update(input.to_pydantic())
+    return MyBulkUpdateAppConfigFragmentsPayloadGQL.from_pydantic(result)

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -15,6 +15,22 @@ from .agent import (
     agent_stats,
     agents_v2,
 )
+from .app_config import (
+    admin_app_configs,
+    public_app_config_fragments,
+    scoped_app_configs,
+)
+from .app_config_fragment.resolver.mutation import (
+    admin_bulk_create_app_config_fragments,
+    admin_bulk_purge_app_config_fragments,
+    admin_bulk_update_app_config_fragments,
+    my_bulk_create_app_config_fragments,
+    my_bulk_update_app_config_fragments,
+)
+from .app_config_fragment.resolver.query import (
+    admin_app_config_fragments,
+    app_config_fragment,
+)
 from .artifact import (
     approve_artifact_revision,
     artifact,
@@ -523,6 +539,13 @@ class Query:
     resource_slot_type = resource_slot_type
     resource_slot_types = resource_slot_types
     admin_image_aliases = admin_image_aliases
+    # App Config Fragment APIs
+    app_config_fragment = app_config_fragment
+    admin_app_config_fragments = admin_app_config_fragments
+    public_app_config_fragments = public_app_config_fragments
+    # App Config merged view APIs
+    scoped_app_configs = scoped_app_configs
+    admin_app_configs = admin_app_configs
     # Prometheus Query Preset APIs (read available to any authenticated user)
     prometheus_query_preset = prometheus_query_preset
     prometheus_query_presets = prometheus_query_presets
@@ -804,6 +827,12 @@ class Mutation:
     admin_unblock_user = admin_unblock_user
     # IP allowlist self-service mutation
     update_my_allowed_client_ip = update_my_allowed_client_ip
+    # App Config Fragment - Bulk mutations
+    admin_bulk_create_app_config_fragments = admin_bulk_create_app_config_fragments
+    admin_bulk_update_app_config_fragments = admin_bulk_update_app_config_fragments
+    admin_bulk_purge_app_config_fragments = admin_bulk_purge_app_config_fragments
+    my_bulk_create_app_config_fragments = my_bulk_create_app_config_fragments
+    my_bulk_update_app_config_fragments = my_bulk_update_app_config_fragments
     # Prometheus Query Preset - Admin APIs
     admin_create_prometheus_query_preset = admin_create_prometheus_query_preset
     admin_modify_prometheus_query_preset = admin_modify_prometheus_query_preset


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 12-PR stack delivering BEP-1052 (rank-based AppConfig). **Merge in order:**

1. ⬇️ **#12224** — `feat(BA-6510): AppConfigFragment schema, value types & repo specs`
2. ⬇️ **#12225** — `feat(BA-6511): AppConfigFragment repository (CRUD + rank merge)`
3. ⬇️ **#12226** — `feat(BA-6512): AppConfigFragment v2 DTOs + conditions/orders`
4. ⬇️ **#12244** — `feat(BA-6513): AppConfigFragment service layer (actions, processors)`
5. ⬇️ **#12228** — `feat(BA-6514): AppConfigFragment adapter`
6. ⬇️ **#12229** — `feat(BA-6515): merged-view scoped/admin backend + DTO + adapter`
7. ⬇️ **#12230** — `feat(BA-6516): AppConfigFragment GraphQL`
8. 👉 **#12231** — `feat(BA-6517): merged AppConfig GraphQL` ← you are here
9. ⬇️ **#11286** — `feat(BA-5830): AppConfig/Fragment REST v2`
10. ⬇️ **#12232** — `feat(BA-6518): AppConfig v2 SDK`
11. ⬇️ **#12233** — `feat(BA-6519): AppConfig v2 CLI`
12. ⬇️ **#11298** — `feat(BA-5837): ValkeyCache for merged-view reads`

## Summary

Merged AppConfig GraphQL (scoped/admin) wired into the schema.


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12231.org.readthedocs.build/en/12231/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12231.org.readthedocs.build/ko/12231/

<!-- readthedocs-preview sorna-ko end -->
