### PR TITLE
doc(BA-6525): rewrite BEP-1052 for the three-table scoped app config model

### DIFF
--- a/changes/12246.doc.md
+++ b/changes/12246.doc.md
@@ -1,0 +1,1 @@
+Rewrite BEP-1052 (Scoped App Config Redesign) around an explicit `app_config_definitions` table, per-scope `app_config_fragments` merged by rank on a join-free read path, and a per-`(config_name, scope_type)` write allow-list.

--- a/proposals/BEP-1052-scoped-app-config-redesign.md
+++ b/proposals/BEP-1052-scoped-app-config-redesign.md
@@ -49,8 +49,10 @@ Three scopes cover the use cases (`public` for the pre-login shell):
 - Where the admin has granted it, users persist their own settings on
   the server (language, recently used sessions, visible/ordered table
   columns, experimental-feature toggles).
-- The same scope may publish several independently-managed documents
-  loaded by different parts of the WebUI.
+- A single `config_name` can hold a different value at each scope: an
+  admin manages the `public` / `domain` value, and the user changes only
+  their own `user`-scope fragment. This one mechanism — per-scope
+  fragments combined by the merge — covers every use case above.
 
 ## Design Principles
 

--- a/proposals/BEP-1052-scoped-app-config-redesign.md
+++ b/proposals/BEP-1052-scoped-app-config-redesign.md
@@ -24,9 +24,11 @@ query with **no joins and no permission lookup**.
 
 **Write authorization is set up ahead of time.** Every document name is
 **explicitly registered** in `app_config_keys`, and `app_config_allow_list`
-records — **pre-configured by admins** — grant the self-service (user)
-path permission to `create` / `update` / `purge` its own fragment. Admin
-writes are ungated. So the cost of permission lives entirely on the
+records — **pre-configured by admins** — enumerate the
+`(config_name, scope_type)` pairs at which a fragment may be written.
+**Every** fragment write, admin or user, requires a matching record;
+admins additionally own the allow-list and the registry themselves
+(users cannot). So the cost of permission lives entirely on the
 (infrequent) write path and the (one-time) admin setup, never on read.
 
 Whether a value is admin-fixed or user-overridable is therefore a matter
@@ -69,12 +71,13 @@ Three scopes cover the use cases (`public` for the pre-login shell):
   `app_config_fragments` alone, ordering the existing fragments by
   `rank`. No allow-list or policy is consulted at read time — the hot
   path stays a single indexed scan.
-- **Allow-list = pre-configured write delegation.** `app_config_allow_list`
-  holds **one record per `(config_name, scope_type)`**; its presence
-  grants the self-service path `create` / `update` / `purge` on its own
-  fragment at that scope. The admin path is ungated. This replaces
-  `AppConfigPolicy.scope_sources`, but it governs **writes only** —
-  never reads.
+- **Allow-list = the write gate for every fragment.** `app_config_allow_list`
+  holds **one record per `(config_name, scope_type)`**; a fragment at
+  that scope may be created/updated/purged **only if** the record exists
+  — for the admin path and the self-service path alike. What sets admins
+  apart is that they alone manage the allow-list (and the registry)
+  itself. This replaces `AppConfigPolicy.scope_sources`, but it governs
+  **writes only** — never reads.
 - **`rank` lives on the fragment.** A fragment's `rank` is its merge
   priority within a `config_name`; the read merge orders fragments by it.
 - **Single source-of-truth table.** One `app_config_fragments` table
@@ -110,23 +113,25 @@ Keyed by the natural composite `(scope_type, scope_id, config_name)`
   higher wins). Assigned on create (see §2).
 - `created_at` / `updated_at`.
 
-### `app_config_allow_list` — pre-configured write grants
+### `app_config_allow_list` — the per-`(name, scope)` write gate
 
 One row per `(config_name, scope_type)` (unique) — the normalized
 replacement for `AppConfigPolicy.scope_sources`, but reduced to a single
-purpose: **write authorization for the self-service path**. Admins set
-these up in advance.
+purpose: **the write gate**. A fragment at `(config_name, scope_type)`
+may be written only if its row exists here. Admins set these up in
+advance.
 
 - `config_name` — FK → `app_config_keys.config_name`.
-- `scope_type` — the scope whose owner is granted self-service writes
-  (`public | domain | user`). In practice the only non-admin owner is
-  `user`, so user-overridable documents carry a `(config_name, user)`
-  row.
+- `scope_type` — a scope at which fragments may be written
+  (`public | domain | user`). A user-overridable document carries a
+  `(config_name, user)` row; an admin-only value carries
+  `(config_name, domain)` and/or `(config_name, public)`.
 - `created_at` / `updated_at`.
 
-A grant's **presence** is the entire signal — there is no `rank` here,
-because the allow-list never participates in the merge. The admin path
-writes any scope of any registered name regardless of the allow-list.
+A row's **presence** is the entire signal — there is no `rank` here,
+because the allow-list never participates in the merge. It gates **both**
+write paths; admins, unlike users, may also create/update/purge the
+allow-list rows themselves.
 
 ### Scope-ID convention
 
@@ -138,30 +143,32 @@ writes any scope of any registered name regardless of the allow-list.
 
 ### Integrity
 
