### PR TITLE
fix(BA-6542): sync desired_replicas with replicas on manual scale

### DIFF
--- a/changes/12282.fix.md
+++ b/changes/12282.fix.md
@@ -1,0 +1,1 @@
+Sync `desired_replicas` with `replicas` on manual deployment scaling so a stale desired replica count no longer overrides the requested count and blocks scale-up.

--- a/src/ai/backend/manager/repositories/deployment/updaters/deployment.py
+++ b/src/ai/backend/manager/repositories/deployment/updaters/deployment.py
@@ -52,8 +52,11 @@ class ReplicaSpecUpdaterSpec(UpdaterSpec[EndpointRow]):
     @override
     def build_values(self) -> dict[str, Any]:
         to_update: dict[str, Any] = {}
-        # Use the actual database column names
+        # Use the actual database column names. The scaling goal is
+        # COALESCE(desired_replicas, replicas), so a manual scale must update
+        # desired_replicas too; otherwise a stale desired_replicas overrides it.
         self.replica_count.update_dict(to_update, "replicas")
+        self.replica_count.update_dict(to_update, "desired_replicas")
         return to_update
 
 

--- a/tests/unit/manager/repositories/deployment/test_deployment_repository.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_repository.py
@@ -2076,6 +2076,9 @@ class TestDeploymentRevisionOperations:
             endpoint = result.scalar_one()
             assert endpoint.name == new_name
             assert endpoint.replicas == new_replica_count
+            # Manual scale syncs desired_replicas so the COALESCE(desired_replicas,
+            # replicas) scaling goal reflects the new count immediately.
+            assert endpoint.desired_replicas == new_replica_count
 
     async def test_retire_replica_groups_on_destroy(
         self,

--- a/tests/unit/manager/repositories/deployment/test_replica_spec_updater_spec.py
+++ b/tests/unit/manager/repositories/deployment/test_replica_spec_updater_spec.py
@@ -1,0 +1,26 @@
+"""Unit tests for the replica spec updater build_values()."""
+
+from ai.backend.manager.repositories.deployment.updaters.deployment import (
+    ReplicaSpecUpdaterSpec,
+)
+from ai.backend.manager.types import OptionalState
+
+
+def test_replica_spec_build_values_empty_when_no_fields_set() -> None:
+    assert ReplicaSpecUpdaterSpec().build_values() == {}
+
+
+def test_replica_spec_build_values_syncs_replicas_and_desired_replicas() -> None:
+    # A manual scale must write desired_replicas alongside replicas; the scaling
+    # goal is COALESCE(desired_replicas, replicas), so a stale desired_replicas
+    # would otherwise override the new count (BA-6542).
+    spec = ReplicaSpecUpdaterSpec(
+        replica_count=OptionalState.update(5),
+    )
+
+    values = spec.build_values()
+
+    assert values == {
+        "replicas": 5,
+        "desired_replicas": 5,
+    }


### PR DESCRIPTION
## Summary
- Manual replica scaling (`updateModelDeployment` GQL and REST v2 `--replicas`) only wrote `endpoints.replicas`, but the scaling goal is `COALESCE(desired_replicas, replicas)`. A stale concrete `desired_replicas` (e.g. left from a past scale-to-0 or a removed autoscaling rule) silently overrode the manual value, so the deployment never scaled (observed on demo `gpt-oss-120b`: setting `replicaCount: 1` left `desiredReplicaCount: 0`).
- `ReplicaSpecUpdaterSpec.build_values()` now writes `desired_replicas` alongside `replicas`, so a manual scale takes effect immediately without depending on the async replica recalc. Covers both REST and GraphQL since both funnel through this spec.

## Test plan
- [x] `pants fmt/fix/lint/check` on changed files
- [x] New unit test `test_replica_spec_updater_spec.py` (build_values writes both fields)
- [x] Repository test `test_update_endpoint_returns_updated_deployment_info` asserts `desired_replicas` is synced
- [ ] CI: component `TestReplicaManagement.test_change_replica_count`

Resolves BA-6542