### PR TITLE
fix(BA-6576): return 4xx not 500 for invalid enqueue resource quantity

### DIFF
--- a/changes/12344.fix.md
+++ b/changes/12344.fix.md
@@ -1,0 +1,1 @@
+Return a 4xx error instead of a 500 when the session enqueue API receives an unparseable resource quantity, and accept human-readable sizes such as `4g` for memory slots like the legacy path.

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -1398,8 +1398,20 @@ class ResourceSlotEntry(BackendAISchema):
         Transitional helper: repository layer still writes ``ResourceSlot``
         to the DB column, so the final boundary converts back. New
         in-memory pipelines should stay on the entry-list form.
+
+        Quantities are parsed with the same tolerance as user input
+        (:meth:`ResourceSlot.from_user_input`), so human-readable sizes such
+        as ``"4g"`` for memory slots are accepted just like the legacy
+        enqueue path. A non-parseable quantity is rejected with a 4xx
+        :class:`InvalidResourceSlotQuantity` instead of letting
+        ``decimal.InvalidOperation`` propagate as an unhandled 500.
         """
-        return ResourceSlot({e.resource_type: Decimal(e.quantity) for e in entries})
+        try:
+            return ResourceSlot.from_user_input(
+                {e.resource_type: e.quantity for e in entries}, None
+            )
+        except ValueError as e:
+            raise InvalidResourceSlotQuantity(extra_msg=str(e)) from e
 
 
 class ResourceSlotState(enum.StrEnum):

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -1392,7 +1392,7 @@ class ResourceSlotEntry(BackendAISchema):
         ]
 
     @classmethod
-    def to_resource_slot(cls, entries: Sequence[ResourceSlotEntry]) -> ResourceSlot:
+    def inputs_to_resource_slot(cls, entries: Sequence[ResourceSlotEntry]) -> ResourceSlot:
         """Collapse an entry list back into the legacy ``ResourceSlot``.
 
         Transitional helper: repository layer still writes ``ResourceSlot``

--- a/src/ai/backend/manager/repositories/scheduler/creators.py
+++ b/src/ai/backend/manager/repositories/scheduler/creators.py
@@ -70,7 +70,7 @@ class KernelRowFromSpec(CreatorSpec[KernelRow]):
         environ_payload = [f"{k}={v}" for k, v in (execution.environ or {}).items()]
         resource_opts_payload = execution.resource_opts.model_dump(exclude_none=True)
         resolved_mounts = list(self.kernel_spec.vfolder_mounts)
-        requested_slots = ResourceSlotEntry.to_resource_slot(execution.resources)
+        requested_slots = ResourceSlotEntry.inputs_to_resource_slot(execution.resources)
 
         return KernelRow(
             session_id=self.spec.identity.session_id,
@@ -160,7 +160,9 @@ class SessionRowFromSpec(CreatorSpec[SessionRow]):
                         session_images.insert(0, image_info.canonical)
                     else:
                         session_images.append(image_info.canonical)
-            requested_slots += ResourceSlotEntry.to_resource_slot(kernel.execution_spec.resources)
+            requested_slots += ResourceSlotEntry.inputs_to_resource_slot(
+                kernel.execution_spec.resources
+            )
 
         main_mounts = list(main_kernel.vfolder_mounts) if main_kernel else []
         session_starts_at = main_kernel.execution_spec.starts_at if main_kernel else None

--- a/tests/unit/common/test_types.py
+++ b/tests/unit/common/test_types.py
@@ -559,23 +559,59 @@ class TestMountInfoEntryLegacyShape:
             })
 
 
+@dataclass(frozen=True)
+class _QuantityCase:
+    """Pairs a resource entry quantity with the slot value it should parse to."""
+
+    resource_type: str
+    quantity: str
+    expected: Decimal
+
+
 class TestResourceSlotEntryToResourceSlot:
     """``ResourceSlotEntry.to_resource_slot`` quantity parsing (BA-6576)."""
 
-    def test_plain_decimal_quantities(self) -> None:
-        entries = [
-            ResourceSlotEntry(resource_type="cpu", quantity="2"),
-            ResourceSlotEntry(resource_type="mem", quantity="4294967296"),
-        ]
+    @pytest.mark.parametrize(
+        "case",
+        [
+            pytest.param(_QuantityCase("cpu", "2", Decimal("2")), id="plain-int"),
+            pytest.param(_QuantityCase("cpu", "0.5", Decimal("0.5")), id="fraction"),
+            pytest.param(
+                _QuantityCase("mem", "4294967296", Decimal("4294967296")), id="bytes-decimal"
+            ),
+            pytest.param(
+                _QuantityCase("mem", "4g", Decimal(BinarySize.from_str("4g"))),
+                id="human-readable-size",
+            ),
+        ],
+    )
+    def test_valid_quantity_is_parsed(self, case: _QuantityCase) -> None:
+        """Plain decimals and human-readable sizes such as ``"4g"`` for a memory
+        slot are parsed with BinarySize tolerance, matching the legacy enqueue
+        path, instead of raising and surfacing as a 500."""
+        entries = [ResourceSlotEntry(resource_type=case.resource_type, quantity=case.quantity)]
         assert ResourceSlotEntry.to_resource_slot(entries) == ResourceSlot({
-            "cpu": Decimal("2"),
-            "mem": Decimal("4294967296"),
+            case.resource_type: case.expected
         })
 
