### PR TITLE
feat(BA-6530): add AppConfigDefinition REST v2 API

### DIFF
--- a/changes/12266.feature.md
+++ b/changes/12266.feature.md
@@ -1,0 +1,1 @@
+Add the REST v2 `app-config-definitions` API (create / get / search / purge) for managing registered app config names (BEP-1052).

--- a/src/ai/backend/common/dto/manager/query.py
+++ b/src/ai/backend/common/dto/manager/query.py
@@ -131,8 +131,8 @@ class ArrayFilter[T](BaseRequestModel):
 class DateTimeFilter(BaseRequestModel):
     """Filter for datetime fields supporting range and equality operations."""
 
-    before: datetime | None = Field(default=None, description="Before this datetime (inclusive)")
-    after: datetime | None = Field(default=None, description="After this datetime (inclusive)")
+    before: datetime | None = Field(default=None, description="Before this datetime (exclusive)")
+    after: datetime | None = Field(default=None, description="After this datetime (exclusive)")
     equals: datetime | None = Field(default=None, description="Exact datetime match")
     not_equals: datetime | None = Field(default=None, description="Not equal to this datetime")
 
@@ -145,8 +145,8 @@ class DateTimeFilter(BaseRequestModel):
         """Build a query condition from this filter using the provided factory callables.
 
         Args:
-            before_factory: Factory function that takes datetime and returns a condition for <= comparison
-            after_factory: Factory function that takes datetime and returns a condition for >= comparison
+            before_factory: Factory function that takes datetime and returns a condition for < comparison
+            after_factory: Factory function that takes datetime and returns a condition for > comparison
             equals_factory: Factory function for = comparison
 
         Returns:

--- a/src/ai/backend/common/dto/manager/v2/app_config_definition/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_definition/request.py
@@ -5,8 +5,15 @@ from __future__ import annotations
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseRequestModel
+from ai.backend.common.dto.manager.query import StringFilter
+from ai.backend.common.dto.manager.v2.app_config_definition.types import (
+    AppConfigDefinitionOrderField,
+)
+from ai.backend.common.dto.manager.v2.common import OrderDirection
 
 __all__ = (
+    "AppConfigDefinitionFilter",
+    "AppConfigDefinitionOrder",
     "CreateAppConfigDefinitionInput",
     "SearchAppConfigDefinitionsInput",
 )
@@ -22,9 +29,26 @@ class CreateAppConfigDefinitionInput(BaseRequestModel):
     )
 
 
+class AppConfigDefinitionFilter(BaseRequestModel):
+    """Filter for app config definition search."""
+
+    config_name: StringFilter | None = Field(default=None, description="Filter by config name.")
+
+
+class AppConfigDefinitionOrder(BaseRequestModel):
+    """Order specifier for app config definition search."""
+
+    field: AppConfigDefinitionOrderField = Field(description="Field to order by.")
+    direction: OrderDirection = Field(default=OrderDirection.ASC, description="Order direction.")
+
+
 class SearchAppConfigDefinitionsInput(BaseRequestModel):
     """Input for paginated app config definition search."""
 
+    filter: AppConfigDefinitionFilter | None = Field(default=None, description="Filter conditions.")
+    order: list[AppConfigDefinitionOrder] | None = Field(
+        default=None, description="Order specifiers, applied in sequence."
+    )
     limit: int | None = Field(
         default=None, ge=1, description="Offset-based: maximum number of results."
     )

--- a/src/ai/backend/common/dto/manager/v2/app_config_definition/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_definition/request.py
@@ -1,0 +1,33 @@
+"""Request DTOs for app_config_definition v2."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from ai.backend.common.api_handlers import BaseRequestModel
+
+__all__ = (
+    "CreateAppConfigDefinitionInput",
+    "SearchAppConfigDefinitionsInput",
+)
+
+
+class CreateAppConfigDefinitionInput(BaseRequestModel):
+    """Input for registering a new app config definition."""
+
+    config_name: str = Field(
+        min_length=1,
+        max_length=128,
+        description="Unique config name to register (e.g. 'theme', 'menu').",
+    )
+
+
+class SearchAppConfigDefinitionsInput(BaseRequestModel):
+    """Input for paginated app config definition search."""
+
+    limit: int | None = Field(
+        default=None, ge=1, description="Offset-based: maximum number of results."
+    )
+    offset: int | None = Field(
+        default=None, ge=0, description="Offset-based: number of results to skip."
+    )

--- a/src/ai/backend/common/dto/manager/v2/app_config_definition/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_definition/request.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseRequestModel
-from ai.backend.common.dto.manager.query import StringFilter
+from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter
 from ai.backend.common.dto.manager.v2.app_config_definition.types import (
     AppConfigDefinitionOrderField,
 )
@@ -33,6 +33,12 @@ class AppConfigDefinitionFilter(BaseRequestModel):
     """Filter for app config definition search."""
 
     config_name: StringFilter | None = Field(default=None, description="Filter by config name.")
