### PR TITLE
feat(BA-6519): AppConfig v2 CLI

### DIFF
--- a/changes/12233.feature.md
+++ b/changes/12233.feature.md
@@ -1,0 +1,1 @@
+Add the AppConfig v2 CLI commands.

--- a/src/ai/backend/client/cli/v2/__init__.py
+++ b/src/ai/backend/client/cli/v2/__init__.py
@@ -260,6 +260,11 @@ def notification() -> None:
     """Notification commands."""
 
 
+@v2.group(cls=LazyGroup, import_name="ai.backend.client.cli.v2.app_config:app_config")
+def app_config() -> None:
+    """App config (merged-view) commands."""
+
+
 @v2.group(
     cls=LazyGroup,
     import_name="ai.backend.client.cli.v2.prometheus_query_preset:prometheus_query_preset",

--- a/src/ai/backend/client/cli/v2/admin/__init__.py
+++ b/src/ai/backend/client/cli/v2/admin/__init__.py
@@ -212,3 +212,21 @@ def invitation() -> None:
 )
 def role_preset() -> None:
     """Admin role preset commands."""
+
+
+@admin.group(
+    cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.admin.app_config:app_config",
+    name="app-config",
+)
+def app_config() -> None:
+    """Admin merged AppConfig commands."""
+
+
+@admin.group(
+    cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.admin.app_config_fragment:app_config_fragment",
+    name="app-config-fragment",
+)
+def app_config_fragment() -> None:
+    """Admin AppConfigFragment commands (cross-scope search + bulk-only writes)."""

