### PR TITLE
feat: Expose per-host permissions from the vfolder host list

### DIFF
--- a/changes/12333.enhance.md
+++ b/changes/12333.enhance.md
@@ -1,0 +1,1 @@
+Include a per-host `allowed_permissions` mapping in the vfolder host list (`GET /folders/_/hosts`) response so clients can distinguish hosts the user may create folders on from read-only hosts.

--- a/src/ai/backend/common/dto/manager/vfolder/response.py
+++ b/src/ai/backend/common/dto/manager/vfolder/response.py
@@ -303,7 +303,7 @@ class ListHostsResponse(BaseResponseModel):
             "by host name (e.g. `create-vfolder`, `mount-in-session`). Lets "
             "clients distinguish hosts the user may create folders on from "
             "read-only hosts, since `allowed` carries only host names. "
-            "Added in 26.4.4."
+            "Added in 26.4.5."
         ),
     )
 

--- a/src/ai/backend/common/dto/manager/vfolder/response.py
+++ b/src/ai/backend/common/dto/manager/vfolder/response.py
@@ -296,6 +296,16 @@ class ListHostsResponse(BaseResponseModel):
     volume_info: dict[str, VolumeInfoDTO] = Field(
         default_factory=dict, description="Volume info per host"
     )
+    allowed_permissions: dict[str, list[str]] = Field(
+        default_factory=dict,
+        description=(
+            "Permissions the requesting user holds on each allowed host, keyed "
+            "by host name (e.g. `create-vfolder`, `mount-in-session`). Lets "
+            "clients distinguish hosts the user may create folders on from "
+            "read-only hosts, since `allowed` carries only host names. "
+            "Added in 26.4.4."
+        ),
+    )
 
 
 class ListAllHostsResponse(BaseResponseModel):

--- a/src/ai/backend/manager/api/rest/vfolder/handler.py
+++ b/src/ai/backend/manager/api/rest/vfolder/handler.py
@@ -412,6 +412,7 @@ class VFolderHandler:
             default=result.default,
             allowed=result.allowed,
             volume_info=volume_info,
+            allowed_permissions=result.allowed_permissions,
         )
         return APIResponse.build(HTTPStatus.OK, resp)
 

--- a/src/ai/backend/manager/services/vfolder/actions/storage_ops.py
+++ b/src/ai/backend/manager/services/vfolder/actions/storage_ops.py
@@ -168,6 +168,11 @@ class ListHostsActionResult(BaseActionResult):
     default: str | None
     allowed: list[str]
     volume_info: dict[str, Any]
+    # Per-host permissions the requesting user holds, keyed by host name
+    # (e.g. ``create-vfolder``, ``mount-in-session``). ``allowed`` only carries
+    # the host names, so this lets callers tell apart hosts the user may create
+    # folders on from read-only hosts.
+    allowed_permissions: dict[str, list[str]]
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -1061,6 +1061,7 @@ class VFolderService:
             default=default_host,
             allowed=sorted(allowed_hosts),
             volume_info=volume_info,
