### PR TITLE
fix(BA-6595): backfill custom runtime variant service block when missing (backport to 26.4)

### DIFF
--- a/changes/12374.fix.md
+++ b/changes/12374.fix.md
@@ -1,0 +1,1 @@
+Backfill a default service block (with port) for the `custom` runtime variant baseline when it was seeded without one, so model-service deployments no longer fail with `port: Field required`.

--- a/src/ai/backend/manager/models/alembic/versions/c7e1a9d4f6b2_backfill_custom_variant_missing_service.py
+++ b/src/ai/backend/manager/models/alembic/versions/c7e1a9d4f6b2_backfill_custom_variant_missing_service.py
@@ -1,0 +1,101 @@
+"""backfill custom runtime variant service block when missing
+
+``f3a8c1d05e64`` only backfilled the default ``port`` when the ``custom``
+variant's ``models[0].service`` was already a JSON object. Databases whose
+``custom`` baseline has no ``service`` block (or no ``models[0]`` at all) were
+left without a port, so deployments still fail with ``port: Field required``.
+
+This migration converges the ``custom`` baseline to the seeded default for
+every remaining state, idempotently:
+
+- ``models[0]`` missing / null / empty array  -> seed the full definition
+- ``models[0]`` present but ``service`` missing/null -> create the full service block
+- ``service`` present but ``port`` missing/null -> set the default port
+
+Re-running is a no-op once ``models[0].service.port`` is present.
+
+Revision ID: c7e1a9d4f6b2
+Revises: 9fc9e6bfe695
+Create Date: 2026-06-23
+
+"""
+
+import json
+from typing import Any
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c7e1a9d4f6b2"
+down_revision = "9fc9e6bfe695"
+# Part of: 26.4.6 (backport), 26.7.0 (main)
+branch_labels = None
+depends_on = None
+
+_DEFAULT_PORT = 8080
+_DEFAULT_SERVICE: dict[str, Any] = {
+    "port": _DEFAULT_PORT,
+    "health_check": {
+        "enable": False,
+        "path": "/health",
+        "interval": 10.0,
+        "max_retries": 10,
+        "initial_delay": 1800.0,
+    },
+}
+_CUSTOM_DEFINITION: dict[str, Any] = {
+    "models": [
+        {
+            "name": "custom-model",
+            "service": _DEFAULT_SERVICE,
+        }
+    ]
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # (1) models[0] missing entirely (default is null / [] / absent / not an
+    #     object) -> seed the full custom definition.
+    bind.execute(
+        sa.text(
+            "UPDATE runtime_variants "
+            "SET default_model_definition = CAST(:definition AS JSONB) "
+            "WHERE name = 'custom' "
+            "AND jsonb_typeof(default_model_definition #> '{models,0}') IS DISTINCT FROM 'object'"
+        ).bindparams(definition=json.dumps(_CUSTOM_DEFINITION))
+    )
+
+    # (2) models[0] is an object but service is missing/null -> create the full
+    #     service block (create_missing = true).
+    bind.execute(
+        sa.text(
+            "UPDATE runtime_variants "
+            "SET default_model_definition = jsonb_set("
+            "default_model_definition, '{models,0,service}', CAST(:service AS JSONB), true) "
+            "WHERE name = 'custom' "
+            "AND jsonb_typeof(default_model_definition #> '{models,0}') = 'object' "
+            "AND jsonb_typeof(default_model_definition #> '{models,0,service}') IS DISTINCT FROM 'object'"
+        ).bindparams(service=json.dumps(_DEFAULT_SERVICE))
+    )
+
+    # (3) service is an object but port is missing/null -> set the default port.
+    bind.execute(
+        sa.text(
+            "UPDATE runtime_variants "
+            "SET default_model_definition = jsonb_set("
+            "default_model_definition, '{models,0,service,port}', to_jsonb(CAST(:port AS integer))) "
+            "WHERE name = 'custom' "
+            "AND jsonb_typeof(default_model_definition #> '{models,0,service}') = 'object' "
+            "AND default_model_definition #>> '{models,0,service,port}' IS NULL"
+        ).bindparams(port=_DEFAULT_PORT)
+    )
+
+
+def downgrade() -> None:
+    # Data-only backfill that repairs an invalid baseline; the corrected state
+    # is the desired one. Reversing would re-introduce the broken baseline and
+    # cannot distinguish repaired rows from always-valid ones, so this is a no-op.
+    pass


### PR DESCRIPTION
Backport of #12373 to `26.4`.

## Problem
`f3a8c1d05e64` / `ed42bc179b91` only backfilled the default `port` when the `custom` runtime variant's `models[0].service` was already a JSON object. Databases whose `custom` baseline has **no `service` block** (or no `models[0]`) were left without a port, so model-service deployments still fail with `port: Field required`.

## Fix
Adds the idempotent migration `c7e1a9d4f6b2` (the **same revision id** as on the main PR) after the 26.4 head `9fc9e6bfe695`, converging the `custom` baseline for every remaining state:

| State | Action |
|---|---|
| `models[0]` null / `[]` / absent | seed full definition |
| `models[0]` present, `service` null/absent | create full service block |
| `service` present, `port` null/absent | set default port (8080) |

Existing non-default ports and custom `health_check`s are preserved; re-running is a no-op. On 26.4 the migration is the head, so no head-duplicate / repoint is needed (those exist only on main, per the README backport strategy).

## Verification
- SQL logic tested against the local DB across all states + idempotency + no-clobber, rolled back (nothing persisted).
- `alembic heads` single (`c7e1a9d4f6b2`); `pants fmt/lint/check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)