### PR TITLE
chore: auto-advance NEXT_RELEASE_VERSION on sprint release

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -46,15 +46,29 @@ Run `scripts/release.sh` which performs these steps:
 scripts/release.sh {target_version} [webui_version]
 ```
 
+To override the next development version (year rollover or planned sprint skip):
+
+```bash
+NEXT_DEV_VERSION={next_version} scripts/release.sh {target_version} [webui_version]
+```
+
 **What the script does:**
 1. Creates branch `release/{target_version}`
 2. Downloads WebUI release (if `webui_version` provided)
-3. Runs quality checks: `pants tailor --check`, `pants check ::`
-4. Updates `VERSION` file
+3. Updates `VERSION` file
+4. Freezes `NEXT_RELEASE_VERSION` placeholders to the actual version (stable releases only; skipped for `rc`/`a`/`b`/`dev`/`post`)
 5. Runs towncrier to generate changelog entries
 6. Generates sample config files
 7. Generates API docs (OpenAPI, GraphQL schema)
-8. Commits everything as `release: {target_version}`
+8. Runs quality checks: `pants tailor --check`, `pants check ::`
+9. Commits everything as `release: {target_version}`
+10. For sprint releases only (`{year}.{sprint}.0`): advances `NEXT_RELEASE_VERSION` in `meta.py` to the next sprint and commits it separately as `chore: bump NEXT_RELEASE_VERSION to {next_version}`
+
+**NEXT_RELEASE_VERSION auto-advance (step 10):**
+- Runs only for sprint releases — patch must be `0` (e.g. `26.7.0`). Patch releases (`26.7.1`) and pre-releases (`rc`/`a`/`b`/`dev`/`post`) are skipped automatically.
+- Default: increments the sprint number, resets patch to `0` (`26.7.0` → `26.8.0`).
+- Override the default by setting `NEXT_DEV_VERSION` (e.g. `27.1.0` for a year rollover, or to skip sprints).
+- Produces a second commit, kept separate from the `release:` commit (freeze = this release; bump = next dev cycle).
 
 **Error handling:**
 - If quality checks fail, report errors and stop

--- a/changes/12332.misc.md
+++ b/changes/12332.misc.md
@@ -1,0 +1,1 @@
+Automatically advance `NEXT_RELEASE_VERSION` to the next sprint version when `scripts/release.sh` cuts a sprint release, overridable via the `NEXT_DEV_VERSION` environment variable.

--- a/scripts/bump_next_release_version.py
+++ b/scripts/bump_next_release_version.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Advance NEXT_RELEASE_VERSION to the next sprint development version.
+
+After a sprint release is cut, the NEXT_RELEASE_VERSION placeholder in meta.py
+must move forward to the next development target. By default the sprint number is
+incremented and the patch reset to zero ({year}.{sprint+1}.0). A new version may
+be passed explicitly to handle year rollover or planned sprint skips.
+
+The new version string is printed to stdout so the caller can reuse it (e.g. in a
+commit message).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+META_PATH = Path("src/ai/backend/common/meta/meta.py")
+
+VERSION_PATTERN = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+ASSIGNMENT_PATTERN = re.compile(r'^NEXT_RELEASE_VERSION = "[^"]+"$', re.MULTILINE)
+
+
+def read_current_version() -> str:
+    text = META_PATH.read_text()
+    match = re.search(r'^NEXT_RELEASE_VERSION = "([^"]+)"$', text, re.MULTILINE)
+    if match is None:
+        print(f"Could not find NEXT_RELEASE_VERSION assignment in {META_PATH}", file=sys.stderr)
+        sys.exit(1)
+    return match.group(1)
+
+
+def compute_next_version(current: str) -> str:
+    match = VERSION_PATTERN.match(current)
+    if match is None:
+        print(
+            f"Current NEXT_RELEASE_VERSION '{current}' is not in {{year}}.{{sprint}}.{{patch}} format",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    year, sprint, _patch = (int(part) for part in match.groups())
+    return f"{year}.{sprint + 1}.0"
+
+
+def write_version(new_version: str) -> None:
+    text = META_PATH.read_text()
+    new_text = ASSIGNMENT_PATTERN.sub(f'NEXT_RELEASE_VERSION = "{new_version}"', text, count=1)
+    META_PATH.write_text(new_text)
+
+
+def main() -> None:
+    if len(sys.argv) > 2:
+        print(f"Usage: {sys.argv[0]} [next_version]", file=sys.stderr)
+        sys.exit(1)
+
+    if len(sys.argv) == 2:
+        next_version = sys.argv[1]
+        if VERSION_PATTERN.match(next_version) is None:
+            print(
+                f"Provided next version '{next_version}' is not in {{year}}.{{sprint}}.{{patch}} format",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    else:
+        next_version = compute_next_version(read_current_version())
+
+    write_version(next_version)
+    print(next_version)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -63,3 +63,13 @@ pants check ::
 
 git add -A
 git commit -m "release: $TARGET_VERSION"
+
+# Advance NEXT_RELEASE_VERSION to the next sprint development cycle.
+# Only for sprint releases (patch == 0); the regex also excludes patch
+# releases and PEP 440 pre-releases (rc/a/b/dev/post). Override the computed
+# sprint+1 default with NEXT_DEV_VERSION (e.g. for year rollover: 27.1.0).
+if [[ "$TARGET_VERSION" =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
+    next_dev=$(python3 scripts/bump_next_release_version.py ${NEXT_DEV_VERSION:+"$NEXT_DEV_VERSION"})
+    git add src/ai/backend/common/meta/meta.py
+    git commit -m "chore: bump NEXT_RELEASE_VERSION to $next_dev"
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/bump_next_release_version.py` to advance the `NEXT_RELEASE_VERSION` placeholder in `meta.py` to the next sprint (sprint+1, patch reset to 0) by default, with an explicit override for year rollover or planned sprint skips.
- Wire it into `scripts/release.sh` after the `release:` commit, guarded to sprint releases only (`{year}.{sprint}.0`), producing a separate `chore: bump NEXT_RELEASE_VERSION to X` commit. The `NEXT_DEV_VERSION` env var overrides the computed default.
- Document the new auto-advance step and the `NEXT_DEV_VERSION` override in the release skill.

## Test plan
- [ ] `python3 scripts/bump_next_release_version.py` advances `26.7.0` → `26.8.0` and prints the new version
- [ ] `python3 scripts/bump_next_release_version.py 27.1.0` applies the explicit override
- [ ] Invalid/extra args exit non-zero
- [ ] `release.sh` guard: `26.7.0`/`27.1.0`/`26.10.0` bump; `26.7.1`/`rc`/`a`/`dev` skip
- [ ] Sprint release produces two commits (`release:` then `chore: bump ...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)