### PR TITLE
feat(BA-6547): add app_config_allow_list GraphQL API

### DIFF
--- a/changes/12296.feature.md
+++ b/changes/12296.feature.md
@@ -1,0 +1,1 @@
+Add the app_config_allow_list GraphQL API.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -11273,7 +11273,7 @@ type Mutation
   """
   Added in 26.7.0. Purge an app config allow-list entry by id (super admin only).
   """
-  adminPurgeAppConfigAllowList(id: UUID!): PurgeAppConfigAllowListPayload @join__field(graph: STRAWBERRY)
+  adminPurgeAppConfigAllowList(input: PurgeAppConfigAllowListInput!): PurgeAppConfigAllowListPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Scan external registries to discover available artifacts. Searches HuggingFace or Reservoir registries for artifacts matching the specified criteria and registers them in the system with SCANNED status. The artifacts become available for import but are not downloaded until explicitly imported. This is the first step in the artifact workflow: Scan → Import → Use
@@ -13687,6 +13687,14 @@ input ProjectWeightInputItem
   Priority weight multiplier. Higher weight = higher priority allocation ratio. Set to null to use resource group's default_weight.
   """
   weight: Decimal = null
+}
+
+"""Added in 26.7.0. Input for purging an app config allow-list entry."""
+input PurgeAppConfigAllowListInput
+  @join__type(graph: STRAWBERRY)
+{
+  """App config allow-list entry id to purge."""
+  id: UUID!
 }
 
 """Added in 26.7.0. Payload for app config allow-list entry purge."""

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -885,6 +885,100 @@ type AllowedResourceGroupsPayload
   items: [String!]!
 }
 
+"""
+Added in 26.7.0. Permission to write config fragments for one config name at one scope type.
+"""
+type AppConfigAllowList implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """The config name this entry permits writes for."""
+  configName: String!
+
+  """Scope type the entry permits writes at (public | domain | user)."""
+  scopeType: AppConfigScopeType!
+
+  """Creation timestamp (UTC)."""
+  createdAt: DateTime!
+
+  """Last update timestamp (UTC)."""
+  updatedAt: DateTime!
+}
+
+"""
+Added in 26.7.0. Paginated connection for app config allow-list records.
+"""
+type AppConfigAllowListConnection
+  @join__type(graph: STRAWBERRY)
+{
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [AppConfigAllowListEdge!]!
+
+  """
+  Total number of app config allow-list records matching the query criteria.
+  """
+  count: Int!
+}
+
+"""An edge in a connection."""
+type AppConfigAllowListEdge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: AppConfigAllowList!
+}
+
+"""
+Added in 26.7.0. Filter input for querying app config allow-list entries.
+"""
+input AppConfigAllowListFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Filter by config name."""
+  configName: StringFilter = null
+
+  """Filter by scope type."""
+  scopeType: AppConfigScopeTypeFilter = null
+
+  """Filter by creation datetime."""
+  createdAt: DateTimeFilter = null
+
+  """Filter by last update datetime."""
+  updatedAt: DateTimeFilter = null
+}
+
+"""Added in 26.7.0. Specifies ordering for app config allow-list results."""
+input AppConfigAllowListOrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  """The field to order by."""
+  field: AppConfigAllowListOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = ASC
+}
+
+"""
+Added in 26.7.0. Fields available for ordering app config allow-list results.
+"""
+enum AppConfigAllowListOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  CONFIG_NAME @join__enumValue(graph: STRAWBERRY)
+  SCOPE_TYPE @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
+  UPDATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
 """Added in 26.7.0. A registered app config."""
 type AppConfigDefinition implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
@@ -966,6 +1060,31 @@ enum AppConfigDefinitionOrderField
   CONFIG_NAME @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   UPDATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
+enum AppConfigScopeType
+  @join__type(graph: STRAWBERRY)
+{
+  PUBLIC @join__enumValue(graph: STRAWBERRY)
+  DOMAIN @join__enumValue(graph: STRAWBERRY)
+  USER @join__enumValue(graph: STRAWBERRY)
+}
+
+"""Added in 26.7.0. Filter input for the scope_type enum field."""
+input AppConfigScopeTypeFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Exact scope type match."""
+  equals: AppConfigScopeType = null
+
+  """Match any of the provided scope types."""
+  in: [AppConfigScopeType!] = null
+
+  """Exclude exact scope type match."""
+  notEquals: AppConfigScopeType = null
+
+  """Exclude any of the provided scope types."""
+  notIn: [AppConfigScopeType!] = null
 }
 
 """
@@ -3275,6 +3394,27 @@ type CreateAccessTokenPayload
 {
   """Created access token"""
   accessToken: AccessToken!
+}
+
+"""
+Added in 26.7.0. Input for registering a new app config allow-list entry.
+"""
+input CreateAppConfigAllowListInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Registered config name to gate."""
+  configName: String!
+
+  """Scope at which fragments may be written (public | domain | user)."""
+  scopeType: AppConfigScopeType!
+}
+
+"""Added in 26.7.0. Payload for app config allow-list entry creation."""
+type CreateAppConfigAllowListPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Created app config allow-list entry."""
+  appConfigAllowList: AppConfigAllowList!
 }
 
 """Added in 26.7.0. Input for registering a new app config definition."""
