### PR TITLE
feat(BA-6556): merged AppConfig REST v2 read API

### DIFF
--- a/changes/12377.feature.md
+++ b/changes/12377.feature.md
@@ -1,0 +1,1 @@
+Add the merged AppConfig REST v2 read API: resolve the deep-merged `(user, config_name)` view (auth required) and an anonymous public-only merged read (BEP-1052).

--- a/changes/12377.feature.md
+++ b/changes/12377.feature.md
@@ -1,1 +1,1 @@
-Add the merged AppConfig REST v2 read API: resolve the deep-merged `(user, config_name)` view (auth required) and an anonymous public-only merged read (BEP-1052).
+Add the merged AppConfig REST v2 read API: get the deep-merged `(user, config_name)` view for the acting user (auth required) and an anonymous public-only merged read (BEP-1052).

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -547,8 +547,24 @@
         "title": "AdminSearchAgentsInput",
         "type": "object"
       },
+      "AppConfigScopeArgumentsDTO": {
+        "description": "The scope a caller supplies for a resolve — the domain, never the user.\n\nThe wire twin of the repository's ``AppConfigScopeArguments``: the adapter fills the\nuser from the session, so a resolve is only ever for the acting user. Grow new\ncaller-supplied scope dimensions here, mirroring the repository type, rather than adding\nflat fields to the request.",
+        "properties": {
+          "domain_id": {
+            "description": "Domain to resolve the domain-scope overlay at.",
+            "format": "uuid",
+            "title": "Domain Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "domain_id"
+        ],
+        "title": "AppConfigScopeArgumentsDTO",
+        "type": "object"
+      },
       "ResolveAppConfigInput": {
-        "description": "Input for resolving merged AppConfigs at a named domain, for the acting user.\n\n``domain_id`` is the caller's to name; the user is not — the adapter takes it from the\nsession, so a resolve is only ever for the acting user.",
+        "description": "Input for resolving merged AppConfigs at a named scope, for the acting user.",
         "properties": {
           "config_names": {
             "description": "Config names to resolve the merged view for.",
@@ -559,16 +575,14 @@
             "title": "Config Names",
             "type": "array"
           },
-          "domain_id": {
-            "description": "Domain to resolve the domain-scope overlay at.",
-            "format": "uuid",
-            "title": "Domain Id",
-            "type": "string"
+          "scope_arguments": {
+            "$ref": "#/components/schemas/AppConfigScopeArgumentsDTO",
+            "description": "Caller-supplied scope for the resolve."
           }
         },
         "required": [
           "config_names",
-          "domain_id"
+          "scope_arguments"
         ],
         "title": "ResolveAppConfigInput",
         "type": "object"

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -547,44 +547,6 @@
         "title": "AdminSearchAgentsInput",
         "type": "object"
       },
-      "ResolveAppConfigInput": {
-        "description": "Input for resolving merged AppConfigs for the acting user.\n\nThe scope is never caller-supplied: the adapter takes both the user and the domain from\nthe session, so a resolve is only ever for the acting user in their own domain.",
-        "properties": {
-          "config_names": {
-            "description": "Config names to resolve the merged view for.",
-            "items": {
-              "type": "string"
-            },
-            "minItems": 1,
-            "title": "Config Names",
-            "type": "array"
-          }
-        },
-        "required": [
-          "config_names"
-        ],
-        "title": "ResolveAppConfigInput",
-        "type": "object"
-      },
-      "ResolvePublicAppConfigInput": {
-        "description": "Input for the anonymous, pre-login read, where only public fragments contribute.\n\nA pre-login screen usually needs several configs at once, so this takes the same batch\nas the authenticated resolve — it just names no principal.",
-        "properties": {
-          "config_names": {
-            "description": "Config names to resolve the merged public view for.",
-            "items": {
-              "type": "string"
-            },
-            "minItems": 1,
-            "title": "Config Names",
-            "type": "array"
-          }
-        },
-        "required": [
-          "config_names"
-        ],
-        "title": "ResolvePublicAppConfigInput",
-        "type": "object"
-      },
       "ConflictingSessionCleanupPolicyEnum": {
         "description": "How to clean up sessions that conflict with an agent's resource group change.",
         "enum": [
@@ -626,6 +588,44 @@
           "resource_group_id"
         ],
         "title": "UpdateAgentResourceGroupBody",
+        "type": "object"
+      },
+      "ResolveAppConfigInput": {
+        "description": "Input for resolving merged AppConfigs for the acting user.\n\nThe scope is never caller-supplied: the adapter takes both the user and the domain from\nthe session, so a resolve is only ever for the acting user in their own domain.",
+        "properties": {
+          "config_names": {
+            "description": "Config names to resolve the merged view for.",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "title": "Config Names",
+            "type": "array"
+          }
+        },
+        "required": [
+          "config_names"
+        ],
+        "title": "ResolveAppConfigInput",
+        "type": "object"
+      },
+      "ResolvePublicAppConfigInput": {
+        "description": "Input for the anonymous, pre-login read, where only public fragments contribute.\n\nA pre-login screen usually needs several configs at once, so this takes the same batch\nas the authenticated resolve — it just names no principal.",
+        "properties": {
+          "config_names": {
+            "description": "Config names to resolve the merged public view for.",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "title": "Config Names",
+            "type": "array"
+          }
+        },
+        "required": [
+          "config_names"
+        ],
+        "title": "ResolvePublicAppConfigInput",
         "type": "object"
       },
       "BulkPurgeAppConfigFragmentInput": {

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -590,11 +590,11 @@
         "title": "UpdateAgentResourceGroupBody",
         "type": "object"
       },
-      "ResolveAppConfigInput": {
-        "description": "Input for resolving merged AppConfigs; the scope comes from the session.",
+      "MyGetAppConfigsInput": {
+        "description": "Input for the acting user's merged AppConfigs; the scope comes from the session.",
         "properties": {
           "config_names": {
-            "description": "Config names to resolve the merged view for.",
+            "description": "Config names to get the merged view for.",
             "items": {
               "type": "string"
             },
@@ -606,14 +606,14 @@
         "required": [
           "config_names"
         ],
-        "title": "ResolveAppConfigInput",
+        "title": "MyGetAppConfigsInput",
         "type": "object"
       },
-      "ResolvePublicAppConfigInput": {
+      "GetPublicAppConfigsInput": {
         "description": "Input for the anonymous, pre-login read, where only public fragments contribute.",
         "properties": {
           "config_names": {
-            "description": "Config names to resolve the merged public view for.",
+            "description": "Config names to get the merged public view for.",
             "items": {
               "type": "string"
             },
@@ -625,7 +625,7 @@
         "required": [
           "config_names"
         ],
-        "title": "ResolvePublicAppConfigInput",
+        "title": "GetPublicAppConfigsInput",
         "type": "object"
       },
       "BulkPurgeAppConfigFragmentInput": {
@@ -41824,9 +41824,9 @@
         "description": "Retrieve aggregate resource capacity/usage across all agents (superadmin only).\n\n**Preconditions:**\n* Superadmin privilege required.\n"
       }
     },
-    "/v2/app-config/resolve": {
+    "/v2/app-config/my/get": {
       "post": {
-        "operationId": "v2/app-config.resolve",
+        "operationId": "v2/app-config.my_get",
         "tags": [
           "v2/app-config"
         ],
@@ -41844,18 +41844,18 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ResolveAppConfigInput"
+                "$ref": "#/components/schemas/MyGetAppConfigsInput"
               }
             }
           }
         },
         "parameters": [],
-        "description": "Resolve merged AppConfigs for the authenticated caller (auth required).\n\n**Preconditions:**\n* User privilege required.\n"
+        "description": "Get the acting user's merged AppConfigs (auth required).\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
-    "/v2/app-config/public/resolve": {
+    "/v2/app-config/public/get": {
       "post": {
-        "operationId": "v2/app-config.resolve_public",
+        "operationId": "v2/app-config.get_public",
         "tags": [
           "v2/app-config"
         ],
@@ -41868,13 +41868,13 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ResolvePublicAppConfigInput"
+                "$ref": "#/components/schemas/GetPublicAppConfigsInput"
               }
             }
           }
         },
         "parameters": [],
-        "description": "Resolve merged AppConfigs from public fragments only (anonymous)."
+        "description": "Get merged AppConfigs from public fragments only (anonymous)."
       }
     },
     "/v2/app-config-fragments/bulk-delete": {

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -609,7 +609,7 @@
         "title": "MyGetAppConfigsInput",
         "type": "object"
       },
-      "GetPublicAppConfigsInput": {
+      "PublicGetAppConfigsInput": {
         "description": "Input for the anonymous, pre-login read, where only public fragments contribute.",
         "properties": {
           "config_names": {
@@ -625,7 +625,7 @@
         "required": [
           "config_names"
         ],
-        "title": "GetPublicAppConfigsInput",
+        "title": "PublicGetAppConfigsInput",
         "type": "object"
       },
       "BulkPurgeAppConfigFragmentInput": {
@@ -41855,7 +41855,7 @@
     },
     "/v2/app-config/public/get": {
       "post": {
-        "operationId": "v2/app-config.get_public",
+        "operationId": "v2/app-config.public_get",
         "tags": [
           "v2/app-config"
         ],
@@ -41868,7 +41868,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GetPublicAppConfigsInput"
+                "$ref": "#/components/schemas/PublicGetAppConfigsInput"
               }
             }
           }

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -547,28 +547,8 @@
         "title": "AdminSearchAgentsInput",
         "type": "object"
       },
-      "AppConfigScopeArgumentsDTO": {
-        "description": "The scope a caller supplies for a resolve — the domain, never the user.\n\nThe wire twin of the repository's ``AppConfigScopeArguments``: the adapter fills the\nuser from the session, so a resolve is only ever for the acting user. Grow new\ncaller-supplied scope dimensions here, mirroring the repository type, rather than adding\nflat fields to the request.",
-        "properties": {
-          "domain_ids": {
-            "description": "Domains to resolve the domain-scope overlay at. Only the first is used.",
-            "items": {
-              "format": "uuid",
-              "type": "string"
-            },
-            "minItems": 1,
-            "title": "Domain Ids",
-            "type": "array"
-          }
-        },
-        "required": [
-          "domain_ids"
-        ],
-        "title": "AppConfigScopeArgumentsDTO",
-        "type": "object"
-      },
       "ResolveAppConfigInput": {
-        "description": "Input for resolving merged AppConfigs at a named scope, for the acting user.",
+        "description": "Input for resolving merged AppConfigs for the acting user.\n\nThe scope is never caller-supplied: the adapter takes both the user and the domain from\nthe session, so a resolve is only ever for the acting user in their own domain.",
         "properties": {
           "config_names": {
             "description": "Config names to resolve the merged view for.",
@@ -578,15 +558,10 @@
             "minItems": 1,
             "title": "Config Names",
             "type": "array"
-          },
-          "scope_arguments": {
-            "$ref": "#/components/schemas/AppConfigScopeArgumentsDTO",
-            "description": "Caller-supplied scope for the resolve."
           }
         },
         "required": [
-          "config_names",
-          "scope_arguments"
+          "config_names"
         ],
         "title": "ResolveAppConfigInput",
         "type": "object"

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -547,6 +547,51 @@
         "title": "AdminSearchAgentsInput",
         "type": "object"
       },
+      "ResolveAppConfigInput": {
+        "description": "Input for resolving merged AppConfigs at a named domain, for the acting user.\n\n``domain_id`` is the caller's to name; the user is not — the adapter takes it from the\nsession, so a resolve is only ever for the acting user.",
+        "properties": {
+          "config_names": {
+            "description": "Config names to resolve the merged view for.",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "title": "Config Names",
+            "type": "array"
+          },
+          "domain_id": {
+            "description": "Domain to resolve the domain-scope overlay at.",
+            "format": "uuid",
+            "title": "Domain Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "config_names",
+          "domain_id"
+        ],
+        "title": "ResolveAppConfigInput",
+        "type": "object"
+      },
+      "ResolvePublicAppConfigInput": {
+        "description": "Input for the anonymous, pre-login read, where only public fragments contribute.\n\nA pre-login screen usually needs several configs at once, so this takes the same batch\nas the authenticated resolve — it just names no principal.",
+        "properties": {
+          "config_names": {
+            "description": "Config names to resolve the merged public view for.",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "title": "Config Names",
+            "type": "array"
+          }
+        },
+        "required": [
+          "config_names"
+        ],
+        "title": "ResolvePublicAppConfigInput",
+        "type": "object"
+      },
       "ConflictingSessionCleanupPolicyEnum": {
         "description": "How to clean up sessions that conflict with an agent's resource group change.",
         "enum": [
@@ -41784,6 +41829,59 @@
         ],
         "parameters": [],
         "description": "Retrieve aggregate resource capacity/usage across all agents (superadmin only).\n\n**Preconditions:**\n* Superadmin privilege required.\n"
+      }
+    },
+    "/v2/app-config/resolve": {
+      "post": {
+        "operationId": "v2/app-config.resolve",
+        "tags": [
+          "v2/app-config"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResolveAppConfigInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Resolve merged AppConfigs for the authenticated caller (auth required).\n\n**Preconditions:**\n* User privilege required.\n"
+      }
+    },
+    "/v2/app-config/public/resolve": {
+      "post": {
+        "operationId": "v2/app-config.resolve_public",
+        "tags": [
+          "v2/app-config"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResolvePublicAppConfigInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Resolve merged AppConfigs from public fragments only (anonymous)."
       }
     },
     "/v2/app-config-fragments/bulk-delete": {

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -591,7 +591,7 @@
         "type": "object"
       },
       "ResolveAppConfigInput": {
-        "description": "Input for resolving merged AppConfigs for the acting user.\n\nThe scope is never caller-supplied: the adapter takes both the user and the domain from\nthe session, so a resolve is only ever for the acting user in their own domain.",
+        "description": "Input for resolving merged AppConfigs; the scope comes from the session.",
         "properties": {
           "config_names": {
             "description": "Config names to resolve the merged view for.",
@@ -610,7 +610,7 @@
         "type": "object"
       },
       "ResolvePublicAppConfigInput": {
-        "description": "Input for the anonymous, pre-login read, where only public fragments contribute.\n\nA pre-login screen usually needs several configs at once, so this takes the same batch\nas the authenticated resolve — it just names no principal.",
+        "description": "Input for the anonymous, pre-login read, where only public fragments contribute.",
         "properties": {
           "config_names": {
             "description": "Config names to resolve the merged public view for.",

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -41826,7 +41826,7 @@
     },
     "/v2/app-config/my/get": {
       "post": {
-        "operationId": "v2/app-config.my_get",
+        "operationId": "v2/app-config.my_get_app_configs",
         "tags": [
           "v2/app-config"
         ],
@@ -41855,7 +41855,7 @@
     },
     "/v2/app-config/public/get": {
       "post": {
-        "operationId": "v2/app-config.public_get",
+        "operationId": "v2/app-config.public_get_app_configs",
         "tags": [
           "v2/app-config"
         ],

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -550,15 +550,19 @@
       "AppConfigScopeArgumentsDTO": {
         "description": "The scope a caller supplies for a resolve — the domain, never the user.\n\nThe wire twin of the repository's ``AppConfigScopeArguments``: the adapter fills the\nuser from the session, so a resolve is only ever for the acting user. Grow new\ncaller-supplied scope dimensions here, mirroring the repository type, rather than adding\nflat fields to the request.",
         "properties": {
-          "domain_id": {
-            "description": "Domain to resolve the domain-scope overlay at.",
-            "format": "uuid",
-            "title": "Domain Id",
-            "type": "string"
+          "domain_ids": {
+            "description": "Domains to resolve the domain-scope overlay at. Only the first is used.",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "minItems": 1,
+            "title": "Domain Ids",
+            "type": "array"
           }
         },
         "required": [
-          "domain_id"
+          "domain_ids"
         ],
         "title": "AppConfigScopeArgumentsDTO",
         "type": "object"

--- a/src/ai/backend/common/data/user/types.py
+++ b/src/ai/backend/common/data/user/types.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Self
 from uuid import UUID
 
+from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.types import CIStrEnum
 
 
@@ -26,6 +27,11 @@ class UserData:
     is_superadmin: bool
     role: UserRole
     domain_name: str
+    domain_id: DomainID | None = None
+    """The id of ``domain_name``, so a caller filtering on the domain need not resolve the
+    name back into an id. The auth middleware always sets it; it is optional only so a
+    payload serialized before this field existed still deserializes.
+    """
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Self:

--- a/src/ai/backend/common/dto/manager/v2/app_config/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/request.py
@@ -8,22 +8,33 @@ from ai.backend.common.api_handlers import BaseRequestModel
 from ai.backend.common.identifier.domain import DomainID
 
 __all__ = (
+    "AppConfigScopeArgumentsDTO",
     "ResolveAppConfigInput",
     "ResolvePublicAppConfigInput",
 )
 
 
-class ResolveAppConfigInput(BaseRequestModel):
-    """Input for resolving merged AppConfigs at a named domain, for the acting user.
+class AppConfigScopeArgumentsDTO(BaseRequestModel):
+    """The scope a caller supplies for a resolve — the domain, never the user.
 
-    ``domain_id`` is the caller's to name; the user is not — the adapter takes it from the
-    session, so a resolve is only ever for the acting user.
+    The wire twin of the repository's ``AppConfigScopeArguments``: the adapter fills the
+    user from the session, so a resolve is only ever for the acting user. Grow new
+    caller-supplied scope dimensions here, mirroring the repository type, rather than adding
+    flat fields to the request.
     """
+
+    domain_id: DomainID = Field(description="Domain to resolve the domain-scope overlay at.")
+
+
+class ResolveAppConfigInput(BaseRequestModel):
+    """Input for resolving merged AppConfigs at a named scope, for the acting user."""
 
     config_names: list[str] = Field(
         min_length=1, description="Config names to resolve the merged view for."
     )
-    domain_id: DomainID = Field(description="Domain to resolve the domain-scope overlay at.")
+    scope_arguments: AppConfigScopeArgumentsDTO = Field(
+        description="Caller-supplied scope for the resolve."
+    )
 
 
 class ResolvePublicAppConfigInput(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/app_config/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/request.py
@@ -1,0 +1,38 @@
+"""Request DTOs for the merged app_config v2 read."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from ai.backend.common.api_handlers import BaseRequestModel
+from ai.backend.common.identifier.domain import DomainID
+
+__all__ = (
+    "ResolveAppConfigInput",
+    "ResolvePublicAppConfigInput",
+)
+
+
+class ResolveAppConfigInput(BaseRequestModel):
+    """Input for resolving merged AppConfigs at a named domain, for the acting user.
+
+    ``domain_id`` is the caller's to name; the user is not — the adapter takes it from the
+    session, so a resolve is only ever for the acting user.
+    """
+
+    config_names: list[str] = Field(
+        min_length=1, description="Config names to resolve the merged view for."
+    )
+    domain_id: DomainID = Field(description="Domain to resolve the domain-scope overlay at.")
+
+
+class ResolvePublicAppConfigInput(BaseRequestModel):
+    """Input for the anonymous, pre-login read, where only public fragments contribute.
+
+    A pre-login screen usually needs several configs at once, so this takes the same batch
+    as the authenticated resolve — it just names no principal.
+    """
+
+    config_names: list[str] = Field(
+        min_length=1, description="Config names to resolve the merged public view for."
+    )

--- a/src/ai/backend/common/dto/manager/v2/app_config/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/request.py
@@ -7,22 +7,22 @@ from pydantic import Field
 from ai.backend.common.api_handlers import BaseRequestModel
 
 __all__ = (
-    "ResolveAppConfigInput",
-    "ResolvePublicAppConfigInput",
+    "MyGetAppConfigsInput",
+    "GetPublicAppConfigsInput",
 )
 
 
-class ResolveAppConfigInput(BaseRequestModel):
-    """Input for resolving merged AppConfigs; the scope comes from the session."""
+class MyGetAppConfigsInput(BaseRequestModel):
+    """Input for the acting user's merged AppConfigs; the scope comes from the session."""
 
     config_names: list[str] = Field(
-        min_length=1, description="Config names to resolve the merged view for."
+        min_length=1, description="Config names to get the merged view for."
     )
 
 
-class ResolvePublicAppConfigInput(BaseRequestModel):
+class GetPublicAppConfigsInput(BaseRequestModel):
     """Input for the anonymous, pre-login read, where only public fragments contribute."""
 
     config_names: list[str] = Field(
-        min_length=1, description="Config names to resolve the merged public view for."
+        min_length=1, description="Config names to get the merged public view for."
     )

--- a/src/ai/backend/common/dto/manager/v2/app_config/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/request.py
@@ -13,11 +13,7 @@ __all__ = (
 
 
 class ResolveAppConfigInput(BaseRequestModel):
-    """Input for resolving merged AppConfigs for the acting user.
-
-    The scope is never caller-supplied: the adapter takes both the user and the domain from
-    the session, so a resolve is only ever for the acting user in their own domain.
-    """
+    """Input for resolving merged AppConfigs; the scope comes from the session."""
 
     config_names: list[str] = Field(
         min_length=1, description="Config names to resolve the merged view for."
@@ -25,11 +21,7 @@ class ResolveAppConfigInput(BaseRequestModel):
 
 
 class ResolvePublicAppConfigInput(BaseRequestModel):
-    """Input for the anonymous, pre-login read, where only public fragments contribute.
-
-    A pre-login screen usually needs several configs at once, so this takes the same batch
-    as the authenticated resolve — it just names no principal.
-    """
+    """Input for the anonymous, pre-login read, where only public fragments contribute."""
 
     config_names: list[str] = Field(
         min_length=1, description="Config names to resolve the merged public view for."

--- a/src/ai/backend/common/dto/manager/v2/app_config/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/request.py
@@ -5,41 +5,22 @@ from __future__ import annotations
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseRequestModel
-from ai.backend.common.identifier.domain import DomainID
 
 __all__ = (
-    "AppConfigScopeArgumentsDTO",
     "ResolveAppConfigInput",
     "ResolvePublicAppConfigInput",
 )
 
 
-class AppConfigScopeArgumentsDTO(BaseRequestModel):
-    """The scope a caller supplies for a resolve — the domain, never the user.
-
-    The wire twin of the repository's ``AppConfigScopeArguments``: the adapter fills the
-    user from the session, so a resolve is only ever for the acting user. Grow new
-    caller-supplied scope dimensions here, mirroring the repository type, rather than adding
-    flat fields to the request.
-    """
-
-    # TODO(BA-7003): domain_ids is a list but only the first element is used. This is a
-    # temporary, strictly-incorrect shape kept for wire compatibility; collapse it to a
-    # single domain once BA-7003 lands.
-    domain_ids: list[DomainID] = Field(
-        min_length=1,
-        description="Domains to resolve the domain-scope overlay at. Only the first is used.",
-    )
-
-
 class ResolveAppConfigInput(BaseRequestModel):
-    """Input for resolving merged AppConfigs at a named scope, for the acting user."""
+    """Input for resolving merged AppConfigs for the acting user.
+
+    The scope is never caller-supplied: the adapter takes both the user and the domain from
+    the session, so a resolve is only ever for the acting user in their own domain.
+    """
 
     config_names: list[str] = Field(
         min_length=1, description="Config names to resolve the merged view for."
-    )
-    scope_arguments: AppConfigScopeArgumentsDTO = Field(
-        description="Caller-supplied scope for the resolve."
     )
 
 

--- a/src/ai/backend/common/dto/manager/v2/app_config/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/request.py
@@ -8,7 +8,7 @@ from ai.backend.common.api_handlers import BaseRequestModel
 
 __all__ = (
     "MyGetAppConfigsInput",
-    "GetPublicAppConfigsInput",
+    "PublicGetAppConfigsInput",
 )
 
 
@@ -20,7 +20,7 @@ class MyGetAppConfigsInput(BaseRequestModel):
     )
 
 
-class GetPublicAppConfigsInput(BaseRequestModel):
+class PublicGetAppConfigsInput(BaseRequestModel):
     """Input for the anonymous, pre-login read, where only public fragments contribute."""
 
     config_names: list[str] = Field(

--- a/src/ai/backend/common/dto/manager/v2/app_config/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/request.py
@@ -23,7 +23,13 @@ class AppConfigScopeArgumentsDTO(BaseRequestModel):
     flat fields to the request.
     """
 
-    domain_id: DomainID = Field(description="Domain to resolve the domain-scope overlay at.")
+    # TODO(BA-7003): domain_ids is a list but only the first element is used. This is a
+    # temporary, strictly-incorrect shape kept for wire compatibility; collapse it to a
+    # single domain once BA-7003 lands.
+    domain_ids: list[DomainID] = Field(
+        min_length=1,
+        description="Domains to resolve the domain-scope overlay at. Only the first is used.",
+    )
 
 
 class ResolveAppConfigInput(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/app_config/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/response.py
@@ -1,0 +1,37 @@
+"""Response DTOs for the merged app_config v2 read."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import Field
+
+from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import AppConfigFragmentNode
+
+__all__ = (
+    "AppConfigNode",
+    "ResolveAppConfigPayload",
+)
+
+
+class AppConfigNode(BaseResponseModel):
+    """The merged AppConfig view for one config name."""
+
+    config_name: str = Field(description="Config name this merged view is for.")
+    merged_config: dict[str, Any] | None = Field(
+        description="Deep-merged config in ascending allow-list rank order; null when no fragment "
+        "contributes (the config name is defined but unconfigured for this scope)."
+    )
+    fragments: list[AppConfigFragmentNode] = Field(
+        description="The fragments that contributed to the merge, in ascending allow-list rank order."
+    )
+
+
+class ResolveAppConfigPayload(BaseResponseModel):
+    """Payload for a merged AppConfig resolve."""
+
+    app_configs: list[AppConfigNode] = Field(
+        description="One merged view per requested config name, in request order; a repeated "
+        "name is repeated here."
+    )

--- a/src/ai/backend/common/dto/manager/v2/app_config/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/response.py
@@ -7,7 +7,6 @@ from typing import Any
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
-from ai.backend.common.dto.manager.v2.app_config_fragment.response import AppConfigFragmentNode
 
 __all__ = (
     "AppConfigNode",
@@ -21,10 +20,8 @@ class AppConfigNode(BaseResponseModel):
     config_name: str = Field(description="Config name this merged view is for.")
     merged_config: dict[str, Any] = Field(
         description="Deep-merged config in ascending allow-list rank order. Empty when nothing "
-        "visible to the caller contributes, or when every contributing fragment was empty."
-    )
-    fragments: list[AppConfigFragmentNode] = Field(
-        description="The fragments that contributed, in ascending allow-list rank order."
+        "visible to the caller contributes, or when every contributing fragment was empty. Read "
+        "the fragment API for the per-scope values behind it."
     )
 
 

--- a/src/ai/backend/common/dto/manager/v2/app_config/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/response.py
@@ -17,11 +17,11 @@ __all__ = (
 class AppConfigNode(BaseResponseModel):
     """The merged AppConfig view for one config name."""
 
-    config_name: str = Field(description="Config name this merged view is for.")
-    merged_config: dict[str, Any] = Field(
-        description="Deep-merged config in ascending allow-list rank order. Empty when nothing "
-        "visible to the caller contributes, or when every contributing fragment was empty. Read "
-        "the fragment API for the per-scope values behind it."
+    config_name: str = Field(description="Config name this view is for.")
+    config: dict[str, Any] = Field(
+        description="Every fragment visible to the caller, deep-merged in ascending allow-list "
+        "rank order. Empty when nothing visible contributes, or when everything that did was "
+        "empty. Read the fragment API for the per-scope values behind it."
     )
 
 

--- a/src/ai/backend/common/dto/manager/v2/app_config/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/response.py
@@ -20,12 +20,14 @@ class AppConfigNode(BaseResponseModel):
 
     config_name: str = Field(description="Config name this merged view is for.")
     merged_config: dict[str, Any] = Field(
-        description="Deep-merged config in ascending allow-list rank order. At least one fragment "
-        "always contributes (a name nothing contributes to fails the call with a 404), so this is "
-        "never null; an empty object means the contributing fragments were themselves empty."
+        description="Deep-merged config in ascending allow-list rank order. Never null; an empty "
+        "object means either that no fragment visible to the caller contributes to this name, or "
+        "that the contributing fragments were themselves empty — read `fragments` to tell the two "
+        "apart."
     )
     fragments: list[AppConfigFragmentNode] = Field(
-        description="The fragments that contributed to the merge, in ascending allow-list rank order."
+        description="The fragments that contributed to the merge, in ascending allow-list rank "
+        "order. Empty when nothing visible to the caller contributes to this name."
     )
 
 

--- a/src/ai/backend/common/dto/manager/v2/app_config/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/response.py
@@ -11,7 +11,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.response import AppCon
 
 __all__ = (
     "AppConfigNode",
-    "ResolveAppConfigPayload",
+    "GetAppConfigsPayload",
 )
 
 
@@ -29,8 +29,8 @@ class AppConfigNode(BaseResponseModel):
     )
 
 
-class ResolveAppConfigPayload(BaseResponseModel):
-    """Payload for a merged AppConfig resolve."""
+class GetAppConfigsPayload(BaseResponseModel):
+    """Payload for a merged AppConfig get."""
 
     app_configs: list[AppConfigNode] = Field(
         description="One merged view per requested config name, in request order; a repeated "

--- a/src/ai/backend/common/dto/manager/v2/app_config/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/response.py
@@ -19,9 +19,10 @@ class AppConfigNode(BaseResponseModel):
     """The merged AppConfig view for one config name."""
 
     config_name: str = Field(description="Config name this merged view is for.")
-    merged_config: dict[str, Any] | None = Field(
-        description="Deep-merged config in ascending allow-list rank order; null when no fragment "
-        "contributes (the config name is defined but unconfigured for this scope)."
+    merged_config: dict[str, Any] = Field(
+        description="Deep-merged config in ascending allow-list rank order. At least one fragment "
+        "always contributes (a name nothing contributes to fails the call with a 404), so this is "
+        "never null; an empty object means the contributing fragments were themselves empty."
     )
     fragments: list[AppConfigFragmentNode] = Field(
         description="The fragments that contributed to the merge, in ascending allow-list rank order."

--- a/src/ai/backend/common/dto/manager/v2/app_config/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/response.py
@@ -20,14 +20,11 @@ class AppConfigNode(BaseResponseModel):
 
     config_name: str = Field(description="Config name this merged view is for.")
     merged_config: dict[str, Any] = Field(
-        description="Deep-merged config in ascending allow-list rank order. Never null; an empty "
-        "object means either that no fragment visible to the caller contributes to this name, or "
-        "that the contributing fragments were themselves empty — read `fragments` to tell the two "
-        "apart."
+        description="Deep-merged config in ascending allow-list rank order. Empty when nothing "
+        "visible to the caller contributes, or when every contributing fragment was empty."
     )
     fragments: list[AppConfigFragmentNode] = Field(
-        description="The fragments that contributed to the merge, in ascending allow-list rank "
-        "order. Empty when nothing visible to the caller contributes to this name."
+        description="The fragments that contributed, in ascending allow-list rank order."
     )
 
 

--- a/src/ai/backend/manager/api/adapters/app_config/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config/adapter.py
@@ -1,0 +1,80 @@
+"""App config adapter bridging v2 DTOs and the merged-config (read) Processors."""
+
+from __future__ import annotations
+
+from ai.backend.common.contexts.user import current_user
+from ai.backend.common.data.app_config.types import AppConfigScopeType as AppConfigScopeTypeDTO
+from ai.backend.common.dto.manager.v2.app_config.request import (
+    ResolveAppConfigInput,
+    ResolvePublicAppConfigInput,
+)
+from ai.backend.common.dto.manager.v2.app_config.response import (
+    AppConfigNode,
+    ResolveAppConfigPayload,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import AppConfigFragmentNode
+from ai.backend.common.identifier.user import UserID
+from ai.backend.manager.api.adapters.base import BaseAdapter
+from ai.backend.manager.data.app_config.types import AppConfigData
+from ai.backend.manager.data.app_config_fragment.types import (
+    AppConfigFragmentData,
+)
+from ai.backend.manager.errors.app_config import AppConfigResolveNotAllowed
+from ai.backend.manager.repositories.app_config_fragment.types import AppConfigScopeArguments
+from ai.backend.manager.services.app_config.actions.resolve import ResolveAppConfigsAction
+
+
+class AppConfigAdapter(BaseAdapter):
+    """Adapter for the merged AppConfig (read) operations."""
+
+    # --- merged AppConfig read ---
+
+    async def resolve(self, input: ResolveAppConfigInput) -> ResolveAppConfigPayload:
+        me = current_user()
+        if me is None:
+            raise AppConfigResolveNotAllowed("App config resolve requires an authenticated user.")
+        action_result = await self._processors.app_config.resolve_app_configs.wait_for_complete(
+            ResolveAppConfigsAction(
+                config_names=input.config_names,
+                scope_arguments=AppConfigScopeArguments(domain_id=input.domain_id),
+                user_id=UserID(me.user_id),
+            )
+        )
+        return ResolveAppConfigPayload(
+            app_configs=[
+                self._app_config_to_node(app_config) for app_config in action_result.app_configs
+            ]
+        )
+
+    async def resolve_public(self, input: ResolvePublicAppConfigInput) -> ResolveAppConfigPayload:
+        # Naming no principal is what makes this the anonymous read: only public contributes.
+        action_result = await self._processors.app_config.resolve_app_configs.wait_for_complete(
+            ResolveAppConfigsAction(config_names=input.config_names)
+        )
+        return ResolveAppConfigPayload(
+            app_configs=[
+                self._app_config_to_node(app_config) for app_config in action_result.app_configs
+            ]
+        )
+
+    # --- guards / converters ---
+
+    @staticmethod
+    def _fragment_to_node(data: AppConfigFragmentData) -> AppConfigFragmentNode:
+        return AppConfigFragmentNode(
+            id=data.id,
+            config_name=data.config_name,
+            scope_type=AppConfigScopeTypeDTO(data.scope_type.value),
+            scope_id=data.scope_id,
+            config=data.config,
+            created_at=data.created_at,
+            updated_at=data.updated_at,
+        )
+
+    @classmethod
+    def _app_config_to_node(cls, data: AppConfigData) -> AppConfigNode:
+        return AppConfigNode(
+            config_name=data.config_name,
+            merged_config=data.merged_config,
+            fragments=[cls._fragment_to_node(fragment) for fragment in data.fragments],
+        )

--- a/src/ai/backend/manager/api/adapters/app_config/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config/adapter.py
@@ -13,13 +13,13 @@ from ai.backend.common.dto.manager.v2.app_config.response import (
     ResolveAppConfigPayload,
 )
 from ai.backend.common.dto.manager.v2.app_config_fragment.response import AppConfigFragmentNode
+from ai.backend.common.exception import UnreachableError
 from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.app_config.types import AppConfigData
 from ai.backend.manager.data.app_config_fragment.types import (
     AppConfigFragmentData,
 )
-from ai.backend.manager.errors.app_config import AppConfigResolveNotAllowed
 from ai.backend.manager.repositories.app_config_fragment.types import AppConfigScopeArguments
 from ai.backend.manager.services.app_config.actions.resolve import ResolveAppConfigsAction
 
@@ -32,7 +32,8 @@ class AppConfigAdapter(BaseAdapter):
     async def resolve(self, input: ResolveAppConfigInput) -> ResolveAppConfigPayload:
         me = current_user()
         if me is None:
-            raise AppConfigResolveNotAllowed("App config resolve requires an authenticated user.")
+            # ``auth_required`` guarantees a session on this route, so this is never hit.
+            raise UnreachableError("User context is not available")
         action_result = await self._processors.app_config.resolve_app_configs.wait_for_complete(
             ResolveAppConfigsAction(
                 config_names=input.config_names,

--- a/src/ai/backend/manager/api/adapters/app_config/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config/adapter.py
@@ -37,7 +37,7 @@ class AppConfigAdapter(BaseAdapter):
         action_result = await self._processors.app_config.resolve_app_configs.wait_for_complete(
             ResolveAppConfigsAction(
                 config_names=input.config_names,
-                scope_arguments=AppConfigScopeArguments(domain_id=input.domain_id),
+                scope_arguments=AppConfigScopeArguments(domain_id=input.scope_arguments.domain_id),
                 user_id=UserID(me.user_id),
             )
         )

--- a/src/ai/backend/manager/api/adapters/app_config/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config/adapter.py
@@ -37,7 +37,10 @@ class AppConfigAdapter(BaseAdapter):
         action_result = await self._processors.app_config.resolve_app_configs.wait_for_complete(
             ResolveAppConfigsAction(
                 config_names=input.config_names,
-                scope_arguments=AppConfigScopeArguments(domain_id=input.scope_arguments.domain_id),
+                # TODO(BA-7003): only the first domain is used — see AppConfigScopeArgumentsDTO.
+                scope_arguments=AppConfigScopeArguments(
+                    domain_id=input.scope_arguments.domain_ids[0]
+                ),
                 user_id=UserID(me.user_id),
             )
         )

--- a/src/ai/backend/manager/api/adapters/app_config/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config/adapter.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from ai.backend.common.contexts.user import current_user
-from ai.backend.common.data.app_config.types import AppConfigScopeType as AppConfigScopeTypeDTO
 from ai.backend.common.dto.manager.v2.app_config.request import (
     MyGetAppConfigsInput,
     PublicGetAppConfigsInput,
@@ -12,14 +11,10 @@ from ai.backend.common.dto.manager.v2.app_config.response import (
     AppConfigNode,
     GetAppConfigsPayload,
 )
-from ai.backend.common.dto.manager.v2.app_config_fragment.response import AppConfigFragmentNode
 from ai.backend.common.exception import UnreachableError
 from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.app_config.types import AppConfigData
-from ai.backend.manager.data.app_config_fragment.types import (
-    AppConfigFragmentData,
-)
 from ai.backend.manager.services.app_config.actions.get import GetAppConfigsAction
 
 
@@ -57,21 +52,8 @@ class AppConfigAdapter(BaseAdapter):
     # --- converters ---
 
     @staticmethod
-    def _fragment_to_node(data: AppConfigFragmentData) -> AppConfigFragmentNode:
-        return AppConfigFragmentNode(
-            id=data.id,
-            config_name=data.config_name,
-            scope_type=AppConfigScopeTypeDTO(data.scope_type.value),
-            scope_id=data.scope_id,
-            config=data.config,
-            created_at=data.created_at,
-            updated_at=data.updated_at,
-        )
-
-    @classmethod
-    def _app_config_to_node(cls, data: AppConfigData) -> AppConfigNode:
+    def _app_config_to_node(data: AppConfigData) -> AppConfigNode:
         return AppConfigNode(
             config_name=data.config_name,
             merged_config=data.merged_config,
-            fragments=[cls._fragment_to_node(fragment) for fragment in data.fragments],
         )

--- a/src/ai/backend/manager/api/adapters/app_config/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config/adapter.py
@@ -20,7 +20,6 @@ from ai.backend.manager.data.app_config.types import AppConfigData
 from ai.backend.manager.data.app_config_fragment.types import (
     AppConfigFragmentData,
 )
-from ai.backend.manager.repositories.app_config_fragment.types import AppConfigScopeArguments
 from ai.backend.manager.services.app_config.actions.resolve import ResolveAppConfigsAction
 
 
@@ -37,10 +36,7 @@ class AppConfigAdapter(BaseAdapter):
         action_result = await self._processors.app_config.resolve_app_configs.wait_for_complete(
             ResolveAppConfigsAction(
                 config_names=input.config_names,
-                # TODO(BA-7003): only the first domain is used — see AppConfigScopeArgumentsDTO.
-                scope_arguments=AppConfigScopeArguments(
-                    domain_id=input.scope_arguments.domain_ids[0]
-                ),
+                domain_name=me.domain_name,
                 user_id=UserID(me.user_id),
             )
         )

--- a/src/ai/backend/manager/api/adapters/app_config/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config/adapter.py
@@ -30,7 +30,11 @@ class AppConfigAdapter(BaseAdapter):
             # ``auth_required`` guarantees a session on this route, so this is never hit.
             raise UnreachableError("User context is not available")
         action_result = await self._processors.app_config.get_app_configs.wait_for_complete(
-            GetAppConfigsAction(config_names=input.config_names, user_id=UserID(me.user_id))
+            GetAppConfigsAction(
+                config_names=input.config_names,
+                user_id=UserID(me.user_id),
+                domain_id=me.domain_id,
+            )
         )
         return GetAppConfigsPayload(
             app_configs=[

--- a/src/ai/backend/manager/api/adapters/app_config/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config/adapter.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from ai.backend.common.contexts.user import current_user
 from ai.backend.common.data.app_config.types import AppConfigScopeType as AppConfigScopeTypeDTO
 from ai.backend.common.dto.manager.v2.app_config.request import (
-    ResolveAppConfigInput,
-    ResolvePublicAppConfigInput,
+    GetPublicAppConfigsInput,
+    MyGetAppConfigsInput,
 )
 from ai.backend.common.dto.manager.v2.app_config.response import (
     AppConfigNode,
-    ResolveAppConfigPayload,
+    GetAppConfigsPayload,
 )
 from ai.backend.common.dto.manager.v2.app_config_fragment.response import AppConfigFragmentNode
 from ai.backend.common.exception import UnreachableError
@@ -20,7 +20,7 @@ from ai.backend.manager.data.app_config.types import AppConfigData
 from ai.backend.manager.data.app_config_fragment.types import (
     AppConfigFragmentData,
 )
-from ai.backend.manager.services.app_config.actions.resolve import ResolveAppConfigsAction
+from ai.backend.manager.services.app_config.actions.get import GetAppConfigsAction
 
 
 class AppConfigAdapter(BaseAdapter):
@@ -28,30 +28,30 @@ class AppConfigAdapter(BaseAdapter):
 
     # --- merged AppConfig read ---
 
-    async def resolve(self, input: ResolveAppConfigInput) -> ResolveAppConfigPayload:
+    async def my_get_app_configs(self, input: MyGetAppConfigsInput) -> GetAppConfigsPayload:
+        """The acting user's merged AppConfigs.
+
+        Calls ``current_user()`` internally — the caller does not pass a scope.
+        """
         me = current_user()
         if me is None:
             # ``auth_required`` guarantees a session on this route, so this is never hit.
             raise UnreachableError("User context is not available")
-        action_result = await self._processors.app_config.resolve_app_configs.wait_for_complete(
-            ResolveAppConfigsAction(
-                config_names=input.config_names,
-                domain_name=me.domain_name,
-                user_id=UserID(me.user_id),
-            )
+        action_result = await self._processors.app_config.get_app_configs.wait_for_complete(
+            GetAppConfigsAction(config_names=input.config_names, user_id=UserID(me.user_id))
         )
-        return ResolveAppConfigPayload(
+        return GetAppConfigsPayload(
             app_configs=[
                 self._app_config_to_node(app_config) for app_config in action_result.app_configs
             ]
         )
 
-    async def resolve_public(self, input: ResolvePublicAppConfigInput) -> ResolveAppConfigPayload:
+    async def get_public_app_configs(self, input: GetPublicAppConfigsInput) -> GetAppConfigsPayload:
         # Naming no principal is what makes this the anonymous read: only public contributes.
-        action_result = await self._processors.app_config.resolve_app_configs.wait_for_complete(
-            ResolveAppConfigsAction(config_names=input.config_names)
+        action_result = await self._processors.app_config.get_app_configs.wait_for_complete(
+            GetAppConfigsAction(config_names=input.config_names)
         )
-        return ResolveAppConfigPayload(
+        return GetAppConfigsPayload(
             app_configs=[
                 self._app_config_to_node(app_config) for app_config in action_result.app_configs
             ]

--- a/src/ai/backend/manager/api/adapters/app_config/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config/adapter.py
@@ -55,5 +55,5 @@ class AppConfigAdapter(BaseAdapter):
     def _app_config_to_node(data: AppConfigData) -> AppConfigNode:
         return AppConfigNode(
             config_name=data.config_name,
-            merged_config=data.merged_config,
+            config=data.config,
         )

--- a/src/ai/backend/manager/api/adapters/app_config/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config/adapter.py
@@ -29,10 +29,7 @@ class AppConfigAdapter(BaseAdapter):
     # --- merged AppConfig read ---
 
     async def my_get_app_configs(self, input: MyGetAppConfigsInput) -> GetAppConfigsPayload:
-        """The acting user's merged AppConfigs.
-
-        Calls ``current_user()`` internally — the caller does not pass a scope.
-        """
+        """The acting user's merged AppConfigs; the scope comes from the session, not the caller."""
         me = current_user()
         if me is None:
             # ``auth_required`` guarantees a session on this route, so this is never hit.
@@ -47,7 +44,7 @@ class AppConfigAdapter(BaseAdapter):
         )
 
     async def public_get_app_configs(self, input: PublicGetAppConfigsInput) -> GetAppConfigsPayload:
-        # Naming no principal is what makes this the anonymous read: only public contributes.
+        """Merged AppConfigs from public fragments only; naming no principal is what makes it anonymous."""
         action_result = await self._processors.app_config.get_app_configs.wait_for_complete(
             GetAppConfigsAction(config_names=input.config_names)
         )
@@ -57,7 +54,7 @@ class AppConfigAdapter(BaseAdapter):
             ]
         )
 
-    # --- guards / converters ---
+    # --- converters ---
 
     @staticmethod
     def _fragment_to_node(data: AppConfigFragmentData) -> AppConfigFragmentNode:

--- a/src/ai/backend/manager/api/adapters/app_config/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config/adapter.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from ai.backend.common.contexts.user import current_user
 from ai.backend.common.data.app_config.types import AppConfigScopeType as AppConfigScopeTypeDTO
 from ai.backend.common.dto.manager.v2.app_config.request import (
-    GetPublicAppConfigsInput,
     MyGetAppConfigsInput,
+    PublicGetAppConfigsInput,
 )
 from ai.backend.common.dto.manager.v2.app_config.response import (
     AppConfigNode,
@@ -46,7 +46,7 @@ class AppConfigAdapter(BaseAdapter):
             ]
         )
 
-    async def get_public_app_configs(self, input: GetPublicAppConfigsInput) -> GetAppConfigsPayload:
+    async def public_get_app_configs(self, input: PublicGetAppConfigsInput) -> GetAppConfigsPayload:
         # Naming no principal is what makes this the anonymous read: only public contributes.
         action_result = await self._processors.app_config.get_app_configs.wait_for_complete(
             GetAppConfigsAction(config_names=input.config_names)

--- a/src/ai/backend/manager/api/adapters/registry.py
+++ b/src/ai/backend/manager/api/adapters/registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ai.backend.manager.api.adapters.agent.adapter import AgentAdapter
+from ai.backend.manager.api.adapters.app_config.adapter import AppConfigAdapter
 from ai.backend.manager.api.adapters.app_config_allow_list.adapter import (
     AppConfigAllowListAdapter,
 )
@@ -86,6 +87,7 @@ class Adapters:
     def __init__(
         self,
         agent: AgentAdapter,
+        app_config: AppConfigAdapter,
         app_config_fragment: AppConfigFragmentAdapter,
         app_config_allow_list: AppConfigAllowListAdapter,
         app_config_definition: AppConfigDefinitionAdapter,
@@ -133,6 +135,7 @@ class Adapters:
         vfs_storage: VFSStorageAdapter,
     ) -> None:
         self.agent = agent
+        self.app_config = app_config
         self.app_config_fragment = app_config_fragment
         self.app_config_allow_list = app_config_allow_list
         self.app_config_definition = app_config_definition
@@ -199,6 +202,7 @@ class Adapters:
         """
         return cls(
             agent=AgentAdapter(processors),
+            app_config=AppConfigAdapter(processors),
             app_config_fragment=AppConfigFragmentAdapter(processors),
             app_config_allow_list=AppConfigAllowListAdapter(processors),
             app_config_definition=AppConfigDefinitionAdapter(processors),

--- a/src/ai/backend/manager/api/rest/middleware/auth.py
+++ b/src/ai/backend/manager/api/rest/middleware/auth.py
@@ -700,7 +700,7 @@ def _authenticated_user(request: web.Request) -> UserData | None:
         is_superadmin=request.get("is_superadmin", False),
         role=UserRole(user["role"]),
         domain_name=user["domain_name"],
-        domain_id=user.get("domain_id"),
+        domain_id=user["domain_id"],
     )
 
 

--- a/src/ai/backend/manager/api/rest/middleware/auth.py
+++ b/src/ai/backend/manager/api/rest/middleware/auth.py
@@ -700,7 +700,7 @@ def _authenticated_user(request: web.Request) -> UserData | None:
         is_superadmin=request.get("is_superadmin", False),
         role=UserRole(user["role"]),
         domain_name=user["domain_name"],
-        domain_id=user["domain_id"],
+        domain_id=user.get("domain_id"),
     )
 
 

--- a/src/ai/backend/manager/api/rest/middleware/auth.py
+++ b/src/ai/backend/manager/api/rest/middleware/auth.py
@@ -54,6 +54,7 @@ from ai.backend.manager.errors.auth import (
     UserNotFound,
 )
 from ai.backend.manager.errors.common import GenericForbidden, InternalServerError, RejectedByHook
+from ai.backend.manager.models.domain.row import DomainRow
 from ai.backend.manager.models.keypair import keypairs
 from ai.backend.manager.models.resource_policy import (
     keypair_resource_policies,
@@ -487,15 +488,23 @@ async def _query_cred_by_access_key(
         if keypair_row is None:
             return None, None
 
-        j = users.join(
-            user_resource_policies,
-            users.c.resource_policy == user_resource_policies.c.name,
-        ).join(
-            keypairs,
-            users.c.uuid == keypairs.c.user,
+        j = (
+            users.join(
+                user_resource_policies,
+                users.c.resource_policy == user_resource_policies.c.name,
+            )
+            .join(
+                keypairs,
+                users.c.uuid == keypairs.c.user,
+            )
+            # A user names its domain, so the id comes from here rather than a later lookup.
+            .join(
+                DomainRow.__table__,
+                users.c.domain_name == DomainRow.__table__.c.name,
+            )
         )
         query = (
-            sa.select(users, user_resource_policies)
+            sa.select(users, user_resource_policies, DomainRow.__table__.c.id.label("domain_id"))
             .set_label_style(sa.LABEL_STYLE_TABLENAME_PLUS_COL)
             .select_from(j)
             .where(keypairs.c.access_key == access_key)
@@ -542,6 +551,7 @@ def _populate_auth_result(
         col.name: user_mapping[f"user_resource_policies_{col.name}"]
         for col in user_resource_policies.c
     }
+    auth_result["user"]["domain_id"] = user_mapping["domain_id"]
     auth_result["user"]["id"] = keypair_mapping["keypairs_user_id"]  # legacy
     auth_result["is_superadmin"] = auth_result["user"]["role"] == "superadmin"
 
@@ -652,25 +662,29 @@ async def _authenticate_via_hook(
 async def _load_user_data(db: ExtendedAsyncSAEngine, user_id: UserID) -> UserData:
     """Load a user's ``UserData`` by UUID (impersonation target). Raises if not found."""
 
-    async def _query() -> UserRow | None:
+    async def _query() -> sa.Row[Any] | None:
         async with db.begin_readonly_session_read_committed() as session:
-            row: UserRow | None = await session.scalar(
-                sa.select(UserRow).where(UserRow.uuid == user_id)
+            result = await session.execute(
+                sa.select(UserRow, DomainRow.id.label("domain_id"))
+                .join(DomainRow, UserRow.domain_name == DomainRow.name)
+                .where(UserRow.uuid == user_id)
             )
-            return row
+            return result.first()
 
     row = await execute_with_retry(_query)
     if row is None:
         raise UserNotFound("Impersonation target user not found")
-    if row.role is None or row.domain_name is None:
+    user_row: UserRow = row.UserRow
+    if user_row.role is None or user_row.domain_name is None:
         raise InternalServerError(f"Impersonation target user is misconfigured (user_id={user_id})")
     return UserData(
-        user_id=row.uuid,
+        user_id=user_row.uuid,
         is_authorized=True,
-        is_admin=row.role in (UserRole.ADMIN, UserRole.SUPERADMIN),
-        is_superadmin=row.role == UserRole.SUPERADMIN,
-        role=row.role,
-        domain_name=row.domain_name,
+        is_admin=user_row.role in (UserRole.ADMIN, UserRole.SUPERADMIN),
+        is_superadmin=user_row.role == UserRole.SUPERADMIN,
+        role=user_row.role,
+        domain_name=user_row.domain_name,
+        domain_id=row.domain_id,
     )
 
 
@@ -686,6 +700,7 @@ def _authenticated_user(request: web.Request) -> UserData | None:
         is_superadmin=request.get("is_superadmin", False),
         role=UserRole(user["role"]),
         domain_name=user["domain_name"],
+        domain_id=user["domain_id"],
     )
 
 

--- a/src/ai/backend/manager/api/rest/v2/app_config/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config/handler.py
@@ -1,0 +1,42 @@
+"""REST v2 handler for the merged app config (read) domain."""
+
+from __future__ import annotations
+
+import logging
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Final
+
+from ai.backend.common.api_handlers import APIResponse, BodyParam
+from ai.backend.common.dto.manager.v2.app_config.request import (
+    ResolveAppConfigInput,
+    ResolvePublicAppConfigInput,
+)
+from ai.backend.logging import BraceStyleAdapter
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.adapters.app_config.adapter import AppConfigAdapter
+
+log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class V2AppConfigHandler:
+    """REST v2 handler for the merged AppConfig read operations."""
+
+    def __init__(self, *, adapter: AppConfigAdapter) -> None:
+        self._adapter = adapter
+
+    async def resolve(
+        self,
+        body: BodyParam[ResolveAppConfigInput],
+    ) -> APIResponse:
+        """Resolve merged AppConfigs for the authenticated caller (auth required)."""
+        result = await self._adapter.resolve(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def resolve_public(
+        self,
+        body: BodyParam[ResolvePublicAppConfigInput],
+    ) -> APIResponse:
+        """Resolve merged AppConfigs from public fragments only (anonymous)."""
+        result = await self._adapter.resolve_public(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/app_config/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config/handler.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING, Final
 
 from ai.backend.common.api_handlers import APIResponse, BodyParam
 from ai.backend.common.dto.manager.v2.app_config.request import (
-    GetPublicAppConfigsInput,
     MyGetAppConfigsInput,
+    PublicGetAppConfigsInput,
 )
 from ai.backend.logging import BraceStyleAdapter
 
@@ -35,10 +35,10 @@ class V2AppConfigHandler:
         result = await self._adapter.my_get_app_configs(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
-    async def get_public(
+    async def public_get(
         self,
-        body: BodyParam[GetPublicAppConfigsInput],
+        body: BodyParam[PublicGetAppConfigsInput],
     ) -> APIResponse:
         """Get merged AppConfigs from public fragments only (anonymous)."""
-        result = await self._adapter.get_public_app_configs(body.parsed)
+        result = await self._adapter.public_get_app_configs(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/app_config/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config/handler.py
@@ -27,7 +27,7 @@ class V2AppConfigHandler:
     def __init__(self, *, adapter: AppConfigAdapter) -> None:
         self._adapter = adapter
 
-    async def my_get(
+    async def my_get_app_configs(
         self,
         body: BodyParam[MyGetAppConfigsInput],
     ) -> APIResponse:
@@ -35,7 +35,7 @@ class V2AppConfigHandler:
         result = await self._adapter.my_get_app_configs(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
-    async def public_get(
+    async def public_get_app_configs(
         self,
         body: BodyParam[PublicGetAppConfigsInput],
     ) -> APIResponse:

--- a/src/ai/backend/manager/api/rest/v2/app_config/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config/handler.py
@@ -22,6 +22,8 @@ log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
 class V2AppConfigHandler:
     """REST v2 handler for the merged AppConfig read operations."""
 
+    _adapter: AppConfigAdapter
+
     def __init__(self, *, adapter: AppConfigAdapter) -> None:
         self._adapter = adapter
 

--- a/src/ai/backend/manager/api/rest/v2/app_config/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config/handler.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING, Final
 
 from ai.backend.common.api_handlers import APIResponse, BodyParam
 from ai.backend.common.dto.manager.v2.app_config.request import (
-    ResolveAppConfigInput,
-    ResolvePublicAppConfigInput,
+    GetPublicAppConfigsInput,
+    MyGetAppConfigsInput,
 )
 from ai.backend.logging import BraceStyleAdapter
 
@@ -27,18 +27,18 @@ class V2AppConfigHandler:
     def __init__(self, *, adapter: AppConfigAdapter) -> None:
         self._adapter = adapter
 
-    async def resolve(
+    async def my_get(
         self,
-        body: BodyParam[ResolveAppConfigInput],
+        body: BodyParam[MyGetAppConfigsInput],
     ) -> APIResponse:
-        """Resolve merged AppConfigs for the authenticated caller (auth required)."""
-        result = await self._adapter.resolve(body.parsed)
+        """Get the acting user's merged AppConfigs (auth required)."""
+        result = await self._adapter.my_get_app_configs(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
-    async def resolve_public(
+    async def get_public(
         self,
-        body: BodyParam[ResolvePublicAppConfigInput],
+        body: BodyParam[GetPublicAppConfigsInput],
     ) -> APIResponse:
-        """Resolve merged AppConfigs from public fragments only (anonymous)."""
-        result = await self._adapter.resolve_public(body.parsed)
+        """Get merged AppConfigs from public fragments only (anonymous)."""
+        result = await self._adapter.get_public_app_configs(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/app_config/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config/registry.py
@@ -1,0 +1,32 @@
+"""Route registry for REST v2 merged app config endpoints."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ai.backend.manager.api.rest.middleware.auth import auth_required
+from ai.backend.manager.api.rest.routing import RouteRegistry
+
+from .handler import V2AppConfigHandler
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.rest.types import RouteDeps
+
+
+def register_v2_app_config_routes(
+    handler: V2AppConfigHandler,
+    route_deps: RouteDeps,
+) -> RouteRegistry:
+    """Register all REST v2 merged app config routes.
+
+    Layout:
+        POST /resolve          resolve merged configs for a principal   (auth)
+        POST /public/resolve   resolve merged public configs            (anonymous)
+    """
+    registry = RouteRegistry.create("app-config", route_deps.cors_options)
+
+    registry.add("POST", "/resolve", handler.resolve, middlewares=[auth_required])
+    # Anonymous (pre-login) public read: no auth middleware.
+    registry.add("POST", "/public/resolve", handler.resolve_public)
+
+    return registry

--- a/src/ai/backend/manager/api/rest/v2/app_config/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config/registry.py
@@ -27,6 +27,6 @@ def register_v2_app_config_routes(
 
     registry.add("POST", "/my/get", handler.my_get, middlewares=[auth_required])
     # Anonymous (pre-login) public read: no auth middleware.
-    registry.add("POST", "/public/get", handler.get_public)
+    registry.add("POST", "/public/get", handler.public_get)
 
     return registry

--- a/src/ai/backend/manager/api/rest/v2/app_config/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config/registry.py
@@ -26,7 +26,7 @@ def register_v2_app_config_routes(
     registry = RouteRegistry.create("app-config", route_deps.cors_options)
 
     registry.add("POST", "/my/get", handler.my_get_app_configs, middlewares=[auth_required])
-    # Anonymous (pre-login) public read: no auth middleware.
+    # Anonymous pre-login read — the missing auth middleware is deliberate.
     registry.add("POST", "/public/get", handler.public_get_app_configs)
 
     return registry

--- a/src/ai/backend/manager/api/rest/v2/app_config/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config/registry.py
@@ -20,13 +20,13 @@ def register_v2_app_config_routes(
     """Register all REST v2 merged app config routes.
 
     Layout:
-        POST /resolve          resolve merged configs for a principal   (auth)
-        POST /public/resolve   resolve merged public configs            (anonymous)
+        POST /my/get       get the acting user's merged configs   (auth)
+        POST /public/get   get the merged public configs          (anonymous)
     """
     registry = RouteRegistry.create("app-config", route_deps.cors_options)
 
-    registry.add("POST", "/resolve", handler.resolve, middlewares=[auth_required])
+    registry.add("POST", "/my/get", handler.my_get, middlewares=[auth_required])
     # Anonymous (pre-login) public read: no auth middleware.
-    registry.add("POST", "/public/resolve", handler.resolve_public)
+    registry.add("POST", "/public/get", handler.get_public)
 
     return registry

--- a/src/ai/backend/manager/api/rest/v2/app_config/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config/registry.py
@@ -25,8 +25,8 @@ def register_v2_app_config_routes(
     """
     registry = RouteRegistry.create("app-config", route_deps.cors_options)
 
-    registry.add("POST", "/my/get", handler.my_get, middlewares=[auth_required])
+    registry.add("POST", "/my/get", handler.my_get_app_configs, middlewares=[auth_required])
     # Anonymous (pre-login) public read: no auth middleware.
-    registry.add("POST", "/public/get", handler.public_get)
+    registry.add("POST", "/public/get", handler.public_get_app_configs)
 
     return registry

--- a/src/ai/backend/manager/api/rest/v2/tree.py
+++ b/src/ai/backend/manager/api/rest/v2/tree.py
@@ -28,6 +28,8 @@ def build_v2_routes(
     # Lazy imports to avoid circular dependencies at module level
     from .agent.handler import V2AgentHandler
     from .agent.registry import register_v2_agent_routes
+    from .app_config.handler import V2AppConfigHandler
+    from .app_config.registry import register_v2_app_config_routes
     from .app_config_allow_list.handler import V2AppConfigAllowListHandler
     from .app_config_allow_list.registry import register_v2_app_config_allow_list_routes
     from .app_config_definition.handler import V2AppConfigDefinitionHandler
@@ -129,6 +131,7 @@ def build_v2_routes(
 
     # Build all handlers (each takes its individual adapter)
     agent_handler = V2AgentHandler(adapter=adapters.agent)
+    app_config_handler = V2AppConfigHandler(adapter=adapters.app_config)
     app_config_fragment_handler = V2AppConfigFragmentHandler(adapter=adapters.app_config_fragment)
     app_config_allow_list_handler = V2AppConfigAllowListHandler(
         adapter=adapters.app_config_allow_list
@@ -198,6 +201,7 @@ def build_v2_routes(
 
     # Add all domain sub-registries
     v2_reg.add_subregistry(register_v2_agent_routes(agent_handler, route_deps))
+    v2_reg.add_subregistry(register_v2_app_config_routes(app_config_handler, route_deps))
     v2_reg.add_subregistry(
         register_v2_app_config_fragment_routes(app_config_fragment_handler, route_deps)
     )

--- a/src/ai/backend/manager/data/app_config/types.py
+++ b/src/ai/backend/manager/data/app_config/types.py
@@ -8,10 +8,10 @@ from typing import Any
 class AppConfigData:
     """Merged per-user view of one ``config_name``.
 
-    Only the merge is carried, not the fragments behind it — the fragment API answers which
-    scope holds which value. An empty ``merged_config`` therefore means either that nothing
-    visible contributed or that everything that did was empty.
+    ``config`` is every visible fragment deep-merged, not the fragments themselves — the
+    fragment API answers which scope holds which value. An empty ``config`` therefore means
+    either that nothing visible contributed or that everything that did was empty.
     """
 
     config_name: str
-    merged_config: dict[str, Any]
+    config: dict[str, Any]

--- a/src/ai/backend/manager/data/app_config/types.py
+++ b/src/ai/backend/manager/data/app_config/types.py
@@ -3,18 +3,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
-
 
 @dataclass(frozen=True)
 class AppConfigData:
     """Merged per-user view of one ``config_name``.
 
-    The contributing ``fragments`` (rank low -> high) plus their deep-merged ``merged_config``.
-    At least one fragment always contributes, so an empty ``merged_config`` means the
-    fragments themselves were empty — not that none were found.
+    Only the merge is carried, not the fragments behind it — the fragment API answers which
+    scope holds which value. An empty ``merged_config`` therefore means either that nothing
+    visible contributed or that everything that did was empty.
     """
 
     config_name: str
-    fragments: list[AppConfigFragmentData]
     merged_config: dict[str, Any]

--- a/src/ai/backend/manager/errors/app_config.py
+++ b/src/ai/backend/manager/errors/app_config.py
@@ -7,6 +7,7 @@ __all__ = (
     "AppConfigDefinitionNotFound",
     "AppConfigFragmentNotFound",
     "AppConfigFragmentWriteNotAllowed",
+    "AppConfigResolveNotAllowed",
 )
 
 
@@ -34,3 +35,14 @@ class AppConfigFragmentWriteNotAllowed(GenericForbidden):
 
     error_type = "https://api.backend.ai/probs/app-config-fragment-write-not-allowed"
     error_title = "App config fragment write is not allowed for this config/scope."
+
+
+class AppConfigResolveNotAllowed(GenericForbidden):
+    """A merged-AppConfig read was requested for a principal other than the caller.
+
+    Temporary per-request guard standing in for an RBAC validator: a resolve / scoped
+    search whose ``user_id`` does not match the authenticated caller is rejected.
+    """
+
+    error_type = "https://api.backend.ai/probs/app-config-resolve-not-allowed"
+    error_title = "App config resolve is not allowed for this principal."

--- a/src/ai/backend/manager/errors/app_config.py
+++ b/src/ai/backend/manager/errors/app_config.py
@@ -7,7 +7,6 @@ __all__ = (
     "AppConfigDefinitionNotFound",
     "AppConfigFragmentNotFound",
     "AppConfigFragmentWriteNotAllowed",
-    "AppConfigResolveNotAllowed",
 )
 
 
@@ -35,15 +34,3 @@ class AppConfigFragmentWriteNotAllowed(GenericForbidden):
 
     error_type = "https://api.backend.ai/probs/app-config-fragment-write-not-allowed"
     error_title = "App config fragment write is not allowed for this config/scope."
-
-
-class AppConfigResolveNotAllowed(GenericForbidden):
-    """A merged-AppConfig read reached the adapter with no principal to resolve for.
-
-    ``/resolve`` is the read for the acting user, so the adapter takes the principal from
-    the session rather than from the request. An empty session there means the caller got
-    past ``auth_required`` without one; the anonymous read is ``/public/resolve``.
-    """
-
-    error_type = "https://api.backend.ai/probs/app-config-resolve-not-allowed"
-    error_title = "App config resolve requires an authenticated principal."

--- a/src/ai/backend/manager/errors/app_config.py
+++ b/src/ai/backend/manager/errors/app_config.py
@@ -38,11 +38,12 @@ class AppConfigFragmentWriteNotAllowed(GenericForbidden):
 
 
 class AppConfigResolveNotAllowed(GenericForbidden):
-    """A merged-AppConfig read was requested for a principal other than the caller.
+    """A merged-AppConfig read reached the adapter with no principal to resolve for.
 
-    Temporary per-request guard standing in for an RBAC validator: a resolve / scoped
-    search whose ``user_id`` does not match the authenticated caller is rejected.
+    ``/resolve`` is the read for the acting user, so the adapter takes the principal from
+    the session rather than from the request. An empty session there means the caller got
+    past ``auth_required`` without one; the anonymous read is ``/public/resolve``.
     """
 
     error_type = "https://api.backend.ai/probs/app-config-resolve-not-allowed"
-    error_title = "App config resolve is not allowed for this principal."
+    error_title = "App config resolve requires an authenticated principal."

--- a/src/ai/backend/manager/models/app_config_fragment/conditions.py
+++ b/src/ai/backend/manager/models/app_config_fragment/conditions.py
@@ -11,12 +11,11 @@ import sqlalchemy as sa
 from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.data.filter_specs import StringMatchSpec, UUIDEqualMatchSpec
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.condition_utils import make_string_in_factory
-from ai.backend.manager.models.domain.row import DomainRow
-from ai.backend.manager.models.user import UserRow
 
 __all__ = ("AppConfigFragmentConditions",)
 
@@ -152,20 +151,15 @@ class AppConfigFragmentConditions:
         return inner
 
     @staticmethod
-    def by_domain_visibility_of_user(user_id: UserID) -> QueryCondition:
-        """The ``domain`` scope of the domain ``user_id`` belongs to.
+    def by_domain_visibility(domain_id: DomainID | sa.ScalarSelect[DomainID]) -> QueryCondition:
+        """The ``domain`` scope for ``domain_id``.
 
-        A user names its domain by name, while a fragment's domain scope keys off the domain
-        id, so the id is looked up in a subquery rather than by a separate round trip.
+        Accepts a scalar subquery as well as a literal id, so a caller that only knows the
+        principal can derive the domain in the same statement (see
+        ``models.user.conditions.domain_id_of_user``).
         """
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            domain_id = (
-                sa.select(DomainRow.id)
-                .join(UserRow, UserRow.domain_name == DomainRow.name)
-                .where(UserRow.uuid == user_id)
-                .scalar_subquery()
-            )
             return sa.and_(
                 AppConfigFragmentRow.scope_type == AppConfigScopeType.DOMAIN,
                 AppConfigFragmentRow.scope_id == domain_id,

--- a/src/ai/backend/manager/models/app_config_fragment/conditions.py
+++ b/src/ai/backend/manager/models/app_config_fragment/conditions.py
@@ -151,13 +151,8 @@ class AppConfigFragmentConditions:
         return inner
 
     @staticmethod
-    def by_domain_visibility(domain_id: DomainID | sa.ScalarSelect[DomainID]) -> QueryCondition:
-        """The ``domain`` scope for ``domain_id``.
-
-        Accepts a scalar subquery as well as a literal id, so a caller that only knows the
-        principal can derive the domain in the same statement (see
-        ``models.user.conditions.domain_id_of_user``).
-        """
+    def by_domain_visibility(domain_id: DomainID) -> QueryCondition:
+        """The ``domain`` scope for ``domain_id``."""
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return sa.and_(

--- a/src/ai/backend/manager/models/app_config_fragment/conditions.py
+++ b/src/ai/backend/manager/models/app_config_fragment/conditions.py
@@ -11,11 +11,12 @@ import sqlalchemy as sa
 from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.data.filter_specs import StringMatchSpec, UUIDEqualMatchSpec
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
-from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.condition_utils import make_string_in_factory
+from ai.backend.manager.models.domain.row import DomainRow
+from ai.backend.manager.models.user import UserRow
 
 __all__ = ("AppConfigFragmentConditions",)
 
@@ -151,10 +152,20 @@ class AppConfigFragmentConditions:
         return inner
 
     @staticmethod
-    def by_domain_visibility(domain_id: DomainID) -> QueryCondition:
-        """The ``domain`` scope for ``domain_id``."""
+    def by_domain_visibility_of_user(user_id: UserID) -> QueryCondition:
+        """The ``domain`` scope of the domain ``user_id`` belongs to.
+
+        A user names its domain by name, while a fragment's domain scope keys off the domain
+        id, so the id is looked up in a subquery rather than by a separate round trip.
+        """
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
+            domain_id = (
+                sa.select(DomainRow.id)
+                .join(UserRow, UserRow.domain_name == DomainRow.name)
+                .where(UserRow.uuid == user_id)
+                .scalar_subquery()
+            )
             return sa.and_(
                 AppConfigFragmentRow.scope_type == AppConfigScopeType.DOMAIN,
                 AppConfigFragmentRow.scope_id == domain_id,

--- a/src/ai/backend/manager/models/user/conditions.py
+++ b/src/ai/backend/manager/models/user/conditions.py
@@ -10,8 +10,6 @@ from sqlalchemy.dialects import postgresql
 
 from ai.backend.common.data.filter_specs import StringMatchSpec, UUIDEqualMatchSpec, UUIDInMatchSpec
 from ai.backend.common.data.user.types import UserRole
-from ai.backend.common.identifier.domain import DomainID
-from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.condition_utils import (
@@ -23,28 +21,7 @@ from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import AssocGroupUserRow, GroupRow
 from ai.backend.manager.models.user import UserRow
 
-__all__ = (
-    "UserConditions",
-    "domain_id_of_user",
-)
-
-
-def domain_id_of_user(user_id: UserID) -> sa.ScalarSelect[DomainID]:
-    """The id of the domain ``user_id`` belongs to, as a scalar subquery.
-
-    A user names its domain by name, so any filter keyed off the domain id needs the
-    lookup. Inlining it as a subquery keeps that off a separate round trip; the subquery
-    is uncorrelated, so it is evaluated once per statement.
-
-    Yields SQL ``NULL`` when the user does not exist, which makes an equality comparison
-    against it match nothing.
-    """
-    return (
-        sa.select(DomainRow.id)
-        .join(UserRow, UserRow.domain_name == DomainRow.name)
-        .where(UserRow.uuid == user_id)
-        .scalar_subquery()
-    )
+__all__ = ("UserConditions",)
 
 
 class UserConditions:

--- a/src/ai/backend/manager/models/user/conditions.py
+++ b/src/ai/backend/manager/models/user/conditions.py
@@ -10,6 +10,8 @@ from sqlalchemy.dialects import postgresql
 
 from ai.backend.common.data.filter_specs import StringMatchSpec, UUIDEqualMatchSpec, UUIDInMatchSpec
 from ai.backend.common.data.user.types import UserRole
+from ai.backend.common.identifier.domain import DomainID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.condition_utils import (
@@ -21,7 +23,28 @@ from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import AssocGroupUserRow, GroupRow
 from ai.backend.manager.models.user import UserRow
 
-__all__ = ("UserConditions",)
+__all__ = (
+    "UserConditions",
+    "domain_id_of_user",
+)
+
+
+def domain_id_of_user(user_id: UserID) -> sa.ScalarSelect[DomainID]:
+    """The id of the domain ``user_id`` belongs to, as a scalar subquery.
+
+    A user names its domain by name, so any filter keyed off the domain id needs the
+    lookup. Inlining it as a subquery keeps that off a separate round trip; the subquery
+    is uncorrelated, so it is evaluated once per statement.
+
+    Yields SQL ``NULL`` when the user does not exist, which makes an equality comparison
+    against it match nothing.
+    """
+    return (
+        sa.select(DomainRow.id)
+        .join(UserRow, UserRow.domain_name == DomainRow.name)
+        .where(UserRow.uuid == user_id)
+        .scalar_subquery()
+    )
 
 
 class UserConditions:

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -28,6 +28,7 @@ from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowLi
 from ai.backend.manager.models.app_config_fragment.conditions import AppConfigFragmentConditions
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
 from ai.backend.manager.models.scopes import SearchScope
+from ai.backend.manager.models.user.conditions import domain_id_of_user
 from ai.backend.manager.repositories.app_config_fragment.purgers import (
     AppConfigFragmentPurgerSpec,
 )
@@ -197,7 +198,7 @@ class AppConfigFragmentDBSource:
         scope_visibility = [AppConfigFragmentConditions.by_public_visibility()]
         if user_id is not None:
             scope_visibility += [
-                AppConfigFragmentConditions.by_domain_visibility_of_user(user_id),
+                AppConfigFragmentConditions.by_domain_visibility(domain_id_of_user(user_id)),
                 AppConfigFragmentConditions.by_user_visibility(user_id),
             ]
         querier = BatchQuerier(

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -9,6 +9,7 @@ import sqlalchemy as sa
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.user import UserID
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
@@ -27,8 +28,9 @@ from ai.backend.manager.errors.app_config import (
 from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
 from ai.backend.manager.models.app_config_fragment.conditions import AppConfigFragmentConditions
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.models.domain.row import DomainRow
 from ai.backend.manager.models.scopes import SearchScope
-from ai.backend.manager.models.user.conditions import domain_id_of_user
+from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.repositories.app_config_fragment.purgers import (
     AppConfigFragmentPurgerSpec,
 )
@@ -45,6 +47,7 @@ from ai.backend.manager.repositories.base.rbac.entity_upserter import (
     ConflictTarget,
     RBACEntityUpserter,
 )
+from ai.backend.manager.repositories.ops.base.provider import ReadOps
 from ai.backend.manager.repositories.ops.rbac.provider import RBACOpsProvider
 
 __all__ = ("AppConfigFragmentDBSource",)
@@ -195,20 +198,6 @@ class AppConfigFragmentDBSource:
         """
         if not config_names:
             return []
-        scope_visibility = [AppConfigFragmentConditions.by_public_visibility()]
-        if user_id is not None:
-            scope_visibility += [
-                AppConfigFragmentConditions.by_domain_visibility(domain_id_of_user(user_id)),
-                AppConfigFragmentConditions.by_user_visibility(user_id),
-            ]
-        querier = BatchQuerier(
-            pagination=NoPagination(),
-            conditions=[
-                AppConfigFragmentConditions.by_config_names(config_names),
-                lambda: sa.or_(*(visibility() for visibility in scope_visibility)),
-            ],
-            orders=[AppConfigAllowListRow.rank.asc()],
-        )
         # Join each fragment to its allow-list entry (indexed ``(config_name, scope_type)`` FK
         # pair), which carries the merge ``rank`` the result is ordered by.
         selector = sa.select(AppConfigFragmentRow).join(
@@ -219,5 +208,34 @@ class AppConfigFragmentDBSource:
             ),
         )
         async with self._rbac_ops_provider.read_ops() as r:
+            scope_visibility = [AppConfigFragmentConditions.by_public_visibility()]
+            if user_id is not None:
+                scope_visibility.append(AppConfigFragmentConditions.by_user_visibility(user_id))
+                domain_id = await self._domain_id_of_user(r, user_id)
+                if domain_id is not None:
+                    scope_visibility.append(
+                        AppConfigFragmentConditions.by_domain_visibility(domain_id)
+                    )
+            querier = BatchQuerier(
+                pagination=NoPagination(),
+                conditions=[
+                    AppConfigFragmentConditions.by_config_names(config_names),
+                    lambda: sa.or_(*(visibility() for visibility in scope_visibility)),
+                ],
+                orders=[AppConfigAllowListRow.rank.asc()],
+            )
             result = await r.batch_query_in_global(selector, querier)
             return [row.AppConfigFragmentRow.to_data() for row in result.rows]
+
+    @staticmethod
+    async def _domain_id_of_user(r: ReadOps, user_id: UserID) -> DomainID | None:
+        """The id of the domain ``user_id`` belongs to, or ``None`` if it has none.
+
+        A user names its domain by name while a fragment's domain scope keys off the domain
+        id, so the id has to be looked up before the visibility filter can be built.
+        """
+        user = await r.query(Querier(row_class=UserRow, pk_value=user_id))
+        if user is None or user.row.domain_name is None:
+            return None
+        domain = await r.query(Querier(row_class=DomainRow, pk_value=user.row.domain_name))
+        return domain.row.id if domain is not None else None

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
-from ai.backend.common.identifier.domain import DomainID, DomainName
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
@@ -24,17 +24,12 @@ from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.errors.app_config import (
     AppConfigFragmentNotFound,
 )
-from ai.backend.manager.errors.resource import DomainNotFound
 from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
 from ai.backend.manager.models.app_config_fragment.conditions import AppConfigFragmentConditions
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
-from ai.backend.manager.models.domain.row import DomainRow
 from ai.backend.manager.models.scopes import SearchScope
 from ai.backend.manager.repositories.app_config_fragment.purgers import (
     AppConfigFragmentPurgerSpec,
-)
-from ai.backend.manager.repositories.app_config_fragment.types import (
-    ResolvedAppConfigScope,
 )
 from ai.backend.manager.repositories.app_config_fragment.upserters import (
     AppConfigFragmentUpserterSpec,
@@ -188,21 +183,22 @@ class AppConfigFragmentDBSource:
 
     @app_config_fragment_db_source_resilience.apply()
     async def list_visible_fragments_bulk(
-        self, config_names: list[str], scope: ResolvedAppConfigScope | None = None
+        self, config_names: list[str], user_id: UserID | None = None
     ) -> list[AppConfigFragmentData]:
         """Visible fragments for several ``config_names`` in one query, ordered by ascending ``rank``.
 
-        ``public`` always contributes; a ``scope`` additionally admits its domain and user
-        overlay, while ``scope=None`` (anonymous) sees only ``public``. Rank-ordered so the
-        caller can group by name and deep-merge each name's fragments in order.
+        ``public`` always contributes; a ``user_id`` additionally admits that user's own
+        overlay and its domain's, while ``user_id=None`` (anonymous) sees only ``public``.
+        Rank-ordered so the caller can group by name and deep-merge each name's fragments in
+        order.
         """
         if not config_names:
             return []
         scope_visibility = [AppConfigFragmentConditions.by_public_visibility()]
-        if scope is not None:
+        if user_id is not None:
             scope_visibility += [
-                AppConfigFragmentConditions.by_domain_visibility(scope.domain_id),
-                AppConfigFragmentConditions.by_user_visibility(scope.user_id),
+                AppConfigFragmentConditions.by_domain_visibility_of_user(user_id),
+                AppConfigFragmentConditions.by_user_visibility(user_id),
             ]
         querier = BatchQuerier(
             pagination=NoPagination(),
@@ -224,13 +220,3 @@ class AppConfigFragmentDBSource:
         async with self._rbac_ops_provider.read_ops() as r:
             result = await r.batch_query_in_global(selector, querier)
             return [row.AppConfigFragmentRow.to_data() for row in result.rows]
-
-    @app_config_fragment_db_source_resilience.apply()
-    async def get_domain_id_by_name(self, name: DomainName) -> DomainID:
-        """Resolve a domain name to its id. Not RBAC-scoped, like the merged-config read."""
-        async with self._rbac_ops_provider.read_ops() as r:
-            # DomainRow's primary key is its name, so a pk query fetches it by name.
-            result = await r.query(Querier(row_class=DomainRow, pk_value=name))
-            if result is None:
-                raise DomainNotFound(f"Domain '{name}' not found")
-            return result.row.id

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -187,13 +187,12 @@ class AppConfigFragmentDBSource:
     async def list_visible_fragments_bulk(
         self, config_names: list[str], user_id: UserID | None
     ) -> list[AppConfigFragmentData]:
-        """Visible fragments for several ``config_names`` in one query, ordered by ascending ``rank``.
+        """Visible fragments for several ``config_names``, ordered by ascending ``rank``.
 
         ``public`` always contributes; a ``user_id`` additionally admits that user's own
         overlay and its domain's, while ``user_id=None`` (anonymous) sees only ``public``.
-        Not defaulted — naming no principal is the anonymous read, which the caller states
-        rather than falls into. Rank-ordered so the caller can group by name and deep-merge
-        each name's fragments in order.
+        Rank-ordered so the caller can group by name and deep-merge each name's fragments
+        in order.
         """
         if not config_names:
             return []
@@ -211,8 +210,7 @@ class AppConfigFragmentDBSource:
             if user_id is not None:
                 scope_visibility.append(AppConfigFragmentConditions.by_user_visibility(user_id))
                 # A user names its domain by name while a fragment's domain scope keys off the
-                # domain id, so the id is looked up before the visibility filter is built. A
-                # user with no resolvable domain simply loses the domain overlay.
+                # id, so the id is looked up first; no resolvable domain means no overlay.
                 user = await r.query(Querier(row_class=UserRow, pk_value=user_id))
                 domain = (
                     await r.query(Querier(row_class=DomainRow, pk_value=user.row.domain_name))

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -187,14 +187,15 @@ class AppConfigFragmentDBSource:
 
     @app_config_fragment_db_source_resilience.apply()
     async def list_visible_fragments_bulk(
-        self, config_names: list[str], user_id: UserID | None = None
+        self, config_names: list[str], user_id: UserID | None
     ) -> list[AppConfigFragmentData]:
         """Visible fragments for several ``config_names`` in one query, ordered by ascending ``rank``.
 
         ``public`` always contributes; a ``user_id`` additionally admits that user's own
         overlay and its domain's, while ``user_id=None`` (anonymous) sees only ``public``.
-        Rank-ordered so the caller can group by name and deep-merge each name's fragments in
-        order.
+        Not defaulted — naming no principal is the anonymous read, which the caller states
+        rather than falls into. Rank-ordered so the caller can group by name and deep-merge
+        each name's fragments in order.
         """
         if not config_names:
             return []

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -9,7 +9,6 @@ import sqlalchemy as sa
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
-from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.user import UserID
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
@@ -47,7 +46,6 @@ from ai.backend.manager.repositories.base.rbac.entity_upserter import (
     ConflictTarget,
     RBACEntityUpserter,
 )
-from ai.backend.manager.repositories.ops.base.provider import ReadOps
 from ai.backend.manager.repositories.ops.rbac.provider import RBACOpsProvider
 
 __all__ = ("AppConfigFragmentDBSource",)
@@ -212,10 +210,18 @@ class AppConfigFragmentDBSource:
             scope_visibility = [AppConfigFragmentConditions.by_public_visibility()]
             if user_id is not None:
                 scope_visibility.append(AppConfigFragmentConditions.by_user_visibility(user_id))
-                domain_id = await self._domain_id_of_user(r, user_id)
-                if domain_id is not None:
+                # A user names its domain by name while a fragment's domain scope keys off the
+                # domain id, so the id is looked up before the visibility filter is built. A
+                # user with no resolvable domain simply loses the domain overlay.
+                user = await r.query(Querier(row_class=UserRow, pk_value=user_id))
+                domain = (
+                    await r.query(Querier(row_class=DomainRow, pk_value=user.row.domain_name))
+                    if user is not None and user.row.domain_name is not None
+                    else None
+                )
+                if domain is not None:
                     scope_visibility.append(
-                        AppConfigFragmentConditions.by_domain_visibility(domain_id)
+                        AppConfigFragmentConditions.by_domain_visibility(domain.row.id)
                     )
             querier = BatchQuerier(
                 pagination=NoPagination(),
@@ -227,16 +233,3 @@ class AppConfigFragmentDBSource:
             )
             result = await r.batch_query_in_global(selector, querier)
             return [row.AppConfigFragmentRow.to_data() for row in result.rows]
-
-    @staticmethod
-    async def _domain_id_of_user(r: ReadOps, user_id: UserID) -> DomainID | None:
-        """The id of the domain ``user_id`` belongs to, or ``None`` if it has none.
-
-        A user names its domain by name while a fragment's domain scope keys off the domain
-        id, so the id has to be looked up before the visibility filter can be built.
-        """
-        user = await r.query(Querier(row_class=UserRow, pk_value=user_id))
-        if user is None or user.row.domain_name is None:
-            return None
-        domain = await r.query(Querier(row_class=DomainRow, pk_value=user.row.domain_name))
-        return domain.row.id if domain is not None else None

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -9,6 +9,7 @@ import sqlalchemy as sa
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+from ai.backend.common.identifier.domain import DomainID, DomainName
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
@@ -23,9 +24,11 @@ from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.errors.app_config import (
     AppConfigFragmentNotFound,
 )
+from ai.backend.manager.errors.resource import DomainNotFound
 from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
 from ai.backend.manager.models.app_config_fragment.conditions import AppConfigFragmentConditions
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.models.domain.row import DomainRow
 from ai.backend.manager.models.scopes import SearchScope
 from ai.backend.manager.repositories.app_config_fragment.purgers import (
     AppConfigFragmentPurgerSpec,
@@ -221,3 +224,16 @@ class AppConfigFragmentDBSource:
         async with self._rbac_ops_provider.read_ops() as r:
             result = await r.batch_query_in_global(selector, querier)
             return [row.AppConfigFragmentRow.to_data() for row in result.rows]
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def get_domain_id_by_name(self, name: DomainName) -> DomainID:
+        """Resolve a domain name to its id — the session names the domain, but a fragment's
+        domain scope keys off the domain id. Not RBAC-scoped: the merged-config read is not
+        RBAC-gated, so the lookup is a plain read of the domain named by the session.
+        """
+        async with self._rbac_ops_provider.read_ops() as r:
+            # DomainRow's primary key is its name, so a pk query fetches it by name.
+            result = await r.query(Querier(row_class=DomainRow, pk_value=name))
+            if result is None:
+                raise DomainNotFound(f"Domain '{name}' not found")
+            return result.row.id

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -9,6 +9,7 @@ import sqlalchemy as sa
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.user import UserID
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
@@ -27,9 +28,7 @@ from ai.backend.manager.errors.app_config import (
 from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
 from ai.backend.manager.models.app_config_fragment.conditions import AppConfigFragmentConditions
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
-from ai.backend.manager.models.domain.row import DomainRow
 from ai.backend.manager.models.scopes import SearchScope
-from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.repositories.app_config_fragment.purgers import (
     AppConfigFragmentPurgerSpec,
 )
@@ -185,14 +184,14 @@ class AppConfigFragmentDBSource:
 
     @app_config_fragment_db_source_resilience.apply()
     async def list_visible_fragments_bulk(
-        self, config_names: list[str], user_id: UserID | None
+        self, config_names: list[str], user_id: UserID | None, domain_id: DomainID | None
     ) -> list[AppConfigFragmentData]:
         """Visible fragments for several ``config_names``, ordered by ascending ``rank``.
 
         ``public`` always contributes; a ``user_id`` additionally admits that user's own
-        overlay and its domain's, while ``user_id=None`` (anonymous) sees only ``public``.
-        Rank-ordered so the caller can group by name and deep-merge each name's fragments
-        in order.
+        overlay and a ``domain_id`` its domain's, while naming neither (anonymous) sees only
+        ``public``. Both come from the session, so neither is looked up here. Rank-ordered so
+        the caller can group by name and deep-merge each name's fragments in order.
         """
         if not config_names:
             return []
@@ -209,18 +208,8 @@ class AppConfigFragmentDBSource:
             scope_visibility = [AppConfigFragmentConditions.by_public_visibility()]
             if user_id is not None:
                 scope_visibility.append(AppConfigFragmentConditions.by_user_visibility(user_id))
-                # A user names its domain by name while a fragment's domain scope keys off the
-                # id, so the id is looked up first; no resolvable domain means no overlay.
-                user = await r.query(Querier(row_class=UserRow, pk_value=user_id))
-                domain = (
-                    await r.query(Querier(row_class=DomainRow, pk_value=user.row.domain_name))
-                    if user is not None and user.row.domain_name is not None
-                    else None
-                )
-                if domain is not None:
-                    scope_visibility.append(
-                        AppConfigFragmentConditions.by_domain_visibility(domain.row.id)
-                    )
+            if domain_id is not None:
+                scope_visibility.append(AppConfigFragmentConditions.by_domain_visibility(domain_id))
             querier = BatchQuerier(
                 pagination=NoPagination(),
                 conditions=[

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -227,10 +227,7 @@ class AppConfigFragmentDBSource:
 
     @app_config_fragment_db_source_resilience.apply()
     async def get_domain_id_by_name(self, name: DomainName) -> DomainID:
-        """Resolve a domain name to its id — the session names the domain, but a fragment's
-        domain scope keys off the domain id. Not RBAC-scoped: the merged-config read is not
-        RBAC-gated, so the lookup is a plain read of the domain named by the session.
-        """
+        """Resolve a domain name to its id. Not RBAC-scoped, like the merged-config read."""
         async with self._rbac_ops_provider.read_ops() as r:
             # DomainRow's primary key is its name, so a pk query fetches it by name.
             result = await r.query(Querier(row_class=DomainRow, pk_value=name))

--- a/src/ai/backend/manager/repositories/app_config_fragment/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repository.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
-from ai.backend.common.identifier.domain import DomainID, DomainName
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
@@ -20,9 +20,6 @@ from ai.backend.manager.repositories.app_config_fragment.db_source import (
 )
 from ai.backend.manager.repositories.app_config_fragment.purgers import (
     AppConfigFragmentPurgerSpec,
-)
-from ai.backend.manager.repositories.app_config_fragment.types import (
-    ResolvedAppConfigScope,
 )
 from ai.backend.manager.repositories.app_config_fragment.upserters import (
     AppConfigFragmentUpserterSpec,
@@ -95,10 +92,6 @@ class AppConfigFragmentRepository:
 
     @app_config_fragment_repository_resilience.apply()
     async def list_visible_fragments_bulk(
-        self, config_names: list[str], scope: ResolvedAppConfigScope | None = None
+        self, config_names: list[str], user_id: UserID | None = None
     ) -> list[AppConfigFragmentData]:
-        return await self._db_source.list_visible_fragments_bulk(config_names, scope)
-
-    @app_config_fragment_repository_resilience.apply()
-    async def get_domain_id_by_name(self, name: DomainName) -> DomainID:
-        return await self._db_source.get_domain_id_by_name(name)
+        return await self._db_source.list_visible_fragments_bulk(config_names, user_id)

--- a/src/ai/backend/manager/repositories/app_config_fragment/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repository.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+from ai.backend.common.identifier.domain import DomainID, DomainName
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
@@ -97,3 +98,7 @@ class AppConfigFragmentRepository:
         self, config_names: list[str], scope: ResolvedAppConfigScope | None = None
     ) -> list[AppConfigFragmentData]:
         return await self._db_source.list_visible_fragments_bulk(config_names, scope)
+
+    @app_config_fragment_repository_resilience.apply()
+    async def get_domain_id_by_name(self, name: DomainName) -> DomainID:
+        return await self._db_source.get_domain_id_by_name(name)

--- a/src/ai/backend/manager/repositories/app_config_fragment/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repository.py
@@ -92,6 +92,6 @@ class AppConfigFragmentRepository:
 
     @app_config_fragment_repository_resilience.apply()
     async def list_visible_fragments_bulk(
-        self, config_names: list[str], user_id: UserID | None = None
+        self, config_names: list[str], user_id: UserID | None
     ) -> list[AppConfigFragmentData]:
         return await self._db_source.list_visible_fragments_bulk(config_names, user_id)

--- a/src/ai/backend/manager/repositories/app_config_fragment/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repository.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.user import UserID
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
@@ -92,6 +93,6 @@ class AppConfigFragmentRepository:
 
     @app_config_fragment_repository_resilience.apply()
     async def list_visible_fragments_bulk(
-        self, config_names: list[str], user_id: UserID | None
+        self, config_names: list[str], user_id: UserID | None, domain_id: DomainID | None
     ) -> list[AppConfigFragmentData]:
-        return await self._db_source.list_visible_fragments_bulk(config_names, user_id)
+        return await self._db_source.list_visible_fragments_bulk(config_names, user_id, domain_id)

--- a/src/ai/backend/manager/repositories/app_config_fragment/types.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/types.py
@@ -22,26 +22,15 @@ from ai.backend.manager.models.user import UserRow
 
 __all__ = (
     "AppConfigFragmentSearchScope",
-    "AppConfigScopeArguments",
     "ResolvedAppConfigScope",
 )
-
-
-@dataclass(frozen=True)
-class AppConfigScopeArguments:
-    """The scope arguments a caller supplies for a resolve — the domain, never the user.
-
-    Add new caller-supplied scope dimensions here rather than growing method signatures.
-    """
-
-    domain_id: DomainID
 
 
 @dataclass(frozen=True)
 class ResolvedAppConfigScope:
     """The principal an ``AppConfig`` is resolved for: the resolving user and its domain.
 
-    :class:`AppConfigScopeArguments` plus the session user. Plain value object — not a
+    Both halves come from the session — never caller-supplied. Plain value object — not a
     :class:`SearchScope`.
     """
 

--- a/src/ai/backend/manager/repositories/app_config_fragment/types.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/types.py
@@ -1,4 +1,4 @@
-"""Types for app config fragment repository operations (search scopes, resolve arguments)."""
+"""Types for app config fragment repository operations (search scopes)."""
 
 from __future__ import annotations
 
@@ -11,8 +11,6 @@ import sqlalchemy as sa
 from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.exception import UserNotFound
 from ai.backend.common.identifier.app_config import AppConfigScopeID
-from ai.backend.common.identifier.domain import DomainID
-from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.errors.resource import DomainNotFound
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
 from ai.backend.manager.models.clauses import QueryCondition
@@ -20,22 +18,7 @@ from ai.backend.manager.models.domain.row import DomainRow
 from ai.backend.manager.models.scopes import ExistenceCheck, SearchScope
 from ai.backend.manager.models.user import UserRow
 
-__all__ = (
-    "AppConfigFragmentSearchScope",
-    "ResolvedAppConfigScope",
-)
-
-
-@dataclass(frozen=True)
-class ResolvedAppConfigScope:
-    """The principal an ``AppConfig`` is resolved for: the resolving user and its domain.
-
-    Both halves come from the session — never caller-supplied. Plain value object — not a
-    :class:`SearchScope`.
-    """
-
-    domain_id: DomainID
-    user_id: UserID
+__all__ = ("AppConfigFragmentSearchScope",)
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/services/app_config/actions/base.py
+++ b/src/ai/backend/manager/services/app_config/actions/base.py
@@ -7,7 +7,7 @@ from ai.backend.manager.actions.action.scope import BaseScopeAction, BaseScopeAc
 
 
 class AppConfigScopeAction(BaseScopeAction):
-    """Base for scope-level merged app config actions (get)."""
+    """Base for scope-level merged app config actions."""
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/app_config/actions/base.py
+++ b/src/ai/backend/manager/services/app_config/actions/base.py
@@ -7,7 +7,7 @@ from ai.backend.manager.actions.action.scope import BaseScopeAction, BaseScopeAc
 
 
 class AppConfigScopeAction(BaseScopeAction):
-    """Base for scope-level merged app config actions (resolve)."""
+    """Base for scope-level merged app config actions (get)."""
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/app_config/actions/get.py
+++ b/src/ai/backend/manager/services/app_config/actions/get.py
@@ -15,16 +15,14 @@ from ai.backend.manager.services.app_config.actions.base import (
 
 
 @dataclass
-class ResolveAppConfigsAction(AppConfigScopeAction):
-    """Resolve the merged ``AppConfig`` for each of ``config_names``.
+class GetAppConfigsAction(AppConfigScopeAction):
+    """Get the merged ``AppConfig`` for each of ``config_names``.
 
-    Neither ``domain_name`` nor ``user_id`` is caller-supplied — the adapter fills both from
-    the session, so a resolve is only ever for the acting user in their own domain. Either
-    half unset is the anonymous, pre-login read.
+    ``user_id`` is never caller-supplied — the adapter fills it from the session, so a get is
+    only ever for the acting user. Unset is the anonymous, pre-login read.
     """
 
     config_names: list[str]
-    domain_name: str | None = None
     user_id: UserID | None = None
 
     @override
@@ -46,7 +44,7 @@ class ResolveAppConfigsAction(AppConfigScopeAction):
 
 
 @dataclass
-class ResolveAppConfigsActionResult(AppConfigScopeActionResult):
+class GetAppConfigsActionResult(AppConfigScopeActionResult):
     app_configs: list[AppConfigData]
     _user_id: UserID | None
 

--- a/src/ai/backend/manager/services/app_config/actions/get.py
+++ b/src/ai/backend/manager/services/app_config/actions/get.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.permission.types import RBACElementType, ScopeType
+from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.app_config.types import AppConfigData
@@ -18,12 +19,14 @@ from ai.backend.manager.services.app_config.actions.base import (
 class GetAppConfigsAction(AppConfigScopeAction):
     """Get the merged ``AppConfig`` for each of ``config_names``.
 
-    ``user_id`` is never caller-supplied — the adapter fills it from the session, so a get is
-    only ever for the acting user. Unset is the anonymous, pre-login read.
+    Neither ``user_id`` nor ``domain_id`` is caller-supplied — the adapter fills both from
+    the session, so a get is only ever for the acting user. Unset is the anonymous, pre-login
+    read.
     """
 
     config_names: list[str]
     user_id: UserID | None = None
+    domain_id: DomainID | None = None
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/app_config/actions/resolve.py
+++ b/src/ai/backend/manager/services/app_config/actions/resolve.py
@@ -8,7 +8,6 @@ from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.app_config.types import AppConfigData
 from ai.backend.manager.data.permission.types import RBACElementRef
-from ai.backend.manager.repositories.app_config_fragment.types import AppConfigScopeArguments
 from ai.backend.manager.services.app_config.actions.base import (
     AppConfigScopeAction,
     AppConfigScopeActionResult,
@@ -19,13 +18,13 @@ from ai.backend.manager.services.app_config.actions.base import (
 class ResolveAppConfigsAction(AppConfigScopeAction):
     """Resolve the merged ``AppConfig`` for each of ``config_names``.
 
-    ``scope_arguments`` is the caller's to name; ``user_id`` is not — the handler fills it
-    from the session, so a resolve is only ever for the acting user. Either half unset is the
-    anonymous, pre-login read.
+    Neither ``domain_name`` nor ``user_id`` is caller-supplied — the adapter fills both from
+    the session, so a resolve is only ever for the acting user in their own domain. Either
+    half unset is the anonymous, pre-login read.
     """
 
     config_names: list[str]
-    scope_arguments: AppConfigScopeArguments | None = None
+    domain_name: str | None = None
     user_id: UserID | None = None
 
     @override

--- a/src/ai/backend/manager/services/app_config/processors.py
+++ b/src/ai/backend/manager/services/app_config/processors.py
@@ -5,31 +5,27 @@ from typing import override
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor.scope import ScopeActionProcessor
 from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
-from ai.backend.manager.services.app_config.actions.resolve import (
-    ResolveAppConfigsAction,
-    ResolveAppConfigsActionResult,
+from ai.backend.manager.services.app_config.actions.get import (
+    GetAppConfigsAction,
+    GetAppConfigsActionResult,
 )
 from ai.backend.manager.services.app_config.service import AppConfigService
 
 
 class AppConfigProcessors(AbstractProcessorPackage):
-    resolve_app_configs: ScopeActionProcessor[
-        ResolveAppConfigsAction, ResolveAppConfigsActionResult
-    ]
+    get_app_configs: ScopeActionProcessor[GetAppConfigsAction, GetAppConfigsActionResult]
 
     def __init__(
         self,
         service: AppConfigService,
         action_monitors: list[ActionMonitor],
     ) -> None:
-        # No RBAC validator on purpose: the handler fills the action's user_id from the
-        # session, so a resolve is only ever for the acting user.
-        self.resolve_app_configs = ScopeActionProcessor(
-            service.resolve_app_configs, action_monitors
-        )
+        # No RBAC validator on purpose: the adapter fills the action's user_id from the
+        # session, so a get is only ever for the acting user.
+        self.get_app_configs = ScopeActionProcessor(service.get_app_configs, action_monitors)
 
     @override
     def supported_actions(self) -> list[ActionSpec]:
         return [
-            ResolveAppConfigsAction.spec(),
+            GetAppConfigsAction.spec(),
         ]

--- a/src/ai/backend/manager/services/app_config/service.py
+++ b/src/ai/backend/manager/services/app_config/service.py
@@ -49,12 +49,11 @@ class AppConfigService:
         self._fragment_repository = fragment_repository
 
     async def get_app_configs(self, action: GetAppConfigsAction) -> GetAppConfigsActionResult:
-        """Get the merged ``AppConfig`` for each of ``config_names`` in a single query.
+        """Get the merged ``AppConfig`` for each of ``config_names``.
 
         One entry per requested name, in request order; a repeated name is repeated in the
-        output. Without a ``user_id`` this is the anonymous, pre-login read — only ``public``
-        fragments contribute. A name nothing contributes to yields an empty merge rather than
-        failing, so one such name never withholds the names that did merge.
+        output. Without a ``user_id`` only ``public`` fragments contribute. A name nothing
+        contributes to yields an empty merge rather than failing the whole call.
         """
         fragments = await self._fragment_repository.list_visible_fragments_bulk(
             action.config_names, action.user_id

--- a/src/ai/backend/manager/services/app_config/service.py
+++ b/src/ai/backend/manager/services/app_config/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+from ai.backend.common.identifier.domain import DomainName
 from ai.backend.manager.data.app_config.types import AppConfigData
 from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
 from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
@@ -56,17 +57,19 @@ class AppConfigService:
         """Resolve the merged ``AppConfig`` for each of ``config_names`` in a single query.
 
         One entry per requested name, in request order; a repeated name is repeated in the
-        output. Without both ``scope_arguments`` and ``user_id`` this is the anonymous,
-        pre-login read — only ``public`` fragments contribute. A name nothing contributes to
-        fails the whole call with ``AppConfigFragmentNotFound``.
+        output. Without both ``domain_name`` and ``user_id`` this is the anonymous, pre-login
+        read — only ``public`` fragments contribute. A name nothing contributes to fails the
+        whole call with ``AppConfigFragmentNotFound``.
         """
-        if action.scope_arguments is None or action.user_id is None:
+        if action.domain_name is None or action.user_id is None:
             # Either half missing is the anonymous, pre-login read.
             scope = None
         else:
-            scope = ResolvedAppConfigScope(
-                domain_id=action.scope_arguments.domain_id, user_id=action.user_id
+            # The session carries the domain name; the fragment scope keys off its id.
+            domain_id = await self._fragment_repository.get_domain_id_by_name(
+                DomainName(action.domain_name)
             )
+            scope = ResolvedAppConfigScope(domain_id=domain_id, user_id=action.user_id)
         fragments = await self._fragment_repository.list_visible_fragments_bulk(
             action.config_names, scope
         )

--- a/src/ai/backend/manager/services/app_config/service.py
+++ b/src/ai/backend/manager/services/app_config/service.py
@@ -5,7 +5,6 @@ from typing import Any
 
 from ai.backend.manager.data.app_config.types import AppConfigData
 from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
-from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
 from ai.backend.manager.repositories.app_config_fragment.repository import (
     AppConfigFragmentRepository,
 )
@@ -54,8 +53,8 @@ class AppConfigService:
 
         One entry per requested name, in request order; a repeated name is repeated in the
         output. Without a ``user_id`` this is the anonymous, pre-login read — only ``public``
-        fragments contribute. A name nothing contributes to fails the whole call with
-        ``AppConfigFragmentNotFound``.
+        fragments contribute. A name nothing contributes to yields an empty merge rather than
+        failing, so one such name never withholds the names that did merge.
         """
         fragments = await self._fragment_repository.list_visible_fragments_bulk(
             action.config_names, action.user_id
@@ -63,10 +62,6 @@ class AppConfigService:
         app_configs: list[AppConfigData] = []
         for config_name in action.config_names:
             visible = [fragment for fragment in fragments if fragment.config_name == config_name]
-            if not visible:
-                raise AppConfigFragmentNotFound(
-                    "No visible fragment contributes to this app config."
-                )
             app_configs.append(
                 AppConfigData(
                     config_name=config_name,

--- a/src/ai/backend/manager/services/app_config/service.py
+++ b/src/ai/backend/manager/services/app_config/service.py
@@ -3,17 +3,15 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-from ai.backend.common.identifier.domain import DomainName
 from ai.backend.manager.data.app_config.types import AppConfigData
 from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
 from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
 from ai.backend.manager.repositories.app_config_fragment.repository import (
     AppConfigFragmentRepository,
 )
-from ai.backend.manager.repositories.app_config_fragment.types import ResolvedAppConfigScope
-from ai.backend.manager.services.app_config.actions.resolve import (
-    ResolveAppConfigsAction,
-    ResolveAppConfigsActionResult,
+from ai.backend.manager.services.app_config.actions.get import (
+    GetAppConfigsAction,
+    GetAppConfigsActionResult,
 )
 
 __all__ = ("AppConfigService",)
@@ -51,27 +49,16 @@ class AppConfigService:
     def __init__(self, fragment_repository: AppConfigFragmentRepository) -> None:
         self._fragment_repository = fragment_repository
 
-    async def resolve_app_configs(
-        self, action: ResolveAppConfigsAction
-    ) -> ResolveAppConfigsActionResult:
-        """Resolve the merged ``AppConfig`` for each of ``config_names`` in a single query.
+    async def get_app_configs(self, action: GetAppConfigsAction) -> GetAppConfigsActionResult:
+        """Get the merged ``AppConfig`` for each of ``config_names`` in a single query.
 
         One entry per requested name, in request order; a repeated name is repeated in the
-        output. Without both ``domain_name`` and ``user_id`` this is the anonymous, pre-login
-        read — only ``public`` fragments contribute. A name nothing contributes to fails the
-        whole call with ``AppConfigFragmentNotFound``.
+        output. Without a ``user_id`` this is the anonymous, pre-login read — only ``public``
+        fragments contribute. A name nothing contributes to fails the whole call with
+        ``AppConfigFragmentNotFound``.
         """
-        if action.domain_name is None or action.user_id is None:
-            # Either half missing is the anonymous, pre-login read.
-            scope = None
-        else:
-            # The session carries the domain name; the fragment scope keys off its id.
-            domain_id = await self._fragment_repository.get_domain_id_by_name(
-                DomainName(action.domain_name)
-            )
-            scope = ResolvedAppConfigScope(domain_id=domain_id, user_id=action.user_id)
         fragments = await self._fragment_repository.list_visible_fragments_bulk(
-            action.config_names, scope
+            action.config_names, action.user_id
         )
         app_configs: list[AppConfigData] = []
         for config_name in action.config_names:
@@ -87,6 +74,4 @@ class AppConfigService:
                     merged_config=_merge_configs(visible),
                 )
             )
-        return ResolveAppConfigsActionResult(
-            app_configs=app_configs, _user_id=scope.user_id if scope is not None else None
-        )
+        return GetAppConfigsActionResult(app_configs=app_configs, _user_id=action.user_id)

--- a/src/ai/backend/manager/services/app_config/service.py
+++ b/src/ai/backend/manager/services/app_config/service.py
@@ -64,7 +64,6 @@ class AppConfigService:
             app_configs.append(
                 AppConfigData(
                     config_name=config_name,
-                    fragments=visible,
                     merged_config=_merge_configs(visible),
                 )
             )

--- a/src/ai/backend/manager/services/app_config/service.py
+++ b/src/ai/backend/manager/services/app_config/service.py
@@ -52,11 +52,11 @@ class AppConfigService:
         """Get the merged ``AppConfig`` for each of ``config_names``.
 
         One entry per requested name, in request order; a repeated name is repeated in the
-        output. Without a ``user_id`` only ``public`` fragments contribute. A name nothing
+        output. Without a principal only ``public`` fragments contribute. A name nothing
         contributes to yields an empty merge rather than failing the whole call.
         """
         fragments = await self._fragment_repository.list_visible_fragments_bulk(
-            action.config_names, action.user_id
+            action.config_names, action.user_id, action.domain_id
         )
         app_configs: list[AppConfigData] = []
         for config_name in action.config_names:

--- a/src/ai/backend/manager/services/app_config/service.py
+++ b/src/ai/backend/manager/services/app_config/service.py
@@ -64,7 +64,7 @@ class AppConfigService:
             app_configs.append(
                 AppConfigData(
                     config_name=config_name,
-                    merged_config=_merge_configs(visible),
+                    config=_merge_configs(visible),
                 )
             )
         return GetAppConfigsActionResult(app_configs=app_configs, _user_id=action.user_id)

--- a/tests/unit/manager/api/adapters/test_app_config_adapter.py
+++ b/tests/unit/manager/api/adapters/test_app_config_adapter.py
@@ -10,6 +10,7 @@ import pytest
 
 from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.dto.manager.v2.app_config.request import ResolveAppConfigInput
+from ai.backend.common.exception import BackendAISchemaValidationFailed
 from ai.backend.common.identifier.app_config import AppConfigScopeID
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
 from ai.backend.manager.api.adapters.app_config.adapter import AppConfigAdapter
@@ -119,7 +120,7 @@ class TestResolveAppConfigInput:
         assert parsed.scope_arguments.domain_id == domain_id
 
     def test_rejects_empty_config_names(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(BackendAISchemaValidationFailed):
             ResolveAppConfigInput.model_validate({
                 "config_names": [],
                 "scope_arguments": {"domain_id": str(uuid4())},

--- a/tests/unit/manager/api/adapters/test_app_config_adapter.py
+++ b/tests/unit/manager/api/adapters/test_app_config_adapter.py
@@ -1,0 +1,126 @@
+"""Unit tests for AppConfigAdapter DTO conversions and the resolve input contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from ai.backend.common.data.app_config.types import AppConfigScopeType
+from ai.backend.common.dto.manager.v2.app_config.request import ResolveAppConfigInput
+from ai.backend.common.identifier.app_config import AppConfigScopeID
+from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+from ai.backend.manager.api.adapters.app_config.adapter import AppConfigAdapter
+from ai.backend.manager.data.app_config.types import AppConfigData
+from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
+
+
+class TestAppConfigAdapterConverters:
+    def test_fragment_to_node_maps_all_fields(self) -> None:
+        created = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        updated = datetime(2026, 1, 2, 12, 0, 0, tzinfo=UTC)
+        fragment_id = AppConfigFragmentID(uuid4())
+        scope_id = AppConfigScopeID(uuid4())
+        data = AppConfigFragmentData(
+            id=fragment_id,
+            config_name="theme",
+            scope_type=AppConfigScopeType.DOMAIN,
+            scope_id=scope_id,
+            config={"color": "dark"},
+            created_at=created,
+            updated_at=updated,
+        )
+
+        node = AppConfigAdapter._fragment_to_node(data)
+
+        assert node.id == fragment_id
+        assert node.config_name == "theme"
+        assert node.scope_type == AppConfigScopeType.DOMAIN
+        assert node.scope_id == scope_id
+        assert node.config == {"color": "dark"}
+        assert node.created_at == created
+        assert node.updated_at == updated
+
+    @dataclass(frozen=True)
+    class _ScopeCase:
+        scope_type: AppConfigScopeType
+        scope_id: AppConfigScopeID | None
+
+    @pytest.mark.parametrize(
+        "case",
+        [
+            _ScopeCase(scope_type=AppConfigScopeType.PUBLIC, scope_id=None),
+            _ScopeCase(scope_type=AppConfigScopeType.DOMAIN, scope_id=AppConfigScopeID(uuid4())),
+            _ScopeCase(scope_type=AppConfigScopeType.USER, scope_id=AppConfigScopeID(uuid4())),
+        ],
+        ids=lambda case: case.scope_type.value,
+    )
+    def test_fragment_to_node_maps_every_scope_type(self, case: _ScopeCase) -> None:
+        data = AppConfigFragmentData(
+            id=AppConfigFragmentID(uuid4()),
+            config_name="theme",
+            scope_type=case.scope_type,
+            scope_id=case.scope_id,
+            config={},
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+
+        node = AppConfigAdapter._fragment_to_node(data)
+
+        assert node.scope_type == case.scope_type
+        assert node.scope_id == case.scope_id
+
+    def test_app_config_to_node_maps_fields_and_preserves_fragment_order(self) -> None:
+        now = datetime(2026, 1, 1, tzinfo=UTC)
+        first = AppConfigFragmentData(
+            id=AppConfigFragmentID(uuid4()),
+            config_name="theme",
+            scope_type=AppConfigScopeType.PUBLIC,
+            scope_id=None,
+            config={"color": "light"},
+            created_at=now,
+            updated_at=now,
+        )
+        second = AppConfigFragmentData(
+            id=AppConfigFragmentID(uuid4()),
+            config_name="theme",
+            scope_type=AppConfigScopeType.USER,
+            scope_id=AppConfigScopeID(uuid4()),
+            config={"color": "dark"},
+            created_at=now,
+            updated_at=now,
+        )
+        data = AppConfigData(
+            config_name="theme",
+            fragments=[first, second],
+            merged_config={"color": "dark"},
+        )
+
+        node = AppConfigAdapter._app_config_to_node(data)
+
+        assert node.config_name == "theme"
+        assert node.merged_config == {"color": "dark"}
+        assert [fragment.id for fragment in node.fragments] == [first.id, second.id]
+
+
+class TestResolveAppConfigInput:
+    def test_parses_nested_scope_arguments(self) -> None:
+        domain_id = uuid4()
+
+        parsed = ResolveAppConfigInput.model_validate({
+            "config_names": ["theme"],
+            "scope_arguments": {"domain_id": str(domain_id)},
+        })
+
+        assert parsed.config_names == ["theme"]
+        assert parsed.scope_arguments.domain_id == domain_id
+
+    def test_rejects_empty_config_names(self) -> None:
+        with pytest.raises(ValueError):
+            ResolveAppConfigInput.model_validate({
+                "config_names": [],
+                "scope_arguments": {"domain_id": str(uuid4())},
+            })

--- a/tests/unit/manager/api/adapters/test_app_config_adapter.py
+++ b/tests/unit/manager/api/adapters/test_app_config_adapter.py
@@ -108,20 +108,11 @@ class TestAppConfigAdapterConverters:
 
 
 class TestResolveAppConfigInput:
-    def test_parses_nested_scope_arguments(self) -> None:
-        domain_id = uuid4()
+    def test_parses_config_names(self) -> None:
+        parsed = ResolveAppConfigInput.model_validate({"config_names": ["theme", "layout"]})
 
-        parsed = ResolveAppConfigInput.model_validate({
-            "config_names": ["theme"],
-            "scope_arguments": {"domain_ids": [str(domain_id)]},
-        })
-
-        assert parsed.config_names == ["theme"]
-        assert parsed.scope_arguments.domain_ids == [domain_id]
+        assert parsed.config_names == ["theme", "layout"]
 
     def test_rejects_empty_config_names(self) -> None:
         with pytest.raises(BackendAISchemaValidationFailed):
-            ResolveAppConfigInput.model_validate({
-                "config_names": [],
-                "scope_arguments": {"domain_ids": [str(uuid4())]},
-            })
+            ResolveAppConfigInput.model_validate({"config_names": []})

--- a/tests/unit/manager/api/adapters/test_app_config_adapter.py
+++ b/tests/unit/manager/api/adapters/test_app_config_adapter.py
@@ -113,15 +113,15 @@ class TestResolveAppConfigInput:
 
         parsed = ResolveAppConfigInput.model_validate({
             "config_names": ["theme"],
-            "scope_arguments": {"domain_id": str(domain_id)},
+            "scope_arguments": {"domain_ids": [str(domain_id)]},
         })
 
         assert parsed.config_names == ["theme"]
-        assert parsed.scope_arguments.domain_id == domain_id
+        assert parsed.scope_arguments.domain_ids == [domain_id]
 
     def test_rejects_empty_config_names(self) -> None:
         with pytest.raises(BackendAISchemaValidationFailed):
             ResolveAppConfigInput.model_validate({
                 "config_names": [],
-                "scope_arguments": {"domain_id": str(uuid4())},
+                "scope_arguments": {"domain_ids": [str(uuid4())]},
             })

--- a/tests/unit/manager/api/adapters/test_app_config_adapter.py
+++ b/tests/unit/manager/api/adapters/test_app_config_adapter.py
@@ -2,112 +2,33 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import UTC, datetime
-from uuid import uuid4
-
 import pytest
 
-from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.dto.manager.v2.app_config.request import (
     MyGetAppConfigsInput,
     PublicGetAppConfigsInput,
 )
 from ai.backend.common.exception import BackendAISchemaValidationFailed
-from ai.backend.common.identifier.app_config import AppConfigScopeID
-from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
 from ai.backend.manager.api.adapters.app_config.adapter import AppConfigAdapter
 from ai.backend.manager.data.app_config.types import AppConfigData
-from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
 
 
 class TestAppConfigAdapterConverters:
-    def test_fragment_to_node_maps_all_fields(self) -> None:
-        created = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
-        updated = datetime(2026, 1, 2, 12, 0, 0, tzinfo=UTC)
-        fragment_id = AppConfigFragmentID(uuid4())
-        scope_id = AppConfigScopeID(uuid4())
-        data = AppConfigFragmentData(
-            id=fragment_id,
-            config_name="theme",
-            scope_type=AppConfigScopeType.DOMAIN,
-            scope_id=scope_id,
-            config={"color": "dark"},
-            created_at=created,
-            updated_at=updated,
+    def test_app_config_to_node_maps_the_merge(self) -> None:
+        node = AppConfigAdapter._app_config_to_node(
+            AppConfigData(config_name="theme", merged_config={"color": "dark"})
         )
-
-        node = AppConfigAdapter._fragment_to_node(data)
-
-        assert node.id == fragment_id
-        assert node.config_name == "theme"
-        assert node.scope_type == AppConfigScopeType.DOMAIN
-        assert node.scope_id == scope_id
-        assert node.config == {"color": "dark"}
-        assert node.created_at == created
-        assert node.updated_at == updated
-
-    @dataclass(frozen=True)
-    class _ScopeCase:
-        scope_type: AppConfigScopeType
-        scope_id: AppConfigScopeID | None
-
-    @pytest.mark.parametrize(
-        "case",
-        [
-            _ScopeCase(scope_type=AppConfigScopeType.PUBLIC, scope_id=None),
-            _ScopeCase(scope_type=AppConfigScopeType.DOMAIN, scope_id=AppConfigScopeID(uuid4())),
-            _ScopeCase(scope_type=AppConfigScopeType.USER, scope_id=AppConfigScopeID(uuid4())),
-        ],
-        ids=lambda case: case.scope_type.value,
-    )
-    def test_fragment_to_node_maps_every_scope_type(self, case: _ScopeCase) -> None:
-        data = AppConfigFragmentData(
-            id=AppConfigFragmentID(uuid4()),
-            config_name="theme",
-            scope_type=case.scope_type,
-            scope_id=case.scope_id,
-            config={},
-            created_at=datetime(2026, 1, 1, tzinfo=UTC),
-            updated_at=datetime(2026, 1, 1, tzinfo=UTC),
-        )
-
-        node = AppConfigAdapter._fragment_to_node(data)
-
-        assert node.scope_type == case.scope_type
-        assert node.scope_id == case.scope_id
-
-    def test_app_config_to_node_maps_fields_and_preserves_fragment_order(self) -> None:
-        now = datetime(2026, 1, 1, tzinfo=UTC)
-        first = AppConfigFragmentData(
-            id=AppConfigFragmentID(uuid4()),
-            config_name="theme",
-            scope_type=AppConfigScopeType.PUBLIC,
-            scope_id=None,
-            config={"color": "light"},
-            created_at=now,
-            updated_at=now,
-        )
-        second = AppConfigFragmentData(
-            id=AppConfigFragmentID(uuid4()),
-            config_name="theme",
-            scope_type=AppConfigScopeType.USER,
-            scope_id=AppConfigScopeID(uuid4()),
-            config={"color": "dark"},
-            created_at=now,
-            updated_at=now,
-        )
-        data = AppConfigData(
-            config_name="theme",
-            fragments=[first, second],
-            merged_config={"color": "dark"},
-        )
-
-        node = AppConfigAdapter._app_config_to_node(data)
 
         assert node.config_name == "theme"
         assert node.merged_config == {"color": "dark"}
-        assert [fragment.id for fragment in node.fragments] == [first.id, second.id]
+
+    def test_app_config_to_node_keeps_an_empty_merge(self) -> None:
+        node = AppConfigAdapter._app_config_to_node(
+            AppConfigData(config_name="menu", merged_config={})
+        )
+
+        assert node.config_name == "menu"
+        assert node.merged_config == {}
 
 
 class TestGetAppConfigsInputs:

--- a/tests/unit/manager/api/adapters/test_app_config_adapter.py
+++ b/tests/unit/manager/api/adapters/test_app_config_adapter.py
@@ -10,8 +10,8 @@ import pytest
 
 from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.dto.manager.v2.app_config.request import (
-    GetPublicAppConfigsInput,
     MyGetAppConfigsInput,
+    PublicGetAppConfigsInput,
 )
 from ai.backend.common.exception import BackendAISchemaValidationFailed
 from ai.backend.common.identifier.app_config import AppConfigScopeID
@@ -115,11 +115,11 @@ class TestGetAppConfigsInputs:
 
     @pytest.mark.parametrize(
         "input_model",
-        [MyGetAppConfigsInput, GetPublicAppConfigsInput],
+        [MyGetAppConfigsInput, PublicGetAppConfigsInput],
         ids=lambda model: model.__name__,
     )
     def test_parses_config_names(
-        self, input_model: type[MyGetAppConfigsInput] | type[GetPublicAppConfigsInput]
+        self, input_model: type[MyGetAppConfigsInput] | type[PublicGetAppConfigsInput]
     ) -> None:
         parsed = input_model.model_validate({"config_names": ["theme", "layout"]})
 
@@ -127,11 +127,11 @@ class TestGetAppConfigsInputs:
 
     @pytest.mark.parametrize(
         "input_model",
-        [MyGetAppConfigsInput, GetPublicAppConfigsInput],
+        [MyGetAppConfigsInput, PublicGetAppConfigsInput],
         ids=lambda model: model.__name__,
     )
     def test_rejects_empty_config_names(
-        self, input_model: type[MyGetAppConfigsInput] | type[GetPublicAppConfigsInput]
+        self, input_model: type[MyGetAppConfigsInput] | type[PublicGetAppConfigsInput]
     ) -> None:
         with pytest.raises(BackendAISchemaValidationFailed):
             input_model.model_validate({"config_names": []})

--- a/tests/unit/manager/api/adapters/test_app_config_adapter.py
+++ b/tests/unit/manager/api/adapters/test_app_config_adapter.py
@@ -1,4 +1,4 @@
-"""Unit tests for AppConfigAdapter DTO conversions and the resolve input contract."""
+"""Unit tests for AppConfigAdapter DTO conversions and the get input contract."""
 
 from __future__ import annotations
 
@@ -9,7 +9,10 @@ from uuid import uuid4
 import pytest
 
 from ai.backend.common.data.app_config.types import AppConfigScopeType
-from ai.backend.common.dto.manager.v2.app_config.request import ResolveAppConfigInput
+from ai.backend.common.dto.manager.v2.app_config.request import (
+    GetPublicAppConfigsInput,
+    MyGetAppConfigsInput,
+)
 from ai.backend.common.exception import BackendAISchemaValidationFailed
 from ai.backend.common.identifier.app_config import AppConfigScopeID
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
@@ -107,12 +110,28 @@ class TestAppConfigAdapterConverters:
         assert [fragment.id for fragment in node.fragments] == [first.id, second.id]
 
 
-class TestResolveAppConfigInput:
-    def test_parses_config_names(self) -> None:
-        parsed = ResolveAppConfigInput.model_validate({"config_names": ["theme", "layout"]})
+class TestGetAppConfigsInputs:
+    """Both get inputs take the same batch of names — only the scope they imply differs."""
+
+    @pytest.mark.parametrize(
+        "input_model",
+        [MyGetAppConfigsInput, GetPublicAppConfigsInput],
+        ids=lambda model: model.__name__,
+    )
+    def test_parses_config_names(
+        self, input_model: type[MyGetAppConfigsInput] | type[GetPublicAppConfigsInput]
+    ) -> None:
+        parsed = input_model.model_validate({"config_names": ["theme", "layout"]})
 
         assert parsed.config_names == ["theme", "layout"]
 
-    def test_rejects_empty_config_names(self) -> None:
+    @pytest.mark.parametrize(
+        "input_model",
+        [MyGetAppConfigsInput, GetPublicAppConfigsInput],
+        ids=lambda model: model.__name__,
+    )
+    def test_rejects_empty_config_names(
+        self, input_model: type[MyGetAppConfigsInput] | type[GetPublicAppConfigsInput]
+    ) -> None:
         with pytest.raises(BackendAISchemaValidationFailed):
-            ResolveAppConfigInput.model_validate({"config_names": []})
+            input_model.model_validate({"config_names": []})

--- a/tests/unit/manager/api/adapters/test_app_config_adapter.py
+++ b/tests/unit/manager/api/adapters/test_app_config_adapter.py
@@ -16,19 +16,17 @@ from ai.backend.manager.data.app_config.types import AppConfigData
 class TestAppConfigAdapterConverters:
     def test_app_config_to_node_maps_the_merge(self) -> None:
         node = AppConfigAdapter._app_config_to_node(
-            AppConfigData(config_name="theme", merged_config={"color": "dark"})
+            AppConfigData(config_name="theme", config={"color": "dark"})
         )
 
         assert node.config_name == "theme"
-        assert node.merged_config == {"color": "dark"}
+        assert node.config == {"color": "dark"}
 
     def test_app_config_to_node_keeps_an_empty_merge(self) -> None:
-        node = AppConfigAdapter._app_config_to_node(
-            AppConfigData(config_name="menu", merged_config={})
-        )
+        node = AppConfigAdapter._app_config_to_node(AppConfigData(config_name="menu", config={}))
 
         assert node.config_name == "menu"
-        assert node.merged_config == {}
+        assert node.config == {}
 
 
 class TestGetAppConfigsInputs:

--- a/tests/unit/manager/api/test_impersonation.py
+++ b/tests/unit/manager/api/test_impersonation.py
@@ -9,6 +9,7 @@ from aiohttp.test_utils import make_mocked_request
 
 from ai.backend.common.contexts.user import current_user, triggered_user
 from ai.backend.common.data.user.types import UserData, UserRole
+from ai.backend.common.identifier.domain import DomainID
 from ai.backend.manager.api.rest.middleware import auth as auth_mw
 from ai.backend.manager.api.rest.middleware.auth import (
     _authenticated_user,
@@ -34,6 +35,7 @@ def _make_request(*, role: UserRole | None, headers: dict[str, str] | None = Non
             "uuid": uuid.uuid4(),
             "role": role.value,
             "domain_name": "default",
+            "domain_id": DomainID(uuid.uuid4()),
         }
     return request
 
@@ -48,6 +50,7 @@ def _install_target_loader(monkeypatch: pytest.MonkeyPatch, target_id: uuid.UUID
             is_superadmin=False,
             role=UserRole.USER,
             domain_name="target-domain",
+            domain_id=DomainID(uuid.uuid4()),
         )
 
     monkeypatch.setattr(auth_mw, "_load_user_data", _fake_load)
@@ -128,6 +131,7 @@ class TestSetupUserContext:
             is_superadmin=False,
             role=UserRole.USER,
             domain_name="target-domain",
+            domain_id=DomainID(uuid.uuid4()),
         )
         trigger = UserData(
             user_id=uuid.uuid4(),

--- a/tests/unit/manager/repositories/app_config_fragment/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_repository.py
@@ -614,16 +614,18 @@ class TestVisibilityConditions:
 
 
 class TestApplicableFragments:
-    async def test_a_user_with_no_domain_row_still_sees_public_and_its_own(
+    async def test_naming_no_domain_drops_the_overlay(
         self,
         repository: AppConfigFragmentRepository,
         scope_owners: None,
         fragments_across_scopes: list[AppConfigFragmentData],
     ) -> None:
-        # An unresolvable domain drops the overlay rather than widening the query.
+        # A caller whose session carries no domain gets public and its own, never a
+        # domain's — the absent domain narrows the query rather than widening it.
         applicable = await repository.list_visible_fragments_bulk(
             ["theme"],
             UserID(uuid.uuid4()),
+            None,
         )
         expected = [
             f
@@ -641,6 +643,7 @@ class TestApplicableFragments:
         applicable = await repository.list_visible_fragments_bulk(
             ["theme"],
             _USER_ID,
+            _DOMAIN_ID,
         )
         # public + the caller's domain + the caller's own user fragment, ordered by the
         # allow-list entries' ranks (scope-type defaults: public < domain < user).
@@ -670,6 +673,7 @@ class TestApplicableFragments:
         applicable = await repository.list_visible_fragments_bulk(
             ["unregistered"],
             _USER_ID,
+            _DOMAIN_ID,
         )
         assert applicable == []
 
@@ -682,6 +686,7 @@ class TestApplicableFragments:
         applicable = await repository.list_visible_fragments_bulk(
             ["theme", "menu"],
             _USER_ID,
+            _DOMAIN_ID,
         )
         # public + the caller's domain + the caller's own user fragment, for both names.
         expected = {
@@ -710,6 +715,7 @@ class TestApplicableFragments:
         applicable = await repository.list_visible_fragments_bulk(
             [],
             _USER_ID,
+            _DOMAIN_ID,
         )
         assert applicable == []
 

--- a/tests/unit/manager/repositories/app_config_fragment/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_repository.py
@@ -44,7 +44,6 @@ from ai.backend.manager.models.resource_policy import (
     UserResourcePolicyRow,
 )
 from ai.backend.manager.models.user import UserRow
-from ai.backend.manager.models.user.conditions import domain_id_of_user
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.app_config_fragment.purgers import (
     AppConfigFragmentPurgerSpec,
@@ -595,49 +594,6 @@ class TestVisibilityConditions:
         }
         assert {item.id for item in result.items} == expected
 
-    async def test_domain_visibility_accepts_the_domain_derived_from_a_user(
-        self,
-        repository: AppConfigFragmentRepository,
-        scope_owners: None,
-        fragments_across_scopes: list[AppConfigFragmentData],
-    ) -> None:
-        # The same filter, fed the subquery form instead of a literal id — the caller names
-        # only the principal and the domain is derived in the same statement.
-        result = await repository.admin_search(
-            BatchQuerier(
-                pagination=OffsetPagination(limit=10, offset=0),
-                conditions=[
-                    AppConfigFragmentConditions.by_domain_visibility(domain_id_of_user(_USER_ID))
-                ],
-            )
-        )
-        expected = {
-            f.id
-            for f in fragments_across_scopes
-            if f.scope_type is AppConfigScopeType.DOMAIN and f.scope_id == _DOMAIN_SCOPE_ID
-        }
-        assert {item.id for item in result.items} == expected
-
-    async def test_domain_visibility_of_an_unknown_user_matches_nothing(
-        self,
-        repository: AppConfigFragmentRepository,
-        scope_owners: None,
-        fragments_across_scopes: list[AppConfigFragmentData],
-    ) -> None:
-        # The derivation yields SQL NULL for a user that does not exist, so the domain half
-        # of a visibility filter drops out instead of widening.
-        result = await repository.admin_search(
-            BatchQuerier(
-                pagination=OffsetPagination(limit=10, offset=0),
-                conditions=[
-                    AppConfigFragmentConditions.by_domain_visibility(
-                        domain_id_of_user(UserID(uuid.uuid4()))
-                    )
-                ],
-            )
-        )
-        assert result.items == []
-
     async def test_user_visibility_selects_only_that_user(
         self,
         repository: AppConfigFragmentRepository,
@@ -658,6 +614,25 @@ class TestVisibilityConditions:
 
 
 class TestApplicableFragments:
+    async def test_a_user_with_no_domain_row_still_sees_public_and_its_own(
+        self,
+        repository: AppConfigFragmentRepository,
+        scope_owners: None,
+        fragments_across_scopes: list[AppConfigFragmentData],
+    ) -> None:
+        # The domain id is resolved from the user before the filter is built; when that
+        # resolves to nothing the domain overlay drops out instead of widening the query.
+        applicable = await repository.list_visible_fragments_bulk(
+            ["theme"],
+            UserID(uuid.uuid4()),
+        )
+        expected = [
+            f
+            for f in fragments_across_scopes
+            if f.config_name == "theme" and f.scope_type is AppConfigScopeType.PUBLIC
+        ]
+        assert [f.id for f in applicable] == [f.id for f in expected]
+
     async def test_one_query_returns_public_domain_user_rank_ordered(
         self,
         repository: AppConfigFragmentRepository,

--- a/tests/unit/manager/repositories/app_config_fragment/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_repository.py
@@ -53,7 +53,6 @@ from ai.backend.manager.repositories.app_config_fragment.repository import (
 )
 from ai.backend.manager.repositories.app_config_fragment.types import (
     AppConfigFragmentSearchScope,
-    ResolvedAppConfigScope,
 )
 from ai.backend.manager.repositories.app_config_fragment.upserters import (
     AppConfigFragmentUpserterSpec,
@@ -577,15 +576,17 @@ class TestVisibilityConditions:
         }
         assert {item.id for item in result.items} == expected
 
-    async def test_domain_visibility_selects_only_that_domain(
+    async def test_domain_visibility_of_user_selects_only_that_user_s_domain(
         self,
         repository: AppConfigFragmentRepository,
+        scope_owners: None,
         fragments_across_scopes: list[AppConfigFragmentData],
     ) -> None:
+        # The domain is never named directly — it is derived from the user's own domain.
         result = await repository.admin_search(
             BatchQuerier(
                 pagination=OffsetPagination(limit=10, offset=0),
-                conditions=[AppConfigFragmentConditions.by_domain_visibility(_DOMAIN_ID)],
+                conditions=[AppConfigFragmentConditions.by_domain_visibility_of_user(_USER_ID)],
             )
         )
         expected = {
@@ -618,11 +619,12 @@ class TestApplicableFragments:
     async def test_one_query_returns_public_domain_user_rank_ordered(
         self,
         repository: AppConfigFragmentRepository,
+        scope_owners: None,
         fragments_across_scopes: list[AppConfigFragmentData],
     ) -> None:
         applicable = await repository.list_visible_fragments_bulk(
             ["theme"],
-            ResolvedAppConfigScope(domain_id=_DOMAIN_ID, user_id=_USER_ID),
+            _USER_ID,
         )
         # public + the caller's domain + the caller's own user fragment, ordered by the
         # allow-list entries' ranks (scope-type defaults: public < domain < user).
@@ -646,22 +648,24 @@ class TestApplicableFragments:
     async def test_unknown_config_name_returns_empty(
         self,
         repository: AppConfigFragmentRepository,
+        scope_owners: None,
         fragments_across_scopes: list[AppConfigFragmentData],
     ) -> None:
         applicable = await repository.list_visible_fragments_bulk(
             ["unregistered"],
-            ResolvedAppConfigScope(domain_id=_DOMAIN_ID, user_id=_USER_ID),
+            _USER_ID,
         )
         assert applicable == []
 
     async def test_bulk_returns_visible_fragments_for_all_names_ordered(
         self,
         repository: AppConfigFragmentRepository,
+        scope_owners: None,
         fragments_across_scopes: list[AppConfigFragmentData],
     ) -> None:
         applicable = await repository.list_visible_fragments_bulk(
             ["theme", "menu"],
-            ResolvedAppConfigScope(domain_id=_DOMAIN_ID, user_id=_USER_ID),
+            _USER_ID,
         )
         # public + the caller's domain + the caller's own user fragment, for both names.
         expected = {
@@ -684,11 +688,12 @@ class TestApplicableFragments:
     async def test_bulk_empty_names_returns_empty(
         self,
         repository: AppConfigFragmentRepository,
+        scope_owners: None,
         fragments_across_scopes: list[AppConfigFragmentData],
     ) -> None:
         applicable = await repository.list_visible_fragments_bulk(
             [],
-            ResolvedAppConfigScope(domain_id=_DOMAIN_ID, user_id=_USER_ID),
+            _USER_ID,
         )
         assert applicable == []
 

--- a/tests/unit/manager/repositories/app_config_fragment/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_repository.py
@@ -620,8 +620,7 @@ class TestApplicableFragments:
         scope_owners: None,
         fragments_across_scopes: list[AppConfigFragmentData],
     ) -> None:
-        # The domain id is resolved from the user before the filter is built; when that
-        # resolves to nothing the domain overlay drops out instead of widening the query.
+        # An unresolvable domain drops the overlay rather than widening the query.
         applicable = await repository.list_visible_fragments_bulk(
             ["theme"],
             UserID(uuid.uuid4()),

--- a/tests/unit/manager/repositories/app_config_fragment/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_repository.py
@@ -44,6 +44,7 @@ from ai.backend.manager.models.resource_policy import (
     UserResourcePolicyRow,
 )
 from ai.backend.manager.models.user import UserRow
+from ai.backend.manager.models.user.conditions import domain_id_of_user
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.app_config_fragment.purgers import (
     AppConfigFragmentPurgerSpec,
@@ -576,17 +577,15 @@ class TestVisibilityConditions:
         }
         assert {item.id for item in result.items} == expected
 
-    async def test_domain_visibility_of_user_selects_only_that_user_s_domain(
+    async def test_domain_visibility_selects_only_that_domain(
         self,
         repository: AppConfigFragmentRepository,
-        scope_owners: None,
         fragments_across_scopes: list[AppConfigFragmentData],
     ) -> None:
-        # The domain is never named directly — it is derived from the user's own domain.
         result = await repository.admin_search(
             BatchQuerier(
                 pagination=OffsetPagination(limit=10, offset=0),
-                conditions=[AppConfigFragmentConditions.by_domain_visibility_of_user(_USER_ID)],
+                conditions=[AppConfigFragmentConditions.by_domain_visibility(_DOMAIN_ID)],
             )
         )
         expected = {
@@ -595,6 +594,49 @@ class TestVisibilityConditions:
             if f.scope_type is AppConfigScopeType.DOMAIN and f.scope_id == _DOMAIN_SCOPE_ID
         }
         assert {item.id for item in result.items} == expected
+
+    async def test_domain_visibility_accepts_the_domain_derived_from_a_user(
+        self,
+        repository: AppConfigFragmentRepository,
+        scope_owners: None,
+        fragments_across_scopes: list[AppConfigFragmentData],
+    ) -> None:
+        # The same filter, fed the subquery form instead of a literal id — the caller names
+        # only the principal and the domain is derived in the same statement.
+        result = await repository.admin_search(
+            BatchQuerier(
+                pagination=OffsetPagination(limit=10, offset=0),
+                conditions=[
+                    AppConfigFragmentConditions.by_domain_visibility(domain_id_of_user(_USER_ID))
+                ],
+            )
+        )
+        expected = {
+            f.id
+            for f in fragments_across_scopes
+            if f.scope_type is AppConfigScopeType.DOMAIN and f.scope_id == _DOMAIN_SCOPE_ID
+        }
+        assert {item.id for item in result.items} == expected
+
+    async def test_domain_visibility_of_an_unknown_user_matches_nothing(
+        self,
+        repository: AppConfigFragmentRepository,
+        scope_owners: None,
+        fragments_across_scopes: list[AppConfigFragmentData],
+    ) -> None:
+        # The derivation yields SQL NULL for a user that does not exist, so the domain half
+        # of a visibility filter drops out instead of widening.
+        result = await repository.admin_search(
+            BatchQuerier(
+                pagination=OffsetPagination(limit=10, offset=0),
+                conditions=[
+                    AppConfigFragmentConditions.by_domain_visibility(
+                        domain_id_of_user(UserID(uuid.uuid4()))
+                    )
+                ],
+            )
+        )
+        assert result.items == []
 
     async def test_user_visibility_selects_only_that_user(
         self,

--- a/tests/unit/manager/services/app_config/test_service.py
+++ b/tests/unit/manager/services/app_config/test_service.py
@@ -15,7 +15,6 @@ from ai.backend.common.identifier.app_config import AppConfigScopeID
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
 from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
-from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
 from ai.backend.manager.repositories.app_config_fragment.repository import (
     AppConfigFragmentRepository,
 )
@@ -233,28 +232,36 @@ class TestAppConfigService:
         assert result.app_configs[0].merged_config == {"theme": "dark"}
         assert result.app_configs[1].merged_config == {"theme": "dark"}
 
-    async def test_get_without_matching_fragments_raises(
+    async def test_get_without_matching_fragments_returns_an_empty_merge(
         self,
         service: AppConfigService,
         no_fragments: list[AppConfigFragmentData],
     ) -> None:
-        # No contributing fragment is a 404 — not an AppConfigData carrying an empty merge.
-        with pytest.raises(AppConfigFragmentNotFound):
-            await service.get_app_configs(
-                GetAppConfigsAction(config_names=["unknown"], user_id=_USER_ID)
-            )
+        # No contributing fragment is an empty merge, not a 404.
+        result = await service.get_app_configs(
+            GetAppConfigsAction(config_names=["unknown"], user_id=_USER_ID)
+        )
 
-    async def test_get_fails_whole_call_on_one_absent_name(
+        assert [c.config_name for c in result.app_configs] == ["unknown"]
+        assert result.app_configs[0].merged_config == {}
+        assert result.app_configs[0].fragments == []
+
+    async def test_get_keeps_the_merged_names_alongside_an_absent_one(
         self,
         service: AppConfigService,
         two_name_fragments: list[AppConfigFragmentData],
     ) -> None:
-        # "unknown" contributes nothing, so the call fails as a whole — the names that did
-        # contribute are not returned alongside it.
-        with pytest.raises(AppConfigFragmentNotFound):
-            await service.get_app_configs(
-                GetAppConfigsAction(config_names=["theme", "menu", "unknown"], user_id=_USER_ID)
-            )
+        # "unknown" contributes nothing, but that must not withhold the names that did
+        # merge — every requested name still gets its entry, in request order.
+        result = await service.get_app_configs(
+            GetAppConfigsAction(config_names=["theme", "menu", "unknown"], user_id=_USER_ID)
+        )
+
+        assert [c.config_name for c in result.app_configs] == ["theme", "menu", "unknown"]
+        assert result.app_configs[0].merged_config == {"theme": "dark", "lang": "en"}
+        assert result.app_configs[1].merged_config == {"items": ["a"]}
+        assert result.app_configs[2].merged_config == {}
+        assert result.app_configs[2].fragments == []
 
     async def test_get_without_an_injected_user_merges_public_fragments_only(
         self,

--- a/tests/unit/manager/services/app_config/test_service.py
+++ b/tests/unit/manager/services/app_config/test_service.py
@@ -168,7 +168,6 @@ class TestAppConfigService:
         )
 
         assert [c.config_name for c in result.app_configs] == ["theme"]
-        assert result.app_configs[0].fragments == deep_merge_fragments
         assert result.app_configs[0].merged_config == {"theme": "dark", "lang": "en"}
 
     async def test_get_scopes_the_query_to_the_injected_user(
@@ -243,7 +242,6 @@ class TestAppConfigService:
 
         assert [c.config_name for c in result.app_configs] == ["unknown"]
         assert result.app_configs[0].merged_config == {}
-        assert result.app_configs[0].fragments == []
 
     async def test_get_keeps_the_merged_names_alongside_an_absent_one(
         self,
@@ -259,7 +257,6 @@ class TestAppConfigService:
         assert result.app_configs[0].merged_config == {"theme": "dark", "lang": "en"}
         assert result.app_configs[1].merged_config == {"items": ["a"]}
         assert result.app_configs[2].merged_config == {}
-        assert result.app_configs[2].fragments == []
 
     async def test_get_without_an_injected_user_merges_public_fragments_only(
         self,

--- a/tests/unit/manager/services/app_config/test_service.py
+++ b/tests/unit/manager/services/app_config/test_service.py
@@ -168,7 +168,7 @@ class TestAppConfigService:
         )
 
         assert [c.config_name for c in result.app_configs] == ["theme"]
-        assert result.app_configs[0].merged_config == {"theme": "dark", "lang": "en"}
+        assert result.app_configs[0].config == {"theme": "dark", "lang": "en"}
 
     async def test_get_scopes_the_query_to_the_injected_user(
         self,
@@ -196,7 +196,7 @@ class TestAppConfigService:
         )
 
         # The user's shorter nav list fully replaces public's — no trailing "about"/"contact".
-        assert result.app_configs[0].merged_config == {
+        assert result.app_configs[0].config == {
             "nav": ["dashboard"],
             "theme": {"light": True, "dark": True},
         }
@@ -212,8 +212,8 @@ class TestAppConfigService:
 
         # One AppConfigData per requested name, in request order.
         assert [c.config_name for c in result.app_configs] == ["theme", "menu"]
-        assert result.app_configs[0].merged_config == {"theme": "dark", "lang": "en"}
-        assert result.app_configs[1].merged_config == {"items": ["a"]}
+        assert result.app_configs[0].config == {"theme": "dark", "lang": "en"}
+        assert result.app_configs[1].config == {"items": ["a"]}
 
     async def test_get_repeats_duplicate_config_names_in_output(
         self,
@@ -227,8 +227,8 @@ class TestAppConfigService:
         )
 
         assert [c.config_name for c in result.app_configs] == ["theme", "theme"]
-        assert result.app_configs[0].merged_config == {"theme": "dark"}
-        assert result.app_configs[1].merged_config == {"theme": "dark"}
+        assert result.app_configs[0].config == {"theme": "dark"}
+        assert result.app_configs[1].config == {"theme": "dark"}
 
     async def test_get_without_matching_fragments_returns_an_empty_merge(
         self,
@@ -241,7 +241,7 @@ class TestAppConfigService:
         )
 
         assert [c.config_name for c in result.app_configs] == ["unknown"]
-        assert result.app_configs[0].merged_config == {}
+        assert result.app_configs[0].config == {}
 
     async def test_get_keeps_the_merged_names_alongside_an_absent_one(
         self,
@@ -254,9 +254,9 @@ class TestAppConfigService:
         )
 
         assert [c.config_name for c in result.app_configs] == ["theme", "menu", "unknown"]
-        assert result.app_configs[0].merged_config == {"theme": "dark", "lang": "en"}
-        assert result.app_configs[1].merged_config == {"items": ["a"]}
-        assert result.app_configs[2].merged_config == {}
+        assert result.app_configs[0].config == {"theme": "dark", "lang": "en"}
+        assert result.app_configs[1].config == {"items": ["a"]}
+        assert result.app_configs[2].config == {}
 
     async def test_get_without_an_injected_user_merges_public_fragments_only(
         self,
@@ -267,7 +267,7 @@ class TestAppConfigService:
         # Naming no user is the anonymous, pre-login read: only public fragments are queried.
         result = await service.get_app_configs(GetAppConfigsAction(config_names=["theme"]))
 
-        assert result.app_configs[0].merged_config == {"theme": "light", "lang": "en"}
+        assert result.app_configs[0].config == {"theme": "light", "lang": "en"}
         assert result._user_id is None
         mock_fragment_repository.list_visible_fragments_bulk.assert_called_once_with(
             ["theme"], None

--- a/tests/unit/manager/services/app_config/test_service.py
+++ b/tests/unit/manager/services/app_config/test_service.py
@@ -224,7 +224,7 @@ class TestAppConfigService:
         duplicate_name_fragments: list[AppConfigFragmentData],
     ) -> None:
         # A config_name repeated in the request must be repeated in the output — each
-        # position resolves independently, never collapsed into a single entry.
+        # position is merged independently, never collapsed into a single entry.
         result = await service.get_app_configs(
             GetAppConfigsAction(config_names=["theme", "theme"], user_id=_USER_ID)
         )
@@ -250,7 +250,7 @@ class TestAppConfigService:
         two_name_fragments: list[AppConfigFragmentData],
     ) -> None:
         # "unknown" contributes nothing, so the call fails as a whole — the names that did
-        # resolve are not returned alongside it.
+        # contribute are not returned alongside it.
         with pytest.raises(AppConfigFragmentNotFound):
             await service.get_app_configs(
                 GetAppConfigsAction(config_names=["theme", "menu", "unknown"], user_id=_USER_ID)

--- a/tests/unit/manager/services/app_config/test_service.py
+++ b/tests/unit/manager/services/app_config/test_service.py
@@ -1,4 +1,4 @@
-"""Tests for AppConfigService (merged AppConfig resolution) with a mocked repository."""
+"""Tests for AppConfigService (merged AppConfig get) with a mocked repository."""
 
 from __future__ import annotations
 
@@ -13,24 +13,19 @@ import pytest
 from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.identifier.app_config import AppConfigScopeID
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
-from ai.backend.common.identifier.domain import DomainID, DomainName
 from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
 from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
 from ai.backend.manager.repositories.app_config_fragment.repository import (
     AppConfigFragmentRepository,
 )
-from ai.backend.manager.repositories.app_config_fragment.types import ResolvedAppConfigScope
-from ai.backend.manager.services.app_config.actions.resolve import ResolveAppConfigsAction
+from ai.backend.manager.services.app_config.actions.get import GetAppConfigsAction
 from ai.backend.manager.services.app_config.service import AppConfigService
 
 _USER_ID = UserID(uuid.uuid4())
-_DOMAIN_ID = DomainID(uuid.uuid4())
-_DOMAIN_NAME = DomainName("default")
 
-# The same owners seen as a fragment's scope_id, which is polymorphic over scope kinds.
+# The same owner seen as a fragment's scope_id, which is polymorphic over scope kinds.
 _USER_SCOPE_ID = AppConfigScopeID(_USER_ID)
-_DOMAIN_SCOPE_ID = AppConfigScopeID(_DOMAIN_ID)
 _NOW = datetime.now(UTC)
 
 FragmentFactory = Callable[
@@ -68,9 +63,7 @@ def make_fragment() -> FragmentFactory:
 class TestAppConfigService:
     @pytest.fixture
     def mock_fragment_repository(self) -> MagicMock:
-        repository = MagicMock(spec=AppConfigFragmentRepository)
-        repository.get_domain_id_by_name = AsyncMock(return_value=_DOMAIN_ID)
-        return repository
+        return MagicMock(spec=AppConfigFragmentRepository)
 
     @pytest.fixture
     def service(self, mock_fragment_repository: MagicMock) -> AppConfigService:
@@ -166,48 +159,43 @@ class TestAppConfigService:
         mock_fragment_repository.list_visible_fragments_bulk = AsyncMock(return_value=fragments)
         return fragments
 
-    async def test_resolve_deep_merges_applicable_fragments(
+    async def test_get_deep_merges_applicable_fragments(
         self,
         service: AppConfigService,
         deep_merge_fragments: list[AppConfigFragmentData],
     ) -> None:
-        result = await service.resolve_app_configs(
-            ResolveAppConfigsAction(
-                config_names=["theme"], domain_name=_DOMAIN_NAME, user_id=_USER_ID
-            )
+        result = await service.get_app_configs(
+            GetAppConfigsAction(config_names=["theme"], user_id=_USER_ID)
         )
 
         assert [c.config_name for c in result.app_configs] == ["theme"]
         assert result.app_configs[0].fragments == deep_merge_fragments
         assert result.app_configs[0].merged_config == {"theme": "dark", "lang": "en"}
 
-    async def test_resolve_builds_the_scope_from_the_injected_session(
+    async def test_get_scopes_the_query_to_the_injected_user(
         self,
         service: AppConfigService,
         mock_fragment_repository: MagicMock,
         deep_merge_fragments: list[AppConfigFragmentData],
     ) -> None:
-        # Both halves come from the session: the domain name is resolved to its id and paired
-        # with the acting user, so there is no way for a caller to resolve someone else's config.
-        result = await service.resolve_app_configs(
-            ResolveAppConfigsAction(
-                config_names=["theme"], domain_name=_DOMAIN_NAME, user_id=_USER_ID
-            )
+        # The acting user is the whole scope — the domain overlay is derived from it in the
+        # query, so a caller has no way to name someone else's config.
+        result = await service.get_app_configs(
+            GetAppConfigsAction(config_names=["theme"], user_id=_USER_ID)
         )
 
-        mock_fragment_repository.get_domain_id_by_name.assert_called_once_with(_DOMAIN_NAME)
         mock_fragment_repository.list_visible_fragments_bulk.assert_called_once_with(
-            ["theme"], ResolvedAppConfigScope(domain_id=_DOMAIN_ID, user_id=_USER_ID)
+            ["theme"], _USER_ID
         )
         assert result.scope_id() == str(_USER_ID)
 
-    async def test_resolve_replaces_lists_wholesale(
+    async def test_get_replaces_lists_wholesale(
         self,
         service: AppConfigService,
         list_replace_fragments: list[AppConfigFragmentData],
     ) -> None:
-        result = await service.resolve_app_configs(
-            ResolveAppConfigsAction(config_names=["ui"], domain_name=_DOMAIN_NAME, user_id=_USER_ID)
+        result = await service.get_app_configs(
+            GetAppConfigsAction(config_names=["ui"], user_id=_USER_ID)
         )
 
         # The user's shorter nav list fully replaces public's — no trailing "about"/"contact".
@@ -216,15 +204,13 @@ class TestAppConfigService:
             "theme": {"light": True, "dark": True},
         }
 
-    async def test_resolve_groups_by_name_and_merges_each(
+    async def test_get_groups_by_name_and_merges_each(
         self,
         service: AppConfigService,
         two_name_fragments: list[AppConfigFragmentData],
     ) -> None:
-        result = await service.resolve_app_configs(
-            ResolveAppConfigsAction(
-                config_names=["theme", "menu"], domain_name=_DOMAIN_NAME, user_id=_USER_ID
-            )
+        result = await service.get_app_configs(
+            GetAppConfigsAction(config_names=["theme", "menu"], user_id=_USER_ID)
         )
 
         # One AppConfigData per requested name, in request order.
@@ -232,37 +218,33 @@ class TestAppConfigService:
         assert result.app_configs[0].merged_config == {"theme": "dark", "lang": "en"}
         assert result.app_configs[1].merged_config == {"items": ["a"]}
 
-    async def test_resolve_repeats_duplicate_config_names_in_output(
+    async def test_get_repeats_duplicate_config_names_in_output(
         self,
         service: AppConfigService,
         duplicate_name_fragments: list[AppConfigFragmentData],
     ) -> None:
         # A config_name repeated in the request must be repeated in the output — each
         # position resolves independently, never collapsed into a single entry.
-        result = await service.resolve_app_configs(
-            ResolveAppConfigsAction(
-                config_names=["theme", "theme"], domain_name=_DOMAIN_NAME, user_id=_USER_ID
-            )
+        result = await service.get_app_configs(
+            GetAppConfigsAction(config_names=["theme", "theme"], user_id=_USER_ID)
         )
 
         assert [c.config_name for c in result.app_configs] == ["theme", "theme"]
         assert result.app_configs[0].merged_config == {"theme": "dark"}
         assert result.app_configs[1].merged_config == {"theme": "dark"}
 
-    async def test_resolve_without_matching_fragments_raises(
+    async def test_get_without_matching_fragments_raises(
         self,
         service: AppConfigService,
         no_fragments: list[AppConfigFragmentData],
     ) -> None:
         # No contributing fragment is a 404 — not an AppConfigData carrying an empty merge.
         with pytest.raises(AppConfigFragmentNotFound):
-            await service.resolve_app_configs(
-                ResolveAppConfigsAction(
-                    config_names=["unknown"], domain_name=_DOMAIN_NAME, user_id=_USER_ID
-                )
+            await service.get_app_configs(
+                GetAppConfigsAction(config_names=["unknown"], user_id=_USER_ID)
             )
 
-    async def test_resolve_fails_whole_call_on_one_absent_name(
+    async def test_get_fails_whole_call_on_one_absent_name(
         self,
         service: AppConfigService,
         two_name_fragments: list[AppConfigFragmentData],
@@ -270,41 +252,19 @@ class TestAppConfigService:
         # "unknown" contributes nothing, so the call fails as a whole — the names that did
         # resolve are not returned alongside it.
         with pytest.raises(AppConfigFragmentNotFound):
-            await service.resolve_app_configs(
-                ResolveAppConfigsAction(
-                    config_names=["theme", "menu", "unknown"],
-                    domain_name=_DOMAIN_NAME,
-                    user_id=_USER_ID,
-                )
+            await service.get_app_configs(
+                GetAppConfigsAction(config_names=["theme", "menu", "unknown"], user_id=_USER_ID)
             )
 
-    async def test_resolve_without_an_injected_user_merges_public_fragments_only(
+    async def test_get_without_an_injected_user_merges_public_fragments_only(
         self,
         service: AppConfigService,
         mock_fragment_repository: MagicMock,
         public_only_fragments: list[AppConfigFragmentData],
     ) -> None:
-        # A domain name but no user_id: the adapter had no session to fill the user from, so
-        # this degrades to the anonymous read rather than failing.
-        result = await service.resolve_app_configs(
-            ResolveAppConfigsAction(config_names=["theme"], domain_name=_DOMAIN_NAME)
-        )
-
-        assert result.app_configs[0].merged_config == {"theme": "light", "lang": "en"}
-        assert result._user_id is None
-        mock_fragment_repository.list_visible_fragments_bulk.assert_called_once_with(
-            ["theme"], None
-        )
-
-    async def test_resolve_without_domain_or_user_merges_public_fragments_only(
-        self,
-        service: AppConfigService,
-        mock_fragment_repository: MagicMock,
-        public_only_fragments: list[AppConfigFragmentData],
-    ) -> None:
-        # Naming no scope at all is the other half of the anonymous read: only public
-        # fragments are queried, and the result is attributable to no user.
-        result = await service.resolve_app_configs(ResolveAppConfigsAction(config_names=["theme"]))
+        # Naming no user is the anonymous, pre-login read: only public fragments are queried,
+        # and the result is attributable to no user.
+        result = await service.get_app_configs(GetAppConfigsAction(config_names=["theme"]))
 
         assert result.app_configs[0].merged_config == {"theme": "light", "lang": "en"}
         assert result._user_id is None

--- a/tests/unit/manager/services/app_config/test_service.py
+++ b/tests/unit/manager/services/app_config/test_service.py
@@ -13,6 +13,7 @@ import pytest
 from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.identifier.app_config import AppConfigScopeID
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
 from ai.backend.manager.repositories.app_config_fragment.repository import (
@@ -22,6 +23,7 @@ from ai.backend.manager.services.app_config.actions.get import GetAppConfigsActi
 from ai.backend.manager.services.app_config.service import AppConfigService
 
 _USER_ID = UserID(uuid.uuid4())
+_DOMAIN_ID = DomainID(uuid.uuid4())
 
 # The same owner seen as a fragment's scope_id, which is polymorphic over scope kinds.
 _USER_SCOPE_ID = AppConfigScopeID(_USER_ID)
@@ -164,7 +166,7 @@ class TestAppConfigService:
         deep_merge_fragments: list[AppConfigFragmentData],
     ) -> None:
         result = await service.get_app_configs(
-            GetAppConfigsAction(config_names=["theme"], user_id=_USER_ID)
+            GetAppConfigsAction(config_names=["theme"], user_id=_USER_ID, domain_id=_DOMAIN_ID)
         )
 
         assert [c.config_name for c in result.app_configs] == ["theme"]
@@ -178,11 +180,11 @@ class TestAppConfigService:
     ) -> None:
         # The acting user is the whole scope, so a caller cannot name someone else's config.
         result = await service.get_app_configs(
-            GetAppConfigsAction(config_names=["theme"], user_id=_USER_ID)
+            GetAppConfigsAction(config_names=["theme"], user_id=_USER_ID, domain_id=_DOMAIN_ID)
         )
 
         mock_fragment_repository.list_visible_fragments_bulk.assert_called_once_with(
-            ["theme"], _USER_ID
+            ["theme"], _USER_ID, _DOMAIN_ID
         )
         assert result.scope_id() == str(_USER_ID)
 
@@ -270,5 +272,5 @@ class TestAppConfigService:
         assert result.app_configs[0].config == {"theme": "light", "lang": "en"}
         assert result._user_id is None
         mock_fragment_repository.list_visible_fragments_bulk.assert_called_once_with(
-            ["theme"], None
+            ["theme"], None, None
         )

--- a/tests/unit/manager/services/app_config/test_service.py
+++ b/tests/unit/manager/services/app_config/test_service.py
@@ -13,28 +13,25 @@ import pytest
 from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.identifier.app_config import AppConfigScopeID
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
-from ai.backend.common.identifier.domain import DomainID
+from ai.backend.common.identifier.domain import DomainID, DomainName
 from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
 from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
 from ai.backend.manager.repositories.app_config_fragment.repository import (
     AppConfigFragmentRepository,
 )
-from ai.backend.manager.repositories.app_config_fragment.types import (
-    AppConfigScopeArguments,
-    ResolvedAppConfigScope,
-)
+from ai.backend.manager.repositories.app_config_fragment.types import ResolvedAppConfigScope
 from ai.backend.manager.services.app_config.actions.resolve import ResolveAppConfigsAction
 from ai.backend.manager.services.app_config.service import AppConfigService
 
 _USER_ID = UserID(uuid.uuid4())
 _DOMAIN_ID = DomainID(uuid.uuid4())
+_DOMAIN_NAME = DomainName("default")
 
 # The same owners seen as a fragment's scope_id, which is polymorphic over scope kinds.
 _USER_SCOPE_ID = AppConfigScopeID(_USER_ID)
 _DOMAIN_SCOPE_ID = AppConfigScopeID(_DOMAIN_ID)
 _NOW = datetime.now(UTC)
-_SCOPE_ARGS = AppConfigScopeArguments(domain_id=_DOMAIN_ID)
 
 FragmentFactory = Callable[
     [str, dict[str, Any], AppConfigScopeType, AppConfigScopeID | None],
@@ -71,7 +68,9 @@ def make_fragment() -> FragmentFactory:
 class TestAppConfigService:
     @pytest.fixture
     def mock_fragment_repository(self) -> MagicMock:
-        return MagicMock(spec=AppConfigFragmentRepository)
+        repository = MagicMock(spec=AppConfigFragmentRepository)
+        repository.get_domain_id_by_name = AsyncMock(return_value=_DOMAIN_ID)
+        return repository
 
     @pytest.fixture
     def service(self, mock_fragment_repository: MagicMock) -> AppConfigService:
@@ -174,7 +173,7 @@ class TestAppConfigService:
     ) -> None:
         result = await service.resolve_app_configs(
             ResolveAppConfigsAction(
-                config_names=["theme"], scope_arguments=_SCOPE_ARGS, user_id=_USER_ID
+                config_names=["theme"], domain_name=_DOMAIN_NAME, user_id=_USER_ID
             )
         )
 
@@ -182,20 +181,21 @@ class TestAppConfigService:
         assert result.app_configs[0].fragments == deep_merge_fragments
         assert result.app_configs[0].merged_config == {"theme": "dark", "lang": "en"}
 
-    async def test_resolve_builds_the_scope_from_the_injected_user(
+    async def test_resolve_builds_the_scope_from_the_injected_session(
         self,
         service: AppConfigService,
         mock_fragment_repository: MagicMock,
         deep_merge_fragments: list[AppConfigFragmentData],
     ) -> None:
-        # The caller names only the domain; the handler injects the user half, so there is
-        # no way for a caller to resolve someone else's config.
+        # Both halves come from the session: the domain name is resolved to its id and paired
+        # with the acting user, so there is no way for a caller to resolve someone else's config.
         result = await service.resolve_app_configs(
             ResolveAppConfigsAction(
-                config_names=["theme"], scope_arguments=_SCOPE_ARGS, user_id=_USER_ID
+                config_names=["theme"], domain_name=_DOMAIN_NAME, user_id=_USER_ID
             )
         )
 
+        mock_fragment_repository.get_domain_id_by_name.assert_called_once_with(_DOMAIN_NAME)
         mock_fragment_repository.list_visible_fragments_bulk.assert_called_once_with(
             ["theme"], ResolvedAppConfigScope(domain_id=_DOMAIN_ID, user_id=_USER_ID)
         )
@@ -207,9 +207,7 @@ class TestAppConfigService:
         list_replace_fragments: list[AppConfigFragmentData],
     ) -> None:
         result = await service.resolve_app_configs(
-            ResolveAppConfigsAction(
-                config_names=["ui"], scope_arguments=_SCOPE_ARGS, user_id=_USER_ID
-            )
+            ResolveAppConfigsAction(config_names=["ui"], domain_name=_DOMAIN_NAME, user_id=_USER_ID)
         )
 
         # The user's shorter nav list fully replaces public's — no trailing "about"/"contact".
@@ -225,7 +223,7 @@ class TestAppConfigService:
     ) -> None:
         result = await service.resolve_app_configs(
             ResolveAppConfigsAction(
-                config_names=["theme", "menu"], scope_arguments=_SCOPE_ARGS, user_id=_USER_ID
+                config_names=["theme", "menu"], domain_name=_DOMAIN_NAME, user_id=_USER_ID
             )
         )
 
@@ -243,7 +241,7 @@ class TestAppConfigService:
         # position resolves independently, never collapsed into a single entry.
         result = await service.resolve_app_configs(
             ResolveAppConfigsAction(
-                config_names=["theme", "theme"], scope_arguments=_SCOPE_ARGS, user_id=_USER_ID
+                config_names=["theme", "theme"], domain_name=_DOMAIN_NAME, user_id=_USER_ID
             )
         )
 
@@ -260,7 +258,7 @@ class TestAppConfigService:
         with pytest.raises(AppConfigFragmentNotFound):
             await service.resolve_app_configs(
                 ResolveAppConfigsAction(
-                    config_names=["unknown"], scope_arguments=_SCOPE_ARGS, user_id=_USER_ID
+                    config_names=["unknown"], domain_name=_DOMAIN_NAME, user_id=_USER_ID
                 )
             )
 
@@ -275,7 +273,7 @@ class TestAppConfigService:
             await service.resolve_app_configs(
                 ResolveAppConfigsAction(
                     config_names=["theme", "menu", "unknown"],
-                    scope_arguments=_SCOPE_ARGS,
+                    domain_name=_DOMAIN_NAME,
                     user_id=_USER_ID,
                 )
             )
@@ -286,10 +284,10 @@ class TestAppConfigService:
         mock_fragment_repository: MagicMock,
         public_only_fragments: list[AppConfigFragmentData],
     ) -> None:
-        # Scope arguments but no user_id: the handler had no session to fill it from, so
+        # A domain name but no user_id: the adapter had no session to fill the user from, so
         # this degrades to the anonymous read rather than failing.
         result = await service.resolve_app_configs(
-            ResolveAppConfigsAction(config_names=["theme"], scope_arguments=_SCOPE_ARGS)
+            ResolveAppConfigsAction(config_names=["theme"], domain_name=_DOMAIN_NAME)
         )
 
         assert result.app_configs[0].merged_config == {"theme": "light", "lang": "en"}
@@ -298,7 +296,7 @@ class TestAppConfigService:
             ["theme"], None
         )
 
-    async def test_resolve_without_scope_arguments_merges_public_fragments_only(
+    async def test_resolve_without_domain_or_user_merges_public_fragments_only(
         self,
         service: AppConfigService,
         mock_fragment_repository: MagicMock,

--- a/tests/unit/manager/services/app_config/test_service.py
+++ b/tests/unit/manager/services/app_config/test_service.py
@@ -177,8 +177,7 @@ class TestAppConfigService:
         mock_fragment_repository: MagicMock,
         deep_merge_fragments: list[AppConfigFragmentData],
     ) -> None:
-        # The acting user is the whole scope — the domain overlay is derived from it in the
-        # query, so a caller has no way to name someone else's config.
+        # The acting user is the whole scope, so a caller cannot name someone else's config.
         result = await service.get_app_configs(
             GetAppConfigsAction(config_names=["theme"], user_id=_USER_ID)
         )
@@ -251,8 +250,7 @@ class TestAppConfigService:
         service: AppConfigService,
         two_name_fragments: list[AppConfigFragmentData],
     ) -> None:
-        # "unknown" contributes nothing, but that must not withhold the names that did
-        # merge — every requested name still gets its entry, in request order.
+        # "unknown" contributes nothing, but that must not withhold the names that did merge.
         result = await service.get_app_configs(
             GetAppConfigsAction(config_names=["theme", "menu", "unknown"], user_id=_USER_ID)
         )
@@ -269,8 +267,7 @@ class TestAppConfigService:
         mock_fragment_repository: MagicMock,
         public_only_fragments: list[AppConfigFragmentData],
     ) -> None:
-        # Naming no user is the anonymous, pre-login read: only public fragments are queried,
-        # and the result is attributable to no user.
+        # Naming no user is the anonymous, pre-login read: only public fragments are queried.
         result = await service.get_app_configs(GetAppConfigsAction(config_names=["theme"]))
 
         assert result.app_configs[0].merged_config == {"theme": "light", "lang": "en"}


### PR DESCRIPTION
## 📚 Stacked PRs

Part of the AppConfigFragment / AppConfig stack under BEP-1052 (epic BA-5781). **Merge in order (bottom-up):**

1. ✅ #12306 — `feat(BA-6552)`: app_config_fragments DB model and Alembic migration
2. ✅ #12307 — `feat(BA-6553)`: repository layer
3. ✅ #12403 — `refactor(BA-6619)`: consolidate AppConfigScopeType into common.data
4. ✅ #12405 — `refactor(BA-6620)`: ExistsQuerier + AppConfigAllowList.exists
5. ✅ #12358 — `feat(BA-6554)`: AppConfigFragment service layer
6. ✅ #12516 — `feat(BA-6702)`: move fragment rank to the allow list with scope defaults
7. ✅ #12517 — `feat(BA-6701)`: expose allow-list rank on the v2 API surface
8. ✅ #12518 — `feat(BA-6704)`: cascade app config subtree deletion from the definition
9. ✅ #12426 — `feat(BA-6626)`: app_config_fragment bulk repository layer
10. ✅ #12401 — `feat(BA-6618)`: app_config_fragment bulk CRUD service layer
11. ✅ #12706 — `feat(BA-6810)`: AppConfigFragment visible-fragments query (repository layer)
12. ✅ #12826 — `feat(BA-6859)`: bind fragments to their RBAC scope on write (repository layer)
13. ✅ #12837 — `fix(BA-6872)`: seed `APP_CONFIG_FRAGMENT` permissions into the RBAC role fixture
14. ✅ #12839 — `chore(BA-6873)`: drop the dead APP_CONFIG RBAC entity type
15. ✅ #12359 — `feat(BA-6555)`: AppConfig merge engine + resolve service (service layer)
16. ✅ #12984 — `feat(BA-6948)`: store `app_config_fragments.scope_id` as a nullable UUID
17. ✅ #12928 — `feat(BA-6921)`: AppConfig fragment write REST v2 API (CRUD)
18. #13020 — `feat(BA-6922)`: AppConfig fragment search REST v2 API (admin + scoped)
19. 👉 **#12377 — `feat(BA-6556)`: merged AppConfig REST v2 read API** ← you are here
20. #13377 — `feat(BA-7150)`: merged AppConfig GraphQL read (my + public)
21. #13378 — `feat(BA-7151)`: merged AppConfig SDK v2
22. #13382 — `feat(BA-7153)`: merged AppConfig CLI v2
23. #13386 — `test(BA-7154)`: component tests for the merged AppConfig read

> **Fork at #12928**: the fragment search (#13020) and this merged-read both stack on #12928, which has merged — either order from here. Rebased onto `main`, so this PR's diff is now its own 12 files.

## Summary

Adds the **merged AppConfig REST v2 read** surface (BA-6556), split out of the original combined PR. Gets the deep-merged `(user, config_name)` view via the service/merge layer (#12359) and renders it — together with the ordered contributing fragments — as REST v2.

## What's included

- **DTOs** (`common/dto/manager/v2/app_config/`): `MyGetAppConfigsInput`, `PublicGetAppConfigsInput`, `AppConfigNode` (merged config + contributing fragments), `GetAppConfigsPayload`.
- **REST v2** (`api/rest/v2/app_config/`): handler + registry under `/v2/app-config`.
- **Adapter** (`api/adapters/app_config/adapter.py`): dedicated `AppConfigAdapter` for the read path.
- **Scope**: the merged read is scoped by the acting user alone, so a caller can never name someone else's scope. `ResolveAppConfigsAction`/`AppConfigScopeArguments` are gone; the action carries only `config_names` + an adapter-injected `user_id`. The domain overlay is derived from the user: the db_source resolves the caller's domain id and then filters on it, so `AppConfigFragmentConditions.by_domain_visibility` keeps taking a plain `DomainID` and the visibility filters stay 1:1 with `AppConfigScopeType`. A user whose domain does not resolve simply loses the domain overlay.
- **Missing names do not fail the batch**: a requested name nothing visible contributes to yields an entry with an empty `merged_config` and no `fragments`, rather than failing the whole call with a 404. One name with no `public` fragment must not withhold the names that did merge — that case is ordinary on the pre-login read.
- **Endpoints**:
  - `POST /v2/app-config/my/get` — merged view for the authenticated caller (`auth_required`). The principal comes from the session, never from the request body.
  - `POST /v2/app-config/public/get` — anonymous, public-fragments-only merged read (no middleware).

## Split note

Split from the combined BA-6556 PR by entity. The raw fragment write/search half moved to **#12928 (BA-6921)**, which has since merged. `AppConfigNode.fragments` reuses `AppConfigFragmentNode` from that PR's DTO. No behavior change vs. the combined PR — the OpenAPI dump of the two stacked PRs is identical to the original.

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12377.org.readthedocs.build/en/12377/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12377.org.readthedocs.build/ko/12377/

<!-- readthedocs-preview sorna-ko end -->


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12377.org.readthedocs.build/en/12377/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12377.org.readthedocs.build/ko/12377/

<!-- readthedocs-preview sorna-ko end -->


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12377.org.readthedocs.build/en/12377/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12377.org.readthedocs.build/ko/12377/

<!-- readthedocs-preview sorna-ko end -->





<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12377.org.readthedocs.build/en/12377/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12377.org.readthedocs.build/ko/12377/

<!-- readthedocs-preview sorna-ko end -->