### PR TITLE
feat(BA-6531): add AppConfigDefinition GraphQL API

### DIFF
--- a/changes/12267.feature.md
+++ b/changes/12267.feature.md
@@ -1,0 +1,1 @@
+Add the AppConfigDefinition GraphQL API (create / get / search / purge) over the shared adapter (BEP-1052).

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -885,9 +885,7 @@ type AllowedResourceGroupsPayload
   items: [String!]!
 }
 
-"""
-Added in 26.4.4. A registered app config definition (one managed config name).
-"""
+"""Added in 26.7.0. A registered app config name."""
 type AppConfigDefinition implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
   @join__type(graph: STRAWBERRY)
@@ -895,7 +893,7 @@ type AppConfigDefinition implements Node
   """The Globally Unique ID of this object"""
   id: ID!
 
-  """Registered config name (e.g. 'theme', 'menu')."""
+  """Registered config name."""
   configName: String!
 
   """Creation timestamp (UTC)."""
@@ -906,7 +904,7 @@ type AppConfigDefinition implements Node
 }
 
 """
-Added in 26.4.4. Paginated connection for app config definition records.
+Added in 26.7.0. Paginated connection for app config definition records.
 """
 type AppConfigDefinitionConnection
   @join__type(graph: STRAWBERRY)
@@ -934,7 +932,7 @@ type AppConfigDefinitionEdge
   node: AppConfigDefinition!
 }
 
-"""Added in 26.4.4. Filter input for querying app config definitions."""
+"""Added in 26.7.0. Filter input for querying app config definitions."""
 input AppConfigDefinitionFilter
   @join__type(graph: STRAWBERRY)
 {
@@ -948,7 +946,7 @@ input AppConfigDefinitionFilter
   updatedAt: DateTimeFilter = null
 }
 
-"""Added in 26.4.4. Specifies ordering for app config definition results."""
+"""Added in 26.7.0. Specifies ordering for app config definition results."""
 input AppConfigDefinitionOrderBy
   @join__type(graph: STRAWBERRY)
 {
@@ -960,7 +958,7 @@ input AppConfigDefinitionOrderBy
 }
 
 """
-Added in 26.4.4. Fields available for ordering app config definition results.
+Added in 26.7.0. Fields available for ordering app config definition results.
 """
 enum AppConfigDefinitionOrderField
   @join__type(graph: STRAWBERRY)
@@ -3279,7 +3277,7 @@ type CreateAccessTokenPayload
   accessToken: AccessToken!
 }
 
-"""Added in 26.4.4. Input for registering a new app config definition."""
+"""Added in 26.7.0. Input for registering a new app config definition."""
 input CreateAppConfigDefinitionInput
   @join__type(graph: STRAWBERRY)
 {
@@ -3287,7 +3285,7 @@ input CreateAppConfigDefinitionInput
   configName: String!
 }
 
-"""Added in 26.4.4. Payload for app config definition creation."""
+"""Added in 26.7.0. Payload for app config definition creation."""
 type CreateAppConfigDefinitionPayload
   @join__type(graph: STRAWBERRY)
 {
@@ -11759,12 +11757,12 @@ type Mutation
   adminDeleteLoginClientType(id: UUID!): DeleteLoginClientTypePayload @join__field(graph: STRAWBERRY)
 
   """
-  Added in 26.4.4. Register a new app config definition (super admin only).
+  Added in 26.7.0. Register a new app config definition (super admin only).
   """
   adminCreateAppConfigDefinition(input: CreateAppConfigDefinitionInput!): CreateAppConfigDefinitionPayload @join__field(graph: STRAWBERRY)
 
   """
-  Added in 26.4.4. Purge an app config definition by id (super admin only).
+  Added in 26.7.0. Purge an app config definition by id (super admin only).
   """
   adminPurgeAppConfigDefinition(id: UUID!): PurgeAppConfigDefinitionPayload @join__field(graph: STRAWBERRY)
 
@@ -13541,7 +13539,7 @@ input ProjectWeightInputItem
   weight: Decimal = null
 }
 
