### PR TITLE
fix(BA-6341): accept session UUID in streaming session path parameters

### DIFF
--- a/changes/12279.fix.md
+++ b/changes/12279.fix.md
@@ -1,0 +1,1 @@
+Accept a session UUID (`row_id`) as well as the session name in the `{session_name}` path of the streaming endpoints (`/stream/session/{ref}/pty,execute,apps,httpproxy,tcpproxy`).

--- a/src/ai/backend/manager/api/rest/stream/handler.py
+++ b/src/ai/backend/manager/api/rest/stream/handler.py
@@ -46,6 +46,9 @@ from ai.backend.manager.errors.kernel import InvalidStreamMode
 from ai.backend.manager.errors.resource import AppNotFound, NoCurrentTaskContext
 from ai.backend.manager.errors.service import AppServiceStartFailed
 from ai.backend.manager.models.kernel import KernelRow
+from ai.backend.manager.services.session.actions.resolve_session_name import (
+    ResolveSessionNameAction,
+)
 from ai.backend.manager.services.stream.actions.execute_in_stream import ExecuteInStreamAction
 from ai.backend.manager.services.stream.actions.gc_stale_connections import (
     GCStaleConnectionsAction,
@@ -67,6 +70,7 @@ if TYPE_CHECKING:
     from ai.backend.manager.event_dispatcher.handlers.stream_cleanup import (
         StreamCleanupEventHandler,
     )
+    from ai.backend.manager.services.session.processors import SessionProcessors
     from ai.backend.manager.services.stream.processors import StreamProcessors
 
 log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
@@ -101,13 +105,32 @@ class StreamHandler:
         *,
         private_ctx: PrivateContext,
         stream_processors: StreamProcessors,
+        session_processors: SessionProcessors,
         config_provider: ManagerConfigProvider,
         error_monitor: ErrorPluginContext,
     ) -> None:
         self._ctx = private_ctx
         self._stream = stream_processors
+        self._session = session_processors
         self.config_provider = config_provider
         self.error_monitor = error_monitor
+
+    async def _resolve_session_name(self, session_name_or_id: str) -> str:
+        """Normalize a streaming path reference (name or UUID) to its canonical name.
+
+        Streaming path parameters historically accepted either a session name or its
+        UUID (row_id). The downstream streaming lookups are keyed by name, so a
+        UUID-shaped reference is resolved to its real name here; a plain name is
+        passed through unchanged so the name lookup stays out of the repository.
+        """
+        try:
+            session_id = SessionId(uuid.UUID(session_name_or_id))
+        except (ValueError, TypeError):
+            return session_name_or_id
+        result = await self._session.resolve_session_name.wait_for_complete(
+            ResolveSessionNameAction(session_id=session_id)
+        )
+        return result.session_name
 
     # ------------------------------------------------------------------
     # stream_pty (GET /stream/session/{session_name}/pty)
@@ -121,7 +144,8 @@ class StreamHandler:
         request = ctx.request
         app_ctx = self._ctx
         user_id = _require_current_user_id()
