### PR TITLE
fix(BA-6560): enforce allowed_client_ips on app proxy workers (#12321)

### DIFF
--- a/changes/12321.fix.md
+++ b/changes/12321.fix.md
@@ -1,0 +1,1 @@
+Enforce per-circuit client IP allowlists (`allowed_client_ips`) at the app proxy layer for both Python and Traefik proxy modes, so externally published apps with IP restrictions are no longer reachable from disallowed addresses.

--- a/docs/app-proxy/traefik-integration.md
+++ b/docs/app-proxy/traefik-integration.md
@@ -136,6 +136,48 @@ experimental:
       moduleName: backend.ai/appproxy-traefik-plugin-go
 ```
 
+## Client IP allowlist behind a proxy
+
+When a circuit sets `allowed_client_ips`, the coordinator emits a Traefik `ipAllowList`
+middleware (HTTP) or a `ClientIP` router rule (TCP) so that only the listed CIDR
+blocks / addresses can reach the published app. The middleware matches against the IP
+Traefik selects per its `ipStrategy`.
+
+If Traefik is **directly exposed** to clients, leave `[proxy_coordinator.traefik].client_ip_strategy`
+unset — the default strategy uses the direct connection address, which cannot be spoofed.
+
+If Traefik sits **behind a load balancer / reverse proxy** (e.g. HAProxy), the direct
+connection address is the proxy's, so you must read the real client IP from
+`X-Forwarded-For`. This requires **two** coordinated settings:
+
+1. `[proxy_coordinator.traefik].client_ip_strategy` — set `excluded_ips` to the trusted
+   proxy networks (Traefik scans `X-Forwarded-For` right-to-left, skipping these), or
+   `depth` to a fixed number of proxy hops.
+2. `entryPoints.<name>.forwardedHeaders.trustedIPs` in the Traefik **static config** — set
+   to the same proxy networks. **This is a prerequisite, not optional**: Traefik discards
+   the incoming `X-Forwarded-For` from an untrusted peer and resets it to the direct remote
+   address. Without `trustedIPs`, the real client IP never reaches the `ipStrategy`, so the
+   allowlist match fails (legitimate clients are rejected or enforcement misbehaves).
+
+```yaml
+# Static config example: HAProxy on the 172.0.0.0/8 bridge network fronts Traefik
+entryPoints:
+  domainproxy:
+    address: 0.0.0.0:8443
+    forwardedHeaders:
+      trustedIPs: ["172.0.0.0/8"]
+```
+
+```toml
+# Matching coordinator config (proxy-coordinator.toml)
+[proxy_coordinator.traefik.client_ip_strategy]
+excluded_ips = ["172.0.0.0/8"]
+```
+
+The worker's Python proxy mode has an equivalent setting,
+`[proxy_worker].trusted_proxies`, which governs the same `X-Forwarded-For` trust decision
+when a circuit is served directly by the worker rather than Traefik.
+
 ## Migrating AppProxy configuration
 
 ### Path relocations

--- a/src/ai/backend/appproxy/common/client_ip.py
+++ b/src/ai/backend/appproxy/common/client_ip.py
@@ -1,0 +1,82 @@
+"""Client-IP allowlist matching for the per-circuit ``allowed_client_ips``
+restriction, shared by the coordinator (Traefik config generation) and the
+worker (Python-mode enforcement).
+
+The allowlist is persisted on a circuit as a comma-separated string of CIDR
+blocks or bare IP addresses (``Circuit.allowed_client_ips``). A null/blank value
+means the circuit is reachable from anywhere.
+
+Resolving the real client IP from ``X-Forwarded-For`` is handled separately: the
+worker installs ``aiohttp_remotes.XForwardedStrict`` as a middleware (see
+:class:`ai.backend.appproxy.worker.proxy.frontend.http.base.BaseHTTPFrontend`),
+so ``request.remote`` already holds the real client IP — trusted only when the
+connection arrives through the configured ``trusted_proxies`` — by the time this
+validator runs.
+"""
+
+import ipaddress
+import logging
+
+from ai.backend.logging import BraceStyleAdapter
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+type IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+
+
+class ClientIPValidator:
+    """Per-circuit client-IP allowlist.
+
+    Constructed from a circuit's ``allowed_client_ips`` string; the string is
+    parsed once at construction and the resulting networks are held as a field,
+    so repeated matching does not re-parse. An empty allowlist (``None``/blank,
+    or every entry invalid) means "no restriction" — every client is allowed.
+    """
+
+    def __init__(self, allowed_client_ips: str | None) -> None:
+        self._networks = self._parse(allowed_client_ips)
+
+    @staticmethod
+    def _parse(value: str | None) -> list[IPNetwork]:
+        """Parse a comma-separated CIDR/IP allowlist into networks. Each entry is
+        a bare IP (host route, ``/32`` or ``/128``) or a CIDR block; whitespace
+        and empty entries are ignored. Invalid entries are logged and skipped, so
+        one malformed entry never breaks enforcement for the rest."""
+        if not value:
+            return []
+        networks: list[IPNetwork] = []
+        for raw in value.split(","):
+            entry = raw.strip()
+            if not entry:
+                continue
+            try:
+                networks.append(ipaddress.ip_network(entry, strict=False))
+            except ValueError:
+                log.exception("Skipping invalid entry in allowed_client_ips: {!r}", entry)
+        return networks
+
+    @property
+    def is_restricted(self) -> bool:
+        """Whether any allowlist entry is configured. ``False`` means every
+        client is allowed."""
+        return bool(self._networks)
+
+    @property
+    def ranges(self) -> list[str]:
+        """Normalized CIDR strings, e.g. for Traefik ``ipAllowList`` /
+        ``ClientIP`` rule generation."""
+        return [str(net) for net in self._networks]
+
+    def is_allowed(self, client_ip: str) -> bool:
+        """Whether ``client_ip`` falls within any allowed network.
+
+        An empty allowlist means no restriction, so every client is allowed. A
+        ``client_ip`` that cannot be parsed is rejected (fail-closed).
+        """
+        if not self._networks:
+            return True
+        try:
+            addr = ipaddress.ip_address(client_ip)
+        except ValueError:
+            return False
+        return any(addr in net for net in self._networks)

--- a/src/ai/backend/appproxy/common/errors/__init__.py
+++ b/src/ai/backend/appproxy/common/errors/__init__.py
@@ -8,6 +8,7 @@ from .config import (
 )
 from .http import (
     AuthorizationFailed,
+    ClientIPNotAllowed,
     GenericBadRequest,
     GenericForbidden,
     GraphQLError,
@@ -50,6 +51,7 @@ __all__ = [
     "RejectedByHook",
     "InvalidCredentials",
     "GenericForbidden",
+    "ClientIPNotAllowed",
     "InsufficientPrivilege",
     "MethodNotAllowed",
     "InternalServerError",

--- a/src/ai/backend/appproxy/common/errors/http.py
+++ b/src/ai/backend/appproxy/common/errors/http.py
@@ -120,6 +120,21 @@ class GenericForbidden(BackendAIError, web.HTTPForbidden):
         )
 
 
+class ClientIPNotAllowed(BackendAIError, web.HTTPForbidden):
+    """Raised when the client's address is not within a circuit's
+    ``allowed_client_ips`` allowlist."""
+
+    error_type = "https://api.backend.ai/probs/client-ip-not-allowed"
+    error_title = "Client address not allowed."
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.APPPROXY,
+            operation=ErrorOperation.ACCESS,
+            error_detail=ErrorDetail.FORBIDDEN,
+        )
+
+
 class InsufficientPrivilege(BackendAIError, web.HTTPForbidden):
     """Raised when user has insufficient privileges."""
 

--- a/src/ai/backend/appproxy/common/types.py
+++ b/src/ai/backend/appproxy/common/types.py
@@ -5,6 +5,7 @@ import textwrap
 from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
+from functools import cached_property
 from typing import (
     Annotated,
     Any,
@@ -16,6 +17,7 @@ import aiohttp_cors
 from aiohttp import web
 from pydantic import AliasChoices, AnyUrl, BaseModel, ConfigDict, Field
 
+from ai.backend.appproxy.common.client_ip import ClientIPValidator
 from ai.backend.common.types import BackendAISchema, ModelServiceStatus, RuntimeVariant
 
 # FIXME: merge majority of common definitions to ai.backend.common when ready
@@ -239,6 +241,11 @@ class SerializableCircuit(BackendAISchema):
     def traefik_router_name(self) -> str:
         """ID of the traefik router which represents this circuit."""
         return f"bai_router_{self.id}@etcd"
+
+    @cached_property
+    def ip_validator(self) -> ClientIPValidator:
+        """Client-IP allowlist parsed once from ``allowed_client_ips``."""
+        return ClientIPValidator(self.allowed_client_ips)
 
 
 class SerializableToken(BackendAISchema):

--- a/src/ai/backend/appproxy/coordinator/config.py
+++ b/src/ai/backend/appproxy/coordinator/config.py
@@ -4,10 +4,10 @@ import socket
 import sys
 from pathlib import Path
 from pprint import pformat
-from typing import Annotated
+from typing import Annotated, Self
 
 import click
-from pydantic import Field, FilePath, ValidationError
+from pydantic import Field, FilePath, IPvAnyNetwork, ValidationError, model_validator
 
 from ai.backend.appproxy.common.config import (
     BaseSchema,
@@ -166,6 +166,51 @@ class DBConfig(BaseSchema):
     ]
 
 
+class ClientIPStrategyConfig(BaseSchema):
+    """How Traefik determines the client IP for the generated ipAllowList
+    middleware when this AppProxy is deployed behind a load balancer / reverse
+    proxy. Maps onto Traefik's ``ipAllowList.ipStrategy``. Leave unset when
+    Traefik is directly exposed to clients (the default strategy then matches the
+    direct connection address)."""
+
+    depth: Annotated[
+        int | None,
+        Field(default=None, ge=1),
+        BackendAIConfigMeta(
+            description=(
+                "Number of trusted proxy hops in front of Traefik. Traefik selects the IP at this "
+                "depth (counted from the rightmost, i.e. nearest-proxy, entry) of 'X-Forwarded-For' "
+                "as the client IP. Mutually exclusive with 'excluded_ips'. Use this when a fixed "
+                "number of proxies always front Traefik."
+            ),
+            added_version="26.4.5",
+            example=ConfigExample(local="", prod="1"),
+        ),
+    ]
+    excluded_ips: Annotated[
+        list[IPvAnyNetwork],
+        Field(default_factory=list),
+        BackendAIConfigMeta(
+            description=(
+                "CIDR blocks (or bare IPs) of trusted proxies in front of Traefik. Traefik scans "
+                "'X-Forwarded-For' right-to-left, skipping these networks, and uses the first "
+                "remaining address as the client IP. Mutually exclusive with 'depth'. Prefer this "
+                "for environments where the proxy chain length varies."
+            ),
+            added_version="26.4.5",
+            example=ConfigExample(local="[]", prod='["10.0.0.0/8"]'),
+        ),
+    ]
+
+    @model_validator(mode="after")
+    def validate_strategy(self) -> Self:
+        if self.depth is not None and self.excluded_ips:
+            raise ConfigValidationError(
+                "client_ip_strategy: 'depth' and 'excluded_ips' are mutually exclusive"
+            )
+        return self
+
+
 class TraefikConfig(BaseSchema):
     etcd: Annotated[
         EtcdConfig,
@@ -177,6 +222,19 @@ class TraefikConfig(BaseSchema):
                 "The namespace should be set to 'traefik' to isolate Traefik's configuration keys."
             ),
             added_version="25.9.0",
+            composite=CompositeType.FIELD,
+        ),
+    ]
+    client_ip_strategy: Annotated[
+        ClientIPStrategyConfig | None,
+        Field(default=None),
+        BackendAIConfigMeta(
+            description=(
+                "Strategy for resolving the real client IP behind a load balancer / reverse proxy "
+                "when enforcing per-circuit client-IP allowlists via Traefik's ipAllowList "
+                "middleware. Leave unset when Traefik is directly exposed to clients."
+            ),
+            added_version="26.4.5",
             composite=CompositeType.FIELD,
         ),
     ]

--- a/src/ai/backend/appproxy/coordinator/models/circuit.py
+++ b/src/ai/backend/appproxy/coordinator/models/circuit.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 from datetime import UTC, datetime
+from functools import cached_property
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
@@ -10,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column, relationship, selectinload
 from yarl import URL
 
+from ai.backend.appproxy.common.client_ip import ClientIPValidator
 from ai.backend.appproxy.common.defs import PERMIT_COOKIE_NAME
 from ai.backend.appproxy.common.errors import ObjectNotFound, UnsupportedProtocol
 from ai.backend.appproxy.common.types import (
@@ -293,10 +295,22 @@ class Circuit(Base, BaseMixin):  # type: ignore[misc]
         worker: Worker = self.worker_row
         return f"{worker.authority}:{self.port or self.subdomain}"
 
+    @cached_property
+    def _ip_validator(self) -> ClientIPValidator:
+        """Client-IP allowlist parsed once from ``allowed_client_ips``."""
+        return ClientIPValidator(self.allowed_client_ips)
+
     @property
     def traefik_rule(self) -> str:
         match self.protocol:
             case ProxyProtocol.TCP:
+                # TCP routers cannot use HTTP middlewares, so the allowlist is
+                # encoded into the router's ClientIP match rule: connections from
+                # other sources match no router and are dropped. Falls back to
+                # accepting any source when unrestricted.
+                ranges = self._ip_validator.ranges
+                if ranges:
+                    return "ClientIP(" + ", ".join(f"`{cidr}`" for cidr in ranges) + ")"
                 return "ClientIP(`0.0.0.0/0`)"
             case _:
                 match self.frontend_mode:
@@ -329,15 +343,21 @@ class Circuit(Base, BaseMixin):  # type: ignore[misc]
     def traefik_routers(self) -> dict[str, Any]:
         match self.protocol:
             case ProxyProtocol.HTTP:
+                # The ipAllowList middleware must precede the auth plugins so that
+                # disallowed clients are rejected before any credential handling.
+                middlewares = ["CORSHeaders"]
+                ranges = self._ip_validator.ranges
+                if ranges:
+                    middlewares.append(f"bai_ipallowlist_{self.id}")
+                middlewares += [
+                    f"bai_appproxy_plugin_{self.id}",
+                    f"bai_appproxy_plugin_{self.id}_go",
+                ]
                 base = {
                     "rule": self.traefik_rule,
                     "service": f"bai_service_{self.id}",
                     "entrypoints": [self.traefik_entrypoint],
-                    "middlewares": [
-                        "CORSHeaders",
-                        f"bai_appproxy_plugin_{self.id}",
-                        f"bai_appproxy_plugin_{self.id}_go",
-                    ],
+                    "middlewares": middlewares,
                 }
                 if self.worker_row.tls_listen:
                     base["tls"] = ""
@@ -435,7 +455,7 @@ class Circuit(Base, BaseMixin):  # type: ignore[misc]
                 if not traefik_config:
                     raise MissingTraefikConfigError("Traefik configuration is required")
 
-                return {
+                middlewares: dict[str, Any] = {
                     "CORSHeaders": {
                         "headers": {
                             "accessControlAllowHeaders": "*",
@@ -465,4 +485,25 @@ class Circuit(Base, BaseMixin):  # type: ignore[misc]
                         }
                     },
                 }
+                ranges = self._ip_validator.ranges
+                if ranges:
+                    # ipAllowList matches against the IP Traefik selects per its
+                    # ipStrategy. Without a strategy Traefik uses the direct
+                    # connection address (correct when Traefik is directly
+                    # exposed); behind a load balancer, client_ip_strategy must
+                    # be configured so the real client IP is read from
+                    # X-Forwarded-For instead of the balancer's address.
+                    ip_allowlist: dict[str, Any] = {"sourceRange": ranges}
+                    strategy = traefik_config.client_ip_strategy
+                    if strategy is not None:
+                        if strategy.depth is not None:
+                            ip_allowlist["ipStrategy"] = {"depth": strategy.depth}
+                        elif strategy.excluded_ips:
+                            ip_allowlist["ipStrategy"] = {
+                                "excludedIPs": [str(net) for net in strategy.excluded_ips],
+                            }
+                    middlewares[f"bai_ipallowlist_{self.id}"] = {
+                        "ipAllowList": ip_allowlist,
+                    }
+                return middlewares
         return {}

--- a/src/ai/backend/appproxy/coordinator/types.py
+++ b/src/ai/backend/appproxy/coordinator/types.py
@@ -288,6 +288,10 @@ class CircuitManager:
             prefixes_to_remove.append(
                 f"{etcd_prefix}/middlewares/appproxy/plugin/bai_appproxy_plugin_{circuit.id}",
             )
+            # Removed even when the circuit had no allowlist.
+            prefixes_to_remove.append(
+                f"{etcd_prefix}/middlewares/bai_ipallowlist_{circuit.id}",
+            )
 
         for prefix in prefixes_to_remove:
             log.debug("traefik_etcd.delete_prefix {}", prefix)
@@ -357,6 +361,10 @@ class CircuitManager:
                         )
                         prefixes_to_remove.append(
                             f"{etcd_prefix}/middlewares/appproxy/plugin/bai_appproxy_plugin_{stale_id}"
+                        )
+                        # Removed even when the stale circuit had no allowlist.
+                        prefixes_to_remove.append(
+                            f"{etcd_prefix}/middlewares/bai_ipallowlist_{stale_id}"
                         )
                     for prefix in prefixes_to_remove:
                         try:

--- a/src/ai/backend/appproxy/worker/config.py
+++ b/src/ai/backend/appproxy/worker/config.py
@@ -10,7 +10,7 @@ from pprint import pformat
 from typing import Annotated, Self
 
 import click
-from pydantic import AnyUrl, Field, FilePath, ValidationError, model_validator
+from pydantic import AnyUrl, Field, FilePath, IPvAnyNetwork, ValidationError, model_validator
 
 from ai.backend.appproxy.common.config import (
     BaseSchema,
@@ -783,6 +783,23 @@ class ProxyWorkerConfig(BaseSchema):
             ),
             added_version="25.9.0",
             example=ConfigExample(local="", prod="worker.example.com:10201"),
+        ),
+    ]
+
+    trusted_proxies: Annotated[
+        list[IPvAnyNetwork],
+        Field(default_factory=list),
+        BackendAIConfigMeta(
+            description=(
+                "CIDR blocks (or bare IP addresses) of load balancers / reverse proxies that sit "
+                "in front of this worker and may be trusted to set the 'X-Forwarded-For' header. "
+                "Client-IP allowlist checks honor 'X-Forwarded-For' only when the immediate peer "
+                "matches one of these networks; otherwise the direct connection address is used, so "
+                "a directly-exposed worker cannot be spoofed by a forged header. Leave empty when "
+                "clients connect directly to the worker."
+            ),
+            added_version="26.4.5",
+            example=ConfigExample(local="[]", prod='["10.0.0.0/8"]'),
         ),
     ]
 

--- a/src/ai/backend/appproxy/worker/proxy/frontend/http/base.py
+++ b/src/ai/backend/appproxy/worker/proxy/frontend/http/base.py
@@ -4,9 +4,10 @@ import time
 import aiohttp_jinja2
 import jwt
 from aiohttp import web
+from aiohttp_remotes import XForwardedStrict
 
 from ai.backend.appproxy.common.defs import PERMIT_COOKIE_NAME
-from ai.backend.appproxy.common.errors import InvalidCredentials
+from ai.backend.appproxy.common.errors import ClientIPNotAllowed, InvalidCredentials
 from ai.backend.appproxy.common.types import RouteInfo, WebRequestHandler
 from ai.backend.appproxy.common.utils import ensure_json_serializable, is_permit_valid, mime_match
 from ai.backend.appproxy.worker.proxy.backend.http import HTTPBackend
@@ -25,6 +26,27 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 class BaseHTTPFrontend[TCircuitKeyType: (int, str)](BaseFrontend[HTTPBackend, TCircuitKeyType]):
     root_context: RootContext
+    _xff_strict: XForwardedStrict | None
+
+    def __init__(self, root_context: RootContext) -> None:
+        super().__init__(root_context)
+        # With trusted proxies set, an XForwardedStrict middleware resolves request.remote from X-Forwarded-For.
+        # Empty means directly exposed — no middleware.
+        trusted_proxies = root_context.local_config.proxy_worker.trusted_proxies
+        self._xff_strict = XForwardedStrict([list(trusted_proxies)]) if trusted_proxies else None
+
+    def ensure_allowed_ip(self, request: web.Request, circuit: Circuit) -> None:
+        validator = circuit.ip_validator
+        if not validator.is_restricted:
+            return
+        client_ip = request.remote
+        if not client_ip or not validator.is_allowed(client_ip):
+            log.debug(
+                "rejecting client {} for circuit {} (not in allowed_client_ips)",
+                client_ip,
+                circuit.id,
+            )
+            raise ClientIPNotAllowed("E20011: Client address not allowed")
 
     def ensure_credential(self, request: web.Request, circuit: Circuit) -> None:
         if circuit.open_to_public or request.method == "OPTIONS":

--- a/src/ai/backend/appproxy/worker/proxy/frontend/http/port.py
+++ b/src/ai/backend/appproxy/worker/proxy/frontend/http/port.py
@@ -48,6 +48,11 @@ class PortFrontend(BaseHTTPFrontend[int]):
             # Keep in mind that implementation of ensure_slot_middleware should manually handle exception and respond with
             # appropriate HTTP response, which usually is automatically covered by exception_middleware
             # That can be achieved by wraping whole execution block with AbstractHTTPFrontend.exception_safe_handler_wrapper()
+            # Resolve the real client IP from X-Forwarded-For first (only when
+            # trusted proxies are configured) so request.remote is the real client
+            # before any other middleware or the proxy handler reads it.
+            if self._xff_strict is not None:
+                app.middlewares.append(self._xff_strict.middleware)
             app.middlewares.extend([
                 self.ensure_slot_middleware,
                 self.metric_collector_middleware,
@@ -93,6 +98,7 @@ class PortFrontend(BaseHTTPFrontend[int]):
         circuit = self.circuits.get(port, None)
         if circuit is None:
             raise GenericBadRequest(f"Unregistered slot {port}")
+        self.ensure_allowed_ip(request, circuit)
         self.ensure_credential(request, circuit)
         backend = self.backends[port]
         request["circuit"] = circuit

--- a/src/ai/backend/appproxy/worker/proxy/frontend/http/subdomain.py
+++ b/src/ai/backend/appproxy/worker/proxy/frontend/http/subdomain.py
@@ -42,6 +42,11 @@ class SubdomainFrontend(BaseHTTPFrontend[str]):
             )
         app = web.Application()
         app.on_response_prepare.append(self.append_cors_headers)
+        # Resolve the real client IP from X-Forwarded-For first (only when trusted
+        # proxies are configured) so request.remote is the real client before any
+        # other middleware or the proxy handler reads it.
+        if self._xff_strict is not None:
+            app.middlewares.append(self._xff_strict.middleware)
         app.middlewares.extend([
             self.ensure_slot_middleware,
             self.metric_collector_middleware,
@@ -88,6 +93,7 @@ class SubdomainFrontend(BaseHTTPFrontend[str]):
         async def _exception_safe_handler(request: web.Request) -> web.StreamResponse:
             slot = self.parse_slot(request)
             circuit = self.circuits[slot]
+            self.ensure_allowed_ip(request, circuit)
             self.ensure_credential(request, circuit)
             backend = self.backends[slot]
             request["circuit"] = circuit

--- a/src/ai/backend/appproxy/worker/proxy/frontend/tcp.py
+++ b/src/ai/backend/appproxy/worker/proxy/frontend/tcp.py
@@ -10,7 +10,7 @@ from aiohttp import web
 from ai.backend.appproxy.common.errors import (
     ServerMisconfiguredError,
 )
-from ai.backend.appproxy.common.types import RouteInfo
+from ai.backend.appproxy.common.types import RouteInfo, SerializableCircuit
 from ai.backend.appproxy.worker.errors import InvalidFrontendTypeError
 from ai.backend.appproxy.worker.proxy.backend import TCPBackend
 from ai.backend.appproxy.worker.types import (
@@ -84,6 +84,26 @@ class TCPFrontend(BaseFrontend[TCPBackend, int]):
         # TCP does not support authentication
         return
 
+    def _is_peer_allowed(self, writer: asyncio.StreamWriter, circuit: SerializableCircuit) -> bool:
+        # TCP carries no forwarded-for header, so the allowlist is matched
+        # against the direct connection peer only.
+        validator = circuit.ip_validator
+        if not validator.is_restricted:
+            return True
+        peername = writer.get_extra_info("peername")
+        if not peername:
+            log.debug("rejecting TCP connection with unknown peer for circuit {}", circuit.id)
+            return False
+        peer_ip = peername[0]
+        if not validator.is_allowed(peer_ip):
+            log.debug(
+                "rejecting TCP client {} for circuit {} (not in allowed_client_ips)",
+                peer_ip,
+                circuit.id,
+            )
+            return False
+        return True
+
     async def initialize_backend(self, circuit: Circuit, routes: list[RouteInfo]) -> TCPBackend:
         return TCPBackend(routes, self.root_context, circuit)
 
@@ -102,6 +122,10 @@ class TCPFrontend(BaseFrontend[TCPBackend, int]):
             if (backend.last_used - now) >= threshold
         ]
 
+    async def _close_writer(self, writer: asyncio.StreamWriter) -> None:
+        writer.close()
+        await writer.wait_closed()
+
     async def pipe(
         self, circuit_key: int, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
@@ -109,8 +133,11 @@ class TCPFrontend(BaseFrontend[TCPBackend, int]):
         backend: TCPBackend | None = self.backends.get(circuit_key)
 
         if not backend:
-            writer.close()
-            await writer.wait_closed()
+            await self._close_writer(writer)
+            return
+
+        if not self._is_peer_allowed(writer, backend.circuit):
+            await self._close_writer(writer)
             return
 
         circuit_id = str(backend.circuit.id)

--- a/tests/unit/appproxy/coordinator/dependencies/infrastructure/test_etcd.py
+++ b/tests/unit/appproxy/coordinator/dependencies/infrastructure/test_etcd.py
@@ -45,7 +45,7 @@ class TestEtcdProvider:
         )
 
         # Create traefik config
-        traefik_config = TraefikConfig(etcd=etcd_config)
+        traefik_config = TraefikConfig(etcd=etcd_config, client_ip_strategy=None)
 
         # Create configs with Mock
         proxy_config = Mock(spec=ProxyCoordinatorConfig)

--- a/tests/unit/appproxy/test_client_ip.py
+++ b/tests/unit/appproxy/test_client_ip.py
@@ -1,0 +1,64 @@
+"""Unit tests for ai.backend.appproxy.common.client_ip.
+
+X-Forwarded-For resolution is no longer done here — the worker installs
+``aiohttp_remotes.XForwardedStrict`` as a middleware, so ``request.remote`` is
+already the real client IP. Only the per-circuit allowlist matcher lives in this
+module and is unit-tested below.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ai.backend.appproxy.common.client_ip import ClientIPValidator
+
+
+class TestIPValidator:
+    @pytest.mark.parametrize(
+        ("allowed", "client_ip", "expected"),
+        [
+            # No restriction -> every client is allowed.
+            (None, "203.0.113.5", True),
+            ("", "203.0.113.5", True),
+            ("   ", "203.0.113.5", True),
+            # Bare IP is a host route.
+            ("203.0.113.5", "203.0.113.5", True),
+            ("203.0.113.5", "203.0.113.6", False),
+            # CIDR membership.
+            ("10.0.0.0/8", "10.1.2.3", True),
+            ("10.0.0.0/8", "11.0.0.1", False),
+            # Multiple entries, any match allows.
+            ("10.0.0.0/8, 192.168.0.0/16", "192.168.1.1", True),
+            ("10.0.0.0/8, 192.168.0.0/16", "172.16.0.1", False),
+            # Unparseable client IP is rejected (fail-closed).
+            ("10.0.0.0/8", "not-an-ip", False),
+            # IPv6.
+            ("fd00::/8", "fd00::1", True),
+            ("fd00::/8", "2001:db8::1", False),
+        ],
+    )
+    def test_is_allowed(self, allowed: str | None, client_ip: str, expected: bool) -> None:
+        assert ClientIPValidator(allowed).is_allowed(client_ip) is expected
+
+    def test_invalid_entries_are_skipped_not_raised(self) -> None:
+        # A malformed entry is dropped; valid entries still enforce.
+        validator = ClientIPValidator("garbage, 10.0.0.0/8")
+        assert validator.is_allowed("10.0.0.1") is True
+        assert validator.is_allowed("11.0.0.1") is False
+
+    def test_all_invalid_means_no_restriction(self) -> None:
+        validator = ClientIPValidator("garbage, also-bad")
+        assert validator.is_restricted is False
+        assert validator.is_allowed("203.0.113.5") is True
+
+    def test_is_restricted(self) -> None:
+        assert ClientIPValidator(None).is_restricted is False
+        assert ClientIPValidator("10.0.0.0/8").is_restricted is True
+
+    def test_ranges_normalizes_entries(self) -> None:
+        # Bare IPs become host routes; whitespace stripped; order preserved.
+        validator = ClientIPValidator(" 10.0.0.0/8 , 203.0.113.5 ")
+        assert validator.ranges == ["10.0.0.0/8", "203.0.113.5/32"]
+
+    def test_ranges_empty_when_unrestricted(self) -> None:
+        assert ClientIPValidator(None).ranges == []


### PR DESCRIPTION
This is an auto-generated backport PR of #12321 to the 26.4 release.

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12353.org.readthedocs.build/en/12353/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12353.org.readthedocs.build/ko/12353/

<!-- readthedocs-preview sorna-ko end -->