-"""Added in 26.4.4. Payload for app config definition purge."""
+"""Added in 26.7.0. Payload for app config definition purge."""
 type PurgeAppConfigDefinitionPayload
   @join__type(graph: STRAWBERRY)
 {
@@ -14715,12 +14713,12 @@ type Query
   loginClientTypes(filter: LoginClientTypeFilter = null, orderBy: [LoginClientTypeOrderBy!] = null, limit: Int = null, offset: Int = null): LoginClientTypeConnection @join__field(graph: STRAWBERRY)
 
   """
-  Added in 26.4.4. Get a single app config definition by id (super admin only).
+  Added in 26.7.0. Get a single app config definition by id (super admin only).
   """
   appConfigDefinition(id: UUID!): AppConfigDefinition @join__field(graph: STRAWBERRY)
 
   """
-  Added in 26.4.4. Search app config definitions with filtering, ordering, and pagination (super admin only).
+  Added in 26.7.0. Search app config definitions with filtering, ordering, and pagination (super admin only).
   """
   appConfigDefinitions(filter: AppConfigDefinitionFilter = null, orderBy: [AppConfigDefinitionOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigDefinitionConnection @join__field(graph: STRAWBERRY)
 

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -885,7 +885,7 @@ type AllowedResourceGroupsPayload
   items: [String!]!
 }
 
-"""Added in 26.7.0. A registered app config name."""
+"""Added in 26.7.0. A registered app config."""
 type AppConfigDefinition implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
   @join__type(graph: STRAWBERRY)
@@ -11764,7 +11764,7 @@ type Mutation
   """
   Added in 26.7.0. Purge an app config definition by id (super admin only).
   """
-  adminPurgeAppConfigDefinition(id: UUID!): PurgeAppConfigDefinitionPayload @join__field(graph: STRAWBERRY)
+  adminPurgeAppConfigDefinition(input: PurgeAppConfigDefinitionInput!): PurgeAppConfigDefinitionPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new runtime variant (superadmin only)."""
   adminCreateRuntimeVariant(input: CreateRuntimeVariantInput!): CreateRuntimeVariantPayload @join__field(graph: STRAWBERRY)
@@ -13537,6 +13537,14 @@ input ProjectWeightInputItem
   Priority weight multiplier. Higher weight = higher priority allocation ratio. Set to null to use resource group's default_weight.
   """
   weight: Decimal = null
+}
+
+"""Added in 26.7.0. Input for purging an app config definition."""
+input PurgeAppConfigDefinitionInput
+  @join__type(graph: STRAWBERRY)
+{
+  """App config definition id to purge."""
+  id: UUID!
 }
 
 """Added in 26.7.0. Payload for app config definition purge."""

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -14723,12 +14723,12 @@ type Query
   """
   Added in 26.7.0. Get a single app config definition by id (super admin only).
   """
-  appConfigDefinition(id: UUID!): AppConfigDefinition @join__field(graph: STRAWBERRY)
+  adminAppConfigDefinition(id: UUID!): AppConfigDefinition @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.7.0. Search app config definitions with filtering, ordering, and pagination (super admin only).
   """
-  appConfigDefinitions(filter: AppConfigDefinitionFilter = null, orderBy: [AppConfigDefinitionOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigDefinitionConnection @join__field(graph: STRAWBERRY)
+  adminAppConfigDefinitions(filter: AppConfigDefinitionFilter = null, orderBy: [AppConfigDefinitionOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigDefinitionConnection @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Search runtime variants."""
   runtimeVariants(filter: RuntimeVariantFilter = null, orderBy: [RuntimeVariantOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RuntimeVariantConnection @join__field(graph: STRAWBERRY)

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -886,6 +886,91 @@ type AllowedResourceGroupsPayload
 }
 
 """
+Added in 26.4.4. A registered app config definition (one managed config name).
+"""
+type AppConfigDefinition implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Registered config name (e.g. 'theme', 'menu')."""
+  configName: String!
+
+  """Creation timestamp (UTC)."""
+  createdAt: DateTime!
+
+  """Last update timestamp (UTC)."""
+  updatedAt: DateTime!
+}
+
+"""
+Added in 26.4.4. Paginated connection for app config definition records.
+"""
+type AppConfigDefinitionConnection
+  @join__type(graph: STRAWBERRY)
+{
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [AppConfigDefinitionEdge!]!
+
+  """
+  Total number of app config definition records matching the query criteria.
+  """
+  count: Int!
+}
+
+"""An edge in a connection."""
+type AppConfigDefinitionEdge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: AppConfigDefinition!
+}
+
+"""Added in 26.4.4. Filter input for querying app config definitions."""
+input AppConfigDefinitionFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Filter by config name."""
+  configName: StringFilter = null
+
+  """Filter by creation datetime."""
+  createdAt: DateTimeFilter = null
+
+  """Filter by last update datetime."""
+  updatedAt: DateTimeFilter = null
+}
+
+"""Added in 26.4.4. Specifies ordering for app config definition results."""
+input AppConfigDefinitionOrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  """The field to order by."""
+  field: AppConfigDefinitionOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = ASC
+}
+
+"""
+Added in 26.4.4. Fields available for ordering app config definition results.
+"""
+enum AppConfigDefinitionOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  CONFIG_NAME @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
+  UPDATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
+"""
 Added in 24.09.0. Input for approving an artifact revision.
 
 Admin-only operation to approve artifact revisions for general use.
@@ -3192,6 +3277,22 @@ type CreateAccessTokenPayload
 {
   """Created access token"""
   accessToken: AccessToken!
+}
+
+"""Added in 26.4.4. Input for registering a new app config definition."""
+input CreateAppConfigDefinitionInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Unique config name to register."""
+  configName: String!
+}
+
+"""Added in 26.4.4. Payload for app config definition creation."""
+type CreateAppConfigDefinitionPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Created app config definition."""
+  appConfigDefinition: AppConfigDefinition!
 }
 
 """Added in 25.19.0. Input for creating an auto-scaling rule."""
@@ -11657,6 +11758,16 @@ type Mutation
   """Added in 26.4.2. Delete a login client type (super admin only)."""
   adminDeleteLoginClientType(id: UUID!): DeleteLoginClientTypePayload @join__field(graph: STRAWBERRY)
 
+  """
+  Added in 26.4.4. Register a new app config definition (super admin only).
+  """
+  adminCreateAppConfigDefinition(input: CreateAppConfigDefinitionInput!): CreateAppConfigDefinitionPayload @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Purge an app config definition by id (super admin only).
+  """
+  adminPurgeAppConfigDefinition(id: UUID!): PurgeAppConfigDefinitionPayload @join__field(graph: STRAWBERRY)
+
   """Added in 26.4.2. Create a new runtime variant (superadmin only)."""
   adminCreateRuntimeVariant(input: CreateRuntimeVariantInput!): CreateRuntimeVariantPayload @join__field(graph: STRAWBERRY)
 
@@ -13430,6 +13541,14 @@ input ProjectWeightInputItem
   weight: Decimal = null
 }
 
+"""Added in 26.4.4. Payload for app config definition purge."""
+type PurgeAppConfigDefinitionPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """UUID of the purged app config definition."""
+  id: UUID!
+}
+
 """
 Completely delete domain from DB.
 
@@ -14594,6 +14713,16 @@ type Query
   Added in 26.4.2. Search login client types with filtering, ordering, and pagination.
   """
   loginClientTypes(filter: LoginClientTypeFilter = null, orderBy: [LoginClientTypeOrderBy!] = null, limit: Int = null, offset: Int = null): LoginClientTypeConnection @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Get a single app config definition by id (super admin only).
