### PR TITLE
fix(ci): pin graphql-inspector to v4.0.0 (master fix for rules regression)

### DIFF
--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -6,8 +6,6 @@ on:
       - 'src/ai/backend/manager/models/**'
       - 'src/ai/backend/manager/api/**'
       - 'VERSION'
-      - '.github/workflows/update-api-schema.yml'
-      - 'gql-inspector-checker.js'
 
 jobs:
   api-updated:

--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -6,6 +6,8 @@ on:
       - 'src/ai/backend/manager/models/**'
       - 'src/ai/backend/manager/api/**'
       - 'VERSION'
+      - '.github/workflows/update-api-schema.yml'
+      - 'gql-inspector-checker.js'
 
 jobs:
   api-updated:
@@ -101,4 +103,4 @@ jobs:
         with:
           schema: '${{ github.base_ref }}:docs/manager/graphql-reference/schema.graphql'
           rules: |
-            gql-inspector-checker.js
+            ${{ github.workspace }}/gql-inspector-checker.js

--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -104,7 +104,7 @@ jobs:
       # the last known-good release (action @4.x, release-1717403590269) and opt
       # back into Node 20 (this release predates the Node 24 runtime fix). Drop
       # both once upstream addresses
-      # https://github.com/graphql-hive/graphql-inspector/issues/<TBD>.
+      # https://github.com/graphql-hive/graphql-inspector/issues/2962.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -95,18 +95,9 @@ jobs:
       contents: read
       pull-requests: write
       checks: write
-    env:
-      # graphql-hive/graphql-inspector @5.0.21 (release-1781692943029) regressed
-      # the `rules` file resolution — it can no longer load a checker file from
-      # the checked-out workspace, failing with "Cannot find module ...". Pin to
-      # the last known-good release (action @4.x, release-1717403590269) and opt
-      # back into Node 20 (this release predates the Node 24 runtime fix). Drop
-      # both once upstream addresses
-      # https://github.com/graphql-hive/graphql-inspector/issues/2962.
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     steps:
       - uses: actions/checkout@v6
-      - uses: graphql-hive/graphql-inspector@release-1717403590269
+      - uses: graphql-hive/graphql-inspector@v4.0.0
         with:
           schema: '${{ github.base_ref }}:docs/manager/graphql-reference/schema.graphql'
           rules: |

--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -97,11 +97,19 @@ jobs:
       contents: read
       pull-requests: write
       checks: write
+    env:
+      # graphql-hive/graphql-inspector @5.0.21 (release-1781692943029) regressed
+      # the `rules` file resolution — it can no longer load a checker file from
+      # the checked-out workspace, failing with "Cannot find module ...". Pin to
+      # the last known-good release (action @4.x, release-1717403590269) and opt
+      # back into Node 20 (this release predates the Node 24 runtime fix). Drop
+      # both once upstream addresses
+      # https://github.com/graphql-hive/graphql-inspector/issues/<TBD>.
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     steps:
       - uses: actions/checkout@v6
-      - uses: graphql-hive/graphql-inspector@release-1781692943029
+      - uses: graphql-hive/graphql-inspector@release-1717403590269
         with:
           schema: '${{ github.base_ref }}:docs/manager/graphql-reference/schema.graphql'
           rules: |
             gql-inspector-checker.js
-          experimental_merge: false

--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -103,4 +103,5 @@ jobs:
         with:
           schema: '${{ github.base_ref }}:docs/manager/graphql-reference/schema.graphql'
           rules: |
-            ${{ github.workspace }}/gql-inspector-checker.js
+            gql-inspector-checker.js
+          experimental_merge: false

--- a/changes/12291.misc.md
+++ b/changes/12291.misc.md
@@ -1,0 +1,1 @@
+Pin `graphql-hive/graphql-inspector` GitHub Action to `release-1717403590269` (last known-good) and opt back into Node 20 to work around a `rules:` file resolution regression in `release-1781692943029` (action@5.0.21). See graphql-hive/graphql-inspector#2962.

