### PR TITLE
fix(BA-6536): normalize app proxy subdomains from deployment names

### DIFF
--- a/changes/12276.fix.md
+++ b/changes/12276.fix.md
@@ -1,0 +1,1 @@
+Normalize App Proxy subdomains derived from deployment names so names with dots or non-ASCII characters yield a valid subdomain.

--- a/src/ai/backend/appproxy/coordinator/models/subdomain.py
+++ b/src/ai/backend/appproxy/coordinator/models/subdomain.py
@@ -41,11 +41,13 @@ class SubdomainGenerator:
             # candidate is empty when the preferred == "." or ""
             candidate = self._fallback_subdomain()
 
+        candidate = self._trim(candidate)
+
         if candidate in taken:
             final = self._find_unique_subdomain(candidate, taken)
         else:
             final = candidate
-        return self._trim(final)
+        return final
 
     def _find_unique_subdomain(self, base: Subdomain, taken: Container[Subdomain]) -> Subdomain:
         """Find a unique subdomain by appending a suffix to ``base``."""

--- a/src/ai/backend/appproxy/coordinator/models/subdomain.py
+++ b/src/ai/backend/appproxy/coordinator/models/subdomain.py
@@ -36,16 +36,30 @@ class SubdomainGenerator:
             candidate = self._fallback_subdomain()
         else:
             candidate = self._normalize(preferred)
+
         if not candidate:
+            # candidate is empty when the preferred == "." or ""
             candidate = self._fallback_subdomain()
-        if candidate not in taken:
-            return candidate
-        trimmed = candidate[: _DNS_LABEL_MAX_LENGTH - _UNIQUE_SUFFIX_LENGTH].strip("-")
-        prefix = trimmed or _FALLBACK_PREFIX
+
+        if candidate in taken:
+            final = self._find_unique_subdomain(candidate, taken)
+        else:
+            final = candidate
+        return self._trim(final)
+
+    def _find_unique_subdomain(self, base: Subdomain, taken: Container[Subdomain]) -> Subdomain:
+        """Find a unique subdomain by appending a suffix to ``base``."""
+        # e.g. base "glm-52" -> prefix_candidate "glm-52" -> candidate "glm-52-1a2b3c4d"
+        prefix_candidate = base[: _DNS_LABEL_MAX_LENGTH - _UNIQUE_SUFFIX_LENGTH].strip("-")
+        prefix = prefix_candidate or _FALLBACK_PREFIX
         while True:
-            candidate = Subdomain(f"{prefix}{self._unique_suffix()}")
+            candidate = self._trim(Subdomain(f"{prefix}{self._unique_suffix()}"))
             if candidate not in taken:
                 return candidate