-    def test_human_readable_memory_size_is_accepted(self) -> None:
-        """A human-readable size such as ``"4g"`` for a memory slot is parsed
-        with BinarySize tolerance, matching the legacy enqueue path, instead of
-        raising and surfacing as a 500."""
+    @pytest.mark.parametrize(
+        ("resource_type", "quantity"),
+        [
+            pytest.param("mem", "not-a-number", id="garbage"),
+            pytest.param("cpu", "abc", id="non-numeric"),
+            pytest.param("mem", "", id="empty"),
+            pytest.param("cpu", "-1", id="negative"),
+        ],
+    )
+    def test_invalid_quantity_raises_4xx(self, resource_type: str, quantity: str) -> None:
+        """A non-parseable or negative quantity is rejected with a 4xx
+        ``InvalidResourceSlotQuantity`` (BackendAIError) rather than letting
+        ``decimal.InvalidOperation`` propagate as an unhandled 500."""
+        entries = [ResourceSlotEntry(resource_type=resource_type, quantity=quantity)]
+        with pytest.raises(InvalidResourceSlotQuantity):
+            ResourceSlotEntry.to_resource_slot(entries)
+
+    def test_multiple_entries_are_merged(self) -> None:
         entries = [
             ResourceSlotEntry(resource_type="cpu", quantity="2"),
             ResourceSlotEntry(resource_type="mem", quantity="4g"),
@@ -584,19 +620,6 @@ class TestResourceSlotEntryToResourceSlot:
             "cpu": Decimal("2"),
             "mem": Decimal(BinarySize.from_str("4g")),
         })
-
-    def test_non_decimal_quantity_raises_4xx(self) -> None:
-        """A non-parseable quantity is rejected with a 4xx
-        ``InvalidResourceSlotQuantity`` (BackendAIError) rather than letting
-        ``decimal.InvalidOperation`` propagate as an unhandled 500."""
-        entries = [ResourceSlotEntry(resource_type="mem", quantity="not-a-number")]
-        with pytest.raises(InvalidResourceSlotQuantity):
-            ResourceSlotEntry.to_resource_slot(entries)
-
-    def test_negative_quantity_raises_4xx(self) -> None:
-        entries = [ResourceSlotEntry(resource_type="cpu", quantity="-1")]
-        with pytest.raises(InvalidResourceSlotQuantity):
-            ResourceSlotEntry.to_resource_slot(entries)
 
     def test_empty_entries(self) -> None:
         assert ResourceSlotEntry.to_resource_slot([]) == ResourceSlot()

--- a/tests/unit/common/test_types.py
+++ b/tests/unit/common/test_types.py
@@ -20,6 +20,7 @@ from ai.backend.common.types import (
     MountInfoEntry,
     MountPermission,
     ResourceSlot,
+    ResourceSlotEntry,
     SlotName,
     SlotTypes,
     _stringify_number,
@@ -556,3 +557,46 @@ class TestMountInfoEntryLegacyShape:
                 "mount_destination": "/home/work/data",
                 "mount_perm": "rw",
             })