--- a/src/ai/backend/client/cli/v2/admin/app_config.py
+++ b/src/ai/backend/client/cli/v2/admin/app_config.py
@@ -1,0 +1,92 @@
+"""Admin CLI commands for the merged AppConfig view."""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    parse_order_options,
+    print_result,
+)
+
+
+@click.group(name="app-config")
+def app_config() -> None:
+    """Admin merged AppConfig commands."""
+
+
+@app_config.command()
+@click.argument("user_id", type=click.UUID)
+@click.argument("name", type=str)
+def get(user_id: UUID, name: str) -> None:
+    """Read a specific user's merged AppConfig (admin only)."""
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config.admin_get(user_id, name)
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@app_config.command()
+@click.option("--limit", type=int, default=None, help="Maximum items to return.")
+@click.option("--offset", type=int, default=None, help="Number of items to skip.")
+@click.option("--name-contains", type=str, default=None, help="Filter `name` by substring.")
+@click.option("--user-id", type=click.UUID, default=None, help="Pin to a single user (UUID).")
+@click.option(
+    "--order-by",
+    multiple=True,
+    help="Order by field:direction. Fields: name, user_id.",
+)
+def search(
+    limit: int | None,
+    offset: int | None,
+    name_contains: str | None,
+    user_id: UUID | None,
+    order_by: tuple[str, ...],
+) -> None:
+    """Cross-user merged-view search (superadmin only)."""
+    from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
+    from ai.backend.common.dto.manager.v2.app_config.request import (
+        AppConfigFilter,
+        AppConfigOrder,
+        SearchAppConfigsInput,
+    )
+    from ai.backend.common.dto.manager.v2.app_config.types import AppConfigOrderField
+
+    filter_dto: AppConfigFilter | None = None
+    if name_contains is not None or user_id is not None:
+        filter_dto = AppConfigFilter(
+            name=StringFilter(contains=name_contains) if name_contains is not None else None,
+            user_id=UUIDFilter(equals=user_id) if user_id is not None else None,
+        )
+
+    orders = (
+        parse_order_options(order_by, AppConfigOrderField, AppConfigOrder) if order_by else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config.admin_search(
+                SearchAppConfigsInput(
+                    filter=filter_dto,
+                    order=orders,
+                    limit=limit,
+                    offset=offset,
+                ),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())

--- a/src/ai/backend/client/cli/v2/admin/app_config_fragment.py
+++ b/src/ai/backend/client/cli/v2/admin/app_config_fragment.py
@@ -1,0 +1,181 @@
+"""Admin CLI commands for AppConfigFragment (cross-scope search + bulk-only writes)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    parse_order_options,
+    print_result,
+)
+
+
+@click.group(name="app-config-fragment")
+def app_config_fragment() -> None:
+    """Admin AppConfigFragment commands (cross-scope search + bulk-only writes)."""
+
+
+def _load_items(items_arg: str) -> list[dict[str, Any]]:
+    """Accept JSON string or `@file.json` path."""
+    if items_arg.startswith("@"):
+        return cast("list[dict[str, Any]]", json.loads(Path(items_arg[1:]).read_text()))
+    return cast("list[dict[str, Any]]", json.loads(items_arg))
+
+
+@app_config_fragment.command()
+@click.option("--limit", type=int, default=None, help="Maximum items to return.")
+@click.option("--offset", type=int, default=None, help="Number of items to skip.")
+@click.option("--name-contains", type=str, default=None, help="Filter `name` by substring.")
+@click.option("--scope-type", type=str, default=None, help="Filter by scope_type.")
+@click.option("--scope-id-contains", type=str, default=None, help="Filter `scope_id` by substring.")
+@click.option(
+    "--order-by",
+    multiple=True,
+    help="Order by field:direction. Fields: scope_type, scope_id, name, created_at, updated_at.",
+)
+def search(
+    limit: int | None,
+    offset: int | None,
+    name_contains: str | None,
+    scope_type: str | None,
+    scope_id_contains: str | None,
+    order_by: tuple[str, ...],
+) -> None:
+    """Cross-scope fragment search (superadmin only)."""
+    from ai.backend.common.dto.manager.query import StringFilter
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        AppConfigFragmentFilter,
+        AppConfigFragmentOrder,
+        SearchAppConfigFragmentsInput,
+    )
+    from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
+        AppConfigFragmentOrderField,
+        AppConfigScopeType,
+    )
+
+    filter_dto: AppConfigFragmentFilter | None = None
+    if any([name_contains, scope_type, scope_id_contains]):
+        filter_dto = AppConfigFragmentFilter(
+            name=StringFilter(contains=name_contains) if name_contains is not None else None,
+            scope_type=AppConfigScopeType(scope_type) if scope_type is not None else None,
+            scope_id=(
+                StringFilter(contains=scope_id_contains) if scope_id_contains is not None else None
+            ),
+        )
+
+    orders = (
+        parse_order_options(order_by, AppConfigFragmentOrderField, AppConfigFragmentOrder)
+        if order_by
+        else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_fragment.admin_search(
+                SearchAppConfigFragmentsInput(
+                    filter=filter_dto,
+                    order=orders,
+                    limit=limit,
+                    offset=offset,
+                ),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@app_config_fragment.command(name="bulk-create")
+@click.option(
+    "--items",
+    required=True,
+    help=(
+        "JSON list of `{key: {scope_type, scope_id, name}, config}` items, "
+        "or `@path/to/items.json`."
+    ),
+)
+def bulk_create(items: str) -> None:
+    """Bulk-create fragments (partial-success semantics)."""
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        AdminAppConfigFragmentItemInput,
+        AdminBulkCreateAppConfigFragmentsInput,
+    )
+
+    parsed = [AdminAppConfigFragmentItemInput.model_validate(item) for item in _load_items(items)]
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_fragment.admin_bulk_create(
+                AdminBulkCreateAppConfigFragmentsInput(items=parsed),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@app_config_fragment.command(name="bulk-update")
+@click.option(
+    "--items",
+    required=True,
+    help="Same shape as `bulk-create`; replaces `config` wholesale.",
+)
+def bulk_update(items: str) -> None:
+    """Bulk-update fragments (partial-success semantics)."""
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        AdminAppConfigFragmentItemInput,
+        AdminBulkUpdateAppConfigFragmentsInput,
+    )
+
+    parsed = [AdminAppConfigFragmentItemInput.model_validate(item) for item in _load_items(items)]
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_fragment.admin_bulk_update(
+                AdminBulkUpdateAppConfigFragmentsInput(items=parsed),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@app_config_fragment.command(name="bulk-purge")
+@click.option(
+    "--keys",
+    required=True,
+    help="JSON list of `{scope_type, scope_id, name}` keys, or `@path/to/keys.json`.",
+)
+def bulk_purge(keys: str) -> None:
+    """Bulk-purge fragments by natural key (partial-success semantics)."""
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        AdminBulkPurgeAppConfigFragmentsInput,
+        AppConfigFragmentKeyInput,
+    )
+
+    parsed = [AppConfigFragmentKeyInput.model_validate(item) for item in _load_items(keys)]
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_fragment.admin_bulk_purge(
+                AdminBulkPurgeAppConfigFragmentsInput(keys=parsed),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())

--- a/src/ai/backend/client/cli/v2/app_config/__init__.py
+++ b/src/ai/backend/client/cli/v2/app_config/__init__.py
@@ -1,0 +1,3 @@
+from .commands import app_config as app_config
+
+__all__ = ("app_config",)

--- a/src/ai/backend/client/cli/v2/app_config/commands.py
+++ b/src/ai/backend/client/cli/v2/app_config/commands.py
@@ -1,0 +1,90 @@
+"""CLI commands for the merged AppConfig view.
+
+Public entrypoint exposes only the read paths that any authenticated
+user can hit. Self-service writes live under `bai my app-config`;
+admin operations live under `bai admin app-config`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    parse_order_options,
+    print_result,
+)
+
+
+@click.group(name="app-config")
+def app_config() -> None:
+    """Merged AppConfig commands (per-policy resolved view)."""
+
+
+@app_config.command()
+@click.option(
+    "--user-id",
+    "user_ids",
+    type=click.UUID,
+    multiple=True,
+    required=True,
+    help="Target user UUID to scope the search to (repeatable, OR'd). "
+    "Pass your own id for self-service.",
+)
+@click.option("--limit", type=int, default=None, help="Maximum items to return.")
+@click.option("--offset", type=int, default=None, help="Number of items to skip.")
+@click.option("--name-contains", type=str, default=None, help="Filter `name` by substring.")
+@click.option(
+    "--order-by",
+    multiple=True,
+    help="Order by field:direction. Fields: name, user_id.",
+)
+def search(
+    user_ids: tuple[UUID, ...],
+    limit: int | None,
+    offset: int | None,
+    name_contains: str | None,
+    order_by: tuple[str, ...],
+) -> None:
+    """Scoped merged-view search (auth required, RBAC-gated).
+
+    `--user-id` is the scope; pass your own id for self-service.
+    """
+    from ai.backend.common.dto.manager.query import StringFilter
+    from ai.backend.common.dto.manager.v2.app_config.request import (
+        AppConfigFilter,
+        AppConfigOrder,
+        AppConfigScope,
+        ScopedSearchAppConfigsInput,
+    )
+    from ai.backend.common.dto.manager.v2.app_config.types import AppConfigOrderField
+
+    filter_dto: AppConfigFilter | None = None
+    if name_contains is not None:
+        filter_dto = AppConfigFilter(name=StringFilter(contains=name_contains))
+
+    orders = (
+        parse_order_options(order_by, AppConfigOrderField, AppConfigOrder) if order_by else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config.scoped_search(
+                ScopedSearchAppConfigsInput(
+                    scope=AppConfigScope(user_ids=list(user_ids)),
+                    filter=filter_dto,
+                    order=orders,
+                    limit=limit,
+                    offset=offset,
+                ),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())

--- a/src/ai/backend/client/cli/v2/my/__init__.py
+++ b/src/ai/backend/client/cli/v2/my/__init__.py
@@ -82,3 +82,12 @@ def resource_policy() -> None:
 )
 def storage_host() -> None:
     """My storage host commands."""