@@ -11126,6 +11266,16 @@ type Mutation
   delete_network(network: String!): DeleteNetwork @join__field(graph: GRAPHENE)
 
   """
+  Added in 26.7.0. Register a new app config allow-list entry (super admin only).
+  """
+  adminCreateAppConfigAllowList(input: CreateAppConfigAllowListInput!): CreateAppConfigAllowListPayload @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.7.0. Purge an app config allow-list entry by id (super admin only).
+  """
+  adminPurgeAppConfigAllowList(id: UUID!): PurgeAppConfigAllowListPayload @join__field(graph: STRAWBERRY)
+
+  """
   Added in 25.14.0. Scan external registries to discover available artifacts. Searches HuggingFace or Reservoir registries for artifacts matching the specified criteria and registers them in the system with SCANNED status. The artifacts become available for import but are not downloaded until explicitly imported. This is the first step in the artifact workflow: Scan → Import → Use
   """
   scanArtifacts(input: ScanArtifactsInput!): ScanArtifactsPayload @join__field(graph: STRAWBERRY)
@@ -13539,6 +13689,14 @@ input ProjectWeightInputItem
   weight: Decimal = null
 }
 
+"""Added in 26.7.0. Payload for app config allow-list entry purge."""
+type PurgeAppConfigAllowListPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """UUID of the purged app config allow-list entry."""
+  id: UUID!
+}
+
 """Added in 26.7.0. Input for purging an app config definition."""
 input PurgeAppConfigDefinitionInput
   @join__type(graph: STRAWBERRY)
@@ -14123,6 +14281,16 @@ type Query
 
   """Added in 26.1.0. List agents with filtering and pagination"""
   agentsV2(filter: AgentFilter = null, orderBy: [AgentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AgentV2Connection @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.7.0. Get a single app config allow-list entry by id (super admin only).
+  """
+  adminAppConfigAllowList(id: UUID!): AppConfigAllowList @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.7.0. Search app config allow-list entries with filtering, ordering, and pagination (super admin only).
+  """
+  adminAppConfigAllowLists(filter: AppConfigAllowListFilter = null, orderBy: [AppConfigAllowListOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigAllowListConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Retrieve a specific artifact by its ID. Returns detailed information about the artifact including its metadata, registry information, and availability status.

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -604,6 +604,87 @@ type AllowedResourceGroupsPayload {
   items: [String!]!
 }
 
+"""
+Added in 26.7.0. Permission to write config fragments for one config name at one scope type.
+"""
+type AppConfigAllowList implements Node {
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """The config name this entry permits writes for."""
+  configName: String!
+
+  """Scope type the entry permits writes at (public | domain | user)."""
+  scopeType: AppConfigScopeType!
+
+  """Creation timestamp (UTC)."""
+  createdAt: DateTime!
+
+  """Last update timestamp (UTC)."""
+  updatedAt: DateTime!
+}
+
+"""
+Added in 26.7.0. Paginated connection for app config allow-list records.
+"""
+type AppConfigAllowListConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [AppConfigAllowListEdge!]!
+
+  """
+  Total number of app config allow-list records matching the query criteria.
+  """
+  count: Int!
+}
+
+"""An edge in a connection."""
+type AppConfigAllowListEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: AppConfigAllowList!
+}
+
+"""
+Added in 26.7.0. Filter input for querying app config allow-list entries.
+"""
+input AppConfigAllowListFilter {
+  """Filter by config name."""
+  configName: StringFilter = null
+
+  """Filter by scope type."""
+  scopeType: AppConfigScopeTypeFilter = null
+
+  """Filter by creation datetime."""
+  createdAt: DateTimeFilter = null
+
+  """Filter by last update datetime."""
+  updatedAt: DateTimeFilter = null
+}
+
+"""Added in 26.7.0. Specifies ordering for app config allow-list results."""
+input AppConfigAllowListOrderBy {
+  """The field to order by."""
+  field: AppConfigAllowListOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = ASC
+}
+
+"""
+Added in 26.7.0. Fields available for ordering app config allow-list results.
+"""
+enum AppConfigAllowListOrderField {
+  CONFIG_NAME
+  SCOPE_TYPE
+  CREATED_AT
+  UPDATED_AT
+}
+
 """Added in 26.7.0. A registered app config."""
 type AppConfigDefinition implements Node {
   """The Globally Unique ID of this object"""
@@ -672,6 +753,27 @@ enum AppConfigDefinitionOrderField {
   CONFIG_NAME
   CREATED_AT
   UPDATED_AT
+}
+
+enum AppConfigScopeType {
+  PUBLIC
+  DOMAIN
+  USER
+}
+
+"""Added in 26.7.0. Filter input for the scope_type enum field."""
+input AppConfigScopeTypeFilter {
+  """Exact scope type match."""
+  equals: AppConfigScopeType = null
+
+  """Match any of the provided scope types."""
+  in: [AppConfigScopeType!] = null
+
+  """Exclude exact scope type match."""
+  notEquals: AppConfigScopeType = null
+
+  """Exclude any of the provided scope types."""
+  notIn: [AppConfigScopeType!] = null
 }
 
 """