-- An **admin** fragment write requires only a registered `config_name`
-  (FK to `app_config_keys`).
-- A **self-service** fragment write additionally requires an
-  `app_config_allow_list` grant for the write's `(config_name,
-  scope_type)`. The service layer rejects per-row when the grant is
-  missing.
+- **Every** fragment write (admin or self-service) requires (a) a
+  registered `config_name` (FK to `app_config_keys`) and (b) an
+  `app_config_allow_list` row for the write's `(config_name,
+  scope_type)`. The service layer rejects per-row when either is missing.
+- The self-service path is further restricted to the caller's own `user`
+  row; the admin path may target any scope (still gated by the
+  allow-list) and is the only path that may write the allow-list and the
+  registry.
 - `app_config_keys` purge is rejected while any fragment or allow-list
   entry still references the name (`ON DELETE NO ACTION`).
-- `app_config_allow_list` purge **revokes future self-service writes**
-  for that scope. Because reads never consult the allow-list, **existing
-  fragments are untouched and keep merging** — to actually drop a value,
-  an admin purges the fragments themselves.
+- `app_config_allow_list` purge **revokes future writes** at that
+  `(config_name, scope_type)`. Because reads never consult the
+  allow-list, **existing fragments are untouched and keep merging** — to
+  actually drop a value, an admin purges the fragments themselves.
 
 <a id="write-model"></a>
 ### Write model
 
 Two write paths:
 
-- **Admin path** — `create` / `update` / `purge` on any scope of any
-  registered name. Ungated by the allow-list. The only way an
-  admin-owned (`public`, `domain`) row, or another user's `user` row,
-  comes into existence.
+- **Admin path** — `create` / `update` / `purge` a fragment at any scope
+  whose `(config_name, scope_type)` is in the allow-list. The only path
+  that may write another user's `user` row, and the only path that may
+  manage the allow-list and the registry themselves.
 - **Self-service (`my`) path** — `create` / `update` / `purge` on the
-  caller's own `user` row, **only when** an allow-list grant exists for
+  caller's own `user` row, **only when** an allow-list row exists for
   `(config_name, user)`.
 
 `create` errors if the natural key already exists; `update` errors if it
@@ -174,9 +181,9 @@ boundary.
 **Overridability is a write-grant decision** — there is no admin-seeding
 dance:
 
-- **Fixed** (user cannot change): no `(config_name, user)` grant exists.
-  The `my` path is rejected, so the merged value is the admin's
-  (`public` / `domain` fragments only).
+- **Fixed** (user cannot change): no `(config_name, user)` row exists in
+  the allow-list. The `my` path is rejected, so the merged value is the
+  admin's (`public` / `domain` fragments only).
 - **Overridable**: the admin grants `(config_name, user)`. The admin
   sets the `domain` default; the user freely creates/updates/purges
   their own `user` fragment, which (higher `rank`) wins on merge.
@@ -263,18 +270,20 @@ likewise `null` — clients fall back to their built-in defaults.
 
 ## 5. User scenarios
 
-- **Register a document name and grant writes** — admin creates the
-  `app_config_keys` row for `theme`, then (if users may customize it)
-  the `app_config_allow_list` grant `(theme, user)`.
+- **Register a document name and open its scopes** — admin creates the
+  `app_config_keys` row for `theme`, then the `app_config_allow_list`
+  rows for every scope it will use — e.g. `(theme, domain)` for the admin
+  default, plus `(theme, user)` if users may customize it. A fragment can
+  be written only after its scope's row exists.
 - **Pre-login public config** — anonymous read of `public` `theme`.
 - **Bootstrap after login** — read merged `AppConfig`s in one round of
   queries; each is a single-table rank merge, no per-scope stitching.
 - **User edits a document** — `my` create/update/purge on the caller's
   own `user` row (only where the grant exists); the response is the
   recomputed merge.
-- **Admin publishes a fixed domain value** — create a `domain` (or
-  `public`) fragment and grant no `user` write; users cannot override
-  it.
+- **Admin publishes a fixed domain value** — add the `(config_name,
+  domain)` allow-list row, write the `domain` fragment, and add no
+  `(config_name, user)` row; users cannot override it.
 - **Admin makes a value user-overridable** — add the `(config_name,
   user)` grant; users then create/update/purge their own copy. No data
   migration.

--- a/proposals/BEP-1052-scoped-app-config-redesign.md
+++ b/proposals/BEP-1052-scoped-app-config-redesign.md
@@ -12,39 +12,42 @@ Implemented-Version:
 ## Overview
 
 App configuration is redesigned as **scoped entities** — one row per
-`(scope_type, scope_id, name)` — so access control and merge semantics
-live at the scope level, not at the field level. A single scope (e.g. one
-domain, one user) can hold **multiple named configuration documents**
-(`theme`, `menu`, `preferences`, …), each managed independently.
+`(scope_type, scope_id, config_name)` — so access control and merge
+semantics live at the scope level, not the field level. A single scope
+(one domain, one user) can hold **multiple named configuration
+documents** (`theme`, `menu`, `preferences`, …), each managed
+independently.
 
-A user's effective configuration for a given `name` is the **deep
-merge of the fragments that apply to them**, combined in **`rank`
-order**. Every fragment carries its
-own merge priority, and which fragments participate is decided by scope
-matching alone.
+Every document name is **explicitly registered** in `app_config_keys`,
+and a config row cannot exist for an unregistered name. For each
+registered name, `app_config_allow_list` enumerates — **one record per
+(name, scope)** — which scopes may hold a fragment and in what **merge
+order**.
+A user's effective configuration for a name is the **deep merge of the
+fragments that apply to them**, combined in the allow-list's order.
 
-A user can **read and modify** their app config, but **only an admin can
-create** fragments (in any scope). This is what lets an admin decide
-whether a domain value is fixed or user-overridable — see [Write model](#write-model).
+A user can read and modify their own `user`-scope config, but **only
+where the name's allow-list admits the `user` scope**. Whether a value
+is admin-fixed or user-overridable is therefore an explicit allow-list
+decision — see [Write model](#write-model).
 
 ## User Stories
 
-Three scopes cover the use cases (plus `public` for the pre-login shell):
+Three scopes cover the use cases (`public` for the pre-login shell):
 
 | Use case                                         | Scope(s)          | Who writes                                  |
 |--------------------------------------------------|-------------------|---------------------------------------------|
 | Pre-login values (theme, branding)               | `public`          | Admin                                       |
 | Domain-wide value the user **cannot** change     | `domain`          | Admin                                       |
-| Per-domain **default** the user **can** override | `domain` + `user` | Admin sets the default + seeds the user copy; user modifies their copy |
-| User value with **no** default                   | `user`            | Admin seeds; user modifies                  |
+| Per-domain **default** the user **can** override | `domain` + `user` | Admin sets the default; user writes their own copy |
+| User value with **no** default                   | `user`            | User (admin may also write)                 |
 
 - Admins set values that apply across a domain; a domain-fixed value
   cannot be changed by users.
 - Some domain settings must be readable **before login** (theme).
-- Admins seed the initial value of a user's personal settings; the user
-  then edits their own copy.
-- Users persist their own settings on the server (language, recently used
-  sessions, visible/ordered table columns, experimental-feature toggles).
+- Where the allow-list admits `user`, users persist their own settings
+  on the server (language, recently used sessions, visible/ordered
+  table columns, experimental-feature toggles).
 - The same scope may publish several independently-managed documents
   loaded by different parts of the WebUI.
 
@@ -52,19 +55,22 @@ Three scopes cover the use cases (plus `public` for the pre-login shell):
 
 - **Schema-less JSON.** The backend is pure storage; the structure and
   meaning of each document are owned by the frontend.
-- **Scope = entity.** Access control is expressed at the scope level, not
-  per field. Three scopes: `public` (anonymous read / admin write),
+- **Scope = entity.** Access control is expressed at the scope level,
+  not per field. Three scopes: `public` (anonymous read / admin write),
   `domain` (same-domain read / admin write), `user` (owner+admin read /
   owner-modify + admin write).
-- **Named documents within a scope.** Each row is identified by the
-  natural key `(scope_type, scope_id, name)`. Clients address documents
+- **Explicitly registered names.** Every document name lives in
+  `app_config_keys`; fragments and allow-list entries reference it by
+  foreign key. No fragment may exist for an unregistered name.
+- **Allow-list = the merge chain and the write gate.** For each name,
+  `app_config_allow_list` holds **one record per participating scope**,
+  each carrying a `rank`. Those records — ordered by `rank` — are
+  exactly the scopes that may be written and exactly the scopes merged
+  into the effective view. This replaces the old
+  `AppConfigPolicy.scope_sources` array with one row per entry.
+- **Named documents within a scope.** Each fragment is identified by
+  `(scope_type, scope_id, config_name)`. Clients address documents
   explicitly by name — no hierarchical fall-through lookup.
-- **Merge by `rank`.** A fragment's `rank` is its merge priority within a
-  `name`. Every fragment whose scope applies to the user participates;
-  their order is decided by `rank`.
-- **Users read and modify; admins create.** All `create` (including
-  `user` scope) is admin-only; the self-service path is **update-only**.
-  See [Write model](#write-model).
 - **Single source-of-truth table.** One `app_config_fragments` table
   holds every scope; only the exposure layer is split.
 
@@ -72,16 +78,48 @@ Three scopes cover the use cases (plus `public` for the pre-login shell):
 
 ## 1. Data model
 
-A single `app_config_fragments` table, keyed by the natural composite
-`(scope_type, scope_id, name)` (unique). Columns of note:
+Three tables, with `app_config_keys` as the hub both others reference.
+
+### `app_config_keys` — the document-name registry
+
+One row per document name. A name must be registered here before any
+fragment or allow-list entry can reference it. **Explicitly managed by
+admins** (`create` / `purge`) — registration is a deliberate step, not a
+side effect of writing a fragment.
+
+- `config_name` — the document name (unique). The foreign-key target for
+  both other tables. Immutable (rename = purge + recreate).
+- `created_at` / `updated_at`.
+
+### `app_config_fragments` — the per-scope values
+
+Keyed by the natural composite `(scope_type, scope_id, config_name)`
+(unique). Columns of note:
 
 - `scope_type` — `public | domain | user`.
 - `scope_id` — the scope's identifier (see convention below).
-- `name` — the document name (unique within the scope).
-- `rank` — integer merge priority within a `name` (low → high; higher
-  wins). Assigned on create (see §2).
+- `config_name` — FK → `app_config_keys.config_name`.
 - `config` — schema-less JSON payload.
 - `created_at` / `updated_at`.
+
+### `app_config_allow_list` — the per-name scope chain
+
+One row per `(config_name, scope_type)` (unique) — the normalized
+replacement for `AppConfigPolicy.scope_sources`. Each row is one entry
+in the name's chain.
+
+- `config_name` — FK → `app_config_keys.config_name`.
+- `scope_type` — a scope that participates in this name
+  (`public | domain | user`).
+- `rank` — integer merge priority within the name (low → high; higher
+  wins). Assigned on create (see §2).
+- `created_at` / `updated_at`.
+
+The set of `scope_type`s present for a `config_name` is **both** the
+**write allow-list** (only these scopes may hold a fragment) **and** the
+**merge chain** (these scopes, in `rank` order, are deep-merged). Adding
+a scope to the chain is a single `create`; removing one is a single
+`purge` — never a read-modify-write of an array.
 
 ### Scope-ID convention
 
@@ -91,56 +129,70 @@ A single `app_config_fragments` table, keyed by the natural composite
 | `domain`     | `domain_id`             | the domain's value / default     |
 | `user`       | `user_id` (UUID string) | the user's own value             |
 
-A fragment can be created in any allowed scope for any `name` — no
-pre-registration step is required. The merge (§3) always resolves from
-whatever fragments exist.
+### Integrity
+
+- A fragment write requires (a) a registered `config_name` (FK to
+  `app_config_keys`) and (b) an allow-list entry for the write's
+  `(config_name, scope_type)`. The service layer rejects per-row when
+  either is missing, with a friendly error; the FK is defense-in-depth.
+- `app_config_keys` purge is rejected while any fragment or allow-list
+  entry still references the name (`ON DELETE NO ACTION`).
+- `app_config_allow_list` purge removes a scope from the chain. Existing
+  fragments at that scope are left in the DB but stop being read or
+  written; an admin removes them with a fragment purge if desired.
 
 <a id="write-model"></a>
 ### Write model
 
 Two write paths:
 
-- **Admin path** — `create` / `update` / `purge`, **any scope**. This is
-  the *only* way a row comes into existence, including `user`-scope rows.
-- **Self-service (`my`) path** — **`update` only**, on the caller's own
-  `user` rows. No `create`, no `purge`.
+- **Admin path** — `create` / `update` / `purge`, on any scope admitted
+  by the allow-list. The only way an admin-owned (`public`, `domain`)
+  row, or another user's `user` row, comes into existence.
+- **Self-service (`my`) path** — `create` / `update` on the caller's own
+  `user` row, **only when** the name's allow-list admits `user`. No
+  `purge`.
 
 `create` errors if the natural key already exists; `update` errors if it
-does not; `purge` (admin-only) is the single deletion verb, for cleaning
-up misconfigured rows. A caller "clears" a document by `update`-ing it
-with `{}`, which reads back as `null` (null projection, §3). `update`
-replaces the stored JSON wholesale — no partial/deep update at the write
-boundary.
+does not; `purge` (admin-only) is the single deletion verb. A caller
+"clears" a document by `update`-ing it with `{}`, which reads back as
+`null` (null projection, §3). `update` replaces the stored JSON
+wholesale — no partial/deep update at the write boundary.
 
-**Why users cannot create.** A user fragment overrides the domain value
-(higher `rank`). If users could freely create their own fragment, they
-could shadow a domain value the admin meant to be fixed. By restricting
-users to *modifying existing* rows, the admin controls overridability:
+**Overridability is an allow-list decision** — there is no admin-seeding
+dance:
 
-- **Fixed** (user cannot change): admin creates only a `domain` fragment.
-  No `user` fragment exists and the user cannot create one, so the merged
-  value is the domain value.
-- **Overridable**: admin creates the `domain` default **and seeds a
-  `user` fragment** (at a higher `rank`). The user then `update`s that
-  seeded fragment to override.
-- **User-only**: admin seeds a `user` fragment with no `domain` default;
-  the user `update`s it.
+- **Fixed** (user cannot change): the name's allow-list omits `user`
+  (e.g. `[domain]` or `[public]`). The `my` path is rejected, so the
+  merged value is the admin's.
+- **Overridable**: the allow-list includes `user` at a higher `rank`
+  than `domain` (e.g. `[domain, user]`). The admin sets the `domain`
+  default; the user creates/updates their own `user` fragment, which
+  wins on merge.
+- **User-only**: the allow-list is `[user]`; no domain default exists.
+
+To promote a fixed value to user-customizable, the admin adds a single
+`user` allow-list entry — no data migration, no schema change. Reverting
+— purging that `user` entry — blocks new user writes and drops `user`
+fragments from the merge, while leaving the rows in the DB (see §1
+*Integrity*).
 
 ---
 
 ## 2. `rank` — merge priority
 
-`rank` is the integer priority a fragment carries within a `name`; the
-merge applies fragments in `rank` order (low → high, higher wins).
+`rank` is the integer priority an **allow-list entry** carries within a
+`config_name`; the merge applies the corresponding fragments in `rank`
+order (low → high, higher wins).
 
-- **Assignment.** A new fragment is placed after the existing ones for
-  the same `name`, so by default a later-created fragment outranks earlier
-  ones. Admins re-order by setting `rank` explicitly. (Seeding the
-  `domain` default before a `user` copy naturally gives the user copy the
-  higher rank, so the user value wins.)
-- **No tier defaults.** Priority is not derived from `scope_type`; a
-  `user` fragment does not *automatically* outrank a `domain` fragment —
-  it outranks only because it was created later.
+- **Assignment.** A new allow-list entry is placed after the existing
+  ones for the same name, so a later-added scope outranks earlier ones
+  by default. Admins re-order by setting `rank` explicitly. (Adding
+  `domain` before `user` naturally gives the `user` entry the higher
+  rank, so the user value wins.)
+- **No tier defaults.** Priority is the allow-list `rank`, not derived
+  from `scope_type` — a `user` entry outranks a `domain` entry only
+  because its `rank` is higher, not because `user` is "above" `domain`.
 
 ---
 
@@ -149,29 +201,40 @@ merge applies fragments in `rank` order (low → high, higher wins).
 Two read shapes exist:
 
 - **`AppConfigFragment`** — one raw row, regardless of scope. Carries
-  `scopeType`, `scopeId`, `name`, `rank`, and `config`. Callers
-  disambiguate scope by reading `scopeType` (no per-scope wrapper types).
-- **`AppConfig`** — the merged per-user view for a `name`: the ordered
-  contributing `fragments` plus the deep-merged `config`.
+  `scopeType`, `scopeId`, `configName`, and `config`. Callers
+  disambiguate scope by reading `scopeType` (no per-scope wrapper
+  types).
+- **`AppConfig`** — the merged per-user view for a `config_name`: the
+  ordered contributing `fragments` plus the deep-merged `config`.
 
 ### How a merge is resolved
 
-For a user resolving `name`, the **applicable** fragments are those
-whose scope applies to them:
+For a user resolving `config_name`, the chain is the name's
+`app_config_allow_list` entries ordered by `rank`. Each entry resolves
+to one applicable `scope_id`:
 
-- every `public` fragment (`scope_id = "public"`),
-- the user's `domain` fragment (`scope_id = the user's domain`),
-- the user's `user` fragment (`scope_id = the user's id`).
+- `public` → `"public"`,
+- `domain` → the user's domain,
+- `user` → the user's id.
 
-Those fragments are ordered by `rank` (low → high) and deep-merged: nested
-objects recurse, scalars and lists are wholesale-replaced, and the higher
-`rank` wins on conflict.
+The fragments that exist at those `(scope_type, scope_id, config_name)`
+keys are ordered by `rank` (low → high) and deep-merged: nested objects
+recurse, scalars and lists are wholesale-replaced, and the higher `rank`
+wins on conflict. A single SQL statement joins `app_config_fragments`
+with `app_config_allow_list ON config_name AND scope_type`, filtered to
+each entry's resolved `scope_id`, and orders by `rank` — a plain
+equi-join, with no array membership/position tricks.
+
+**Null projection.** A stored `config` of `{}` reads back as `null`, and
+a merged `config` that is empty after combining every fragment is
+likewise `null` — clients fall back to their built-in defaults.
 
 ### Read variants
 
-- **Single** — resolve one `(user, name)` to its `AppConfig`.
+- **Single** — resolve one `(user, config_name)` to its `AppConfig`.
 - **Search (self)** — paginate the user's own `AppConfig`s, grouped by
-  `(user_id, name)`; each name's merge is evaluated independently.
+  `(user_id, config_name)`; each name's merge is evaluated
+  independently.
 - **Search (admin, cross-user)** — resolve any user's `AppConfig` for
   audit / support; admin-only.
 
@@ -182,28 +245,33 @@ objects recurse, scalars and lists are wholesale-replaced, and the higher
 - **Before login**, the WebUI fetches `public` documents (theme,
   branding) anonymously so the shell can render.
 - **After login**, it reads its merged `AppConfig`s (`theme`, `menu`,
-  `preferences`, …) — already combining public + domain + user fragments
-  in `rank` order — and persists user changes through the `my`
-  **update**, which returns the recomputed merged view. (A user only sees
-  an editable value where the admin has seeded a `user` fragment.)
+  `preferences`, …) — already combining the public/domain/user fragments
+  admitted by each name's allow-list — and persists user changes through
+  the `my` **update** (allowed only where the allow-list admits `user`),
+  which returns the recomputed merged view.
 
 ---
 
 ## 5. User scenarios
 
+- **Register a document name** — admin creates the `app_config_keys` row
+  for `theme` and its `app_config_allow_list` entries (the chain) before
+  any fragment exists.
 - **Pre-login public config** — anonymous read of `public` `theme`.
 - **Bootstrap after login** — read merged `AppConfig`s in one round of
   queries; no per-scope stitching on the client.
-- **User edits a document** — `my` update on the caller's seeded
-  `user` row; the response is the recomputed merge.
-- **Admin publishes a fixed domain value** — admin create/update a
-  `domain` (or `public`) fragment; no `user` fragments seeded, so users
+- **User edits a document** — `my` create/update on the caller's own
+  `user` row (only where the allow-list admits `user`); the response is
+  the recomputed merge.
+- **Admin publishes a fixed domain value** — register the name with
+  allow-list `[domain]` (or `[public]`); with no `user` entry, users
   cannot override it.
-- **Admin makes a value user-overridable** — admin keeps the `domain`
-  default and seeds each user a `user` fragment (higher `rank`); users
-  then edit their own copy.
-- **Promote fixed → user-customizable** — no schema change: the admin
-  seeds the missing `user` fragments; users can now modify them.
-- **Admin reorders contributions** — adjust fragment `rank`s.
+- **Admin makes a value user-overridable** — add a `user` allow-list
+  entry at a higher `rank`; users then create/update their own copy. No
+  data migration.
+- **Admin reorders contributions** — adjust allow-list `rank`s.
+- **Admin retires a document name** — purge the fragments, then the
+  allow-list entries, then the `app_config_keys` row (purge is rejected
+  while references remain).
 - **Admin audit** — cross-scope fragment search and cross-user merged
   search for support.

--- a/proposals/BEP-1052-scoped-app-config-redesign.md
+++ b/proposals/BEP-1052-scoped-app-config-redesign.md
@@ -12,42 +12,43 @@ Implemented-Version:
 ## Overview
 
 App configuration is redesigned as **scoped entities** — one row per
-`(scope_type, scope_id, config_name)` — so access control and merge
-semantics live at the scope level, not the field level. A single scope
-(one domain, one user) can hold **multiple named configuration
-documents** (`theme`, `menu`, `preferences`, …), each managed
-independently.
+`(scope_type, scope_id, config_name)` — so storage and merge live at the
+scope level. A single scope (one domain, one user) can hold **multiple
+named configuration documents** (`theme`, `menu`, `preferences`, …),
+each managed independently.
 
-Every document name is **explicitly registered** in `app_config_keys`,
-and a config row cannot exist for an unregistered name. For each
-registered name, `app_config_allow_list` enumerates — **one record per
-(name, scope)** — which scopes may hold a fragment and in what **merge
-order**.
-A user's effective configuration for a name is the **deep merge of the
-fragments that apply to them**, combined in the allow-list's order.
+**Reads are the hot path.** A user's effective configuration for a name
+is the **deep merge of every fragment that applies to them**, taken
+straight from `app_config_fragments` in `rank` order — a single-table
+query with **no joins and no permission lookup**.
 
-A user can read and modify their own `user`-scope config, but **only
-where the name's allow-list admits the `user` scope**. Whether a value
-is admin-fixed or user-overridable is therefore an explicit allow-list
-decision — see [Write model](#write-model).
+**Write authorization is set up ahead of time.** Every document name is
+**explicitly registered** in `app_config_keys`, and `app_config_allow_list`
+records — **pre-configured by admins** — grant the self-service (user)
+path permission to `create` / `update` / `purge` its own fragment. Admin
+writes are ungated. So the cost of permission lives entirely on the
+(infrequent) write path and the (one-time) admin setup, never on read.
+
+Whether a value is admin-fixed or user-overridable is therefore a matter
+of whether an allow-list grant exists — see [Write model](#write-model).
 
 ## User Stories
 
 Three scopes cover the use cases (`public` for the pre-login shell):
 
-| Use case                                         | Scope(s)          | Who writes                                  |
-|--------------------------------------------------|-------------------|---------------------------------------------|
-| Pre-login values (theme, branding)               | `public`          | Admin                                       |
-| Domain-wide value the user **cannot** change     | `domain`          | Admin                                       |
-| Per-domain **default** the user **can** override | `domain` + `user` | Admin sets the default; user writes their own copy |
-| User value with **no** default                   | `user`            | User (admin may also write)                 |
+| Use case                                         | Scope(s)          | Who writes                                       |
+|--------------------------------------------------|-------------------|--------------------------------------------------|
+| Pre-login values (theme, branding)               | `public`          | Admin                                            |
+| Domain-wide value the user **cannot** change     | `domain`          | Admin                                            |
+| Per-domain **default** the user **can** override | `domain` + `user` | Admin sets the default; user writes their own copy (where granted) |
+| User value with **no** default                   | `user`            | User (where granted); admin may also write       |
 
 - Admins set values that apply across a domain; a domain-fixed value
-  cannot be changed by users.
+  cannot be changed by users (no `user` write grant exists).
 - Some domain settings must be readable **before login** (theme).
-- Where the allow-list admits `user`, users persist their own settings
-  on the server (language, recently used sessions, visible/ordered
-  table columns, experimental-feature toggles).
+- Where the admin has granted it, users persist their own settings on
+  the server (language, recently used sessions, visible/ordered table
+  columns, experimental-feature toggles).
 - The same scope may publish several independently-managed documents
   loaded by different parts of the WebUI.
 
@@ -62,15 +63,18 @@ Three scopes cover the use cases (`public` for the pre-login shell):
 - **Explicitly registered names.** Every document name lives in
   `app_config_keys`; fragments and allow-list entries reference it by
   foreign key. No fragment may exist for an unregistered name.
-- **Allow-list = the merge chain and the write gate.** For each name,
-  `app_config_allow_list` holds **one record per participating scope**,
-  each carrying a `rank`. Those records — ordered by `rank` — are
-  exactly the scopes that may be written and exactly the scopes merged
-  into the effective view. This replaces the old
-  `AppConfigPolicy.scope_sources` array with one row per entry.
-- **Named documents within a scope.** Each fragment is identified by
-  `(scope_type, scope_id, config_name)`. Clients address documents
-  explicitly by name — no hierarchical fall-through lookup.
+- **Reads are join-free and unconditional.** The merge reads
+  `app_config_fragments` alone, ordering the existing fragments by
+  `rank`. No allow-list or policy is consulted at read time — the hot
+  path stays a single indexed scan.
+- **Allow-list = pre-configured write delegation.** `app_config_allow_list`
+  holds **one record per `(config_name, scope_type)`**; its presence
+  grants the self-service path `create` / `update` / `purge` on its own
+  fragment at that scope. The admin path is ungated. This replaces
+  `AppConfigPolicy.scope_sources`, but it governs **writes only** —
+  never reads.
+- **`rank` lives on the fragment.** A fragment's `rank` is its merge
+  priority within a `config_name`; the read merge orders fragments by it.
 - **Single source-of-truth table.** One `app_config_fragments` table
   holds every scope; only the exposure layer is split.
 
@@ -91,35 +95,36 @@ side effect of writing a fragment.
   both other tables. Immutable (rename = purge + recreate).
 - `created_at` / `updated_at`.
 
-### `app_config_fragments` — the per-scope values
+### `app_config_fragments` — the per-scope values (read hot path)
 
 Keyed by the natural composite `(scope_type, scope_id, config_name)`
-(unique). Columns of note:
+(unique). The read merge scans this table alone. Columns of note:
 
 - `scope_type` — `public | domain | user`.
 - `scope_id` — the scope's identifier (see convention below).
 - `config_name` — FK → `app_config_keys.config_name`.
 - `config` — schema-less JSON payload.
+- `rank` — integer merge priority within the `config_name` (low → high;
+  higher wins). Assigned on create (see §2).
 - `created_at` / `updated_at`.
 
-### `app_config_allow_list` — the per-name scope chain
+### `app_config_allow_list` — pre-configured write grants
 
 One row per `(config_name, scope_type)` (unique) — the normalized
-replacement for `AppConfigPolicy.scope_sources`. Each row is one entry
-in the name's chain.
+replacement for `AppConfigPolicy.scope_sources`, but reduced to a single
+purpose: **write authorization for the self-service path**. Admins set
+these up in advance.
 
 - `config_name` — FK → `app_config_keys.config_name`.
-- `scope_type` — a scope that participates in this name
-  (`public | domain | user`).
-- `rank` — integer merge priority within the name (low → high; higher
-  wins). Assigned on create (see §2).
+- `scope_type` — the scope whose owner is granted self-service writes
+  (`public | domain | user`). In practice the only non-admin owner is
+  `user`, so user-overridable documents carry a `(config_name, user)`
+  row.
 - `created_at` / `updated_at`.
 
-The set of `scope_type`s present for a `config_name` is **both** the
-**write allow-list** (only these scopes may hold a fragment) **and** the
-**merge chain** (these scopes, in `rank` order, are deep-merged). Adding
-a scope to the chain is a single `create`; removing one is a single
-`purge` — never a read-modify-write of an array.
+A grant's **presence** is the entire signal — there is no `rank` here,
+because the allow-list never participates in the merge. The admin path
+writes any scope of any registered name regardless of the allow-list.
 
 ### Scope-ID convention
 
@@ -131,68 +136,73 @@ a scope to the chain is a single `create`; removing one is a single
 
 ### Integrity
 
-- A fragment write requires (a) a registered `config_name` (FK to
-  `app_config_keys`) and (b) an allow-list entry for the write's
-  `(config_name, scope_type)`. The service layer rejects per-row when
-  either is missing, with a friendly error; the FK is defense-in-depth.
+- An **admin** fragment write requires only a registered `config_name`
+  (FK to `app_config_keys`).
+- A **self-service** fragment write additionally requires an
+  `app_config_allow_list` grant for the write's `(config_name,
+  scope_type)`. The service layer rejects per-row when the grant is
+  missing.
 - `app_config_keys` purge is rejected while any fragment or allow-list
   entry still references the name (`ON DELETE NO ACTION`).
-- `app_config_allow_list` purge removes a scope from the chain. Existing
-  fragments at that scope are left in the DB but stop being read or
-  written; an admin removes them with a fragment purge if desired.
+- `app_config_allow_list` purge **revokes future self-service writes**
+  for that scope. Because reads never consult the allow-list, **existing
+  fragments are untouched and keep merging** — to actually drop a value,
+  an admin purges the fragments themselves.
 
 <a id="write-model"></a>
 ### Write model
 
 Two write paths:
 
-- **Admin path** — `create` / `update` / `purge`, on any scope admitted
-  by the allow-list. The only way an admin-owned (`public`, `domain`)
-  row, or another user's `user` row, comes into existence.
-- **Self-service (`my`) path** — `create` / `update` on the caller's own
-  `user` row, **only when** the name's allow-list admits `user`. No
-  `purge`.
+- **Admin path** — `create` / `update` / `purge` on any scope of any
+  registered name. Ungated by the allow-list. The only way an
+  admin-owned (`public`, `domain`) row, or another user's `user` row,
+  comes into existence.
+- **Self-service (`my`) path** — `create` / `update` / `purge` on the
+  caller's own `user` row, **only when** an allow-list grant exists for
+  `(config_name, user)`.
 
 `create` errors if the natural key already exists; `update` errors if it
-does not; `purge` (admin-only) is the single deletion verb. A caller
-"clears" a document by `update`-ing it with `{}`, which reads back as
-`null` (null projection, §3). `update` replaces the stored JSON
-wholesale — no partial/deep update at the write boundary.
+does not; `purge` removes the row (and thus its contribution to the
+merge). A caller "clears" a document without deleting it by `update`-ing
+with `{}`, which reads back as `null` (null projection, §3). `update`
+replaces the stored JSON wholesale — no partial/deep update at the write
+boundary.
 
-**Overridability is an allow-list decision** — there is no admin-seeding
+**Overridability is a write-grant decision** — there is no admin-seeding
 dance:
 
-- **Fixed** (user cannot change): the name's allow-list omits `user`
-  (e.g. `[domain]` or `[public]`). The `my` path is rejected, so the
-  merged value is the admin's.
-- **Overridable**: the allow-list includes `user` at a higher `rank`
-  than `domain` (e.g. `[domain, user]`). The admin sets the `domain`
-  default; the user creates/updates their own `user` fragment, which
-  wins on merge.
-- **User-only**: the allow-list is `[user]`; no domain default exists.
+- **Fixed** (user cannot change): no `(config_name, user)` grant exists.
+  The `my` path is rejected, so the merged value is the admin's
+  (`public` / `domain` fragments only).
+- **Overridable**: the admin grants `(config_name, user)`. The admin
+  sets the `domain` default; the user freely creates/updates/purges
+  their own `user` fragment, which (higher `rank`) wins on merge.
+- **User-only**: the grant exists and no admin fragment is published.
 
 To promote a fixed value to user-customizable, the admin adds a single
-`user` allow-list entry — no data migration, no schema change. Reverting
-— purging that `user` entry — blocks new user writes and drops `user`
-fragments from the merge, while leaving the rows in the DB (see §1
-*Integrity*).
+`(config_name, user)` grant — no data migration. To lock it back down,
+the admin removes the grant **and** purges any existing `user` fragments
+(removing the grant alone only blocks new writes; reads still merge what
+is already stored).
 
 ---
 
 ## 2. `rank` — merge priority
 
-`rank` is the integer priority an **allow-list entry** carries within a
-`config_name`; the merge applies the corresponding fragments in `rank`
-order (low → high, higher wins).
+`rank` is the integer priority a **fragment** carries within a
+`config_name`; the read merge applies fragments in `rank` order (low →
+high, higher wins).
 
-- **Assignment.** A new allow-list entry is placed after the existing
-  ones for the same name, so a later-added scope outranks earlier ones
-  by default. Admins re-order by setting `rank` explicitly. (Adding
-  `domain` before `user` naturally gives the `user` entry the higher
-  rank, so the user value wins.)
-- **No tier defaults.** Priority is the allow-list `rank`, not derived
-  from `scope_type` — a `user` entry outranks a `domain` entry only
-  because its `rank` is higher, not because `user` is "above" `domain`.
+- **Assignment.** A new fragment is placed after the existing ones for
+  the same name, so a later-created fragment outranks earlier ones by
+  default. Admins re-order by setting `rank` explicitly. (Publishing the
+  `domain` default before a user writes their own copy naturally gives
+  the `user` fragment the higher rank, so the user value wins.)
+- **No tier defaults.** Priority is the fragment's `rank`, not derived
+  from `scope_type` — a `user` fragment outranks a `domain` fragment
+  only because its `rank` is higher, not because `user` is "above"
+  `domain`.
 
 ---
 
@@ -201,7 +211,7 @@ order (low → high, higher wins).
 Two read shapes exist:
 
 - **`AppConfigFragment`** — one raw row, regardless of scope. Carries
-  `scopeType`, `scopeId`, `configName`, and `config`. Callers
+  `scopeType`, `scopeId`, `configName`, `rank`, and `config`. Callers
   disambiguate scope by reading `scopeType` (no per-scope wrapper
   types).
 - **`AppConfig`** — the merged per-user view for a `config_name`: the
@@ -209,21 +219,18 @@ Two read shapes exist:
 
 ### How a merge is resolved
 
-For a user resolving `config_name`, the chain is the name's
-`app_config_allow_list` entries ordered by `rank`. Each entry resolves
-to one applicable `scope_id`:
+For a user resolving `config_name`, the **applicable** fragments are
+those whose scope applies to them:
 
-- `public` → `"public"`,
-- `domain` → the user's domain,
-- `user` → the user's id.
+- every `public` fragment (`scope_id = "public"`),
+- the user's `domain` fragment (`scope_id = the user's domain`),
+- the user's `user` fragment (`scope_id = the user's id`).
 
-The fragments that exist at those `(scope_type, scope_id, config_name)`
-keys are ordered by `rank` (low → high) and deep-merged: nested objects
-recurse, scalars and lists are wholesale-replaced, and the higher `rank`
-wins on conflict. A single SQL statement joins `app_config_fragments`
-with `app_config_allow_list ON config_name AND scope_type`, filtered to
-each entry's resolved `scope_id`, and orders by `rank` — a plain
-equi-join, with no array membership/position tricks.
+A single `app_config_fragments` query selects exactly those rows (the
+user's domain is known from the session — **no join, no allow-list
+lookup**), orders them by `rank` (low → high), and deep-merges: nested
+objects recurse, scalars and lists are wholesale-replaced, and the
+higher `rank` wins on conflict.
 
 **Null projection.** A stored `config` of `{}` reads back as `null`, and
 a merged `config` that is empty after combining every fragment is
@@ -245,31 +252,34 @@ likewise `null` — clients fall back to their built-in defaults.
 - **Before login**, the WebUI fetches `public` documents (theme,
   branding) anonymously so the shell can render.
 - **After login**, it reads its merged `AppConfig`s (`theme`, `menu`,
-  `preferences`, …) — already combining the public/domain/user fragments
-  admitted by each name's allow-list — and persists user changes through
-  the `my` **update** (allowed only where the allow-list admits `user`),
-  which returns the recomputed merged view.
+  `preferences`, …) — a fast, join-free merge of every public/domain/user
+  fragment that exists for the caller — and persists user changes through
+  the `my` path (allowed only where the admin has granted it), which
+  returns the recomputed merged view.
 
 ---
 
 ## 5. User scenarios
 
-- **Register a document name** — admin creates the `app_config_keys` row
-  for `theme` and its `app_config_allow_list` entries (the chain) before
-  any fragment exists.
+- **Register a document name and grant writes** — admin creates the
+  `app_config_keys` row for `theme`, then (if users may customize it)
+  the `app_config_allow_list` grant `(theme, user)`.
 - **Pre-login public config** — anonymous read of `public` `theme`.
 - **Bootstrap after login** — read merged `AppConfig`s in one round of
-  queries; no per-scope stitching on the client.
-- **User edits a document** — `my` create/update on the caller's own
-  `user` row (only where the allow-list admits `user`); the response is
-  the recomputed merge.
-- **Admin publishes a fixed domain value** — register the name with
-  allow-list `[domain]` (or `[public]`); with no `user` entry, users
-  cannot override it.
-- **Admin makes a value user-overridable** — add a `user` allow-list
-  entry at a higher `rank`; users then create/update their own copy. No
-  data migration.
-- **Admin reorders contributions** — adjust allow-list `rank`s.
+  queries; each is a single-table rank merge, no per-scope stitching.
+- **User edits a document** — `my` create/update/purge on the caller's
+  own `user` row (only where the grant exists); the response is the
+  recomputed merge.
+- **Admin publishes a fixed domain value** — create a `domain` (or
+  `public`) fragment and grant no `user` write; users cannot override
+  it.
+- **Admin makes a value user-overridable** — add the `(config_name,
+  user)` grant; users then create/update/purge their own copy. No data
+  migration.
+- **Admin locks a value back down** — remove the `(config_name, user)`
+  grant **and** purge existing `user` fragments (the grant gates writes,
+  not reads).
+- **Admin reorders contributions** — adjust fragment `rank`s.
 - **Admin retires a document name** — purge the fragments, then the
   allow-list entries, then the `app_config_keys` row (purge is rejected
   while references remain).

--- a/proposals/BEP-1052-scoped-app-config-redesign.md
+++ b/proposals/BEP-1052-scoped-app-config-redesign.md
@@ -27,7 +27,7 @@ query with **no joins and no permission lookup**.
 records — **pre-configured by admins** — enumerate the
 `(config_name, scope_type)` pairs at which a fragment may be written.
 **Every** fragment write, admin or user, requires a matching record;
-admins additionally own the allow-list and the registry themselves
+admins additionally own the allow-list and the `app_config_keys` registry themselves
 (users cannot). So the cost of permission lives entirely on the
 (infrequent) write path and the (one-time) admin setup, never on read.
 
@@ -75,8 +75,8 @@ Three scopes cover the use cases (`public` for the pre-login shell):
   holds **one record per `(config_name, scope_type)`**; a fragment at
   that scope may be created/updated/purged **only if** the record exists
   — for the admin path and the self-service path alike. What sets admins
-  apart is that they alone manage the allow-list (and the registry)
-  itself. It governs **writes only** — never reads.
+  apart is that they alone manage the allow-list (and the
+  `app_config_keys` registry) itself. It governs **writes only** — never reads.
 - **`rank` lives on the fragment.** A fragment's `rank` is its merge
   priority within a `config_name`; the read merge orders fragments by it.
 - **Single source-of-truth table.** One `app_config_fragments` table
@@ -147,8 +147,8 @@ allow-list rows themselves.
   scope_type)`. The service layer rejects per-row when either is missing.
 - The self-service path is further restricted to the caller's own `user`
   row; the admin path may target any scope (still gated by the
-  allow-list) and is the only path that may write the allow-list and the
-  registry.
+  allow-list) and is the only path that may write the allow-list and
+  `app_config_keys`.
 - `app_config_keys` purge is rejected while any fragment or allow-list
   entry still references the name (`ON DELETE NO ACTION`).
 - `app_config_allow_list` purge **revokes future writes** at that