+    created_at: DateTimeFilter | None = Field(
+        default=None, description="Filter by creation datetime."
+    )
+    updated_at: DateTimeFilter | None = Field(
+        default=None, description="Filter by last update datetime."
+    )
 
 
 class AppConfigDefinitionOrder(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/app_config_definition/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_definition/request.py
@@ -55,6 +55,10 @@ class SearchAppConfigDefinitionsInput(BaseRequestModel):
     order: list[AppConfigDefinitionOrder] | None = Field(
         default=None, description="Order specifiers, applied in sequence."
     )
+    first: int | None = Field(default=None, ge=1, description="Cursor-forward page size.")
+    after: str | None = Field(default=None, description="Cursor-forward start cursor.")
+    last: int | None = Field(default=None, ge=1, description="Cursor-backward page size.")
+    before: str | None = Field(default=None, description="Cursor-backward end cursor.")
     limit: int | None = Field(
         default=None, ge=1, description="Offset-based: maximum number of results."
     )

--- a/src/ai/backend/common/dto/manager/v2/app_config_definition/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_definition/response.py
@@ -1,0 +1,49 @@
+"""Response DTOs for app_config_definition v2."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import Field
+
+from ai.backend.common.api_handlers import BaseResponseModel
+
+__all__ = (
+    "AppConfigDefinitionNode",
+    "CreateAppConfigDefinitionPayload",
+    "PurgeAppConfigDefinitionPayload",
+    "SearchAppConfigDefinitionsPayload",
+)
+
+
+class AppConfigDefinitionNode(BaseResponseModel):
+    """Node model representing a registered app config definition."""
+
+    id: UUID = Field(description="App config definition UUID.")
+    config_name: str = Field(description="Registered config name.")
+    created_at: datetime = Field(description="Creation timestamp (UTC).")
+    updated_at: datetime = Field(description="Last update timestamp (UTC).")
+
+
+class CreateAppConfigDefinitionPayload(BaseResponseModel):
+    """Payload for app config definition creation."""
+
+    app_config_definition: AppConfigDefinitionNode = Field(
+        description="Created app config definition."
+    )
+
+
+class PurgeAppConfigDefinitionPayload(BaseResponseModel):
+    """Payload for app config definition purge."""
+
+    id: UUID = Field(description="UUID of the purged app config definition.")
+
+
+class SearchAppConfigDefinitionsPayload(BaseResponseModel):
+    """Payload for paginated app config definition search results."""
+
+    items: list[AppConfigDefinitionNode] = Field(description="App config definition nodes.")
+    total_count: int = Field(description="Total count matching the query.")
+    has_next_page: bool = Field(description="Whether there is a next page.")
+    has_previous_page: bool = Field(description="Whether there is a previous page.")

--- a/src/ai/backend/common/dto/manager/v2/app_config_definition/types.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_definition/types.py
@@ -1,0 +1,12 @@
+"""Enum types for app_config_definition v2 DTOs."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+__all__ = ("AppConfigDefinitionOrderField",)
+
+
+class AppConfigDefinitionOrderField(StrEnum):
+    CONFIG_NAME = "config_name"
+    CREATED_AT = "created_at"

--- a/src/ai/backend/common/dto/manager/v2/app_config_definition/types.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_definition/types.py
@@ -10,3 +10,4 @@ __all__ = ("AppConfigDefinitionOrderField",)
 class AppConfigDefinitionOrderField(StrEnum):
     CONFIG_NAME = "config_name"
     CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"

--- a/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
 from uuid import UUID
 
 from ai.backend.common.dto.manager.v2.app_config_definition.request import (
@@ -50,10 +51,11 @@ from ai.backend.manager.services.app_config_definition.actions.search import (
 )
 
 
-def _pagination_spec() -> PaginationSpec:
+@lru_cache(maxsize=1)
+def _get_app_config_definition_pagination_spec() -> PaginationSpec:
     return PaginationSpec(
-        forward_order=AppConfigDefinitionOrders.id(ascending=False),
-        backward_order=AppConfigDefinitionOrders.id(ascending=True),
+        forward_order=AppConfigDefinitionOrders.created_at(ascending=False),
+        backward_order=AppConfigDefinitionOrders.created_at(ascending=True),
         forward_condition_factory=AppConfigDefinitionConditions.by_cursor_forward,
         backward_condition_factory=AppConfigDefinitionConditions.by_cursor_backward,
         tiebreaker_order=AppConfigDefinitionOrders.id(ascending=True),
@@ -88,7 +90,7 @@ class AppConfigDefinitionAdapter(BaseAdapter):
         querier = self._build_querier(
             conditions=conditions,
             orders=orders,
-            pagination_spec=_pagination_spec(),
+            pagination_spec=_get_app_config_definition_pagination_spec(),
             first=input.first,
             after=input.after,
             last=input.last,

--- a/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
@@ -29,10 +29,12 @@ from ai.backend.manager.models.app_config_definition.conditions import (
     AppConfigDefinitionConditions,
 )
 from ai.backend.manager.models.app_config_definition.orders import AppConfigDefinitionOrders
+from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
 from ai.backend.manager.repositories.app_config_definition.creators import (
     AppConfigDefinitionCreatorSpec,
 )
 from ai.backend.manager.repositories.base import (
+    Purger,
     QueryCondition,
     QueryOrder,
 )
@@ -109,8 +111,11 @@ class AppConfigDefinitionAdapter(BaseAdapter):
         )
 
     async def admin_purge(self, definition_id: UUID) -> PurgeAppConfigDefinitionPayload:
+        purger = Purger(
+            row_class=AppConfigDefinitionRow, pk_value=AppConfigDefinitionID(definition_id)
+        )
         action_result = await self._processors.app_config_definition.purge.wait_for_complete(
-            PurgeAppConfigDefinitionAction(definition_id=AppConfigDefinitionID(definition_id))
+            PurgeAppConfigDefinitionAction(purger=purger)
         )
         return PurgeAppConfigDefinitionPayload(id=action_result.definition.id)
 

--- a/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
@@ -1,0 +1,99 @@
+"""App config definition adapter bridging DTOs and Processors."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from ai.backend.common.dto.manager.v2.app_config_definition.request import (
+    CreateAppConfigDefinitionInput,
+    SearchAppConfigDefinitionsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_definition.response import (
+    AppConfigDefinitionNode,
+    CreateAppConfigDefinitionPayload,
+    PurgeAppConfigDefinitionPayload,
+    SearchAppConfigDefinitionsPayload,
+)
+from ai.backend.common.identifier.app_config_definition import AppConfigDefinitionID
+from ai.backend.manager.api.adapters.base import BaseAdapter
+from ai.backend.manager.data.app_config_definition.types import AppConfigDefinitionData
+from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
+from ai.backend.manager.repositories.app_config_definition.creators import (
+    AppConfigDefinitionCreatorSpec,
+)
+from ai.backend.manager.repositories.base import BatchQuerier, OffsetPagination
+from ai.backend.manager.repositories.base.creator import Creator
+from ai.backend.manager.repositories.base.purger import Purger
+from ai.backend.manager.services.app_config_definition.actions.create import (
+    CreateAppConfigDefinitionAction,
+)
+from ai.backend.manager.services.app_config_definition.actions.get import (
+    GetAppConfigDefinitionAction,
+)
+from ai.backend.manager.services.app_config_definition.actions.purge import (
+    PurgeAppConfigDefinitionAction,
+)
+from ai.backend.manager.services.app_config_definition.actions.search import (
+    SearchAppConfigDefinitionsAction,
+)
+
+DEFAULT_PAGINATION_LIMIT = 50
+
+
+class AppConfigDefinitionAdapter(BaseAdapter):
+    """Adapter for app config definition domain operations (admin-only)."""
+
+    @staticmethod
+    def _data_to_node(data: AppConfigDefinitionData) -> AppConfigDefinitionNode:
+        return AppConfigDefinitionNode(
+            id=data.id,
+            config_name=data.config_name,
+            created_at=data.created_at,
+            updated_at=data.updated_at,
+        )
+
+    async def admin_create(
+        self, input: CreateAppConfigDefinitionInput
+    ) -> CreateAppConfigDefinitionPayload:
+        creator = Creator[AppConfigDefinitionRow](
+            spec=AppConfigDefinitionCreatorSpec(config_name=input.config_name),
+        )
+        action_result = await self._processors.app_config_definition.create.wait_for_complete(
+            CreateAppConfigDefinitionAction(creator=creator)
+        )
+        return CreateAppConfigDefinitionPayload(
+            app_config_definition=self._data_to_node(action_result.definition),
+        )
+
+    async def admin_get(self, definition_id: UUID) -> AppConfigDefinitionNode:
+        action_result = await self._processors.app_config_definition.get.wait_for_complete(
+            GetAppConfigDefinitionAction(definition_id=AppConfigDefinitionID(definition_id))
+        )
+        return self._data_to_node(action_result.definition)
+
+    async def admin_search(
+        self, input: SearchAppConfigDefinitionsInput
+    ) -> SearchAppConfigDefinitionsPayload:
+        pagination = OffsetPagination(
+            limit=input.limit if input.limit is not None else DEFAULT_PAGINATION_LIMIT,
+            offset=input.offset if input.offset is not None else 0,
+        )
+        action_result = await self._processors.app_config_definition.search.wait_for_complete(
+            SearchAppConfigDefinitionsAction(querier=BatchQuerier(pagination=pagination))
+        )
+        return SearchAppConfigDefinitionsPayload(
+            items=[self._data_to_node(item) for item in action_result.data],
+            total_count=action_result.total_count,
+            has_next_page=action_result.has_next_page,
+            has_previous_page=action_result.has_previous_page,
+        )
+
+    async def admin_purge(self, definition_id: UUID) -> PurgeAppConfigDefinitionPayload:
+        purger = Purger[AppConfigDefinitionRow](
+            row_class=AppConfigDefinitionRow,
+            pk_value=AppConfigDefinitionID(definition_id),
+        )
+        action_result = await self._processors.app_config_definition.purge.wait_for_complete(
+            PurgeAppConfigDefinitionAction(purger=purger)
+        )
+        return PurgeAppConfigDefinitionPayload(id=action_result.definition.id)

--- a/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
@@ -63,15 +63,6 @@ def _pagination_spec() -> PaginationSpec:
 class AppConfigDefinitionAdapter(BaseAdapter):
     """Adapter for app config definition domain operations (admin-only)."""
 
-    @staticmethod
-    def _data_to_node(data: AppConfigDefinitionData) -> AppConfigDefinitionNode:
-        return AppConfigDefinitionNode(
-            id=data.id,
-            config_name=data.config_name,
-            created_at=data.created_at,
-            updated_at=data.updated_at,
-        )
-
     async def admin_create(
         self, input: CreateAppConfigDefinitionInput
     ) -> CreateAppConfigDefinitionPayload:
@@ -88,6 +79,47 @@ class AppConfigDefinitionAdapter(BaseAdapter):
             GetAppConfigDefinitionAction(definition_id=AppConfigDefinitionID(definition_id))
         )
         return self._data_to_node(action_result.definition)
+
+    async def admin_search(
+        self, input: SearchAppConfigDefinitionsInput
+    ) -> SearchAppConfigDefinitionsPayload:
+        conditions = self._convert_filter(input.filter) if input.filter else []
+        orders = self._convert_orders(input.order) if input.order else []
+        querier = self._build_querier(
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=_pagination_spec(),
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+        )
+        action_result = await self._processors.app_config_definition.search.wait_for_complete(
+            SearchAppConfigDefinitionsAction(querier=querier)
+        )
+        return SearchAppConfigDefinitionsPayload(
+            items=[self._data_to_node(item) for item in action_result.data],
+            total_count=action_result.total_count,
+            has_next_page=action_result.has_next_page,
+            has_previous_page=action_result.has_previous_page,
+        )
+
+    async def admin_purge(self, definition_id: UUID) -> PurgeAppConfigDefinitionPayload:
+        action_result = await self._processors.app_config_definition.purge.wait_for_complete(
+            PurgeAppConfigDefinitionAction(definition_id=AppConfigDefinitionID(definition_id))
+        )
+        return PurgeAppConfigDefinitionPayload(id=action_result.definition.id)
+
+    @staticmethod
+    def _data_to_node(data: AppConfigDefinitionData) -> AppConfigDefinitionNode:
+        return AppConfigDefinitionNode(
+            id=data.id,
+            config_name=data.config_name,
+            created_at=data.created_at,
+            updated_at=data.updated_at,
+        )
 
     def _convert_filter(self, filter_: AppConfigDefinitionFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
@@ -132,35 +164,3 @@ class AppConfigDefinitionAdapter(BaseAdapter):
                 case AppConfigDefinitionOrderField.UPDATED_AT:
                     result.append(AppConfigDefinitionOrders.updated_at(ascending))
         return result
-
-    async def admin_search(
-        self, input: SearchAppConfigDefinitionsInput
-    ) -> SearchAppConfigDefinitionsPayload:
-        conditions = self._convert_filter(input.filter) if input.filter else []
-        orders = self._convert_orders(input.order) if input.order else []
-        querier = self._build_querier(
-            conditions=conditions,
-            orders=orders,
-            pagination_spec=_pagination_spec(),
-            first=input.first,
-            after=input.after,
-            last=input.last,
-            before=input.before,
-            limit=input.limit,
-            offset=input.offset,
-        )
-        action_result = await self._processors.app_config_definition.search.wait_for_complete(
-            SearchAppConfigDefinitionsAction(querier=querier)
-        )
-        return SearchAppConfigDefinitionsPayload(
-            items=[self._data_to_node(item) for item in action_result.data],
-            total_count=action_result.total_count,
-            has_next_page=action_result.has_next_page,
-            has_previous_page=action_result.has_previous_page,
-        )
-
-    async def admin_purge(self, definition_id: UUID) -> PurgeAppConfigDefinitionPayload:
-        action_result = await self._processors.app_config_definition.purge.wait_for_complete(
-            PurgeAppConfigDefinitionAction(definition_id=AppConfigDefinitionID(definition_id))
-        )
-        return PurgeAppConfigDefinitionPayload(id=action_result.definition.id)

--- a/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
@@ -21,24 +21,21 @@ from ai.backend.common.dto.manager.v2.app_config_definition.types import (
 )
 from ai.backend.common.dto.manager.v2.common import OrderDirection
 from ai.backend.common.identifier.app_config_definition import AppConfigDefinitionID
+from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.app_config_definition.types import AppConfigDefinitionData
 from ai.backend.manager.models.app_config_definition.conditions import (
     AppConfigDefinitionConditions,
 )
 from ai.backend.manager.models.app_config_definition.orders import AppConfigDefinitionOrders
-from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
 from ai.backend.manager.repositories.app_config_definition.creators import (
     AppConfigDefinitionCreatorSpec,
 )
 from ai.backend.manager.repositories.base import (
-    BatchQuerier,
-    OffsetPagination,
     QueryCondition,
     QueryOrder,
 )
 from ai.backend.manager.repositories.base.creator import Creator
-from ai.backend.manager.repositories.base.purger import Purger
 from ai.backend.manager.services.app_config_definition.actions.create import (
     CreateAppConfigDefinitionAction,
 )
@@ -52,7 +49,15 @@ from ai.backend.manager.services.app_config_definition.actions.search import (
     SearchAppConfigDefinitionsAction,
 )
 
-DEFAULT_PAGINATION_LIMIT = 50
+
+def _pagination_spec() -> PaginationSpec:
+    return PaginationSpec(
+        forward_order=AppConfigDefinitionOrders.id(ascending=False),
+        backward_order=AppConfigDefinitionOrders.id(ascending=True),
+        forward_condition_factory=AppConfigDefinitionConditions.by_cursor_forward,
+        backward_condition_factory=AppConfigDefinitionConditions.by_cursor_backward,
+        tiebreaker_order=AppConfigDefinitionOrders.id(ascending=True),
+    )
 
 
 class AppConfigDefinitionAdapter(BaseAdapter):
@@ -70,9 +75,7 @@ class AppConfigDefinitionAdapter(BaseAdapter):
     async def admin_create(
         self, input: CreateAppConfigDefinitionInput
     ) -> CreateAppConfigDefinitionPayload:
-        creator = Creator[AppConfigDefinitionRow](
-            spec=AppConfigDefinitionCreatorSpec(config_name=input.config_name),
-        )
+        creator = Creator(spec=AppConfigDefinitionCreatorSpec(config_name=input.config_name))
         action_result = await self._processors.app_config_definition.create.wait_for_complete(
             CreateAppConfigDefinitionAction(creator=creator)
         )
@@ -133,16 +136,21 @@ class AppConfigDefinitionAdapter(BaseAdapter):
     async def admin_search(
         self, input: SearchAppConfigDefinitionsInput
     ) -> SearchAppConfigDefinitionsPayload:
-        pagination = OffsetPagination(
-            limit=input.limit if input.limit is not None else DEFAULT_PAGINATION_LIMIT,
-            offset=input.offset if input.offset is not None else 0,
-        )
         conditions = self._convert_filter(input.filter) if input.filter else []
         orders = self._convert_orders(input.order) if input.order else []
+        querier = self._build_querier(
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=_pagination_spec(),
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+        )
         action_result = await self._processors.app_config_definition.search.wait_for_complete(
-            SearchAppConfigDefinitionsAction(
-                querier=BatchQuerier(pagination=pagination, conditions=conditions, orders=orders)
-            )
+            SearchAppConfigDefinitionsAction(querier=querier)
         )
         return SearchAppConfigDefinitionsPayload(
             items=[self._data_to_node(item) for item in action_result.data],
@@ -152,11 +160,7 @@ class AppConfigDefinitionAdapter(BaseAdapter):
         )
 
     async def admin_purge(self, definition_id: UUID) -> PurgeAppConfigDefinitionPayload:
-        purger = Purger[AppConfigDefinitionRow](
-            row_class=AppConfigDefinitionRow,
-            pk_value=AppConfigDefinitionID(definition_id),
-        )
         action_result = await self._processors.app_config_definition.purge.wait_for_complete(
-            PurgeAppConfigDefinitionAction(purger=purger)
+            PurgeAppConfigDefinitionAction(definition_id=AppConfigDefinitionID(definition_id))
         )
         return PurgeAppConfigDefinitionPayload(id=action_result.definition.id)

--- a/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
@@ -99,6 +99,22 @@ class AppConfigDefinitionAdapter(BaseAdapter):
             )
             if condition:
                 conditions.append(condition)
+        if filter_.created_at:
+            condition = filter_.created_at.build_query_condition(
+                before_factory=AppConfigDefinitionConditions.by_created_at_before,
+                after_factory=AppConfigDefinitionConditions.by_created_at_after,
+                equals_factory=AppConfigDefinitionConditions.by_created_at_equals,
+            )
+            if condition:
+                conditions.append(condition)
+        if filter_.updated_at:
+            condition = filter_.updated_at.build_query_condition(
+                before_factory=AppConfigDefinitionConditions.by_updated_at_before,
+                after_factory=AppConfigDefinitionConditions.by_updated_at_after,
+                equals_factory=AppConfigDefinitionConditions.by_updated_at_equals,
+            )
+            if condition:
+                conditions.append(condition)
         return conditions
 
     def _convert_orders(self, orders: list[AppConfigDefinitionOrder]) -> list[QueryOrder]:
@@ -110,6 +126,8 @@ class AppConfigDefinitionAdapter(BaseAdapter):
                     result.append(AppConfigDefinitionOrders.config_name(ascending))
                 case AppConfigDefinitionOrderField.CREATED_AT:
                     result.append(AppConfigDefinitionOrders.created_at(ascending))
+                case AppConfigDefinitionOrderField.UPDATED_AT:
+                    result.append(AppConfigDefinitionOrders.updated_at(ascending))
         return result
 
     async def admin_search(

--- a/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from uuid import UUID
 
 from ai.backend.common.dto.manager.v2.app_config_definition.request import (
+    AppConfigDefinitionFilter,
+    AppConfigDefinitionOrder,
     CreateAppConfigDefinitionInput,
     SearchAppConfigDefinitionsInput,
 )
@@ -14,14 +16,27 @@ from ai.backend.common.dto.manager.v2.app_config_definition.response import (
     PurgeAppConfigDefinitionPayload,
     SearchAppConfigDefinitionsPayload,
 )
+from ai.backend.common.dto.manager.v2.app_config_definition.types import (
+    AppConfigDefinitionOrderField,
+)
+from ai.backend.common.dto.manager.v2.common import OrderDirection
 from ai.backend.common.identifier.app_config_definition import AppConfigDefinitionID
 from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.app_config_definition.types import AppConfigDefinitionData
+from ai.backend.manager.models.app_config_definition.conditions import (
+    AppConfigDefinitionConditions,
+)
+from ai.backend.manager.models.app_config_definition.orders import AppConfigDefinitionOrders
 from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
 from ai.backend.manager.repositories.app_config_definition.creators import (
     AppConfigDefinitionCreatorSpec,
 )
-from ai.backend.manager.repositories.base import BatchQuerier, OffsetPagination
+from ai.backend.manager.repositories.base import (
+    BatchQuerier,
+    OffsetPagination,
+    QueryCondition,
+    QueryOrder,
+)
 from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.purger import Purger
 from ai.backend.manager.services.app_config_definition.actions.create import (
@@ -71,6 +86,32 @@ class AppConfigDefinitionAdapter(BaseAdapter):
         )
         return self._data_to_node(action_result.definition)
 
+    def _convert_filter(self, filter_: AppConfigDefinitionFilter) -> list[QueryCondition]:
+        conditions: list[QueryCondition] = []
+        if filter_.config_name:
+            condition = self.convert_string_filter(
+                filter_.config_name,
+                contains_factory=AppConfigDefinitionConditions.by_config_name_contains,
+                equals_factory=AppConfigDefinitionConditions.by_config_name_equals,
+                starts_with_factory=AppConfigDefinitionConditions.by_config_name_starts_with,
+                ends_with_factory=AppConfigDefinitionConditions.by_config_name_ends_with,
+                in_factory=AppConfigDefinitionConditions.by_config_name_in,
+            )
+            if condition:
+                conditions.append(condition)
+        return conditions
+
+    def _convert_orders(self, orders: list[AppConfigDefinitionOrder]) -> list[QueryOrder]:
+        result: list[QueryOrder] = []
+        for order in orders:
+            ascending = order.direction == OrderDirection.ASC
+            match order.field:
+                case AppConfigDefinitionOrderField.CONFIG_NAME:
+                    result.append(AppConfigDefinitionOrders.config_name(ascending))
+                case AppConfigDefinitionOrderField.CREATED_AT:
+                    result.append(AppConfigDefinitionOrders.created_at(ascending))
+        return result
+
     async def admin_search(
         self, input: SearchAppConfigDefinitionsInput
     ) -> SearchAppConfigDefinitionsPayload:
@@ -78,8 +119,12 @@ class AppConfigDefinitionAdapter(BaseAdapter):
             limit=input.limit if input.limit is not None else DEFAULT_PAGINATION_LIMIT,
             offset=input.offset if input.offset is not None else 0,
         )
+        conditions = self._convert_filter(input.filter) if input.filter else []
+        orders = self._convert_orders(input.order) if input.order else []
         action_result = await self._processors.app_config_definition.search.wait_for_complete(
-            SearchAppConfigDefinitionsAction(querier=BatchQuerier(pagination=pagination))
+            SearchAppConfigDefinitionsAction(
+                querier=BatchQuerier(pagination=pagination, conditions=conditions, orders=orders)
+            )
         )
         return SearchAppConfigDefinitionsPayload(
             items=[self._data_to_node(item) for item in action_result.data],

--- a/src/ai/backend/manager/api/adapters/registry.py
+++ b/src/ai/backend/manager/api/adapters/registry.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ai.backend.manager.api.adapters.agent.adapter import AgentAdapter
+from ai.backend.manager.api.adapters.app_config_definition.adapter import (
+    AppConfigDefinitionAdapter,
+)
 from ai.backend.manager.api.adapters.artifact.adapter import ArtifactAdapter
 from ai.backend.manager.api.adapters.artifact_registry.adapter import ArtifactRegistryAdapter
 from ai.backend.manager.api.adapters.audit_log.adapter import AuditLogAdapter
@@ -72,6 +75,7 @@ class Adapters:
     def __init__(
         self,
         agent: AgentAdapter,
+        app_config_definition: AppConfigDefinitionAdapter,
         artifact: ArtifactAdapter,
         artifact_registry: ArtifactRegistryAdapter,
         audit_log: AuditLogAdapter,
@@ -113,6 +117,7 @@ class Adapters:
         vfs_storage: VFSStorageAdapter,
     ) -> None:
         self.agent = agent
+        self.app_config_definition = app_config_definition
         self.artifact = artifact
         self.artifact_registry = artifact_registry
         self.audit_log = audit_log
@@ -173,6 +178,7 @@ class Adapters:
         """
         return cls(
             agent=AgentAdapter(processors),
+            app_config_definition=AppConfigDefinitionAdapter(processors),
             artifact=ArtifactAdapter(processors),
             artifact_registry=ArtifactRegistryAdapter(processors),
             audit_log=AuditLogAdapter(processors),

--- a/src/ai/backend/manager/api/rest/v2/app_config_definition/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_definition/handler.py
@@ -1,0 +1,61 @@
+"""REST v2 handler for the app config definition domain."""
+
+from __future__ import annotations
+
+import logging
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Final
+
+from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam
+from ai.backend.common.dto.manager.v2.app_config_definition.request import (
+    CreateAppConfigDefinitionInput,
+    SearchAppConfigDefinitionsInput,
+)
+from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.api.rest.v2.path_params import AppConfigDefinitionIdPathParam
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.adapters.app_config_definition.adapter import (
+        AppConfigDefinitionAdapter,
+    )
+
+log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class V2AppConfigDefinitionHandler:
+    """REST v2 handler for app config definition operations (admin-only)."""
+
+    def __init__(self, *, adapter: AppConfigDefinitionAdapter) -> None:
+        self._adapter = adapter
+
+    async def admin_create(
+        self,
+        body: BodyParam[CreateAppConfigDefinitionInput],
+    ) -> APIResponse:
+        """Register a new app config definition (superadmin only)."""
+        result = await self._adapter.admin_create(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.CREATED, response_model=result)
+
+    async def admin_search(
+        self,
+        body: BodyParam[SearchAppConfigDefinitionsInput],
+    ) -> APIResponse:
+        """Search app config definitions with pagination (superadmin only)."""
+        result = await self._adapter.admin_search(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def admin_get(
+        self,
+        path: PathParam[AppConfigDefinitionIdPathParam],
+    ) -> APIResponse:
+        """Get an app config definition by id (superadmin only)."""
+        result = await self._adapter.admin_get(path.parsed.app_config_definition_id)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def admin_purge(
+        self,
+        path: PathParam[AppConfigDefinitionIdPathParam],
+    ) -> APIResponse:
+        """Purge an app config definition by id (superadmin only)."""
+        result = await self._adapter.admin_purge(path.parsed.app_config_definition_id)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/app_config_definition/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_definition/registry.py
@@ -1,0 +1,45 @@
+"""Route registry for REST v2 app config definition endpoints."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ai.backend.manager.api.rest.middleware.auth import superadmin_required
+from ai.backend.manager.api.rest.routing import RouteRegistry
+
+from .handler import V2AppConfigDefinitionHandler
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.rest.types import RouteDeps
+
+
+def register_v2_app_config_definition_routes(
+    handler: V2AppConfigDefinitionHandler,
+    route_deps: RouteDeps,
+) -> RouteRegistry:
+    """Register all REST v2 app config definition routes (superadmin only).
+
+    Layout:
+        POST   /                              register a config definition
+        POST   /search                        paginated search
+        GET    /{app_config_definition_id}    get by id
+        DELETE /{app_config_definition_id}    purge by id
+    """
+    registry = RouteRegistry.create("app-config-definitions", route_deps.cors_options)
+
+    registry.add("POST", "/", handler.admin_create, middlewares=[superadmin_required])
+    registry.add("POST", "/search", handler.admin_search, middlewares=[superadmin_required])
+    registry.add(
+        "GET",
+        "/{app_config_definition_id}",
+        handler.admin_get,
+        middlewares=[superadmin_required],
+    )
+    registry.add(
+        "DELETE",
+        "/{app_config_definition_id}",
+        handler.admin_purge,
+        middlewares=[superadmin_required],
+    )
+
+    return registry

--- a/src/ai/backend/manager/api/rest/v2/path_params.py
+++ b/src/ai/backend/manager/api/rest/v2/path_params.py
@@ -86,6 +86,10 @@ class LoginClientTypeIdPathParam(BaseRequestModel):
     login_client_type_id: UUID = Field(description="Login client type UUID")
 
 
+class AppConfigDefinitionIdPathParam(BaseRequestModel):
+    app_config_definition_id: UUID = Field(description="App config definition UUID")
+
+
 class ReplicaIdPathParam(BaseRequestModel):
     replica_id: UUID = Field(description="Replica UUID")
 

--- a/src/ai/backend/manager/api/rest/v2/tree.py
+++ b/src/ai/backend/manager/api/rest/v2/tree.py
@@ -28,6 +28,8 @@ def build_v2_routes(
     # Lazy imports to avoid circular dependencies at module level
     from .agent.handler import V2AgentHandler
     from .agent.registry import register_v2_agent_routes
+    from .app_config_definition.handler import V2AppConfigDefinitionHandler
+    from .app_config_definition.registry import register_v2_app_config_definition_routes
     from .artifact.handler import V2ArtifactHandler
     from .artifact.registry import register_v2_artifact_routes
     from .artifact_registry.handler import V2ArtifactRegistryHandler
@@ -117,6 +119,9 @@ def build_v2_routes(
 
     # Build all handlers (each takes its individual adapter)
     agent_handler = V2AgentHandler(adapter=adapters.agent)
+    app_config_definition_handler = V2AppConfigDefinitionHandler(
+        adapter=adapters.app_config_definition
+    )
     artifact_handler = V2ArtifactHandler(adapter=adapters.artifact)
     artifact_registry_handler = V2ArtifactRegistryHandler(adapter=adapters.artifact_registry)
     audit_log_handler = V2AuditLogHandler(adapter=adapters.audit_log)
@@ -174,6 +179,9 @@ def build_v2_routes(
 
     # Add all domain sub-registries
     v2_reg.add_subregistry(register_v2_agent_routes(agent_handler, route_deps))
+    v2_reg.add_subregistry(
+        register_v2_app_config_definition_routes(app_config_definition_handler, route_deps)
+    )
     v2_reg.add_subregistry(register_v2_artifact_routes(artifact_handler, route_deps))
     v2_reg.add_subregistry(
         register_v2_artifact_registry_routes(artifact_registry_handler, route_deps)

--- a/src/ai/backend/manager/models/app_config_definition/conditions.py
+++ b/src/ai/backend/manager/models/app_config_definition/conditions.py
@@ -1,0 +1,68 @@
+"""Query conditions for app config definition rows."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from ai.backend.common.data.filter_specs import StringMatchSpec
+from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
+from ai.backend.manager.models.condition_utils import make_string_in_factory
+from ai.backend.manager.repositories.base import QueryCondition
+
+__all__ = ("AppConfigDefinitionConditions",)
+
+
+class AppConfigDefinitionConditions:
+    @staticmethod
+    def by_config_name_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AppConfigDefinitionRow.config_name.ilike(f"%{spec.value}%")
+            else:
+                condition = AppConfigDefinitionRow.config_name.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_config_name_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = sa.func.lower(AppConfigDefinitionRow.config_name) == spec.value.lower()
+            else:
+                condition = AppConfigDefinitionRow.config_name == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_config_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AppConfigDefinitionRow.config_name.ilike(f"{spec.value}%")
+            else:
+                condition = AppConfigDefinitionRow.config_name.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_config_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AppConfigDefinitionRow.config_name.ilike(f"%{spec.value}")
+            else:
+                condition = AppConfigDefinitionRow.config_name.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    by_config_name_in = staticmethod(make_string_in_factory(AppConfigDefinitionRow.config_name))

--- a/src/ai/backend/manager/models/app_config_definition/conditions.py
+++ b/src/ai/backend/manager/models/app_config_definition/conditions.py
@@ -69,6 +69,22 @@ class AppConfigDefinitionConditions:
 
     by_config_name_in = staticmethod(make_string_in_factory(AppConfigDefinitionRow.config_name))
 
+    # --- cursor (id-based) pagination ---
+
+    @staticmethod
+    def by_cursor_forward(cursor_id: str) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigDefinitionRow.id < sa.text(f"'{cursor_id}'::uuid")
+
+        return inner
+
+    @staticmethod
+    def by_cursor_backward(cursor_id: str) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigDefinitionRow.id > sa.text(f"'{cursor_id}'::uuid")
+
+        return inner
+
     # --- created_at datetime filters ---
 
     @staticmethod

--- a/src/ai/backend/manager/models/app_config_definition/conditions.py
+++ b/src/ai/backend/manager/models/app_config_definition/conditions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 import sqlalchemy as sa
 
 from ai.backend.common.data.filter_specs import StringMatchSpec
@@ -66,3 +68,49 @@ class AppConfigDefinitionConditions:
         return inner
 
     by_config_name_in = staticmethod(make_string_in_factory(AppConfigDefinitionRow.config_name))
+
+    # --- created_at datetime filters ---
+
+    @staticmethod
+    def by_created_at_before(dt: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigDefinitionRow.created_at < dt
+
+        return inner
+
+    @staticmethod
+    def by_created_at_after(dt: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigDefinitionRow.created_at > dt
+
+        return inner
+
+    @staticmethod
+    def by_created_at_equals(dt: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigDefinitionRow.created_at == dt
+
+        return inner
+
+    # --- updated_at datetime filters ---
+
+    @staticmethod
+    def by_updated_at_before(dt: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigDefinitionRow.updated_at < dt
+
+        return inner
+
+    @staticmethod
+    def by_updated_at_after(dt: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigDefinitionRow.updated_at > dt
+
+        return inner
+
+    @staticmethod
+    def by_updated_at_equals(dt: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigDefinitionRow.updated_at == dt
+
+        return inner

--- a/src/ai/backend/manager/models/app_config_definition/conditions.py
+++ b/src/ai/backend/manager/models/app_config_definition/conditions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from datetime import datetime
 
 import sqlalchemy as sa
@@ -73,15 +74,37 @@ class AppConfigDefinitionConditions:
 
     @staticmethod
     def by_cursor_forward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for forward pagination (after cursor).
+
+        Uses subquery to get created_at of the cursor row and compare.
+        """
+        cursor_uuid = uuid.UUID(cursor_id)
+
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return AppConfigDefinitionRow.id < sa.text(f"'{cursor_id}'::uuid")
+            subquery = (
+                sa.select(AppConfigDefinitionRow.created_at)
+                .where(AppConfigDefinitionRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return AppConfigDefinitionRow.created_at < subquery
 
         return inner
 
     @staticmethod
     def by_cursor_backward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for backward pagination (before cursor).
+
+        Uses subquery to get created_at of the cursor row and compare.
+        """
+        cursor_uuid = uuid.UUID(cursor_id)
+
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return AppConfigDefinitionRow.id > sa.text(f"'{cursor_id}'::uuid")
+            subquery = (
+                sa.select(AppConfigDefinitionRow.created_at)
+                .where(AppConfigDefinitionRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return AppConfigDefinitionRow.created_at > subquery
 
         return inner
 

--- a/src/ai/backend/manager/models/app_config_definition/orders.py
+++ b/src/ai/backend/manager/models/app_config_definition/orders.py
@@ -1,0 +1,22 @@
+"""Query orders for app config definition rows."""
+
+from __future__ import annotations
+
+from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
+from ai.backend.manager.repositories.base import QueryOrder
+
+__all__ = ("AppConfigDefinitionOrders",)
+
+
+class AppConfigDefinitionOrders:
+    @staticmethod
+    def config_name(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AppConfigDefinitionRow.config_name.asc()
+        return AppConfigDefinitionRow.config_name.desc()
+
+    @staticmethod
+    def created_at(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AppConfigDefinitionRow.created_at.asc()
+        return AppConfigDefinitionRow.created_at.desc()

--- a/src/ai/backend/manager/models/app_config_definition/orders.py
+++ b/src/ai/backend/manager/models/app_config_definition/orders.py
@@ -20,3 +20,9 @@ class AppConfigDefinitionOrders:
         if ascending:
             return AppConfigDefinitionRow.created_at.asc()
         return AppConfigDefinitionRow.created_at.desc()
+
+    @staticmethod
+    def updated_at(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AppConfigDefinitionRow.updated_at.asc()
+        return AppConfigDefinitionRow.updated_at.desc()

--- a/src/ai/backend/manager/models/app_config_definition/orders.py
+++ b/src/ai/backend/manager/models/app_config_definition/orders.py
@@ -10,6 +10,12 @@ __all__ = ("AppConfigDefinitionOrders",)
 
 class AppConfigDefinitionOrders:
     @staticmethod
+    def id(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AppConfigDefinitionRow.id.asc()
+        return AppConfigDefinitionRow.id.desc()
+
+    @staticmethod
     def config_name(ascending: bool = True) -> QueryOrder:
         if ascending:
             return AppConfigDefinitionRow.config_name.asc()

--- a/src/ai/backend/manager/repositories/app_config_definition/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_definition/db_source/db_source.py
@@ -48,13 +48,11 @@ class AppConfigDefinitionDBSource:
                 )
             return result.row.to_data()
 
-    async def purge(self, definition_id: AppConfigDefinitionID) -> AppConfigDefinitionData:
+    async def purge(self, purger: Purger[AppConfigDefinitionRow]) -> AppConfigDefinitionData:
         async with self._ops.write_ops() as w:
-            result = await w.purge(Purger(row_class=AppConfigDefinitionRow, pk_value=definition_id))
+            result = await w.purge(purger)
             if result is None:
-                raise AppConfigDefinitionNotFound(
-                    f"App config definition {definition_id} not found"
-                )
+                raise AppConfigDefinitionNotFound("App config definition not found")
             return result.row.to_data()
 
     async def search(self, querier: BatchQuerier) -> AppConfigDefinitionListResult:

--- a/src/ai/backend/manager/repositories/app_config_definition/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_definition/db_source/db_source.py
@@ -48,12 +48,12 @@ class AppConfigDefinitionDBSource:
                 )
             return result.row.to_data()
 
-    async def purge(self, purger: Purger[AppConfigDefinitionRow]) -> AppConfigDefinitionData:
+    async def purge(self, definition_id: AppConfigDefinitionID) -> AppConfigDefinitionData:
         async with self._ops.write_ops() as w:
-            result = await w.purge(purger)
+            result = await w.purge(Purger(row_class=AppConfigDefinitionRow, pk_value=definition_id))
             if result is None:
                 raise AppConfigDefinitionNotFound(
-                    f"App config definition {purger.pk_value} not found"
+                    f"App config definition {definition_id} not found"
                 )
             return result.row.to_data()
 

--- a/src/ai/backend/manager/repositories/app_config_definition/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_definition/repository.py
@@ -9,7 +9,7 @@ from ai.backend.manager.models.app_config_definition.row import AppConfigDefinit
 from ai.backend.manager.repositories.app_config_definition.db_source import (
     AppConfigDefinitionDBSource,
 )
-from ai.backend.manager.repositories.base import BatchQuerier, Creator, Purger
+from ai.backend.manager.repositories.base import BatchQuerier, Creator
 from ai.backend.manager.repositories.ops import DBOpsProvider
 
 __all__ = ("AppConfigDefinitionRepository",)
@@ -35,5 +35,5 @@ class AppConfigDefinitionRepository:
     async def search(self, querier: BatchQuerier) -> AppConfigDefinitionListResult:
         return await self._db_source.search(querier)
 
-    async def purge(self, purger: Purger[AppConfigDefinitionRow]) -> AppConfigDefinitionData:
-        return await self._db_source.purge(purger)
+    async def purge(self, definition_id: AppConfigDefinitionID) -> AppConfigDefinitionData:
+        return await self._db_source.purge(definition_id)

--- a/src/ai/backend/manager/repositories/app_config_definition/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_definition/repository.py
@@ -9,7 +9,7 @@ from ai.backend.manager.models.app_config_definition.row import AppConfigDefinit
 from ai.backend.manager.repositories.app_config_definition.db_source import (
     AppConfigDefinitionDBSource,
 )
-from ai.backend.manager.repositories.base import BatchQuerier, Creator
+from ai.backend.manager.repositories.base import BatchQuerier, Creator, Purger
 from ai.backend.manager.repositories.ops import DBOpsProvider
 
 __all__ = ("AppConfigDefinitionRepository",)
@@ -35,5 +35,5 @@ class AppConfigDefinitionRepository:
     async def search(self, querier: BatchQuerier) -> AppConfigDefinitionListResult:
         return await self._db_source.search(querier)
 
-    async def purge(self, definition_id: AppConfigDefinitionID) -> AppConfigDefinitionData:
-        return await self._db_source.purge(definition_id)
+    async def purge(self, purger: Purger[AppConfigDefinitionRow]) -> AppConfigDefinitionData:
+        return await self._db_source.purge(purger)

--- a/src/ai/backend/manager/repositories/repositories.py
+++ b/src/ai/backend/manager/repositories/repositories.py
@@ -2,6 +2,9 @@ from dataclasses import dataclass
 from typing import Self
 
 from ai.backend.manager.repositories.agent.repositories import AgentRepositories
+from ai.backend.manager.repositories.app_config_definition.repositories import (
+    AppConfigDefinitionRepositories,
+)
 from ai.backend.manager.repositories.artifact.repositories import ArtifactRepositories
 from ai.backend.manager.repositories.artifact_registry.repositories import (
     ArtifactRegistryRepositories,
@@ -85,6 +88,7 @@ from ai.backend.manager.repositories.vfs_storage.repositories import VFSStorageR
 @dataclass
 class Repositories:
     agent: AgentRepositories
+    app_config_definition: AppConfigDefinitionRepositories
     auth: AuthRepositories
     container_registry: ContainerRegistryRepositories
     deployment: DeploymentRepositories
@@ -136,6 +140,7 @@ class Repositories:
     @classmethod
     def create(cls, args: RepositoryArgs) -> Self:
         agent_repositories = AgentRepositories.create(args)
+        app_config_definition_repositories = AppConfigDefinitionRepositories.create(args)
         auth_repositories = AuthRepositories.create(args)
         container_registry_repositories = ContainerRegistryRepositories.create(args)
         deployment_repositories = DeploymentRepositories.create(args)
@@ -188,6 +193,7 @@ class Repositories:
 
         return cls(
             agent=agent_repositories,
+            app_config_definition=app_config_definition_repositories,
             auth=auth_repositories,
             container_registry=container_registry_repositories,
             deployment=deployment_repositories,

--- a/src/ai/backend/manager/services/app_config_definition/actions/purge.py
+++ b/src/ai/backend/manager/services/app_config_definition/actions/purge.py
@@ -4,10 +4,11 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.permission.types import RBACElementType
-from ai.backend.common.identifier.app_config_definition import AppConfigDefinitionID
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.app_config_definition.types import AppConfigDefinitionData
 from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
+from ai.backend.manager.repositories.base import Purger
 from ai.backend.manager.services.app_config_definition.actions.base import (
     AppConfigDefinitionSingleEntityAction,
     AppConfigDefinitionSingleEntityActionResult,
@@ -16,7 +17,7 @@ from ai.backend.manager.services.app_config_definition.actions.base import (
 
 @dataclass
 class PurgeAppConfigDefinitionAction(AppConfigDefinitionSingleEntityAction):
-    definition_id: AppConfigDefinitionID
+    purger: Purger[AppConfigDefinitionRow]
 
     @override
     @classmethod
@@ -25,11 +26,11 @@ class PurgeAppConfigDefinitionAction(AppConfigDefinitionSingleEntityAction):
 
     @override
     def target_entity_id(self) -> str:
-        return str(self.definition_id)
+        return str(self.purger.pk_value)
 
     @override
     def target_element(self) -> RBACElementRef:
-        return RBACElementRef(RBACElementType.APP_CONFIG_DEFINITION, str(self.definition_id))
+        return RBACElementRef(RBACElementType.APP_CONFIG_DEFINITION, str(self.purger.pk_value))
 
 
 @dataclass

--- a/src/ai/backend/manager/services/app_config_definition/actions/purge.py
+++ b/src/ai/backend/manager/services/app_config_definition/actions/purge.py
@@ -4,11 +4,10 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.common.identifier.app_config_definition import AppConfigDefinitionID
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.app_config_definition.types import AppConfigDefinitionData
 from ai.backend.manager.data.permission.types import RBACElementRef
-from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
-from ai.backend.manager.repositories.base.purger import Purger
 from ai.backend.manager.services.app_config_definition.actions.base import (
     AppConfigDefinitionSingleEntityAction,
     AppConfigDefinitionSingleEntityActionResult,
@@ -17,7 +16,7 @@ from ai.backend.manager.services.app_config_definition.actions.base import (
 
 @dataclass
 class PurgeAppConfigDefinitionAction(AppConfigDefinitionSingleEntityAction):
-    purger: Purger[AppConfigDefinitionRow]
+    definition_id: AppConfigDefinitionID
 
     @override
     @classmethod
@@ -26,11 +25,11 @@ class PurgeAppConfigDefinitionAction(AppConfigDefinitionSingleEntityAction):
 
     @override
     def target_entity_id(self) -> str:
-        return str(self.purger.pk_value)
+        return str(self.definition_id)
 
     @override
     def target_element(self) -> RBACElementRef:
-        return RBACElementRef(RBACElementType.APP_CONFIG_DEFINITION, str(self.purger.pk_value))
+        return RBACElementRef(RBACElementType.APP_CONFIG_DEFINITION, str(self.definition_id))
 
 
 @dataclass

--- a/src/ai/backend/manager/services/app_config_definition/service.py
+++ b/src/ai/backend/manager/services/app_config_definition/service.py
@@ -53,5 +53,5 @@ class AppConfigDefinitionService:
     async def purge(
         self, action: PurgeAppConfigDefinitionAction
     ) -> PurgeAppConfigDefinitionActionResult:
-        data = await self._repository.purge(action.definition_id)
+        data = await self._repository.purge(action.purger)
         return PurgeAppConfigDefinitionActionResult(definition=data)

--- a/src/ai/backend/manager/services/app_config_definition/service.py
+++ b/src/ai/backend/manager/services/app_config_definition/service.py
@@ -53,5 +53,5 @@ class AppConfigDefinitionService:
     async def purge(
         self, action: PurgeAppConfigDefinitionAction
     ) -> PurgeAppConfigDefinitionActionResult:
-        data = await self._repository.purge(action.purger)
+        data = await self._repository.purge(action.definition_id)
         return PurgeAppConfigDefinitionActionResult(definition=data)

--- a/src/ai/backend/manager/services/factory.py
+++ b/src/ai/backend/manager/services/factory.py
@@ -6,6 +6,12 @@ from ai.backend.manager.repositories.resource_allocation.repository import (
 )
 from ai.backend.manager.services.agent.processors import AgentProcessors
 from ai.backend.manager.services.agent.service import AgentService
+from ai.backend.manager.services.app_config_definition.processors import (
+    AppConfigDefinitionProcessors,
+)
+from ai.backend.manager.services.app_config_definition.service import (
+    AppConfigDefinitionService,
+)
 from ai.backend.manager.services.artifact.processors import ArtifactProcessors
 from ai.backend.manager.services.artifact.service import ArtifactService
 from ai.backend.manager.services.artifact_registry.processors import ArtifactRegistryProcessors
@@ -326,6 +332,9 @@ def create_services(args: ServiceArgs) -> Services:
             group_repository=repositories.group.repository,
             ssh_key_validator=args.ssh_key_validator,
         ),
+        app_config_definition=AppConfigDefinitionService(
+            repository=repositories.app_config_definition.repository,
+        ),
         login_client_type=LoginClientTypeService(
             repository=repositories.auth.login_client_type,
         ),
@@ -487,6 +496,9 @@ def create_processors(
             services.model_serving_auto_scaling, action_monitors, validators
         ),
         auth=AuthProcessors(services.auth, action_monitors, validators),
+        app_config_definition=AppConfigDefinitionProcessors(
+            services.app_config_definition, action_monitors
+        ),
         login_client_type=LoginClientTypeProcessors(services.login_client_type, action_monitors),
         login_client_type_admin=LoginClientTypeAdminProcessors(
             services.login_client_type_admin, action_monitors

--- a/src/ai/backend/manager/services/processors.py
+++ b/src/ai/backend/manager/services/processors.py
@@ -45,6 +45,12 @@ if TYPE_CHECKING:
     )
     from ai.backend.manager.services.agent.processors import AgentProcessors
     from ai.backend.manager.services.agent.service import AgentService
+    from ai.backend.manager.services.app_config_definition.processors import (
+        AppConfigDefinitionProcessors,
+    )
+    from ai.backend.manager.services.app_config_definition.service import (
+        AppConfigDefinitionService,
+    )
     from ai.backend.manager.services.artifact.processors import (
         ArtifactProcessors,
     )
@@ -363,6 +369,7 @@ class ServiceArgs:
 @dataclass
 class Services:
     agent: AgentService
+    app_config_definition: AppConfigDefinitionService
     domain: DomainService
     dotfile: DotfileService
     error_log: ErrorLogService
@@ -428,6 +435,7 @@ class ProcessorArgs:
 @dataclass
 class Processors(AbstractProcessorPackage):
     agent: AgentProcessors
+    app_config_definition: AppConfigDefinitionProcessors
     domain: DomainProcessors
     dotfile: DotfileProcessors
     error_log: ErrorLogProcessors
@@ -486,6 +494,7 @@ class Processors(AbstractProcessorPackage):
     def supported_actions(self) -> list[ActionSpec]:
         return [
             *self.agent.supported_actions(),
+            *self.app_config_definition.supported_actions(),
             *self.domain.supported_actions(),
             *self.dotfile.supported_actions(),
             *self.error_log.supported_actions(),

--- a/tests/unit/manager/repositories/app_config_definition/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_definition/test_repository.py
@@ -197,15 +197,15 @@ class TestSearch:
         repository: AppConfigDefinitionRepository,
         seeded_definitions: list[AppConfigDefinitionData],
     ) -> None:
-        by_id_desc = sorted(seeded_definitions, key=lambda d: d.id, reverse=True)
-        cursor = by_id_desc[0].id
+        by_created_desc = sorted(seeded_definitions, key=lambda d: d.created_at, reverse=True)
+        cursor = by_created_desc[0].id
         result = await repository.search(
             BatchQuerier(
                 pagination=CursorForwardPagination(
                     first=10,
-                    cursor_order=AppConfigDefinitionOrders.id(ascending=False),
+                    cursor_order=AppConfigDefinitionOrders.created_at(ascending=False),
                     cursor_condition=AppConfigDefinitionConditions.by_cursor_forward(str(cursor)),
                 )
             )
         )
-        assert [item.id for item in result.items] == [d.id for d in by_id_desc[1:]]
+        assert [item.id for item in result.items] == [d.id for d in by_created_desc[1:]]

--- a/tests/unit/manager/repositories/app_config_definition/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_definition/test_repository.py
@@ -163,3 +163,33 @@ class TestSearch:
             (definition.config_name for definition in seeded_definitions), reverse=True
         )
         assert [item.config_name for item in result.items] == expected
+
+    async def test_search_filters_by_created_at(
+        self,
+        repository: AppConfigDefinitionRepository,
+        seeded_definitions: list[AppConfigDefinitionData],
+    ) -> None:
+        target = seeded_definitions[1]
+        result = await repository.search(
+            BatchQuerier(
+                pagination=OffsetPagination(limit=10, offset=0),
+                conditions=[AppConfigDefinitionConditions.by_created_at_equals(target.created_at)],
+            )
+        )
+        assert [item.id for item in result.items] == [target.id]
+
+    async def test_search_orders_by_created_at(
+        self,
+        repository: AppConfigDefinitionRepository,
+        seeded_definitions: list[AppConfigDefinitionData],
+    ) -> None:
+        result = await repository.search(
+            BatchQuerier(
+                pagination=OffsetPagination(limit=10, offset=0),
+                orders=[AppConfigDefinitionOrders.created_at(ascending=True)],
+            )
+        )
+        expected = [
+            definition.id for definition in sorted(seeded_definitions, key=lambda d: d.created_at)
+        ]
+        assert [item.id for item in result.items] == expected

--- a/tests/unit/manager/repositories/app_config_definition/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_definition/test_repository.py
@@ -7,9 +7,14 @@ from collections.abc import AsyncGenerator
 
 import pytest
 
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.common.identifier.app_config_definition import AppConfigDefinitionID
 from ai.backend.manager.data.app_config_definition.types import AppConfigDefinitionData
 from ai.backend.manager.errors.app_config import AppConfigDefinitionNotFound
+from ai.backend.manager.models.app_config_definition.conditions import (
+    AppConfigDefinitionConditions,
+)
+from ai.backend.manager.models.app_config_definition.orders import AppConfigDefinitionOrders
 from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.app_config_definition.creators import (
@@ -119,3 +124,42 @@ class TestSearch:
         assert result.total_count == len(seeded_definitions)
         assert len(result.items) == 2
         assert result.has_next_page is True
+
+    async def test_search_filters_by_config_name(
+        self,
+        repository: AppConfigDefinitionRepository,
+        seeded_definitions: list[AppConfigDefinitionData],
+    ) -> None:
+        result = await repository.search(
+            BatchQuerier(
+                pagination=OffsetPagination(limit=10, offset=0),
+                conditions=[
+                    AppConfigDefinitionConditions.by_config_name_equals(
+                        StringMatchSpec("menu", case_insensitive=False, negated=False)
+                    )
+                ],
+            )
+        )
+        expected = [
+            definition.config_name
+            for definition in seeded_definitions
+            if definition.config_name == "menu"
+        ]
+        assert result.total_count == len(expected)
+        assert [item.config_name for item in result.items] == expected
+
+    async def test_search_orders_by_config_name_desc(
+        self,
+        repository: AppConfigDefinitionRepository,
+        seeded_definitions: list[AppConfigDefinitionData],
+    ) -> None:
+        result = await repository.search(
+            BatchQuerier(
+                pagination=OffsetPagination(limit=10, offset=0),
+                orders=[AppConfigDefinitionOrders.config_name(ascending=False)],
+            )
+        )
+        expected = sorted(
+            (definition.config_name for definition in seeded_definitions), reverse=True
+        )
+        assert [item.config_name for item in result.items] == expected

--- a/tests/unit/manager/repositories/app_config_definition/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_definition/test_repository.py
@@ -28,6 +28,7 @@ from ai.backend.manager.repositories.base import (
     Creator,
     CursorForwardPagination,
     OffsetPagination,
+    Purger,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.testutils.db import with_tables
@@ -87,14 +88,16 @@ class TestPurge:
         repository: AppConfigDefinitionRepository,
         existing_definition: AppConfigDefinitionData,
     ) -> None:
-        purged = await repository.purge(existing_definition.id)
+        purged = await repository.purge(
+            Purger(row_class=AppConfigDefinitionRow, pk_value=existing_definition.id)
+        )
         assert purged.id == existing_definition.id
         with pytest.raises(AppConfigDefinitionNotFound):
             await repository.get_by_id(existing_definition.id)
 
     async def test_purge_missing_raises(self, repository: AppConfigDefinitionRepository) -> None:
         with pytest.raises(AppConfigDefinitionNotFound):
-            await repository.purge(_missing_id())
+            await repository.purge(Purger(row_class=AppConfigDefinitionRow, pk_value=_missing_id()))
 
 
 class TestSearch:

--- a/tests/unit/manager/repositories/app_config_definition/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_definition/test_repository.py
@@ -26,8 +26,8 @@ from ai.backend.manager.repositories.app_config_definition.repository import (
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
     Creator,
+    CursorForwardPagination,
     OffsetPagination,
-    Purger,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.testutils.db import with_tables
@@ -87,16 +87,14 @@ class TestPurge:
         repository: AppConfigDefinitionRepository,
         existing_definition: AppConfigDefinitionData,
     ) -> None:
-        purged = await repository.purge(
-            Purger(row_class=AppConfigDefinitionRow, pk_value=existing_definition.id)
-        )
+        purged = await repository.purge(existing_definition.id)
         assert purged.id == existing_definition.id
         with pytest.raises(AppConfigDefinitionNotFound):
             await repository.get_by_id(existing_definition.id)
 
     async def test_purge_missing_raises(self, repository: AppConfigDefinitionRepository) -> None:
         with pytest.raises(AppConfigDefinitionNotFound):
-            await repository.purge(Purger(row_class=AppConfigDefinitionRow, pk_value=_missing_id()))
+            await repository.purge(_missing_id())
 
 
 class TestSearch:
@@ -193,3 +191,21 @@ class TestSearch:
             definition.id for definition in sorted(seeded_definitions, key=lambda d: d.created_at)
         ]
         assert [item.id for item in result.items] == expected
+
+    async def test_search_cursor_forward(
+        self,
+        repository: AppConfigDefinitionRepository,
+        seeded_definitions: list[AppConfigDefinitionData],
+    ) -> None:
+        by_id_desc = sorted(seeded_definitions, key=lambda d: d.id, reverse=True)
+        cursor = by_id_desc[0].id
+        result = await repository.search(
+            BatchQuerier(
+                pagination=CursorForwardPagination(
+                    first=10,
+                    cursor_order=AppConfigDefinitionOrders.id(ascending=False),
+                    cursor_condition=AppConfigDefinitionConditions.by_cursor_forward(str(cursor)),
+                )
+            )
+        )
+        assert [item.id for item in result.items] == [d.id for d in by_id_desc[1:]]

--- a/tests/unit/manager/services/app_config_definition/test_service.py
+++ b/tests/unit/manager/services/app_config_definition/test_service.py
@@ -14,6 +14,7 @@ from ai.backend.manager.data.app_config_definition.types import (
     AppConfigDefinitionListResult,
 )
 from ai.backend.manager.errors.app_config import AppConfigDefinitionNotFound
+from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
 from ai.backend.manager.repositories.app_config_definition.creators import (
     AppConfigDefinitionCreatorSpec,
 )
@@ -24,6 +25,7 @@ from ai.backend.manager.repositories.base import (
     BatchQuerier,
     Creator,
     OffsetPagination,
+    Purger,
 )
 from ai.backend.manager.services.app_config_definition.actions.create import (
     CreateAppConfigDefinitionAction,
@@ -129,10 +131,9 @@ class TestAppConfigDefinitionService:
         definition_data: AppConfigDefinitionData,
     ) -> None:
         mock_repository.purge = AsyncMock(return_value=definition_data)
+        purger = Purger(row_class=AppConfigDefinitionRow, pk_value=definition_data.id)
 
-        result = await service.purge(
-            PurgeAppConfigDefinitionAction(definition_id=definition_data.id)
-        )
+        result = await service.purge(PurgeAppConfigDefinitionAction(purger=purger))
 
         assert result.definition == definition_data
-        mock_repository.purge.assert_called_once_with(definition_data.id)
+        mock_repository.purge.assert_called_once_with(purger)

--- a/tests/unit/manager/services/app_config_definition/test_service.py
+++ b/tests/unit/manager/services/app_config_definition/test_service.py
@@ -14,7 +14,6 @@ from ai.backend.manager.data.app_config_definition.types import (
     AppConfigDefinitionListResult,
 )
 from ai.backend.manager.errors.app_config import AppConfigDefinitionNotFound
-from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
 from ai.backend.manager.repositories.app_config_definition.creators import (
     AppConfigDefinitionCreatorSpec,
 )
@@ -25,7 +24,6 @@ from ai.backend.manager.repositories.base import (
     BatchQuerier,
     Creator,
     OffsetPagination,
-    Purger,
 )
 from ai.backend.manager.services.app_config_definition.actions.create import (
     CreateAppConfigDefinitionAction,
@@ -131,9 +129,10 @@ class TestAppConfigDefinitionService:
         definition_data: AppConfigDefinitionData,
     ) -> None:
         mock_repository.purge = AsyncMock(return_value=definition_data)
-        purger = Purger(row_class=AppConfigDefinitionRow, pk_value=definition_data.id)
 
-        result = await service.purge(PurgeAppConfigDefinitionAction(purger=purger))
+        result = await service.purge(
+            PurgeAppConfigDefinitionAction(definition_id=definition_data.id)
+        )
 
         assert result.definition == definition_data
-        mock_repository.purge.assert_called_once_with(purger)
+        mock_repository.purge.assert_called_once_with(definition_data.id)


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of the AppConfigDefinition stack (BA-6527 → BA-6533). **Merge in order:**

1. ✅ #12263 — `feat(BA-6527): app_config_definitions DB model and Alembic migration` (merged)
2. ✅ #12264 — `feat(BA-6528): AppConfigDefinitionRepository (create/get/search/purge)` (merged)
3. ✅ #12265 — `feat(BA-6529): AppConfigDefinitionService and processors` (merged)
4. 👉 **#12266** — `feat(BA-6530): AppConfigDefinition REST v2 API` ← you are here
5. ⬇️ #12267 — `feat(BA-6531): AppConfigDefinition GraphQL API`
6. ⬇️ #12268 — `feat(BA-6532 + BA-6533): AppConfigDefinition client SDK v2 & CLI v2`

> #12269 (BA-6533 CLI v2) was folded into #12268 and closed.

## Summary
- Expose AppConfigDefinition through REST v2 (`/v2/app-config-definitions`) — create / get / search / purge, admin-only — with config_name/created_at/updated_at filters, ordering, and cursor + offset pagination.

Resolves BA-6530.