+
+
+class TestResourceSlotEntryToResourceSlot:
+    """``ResourceSlotEntry.to_resource_slot`` quantity parsing (BA-6576)."""
+
+    def test_plain_decimal_quantities(self) -> None:
+        entries = [
+            ResourceSlotEntry(resource_type="cpu", quantity="2"),
+            ResourceSlotEntry(resource_type="mem", quantity="4294967296"),
+        ]
+        assert ResourceSlotEntry.to_resource_slot(entries) == ResourceSlot({
+            "cpu": Decimal("2"),
+            "mem": Decimal("4294967296"),
+        })
+
+    def test_human_readable_memory_size_is_accepted(self) -> None:
+        """A human-readable size such as ``"4g"`` for a memory slot is parsed
+        with BinarySize tolerance, matching the legacy enqueue path, instead of
+        raising and surfacing as a 500."""
+        entries = [
+            ResourceSlotEntry(resource_type="cpu", quantity="2"),
+            ResourceSlotEntry(resource_type="mem", quantity="4g"),
+        ]
+        assert ResourceSlotEntry.to_resource_slot(entries) == ResourceSlot({
+            "cpu": Decimal("2"),
+            "mem": Decimal(BinarySize.from_str("4g")),
+        })
+
+    def test_non_decimal_quantity_raises_4xx(self) -> None:
+        """A non-parseable quantity is rejected with a 4xx
+        ``InvalidResourceSlotQuantity`` (BackendAIError) rather than letting
+        ``decimal.InvalidOperation`` propagate as an unhandled 500."""
+        entries = [ResourceSlotEntry(resource_type="mem", quantity="not-a-number")]
+        with pytest.raises(InvalidResourceSlotQuantity):
+            ResourceSlotEntry.to_resource_slot(entries)
+
+    def test_negative_quantity_raises_4xx(self) -> None:
+        entries = [ResourceSlotEntry(resource_type="cpu", quantity="-1")]
+        with pytest.raises(InvalidResourceSlotQuantity):
+            ResourceSlotEntry.to_resource_slot(entries)
+
+    def test_empty_entries(self) -> None:
+        assert ResourceSlotEntry.to_resource_slot([]) == ResourceSlot()

--- a/tests/unit/common/test_types.py
+++ b/tests/unit/common/test_types.py
@@ -590,7 +590,7 @@ class TestResourceSlotEntryToResourceSlot:
         slot are parsed with BinarySize tolerance, matching the legacy enqueue
         path, instead of raising and surfacing as a 500."""
         entries = [ResourceSlotEntry(resource_type=case.resource_type, quantity=case.quantity)]
-        assert ResourceSlotEntry.to_resource_slot(entries) == ResourceSlot({
+        assert ResourceSlotEntry.inputs_to_resource_slot(entries) == ResourceSlot({
             case.resource_type: case.expected
         })
 
@@ -609,17 +609,17 @@ class TestResourceSlotEntryToResourceSlot:
         ``decimal.InvalidOperation`` propagate as an unhandled 500."""
         entries = [ResourceSlotEntry(resource_type=resource_type, quantity=quantity)]
         with pytest.raises(InvalidResourceSlotQuantity):
-            ResourceSlotEntry.to_resource_slot(entries)
+            ResourceSlotEntry.inputs_to_resource_slot(entries)
 
     def test_multiple_entries_are_merged(self) -> None:
         entries = [
             ResourceSlotEntry(resource_type="cpu", quantity="2"),
             ResourceSlotEntry(resource_type="mem", quantity="4g"),
         ]
-        assert ResourceSlotEntry.to_resource_slot(entries) == ResourceSlot({
+        assert ResourceSlotEntry.inputs_to_resource_slot(entries) == ResourceSlot({
             "cpu": Decimal("2"),
             "mem": Decimal(BinarySize.from_str("4g")),
         })
 
     def test_empty_entries(self) -> None:
-        assert ResourceSlotEntry.to_resource_slot([]) == ResourceSlot()
+        assert ResourceSlotEntry.inputs_to_resource_slot([]) == ResourceSlot()


### PR DESCRIPTION
## Summary
- The session enqueue API returned an unhandled **500** when a resource entry `quantity` was not a parseable decimal (e.g. `"4g"`): `ResourceSlotEntry.to_resource_slot` called bare `Decimal(quantity)`, raising `decimal.InvalidOperation`, which does not inherit `BackendAIError` and so fell through the action processor as an "Unexpected error".
- Route the conversion through `ResourceSlot.from_user_input` — the same tolerant parser already used by the legacy (`AgentRegistry.create_session`, `registry.py:496`) and sokovan (`scheduling_controller.py:380`) enqueue paths — so human-readable sizes such as `"4g"` for memory slots are accepted, and genuinely invalid values raise `InvalidResourceSlotQuantity` (**4xx**).
- Scope is limited to the session enqueue scheduler path: `to_resource_slot`'s only callers are `repositories/scheduler/creators.py:73,163`, so deployment / preset / resource-policy paths (which already tolerate `"4g"` by storing it as a string) are untouched — no regression.

## Test plan
- [x] `tests/unit/common/test_types.py::TestResourceSlotEntryToResourceSlot` — plain decimals, `"4g"` accepted, non-decimal & negative → 4xx, empty input
- [x] `pants lint` (ruff) on changed files
- [x] Regression: `sokovan/scheduler`, session & deployment adapter, session v2 DTO tests pass
- [ ] Live: enqueue with `mem: "4g"` → 200, `mem: "abc"` → 400 (manual check)

Resolves BA-6576