@@ -164,7 +164,7 @@ Two write paths:
 - **Admin path** — `create` / `update` / `purge` a fragment at any scope
   whose `(config_name, scope_type)` is in the allow-list. The only path
   that may write another user's `user` row, and the only path that may
-  manage the allow-list and the registry themselves.
+  manage the allow-list and `app_config_keys` themselves.
 - **Self-service (`my`) path** — `create` / `update` / `purge` on the
   caller's own `user` row, **only when** an allow-list row exists for
   `(config_name, user)`.

--- a/proposals/BEP-1052-scoped-app-config-redesign.md
+++ b/proposals/BEP-1052-scoped-app-config-redesign.md
@@ -76,8 +76,7 @@ Three scopes cover the use cases (`public` for the pre-login shell):
   that scope may be created/updated/purged **only if** the record exists
   — for the admin path and the self-service path alike. What sets admins
   apart is that they alone manage the allow-list (and the registry)
-  itself. This replaces `AppConfigPolicy.scope_sources`, but it governs
-  **writes only** — never reads.
+  itself. It governs **writes only** — never reads.
 - **`rank` lives on the fragment.** A fragment's `rank` is its merge
   priority within a `config_name`; the read merge orders fragments by it.
 - **Single source-of-truth table.** One `app_config_fragments` table
