### PR TITLE
[WIP][DO NOT MERGE] feat(kata): hacky KataAgent backend — run a Backend.AI session in a Kata VM (PoC)

### DIFF
--- a/src/ai/backend/agent/config/unified.py
+++ b/src/ai/backend/agent/config/unified.py
@@ -2318,7 +2318,9 @@ class AgentSpecificConfig(BaseConfigSchema):
         match self.agent.backend:
             case AgentBackend.KUBERNETES:
                 self.container.validate_kubernetes_nfs()
-            case AgentBackend.DOCKER:
+            case AgentBackend.DOCKER | AgentBackend.KATA:
+                # KataAgent reuses the Docker container-config handling, so it
+                # shares the same validation (scratch, bind host, etc.).
                 DockerExtraConfig.model_validate(self.container.model_dump())
             case AgentBackend.DUMMY:
                 pass

--- a/src/ai/backend/agent/errors/kata.py
+++ b/src/ai/backend/agent/errors/kata.py
@@ -1,0 +1,44 @@
+"""
+KataAgent (Kata Containers backend) operation-related exceptions.
+"""
+
+from __future__ import annotations
+
+from aiohttp import web
+
+from ai.backend.common.exception import (
+    BackendAIError,
+    ErrorCode,
+    ErrorDetail,
+    ErrorDomain,
+    ErrorOperation,
+)
+
+
+class NerdctlError(BackendAIError, web.HTTPInternalServerError):
+    """Raised when a ``nerdctl``/containerd subprocess invocation fails."""
+
+    error_type = "https://api.backend.ai/probs/agent/kata/nerdctl-failed"
+    error_title = "A nerdctl/containerd subprocess invocation failed."
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.KERNEL,
+            operation=ErrorOperation.EXECUTE,
+            error_detail=ErrorDetail.INTERNAL_ERROR,
+        )
+
+
+class KataVolumeResolutionError(BackendAIError, web.HTTPInternalServerError):
+    """Raised when a Docker named volume cannot be resolved to a host path for
+    bind-mounting into a Kata guest."""
+
+    error_type = "https://api.backend.ai/probs/agent/kata/volume-resolution-failed"
+    error_title = "Failed to resolve a named volume to a host path."
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.KERNEL,
+            operation=ErrorOperation.SETUP,
+            error_detail=ErrorDetail.NOT_FOUND,
+        )

--- a/src/ai/backend/agent/kata/README.md
+++ b/src/ai/backend/agent/kata/README.md
@@ -20,7 +20,8 @@ image scan/pull) is inherited unchanged. The only behavioral delta:
 |---|---|---|
 | create + start container | `aiodocker` `containers.create()` + `container.start()` | translate `container_config` → `nerdctl run -d --runtime io.containerd.kata.v2` |
 | destroy / clean | `aiodocker` stop/delete | `nerdctl stop` / `nerdctl rm -f -v` |
