### PR TITLE
feat(BA-6544): add app_config_allow_list repository layer

### DIFF
--- a/changes/12290.feature.md
+++ b/changes/12290.feature.md
@@ -1,0 +1,1 @@
+Add the app_config_allow_list repository layer (create / get / search / purge).

--- a/src/ai/backend/manager/data/app_config_allow_list/types.py
+++ b/src/ai/backend/manager/data/app_config_allow_list/types.py
@@ -24,3 +24,13 @@ class AppConfigAllowListData:
     scope_type: AppConfigScopeType
     created_at: datetime
     updated_at: datetime
+
+
+@dataclass(frozen=True)
+class AppConfigAllowListSearchResult:
+    """Search result with total count for app config allow-list entries."""
+
+    items: list[AppConfigAllowListData]
+    total_count: int
+    has_next_page: bool
+    has_previous_page: bool

--- a/src/ai/backend/manager/errors/app_config.py
+++ b/src/ai/backend/manager/errors/app_config.py
@@ -2,9 +2,17 @@ from __future__ import annotations
 
 from ai.backend.manager.errors.common import ObjectNotFound
 
-__all__ = ("AppConfigDefinitionNotFound",)
+__all__ = (
+    "AppConfigAllowListNotFound",
+    "AppConfigDefinitionNotFound",
+)
 
 
 class AppConfigDefinitionNotFound(ObjectNotFound):
     error_type = "https://api.backend.ai/probs/app-config-definition-not-found"
     object_name = "app config definition"
+
+
+class AppConfigAllowListNotFound(ObjectNotFound):
+    error_type = "https://api.backend.ai/probs/app-config-allow-list-not-found"
+    object_name = "app config allow-list entry"

