### PR TITLE
fix(BA-6571): measure session lifetime from starts_at instead of created_at

### DIFF
--- a/changes/12325.fix.md
+++ b/changes/12325.fix.md
@@ -1,0 +1,1 @@
+Measure the session lifetime limit (`max_session_lifetime`) from when the session starts running (`starts_at`) instead of when it was created, so scheduling wait time is no longer counted against the user's allowed lifetime.

--- a/src/ai/backend/manager/idle.py
+++ b/src/ai/backend/manager/idle.py
@@ -844,7 +844,9 @@ class SessionLifetimeChecker(BaseIdleChecker):
         if (max_session_lifetime := policy.max_session_lifetime) > 0:
             idle_timeout = timedelta(seconds=max_session_lifetime)
             now: datetime = await get_db_now(dbconn)
-            kernel_starts_at: datetime = kernel.starts_at
+            # starts_at is set at the RUNNING transition; fall back to created_at
+            # for abnormal/legacy rows where it was never populated.
+            kernel_starts_at: datetime = kernel.starts_at or kernel.created_at
             remaining = calculate_remaining_time(
                 now, kernel_starts_at, idle_timeout, grace_period_end
             )

--- a/src/ai/backend/manager/idle.py
+++ b/src/ai/backend/manager/idle.py
@@ -288,6 +288,7 @@ class IdleCheckerHost:
                     kernels.c.session_id,
                     kernels.c.session_type,
                     kernels.c.created_at,
+                    kernels.c.starts_at,
                     kernels.c.occupied_slots,
                     kernels.c.requested_slots,
                     kernels.c.cluster_size,
@@ -841,13 +842,11 @@ class SessionLifetimeChecker(BaseIdleChecker):
 
         session_id = kernel.session_id
         if (max_session_lifetime := policy.max_session_lifetime) > 0:
-            # TODO: once per-status time tracking is implemented, let's change created_at
-            #       to the timestamp when the session entered PREPARING status.
             idle_timeout = timedelta(seconds=max_session_lifetime)
             now: datetime = await get_db_now(dbconn)
-            kernel_created_at: datetime = kernel.created_at
+            kernel_starts_at: datetime = kernel.starts_at
             remaining = calculate_remaining_time(
-                now, kernel_created_at, idle_timeout, grace_period_end
+                now, kernel_starts_at, idle_timeout, grace_period_end
             )
             await self.set_remaining_time_report(
                 session_id, remaining if remaining > 0 else IDLE_TIMEOUT_VALUE

--- a/tests/unit/manager/test_idle_checker.py
+++ b/tests/unit/manager/test_idle_checker.py
@@ -463,6 +463,17 @@ class TestSessionLifetimeChecker:
         )
 
     @pytest.fixture
+    def session_kernel_row_without_starts_at(
+        self, session_id: SessionId, base_time: datetime
+    ) -> Any:
+        """Kernel row missing starts_at; created_at is the fallback baseline"""
+        return mock_row(
+            session_id=session_id,
+            starts_at=None,
+            created_at=base_time,
+        )
+
+    @pytest.fixture
     def session_lifetime_policy(self, test_config: _SessionLifetimeTestConfig) -> Any:
         """Policy with max_session_lifetime from test_config"""
         return mock_row(max_session_lifetime=test_config.max_lifetime_seconds)
@@ -539,6 +550,47 @@ class TestSessionLifetimeChecker:
         )
 
         # Then
