### PR TITLE
ci(BA-6526): add workflow to notify and close stale PRs

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -1,0 +1,38 @@
+name: 'Close Stale PRs'
+
+on:
+  schedule:
+    # Run daily at 00:00 UTC
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+env:
+  # Days of inactivity before a PR is marked stale and notified.
+  DAYS_BEFORE_STALE: 7
+  # Days of further inactivity after being marked stale before the PR is closed.
+  DAYS_BEFORE_CLOSE: 7
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: ${{ env.DAYS_BEFORE_STALE }}
+          days-before-close: ${{ env.DAYS_BEFORE_CLOSE }}
+          stale-pr-label: 'stale'
+          stale-pr-message: >
+            This PR has had no activity for ${{ env.DAYS_BEFORE_STALE }} days
+            and has been marked as stale. It will be closed in
+            ${{ env.DAYS_BEFORE_CLOSE }} days if no further activity occurs.
+            Push a commit or leave a comment to keep it open.
+          close-pr-message: >
+            This PR has been automatically closed because it had no activity
+            for ${{ env.DAYS_BEFORE_CLOSE }} days after being marked as stale.
+            Feel free to reopen it if you intend to continue the work.
+          # Only act on pull requests, not issues.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -11,14 +11,17 @@ permissions:
 
 env:
   # Days of inactivity before a PR is marked stale and notified.
-  DAYS_BEFORE_STALE: 7
+  DAYS_BEFORE_STALE: 14
   # Days of further inactivity after being marked stale before the PR is closed.
-  DAYS_BEFORE_CLOSE: 7
+  DAYS_BEFORE_CLOSE: 14
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
+      - name: Compute projected close date
+        run: echo "CLOSE_DATE=$(date -u -d "+${DAYS_BEFORE_CLOSE} days" +%Y-%m-%d)" >> "$GITHUB_ENV"
+
       - uses: actions/stale@v9
         with:
           days-before-stale: ${{ env.DAYS_BEFORE_STALE }}
@@ -26,9 +29,10 @@ jobs:
           stale-pr-label: 'stale'
           stale-pr-message: >
             This PR has had no activity for ${{ env.DAYS_BEFORE_STALE }} days
-            and has been marked as stale. It will be closed in
-            ${{ env.DAYS_BEFORE_CLOSE }} days if no further activity occurs.
-            Push a commit or leave a comment to keep it open.
+            and has been marked as stale. It will be closed on
+            ${{ env.CLOSE_DATE }} (in ${{ env.DAYS_BEFORE_CLOSE }} days) if no
+            further activity occurs. Push a commit or leave a comment to keep it
+            open.
           close-pr-message: >
             This PR has been automatically closed because it had no activity
             for ${{ env.DAYS_BEFORE_CLOSE }} days after being marked as stale.

--- a/changes/12254.misc.md
+++ b/changes/12254.misc.md
@@ -1,0 +1,1 @@
+Add a CI workflow that notifies and closes pull requests after prolonged inactivity.


### PR DESCRIPTION
## Summary
- Add `actions/stale@v9` workflow that marks PRs stale after 14 days of inactivity and closes them after 14 more days, posting a comment at each step.
- Stale/close thresholds are surfaced as constants in a top-level `env` block; comment text references them automatically.
- Issues are excluded; only PRs are processed. Runs daily via cron and supports manual `workflow_dispatch`.

You can check specs about the stale action here (https://github.com/actions/stale#all-options).

Resolves BA-6526

🤖 Generated with [Claude Code](https://claude.com/claude-code)