### PR TITLE
fix(BA-6570): order scale-in drain by termination priority

### DIFF
--- a/changes/12323.fix.md
+++ b/changes/12323.fix.md
@@ -1,0 +1,1 @@
+Terminate not-yet-serving and unhealthy model-service replicas first on scale-in, instead of ordering removal solely by creation time.

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -975,14 +975,6 @@ class ScaleOutDecision:
     target_revision_id: DeploymentRevisionID | None = None
 
 
-_HEALTH_TERMINATION_PRIORITY: dict[RouteHealthStatus, int] = {
-    RouteHealthStatus.UNHEALTHY: 1,
-    RouteHealthStatus.DEGRADED: 2,
-    RouteHealthStatus.NOT_CHECKED: 3,
-    RouteHealthStatus.HEALTHY: 4,
-}
-
-
 @dataclass
 class RouteInfo:
     """Route information for deployment."""
@@ -999,17 +991,6 @@ class RouteInfo:
     health_check: ModelHealthCheck | None
     replica_group_id: ReplicaGroupID | None = None
     error_data: dict[str, Any] = field(default_factory=dict)
-
-    @property
-    def termination_priority(self) -> int:
-        """Priority for scale-in termination (lower = terminated first).
-
-        Non-RUNNING routes are terminated first (0).
-        Among RUNNING routes: UNHEALTHY(1) > DEGRADED(2) > NOT_CHECKED(3) > HEALTHY(4).
-        """
-        if self.status != RouteStatus.RUNNING:
-            return 0
-        return _HEALTH_TERMINATION_PRIORITY.get(self.health_status, 0)
 
 
 @dataclass

--- a/src/ai/backend/manager/repositories/replica_group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/replica_group/db_source/db_source.py
@@ -19,6 +19,7 @@ from ai.backend.manager.data.deployment.types import (
     DeploymentHandlerOptions,
     ReplicaGroupHandlerCategory,
     ReplicaGroupLifecycle,
+    RouteHealthStatus,
     RouteStatus,
     RouteSubStatus,
     RouteTrafficStatus,
@@ -87,6 +88,31 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+def _serving_predicate() -> sa.ColumnElement[bool]:
+    """RUNNING & traffic ACTIVE — routes actually receiving traffic."""
+    return sa.and_(
+        RoutingRow.status == RouteStatus.RUNNING,
+        RoutingRow.traffic_status == RouteTrafficStatus.ACTIVE,
+    )
+
+
+def _live_predicate() -> sa.ColumnElement[bool]:
+    """PROVISIONING (warming) or serving — routes counted toward the replica count."""
+    return sa.or_(RoutingRow.status == RouteStatus.PROVISIONING, _serving_predicate())
+
+
+def _scale_in_termination_priority() -> sa.ColumnElement[int]:
+    """Scale-in drain order (lower drains first): not-yet-serving (PROVISIONING) first,
+    then RUNNING by health UNHEALTHY < DEGRADED < NOT_CHECKED < HEALTHY."""
+    return sa.case(
+        (RoutingRow.status != RouteStatus.RUNNING, 0),
+        (RoutingRow.health_status == RouteHealthStatus.UNHEALTHY, 1),
+        (RoutingRow.health_status == RouteHealthStatus.DEGRADED, 2),
+        (RoutingRow.health_status == RouteHealthStatus.NOT_CHECKED, 3),
+        else_=4,
+    )
 
 
 class ReplicaGroupDBSource:
@@ -309,11 +335,8 @@ class ReplicaGroupDBSource:
     ) -> Mapping[ReplicaGroupID, Mapping[DeploymentRevisionID, RevisionReplicaCount]]:
         if not group_ids:
             return {}
