### PR TITLE
feat(BA-6543): add app_config_allow_list DB model and Alembic migration

### DIFF
--- a/changes/12289.feature.md
+++ b/changes/12289.feature.md
@@ -1,0 +1,1 @@
+Add the `app_config_allow_list` DB model and Alembic migration (BEP-1052).

--- a/src/ai/backend/common/identifier/app_config_allow_list.py
+++ b/src/ai/backend/common/identifier/app_config_allow_list.py
@@ -1,0 +1,7 @@
+from typing import NewType
+from uuid import UUID
+
+__all__ = ("AppConfigAllowListID",)
+
+
+AppConfigAllowListID = NewType("AppConfigAllowListID", UUID)

--- a/src/ai/backend/manager/data/app_config_allow_list/types.py
+++ b/src/ai/backend/manager/data/app_config_allow_list/types.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+from datetime import datetime
+
+from ai.backend.common.identifier.app_config_allow_list import AppConfigAllowListID
+
+
+class AppConfigScopeType(enum.StrEnum):
+    """Scope at which an app config fragment may be written (BEP-1052)."""
+
+    PUBLIC = "public"
+    DOMAIN = "domain"
+    USER = "user"
+
+
+@dataclass(frozen=True)
+class AppConfigAllowListData:
+    """Domain data for one app config allow-list entry — a per-``(config_name, scope_type)`` write gate."""
+
+    id: AppConfigAllowListID
+    config_name: str
+    scope_type: AppConfigScopeType
+    created_at: datetime
+    updated_at: datetime

--- a/src/ai/backend/manager/models/alembic/versions/2d6443ac0d4a_create_app_config_allow_list_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/2d6443ac0d4a_create_app_config_allow_list_table.py
@@ -1,0 +1,59 @@
+"""create app_config_allow_list table
+
+Introduce ``app_config_allow_list`` — the per-``(config_name, scope_type)``
+write gate (BEP-1052). A config fragment at a given ``(config_name,
+scope_type)`` may be written only if a row exists here; admins pre-configure
+these. ``config_name`` is a foreign key into ``app_config_definitions`` so an
+entry may only reference a registered config name.
+
+Revision ID: 2d6443ac0d4a
+Revises: 9fc9e6bfe695
+Create Date: 2026-06-18
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.base import IDColumn
+
+# revision identifiers, used by Alembic.
+revision = "2d6443ac0d4a"
+down_revision = "9fc9e6bfe695"
+# Part of: 26.5.0
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "app_config_allow_list",
+        IDColumn(),
+        sa.Column("config_name", sa.String(length=128), nullable=False),
+        sa.Column("scope_type", sa.String(length=64), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["config_name"],
+            ["app_config_definitions.config_name"],
+            name="fk_app_config_allow_list_config_name",
+            ondelete="NO ACTION",
+        ),
+        sa.UniqueConstraint(
+            "config_name", "scope_type", name="uq_app_config_allow_list_config_name_scope_type"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("app_config_allow_list")

--- a/src/ai/backend/manager/models/alembic/versions/2d6443ac0d4a_create_app_config_allow_list_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/2d6443ac0d4a_create_app_config_allow_list_table.py
@@ -1,10 +1,11 @@
 """create app_config_allow_list table
 
-Introduce ``app_config_allow_list`` — the per-``(config_name, scope_type)``
-write gate (BEP-1052). A config fragment at a given ``(config_name,
-scope_type)`` may be written only if a row exists here; admins pre-configure
-these. ``config_name`` is a foreign key into ``app_config_definitions`` so an
-entry may only reference a registered config name.
+Introduce ``app_config_allow_list`` (BEP-1052). Each row grants permission to
+write config fragments for one ``(config_name, scope_type)``: a config fragment
+at that ``(config_name, scope_type)`` may be created, updated, or purged only if
+a row exists here, and admins pre-configure these rows. ``config_name`` is a
+foreign key into ``app_config_definitions`` so an entry may only reference a
+registered config name.
 
 Revision ID: 2d6443ac0d4a
 Revises: 9fc9e6bfe695

--- a/src/ai/backend/manager/models/app_config_allow_list/__init__.py
+++ b/src/ai/backend/manager/models/app_config_allow_list/__init__.py
@@ -1,0 +1,3 @@
+from .row import AppConfigAllowListRow
+
+__all__ = ("AppConfigAllowListRow",)