--- a/changes/12291.misc.md
+++ b/changes/12291.misc.md
@@ -1,1 +1,1 @@
-Pin `graphql-hive/graphql-inspector` GitHub Action to `release-1717403590269` (last known-good) and opt back into Node 20 to work around a `rules:` file resolution regression in `release-1781692943029` (action@5.0.21). See graphql-hive/graphql-inspector#2962.
+Pin `graphql-hive/graphql-inspector` GitHub Action to `v4.0.0`, which includes the `createRequire(import.meta.url)` fix for the `rules:` file resolution regression introduced in `release-1781692943029` (action@5.0.21). See graphql-hive/graphql-inspector#2962.

--- a/src/ai/backend/manager/api/AGENTS.md
+++ b/src/ai/backend/manager/api/AGENTS.md
@@ -55,3 +55,4 @@ The v2 DTOs (`common/dto/manager/v2/`) are the schema shared by REST v2 handlers
 - Belongs: HTTP request/response conversion, auth decorators (`@auth_required_for_method`).
 - Does NOT belong: business logic / domain rules, direct DB access or `manager/models/` ORM imports,
   Repository/Service class imports.
+

--- a/src/ai/backend/manager/api/AGENTS.md
+++ b/src/ai/backend/manager/api/AGENTS.md
@@ -55,4 +55,3 @@ The v2 DTOs (`common/dto/manager/v2/`) are the schema shared by REST v2 handlers
 - Belongs: HTTP request/response conversion, auth decorators (`@auth_required_for_method`).
 - Does NOT belong: business logic / domain rules, direct DB access or `manager/models/` ORM imports,
   Repository/Service class imports.
-


### PR DESCRIPTION
## Summary

- Pin `graphql-hive/graphql-inspector` to **`v4.0.0`** — a tag that points at the `c0ecb19a` master HEAD commit, where upstream has already added the `createRequire(import.meta.url)` fix for the `rules:` file regression.

## Why

`release-1781692943029` (action@5.0.21, monorepo "June 17, 2026" release) regresses the `rules:` file resolution — every run dies with:

```
Cannot find module '/home/runner/work/backend.ai/backend.ai/gql-inspector-checker.js'
```

I bisected this on a separate branch:

| `@graphql-inspector/action` | release tag | Result |
|---|---|---|
| 5.0.7 | `release-1731490071726` | ✅ pass |
| 5.0.8 | `release-1733751254476` | ✅ pass |
| **5.0.9** | `release-1762508344828` | ❌ **first failing** |
| 5.0.11 | `release-1762782918138` | ❌ fail |
| 5.0.21 | `release-1781692943029` | ❌ fail |

Root cause: 5.0.8 → 5.0.9 swapped the bundler (`@zeit/ncc@0.22.3` → `@vercel/ncc@0.38.3`), which honors `packages/action/package.json` `"type": "module"` and emits an **ESM** bundle. ncc/webpack then rewrites the bare `require(filepath)` in `resolveRule` into a `webpackEmptyContext` stub that unconditionally throws `MODULE_NOT_FOUND`. Both relative and absolute paths fail the same way.

Upstream already landed the fix on `master` (commit `c0ecb19a`), replacing the bare `require` with `process.getBuiltinModule('module').createRequire(import.meta.url)(filepath)`. That commit is tagged as `v4.0.0` but has not been published as a `release-…` tag yet (changesets-style publish vs. manual semver tag — see graphql-hive/graphql-inspector#2962). Pinning to `v4.0.0` consumes the fix today; we can switch to a `release-…` tag once one is published.

Bonus: `v4.0.0`'s `action.yml` declares `using: node24`, so we don't need the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` workaround anymore — net diff is a single line.

## Test plan

- [x] `update-api-schema/graphql-inspector` job runs and reports success on this PR.