--- a/src/ai/backend/manager/models/app_config_allow_list/conditions.py
+++ b/src/ai/backend/manager/models/app_config_allow_list/conditions.py
@@ -1,0 +1,173 @@
+"""Query conditions for app config allow-list rows."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from datetime import datetime
+
+import sqlalchemy as sa
+
+from ai.backend.common.data.filter_specs import StringMatchSpec
+from ai.backend.manager.data.app_config_allow_list.types import AppConfigScopeType
+from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
+from ai.backend.manager.models.condition_utils import make_string_in_factory
+from ai.backend.manager.repositories.base import QueryCondition
+
+__all__ = ("AppConfigAllowListConditions",)
+
+
+class AppConfigAllowListConditions:
+    @staticmethod
+    def by_config_name_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AppConfigAllowListRow.config_name.ilike(f"%{spec.value}%")
+            else:
+                condition = AppConfigAllowListRow.config_name.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_config_name_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = sa.func.lower(AppConfigAllowListRow.config_name) == spec.value.lower()
+            else:
+                condition = AppConfigAllowListRow.config_name == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_config_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AppConfigAllowListRow.config_name.ilike(f"{spec.value}%")
+            else:
+                condition = AppConfigAllowListRow.config_name.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_config_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AppConfigAllowListRow.config_name.ilike(f"%{spec.value}")
+            else:
+                condition = AppConfigAllowListRow.config_name.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    by_config_name_in = staticmethod(make_string_in_factory(AppConfigAllowListRow.config_name))
+
+    # --- scope_type filters ---
+
+    @staticmethod
+    def by_scope_type_equals(scope_type: AppConfigScopeType) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigAllowListRow.scope_type == scope_type
+
+        return inner
+
+    @staticmethod
+    def by_scope_type_in(scope_types: Sequence[AppConfigScopeType]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigAllowListRow.scope_type.in_(list(scope_types))
+
+        return inner
+
+    # --- cursor (created_at-based) pagination ---
+
+    @staticmethod
+    def by_cursor_forward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for forward pagination (after cursor).
+
+        Uses subquery to get created_at of the cursor row and compare.
+        """
+        cursor_uuid = uuid.UUID(cursor_id)
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            subquery = (
+                sa.select(AppConfigAllowListRow.created_at)
+                .where(AppConfigAllowListRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return AppConfigAllowListRow.created_at < subquery
+
+        return inner
+
+    @staticmethod
+    def by_cursor_backward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for backward pagination (before cursor).
+
+        Uses subquery to get created_at of the cursor row and compare.
+        """
+        cursor_uuid = uuid.UUID(cursor_id)
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            subquery = (
+                sa.select(AppConfigAllowListRow.created_at)
+                .where(AppConfigAllowListRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return AppConfigAllowListRow.created_at > subquery
+
+        return inner
+
+    # --- created_at datetime filters ---
+
+    @staticmethod
+    def by_created_at_before(dt: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigAllowListRow.created_at < dt
+
+        return inner
+
+    @staticmethod
+    def by_created_at_after(dt: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigAllowListRow.created_at > dt
+
+        return inner
+
+    @staticmethod
+    def by_created_at_equals(dt: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigAllowListRow.created_at == dt
+
+        return inner
+
+    # --- updated_at datetime filters ---
+
+    @staticmethod
+    def by_updated_at_before(dt: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigAllowListRow.updated_at < dt
+
+        return inner
+
+    @staticmethod
+    def by_updated_at_after(dt: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigAllowListRow.updated_at > dt
+
+        return inner
+
+    @staticmethod
+    def by_updated_at_equals(dt: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigAllowListRow.updated_at == dt
+
+        return inner

--- a/src/ai/backend/manager/models/app_config_allow_list/orders.py
+++ b/src/ai/backend/manager/models/app_config_allow_list/orders.py
@@ -1,0 +1,40 @@
+"""Query orders for app config allow-list rows."""
+
+from __future__ import annotations
+
+from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
+from ai.backend.manager.repositories.base import QueryOrder
+
+__all__ = ("AppConfigAllowListOrders",)
+
+
+class AppConfigAllowListOrders:
+    @staticmethod
+    def id(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AppConfigAllowListRow.id.asc()
+        return AppConfigAllowListRow.id.desc()
+
+    @staticmethod
+    def config_name(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AppConfigAllowListRow.config_name.asc()
+        return AppConfigAllowListRow.config_name.desc()
+
+    @staticmethod
+    def scope_type(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AppConfigAllowListRow.scope_type.asc()
+        return AppConfigAllowListRow.scope_type.desc()
+
+    @staticmethod
+    def created_at(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AppConfigAllowListRow.created_at.asc()
+        return AppConfigAllowListRow.created_at.desc()
+
+    @staticmethod
+    def updated_at(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AppConfigAllowListRow.updated_at.asc()
+        return AppConfigAllowListRow.updated_at.desc()

--- a/src/ai/backend/manager/repositories/app_config_allow_list/__init__.py
+++ b/src/ai/backend/manager/repositories/app_config_allow_list/__init__.py
@@ -1,0 +1,3 @@
+from .repository import AppConfigAllowListRepository
+
+__all__ = ("AppConfigAllowListRepository",)

--- a/src/ai/backend/manager/repositories/app_config_allow_list/creators.py
+++ b/src/ai/backend/manager/repositories/app_config_allow_list/creators.py
@@ -1,0 +1,22 @@
+"""CreatorSpec implementations for app config allow-list repository."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.manager.data.app_config_allow_list.types import AppConfigScopeType
+from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
+from ai.backend.manager.repositories.base import CreatorSpec
+
+
+@dataclass
+class AppConfigAllowListCreatorSpec(CreatorSpec[AppConfigAllowListRow]):
+    """CreatorSpec for an app config allow-list entry."""
+
+    config_name: str
+    scope_type: AppConfigScopeType
+
+    @override
+    def build_row(self) -> AppConfigAllowListRow:
+        return AppConfigAllowListRow(config_name=self.config_name, scope_type=self.scope_type)

--- a/src/ai/backend/manager/repositories/app_config_allow_list/db_source/__init__.py
+++ b/src/ai/backend/manager/repositories/app_config_allow_list/db_source/__init__.py
@@ -1,0 +1,3 @@
+from .db_source import AppConfigAllowListDBSource
+
+__all__ = ("AppConfigAllowListDBSource",)

--- a/src/ai/backend/manager/repositories/app_config_allow_list/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_allow_list/db_source/db_source.py
@@ -46,13 +46,11 @@ class AppConfigAllowListDBSource:
                 )
             return result.row.to_data()
 
-    async def purge(self, allow_list_id: AppConfigAllowListID) -> AppConfigAllowListData:
+    async def purge(self, purger: Purger[AppConfigAllowListRow]) -> AppConfigAllowListData:
         async with self._ops.write_ops() as w:
-            result = await w.purge(Purger(row_class=AppConfigAllowListRow, pk_value=allow_list_id))
+            result = await w.purge(purger)
             if result is None:
-                raise AppConfigAllowListNotFound(
-                    f"App config allow-list entry {allow_list_id} not found"
-                )
+                raise AppConfigAllowListNotFound("App config allow-list entry not found")
             return result.row.to_data()
 
     async def search(self, querier: BatchQuerier) -> AppConfigAllowListSearchResult:

--- a/src/ai/backend/manager/repositories/app_config_allow_list/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_allow_list/db_source/db_source.py
@@ -1,7 +1,8 @@
 """Database source for app config allow-list repository operations.
 
 Each public method binds its work to a single session through the injected
-``DBOpsProvider`` and builds the spec/wrapper it needs internally.
+``DBOpsProvider``. The caller passes in the spec
+(``Creator``/``Purger``/``BatchQuerier``) that scopes the operation.
 """
 
 from __future__ import annotations

--- a/src/ai/backend/manager/repositories/app_config_allow_list/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_allow_list/db_source/db_source.py
@@ -1,0 +1,67 @@
+"""Database source for app config allow-list repository operations.
+
+Each public method binds its work to a single session through the injected
+``DBOpsProvider`` and builds the spec/wrapper it needs internally.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from ai.backend.common.identifier.app_config_allow_list import AppConfigAllowListID
+from ai.backend.manager.data.app_config_allow_list.types import (
+    AppConfigAllowListData,
+    AppConfigAllowListSearchResult,
+)
+from ai.backend.manager.errors.app_config import AppConfigAllowListNotFound
+from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
+from ai.backend.manager.repositories.base import BatchQuerier, Creator, Purger, Querier
+from ai.backend.manager.repositories.ops import DBOpsProvider
+
+__all__ = ("AppConfigAllowListDBSource",)
+
+
+class AppConfigAllowListDBSource:
+    """Database source for app config allow-list operations."""
+
+    _ops: DBOpsProvider
+
+    def __init__(self, ops_provider: DBOpsProvider) -> None:
+        self._ops = ops_provider
+
+    async def create(
+        self,
+        creator: Creator[AppConfigAllowListRow],
+    ) -> AppConfigAllowListData:
+        async with self._ops.write_ops() as w:
+            created = await w.create(creator)
+            return created.row.to_data()
+
+    async def get_by_id(self, allow_list_id: AppConfigAllowListID) -> AppConfigAllowListData:
+        async with self._ops.read_ops() as r:
+            result = await r.query(Querier(row_class=AppConfigAllowListRow, pk_value=allow_list_id))
+            if result is None:
+                raise AppConfigAllowListNotFound(
+                    f"App config allow-list entry {allow_list_id} not found"
+                )
+            return result.row.to_data()
+
+    async def purge(self, allow_list_id: AppConfigAllowListID) -> AppConfigAllowListData:
+        async with self._ops.write_ops() as w:
+            result = await w.purge(Purger(row_class=AppConfigAllowListRow, pk_value=allow_list_id))
+            if result is None:
+                raise AppConfigAllowListNotFound(
+                    f"App config allow-list entry {allow_list_id} not found"
+                )
+            return result.row.to_data()
+
+    async def search(self, querier: BatchQuerier) -> AppConfigAllowListSearchResult:
+        async with self._ops.read_ops() as r:
+            result = await r.batch_query_in_global(sa.select(AppConfigAllowListRow), querier)
+            items = [row.AppConfigAllowListRow.to_data() for row in result.rows]
+            return AppConfigAllowListSearchResult(
+                items=items,
+                total_count=result.total_count,
+                has_next_page=result.has_next_page,
+                has_previous_page=result.has_previous_page,
+            )

--- a/src/ai/backend/manager/repositories/app_config_allow_list/repositories.py
+++ b/src/ai/backend/manager/repositories/app_config_allow_list/repositories.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from typing import Self
+
+from ai.backend.manager.repositories.app_config_allow_list.repository import (
+    AppConfigAllowListRepository,
+)
+from ai.backend.manager.repositories.types import RepositoryArgs
+
+
+@dataclass
+class AppConfigAllowListRepositories:
+    repository: AppConfigAllowListRepository
+
+    @classmethod
+    def create(cls, args: RepositoryArgs) -> Self:
+        return cls(
+            repository=AppConfigAllowListRepository(args.ops_provider),
+        )

--- a/src/ai/backend/manager/repositories/app_config_allow_list/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_allow_list/repository.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from ai.backend.common.identifier.app_config_allow_list import AppConfigAllowListID
+from ai.backend.manager.data.app_config_allow_list.types import (
+    AppConfigAllowListData,
+    AppConfigAllowListSearchResult,
+)
+from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
+from ai.backend.manager.repositories.app_config_allow_list.db_source import (
+    AppConfigAllowListDBSource,
+)
+from ai.backend.manager.repositories.base import BatchQuerier, Creator
+from ai.backend.manager.repositories.ops import DBOpsProvider
+
+__all__ = ("AppConfigAllowListRepository",)
+
+
+class AppConfigAllowListRepository:
+    """Access to app config allow-list entries."""
+
+    _db_source: AppConfigAllowListDBSource
+
+    def __init__(self, ops_provider: DBOpsProvider) -> None:
+        self._db_source = AppConfigAllowListDBSource(ops_provider)
+
+    async def create(
+        self,
+        creator: Creator[AppConfigAllowListRow],
+    ) -> AppConfigAllowListData:
+        return await self._db_source.create(creator)
+
+    async def get_by_id(self, allow_list_id: AppConfigAllowListID) -> AppConfigAllowListData:
+        return await self._db_source.get_by_id(allow_list_id)
+
+    async def search(self, querier: BatchQuerier) -> AppConfigAllowListSearchResult:
+        return await self._db_source.search(querier)
+
+    async def purge(self, allow_list_id: AppConfigAllowListID) -> AppConfigAllowListData:
+        return await self._db_source.purge(allow_list_id)

--- a/src/ai/backend/manager/repositories/app_config_allow_list/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_allow_list/repository.py
@@ -9,7 +9,7 @@ from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowLi
 from ai.backend.manager.repositories.app_config_allow_list.db_source import (
     AppConfigAllowListDBSource,
 )
-from ai.backend.manager.repositories.base import BatchQuerier, Creator
+from ai.backend.manager.repositories.base import BatchQuerier, Creator, Purger
 from ai.backend.manager.repositories.ops import DBOpsProvider
 
 __all__ = ("AppConfigAllowListRepository",)
@@ -35,5 +35,5 @@ class AppConfigAllowListRepository:
     async def search(self, querier: BatchQuerier) -> AppConfigAllowListSearchResult:
         return await self._db_source.search(querier)
 
-    async def purge(self, allow_list_id: AppConfigAllowListID) -> AppConfigAllowListData:
-        return await self._db_source.purge(allow_list_id)
+    async def purge(self, purger: Purger[AppConfigAllowListRow]) -> AppConfigAllowListData:
+        return await self._db_source.purge(purger)

--- a/tests/unit/manager/repositories/app_config_allow_list/BUILD
+++ b/tests/unit/manager/repositories/app_config_allow_list/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests")

--- a/tests/unit/manager/repositories/app_config_allow_list/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_allow_list/test_repository.py
@@ -40,6 +40,8 @@ from ai.backend.manager.repositories.app_config_definition.repository import (
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
     Creator,
+    CursorBackwardPagination,
+    CursorForwardPagination,
     OffsetPagination,
     Purger,
 )
@@ -237,3 +239,81 @@ class TestSearch:
         )
         config_names = [item.config_name for item in result.items]
         assert config_names == sorted(config_names, reverse=True)
+
+    async def test_search_filters_by_created_at(
+        self,
+        repository: AppConfigAllowListRepository,
+        seeded_entries: list[AppConfigAllowListData],
+    ) -> None:
+        target = seeded_entries[1]
+        result = await repository.search(
+            BatchQuerier(
+                pagination=OffsetPagination(limit=10, offset=0),
+                conditions=[AppConfigAllowListConditions.by_created_at_equals(target.created_at)],
+            )
+        )
+        assert [item.id for item in result.items] == [target.id]
+
+    async def test_search_filters_by_updated_at(
+        self,
+        repository: AppConfigAllowListRepository,
+        seeded_entries: list[AppConfigAllowListData],
+    ) -> None:
+        target = seeded_entries[1]
+        result = await repository.search(
+            BatchQuerier(
+                pagination=OffsetPagination(limit=10, offset=0),
+                conditions=[AppConfigAllowListConditions.by_updated_at_equals(target.updated_at)],
+            )
+        )
+        assert [item.id for item in result.items] == [target.id]
+
+    async def test_search_orders_by_created_at(
+        self,
+        repository: AppConfigAllowListRepository,
+        seeded_entries: list[AppConfigAllowListData],
+    ) -> None:
+        result = await repository.search(
+            BatchQuerier(
+                pagination=OffsetPagination(limit=10, offset=0),
+                orders=[AppConfigAllowListOrders.created_at(ascending=True)],
+            )
+        )
+        expected = [entry.id for entry in sorted(seeded_entries, key=lambda e: e.created_at)]
+        assert [item.id for item in result.items] == expected
+
+    async def test_search_cursor_forward(
+        self,
+        repository: AppConfigAllowListRepository,
+        seeded_entries: list[AppConfigAllowListData],
+    ) -> None:
+        by_created_desc = sorted(seeded_entries, key=lambda e: e.created_at, reverse=True)
+        cursor = by_created_desc[0].id
+        result = await repository.search(
+            BatchQuerier(
+                pagination=CursorForwardPagination(
+                    first=10,
+                    cursor_order=AppConfigAllowListOrders.created_at(ascending=False),
+                    cursor_condition=AppConfigAllowListConditions.by_cursor_forward(str(cursor)),
+                )
+            )
+        )
+        assert [item.id for item in result.items] == [entry.id for entry in by_created_desc[1:]]
+
+    async def test_search_cursor_backward(
+        self,
+        repository: AppConfigAllowListRepository,
+        seeded_entries: list[AppConfigAllowListData],
+    ) -> None:
+        by_created_asc = sorted(seeded_entries, key=lambda e: e.created_at)
+        cursor = by_created_asc[0].id
+        result = await repository.search(
+            BatchQuerier(
+                pagination=CursorBackwardPagination(
+                    last=10,
+                    cursor_order=AppConfigAllowListOrders.created_at(ascending=True),
+                    cursor_condition=AppConfigAllowListConditions.by_cursor_backward(str(cursor)),
+                )
+            )
+        )
+        assert {item.id for item in result.items} == {entry.id for entry in by_created_asc[1:]}

--- a/tests/unit/manager/repositories/app_config_allow_list/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_allow_list/test_repository.py
@@ -1,0 +1,232 @@
+"""Tests for AppConfigAllowListRepository with real database operations."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from ai.backend.common.data.filter_specs import StringMatchSpec
+from ai.backend.common.identifier.app_config_allow_list import AppConfigAllowListID
+from ai.backend.manager.data.app_config_allow_list.types import (
+    AppConfigAllowListData,
+    AppConfigScopeType,
+)
+from ai.backend.manager.errors.app_config import AppConfigAllowListNotFound
+from ai.backend.manager.errors.repository import (
+    ForeignKeyViolationError,
+    UniqueConstraintViolationError,
+)
+from ai.backend.manager.models.app_config_allow_list.conditions import (
+    AppConfigAllowListConditions,
+)
+from ai.backend.manager.models.app_config_allow_list.orders import AppConfigAllowListOrders
+from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
+from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.app_config_allow_list.creators import (
+    AppConfigAllowListCreatorSpec,
+)
+from ai.backend.manager.repositories.app_config_allow_list.repository import (
+    AppConfigAllowListRepository,
+)
+from ai.backend.manager.repositories.app_config_definition.creators import (
+    AppConfigDefinitionCreatorSpec,
+)
+from ai.backend.manager.repositories.app_config_definition.repository import (
+    AppConfigDefinitionRepository,
+)
+from ai.backend.manager.repositories.base import BatchQuerier, Creator, OffsetPagination
+from ai.backend.manager.repositories.ops import DBOpsProvider
+from ai.backend.testutils.db import with_tables
+
+
+@pytest.fixture
+async def database(
+    database_connection: ExtendedAsyncSAEngine,
+) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+    # FK order: app_config_definitions (parent) before app_config_allow_list (child).
+    async with with_tables(database_connection, [AppConfigDefinitionRow, AppConfigAllowListRow]):
+        yield database_connection
+
+
+@pytest.fixture
+def repository(database: ExtendedAsyncSAEngine) -> AppConfigAllowListRepository:
+    return AppConfigAllowListRepository(DBOpsProvider(database))
+
+
+@pytest.fixture
+def definition_repository(database: ExtendedAsyncSAEngine) -> AppConfigDefinitionRepository:
+    return AppConfigDefinitionRepository(DBOpsProvider(database))
+
+
+async def _register(definition_repository: AppConfigDefinitionRepository, config_name: str) -> None:
+    """Seed the FK parent: register a config_name in app_config_definitions."""
+    await definition_repository.create(
+        Creator(spec=AppConfigDefinitionCreatorSpec(config_name=config_name))
+    )
+
+
+async def _create_entry(
+    repository: AppConfigAllowListRepository,
+    config_name: str,
+    scope_type: AppConfigScopeType,
+) -> AppConfigAllowListData:
+    return await repository.create(
+        Creator(spec=AppConfigAllowListCreatorSpec(config_name=config_name, scope_type=scope_type))
+    )
+
+
+def _missing_id() -> AppConfigAllowListID:
+    return AppConfigAllowListID(uuid.uuid4())
+
+
+@pytest.fixture
+async def existing_entry(
+    repository: AppConfigAllowListRepository,
+    definition_repository: AppConfigDefinitionRepository,
+) -> AppConfigAllowListData:
+    await _register(definition_repository, "theme")
+    return await _create_entry(repository, "theme", AppConfigScopeType.PUBLIC)
+
+
+@pytest.fixture
+async def seeded_entries(
+    repository: AppConfigAllowListRepository,
+    definition_repository: AppConfigDefinitionRepository,
+) -> list[AppConfigAllowListData]:
+    for config_name in ("theme", "menu"):
+        await _register(definition_repository, config_name)
+    entries: list[AppConfigAllowListData] = []
+    for config_name, scope_type in (
+        ("theme", AppConfigScopeType.PUBLIC),
+        ("theme", AppConfigScopeType.DOMAIN),
+        ("menu", AppConfigScopeType.USER),
+    ):
+        entries.append(await _create_entry(repository, config_name, scope_type))
+    return entries
+
+
+class TestCreateAndGet:
+    async def test_create_then_get_by_id(
+        self,
+        repository: AppConfigAllowListRepository,
+        definition_repository: AppConfigDefinitionRepository,
+    ) -> None:
+        await _register(definition_repository, "theme")
+        created = await _create_entry(repository, "theme", AppConfigScopeType.PUBLIC)
+        fetched = await repository.get_by_id(created.id)
+        assert fetched.id == created.id
+        assert fetched.config_name == "theme"
+        assert fetched.scope_type is AppConfigScopeType.PUBLIC
+
+    async def test_get_by_id_missing_raises(self, repository: AppConfigAllowListRepository) -> None:
+        with pytest.raises(AppConfigAllowListNotFound):
+            await repository.get_by_id(_missing_id())
+
+    async def test_create_requires_registered_config_name(
+        self, repository: AppConfigAllowListRepository
+    ) -> None:
+        # No app_config_definitions row for "unregistered" -> FK violation.
+        with pytest.raises(ForeignKeyViolationError):
+            await _create_entry(repository, "unregistered", AppConfigScopeType.PUBLIC)
+
+    async def test_duplicate_config_name_scope_type_rejected(
+        self,
+        repository: AppConfigAllowListRepository,
+        existing_entry: AppConfigAllowListData,
+    ) -> None:
+        with pytest.raises(UniqueConstraintViolationError):
+            await _create_entry(repository, existing_entry.config_name, existing_entry.scope_type)
+
+
+class TestPurge:
+    async def test_purge_removes_row(
+        self,
+        repository: AppConfigAllowListRepository,
+        existing_entry: AppConfigAllowListData,
+    ) -> None:
+        purged = await repository.purge(existing_entry.id)
+        assert purged.id == existing_entry.id
+        with pytest.raises(AppConfigAllowListNotFound):
+            await repository.get_by_id(existing_entry.id)
+
+    async def test_purge_missing_raises(self, repository: AppConfigAllowListRepository) -> None:
+        with pytest.raises(AppConfigAllowListNotFound):
+            await repository.purge(_missing_id())
+
+
+class TestSearch:
+    async def test_search_returns_all_with_total_count(
+        self,
+        repository: AppConfigAllowListRepository,
+        seeded_entries: list[AppConfigAllowListData],
+    ) -> None:
+        result = await repository.search(
+            BatchQuerier(pagination=OffsetPagination(limit=10, offset=0))
+        )
+        assert result.total_count == len(seeded_entries)
+        assert {item.id for item in result.items} == {entry.id for entry in seeded_entries}
+
+    async def test_search_respects_pagination(
+        self,
+        repository: AppConfigAllowListRepository,
+        seeded_entries: list[AppConfigAllowListData],
+    ) -> None:
+        result = await repository.search(
+            BatchQuerier(pagination=OffsetPagination(limit=2, offset=0))
+        )
+        assert result.total_count == len(seeded_entries)
+        assert len(result.items) == 2
+        assert result.has_next_page is True
+
+    async def test_search_filters_by_config_name(
+        self,
+        repository: AppConfigAllowListRepository,
+        seeded_entries: list[AppConfigAllowListData],
+    ) -> None:
+        result = await repository.search(
+            BatchQuerier(
+                pagination=OffsetPagination(limit=10, offset=0),
+                conditions=[
+                    AppConfigAllowListConditions.by_config_name_equals(
+                        StringMatchSpec("theme", case_insensitive=False, negated=False)
+                    )
+                ],
+            )
+        )
+        expected = {entry.id for entry in seeded_entries if entry.config_name == "theme"}
+        assert {item.id for item in result.items} == expected
+
+    async def test_search_filters_by_scope_type(
+        self,
+        repository: AppConfigAllowListRepository,
+        seeded_entries: list[AppConfigAllowListData],
+    ) -> None:
+        result = await repository.search(
+            BatchQuerier(
+                pagination=OffsetPagination(limit=10, offset=0),
+                conditions=[
+                    AppConfigAllowListConditions.by_scope_type_equals(AppConfigScopeType.USER)
+                ],
+            )
+        )
+        expected = {
+            entry.id for entry in seeded_entries if entry.scope_type is AppConfigScopeType.USER
+        }
+        assert {item.id for item in result.items} == expected
+
+    async def test_search_orders_by_config_name_desc(
+        self,
+        repository: AppConfigAllowListRepository,
+        seeded_entries: list[AppConfigAllowListData],
+    ) -> None:
+        result = await repository.search(
+            BatchQuerier(
+                pagination=OffsetPagination(limit=10, offset=0),
+                orders=[AppConfigAllowListOrders.config_name(ascending=False)],
+            )
+        )
+        config_names = [item.config_name for item in result.items]
+        assert config_names == sorted(config_names, reverse=True)

--- a/tests/unit/manager/repositories/app_config_allow_list/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_allow_list/test_repository.py
@@ -37,7 +37,12 @@ from ai.backend.manager.repositories.app_config_definition.creators import (
 from ai.backend.manager.repositories.app_config_definition.repository import (
     AppConfigDefinitionRepository,
 )
-from ai.backend.manager.repositories.base import BatchQuerier, Creator, OffsetPagination
+from ai.backend.manager.repositories.base import (
+    BatchQuerier,
+    Creator,
+    OffsetPagination,
+    Purger,
+)
 from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.testutils.db import with_tables
 
@@ -147,14 +152,16 @@ class TestPurge:
         repository: AppConfigAllowListRepository,
         existing_entry: AppConfigAllowListData,
     ) -> None:
-        purged = await repository.purge(existing_entry.id)
+        purged = await repository.purge(
+            Purger(row_class=AppConfigAllowListRow, pk_value=existing_entry.id)
+        )
         assert purged.id == existing_entry.id
         with pytest.raises(AppConfigAllowListNotFound):
             await repository.get_by_id(existing_entry.id)
 
     async def test_purge_missing_raises(self, repository: AppConfigAllowListRepository) -> None:
         with pytest.raises(AppConfigAllowListNotFound):
-            await repository.purge(_missing_id())
+            await repository.purge(Purger(row_class=AppConfigAllowListRow, pk_value=_missing_id()))
 
 
 class TestSearch:


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of the AppConfigAllowList stack (BA-6543 → BA-6548), built on `main`. **Merge in order:**

1. ⬇️ #12289 — `feat(BA-6543): app_config_allow_list DB model and Alembic migration`
2. 👉 **#12290** — `feat(BA-6544): repository layer` ← you are here
3. ⬇️ #12292 — `feat(BA-6545): service layer (actions, processors)`
4. ⬇️ #12293 — `feat(BA-6546): REST v2 API`
5. ⬇️ #12296 — `feat(BA-6547): GraphQL API (Strawberry)`
6. ⬇️ #12298 — `feat(BA-6548): client SDK v2 & CLI v2`

## Summary
- Add `AppConfigAllowListRepository` (create / get_by_id / search / purge) over `DBOpsProvider` with a dedicated `db_source`.
- Add `AppConfigAllowListCreatorSpec`, the `AppConfigAllowListConditions` / `AppConfigAllowListOrders` query factories (config_name / scope_type / created_at / updated_at filters, id-based cursor, ordering), the `AppConfigAllowListSearchResult` data type, and the `AppConfigAllowListNotFound` error.
- `purge` is id-based — the `Purger` is built inside `db_source`, so callers pass only an id.
- Real-DB tests (`with_tables`) cover create/get, purge, search/pagination/filter/order, the FK to `app_config_definitions`, and the `(config_name, scope_type)` unique constraint.

Note: wiring `AppConfigAllowListRepositories` into the global repository aggregator is deferred to the REST PR (BA-6546), mirroring how AppConfigDefinition was wired at its REST stage.

Resolves BA-6544.


