### PR TITLE
feat(BA-6548): add app_config_allow_list client SDK v2 and CLI v2

### DIFF
--- a/changes/12298.feature.md
+++ b/changes/12298.feature.md
@@ -1,0 +1,1 @@
+Add the app_config_allow_list client SDK v2 and CLI v2 commands.

--- a/src/ai/backend/client/cli/v2/admin/__init__.py
+++ b/src/ai/backend/client/cli/v2/admin/__init__.py
@@ -45,6 +45,15 @@ def agent() -> None:
     """Admin agent commands."""
 
 
+@admin.group(
+    cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.admin.app_config_allow_list:app_config_allow_list",
+    name="app-config-allow-list",
+)
+def app_config_allow_list() -> None:
+    """Admin app config allow-list commands."""
+
+
 @admin.group(cls=LazyGroup, import_name="ai.backend.client.cli.v2.admin.deployment:deployment")
 def deployment() -> None:
     """Admin deployment commands."""

--- a/src/ai/backend/client/cli/v2/admin/app_config_allow_list.py
+++ b/src/ai/backend/client/cli/v2/admin/app_config_allow_list.py
@@ -1,0 +1,162 @@
+"""Admin CLI commands for app config allow-list entries."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    parse_order_options,
+    print_result,
+)
+from ai.backend.common.dto.manager.v2.app_config_allow_list.types import AppConfigScopeType
+
+
+@click.group()
+def app_config_allow_list() -> None:
+    """App config allow-list admin commands (superadmin required)."""
+
+
+@app_config_allow_list.command()
+@click.option("--config-name", required=True, type=str, help="Registered config name to gate.")
+@click.option(
+    "--scope-type",
+    required=True,
+    type=click.Choice([scope_type.value for scope_type in AppConfigScopeType]),
+    help="Scope type the entry permits writes at.",
+)
+def create(config_name: str, scope_type: str) -> None:
+    """Register a new app config allow-list entry."""
+    from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
+        CreateAppConfigAllowListInput,
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_allow_list.admin_create(
+                CreateAppConfigAllowListInput(
+                    config_name=config_name,
+                    scope_type=AppConfigScopeType(scope_type),
+                )
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@app_config_allow_list.command()
+@click.argument("app_config_allow_list_id", type=click.UUID)
+def get(app_config_allow_list_id: uuid.UUID) -> None:
+    """Get an app config allow-list entry by ID."""
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_allow_list.admin_get(app_config_allow_list_id)
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@app_config_allow_list.command()
+@click.option("--limit", type=int, default=20, help="Maximum number of items to return.")
+@click.option("--offset", type=int, default=0, help="Number of items to skip.")
+@click.option(
+    "--config-name-contains",
+    default=None,
+    type=str,
+    help="Filter by config name (substring match).",
+)
+@click.option(
+    "--scope-type",
+    default=None,
+    type=click.Choice([scope_type.value for scope_type in AppConfigScopeType]),
+    help="Filter by scope type (exact match).",
+)
+@click.option(
+    "--order-by",
+    multiple=True,
+    help="Order by field:direction (e.g., config_name:asc, created_at:desc).",
+)
+def search(
+    limit: int,
+    offset: int,
+    config_name_contains: str | None,
+    scope_type: str | None,
+    order_by: tuple[str, ...],
+) -> None:
+    """Search app config allow-list entries."""
+    from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
+        AppConfigAllowListFilter,
+        AppConfigAllowListOrder,
+        SearchAppConfigAllowListInput,
+    )
+    from ai.backend.common.dto.manager.v2.app_config_allow_list.types import (
+        AppConfigAllowListOrderField,
+        AppConfigScopeTypeFilter,
+    )
+
+    filter_dto: AppConfigAllowListFilter | None = None
+    if config_name_contains is not None or scope_type is not None:
+        from ai.backend.common.dto.manager.query import StringFilter
+
+        filter_dto = AppConfigAllowListFilter(
+            config_name=(
+                StringFilter(contains=config_name_contains)
+                if config_name_contains is not None
+                else None
+            ),
+            scope_type=(
+                AppConfigScopeTypeFilter(equals=AppConfigScopeType(scope_type))
+                if scope_type is not None
+                else None
+            ),
+        )
+
+    orders = (
+        parse_order_options(order_by, AppConfigAllowListOrderField, AppConfigAllowListOrder)
+        if order_by
+        else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_allow_list.admin_search(
+                SearchAppConfigAllowListInput(
+                    filter=filter_dto,
+                    order=orders,
+                    limit=limit,
+                    offset=offset,
+                )
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@app_config_allow_list.command()
+@click.argument("app_config_allow_list_id", type=click.UUID)
+def purge(app_config_allow_list_id: uuid.UUID) -> None:
+    """Purge an app config allow-list entry by ID."""
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_allow_list.admin_purge(app_config_allow_list_id)
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())

--- a/src/ai/backend/client/v2/domains_v2/app_config_allow_list.py
+++ b/src/ai/backend/client/v2/domains_v2/app_config_allow_list.py
@@ -1,0 +1,72 @@
+"""V2 SDK client for the app config allow-list domain."""
+
+from __future__ import annotations
+
+from typing import Final
+from uuid import UUID
+
+from ai.backend.client.v2.base_domain import BaseDomainClient
+from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
+    CreateAppConfigAllowListInput,
+    SearchAppConfigAllowListInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_allow_list.response import (
+    AppConfigAllowListNode,
+    CreateAppConfigAllowListPayload,
+    PurgeAppConfigAllowListPayload,
+    SearchAppConfigAllowListPayload,
+)
+
+_PATH: Final = "/v2/app-config-allow-list"
+
+
+class V2AppConfigAllowListClient(BaseDomainClient):
+    """SDK client for app config allow-list operations.
+
+    Mirrors the REST v2 surface introduced in BA-6546. All calls require
+    super-admin privileges; the entity supports create, get, search, and
+    purge (no update or delete).
+    """
+
+    async def admin_create(
+        self,
+        request: CreateAppConfigAllowListInput,
+    ) -> CreateAppConfigAllowListPayload:
+        """Register a new app config allow-list entry (superadmin only)."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/",
+            request=request,
+            response_model=CreateAppConfigAllowListPayload,
+        )
+
+    async def admin_search(
+        self,
+        request: SearchAppConfigAllowListInput,
+    ) -> SearchAppConfigAllowListPayload:
+        """Search app config allow-list entries with filter/order/pagination (superadmin only)."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/search",
+            request=request,
+            response_model=SearchAppConfigAllowListPayload,
+        )
+
+    async def admin_get(self, app_config_allow_list_id: UUID) -> AppConfigAllowListNode:
+        """Get a single app config allow-list entry by ID (superadmin only)."""
+        return await self._client.typed_request(
+            "GET",
+            f"{_PATH}/{app_config_allow_list_id}",
+            response_model=AppConfigAllowListNode,
+        )
+
+    async def admin_purge(
+        self,
+        app_config_allow_list_id: UUID,
+    ) -> PurgeAppConfigAllowListPayload:
+        """Purge an app config allow-list entry by ID (superadmin only)."""
+        return await self._client.typed_request(
+            "DELETE",
+            f"{_PATH}/{app_config_allow_list_id}",
+            response_model=PurgeAppConfigAllowListPayload,
+        )

--- a/src/ai/backend/client/v2/v2_registry.py
+++ b/src/ai/backend/client/v2/v2_registry.py
@@ -16,6 +16,7 @@ from .config import ClientConfig
 
 if TYPE_CHECKING:
     from .domains_v2.agent import V2AgentClient
+    from .domains_v2.app_config_allow_list import V2AppConfigAllowListClient
     from .domains_v2.app_config_definition import V2AppConfigDefinitionClient
     from .domains_v2.artifact import V2ArtifactClient
     from .domains_v2.artifact_registry import V2ArtifactRegistryClient
@@ -89,6 +90,12 @@ class V2ClientRegistry:
         from .domains_v2.agent import V2AgentClient
 
         return V2AgentClient(self._client)
+
+    @cached_property
+    def app_config_allow_list(self) -> V2AppConfigAllowListClient:
+        from .domains_v2.app_config_allow_list import V2AppConfigAllowListClient
+
+        return V2AppConfigAllowListClient(self._client)
 
     @cached_property
     def app_config_definition(self) -> V2AppConfigDefinitionClient:

--- a/tests/unit/client_v2/test_app_config_allow_list.py
+++ b/tests/unit/client_v2/test_app_config_allow_list.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+from yarl import URL
+
+from ai.backend.client.v2.base_client import BackendAIAuthClient
+from ai.backend.client.v2.config import ClientConfig
+from ai.backend.client.v2.domains_v2.app_config_allow_list import V2AppConfigAllowListClient
+from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
+    CreateAppConfigAllowListInput,
+    SearchAppConfigAllowListInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_allow_list.response import (
+    AppConfigAllowListNode,
+    CreateAppConfigAllowListPayload,
+    PurgeAppConfigAllowListPayload,
+    SearchAppConfigAllowListPayload,
+)
+from ai.backend.common.dto.manager.v2.app_config_allow_list.types import AppConfigScopeType
+
+from .conftest import MockAuth
+
+_DEFAULT_CONFIG = ClientConfig(endpoint=URL("https://api.example.com"))
+
+
+def _make_request_session(resp: AsyncMock) -> MagicMock:
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=resp)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+    mock_session = MagicMock()
+    mock_session.request = MagicMock(return_value=mock_ctx)
+    return mock_session
+
+
+def _make_client(mock_session: MagicMock) -> V2AppConfigAllowListClient:
+    auth_client = BackendAIAuthClient(_DEFAULT_CONFIG, MockAuth(), mock_session)
+    return V2AppConfigAllowListClient(auth_client)
+
+
+def _node_payload(entry_id: str, config_name: str) -> dict[str, str]:
+    return {
+        "id": entry_id,
+        "config_name": config_name,
+        "scope_type": "domain",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-02T00:00:00+00:00",
+    }
+
+
+class TestAdminCreate:
+    async def test_happy_path(self) -> None:
+        entry_id = str(uuid4())
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(
+            return_value={"app_config_allow_list": _node_payload(entry_id, "theme")}
+        )
+        mock_session = _make_request_session(mock_resp)
+        client = _make_client(mock_session)
+
+        result = await client.admin_create(
+            CreateAppConfigAllowListInput(
+                config_name="theme",
+                scope_type=AppConfigScopeType.DOMAIN,
+            )
+        )
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "POST"
+        assert str(call_args[0][1]).endswith("/v2/app-config-allow-list/")
+        assert isinstance(result, CreateAppConfigAllowListPayload)
+        assert result.app_config_allow_list.config_name == "theme"
+        assert result.app_config_allow_list.scope_type == AppConfigScopeType.DOMAIN
+
+
+class TestAdminSearch:
+    async def test_happy_path(self) -> None:
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(
+            return_value={
+                "items": [_node_payload(str(uuid4()), "menu")],
+                "total_count": 1,
+                "has_next_page": False,
+                "has_previous_page": False,
+            }
+        )
+        mock_session = _make_request_session(mock_resp)
+        client = _make_client(mock_session)
+
+        result = await client.admin_search(SearchAppConfigAllowListInput(limit=10))
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "POST"
+        assert "/v2/app-config-allow-list/search" in str(call_args[0][1])
+        assert isinstance(result, SearchAppConfigAllowListPayload)
+        assert [item.config_name for item in result.items] == ["menu"]
+        assert result.total_count == 1
+
+
+class TestAdminGet:
+    async def test_happy_path(self) -> None:
+        entry_id = uuid4()
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value=_node_payload(str(entry_id), "preferences"))
+        mock_session = _make_request_session(mock_resp)
+        client = _make_client(mock_session)
+
+        result = await client.admin_get(entry_id)
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "GET"
+        assert str(call_args[0][1]).endswith(f"/v2/app-config-allow-list/{entry_id}")
+        assert isinstance(result, AppConfigAllowListNode)
+        assert result.config_name == "preferences"
+
+
+class TestAdminPurge:
+    async def test_happy_path(self) -> None:
+        entry_id = uuid4()
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": str(entry_id)})
+        mock_session = _make_request_session(mock_resp)
+        client = _make_client(mock_session)
+
+        result = await client.admin_purge(entry_id)
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "DELETE"
+        assert str(call_args[0][1]).endswith(f"/v2/app-config-allow-list/{entry_id}")
+        assert isinstance(result, PurgeAppConfigAllowListPayload)
+        assert result.id == entry_id


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of the AppConfigAllowList stack (BA-6543 → BA-6548), built on `main`. **Merge in order:**

1. ⬇️ #12289 — `feat(BA-6543): app_config_allow_list DB model and Alembic migration`
2. ⬇️ #12290 — `feat(BA-6544): repository layer`
3. ⬇️ #12292 — `feat(BA-6545): service layer (actions, processors)`
4. ⬇️ #12293 — `feat(BA-6546): REST v2 API`
5. ⬇️ #12296 — `feat(BA-6547): GraphQL API (Strawberry)`
6. 👉 **#12298** — `feat(BA-6548): client SDK v2 & CLI v2` ← you are here

## Summary
- Add `V2AppConfigAllowListClient` (`admin_create` / `admin_get` / `admin_search` / `admin_purge`) over the shared v2 DTOs, hitting the REST v2 routes under `/v2/app-config-allow-list`; registered in `V2ClientRegistry`.
- Add the `./bai admin app-config-allow-list {create,get,search,purge}` CLI command group calling the SDK (superadmin only).

## CLI usage & results

Run against a live local manager (superadmin). `config_name` is an FK into `app_config_definitions`, so a definition (`theme`) was registered first.

**Command tree**

```console
$ ./bai admin app-config-allow-list --help
Commands:
  create  Register a new app config allow-list entry.
  get     Get an app config allow-list entry by ID.
  purge   Purge an app config allow-list entry by ID.
  search  Search app config allow-list entries.
```

**create**

```console
$ ./bai admin app-config-allow-list create --config-name theme --scope-type domain
{
  "app_config_allow_list": {
    "id": "db6dbbdd-3c70-48fb-9fac-68c85cae7f43",
    "config_name": "theme",
    "scope_type": "domain",
    "created_at": "2026-06-23T02:24:12.790319Z",
    "updated_at": "2026-06-23T02:24:12.790319Z"
  }
}
```

**search** (with ordering / filtering)

```console
$ ./bai admin app-config-allow-list search --limit 10 --order-by created_at:desc
{
  "items": [
    { "id": "022fb5f1-aeb9-45d2-b9d7-1bd70ed71e80", "config_name": "theme", "scope_type": "user",   "created_at": "2026-06-23T02:24:22.830553Z", "updated_at": "2026-06-23T02:24:22.830553Z" },
    { "id": "db6dbbdd-3c70-48fb-9fac-68c85cae7f43", "config_name": "theme", "scope_type": "domain", "created_at": "2026-06-23T02:24:12.790319Z", "updated_at": "2026-06-23T02:24:12.790319Z" }
  ],
  "total_count": 2,
  "has_next_page": false,
  "has_previous_page": false
}

$ ./bai admin app-config-allow-list search --scope-type user
{
  "items": [
    { "id": "022fb5f1-aeb9-45d2-b9d7-1bd70ed71e80", "config_name": "theme", "scope_type": "user", "created_at": "2026-06-23T02:24:22.830553Z", "updated_at": "2026-06-23T02:24:22.830553Z" }
  ],
  "total_count": 1,
  "has_next_page": false,
  "has_previous_page": false
}
```

**get**

```console
$ ./bai admin app-config-allow-list get db6dbbdd-3c70-48fb-9fac-68c85cae7f43
{
  "id": "db6dbbdd-3c70-48fb-9fac-68c85cae7f43",
  "config_name": "theme",
  "scope_type": "domain",
  "created_at": "2026-06-23T02:24:12.790319Z",
  "updated_at": "2026-06-23T02:24:12.790319Z"
}
```

**purge** (and confirming it's gone)

```console
$ ./bai admin app-config-allow-list purge 022fb5f1-aeb9-45d2-b9d7-1bd70ed71e80
{
  "id": "022fb5f1-aeb9-45d2-b9d7-1bd70ed71e80"
}

$ ./bai admin app-config-allow-list get 022fb5f1-aeb9-45d2-b9d7-1bd70ed71e80
NotFoundError(404, 'Not Found', {'title': 'No such app config allow-list entry.',
  'error_code': 'backendai_read_not-found',
  'msg': 'App config allow-list entry 022fb5f1-aeb9-45d2-b9d7-1bd70ed71e80 not found'})
```

Resolves BA-6548.


