### PR TITLE
ci(BA-6540): keep graphql-inspector on Node 20 to avoid the forced-Node-24 crash

### DIFF
--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -95,6 +95,13 @@ jobs:
       contents: read
       pull-requests: write
       checks: write
+    env:
+      # The pinned graphql-inspector action declares `runs.using: node20`.
+      # GitHub now force-runs node20 actions on Node 24, where this old bundle
+      # crashes at module load (the job dies at `action/index.js:1` with no
+      # output). Opt back to Node 20 until upstream ships a node24 release
+      # (graphql-hive/graphql-inspector#2948); then bump the pin and drop this.
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     steps:
       - uses: actions/checkout@v6
       - uses: kamilkisiela/graphql-inspector@release-1717403590269

--- a/changes/12271.misc.md
+++ b/changes/12271.misc.md
@@ -1,0 +1,1 @@
+Run the `graphql-inspector` schema-compatibility CI job on Node 20 so it stops crashing under the GitHub-forced Node 24 runtime (the pinned action still targets `node20`).


### PR DESCRIPTION
## Summary
- The pinned `kamilkisiela/graphql-inspector@release-1717403590269` declares `runs.using: node20`. GitHub now force-runs node20 actions on Node 24, where the old action bundle throws at module load — the `graphql-inspector` job dies at `action/index.js:1` with no schema-comparison output, failing every PR that touches `manager/models`, `manager/api`, or `VERSION`.
- The same commit passes/fails purely by time, not code: re-running a commit that passed under Node 20 now fails under the forced Node 24, with zero code change.
- Set `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` on the job to run the action on its declared Node 20 again — GitHub's documented temporary opt-out. No change to the schema-check behavior itself.

Temporary: drop this and bump the action pin once upstream ships a node24 release (graphql-hive/graphql-inspector#2948). Even the latest action releases (through 2026-04-30) still declare `node20`, so a version bump alone does not fix it yet.

Resolves BA-6540.