### PR TITLE
fix(BA-6520): read revision preset values from live model runtime config

### DIFF
--- a/changes/12236.fix.md
+++ b/changes/12236.fix.md
@@ -1,0 +1,1 @@
+Fix `runtimeVariantPresetValues` on a deployment revision returning an empty array instead of the persisted preset values

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -2351,7 +2351,7 @@ class DeploymentAdapter(BaseAdapter):
                 environ=environ_dto,
                 runtime_variant_preset_values=[
                     RuntimeVariantPresetValueInfoDTO(preset_id=pv.preset_id, value=pv.value)
-                    for pv in data.revision_preset.values
+                    for pv in data.model_runtime_config.runtime_variant_preset_values
                 ],
             ),
             model_mount_config=model_mount_config_dto,


### PR DESCRIPTION
## Summary
- The `runtimeVariantPresetValues` GraphQL field on a deployment revision returned an empty array even when values were persisted in `deployment_revisions.preset_values`.
- Root cause: the revision DTO adapter iterated `data.revision_preset.values`, which has been hardcoded to `[]` ("currently dead code") since the BA-6507 refactor moved the real values onto `model_runtime_config.runtime_variant_preset_values`.
- Fix: read from the live `data.model_runtime_config.runtime_variant_preset_values`.

The write path, draft-merge, and refresh path were all verified to read/write the live location correctly — this READ site was the only one left pointing at the dead field.

## Test plan
- [ ] Query `deployment.revisionHistory { ... modelRuntimeConfig { runtimeVariantPresetValues { presetId value } } }` and confirm persisted values are returned (was `[]`).
- [ ] Existing `test_deployment_adapter` / `test_deployment` suites pass (green on push).

Resolves BA-6520