+        assert should_alive is test_config.expected_alive
+        assert remaining == test_config.expected_remaining
+
+    @pytest.mark.parametrize(
+        "test_config",
+        [
+            # Remaining = max_lifetime - elapsed = 30 - 10 = 20s
+            _SessionLifetimeTestConfig(
+                elapsed_seconds=10,
+                max_lifetime_seconds=30,
+                expected_remaining=20.0,
+                expected_alive=True,
+            ),
+        ],
+        ids=["fallback_to_created_at"],
+    )
+    async def test_session_lifetime_falls_back_to_created_at(
+        self,
+        test_config: _SessionLifetimeTestConfig,
+        session_id: SessionId,
+        valkey_live: AsyncMock,
+        db_connection: AsyncMock,
+        session_lifetime_checker: SessionLifetimeChecker,
+        session_kernel_row_without_starts_at: Any,
+        session_lifetime_policy: Any,
+    ) -> None:
+        """When starts_at is None, created_at is used as the lifetime baseline"""
+        # When - check_idleness runs against a row without starts_at
+        should_alive = await session_lifetime_checker.check_idleness(
+            session_kernel_row_without_starts_at,
+            db_connection,
+            session_lifetime_policy,
+        )
+
+        # Mock: get_checker_result will read the stored result
+        valkey_live.get_live_data.return_value = msgpack.packb(test_config.expected_remaining)
+        remaining = await session_lifetime_checker.get_checker_result(
+            session_lifetime_checker._redis_live, session_id
+        )
+
+        # Then - baseline falls back to created_at, yielding the same remaining time
         assert should_alive is test_config.expected_alive
         assert remaining == test_config.expected_remaining
 

--- a/tests/unit/manager/test_idle_checker.py
+++ b/tests/unit/manager/test_idle_checker.py
@@ -456,10 +456,10 @@ class TestSessionLifetimeChecker:
 
     @pytest.fixture
     def session_kernel_row(self, session_id: SessionId, base_time: datetime) -> Any:
-        """Kernel row with session created at base_time"""
+        """Kernel row with session started (RUNNING) at base_time"""
         return mock_row(
             session_id=session_id,
-            created_at=base_time,
+            starts_at=base_time,
         )
 
     @pytest.fixture


### PR DESCRIPTION
## Summary

- The `session_lifetime` idle checker compared `max_session_lifetime` against `kernel.created_at` (set at PENDING / row creation), so scheduling wait time (PENDING~PREPARING) was counted against the user's allowed lifetime. A VOC reported that sessions which queued before running were kept alive for less running time than the policy intended.
- Switch the baseline to `kernel.starts_at` (set at the RUNNING transition) so the lifetime is measured from actual execution start.
- The idle check only queries RUNNING kernels (`LIVE_STATUS = (KernelStatus.RUNNING,)`), so `starts_at` is always populated at check time — no NULL fallback needed. Added `kernels.c.starts_at` to the idle-check SELECT.
- Scope is unchanged: interactive and batch sessions (the idle lifetime query filters out `INFERENCE`). Batch sessions also set `starts_at` at RUNNING (the batch startup command runs after RUNNING), so they begin counting from actual execution start as well.

## Test plan

**Unit**
- [x] `pants test tests/unit/manager/test_idle_checker.py` — `TestSessionLifetimeChecker` updated to use `starts_at` baseline; passes.
- [x] `pants fmt / fix / lint` — all pass.

**Live verification** (local manager rebuilt with this change; `./bai` v2 CLI + Grafana Loki)

1. Confirmed timestamp semantics — both interactive and batch sessions set `starts_at` at the RUNNING transition, ~62s after `created_at` (image pull + prepare):

   | session | created_at | starts_at | gap |
   |---------|-----------|-----------|-----|
   | interactive | 04:20:54 | 04:21:57 | ~63s |
   | batch | 04:20:55 | 04:21:57 | ~62s |

2. Confirmed scope — the idle lifetime query excludes `INFERENCE`; applies to interactive/batch.

3. **Discriminating PENDING-starvation test** (`max_session_lifetime = 120s`):
   - Held the agent with a large session so a small session stayed **PENDING for ~118s**, then freed resources so it reached RUNNING.
   - `created_at = 04:36:08`, `starts_at = 04:38:06`, terminated at `04:40:23`.
   - With the old `created_at` baseline the session would have been killed ~2s after RUNNING (`created_at + 120 = 04:38:08`). Instead it survived the full lifetime from `starts_at` (`starts_at + 120 = 04:40:06`, terminated on the next ~15s idle-check cycle).
   - Manager log confirms the terminator and timing:
     ```
     04:40:19 INFO idle.py:348 do_idle_check
     "The session_lifetime idle checker triggered termination of s:2a5e98cc-..."
     ```
   - The ~118s of PENDING wait was not counted against the lifetime. ✅

Resolves BA-6571
