### PR TITLE
fix: Deduplicate mounted folders in session detail by folder id

### DIFF
--- a/changes/12349.fix.md
+++ b/changes/12349.fix.md
@@ -1,0 +1,1 @@
+Fixed a compute session's mounted-folder list (`vfolder_nodes`) showing the same folder multiple times when it is mounted at more than one subpath.

--- a/src/ai/backend/manager/api/gql_legacy/session.py
+++ b/src/ai/backend/manager/api/gql_legacy/session.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import (
     TYPE_CHECKING,
     Any,
+    Protocol,
     Self,
     cast,
 )
@@ -30,6 +31,7 @@ from ai.backend.common.types import (
     ResourceSlot,
     SessionId,
     SessionResult,
+    VFolderID,
     VFolderMount,
 )
 from ai.backend.manager.api.gql.base import resolve_global_id
@@ -189,6 +191,22 @@ class SessionPermissionValueField(graphene.Scalar):  # type: ignore[misc]
     @staticmethod
     def parse_value(value: str) -> ComputeSessionPermission:
         return ComputeSessionPermission(value)
+
+
+class _HasVFID(Protocol):
+    vfid: VFolderID
+
+
+def _dedup_folder_ids(mounts: Iterable[_HasVFID]) -> list[uuid.UUID]:
+    """Project mounts to their folder ids, deduplicated by folder.
+
+    A vfolder mounted at multiple subpaths yields one mount entry per subpath
+    but is still a single folder, so the ``vfolder_nodes`` connection (and the
+    deprecated ``vfolder_mounts`` id list it is resolved from) must surface each
+    folder once. Accepts both ``VFolderMount`` and ``VFolderMountData`` (the two
+    constructors feed different types). First-occurrence order is preserved.
+    """
+    return list(dict.fromkeys(vf.vfid.folder_id for vf in mounts))
 
 
 @graphene_federation.key("id")
@@ -377,7 +395,7 @@ class ComputeSessionNode(graphene.ObjectType):  # type: ignore[misc]
             agent_ids=row.agent_ids,
             scaling_group=row.scaling_group_name,
             # TODO: Deprecate 'vfolder_mounts' and replace it with a list of VirtualFolderNodes
-            vfolder_mounts=[vf.vfid.folder_id for vf in row.vfolders_sorted_by_id],
+            vfolder_mounts=_dedup_folder_ids(row.vfolders_sorted_by_id),
             occupied_slots=row.occupying_slots.to_json(),
             requested_slots=row.requested_slots.to_json(),
             image_references=row.images,
@@ -398,10 +416,7 @@ class ComputeSessionNode(graphene.ObjectType):  # type: ignore[misc]
     ) -> Self:
         status_history = session_data.status_history or {}
         raw_scheduled_at = status_history.get(SessionStatus.SCHEDULED.name)
-        if not session_data.vfolder_mounts:
-            vfolder_mounts = []
-        else:
-            vfolder_mounts = [vf.vfid.folder_id for vf in session_data.vfolder_mounts]
+        vfolder_mounts = _dedup_folder_ids(session_data.vfolder_mounts or [])
 
         if session_data.owner is None:
             raise SessionWithInvalidStateError()