@@ -115,9 +114,8 @@ Keyed by the natural composite `(scope_type, scope_id, config_name)`
 
 ### `app_config_allow_list` — the per-`(name, scope)` write gate
 
-One row per `(config_name, scope_type)` (unique) — the normalized
-replacement for `AppConfigPolicy.scope_sources`, but reduced to a single
-purpose: **the write gate**. A fragment at `(config_name, scope_type)`
+One row per `(config_name, scope_type)` (unique) — a normalized,
+single-purpose table: **the write gate**. A fragment at `(config_name, scope_type)`
 may be written only if its row exists here. Admins set these up in
 advance.
 

--- a/proposals/BEP-1052-scoped-app-config-redesign.md
+++ b/proposals/BEP-1052-scoped-app-config-redesign.md
@@ -74,8 +74,8 @@ Three scopes cover the use cases (`public` for the pre-login shell):
 - **Allow-list = the write gate for every fragment.** `app_config_allow_list`
   holds **one record per `(config_name, scope_type)`**; a fragment at
   that scope may be created/updated/purged **only if** the record exists
-  — for the admin path and the self-service path alike. What sets admins
-  apart is that they alone manage the allow-list (and the
+  — through the admin mutations and the regular ones alike. What sets
+  admins apart is that they alone manage the allow-list (and the
   `app_config_keys` registry) itself. It governs **writes only** — never reads.
 - **`rank` lives on the fragment.** A fragment's `rank` is its merge
   priority within a `config_name`; the read merge orders fragments by it.
@@ -141,14 +141,14 @@ allow-list rows themselves.
 
 ### Integrity
 
-- **Every** fragment write (admin or self-service) requires (a) a
-  registered `config_name` (FK to `app_config_keys`) and (b) an
+- **Every** fragment write (admin or regular) requires (a) a registered
+  `config_name` (FK to `app_config_keys`) and (b) an
   `app_config_allow_list` row for the write's `(config_name,
   scope_type)`. The service layer rejects per-row when either is missing.
-- The self-service path is further restricted to the caller's own `user`
-  row; the admin path may target any scope (still gated by the
-  allow-list) and is the only path that may write the allow-list and
-  `app_config_keys`.
+- A regular (non-admin) mutation is further restricted to the caller's
+  own `user` row; admin mutations may target any scope (still gated by
+  the allow-list) and are the only writes that may touch the allow-list
+  and `app_config_keys`.
 - `app_config_keys` purge is rejected while any fragment or allow-list
   entry still references the name (`ON DELETE NO ACTION`).
 - `app_config_allow_list` purge **revokes future writes** at that
@@ -159,15 +159,16 @@ allow-list rows themselves.
 <a id="write-model"></a>
 ### Write model
 
-Two write paths:
+Two kinds of mutation:
 
-- **Admin path** — `create` / `update` / `purge` a fragment at any scope
-  whose `(config_name, scope_type)` is in the allow-list. The only path
-  that may write another user's `user` row, and the only path that may
-  manage the allow-list and `app_config_keys` themselves.
-- **Self-service (`my`) path** — `create` / `update` / `purge` on the
-  caller's own `user` row, **only when** an allow-list row exists for
-  `(config_name, user)`.
+- **Admin mutations** (admin-only) — `create` / `update` / `purge` a
+  fragment at any scope whose `(config_name, scope_type)` is in the
+  allow-list. The only mutations that may write another user's `user`
+  row, and the only ones that may manage the allow-list and
+  `app_config_keys` themselves.
+- **Regular mutations** (any authenticated user) — `create` / `update` /
+  `purge` the caller's own `user` row, **only when** an allow-list row
+  exists for `(config_name, user)`.
 
 `create` errors if the natural key already exists; `update` errors if it
 does not; `purge` removes the row (and thus its contribution to the
@@ -180,8 +181,8 @@ boundary.
 dance:
 
 - **Fixed** (user cannot change): no `(config_name, user)` row exists in
-  the allow-list. The `my` path is rejected, so the merged value is the
-  admin's (`public` / `domain` fragments only).
+  the allow-list, so a regular `user`-scope write is rejected and the
+  merged value is the admin's (`public` / `domain` fragments only).
 - **Overridable**: the admin grants `(config_name, user)`. The admin
   sets the `domain` default; the user freely creates/updates/purges
   their own `user` fragment, which (higher `rank`) wins on merge.
@@ -261,8 +262,8 @@ likewise `null` — clients fall back to their built-in defaults.
 - **After login**, it reads its merged `AppConfig`s (`theme`, `menu`,
   `preferences`, …) — a fast, join-free merge of every public/domain/user
   fragment that exists for the caller — and persists user changes through
-  the `my` path (allowed only where the admin has granted it), which
-  returns the recomputed merged view.
+  a regular mutation on its own `user` fragment (allowed only where the
+  admin has granted it), which returns the recomputed merged view.
 
 ---
 
@@ -276,9 +277,9 @@ likewise `null` — clients fall back to their built-in defaults.
 - **Pre-login public config** — anonymous read of `public` `theme`.
 - **Bootstrap after login** — read merged `AppConfig`s in one round of
   queries; each is a single-table rank merge, no per-scope stitching.
-- **User edits a document** — `my` create/update/purge on the caller's
-  own `user` row (only where the grant exists); the response is the
-  recomputed merge.
+- **User edits a document** — a regular create/update/purge on the
+  caller's own `user` row (only where the grant exists); the response is
+  the recomputed merge.
 - **Admin publishes a fixed domain value** — add the `(config_name,
   domain)` allow-list row, write the `domain` fragment, and add no
   `(config_name, user)` row; users cannot override it.

--- a/proposals/BEP-1052-scoped-app-config-redesign.md
+++ b/proposals/BEP-1052-scoped-app-config-redesign.md
@@ -28,7 +28,7 @@ query with **no joins and no permission lookup**.
 records — **pre-configured by admins** — enumerate the
 `(config_name, scope_type)` pairs at which a fragment may be written.
 **Every** fragment write, admin or user, requires a matching record;
-admins additionally own the allow-list and the `app_config_definitions` registry themselves
+admins additionally own the allow-list and `app_config_definitions` themselves
 (users cannot). So the cost of permission lives entirely on the
 (infrequent) write path and the (one-time) admin setup, never on read.
 
@@ -77,7 +77,7 @@ Three scopes cover the use cases (`public` for the pre-login shell):
   that scope may be created/updated/purged **only if** the record exists
   — through the admin mutations and the regular ones alike. What sets
   admins apart is that they alone manage the allow-list (and the
-  `app_config_definitions` registry) itself. It governs **writes only** — never reads.
+  `app_config_definitions`) itself. It governs **writes only** — never reads.
 - **`rank` lives on the fragment.** A fragment's `rank` is its merge
   priority within a `config_name`; the read merge orders fragments by it.
 - **Single source-of-truth table.** One `app_config_fragments` table
@@ -89,7 +89,7 @@ Three scopes cover the use cases (`public` for the pre-login shell):
 
 Three tables, with `app_config_definitions` as the hub both others reference.
 
-### `app_config_definitions` — the document-name registry
+### `app_config_definitions` — the registered config documents
 
 One row per document name. A name must be registered here before any
 fragment or allow-list entry can reference it. **Explicitly managed by

--- a/proposals/BEP-1052-scoped-app-config-redesign.md
+++ b/proposals/BEP-1052-scoped-app-config-redesign.md
@@ -14,7 +14,7 @@ Implemented-Version:
 App configuration is redesigned as **scoped entities** — one row per
 `(scope_type, scope_id, config_name)` — so storage and merge live at the
 scope level. A single scope (one domain, one user) can hold **multiple
-named configuration documents** (`theme`, `menu`, `preferences`, …),
+named configs** (`theme`, `menu`, `preferences`, …),
 each managed independently.
 
 **Reads are the hot path.** A user's effective configuration for a
@@ -23,7 +23,7 @@ them**, taken
 straight from `app_config_fragments` in `rank` order — a single-table
 query with **no joins and no permission lookup**.
 
-**Write authorization is set up ahead of time.** Every document name is
+**Write authorization is set up ahead of time.** Every config name is
 **explicitly registered** in `app_config_definitions`, and `app_config_allow_list`
 records — **pre-configured by admins** — enumerate the
 `(config_name, scope_type)` pairs at which a fragment may be written.
@@ -60,12 +60,12 @@ Three scopes cover the use cases (`public` for the pre-login shell):
 ## Design Principles
 
 - **Schema-less JSON.** The backend is pure storage; the structure and
-  meaning of each document are owned by the frontend.
+  meaning of each config are owned by the frontend.
 - **Scope = entity.** Access control is expressed at the scope level,
   not per field. Three scopes: `public` (anonymous read / admin write),
   `domain` (same-domain read / admin write), `user` (owner+admin read /
   owner-modify + admin write).
-- **Explicitly registered names.** Every document name lives in
+- **Explicitly registered names.** Every config name lives in
   `app_config_definitions`; fragments and allow-list entries reference it by
   foreign key. No fragment may exist for an unregistered `config_name`.
 - **Reads are join-free and unconditional.** The merge reads
@@ -89,14 +89,14 @@ Three scopes cover the use cases (`public` for the pre-login shell):
 
 Three tables, with `app_config_definitions` as the hub both others reference.
 
-### `app_config_definitions` — the registered config documents
+### `app_config_definitions` — the registered configs
 
-One row per document name. A name must be registered here before any
+One row per config name. A name must be registered here before any
 fragment or allow-list entry can reference it. **Explicitly managed by
 admins** (`create` / `purge`) — registration is a deliberate step, not a
 side effect of writing a fragment.
 
-- `config_name` — the document name (unique). The foreign-key target for
+- `config_name` — the config name (unique). The foreign-key target for
   both other tables. Immutable (rename = purge + recreate).
 - `created_at` / `updated_at`.
 
@@ -122,7 +122,7 @@ advance.
 
 - `config_name` — FK → `app_config_definitions.config_name`.
 - `scope_type` — a scope at which fragments may be written
-  (`public | domain | user`). A user-overridable document carries a
+  (`public | domain | user`). A user-overridable config carries a
   `(config_name, user)` row; an admin-only value carries
   `(config_name, domain)` and/or `(config_name, public)`.
 - `created_at` / `updated_at`.
@@ -136,7 +136,7 @@ allow-list rows themselves.
 
 | `scope_type` | `scope_id`              | Meaning of `config`              |
 |--------------|-------------------------|----------------------------------|
-| `public`     | literal `"public"`      | pre-login value of the document  |
+| `public`     | literal `"public"`      | pre-login value of the config  |
 | `domain`     | `domain_id`             | the domain's value / default     |
 | `user`       | `user_id` (UUID string) | the user's own value             |
 
@@ -173,7 +173,7 @@ Two kinds of mutation:
 
 `create` errors if the natural key already exists; `update` errors if it
 does not; `purge` removes the row (and thus its contribution to the
-merge). A caller "clears" a document without deleting it by `update`-ing
+merge). A caller "clears" a config without deleting it by `update`-ing
 with `{}`, which reads back as `null` (null projection, §3). `update`
 replaces the stored JSON wholesale — no partial/deep update at the write
 boundary.
@@ -257,7 +257,7 @@ likewise `null` — clients fall back to their built-in defaults.
 
 ## 4. Client integration (WebUI)
 
-- **Before login**, the WebUI fetches `public` documents (theme,
+- **Before login**, the WebUI fetches `public` configs (theme,
   branding) anonymously so the shell can render.
 - **After login**, it reads its merged `AppConfig`s (`theme`, `menu`,
   `preferences`, …) — a fast, join-free merge of every public/domain/user
@@ -269,7 +269,7 @@ likewise `null` — clients fall back to their built-in defaults.
 
 ## 5. User scenarios
 
-- **Register a document name and open its scopes** — admin creates the
+- **Register a config name and open its scopes** — admin creates the
   `app_config_definitions` row for `theme`, then the `app_config_allow_list`
   rows for every scope it will use — e.g. `(theme, domain)` for the admin
   default, plus `(theme, user)` if users may customize it. A fragment can
@@ -277,7 +277,7 @@ likewise `null` — clients fall back to their built-in defaults.
 - **Pre-login public config** — anonymous read of `public` `theme`.
 - **Bootstrap after login** — read merged `AppConfig`s in one round of
   queries; each is a single-table rank merge, no per-scope stitching.
-- **User edits a document** — a regular create/update/purge on the
+- **User edits a config** — a regular create/update/purge on the
   caller's own `user` row (only where the grant exists); the response is
   the recomputed merge.
 - **Admin publishes a fixed domain value** — add the `(config_name,
@@ -290,7 +290,7 @@ likewise `null` — clients fall back to their built-in defaults.
   grant **and** purge existing `user` fragments (the grant gates writes,
   not reads).
 - **Admin reorders contributions** — adjust fragment `rank`s.
-- **Admin retires a document name** — purge the fragments, then the
+- **Admin retires a config name** — purge the fragments, then the
   allow-list entries, then the `app_config_definitions` row (purge is rejected
   while references remain).
 - **Admin audit** — cross-scope fragment search and cross-user merged

--- a/proposals/BEP-1052-scoped-app-config-redesign.md
+++ b/proposals/BEP-1052-scoped-app-config-redesign.md
@@ -24,11 +24,11 @@ straight from `app_config_fragments` in `rank` order — a single-table
 query with **no joins and no permission lookup**.
 
 **Write authorization is set up ahead of time.** Every document name is
-**explicitly registered** in `app_config_keys`, and `app_config_allow_list`
+**explicitly registered** in `app_config_definitions`, and `app_config_allow_list`
 records — **pre-configured by admins** — enumerate the
 `(config_name, scope_type)` pairs at which a fragment may be written.
 **Every** fragment write, admin or user, requires a matching record;
-admins additionally own the allow-list and the `app_config_keys` registry themselves
+admins additionally own the allow-list and the `app_config_definitions` registry themselves
 (users cannot). So the cost of permission lives entirely on the
 (infrequent) write path and the (one-time) admin setup, never on read.
 
@@ -66,7 +66,7 @@ Three scopes cover the use cases (`public` for the pre-login shell):
   `domain` (same-domain read / admin write), `user` (owner+admin read /
   owner-modify + admin write).
 - **Explicitly registered names.** Every document name lives in
-  `app_config_keys`; fragments and allow-list entries reference it by
+  `app_config_definitions`; fragments and allow-list entries reference it by
   foreign key. No fragment may exist for an unregistered `config_name`.
 - **Reads are join-free and unconditional.** The merge reads
   `app_config_fragments` alone, ordering the existing fragments by
@@ -77,7 +77,7 @@ Three scopes cover the use cases (`public` for the pre-login shell):
   that scope may be created/updated/purged **only if** the record exists
   — through the admin mutations and the regular ones alike. What sets
   admins apart is that they alone manage the allow-list (and the
-  `app_config_keys` registry) itself. It governs **writes only** — never reads.
+  `app_config_definitions` registry) itself. It governs **writes only** — never reads.
 - **`rank` lives on the fragment.** A fragment's `rank` is its merge
   priority within a `config_name`; the read merge orders fragments by it.
 - **Single source-of-truth table.** One `app_config_fragments` table
