### PR TITLE
refactor(BA-6619): consolidate AppConfigScopeType into common.data (single definition)

### DIFF
--- a/changes/12403.misc.md
+++ b/changes/12403.misc.md
@@ -1,0 +1,1 @@
+Consolidate the duplicated `AppConfigScopeType` enum into a single definition in `ai.backend.common.data.app_config` (imported directly by every layer).

--- a/src/ai/backend/client/cli/v2/admin/app_config_allow_list.py
+++ b/src/ai/backend/client/cli/v2/admin/app_config_allow_list.py
@@ -13,7 +13,7 @@ from ai.backend.client.cli.v2.helpers import (
     parse_order_options,
     print_result,
 )
-from ai.backend.common.dto.manager.v2.app_config_allow_list.types import AppConfigScopeType
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 
 
 @click.group()

--- a/src/ai/backend/common/data/app_config/types.py
+++ b/src/ai/backend/common/data/app_config/types.py
@@ -1,0 +1,43 @@
+"""Shared app config types — the single source for the app config scope enum (BEP-1052)."""
+
+from __future__ import annotations
+
+import enum
+
+from ai.backend.common.data.permission.types import ScopeType
+
+__all__ = ("AppConfigScopeType",)
+
+
+class AppConfigScopeType(enum.StrEnum):
+    """Scope at which an app config fragment is written (BEP-1052).
+
+    The single definition shared across the data, DTO, GraphQL, and API layers.
+    """
+
+    PUBLIC = "public"
+    DOMAIN = "domain"
+    USER = "user"
+
+    def to_rbac_scope_type(self) -> ScopeType:
+        """The RBAC scope a write at this fragment scope acts on.
+
+        ``public`` is a system-wide write (``GLOBAL``); ``domain`` / ``user`` act at that
+        domain / user scope. This is why writing a fragment is not admin-only — an
+        allow-listed user may write their own ``user``-scope fragment.
+        """
+        match self:
+            case AppConfigScopeType.PUBLIC:
+                return ScopeType.GLOBAL
+            case AppConfigScopeType.DOMAIN:
+                return ScopeType.DOMAIN
+            case AppConfigScopeType.USER:
+                return ScopeType.USER
+
+    def to_rbac_scope_id(self, scope_id: str) -> str:
+        """The RBAC scope id for a write at this fragment scope.
+
+        ``public`` is system-wide (no per-entity scope id); ``domain`` / ``user`` carry
+        their own ``scope_id``.
+        """
+        return "" if self is AppConfigScopeType.PUBLIC else scope_id

--- a/src/ai/backend/common/dto/manager/v2/app_config_allow_list/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_allow_list/request.py
@@ -7,10 +7,10 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseRequestModel
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter
 from ai.backend.common.dto.manager.v2.app_config_allow_list.types import (
     AppConfigAllowListOrderField,
-    AppConfigScopeType,
     AppConfigScopeTypeFilter,
 )
 from ai.backend.common.dto.manager.v2.common import OrderDirection

