### PR TITLE
fix(BA-6571): measure session lifetime from starts_at instead of created_at (#12325)

### DIFF
--- a/changes/12325.fix.md
+++ b/changes/12325.fix.md
@@ -1,0 +1,1 @@
+Measure the session lifetime limit (`max_session_lifetime`) from when the session starts running (`starts_at`) instead of when it was created, so scheduling wait time is no longer counted against the user's allowed lifetime.

--- a/src/ai/backend/manager/idle.py
+++ b/src/ai/backend/manager/idle.py
@@ -288,6 +288,7 @@ class IdleCheckerHost:
                     kernels.c.session_id,
                     kernels.c.session_type,
                     kernels.c.created_at,
+                    kernels.c.starts_at,
                     kernels.c.occupied_slots,
                     kernels.c.requested_slots,
                     kernels.c.cluster_size,
@@ -841,13 +842,13 @@ class SessionLifetimeChecker(BaseIdleChecker):
 
         session_id = kernel.session_id
         if (max_session_lifetime := policy.max_session_lifetime) > 0:
-            # TODO: once per-status time tracking is implemented, let's change created_at
-            #       to the timestamp when the session entered PREPARING status.
             idle_timeout = timedelta(seconds=max_session_lifetime)
             now: datetime = await get_db_now(dbconn)
-            kernel_created_at: datetime = kernel.created_at
+            # starts_at is set at the RUNNING transition; fall back to created_at
+            # for abnormal/legacy rows where it was never populated.
+            kernel_starts_at: datetime = kernel.starts_at or kernel.created_at
             remaining = calculate_remaining_time(
-                now, kernel_created_at, idle_timeout, grace_period_end
+                now, kernel_starts_at, idle_timeout, grace_period_end
             )
             await self.set_remaining_time_report(
                 session_id, remaining if remaining > 0 else IDLE_TIMEOUT_VALUE

--- a/tests/unit/manager/test_idle_checker.py
+++ b/tests/unit/manager/test_idle_checker.py
@@ -456,9 +456,20 @@ class TestSessionLifetimeChecker:
 
     @pytest.fixture
     def session_kernel_row(self, session_id: SessionId, base_time: datetime) -> Any:
-        """Kernel row with session created at base_time"""
+        """Kernel row with session started (RUNNING) at base_time"""
         return mock_row(
             session_id=session_id,
+            starts_at=base_time,
+        )
+
+    @pytest.fixture
+    def session_kernel_row_without_starts_at(
+        self, session_id: SessionId, base_time: datetime
+    ) -> Any:
+        """Kernel row missing starts_at; created_at is the fallback baseline"""
+        return mock_row(
+            session_id=session_id,
+            starts_at=None,
             created_at=base_time,
         )
 
@@ -539,6 +550,47 @@ class TestSessionLifetimeChecker:
         )
 
         # Then
+        assert should_alive is test_config.expected_alive
+        assert remaining == test_config.expected_remaining
+
+    @pytest.mark.parametrize(
+        "test_config",
+        [
+            # Remaining = max_lifetime - elapsed = 30 - 10 = 20s
+            _SessionLifetimeTestConfig(
+                elapsed_seconds=10,
+                max_lifetime_seconds=30,
+                expected_remaining=20.0,
+                expected_alive=True,
+            ),
+        ],
+        ids=["fallback_to_created_at"],
+    )
+    async def test_session_lifetime_falls_back_to_created_at(
+        self,
+        test_config: _SessionLifetimeTestConfig,
+        session_id: SessionId,
+        valkey_live: AsyncMock,
+        db_connection: AsyncMock,
+        session_lifetime_checker: SessionLifetimeChecker,
+        session_kernel_row_without_starts_at: Any,
+        session_lifetime_policy: Any,
+    ) -> None:
+        """When starts_at is None, created_at is used as the lifetime baseline"""
+        # When - check_idleness runs against a row without starts_at
+        should_alive = await session_lifetime_checker.check_idleness(
+            session_kernel_row_without_starts_at,
+            db_connection,
+            session_lifetime_policy,
+        )
+
+        # Mock: get_checker_result will read the stored result
+        valkey_live.get_live_data.return_value = msgpack.packb(test_config.expected_remaining)
+        remaining = await session_lifetime_checker.get_checker_result(
+            session_lifetime_checker._redis_live, session_id
+        )
+
+        # Then - baseline falls back to created_at, yielding the same remaining time
         assert should_alive is test_config.expected_alive
         assert remaining == test_config.expected_remaining
 


### PR DESCRIPTION
This is an auto-generated backport PR of #12325 to the 26.4 release.