+
+    def _trim(self, candidate: Subdomain) -> Subdomain:
+        """Trim a candidate subdomain to fit within the DNS label limit."""
+        return Subdomain(candidate[:_DNS_LABEL_MAX_LENGTH].strip("-"))
 
     def _normalize(self, raw: Subdomain) -> Subdomain:
         """Convert ``raw`` into a single DNS label usable as a wildcard subdomain.
@@ -72,7 +86,7 @@ class SubdomainGenerator:
         else:
             # Punycode keeps every character within one ASCII label.
             final = "xn--" + text.encode("punycode").decode("ascii")
-        return Subdomain(final[:_DNS_LABEL_MAX_LENGTH].strip("-"))
+        return self._trim(Subdomain(final))
 
     def _fallback_subdomain(self) -> Subdomain:
         """Generate a fallback subdomain when the preferred value is unusable."""

--- a/src/ai/backend/appproxy/coordinator/models/subdomain.py
+++ b/src/ai/backend/appproxy/coordinator/models/subdomain.py
@@ -1,0 +1,83 @@
+import re
+import unicodedata
+import uuid
+from collections.abc import Container
+
+from ai.backend.common.types import Subdomain
+
+__all__ = [
+    "SubdomainGenerator",
+]
+
+# RFC 1123 DNS label: only [a-z0-9-], at most 63 characters, no leading or
+# trailing hyphen. A wildcard certificate (``*.example.com``) only covers a
+# single label, so a subdomain must never contain a dot.
+_DNS_LABEL_MAX_LENGTH = 63
+_LETTER_DIGIT_HYPHEN_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789-")
+_HYPHEN_RUN = re.compile(r"-{2,}")
+# Length reserved for a "-<8 hex>" uniqueness suffix so the suffixed form still
+# fits within the DNS label limit.
+_UNIQUE_SUFFIX_LENGTH = 9
+_FALLBACK_PREFIX = "app"
+
+
+class SubdomainGenerator:
+    """Generate a DNS-label-safe, collision-free wildcard subdomain from an
+    arbitrary deployment/app name.
+
+    Subdomain allocation is solely the coordinator's responsibility; workers
+    consume the resulting string verbatim for routing.
+    """
+
+    def generate_subdomain(
+        self, preferred: Subdomain | None, taken: Container[Subdomain]
+    ) -> Subdomain:
+        if preferred is None:
+            candidate = self._fallback_subdomain()
+        else:
+            candidate = self._normalize(preferred)
+        if not candidate:
+            candidate = self._fallback_subdomain()
+        if candidate not in taken:
+            return candidate
+        trimmed = candidate[: _DNS_LABEL_MAX_LENGTH - _UNIQUE_SUFFIX_LENGTH].strip("-")
+        prefix = trimmed or _FALLBACK_PREFIX
+        while True:
+            candidate = Subdomain(f"{prefix}{self._unique_suffix()}")
+            if candidate not in taken:
+                return candidate
+
+    def _normalize(self, raw: Subdomain) -> Subdomain:
+        """Convert ``raw`` into a single DNS label usable as a wildcard subdomain.
+
+        - Lowercased and Unicode-normalized (NFC).
+        - ``.`` and any other character invalid in a DNS label are replaced with
+          ``-`` so they cannot introduce extra domain levels and fall outside
+          the wildcard certificate.
+        - Non-ASCII characters (e.g. Korean) are Punycode-encoded (the IDNA
+          ``xn--`` form) so the result stays within a single ASCII label.
+        - Trimmed to 63 characters with no leading or trailing hyphen.
+
+        Returns an empty string when nothing usable remains; in that case
+        :meth:`generate_subdomain` falls back to a generated label.
+        """
+        text = unicodedata.normalize("NFC", raw).strip().lower().replace(".", "-")
+        # Replace ASCII characters that are invalid in a DNS label with "-",
+        # while keeping non-ASCII characters so they can be Punycode-encoded.
+        text = "".join(
+            ch if (ch in _LETTER_DIGIT_HYPHEN_CHARS or ord(ch) >= 0x80) else "-" for ch in text
+        )
+        if text.isascii():
+            final = _HYPHEN_RUN.sub("-", text)
+        else:
+            # Punycode keeps every character within one ASCII label.
+            final = "xn--" + text.encode("punycode").decode("ascii")
+        return Subdomain(final[:_DNS_LABEL_MAX_LENGTH].strip("-"))
+
+    def _fallback_subdomain(self) -> Subdomain:
+        """Generate a fallback subdomain when the preferred value is unusable."""
+        return Subdomain(f"{_FALLBACK_PREFIX}{self._unique_suffix()}")
+
+    def _unique_suffix(self) -> str:
+        """Return a short unique suffix for a subdomain."""
+        return f"-{uuid.uuid4().hex}"[:_UNIQUE_SUFFIX_LENGTH]

--- a/src/ai/backend/appproxy/coordinator/models/worker.py
+++ b/src/ai/backend/appproxy/coordinator/models/worker.py
@@ -31,10 +31,12 @@ from ai.backend.appproxy.common.types import (
 )
 from ai.backend.appproxy.coordinator.errors import MissingFrontendConfigError
 from ai.backend.common.exception import UnreachableError
+from ai.backend.common.types import Subdomain
 from ai.backend.logging import BraceStyleAdapter
 
 from .base import GUID, Base, BaseMixin, EnumType, StrEnumType
 from .circuit import Circuit
+from .subdomain import SubdomainGenerator
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -436,17 +438,12 @@ async def add_circuit(
     circuit_params: dict[str, Any] = {}
 
     if worker.frontend_mode == FrontendMode.WILDCARD_DOMAIN:
-        acquired_subdomains = [c.subdomain for c in worker.circuits]
-        if _requested_subdomain := preferred_subdomain:
-            subdomain = _requested_subdomain
-        else:
-            sub_id = str(uuid.uuid4()).split("-")[0]
-            subdomain = f"app-{sub_id}"
-
-        while subdomain in acquired_subdomains:
-            sub_id = str(uuid.uuid4()).split("-")[0]
-            subdomain = f"{_requested_subdomain}-{sub_id}"
-        circuit_params["subdomain"] = subdomain
+        generator = SubdomainGenerator()
+        preferred = Subdomain(preferred_subdomain) if preferred_subdomain else None
+        # Subdomains already taken on this worker; the generator avoids
+        # collisions against them while normalizing the requested name.
+        taken: set[Subdomain] = {Subdomain(c.subdomain) for c in worker.circuits if c.subdomain}
+        circuit_params["subdomain"] = generator.generate_subdomain(preferred, taken)
     else:
         acquired_ports = {c.port for c in worker.circuits}
         port_range = worker.port_range

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -403,6 +403,7 @@ SessionId = NewType("SessionId", UUID)
 KernelId = NewType("KernelId", UUID)
 ImageAlias = NewType("ImageAlias", str)
 ArchName = NewType("ArchName", str)
+Subdomain = NewType("Subdomain", str)
 
 ResourceGroupID = NewType("ResourceGroupID", str)
 AgentId = NewType("AgentId", str)

--- a/tests/unit/appproxy/coordinator/test_subdomain.py
+++ b/tests/unit/appproxy/coordinator/test_subdomain.py
@@ -74,6 +74,15 @@ class TestFallback:
         result = generator.generate_subdomain(Subdomain("..."), set())
         assert result.startswith("app-")
 
+    def test_single_dot_preferred_uses_generated_fallback(
+        self, generator: SubdomainGenerator
+    ) -> None:
+        # "." normalizes to an empty label, so it must fall back rather than
+        # yield an empty subdomain.
+        result = generator.generate_subdomain(Subdomain("."), set())
+        assert result.startswith("app-")
+        assert set(result) <= LDH_CHARS
+
 
 class TestUniqueness:
     def test_returns_normalized_when_not_taken(self, generator: SubdomainGenerator) -> None:

--- a/tests/unit/appproxy/coordinator/test_subdomain.py
+++ b/tests/unit/appproxy/coordinator/test_subdomain.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+
+from ai.backend.appproxy.coordinator.models.subdomain import SubdomainGenerator
+from ai.backend.common.types import Subdomain
+
+LDH_CHARS = set("abcdefghijklmnopqrstuvwxyz0123456789-")
+
+
+@pytest.fixture
+def generator() -> SubdomainGenerator:
+    return SubdomainGenerator()
+
+
+class TestNormalization:
+    """Behavior of name normalization, observed via ``generate_subdomain`` with
+    an empty ``taken`` set so the normalized preferred value is returned as-is.
+    """
+
+    def test_dot_is_replaced_so_it_stays_a_single_label(
+        self, generator: SubdomainGenerator
+    ) -> None:
+        assert generator.generate_subdomain(Subdomain("glm-5.2-fp8"), set()) == "glm-5-2-fp8"
+
+    def test_uppercase_is_lowercased(self, generator: SubdomainGenerator) -> None:
+        assert generator.generate_subdomain(Subdomain("GLM-52"), set()) == "glm-52"
+
+    def test_disallowed_ascii_characters_become_hyphen(self, generator: SubdomainGenerator) -> None:
+        assert generator.generate_subdomain(Subdomain("my_app!name"), set()) == "my-app-name"
+
+    def test_leading_and_trailing_hyphens_are_stripped(self, generator: SubdomainGenerator) -> None:
+        assert generator.generate_subdomain(Subdomain("--foo--"), set()) == "foo"
+
+    def test_hyphen_runs_are_collapsed(self, generator: SubdomainGenerator) -> None:
+        assert generator.generate_subdomain(Subdomain("a...b"), set()) == "a-b"
+
+    def test_non_ascii_is_punycode_encoded(self, generator: SubdomainGenerator) -> None:
+        result = generator.generate_subdomain(Subdomain("한글"), set())
+        assert result.startswith("xn--")
+        assert result.isascii()
+        # The encoded portion round-trips back to the original label.
+        assert result.removeprefix("xn--").encode("ascii").decode("punycode") == "한글"
+
+    def test_mixed_ascii_and_non_ascii_stays_single_ascii_label(
+        self, generator: SubdomainGenerator
+    ) -> None:
+        result = generator.generate_subdomain(Subdomain("glm-한글"), set())
+        assert result.startswith("xn--")
+        assert set(result) <= LDH_CHARS
+
+    def test_result_contains_only_ldh_characters(self, generator: SubdomainGenerator) -> None:
+        assert set(generator.generate_subdomain(Subdomain("Model Service @ v2.0!"), set())) <= (
+            LDH_CHARS
+        )
+
+    def test_length_is_capped_at_63(self, generator: SubdomainGenerator) -> None:
+        assert len(generator.generate_subdomain(Subdomain("a" * 100), set())) == 63
+
+
+class TestFallback:
+    def test_none_preferred_uses_generated_fallback(self, generator: SubdomainGenerator) -> None:
+        result = generator.generate_subdomain(None, set())
+        assert result.startswith("app-")
+        assert set(result) <= LDH_CHARS
+
+    def test_empty_preferred_uses_generated_fallback(self, generator: SubdomainGenerator) -> None:
+        result = generator.generate_subdomain(Subdomain(""), set())
+        assert result.startswith("app-")
+
+    def test_unusable_preferred_uses_generated_fallback(
+        self, generator: SubdomainGenerator
+    ) -> None:
+        result = generator.generate_subdomain(Subdomain("..."), set())
+        assert result.startswith("app-")
+
+
+class TestUniqueness:
+    def test_returns_normalized_when_not_taken(self, generator: SubdomainGenerator) -> None:
+        assert generator.generate_subdomain(Subdomain("glm-52"), set()) == "glm-52"
+
+    def test_appends_suffix_when_taken(self, generator: SubdomainGenerator) -> None:
+        result = generator.generate_subdomain(Subdomain("glm-52"), {Subdomain("glm-52")})
+        assert result != "glm-52"
+        assert result.startswith("glm-52-")
+        assert set(result) <= LDH_CHARS
+
+    def test_suffixed_form_fits_label_limit(self, generator: SubdomainGenerator) -> None:
+        base = Subdomain("a" * 63)
+        result = generator.generate_subdomain(base, {base})
+        assert len(result) <= 63
+        assert result != base


### PR DESCRIPTION
## Summary
- Deployment names are passed verbatim as app proxy wildcard subdomains; a name with a dot (e.g. `glm-5.2-fp8`) or non-ASCII characters yielded an invalid DNS label.
- Add `SubdomainGenerator` (new `Subdomain` type in `common.types`) that folds a name into a single DNS label — lowercase, replace `.`/invalid chars with `-`, Punycode (`xn--`) for non-ASCII, 63-char cap — and returns a collision-free variant against subdomains already taken on the worker.
- Apply it in `add_circuit` for wildcard-domain mode.

## Test plan
- [x] CI: `pants check` / `pants test`
- [x] `tests/unit/appproxy/coordinator/test_subdomain.py`
- [x] Deploy a model with a dotted/non-ASCII name and confirm the issued endpoint URL is a single valid wildcard label

Resolves BA-6536