-        serving = sa.and_(
-            RoutingRow.status == RouteStatus.RUNNING,
-            RoutingRow.traffic_status == RouteTrafficStatus.ACTIVE,
-        )
-        live = sa.or_(RoutingRow.status == RouteStatus.PROVISIONING, serving)
+        serving = _serving_predicate()
+        live = _live_predicate()
         query = (
             sa.select(
                 RoutingRow.replica_group_id,
@@ -520,15 +543,16 @@ class ReplicaGroupDBSource:
         for drain in drain_instructions:
             if drain.count <= 0:
                 continue
+            # Candidates are the live set (same as the deficit count): not-yet-serving
+            # PROVISIONING routes drain before serving RUNNING routes, RUNNING by health.
             query = (
                 sa.select(RoutingRow.id)
                 .where(
                     RoutingRow.replica_group_id == drain.replica_group_id,
                     RoutingRow.revision == drain.revision_id,
-                    RoutingRow.status == RouteStatus.RUNNING,
-                    RoutingRow.traffic_status == RouteTrafficStatus.ACTIVE,
+                    _live_predicate(),
                 )
-                .order_by(RoutingRow.created_at.desc())
+                .order_by(_scale_in_termination_priority().asc(), RoutingRow.created_at.asc())
                 .limit(drain.count)
             )
             result = await db_sess.execute(query)

--- a/tests/unit/manager/repositories/replica_group/test_replica_group_repository.py
+++ b/tests/unit/manager/repositories/replica_group/test_replica_group_repository.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
 
 import pytest
 import sqlalchemy as sa
@@ -18,7 +19,9 @@ from ai.backend.manager.data.deployment.types import (
     ReplicaGroupHandlerCategory,
     ReplicaGroupLifecycle,
     ReplicaGroupScalingStatus,
+    RouteHealthStatus,
     RouteStatus,
+    RouteSubStatus,
     RouteTrafficStatus,
 )
 from ai.backend.manager.models.domain import DomainRow
@@ -49,8 +52,63 @@ from ai.backend.manager.repositories.deployment.updaters import (
     ReplicaGroupScalingUpdaterSpec,
 )
 from ai.backend.manager.repositories.replica_group import ReplicaGroupRepository
+from ai.backend.manager.repositories.replica_group.types import (
+    GroupRouteDrainInstruction,
+    ReplicaGroupScalingReconcileApply,
+)
 from ai.backend.manager.types import OptionalState
 from ai.backend.testutils.db import with_tables
+
+
+def _running_route(
+    endpoint_row: EndpointRow,
+    group_id: ReplicaGroupID,
+    revision_id: DeploymentRevisionID,
+    *,
+    route_id: uuid.UUID,
+    health_status: RouteHealthStatus,
+    created_at: datetime,
+) -> RoutingRow:
+    return RoutingRow(
+        id=route_id,
+        endpoint=endpoint_row.id,
+        session=None,
+        session_owner=endpoint_row.session_owner,
+        domain=endpoint_row.domain,
+        project=endpoint_row.project,
+        traffic_ratio=1.0,
+        revision=revision_id,
+        replica_group_id=group_id,
+        status=RouteStatus.RUNNING,
+        traffic_status=RouteTrafficStatus.ACTIVE,
+        health_status=health_status,
+        created_at=created_at,
+    )
+
+
+def _provisioning_route(
+    endpoint_row: EndpointRow,
+    group_id: ReplicaGroupID,
+    revision_id: DeploymentRevisionID,
+    *,
+    route_id: uuid.UUID,
+    created_at: datetime,
+) -> RoutingRow:
+    return RoutingRow(
+        id=route_id,
+        endpoint=endpoint_row.id,
+        session=None,
+        session_owner=endpoint_row.session_owner,
+        domain=endpoint_row.domain,
+        project=endpoint_row.project,
+        traffic_ratio=1.0,
+        revision=revision_id,
+        replica_group_id=group_id,
+        status=RouteStatus.PROVISIONING,
+        traffic_status=RouteTrafficStatus.INACTIVE,
+        health_status=RouteHealthStatus.NOT_CHECKED,
+        created_at=created_at,
+    )
 
 
 def _password_info(password: str) -> PasswordInfo:
@@ -401,3 +459,276 @@ class TestReplicaGroupRepository:
         count_by_id = {group.group_id: group.desired_current_replica_count for group in groups}
         assert count_by_id[first_id] == 5
         assert count_by_id[second_id] == 7
+
+    async def test_apply_scaling_reconcile_drains_least_healthy_routes_first(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        replica_group_repository: ReplicaGroupRepository,
+        test_endpoint_id: DeploymentID,
+    ) -> None:
+        group_id = ReplicaGroupID(uuid.uuid4())
+        revision_id = DeploymentRevisionID(uuid.uuid4())
+        base = datetime(2026, 1, 1, tzinfo=UTC)
+        healthy_old_id = uuid.uuid4()
+        healthy_new_id = uuid.uuid4()
+        unhealthy_id = uuid.uuid4()
+        degraded_id = uuid.uuid4()
+        async with db_with_cleanup.begin_session() as db_sess:
+            endpoint_row = (
+                await db_sess.execute(
+                    sa.select(EndpointRow).where(EndpointRow.id == test_endpoint_id)
+                )
+            ).scalar_one()
+            db_sess.add(
+                ReplicaGroupRow(
+                    id=group_id,
+                    deployment_id=test_endpoint_id,
+                    current_revision_id=revision_id,
+                    desired_current_replica_count=2,
+                    desired_target_replica_count=0,
+                    lifecycle=ReplicaGroupLifecycle.STABLE,
+                    scaling_status=ReplicaGroupScalingStatus.SCALING,
+                )
+            )
+            # Oldest routes are HEALTHY; newer routes are UNHEALTHY/DEGRADED.
+            # Priority must win over created_at, so the unhealthy ones drain first.
+            db_sess.add(
+                _running_route(
+                    endpoint_row,
+                    group_id,
+                    revision_id,
+                    route_id=healthy_old_id,
+                    health_status=RouteHealthStatus.HEALTHY,
+                    created_at=base,
+                )
+            )
+            db_sess.add(
+                _running_route(
+                    endpoint_row,
+                    group_id,
+                    revision_id,
+                    route_id=unhealthy_id,
+                    health_status=RouteHealthStatus.UNHEALTHY,
+                    created_at=base + timedelta(minutes=1),
+                )
+            )
+            db_sess.add(
+                _running_route(
+                    endpoint_row,
+                    group_id,
+                    revision_id,
+                    route_id=degraded_id,
+                    health_status=RouteHealthStatus.DEGRADED,
+                    created_at=base + timedelta(minutes=2),
+                )
+            )
+            db_sess.add(
+                _running_route(
+                    endpoint_row,
+                    group_id,
+                    revision_id,
+                    route_id=healthy_new_id,
+                    health_status=RouteHealthStatus.HEALTHY,
+                    created_at=base + timedelta(minutes=3),
+                )
+            )
+            await db_sess.commit()
+
+        await replica_group_repository.apply_scaling_reconcile(
+            ReplicaGroupScalingReconcileApply(
+                drain_instructions=[
+                    GroupRouteDrainInstruction(
+                        replica_group_id=group_id,
+                        revision_id=revision_id,
+                        count=2,
+                    )
+                ],
+            )
+        )
+
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            rows = (
+                await db_sess.execute(
+                    sa.select(RoutingRow.id, RoutingRow.status, RoutingRow.sub_status).where(
+                        RoutingRow.replica_group_id == group_id
+                    )
+                )
+            ).all()
+        status_by_id = {row.id: row.status for row in rows}
+        sub_status_by_id = {row.id: row.sub_status for row in rows}
+        assert status_by_id[unhealthy_id] is RouteStatus.TERMINATING
+        assert status_by_id[degraded_id] is RouteStatus.TERMINATING
+        assert sub_status_by_id[unhealthy_id] is RouteSubStatus.DRAINING
+        assert sub_status_by_id[degraded_id] is RouteSubStatus.DRAINING
+        assert status_by_id[healthy_old_id] is RouteStatus.RUNNING
+        assert status_by_id[healthy_new_id] is RouteStatus.RUNNING
+
+    async def test_apply_scaling_reconcile_breaks_ties_by_oldest_first(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        replica_group_repository: ReplicaGroupRepository,
+        test_endpoint_id: DeploymentID,
+    ) -> None:
+        group_id = ReplicaGroupID(uuid.uuid4())
+        revision_id = DeploymentRevisionID(uuid.uuid4())
+        base = datetime(2026, 1, 1, tzinfo=UTC)
+        oldest_id = uuid.uuid4()
+        middle_id = uuid.uuid4()
+        newest_id = uuid.uuid4()
+        async with db_with_cleanup.begin_session() as db_sess:
+            endpoint_row = (
+                await db_sess.execute(
+                    sa.select(EndpointRow).where(EndpointRow.id == test_endpoint_id)
+                )
+            ).scalar_one()
+            db_sess.add(
+                ReplicaGroupRow(
+                    id=group_id,
+                    deployment_id=test_endpoint_id,
+                    current_revision_id=revision_id,
+                    desired_current_replica_count=1,
+                    desired_target_replica_count=0,
+                    lifecycle=ReplicaGroupLifecycle.STABLE,
+                    scaling_status=ReplicaGroupScalingStatus.SCALING,
+                )
+            )
+            # All equally healthy -> created_at ascending decides: oldest drains first.
+            for route_id, offset in (
+                (oldest_id, 0),
+                (middle_id, 1),
+                (newest_id, 2),
+            ):
+                db_sess.add(
+                    _running_route(
+                        endpoint_row,
+                        group_id,
+                        revision_id,
+                        route_id=route_id,
+                        health_status=RouteHealthStatus.HEALTHY,
+                        created_at=base + timedelta(minutes=offset),
+                    )
+                )
+            await db_sess.commit()
+
+        await replica_group_repository.apply_scaling_reconcile(
+            ReplicaGroupScalingReconcileApply(
+                drain_instructions=[
+                    GroupRouteDrainInstruction(
+                        replica_group_id=group_id,
+                        revision_id=revision_id,
+                        count=2,
+                    )
+                ],
+            )
+        )
+
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            rows = (
+                await db_sess.execute(
+                    sa.select(RoutingRow.id, RoutingRow.status).where(
+                        RoutingRow.replica_group_id == group_id
+                    )
+                )
+            ).all()
+        status_by_id = {row.id: row.status for row in rows}
+        assert status_by_id[oldest_id] is RouteStatus.TERMINATING
+        assert status_by_id[middle_id] is RouteStatus.TERMINATING
+        assert status_by_id[newest_id] is RouteStatus.RUNNING
+
+    async def test_apply_scaling_reconcile_drains_not_yet_serving_routes_first(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        replica_group_repository: ReplicaGroupRepository,
+        test_endpoint_id: DeploymentID,
+    ) -> None:
+        group_id = ReplicaGroupID(uuid.uuid4())
+        revision_id = DeploymentRevisionID(uuid.uuid4())
+        base = datetime(2026, 1, 1, tzinfo=UTC)
+        provisioning_old_id = uuid.uuid4()
+        provisioning_new_id = uuid.uuid4()
+        running_healthy_id = uuid.uuid4()
+        running_unhealthy_id = uuid.uuid4()
+        async with db_with_cleanup.begin_session() as db_sess:
+            endpoint_row = (
+                await db_sess.execute(
+                    sa.select(EndpointRow).where(EndpointRow.id == test_endpoint_id)
+                )
+            ).scalar_one()
+            db_sess.add(
+                ReplicaGroupRow(
+                    id=group_id,
+                    deployment_id=test_endpoint_id,
+                    current_revision_id=revision_id,
+                    desired_current_replica_count=2,
+                    desired_target_replica_count=0,
+                    lifecycle=ReplicaGroupLifecycle.STABLE,
+                    scaling_status=ReplicaGroupScalingStatus.SCALING,
+                )
+            )
+            # Not-yet-serving PROVISIONING routes must drain before serving RUNNING ones,
+            # even an UNHEALTHY RUNNING route, since they are not receiving traffic yet.
+            db_sess.add(
+                _provisioning_route(
+                    endpoint_row,
+                    group_id,
+                    revision_id,
+                    route_id=provisioning_old_id,
+                    created_at=base,
+                )
+            )
+            db_sess.add(
+                _running_route(
+                    endpoint_row,
+                    group_id,
+                    revision_id,
+                    route_id=running_healthy_id,
+                    health_status=RouteHealthStatus.HEALTHY,
+                    created_at=base + timedelta(minutes=1),
+                )
+            )
+            db_sess.add(
+                _provisioning_route(
+                    endpoint_row,
+                    group_id,
+                    revision_id,
+                    route_id=provisioning_new_id,
+                    created_at=base + timedelta(minutes=2),
+                )
+            )
+            db_sess.add(
+                _running_route(
+                    endpoint_row,
+                    group_id,
+                    revision_id,
+                    route_id=running_unhealthy_id,
+                    health_status=RouteHealthStatus.UNHEALTHY,
+                    created_at=base + timedelta(minutes=3),
+                )
+            )
+            await db_sess.commit()
+
+        await replica_group_repository.apply_scaling_reconcile(
+            ReplicaGroupScalingReconcileApply(
+                drain_instructions=[
+                    GroupRouteDrainInstruction(
+                        replica_group_id=group_id,
+                        revision_id=revision_id,
+                        count=2,
+                    )
+                ],
+            )
+        )
+
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            rows = (
+                await db_sess.execute(
+                    sa.select(RoutingRow.id, RoutingRow.status).where(
+                        RoutingRow.replica_group_id == group_id
+                    )
+                )
+            ).all()
+        status_by_id = {row.id: row.status for row in rows}
+        assert status_by_id[provisioning_old_id] is RouteStatus.TERMINATING
+        assert status_by_id[provisioning_new_id] is RouteStatus.TERMINATING
+        assert status_by_id[running_healthy_id] is RouteStatus.RUNNING
+        assert status_by_id[running_unhealthy_id] is RouteStatus.RUNNING


### PR DESCRIPTION
## Summary
- Scale-in selected drain targets by `created_at` only, so it could keep unhealthy or still-provisioning replicas while terminating healthy, serving ones.
- Drain candidates now match the **live set** (`PROVISIONING OR (RUNNING & ACTIVE)`) that the deficit counts, removing the live/drain asymmetry that left PROVISIONING replicas alive during scale-in.
- Candidates are ordered by termination priority: not-yet-serving PROVISIONING routes first, then RUNNING by health (`UNHEALTHY < DEGRADED < NOT_CHECKED < HEALTHY`), ties broken oldest-first.
- Removes the unused `RouteInfo.termination_priority` property and its priority dict (dead code) in favor of shared SQL predicates/`CASE` helpers in the db source.

## Test plan
- [x] `pants fmt :: / fix :: / lint` pass
- [x] `pants test tests/unit/manager/repositories/replica_group::` passes
- [ ] DB-backed unit tests cover: health priority beats created_at; oldest-first tie-break; PROVISIONING drained before RUNNING
- [ ] Live: scale a deployment down with mixed UNHEALTHY / PROVISIONING replicas and confirm non-serving / unhealthy replicas terminate first

Resolves BA-6570