### PR TITLE
fix(ci): bump graphql-inspector to Node 24 compatible release

### DIFF
--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -95,16 +95,9 @@ jobs:
       contents: read
       pull-requests: write
       checks: write
-    env:
-      # The pinned graphql-inspector action declares `runs.using: node20`.
-      # GitHub now force-runs node20 actions on Node 24, where this old bundle
-      # crashes at module load (the job dies at `action/index.js:1` with no
-      # output). Opt back to Node 20 until upstream ships a node24 release
-      # (graphql-hive/graphql-inspector#2948); then bump the pin and drop this.
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     steps:
       - uses: actions/checkout@v6
-      - uses: kamilkisiela/graphql-inspector@release-1717403590269
+      - uses: graphql-hive/graphql-inspector@release-1781692943029
         with:
           schema: '${{ github.base_ref }}:docs/manager/graphql-reference/schema.graphql'
           rules: |

--- a/changes/12275.misc.md
+++ b/changes/12275.misc.md
@@ -1,0 +1,1 @@
+Bump `graphql-inspector` GitHub Action to `release-1781692943029` (Node 24 compatible) and drop the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` env workaround.


### PR DESCRIPTION
## Summary

- Upstream (`graphql-hive/graphql-inspector`) shipped a Node 24 fix in [release-1781692943029](https://github.com/graphql-hive/graphql-inspector/releases/tag/release-1781692943029) via [PR #2957](https://github.com/graphql-hive/graphql-inspector/pull/2957). Bump the pin.
- Drop the now-unneeded `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` env workaround that was added as a temporary mitigation.
- Reflect the org rename `kamilkisiela/graphql-inspector` → `graphql-hive/graphql-inspector`.

## Why

The previously pinned action (`@release-1717403590269`, 2024-06) crashed at module load on the GitHub Actions runner once Node 20 was deprecated and runners started force-substituting Node 24. Workflow logs showed the job dying at `action/index.js:1` with no further output. The upstream fix ([graphql-hive/graphql-inspector#2948](https://github.com/graphql-hive/graphql-inspector/issues/2948)) landed in `release-1781692943029` — bumping the pin removes the need for the env workaround.

## Test plan

- [ ] CI passes — the `graphql-inspector` job in `update-api-schema.yml` runs the new pinned release on Node 24 without crashing.