### PR TITLE
fix(BA-6595): backfill custom runtime variant service block when missing

### DIFF
--- a/changes/12373.fix.md
+++ b/changes/12373.fix.md
@@ -1,0 +1,1 @@
+Backfill a default service block (with port) for the `custom` runtime variant baseline when it was seeded without one, so model-service deployments no longer fail with `port: Field required`.

--- a/src/ai/backend/manager/models/alembic/versions/2d6443ac0d4a_create_app_config_allow_list_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/2d6443ac0d4a_create_app_config_allow_list_table.py
@@ -8,7 +8,7 @@ foreign key into ``app_config_definitions`` so an entry may only reference a
 registered config name.
 
 Revision ID: 2d6443ac0d4a
-Revises: 9fc9e6bfe695
+Revises: c7e1a9d4f6b2
 Create Date: 2026-06-18
 
 """
@@ -20,7 +20,7 @@ from ai.backend.manager.models.base import IDColumn
 
 # revision identifiers, used by Alembic.
 revision = "2d6443ac0d4a"
-down_revision = "9fc9e6bfe695"
+down_revision = "c7e1a9d4f6b2"
 # Part of: 26.5.0
 branch_labels = None
 depends_on = None

--- a/src/ai/backend/manager/models/alembic/versions/c7e1a9d4f6b2_backfill_custom_variant_missing_service.py
+++ b/src/ai/backend/manager/models/alembic/versions/c7e1a9d4f6b2_backfill_custom_variant_missing_service.py
@@ -1,0 +1,101 @@
+"""backfill custom runtime variant service block when missing
+
+``f3a8c1d05e64`` only backfilled the default ``port`` when the ``custom``
+variant's ``models[0].service`` was already a JSON object. Databases whose
+``custom`` baseline has no ``service`` block (or no ``models[0]`` at all) were
+left without a port, so deployments still fail with ``port: Field required``.
+
+This migration converges the ``custom`` baseline to the seeded default for
+every remaining state, idempotently:
+
+- ``models[0]`` missing / null / empty array  -> seed the full definition
+- ``models[0]`` present but ``service`` missing/null -> create the full service block
+- ``service`` present but ``port`` missing/null -> set the default port
+
+Re-running is a no-op once ``models[0].service.port`` is present.
+
+Revision ID: c7e1a9d4f6b2
+Revises: 9fc9e6bfe695
+Create Date: 2026-06-23
+
+"""
+
+import json
+from typing import Any
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c7e1a9d4f6b2"
+down_revision = "9fc9e6bfe695"
+# Part of: 26.4.6 (backport), 26.7.0 (main)
+branch_labels = None
+depends_on = None
+
+_DEFAULT_PORT = 8080
+_DEFAULT_SERVICE: dict[str, Any] = {
+    "port": _DEFAULT_PORT,
+    "health_check": {
+        "enable": False,
+        "path": "/health",
+        "interval": 10.0,
+        "max_retries": 10,
+        "initial_delay": 1800.0,
+    },
+}
+_CUSTOM_DEFINITION: dict[str, Any] = {
+    "models": [
+        {
+            "name": "custom-model",
+            "service": _DEFAULT_SERVICE,
+        }
+    ]
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # (1) models[0] missing entirely (default is null / [] / absent / not an
+    #     object) -> seed the full custom definition.
+    bind.execute(
+        sa.text(
+            "UPDATE runtime_variants "
+            "SET default_model_definition = CAST(:definition AS JSONB) "
+            "WHERE name = 'custom' "
+            "AND jsonb_typeof(default_model_definition #> '{models,0}') IS DISTINCT FROM 'object'"
+        ).bindparams(definition=json.dumps(_CUSTOM_DEFINITION))
+    )
+
+    # (2) models[0] is an object but service is missing/null -> create the full
+    #     service block (create_missing = true).
+    bind.execute(
+        sa.text(
+            "UPDATE runtime_variants "
+            "SET default_model_definition = jsonb_set("
+            "default_model_definition, '{models,0,service}', CAST(:service AS JSONB), true) "
+            "WHERE name = 'custom' "
+            "AND jsonb_typeof(default_model_definition #> '{models,0}') = 'object' "
+            "AND jsonb_typeof(default_model_definition #> '{models,0,service}') IS DISTINCT FROM 'object'"
+        ).bindparams(service=json.dumps(_DEFAULT_SERVICE))
+    )
+
+    # (3) service is an object but port is missing/null -> set the default port.
+    bind.execute(
+        sa.text(
+            "UPDATE runtime_variants "
+            "SET default_model_definition = jsonb_set("
+            "default_model_definition, '{models,0,service,port}', to_jsonb(CAST(:port AS integer))) "
+            "WHERE name = 'custom' "
+            "AND jsonb_typeof(default_model_definition #> '{models,0,service}') = 'object' "
+            "AND default_model_definition #>> '{models,0,service,port}' IS NULL"
+        ).bindparams(port=_DEFAULT_PORT)
+    )
+
+
+def downgrade() -> None:
+    # Data-only backfill that repairs an invalid baseline; the corrected state
+    # is the desired one. Reversing would re-introduce the broken baseline and
+    # cannot distinguish repaired rows from always-valid ones, so this is a no-op.
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/e3b8d2a1c5f7_backfill_custom_variant_missing_service_followup.py
+++ b/src/ai/backend/manager/models/alembic/versions/e3b8d2a1c5f7_backfill_custom_variant_missing_service_followup.py
@@ -1,0 +1,93 @@
+"""backfill custom runtime variant service block (main-head duplicate)
+
+Idempotent duplicate of ``c7e1a9d4f6b2`` placed at the main head. ``c7e1a9d4f6b2``
+is inserted into the chain right after ``9fc9e6bfe695``, so databases already
+upgraded past that point (i.e. existing ``main`` databases) never run it; this
+revision re-applies the same repair for them. A no-op once
+``models[0].service.port`` is present.
+
+Revision ID: e3b8d2a1c5f7
+Revises: d3f8a1c45e9b
+Create Date: 2026-06-23
+
+"""
+
+import json
+from typing import Any
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e3b8d2a1c5f7"
+down_revision = "d3f8a1c45e9b"
+# Part of: 26.4.6 (backport), 26.7.0 (main)
+branch_labels = None
+depends_on = None
+
+_DEFAULT_PORT = 8080
+_DEFAULT_SERVICE: dict[str, Any] = {
+    "port": _DEFAULT_PORT,
+    "health_check": {
+        "enable": False,
+        "path": "/health",
+        "interval": 10.0,
+        "max_retries": 10,
+        "initial_delay": 1800.0,
+    },
+}
+_CUSTOM_DEFINITION: dict[str, Any] = {
+    "models": [
+        {
+            "name": "custom-model",
+            "service": _DEFAULT_SERVICE,
+        }
+    ]
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # (1) models[0] missing entirely (default is null / [] / absent / not an
+    #     object) -> seed the full custom definition.
+    bind.execute(
+        sa.text(
+            "UPDATE runtime_variants "
+            "SET default_model_definition = CAST(:definition AS JSONB) "
+            "WHERE name = 'custom' "
+            "AND jsonb_typeof(default_model_definition #> '{models,0}') IS DISTINCT FROM 'object'"
+        ).bindparams(definition=json.dumps(_CUSTOM_DEFINITION))
+    )
+
+    # (2) models[0] is an object but service is missing/null -> create the full
+    #     service block (create_missing = true).
+    bind.execute(
+        sa.text(
+            "UPDATE runtime_variants "
+            "SET default_model_definition = jsonb_set("
+            "default_model_definition, '{models,0,service}', CAST(:service AS JSONB), true) "
+            "WHERE name = 'custom' "
+            "AND jsonb_typeof(default_model_definition #> '{models,0}') = 'object' "
+            "AND jsonb_typeof(default_model_definition #> '{models,0,service}') IS DISTINCT FROM 'object'"
+        ).bindparams(service=json.dumps(_DEFAULT_SERVICE))
+    )
+
+    # (3) service is an object but port is missing/null -> set the default port.
+    bind.execute(
+        sa.text(
+            "UPDATE runtime_variants "
+            "SET default_model_definition = jsonb_set("
+            "default_model_definition, '{models,0,service,port}', to_jsonb(CAST(:port AS integer))) "
+            "WHERE name = 'custom' "
+            "AND jsonb_typeof(default_model_definition #> '{models,0,service}') = 'object' "
+            "AND default_model_definition #>> '{models,0,service,port}' IS NULL"
+        ).bindparams(port=_DEFAULT_PORT)
+    )
+
+
+def downgrade() -> None:
+    # Data-only backfill that repairs an invalid baseline; the corrected state
+    # is the desired one. Reversing would re-introduce the broken baseline and
+    # cannot distinguish repaired rows from always-valid ones, so this is a no-op.
+    pass


### PR DESCRIPTION
## Problem
`f3a8c1d05e64` / `ed42bc179b91` only backfilled the default `port` when the `custom` runtime variant's `models[0].service` was already a JSON object. Databases whose `custom` baseline has **no `service` block** (or no `models[0]`) were left without a port, so model-service deployments still fail with `port: Field required` (`port` is required; `health_check` is optional).

## Fix
A new idempotent migration converges the `custom` baseline for every remaining state:

| State | Action |
|---|---|
| `models[0]` null / `[]` / absent | seed full definition |
| `models[0]` present, `service` null/absent | create full service block |
| `service` present, `port` null/absent | set default port (8080) |

Existing non-default ports and custom `health_check`s are preserved (no clobber); re-running is a no-op.

## Migration chain (per `models/alembic/README.md` backport strategy)
- `c7e1a9d4f6b2` (d) — inserted after `9fc9e6bfe695`; the **same revision id is reused on the 26.4 backport** so the chains don't diverge.
- `2d6443ac0d4a` repointed `9fc9e6bfe695 → c7e1a9d4f6b2`.
- `e3b8d2a1c5f7` (d') — idempotent head duplicate for DBs already upgraded past the insertion point.

Single head after: `e3b8d2a1c5f7`.

## Verification
- SQL logic tested against the local DB across all states + idempotency + no-clobber, rolled back (nothing persisted).
- `alembic heads` single; `pants fmt/lint/check` clean.

## Backport
26.4 backport: see linked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)