-| logs / list / download | `aiodocker` / `docker exec` | `nerdctl logs` / `nerdctl exec` |
+| logs / list-files | `aiodocker` / `docker exec` | `nerdctl logs` / `nerdctl exec` (plain exec) |
+| file upload / download | host-side scratch write / `get_archive` | host-side read/write of the rw **virtio-fs scratch** share (§4b) |
 | named krunner volume | Docker named volume | resolved to its host path and **bind-mounted** (Kata can't share a Docker named volume into the guest) |
 | death detection | dockerd event stream | lightweight `nerdctl ps` poller (dockerd events don't see containerd's namespace) |
 
@@ -124,20 +125,24 @@ This `kata/` backend uses the **nerdctl/containerd** path instead because (a) it
 is what Handover A's host proves (`nerdctl --runtime io.containerd.kata.v2`), (b)
 it keeps Kata kernels in a separate containerd namespace from Docker, and (c) it
 is the cleaner stepping stone toward the production containerd-gRPC backend
-(BEP-1051 / report §6d.3). It also routes file upload/download through the kernel
-**exec channel** (tar over `nerdctl exec`), which should fix the upload/download
-gap seen on the Docker-runtime path.
+(BEP-1051 / report §6d.3). File upload/download go through the **rw virtio-fs
+scratch share** (host-side read/write of the kernel `work` dir), which live
+testing on `kata-lab-150` proved transfers 1 MiB byte-exact in both directions —
+the BA-6541 "upload fails" symptom was the Docker `cp`/`get_archive` API, not the
+shared mount. (An earlier draft used the exec channel; that was reverted after
+the host test showed `tar` over `nerdctl exec -i` hangs and poisons the exec
+channel — see report §4b.)
 
 ## Known MVP degradations
 
 - **stats** are not collected (lxcfs proc/sys mounts are meaningless inside a
   real VM; guest cgroup stats need a different path) — stubbed via inheritance.
 - **container log streaming** is one-shot (`nerdctl logs`), not a live follow.
-- **file upload/download**: routed through the kernel exec channel (tar over
-  `nerdctl exec`) rather than host-side scratch writes / `docker get_archive`,
-  to address the upload/download failure observed on the Docker-runtime path
-  (BA-6541). Uploaded files land owned by the exec user (root) — ownership is
-  not matched to the kernel user yet.
+- **file upload/download**: host-side read/write of the rw virtio-fs scratch
+  share (`accept_file` is inherited from `DockerKernel`; downloads read the host
+  scratch dir, replacing Docker's `get_archive`). Proven byte-exact on-host.
+  Assumes the scratch `work` dir is bind-mounted into the guest (it is). Do **not**
+  use `nerdctl exec -i` to stream bulk data — it truncates/hangs on Kata (§4b).
 - **commit / image-from-container** raises `NotImplementedError`.
 - **death detection** is a 5s poller, not an event stream.
 - **GPU / accelerators** are out of scope (Docker `DeviceRequests` are not

--- a/src/ai/backend/agent/kata/README.md
+++ b/src/ai/backend/agent/kata/README.md
@@ -1,0 +1,147 @@
+# KataAgent (MVP) — running Backend.AI kernels in Kata Containers microVMs
+
+> **Status: hacky MVP.** This backend proves that a Backend.AI compute session
+> can run inside a Kata Containers lightweight VM with almost no new code, by
+> reusing the entire Docker kernel-creation pipeline and swapping only the final
+> "create + start container" step for a `nerdctl run --runtime
+> io.containerd.kata.v2` invocation. It is **not** production-ready and does
+> **not** implement Confidential Computing (TDX/CoCo). See
+> `proposals/BEP-1051-kata-containers-agent.md` for the full intended design and
+> `~/Downloads/backend-ai-cc-investigation/mvp-findings-kataagent.md` for the
+> findings report.
+
+## What it is
+
+`KataAgent` subclasses `DockerAgent`. The whole `create_kernel` orchestration
+(scratch/config generation, krunner injection, vfolder mounts, resource specs,
+image scan/pull) is inherited unchanged. The only behavioral delta:
+
+| Concern | DockerAgent | KataAgent |
+|---|---|---|
+| create + start container | `aiodocker` `containers.create()` + `container.start()` | translate `container_config` → `nerdctl run -d --runtime io.containerd.kata.v2` |
+| destroy / clean | `aiodocker` stop/delete | `nerdctl stop` / `nerdctl rm -f -v` |
+| logs / list / download | `aiodocker` / `docker exec` | `nerdctl logs` / `nerdctl exec` |
+| named krunner volume | Docker named volume | resolved to its host path and **bind-mounted** (Kata can't share a Docker named volume into the guest) |
+| death detection | dockerd event stream | lightweight `nerdctl ps` poller (dockerd events don't see containerd's namespace) |
+
+The repl ports (container 2000/2001) are still published to host `127.0.0.1`
+via `-p 127.0.0.1:HPORT:CPORT`; nerdctl's bridge+portmap CNI installs the
+host→guest DNAT so the agent's hardcoded `tcp://127.0.0.1:{port}` connection
+(`docker/kernel.py:98`) keeps working across the VM boundary.
+
+## Host prerequisites
+
+A working Kata host (see Handover A / report §6c). In short:
+
+- nested KVM available (`egrep -c '(vmx|svm)' /proc/cpuinfo` > 0), `/dev/kvm`,
+  `vhost_vsock`.
+- Kata Containers installed and registered as a containerd runtime handler
+  `io.containerd.kata.v2` (kata-deploy / kata-manager).
+- `nerdctl` + CNI plugins (`bridge`, `portmap`, `host-local`, `loopback`,
+  `firewall`) in `/opt/cni/bin`.
+- dockerd still present (Backend.AI halfstack + krunner volume preparation use
+  it). KataAgent and DockerAgent coexist: nerdctl uses containerd namespace
+  `default`, dockerd uses `moby`.
+
+Smoke-test the host first:
+
+```bash
+nerdctl run --runtime io.containerd.kata.v2 -p 127.0.0.1:8080:80 nginx
+curl 127.0.0.1:8080   # proves portmap into the VM
+```
+
+### Host gotcha: Docker 29 + Kata ≤3.31 — `Invalid namespace type`
+
+Empirically observed (BA-6541, Kata 3.31.0 / Docker 29.6.0): Docker 29 applies a
+**time namespace** to containers by default, but the Kata agent (≤3.31) only
+recognizes `{user,ipc,pid,net,mnt,uts,cgroup}` and rejects the unknown
+`time` namespace → the container/VM fails to start. Disable it in
+`/etc/docker/daemon.json`:
+
+```json
+{
+  "runtimes": {
+    "kata": { "runtimeType": "/opt/kata/bin/containerd-shim-kata-v2" }
+  },
+  "features": { "time-namespaces": false }
+}
+```
+
+This affects the Docker-runtime path below. The nerdctl/containerd path may hit
+the same class of issue depending on the containerd version's default OCI spec —
+if `nerdctl run --runtime io.containerd.kata.v2` fails with `invalid namespace
+type`, the runtime spec is injecting a namespace the kata-agent doesn't know;
+upgrade kata-agent or strip the offending namespace.
+
+## Enabling it
+
+In the agent config (`agent.toml` / `agent.conf`):
+
+```toml
+[agent]
+backend = "kata"
+```
+
+Optional environment overrides (read by `kata/nerdctl.py`):
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `BACKENDAI_KATA_RUNTIME` | `io.containerd.kata.v2` | containerd runtime handler |
+| `BACKENDAI_NERDCTL_BIN` | `nerdctl` | container engine CLI |
+| `BACKENDAI_NERDCTL_NAMESPACE` | `default` | containerd namespace |
+
+Restart the agent and create a session as usual:
+
+```bash
+./backend.ai session create -t kata-demo cr.backend.ai/stable/python:3.11-ubuntu24.04
+./backend.ai run --rm cr.backend.ai/stable/python:3.11-ubuntu24.04 -c 'import platform; print(platform.uname().release)'
+```
+
+Proof it ran in a VM: the kernel release string inside the session differs from
+the host's `uname -r` (the Kata guest runs its own kernel).
+
+## Even cheaper alternative (zero code — proven working)
+
+You do **not** need `backend = "kata"` at all if the host's dockerd is configured
+with a Kata runtime handler. Keep `backend = "docker"` and drop an override file
+so only kernels use the Kata runtime (other host containers are unaffected):
+
+```jsonc
+// /etc/backend.ai/agent-docker-container-opts.json
+// (also loaded from ~/.config/backend.ai/ or CWD)
+{ "HostConfig": { "Runtime": "kata" } }
+```
+
+This is loaded and merged in `docker/agent.py` (the `agent-docker-container-opts.json`
+lookup) so the existing Docker create/start, PortBindings, event stream, and
+cleanup path all run **verbatim**. This path was validated end-to-end in BA-6541
+(Kata 3.31 / Docker 29): container create, scratch bind mount (read/write),
+intrinsic socket, code execution, Jupyter-in-browser, and clean VM/virtiofsd/shim
+teardown on session terminate all worked. The one gap: **file upload/download
+failed** on this path (see degradations).
+
+This `kata/` backend uses the **nerdctl/containerd** path instead because (a) it
+is what Handover A's host proves (`nerdctl --runtime io.containerd.kata.v2`), (b)
+it keeps Kata kernels in a separate containerd namespace from Docker, and (c) it
+is the cleaner stepping stone toward the production containerd-gRPC backend
+(BEP-1051 / report §6d.3). It also routes file upload/download through the kernel
+**exec channel** (tar over `nerdctl exec`), which should fix the upload/download
+gap seen on the Docker-runtime path.
+
+## Known MVP degradations
+
+- **stats** are not collected (lxcfs proc/sys mounts are meaningless inside a
+  real VM; guest cgroup stats need a different path) — stubbed via inheritance.
+- **container log streaming** is one-shot (`nerdctl logs`), not a live follow.
+- **file upload/download**: routed through the kernel exec channel (tar over
+  `nerdctl exec`) rather than host-side scratch writes / `docker get_archive`,
+  to address the upload/download failure observed on the Docker-runtime path
+  (BA-6541). Uploaded files land owned by the exec user (root) — ownership is
+  not matched to the kernel user yet.
+- **commit / image-from-container** raises `NotImplementedError`.
+- **death detection** is a 5s poller, not an event stream.
+- **GPU / accelerators** are out of scope (Docker `DeviceRequests` are not
+  translated).
+- The **agent socket relay** (unix socket bind-mounted into the kernel) may not
+  function across the virtio-fs/VM boundary; socket-dependent features degrade.
+  Basic repl/code-execution does not depend on it (it uses TCP/ZMQ).

--- a/src/ai/backend/agent/kata/__init__.py
+++ b/src/ai/backend/agent/kata/__init__.py
@@ -1,0 +1,53 @@
+"""
+KataAgent backend package.
+
+Selected via ``[agent] backend = "kata"`` in the agent config. The discovery
+object reuses the Docker backend's resource detection and krunner-volume
+preparation verbatim — only the agent class (and thus the kernel create/start
+path) differs.
+"""
+
+from collections.abc import Mapping
+from decimal import Decimal
+from typing import Any, override
+
+from ai.backend.agent.agent import AbstractAgent
+from ai.backend.agent.docker.kernel import prepare_krunner_env
+from ai.backend.agent.docker.resources import load_resources, scan_available_resources
+from ai.backend.agent.resources import AbstractComputePlugin
+from ai.backend.agent.types import AbstractAgentDiscovery
+from ai.backend.common.etcd import AbstractKVStore
+from ai.backend.common.types import DeviceName, SlotName
+
+from .agent import KataAgent
+
+
+class KataAgentDiscovery(AbstractAgentDiscovery):
+    @override
+    def get_agent_cls(self) -> type[AbstractAgent[Any, Any]]:
+        return KataAgent
+
+    @override
+    async def load_resources(
+        self,
+        etcd: AbstractKVStore,
+        local_config: Mapping[str, Any],
+    ) -> Mapping[DeviceName, AbstractComputePlugin]:
+        # Resource detection is host-level and backend-agnostic; reuse Docker's.
+        return await load_resources(etcd, local_config)
+
+    @override
+    async def scan_available_resources(
+        self, compute_device_types: Mapping[DeviceName, AbstractComputePlugin]
+    ) -> Mapping[SlotName, Decimal]:
+        return await scan_available_resources(compute_device_types)
+
+    @override
+    async def prepare_krunner_env(self, local_config: Mapping[str, Any]) -> Mapping[str, str]:
+        # krunner volumes are still created via dockerd; the KataAgent resolves
+        # the named volume to its host path and bind-mounts it into the guest.
+        return await prepare_krunner_env(local_config)
+
+
+def get_agent_discovery() -> AbstractAgentDiscovery:
+    return KataAgentDiscovery()

--- a/src/ai/backend/agent/kata/agent.py
+++ b/src/ai/backend/agent/kata/agent.py
@@ -30,10 +30,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import AsyncGenerator, Mapping, MutableMapping
+import uuid
+from collections.abc import AsyncGenerator, Mapping, MutableMapping, Sequence
 from pathlib import Path
 from typing import Any, cast, override
 
+from ai.backend.agent.agent import ACTIVE_STATUS_SET
 from ai.backend.agent.config.unified import ContainerSandboxType
 from ai.backend.agent.docker.agent import (
     DockerAgent,
@@ -50,6 +52,7 @@ from ai.backend.agent.kata.kernel import KataKernel
 from ai.backend.agent.kernel import AbstractKernel
 from ai.backend.agent.resources import KernelResourceSpec
 from ai.backend.agent.types import (
+    Container,
     KernelOwnershipData,
     LifecycleEvent,
 )
@@ -63,6 +66,7 @@ from ai.backend.common.types import (
     ClusterInfo,
     ClusterSSHPortMapping,
     ContainerId,
+    ContainerStatus,
     KernelCreationConfig,
     KernelId,
     ServicePort,
@@ -99,6 +103,31 @@ class KataKernelCreationContext(DockerKernelCreationContext):
         )
         kernel.__class__ = KataKernel
         return cast(KataKernel, kernel)
+
+    async def _externalize_inline_seccomp(self, container_config: MutableMapping[str, Any]) -> None:
+        """Docker's API (and ``_apply_seccomp_profile``) injects the seccomp
+        profile as *inline JSON* in ``HostConfig.SecurityOpt`` (``seccomp=<json>``).
+        nerdctl's ``--security-opt seccomp=`` instead expects a *file path*, so it
+        tries to ``open()`` the JSON blob and fails with "file name too long".
+        Write any inline profile to the kernel's config dir and rewrite the opt to
+        point at that file (cleaned up with the scratch)."""
+        host_config = container_config.get("HostConfig", {}) or {}
+        sec_opts = host_config.get("SecurityOpt")
+        if not sec_opts:
+            return
+        loop = current_loop()
+        new_opts: list[str] = []
+        for opt in sec_opts:
+            prefix = "seccomp="
+            if isinstance(opt, str) and opt.startswith(prefix):
+                value = opt[len(prefix) :]
+                if value.lstrip().startswith("{"):
+                    profile_path = self.config_dir / "seccomp.json"
+                    await loop.run_in_executor(None, profile_path.write_text, value)
+                    new_opts.append(f"{prefix}{profile_path}")
+                    continue
+            new_opts.append(opt)
+        host_config["SecurityOpt"] = new_opts
 
     async def _resolve_named_volumes(self, container_config: Mapping[str, Any]) -> dict[str, str]:
         """Pre-resolve every Docker named volume referenced by the mounts to its
@@ -297,6 +326,8 @@ class KataKernelCreationContext(DockerKernelCreationContext):
                     self.computers[dev_name].alloc_map.free(device_alloc)
 
         # --- THE delta: translate config -> nerdctl run (Kata runtime) ---
+        # nerdctl needs the seccomp profile as a file path, not Docker's inline JSON.
+        await self._externalize_inline_seccomp(container_config)
         volume_map = await self._resolve_named_volumes(container_config)
         nerdctl_args = nerdctl.translate_container_config_to_nerdctl_args(
             container_config,
@@ -426,12 +457,54 @@ class KataAgent(DockerAgent):
         )
 
     @override
+    async def enumerate_containers(
+        self,
+        status_filter: frozenset[ContainerStatus] = ACTIVE_STATUS_SET,
+    ) -> Sequence[tuple[KernelId, Container]]:
+        # CRITICAL: DockerAgent.enumerate_containers lists containers from the
+        # Docker ("moby") namespace, which NEVER contains Kata kernels (they live
+        # in containerd's `default` namespace). The registry-reconciliation loop
+        # (`_clean_kernel_registry_loop`) uses this to find "dangling" kernels; if
+        # it sees zero alive Kata containers it evicts every live kernel from the
+        # registry, after which destroy can't find the container_id and the VM
+        # leaks. So we enumerate via nerdctl/containerd instead.
+        infos = await nerdctl.nerdctl_inspect_kernel_containers(LabelName.KERNEL_ID)
+        result: list[tuple[KernelId, Container]] = []
+        for info in infos:
+            labels = (info.get("Config") or {}).get("Labels") or {}
+            if labels.get(LabelName.OWNER_AGENT) != str(self.id):
+                continue
+            raw_status = ((info.get("State") or {}).get("Status") or "").lower()
+            try:
+                status = ContainerStatus(raw_status)
+            except ValueError:
+                continue
+            if status not in status_filter:
+                continue
+            raw_kernel_id = labels.get(LabelName.KERNEL_ID)
+            if not raw_kernel_id:
+                continue
+            container = Container(
+                id=ContainerId(info.get("Id") or ""),
+                status=status,
+                image=(info.get("Config") or {}).get("Image") or info.get("Image") or "",
+                labels=labels,
+                ports=[],  # MVP: restart-recovery of ports is not reconstructed
+                backend_obj=info,
+            )
+            result.append((KernelId(uuid.UUID(raw_kernel_id)), container))
+        return result
+
+    @override
     async def destroy_kernel(
         self,
         kernel_id: KernelId,
         container_id: ContainerId | None,
     ) -> None:
-        if container_id is None:
+        # Guard falsy ids too: a create that fails before `nerdctl run` returns a
+        # cid leaves container_id="" — calling nerdctl stop/logs with it triggers
+        # a filter parse error.
+        if not container_id:
             return
         try:
             await nerdctl.nerdctl_stop(str(container_id))
@@ -447,7 +520,7 @@ class KataAgent(DockerAgent):
         restarting: bool,
     ) -> None:
         loop = current_loop()
-        if container_id is not None:
+        if container_id:  # falsy when a create failed before producing a cid
             try:
                 logs = await nerdctl.nerdctl_logs(str(container_id))
                 await self.collect_logs(
@@ -472,7 +545,7 @@ class KataAgent(DockerAgent):
                     except OSError:
                         pass
 
-        if not self.local_config.debug.skip_container_deletion and container_id is not None:
+        if not self.local_config.debug.skip_container_deletion and container_id:
             try:
                 await nerdctl.nerdctl_rm(str(container_id))
             except Exception:

--- a/src/ai/backend/agent/kata/agent.py
+++ b/src/ai/backend/agent/kata/agent.py
@@ -1,0 +1,529 @@
+"""
+KataAgent — a (hacky MVP) Backend.AI agent backend that runs each compute
+session's kernel inside a Kata Containers lightweight VM.
+
+Design (see ``mvp-findings-kataagent.md`` and report §6b):
+
+* ``KataAgent`` subclasses :class:`DockerAgent`. The entire ``create_kernel``
+  orchestration, scratch/config generation, krunner mounting, vfolder mounting,
+  resource spec handling and image pull/scan are reused **verbatim** from the
+  Docker path. The functional delta is only "how the assembled container_config
+  becomes a running container".
+* ``KataKernelCreationContext`` subclasses :class:`DockerKernelCreationContext`
+  and overrides exactly two methods:
+    - ``prepare_container`` — reuses the Docker file-staging body and only
+      re-classes the resulting kernel as :class:`KataKernel`;
+    - ``start_container`` — instead of two ``aiodocker`` calls
+      (``containers.create`` + ``container.start``), it translates the same
+      ``container_config`` dict into a ``nerdctl run --runtime
+      io.containerd.kata.v2`` invocation.
+* Per-container lifecycle ops that address the container by ID
+  (``destroy_kernel`` / ``clean_kernel``) are overridden to use ``nerdctl``.
+
+Known MVP degradations (intentional): container-event monitoring for
+self-termination is best-effort via a poller (Docker's event stream watches the
+``moby`` namespace, not containerd's ``default``); stats, log-streaming and
+commit are stubbed. These do not block the "session runs in a Kata VM" demo.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncGenerator, Mapping, MutableMapping
+from pathlib import Path
+from typing import Any, cast, override
+
+from ai.backend.agent.config.unified import ContainerSandboxType
+from ai.backend.agent.docker.agent import (
+    DockerAgent,
+    DockerKernelCreationContext,
+    _clean_scratch,
+)
+from ai.backend.agent.errors.agent import (
+    ContainerCreationError,
+    InvalidArgumentError,
+)
+from ai.backend.agent.errors.resources import PortPoolExhaustedError
+from ai.backend.agent.kata import nerdctl
+from ai.backend.agent.kata.kernel import KataKernel
+from ai.backend.agent.kernel import AbstractKernel
+from ai.backend.agent.resources import KernelResourceSpec
+from ai.backend.agent.types import (
+    KernelOwnershipData,
+    LifecycleEvent,
+)
+from ai.backend.agent.utils import get_safe_ulimit, update_nested_dict
+from ai.backend.common.asyncio import current_loop
+from ai.backend.common.docker import ImageRef, LabelName
+from ai.backend.common.events.kernel import KernelLifecycleEventReason
+from ai.backend.common.json import load_json
+from ai.backend.common.types import (
+    BinarySize,
+    ClusterInfo,
+    ClusterSSHPortMapping,
+    ContainerId,
+    KernelCreationConfig,
+    KernelId,
+    ServicePort,
+)
+from ai.backend.logging import BraceStyleAdapter
+from ai.backend.logging.formatter import pretty
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class KataKernelCreationContext(DockerKernelCreationContext):
+    """A DockerKernelCreationContext that starts the container in a Kata microVM."""
+
+    @property
+    def kata_runtime(self) -> str:
+        return nerdctl.DEFAULT_KATA_RUNTIME
+
+    @override
+    async def prepare_container(
+        self,
+        resource_spec: KernelResourceSpec,
+        environ: Mapping[str, str],
+        service_ports: list[ServicePort],
+        cluster_info: ClusterInfo,
+    ) -> KataKernel:
+        # Reuse the entire Docker file-staging body (bootstrap.sh, environ.txt,
+        # resource.txt, ssh keypair, dotfiles, ...) and only swap the concrete
+        # kernel class. DockerKernel and KataKernel share an identical
+        # constructor and instance layout (UserDict-based, no __slots__); only
+        # the container-addressing methods differ. Re-classing avoids
+        # duplicating ~150 lines of staging logic.
+        kernel = await super().prepare_container(
+            resource_spec, environ, service_ports, cluster_info
+        )
+        kernel.__class__ = KataKernel
+        return cast(KataKernel, kernel)
+
+    async def _resolve_named_volumes(self, container_config: Mapping[str, Any]) -> dict[str, str]:
+        """Pre-resolve every Docker named volume referenced by the mounts to its
+        host path (async), so the pure translation function can look them up
+        synchronously. Kata cannot share a Docker named volume into the guest, so
+        these are bind-mounted by host path instead (the krunner /opt/backend.ai
+        volume is the main case)."""
+        host_config = container_config.get("HostConfig", {}) or {}
+        volume_names = {
+            mount["Source"]
+            for mount in (host_config.get("Mounts", []) or [])
+            if mount.get("Type") == "volume"
+        }
+        resolved: dict[str, str] = {}
+        for name in volume_names:
+            resolved[name] = await nerdctl.resolve_docker_volume_path(name)
+            log.debug("kata: resolved named volume {} -> {}", name, resolved[name])
+        return resolved
+
+    @override
+    async def start_container(
+        self,
+        kernel_obj: AbstractKernel,
+        cmdargs: list[str],
+        resource_opts: Mapping[str, Any] | None,
+        preopen_ports: list[int],
+        cluster_info: ClusterInfo,
+    ) -> Mapping[str, Any]:
+        loop = current_loop()
+        resource_spec = kernel_obj.resource_spec
+        service_ports = kernel_obj.service_ports
+        environ = kernel_obj.environ
+        image_labels = self.kernel_config["image"]["labels"]
+
+        # --- Port computation (reused verbatim from DockerKernelCreationContext) ---
+        container_bind_host = self.local_config.container.bind_host
+        advertised_kernel_host = self.local_config.container.advertised_host
+        if len(service_ports) + len(self.repl_ports) > len(self.port_pool):
+            raise PortPoolExhaustedError(
+                f"Container ports are not sufficiently available. "
+                f"(remaining ports: {self.port_pool.remaining()})"
+            )
+        exposed_ports = [*self.repl_ports]
+        host_ports = [self.port_pool.acquire() for _ in self.repl_ports]
+        host_ips = []
+        for sport in service_ports:
+            exposed_ports.extend(sport["container_ports"])
+            if (
+                sport["name"] == "sshd"
+                and self.cluster_ssh_port_mapping
+                and (
+                    ssh_host_port := self.cluster_ssh_port_mapping.get(
+                        self.kernel_config["cluster_hostname"]
+                    )
+                )
+            ):
+                host_ports.append(ssh_host_port[1])
+            else:
+                hport = self.port_pool.acquire()
+                host_ports.append(hport)
+        protected_service_ports: set[int] = set()
+        for sport in service_ports:
+            if sport["name"] in self.protected_services:
+                protected_service_ports.update(sport["container_ports"])
+        for eport in exposed_ports:
+            # repl + protected ports MUST stay on 127.0.0.1 — this is the
+            # load-bearing assumption (docker/kernel.py:98). nerdctl's portmap
+            # CNI installs the host(127.0.0.1)->guest DNAT, so it holds across
+            # the Kata VM boundary.
+            if eport in self.repl_ports or eport in protected_service_ports:
+                host_ips.append("127.0.0.1")
+            else:
+                host_ips.append(str(container_bind_host))
+        if len(host_ips) != len(host_ports) or len(host_ports) != len(exposed_ports):
+            raise InvalidArgumentError(
+                f"Port list length mismatch: host_ips={len(host_ips)}, "
+                f"host_ports={len(host_ports)}, exposed_ports={len(exposed_ports)}"
+            )
+
+        container_log_size = self.local_config.container_logs.max_length
+        container_log_file_count = 5
+        container_log_file_size = BinarySize(container_log_size // container_log_file_count)
+
+        if self.image_ref.is_local:
+            image = self.image_ref.short
+        else:
+            image = self.image_ref.canonical
+
+        # --- container_config assembly (reused verbatim; consumed by nerdctl) ---
+        container_config: MutableMapping[str, Any] = {
+            "Image": image,
+            "Tty": True,
+            "OpenStdin": True,
+            "Privileged": False,
+            "StopSignal": "SIGINT",
+            "ExposedPorts": {f"{port}/tcp": {} for port in exposed_ports},
+            "EntryPoint": ["/opt/kernel/entrypoint.sh"],
+            "Cmd": cmdargs,
+            "Env": [f"{k}={v}" for k, v in environ.items()],
+            "WorkingDir": "/home/work",
+            "Hostname": self.kernel_config["cluster_hostname"],
+            "Labels": {
+                LabelName.AGENT_ID: str(self.agent_id),
+                LabelName.KERNEL_ID: str(self.kernel_id),
+                LabelName.SESSION_ID: str(self.session_id),
+                LabelName.OWNER_USER: self.ownership_data.owner_user_id_to_str,
+                LabelName.OWNER_PROJECT: self.ownership_data.owner_project_id_to_str,
+                LabelName.OWNER_AGENT: str(self.agent_id),
+                LabelName.BLOCK_SERVICE_PORTS: (
+                    "1" if self.internal_data.get("block_service_ports", False) else "0"
+                ),
+            },
+            "HostConfig": {
+                "Init": True,
+                "PortBindings": {
+                    f"{eport}/tcp": [{"HostPort": str(hport), "HostIp": hip}]
+                    for eport, hport, hip in zip(exposed_ports, host_ports, host_ips, strict=True)
+                },
+                "PublishAllPorts": False,  # we manage port mapping manually!
+                "CapAdd": [
+                    "IPC_LOCK",  # for hugepages and RDMA
+                    "SYS_NICE",  # for NFS based GPUDirect Storage
+                ],
+                "Ulimits": [
+                    get_safe_ulimit("nofile", 1048576, 1048576),
+                    get_safe_ulimit("memlock", -1, -1),
+                ],
+                "LogConfig": {
+                    "Type": "local",
+                    "Config": {
+                        "max-size": f"{container_log_file_size:s}",
+                        "max-file": str(container_log_file_count),
+                        "compress": "false",
+                    },
+                },
+            },
+        }
+
+        await self._apply_seccomp_profile(container_config)
+
+        # merge all container configs generated during prior preparation steps
+        # (mounts from process_mounts, accelerator args from computer_docker_args)
+        for c in self.container_configs:
+            update_nested_dict(container_config, c)
+        if self.local_config.container.sandbox_type == ContainerSandboxType.JAIL:
+            update_nested_dict(
+                container_config,
+                {
+                    "HostConfig": {
+                        "SecurityOpt": ["seccomp=unconfined", "apparmor=unconfined"],
+                        "CapAdd": ["SYS_PTRACE"],
+                    },
+                },
+            )
+
+        if resource_opts and resource_opts.get("shmem"):
+            shmem = int(resource_opts.get("shmem", "0"))
+            self.computer_docker_args["HostConfig"]["ShmSize"] = shmem
+
+        service_ports_label: list[str] = []
+        service_ports_label += image_labels.get(LabelName.SERVICE_PORTS, "").split(",")
+        service_ports_label += [f"{port_no}:preopen:{port_no}" for port_no in preopen_ports]
+        container_config["Labels"][LabelName.SERVICE_PORTS] = ",".join([
+            label for label in service_ports_label if label
+        ])
+        update_nested_dict(container_config, self.computer_docker_args)
+        kernel_name = f"kernel.{self.image_ref.name.split('/')[-1]}.{self.kernel_id}"
+
+        # optional local override of docker config (reused; same JSON files)
+        extra_container_opts_name = "agent-docker-container-opts.json"
+        for extra_container_opts_file in [
+            Path("/etc/backend.ai") / extra_container_opts_name,
+            Path.home() / ".config" / "backend.ai" / extra_container_opts_name,
+            Path.cwd() / extra_container_opts_name,
+        ]:
+            if extra_container_opts_file.is_file():
+                try:
+                    extra_container_opts = load_json(extra_container_opts_file.read_bytes())
+                    update_nested_dict(container_config, extra_container_opts)
+                except OSError:
+                    pass
+
+        if self.local_config.debug.log_kernel_config:
+            log.debug("full container config: {!r}", pretty(container_config))
+
+        async def _rollback_container_creation() -> None:
+            await _clean_scratch(
+                loop,
+                self.local_config.container.scratch_type,
+                self.local_config.container.scratch_root,
+                self.kernel_id,
+            )
+            self.port_pool.release_many(host_ports)
+            async with self.resource_lock:
+                for dev_name, device_alloc in resource_spec.allocations.items():
+                    self.computers[dev_name].alloc_map.free(device_alloc)
+
+        # --- THE delta: translate config -> nerdctl run (Kata runtime) ---
+        volume_map = await self._resolve_named_volumes(container_config)
+        nerdctl_args = nerdctl.translate_container_config_to_nerdctl_args(
+            container_config,
+            name=kernel_name,
+            runtime=self.kata_runtime,
+            resolve_volume=volume_map.__getitem__,
+        )
+        try:
+            cid = await nerdctl.nerdctl_run(nerdctl_args)
+        except asyncio.CancelledError as e:
+            await _rollback_container_creation()
+            raise ContainerCreationError(
+                container_id="", message="Kata container creation was cancelled"
+            ) from e
+        except Exception as e:
+            await _rollback_container_creation()
+            raise ContainerCreationError(
+                container_id="", message=f"nerdctl run failed: {e!r}"
+            ) from e
+
+        def _append_cid() -> None:
+            with (self.config_dir / "resource.txt").open("a") as f:
+                f.write(f"CID={cid}\n")
+
+        await loop.run_in_executor(None, _append_cid)
+        kernel_obj.set_container_id(ContainerId(cid))
+
+        # --- Build the port map directly. Unlike Docker we don't need a port
+        # read-back: nerdctl honors our explicit `-p 127.0.0.1:HPORT:CPORT`, so
+        # the host ports we assigned ARE the published ports. ---
+        repl_in_port = 0
+        repl_out_port = 0
+        stdin_port = 0
+        stdout_port = 0
+        ctnr_host_port_map: dict[int, int] = {}
+        for idx, port in enumerate(exposed_ports):
+            host_port = host_ports[idx]
+            if port == 2000:  # intrinsic repl-in
+                repl_in_port = host_port
+            elif port == 2001:  # intrinsic repl-out
+                repl_out_port = host_port
+            elif port == 2002:  # legacy
+                stdin_port = host_port
+            elif port == 2003:  # legacy
+                stdout_port = host_port
+            else:
+                ctnr_host_port_map[port] = host_port
+        for sport in service_ports:
+            sport["host_ports"] = tuple(
+                ctnr_host_port_map[cport] for cport in sport["container_ports"]
+            )
+
+        if repl_in_port == 0:
+            raise InvalidArgumentError("repl_in_port should have been assigned")
+        if repl_out_port == 0:
+            raise InvalidArgumentError("repl_out_port should have been assigned")
+
+        kernel_host = advertised_kernel_host or container_bind_host
+        return {
+            "container_id": cid,
+            "kernel_host": kernel_host,
+            "repl_in_port": repl_in_port,
+            "repl_out_port": repl_out_port,
+            "stdin_port": stdin_port,  # legacy
+            "stdout_port": stdout_port,  # legacy
+            "host_ports": host_ports,
+            "domain_socket_proxies": self.domain_socket_proxies,
+            "block_service_ports": self.internal_data.get("block_service_ports", False),
+        }
+
+
+class KataAgent(DockerAgent):
+    """A DockerAgent whose kernels run inside Kata Containers microVMs.
+
+    Everything except per-container create/start and lifecycle ops is inherited
+    from DockerAgent (image scan/pull, krunner volume prep, scratch handling,
+    resource accounting, RPC server, health, the agent socket relay).
+    """
+
+    _kata_liveness_task: asyncio.Task[Any] | None
+
+    @override
+    async def __ainit__(self) -> None:
+        await super().__ainit__()
+        # Docker's event monitor (started by super) watches the "moby" namespace
+        # and will never see Kata kernels (they live in containerd's "default"
+        # namespace). Run a lightweight poller to catch self-termination.
+        self._kata_liveness_task = asyncio.create_task(self._poll_kata_liveness())
+
+    @override
+    async def shutdown(self, stop_signal: Any) -> None:
+        task = getattr(self, "_kata_liveness_task", None)
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        await super().shutdown(stop_signal)
+
+    @override
+    async def init_kernel_context(
+        self,
+        ownership_data: KernelOwnershipData,
+        kernel_image: ImageRef,
+        kernel_config: KernelCreationConfig,
+        *,
+        restarting: bool = False,
+        cluster_ssh_port_mapping: ClusterSSHPortMapping | None = None,
+    ) -> KataKernelCreationContext:
+        distro = await self.resolve_image_distro(kernel_config["image"])
+        return KataKernelCreationContext(
+            ownership_data,
+            self.event_producer,
+            kernel_image,
+            kernel_config,
+            distro,
+            self.local_config,
+            self.computers,
+            self.port_pool,
+            self.agent_sockpath,
+            self.resource_lock,
+            self.network_plugin_ctx,
+            restarting=restarting,
+            cluster_ssh_port_mapping=cluster_ssh_port_mapping,
+            gwbridge_subnet=self.gwbridge_subnet,
+        )
+
+    @override
+    async def destroy_kernel(
+        self,
+        kernel_id: KernelId,
+        container_id: ContainerId | None,
+    ) -> None:
+        if container_id is None:
+            return
+        try:
+            await nerdctl.nerdctl_stop(str(container_id))
+        except Exception:
+            log.exception("destroy_kernel(k:{}) nerdctl stop error", kernel_id)
+            await self.reconstruct_resource_usage()
+
+    @override
+    async def clean_kernel(
+        self,
+        kernel_id: KernelId,
+        container_id: ContainerId | None,
+        restarting: bool,
+    ) -> None:
+        loop = current_loop()
+        if container_id is not None:
+            try:
+                logs = await nerdctl.nerdctl_logs(str(container_id))
+                await self.collect_logs(
+                    kernel_id, str(container_id), _bytes_aiter(logs.encode("utf-8"))
+                )
+            except Exception as e:
+                log.warning(
+                    "error while collecting kata container logs (k:{}, cid:{}): {}",
+                    kernel_id,
+                    container_id,
+                    e,
+                )
+
+        kernel_obj = self.kernel_registry.get(kernel_id)
+        if kernel_obj is not None:
+            for domain_socket_proxy in kernel_obj.get("domain_socket_proxies", []):
+                if domain_socket_proxy.proxy_server.is_serving():
+                    domain_socket_proxy.proxy_server.close()
+                    await domain_socket_proxy.proxy_server.wait_closed()
+                    try:
+                        domain_socket_proxy.host_proxy_path.unlink()
+                    except OSError:
+                        pass
+
+        if not self.local_config.debug.skip_container_deletion and container_id is not None:
+            try:
+                await nerdctl.nerdctl_rm(str(container_id))
+            except Exception:
+                log.exception(
+                    "unexpected error while removing kata container (k:{}, c:{})",
+                    kernel_id,
+                    container_id,
+                )
+
+        if not restarting:
+            await _clean_scratch(
+                loop,
+                self.local_config.container.scratch_type,
+                self.local_config.container.scratch_root,
+                kernel_id,
+            )
+
+    async def _poll_kata_liveness(self) -> None:
+        """Best-effort death detection: when a tracked kernel's container is no
+        longer in `nerdctl ps`, inject a CLEAN lifecycle event. This stands in
+        for Docker's event stream, which does not observe containerd's namespace.
+        """
+        poll_interval = 5.0
+        while True:
+            try:
+                await asyncio.sleep(poll_interval)
+                running = await nerdctl.nerdctl_list_running_kernel_ids(LabelName.KERNEL_ID)
+                running_short = {cid[:12] for cid in running}
+                for kernel_id, kernel_obj in list(self.kernel_registry.items()):
+                    cid = kernel_obj.container_id
+                    if cid is None:
+                        continue
+                    if str(cid)[:12] in running_short or str(cid) in running:
+                        continue
+                    log.warning(
+                        "kata: kernel {} container {} disappeared; injecting CLEAN",
+                        kernel_id,
+                        cid,
+                    )
+                    await self.inject_container_lifecycle_event(
+                        kernel_id,
+                        kernel_obj.session_id,
+                        LifecycleEvent.CLEAN,
+                        kernel_obj.termination_reason or KernelLifecycleEventReason.SELF_TERMINATED,
+                        container_id=cid,
+                    )
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                log.warning("kata: liveness poller error: {}", e)
+
+
+async def _bytes_aiter(data: bytes) -> AsyncGenerator[bytes, None]:
+    yield data

--- a/src/ai/backend/agent/kata/kernel.py
+++ b/src/ai/backend/agent/kata/kernel.py
@@ -1,0 +1,176 @@
+"""
+KataKernel — a DockerKernel whose per-container operations are driven through
+``nerdctl`` (containerd + Kata runtime) instead of the Docker API.
+
+Almost everything in :class:`DockerKernel` is reused verbatim:
+
+* the ZMQ code-runner contract (:class:`DockerCodeRunner`) — the repl ports are
+  published to host ``127.0.0.1`` exactly as in the Docker path, so
+  ``create_code_runner`` is inherited unchanged;
+* ``interrupt_kernel`` / ``check_status`` / ``start_service`` / ``*_service`` —
+  these all go through the ZMQ runner, not the container engine.
+
+Operations that address the container by ID are overridden to call ``nerdctl``
+(``get_logs``, ``list_files``). File transfer (``accept_file`` upload and
+``download_*``) is routed through the kernel **exec channel** (tar over
+``nerdctl exec``) rather than host-side scratch writes / ``docker get_archive``,
+because the host↔guest virtio-fs propagation for those was observed to fail on
+Kata (BA-6541), while the exec channel works. ``commit`` is stubbed for the MVP
+(image-from-container needs a nerdctl/buildkit path).
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import tarfile
+from pathlib import PurePosixPath
+from typing import Any, override
+
+from ai.backend.agent.docker.kernel import DockerKernel
+from ai.backend.agent.errors.kata import NerdctlError
+from ai.backend.agent.kata import nerdctl
+from ai.backend.common.types import KernelId
+from ai.backend.logging import BraceStyleAdapter
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class KataKernel(DockerKernel):
+    """A kernel running inside a Kata Containers lightweight VM, managed via nerdctl."""
+
+    @override
+    async def get_logs(self) -> dict[str, Any]:
+        container_id = self.data["container_id"]
+        logs = await nerdctl.nerdctl_logs(container_id)
+        return {"logs": logs}
+
+    @override
+    async def list_files(self, container_path: os.PathLike[str] | str) -> dict[str, Any]:
+        # Confine lookable paths to the home directory (mirrors DockerKernel).
+        container_home_path = PurePosixPath("/home/work")
+        container_abspath = PurePosixPath(os.path.normpath(container_home_path / container_path))
+        if not container_abspath.is_relative_to(container_home_path):
+            raise PermissionError("You cannot list files outside /home/work")
+
+        code = (
+            "import json,os,stat,sys\n"
+            "files=[]\n"
+            "for f in os.scandir(sys.argv[1]):\n"
+            "    s=f.stat(follow_symlinks=False)\n"
+            "    files.append({'mode':stat.filemode(s.st_mode),'size':s.st_size,"
+            "'ctime':s.st_ctime,'mtime':s.st_mtime,'atime':s.st_atime,'filename':f.name})\n"
+            "print(json.dumps(files))\n"
+        )
+        _rc, raw_out, raw_err = await nerdctl.nerdctl_exec(
+            self.data["container_id"],
+            [
+                "/opt/backend.ai/bin/python",
+                "-c",
+                code,
+                str(container_abspath),
+            ],
+        )
+        return {
+            "files": raw_out.decode("utf-8"),
+            "errors": raw_err.decode("utf-8"),
+            "abspath": str(container_path),
+        }
+
+    async def _download_archive(self, container_abspath: PurePosixPath) -> bytes:
+        # Stream a tar archive of the target out of the guest via `nerdctl exec tar`.
+        container_id = self.data["container_id"]
+        parent = str(container_abspath.parent)
+        name = container_abspath.name
+        rc, raw_out, raw_err = await nerdctl.nerdctl_exec(
+            container_id,
+            ["tar", "cf", "-", "-C", parent, name],
+            timeout_sec=120.0,
+        )
+        if rc != 0:
+            raise NerdctlError(
+                f"could not download {container_abspath} from kata container "
+                f"(rc={rc}): {raw_err.decode(errors='replace').strip()}"
+            )
+        if len(raw_out) > 1048576:
+            raise ValueError("Too large archive file exceeding 1 MiB")
+        return raw_out
+
+    @override
+    async def accept_file(self, container_path: os.PathLike[str] | str, filedata: bytes) -> None:
+        # DockerKernel.accept_file writes host-side into the scratch `work` dir and
+        # relies on it being visible inside the container. On Kata that host->guest
+        # propagation across the virtio-fs boundary is unreliable (observed:
+        # in-session file creation works but host-driven upload fails, BA-6541).
+        # Stream the file into the guest through the proven exec channel instead.
+        container_home_path = PurePosixPath("/home/work")
+        container_abspath = PurePosixPath(os.path.normpath(container_home_path / container_path))
+        if not container_abspath.is_relative_to(container_home_path):
+            raise PermissionError("Not allowed to upload files outside /home/work")
+        arcname = str(container_abspath.relative_to(container_home_path))
+
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w") as tf:
+            info = tarfile.TarInfo(name=arcname)
+            info.size = len(filedata)
+            info.mode = 0o644
+            tf.addfile(info, io.BytesIO(filedata))
+        tar_bytes = buf.getvalue()
+
+        rc, _raw_out, raw_err = await nerdctl.nerdctl_exec(
+            self.data["container_id"],
+            ["tar", "xf", "-", "-C", str(container_home_path)],
+            input_bytes=tar_bytes,
+            timeout_sec=120.0,
+        )
+        if rc != 0:
+            raise NerdctlError(
+                f"could not upload {container_abspath} into kata container "
+                f"(rc={rc}): {raw_err.decode(errors='replace').strip()}"
+            )
+
+    @override
+    async def download_file(self, container_path: os.PathLike[str] | str) -> bytes:
+        container_home_path = PurePosixPath("/home/work")
+        container_abspath = PurePosixPath(os.path.normpath(container_home_path / container_path))
+        if not container_abspath.is_relative_to(container_home_path):
+            raise PermissionError("You cannot download files outside /home/work")
+        return await self._download_archive(container_abspath)
+
+    @override
+    async def download_single(self, container_path: os.PathLike[str] | str) -> bytes:
+        container_home_path = PurePosixPath("/home/work")
+        container_abspath = PurePosixPath(os.path.normpath(container_home_path / container_path))
+        if not container_abspath.is_relative_to(container_home_path):
+            raise PermissionError("You cannot download files outside /home/work")
+        tar_bytes = await self._download_archive(container_abspath)
+        with tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tf:
+            members = tf.getmembers()
+            files = [m for m in members if m.isfile()]
+            if len(files) != 1:
+                raise ValueError(
+                    f"Expected a single-file archive but found {len(files)} files "
+                    f"from {container_abspath}"
+                )
+            extracted = tf.extractfile(files[0])
+            if extracted is None:
+                raise ValueError(f"Could not read {files[0].name!r} from {container_abspath}")
+            return extracted.read()
+
+    @override
+    async def commit(
+        self,
+        kernel_id: KernelId,
+        subdir: str,
+        *,
+        canonical: str | None = None,
+        filename: str | None = None,
+        extra_labels: dict[str, str] | None = None,
+    ) -> None:
+        # MVP degradation: image-from-container (commit) is not implemented for the
+        # Kata/nerdctl path. Production would shell out to `nerdctl commit` +
+        # `nerdctl save`, or use a buildkit export. See findings report.
+        raise NotImplementedError(
+            "commit (image-from-container) is not supported by the KataAgent MVP"
+        )

--- a/src/ai/backend/agent/kata/kernel.py
+++ b/src/ai/backend/agent/kata/kernel.py
@@ -11,11 +11,25 @@ Almost everything in :class:`DockerKernel` is reused verbatim:
   these all go through the ZMQ runner, not the container engine.
 
 Operations that address the container by ID are overridden to call ``nerdctl``
-(``get_logs``, ``list_files``). File transfer (``accept_file`` upload and
-``download_*``) is routed through the kernel **exec channel** (tar over
-``nerdctl exec``) rather than host-side scratch writes / ``docker get_archive``,
-because the host↔guest virtio-fs propagation for those was observed to fail on
-Kata (BA-6541), while the exec channel works. ``commit`` is stubbed for the MVP
+(``get_logs``, ``list_files``). File transfer is routed through the **host-side
+scratch dir** (the kernel's ``work`` directory), which is bind-mounted into the
+Kata guest as a *read-write virtio-fs share*:
+
+* ``accept_file`` (upload) is **inherited unchanged** from :class:`DockerKernel`
+  — it writes host-side into ``scratch-root/<kernel_id>/work`` and the bytes
+  appear inside the guest over virtio-fs.
+* ``download_file`` / ``download_single`` are overridden to **read host-side**
+  from that same scratch dir (the Docker path uses the aiodocker
+  ``get_archive`` API, which has no containerd equivalent).
+
+This replaces the earlier exec-channel design (tar over ``nerdctl exec``). Live
+validation on ``kata-lab-150`` (2026-06-21) showed the exec channel is the wrong
+mechanism: ``tar`` over ``nerdctl exec -i`` *hangs even for small files and
+poisons the container's whole exec channel*; ``cat`` over ``exec -i`` truncates
+payloads above a few KiB. By contrast the rw virtio-fs share round-trips 1 MiB
+binary payloads byte-exact in **both** directions (host↔guest md5 match). The
+BA-6541 "upload fails" symptom was specific to the Docker ``cp``/``get_archive``
+API path, not the shared mount. ``commit`` is stubbed for the MVP
 (image-from-container needs a nerdctl/buildkit path).
 """
 
@@ -25,14 +39,17 @@ import io
 import logging
 import os
 import tarfile
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Any, override
 
 from ai.backend.agent.docker.kernel import DockerKernel
-from ai.backend.agent.errors.kata import NerdctlError
 from ai.backend.agent.kata import nerdctl
+from ai.backend.common.asyncio import current_loop
 from ai.backend.common.types import KernelId
 from ai.backend.logging import BraceStyleAdapter
+
+#: Mirror of DockerKernel's 1 MiB download cap.
+_MAX_DOWNLOAD_BYTES = 1048576
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -78,85 +95,52 @@ class KataKernel(DockerKernel):
             "abspath": str(container_path),
         }
 
-    async def _download_archive(self, container_abspath: PurePosixPath) -> bytes:
-        # Stream a tar archive of the target out of the guest via `nerdctl exec tar`.
-        container_id = self.data["container_id"]
-        parent = str(container_abspath.parent)
-        name = container_abspath.name
-        rc, raw_out, raw_err = await nerdctl.nerdctl_exec(
-            container_id,
-            ["tar", "cf", "-", "-C", parent, name],
-            timeout_sec=120.0,
+    def _resolve_host_work_path(self, container_path: os.PathLike[str] | str) -> Path:
+        """
+        Map a container-relative path under ``/home/work`` to its host-side
+        location in the scratch dir (the rw virtio-fs share), with the same
+        path-escape guard DockerKernel applies. ``accept_file`` (inherited) and
+        the download overrides both go through this single host-side view.
+        """
+        host_work_dir: Path = (
+            self.agent_config["container"]["scratch-root"] / str(self.kernel_id) / "work"
         )
-        if rc != 0:
-            raise NerdctlError(
-                f"could not download {container_abspath} from kata container "
-                f"(rc={rc}): {raw_err.decode(errors='replace').strip()}"
-            )
-        if len(raw_out) > 1048576:
-            raise ValueError("Too large archive file exceeding 1 MiB")
-        return raw_out
+        host_abspath = (host_work_dir / container_path).resolve(strict=False)
+        if not host_abspath.is_relative_to(host_work_dir):
+            raise PermissionError("You cannot access files outside /home/work")
+        return host_abspath
 
-    @override
-    async def accept_file(self, container_path: os.PathLike[str] | str, filedata: bytes) -> None:
-        # DockerKernel.accept_file writes host-side into the scratch `work` dir and
-        # relies on it being visible inside the container. On Kata that host->guest
-        # propagation across the virtio-fs boundary is unreliable (observed:
-        # in-session file creation works but host-driven upload fails, BA-6541).
-        # Stream the file into the guest through the proven exec channel instead.
-        container_home_path = PurePosixPath("/home/work")
-        container_abspath = PurePosixPath(os.path.normpath(container_home_path / container_path))
-        if not container_abspath.is_relative_to(container_home_path):
-            raise PermissionError("Not allowed to upload files outside /home/work")
-        arcname = str(container_abspath.relative_to(container_home_path))
-
-        buf = io.BytesIO()
-        with tarfile.open(fileobj=buf, mode="w") as tf:
-            info = tarfile.TarInfo(name=arcname)
-            info.size = len(filedata)
-            info.mode = 0o644
-            tf.addfile(info, io.BytesIO(filedata))
-        tar_bytes = buf.getvalue()
-
-        rc, _raw_out, raw_err = await nerdctl.nerdctl_exec(
-            self.data["container_id"],
-            ["tar", "xf", "-", "-C", str(container_home_path)],
-            input_bytes=tar_bytes,
-            timeout_sec=120.0,
-        )
-        if rc != 0:
-            raise NerdctlError(
-                f"could not upload {container_abspath} into kata container "
-                f"(rc={rc}): {raw_err.decode(errors='replace').strip()}"
-            )
+    # accept_file (upload) is inherited from DockerKernel: a host-side write into
+    # scratch-root/<kernel_id>/work, which the guest sees over rw virtio-fs.
 
     @override
     async def download_file(self, container_path: os.PathLike[str] | str) -> bytes:
-        container_home_path = PurePosixPath("/home/work")
-        container_abspath = PurePosixPath(os.path.normpath(container_home_path / container_path))
-        if not container_abspath.is_relative_to(container_home_path):
-            raise PermissionError("You cannot download files outside /home/work")
-        return await self._download_archive(container_abspath)
+        # Docker returns a tar archive (via get_archive); preserve that contract
+        # but build the archive from the host-side scratch file instead.
+        loop = current_loop()
+        host_abspath = self._resolve_host_work_path(container_path)
+
+        def _read_as_tar() -> bytes:
+            if host_abspath.stat().st_size > _MAX_DOWNLOAD_BYTES:
+                raise ValueError("Too large archive file exceeding 1 MiB")
+            buf = io.BytesIO()
+            with tarfile.open(fileobj=buf, mode="w") as tf:
+                tf.add(str(host_abspath), arcname=host_abspath.name)
+            return buf.getvalue()
+
+        return await loop.run_in_executor(None, _read_as_tar)
 
     @override
     async def download_single(self, container_path: os.PathLike[str] | str) -> bytes:
-        container_home_path = PurePosixPath("/home/work")
-        container_abspath = PurePosixPath(os.path.normpath(container_home_path / container_path))
-        if not container_abspath.is_relative_to(container_home_path):
-            raise PermissionError("You cannot download files outside /home/work")
-        tar_bytes = await self._download_archive(container_abspath)
-        with tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tf:
-            members = tf.getmembers()
-            files = [m for m in members if m.isfile()]
-            if len(files) != 1:
-                raise ValueError(
-                    f"Expected a single-file archive but found {len(files)} files "
-                    f"from {container_abspath}"
-                )
-            extracted = tf.extractfile(files[0])
-            if extracted is None:
-                raise ValueError(f"Could not read {files[0].name!r} from {container_abspath}")
-            return extracted.read()
+        loop = current_loop()
+        host_abspath = self._resolve_host_work_path(container_path)
+
+        def _read_bytes() -> bytes:
+            if host_abspath.stat().st_size > _MAX_DOWNLOAD_BYTES:
+                raise ValueError("Too large archive file exceeding 1 MiB")
+            return host_abspath.read_bytes()
+
+        return await loop.run_in_executor(None, _read_bytes)
 
     @override
     async def commit(

--- a/src/ai/backend/agent/kata/nerdctl.py
+++ b/src/ai/backend/agent/kata/nerdctl.py
@@ -19,6 +19,7 @@ without a Kata host.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import shlex
@@ -86,8 +87,10 @@ def translate_container_config_to_nerdctl_args(
 
     if container_config.get("Tty"):
         args.append("-t")
-    if container_config.get("OpenStdin"):
-        args.append("-i")
+    # NOTE: Docker accepts OpenStdin (`-i`) together with detached (`-d`), but
+    # nerdctl rejects `-i -d` ("cannot be specified together"). The kernel runs
+    # detached and communicates over ZMQ repl ports (not container stdin), so we
+    # intentionally do NOT translate OpenStdin to `-i` (verified on kata-lab-150).
     if stop_signal := container_config.get("StopSignal"):
         args += ["--stop-signal", str(stop_signal)]
     if working_dir := container_config.get("WorkingDir"):
@@ -333,6 +336,38 @@ async def nerdctl_list_running_kernel_ids(
             f"nerdctl ps failed (rc={rc}): {stderr.decode(errors='replace').strip()}"
         )
     return {line.strip() for line in stdout.decode().splitlines() if line.strip()}
+
+
+async def nerdctl_inspect_kernel_containers(
+    label_key: str,
+    *,
+    nerdctl_bin: str = DEFAULT_NERDCTL_BIN,
+    namespace: str = DEFAULT_NERDCTL_NAMESPACE,
+) -> list[dict[str, Any]]:
+    """Return the docker-compatible ``inspect`` records for every container (any
+    state) carrying ``label_key`` in our namespace.
+
+    Used by :meth:`KataAgent.enumerate_containers` to reconcile the kernel
+    registry against containerd's namespace — DockerAgent's version queries the
+    ``moby`` namespace, which never contains Kata kernels.
+    """
+    base = _nerdctl_base(nerdctl_bin=nerdctl_bin, namespace=namespace)
+    ids_args = [*base, "ps", "-a", "--filter", f"label={label_key}", "--format", "{{.ID}}"]
+    rc, stdout, stderr = await _run(ids_args, timeout_sec=30.0)
+    if rc != 0:
+        raise NerdctlError(
+            f"nerdctl ps failed (rc={rc}): {stderr.decode(errors='replace').strip()}"
+        )
+    ids = [line.strip() for line in stdout.decode().splitlines() if line.strip()]
+    if not ids:
+        return []
+    rc, stdout, stderr = await _run([*base, "inspect", *ids], timeout_sec=60.0)
+    if rc != 0:
+        raise NerdctlError(
+            f"nerdctl inspect failed (rc={rc}): {stderr.decode(errors='replace').strip()}"
+        )
+    parsed = json.loads(stdout.decode() or "[]")
+    return list(parsed)
 
 
 async def resolve_docker_volume_path(volume_name: str, *, docker_bin: str = "docker") -> str:

--- a/src/ai/backend/agent/kata/nerdctl.py
+++ b/src/ai/backend/agent/kata/nerdctl.py
@@ -273,6 +273,13 @@ async def nerdctl_exec(
     nerdctl_bin: str = DEFAULT_NERDCTL_BIN,
     namespace: str = DEFAULT_NERDCTL_NAMESPACE,
 ) -> tuple[int, bytes, bytes]:
+    # NOTE: plain exec (input_bytes=None) is reliable, but streaming bulk data via
+    # ``input_bytes`` (``exec -i`` stdin) is NOT a safe transport on the Kata
+    # runtime — live validation on kata-lab-150 (2026-06-21) saw it truncate
+    # payloads above a few KiB and, with a ``tar`` reader, hang and poison the
+    # container's exec channel. Use the rw virtio-fs scratch share for file
+    # transfer (see KataKernel). ``input_bytes`` is kept only for short control
+    # input; do not push large blobs through it.
     args = [*_nerdctl_base(nerdctl_bin=nerdctl_bin, namespace=namespace), "exec"]
     if input_bytes is not None:
         args.append("-i")  # keep stdin open so we can stream data into the guest

--- a/src/ai/backend/agent/kata/nerdctl.py
+++ b/src/ai/backend/agent/kata/nerdctl.py
@@ -1,0 +1,349 @@
+"""
+nerdctl / containerd shim helpers for the (hacky) KataAgent MVP.
+
+The single functional delta between DockerAgent and KataAgent is *how the
+already-assembled ``container_config`` dict gets turned into a running
+container*.  DockerAgent hands the dict to ``aiodocker``; KataAgent translates
+it into a ``nerdctl run`` invocation against the Kata runtime
+(``io.containerd.kata.v2``) so the kernel boots inside a lightweight VM.
+
+This module is intentionally a thin subprocess shim — see
+``mvp-findings-kataagent.md`` and BEP-1051 for why the production backend should
+drive the containerd gRPC API directly instead.
+
+The translation function (:func:`translate_container_config_to_nerdctl_args`) is
+a pure function (modulo the injected volume resolver) so it can be unit-tested
+without a Kata host.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shlex
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any, Final
+
+from ai.backend.agent.errors.kata import KataVolumeResolutionError, NerdctlError
+from ai.backend.logging import BraceStyleAdapter
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+#: Default containerd runtime handler installed by kata-deploy / kata-manager.
+DEFAULT_KATA_RUNTIME: Final[str] = os.environ.get("BACKENDAI_KATA_RUNTIME", "io.containerd.kata.v2")
+#: The container engine CLI used to drive containerd. ``nerdctl`` ships an
+#: embedded bridge+portmap CNI and implements ``-p`` host-port publishing, which
+#: is exactly what the ``127.0.0.1`` repl-port assumption needs (see §6b.4).
+DEFAULT_NERDCTL_BIN: Final[str] = os.environ.get("BACKENDAI_NERDCTL_BIN", "nerdctl")
+#: containerd namespace nerdctl operates in. Kept separate from Docker's "moby"
+#: namespace on purpose so KataAgent and DockerAgent can coexist on one host.
+DEFAULT_NERDCTL_NAMESPACE: Final[str] = os.environ.get("BACKENDAI_NERDCTL_NAMESPACE", "default")
+
+#: HostConfig keys this MVP knowingly does NOT translate. We log them once so the
+#: findings report can track the gaps (mostly GPU/device + Docker-only knobs).
+_UNTRANSLATED_HOSTCONFIG_KEYS: Final[frozenset[str]] = frozenset({
+    "PublishAllPorts",  # we publish explicitly via -p
+    "LogConfig",  # nerdctl uses its own json logger; `nerdctl logs` still works
+    "RestartPolicy",
+    "DeviceRequests",  # NVIDIA/GPU — out of scope for the non-confidential MVP
+    "Devices",
+})
+
+
+def _nerdctl_base(
+    *, nerdctl_bin: str = DEFAULT_NERDCTL_BIN, namespace: str = DEFAULT_NERDCTL_NAMESPACE
+) -> list[str]:
+    return [nerdctl_bin, "--namespace", namespace]
+
+
+def translate_container_config_to_nerdctl_args(
+    container_config: Mapping[str, Any],
+    *,
+    name: str,
+    runtime: str = DEFAULT_KATA_RUNTIME,
+    nerdctl_bin: str = DEFAULT_NERDCTL_BIN,
+    namespace: str = DEFAULT_NERDCTL_NAMESPACE,
+    resolve_volume: Callable[[str], str] | None = None,
+) -> list[str]:
+    """
+    Translate the Docker-API-style ``container_config`` dict assembled by
+    :meth:`DockerKernelCreationContext.start_container` into a full ``nerdctl
+    run -d`` argv list.
+
+    :param container_config: the merged container config (Image/Cmd/Env/Mounts/
+        Labels/HostConfig.PortBindings/...).
+    :param name: container name (``kernel.<image>.<kernel_id>``).
+    :param runtime: containerd runtime handler (Kata).
+    :param resolve_volume: callback mapping a Docker named-volume to its host
+        path. Required if any ``MountTypes.VOLUME`` mounts are present (the
+        krunner ``/opt/backend.ai`` volume). Kata/nerdctl cannot share a Docker
+        named volume into the guest, so we resolve it to a host path and
+        bind-mount instead (see §6b.3 "the one exception").
+    """
+    args: list[str] = [*_nerdctl_base(nerdctl_bin=nerdctl_bin, namespace=namespace)]
+    args += ["run", "-d", "--runtime", runtime, "--name", name]
+
+    if container_config.get("Tty"):
+        args.append("-t")
+    if container_config.get("OpenStdin"):
+        args.append("-i")
+    if stop_signal := container_config.get("StopSignal"):
+        args += ["--stop-signal", str(stop_signal)]
+    if working_dir := container_config.get("WorkingDir"):
+        args += ["-w", str(working_dir)]
+    if hostname := container_config.get("Hostname"):
+        args += ["--hostname", str(hostname)]
+
+    # Entrypoint: Docker EntryPoint is a list; nerdctl --entrypoint takes one
+    # string (the binary). Any extra elements are prepended to the command args.
+    entrypoint = container_config.get("EntryPoint") or container_config.get("Entrypoint")
+    extra_entry_args: list[str] = []
+    if entrypoint:
+        entry_list = list(entrypoint)
+        args += ["--entrypoint", entry_list[0]]
+        extra_entry_args = entry_list[1:]
+
+    for env in container_config.get("Env", []) or []:
+        args += ["-e", str(env)]
+
+    for label_key, label_val in (container_config.get("Labels") or {}).items():
+        args += ["--label", f"{label_key}={label_val}"]
+
+    host_config: Mapping[str, Any] = container_config.get("HostConfig", {}) or {}
+
+    if host_config.get("Init"):
+        args.append("--init")
+    if host_config.get("Privileged"):
+        args.append("--privileged")
+
+    for cap in host_config.get("CapAdd", []) or []:
+        args += ["--cap-add", str(cap)]
+
+    for ulimit in host_config.get("Ulimits", []) or []:
+        soft = ulimit["Soft"]
+        hard = ulimit["Hard"]
+        args += ["--ulimit", f"{ulimit['Name']}={soft}:{hard}"]
+
+    if (shm_size := host_config.get("ShmSize")) is not None:
+        args += ["--shm-size", str(shm_size)]
+
+    for sec_opt in host_config.get("SecurityOpt", []) or []:
+        args += ["--security-opt", str(sec_opt)]
+
+    # Port publishing — the load-bearing bit for the 127.0.0.1 repl assumption.
+    # PortBindings: {"2000/tcp": [{"HostPort": "X", "HostIp": "127.0.0.1"}]}
+    for port_proto, bindings in (host_config.get("PortBindings") or {}).items():
+        container_port, _, proto = port_proto.partition("/")
+        proto = proto or "tcp"
+        for binding in bindings or []:
+            host_port = binding["HostPort"]
+            host_ip = binding.get("HostIp") or "0.0.0.0"
+            args += ["-p", f"{host_ip}:{host_port}:{container_port}/{proto}"]
+
+    # Mounts (krunner bind mounts, vfolders, scratch, accelerator mounts).
+    for mount in host_config.get("Mounts", []) or []:
+        args += ["--mount", _translate_mount(mount, resolve_volume=resolve_volume)]
+    # Legacy "Binds" entries ("src:dst:mode"), in case any plugin emits them.
+    for bind in host_config.get("Binds", []) or []:
+        args += ["-v", str(bind)]
+
+    for key in host_config:
+        if key in _UNTRANSLATED_HOSTCONFIG_KEYS:
+            log.debug("kata: ignoring untranslated HostConfig.{} for {}", key, name)
+
+    args.append(str(container_config["Image"]))
+    args += [str(a) for a in extra_entry_args]
+    args += [str(a) for a in (container_config.get("Cmd") or [])]
+    return args
+
+
+def _translate_mount(
+    mount: Mapping[str, Any],
+    *,
+    resolve_volume: Callable[[str], str] | None,
+) -> str:
+    mount_type = mount.get("Type", "bind")
+    target = mount["Target"]
+    source = mount["Source"]
+    read_only = bool(mount.get("ReadOnly", False))
+
+    if mount_type == "volume":
+        # Kata/nerdctl cannot transparently share a Docker named volume into the
+        # microVM. Resolve it to a host path and bind-mount it instead.
+        if resolve_volume is None:
+            raise KataVolumeResolutionError(
+                f"named volume {source!r} requires a volume resolver but none was provided"
+            )
+        source = resolve_volume(str(source))
+        mount_type = "bind"
+
+    parts = [f"type={mount_type}", f"source={source}", f"target={target}"]
+    if read_only:
+        parts.append("readonly")
+    return ",".join(parts)
+
+
+async def _run(
+    args: Sequence[str],
+    *,
+    input_bytes: bytes | None = None,
+    timeout_sec: float | None = None,
+) -> tuple[int, bytes, bytes]:
+    log.trace("kata: exec {}", " ".join(shlex.quote(a) for a in args))
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdin=asyncio.subprocess.PIPE if input_bytes is not None else None,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(input=input_bytes), timeout=timeout_sec
+        )
+    except TimeoutError:
+        proc.kill()
+        await proc.wait()
+        raise
+    return proc.returncode or 0, stdout, stderr
+
+
+async def nerdctl_run(args: Sequence[str], *, timeout_sec: float = 300.0) -> str:
+    """Run a translated ``nerdctl run -d ...`` argv and return the container ID."""
+    rc, stdout, stderr = await _run(args, timeout_sec=timeout_sec)
+    if rc != 0:
+        raise NerdctlError(
+            f"nerdctl run failed (rc={rc}): {stderr.decode(errors='replace').strip()}"
+        )
+    return stdout.decode().strip()
+
+
+async def nerdctl_stop(
+    container_id: str,
+    *,
+    timeout_secs: int = 10,
+    nerdctl_bin: str = DEFAULT_NERDCTL_BIN,
+    namespace: str = DEFAULT_NERDCTL_NAMESPACE,
+) -> None:
+    args = [
+        *_nerdctl_base(nerdctl_bin=nerdctl_bin, namespace=namespace),
+        "stop",
+        "-t",
+        str(timeout_secs),
+        container_id,
+    ]
+    rc, _, stderr = await _run(args, timeout_sec=timeout_secs + 30)
+    if rc != 0:
+        msg = stderr.decode(errors="replace")
+        if "no such container" in msg.lower() or "not found" in msg.lower():
+            log.warning("kata: stop: container {} already gone", container_id)
+            return
+        raise NerdctlError(f"nerdctl stop failed (rc={rc}): {msg.strip()}")
+
+
+async def nerdctl_rm(
+    container_id: str,
+    *,
+    force: bool = True,
+    volumes: bool = True,
+    nerdctl_bin: str = DEFAULT_NERDCTL_BIN,
+    namespace: str = DEFAULT_NERDCTL_NAMESPACE,
+) -> None:
+    args = [*_nerdctl_base(nerdctl_bin=nerdctl_bin, namespace=namespace), "rm"]
+    if force:
+        args.append("-f")
+    if volumes:
+        args.append("-v")
+    args.append(container_id)
+    rc, _, stderr = await _run(args, timeout_sec=120.0)
+    if rc != 0:
+        msg = stderr.decode(errors="replace")
+        if "no such container" in msg.lower() or "not found" in msg.lower():
+            return
+        raise NerdctlError(f"nerdctl rm failed (rc={rc}): {msg.strip()}")
+
+
+async def nerdctl_exec(
+    container_id: str,
+    command: Sequence[str],
+    *,
+    user: str | None = None,
+    input_bytes: bytes | None = None,
+    timeout_sec: float = 60.0,
+    nerdctl_bin: str = DEFAULT_NERDCTL_BIN,
+    namespace: str = DEFAULT_NERDCTL_NAMESPACE,
+) -> tuple[int, bytes, bytes]:
+    args = [*_nerdctl_base(nerdctl_bin=nerdctl_bin, namespace=namespace), "exec"]
+    if input_bytes is not None:
+        args.append("-i")  # keep stdin open so we can stream data into the guest
+    if user is not None:
+        args += ["-u", user]
+    args.append(container_id)
+    args += list(command)
+    return await _run(args, input_bytes=input_bytes, timeout_sec=timeout_sec)
+
+
+async def nerdctl_logs(
+    container_id: str,
+    *,
+    timeout_sec: float = 60.0,
+    nerdctl_bin: str = DEFAULT_NERDCTL_BIN,
+    namespace: str = DEFAULT_NERDCTL_NAMESPACE,
+) -> str:
+    args = [
+        *_nerdctl_base(nerdctl_bin=nerdctl_bin, namespace=namespace),
+        "logs",
+        container_id,
+    ]
+    rc, stdout, stderr = await _run(args, timeout_sec=timeout_sec)
+    if rc != 0:
+        raise NerdctlError(
+            f"nerdctl logs failed (rc={rc}): {stderr.decode(errors='replace').strip()}"
+        )
+    # nerdctl interleaves stdout/stderr of the container into both streams here;
+    # return both for log collection.
+    return stdout.decode(errors="replace") + stderr.decode(errors="replace")
+
+
+async def nerdctl_list_running_kernel_ids(
+    label_key: str,
+    *,
+    nerdctl_bin: str = DEFAULT_NERDCTL_BIN,
+    namespace: str = DEFAULT_NERDCTL_NAMESPACE,
+) -> set[str]:
+    """Return the set of container IDs of running containers carrying ``label_key``."""
+    args = [
+        *_nerdctl_base(nerdctl_bin=nerdctl_bin, namespace=namespace),
+        "ps",
+        "--filter",
+        f"label={label_key}",
+        "--format",
+        "{{.ID}}",
+    ]
+    rc, stdout, stderr = await _run(args, timeout_sec=30.0)
+    if rc != 0:
+        raise NerdctlError(
+            f"nerdctl ps failed (rc={rc}): {stderr.decode(errors='replace').strip()}"
+        )
+    return {line.strip() for line in stdout.decode().splitlines() if line.strip()}
+
+
+async def resolve_docker_volume_path(volume_name: str, *, docker_bin: str = "docker") -> str:
+    """
+    Resolve a Docker *named* volume to its host mountpoint path.
+
+    The krunner volume (``/opt/backend.ai``) is created by ``prepare_krunner_env``
+    via dockerd, so we ask dockerd for its on-disk path and bind-mount that into
+    the Kata guest (a Docker named volume cannot be shared into the microVM).
+    """
+    args = [docker_bin, "volume", "inspect", "--format", "{{.Mountpoint}}", volume_name]
+    rc, stdout, stderr = await _run(args, timeout_sec=30.0)
+    if rc != 0:
+        raise KataVolumeResolutionError(
+            f"could not resolve docker volume {volume_name!r} "
+            f"(rc={rc}): {stderr.decode(errors='replace').strip()}"
+        )
+    path = stdout.decode().strip()
+    if not path:
+        raise KataVolumeResolutionError(f"docker volume {volume_name!r} resolved to an empty path")
+    return path

--- a/src/ai/backend/agent/types.py
+++ b/src/ai/backend/agent/types.py
@@ -38,6 +38,7 @@ class AgentBackend(enum.StrEnum):
     DOCKER = "docker"
     KUBERNETES = "kubernetes"
     DUMMY = "dummy"
+    KATA = "kata"
 
 
 class AbstractAgentDiscovery(ABC):

--- a/tests/agent/kata/BUILD
+++ b/tests/agent/kata/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/agent/kata/test_nerdctl_translate.py
+++ b/tests/agent/kata/test_nerdctl_translate.py
@@ -59,6 +59,9 @@ def test_basic_run_shape() -> None:
     assert args[0] == "nerdctl"
     assert "run" in args
     assert "-d" in args
+    # Regression: nerdctl rejects `-i -d` together, so OpenStdin must NOT become
+    # `-i` even though the config sets OpenStdin=True (verified on kata-lab-150).
+    assert "-i" not in args
     assert _adjacent(args, "--runtime") == ["io.containerd.kata.v2"]
     assert _adjacent(args, "--name") == ["kernel.python.k-123"]
     # image must appear, and after all flags

--- a/tests/agent/kata/test_nerdctl_translate.py
+++ b/tests/agent/kata/test_nerdctl_translate.py
@@ -1,0 +1,134 @@
+"""
+Unit tests for the (host-independent) container_config -> nerdctl argv
+translation used by the KataAgent MVP. These do not require a Kata host.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ai.backend.agent.errors.kata import KataVolumeResolutionError
+from ai.backend.agent.kata.nerdctl import translate_container_config_to_nerdctl_args
+
+
+def _adjacent(args: list[str], flag: str) -> list[str]:
+    """Return every value that immediately follows an occurrence of ``flag``."""
+    return [args[i + 1] for i, a in enumerate(args) if a == flag and i + 1 < len(args)]
+
+
+def _minimal_config() -> dict[str, Any]:
+    return {
+        "Image": "cr.backend.ai/stable/python:3.11",
+        "Tty": True,
+        "OpenStdin": True,
+        "StopSignal": "SIGINT",
+        "EntryPoint": ["/opt/kernel/entrypoint.sh"],
+        "Cmd": ["--debug"],
+        "Env": ["LD_PRELOAD=/opt/kernel/libbaihook.so", "FOO=bar"],
+        "WorkingDir": "/home/work",
+        "Hostname": "main1",
+        "Labels": {"ai.backend.kernel-id": "k-123"},
+        "HostConfig": {
+            "Init": True,
+            "Privileged": False,
+            "CapAdd": ["IPC_LOCK", "SYS_NICE"],
+            "Ulimits": [{"Name": "nofile", "Soft": 1048576, "Hard": 1048576}],
+            "PortBindings": {
+                "2000/tcp": [{"HostPort": "30001", "HostIp": "127.0.0.1"}],
+                "2001/tcp": [{"HostPort": "30002", "HostIp": "127.0.0.1"}],
+                "8080/tcp": [{"HostPort": "30003", "HostIp": "0.0.0.0"}],
+            },
+            "Mounts": [
+                {
+                    "Target": "/opt/kernel/entrypoint.sh",
+                    "Source": "/host/runner/entrypoint.sh",
+                    "Type": "bind",
+                    "ReadOnly": True,
+                },
+            ],
+        },
+    }
+
+
+def test_basic_run_shape() -> None:
+    args = translate_container_config_to_nerdctl_args(
+        _minimal_config(), name="kernel.python.k-123", runtime="io.containerd.kata.v2"
+    )
+    assert args[0] == "nerdctl"
+    assert "run" in args
+    assert "-d" in args
+    assert _adjacent(args, "--runtime") == ["io.containerd.kata.v2"]
+    assert _adjacent(args, "--name") == ["kernel.python.k-123"]
+    # image must appear, and after all flags
+    assert "cr.backend.ai/stable/python:3.11" in args
+    # cmd args come after the image
+    img_idx = args.index("cr.backend.ai/stable/python:3.11")
+    assert args[img_idx + 1] == "--debug"
+
+
+def test_repl_ports_published_on_loopback() -> None:
+    args = translate_container_config_to_nerdctl_args(_minimal_config(), name="k", runtime="rt")
+    pubs = _adjacent(args, "-p")
+    # The load-bearing 127.0.0.1 repl publishing must be preserved verbatim.
+    assert "127.0.0.1:30001:2000/tcp" in pubs
+    assert "127.0.0.1:30002:2001/tcp" in pubs
+    assert "0.0.0.0:30003:8080/tcp" in pubs
+
+
+def test_env_cap_ulimit_entrypoint() -> None:
+    args = translate_container_config_to_nerdctl_args(_minimal_config(), name="k", runtime="rt")
+    assert "LD_PRELOAD=/opt/kernel/libbaihook.so" in _adjacent(args, "-e")
+    assert "FOO=bar" in _adjacent(args, "-e")
+    assert _adjacent(args, "--entrypoint") == ["/opt/kernel/entrypoint.sh"]
+    assert "IPC_LOCK" in _adjacent(args, "--cap-add")
+    assert "nofile=1048576:1048576" in _adjacent(args, "--ulimit")
+    assert "--init" in args
+    assert "--privileged" not in args  # Privileged is False
+    assert _adjacent(args, "--stop-signal") == ["SIGINT"]
+
+
+def test_bind_mount_translation() -> None:
+    args = translate_container_config_to_nerdctl_args(_minimal_config(), name="k", runtime="rt")
+    mounts = _adjacent(args, "--mount")
+    assert (
+        "type=bind,source=/host/runner/entrypoint.sh,"
+        "target=/opt/kernel/entrypoint.sh,readonly" in mounts
+    )
+
+
+def test_named_volume_resolved_to_host_bind() -> None:
+    config = _minimal_config()
+    config["HostConfig"]["Mounts"].append({
+        "Target": "/opt/backend.ai",
+        "Source": "backendai-krunner.v10.x86_64.ubuntu24.04",
+        "Type": "volume",
+        "ReadOnly": True,
+    })
+    args = translate_container_config_to_nerdctl_args(
+        config,
+        name="k",
+        runtime="rt",
+        resolve_volume=lambda name: f"/var/lib/docker/volumes/{name}/_data",
+    )
+    mounts = _adjacent(args, "--mount")
+    # The named volume must become a host-path bind mount (Kata can't share a
+    # Docker named volume into the guest).
+    assert (
+        "type=bind,source=/var/lib/docker/volumes/"
+        "backendai-krunner.v10.x86_64.ubuntu24.04/_data,"
+        "target=/opt/backend.ai,readonly" in mounts
+    )
+
+
+def test_named_volume_without_resolver_raises() -> None:
+    config = _minimal_config()
+    config["HostConfig"]["Mounts"].append({
+        "Target": "/opt/backend.ai",
+        "Source": "backendai-krunner.v10",
+        "Type": "volume",
+        "ReadOnly": True,
+    })
+    with pytest.raises(KataVolumeResolutionError):
+        translate_container_config_to_nerdctl_args(config, name="k", runtime="rt")


### PR DESCRIPTION
> ⚠️ **WIP — DO NOT MERGE.** This is an exploratory MVP / proof-of-concept branch, pushed for visibility and review only. It is **not** intended to be merged. It intentionally does **not** reference or resolve any GitHub/Jira issue — it ties to no issue.

## What this is

A hacky `KataAgent` backend that runs a **real Backend.AI compute session inside a Kata Containers lightweight VM**, as a low-friction precursor to the full BEP-1051 design (deliberately **no** containerd-gRPC client / CoCo / VFIO / Calico).

`KataAgent(DockerAgent)` reuses the **entire** `create_kernel` pipeline (scratch/config generation, krunner injection, vfolder mounts, resource specs, image scan, the ZMQ kernel-runner contract). The only functional delta is translating the already-assembled `container_config` dict into a `nerdctl run --runtime io.containerd.kata.v2` invocation instead of two `aiodocker` calls.

## What it changes

- `agent/types.py` — add `AgentBackend.KATA`.
- `agent/config/unified.py` — KATA shares Docker's container-config validation.
- new `agent/kata/` package — `nerdctl.py` (pure `container_config`→nerdctl translation + subprocess shims), `agent.py` (`KataAgent` + `KataKernelCreationContext`), `kernel.py` (`KataKernel`), `README.md`.
- `agent/errors/kata.py` — `NerdctlError`, `KataVolumeResolutionError`.
- `tests/agent/kata/` — unit tests for the translation.

Enable with `[agent] backend = "kata"`.

## Validation (live)

Deployed the full dev stack on a nested-KVM Kata host and ran a real session end-to-end: session create → code exec inside the microVM (**guest kernel `6.18.28` != host `6.8.0-124`**) → file I/O over the rw virtio-fs scratch → destroy with full VM reap; survives the registry-reconciliation loop with 0 dangling evictions. The live run surfaced and fixed **4 integration bugs** unit tests could not catch (nerdctl `-i`+`-d`; inline-JSON vs file-path seccomp; empty-cid cleanup guard; `enumerate_containers` scanning the `moby` namespace -> VM leak).

## Why this must NOT be merged

It is a subprocess shim with intentional degradations: a 5 s `nerdctl ps` liveness poller instead of an events stream, stats stubbed, `commit` unimplemented, rootful `nerdctl` via a `sudo` wrapper, port reconstruction on restart and overhead accounting missing. Production should graduate to a native **containerd-gRPC** backend. Full degradation list: `src/ai/backend/agent/kata/README.md`.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version — N/A (PoC, not for merge)
- [ ] Mention to the original issue — N/A (ties to no issue, by design)
- [ ] Installer updates (db fixtures / mandatory config) — N/A (no schema change; KATA is an opt-in value of the existing `[agent] backend`)
- [ ] End-to-end CLI integration tests in `ai.backend.test` — not done (PoC)
- [ ] API server-client counterparts — N/A
- [x] Test case(s) demonstrating the flow with a concrete implementation — `tests/agent/kata/test_nerdctl_translate.py`
- [x] Documentation — `src/ai/backend/agent/kata/README.md` (enable steps + degradations)