--- a/tests/unit/manager/api/gql_legacy/test_session_vfolder_dedup.py
+++ b/tests/unit/manager/api/gql_legacy/test_session_vfolder_dedup.py
@@ -1,0 +1,67 @@
+"""Tests for ``_dedup_folder_ids`` feeding the session ``vfolder_nodes``."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import PurePosixPath
+
+from ai.backend.common.types import (
+    MountPermission,
+    VFolderID,
+    VFolderMount,
+    VFolderUsageMode,
+)
+from ai.backend.manager.api.gql_legacy.session import _dedup_folder_ids
+
+
+def _mount(
+    name: str,
+    *,
+    folder_id: uuid.UUID | None = None,
+    vfsubpath: str = ".",
+) -> VFolderMount:
+    return VFolderMount(
+        name=name,
+        vfid=VFolderID(quota_scope_id=None, folder_id=folder_id or uuid.uuid4()),
+        vfsubpath=PurePosixPath(vfsubpath),
+        host_path=PurePosixPath(f"/mnt/host/{name}/{vfsubpath}"),
+        kernel_path=PurePosixPath(f"/home/work/{name}"),
+        mount_perm=MountPermission.READ_WRITE,
+        usage_mode=VFolderUsageMode.GENERAL,
+    )
+
+
+def test_collapses_same_folder_mounted_at_multiple_subpaths() -> None:
+    # The reported bug: one vfolder mounted at several subpaths showed up as
+    # several identical folder nodes. It must surface as a single folder id.
+    folder_id = uuid.uuid4()
+    mounts = [
+        _mount("data", folder_id=folder_id, vfsubpath="."),
+        _mount("data", folder_id=folder_id, vfsubpath="a"),
+        _mount("data", folder_id=folder_id, vfsubpath="b"),
+    ]
+
+    assert _dedup_folder_ids(mounts) == [folder_id]
+
+
+def test_keeps_distinct_folders() -> None:
+    first, second = uuid.uuid4(), uuid.uuid4()
+    mounts = [_mount("a", folder_id=first), _mount("b", folder_id=second)]
+
+    assert _dedup_folder_ids(mounts) == [first, second]
+
+
+def test_preserves_first_occurrence_order() -> None:
+    a, b, c = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    mounts = [
+        _mount("a", folder_id=a),
+        _mount("b", folder_id=b),
+        _mount("a", folder_id=a),
+        _mount("c", folder_id=c),
+    ]
+
+    assert _dedup_folder_ids(mounts) == [a, b, c]
+
+
+def test_empty() -> None:
+    assert _dedup_folder_ids([]) == []


### PR DESCRIPTION
Resolves #12352

## Problem

A compute session's **mounted-folder list** (session-detail "마운트된 폴더" panel)
shows the **same folder multiple times** — e.g. three identical `teset_for_nota-…`
entries — when that vfolder is mounted at more than one subpath.

## Root cause

The panel is rendered from the `vfolder_nodes` connection on `ComputeSessionNode`.
A vfolder mounted at N subpaths produces N `VFolderMount` entries (one per subpath),
and both node constructors projected those to folder ids **without deduplication**:

```python
# from_row
vfolder_mounts=[vf.vfid.folder_id for vf in row.vfolders_sorted_by_id]
# from_dataclass
vfolder_mounts = [vf.vfid.folder_id for vf in session_data.vfolder_mounts]
```

`resolve_vfolder_nodes` then does `load_many(folder_ids)` → one node per entry →
duplicate folder nodes. (The legacy `parse_row` path already dedups the equivalent
list, though with an unordered set; this fix dedups the node source too, and does so
order-preservingly.)

## Fix

Deduplicate by **folder id** — subpath-agnostic, since the list shows *folders*,
not mounts — in both constructors, via a small order-preserving helper
`_dedup_folder_ids()`. A folder mounted at several subpaths now surfaces once.

`src/ai/backend/manager/api/gql_legacy/session.py`:
- `_dedup_folder_ids(mounts)` → `list(dict.fromkeys(vf.vfid.folder_id for vf in mounts))`,
  typed structurally (`_HasVFID`) to accept both `VFolderMount` (`from_row`) and
  `VFolderMountData` (`from_dataclass`).
- `ComputeSessionNode.from_row` / `.from_dataclass` use it.
- Unit tests (`tests/unit/manager/api/gql_legacy/test_session_vfolder_dedup.py`):
  multi-subpath collapse, distinct folders preserved, order, empty.

## Note on layering / scope

This is intentionally a **read/display-layer** fix keyed on `vfid`. The underlying
mount data (`KernelRow.vfolder_mounts`) must *not* be deduped by folder id — a folder
legitimately mounted at two subpaths is two real mounts (e.g. `.local` root vs.
per-user subdir). That data-layer / enqueue concern is separate and tracked in #12348;
it is not user-visible and is not addressed here.

## Verification

- `pants test tests/unit/manager/api/gql_legacy/test_session_vfolder_dedup.py` — passes.
- `pants check` (mypy) on the changed file — passes.
