### PR TITLE
fix: Surface vfolder-create domain errors instead of masking them as 500

### DIFF
--- a/changes/12248.fix.md
+++ b/changes/12248.fix.md
@@ -1,0 +1,1 @@
+Surface vfolder-create domain errors (`Forbidden`, `ProjectNotFound`, `VFolderCreationFailure`) with their own HTTP status instead of masking them as a generic 500 "Internal server error."

--- a/src/ai/backend/manager/api/rest/vfolder/handler.py
+++ b/src/ai/backend/manager/api/rest/vfolder/handler.py
@@ -97,7 +97,6 @@ from ai.backend.common.dto.manager.vfolder.response import (
     VFolderSharedInfoDTO,
     VolumeInfoDTO,
 )
-from ai.backend.common.exception import BackendAIError
 from ai.backend.common.types import VFolderID
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.permission.types import ScopeType
@@ -276,8 +275,11 @@ class VFolderHandler:
             )
         except (VFolderInvalidParameter, VFolderAlreadyExists) as e:
             raise InvalidAPIParameters(str(e)) from e
-        except BackendAIError as e:
-            raise InternalServerError(str(e)) from e
+        # Every other BackendAIError carries its own HTTP status (Forbidden ->
+        # 403, ProjectNotFound -> 404, VFolderCreationFailure -> 400); let it
+        # propagate so the exception middleware serializes the real error.
+        # Collapsing them into InternalServerError hid the actual cause behind
+        # a generic 500 "Internal server error." title.
 
         item = VFolderItemField(
             id=result.id.hex,

--- a/tests/component/vfolder/test_vfolder_crud.py
+++ b/tests/component/vfolder/test_vfolder_crud.py
@@ -125,8 +125,8 @@ class TestVFolderCreateErrors:
                     unmanaged_path="/mnt/forbidden",
                 ),
             )
-        # Server wraps Forbidden as InternalServerError (500) at the API boundary
-        assert exc_info.value.status == 500
+        # Forbidden propagates with its own 403 status (no longer masked as 500)
+        assert exc_info.value.status == 403
 
     async def test_dot_prefix_name_for_group_vfolder_raises_error(
         self,
@@ -158,8 +158,8 @@ class TestVFolderCreateErrors:
                     group_id=group_fixture,
                 ),
             )
-        # Server wraps Forbidden as InternalServerError (500) at the API boundary
-        assert exc_info.value.status == 500
+        # Forbidden propagates with its own 403 status (no longer masked as 500)
+        assert exc_info.value.status == 403
 
     async def test_duplicate_name_raises_conflict(
         self,


### PR DESCRIPTION
## TL;DR

`VFolderHandler.create` masked every domain `BackendAIError` (except `VFolderInvalidParameter`/`VFolderAlreadyExists`) as a generic HTTP 500 `"Internal server error."`. This drops that masking so `Forbidden` → 403, `ProjectNotFound` → 404, and `VFolderCreationFailure` → 400 reach the client.

Resolves #12247.

## Problem

```python
# src/ai/backend/manager/api/rest/vfolder/handler.py — create()
except (VFolderInvalidParameter, VFolderAlreadyExists) as e:
    raise InvalidAPIParameters(str(e)) from e
except BackendAIError as e:            # catches the base class
    raise InternalServerError(str(e)) from e
```

The create service raises `Forbidden` (e.g. a regular user creating a project/group vfolder, or an unmanaged_path), `ProjectNotFound`, and `VFolderCreationFailure` — each already carrying a correct 4xx status. Catching the **base** `BackendAIError` collapsed all of them into a 500 whose title is the constant `"Internal server error."`.

Downstream, clients that surface the error `title` (Backend.AI FastTrack pipeline creation reads `e.data["title"]`) showed only `"Failed to provision storage folder: Internal server error"` for what is really a 403 — undiagnosable without manager logs.

## Fix

Drop the `except BackendAIError -> InternalServerError` branch and let domain errors propagate. The REST exception middleware already serializes `BackendAIError` subclasses by their own `status_code` (4xx logged as client errors), so the correct status reaches the client. The `VFolderInvalidParameter`/`VFolderAlreadyExists -> InvalidAPIParameters` mapping is preserved for backward compatibility.

## Tests

`tests/component/vfolder/test_vfolder_crud.py` previously **encoded** the bug:

```python
# Server wraps Forbidden as InternalServerError (500) at the API boundary
assert exc_info.value.status == 500
```

Updated `test_non_admin_cannot_create_unmanaged_vfolder` and `test_non_admin_cannot_create_group_vfolder_in_regular_project` to assert **403**.

## Notes

- The masking predates the Feb 2026 handler-class refactor (#9459); the regular-user `Forbidden` path was added in #5111. Present on `main` and the 26.4 series (verified 26.4.4rc9).
- Local `ruff format` / `ruff check` (Pants pre-commit) pass. Component tests require the DB/storage-proxy harness; the two updated assertions are pure status-code checks.
