### PR TITLE
feat(BA-6532, BA-6533): add AppConfigDefinition client SDK v2 and CLI v2

### DIFF
--- a/changes/12268.feature.md
+++ b/changes/12268.feature.md
@@ -1,1 +1,1 @@
-Add the AppConfigDefinition client SDK v2 (create / get / search / purge) targeting the REST v2 endpoints (BEP-1052).
+Add the AppConfigDefinition client SDK v2 and `admin app-config-definition` CLI v2 commands (create / get / search / purge) targeting the REST v2 endpoints (BEP-1052).

--- a/changes/12268.feature.md
+++ b/changes/12268.feature.md
@@ -1,0 +1,1 @@
+Add the AppConfigDefinition client SDK v2 (create / get / search / purge) targeting the REST v2 endpoints (BEP-1052).

--- a/src/ai/backend/client/cli/v2/admin/__init__.py
+++ b/src/ai/backend/client/cli/v2/admin/__init__.py
@@ -16,6 +16,15 @@ def admin() -> None:
     """Admin-only management commands (superadmin required)."""
 
 
+@admin.group(
+    cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.admin.app_config_definition:app_config_definition",
+    name="app-config-definition",
+)
+def app_config_definition() -> None:
+    """Admin app config definition commands."""
+
+
 @admin.group(cls=LazyGroup, import_name="ai.backend.client.cli.v2.admin.domain:domain")
 def domain() -> None:
     """Admin domain commands."""