--- a/src/ai/backend/manager/models/app_config_allow_list/row.py
+++ b/src/ai/backend/manager/models/app_config_allow_list/row.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ai.backend.common.identifier.app_config_allow_list import AppConfigAllowListID
+from ai.backend.manager.data.app_config_allow_list.types import (
+    AppConfigAllowListData,
+    AppConfigScopeType,
+)
+from ai.backend.manager.models.base import GUID, Base, StrEnumType
+
+__all__ = ("AppConfigAllowListRow",)
+
+
+class AppConfigAllowListRow(Base):  # type: ignore[misc]
+    """One per-``(config_name, scope_type)`` write gate (admin-managed)."""
+
+    __tablename__ = "app_config_allow_list"
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "config_name", "scope_type", name="uq_app_config_allow_list_config_name_scope_type"
+        ),
+    )
+
+    id: Mapped[AppConfigAllowListID] = mapped_column(
+        "id",
+        GUID(AppConfigAllowListID),
+        primary_key=True,
+        server_default=sa.text("uuid_generate_v4()"),
+    )
+    config_name: Mapped[str] = mapped_column(
+        "config_name",
+        sa.String(length=128),
+        sa.ForeignKey("app_config_definitions.config_name", ondelete="NO ACTION"),
+        nullable=False,
+    )
+    scope_type: Mapped[AppConfigScopeType] = mapped_column(
+        "scope_type",
+        StrEnumType(AppConfigScopeType),
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        "created_at",
+        sa.DateTime(timezone=True),
+        server_default=sa.func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        "updated_at",
+        sa.DateTime(timezone=True),
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+        nullable=False,
+    )
+
+    def to_data(self) -> AppConfigAllowListData:
+        return AppConfigAllowListData(
+            id=self.id,
+            config_name=self.config_name,
+            scope_type=self.scope_type,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+        )

--- a/src/ai/backend/manager/models/app_config_allow_list/row.py
+++ b/src/ai/backend/manager/models/app_config_allow_list/row.py
@@ -16,7 +16,13 @@ __all__ = ("AppConfigAllowListRow",)
 
 
 class AppConfigAllowListRow(Base):  # type: ignore[misc]
-    """One per-``(config_name, scope_type)`` write gate (admin-managed)."""
+    """Permission to write config fragments for one config name at one scope type.
+
+    A config fragment may be created, updated, or purged only when a matching row
+    exists here; without one, the write is rejected. Reads never consult this table.
+    There is at most one row per ``(config_name, scope_type)``, and only admins
+    create or remove these rows.
+    """
 
     __tablename__ = "app_config_allow_list"
     __table_args__ = (


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of the AppConfigAllowList stack (BA-6543 → BA-6548), built on `main`. **Merge in order:**

1. 👉 **#12289** — `feat(BA-6543): app_config_allow_list DB model and Alembic migration` ← you are here
2. ⬇️ #12290 — `feat(BA-6544): repository layer`
3. ⬇️ #12292 — `feat(BA-6545): service layer (actions, processors)`
4. ⬇️ #12293 — `feat(BA-6546): REST v2 API`
5. ⬇️ #12296 — `feat(BA-6547): GraphQL API (Strawberry)`
6. ⬇️ #12298 — `feat(BA-6548): client SDK v2 & CLI v2`

## Summary
- Add the `app_config_allow_list` table (BEP-1052): the per-`(config_name, scope_type)` write gate.
  - `config_name` — FK → `app_config_definitions.config_name` (`ON DELETE NO ACTION`).
  - `scope_type` — one of `public | domain | user` (`AppConfigScopeType`, stored as VARCHAR).
  - `created_at` / `updated_at`; UNIQUE `(config_name, scope_type)`.
- Add the `AppConfigAllowListRow` model, the `AppConfigAllowListData` value object, and the `AppConfigAllowListID` identifier.
- The Alembic migration chains off the current head (`9fc9e6bfe695`, app_config_definitions).

Constraint behavior (FK/unique) is covered by the upcoming repository-layer tests (BA-6544), mirroring how the AppConfigDefinition table was exercised.

Resolves BA-6543.