@@ -2117,6 +2219,23 @@ input CreateAccessTokenInput {
 type CreateAccessTokenPayload {
   """Created access token"""
   accessToken: AccessToken!
+}
+
+"""
+Added in 26.7.0. Input for registering a new app config allow-list entry.
+"""
+input CreateAppConfigAllowListInput {
+  """Registered config name to gate."""
+  configName: String!
+
+  """Scope at which fragments may be written (public | domain | user)."""
+  scopeType: AppConfigScopeType!
+}
+
+"""Added in 26.7.0. Payload for app config allow-list entry creation."""
+type CreateAppConfigAllowListPayload {
+  """Created app config allow-list entry."""
+  appConfigAllowList: AppConfigAllowList!
 }
 
 """Added in 26.7.0. Input for registering a new app config definition."""
@@ -6997,6 +7116,16 @@ type MoveFileV2Payload {
 
 type Mutation {
   """
+  Added in 26.7.0. Register a new app config allow-list entry (super admin only).
+  """
+  adminCreateAppConfigAllowList(input: CreateAppConfigAllowListInput!): CreateAppConfigAllowListPayload
+
+  """
+  Added in 26.7.0. Purge an app config allow-list entry by id (super admin only).
+  """
+  adminPurgeAppConfigAllowList(id: UUID!): PurgeAppConfigAllowListPayload
+
+  """
   Added in 25.14.0. Scan external registries to discover available artifacts. Searches HuggingFace or Reservoir registries for artifacts matching the specified criteria and registers them in the system with SCANNED status. The artifacts become available for import but are not downloaded until explicitly imported. This is the first step in the artifact workflow: Scan → Import → Use
   """
   scanArtifacts(input: ScanArtifactsInput!): ScanArtifactsPayload
@@ -9101,6 +9230,12 @@ input ProjectWeightInputItem {
   weight: Decimal = null
 }
 
+"""Added in 26.7.0. Payload for app config allow-list entry purge."""
+type PurgeAppConfigAllowListPayload {
+  """UUID of the purged app config allow-list entry."""
+  id: UUID!
+}
+
 """Added in 26.7.0. Input for purging an app config definition."""
 input PurgeAppConfigDefinitionInput {
   """App config definition id to purge."""
@@ -9189,6 +9324,16 @@ type Query {
 
   """Added in 26.1.0. List agents with filtering and pagination"""
   agentsV2(filter: AgentFilter = null, orderBy: [AgentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AgentV2Connection
+
+  """
+  Added in 26.7.0. Get a single app config allow-list entry by id (super admin only).
+  """
+  adminAppConfigAllowList(id: UUID!): AppConfigAllowList
+
+  """
+  Added in 26.7.0. Search app config allow-list entries with filtering, ordering, and pagination (super admin only).
+  """
+  adminAppConfigAllowLists(filter: AppConfigAllowListFilter = null, orderBy: [AppConfigAllowListOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigAllowListConnection
 
   """
   Added in 25.14.0. Retrieve a specific artifact by its ID. Returns detailed information about the artifact including its metadata, registry information, and availability status.

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -7123,7 +7123,7 @@ type Mutation {
   """
   Added in 26.7.0. Purge an app config allow-list entry by id (super admin only).
   """
-  adminPurgeAppConfigAllowList(id: UUID!): PurgeAppConfigAllowListPayload
+  adminPurgeAppConfigAllowList(input: PurgeAppConfigAllowListInput!): PurgeAppConfigAllowListPayload
 
   """
   Added in 25.14.0. Scan external registries to discover available artifacts. Searches HuggingFace or Reservoir registries for artifacts matching the specified criteria and registers them in the system with SCANNED status. The artifacts become available for import but are not downloaded until explicitly imported. This is the first step in the artifact workflow: Scan → Import → Use
@@ -9228,6 +9228,12 @@ input ProjectWeightInputItem {
   Priority weight multiplier. Higher weight = higher priority allocation ratio. Set to null to use resource group's default_weight.
   """
   weight: Decimal = null
+}
+
+"""Added in 26.7.0. Input for purging an app config allow-list entry."""
+input PurgeAppConfigAllowListInput {
+  """App config allow-list entry id to purge."""
+  id: UUID!
 }
 
 """Added in 26.7.0. Payload for app config allow-list entry purge."""

--- a/src/ai/backend/common/dto/manager/v2/app_config_allow_list/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_allow_list/request.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from uuid import UUID
+
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseRequestModel
@@ -17,6 +19,7 @@ __all__ = (
     "AppConfigAllowListFilter",
     "AppConfigAllowListOrder",
     "CreateAppConfigAllowListInput",
+    "PurgeAppConfigAllowListInput",
     "SearchAppConfigAllowListInput",
 )
 
@@ -32,6 +35,12 @@ class CreateAppConfigAllowListInput(BaseRequestModel):
     scope_type: AppConfigScopeType = Field(
         description="Scope at which fragments may be written (public | domain | user)."
     )
+
+
+class PurgeAppConfigAllowListInput(BaseRequestModel):
+    """Input for purging an app config allow-list entry."""
+
+    id: UUID = Field(description="App config allow-list entry id to purge.")
 
 
 class AppConfigAllowListFilter(BaseRequestModel):

--- a/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from functools import lru_cache
 
 from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
@@ -94,6 +95,25 @@ class AppConfigAllowListAdapter(BaseAdapter):
             GetAppConfigAllowListAction(allow_list_id=allow_list_id)
         )
         return self._data_to_node(action_result.allow_list)
+
+    async def batch_load_by_ids(self, ids: Sequence[UUID]) -> list[AppConfigAllowListNode | None]:
+        """Batch load app config allow-list entries by id for DataLoader use.
+
+        Returns nodes in the same order as the input ids, with None for missing ones.
+        """
+        if not ids:
+            return []
+        querier = self._build_querier(
+            conditions=[AppConfigAllowListConditions.by_ids(list(ids))],
+            orders=[],
+            pagination_spec=_get_app_config_allow_list_pagination_spec(),
+            limit=len(ids),
+        )
+        action_result = await self._processors.app_config_allow_list.search.wait_for_complete(
+            SearchAppConfigAllowListAction(querier=querier)
+        )
+        node_map = {node.id: node for node in map(self._data_to_node, action_result.data)}
+        return [node_map.get(allow_list_id) for allow_list_id in ids]
 
     async def admin_search(
         self, input: SearchAppConfigAllowListInput

--- a/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
@@ -9,6 +9,7 @@ from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
     AppConfigAllowListFilter,
     AppConfigAllowListOrder,
     CreateAppConfigAllowListInput,
+    PurgeAppConfigAllowListInput,
     SearchAppConfigAllowListInput,
 )
 from ai.backend.common.dto.manager.v2.app_config_allow_list.response import (
@@ -144,9 +145,9 @@ class AppConfigAllowListAdapter(BaseAdapter):
         )
 
     async def admin_purge(
-        self, allow_list_id: AppConfigAllowListID
+        self, input: PurgeAppConfigAllowListInput
     ) -> PurgeAppConfigAllowListPayload:
-        purger = Purger(row_class=AppConfigAllowListRow, pk_value=allow_list_id)
+        purger = Purger(row_class=AppConfigAllowListRow, pk_value=AppConfigAllowListID(input.id))
         action_result = await self._processors.app_config_allow_list.purge.wait_for_complete(
             PurgeAppConfigAllowListAction(purger=purger)
         )

--- a/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
@@ -96,7 +96,9 @@ class AppConfigAllowListAdapter(BaseAdapter):
         )
         return self._data_to_node(action_result.allow_list)
 
-    async def batch_load_by_ids(self, ids: Sequence[UUID]) -> list[AppConfigAllowListNode | None]:
+    async def batch_load_by_ids(
+        self, ids: Sequence[AppConfigAllowListID]
+    ) -> list[AppConfigAllowListNode | None]:
         """Batch load app config allow-list entries by id for DataLoader use.
 
         Returns nodes in the same order as the input ids, with None for missing ones.

--- a/src/ai/backend/manager/api/gql/app_config_allow_list/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config_allow_list/__init__.py
@@ -1,10 +1,10 @@
 """GraphQL app config allow-list module."""
 
 from .resolver import (
+    admin_app_config_allow_list,
+    admin_app_config_allow_lists,
     admin_create_app_config_allow_list,
     admin_purge_app_config_allow_list,
-    app_config_allow_list,
-    app_config_allow_lists,
 )
 from .types import (
     AppConfigAllowListConnection,
@@ -32,8 +32,8 @@ __all__ = (
     "CreateAppConfigAllowListPayloadGQL",
     "PurgeAppConfigAllowListPayloadGQL",
     # Query resolvers
-    "app_config_allow_list",
-    "app_config_allow_lists",
+    "admin_app_config_allow_list",
+    "admin_app_config_allow_lists",
     # Mutation resolvers
     "admin_create_app_config_allow_list",
     "admin_purge_app_config_allow_list",

--- a/src/ai/backend/manager/api/gql/app_config_allow_list/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config_allow_list/__init__.py
@@ -1,0 +1,40 @@
+"""GraphQL app config allow-list module."""
+
+from .resolver import (
+    admin_create_app_config_allow_list,
+    admin_purge_app_config_allow_list,
+    app_config_allow_list,
+    app_config_allow_lists,
+)
+from .types import (
+    AppConfigAllowListConnection,
+    AppConfigAllowListEdge,
+    AppConfigAllowListFilterGQL,
+    AppConfigAllowListGQL,
+    AppConfigAllowListOrderByGQL,
+    AppConfigAllowListOrderFieldGQL,
+    AppConfigScopeTypeFilterGQL,
+    CreateAppConfigAllowListInputGQL,
+    CreateAppConfigAllowListPayloadGQL,
+    PurgeAppConfigAllowListPayloadGQL,
+)
+
+__all__ = (
+    # Types
+    "AppConfigAllowListConnection",
+    "AppConfigAllowListEdge",
+    "AppConfigAllowListFilterGQL",
+    "AppConfigAllowListGQL",
+    "AppConfigAllowListOrderByGQL",
+    "AppConfigAllowListOrderFieldGQL",
+    "AppConfigScopeTypeFilterGQL",
+    "CreateAppConfigAllowListInputGQL",
+    "CreateAppConfigAllowListPayloadGQL",
+    "PurgeAppConfigAllowListPayloadGQL",
+    # Query resolvers
+    "app_config_allow_list",
+    "app_config_allow_lists",
+    # Mutation resolvers
+    "admin_create_app_config_allow_list",
+    "admin_purge_app_config_allow_list",
+)

--- a/src/ai/backend/manager/api/gql/app_config_allow_list/resolver.py
+++ b/src/ai/backend/manager/api/gql/app_config_allow_list/resolver.py
@@ -28,6 +28,7 @@ from .types import (
     AppConfigAllowListOrderByGQL,
     CreateAppConfigAllowListInputGQL,
     CreateAppConfigAllowListPayloadGQL,
+    PurgeAppConfigAllowListInputGQL,
     PurgeAppConfigAllowListPayloadGQL,
 )
 
@@ -124,8 +125,8 @@ async def admin_create_app_config_allow_list(
 )
 async def admin_purge_app_config_allow_list(
     info: Info[StrawberryGQLContext],
-    id: UUID,
+    input: PurgeAppConfigAllowListInputGQL,
 ) -> PurgeAppConfigAllowListPayloadGQL | None:
     check_admin_only()
-    payload = await info.context.adapters.app_config_allow_list.admin_purge(id)
+    payload = await info.context.adapters.app_config_allow_list.admin_purge(input.to_pydantic())
     return PurgeAppConfigAllowListPayloadGQL.from_pydantic(payload)

--- a/src/ai/backend/manager/api/gql/app_config_allow_list/resolver.py
+++ b/src/ai/backend/manager/api/gql/app_config_allow_list/resolver.py
@@ -38,7 +38,7 @@ from .types import (
         description="Get a single app config allow-list entry by id (super admin only).",
     )
 )  # type: ignore[misc]
-async def app_config_allow_list(
+async def admin_app_config_allow_list(
     info: Info[StrawberryGQLContext],
     id: UUID,
 ) -> AppConfigAllowListGQL | None:
@@ -56,7 +56,7 @@ async def app_config_allow_list(
         ),
     )
 )  # type: ignore[misc]
-async def app_config_allow_lists(
+async def admin_app_config_allow_lists(
     info: Info[StrawberryGQLContext],
     filter: AppConfigAllowListFilterGQL | None = None,
     order_by: list[AppConfigAllowListOrderByGQL] | None = None,

--- a/src/ai/backend/manager/api/gql/app_config_allow_list/resolver.py
+++ b/src/ai/backend/manager/api/gql/app_config_allow_list/resolver.py
@@ -10,6 +10,7 @@ from strawberry.relay import PageInfo
 from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
     SearchAppConfigAllowListInput,
 )
+from ai.backend.common.identifier.app_config_allow_list import AppConfigAllowListID
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import encode_cursor
 from ai.backend.manager.api.gql.decorators import (
@@ -44,7 +45,7 @@ async def admin_app_config_allow_list(
     id: UUID,
 ) -> AppConfigAllowListGQL | None:
     check_admin_only()
-    node = await info.context.adapters.app_config_allow_list.admin_get(id)
+    node = await info.context.adapters.app_config_allow_list.admin_get(AppConfigAllowListID(id))
     return AppConfigAllowListGQL.from_pydantic(node)
 
 

--- a/src/ai/backend/manager/api/gql/app_config_allow_list/resolver.py
+++ b/src/ai/backend/manager/api/gql/app_config_allow_list/resolver.py
@@ -1,0 +1,131 @@
+"""GraphQL query and mutation resolvers for app config allow-list entries."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from strawberry import Info
+from strawberry.relay import PageInfo
+
+from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
+    SearchAppConfigAllowListInput,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.base import encode_cursor
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_mutation,
+    gql_root_field,
+)
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+from ai.backend.manager.api.gql.utils import check_admin_only
+
+from .types import (
+    AppConfigAllowListConnection,
+    AppConfigAllowListEdge,
+    AppConfigAllowListFilterGQL,
+    AppConfigAllowListGQL,
+    AppConfigAllowListOrderByGQL,
+    CreateAppConfigAllowListInputGQL,
+    CreateAppConfigAllowListPayloadGQL,
+    PurgeAppConfigAllowListPayloadGQL,
+)
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Get a single app config allow-list entry by id (super admin only).",
+    )
+)  # type: ignore[misc]
+async def app_config_allow_list(
+    info: Info[StrawberryGQLContext],
+    id: UUID,
+) -> AppConfigAllowListGQL | None:
+    check_admin_only()
+    node = await info.context.adapters.app_config_allow_list.admin_get(id)
+    return AppConfigAllowListGQL.from_pydantic(node)
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Search app config allow-list entries with filtering, ordering, and pagination "
+            "(super admin only)."
+        ),
+    )
+)  # type: ignore[misc]
+async def app_config_allow_lists(
+    info: Info[StrawberryGQLContext],
+    filter: AppConfigAllowListFilterGQL | None = None,
+    order_by: list[AppConfigAllowListOrderByGQL] | None = None,
+    first: int | None = None,
+    after: str | None = None,
+    last: int | None = None,
+    before: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> AppConfigAllowListConnection | None:
+    check_admin_only()
+    pydantic_filter = filter.to_pydantic() if filter else None
+    pydantic_order = [o.to_pydantic() for o in order_by] if order_by else None
+
+    payload = await info.context.adapters.app_config_allow_list.admin_search(
+        SearchAppConfigAllowListInput(
+            filter=pydantic_filter,
+            order=pydantic_order,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        )
+    )
+
+    nodes = [AppConfigAllowListGQL.from_pydantic(node) for node in payload.items]
+    edges = [
+        AppConfigAllowListEdge(node=node, cursor=encode_cursor(str(node.id))) for node in nodes
+    ]
+
+    return AppConfigAllowListConnection(
+        edges=edges,
+        page_info=PageInfo(
+            has_next_page=payload.has_next_page,
+            has_previous_page=payload.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        ),
+        count=payload.total_count,
+    )
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Register a new app config allow-list entry (super admin only).",
+    )
+)
+async def admin_create_app_config_allow_list(
+    info: Info[StrawberryGQLContext],
+    input: CreateAppConfigAllowListInputGQL,
+) -> CreateAppConfigAllowListPayloadGQL | None:
+    check_admin_only()
+    payload = await info.context.adapters.app_config_allow_list.admin_create(input.to_pydantic())
+    return CreateAppConfigAllowListPayloadGQL.from_pydantic(payload)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Purge an app config allow-list entry by id (super admin only).",
+    )
+)
+async def admin_purge_app_config_allow_list(
+    info: Info[StrawberryGQLContext],
+    id: UUID,
+) -> PurgeAppConfigAllowListPayloadGQL | None:
+    check_admin_only()
+    payload = await info.context.adapters.app_config_allow_list.admin_purge(id)
+    return PurgeAppConfigAllowListPayloadGQL.from_pydantic(payload)

--- a/src/ai/backend/manager/api/gql/app_config_allow_list/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_allow_list/types.py
@@ -20,6 +20,9 @@ from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
 from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
     CreateAppConfigAllowListInput as CreateAppConfigAllowListInputDTO,
 )
+from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
+    PurgeAppConfigAllowListInput as PurgeAppConfigAllowListInputDTO,
+)
 from ai.backend.common.dto.manager.v2.app_config_allow_list.response import (
     AppConfigAllowListNode,
 )
@@ -61,6 +64,7 @@ __all__ = (
     "AppConfigScopeTypeFilterGQL",
     "CreateAppConfigAllowListInputGQL",
     "CreateAppConfigAllowListPayloadGQL",
+    "PurgeAppConfigAllowListInputGQL",
     "PurgeAppConfigAllowListPayloadGQL",
 )
 
@@ -225,6 +229,17 @@ class CreateAppConfigAllowListPayloadGQL(PydanticOutputMixin[CreateAppConfigAllo
     app_config_allow_list: AppConfigAllowListGQL = gql_field(
         description="The created app config allow-list entry."
     )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Input for purging an app config allow-list entry.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="PurgeAppConfigAllowListInput",
+)
+class PurgeAppConfigAllowListInputGQL(PydanticInputMixin[PurgeAppConfigAllowListInputDTO]):
+    id: UUID = gql_field(description="App config allow-list entry id to purge.")
 
 
 @gql_pydantic_type(

--- a/src/ai/backend/manager/api/gql/app_config_allow_list/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_allow_list/types.py
@@ -1,0 +1,222 @@
+"""GraphQL types for app config allow-list."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from strawberry.relay import Connection, Edge, NodeID
+
+from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
+    AppConfigAllowListFilter as AppConfigAllowListFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
+    AppConfigAllowListOrder as AppConfigAllowListOrderDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
+    CreateAppConfigAllowListInput as CreateAppConfigAllowListInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_allow_list.response import (
+    AppConfigAllowListNode,
+)
+from ai.backend.common.dto.manager.v2.app_config_allow_list.response import (
+    CreateAppConfigAllowListPayload as CreateAppConfigAllowListPayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_allow_list.response import (
+    PurgeAppConfigAllowListPayload as PurgeAppConfigAllowListPayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_allow_list.types import (
+    AppConfigScopeType,
+)
+from ai.backend.common.dto.manager.v2.app_config_allow_list.types import (
+    AppConfigScopeTypeFilter as AppConfigScopeTypeFilterDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection, StringFilter
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    PydanticInputMixin,
+    gql_connection_type,
+    gql_enum,
+    gql_field,
+    gql_node_type,
+    gql_pydantic_input,
+    gql_pydantic_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
+
+__all__ = (
+    "AppConfigAllowListConnection",
+    "AppConfigAllowListEdge",
+    "AppConfigAllowListFilterGQL",
+    "AppConfigAllowListGQL",
+    "AppConfigAllowListOrderByGQL",
+    "AppConfigAllowListOrderFieldGQL",
+    "AppConfigScopeTypeFilterGQL",
+    "CreateAppConfigAllowListInputGQL",
+    "CreateAppConfigAllowListPayloadGQL",
+    "PurgeAppConfigAllowListPayloadGQL",
+)
+
+
+# ---------------------------------------------------------------------------
+# Node / Edge / Connection
+# ---------------------------------------------------------------------------
+
+
+@gql_node_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="An app config allow-list entry (a per-(config_name, scope_type) write gate).",
+    ),
+    name="AppConfigAllowList",
+)
+class AppConfigAllowListGQL(PydanticNodeMixin[AppConfigAllowListNode]):
+    id: NodeID[str] = gql_field(
+        description="Relay-style global node identifier for the app config allow-list entry."
+    )
+    config_name: str = gql_field(description="Gated config name (FK to app config definitions).")
+    scope_type: AppConfigScopeType = gql_field(
+        description="Scope type the entry permits writes at (public | domain | user)."
+    )
+    created_at: datetime = gql_field(description="Creation timestamp (UTC).")
+    updated_at: datetime = gql_field(description="Last update timestamp (UTC).")
+
+
+AppConfigAllowListEdge = Edge[AppConfigAllowListGQL]
+
+
+@gql_connection_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Paginated connection for app config allow-list records.",
+    ),
+)
+class AppConfigAllowListConnection(Connection[AppConfigAllowListGQL]):
+    count: int = gql_field(
+        description="Total number of app config allow-list records matching the query criteria."
+    )
+
+    def __init__(self, *args: Any, count: int, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.count = count
+
+
+# ---------------------------------------------------------------------------
+# Filter / OrderBy
+# ---------------------------------------------------------------------------
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Filter input for the scope_type enum field.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="AppConfigScopeTypeFilter",
+)
+class AppConfigScopeTypeFilterGQL(PydanticInputMixin[AppConfigScopeTypeFilterDTO]):
+    equals: AppConfigScopeType | None = gql_field(
+        description="Exact scope type match.", default=None
+    )
+    in_: list[AppConfigScopeType] | None = gql_field(
+        description="Match any of the provided scope types.", name="in", default=None
+    )
+    not_equals: AppConfigScopeType | None = gql_field(
+        description="Exclude exact scope type match.", default=None
+    )
+    not_in: list[AppConfigScopeType] | None = gql_field(
+        description="Exclude any of the provided scope types.", default=None
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Filter input for querying app config allow-list entries.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="AppConfigAllowListFilter",
+)
+class AppConfigAllowListFilterGQL(PydanticInputMixin[AppConfigAllowListFilterDTO]):
+    config_name: StringFilter | None = gql_field(description="Filter by config name.", default=None)
+    scope_type: AppConfigScopeTypeFilterGQL | None = gql_field(
+        description="Filter by scope type.", default=None
+    )
+    created_at: DateTimeFilter | None = gql_field(
+        description="Filter by creation datetime.", default=None
+    )
+    updated_at: DateTimeFilter | None = gql_field(
+        description="Filter by last update datetime.", default=None
+    )
+
+
+@gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Fields available for ordering app config allow-list results.",
+    ),
+    name="AppConfigAllowListOrderField",
+)
+class AppConfigAllowListOrderFieldGQL(StrEnum):
+    CONFIG_NAME = "config_name"
+    SCOPE_TYPE = "scope_type"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Specifies ordering for app config allow-list results.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="AppConfigAllowListOrderBy",
+)
+class AppConfigAllowListOrderByGQL(PydanticInputMixin[AppConfigAllowListOrderDTO]):
+    field: AppConfigAllowListOrderFieldGQL = gql_field(description="The field to order by.")
+    direction: OrderDirection = gql_field(description="Sort direction.", default=OrderDirection.ASC)
+
+
+# ---------------------------------------------------------------------------
+# Mutation inputs / payloads
+# ---------------------------------------------------------------------------
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Input for registering a new app config allow-list entry.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="CreateAppConfigAllowListInput",
+)
+class CreateAppConfigAllowListInputGQL(PydanticInputMixin[CreateAppConfigAllowListInputDTO]):
+    config_name: str = gql_field(description="Registered config name to gate.")
+    scope_type: AppConfigScopeType = gql_field(
+        description="Scope at which fragments may be written (public | domain | user)."
+    )
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for app config allow-list entry creation.",
+    ),
+    model=CreateAppConfigAllowListPayloadDTO,
+    name="CreateAppConfigAllowListPayload",
+)
+class CreateAppConfigAllowListPayloadGQL(PydanticOutputMixin[CreateAppConfigAllowListPayloadDTO]):
+    app_config_allow_list: AppConfigAllowListGQL = gql_field(
+        description="The created app config allow-list entry."
+    )
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for app config allow-list entry purge.",
+    ),
+    model=PurgeAppConfigAllowListPayloadDTO,
+    all_fields=True,
+    name="PurgeAppConfigAllowListPayload",
+)
+class PurgeAppConfigAllowListPayloadGQL(PydanticOutputMixin[PurgeAppConfigAllowListPayloadDTO]):
+    pass

--- a/src/ai/backend/manager/api/gql/app_config_allow_list/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_allow_list/types.py
@@ -35,6 +35,7 @@ from ai.backend.common.dto.manager.v2.app_config_allow_list.types import (
 from ai.backend.common.dto.manager.v2.app_config_allow_list.types import (
     AppConfigScopeTypeFilter as AppConfigScopeTypeFilterDTO,
 )
+from ai.backend.common.identifier.app_config_allow_list import AppConfigAllowListID
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection, StringFilter
 from ai.backend.manager.api.gql.decorators import (
@@ -96,7 +97,7 @@ class AppConfigAllowListGQL(PydanticNodeMixin[AppConfigAllowListNode]):
         required: bool = False,
     ) -> Iterable[Self | None]:
         results = await info.context.data_loaders.app_config_allow_list_loader.load_many([
-            UUID(nid) for nid in node_ids
+            AppConfigAllowListID(UUID(nid)) for nid in node_ids
         ])
         return cast(list[Self | None], results)
 

--- a/src/ai/backend/manager/api/gql/app_config_allow_list/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_allow_list/types.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime
 from enum import StrEnum
-from typing import Any
+from typing import Any, Self, cast
+from uuid import UUID
 
+from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID
 
 from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
@@ -45,6 +48,7 @@ from ai.backend.manager.api.gql.decorators import (
     gql_pydantic_type,
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
 
 __all__ = (
     "AppConfigAllowListConnection",
@@ -68,7 +72,7 @@ __all__ = (
 @gql_node_type(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
-        description="An app config allow-list entry (a per-(config_name, scope_type) write gate).",
+        description="Permission to write config fragments for one config name at one scope type.",
     ),
     name="AppConfigAllowList",
 )
@@ -76,12 +80,25 @@ class AppConfigAllowListGQL(PydanticNodeMixin[AppConfigAllowListNode]):
     id: NodeID[str] = gql_field(
         description="Relay-style global node identifier for the app config allow-list entry."
     )
-    config_name: str = gql_field(description="Gated config name (FK to app config definitions).")
+    config_name: str = gql_field(description="The config name this entry permits writes for.")
     scope_type: AppConfigScopeType = gql_field(
         description="Scope type the entry permits writes at (public | domain | user)."
     )
     created_at: datetime = gql_field(description="Creation timestamp (UTC).")
     updated_at: datetime = gql_field(description="Last update timestamp (UTC).")
+
+    @classmethod
+    async def resolve_nodes(  # type: ignore[override]  # Strawberry Node uses AwaitableOrValue overloads incompatible with async def
+        cls,
+        *,
+        info: Info[StrawberryGQLContext],
+        node_ids: Iterable[str],
+        required: bool = False,
+    ) -> Iterable[Self | None]:
+        results = await info.context.data_loaders.app_config_allow_list_loader.load_many([
+            UUID(nid) for nid in node_ids
+        ])
+        return cast(list[Self | None], results)
 
 
 AppConfigAllowListEdge = Edge[AppConfigAllowListGQL]

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from strawberry.dataloader import DataLoader
 
+from ai.backend.common.identifier.app_config_allow_list import AppConfigAllowListID
 from ai.backend.common.identifier.app_config_definition import AppConfigDefinitionID
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.types import AgentId, ImageID, KernelId, SessionId
@@ -129,10 +130,12 @@ class DataLoaders:
     @cached_property
     def app_config_allow_list_loader(
         self,
-    ) -> DataLoader[uuid.UUID, AppConfigAllowListGQL | None]:
+    ) -> DataLoader[AppConfigAllowListID, AppConfigAllowListGQL | None]:
         adapter = self._adapters.app_config_allow_list
 
-        async def load_fn(ids: list[uuid.UUID]) -> list[AppConfigAllowListGQL | None]:
+        async def load_fn(
+            ids: list[AppConfigAllowListID],
+        ) -> list[AppConfigAllowListGQL | None]:
             from ai.backend.manager.api.gql.app_config_allow_list.types import (  # pants: no-infer-dep
                 AppConfigAllowListGQL as ACL,
             )

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -161,6 +161,8 @@ class DataLoaders:
             dtos = await adapter.batch_load_by_ids(ids)
             return [ACD.from_pydantic(dto) if dto is not None else None for dto in dtos]
 
+        return DataLoader(load_fn=load_fn)
+
     @cached_property
     def audit_log_loader(
         self,

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -15,6 +15,9 @@ if TYPE_CHECKING:
     from ai.backend.common.dto.manager.v2.rbac.response import EntityNode  # pants: no-infer-dep
     from ai.backend.manager.api.adapters.registry import Adapters  # pants: no-infer-dep
     from ai.backend.manager.api.gql.agent.types import AgentV2GQL  # pants: no-infer-dep
+    from ai.backend.manager.api.gql.app_config_allow_list.types import (  # pants: no-infer-dep
+        AppConfigAllowListGQL,
+    )
     from ai.backend.manager.api.gql.app_config_definition.types import (  # pants: no-infer-dep
         AppConfigDefinitionGQL,
     )
@@ -124,6 +127,22 @@ class DataLoaders:
         self._adapters = adapters
 
     @cached_property
+    def app_config_allow_list_loader(
+        self,
+    ) -> DataLoader[uuid.UUID, AppConfigAllowListGQL | None]:
+        adapter = self._adapters.app_config_allow_list
+
+        async def load_fn(ids: list[uuid.UUID]) -> list[AppConfigAllowListGQL | None]:
+            from ai.backend.manager.api.gql.app_config_allow_list.types import (  # pants: no-infer-dep
+                AppConfigAllowListGQL as ACL,
+            )
+
+            dtos = await adapter.batch_load_by_ids(ids)
+            return [ACL.from_pydantic(dto) if dto is not None else None for dto in dtos]
+
+        return DataLoader(load_fn=load_fn)
+
+    @cached_property
     def app_config_definition_loader(
         self,
     ) -> DataLoader[AppConfigDefinitionID, AppConfigDefinitionGQL | None]:
@@ -138,8 +157,6 @@ class DataLoaders:
 
             dtos = await adapter.batch_load_by_ids(ids)
             return [ACD.from_pydantic(dto) if dto is not None else None for dto in dtos]
-
-        return DataLoader(load_fn=load_fn)
 
     @cached_property
     def audit_log_loader(

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -16,10 +16,10 @@ from .agent import (
     agents_v2,
 )
 from .app_config_allow_list import (
+    admin_app_config_allow_list,
+    admin_app_config_allow_lists,
     admin_create_app_config_allow_list,
     admin_purge_app_config_allow_list,
-    app_config_allow_list,
-    app_config_allow_lists,
 )
 from .app_config_definition import (
     admin_app_config_definition,
@@ -472,8 +472,8 @@ from .vfs_storage import (
 class Query:
     agent_stats = agent_stats
     agents_v2 = agents_v2
-    app_config_allow_list = app_config_allow_list
-    app_config_allow_lists = app_config_allow_lists
+    admin_app_config_allow_list = admin_app_config_allow_list
+    admin_app_config_allow_lists = admin_app_config_allow_lists
     artifact = artifact
     artifacts = artifacts
     artifact_revision = artifact_revision

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -15,6 +15,12 @@ from .agent import (
     agent_stats,
     agents_v2,
 )
+from .app_config_allow_list import (
+    admin_create_app_config_allow_list,
+    admin_purge_app_config_allow_list,
+    app_config_allow_list,
+    app_config_allow_lists,
+)
 from .app_config_definition import (
     admin_app_config_definition,
     admin_app_config_definitions,
@@ -466,6 +472,8 @@ from .vfs_storage import (
 class Query:
     agent_stats = agent_stats
     agents_v2 = agents_v2
+    app_config_allow_list = app_config_allow_list
+    app_config_allow_lists = app_config_allow_lists
     artifact = artifact
     artifacts = artifacts
     artifact_revision = artifact_revision
@@ -673,6 +681,8 @@ class Query:
 
 @strawberry.type
 class Mutation:
+    admin_create_app_config_allow_list = admin_create_app_config_allow_list
+    admin_purge_app_config_allow_list = admin_purge_app_config_allow_list
     scan_artifacts = scan_artifacts
     scan_artifact_models = scan_artifact_models
     import_artifacts = import_artifacts

--- a/src/ai/backend/manager/api/rest/v2/app_config_allow_list/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_allow_list/handler.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Final
 from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam
 from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
     CreateAppConfigAllowListInput,
+    PurgeAppConfigAllowListInput,
     SearchAppConfigAllowListInput,
 )
 from ai.backend.common.identifier.app_config_allow_list import AppConfigAllowListID
@@ -61,6 +62,6 @@ class V2AppConfigAllowListHandler:
     ) -> APIResponse:
         """Purge an app config allow-list entry by id (superadmin only)."""
         result = await self._adapter.admin_purge(
-            AppConfigAllowListID(path.parsed.app_config_allow_list_id)
+            PurgeAppConfigAllowListInput(id=path.parsed.app_config_allow_list_id)
         )
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/models/app_config_allow_list/conditions.py
+++ b/src/ai/backend/manager/models/app_config_allow_list/conditions.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from datetime import datetime
 
 import sqlalchemy as sa
@@ -71,6 +71,13 @@ class AppConfigAllowListConditions:
         return inner
 
     by_config_name_in = staticmethod(make_string_in_factory(AppConfigAllowListRow.config_name))
+
+    @staticmethod
+    def by_ids(ids: Collection[uuid.UUID]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigAllowListRow.id.in_(ids)
+
+        return inner
 
     # --- scope_type filters ---
 

--- a/tests/unit/manager/api/gql/test_app_config_allow_list_types.py
+++ b/tests/unit/manager/api/gql/test_app_config_allow_list_types.py
@@ -100,7 +100,7 @@ class TestSchemaRegistration:
     def test_types_and_root_fields_present_in_schema(self) -> None:
         sdl = schema.as_str()
         assert "type AppConfigAllowList " in sdl
-        assert "appConfigAllowList(" in sdl
-        assert "appConfigAllowLists(" in sdl
+        assert "adminAppConfigAllowList(" in sdl
+        assert "adminAppConfigAllowLists(" in sdl
         assert "adminCreateAppConfigAllowList(" in sdl
         assert "adminPurgeAppConfigAllowList(" in sdl

--- a/tests/unit/manager/api/gql/test_app_config_allow_list_types.py
+++ b/tests/unit/manager/api/gql/test_app_config_allow_list_types.py
@@ -20,7 +20,6 @@ from ai.backend.manager.api.gql.app_config_allow_list.types import (
     AppConfigScopeTypeFilterGQL,
 )
 from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection, StringFilter
-from ai.backend.manager.api.gql.schema import schema
 
 
 class TestAppConfigAllowListGQL:
@@ -94,14 +93,3 @@ class TestAppConfigAllowListInputs:
 
         assert dto.field == AppConfigAllowListOrderField.SCOPE_TYPE
         assert dto.direction.value == OrderDirection.DESC.value
-
-
-class TestSchemaRegistration:
-    def test_types_and_root_fields_present_in_schema(self) -> None:
-        sdl = schema.as_str()
-        assert "type AppConfigAllowList " in sdl
-        assert "adminAppConfigAllowList(" in sdl
-        assert "adminAppConfigAllowLists(" in sdl
-        assert "adminCreateAppConfigAllowList(" in sdl
-        assert "adminPurgeAppConfigAllowList(" in sdl
-        assert "input PurgeAppConfigAllowListInput " in sdl

--- a/tests/unit/manager/api/gql/test_app_config_allow_list_types.py
+++ b/tests/unit/manager/api/gql/test_app_config_allow_list_types.py
@@ -104,3 +104,4 @@ class TestSchemaRegistration:
         assert "adminAppConfigAllowLists(" in sdl
         assert "adminCreateAppConfigAllowList(" in sdl
         assert "adminPurgeAppConfigAllowList(" in sdl
+        assert "input PurgeAppConfigAllowListInput " in sdl

--- a/tests/unit/manager/api/gql/test_app_config_allow_list_types.py
+++ b/tests/unit/manager/api/gql/test_app_config_allow_list_types.py
@@ -1,0 +1,106 @@
+"""Unit tests for AppConfigAllowList GraphQL types and schema registration."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from ai.backend.common.dto.manager.v2.app_config_allow_list.response import (
+    AppConfigAllowListNode,
+)
+from ai.backend.common.dto.manager.v2.app_config_allow_list.types import (
+    AppConfigAllowListOrderField,
+    AppConfigScopeType,
+)
+from ai.backend.manager.api.gql.app_config_allow_list.types import (
+    AppConfigAllowListFilterGQL,
+    AppConfigAllowListGQL,
+    AppConfigAllowListOrderByGQL,
+    AppConfigAllowListOrderFieldGQL,
+    AppConfigScopeTypeFilterGQL,
+)
+from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection, StringFilter
+from ai.backend.manager.api.gql.schema import schema
+
+
+class TestAppConfigAllowListGQL:
+    def test_from_pydantic_maps_all_fields(self) -> None:
+        created = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        updated = datetime(2026, 1, 2, 12, 0, 0, tzinfo=UTC)
+        node = AppConfigAllowListNode(
+            id=uuid.uuid4(),
+            config_name="theme",
+            scope_type=AppConfigScopeType.DOMAIN,
+            created_at=created,
+            updated_at=updated,
+        )
+
+        gql = AppConfigAllowListGQL.from_pydantic(node)
+
+        assert gql.config_name == "theme"
+        assert gql.scope_type == AppConfigScopeType.DOMAIN
+        assert gql.created_at == created
+        assert gql.updated_at == updated
+
+
+class TestAppConfigAllowListInputs:
+    def test_filter_to_pydantic_string(self) -> None:
+        filter_gql = AppConfigAllowListFilterGQL(
+            config_name=StringFilter(contains="the"),
+            scope_type=None,
+            created_at=None,
+            updated_at=None,
+        )
+
+        dto = filter_gql.to_pydantic()
+
+        assert dto.config_name is not None
+        assert dto.config_name.contains == "the"
+
+    def test_filter_to_pydantic_scope_type(self) -> None:
+        filter_gql = AppConfigAllowListFilterGQL(
+            config_name=None,
+            scope_type=AppConfigScopeTypeFilterGQL(equals=AppConfigScopeType.USER),
+            created_at=None,
+            updated_at=None,
+        )
+
+        dto = filter_gql.to_pydantic()
+
+        assert dto.scope_type is not None
+        assert dto.scope_type.equals == AppConfigScopeType.USER
+
+    def test_filter_to_pydantic_datetime(self) -> None:
+        after = datetime(2026, 1, 1, tzinfo=UTC)
+        filter_gql = AppConfigAllowListFilterGQL(
+            config_name=None,
+            scope_type=None,
+            created_at=DateTimeFilter(after=after),
+            updated_at=None,
+        )
+
+        dto = filter_gql.to_pydantic()
+
+        assert dto.created_at is not None
+        assert dto.created_at.after == after
+
+    def test_order_by_to_pydantic(self) -> None:
+        order_gql = AppConfigAllowListOrderByGQL(
+            field=AppConfigAllowListOrderFieldGQL.SCOPE_TYPE,
+            direction=OrderDirection.DESC,
+        )
+
+        dto = order_gql.to_pydantic()
+
+        assert dto.field == AppConfigAllowListOrderField.SCOPE_TYPE
+        assert dto.direction.value == OrderDirection.DESC.value
+
+
+class TestSchemaRegistration:
+    def test_types_and_root_fields_present_in_schema(self) -> None:
+        sdl = schema.as_str()
+        assert "type AppConfigAllowList " in sdl
+        assert "appConfigAllowList(" in sdl
+        assert "appConfigAllowLists(" in sdl
+        assert "adminCreateAppConfigAllowList(" in sdl
+        assert "adminPurgeAppConfigAllowList(" in sdl


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of the AppConfigAllowList stack (BA-6543 → BA-6548), built on `main`. **Merge in order:**

1. ⬇️ #12289 — `feat(BA-6543): app_config_allow_list DB model and Alembic migration`
2. ⬇️ #12290 — `feat(BA-6544): repository layer`
3. ⬇️ #12292 — `feat(BA-6545): service layer (actions, processors)`
4. ⬇️ #12293 — `feat(BA-6546): REST v2 API`
5. 👉 **#12296** — `feat(BA-6547): GraphQL API (Strawberry)` ← you are here
6. ⬇️ #12298 — `feat(BA-6548): client SDK v2 & CLI v2`

## Summary
- Add the Strawberry GraphQL surface for `app_config_allow_list`: the `AppConfigAllowList` node, filter (config_name / scope_type / created_at / updated_at), order, the `app_config_allow_list` / `app_config_allow_lists` queries, and the `admin_create` / `admin_purge` mutations.
- Super-admin-only; reuses the shared `AppConfigAllowListAdapter` and the v2 DTOs (no Model/Row imports in the GQL layer).
- Entity supports only create / get / search / purge (no update / delete).

> The GraphQL schema dump (`docs/manager/graphql-reference/{v2-schema,supergraph}.graphql`) is regenerated and included in this PR (after rebasing onto `main`) so the dump stays consistent with the new GQL types; the new types are also verified present via the schema-registration test.

Resolves BA-6547.




<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12296.org.readthedocs.build/en/12296/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12296.org.readthedocs.build/ko/12296/

<!-- readthedocs-preview sorna-ko end -->


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12296.org.readthedocs.build/en/12296/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12296.org.readthedocs.build/ko/12296/

<!-- readthedocs-preview sorna-ko end -->