--- a/src/ai/backend/client/cli/v2/admin/app_config_definition.py
+++ b/src/ai/backend/client/cli/v2/admin/app_config_definition.py
@@ -1,0 +1,135 @@
+"""Admin CLI commands for app config definitions."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    parse_order_options,
+    print_result,
+)
+
+
+@click.group()
+def app_config_definition() -> None:
+    """App config definition admin commands (superadmin required)."""
+
+
+@app_config_definition.command()
+@click.option("--config-name", required=True, type=str, help="Unique config name to register.")
+def create(config_name: str) -> None:
+    """Register a new app config definition."""
+    from ai.backend.common.dto.manager.v2.app_config_definition.request import (
+        CreateAppConfigDefinitionInput,
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_definition.admin_create(
+                CreateAppConfigDefinitionInput(config_name=config_name)
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@app_config_definition.command()
+@click.argument("app_config_definition_id", type=click.UUID)
+def get(app_config_definition_id: uuid.UUID) -> None:
+    """Get an app config definition by ID."""
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_definition.admin_get(app_config_definition_id)
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@app_config_definition.command()
+@click.option("--limit", type=int, default=20, help="Maximum number of items to return.")
+@click.option("--offset", type=int, default=0, help="Number of items to skip.")
+@click.option(
+    "--config-name-contains",
+    default=None,
+    type=str,
+    help="Filter by config name (substring match).",
+)
+@click.option(
+    "--order-by",
+    multiple=True,
+    help="Order by field:direction (e.g., config_name:asc, created_at:desc).",
+)
+def search(
+    limit: int,
+    offset: int,
+    config_name_contains: str | None,
+    order_by: tuple[str, ...],
+) -> None:
+    """Search app config definitions."""
+    from ai.backend.common.dto.manager.v2.app_config_definition.request import (
+        AppConfigDefinitionFilter,
+        AppConfigDefinitionOrder,
+        SearchAppConfigDefinitionsInput,
+    )
+    from ai.backend.common.dto.manager.v2.app_config_definition.types import (
+        AppConfigDefinitionOrderField,
+    )
+
+    filter_dto: AppConfigDefinitionFilter | None = None
+    if config_name_contains is not None:
+        from ai.backend.common.dto.manager.query import StringFilter
+
+        filter_dto = AppConfigDefinitionFilter(
+            config_name=StringFilter(contains=config_name_contains),
+        )
+
+    orders = (
+        parse_order_options(order_by, AppConfigDefinitionOrderField, AppConfigDefinitionOrder)
+        if order_by
+        else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_definition.admin_search(
+                SearchAppConfigDefinitionsInput(
+                    filter=filter_dto,
+                    order=orders,
+                    limit=limit,
+                    offset=offset,
+                )
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@app_config_definition.command()
+@click.argument("app_config_definition_id", type=click.UUID)
+def purge(app_config_definition_id: uuid.UUID) -> None:
+    """Purge an app config definition by ID."""
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_definition.admin_purge(app_config_definition_id)
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())

--- a/src/ai/backend/client/v2/domains_v2/app_config_definition.py
+++ b/src/ai/backend/client/v2/domains_v2/app_config_definition.py
@@ -1,0 +1,72 @@
+"""V2 SDK client for the app config definition domain."""
+
+from __future__ import annotations
+
+from typing import Final
+from uuid import UUID
+
+from ai.backend.client.v2.base_domain import BaseDomainClient
+from ai.backend.common.dto.manager.v2.app_config_definition.request import (
+    CreateAppConfigDefinitionInput,
+    SearchAppConfigDefinitionsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_definition.response import (
+    AppConfigDefinitionNode,
+    CreateAppConfigDefinitionPayload,
+    PurgeAppConfigDefinitionPayload,
+    SearchAppConfigDefinitionsPayload,
+)
+
+_PATH: Final = "/v2/app-config-definitions"
+
+
+class V2AppConfigDefinitionClient(BaseDomainClient):
+    """SDK client for app config definition operations.
+
+    Mirrors the REST v2 surface introduced in BA-6530. All calls require
+    super-admin privileges; the entity supports create, get, search, and
+    purge (no update or delete).
+    """
+
+    async def admin_create(
+        self,
+        request: CreateAppConfigDefinitionInput,
+    ) -> CreateAppConfigDefinitionPayload:
+        """Register a new app config definition (superadmin only)."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/",
+            request=request,
+            response_model=CreateAppConfigDefinitionPayload,
+        )
+
+    async def admin_search(
+        self,
+        request: SearchAppConfigDefinitionsInput,
+    ) -> SearchAppConfigDefinitionsPayload:
+        """Search app config definitions with filter/order/pagination (superadmin only)."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/search",
+            request=request,
+            response_model=SearchAppConfigDefinitionsPayload,
+        )
+
+    async def admin_get(self, app_config_definition_id: UUID) -> AppConfigDefinitionNode:
+        """Get a single app config definition by ID (superadmin only)."""
+        return await self._client.typed_request(
+            "GET",
+            f"{_PATH}/{app_config_definition_id}",
+            response_model=AppConfigDefinitionNode,
+        )
+
+    async def admin_purge(
+        self,
+        app_config_definition_id: UUID,
+    ) -> PurgeAppConfigDefinitionPayload:
+        """Purge an app config definition by ID (superadmin only)."""
+        return await self._client.typed_request(
+            "DELETE",
+            f"{_PATH}/{app_config_definition_id}",
+            response_model=PurgeAppConfigDefinitionPayload,
+        )

--- a/src/ai/backend/client/v2/v2_registry.py
+++ b/src/ai/backend/client/v2/v2_registry.py
@@ -16,6 +16,7 @@ from .config import ClientConfig
 
 if TYPE_CHECKING:
     from .domains_v2.agent import V2AgentClient
+    from .domains_v2.app_config_definition import V2AppConfigDefinitionClient
     from .domains_v2.artifact import V2ArtifactClient
     from .domains_v2.artifact_registry import V2ArtifactRegistryClient
     from .domains_v2.audit_log import V2AuditLogClient
@@ -88,6 +89,12 @@ class V2ClientRegistry:
         from .domains_v2.agent import V2AgentClient
 
         return V2AgentClient(self._client)
+
+    @cached_property
+    def app_config_definition(self) -> V2AppConfigDefinitionClient:
+        from .domains_v2.app_config_definition import V2AppConfigDefinitionClient
+
+        return V2AppConfigDefinitionClient(self._client)
 
     @cached_property
     def artifact(self) -> V2ArtifactClient:

--- a/tests/unit/client_v2/test_app_config_definition.py
+++ b/tests/unit/client_v2/test_app_config_definition.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+from yarl import URL
+
+from ai.backend.client.v2.base_client import BackendAIAuthClient
+from ai.backend.client.v2.config import ClientConfig
+from ai.backend.client.v2.domains_v2.app_config_definition import V2AppConfigDefinitionClient
+from ai.backend.common.dto.manager.v2.app_config_definition.request import (
+    CreateAppConfigDefinitionInput,
+    SearchAppConfigDefinitionsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_definition.response import (
+    AppConfigDefinitionNode,
+    CreateAppConfigDefinitionPayload,
+    PurgeAppConfigDefinitionPayload,
+    SearchAppConfigDefinitionsPayload,
+)
+
+from .conftest import MockAuth
+
+_DEFAULT_CONFIG = ClientConfig(endpoint=URL("https://api.example.com"))
+
+
+def _make_request_session(resp: AsyncMock) -> MagicMock:
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=resp)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+    mock_session = MagicMock()
+    mock_session.request = MagicMock(return_value=mock_ctx)
+    return mock_session
+
+
+def _make_client(mock_session: MagicMock) -> V2AppConfigDefinitionClient:
+    auth_client = BackendAIAuthClient(_DEFAULT_CONFIG, MockAuth(), mock_session)
+    return V2AppConfigDefinitionClient(auth_client)
+
+
+def _node_payload(definition_id: str, config_name: str) -> dict[str, str]:
+    return {
+        "id": definition_id,
+        "config_name": config_name,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-02T00:00:00+00:00",
+    }
+
+
+class TestAdminCreate:
+    async def test_happy_path(self) -> None:
+        definition_id = str(uuid4())
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(
+            return_value={"app_config_definition": _node_payload(definition_id, "theme")}
+        )
+        mock_session = _make_request_session(mock_resp)
+        client = _make_client(mock_session)
+
+        result = await client.admin_create(CreateAppConfigDefinitionInput(config_name="theme"))
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "POST"
+        assert str(call_args[0][1]).endswith("/v2/app-config-definitions/")
+        assert isinstance(result, CreateAppConfigDefinitionPayload)
+        assert result.app_config_definition.config_name == "theme"
+
+
+class TestAdminSearch:
+    async def test_happy_path(self) -> None:
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(
+            return_value={
+                "items": [_node_payload(str(uuid4()), "menu")],
+                "total_count": 1,
+                "has_next_page": False,
+                "has_previous_page": False,
+            }
+        )
+        mock_session = _make_request_session(mock_resp)
+        client = _make_client(mock_session)
+
+        result = await client.admin_search(SearchAppConfigDefinitionsInput(limit=10))
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "POST"
+        assert "/v2/app-config-definitions/search" in str(call_args[0][1])
+        assert isinstance(result, SearchAppConfigDefinitionsPayload)
+        assert [item.config_name for item in result.items] == ["menu"]
+        assert result.total_count == 1
+
+
+class TestAdminGet:
+    async def test_happy_path(self) -> None:
+        definition_id = uuid4()
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value=_node_payload(str(definition_id), "preferences"))
+        mock_session = _make_request_session(mock_resp)
+        client = _make_client(mock_session)
+
+        result = await client.admin_get(definition_id)
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "GET"
+        assert str(call_args[0][1]).endswith(f"/v2/app-config-definitions/{definition_id}")
+        assert isinstance(result, AppConfigDefinitionNode)
+        assert result.config_name == "preferences"
+
+
+class TestAdminPurge:
+    async def test_happy_path(self) -> None:
+        definition_id = uuid4()
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": str(definition_id)})
+        mock_session = _make_request_session(mock_resp)
+        client = _make_client(mock_session)
+
+        result = await client.admin_purge(definition_id)
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "DELETE"
+        assert str(call_args[0][1]).endswith(f"/v2/app-config-definitions/{definition_id}")
+        assert isinstance(result, PurgeAppConfigDefinitionPayload)
+        assert result.id == definition_id

--- a/tests/unit/client_v2/test_app_config_definition.py
+++ b/tests/unit/client_v2/test_app_config_definition.py
@@ -51,7 +51,7 @@ class TestAdminCreate:
     async def test_happy_path(self) -> None:
         definition_id = str(uuid4())
         mock_resp = AsyncMock()
-        mock_resp.status = 200
+        mock_resp.status = 201
         mock_resp.json = AsyncMock(
             return_value={"app_config_definition": _node_payload(definition_id, "theme")}
         )
@@ -63,6 +63,7 @@ class TestAdminCreate:
         call_args = mock_session.request.call_args
         assert call_args[0][0] == "POST"
         assert str(call_args[0][1]).endswith("/v2/app-config-definitions/")
+        assert call_args.kwargs["json"]["config_name"] == "theme"
         assert isinstance(result, CreateAppConfigDefinitionPayload)
         assert result.app_config_definition.config_name == "theme"
 


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of the AppConfigDefinition stack (BA-6527 → BA-6533). **Merge in order:**

1. ✅ #12263 — `feat(BA-6527): app_config_definitions DB model and Alembic migration` (merged)
2. ✅ #12264 — `feat(BA-6528): AppConfigDefinitionRepository (create/get/search/purge)` (merged)
3. ✅ #12265 — `feat(BA-6529): AppConfigDefinitionService and processors` (merged)
4. ⬇️ #12266 — `feat(BA-6530): AppConfigDefinition REST v2 API`
5. ⬇️ #12267 — `feat(BA-6531): AppConfigDefinition GraphQL API`
6. 👉 **#12268** — `feat(BA-6532 + BA-6533): AppConfigDefinition client SDK v2 & CLI v2` ← you are here

> #12269 (BA-6533 CLI v2) was folded into this PR and closed.

## Summary
- Add the typed client SDK v2 for AppConfigDefinition (`admin_create` / `admin_get` / `admin_search` / `admin_purge`) reusing the shared v2 DTOs.
- Add the CLI v2 commands under `./bai admin app-config-definition` calling the SDK (BA-6533, folded in from #12269).

## CLI Usage

All commands are **superadmin-only** and live under `./bai admin app-config-definition`:

| Command | Description |
| --- | --- |
| `./bai admin app-config-definition create --config-name <name>` | Register a new config name |
| `./bai admin app-config-definition get <UUID>` | Get a single entry by id |
| `./bai admin app-config-definition search [options]` | Search with filter / ordering / pagination |
| `./bai admin app-config-definition purge <UUID>` | Purge an entry by id |

`search` options: `--limit <N>` (default 20), `--offset <N>` (default 0), `--config-name-contains <str>`, `--order-by <field:dir>` (repeatable; `field` ∈ `config_name|created_at|updated_at`, `dir` ∈ `asc|desc`).

```sh
# register a config name
./bai admin app-config-definition create --config-name theme

# get one by id
./bai admin app-config-definition get 0a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9

# search: substring filter + ordering + pagination
./bai admin app-config-definition search \
    --config-name-contains the \
    --order-by created_at:desc \
    --limit 10

# purge by id
./bai admin app-config-definition purge 0a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9
```

Resolves BA-6532.
Resolves BA-6533.
