### PR TITLE
feat(BA-6503): make CSP nonce injection opt-in via the 'nonce' keyword

### DIFF
--- a/changes/12278.feature.md
+++ b/changes/12278.feature.md
@@ -1,0 +1,1 @@
+Make CSP nonce injection opt-in: a directive receives a per-request nonce only when its source list includes the `'nonce'` keyword, and the nonce is dropped when `'unsafe-inline'` is also present.

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -115,10 +115,15 @@ response_policies = ["set_content_type_nosniff_policy"]
 [security.csp]
 # Content Security Policy (CSP) settings.
 # See https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP for more details.
-# When script-src/style-src are set, the webserver appends a per-request
-# "'nonce-<random>'" to them and renders the same value into index.html. Keep
-# "'self'" in script-src (do NOT use "'strict-dynamic'") so the bundled module
-# script keeps loading.
+# Add "'nonce'" to a directive to opt in to a per-request nonce: the webserver
+# replaces it with "'nonce-<random>'" and renders the same value into index.html.
+# Keep "'self'" in script-src (do NOT use "'strict-dynamic'") so the bundled
+# module script keeps loading. Do NOT combine "'nonce'" with "'unsafe-inline'"
+# in the same directive: a browser ignores "'unsafe-inline'" when a nonce is
+# present, so the webserver drops the nonce in that case. Other unsafe-*
+# keywords ("'unsafe-eval'" etc.) are orthogonal and may coexist with "'nonce'".
+# To let inline scripts in index.html run, opt in with the nonce keyword:
+#   script-src = ["'self'", "'nonce'"]
 default-src = ["'self'"]
 style-src = ["'self'", "'unsafe-inline'"]
 font-src = ["'self'", "data:"]

--- a/configs/webserver/sample.toml
+++ b/configs/webserver/sample.toml
@@ -217,10 +217,13 @@
 
   # Content Security Policy configuration. When set, adds CSP headers to
   # responses to protect against XSS and other injection attacks. Leave unset
-  # (None) to skip CSP headers entirely. When script-src and/or style-src are
-  # set, the webserver appends a per-request "'nonce-<random>'" to those
-  # directives and renders the same value into index.html (the {{nonce}}
-  # placeholders / globalThis.baiNonce).
+  # (None) to skip CSP headers entirely. Any directive that lists the "'nonce'"
+  # keyword opts in to a per-request nonce: the webserver replaces the keyword
+  # with "'nonce-<random>'" and renders the same value into index.html (the
+  # {{nonce}} placeholders / globalThis.baiNonce). A directive that also lists
+  # "'unsafe-inline'" keeps that source and drops the nonce (a browser ignores
+  # "'unsafe-inline'" when a nonce is present); other unsafe-* keywords may
+  # coexist with the nonce.
   # Added in 25.12.0
   [security.csp]
     # CSP default-src directive. Serves as the fallback for other resource types
@@ -248,20 +251,29 @@
     # locations.
     # Added in 25.12.0
     ## font-src = []
-    # CSP script-src directive. Specifies valid sources for JavaScript.
-    # "'unsafe-inline'" allows inline scripts (less secure but often required).
-    # When set, the webserver appends a per-request "'nonce-<random>'" so inline
-    # scripts in index.html are allowed; keep "'self'" and avoid "'strict-
-    # dynamic'" so the bundled module script keeps loading.
+    # CSP script-src directive. Specifies valid sources for JavaScript. Add
+    # "'nonce'" to opt in to a per-request nonce: the webserver replaces it with
+    # "'nonce-<random>'" and renders the same value into index.html so inline
+    # scripts there are allowed. Keep "'self'" and avoid "'strict-dynamic'" so
+    # the bundled module script keeps loading. "'unsafe-inline'" allows inline
+    # scripts instead (less secure); do NOT combine it with "'nonce'" since a
+    # browser ignores "'unsafe-inline'" when a nonce is present, so the
+    # webserver drops the nonce in that case. Other unsafe-* keywords ("'unsafe-
+    # eval'" etc.) are orthogonal and may coexist with "'nonce'". Example:
+    # ["'self'", "'nonce'"].
     # Added in 25.12.0
-    ## script-src = []
-    # CSP style-src directive. Specifies valid sources for stylesheets.
+    ## script-src = ["'self'", "'nonce'"]
+    # CSP style-src directive. Specifies valid sources for stylesheets. Add
+    # "'nonce'" to opt in to a per-request nonce: the webserver replaces it with
+    # "'nonce-<random>'" and renders the same value into index.html so nonce-
+    # aware style injectors (e.g. antd via globalThis.baiNonce) are allowed.
     # "'unsafe-inline'" is often needed for frameworks that inject styles