+  """
+  appConfigDefinition(id: UUID!): AppConfigDefinition @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Search app config definitions with filtering, ordering, and pagination (super admin only).
+  """
+  appConfigDefinitions(filter: AppConfigDefinitionFilter = null, orderBy: [AppConfigDefinitionOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigDefinitionConnection @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Search runtime variants."""
   runtimeVariants(filter: RuntimeVariantFilter = null, orderBy: [RuntimeVariantOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RuntimeVariantConnection @join__field(graph: STRAWBERRY)

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -604,14 +604,12 @@ type AllowedResourceGroupsPayload {
   items: [String!]!
 }
 
-"""
-Added in 26.4.4. A registered app config definition (one managed config name).
-"""
+"""Added in 26.7.0. A registered app config name."""
 type AppConfigDefinition implements Node {
   """The Globally Unique ID of this object"""
   id: ID!
 
-  """Registered config name (e.g. 'theme', 'menu')."""
+  """Registered config name."""
   configName: String!
 
   """Creation timestamp (UTC)."""
@@ -622,7 +620,7 @@ type AppConfigDefinition implements Node {
 }
 
 """
-Added in 26.4.4. Paginated connection for app config definition records.
+Added in 26.7.0. Paginated connection for app config definition records.
 """
 type AppConfigDefinitionConnection {
   """Pagination data for this connection"""
@@ -646,7 +644,7 @@ type AppConfigDefinitionEdge {
   node: AppConfigDefinition!
 }
 
-"""Added in 26.4.4. Filter input for querying app config definitions."""
+"""Added in 26.7.0. Filter input for querying app config definitions."""
 input AppConfigDefinitionFilter {
   """Filter by config name."""
   configName: StringFilter = null
@@ -658,7 +656,7 @@ input AppConfigDefinitionFilter {
   updatedAt: DateTimeFilter = null
 }
 
-"""Added in 26.4.4. Specifies ordering for app config definition results."""
+"""Added in 26.7.0. Specifies ordering for app config definition results."""
 input AppConfigDefinitionOrderBy {
   """The field to order by."""
   field: AppConfigDefinitionOrderField!
@@ -668,7 +666,7 @@ input AppConfigDefinitionOrderBy {
 }
 
 """
-Added in 26.4.4. Fields available for ordering app config definition results.
+Added in 26.7.0. Fields available for ordering app config definition results.
 """
 enum AppConfigDefinitionOrderField {
   CONFIG_NAME
@@ -2121,13 +2119,13 @@ type CreateAccessTokenPayload {
   accessToken: AccessToken!
 }
 
-"""Added in 26.4.4. Input for registering a new app config definition."""
+"""Added in 26.7.0. Input for registering a new app config definition."""
 input CreateAppConfigDefinitionInput {
   """Unique config name to register."""
   configName: String!
 }
 
-"""Added in 26.4.4. Payload for app config definition creation."""
+"""Added in 26.7.0. Payload for app config definition creation."""
 type CreateAppConfigDefinitionPayload {
   """Created app config definition."""
   appConfigDefinition: AppConfigDefinition!
@@ -7630,12 +7628,12 @@ type Mutation {
   adminDeleteLoginClientType(id: UUID!): DeleteLoginClientTypePayload
 
   """
-  Added in 26.4.4. Register a new app config definition (super admin only).
+  Added in 26.7.0. Register a new app config definition (super admin only).
   """
   adminCreateAppConfigDefinition(input: CreateAppConfigDefinitionInput!): CreateAppConfigDefinitionPayload
 
   """
-  Added in 26.4.4. Purge an app config definition by id (super admin only).
+  Added in 26.7.0. Purge an app config definition by id (super admin only).
   """
   adminPurgeAppConfigDefinition(id: UUID!): PurgeAppConfigDefinitionPayload
 
@@ -9103,7 +9101,7 @@ input ProjectWeightInputItem {
   weight: Decimal = null
 }
 
-"""Added in 26.4.4. Payload for app config definition purge."""
+"""Added in 26.7.0. Payload for app config definition purge."""
 type PurgeAppConfigDefinitionPayload {
   """UUID of the purged app config definition."""
   id: UUID!
@@ -9783,12 +9781,12 @@ type Query {
   loginClientTypes(filter: LoginClientTypeFilter = null, orderBy: [LoginClientTypeOrderBy!] = null, limit: Int = null, offset: Int = null): LoginClientTypeConnection
 
   """
-  Added in 26.4.4. Get a single app config definition by id (super admin only).
+  Added in 26.7.0. Get a single app config definition by id (super admin only).
   """
   appConfigDefinition(id: UUID!): AppConfigDefinition
 
   """
-  Added in 26.4.4. Search app config definitions with filtering, ordering, and pagination (super admin only).
+  Added in 26.7.0. Search app config definitions with filtering, ordering, and pagination (super admin only).
   """
   appConfigDefinitions(filter: AppConfigDefinitionFilter = null, orderBy: [AppConfigDefinitionOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigDefinitionConnection
 

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -605,6 +605,78 @@ type AllowedResourceGroupsPayload {
 }
 
 """
+Added in 26.4.4. A registered app config definition (one managed config name).
+"""
+type AppConfigDefinition implements Node {
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Registered config name (e.g. 'theme', 'menu')."""
+  configName: String!
+
+  """Creation timestamp (UTC)."""
+  createdAt: DateTime!
+
+  """Last update timestamp (UTC)."""
+  updatedAt: DateTime!
+}
+
+"""
+Added in 26.4.4. Paginated connection for app config definition records.
+"""
+type AppConfigDefinitionConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [AppConfigDefinitionEdge!]!
+
+  """
+  Total number of app config definition records matching the query criteria.
+  """
+  count: Int!
+}
+
+"""An edge in a connection."""
+type AppConfigDefinitionEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: AppConfigDefinition!
+}
+
+"""Added in 26.4.4. Filter input for querying app config definitions."""
+input AppConfigDefinitionFilter {
+  """Filter by config name."""
+  configName: StringFilter = null
+
+  """Filter by creation datetime."""
+  createdAt: DateTimeFilter = null
+
+  """Filter by last update datetime."""
+  updatedAt: DateTimeFilter = null
+}
+
+"""Added in 26.4.4. Specifies ordering for app config definition results."""
+input AppConfigDefinitionOrderBy {
+  """The field to order by."""
+  field: AppConfigDefinitionOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = ASC
+}
+
+"""
+Added in 26.4.4. Fields available for ordering app config definition results.
+"""
+enum AppConfigDefinitionOrderField {
+  CONFIG_NAME
+  CREATED_AT
+  UPDATED_AT
+}
+
+"""
 Added in 24.09.0. Input for approving an artifact revision.
 
 Admin-only operation to approve artifact revisions for general use.
@@ -2047,6 +2119,18 @@ input CreateAccessTokenInput {
 type CreateAccessTokenPayload {
   """Created access token"""
   accessToken: AccessToken!
+}
+
+"""Added in 26.4.4. Input for registering a new app config definition."""
+input CreateAppConfigDefinitionInput {
+  """Unique config name to register."""
+  configName: String!
+}
+
+"""Added in 26.4.4. Payload for app config definition creation."""
+type CreateAppConfigDefinitionPayload {
+  """Created app config definition."""
+  appConfigDefinition: AppConfigDefinition!
 }
 
 """Added in 25.19.0. Input for creating an auto-scaling rule."""
@@ -7545,6 +7629,16 @@ type Mutation {
   """Added in 26.4.2. Delete a login client type (super admin only)."""
   adminDeleteLoginClientType(id: UUID!): DeleteLoginClientTypePayload
 
+  """
+  Added in 26.4.4. Register a new app config definition (super admin only).
+  """
+  adminCreateAppConfigDefinition(input: CreateAppConfigDefinitionInput!): CreateAppConfigDefinitionPayload
+
+  """
+  Added in 26.4.4. Purge an app config definition by id (super admin only).
+  """
+  adminPurgeAppConfigDefinition(id: UUID!): PurgeAppConfigDefinitionPayload
+
   """Added in 26.4.2. Create a new runtime variant (superadmin only)."""
   adminCreateRuntimeVariant(input: CreateRuntimeVariantInput!): CreateRuntimeVariantPayload
 
@@ -9009,6 +9103,12 @@ input ProjectWeightInputItem {
   weight: Decimal = null
 }
 
+"""Added in 26.4.4. Payload for app config definition purge."""
+type PurgeAppConfigDefinitionPayload {
+  """UUID of the purged app config definition."""
+  id: UUID!
+}
+
 """Added in 26.4.2. Payload for domain permanent deletion mutation."""
 type PurgeDomainPayload {
   """Whether the purge was successful."""
@@ -9681,6 +9781,16 @@ type Query {
   Added in 26.4.2. Search login client types with filtering, ordering, and pagination.
   """
   loginClientTypes(filter: LoginClientTypeFilter = null, orderBy: [LoginClientTypeOrderBy!] = null, limit: Int = null, offset: Int = null): LoginClientTypeConnection
