### PR TITLE
fix(BA-6597): preserve container-registry API error category in metrics

### DIFF
--- a/changes/12397.fix.md
+++ b/changes/12397.fix.md
@@ -1,0 +1,1 @@
+Preserve the container registry API failure category (e.g. forbidden) in action metrics instead of collapsing it into a generic internal error

--- a/src/ai/backend/common/exception.py
+++ b/src/ai/backend/common/exception.py
@@ -876,6 +876,26 @@ class ModelRevisionNotFound(BackendAIError, web.HTTPNotFound):
         )
 
 
+# Standard HTTP error statuses -> ErrorDetail. Statuses without a corresponding ErrorDetail
+# (e.g. 405, 429) fall back to INTERNAL_ERROR.
+_HTTP_STATUS_TO_ERROR_DETAIL: dict[int, ErrorDetail] = {
+    400: ErrorDetail.BAD_REQUEST,
+    401: ErrorDetail.UNAUTHORIZED,
+    403: ErrorDetail.FORBIDDEN,
+    404: ErrorDetail.NOT_FOUND,
+    408: ErrorDetail.TIMEOUT,
+    409: ErrorDetail.CONFLICT,
+    410: ErrorDetail.GONE,
+    415: ErrorDetail.CONTENT_TYPE_MISMATCH,
+    422: ErrorDetail.INVALID_PARAMETERS,
+    500: ErrorDetail.INTERNAL_ERROR,
+    501: ErrorDetail.NOT_IMPLEMENTED,
+    502: ErrorDetail.UNREACHABLE,
+    503: ErrorDetail.UNAVAILABLE,
+    504: ErrorDetail.TIMEOUT,
+}
+
+
 class PassthroughError(BackendAIError):
     """
     Wraps and forwards errors from requests with original status code and message.
@@ -895,6 +915,26 @@ class PassthroughError(BackendAIError):
         self._error_code = error_code
         extra_msg = error_message or f"An error occurred with status code {status_code}"
         super().__init__(extra_msg=extra_msg)
+
+    @classmethod
+    def from_http_status(
+        cls,
+        status_code: int,
+        *,
+        domain: ErrorDomain,
+        operation: ErrorOperation,
+        error_message: str | None = None,
+    ) -> Self:
+        """
+        Build from an upstream HTTP status, mapping standard error statuses to an ErrorDetail
+        (unmapped statuses -> INTERNAL_ERROR) so the failure category is preserved.
+        """
+        error_detail = _HTTP_STATUS_TO_ERROR_DETAIL.get(status_code, ErrorDetail.INTERNAL_ERROR)
+        return cls(
+            status_code=status_code,
+            error_code=ErrorCode(domain=domain, operation=operation, error_detail=error_detail),
+            error_message=error_message,
+        )
 
     def error_code(self) -> ErrorCode:
         return self._error_code

--- a/src/ai/backend/manager/container_registry/github.py
+++ b/src/ai/backend/manager/container_registry/github.py
@@ -4,6 +4,7 @@ from typing import override
 
 import aiohttp
 
+from ai.backend.common.exception import ErrorDomain, ErrorOperation, PassthroughError
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.exceptions import ContainerRegistryProjectEmpty
 
@@ -51,6 +52,9 @@ class GitHubRegistry(BaseContainerRegistry):
                     else:
                         break
                 else:
-                    raise RuntimeError(
-                        f"Failed to fetch repositories! {response.status} error occured."
+                    raise PassthroughError.from_http_status(
+                        response.status,
+                        domain=ErrorDomain.CONTAINER_REGISTRY,
+                        operation=ErrorOperation.LIST,
+                        error_message=f"Failed to fetch repositories! {response.status} error occurred.",
                     )

--- a/src/ai/backend/manager/container_registry/github.py
+++ b/src/ai/backend/manager/container_registry/github.py
@@ -55,6 +55,6 @@ class GitHubRegistry(BaseContainerRegistry):
                     raise PassthroughError.from_http_status(
                         response.status,
                         domain=ErrorDomain.CONTAINER_REGISTRY,
-                        operation=ErrorOperation.LIST,
+                        operation=ErrorOperation.UPDATE,
                         error_message=f"Failed to fetch repositories! {response.status} error occurred.",
                     )

--- a/src/ai/backend/manager/container_registry/gitlab.py
+++ b/src/ai/backend/manager/container_registry/gitlab.py
@@ -5,6 +5,7 @@ from typing import override
 
 import aiohttp
 
+from ai.backend.common.exception import ErrorDomain, ErrorOperation, PassthroughError
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.exceptions import ContainerRegistryProjectEmpty
 
@@ -54,6 +55,10 @@ class GitLabRegistry(BaseContainerRegistry):
                     else:
                         break
                 else:
-                    raise RuntimeError(
-                        f"Failed to fetch repositories for project {self.registry_info.project}! {response.status} error occurred."
+                    raise PassthroughError.from_http_status(
+                        response.status,
+                        domain=ErrorDomain.CONTAINER_REGISTRY,
+                        operation=ErrorOperation.LIST,
+                        error_message=f"Failed to fetch repositories for project "
+                        f"{self.registry_info.project}! {response.status} error occurred.",
                     )

--- a/src/ai/backend/manager/container_registry/gitlab.py
+++ b/src/ai/backend/manager/container_registry/gitlab.py
@@ -58,7 +58,7 @@ class GitLabRegistry(BaseContainerRegistry):
                     raise PassthroughError.from_http_status(
                         response.status,
                         domain=ErrorDomain.CONTAINER_REGISTRY,
-                        operation=ErrorOperation.LIST,
+                        operation=ErrorOperation.UPDATE,
                         error_message=f"Failed to fetch repositories for project "
                         f"{self.registry_info.project}! {response.status} error occurred.",
                     )

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -13,6 +13,7 @@ import yarl
 
 from ai.backend.common.docker import ImageRef, arch_name_aliases
 from ai.backend.common.docker import login as registry_login
+from ai.backend.common.exception import ErrorDomain, ErrorOperation, PassthroughError
 from ai.backend.common.json import read_json
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.exceptions import (
@@ -186,7 +187,12 @@ class HarborRegistry_v2(BaseContainerRegistry):
                     if (
                         e.status != 404
                     ):  #  404 means image is already removed from harbor so we can just safely ignore the exception
-                        raise RuntimeError(f"Failed to untag {image}: {e.message}") from e
+                        raise PassthroughError.from_http_status(
+                            e.status,
+                            domain=ErrorDomain.CONTAINER_REGISTRY,
+                            operation=ErrorOperation.SOFT_DELETE,
+                            error_message=f"Failed to untag {image}: {e.message}",
+                        ) from e
 
     @override
     async def fetch_repositories(
@@ -215,10 +221,14 @@ class HarborRegistry_v2(BaseContainerRegistry):
             async with sess.get(repo_list_url, allow_redirects=False, **rqst_args) as resp:
                 items = await resp.json()
                 if isinstance(items, dict) and (errors := items.get("errors", [])):
-                    raise RuntimeError(
-                        f"failed to fetch repositories in project {self.registry_info.project}",
-                        errors[0]["code"],
-                        errors[0]["message"],
+                    code = errors[0].get("code")
+                    message = errors[0].get("message")
+                    raise PassthroughError.from_http_status(
+                        resp.status,
+                        domain=ErrorDomain.CONTAINER_REGISTRY,
+                        operation=ErrorOperation.LIST,
+                        error_message=f"failed to fetch repositories in project "
+                        f"{self.registry_info.project} (code={code}): {message}",
                     )
                 repos = [item["name"] for item in items]
                 for item in repos:

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -190,7 +190,7 @@ class HarborRegistry_v2(BaseContainerRegistry):
                         raise PassthroughError.from_http_status(
                             e.status,
                             domain=ErrorDomain.CONTAINER_REGISTRY,
-                            operation=ErrorOperation.SOFT_DELETE,
+                            operation=ErrorOperation.HARD_DELETE,
                             error_message=f"Failed to untag {image}: {e.message}",
                         ) from e
 
@@ -226,7 +226,7 @@ class HarborRegistry_v2(BaseContainerRegistry):
                     raise PassthroughError.from_http_status(
                         resp.status,
                         domain=ErrorDomain.CONTAINER_REGISTRY,
-                        operation=ErrorOperation.LIST,
+                        operation=ErrorOperation.UPDATE,
                         error_message=f"failed to fetch repositories in project "
                         f"{self.registry_info.project} (code={code}): {message}",
                     )

--- a/tests/unit/common/test_exception.py
+++ b/tests/unit/common/test_exception.py
@@ -111,3 +111,40 @@ class TestBackendAIErrorCode:
 
         # Verify content type is application/problem+json
         assert resp.content_type == "application/problem+json"
+
+
+class TestPassthroughErrorFromHttpStatus:
+    def test_maps_status_to_error_code(self) -> None:
+        # 403 must surface as forbidden (the observed container-registry bug); this string is
+        # what the metric error_detail is derived from.
+        err = PassthroughError.from_http_status(
+            403,
+            domain=ErrorDomain.CONTAINER_REGISTRY,
+            operation=ErrorOperation.LIST,
+        )
+        assert str(err.error_code()) == "container-registry_list-query_forbidden"
+
+    def test_maps_server_error_status(self) -> None:
+        # The mapping covers server-error statuses too, not just 4xx.
+        err = PassthroughError.from_http_status(
+            503,
+            domain=ErrorDomain.CONTAINER_REGISTRY,
+            operation=ErrorOperation.READ,
+        )
+        assert err.error_code().error_detail == ErrorDetail.UNAVAILABLE
+
+    def test_unmapped_status_falls_back_to_internal(self) -> None:
+        err = PassthroughError.from_http_status(
+            429,
+            domain=ErrorDomain.CONTAINER_REGISTRY,
+            operation=ErrorOperation.READ,
+        )
+        assert err.error_code().error_detail == ErrorDetail.INTERNAL_ERROR
+
+    def test_preserves_original_status_code(self) -> None:
+        err = PassthroughError.from_http_status(
+            403,
+            domain=ErrorDomain.CONTAINER_REGISTRY,
+            operation=ErrorOperation.READ,
+        )
+        assert err.status_code == 403


### PR DESCRIPTION
## Summary
- Registry-side API errors (e.g. Harbor `FORBIDDEN`) during rescan were raised as a bare `RuntimeError`, so the action processor caught them in its generic `except BaseException` branch and tagged them `backendai_generic_internal-error` in `backendai_action_count_total` — masking the real failure category (forbidden vs genuine internal error).
- Add `PassthroughError.from_http_status()` in `common/exception.py`: a standard HTTP-status → `ErrorDetail` mapping (4xx + 5xx; unmapped → `INTERNAL_ERROR`) that preserves the upstream status code.
- Raise `PassthroughError.from_http_status(...)` from the Harbor/GitLab/GitHub scanners (`fetch_repositories`, Harbor untag) instead of bare `RuntimeError`, so the failure category survives into metrics and audit logs.

## Test plan
- [ ] `pants test tests/unit/common/test_exception.py` — `from_http_status` mapping (403→forbidden, 503→unavailable, unmapped→internal, status preserved)
- [ ] CI: container_registry unit + component suites (no regression)

Resolves BA-6597