### PR TITLE
feat(BA-6261): add idle checker persistence foundation

### DIFF
--- a/changes/12346.feature.md
+++ b/changes/12346.feature.md
@@ -1,0 +1,1 @@
+Add the persistence foundation for first-class idle checkers (idle_checkers / idle_checker_bindings tables) and a reusable ABCColumn polymorphic JSONB column type (BEP-1054)

--- a/src/ai/backend/common/identifier/idle_checker.py
+++ b/src/ai/backend/common/identifier/idle_checker.py
@@ -1,0 +1,7 @@
+from typing import NewType
+from uuid import UUID
+
+__all__ = ("IdleCheckerID",)
+
+
+IdleCheckerID = NewType("IdleCheckerID", UUID)

--- a/src/ai/backend/manager/data/idle_checker/types.py
+++ b/src/ai/backend/manager/data/idle_checker/types.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import enum
+
+
+class CheckerType(enum.StrEnum):
+    """Discriminator for the kind of idle checker; selects the concrete spec."""
+
+    SESSION_LIFETIME = "session_lifetime"
+    NETWORK_TIMEOUT = "network_timeout"
+    UTILIZATION = "utilization"

--- a/src/ai/backend/manager/models/alembic/versions/d3f8a1c45e9b_create_idle_checker_tables.py
+++ b/src/ai/backend/manager/models/alembic/versions/d3f8a1c45e9b_create_idle_checker_tables.py
@@ -42,7 +42,7 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column(
-            "modified_at",
+            "updated_at",
             sa.DateTime(timezone=True),
             server_default=sa.func.now(),
             nullable=False,
@@ -62,7 +62,7 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column(
-            "modified_at",
+            "updated_at",
             sa.DateTime(timezone=True),
             server_default=sa.func.now(),
             nullable=False,

--- a/src/ai/backend/manager/models/alembic/versions/d3f8a1c45e9b_create_idle_checker_tables.py
+++ b/src/ai/backend/manager/models/alembic/versions/d3f8a1c45e9b_create_idle_checker_tables.py
@@ -8,7 +8,7 @@ polymorphic ``(scope_type, scope_id)`` string pair validated on the write
 path rather than by a DB foreign key.
 
 Revision ID: d3f8a1c45e9b
-Revises: 2d6443ac0d4a
+Revises: a8e06485829f
 Create Date: 2026-06-22
 
 """
@@ -21,7 +21,7 @@ from ai.backend.manager.models.base import GUID
 
 # revision identifiers, used by Alembic.
 revision = "d3f8a1c45e9b"
-down_revision = "2d6443ac0d4a"
+down_revision = "a8e06485829f"
 # Part of: 26.5.0
 branch_labels = None
 depends_on = None

--- a/src/ai/backend/manager/models/alembic/versions/d3f8a1c45e9b_create_idle_checker_tables.py
+++ b/src/ai/backend/manager/models/alembic/versions/d3f8a1c45e9b_create_idle_checker_tables.py
@@ -1,0 +1,93 @@
+"""create idle_checker tables
+
+Introduce the persistence foundation for the first-class idle checker
+(BEP-1054). ``idle_checkers`` holds a reusable, scope-free checker spec
+(``checker_type`` + JSONB ``spec``); ``idle_checker_bindings`` is the
+scope <-> checker association carrying its own ``enabled`` flag. Scope is a
+polymorphic ``(scope_type, scope_id)`` string pair validated on the write
+path rather than by a DB foreign key.
+
+Revision ID: d3f8a1c45e9b
+Revises: 2d6443ac0d4a
+Create Date: 2026-06-22
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from ai.backend.manager.models.base import GUID
+
+# revision identifiers, used by Alembic.
+revision = "d3f8a1c45e9b"
+down_revision = "2d6443ac0d4a"
+# Part of: 26.5.0
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "idle_checkers",
+        sa.Column("id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("checker_type", sa.String(length=64), nullable=False),
+        sa.Column("spec", postgresql.JSONB(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_table(
+        "idle_checker_bindings",
+        sa.Column("id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")),
+        sa.Column("scope_type", sa.String(length=64), nullable=False),
+        sa.Column("scope_id", GUID, nullable=False),
+        sa.Column("idle_checker_id", GUID, nullable=False),
+        sa.Column("enabled", sa.Boolean(), server_default=sa.true(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["idle_checker_id"],
+            ["idle_checkers.id"],
+            name="fk_idle_checker_bindings_idle_checker_id",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint(
+            "idle_checker_id",
+            "scope_type",
+            "scope_id",
+            name="uq_idle_checker_bindings_checker_scope",
+        ),
+    )
+    op.create_index(
+        "ix_idle_checker_bindings_scope",
+        "idle_checker_bindings",
+        ["scope_type", "scope_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_idle_checker_bindings_scope", table_name="idle_checker_bindings")
+    op.drop_table("idle_checker_bindings")
+    op.drop_table("idle_checkers")

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import abc
 import enum
 import ipaddress
 import json
@@ -635,6 +636,60 @@ class PydanticListColumn[TBaseModel: BaseModel](TypeDecorator[list[TBaseModel]])
 
     def copy(self, **_kw: Any) -> Self:
         return PydanticListColumn(self._schema)  # type: ignore[return-value]
+
+
+class ABCColumnPayload(abc.ABC):
+    """
+    Storage contract for :class:`ABCColumn`: ``write`` serializes to a JSONB
+    dict, ``load`` rehydrates one (and may dispatch by discriminator to a
+    concrete subtype). Informal abstracts rather than ``@abc.abstractmethod`` so
+    the base can be passed to ``ABCColumn(...)`` without tripping mypy's
+    ``type-abstract`` check; subclasses must override both.
+    """
+
+    def write(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+    @classmethod
+    def load(cls, raw: dict[str, Any]) -> ABCColumnPayload:
+        raise NotImplementedError
+
+
+class ABCColumn(TypeDecorator[ABCColumnPayload]):
+    """Polymorphic JSONB column: stores ``value.write()``, reads via
+    ``schema.load(...)``. Domain-agnostic; modeled on :class:`PydanticColumn`."""
+
+    impl = JSONB
+    cache_ok = True
+
+    _schema: type[ABCColumnPayload]
+
+    def __init__(self, schema: type[ABCColumnPayload]) -> None:
+        super().__init__()
+        self._schema = schema
+
+    def process_bind_param(
+        self,
+        value: ABCColumnPayload | None,
+        dialect: Dialect,
+    ) -> dict[str, Any] | None:
+        # JSONB accepts Python objects directly, not JSON strings
+        if value is None:
+            return None
+        return value.write()
+
+    def process_result_value(
+        self,
+        value: dict[str, Any] | None,
+        dialect: Dialect,
+    ) -> ABCColumnPayload | None:
+        # JSONB returns already parsed Python objects, not strings
+        if value is None:
+            return None
+        return self._schema.load(value)
+
+    def copy(self, **_kw: Any) -> Self:
+        return ABCColumn(self._schema)  # type: ignore[return-value]
 
 
 class URLColumn(TypeDecorator[yarl.URL]):

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -640,14 +640,14 @@ class PydanticListColumn[TBaseModel: BaseModel](TypeDecorator[list[TBaseModel]])
 
 class ABCColumnPayload(abc.ABC):
     """
-    Storage contract for :class:`ABCColumn`: ``write`` serializes to a JSONB
+    Storage contract for :class:`ABCColumn`: ``serialize`` produces a JSONB
     dict, ``load`` rehydrates one (and may dispatch by discriminator to a
     concrete subtype). Informal abstracts rather than ``@abc.abstractmethod`` so
     the base can be passed to ``ABCColumn(...)`` without tripping mypy's
     ``type-abstract`` check; subclasses must override both.
     """
 
-    def write(self) -> dict[str, Any]:
+    def serialize(self) -> dict[str, Any]:
         raise NotImplementedError
 
     @classmethod
@@ -656,7 +656,7 @@ class ABCColumnPayload(abc.ABC):
 
 
 class ABCColumn(TypeDecorator[ABCColumnPayload]):
-    """Polymorphic JSONB column: stores ``value.write()``, reads via
+    """Polymorphic JSONB column: stores ``value.serialize()``, reads via
     ``schema.load(...)``. Domain-agnostic; modeled on :class:`PydanticColumn`."""
 
     impl = JSONB
@@ -676,7 +676,7 @@ class ABCColumn(TypeDecorator[ABCColumnPayload]):
         # JSONB accepts Python objects directly, not JSON strings
         if value is None:
             return None
-        return value.write()
+        return value.serialize()
 
     def process_result_value(
         self,

--- a/src/ai/backend/manager/models/idle_checker/__init__.py
+++ b/src/ai/backend/manager/models/idle_checker/__init__.py
@@ -1,0 +1,3 @@
+from .row import IdleCheckerBindingRow, IdleCheckerRow
+
+__all__ = ("IdleCheckerRow", "IdleCheckerBindingRow")

--- a/src/ai/backend/manager/models/idle_checker/row.py
+++ b/src/ai/backend/manager/models/idle_checker/row.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ai.backend.manager.models.base import GUID, ABCColumn, Base
+from ai.backend.manager.models.idle_checker.spec import IdleCheckerSpecABC
+
+
+class IdleCheckerRow(Base):  # type: ignore[misc]
+    __tablename__ = "idle_checkers"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
+    )
+    name: Mapped[str] = mapped_column("name", sa.String(length=128), nullable=False)
+    description: Mapped[str | None] = mapped_column("description", sa.Text, nullable=True)
+    checker_type: Mapped[str] = mapped_column("checker_type", sa.String(length=64), nullable=False)
+    spec: Mapped[IdleCheckerSpecABC] = mapped_column(
+        "spec", ABCColumn(IdleCheckerSpecABC), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+    )
+    modified_at: Mapped[datetime] = mapped_column(
+        "modified_at",
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+    )
+
+
+class IdleCheckerBindingRow(Base):  # type: ignore[misc]
+    __tablename__ = "idle_checker_bindings"
+    __table_args__ = (
+        sa.ForeignKeyConstraint(
+            ["idle_checker_id"],
+            ["idle_checkers.id"],
+            name="fk_idle_checker_bindings_idle_checker_id",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint(
+            "idle_checker_id",
+            "scope_type",
+            "scope_id",
+            name="uq_idle_checker_bindings_checker_scope",
+        ),
+        sa.Index("ix_idle_checker_bindings_scope", "scope_type", "scope_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
+    )
+    scope_type: Mapped[str] = mapped_column("scope_type", sa.String(length=64), nullable=False)
+    scope_id: Mapped[uuid.UUID] = mapped_column("scope_id", GUID, nullable=False)
+    idle_checker_id: Mapped[uuid.UUID] = mapped_column("idle_checker_id", GUID, nullable=False)
+    enabled: Mapped[bool] = mapped_column(
+        "enabled", sa.Boolean, nullable=False, server_default=sa.true()
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+    )
+    modified_at: Mapped[datetime] = mapped_column(
+        "modified_at",
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+    )

--- a/src/ai/backend/manager/models/idle_checker/row.py
+++ b/src/ai/backend/manager/models/idle_checker/row.py
@@ -26,8 +26,8 @@ class IdleCheckerRow(Base):  # type: ignore[misc]
     created_at: Mapped[datetime] = mapped_column(
         "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
     )
-    modified_at: Mapped[datetime] = mapped_column(
-        "modified_at",
+    updated_at: Mapped[datetime] = mapped_column(
+        "updated_at",
         sa.DateTime(timezone=True),
         nullable=False,
         server_default=sa.func.now(),
@@ -67,8 +67,8 @@ class IdleCheckerBindingRow(Base):  # type: ignore[misc]
     created_at: Mapped[datetime] = mapped_column(
         "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
     )
-    modified_at: Mapped[datetime] = mapped_column(
-        "modified_at",
+    updated_at: Mapped[datetime] = mapped_column(
+        "updated_at",
         sa.DateTime(timezone=True),
         nullable=False,
         server_default=sa.func.now(),

--- a/src/ai/backend/manager/models/idle_checker/row.py
+++ b/src/ai/backend/manager/models/idle_checker/row.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
+from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.manager.models.base import GUID, ABCColumn, Base
 from ai.backend.manager.models.idle_checker.spec import IdleCheckerSpecABC
 
@@ -13,8 +14,8 @@ from ai.backend.manager.models.idle_checker.spec import IdleCheckerSpecABC
 class IdleCheckerRow(Base):  # type: ignore[misc]
     __tablename__ = "idle_checkers"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
+    id: Mapped[IdleCheckerID] = mapped_column(
+        "id", GUID(IdleCheckerID), primary_key=True, server_default=sa.text("uuid_generate_v4()")
     )
     name: Mapped[str] = mapped_column("name", sa.String(length=128), nullable=False)
     description: Mapped[str | None] = mapped_column("description", sa.Text, nullable=True)
@@ -57,7 +58,9 @@ class IdleCheckerBindingRow(Base):  # type: ignore[misc]
     )
     scope_type: Mapped[str] = mapped_column("scope_type", sa.String(length=64), nullable=False)
     scope_id: Mapped[uuid.UUID] = mapped_column("scope_id", GUID, nullable=False)
-    idle_checker_id: Mapped[uuid.UUID] = mapped_column("idle_checker_id", GUID, nullable=False)
+    idle_checker_id: Mapped[IdleCheckerID] = mapped_column(
+        "idle_checker_id", GUID(IdleCheckerID), nullable=False
+    )
     enabled: Mapped[bool] = mapped_column(
         "enabled", sa.Boolean, nullable=False, server_default=sa.true()
     )

--- a/src/ai/backend/manager/models/idle_checker/row.py
+++ b/src/ai/backend/manager/models/idle_checker/row.py
@@ -7,7 +7,8 @@ import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
-from ai.backend.manager.models.base import GUID, ABCColumn, Base
+from ai.backend.manager.data.idle_checker.types import CheckerType
+from ai.backend.manager.models.base import GUID, ABCColumn, Base, StrEnumType
 from ai.backend.manager.models.idle_checker.spec import IdleCheckerSpecABC
 
 
@@ -19,7 +20,9 @@ class IdleCheckerRow(Base):  # type: ignore[misc]
     )
     name: Mapped[str] = mapped_column("name", sa.String(length=128), nullable=False)
     description: Mapped[str | None] = mapped_column("description", sa.Text, nullable=True)
-    checker_type: Mapped[str] = mapped_column("checker_type", sa.String(length=64), nullable=False)
+    checker_type: Mapped[CheckerType] = mapped_column(
+        "checker_type", StrEnumType(CheckerType), nullable=False
+    )
     spec: Mapped[IdleCheckerSpecABC] = mapped_column(
         "spec", ABCColumn(IdleCheckerSpecABC), nullable=False
     )

--- a/src/ai/backend/manager/models/idle_checker/spec.py
+++ b/src/ai/backend/manager/models/idle_checker/spec.py
@@ -9,13 +9,13 @@ class IdleCheckerSpecABC(ABCColumnPayload):
     """
     Base for idle checker spec payloads stored in ``idle_checkers.spec``.
 
-    Declares the :class:`ABCColumnPayload` write/load contract but leaves it
+    Declares the :class:`ABCColumnPayload` serialize/load contract but leaves it
     unimplemented for now. The polymorphic serialization (dispatching by
     ``checker_type``) and the concrete per-``checker_type`` specs land in a
     follow-up; this PR only establishes the payload base type.
     """
 
-    def write(self) -> dict[str, Any]:
+    def serialize(self) -> dict[str, Any]:
         raise NotImplementedError
 
     @classmethod

--- a/src/ai/backend/manager/models/idle_checker/spec.py
+++ b/src/ai/backend/manager/models/idle_checker/spec.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ai.backend.manager.models.base import ABCColumnPayload
+
+
+class IdleCheckerSpecABC(ABCColumnPayload):
+    """
+    Base for idle checker spec payloads stored in ``idle_checkers.spec``.
+
+    Declares the :class:`ABCColumnPayload` write/load contract but leaves it
+    unimplemented for now. The polymorphic serialization (dispatching by
+    ``checker_type``) and the concrete per-``checker_type`` specs land in a
+    follow-up; this PR only establishes the payload base type.
+    """
+
+    def write(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+    @classmethod
+    def load(cls, raw: dict[str, Any]) -> IdleCheckerSpecABC:
+        raise NotImplementedError

--- a/tests/unit/manager/models/test_base.py
+++ b/tests/unit/manager/models/test_base.py
@@ -107,7 +107,7 @@ class _Shape(ABCColumnPayload):
 class _Circle(_Shape):
     radius: float
 
-    def write(self) -> dict[str, Any]:
+    def serialize(self) -> dict[str, Any]:
         return {"kind": "circle", "radius": self.radius}
 
 
@@ -115,7 +115,7 @@ class _Circle(_Shape):
 class _Square(_Shape):
     side: float
 
-    def write(self) -> dict[str, Any]:
+    def serialize(self) -> dict[str, Any]:
         return {"kind": "square", "side": self.side}
 
 

--- a/tests/unit/manager/models/test_base.py
+++ b/tests/unit/manager/models/test_base.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
+from dataclasses import dataclass
 from decimal import Decimal
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import sqlalchemy as sa
+from sqlalchemy.engine.default import DefaultDialect
 
 from ai.backend.manager.api.gql_legacy.base import batch_result_in_scalar_stream
-from ai.backend.manager.models.base import DecimalType
+from ai.backend.manager.models.base import ABCColumn, ABCColumnPayload, DecimalType
 
 
 async def test_batch_result_in_scalar_stream() -> None:
@@ -86,3 +88,52 @@ class TestDecimalType:
         decimal_type = DecimalType()
         result = decimal_type.process_result_value(None, None)  # type: ignore[arg-type]
         assert result is None
+
+
+class _Shape(ABCColumnPayload):
+    """Test-only polymorphic payload base; `load` dispatches by the `kind` tag."""
+
+    @classmethod
+    def load(cls, raw: dict[str, Any]) -> _Shape:
+        kind = raw["kind"]
+        if kind == "circle":
+            return _Circle(radius=raw["radius"])
+        if kind == "square":
+            return _Square(side=raw["side"])
+        raise ValueError(f"unknown shape kind: {kind!r}")
+
+
+@dataclass
+class _Circle(_Shape):
+    radius: float
+
+    def write(self) -> dict[str, Any]:
+        return {"kind": "circle", "radius": self.radius}
+
+
+@dataclass
+class _Square(_Shape):
+    side: float
+
+    def write(self) -> dict[str, Any]:
+        return {"kind": "square", "side": self.side}
+
+
+class TestABCColumn:
+    def test_process_bind_param_serializes_to_dict(self) -> None:
+        column = ABCColumn(_Shape)
+        result = column.process_bind_param(_Circle(radius=2.0), DefaultDialect())
+        assert result == {"kind": "circle", "radius": 2.0}
+
+    def test_process_result_value_rehydrates_typed_object(self) -> None:
+        column = ABCColumn(_Shape)
+        result = column.process_result_value({"kind": "square", "side": 3.0}, DefaultDialect())
+        assert result == _Square(side=3.0)
+
+    def test_roundtrip_preserves_concrete_subtype(self) -> None:
+        column = ABCColumn(_Shape)
+        original = _Circle(radius=1.5)
+        stored = column.process_bind_param(original, DefaultDialect())
+        restored = column.process_result_value(stored, DefaultDialect())
+        assert restored == original
+        assert type(restored) is _Circle


### PR DESCRIPTION
## Summary
- Add `ABCColumn` + `ABCColumnPayload`: a reusable, domain-agnostic polymorphic JSONB column (write → JSONB dict, load → typed object). Modeled on `PydanticColumn`.
- Add `idle_checkers` / `idle_checker_bindings` ORM rows + Alembic migration (BEP-1054): FK `idle_checker_id → idle_checkers.id` ON DELETE CASCADE, unique `(idle_checker_id, scope_type, scope_id)`, index `(scope_type, scope_id)`.
- Add `IdleCheckerSpecABC` payload base; `idle_checkers.spec` is typed via `ABCColumn(IdleCheckerSpecABC)`. Its `write`/`load` are intentionally **stubbed** (`NotImplementedError`) — polymorphic serialization and the concrete per-`checker_type` specs land in a follow-up, so the `spec` column is not runtime-functional yet.

## Notes / open questions
- **`scope_id` type**: currently `UUID`. BEP-1054 describes scope as a polymorphic string key (domain name / project id / resource group name); only project ids are UUIDs, so domain / resource-group names wouldn't fit a UUID. Should this be `str` instead? Leaving for review.
- `idle_checkers.name` is intentionally **not** unique.
- The data-conversion layer (`to_data` / `IdleCheckerData`) is deferred to a follow-up.

## Test plan
- [ ] `ABCColumn` unit tests pass (write → dict, load → typed subtype, round-trip)
- [ ] `alembic upgrade head` creates both tables / `downgrade` drops them (offline SQL verified; live run pending — local dev DB is behind head)
- [ ] CI green

Resolves BA-6261