### PR TITLE
feat(BA-6058): add llama-cpp runtime variant to example fixtures (#11940)

### DIFF
--- a/changes/11940.feature.md
+++ b/changes/11940.feature.md
@@ -1,0 +1,1 @@
+Add a llama-cpp runtime variant to the model-service example fixtures

--- a/fixtures/manager/example-runtime-variants.json
+++ b/fixtures/manager/example-runtime-variants.json
@@ -1,11 +1,188 @@
 {
   "runtime_variants": [
-    {"name": "vllm", "description": "vLLM"},
-    {"name": "nim", "description": "NVIDIA NIM"},
-    {"name": "cmd", "description": "Predefined Image Command"},
-    {"name": "huggingface-tgi", "description": "Huggingface TGI"},
-    {"name": "sglang", "description": "SGLang"},
-    {"name": "modular-max", "description": "Modular MAX"},
-    {"name": "custom", "description": "Custom (Default)"}
+    {
+      "name": "vllm",
+      "description": "vLLM",
+      "reads_vfolder_config_files": false,
+      "default_model_definition": {
+        "models": [
+          {
+            "name": "vllm-model",
+            "service": {
+              "start_command": ["vllm", "serve", "{model_path}"],
+              "port": 8000,
+              "health_check": {
+                "enable": true,
+                "path": "/health",
+                "interval": 10.0,
+                "max_retries": 10,
+                "initial_delay": 1800.0
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "nim",
+      "description": "NVIDIA NIM",
+      "reads_vfolder_config_files": false,
+      "default_model_definition": {
+        "models": [
+          {
+            "name": "nim-model",
+            "service": {
+              "port": 8000,
+              "health_check": {
+                "enable": true,
+                "path": "/v1/health/ready",
+                "interval": 10.0,
+                "max_retries": 10,
+                "initial_delay": 1800.0
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "cmd",
+      "description": "Predefined Image Command",
+      "reads_vfolder_config_files": false,
+      "default_model_definition": {
+        "models": [
+          {
+            "name": "image-model",
+            "service": {
+              "port": 8000
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "huggingface-tgi",
+      "description": "Huggingface TGI",
+      "reads_vfolder_config_files": false,
+      "default_model_definition": {
+        "models": [
+          {
+            "name": "tgi-model",
+            "service": {
+              "start_command": ["text-generation-launcher", "--model-id", "{model_path}"],
+              "port": 3000,
+              "health_check": {
+                "enable": true,
+                "path": "/info",
+                "interval": 10.0,
+                "max_retries": 10,
+                "initial_delay": 1800.0
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "sglang",
+      "description": "SGLang",
+      "reads_vfolder_config_files": false,
+      "default_model_definition": {
+        "models": [
+          {
+            "name": "sglang-model",
+            "service": {
+              "start_command": [
+                "python",
+                "-m",
+                "sglang.launch_server",
+                "--model-path",
+                "{model_path}"
+              ],
+              "port": 9001,
+              "health_check": {
+                "enable": true,
+                "path": "/health",
+                "interval": 10.0,
+                "max_retries": 10,
+                "initial_delay": 1800.0
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "modular-max",
+      "description": "Modular MAX",
+      "reads_vfolder_config_files": false,
+      "default_model_definition": {
+        "models": [
+          {
+            "name": "max-model",
+            "service": {
+              "start_command": ["max", "serve", "--model", "{model_path}"],
+              "port": 8000,
+              "health_check": {
+                "enable": true,
+                "path": "/health",
+                "interval": 10.0,
+                "max_retries": 10,
+                "initial_delay": 1800.0
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "llama-cpp",
+      "description": "llama.cpp",
+      "reads_vfolder_config_files": false,
+      "default_model_definition": {
+        "models": [
+          {
+            "name": "llamacpp-model",
+            "service": {
+              "start_command": [
+                "sh",
+                "-c",
+                "llama-server -m \"$(ls /models/*.gguf | head -n1)\" \"$@\"",
+                "llama-cpp"
+              ],
+              "port": 8080,
+              "health_check": {
+                "path": "/health",
+                "interval": 10.0,
+                "max_retries": 30,
+                "initial_delay": 60.0
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "custom",
+      "description": "Custom (Default)",
+      "reads_vfolder_config_files": true,
+      "default_model_definition": {
+        "models": [
+          {
+            "name": "custom-model",
+            "service": {
+              "port": 8080,
+              "health_check": {
+                "enable": false,
+                "path": "/health",
+                "interval": 10.0,
+                "max_retries": 10,
+                "initial_delay": 1800.0
+              }
+            }
+          }
+        ]
+      }
+    }
   ]
 }

--- a/src/ai/backend/install/fixtures/example-runtime-variants.json
+++ b/src/ai/backend/install/fixtures/example-runtime-variants.json
@@ -1,11 +1,188 @@
 {
   "runtime_variants": [
-    {"name": "vllm", "description": "vLLM"},
-    {"name": "nim", "description": "NVIDIA NIM"},
-    {"name": "cmd", "description": "Predefined Image Command"},
-    {"name": "huggingface-tgi", "description": "Huggingface TGI"},
-    {"name": "sglang", "description": "SGLang"},
-    {"name": "modular-max", "description": "Modular MAX"},
-    {"name": "custom", "description": "Custom (Default)"}
+    {
+      "name": "vllm",
+      "description": "vLLM",
+      "reads_vfolder_config_files": false,
+      "default_model_definition": {
+        "models": [
+          {
+            "name": "vllm-model",
+            "service": {
+              "start_command": ["vllm", "serve", "{model_path}"],
+              "port": 8000,
+              "health_check": {
+                "enable": true,
+                "path": "/health",
+                "interval": 10.0,
+                "max_retries": 10,
+                "initial_delay": 1800.0
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "nim",
+      "description": "NVIDIA NIM",
+      "reads_vfolder_config_files": false,
+      "default_model_definition": {
+        "models": [
+          {
+            "name": "nim-model",
+            "service": {
+              "port": 8000,
+              "health_check": {
+                "enable": true,
+                "path": "/v1/health/ready",
+                "interval": 10.0,
+                "max_retries": 10,
+                "initial_delay": 1800.0
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "cmd",
+      "description": "Predefined Image Command",
+      "reads_vfolder_config_files": false,
+      "default_model_definition": {
+        "models": [
+          {
+            "name": "image-model",
+            "service": {
+              "port": 8000
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "huggingface-tgi",
+      "description": "Huggingface TGI",
+      "reads_vfolder_config_files": false,
+      "default_model_definition": {
+        "models": [
+          {
+            "name": "tgi-model",
+            "service": {
+              "start_command": ["text-generation-launcher", "--model-id", "{model_path}"],
+              "port": 3000,
+              "health_check": {
+                "enable": true,
+                "path": "/info",
+                "interval": 10.0,
+                "max_retries": 10,
+                "initial_delay": 1800.0
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "sglang",
+      "description": "SGLang",
+      "reads_vfolder_config_files": false,
+      "default_model_definition": {
+        "models": [
+          {
+            "name": "sglang-model",
+            "service": {
+              "start_command": [
+                "python",
+                "-m",
+                "sglang.launch_server",
+                "--model-path",
+                "{model_path}"
+              ],
+              "port": 9001,
+              "health_check": {
+                "enable": true,
+                "path": "/health",
+                "interval": 10.0,
+                "max_retries": 10,
+                "initial_delay": 1800.0
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "modular-max",
+      "description": "Modular MAX",
+      "reads_vfolder_config_files": false,
+      "default_model_definition": {
+        "models": [
+          {
+            "name": "max-model",
+            "service": {
+              "start_command": ["max", "serve", "--model", "{model_path}"],
+              "port": 8000,
+              "health_check": {
+                "enable": true,
+                "path": "/health",
+                "interval": 10.0,
+                "max_retries": 10,
+                "initial_delay": 1800.0
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "llama-cpp",
+      "description": "llama.cpp",
+      "reads_vfolder_config_files": false,
+      "default_model_definition": {
+        "models": [
+          {
+            "name": "llamacpp-model",
+            "service": {
+              "start_command": [
+                "sh",
+                "-c",
+                "llama-server -m \"$(ls /models/*.gguf | head -n1)\" \"$@\"",
+                "llama-cpp"
+              ],
+              "port": 8080,
+              "health_check": {
+                "path": "/health",
+                "interval": 10.0,
+                "max_retries": 30,
+                "initial_delay": 60.0
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "custom",
+      "description": "Custom (Default)",
+      "reads_vfolder_config_files": true,
+      "default_model_definition": {
+        "models": [
+          {
+            "name": "custom-model",
+            "service": {
+              "port": 8080,
+              "health_check": {
+                "enable": false,
+                "path": "/health",
+                "interval": 10.0,
+                "max_retries": 10,
+                "initial_delay": 1800.0
+              }
+            }
+          }
+        ]
+      }
+    }
   ]
 }


### PR DESCRIPTION
This is an auto-generated backport PR of #11940 to the 26.4 release.