+
+
+@my.group(
+    cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.my.app_config:app_config",
+    name="app-config",
+)
+def app_config() -> None:
+    """My merged AppConfig commands."""

--- a/src/ai/backend/client/cli/v2/my/app_config.py
+++ b/src/ai/backend/client/cli/v2/my/app_config.py
@@ -1,0 +1,88 @@
+"""Self-service CLI commands for the merged AppConfig view."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    print_result,
+)
+
+
+@click.group(name="app-config")
+def app_config() -> None:
+    """Self-service AppConfig commands for the current user.
+
+    Self-service search has moved to the scoped surface — use
+    `bai app-config search --user-id <your-id>`.
+    """
+
+
+def _load_items(items_arg: str) -> list[dict[str, Any]]:
+    """Accept JSON string or `@file.json` path."""
+    if items_arg.startswith("@"):
+        return cast("list[dict[str, Any]]", json.loads(Path(items_arg[1:]).read_text()))
+    return cast("list[dict[str, Any]]", json.loads(items_arg))
+
+
+@app_config.command(name="bulk-create")
+@click.option(
+    "--items",
+    required=True,
+    help="JSON list of `{name, config}` items, or `@path/to/items.json`.",
+)
+def bulk_create(items: str) -> None:
+    """Bulk-create USER-scope fragments; returns recomputed merged views."""
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        MyAppConfigFragmentItemInput,
+        MyBulkCreateAppConfigFragmentsInput,
+    )
+
+    parsed = [MyAppConfigFragmentItemInput.model_validate(item) for item in _load_items(items)]
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config.my_bulk_create(
+                MyBulkCreateAppConfigFragmentsInput(items=parsed),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@app_config.command(name="bulk-update")
+@click.option(
+    "--items",
+    required=True,
+    help="Same shape as `bulk-create`; replaces `config` wholesale.",
+)
+def bulk_update(items: str) -> None:
+    """Bulk-update USER-scope fragments; returns recomputed merged views."""
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        MyAppConfigFragmentItemInput,
+        MyBulkUpdateAppConfigFragmentsInput,
+    )
+
+    parsed = [MyAppConfigFragmentItemInput.model_validate(item) for item in _load_items(items)]
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config.my_bulk_update(
+                MyBulkUpdateAppConfigFragmentsInput(items=parsed),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 12-PR stack delivering BEP-1052 (rank-based AppConfig). **Merge in order:**

1. ⬇️ **#12224** — `feat(BA-6510): AppConfigFragment schema, value types & repo specs`
2. ⬇️ **#12225** — `feat(BA-6511): AppConfigFragment repository (CRUD + rank merge)`
3. ⬇️ **#12226** — `feat(BA-6512): AppConfigFragment v2 DTOs + conditions/orders`
4. ⬇️ **#12244** — `feat(BA-6513): AppConfigFragment service layer (actions, processors)`
5. ⬇️ **#12228** — `feat(BA-6514): AppConfigFragment adapter`
6. ⬇️ **#12229** — `feat(BA-6515): merged-view scoped/admin backend + DTO + adapter`
7. ⬇️ **#12230** — `feat(BA-6516): AppConfigFragment GraphQL`
8. ⬇️ **#12231** — `feat(BA-6517): merged AppConfig GraphQL`
9. ⬇️ **#11286** — `feat(BA-5830): AppConfig/Fragment REST v2`
10. ⬇️ **#12232** — `feat(BA-6518): AppConfig v2 SDK`
11. 👉 **#12233** — `feat(BA-6519): AppConfig v2 CLI` ← you are here
12. ⬇️ **#11298** — `feat(BA-5837): ValkeyCache for merged-view reads`

## Summary

v2 CLI commands over the SDK.

