### PR TITLE
fix(BA-6459): populate the RBAC roles fixture on install

### DIFF
--- a/changes/12347.fix.md
+++ b/changes/12347.fix.md
@@ -1,0 +1,1 @@
+Populate the RBAC roles fixture (`example-roles.json`) during install so installer-created users get their default roles and permissions, instead of landing with no roles and hitting 403/500 on first use.

--- a/src/ai/backend/install/context.py
+++ b/src/ai/backend/install/context.py
@@ -518,6 +518,8 @@ class Context(metaclass=ABCMeta):
             "ai.backend.install.fixtures", "example-runtime-variant-presets.json"
         ) as path:
             await self.run_manager_cli(["mgr", "fixture", "populate", str(path)])
+        with self.resource_path("ai.backend.install.fixtures", "example-roles.json") as path:
+            await self.run_manager_cli(["mgr", "fixture", "populate", str(path)])
         with self.resource_path(
             "ai.backend.install.fixtures", "example-prometheus-query-preset-categories.json"
         ) as path:


### PR DESCRIPTION
## Summary

- The TUI installer's `load_fixtures()` populated every example fixture except `example-roles.json`, so a fresh install left the RBAC tables (`roles`, `permissions`, `user_roles`, `association_scopes_entities`, `role_presets`, `role_permission_presets`) empty.
- The legacy `scripts/install-dev.sh` already populates this fixture (`./backend.ai mgr fixture populate fixtures/manager/example-roles.json`); the TUI installer did not.
- Add `example-roles.json` to `load_fixtures()` in `src/ai/backend/install/context.py`, right after `example-users.json` so the `user_roles` rows resolve to existing users. The fixture is already bundled in the installer (symlink to `fixtures/manager/example-roles.json`), so no new asset is added.
- Scope: install path only. The fixture loader and RBAC enforcement are unchanged. On a fresh DB, `alembic upgrade head` plus this fixture is sufficient; the bitmask/auto_assign backfill migrations only matter for upgrading existing installs.

## Test plan

**Static**
- [x] `pants fmt / lint / check` on `context.py` pass (ruff + mypy clean).

**Manual (fresh install)**
- [x] Run a fresh DEVELOP (and PACKAGE) install.
- [x] Confirm the `roles` / `permissions` / `user_roles` tables are populated after install (previously empty).
- [x] Confirm the example `admin@lablup.com` can list/create sessions and access vfolders without 403/500.

Resolves BA-6459