+            allowed_permissions=allowed_hosts.to_json(),
         )
 
     async def get_my_storage_host_permissions(

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -1061,7 +1061,12 @@ class VFolderService:
             default=default_host,
             allowed=sorted(allowed_hosts),
             volume_info=volume_info,
-            allowed_permissions=allowed_hosts.to_json(),
+            # Sort hosts and permissions for a deterministic REST response;
+            # `to_json()` emits set-ordered (nondeterministic) permission lists.
+            allowed_permissions={
+                host: sorted(perm.value for perm in perms)
+                for host, perms in sorted(allowed_hosts.items())
+            },
         )
 
     async def get_my_storage_host_permissions(

--- a/tests/unit/common/dto/manager/vfolder/test_response.py
+++ b/tests/unit/common/dto/manager/vfolder/test_response.py
@@ -16,6 +16,7 @@ from ai.backend.common.dto.manager.vfolder.response import (
     InviteVFolderResponse,
     ListAllHostsResponse,
     ListAllowedTypesResponse,
+    ListHostsResponse,
     ListInvitationsResponse,
     ListSharedVFoldersResponse,
     MessageResponse,
@@ -298,6 +299,23 @@ class TestAdminResponses:
         resp = ListAllHostsResponse(default="host-1", allowed=["host-1", "host-2"])
         assert resp.default == "host-1"
         assert len(resp.allowed) == 2
+
+    def test_list_hosts_response_carries_per_host_permissions(self) -> None:
+        resp = ListHostsResponse(
+            default="host-1",
+            allowed=["host-1", "host-2"],
+            allowed_permissions={
+                "host-1": ["create-vfolder", "mount-in-session"],
+                "host-2": ["download-file"],
+            },
+        )
+        assert resp.allowed_permissions["host-1"] == ["create-vfolder", "mount-in-session"]
+        assert "create-vfolder" not in resp.allowed_permissions["host-2"]
+
+    def test_list_hosts_response_permissions_default_empty(self) -> None:
+        # Backward compatibility: clients/responses predating the field still parse.
+        resp = ListHostsResponse(default="host-1", allowed=["host-1"])
+        assert resp.allowed_permissions == {}
 
     def test_allowed_types_response(self) -> None:
         resp = ListAllowedTypesResponse(["user", "group"])

--- a/tests/unit/manager/services/vfolder/test_vfolder_storage_service.py
+++ b/tests/unit/manager/services/vfolder/test_vfolder_storage_service.py
@@ -199,6 +199,36 @@ class TestListHostsAction:
         assert "proxy2:volume2" not in result.allowed
         mock_vfolder_repository.get_allowed_hosts_for_listing.assert_awaited_once()
 
+    async def test_reports_per_host_permissions(
+        self,
+        vfolder_service: VFolderService,
+        mock_vfolder_repository: MagicMock,
+        user_uuid: uuid.UUID,
+    ) -> None:
+        # A host the user may create on and a host they only have read access to
+        # must both appear in `allowed`, but `allowed_permissions` must reflect
+        # which one actually grants create.
+        mock_vfolder_repository.get_allowed_hosts_for_listing = AsyncMock(
+            return_value=VFolderHostPermissionMap({
+                "proxy1:volume1": {VFolderHostPermission.CREATE, VFolderHostPermission.MODIFY},
+                "proxy2:volume2": {VFolderHostPermission.DOWNLOAD_FILE},
+            })
+        )
+        action = ListHostsAction(
+            user_uuid=user_uuid,
+            domain_name="default",
+            group_id=None,
+            resource_policy={"max_vfolder_count": 10},
+        )
+        result = await vfolder_service.list_hosts(action)
+
+        # Every allowed host is represented in the permission map.
+        assert set(result.allowed_permissions) == set(result.allowed)
+        assert VFolderHostPermission.CREATE.value in result.allowed_permissions["proxy1:volume1"]
+        assert (
+            VFolderHostPermission.CREATE.value not in result.allowed_permissions["proxy2:volume2"]
+        )
+
     async def test_volume_info_includes_backend_capabilities_usage(
         self,
         vfolder_service: VFolderService,

--- a/tests/unit/manager/services/vfolder/test_vfolder_storage_service.py
+++ b/tests/unit/manager/services/vfolder/test_vfolder_storage_service.py
@@ -228,6 +228,9 @@ class TestListHostsAction:
         assert (
             VFolderHostPermission.CREATE.value not in result.allowed_permissions["proxy2:volume2"]
         )
+        # Permissions are sorted for a deterministic response (sets are unordered).
+        for perms in result.allowed_permissions.values():
+            assert perms == sorted(perms)
 
     async def test_volume_info_includes_backend_capabilities_usage(
         self,


### PR DESCRIPTION
## Summary

`GET /folders/_/hosts` returned only `allowed` — the list of host *names* a user may use — while discarding the per-host permission sets that `list_hosts` already computes internally as a `VFolderHostPermissionMap`. As a result, a client cannot tell apart hosts where the user may **create** a vfolder (`create-vfolder`) from hosts where they only hold read/mount permissions (`mount-in-session`, `download-file`, …). The host list therefore advertises hosts that fail later when a create is attempted against them.

This adds an `allowed_permissions` mapping (host → permission names) to the response, sourced from the permission map the service already builds — so clients can mark or hide non-writable hosts up front.

## Changes

- `ListHostsActionResult` (`services/vfolder/actions/storage_ops.py`): add `allowed_permissions: dict[str, list[str]]`.
- `VFolderService.list_hosts` (`services/vfolder/services/vfolder.py`): populate it from `allowed_hosts.to_json()` (the same filtered `VFolderHostPermissionMap` used for `allowed`).
- `ListHostsResponse` (`common/dto/manager/vfolder/response.py`): add `allowed_permissions`, defaulting to `{}` so existing clients parse unchanged.
- `VFolderHandler.list_hosts` (`api/rest/vfolder/handler.py`): pass the field through.
- Tests: service-level assertion that a create-capable host and a read-only host are distinguished; DTO round-trip + backward-compat (absent field → `{}`).

## Compatibility

Additive and backward-compatible: `allowed` is unchanged and `allowed_permissions` is optional with an empty-mapping default. Its keys mirror `allowed` exactly. The per-host permission data was already exposed via the V2 GraphQL storage-host-permissions query; this closes the gap for the REST host-list endpoint.