+
+  """
+  Added in 26.4.4. Get a single app config definition by id (super admin only).
+  """
+  appConfigDefinition(id: UUID!): AppConfigDefinition
+
+  """
+  Added in 26.4.4. Search app config definitions with filtering, ordering, and pagination (super admin only).
+  """
+  appConfigDefinitions(filter: AppConfigDefinitionFilter = null, orderBy: [AppConfigDefinitionOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigDefinitionConnection
 
   """Added in 26.4.2. Search runtime variants."""
   runtimeVariants(filter: RuntimeVariantFilter = null, orderBy: [RuntimeVariantOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RuntimeVariantConnection

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -604,7 +604,7 @@ type AllowedResourceGroupsPayload {
   items: [String!]!
 }
 
-"""Added in 26.7.0. A registered app config name."""
+"""Added in 26.7.0. A registered app config."""
 type AppConfigDefinition implements Node {
   """The Globally Unique ID of this object"""
   id: ID!
@@ -7635,7 +7635,7 @@ type Mutation {
   """
   Added in 26.7.0. Purge an app config definition by id (super admin only).
   """
-  adminPurgeAppConfigDefinition(id: UUID!): PurgeAppConfigDefinitionPayload
+  adminPurgeAppConfigDefinition(input: PurgeAppConfigDefinitionInput!): PurgeAppConfigDefinitionPayload
 
   """Added in 26.4.2. Create a new runtime variant (superadmin only)."""
   adminCreateRuntimeVariant(input: CreateRuntimeVariantInput!): CreateRuntimeVariantPayload
@@ -9099,6 +9099,12 @@ input ProjectWeightInputItem {
   Priority weight multiplier. Higher weight = higher priority allocation ratio. Set to null to use resource group's default_weight.
   """
   weight: Decimal = null
+}
+
+"""Added in 26.7.0. Input for purging an app config definition."""
+input PurgeAppConfigDefinitionInput {
+  """App config definition id to purge."""
+  id: UUID!
 }
 
 """Added in 26.7.0. Payload for app config definition purge."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -9789,12 +9789,12 @@ type Query {
   """
   Added in 26.7.0. Get a single app config definition by id (super admin only).
   """
-  appConfigDefinition(id: UUID!): AppConfigDefinition
+  adminAppConfigDefinition(id: UUID!): AppConfigDefinition
 
   """
   Added in 26.7.0. Search app config definitions with filtering, ordering, and pagination (super admin only).
   """
-  appConfigDefinitions(filter: AppConfigDefinitionFilter = null, orderBy: [AppConfigDefinitionOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigDefinitionConnection
+  adminAppConfigDefinitions(filter: AppConfigDefinitionFilter = null, orderBy: [AppConfigDefinitionOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigDefinitionConnection
 
   """Added in 26.4.2. Search runtime variants."""
   runtimeVariants(filter: RuntimeVariantFilter = null, orderBy: [RuntimeVariantOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RuntimeVariantConnection

--- a/src/ai/backend/common/dto/manager/v2/app_config_definition/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_definition/request.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from uuid import UUID
+
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseRequestModel
@@ -15,6 +17,7 @@ __all__ = (
     "AppConfigDefinitionFilter",
     "AppConfigDefinitionOrder",
     "CreateAppConfigDefinitionInput",
+    "PurgeAppConfigDefinitionInput",
     "SearchAppConfigDefinitionsInput",
 )
 
@@ -27,6 +30,12 @@ class CreateAppConfigDefinitionInput(BaseRequestModel):
         max_length=128,
         description="Unique config name to register (e.g. 'theme', 'menu').",
     )
+
+
+class PurgeAppConfigDefinitionInput(BaseRequestModel):
+    """Input for purging an app config definition."""
+
+    id: UUID = Field(description="App config definition id to purge.")
 
 
 class AppConfigDefinitionFilter(BaseRequestModel):

--- a/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from functools import lru_cache
 from uuid import UUID
 
@@ -83,6 +84,27 @@ class AppConfigDefinitionAdapter(BaseAdapter):
             GetAppConfigDefinitionAction(definition_id=AppConfigDefinitionID(definition_id))
         )
         return self._data_to_node(action_result.definition)
+
+    async def batch_load_by_ids(
+        self, ids: Sequence[AppConfigDefinitionID]
+    ) -> list[AppConfigDefinitionNode | None]:
+        """Batch load app config definitions by id for DataLoader use.
+
+        Returns nodes in the same order as the input ids, with None for missing ones.
+        """
+        if not ids:
+            return []
+        querier = self._build_querier(
+            conditions=[AppConfigDefinitionConditions.by_ids(list(ids))],
+            orders=[],
+            pagination_spec=_get_app_config_definition_pagination_spec(),
+            limit=len(ids),
+        )
+        action_result = await self._processors.app_config_definition.search.wait_for_complete(
+            SearchAppConfigDefinitionsAction(querier=querier)
+        )
+        node_map = {node.id: node for node in map(self._data_to_node, action_result.data)}
+        return [node_map.get(definition_id) for definition_id in ids]
 
     async def admin_search(
         self, input: SearchAppConfigDefinitionsInput

--- a/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
@@ -10,6 +10,7 @@ from ai.backend.common.dto.manager.v2.app_config_definition.request import (
     AppConfigDefinitionFilter,
     AppConfigDefinitionOrder,
     CreateAppConfigDefinitionInput,
+    PurgeAppConfigDefinitionInput,
     SearchAppConfigDefinitionsInput,
 )
 from ai.backend.common.dto.manager.v2.app_config_definition.response import (
@@ -132,10 +133,10 @@ class AppConfigDefinitionAdapter(BaseAdapter):
             has_previous_page=action_result.has_previous_page,
         )
 
-    async def admin_purge(self, definition_id: UUID) -> PurgeAppConfigDefinitionPayload:
-        purger = Purger(
-            row_class=AppConfigDefinitionRow, pk_value=AppConfigDefinitionID(definition_id)
-        )
+    async def admin_purge(
+        self, input: PurgeAppConfigDefinitionInput
+    ) -> PurgeAppConfigDefinitionPayload:
+        purger = Purger(row_class=AppConfigDefinitionRow, pk_value=AppConfigDefinitionID(input.id))
         action_result = await self._processors.app_config_definition.purge.wait_for_complete(
             PurgeAppConfigDefinitionAction(purger=purger)
         )

--- a/src/ai/backend/manager/api/gql/app_config_definition/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config_definition/__init__.py
@@ -1,0 +1,38 @@
+"""GraphQL app config definition module."""
+
+from .resolver import (
+    admin_create_app_config_definition,
+    admin_purge_app_config_definition,
+    app_config_definition,
+    app_config_definitions,
+)
+from .types import (
+    AppConfigDefinitionConnection,
+    AppConfigDefinitionEdge,
+    AppConfigDefinitionFilterGQL,
+    AppConfigDefinitionGQL,
+    AppConfigDefinitionOrderByGQL,
+    AppConfigDefinitionOrderFieldGQL,
+    CreateAppConfigDefinitionInputGQL,
+    CreateAppConfigDefinitionPayloadGQL,
+    PurgeAppConfigDefinitionPayloadGQL,
+)
+
+__all__ = (
+    # Types
+    "AppConfigDefinitionConnection",
+    "AppConfigDefinitionEdge",
+    "AppConfigDefinitionFilterGQL",
+    "AppConfigDefinitionGQL",
+    "AppConfigDefinitionOrderByGQL",
+    "AppConfigDefinitionOrderFieldGQL",
+    "CreateAppConfigDefinitionInputGQL",
+    "CreateAppConfigDefinitionPayloadGQL",
+    "PurgeAppConfigDefinitionPayloadGQL",
+    # Query resolvers
+    "app_config_definition",
+    "app_config_definitions",
+    # Mutation resolvers
+    "admin_create_app_config_definition",
+    "admin_purge_app_config_definition",
+)

--- a/src/ai/backend/manager/api/gql/app_config_definition/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config_definition/__init__.py
@@ -15,6 +15,7 @@ from .types import (
     AppConfigDefinitionOrderFieldGQL,
     CreateAppConfigDefinitionInputGQL,
     CreateAppConfigDefinitionPayloadGQL,
+    PurgeAppConfigDefinitionInputGQL,
     PurgeAppConfigDefinitionPayloadGQL,
 )
 
@@ -28,6 +29,7 @@ __all__ = (
     "AppConfigDefinitionOrderFieldGQL",
     "CreateAppConfigDefinitionInputGQL",
     "CreateAppConfigDefinitionPayloadGQL",
+    "PurgeAppConfigDefinitionInputGQL",
     "PurgeAppConfigDefinitionPayloadGQL",
     # Query resolvers
     "admin_app_config_definition",

--- a/src/ai/backend/manager/api/gql/app_config_definition/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config_definition/__init__.py
@@ -1,10 +1,10 @@
 """GraphQL app config definition module."""
 
 from .resolver import (
+    admin_app_config_definition,
+    admin_app_config_definitions,
     admin_create_app_config_definition,
     admin_purge_app_config_definition,
-    app_config_definition,
-    app_config_definitions,
 )
 from .types import (
     AppConfigDefinitionConnection,
@@ -30,8 +30,8 @@ __all__ = (
     "CreateAppConfigDefinitionPayloadGQL",
     "PurgeAppConfigDefinitionPayloadGQL",
     # Query resolvers
-    "app_config_definition",
-    "app_config_definitions",
+    "admin_app_config_definition",
+    "admin_app_config_definitions",
     # Mutation resolvers
     "admin_create_app_config_definition",
     "admin_purge_app_config_definition",

--- a/src/ai/backend/manager/api/gql/app_config_definition/resolver.py
+++ b/src/ai/backend/manager/api/gql/app_config_definition/resolver.py
@@ -28,6 +28,7 @@ from .types import (
     AppConfigDefinitionOrderByGQL,
     CreateAppConfigDefinitionInputGQL,
     CreateAppConfigDefinitionPayloadGQL,
+    PurgeAppConfigDefinitionInputGQL,
     PurgeAppConfigDefinitionPayloadGQL,
 )
 
@@ -124,8 +125,8 @@ async def admin_create_app_config_definition(
 )
 async def admin_purge_app_config_definition(
     info: Info[StrawberryGQLContext],
-    id: UUID,
+    input: PurgeAppConfigDefinitionInputGQL,
 ) -> PurgeAppConfigDefinitionPayloadGQL | None:
     check_admin_only()
-    payload = await info.context.adapters.app_config_definition.admin_purge(id)
+    payload = await info.context.adapters.app_config_definition.admin_purge(input.to_pydantic())
     return PurgeAppConfigDefinitionPayloadGQL.from_pydantic(payload)

--- a/src/ai/backend/manager/api/gql/app_config_definition/resolver.py
+++ b/src/ai/backend/manager/api/gql/app_config_definition/resolver.py
@@ -39,7 +39,7 @@ from .types import (
         description="Get a single app config definition by id (super admin only).",
     )
 )  # type: ignore[misc]
-async def app_config_definition(
+async def admin_app_config_definition(
     info: Info[StrawberryGQLContext],
     id: UUID,
 ) -> AppConfigDefinitionGQL | None:
@@ -57,7 +57,7 @@ async def app_config_definition(
         ),
     )
 )  # type: ignore[misc]
-async def app_config_definitions(
+async def admin_app_config_definitions(
     info: Info[StrawberryGQLContext],
     filter: AppConfigDefinitionFilterGQL | None = None,
     order_by: list[AppConfigDefinitionOrderByGQL] | None = None,

--- a/src/ai/backend/manager/api/gql/app_config_definition/resolver.py
+++ b/src/ai/backend/manager/api/gql/app_config_definition/resolver.py
@@ -1,0 +1,131 @@
+"""GraphQL query and mutation resolvers for app config definitions."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from strawberry import Info
+from strawberry.relay import PageInfo
+
+from ai.backend.common.dto.manager.v2.app_config_definition.request import (
+    SearchAppConfigDefinitionsInput,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.base import encode_cursor
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_mutation,
+    gql_root_field,
+)
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+from ai.backend.manager.api.gql.utils import check_admin_only
+
+from .types import (
+    AppConfigDefinitionConnection,
+    AppConfigDefinitionEdge,
+    AppConfigDefinitionFilterGQL,
+    AppConfigDefinitionGQL,
+    AppConfigDefinitionOrderByGQL,
+    CreateAppConfigDefinitionInputGQL,
+    CreateAppConfigDefinitionPayloadGQL,
+    PurgeAppConfigDefinitionPayloadGQL,
+)
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Get a single app config definition by id (super admin only).",
+    )
+)  # type: ignore[misc]
+async def app_config_definition(
+    info: Info[StrawberryGQLContext],
+    id: UUID,
+) -> AppConfigDefinitionGQL | None:
+    check_admin_only()
+    node = await info.context.adapters.app_config_definition.admin_get(id)
+    return AppConfigDefinitionGQL.from_pydantic(node)
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Search app config definitions with filtering, ordering, and pagination "
+            "(super admin only)."
+        ),
+    )
+)  # type: ignore[misc]
+async def app_config_definitions(
+    info: Info[StrawberryGQLContext],
+    filter: AppConfigDefinitionFilterGQL | None = None,
+    order_by: list[AppConfigDefinitionOrderByGQL] | None = None,
+    first: int | None = None,
+    after: str | None = None,
+    last: int | None = None,
+    before: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> AppConfigDefinitionConnection | None:
+    check_admin_only()
+    pydantic_filter = filter.to_pydantic() if filter else None
+    pydantic_order = [o.to_pydantic() for o in order_by] if order_by else None
+
+    payload = await info.context.adapters.app_config_definition.admin_search(
+        SearchAppConfigDefinitionsInput(
+            filter=pydantic_filter,
+            order=pydantic_order,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        )
+    )
+
+    nodes = [AppConfigDefinitionGQL.from_pydantic(node) for node in payload.items]
+    edges = [
+        AppConfigDefinitionEdge(node=node, cursor=encode_cursor(str(node.id))) for node in nodes
+    ]
+
+    return AppConfigDefinitionConnection(
+        edges=edges,
+        page_info=PageInfo(
+            has_next_page=payload.has_next_page,
+            has_previous_page=payload.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        ),
+        count=payload.total_count,
+    )
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Register a new app config definition (super admin only).",
+    )
+)
+async def admin_create_app_config_definition(
+    info: Info[StrawberryGQLContext],
+    input: CreateAppConfigDefinitionInputGQL,
+) -> CreateAppConfigDefinitionPayloadGQL | None:
+    check_admin_only()
+    payload = await info.context.adapters.app_config_definition.admin_create(input.to_pydantic())
+    return CreateAppConfigDefinitionPayloadGQL.from_pydantic(payload)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Purge an app config definition by id (super admin only).",
+    )
+)
+async def admin_purge_app_config_definition(
+    info: Info[StrawberryGQLContext],
+    id: UUID,
+) -> PurgeAppConfigDefinitionPayloadGQL | None:
+    check_admin_only()
+    payload = await info.context.adapters.app_config_definition.admin_purge(id)
+    return PurgeAppConfigDefinitionPayloadGQL.from_pydantic(payload)

--- a/src/ai/backend/manager/api/gql/app_config_definition/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_definition/types.py
@@ -32,6 +32,7 @@ from ai.backend.common.dto.manager.v2.app_config_definition.response import (
 from ai.backend.common.dto.manager.v2.app_config_definition.response import (
     PurgeAppConfigDefinitionPayload as PurgeAppConfigDefinitionPayloadDTO,
 )
+from ai.backend.common.identifier.app_config_definition import AppConfigDefinitionID
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection, StringFilter
 from ai.backend.manager.api.gql.decorators import (
@@ -90,7 +91,7 @@ class AppConfigDefinitionGQL(PydanticNodeMixin[AppConfigDefinitionNode]):
         required: bool = False,
     ) -> Iterable[Self | None]:
         results = await info.context.data_loaders.app_config_definition_loader.load_many([
-            UUID(nid) for nid in node_ids
+            AppConfigDefinitionID(UUID(nid)) for nid in node_ids
         ])
         return cast(list[Self | None], results)
 

--- a/src/ai/backend/manager/api/gql/app_config_definition/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_definition/types.py
@@ -20,6 +20,9 @@ from ai.backend.common.dto.manager.v2.app_config_definition.request import (
 from ai.backend.common.dto.manager.v2.app_config_definition.request import (
     CreateAppConfigDefinitionInput as CreateAppConfigDefinitionInputDTO,
 )
+from ai.backend.common.dto.manager.v2.app_config_definition.request import (
+    PurgeAppConfigDefinitionInput as PurgeAppConfigDefinitionInputDTO,
+)
 from ai.backend.common.dto.manager.v2.app_config_definition.response import (
     AppConfigDefinitionNode,
 )
@@ -53,6 +56,7 @@ __all__ = (
     "AppConfigDefinitionOrderFieldGQL",
     "CreateAppConfigDefinitionInputGQL",
     "CreateAppConfigDefinitionPayloadGQL",
+    "PurgeAppConfigDefinitionInputGQL",
     "PurgeAppConfigDefinitionPayloadGQL",
 )
 
@@ -65,7 +69,7 @@ __all__ = (
 @gql_node_type(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
-        description="A registered app config name.",
+        description="A registered app config.",
     ),
     name="AppConfigDefinition",
 )
@@ -171,6 +175,17 @@ class AppConfigDefinitionOrderByGQL(PydanticInputMixin[AppConfigDefinitionOrderD
 )
 class CreateAppConfigDefinitionInputGQL(PydanticInputMixin[CreateAppConfigDefinitionInputDTO]):
     config_name: str = gql_field(description="Unique config name to register.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Input for purging an app config definition.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="PurgeAppConfigDefinitionInput",
+)
+class PurgeAppConfigDefinitionInputGQL(PydanticInputMixin[PurgeAppConfigDefinitionInputDTO]):
+    id: UUID = gql_field(description="App config definition id to purge.")
 
 
 @gql_pydantic_type(

--- a/src/ai/backend/manager/api/gql/app_config_definition/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_definition/types.py
@@ -1,0 +1,183 @@
+"""GraphQL types for app config definition."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from strawberry.relay import Connection, Edge, NodeID
+
+from ai.backend.common.dto.manager.v2.app_config_definition.request import (
+    AppConfigDefinitionFilter as AppConfigDefinitionFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_definition.request import (
+    AppConfigDefinitionOrder as AppConfigDefinitionOrderDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_definition.request import (
+    CreateAppConfigDefinitionInput as CreateAppConfigDefinitionInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_definition.response import (
+    AppConfigDefinitionNode,
+)
+from ai.backend.common.dto.manager.v2.app_config_definition.response import (
+    CreateAppConfigDefinitionPayload as CreateAppConfigDefinitionPayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_definition.response import (
+    PurgeAppConfigDefinitionPayload as PurgeAppConfigDefinitionPayloadDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection, StringFilter
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    PydanticInputMixin,
+    gql_connection_type,
+    gql_enum,
+    gql_field,
+    gql_node_type,
+    gql_pydantic_input,
+    gql_pydantic_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
+
+__all__ = (
+    "AppConfigDefinitionConnection",
+    "AppConfigDefinitionEdge",
+    "AppConfigDefinitionFilterGQL",
+    "AppConfigDefinitionGQL",
+    "AppConfigDefinitionOrderByGQL",
+    "AppConfigDefinitionOrderFieldGQL",
+    "CreateAppConfigDefinitionInputGQL",
+    "CreateAppConfigDefinitionPayloadGQL",
+    "PurgeAppConfigDefinitionPayloadGQL",
+)
+
+
+# ---------------------------------------------------------------------------
+# Node / Edge / Connection
+# ---------------------------------------------------------------------------
+
+
+@gql_node_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="A registered app config definition (one managed config name).",
+    ),
+    name="AppConfigDefinition",
+)
+class AppConfigDefinitionGQL(PydanticNodeMixin[AppConfigDefinitionNode]):
+    id: NodeID[str] = gql_field(
+        description="Relay-style global node identifier for the app config definition."
+    )
+    config_name: str = gql_field(description="Registered config name (e.g. 'theme', 'menu').")
+    created_at: datetime = gql_field(description="Creation timestamp (UTC).")
+    updated_at: datetime = gql_field(description="Last update timestamp (UTC).")
+
+
+AppConfigDefinitionEdge = Edge[AppConfigDefinitionGQL]
+
+
+@gql_connection_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Paginated connection for app config definition records.",
+    ),
+)
+class AppConfigDefinitionConnection(Connection[AppConfigDefinitionGQL]):
+    count: int = gql_field(
+        description="Total number of app config definition records matching the query criteria."
+    )
+
+    def __init__(self, *args: Any, count: int, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.count = count
+
+
+# ---------------------------------------------------------------------------
+# Filter / OrderBy
+# ---------------------------------------------------------------------------
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Filter input for querying app config definitions.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="AppConfigDefinitionFilter",
+)
+class AppConfigDefinitionFilterGQL(PydanticInputMixin[AppConfigDefinitionFilterDTO]):
+    config_name: StringFilter | None = gql_field(description="Filter by config name.", default=None)
+    created_at: DateTimeFilter | None = gql_field(
+        description="Filter by creation datetime.", default=None
+    )
+    updated_at: DateTimeFilter | None = gql_field(
+        description="Filter by last update datetime.", default=None
+    )
+
+
+@gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Fields available for ordering app config definition results.",
+    ),
+    name="AppConfigDefinitionOrderField",
+)
+class AppConfigDefinitionOrderFieldGQL(StrEnum):
+    CONFIG_NAME = "config_name"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Specifies ordering for app config definition results.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="AppConfigDefinitionOrderBy",
+)
+class AppConfigDefinitionOrderByGQL(PydanticInputMixin[AppConfigDefinitionOrderDTO]):
+    field: AppConfigDefinitionOrderFieldGQL = gql_field(description="The field to order by.")
+    direction: OrderDirection = gql_field(description="Sort direction.", default=OrderDirection.ASC)
+
+
+# ---------------------------------------------------------------------------
+# Mutation inputs / payloads
+# ---------------------------------------------------------------------------
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Input for registering a new app config definition.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="CreateAppConfigDefinitionInput",
+)
+class CreateAppConfigDefinitionInputGQL(PydanticInputMixin[CreateAppConfigDefinitionInputDTO]):
+    config_name: str = gql_field(description="Unique config name to register.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for app config definition creation.",
+    ),
+    model=CreateAppConfigDefinitionPayloadDTO,
+    name="CreateAppConfigDefinitionPayload",
+)
+class CreateAppConfigDefinitionPayloadGQL(PydanticOutputMixin[CreateAppConfigDefinitionPayloadDTO]):
+    app_config_definition: AppConfigDefinitionGQL = gql_field(
+        description="The created app config definition."
+    )
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for app config definition purge.",
+    ),
+    model=PurgeAppConfigDefinitionPayloadDTO,
+    all_fields=True,
+    name="PurgeAppConfigDefinitionPayload",
+)
+class PurgeAppConfigDefinitionPayloadGQL(PydanticOutputMixin[PurgeAppConfigDefinitionPayloadDTO]):
+    pass

--- a/src/ai/backend/manager/api/gql/app_config_definition/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_definition/types.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime
 from enum import StrEnum
-from typing import Any
+from typing import Any, Self, cast
+from uuid import UUID
 
+from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID
 
 from ai.backend.common.dto.manager.v2.app_config_definition.request import (
@@ -39,6 +42,7 @@ from ai.backend.manager.api.gql.decorators import (
     gql_pydantic_type,
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
 
 __all__ = (
     "AppConfigDefinitionConnection",
@@ -61,7 +65,7 @@ __all__ = (
 @gql_node_type(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
-        description="A registered app config definition (one managed config name).",
+        description="A registered app config name.",
     ),
     name="AppConfigDefinition",
 )
@@ -69,9 +73,22 @@ class AppConfigDefinitionGQL(PydanticNodeMixin[AppConfigDefinitionNode]):
     id: NodeID[str] = gql_field(
         description="Relay-style global node identifier for the app config definition."
     )
-    config_name: str = gql_field(description="Registered config name (e.g. 'theme', 'menu').")
+    config_name: str = gql_field(description="Registered config name.")
     created_at: datetime = gql_field(description="Creation timestamp (UTC).")
     updated_at: datetime = gql_field(description="Last update timestamp (UTC).")
+
+    @classmethod
+    async def resolve_nodes(  # type: ignore[override]  # Strawberry Node uses AwaitableOrValue overloads incompatible with async def
+        cls,
+        *,
+        info: Info[StrawberryGQLContext],
+        node_ids: Iterable[str],
+        required: bool = False,
+    ) -> Iterable[Self | None]:
+        results = await info.context.data_loaders.app_config_definition_loader.load_many([
+            UUID(nid) for nid in node_ids
+        ])
+        return cast(list[Self | None], results)
 
 
 AppConfigDefinitionEdge = Edge[AppConfigDefinitionGQL]

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from strawberry.dataloader import DataLoader
 
+from ai.backend.common.identifier.app_config_definition import AppConfigDefinitionID
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.types import AgentId, ImageID, KernelId, SessionId
 from ai.backend.manager.data.permission.id import ObjectId
@@ -14,6 +15,9 @@ if TYPE_CHECKING:
     from ai.backend.common.dto.manager.v2.rbac.response import EntityNode  # pants: no-infer-dep
     from ai.backend.manager.api.adapters.registry import Adapters  # pants: no-infer-dep
     from ai.backend.manager.api.gql.agent.types import AgentV2GQL  # pants: no-infer-dep
+    from ai.backend.manager.api.gql.app_config_definition.types import (  # pants: no-infer-dep
+        AppConfigDefinitionGQL,
+    )
     from ai.backend.manager.api.gql.artifact.types import (  # pants: no-infer-dep
         ArtifactRevision,
     )
@@ -118,6 +122,22 @@ class DataLoaders:
 
     def __init__(self, adapters: Adapters) -> None:
         self._adapters = adapters
+
+    @cached_property
+    def app_config_definition_loader(
+        self,
+    ) -> DataLoader[uuid.UUID, AppConfigDefinitionGQL | None]:
+        adapter = self._adapters.app_config_definition
+
+        async def load_fn(ids: list[uuid.UUID]) -> list[AppConfigDefinitionGQL | None]:
+            from ai.backend.manager.api.gql.app_config_definition.types import (  # pants: no-infer-dep
+                AppConfigDefinitionGQL as ACD,
+            )
+
+            dtos = await adapter.batch_load_by_ids([AppConfigDefinitionID(i) for i in ids])
+            return [ACD.from_pydantic(dto) if dto is not None else None for dto in dtos]
+
+        return DataLoader(load_fn=load_fn)
 
     @cached_property
     def audit_log_loader(

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -126,15 +126,17 @@ class DataLoaders:
     @cached_property
     def app_config_definition_loader(
         self,
-    ) -> DataLoader[uuid.UUID, AppConfigDefinitionGQL | None]:
+    ) -> DataLoader[AppConfigDefinitionID, AppConfigDefinitionGQL | None]:
         adapter = self._adapters.app_config_definition
 
-        async def load_fn(ids: list[uuid.UUID]) -> list[AppConfigDefinitionGQL | None]:
+        async def load_fn(
+            ids: list[AppConfigDefinitionID],
+        ) -> list[AppConfigDefinitionGQL | None]:
             from ai.backend.manager.api.gql.app_config_definition.types import (  # pants: no-infer-dep
                 AppConfigDefinitionGQL as ACD,
             )
 
-            dtos = await adapter.batch_load_by_ids([AppConfigDefinitionID(i) for i in ids])
+            dtos = await adapter.batch_load_by_ids(ids)
             return [ACD.from_pydantic(dto) if dto is not None else None for dto in dtos]
 
         return DataLoader(load_fn=load_fn)

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -15,6 +15,12 @@ from .agent import (
     agent_stats,
     agents_v2,
 )
+from .app_config_definition import (
+    admin_create_app_config_definition,
+    admin_purge_app_config_definition,
+    app_config_definition,
+    app_config_definitions,
+)
 from .artifact import (
     approve_artifact_revision,
     artifact,
@@ -633,6 +639,9 @@ class Query:
     admin_resource_preset_v2 = admin_resource_preset_v2
     login_client_type = login_client_type
     login_client_types = login_client_types
+    # App Config Definition APIs
+    app_config_definition = app_config_definition
+    app_config_definitions = app_config_definitions
     # Runtime Variant APIs
     runtime_variants = runtime_variants
     runtime_variant = runtime_variant
@@ -857,6 +866,9 @@ class Mutation:
     admin_create_login_client_type = admin_create_login_client_type
     admin_update_login_client_type = admin_update_login_client_type
     admin_delete_login_client_type = admin_delete_login_client_type
+    # App Config Definition mutations
+    admin_create_app_config_definition = admin_create_app_config_definition
+    admin_purge_app_config_definition = admin_purge_app_config_definition
     # Runtime Variant mutations
     admin_create_runtime_variant = admin_create_runtime_variant
     admin_update_runtime_variant = admin_update_runtime_variant

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -16,10 +16,10 @@ from .agent import (
     agents_v2,
 )
 from .app_config_definition import (
+    admin_app_config_definition,
+    admin_app_config_definitions,
     admin_create_app_config_definition,
     admin_purge_app_config_definition,
-    app_config_definition,
-    app_config_definitions,
 )
 from .artifact import (
     approve_artifact_revision,
@@ -640,8 +640,8 @@ class Query:
     login_client_type = login_client_type
     login_client_types = login_client_types
     # App Config Definition APIs
-    app_config_definition = app_config_definition
-    app_config_definitions = app_config_definitions
+    admin_app_config_definition = admin_app_config_definition
+    admin_app_config_definitions = admin_app_config_definitions
     # Runtime Variant APIs
     runtime_variants = runtime_variants
     runtime_variant = runtime_variant

--- a/src/ai/backend/manager/api/rest/v2/app_config_definition/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_definition/handler.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Final
 from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam
 from ai.backend.common.dto.manager.v2.app_config_definition.request import (
     CreateAppConfigDefinitionInput,
+    PurgeAppConfigDefinitionInput,
     SearchAppConfigDefinitionsInput,
 )
 from ai.backend.logging import BraceStyleAdapter
@@ -57,5 +58,7 @@ class V2AppConfigDefinitionHandler:
         path: PathParam[AppConfigDefinitionIdPathParam],
     ) -> APIResponse:
         """Purge an app config definition by id (superadmin only)."""
-        result = await self._adapter.admin_purge(path.parsed.app_config_definition_id)
+        result = await self._adapter.admin_purge(
+            PurgeAppConfigDefinitionInput(id=path.parsed.app_config_definition_id)
+        )
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/models/app_config_definition/conditions.py
+++ b/src/ai/backend/manager/models/app_config_definition/conditions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Collection
 from datetime import datetime
 
 import sqlalchemy as sa
@@ -70,7 +71,14 @@ class AppConfigDefinitionConditions:
 
     by_config_name_in = staticmethod(make_string_in_factory(AppConfigDefinitionRow.config_name))
 
-    # --- cursor (id-based) pagination ---
+    @staticmethod
+    def by_ids(ids: Collection[uuid.UUID]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigDefinitionRow.id.in_(ids)
+
+        return inner
+
+    # --- cursor (created_at-based) pagination ---
 
     @staticmethod
     def by_cursor_forward(cursor_id: str) -> QueryCondition:

--- a/tests/unit/manager/api/gql/test_app_config_definition_types.py
+++ b/tests/unit/manager/api/gql/test_app_config_definition_types.py
@@ -1,0 +1,87 @@
+"""Unit tests for AppConfigDefinition GraphQL types and schema registration."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from ai.backend.common.dto.manager.v2.app_config_definition.response import (
+    AppConfigDefinitionNode,
+)
+from ai.backend.common.dto.manager.v2.app_config_definition.types import (
+    AppConfigDefinitionOrderField,
+)
+from ai.backend.manager.api.gql.app_config_definition.types import (
+    AppConfigDefinitionFilterGQL,
+    AppConfigDefinitionGQL,
+    AppConfigDefinitionOrderByGQL,
+    AppConfigDefinitionOrderFieldGQL,
+)
+from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection, StringFilter
+from ai.backend.manager.api.gql.schema import schema
+
+
+class TestAppConfigDefinitionGQL:
+    def test_from_pydantic_maps_all_fields(self) -> None:
+        created = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        updated = datetime(2026, 1, 2, 12, 0, 0, tzinfo=UTC)
+        node = AppConfigDefinitionNode(
+            id=uuid.uuid4(),
+            config_name="theme",
+            created_at=created,
+            updated_at=updated,
+        )
+
+        gql = AppConfigDefinitionGQL.from_pydantic(node)
+
+        assert gql.config_name == "theme"
+        assert gql.created_at == created
+        assert gql.updated_at == updated
+
+
+class TestAppConfigDefinitionInputs:
+    def test_filter_to_pydantic_string(self) -> None:
+        filter_gql = AppConfigDefinitionFilterGQL(
+            config_name=StringFilter(contains="the"),
+            created_at=None,
+            updated_at=None,
+        )
+
+        dto = filter_gql.to_pydantic()
+
+        assert dto.config_name is not None
+        assert dto.config_name.contains == "the"
+
+    def test_filter_to_pydantic_datetime(self) -> None:
+        after = datetime(2026, 1, 1, tzinfo=UTC)
+        filter_gql = AppConfigDefinitionFilterGQL(
+            config_name=None,
+            created_at=DateTimeFilter(after=after),
+            updated_at=None,
+        )
+
+        dto = filter_gql.to_pydantic()
+
+        assert dto.created_at is not None
+        assert dto.created_at.after == after
+
+    def test_order_by_to_pydantic(self) -> None:
+        order_gql = AppConfigDefinitionOrderByGQL(
+            field=AppConfigDefinitionOrderFieldGQL.CONFIG_NAME,
+            direction=OrderDirection.DESC,
+        )
+
+        dto = order_gql.to_pydantic()
+
+        assert dto.field == AppConfigDefinitionOrderField.CONFIG_NAME
+        assert dto.direction.value == OrderDirection.DESC.value
+
+
+class TestSchemaRegistration:
+    def test_types_and_root_fields_present_in_schema(self) -> None:
+        sdl = schema.as_str()
+        assert "type AppConfigDefinition " in sdl
+        assert "appConfigDefinition(" in sdl
+        assert "appConfigDefinitions(" in sdl
+        assert "adminCreateAppConfigDefinition(" in sdl
+        assert "adminPurgeAppConfigDefinition(" in sdl

--- a/tests/unit/manager/api/gql/test_app_config_definition_types.py
+++ b/tests/unit/manager/api/gql/test_app_config_definition_types.py
@@ -81,7 +81,7 @@ class TestSchemaRegistration:
     def test_types_and_root_fields_present_in_schema(self) -> None:
         sdl = schema.as_str()
         assert "type AppConfigDefinition " in sdl
-        assert "appConfigDefinition(" in sdl
-        assert "appConfigDefinitions(" in sdl
+        assert "adminAppConfigDefinition(" in sdl
+        assert "adminAppConfigDefinitions(" in sdl
         assert "adminCreateAppConfigDefinition(" in sdl
         assert "adminPurgeAppConfigDefinition(" in sdl


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of the AppConfigDefinition stack (BA-6527 → BA-6533). **Merge in order:**

1. ✅ #12263 — `feat(BA-6527): app_config_definitions DB model and Alembic migration` (merged)
2. ✅ #12264 — `feat(BA-6528): AppConfigDefinitionRepository (create/get/search/purge)` (merged)
3. ✅ #12265 — `feat(BA-6529): AppConfigDefinitionService and processors` (merged)
4. ⬇️ #12266 — `feat(BA-6530): AppConfigDefinition REST v2 API`
5. 👉 **#12267** — `feat(BA-6531): AppConfigDefinition GraphQL API` ← you are here
6. ⬇️ #12268 — `feat(BA-6532 + BA-6533): AppConfigDefinition client SDK v2 & CLI v2`

> #12269 (BA-6533 CLI v2) was folded into #12268 and closed.

## Summary
- Add the Strawberry GraphQL surface for AppConfigDefinition — `app_config_definition` / `app_config_definitions` queries and admin create / purge mutations, reusing the shared adapter and v2 DTOs.

Resolves BA-6531.


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12267.org.readthedocs.build/en/12267/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12267.org.readthedocs.build/ko/12267/

<!-- readthedocs-preview sorna-ko end -->