--- a/src/ai/backend/common/dto/manager/v2/app_config_allow_list/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_allow_list/response.py
@@ -8,7 +8,7 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
-from ai.backend.common.dto.manager.v2.app_config_allow_list.types import AppConfigScopeType
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 
 __all__ = (
     "AppConfigAllowListNode",

--- a/src/ai/backend/common/dto/manager/v2/app_config_allow_list/types.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_allow_list/types.py
@@ -7,18 +7,12 @@ from enum import StrEnum
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseRequestModel
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 
 __all__ = (
-    "AppConfigScopeType",
     "AppConfigScopeTypeFilter",
     "AppConfigAllowListOrderField",
 )
-
-
-class AppConfigScopeType(StrEnum):
-    PUBLIC = "public"
-    DOMAIN = "domain"
-    USER = "user"
 
 
 class AppConfigScopeTypeFilter(BaseRequestModel):

--- a/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from functools import lru_cache
 
+from ai.backend.common.data.app_config.types import AppConfigScopeType
+from ai.backend.common.data.app_config.types import AppConfigScopeType as AppConfigScopeTypeDTO
 from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
     AppConfigAllowListFilter,
     AppConfigAllowListOrder,
@@ -22,16 +24,12 @@ from ai.backend.common.dto.manager.v2.app_config_allow_list.types import (
     AppConfigAllowListOrderField,
     AppConfigScopeTypeFilter,
 )
-from ai.backend.common.dto.manager.v2.app_config_allow_list.types import (
-    AppConfigScopeType as AppConfigScopeTypeDTO,
-)
 from ai.backend.common.dto.manager.v2.common import OrderDirection
 from ai.backend.common.identifier.app_config_allow_list import AppConfigAllowListID
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.app_config_allow_list.types import (
     AppConfigAllowListData,
-    AppConfigScopeType,
 )
 from ai.backend.manager.models.app_config_allow_list.conditions import (
     AppConfigAllowListConditions,

--- a/src/ai/backend/manager/api/gql/app_config_allow_list/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_allow_list/types.py
@@ -11,6 +11,7 @@ from uuid import UUID
 from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID
 
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
     AppConfigAllowListFilter as AppConfigAllowListFilterDTO,
 )
@@ -31,9 +32,6 @@ from ai.backend.common.dto.manager.v2.app_config_allow_list.response import (
 )
 from ai.backend.common.dto.manager.v2.app_config_allow_list.response import (
     PurgeAppConfigAllowListPayload as PurgeAppConfigAllowListPayloadDTO,
-)
-from ai.backend.common.dto.manager.v2.app_config_allow_list.types import (
-    AppConfigScopeType,
 )
 from ai.backend.common.dto.manager.v2.app_config_allow_list.types import (
     AppConfigScopeTypeFilter as AppConfigScopeTypeFilterDTO,

--- a/src/ai/backend/manager/data/app_config_allow_list/types.py
+++ b/src/ai/backend/manager/data/app_config_allow_list/types.py
@@ -1,18 +1,10 @@
 from __future__ import annotations
 
-import enum
 from dataclasses import dataclass
 from datetime import datetime
 
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.identifier.app_config_allow_list import AppConfigAllowListID
-
-
-class AppConfigScopeType(enum.StrEnum):
-    """Scope at which an app config fragment may be written (BEP-1052)."""
-
-    PUBLIC = "public"
-    DOMAIN = "domain"
-    USER = "user"
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/data/app_config_fragment/types.py
+++ b/src/ai/backend/manager/data/app_config_fragment/types.py
@@ -1,19 +1,11 @@
 from __future__ import annotations
 
-import enum
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
-
-
-class AppConfigScopeType(enum.StrEnum):
-    """Scope at which an app config fragment is written (BEP-1052)."""
-
-    PUBLIC = "public"
-    DOMAIN = "domain"
-    USER = "user"
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/models/app_config_allow_list/conditions.py
+++ b/src/ai/backend/manager/models/app_config_allow_list/conditions.py
@@ -8,8 +8,8 @@ from datetime import datetime
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.data.filter_specs import StringMatchSpec
-from ai.backend.manager.data.app_config_allow_list.types import AppConfigScopeType
 from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
 from ai.backend.manager.models.condition_utils import make_string_in_factory
 from ai.backend.manager.repositories.base import QueryCondition

--- a/src/ai/backend/manager/models/app_config_allow_list/row.py
+++ b/src/ai/backend/manager/models/app_config_allow_list/row.py
@@ -5,10 +5,10 @@ from datetime import datetime
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.identifier.app_config_allow_list import AppConfigAllowListID
 from ai.backend.manager.data.app_config_allow_list.types import (
     AppConfigAllowListData,
-    AppConfigScopeType,
 )
 from ai.backend.manager.models.base import GUID, Base, StrEnumType
 

--- a/src/ai/backend/manager/models/app_config_fragment/conditions.py
+++ b/src/ai/backend/manager/models/app_config_fragment/conditions.py
@@ -8,8 +8,8 @@ from datetime import datetime
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.data.filter_specs import StringMatchSpec
-from ai.backend.manager.data.app_config_fragment.types import AppConfigScopeType
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
 from ai.backend.manager.models.condition_utils import make_string_in_factory
 from ai.backend.manager.repositories.base import QueryCondition

--- a/src/ai/backend/manager/models/app_config_fragment/row.py
+++ b/src/ai/backend/manager/models/app_config_fragment/row.py
@@ -7,10 +7,10 @@ import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
 from ai.backend.manager.data.app_config_fragment.types import (
     AppConfigFragmentData,
-    AppConfigScopeType,
 )
 from ai.backend.manager.models.base import GUID, Base, StrEnumType
 

--- a/src/ai/backend/manager/repositories/app_config_allow_list/creators.py
+++ b/src/ai/backend/manager/repositories/app_config_allow_list/creators.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.manager.data.app_config_allow_list.types import AppConfigScopeType
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
 from ai.backend.manager.repositories.base import CreatorSpec
 

--- a/src/ai/backend/manager/repositories/app_config_fragment/creators.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/creators.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.manager.data.app_config_fragment.types import AppConfigScopeType
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
 from ai.backend.manager.repositories.base.creator import DependentCreatorSpec
 

--- a/tests/unit/client_v2/test_app_config_allow_list.py
+++ b/tests/unit/client_v2/test_app_config_allow_list.py
@@ -8,6 +8,7 @@ from yarl import URL
 from ai.backend.client.v2.base_client import BackendAIAuthClient
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.domains_v2.app_config_allow_list import V2AppConfigAllowListClient
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
     CreateAppConfigAllowListInput,
     SearchAppConfigAllowListInput,
@@ -18,7 +19,6 @@ from ai.backend.common.dto.manager.v2.app_config_allow_list.response import (
     PurgeAppConfigAllowListPayload,
     SearchAppConfigAllowListPayload,
 )
-from ai.backend.common.dto.manager.v2.app_config_allow_list.types import AppConfigScopeType
 
 from .conftest import MockAuth
 

--- a/tests/unit/manager/api/gql/test_app_config_allow_list_types.py
+++ b/tests/unit/manager/api/gql/test_app_config_allow_list_types.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.dto.manager.v2.app_config_allow_list.response import (
     AppConfigAllowListNode,
 )
 from ai.backend.common.dto.manager.v2.app_config_allow_list.types import (
     AppConfigAllowListOrderField,
-    AppConfigScopeType,
 )
 from ai.backend.manager.api.gql.app_config_allow_list.types import (
     AppConfigAllowListFilterGQL,

--- a/tests/unit/manager/repositories/app_config_allow_list/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_allow_list/test_repository.py
@@ -7,11 +7,11 @@ from collections.abc import AsyncGenerator
 
 import pytest
 
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.common.identifier.app_config_allow_list import AppConfigAllowListID
 from ai.backend.manager.data.app_config_allow_list.types import (
     AppConfigAllowListData,
-    AppConfigScopeType,
 )
 from ai.backend.manager.errors.app_config import AppConfigAllowListNotFound
 from ai.backend.manager.errors.repository import (

--- a/tests/unit/manager/repositories/app_config_fragment/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_repository.py
@@ -7,11 +7,11 @@ from collections.abc import AsyncGenerator
 
 import pytest
 
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
 from ai.backend.manager.data.app_config_fragment.types import (
     AppConfigFragmentData,
-    AppConfigScopeType,
 )
 from ai.backend.manager.errors.app_config import (
     AppConfigDefinitionNotFound,

--- a/tests/unit/manager/services/app_config_allow_list/test_service.py
+++ b/tests/unit/manager/services/app_config_allow_list/test_service.py
@@ -8,11 +8,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.identifier.app_config_allow_list import AppConfigAllowListID
 from ai.backend.manager.data.app_config_allow_list.types import (
     AppConfigAllowListData,
     AppConfigAllowListSearchResult,
-    AppConfigScopeType,
 )
 from ai.backend.manager.errors.app_config import AppConfigAllowListNotFound
 from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow


### PR DESCRIPTION
## Summary

`AppConfigScopeType` was defined **three times** — in the `app_config_allow_list` DTO, the `app_config_allow_list` data, and the `app_config_fragment` data. This consolidates it to a **single definition** in `ai.backend.common.data.app_config.types` (with the `to_rbac_scope_type` / `to_rbac_scope_id` helpers), and has every layer (data, DTO, GraphQL, models, repositories, client, tests) import it directly from there.

**No re-exports**: the DTO `types` module keeps the import only for its `AppConfigScopeTypeFilter` model and drops it from `__all__`; all other modules import from `common.data` directly.

Split out of the AppConfigFragment service PR (#12358) so the enum consolidation lands independently at the **base of the stack**.

## Changes

- New `common/data/app_config/types.py` — the single `AppConfigScopeType`.
- Removed the 3 duplicate `class AppConfigScopeType` definitions; repointed all importers to `common.data`.

## 📚 Stacked PRs

Part of the AppConfigFragment / AppConfig stack under BEP-1052 (epic BA-5781). **Merge in order:**

1. ✅ #12306 — `feat(BA-6552): app_config_fragments DB model and Alembic migration`
2. ✅ #12307 — `feat(BA-6553): repository layer`
3. 👉 **#12403 — `refactor(BA-6619): consolidate AppConfigScopeType into common.data`** ← you are here
4. #12405 — `refactor(BA-6620): ExistsQuerier + AppConfigAllowList.exists`
5. #12358 — `feat(BA-6554): AppConfigFragment service layer`
6. #12401 — `feat(BA-6618): AppConfigFragment bulk CRUD service layer`
7. #12359 — `feat(BA-6555): app_config service layer`
8. #12377 — `feat(BA-6556): AppConfig REST v2 API`