@@ -87,9 +87,9 @@ Three scopes cover the use cases (`public` for the pre-login shell):
 
 ## 1. Data model
 
-Three tables, with `app_config_keys` as the hub both others reference.
+Three tables, with `app_config_definitions` as the hub both others reference.
 
-### `app_config_keys` — the document-name registry
+### `app_config_definitions` — the document-name registry
 
 One row per document name. A name must be registered here before any
 fragment or allow-list entry can reference it. **Explicitly managed by
@@ -107,7 +107,7 @@ Keyed by the natural composite `(scope_type, scope_id, config_name)`
 
 - `scope_type` — `public | domain | user`.
 - `scope_id` — the scope's identifier (see convention below).
-- `config_name` — FK → `app_config_keys.config_name`.
+- `config_name` — FK → `app_config_definitions.config_name`.
 - `config` — schema-less JSON payload.
 - `rank` — integer merge priority within the `config_name` (low → high;
   higher wins). Assigned on create (see §2).
@@ -120,7 +120,7 @@ single-purpose table: **the write gate**. A fragment at `(config_name, scope_typ
 may be written only if its row exists here. Admins set these up in
 advance.
 
-- `config_name` — FK → `app_config_keys.config_name`.
+- `config_name` — FK → `app_config_definitions.config_name`.
 - `scope_type` — a scope at which fragments may be written
   (`public | domain | user`). A user-overridable document carries a
   `(config_name, user)` row; an admin-only value carries
@@ -143,14 +143,14 @@ allow-list rows themselves.
 ### Integrity
 
 - **Every** fragment write (admin or regular) requires (a) a registered
-  `config_name` (FK to `app_config_keys`) and (b) an
+  `config_name` (FK to `app_config_definitions`) and (b) an
   `app_config_allow_list` row for the write's `(config_name,
   scope_type)`. The service layer rejects per-row when either is missing.
 - A regular (non-admin) mutation is further restricted to the caller's
   own `user` row; admin mutations may target any scope (still gated by
   the allow-list) and are the only writes that may touch the allow-list
-  and `app_config_keys`.
-- `app_config_keys` purge is rejected while any fragment or allow-list
+  and `app_config_definitions`.
+- `app_config_definitions` purge is rejected while any fragment or allow-list
   entry still references the `config_name` (`ON DELETE NO ACTION`).
 - `app_config_allow_list` purge **revokes future writes** at that
   `(config_name, scope_type)`. Because reads never consult the
@@ -166,7 +166,7 @@ Two kinds of mutation:
   fragment at any scope whose `(config_name, scope_type)` is in the
   allow-list. The only mutations that may write another user's `user`
   row, and the only ones that may manage the allow-list and
-  `app_config_keys` themselves.
+  `app_config_definitions` themselves.
 - **Regular mutations** (any authenticated user) — `create` / `update` /
   `purge` the caller's own `user` row, **only when** an allow-list row
   exists for `(config_name, user)`.
@@ -270,7 +270,7 @@ likewise `null` — clients fall back to their built-in defaults.
 ## 5. User scenarios
 
 - **Register a document name and open its scopes** — admin creates the
-  `app_config_keys` row for `theme`, then the `app_config_allow_list`
+  `app_config_definitions` row for `theme`, then the `app_config_allow_list`
   rows for every scope it will use — e.g. `(theme, domain)` for the admin
   default, plus `(theme, user)` if users may customize it. A fragment can
   be written only after its scope's row exists.
@@ -291,7 +291,7 @@ likewise `null` — clients fall back to their built-in defaults.
   not reads).
 - **Admin reorders contributions** — adjust fragment `rank`s.
 - **Admin retires a document name** — purge the fragments, then the
-  allow-list entries, then the `app_config_keys` row (purge is rejected
+  allow-list entries, then the `app_config_definitions` row (purge is rejected
   while references remain).
 - **Admin audit** — cross-scope fragment search and cross-user merged
   search for support.

--- a/proposals/BEP-1052-scoped-app-config-redesign.md
+++ b/proposals/BEP-1052-scoped-app-config-redesign.md
@@ -177,8 +177,7 @@ with `{}`, which reads back as `null` (null projection, §3). `update`
 replaces the stored JSON wholesale — no partial/deep update at the write
 boundary.
 
-**Overridability is a write-grant decision** — there is no admin-seeding
-dance:
+**Overridability is a write-grant decision:**
 
 - **Fixed** (user cannot change): no `(config_name, user)` row exists in
   the allow-list, so a regular `user`-scope write is rejected and the

--- a/proposals/BEP-1052-scoped-app-config-redesign.md
+++ b/proposals/BEP-1052-scoped-app-config-redesign.md
@@ -17,8 +17,9 @@ scope level. A single scope (one domain, one user) can hold **multiple
 named configuration documents** (`theme`, `menu`, `preferences`, …),
 each managed independently.
 
-**Reads are the hot path.** A user's effective configuration for a name
-is the **deep merge of every fragment that applies to them**, taken
+**Reads are the hot path.** A user's effective configuration for a
+`config_name` is the **deep merge of every fragment that applies to
+them**, taken
 straight from `app_config_fragments` in `rank` order — a single-table
 query with **no joins and no permission lookup**.
 
@@ -66,7 +67,7 @@ Three scopes cover the use cases (`public` for the pre-login shell):
   owner-modify + admin write).
 - **Explicitly registered names.** Every document name lives in
   `app_config_keys`; fragments and allow-list entries reference it by
-  foreign key. No fragment may exist for an unregistered name.
+  foreign key. No fragment may exist for an unregistered `config_name`.
 - **Reads are join-free and unconditional.** The merge reads
   `app_config_fragments` alone, ordering the existing fragments by
   `rank`. No allow-list or policy is consulted at read time — the hot
@@ -112,7 +113,7 @@ Keyed by the natural composite `(scope_type, scope_id, config_name)`
   higher wins). Assigned on create (see §2).
 - `created_at` / `updated_at`.
 
-### `app_config_allow_list` — the per-`(name, scope)` write gate
+### `app_config_allow_list` — the per-`(config_name, scope_type)` write gate
 
 One row per `(config_name, scope_type)` (unique) — a normalized,
 single-purpose table: **the write gate**. A fragment at `(config_name, scope_type)`
@@ -150,7 +151,7 @@ allow-list rows themselves.
   the allow-list) and are the only writes that may touch the allow-list
   and `app_config_keys`.
 - `app_config_keys` purge is rejected while any fragment or allow-list
-  entry still references the name (`ON DELETE NO ACTION`).
+  entry still references the `config_name` (`ON DELETE NO ACTION`).
 - `app_config_allow_list` purge **revokes future writes** at that
   `(config_name, scope_type)`. Because reads never consult the
   allow-list, **existing fragments are untouched and keep merging** — to
@@ -202,7 +203,7 @@ is already stored).
 high, higher wins).
 
 - **Assignment.** A new fragment is placed after the existing ones for
-  the same name, so a later-created fragment outranks earlier ones by
+  the same `config_name`, so a later-created fragment outranks earlier ones by
   default. Admins re-order by setting `rank` explicitly. (Publishing the
   `domain` default before a user writes their own copy naturally gives
   the `user` fragment the higher rank, so the user value wins.)


### PR DESCRIPTION
## Summary
- Rewrite BEP-1052 (Scoped App Config Redesign) around three tables: `app_config_definitions`, `app_config_fragments`, and `app_config_allow_list`.
- `app_config_definitions`: an explicitly admin-managed table of registered `config_name`s; no fragment may exist for an unregistered name.
- `app_config_fragments`: the per-scope JSON values keyed by `(scope_type, scope_id, config_name)`, each carrying a `rank`. Reads are the hot path — a single-table merge of the applicable fragments ordered by `rank`, with no join and no permission lookup.
- `app_config_allow_list`: one row per `(config_name, scope_type)` that gates every fragment write (admin and regular mutations alike). It carries no `rank` and is never consulted on read; admins alone manage the allow-list and `app_config_definitions`.
- Scopes are `public` / `domain` / `user`; overridability is decided by whether a `(config_name, user)` allow-list row exists.

Resolves BA-6525.