-    # dynamically. When set, the webserver appends a per-request
-    # "'nonce-<random>'" so nonce-aware style injectors (e.g. antd via
-    # globalThis.baiNonce) are allowed.
+    # dynamically; do NOT combine it with "'nonce'" since a browser ignores
+    # "'unsafe-inline'" when a nonce is present, so the webserver drops the
+    # nonce in that case. Other unsafe-* keywords are orthogonal and may coexist
+    # with "'nonce'". Example: ["'self'", "'nonce'"].
     # Added in 25.12.0
-    ## style-src = []
+    ## style-src = ["'self'", "'nonce'"]
     # CSP frame-src directive. Specifies valid sources for nested browsing
     # contexts using <frame> and <iframe>. Important for embedded content like
     # Jupyter notebooks or app proxies.

--- a/src/ai/backend/web/config/unified.py
+++ b/src/ai/backend/web/config/unified.py
@@ -768,12 +768,20 @@ class CSPConfig(BaseConfigSchema):
         BackendAIConfigMeta(
             description=(
                 "CSP script-src directive. Specifies valid sources for JavaScript. "
-                "\"'unsafe-inline'\" allows inline scripts (less secure but often required). "
-                "When set, the webserver appends a per-request \"'nonce-<random>'\" so inline "
-                "scripts in index.html are allowed; keep \"'self'\" and avoid \"'strict-dynamic'\" "
-                "so the bundled module script keeps loading."
+                "Add \"'nonce'\" to opt in to a per-request nonce: the webserver replaces it "
+                "with \"'nonce-<random>'\" and renders the same value into index.html so inline "
+                "scripts there are allowed. Keep \"'self'\" and avoid \"'strict-dynamic'\" so the "
+                "bundled module script keeps loading. \"'unsafe-inline'\" allows inline scripts "
+                "instead (less secure); do NOT combine it with \"'nonce'\" since a browser ignores "
+                "\"'unsafe-inline'\" when a nonce is present, so the webserver drops the nonce in "
+                "that case. Other unsafe-* keywords (\"'unsafe-eval'\" etc.) are orthogonal and may "
+                "coexist with \"'nonce'\". Example: [\"'self'\", \"'nonce'\"]."
             ),
             added_version="25.12.0",
+            example=ConfigExample(
+                local="""["'self'", "'nonce'"]""",
+                prod="""["'self'", "'nonce'"]""",
+            ),
         ),
     ]
     style_src: Annotated[
@@ -786,11 +794,20 @@ class CSPConfig(BaseConfigSchema):
         BackendAIConfigMeta(
             description=(
                 "CSP style-src directive. Specifies valid sources for stylesheets. "
-                "\"'unsafe-inline'\" is often needed for frameworks that inject styles dynamically. "
-                "When set, the webserver appends a per-request \"'nonce-<random>'\" so nonce-aware "
-                "style injectors (e.g. antd via globalThis.baiNonce) are allowed."
+                "Add \"'nonce'\" to opt in to a per-request nonce: the webserver replaces it "
+                "with \"'nonce-<random>'\" and renders the same value into index.html so nonce-aware "
+                "style injectors (e.g. antd via globalThis.baiNonce) are allowed. "
+                "\"'unsafe-inline'\" is often needed for frameworks that inject styles dynamically; "
+                "do NOT combine it with \"'nonce'\" since a browser ignores \"'unsafe-inline'\" when a "
+                "nonce is present, so the webserver drops the nonce in that case. Other unsafe-* "
+                "keywords are orthogonal and may coexist with \"'nonce'\". "
+                "Example: [\"'self'\", \"'nonce'\"]."
             ),
             added_version="25.12.0",
+            example=ConfigExample(
+                local="""["'self'", "'nonce'"]""",
+                prod="""["'self'", "'nonce'"]""",
+            ),
         ),
     ]
     frame_src: Annotated[
@@ -923,9 +940,12 @@ class SecurityConfig(BaseConfigSchema):
             description=(
                 "Content Security Policy configuration. When set, adds CSP headers to responses "
                 "to protect against XSS and other injection attacks. Leave unset (None) to skip "
-                "CSP headers entirely. When script-src and/or style-src are set, the webserver "
-                "appends a per-request \"'nonce-<random>'\" to those directives and renders the "
-                "same value into index.html (the {{nonce}} placeholders / globalThis.baiNonce)."
+                "CSP headers entirely. Any directive that lists the \"'nonce'\" keyword opts in to a "
+                "per-request nonce: the webserver replaces the keyword with \"'nonce-<random>'\" and "
+                "renders the same value into index.html (the {{nonce}} placeholders / "
+                "globalThis.baiNonce). A directive that also lists \"'unsafe-inline'\" keeps that "
+                "source and drops the nonce (a browser ignores \"'unsafe-inline'\" when a nonce is "
+                "present); other unsafe-* keywords may coexist with the nonce."
             ),
             added_version="25.12.0",
             composite=CompositeType.FIELD,

--- a/src/ai/backend/web/security.py
+++ b/src/ai/backend/web/security.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import secrets
 from collections.abc import Callable, Iterable, Mapping
 from contextvars import ContextVar
@@ -7,6 +8,10 @@ from typing import Self
 
 from aiohttp import web
 from aiohttp.typedefs import Handler
+
+from ai.backend.logging import BraceStyleAdapter
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 type RequestPolicy = Callable[[web.Request], None]
 
@@ -16,7 +21,22 @@ type ResponsePolicy = Callable[[web.StreamResponse], web.StreamResponse]
 # Content-Security-Policy header) and the handler that renders index.html.
 csp_nonce_var: ContextVar[str] = ContextVar("csp_nonce", default="")
 
-_NONCED_CSP_DIRECTIVES = frozenset({"script-src", "style-src"})
+# Opt-in placeholder a directive lists to request the per-request nonce.
+_CSP_NONCE_KEYWORD = "nonce"
+
+# The only CSP keyword a nonce overrides: a browser ignores 'unsafe-inline' once
+# a nonce-source is present, so the two cannot take effect together. Other
+# unsafe-* keywords (unsafe-eval, unsafe-hashes, wasm-unsafe-eval) are
+# orthogonal to nonces and may coexist.
+_CSP_UNSAFE_INLINE_KEYWORD = "unsafe-inline"
+
+
+def _is_nonce_keyword(source: str) -> bool:
+    return source.strip("'") == _CSP_NONCE_KEYWORD
+
+
+def _is_unsafe_inline_keyword(source: str) -> bool:
+    return source.strip("'") == _CSP_UNSAFE_INLINE_KEYWORD
 
 
 @web.middleware
@@ -122,9 +142,7 @@ def csp_policy_builder(csp_config: Mapping[str, list[str] | None]) -> ResponsePo
         for key, value in csp_config.items():
             if not value:
                 continue
-            sources = list(value)
-            if nonce and key in _NONCED_CSP_DIRECTIVES:
-                sources.append(f"'nonce-{nonce}'")
+            sources = _resolve_csp_sources(key, list(value), nonce)
             directives.append(key + " " + " ".join(sources))
         csp_str = "; ".join(directives)
         if csp_str:
@@ -133,6 +151,21 @@ def csp_policy_builder(csp_config: Mapping[str, list[str] | None]) -> ResponsePo
         return response
 
     return policy
+
+
+def _resolve_csp_sources(directive: str, sources: list[str], nonce: str) -> list[str]:
+    if not any(_is_nonce_keyword(source) for source in sources):
+        return sources
+    has_unsafe_inline = any(_is_unsafe_inline_keyword(source) for source in sources)
+    if has_unsafe_inline:
+        log.warning(
+            "CSP directive {} lists both the nonce keyword and 'unsafe-inline'; "
+            "dropping the nonce so 'unsafe-inline' keeps effect.",
+            directive,
+        )
+    if has_unsafe_inline or not nonce:
+        return [source for source in sources if not _is_nonce_keyword(source)]
+    return [f"'nonce-{nonce}'" if _is_nonce_keyword(source) else source for source in sources]
 
 
 def set_content_type_nosniff_policy(response: web.StreamResponse) -> web.StreamResponse:

--- a/tests/unit/webserver/test_security_policy.py
+++ b/tests/unit/webserver/test_security_policy.py
@@ -99,15 +99,17 @@ async def test_set_content_type_nosniff_policy(async_handler: Handler) -> None:
     assert response.headers["X-Content-Type-Options"] == "nosniff"
 
 
-async def test_csp_policy_injects_nonce_into_script_and_style_src(async_handler: Handler) -> None:
+async def test_csp_policy_injects_nonce_into_directives_with_keyword(
+    async_handler: Handler,
+) -> None:
     test_app = web.Application()
     test_app["security_policy"] = SecurityPolicy(
         request_policies=[],
         response_policies=[
             csp_policy_builder({
                 "default-src": ["'self'"],
-                "script-src": ["'self'"],
-                "style-src": ["'self'", "'unsafe-inline'"],
+                "script-src": ["'self'", "'nonce'"],
+                "style-src": ["'self'", "'nonce'"],
             })
         ],
     )
@@ -125,15 +127,82 @@ async def test_csp_policy_injects_nonce_into_script_and_style_src(async_handler:
     assert style_nonce is not None
     # Same nonce is shared across directives within a single request.
     assert script_nonce.group(1) == style_nonce.group(1)
-    # default-src is not a nonce-able directive, so it stays untouched.
+    # The placeholder keyword is replaced in place, not left behind.
+    assert "'nonce'" not in script_directive
+    # default-src has no nonce keyword, so it stays untouched.
     assert _NONCE_RE.search(default_directive) is None
+
+
+async def test_csp_policy_skips_directive_without_nonce_keyword(async_handler: Handler) -> None:
+    test_app = web.Application()
+    test_app["security_policy"] = SecurityPolicy(
+        request_policies=[],
+        response_policies=[csp_policy_builder({"script-src": ["'self'"]})],
+    )
+    request = make_mocked_request("GET", "/", headers={"Host": "localhost"}, app=test_app)
+    response = await security_policy_middleware(request, async_handler)
+
+    assert response.headers["Content-Security-Policy"] == "script-src 'self';"
+
+
+async def test_csp_policy_drops_nonce_when_unsafe_inline_present(
+    async_handler: Handler, caplog: pytest.LogCaptureFixture
+) -> None:
+    test_app = web.Application()
+    test_app["security_policy"] = SecurityPolicy(
+        request_policies=[],
+        response_policies=[
+            csp_policy_builder({"style-src": ["'self'", "'unsafe-inline'", "'nonce'"]})
+        ],
+    )
+    request = make_mocked_request("GET", "/", headers={"Host": "localhost"}, app=test_app)
+    with caplog.at_level("WARNING"):
+        response = await security_policy_middleware(request, async_handler)
+
+    csp = response.headers["Content-Security-Policy"]
+    # The nonce is dropped and the placeholder keyword is removed, but 'unsafe-inline' stays.
+    assert _NONCE_RE.search(csp) is None
+    assert "'nonce'" not in csp
+    assert "'unsafe-inline'" in csp
+    assert any("unsafe-inline" in record.message for record in caplog.records)
+
+
+async def test_csp_policy_keeps_nonce_with_other_unsafe_keywords(async_handler: Handler) -> None:
+    # Only 'unsafe-inline' conflicts with a nonce; 'unsafe-eval' is orthogonal and coexists.
+    test_app = web.Application()
+    test_app["security_policy"] = SecurityPolicy(
+        request_policies=[],
+        response_policies=[
+            csp_policy_builder({"script-src": ["'self'", "'unsafe-eval'", "'nonce'"]})
+        ],
+    )
+    request = make_mocked_request("GET", "/", headers={"Host": "localhost"}, app=test_app)
+    response = await security_policy_middleware(request, async_handler)
+
+    csp = response.headers["Content-Security-Policy"]
+    assert _NONCE_RE.search(csp) is not None
+    assert "'unsafe-eval'" in csp
+    assert "'nonce'" not in csp
+
+
+async def test_csp_policy_nonces_any_directive_with_keyword(async_handler: Handler) -> None:
+    # The nonce keyword is honored regardless of the directive name.
+    test_app = web.Application()
+    test_app["security_policy"] = SecurityPolicy(
+        request_policies=[],
+        response_policies=[csp_policy_builder({"style-src-elem": ["'self'", "'nonce'"]})],
+    )
+    request = make_mocked_request("GET", "/", headers={"Host": "localhost"}, app=test_app)
+    response = await security_policy_middleware(request, async_handler)
+
+    assert _NONCE_RE.search(response.headers["Content-Security-Policy"]) is not None
 
 
 async def test_csp_policy_uses_new_nonce_per_request(async_handler: Handler) -> None:
     test_app = web.Application()
     test_app["security_policy"] = SecurityPolicy(
         request_policies=[],
-        response_policies=[csp_policy_builder({"script-src": ["'self'"]})],
+        response_policies=[csp_policy_builder({"script-src": ["'self'", "'nonce'"]})],
     )
 
     def nonce_of(response: web.StreamResponse) -> str:


### PR DESCRIPTION
## Summary
- CSP nonce is now injected only into directives whose config source list contains the `'nonce'` keyword (replaced in place with `'nonce-<random>'`), instead of always nonce-ing `script-src`/`style-src`.
- A directive that also lists `'unsafe-inline'` keeps that source and drops the nonce (a browser ignores `'unsafe-inline'` once a nonce is present); other unsafe-* keywords (`'unsafe-eval'` etc.) are orthogonal and coexist with the nonce.
- Updated CSP config descriptions/examples (`unified.py`, regenerated `sample.toml`) and the hand-maintained `sample.conf` with the opt-in usage guide.

## Test plan
- [ ] `pants test tests/unit/webserver/test_security_policy.py` (nonce keyword opt-in, no-keyword skip, unsafe-inline drops nonce + warning, unsafe-eval keeps nonce, any-directive keyword)
- [ ] Live: set `script-src = ["'self'", "'nonce'"]`, restart webserver, `curl -I` shows `script-src 'self' 'nonce-...'`
- [ ] Live: set `style-src = ["'self'", "'unsafe-inline'", "'nonce'"]`, header has no nonce + warning logged

> Note: behavior change — deployments relying on the old implicit nonce must now add `'nonce'` to opt in. The feature (25.12.0) is unreleased, so blast radius is minimal.

Resolves BA-6503