### PR TITLE
fix(BA-6341): accept session UUID in session REST path parameters

### DIFF
--- a/changes/12277.fix.md
+++ b/changes/12277.fix.md
@@ -1,0 +1,1 @@
+Restore acceptance of a session UUID (in addition to the session name) in the `{session_name}` path of session REST endpoints (e.g. `start-service`, `shutdown-service`), normalizing the reference to the canonical session name at the adapter boundary.

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -85,6 +85,7 @@ from ai.backend.common.identifier.session import SessionID
 from ai.backend.common.types import (
     AgentId,
     KernelId,
+    SessionId,
 )
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.api.utils import undefined
@@ -165,6 +166,9 @@ from ai.backend.manager.services.session.actions.rename_session import (
 )
 from ai.backend.manager.services.session.actions.resolve_session import (
     ResolveSessionAction,
+)
+from ai.backend.manager.services.session.actions.resolve_session_name import (
+    ResolveSessionNameAction,
 )
 from ai.backend.manager.services.session.actions.shutdown_service import (
     ShutdownServiceAction,
@@ -420,6 +424,23 @@ class SessionHandler:
         self._agent = agent
         self._vfolder = vfolder
         self._config_provider = config_provider
+
+    async def _resolve_session_name(self, session_name_or_id: str) -> str:
+        """Normalize a session path reference (name or UUID) to its canonical name.
+
+        Session REST path parameters historically accepted either a session name or
+        its UUID (row_id). Downstream operations are keyed by name, so a UUID-shaped
+        reference is resolved to its real name here; a non-UUID reference is passed
+        through unchanged so the name lookup stays out of the repositories.
+        """
+        try:
+            session_id = SessionId(UUID(session_name_or_id))
+        except (ValueError, TypeError):
+            return session_name_or_id
+        result = await self._session.resolve_session_name.wait_for_complete(
+            ResolveSessionNameAction(session_id=session_id)
+        )
+        return result.session_name
 
     def _require_user_id(self) -> UUID:
         """Return the authenticated user's id from the request context.
@@ -855,7 +876,8 @@ class SessionHandler:
 
     async def get_info(self, ctx: RequestCtx) -> APIResponse:
         request = ctx.request
-        session_name = request.match_info["session_name"]
+        session_name_or_id = request.match_info["session_name"]
+        session_name = await self._resolve_session_name(session_name_or_id)
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
@@ -918,7 +940,8 @@ class SessionHandler:
     ) -> APIResponse:
         request = ctx.request
         params = query.parsed
-        session_name = request.match_info["session_name"]
+        session_name_or_id = request.match_info["session_name"]
+        session_name = await self._resolve_session_name(session_name_or_id)
         user_role = cast(UserRole, request["user"]["role"])
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
@@ -966,7 +989,8 @@ class SessionHandler:
     ) -> APIResponse:
         request = ctx.request
         params = body.parsed
-        session_name = request.match_info["session_name"]
+        session_name_or_id = request.match_info["session_name"]
+        session_name = await self._resolve_session_name(session_name_or_id)
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
@@ -1004,7 +1028,8 @@ class SessionHandler:
 
     async def interrupt(self, ctx: RequestCtx) -> web.Response:
         request = ctx.request
-        session_name = request.match_info["session_name"]
+        session_name_or_id = request.match_info["session_name"]
+        session_name = await self._resolve_session_name(session_name_or_id)
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
@@ -1043,7 +1068,8 @@ class SessionHandler:
     ) -> APIResponse:
         request = ctx.request
         params = body.parsed
-        session_name = request.match_info["session_name"]
+        session_name_or_id = request.match_info["session_name"]
+        session_name = await self._resolve_session_name(session_name_or_id)
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
@@ -1084,7 +1110,8 @@ class SessionHandler:
     ) -> APIResponse:
         request = ctx.request
         params = body.parsed
-        session_name: str = request.match_info["session_name"]
+        session_name_or_id = request.match_info["session_name"]
+        session_name: str = await self._resolve_session_name(session_name_or_id)
         myself = asyncio.current_task()
         if myself is None:
             raise NoCurrentTaskContext("No current task context")
@@ -1118,7 +1145,8 @@ class SessionHandler:
     ) -> web.Response:
         request = ctx.request
         params = body.parsed
-        session_name = request.match_info["session_name"]
+        session_name_or_id = request.match_info["session_name"]
+        session_name = await self._resolve_session_name(session_name_or_id)
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
@@ -1154,7 +1182,8 @@ class SessionHandler:
     async def upload_files(self, ctx: RequestCtx) -> web.Response:
         request = ctx.request
         reader = await request.multipart()
-        session_name = request.match_info["session_name"]
+        session_name_or_id = request.match_info["session_name"]
+        session_name = await self._resolve_session_name(session_name_or_id)
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
@@ -1194,7 +1223,8 @@ class SessionHandler:
     ) -> web.Response:
         request = ctx.request
         params = body.parsed
-        session_name = request.match_info["session_name"]
+        session_name_or_id = request.match_info["session_name"]
+        session_name = await self._resolve_session_name(session_name_or_id)
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
@@ -1232,7 +1262,8 @@ class SessionHandler:
     ) -> web.Response:
         request = ctx.request
         params = query.parsed
-        session_name = request.match_info["session_name"]
+        session_name_or_id = request.match_info["session_name"]
+        session_name = await self._resolve_session_name(session_name_or_id)
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
@@ -1270,7 +1301,8 @@ class SessionHandler:
     ) -> APIResponse:
         request = ctx.request
         params = query.parsed
-        session_name = request.match_info["session_name"]
+        session_name_or_id = request.match_info["session_name"]
+        session_name = await self._resolve_session_name(session_name_or_id)
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
@@ -1308,7 +1340,8 @@ class SessionHandler:
     ) -> web.Response:
         request = ctx.request
         params = body.parsed
-        session_name = request.match_info["session_name"]
+        session_name_or_id = request.match_info["session_name"]
+        session_name = await self._resolve_session_name(session_name_or_id)
         new_name = params.session_name
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
@@ -1346,7 +1379,8 @@ class SessionHandler:
     ) -> APIResponse:
         request = ctx.request
         params = query.parsed
-        session_name: str = request.match_info["session_name"]
+        session_name_or_id = request.match_info["session_name"]
+        session_name: str = await self._resolve_session_name(session_name_or_id)
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
@@ -1385,7 +1419,8 @@ class SessionHandler:
     ) -> APIResponse:
         request = ctx.request
         params = query.parsed
-        session_name: str = request.match_info["session_name"]
+        session_name_or_id = request.match_info["session_name"]
+        session_name: str = await self._resolve_session_name(session_name_or_id)
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
@@ -1429,7 +1464,8 @@ class SessionHandler:
         ctx: RequestCtx,
     ) -> APIResponse:
         request = ctx.request
-        session_name: str = request.match_info["session_name"]
+        session_name_or_id = request.match_info["session_name"]
+        session_name: str = await self._resolve_session_name(session_name_or_id)
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
@@ -1469,7 +1505,8 @@ class SessionHandler:
         ctx: RequestCtx,
     ) -> APIResponse:
         request = ctx.request
-        session_name: str = request.match_info["session_name"]
+        session_name_or_id = request.match_info["session_name"]
+        session_name: str = await self._resolve_session_name(session_name_or_id)
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
@@ -1509,7 +1546,8 @@ class SessionHandler:
     ) -> APIResponse:
         request = ctx.request
         params = query.parsed
-        session_name: str = request.match_info["session_name"]
+        session_name_or_id = request.match_info["session_name"]
+        session_name: str = await self._resolve_session_name(session_name_or_id)
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
@@ -1542,7 +1580,8 @@ class SessionHandler:
 
     async def get_direct_access_info(self, ctx: RequestCtx) -> APIResponse:
         request = ctx.request
-        session_name = request.match_info["session_name"]
+        session_name_or_id = request.match_info["session_name"]
+        session_name = await self._resolve_session_name(session_name_or_id)
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
@@ -1574,7 +1613,8 @@ class SessionHandler:
     ) -> APIResponse:
         request = ctx.request
         params = query.parsed
-        session_name: str = request.match_info["session_name"]
+        session_name_or_id = request.match_info["session_name"]
+        session_name: str = await self._resolve_session_name(session_name_or_id)
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
@@ -1652,7 +1692,8 @@ class SessionHandler:
 
     async def get_dependency_graph(self, ctx: RequestCtx) -> APIResponse:
         request = ctx.request
-        root_session_name = request.match_info["session_name"]
+        session_name_or_id = request.match_info["session_name"]
+        root_session_name = await self._resolve_session_name(session_name_or_id)
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],

--- a/src/ai/backend/manager/repositories/session/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/session/db_source/db_source.py
@@ -113,6 +113,20 @@ class SessionDBSource:
             )
         return rows[0].id
 
+    async def get_session_name(self, session_id: SessionId) -> str:
+        """Return the canonical session name for a session id.
+
+        A session id maps to exactly one row, so this lookup is unambiguous. Used to
+        normalize a UUID-shaped path reference back to its real name; ownership and
+        state checks remain the caller's job.
+        """
+        async with self._db.begin_readonly_session_read_committed() as db_sess:
+            query = sa.select(SessionRow.name).where(SessionRow.id == session_id)
+            name = await db_sess.scalar(query)
+            if name is None:
+                raise SessionNotFound(f"Session with id {session_id} not found")
+            return name
+
     async def get_session_owner(self, session_id: str | SessionId) -> UserData:
         async with self._db.begin_readonly_session_read_committed() as db_sess:
             query = (

--- a/src/ai/backend/manager/repositories/session/repository.py
+++ b/src/ai/backend/manager/repositories/session/repository.py
@@ -55,6 +55,11 @@ class SessionRepository:
         self._db_source = SessionDBSource(db)
 
     @session_repository_resilience.apply()
+    async def get_session_name(self, session_id: SessionId) -> str:
+        """Return the canonical session name for a session id."""
+        return await self._db_source.get_session_name(session_id)
+
+    @session_repository_resilience.apply()
     async def get_session_owner(self, session_id: str | SessionId) -> UserData:
         return await self._db_source.get_session_owner(session_id)
 

--- a/src/ai/backend/manager/services/session/actions/resolve_session_name.py
+++ b/src/ai/backend/manager/services/session/actions/resolve_session_name.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.types import SessionId
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.services.session.base import SessionAction
+
+
+@dataclass
+class ResolveSessionNameAction(SessionAction):
+    session_id: SessionId
+
+    @override
+    def entity_id(self) -> str | None:
+        return str(self.session_id)
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+
+@dataclass
+class ResolveSessionNameActionResult(BaseActionResult):
+    session_name: str
+
+    @override
+    def entity_id(self) -> str | None:
+        return None

--- a/src/ai/backend/manager/services/session/processors.py
+++ b/src/ai/backend/manager/services/session/processors.py
@@ -107,6 +107,10 @@ from ai.backend.manager.services.session.actions.resolve_session import (
     ResolveSessionAction,
     ResolveSessionActionResult,
 )
+from ai.backend.manager.services.session.actions.resolve_session_name import (
+    ResolveSessionNameAction,
+    ResolveSessionNameActionResult,
+)
 from ai.backend.manager.services.session.actions.search import (
     SearchSessionsAction,
     SearchSessionsActionResult,
@@ -172,6 +176,7 @@ class SessionProcessors(AbstractProcessorPackage):
     match_sessions: ActionProcessor[MatchSessionsAction, MatchSessionsActionResult]
     rename_session: ActionProcessor[RenameSessionAction, RenameSessionActionResult]
     resolve_session: ActionProcessor[ResolveSessionAction, ResolveSessionActionResult]
+    resolve_session_name: ActionProcessor[ResolveSessionNameAction, ResolveSessionNameActionResult]
     search_kernels: ActionProcessor[SearchKernelsAction, SearchKernelsActionResult]
     search_sessions: ActionProcessor[SearchSessionsAction, SearchSessionsActionResult]
     search_sessions_in_project: ActionProcessor[
@@ -213,6 +218,7 @@ class SessionProcessors(AbstractProcessorPackage):
         self.list_files = ActionProcessor(service.list_files, action_monitors)
         self.rename_session = ActionProcessor(service.rename_session, action_monitors)
         self.resolve_session = ActionProcessor(service.resolve_session, action_monitors)
+        self.resolve_session_name = ActionProcessor(service.resolve_session_name, action_monitors)
         self.shutdown_service = ActionProcessor(service.shutdown_service, action_monitors)
         self.upload_files = ActionProcessor(service.upload_files, action_monitors)
 
@@ -310,6 +316,7 @@ class SessionProcessors(AbstractProcessorPackage):
             MatchSessionsAction.spec(),
             RenameSessionAction.spec(),
             ResolveSessionAction.spec(),
+            ResolveSessionNameAction.spec(),
             SearchKernelsAction.spec(),
             SearchSessionsAction.spec(),
             SearchSessionsInProjectAction.spec(),

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -201,6 +201,10 @@ from ai.backend.manager.services.session.actions.resolve_session import (
     ResolveSessionAction,
     ResolveSessionActionResult,
 )
+from ai.backend.manager.services.session.actions.resolve_session_name import (
+    ResolveSessionNameAction,
+    ResolveSessionNameActionResult,
+)
 from ai.backend.manager.services.session.actions.search import (
     SearchSessionsAction,
     SearchSessionsActionResult,
@@ -303,6 +307,18 @@ class SessionService:
             action.user_id,
         )
         return ResolveSessionActionResult(session_id=session_id)
+
+    async def resolve_session_name(
+        self, action: ResolveSessionNameAction
+    ) -> ResolveSessionNameActionResult:
+        """Resolve a session id to its canonical session name.
+
+        Callers normalize a UUID-shaped path reference back to a name so that
+        downstream name-keyed operations receive a real name. DO NOT USE THIS FOR
+        NEW DEVELOPMENT — it only bridges the legacy name-or-id path parameter.
+        """
+        session_name = await self._session_repository.get_session_name(action.session_id)
+        return ResolveSessionNameActionResult(session_name=session_name)
 
     async def commit_session(self, action: CommitSessionAction) -> CommitSessionActionResult:
         session_name = action.session_name

--- a/tests/unit/manager/services/session/test_session_service.py
+++ b/tests/unit/manager/services/session/test_session_service.py
@@ -99,6 +99,10 @@ from ai.backend.manager.services.session.actions.rename_session import (
     RenameSessionAction,
     RenameSessionActionResult,
 )
+from ai.backend.manager.services.session.actions.resolve_session_name import (
+    ResolveSessionNameAction,
+    ResolveSessionNameActionResult,
+)
 from ai.backend.manager.services.session.actions.search import SearchSessionsAction
 from ai.backend.manager.services.session.actions.search_kernel import SearchKernelsAction
 from ai.backend.manager.services.session.actions.shutdown_service import (
@@ -1019,6 +1023,43 @@ class TestRenameSession:
 
         with pytest.raises(InvalidAPIParameters):
             await session_service.rename_session(action)
+
+
+class TestResolveSessionName:
+    """Test cases for SessionService.resolve_session_name"""
+
+    async def test_success(
+        self,
+        session_service: SessionService,
+        mock_session_repository: MagicMock,
+        sample_session_id: SessionId,
+    ) -> None:
+        """A session id resolves to its canonical session name."""
+        mock_session_repository.get_session_name = AsyncMock(return_value="test-session")
+
+        result = await session_service.resolve_session_name(
+            ResolveSessionNameAction(session_id=sample_session_id)
+        )
+
+        assert isinstance(result, ResolveSessionNameActionResult)
+        assert result.session_name == "test-session"
+        mock_session_repository.get_session_name.assert_called_once_with(sample_session_id)
+
+    async def test_session_not_found(
+        self,
+        session_service: SessionService,
+        mock_session_repository: MagicMock,
+        sample_session_id: SessionId,
+    ) -> None:
+        """An unknown session id surfaces SessionNotFound from the repository."""
+        mock_session_repository.get_session_name = AsyncMock(
+            side_effect=SessionNotFound("Session not found")
+        )
+
+        with pytest.raises(SessionNotFound):
+            await session_service.resolve_session_name(
+                ResolveSessionNameAction(session_id=sample_session_id)
+            )
 
 
 class TestShutdownService:


### PR DESCRIPTION
## Summary

Session REST handlers read `request.match_info["session_name"]` and passed it straight into name-keyed actions, so a **UUID (row_id)** in the `{session_name}` path segment was rejected with `Session(name=<UUID>) does not exist`. This regressed the legacy (24.09) behavior where the `{session_name}` segment accepted either a session **name or its id** — an API breaking change introduced during the handler-class migration (BA-4723).

Reported on 26.4.4 for `POST /func/session/{UUID}/shutdown-service` and `.../start-service`, but it affects every session handler that takes the `{session_name}` path parameter.

## Changes

- New **pure id→name** action `resolve_session_name` (service + repository `get_session_name(session_id)`), returning the canonical session name for a session id.
- New `SessionHandler._resolve_session_name(session_name_or_id)` helper: resolves a UUID-shaped reference to its real name via the processor, and passes a plain name through unchanged. The UUID/name discrimination lives at the API boundary, not in the repository.
- All ~19 session handlers (`shutdown-service`, `start-service`, `get_info`, `destroy`, `execute`, `rename`, `commit`, `logs`, `files`, `dependency-graph`, …) now normalize the path reference through this helper before downstream lookups.

## Verification

- Unit tests: `resolve_session_name` service (success + `SessionNotFound`).
- Integration (live local cluster, legacy `GET /session/{ref}` via v1 SDK against a RUNNING session):
  - by name → `200`, by UUID → `200`, identical session identity (same `containerId`/`image`/`creationTime`).
  - bogus UUID → correctly rejected.
  - On `main` (without this fix) the UUID reference reproduces `Session does not exist`.

## Notes

- `match_sessions`' existing name-or-id discrimination in the repository is left untouched here; it can be removed once all callers go through the adapter/handler normalization.