-        session_name = path.parsed.session_name
+        session_name_or_id = path.parsed.session_name
+        session_name = await self._resolve_session_name(session_name_or_id)
         api_version = request["api_version"]
         result = await self._stream.get_streaming_session.wait_for_complete(
             GetStreamingSessionAction(session_name=session_name, user_uuid=user_id),
@@ -316,7 +340,8 @@ class StreamHandler:
 
         config = self.config_provider.config
         user_id = _require_current_user_id()
-        session_name = path.parsed.session_name
+        session_name_or_id = path.parsed.session_name
+        session_name = await self._resolve_session_name(session_name_or_id)
         api_version = request["api_version"]
         log.info("STREAM_EXECUTE(s:{0})", session_name)
         session_result = await self._stream.get_streaming_session.wait_for_complete(
@@ -429,7 +454,8 @@ class StreamHandler:
         app_ctx = self._ctx
         rpc_ptask_group = app_ctx.rpc_ptask_group
         user_id = _require_current_user_id()
-        session_name: str = path.parsed.session_name
+        session_name_or_id = path.parsed.session_name
+        session_name: str = await self._resolve_session_name(session_name_or_id)
         params = query.parsed
         service: str = params.app
         myself = asyncio.current_task()
@@ -594,7 +620,8 @@ class StreamHandler:
         ctx: RequestCtx,
     ) -> web.StreamResponse:
         user_id = _require_current_user_id()
-        session_name = path.parsed.session_name
+        session_name_or_id = path.parsed.session_name
+        session_name = await self._resolve_session_name(session_name_or_id)
         result = await self._stream.get_streaming_session.wait_for_complete(
             GetStreamingSessionAction(session_name=session_name, user_uuid=user_id),
         )

--- a/src/ai/backend/manager/api/rest/tree.py
+++ b/src/ai/backend/manager/api/rest/tree.py
@@ -296,6 +296,7 @@ def build_api_routes(
     stream_handler = StreamHandler(
         private_ctx=stream_ctx,
         stream_processors=stream_processors,
+        session_processors=processors.session,
         config_provider=config_provider,
         error_monitor=error_monitor,
     )

--- a/src/ai/backend/manager/repositories/session/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/session/db_source/db_source.py
@@ -113,6 +113,19 @@ class SessionDBSource:
             )
         return rows[0].id
 
+    async def get_session_name(self, session_id: SessionId) -> str:
+        """Return the canonical session name for a session id.
+
+        Used to normalize a UUID-shaped path reference back to its real name;
+        ownership and state checks remain the caller's job.
+        """
+        async with self._db.begin_readonly_session_read_committed() as db_sess:
+            query = sa.select(SessionRow.name).where(SessionRow.id == session_id)
+            name = await db_sess.scalar(query)
+            if name is None:
+                raise SessionNotFound(f"Session with id {session_id} not found")
+            return name
+
     async def get_session_owner(self, session_id: str | SessionId) -> UserData:
         async with self._db.begin_readonly_session_read_committed() as db_sess:
             query = (

--- a/src/ai/backend/manager/repositories/session/repository.py
+++ b/src/ai/backend/manager/repositories/session/repository.py
@@ -55,6 +55,11 @@ class SessionRepository:
         self._db_source = SessionDBSource(db)
 
     @session_repository_resilience.apply()
+    async def get_session_name(self, session_id: SessionId) -> str:
+        """Return the canonical session name for a session id."""
+        return await self._db_source.get_session_name(session_id)
+
+    @session_repository_resilience.apply()
     async def get_session_owner(self, session_id: str | SessionId) -> UserData:
         return await self._db_source.get_session_owner(session_id)
 

--- a/src/ai/backend/manager/services/session/actions/resolve_session_name.py
+++ b/src/ai/backend/manager/services/session/actions/resolve_session_name.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.types import SessionId
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.services.session.base import SessionAction
+
+
+@dataclass
+class ResolveSessionNameAction(SessionAction):
+    session_id: SessionId
+
+    @override
+    def entity_id(self) -> str | None:
+        return str(self.session_id)
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+
+@dataclass
+class ResolveSessionNameActionResult(BaseActionResult):
+    session_name: str
+
+    @override
+    def entity_id(self) -> str | None:
+        return None

--- a/src/ai/backend/manager/services/session/processors.py
+++ b/src/ai/backend/manager/services/session/processors.py
@@ -107,6 +107,10 @@ from ai.backend.manager.services.session.actions.resolve_session import (
     ResolveSessionAction,
     ResolveSessionActionResult,
 )
+from ai.backend.manager.services.session.actions.resolve_session_name import (
+    ResolveSessionNameAction,
+    ResolveSessionNameActionResult,
+)
 from ai.backend.manager.services.session.actions.search import (
     SearchSessionsAction,
     SearchSessionsActionResult,
@@ -172,6 +176,7 @@ class SessionProcessors(AbstractProcessorPackage):
     match_sessions: ActionProcessor[MatchSessionsAction, MatchSessionsActionResult]
     rename_session: ActionProcessor[RenameSessionAction, RenameSessionActionResult]
     resolve_session: ActionProcessor[ResolveSessionAction, ResolveSessionActionResult]
+    resolve_session_name: ActionProcessor[ResolveSessionNameAction, ResolveSessionNameActionResult]
     search_kernels: ActionProcessor[SearchKernelsAction, SearchKernelsActionResult]
     search_sessions: ActionProcessor[SearchSessionsAction, SearchSessionsActionResult]
     search_sessions_in_project: ActionProcessor[
@@ -213,6 +218,7 @@ class SessionProcessors(AbstractProcessorPackage):
         self.list_files = ActionProcessor(service.list_files, action_monitors)
         self.rename_session = ActionProcessor(service.rename_session, action_monitors)
         self.resolve_session = ActionProcessor(service.resolve_session, action_monitors)
+        self.resolve_session_name = ActionProcessor(service.resolve_session_name, action_monitors)
         self.shutdown_service = ActionProcessor(service.shutdown_service, action_monitors)
         self.upload_files = ActionProcessor(service.upload_files, action_monitors)
 
@@ -310,6 +316,7 @@ class SessionProcessors(AbstractProcessorPackage):
             MatchSessionsAction.spec(),
             RenameSessionAction.spec(),
             ResolveSessionAction.spec(),
+            ResolveSessionNameAction.spec(),
             SearchKernelsAction.spec(),
             SearchSessionsAction.spec(),
             SearchSessionsInProjectAction.spec(),

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -201,6 +201,10 @@ from ai.backend.manager.services.session.actions.resolve_session import (
     ResolveSessionAction,
     ResolveSessionActionResult,
 )
+from ai.backend.manager.services.session.actions.resolve_session_name import (
+    ResolveSessionNameAction,
+    ResolveSessionNameActionResult,
+)
 from ai.backend.manager.services.session.actions.search import (
     SearchSessionsAction,
     SearchSessionsActionResult,
@@ -303,6 +307,18 @@ class SessionService:
             action.user_id,
         )
         return ResolveSessionActionResult(session_id=session_id)
+
+    async def resolve_session_name(
+        self, action: ResolveSessionNameAction
+    ) -> ResolveSessionNameActionResult:
+        """Resolve a session id to its canonical session name.
+
+        Callers normalize a UUID-shaped path reference back to a name so that
+        downstream name-keyed operations receive a real name. DO NOT USE THIS FOR
+        NEW DEVELOPMENT — it only bridges the legacy name-or-id path parameter.
+        """
+        session_name = await self._session_repository.get_session_name(action.session_id)
+        return ResolveSessionNameActionResult(session_name=session_name)
 
     async def commit_session(self, action: CommitSessionAction) -> CommitSessionActionResult:
         session_name = action.session_name

--- a/tests/component/stream/conftest.py
+++ b/tests/component/stream/conftest.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.plugin.monitor import ErrorPluginContext
 from ai.backend.common.types import ResourceSlot, SessionId, SessionTypes
+from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.api.rest.middleware import auth as _auth_api
 from ai.backend.manager.api.rest.routing import RouteRegistry
 from ai.backend.manager.api.rest.stream.handler import StreamHandler
@@ -28,7 +29,9 @@ from ai.backend.manager.dependencies.infrastructure.redis import ValkeyClients
 from ai.backend.manager.models.kernel import kernels
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.session.repository import SessionRepository
 from ai.backend.manager.repositories.stream.repository import StreamRepository
+from ai.backend.manager.services.session.service import SessionService, SessionServiceArgs
 from ai.backend.manager.services.stream.processors import StreamProcessors
 from ai.backend.manager.services.stream.service import StreamService
 from ai.backend.testutils.fixtures import DomainFixtureData
@@ -76,9 +79,39 @@ def stream_processors(
 
 
 @pytest.fixture()
+async def session_processors(database_engine: ExtendedAsyncSAEngine) -> Any:
+    """Minimal real resolver for the stream handler.
+
+    Only ``resolve_session_name`` is wired to the real DB (via a real
+    ``SessionRepository``); that is all the stream handler uses to normalize a
+    UUID-shaped path reference to its canonical session name.
+    """
+    repo = SessionRepository(database_engine)
+    service = SessionService(
+        SessionServiceArgs(
+            agent_registry=AsyncMock(),
+            event_fetcher=AsyncMock(),
+            background_task_manager=AsyncMock(),
+            event_hub=AsyncMock(),
+            error_monitor=AsyncMock(),
+            idle_checker_host=AsyncMock(),
+            session_repository=repo,
+            scheduler_repository=AsyncMock(),
+            scheduling_controller=AsyncMock(),
+            appproxy_client_pool=AsyncMock(),
+            user_repository=AsyncMock(),
+        )
+    )
+    processors = MagicMock()
+    processors.resolve_session_name = ActionProcessor(service.resolve_session_name, [])
+    return processors
+
+
+@pytest.fixture()
 def server_module_registries(
     route_deps: RouteDeps,
     stream_processors: StreamProcessors,
+    session_processors: Any,
     config_provider: ManagerConfigProvider,
     error_monitor: ErrorPluginContext,
 ) -> list[RouteRegistry]:
@@ -88,6 +121,7 @@ def server_module_registries(
             StreamHandler(
                 private_ctx=MagicMock(),
                 stream_processors=stream_processors,
+                session_processors=session_processors,
                 config_provider=config_provider,
                 error_monitor=error_monitor,
             ),

--- a/tests/component/stream/test_stream_websocket.py
+++ b/tests/component/stream/test_stream_websocket.py
@@ -25,6 +25,22 @@ class TestStreamWebSocketGetApps:
         app_names = {app.name for app in apps}
         assert app_names == {"jupyter", "ttyd"}
 
+    async def test_get_stream_apps_by_uuid(
+        self,
+        admin_registry: BackendAIClientRegistry,
+        session_seed: SessionSeedData,
+    ) -> None:
+        """Regression (BA-6341): a session UUID (row_id) is accepted in the
+        streaming path and resolves to the same session as its name.
+
+        Before the fix the streaming endpoints looked the session up by name
+        only, so a UUID raised ``Session (name=<UUID>) does not exist``.
+        """
+        result = await admin_registry.streaming.get_stream_apps(str(session_seed.session_id))
+        assert isinstance(result, GetStreamAppsResponse)
+        app_names = {app.name for app in result.root}
+        assert app_names == {"jupyter", "ttyd"}
+
     async def test_get_stream_apps_nonexistent_session(
         self,
         admin_registry: BackendAIClientRegistry,

--- a/tests/component/streaming/conftest.py
+++ b/tests/component/streaming/conftest.py
@@ -88,6 +88,7 @@ def server_module_registries(
             StreamHandler(
                 private_ctx=MagicMock(),
                 stream_processors=stream_processors,
+                session_processors=MagicMock(),
                 config_provider=config_provider,
                 error_monitor=error_monitor,
             ),

--- a/tests/unit/manager/services/session/test_session_service.py
+++ b/tests/unit/manager/services/session/test_session_service.py
@@ -99,6 +99,10 @@ from ai.backend.manager.services.session.actions.rename_session import (
     RenameSessionAction,
     RenameSessionActionResult,
 )
+from ai.backend.manager.services.session.actions.resolve_session_name import (
+    ResolveSessionNameAction,
+    ResolveSessionNameActionResult,
+)
 from ai.backend.manager.services.session.actions.search import SearchSessionsAction
 from ai.backend.manager.services.session.actions.search_kernel import SearchKernelsAction
 from ai.backend.manager.services.session.actions.shutdown_service import (
@@ -1019,6 +1023,43 @@ class TestRenameSession:
 
         with pytest.raises(InvalidAPIParameters):
             await session_service.rename_session(action)
+
+
+class TestResolveSessionName:
+    """Test cases for SessionService.resolve_session_name"""
+
+    async def test_success(
+        self,
+        session_service: SessionService,
+        mock_session_repository: MagicMock,
+        sample_session_id: SessionId,
+    ) -> None:
+        """A session id resolves to its canonical session name."""
+        mock_session_repository.get_session_name = AsyncMock(return_value="test-session")
+
+        result = await session_service.resolve_session_name(
+            ResolveSessionNameAction(session_id=sample_session_id)
+        )
+
+        assert isinstance(result, ResolveSessionNameActionResult)
+        assert result.session_name == "test-session"
+        mock_session_repository.get_session_name.assert_called_once_with(sample_session_id)
+
+    async def test_session_not_found(
+        self,
+        session_service: SessionService,
+        mock_session_repository: MagicMock,
+        sample_session_id: SessionId,
+    ) -> None:
+        """An unknown session id surfaces SessionNotFound from the repository."""
+        mock_session_repository.get_session_name = AsyncMock(
+            side_effect=SessionNotFound("Session not found")
+        )
+
+        with pytest.raises(SessionNotFound):
+            await session_service.resolve_session_name(
+                ResolveSessionNameAction(session_id=sample_session_id)
+            )
 
 
 class TestShutdownService:


### PR DESCRIPTION
## Summary

The streaming endpoints — `GET /stream/session/{session_name}/{pty,execute,apps,httpproxy,tcpproxy}` — resolved the `{session_name}` path segment with a **name-only** lookup (`StreamRepository.get_streaming_session` → `SessionRow.name == session_name`). So a **UUID (row_id)** was rejected with `Session (name=<UUID>) does not exist` — exactly the error in BA-6341.

The desktop (**Electron**) build forces the **v1 local wsproxy** (`useBackendAIAppLauncher` → Electron ⇒ `'v1'`), whose local proxy (`src/wsproxy/lib/console-appproxy.js`) launches in-session apps via `/stream/session/{session.row_id}/httpproxy`. Because that path carries the **UUID**, in-session app access broke on the desktop app. (The REST `/session/{ref}/...` endpoints were never broken — they resolve UUID via `match_sessions`.)

## Changes

- New pure **id→name** `resolve_session_name` action in the stream service + `StreamRepository.get_session_name(session_id)`.
- `StreamHandler._resolve_session_name(session_name_or_id)` helper: resolves a UUID-shaped reference to its real name via the processor, passes a plain name through unchanged. The UUID/name discrimination lives at the handler boundary; the repository keeps its name-only lookup.
- Applied at all four streaming handlers (`stream_pty`, `stream_execute`, `stream_proxy`, `get_stream_apps`).

## Verification

- Unit: stream-service `resolve_session_name` (success + `SessionNotFound`).
- Live (local cluster, RUNNING session, the exact desktop path `GET /func/stream/session/{ref}/httpproxy?app=ttyd`):
  - by **name** → `WS 101` (connected), by **UUID** → `WS 101` (connected). Before the fix, UUID → `Session (name=<UUID>)`.
  - Reproduced the pre-fix failure on the deployed node (rc9): name → `101`, UUID → `502` (handshake), and a non-existent UUID returns the `Session (name=…)` format that matches this lookup.