### PR TITLE
fix(BA-6594): converge steady-state scaling on count to avoid scale-down deadlock (#12370)

### DIFF
--- a/changes/12370.fix.md
+++ b/changes/12370.fix.md
@@ -1,0 +1,1 @@
+Fix a deployment auto-scaling deadlock where scale-down (and other replica-count changes) were never applied while replicas stayed pending due to resource limits.

--- a/src/ai/backend/manager/sokovan/deployment/group/lifecycle/handlers/autoscale.py
+++ b/src/ai/backend/manager/sokovan/deployment/group/lifecycle/handlers/autoscale.py
@@ -33,11 +33,11 @@ class GroupAutoscaleHandler(
             with recorder.phase("group_autoscale"):
                 with recorder.step("evaluate"):
                     goal = view.deployment_desired_replica_count
-                    # Same convergence criteria as the scaling reconcile; a group with no
-                    # current revision has nothing the scaling reconcile could fill.
-                    converged = view.current_revision_id is None or (
-                        view.current_live_replica_count == goal
-                        and view.current_serving_replica_count == goal
+                    # Count-only, mirroring the steady-state scaling reconcile. Serving health
+                    # is judged separately and must not re-arm scaling; otherwise a group that
+                    # cannot fully serve (resource starvation) would oscillate STABLE<->SCALING.
+                    converged = (
+                        view.current_revision_id is None or view.current_live_replica_count == goal
                     )
                     # FAILURE re-arms scaling so the scaling reconcile fills/drains routes.
                     if view.desired_current_replica_count != goal:

--- a/src/ai/backend/manager/sokovan/deployment/group/scaling/handlers/reconcile.py
+++ b/src/ai/backend/manager/sokovan/deployment/group/scaling/handlers/reconcile.py
@@ -75,10 +75,21 @@ class GroupScalingReconcileHandler(
                                     count=-deficit,
                                 )
                             )
-                    current_matched = (
-                        view.current_live_replica_count == view.desired_current_replica_count
-                        and view.current_serving_replica_count == view.desired_current_replica_count
-                    )
+                    if view.target_revision_id is None:
+                        # Steady-state scaling: converge on count alone. Replicas that cannot
+                        # be scheduled stay PENDING; serving health is judged separately and
+                        # must not block the loop, so a rising/falling goal is always absorbed.
+                        current_matched = (
+                            view.current_live_replica_count == view.desired_current_replica_count
+                        )
+                    else:
+                        # Rollout in flight: require serving so the rolling step waits for the
+                        # new replicas before draining the old (no-downtime invariant).
+                        current_matched = (
+                            view.current_live_replica_count == view.desired_current_replica_count
+                            and view.current_serving_replica_count
+                            == view.desired_current_replica_count
+                        )
                     target_matched = (
                         view.target_live_replica_count == view.desired_target_replica_count
                         and view.target_serving_replica_count == view.desired_target_replica_count

--- a/tests/unit/manager/sokovan/deployment/group/lifecycle/test_lifecycle_handlers.py
+++ b/tests/unit/manager/sokovan/deployment/group/lifecycle/test_lifecycle_handlers.py
@@ -118,15 +118,17 @@ async def test_autoscale_rearms_scaling_when_live_routes_drop() -> None:
     assert decision.next_desired_current_replica_count == 4
 
 
-async def test_autoscale_rearms_scaling_when_serving_short_of_live() -> None:
-    # A leftover PROVISIONING route counts as live but not serving yet.
+async def test_autoscale_stays_stable_when_serving_short_but_count_met() -> None:
+    # Resource-starved steady state: count is met (live == goal) but some routes never reach
+    # serving. Health is judged separately, so scaling must NOT re-arm here — otherwise the
+    # group oscillates STABLE<->SCALING and a falling goal (scale-down) would never apply.
     view = _autoscale_view(
         current_live=4,
         current_serving=3,
         current_revision_id=DeploymentRevisionID(uuid.uuid4()),
     )
     decision = await _autoscale_decision(view)
-    assert decision.outcome() is HandlerOutcome.FAILURE
+    assert decision.outcome() is HandlerOutcome.SUCCESS
 
 
 async def test_autoscale_rearms_scaling_when_goal_changes() -> None:

--- a/tests/unit/manager/sokovan/deployment/group/scaling/BUILD
+++ b/tests/unit/manager/sokovan/deployment/group/scaling/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/tests/unit/manager/sokovan/deployment/group/scaling/test_scaling_reconcile_handler.py
+++ b/tests/unit/manager/sokovan/deployment/group/scaling/test_scaling_reconcile_handler.py
@@ -1,0 +1,132 @@
+import uuid
+from datetime import UTC, datetime
+from uuid import UUID
+
+from ai.backend.common.identifier.deployment import DeploymentID
+from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
+from ai.backend.common.identifier.replica_group import ReplicaGroupID
+from ai.backend.manager.data.deployment.types import (
+    DeploymentHandlerOptions,
+    ReplicaGroupScalingStatus,
+)
+from ai.backend.manager.data.reconciler.types import HandlerOutcome
+from ai.backend.manager.sokovan.deployment.group.scaling.handlers.reconcile import (
+    GroupScalingReconcileHandler,
+)
+from ai.backend.manager.sokovan.deployment.group.scaling.types import (
+    GroupScalingDecision,
+    GroupScalingReconcileInfo,
+    GroupScalingReconcileResult,
+)
+from ai.backend.manager.sokovan.recorder.context import RecorderContext
+from ai.backend.manager.views.replica_group import ReplicaGroupScalingReconcileView
+
+
+def _scaling_view(
+    *,
+    current_revision_id: DeploymentRevisionID | None = None,
+    target_revision_id: DeploymentRevisionID | None = None,
+    desired_current: int = 4,
+    desired_target: int = 0,
+    current_live: int = 4,
+    current_serving: int = 4,
+    target_live: int = 0,
+    target_serving: int = 0,
+) -> ReplicaGroupScalingReconcileView:
+    return ReplicaGroupScalingReconcileView(
+        group_id=ReplicaGroupID(uuid.uuid4()),
+        deployment_id=DeploymentID(uuid.uuid4()),
+        current_revision_id=current_revision_id,
+        target_revision_id=target_revision_id,
+        scaling_status=ReplicaGroupScalingStatus.SCALING,
+        desired_current_replica_count=desired_current,
+        desired_target_replica_count=desired_target,
+        current_live_replica_count=current_live,
+        current_serving_replica_count=current_serving,
+        target_live_replica_count=target_live,
+        target_serving_replica_count=target_serving,
+        last_history=None,
+        handler_options=DeploymentHandlerOptions(),
+    )
+
+
+async def _execute(view: ReplicaGroupScalingReconcileView) -> GroupScalingReconcileResult:
+    info = GroupScalingReconcileInfo(views=[view], current_time=datetime(2026, 1, 1, tzinfo=UTC))
+    with RecorderContext[UUID].scope("scaling_reconcile", [view.group_id]):
+        return await GroupScalingReconcileHandler().execute(info)
+
+
+async def _decision(view: ReplicaGroupScalingReconcileView) -> GroupScalingDecision:
+    return (await _execute(view)).scaling_decisions[0]
+
+
+async def test_steady_state_converges_on_count_despite_short_serving() -> None:
+    # No target revision (steady state): count is met (live == desired) but serving lags
+    # because some routes are stuck PENDING. Must converge so the group reaches STABLE.
+    view = _scaling_view(
+        current_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        target_revision_id=None,
+        desired_current=6,
+        current_live=6,
+        current_serving=3,
+    )
+    decision = await _decision(view)
+    assert decision.outcome() is HandlerOutcome.SUCCESS
+
+
+async def test_steady_state_not_converged_when_count_short() -> None:
+    view = _scaling_view(
+        current_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        target_revision_id=None,
+        desired_current=6,
+        current_live=4,
+        current_serving=4,
+    )
+    decision = await _decision(view)
+    assert decision.outcome() is HandlerOutcome.FAILURE
+
+
+async def test_steady_state_scale_down_drains_excess() -> None:
+    # Goal dropped to 1 while 6 routes (3 serving + 3 PENDING) exist: drain the 5 surplus.
+    view = _scaling_view(
+        current_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        target_revision_id=None,
+        desired_current=1,
+        current_live=6,
+        current_serving=3,
+    )
+    result = await _execute(view)
+    assert len(result.drain_instructions) == 1
+    assert result.drain_instructions[0].count == 5
+
+
+async def test_rollout_still_requires_serving() -> None:
+    # A target revision is in flight (rollout): the current side must reach serving, not just
+    # count, so the rolling step waits before draining the old revision (no-downtime).
+    view = _scaling_view(
+        current_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        target_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        desired_current=3,
+        desired_target=3,
+        current_live=3,
+        current_serving=2,
+        target_live=3,
+        target_serving=3,
+    )
+    decision = await _decision(view)
+    assert decision.outcome() is HandlerOutcome.FAILURE
+
+
+async def test_rollout_converges_when_both_sides_serving() -> None:
+    view = _scaling_view(
+        current_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        target_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        desired_current=2,
+        desired_target=2,
+        current_live=2,
+        current_serving=2,
+        target_live=2,
+        target_serving=2,
+    )
+    decision = await _decision(view)
+    assert decision.outcome() is HandlerOutcome.SUCCESS


### PR DESCRIPTION
This is an auto-generated backport PR of #12370 to the 26.4 release.