### PR TITLE
feat(BA-6552): add app_config_fragments DB model and Alembic migration

### DIFF
--- a/changes/12306.feature.md
+++ b/changes/12306.feature.md
@@ -1,0 +1,1 @@
+Add the app_config_fragments DB model and Alembic migration (BEP-1052).

--- a/src/ai/backend/common/identifier/app_config_fragment.py
+++ b/src/ai/backend/common/identifier/app_config_fragment.py
@@ -1,0 +1,7 @@
+from typing import NewType
+from uuid import UUID
+
+__all__ = ("AppConfigFragmentID",)
+
+
+AppConfigFragmentID = NewType("AppConfigFragmentID", UUID)

--- a/src/ai/backend/manager/data/app_config_fragment/types.py
+++ b/src/ai/backend/manager/data/app_config_fragment/types.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+
+
+class AppConfigScopeType(enum.StrEnum):
+    """Scope at which an app config fragment is written (BEP-1052)."""
+
+    PUBLIC = "public"
+    DOMAIN = "domain"
+    USER = "user"
+
+
+@dataclass(frozen=True)
+class AppConfigFragmentData:
+    """Domain data for one app config fragment — a single scoped JSON document."""
+
+    id: AppConfigFragmentID
+    config_name: str
+    scope_type: AppConfigScopeType
+    scope_id: str
+    rank: int
+    config: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime

--- a/src/ai/backend/manager/models/alembic/versions/a8e06485829f_create_app_config_fragments_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/a8e06485829f_create_app_config_fragments_table.py
@@ -1,0 +1,66 @@
+"""create app_config_fragments table
+
+Introduce ``app_config_fragments`` — the single source-of-truth table for
+scoped app-config values (BEP-1052). Each row is one JSON ``config`` document
+at a ``(config_name, scope_type, scope_id)`` natural key, carrying a ``rank``
+that orders fragments for the deep-merge that produces the merged ``AppConfig``
+view. ``config_name`` references the registered set in
+``app_config_definitions``.
+
+Revision ID: a8e06485829f
+Revises: 2d6443ac0d4a
+Create Date: 2026-06-18
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+from ai.backend.manager.models.base import IDColumn
+
+# revision identifiers, used by Alembic.
+revision = "a8e06485829f"
+down_revision = "2d6443ac0d4a"
+# Part of: 26.5.0
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "app_config_fragments",
+        IDColumn(),
+        sa.Column(
+            "config_name",
+            sa.String(length=128),
+            sa.ForeignKey("app_config_definitions.config_name", ondelete="NO ACTION"),
+            nullable=False,
+        ),
+        sa.Column("scope_type", sa.String(length=64), nullable=False),
+        sa.Column("scope_id", sa.String(length=255), nullable=False),
+        sa.Column("rank", sa.Integer(), nullable=False),
+        sa.Column("config", JSONB(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "config_name",
+            "scope_type",
+            "scope_id",
+            name="uq_app_config_fragments_config_name_scope_type_scope_id",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("app_config_fragments")

--- a/src/ai/backend/manager/models/app_config_fragment/__init__.py
+++ b/src/ai/backend/manager/models/app_config_fragment/__init__.py
@@ -1,0 +1,3 @@
+from .row import AppConfigFragmentRow
+
+__all__ = ("AppConfigFragmentRow",)

--- a/src/ai/backend/manager/models/app_config_fragment/row.py
+++ b/src/ai/backend/manager/models/app_config_fragment/row.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+from ai.backend.manager.data.app_config_fragment.types import (
+    AppConfigFragmentData,
+    AppConfigScopeType,
+)
+from ai.backend.manager.models.base import GUID, Base, StrEnumType
+
+__all__ = ("AppConfigFragmentRow",)
+
+
+class AppConfigFragmentRow(Base):  # type: ignore[misc]
+    """One scoped app config fragment — a single JSON document at ``(config_name, scope_type, scope_id)``."""
+
+    __tablename__ = "app_config_fragments"
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "config_name",
+            "scope_type",
+            "scope_id",
+            name="uq_app_config_fragments_config_name_scope_type_scope_id",
+        ),
+    )
+
+    id: Mapped[AppConfigFragmentID] = mapped_column(
+        "id",
+        GUID(AppConfigFragmentID),
+        primary_key=True,
+        server_default=sa.text("uuid_generate_v4()"),
+    )
+    config_name: Mapped[str] = mapped_column(
+        "config_name",
+        sa.String(length=128),
+        sa.ForeignKey("app_config_definitions.config_name", ondelete="NO ACTION"),
+        nullable=False,
+    )
+    scope_type: Mapped[AppConfigScopeType] = mapped_column(
+        "scope_type",
+        StrEnumType(AppConfigScopeType),
+        nullable=False,
+    )
+    scope_id: Mapped[str] = mapped_column(
+        "scope_id",
+        sa.String(length=255),
+        nullable=False,
+    )
+    rank: Mapped[int] = mapped_column(
+        "rank",
+        sa.Integer,
+        nullable=False,
+    )
+    config: Mapped[dict[str, Any]] = mapped_column(
+        "config",
+        JSONB,
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        "created_at",
+        sa.DateTime(timezone=True),
+        server_default=sa.func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        "updated_at",
+        sa.DateTime(timezone=True),
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+        nullable=False,
+    )
+
+    def to_data(self) -> AppConfigFragmentData:
+        return AppConfigFragmentData(
+            id=self.id,
+            config_name=self.config_name,
+            scope_type=self.scope_type,
+            scope_id=self.scope_id,
+            rank=self.rank,
+            config=self.config,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+        )


### PR DESCRIPTION
## 📚 Stacked PRs

Part of the AppConfigFragment / AppConfig stack under BEP-1052 (epic BA-5781). **Merge in order:**

1. 👉 **#12306 — `feat(BA-6552): app_config_fragments DB model and Alembic migration`** ← you are here
2. #12307 — `feat(BA-6553): repository layer`
3. #12358 — `feat(BA-6554): service layer (admin/self write paths, allow-list write-gate)`
4. #12359 — `feat(BA-6555): merge engine (deep-merge across applicable fragments)`

## Summary
- Add the `app_config_fragments` table — the single source-of-truth for scoped app-config values (BEP-1052).
- Columns: `id` (UUID PK), `config_name` (FK → `app_config_definitions.config_name`, `ON DELETE NO ACTION`), `scope_type` (`public` | `domain` | `user`), `scope_id`, `rank` (merge priority within a `config_name`), `config` (JSONB), `created_at` / `updated_at`.
- Natural-key uniqueness on `(config_name, scope_type, scope_id)`.
- Adds the SQLAlchemy `AppConfigFragmentRow`, the `AppConfigFragmentData` value type, and the `AppConfigFragmentID` identifier.

## Notes
- The migration chains off `9fc9e6bfe695` (the app_config_definitions migration), which is the same head the **unmerged** AppConfigAllowList migration (#12289) also chains off. Expect a diverged-alembic-heads conflict when both lines land — resolve by re-chaining one migration onto the other.
- `AppConfigScopeType` (`public`/`domain`/`user`) is defined locally in this stack's data module; it **duplicates** the identical enum on the unmerged AppConfigAllowList stack (cross-stack import isn't possible while both are open). A follow-up should consolidate both into a shared `app_config` module once the stacks land.
- DB-only PR; no tests (matches the AppConfigDefinition / AppConfigAllowList DB PRs). The table is exercised by the repository PR's `with_tables` tests (BA-6553).

Resolves BA-6552.


