### PR TITLE
chore(ci): bump pants GHA cache keys to clear stale lmdb after pex->uv migration

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Bootstrap Pants
       uses: pantsbuild/actions/init-pants@v11
       with:
-        gha-cache-key: pants-cache-main-1-deploy-py${{ env.PROJECT_PYTHON_VERSION }}-${{ runner.os }}-${{ runner.arch }}
+        gha-cache-key: pants-cache-main-2-deploy-py${{ env.PROJECT_PYTHON_VERSION }}-${{ runner.os }}-${{ runner.arch }}
         named-caches-hash: ${{ hashFiles('python*.lock', 'tools/*.lock') }}
         cache-lmdb-store: 'false'
     - name: Build both lazy and fat packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
       # See: github.com/pantsbuild/actions/tree/main/init-pants/
       # ref) https://github.com/pantsbuild/example-python/blob/main/.github/workflows/pants.yaml#L30-L49
       with:
-        gha-cache-key: v0
+        gha-cache-key: v1
         named-caches-hash: ${{ hashFiles('python*.lock', 'tools/*.lock') }}
         cache-lmdb-store: 'true'
     - name: Calculate base ref
@@ -207,7 +207,7 @@ jobs:
     - name: Bootstrap Pants
       uses: pantsbuild/actions/init-pants@v11
       with:
-        gha-cache-key: v0
+        gha-cache-key: v1
         named-caches-hash: ${{ hashFiles('python*.lock', 'tools/*.lock') }}
         cache-lmdb-store: 'true'
     - name: Calculate base ref
@@ -302,7 +302,7 @@ jobs:
       if: steps.filter.outputs.models == 'true' || startsWith(github.ref, 'refs/tags/')
       uses: pantsbuild/actions/init-pants@v11
       with:
-        gha-cache-key: v0
+        gha-cache-key: v1
         named-caches-hash: ${{ hashFiles('python*.lock', 'tools/*.lock') }}
         # ``pants export`` builds a venv into the named caches; caching the
         # lmdb_store (process cache) here desyncs from the named-caches cache
@@ -384,7 +384,7 @@ jobs:
     - name: Bootstrap Pants
       uses: pantsbuild/actions/init-pants@v11
       with:
-        gha-cache-key: v0
+        gha-cache-key: v1
         named-caches-hash: ${{ hashFiles('python*.lock', 'tools/*.lock') }}
         cache-lmdb-store: 'true'
     - name: Test
@@ -463,7 +463,7 @@ jobs:
     - name: Bootstrap Pants
       uses: pantsbuild/actions/init-pants@v11
       with:
-        gha-cache-key: v0
+        gha-cache-key: v1
         named-caches-hash: ${{ hashFiles('python*.lock', 'tools/*.lock') }}
         cache-lmdb-store: 'true'
     - name: Test
@@ -546,7 +546,7 @@ jobs:
     - name: Bootstrap Pants
       uses: pantsbuild/actions/init-pants@v11
       with:
-        gha-cache-key: v0
+        gha-cache-key: v1
         named-caches-hash: ${{ hashFiles('python*.lock', 'tools/*.lock') }}
         cache-lmdb-store: 'true'
     - name: Test
@@ -660,7 +660,7 @@ jobs:
     - name: Bootstrap Pants
       uses: pantsbuild/actions/init-pants@v11
       with:
-        gha-cache-key: v0-${{ runner.arch }}
+        gha-cache-key: v1-${{ runner.arch }}
         named-caches-hash: ${{ hashFiles('python*.lock', 'tools/*.lock') }}
         cache-lmdb-store: 'false'
     - name: Build both lazy and fat packages
@@ -717,7 +717,7 @@ jobs:
     - name: Bootstrap Pants
       uses: pantsbuild/actions/init-pants@v11
       with:
-        gha-cache-key: v0
+        gha-cache-key: v1
         named-caches-hash: ${{ hashFiles('python*.lock', 'tools/*.lock') }}
         cache-lmdb-store: 'false'
     - name: Build wheel packages
@@ -764,7 +764,7 @@ jobs:
     - name: Bootstrap Pants
       uses: pantsbuild/actions/init-pants@v11
       with:
-        gha-cache-key: v0
+        gha-cache-key: v1
         named-caches-hash: ${{ hashFiles('python*.lock', 'tools/*.lock') }}
         cache-lmdb-store: 'false'
     - name: Pants export

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Bootstrap Pants
       uses: pantsbuild/actions/init-pants@v11
       with:
-        gha-cache-key: v0
+        gha-cache-key: v1
         named-caches-hash: ${{ hashFiles('python*.lock', 'tools/*.lock') }}
         cache-lmdb-store: 'true'
     - name: Run the full test suite

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Bootstrap Pants
       uses: pantsbuild/actions/init-pants@v11
       with:
-        gha-cache-key: pants-cache-main-1-integration-py${{ env.PROJECT_PYTHON_VERSION }}-${{ runner.os }}-${{ runner.arch }}
+        gha-cache-key: pants-cache-main-2-integration-py${{ env.PROJECT_PYTHON_VERSION }}-${{ runner.os }}-${{ runner.arch }}
         named-caches-hash: ${{ hashFiles('python*.lock', 'tools/*.lock') }}
         cache-lmdb-store: 'true'
     - name: Test

--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -50,7 +50,7 @@ jobs:
       # See: github.com/pantsbuild/actions/tree/main/init-pants/
       # ref) https://github.com/pantsbuild/example-python/blob/main/.github/workflows/pants.yaml#L30-L49
       with:
-        gha-cache-key: v0
+        gha-cache-key: v1
         named-caches-hash: ${{ hashFiles('python*.lock', 'tools/*.lock') }}
         # ``pants export`` fails when a stale PEX from the pex->uv lockfile
         # migration is restored from the lmdb_store cache; disable it here


### PR DESCRIPTION
## Summary
- After the pex→uv lockfile migration, Pants' `lmdb_store` process cache holds a stale PEX. CI restores it and `pants check`/`pants export` fail **intermittently** with `Error launching process: ... No such file or directory` for the venv python (dangling reference into the cached named caches). Re-runs restore the same poisoned cache, so it does not self-heal.
- #12234 only disabled lmdb caching on the **export** jobs; the **lint/typecheck/test** jobs still restore the stale cache (e.g. #12212's `typecheck` failure).
- Bumps every Pants GHA cache key (`v0`→`v1`, `v0-${arch}`→`v1-${arch}`, `pants-cache-main-1-*`→`pants-cache-main-2-*`) to invalidate the poisoned caches **once** — the CI equivalent of the developer one-time `rm -rf ~/.cache/pants/lmdb_store/` — while keeping the process cache enabled for future runs.

## Test plan
- [ ] CI green on this PR (first run rebuilds caches cold, then warm).
- [ ] After merge, rebase open PRs to pick up the new keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)