### PR TITLE
refactor(BA-6620): ExistsQuerier ops primitive + AppConfigAllowList.exists

### DIFF
--- a/changes/12405.misc.md
+++ b/changes/12405.misc.md
@@ -1,0 +1,1 @@
+Add a generic `ExistsQuerier` ops primitive (`SELECT EXISTS(...)`) and `AppConfigAllowListRepository.exists` built on it.

--- a/src/ai/backend/manager/repositories/app_config_allow_list/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_allow_list/db_source/db_source.py
@@ -21,7 +21,13 @@ from ai.backend.manager.data.app_config_allow_list.types import (
 )
 from ai.backend.manager.errors.app_config import AppConfigAllowListNotFound
 from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
-from ai.backend.manager.repositories.base import BatchQuerier, Creator, Purger, Querier
+from ai.backend.manager.repositories.base import (
+    BatchQuerier,
+    Creator,
+    ExistsQuerier,
+    Purger,
+    Querier,
+)
 from ai.backend.manager.repositories.ops import DBOpsProvider
 
 __all__ = ("AppConfigAllowListDBSource",)
@@ -89,3 +95,9 @@ class AppConfigAllowListDBSource:
                 has_next_page=result.has_next_page,
                 has_previous_page=result.has_previous_page,
             )
+
+    @app_config_allow_list_db_source_resilience.apply()
+    async def exists(self, querier: ExistsQuerier[AppConfigAllowListRow]) -> bool:
+        """Whether any allow-list row matches the querier's conditions."""
+        async with self._ops.read_ops() as r:
+            return await r.exists(querier)

--- a/src/ai/backend/manager/repositories/app_config_allow_list/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_allow_list/repository.py
@@ -14,7 +14,7 @@ from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowLi
 from ai.backend.manager.repositories.app_config_allow_list.db_source import (
     AppConfigAllowListDBSource,
 )
-from ai.backend.manager.repositories.base import BatchQuerier, Creator, Purger
+from ai.backend.manager.repositories.base import BatchQuerier, Creator, ExistsQuerier, Purger
 from ai.backend.manager.repositories.ops import DBOpsProvider
 
 __all__ = ("AppConfigAllowListRepository",)
@@ -65,3 +65,8 @@ class AppConfigAllowListRepository:
     @app_config_allow_list_repository_resilience.apply()
     async def purge(self, purger: Purger[AppConfigAllowListRow]) -> AppConfigAllowListData:
         return await self._db_source.purge(purger)
+
+    @app_config_allow_list_repository_resilience.apply()
+    async def exists(self, querier: ExistsQuerier[AppConfigAllowListRow]) -> bool:
+        """Whether any allow-list row matches the querier's conditions."""
+        return await self._db_source.exists(querier)

--- a/src/ai/backend/manager/repositories/base/__init__.py
+++ b/src/ai/backend/manager/repositories/base/__init__.py
@@ -62,7 +62,6 @@ from .querier import (
     Querier,
     QuerierResult,
     execute_batch_querier,
-    execute_exists,
     execute_querier,
 )
 from .types import (
@@ -126,7 +125,6 @@ __all__ = [
     "QuerierResult",
     "execute_querier",
     "ExistsQuerier",
-    "execute_exists",
     # BatchQuerier
     "BatchQuerier",
     "BatchQuerierResult",

--- a/src/ai/backend/manager/repositories/base/__init__.py
+++ b/src/ai/backend/manager/repositories/base/__init__.py
@@ -58,9 +58,11 @@ from .purger import (
 from .querier import (
     BatchQuerier,
     BatchQuerierResult,
+    ExistsQuerier,
     Querier,
     QuerierResult,
     execute_batch_querier,
+    execute_exists,
     execute_querier,
 )
 from .types import (
@@ -123,6 +125,8 @@ __all__ = [
     "Querier",
     "QuerierResult",
     "execute_querier",
+    "ExistsQuerier",
+    "execute_exists",
     # BatchQuerier
     "BatchQuerier",
     "BatchQuerierResult",

--- a/src/ai/backend/manager/repositories/base/querier.py
+++ b/src/ai/backend/manager/repositories/base/querier.py
@@ -109,23 +109,6 @@ class ExistsQuerier[TRow: Base]:
     conditions: list[QueryCondition] = field(default_factory=list)
 
 
-async def execute_exists[TRow: Base](
-    db_sess: SASession,
-    querier: ExistsQuerier[TRow],
-) -> bool:
-    """Execute ``SELECT EXISTS(SELECT 1 FROM table WHERE ...)`` and return the boolean.
-
-    Does not count or fetch rows.
-    """
-    inner = (
-        sa.select(sa.literal(True))
-        .select_from(querier.row_class.__table__)
-        .where(*[condition() for condition in querier.conditions])
-    )
-    result = await db_sess.execute(sa.select(inner.exists()))
-    return bool(result.scalar_one())
-
-
 # =============================================================================
 # Batch Querier (with pagination)
 # =============================================================================

--- a/src/ai/backend/manager/repositories/base/querier.py
+++ b/src/ai/backend/manager/repositories/base/querier.py
@@ -92,6 +92,41 @@ async def execute_querier[TRow: Base](
 
 
 # =============================================================================
+# Existence Querier (by conditions)
+# =============================================================================
+
+
+@dataclass
+class ExistsQuerier[TRow: Base]:
+    """Existence check over a table by a set of conditions (combined with AND).
+
+    Attributes:
+        row_class: ORM class for table access.
+        conditions: Query conditions; an empty list checks whether the table has any row.
+    """
+
+    row_class: type[TRow]
+    conditions: list[QueryCondition] = field(default_factory=list)
+
+
+async def execute_exists[TRow: Base](
+    db_sess: SASession,
+    querier: ExistsQuerier[TRow],
+) -> bool:
+    """Execute ``SELECT EXISTS(SELECT 1 FROM table WHERE ...)`` and return the boolean.
+
+    Does not count or fetch rows.
+    """
+    inner = (
+        sa.select(sa.literal(True))
+        .select_from(querier.row_class.__table__)
+        .where(*[condition() for condition in querier.conditions])
+    )
+    result = await db_sess.execute(sa.select(inner.exists()))
+    return bool(result.scalar_one())
+
+
+# =============================================================================
 # Batch Querier (with pagination)
 # =============================================================================
 

--- a/src/ai/backend/manager/repositories/ops/base/provider.py
+++ b/src/ai/backend/manager/repositories/ops/base/provider.py
@@ -34,6 +34,7 @@ from ai.backend.manager.repositories.base import (
     Creator,
     CreatorResult,
     DependentCreatorSpec,
+    ExistsQuerier,
     NextValuePolicy,
     Purger,
     PurgerResult,
@@ -53,6 +54,7 @@ from ai.backend.manager.repositories.base import (
     execute_bulk_updater_partial,
     execute_creator,
     execute_dependent_creator,
+    execute_exists,
     execute_next_value_creator,
     execute_purger,
     execute_querier,
@@ -85,6 +87,10 @@ class ReadOps:
     async def query[TRow: Base](self, querier: Querier[TRow]) -> QuerierResult[TRow] | None:
         """Fetch a single row by primary key."""
         return await execute_querier(self._sess, querier)
+
+    async def exists[TRow: Base](self, querier: ExistsQuerier[TRow]) -> bool:
+        """Whether any row matches the querier's conditions (``SELECT EXISTS(...)``)."""
+        return await execute_exists(self._sess, querier)
 
     async def batch_query_in_global(
         self,

--- a/src/ai/backend/manager/repositories/ops/base/provider.py
+++ b/src/ai/backend/manager/repositories/ops/base/provider.py
@@ -54,7 +54,6 @@ from ai.backend.manager.repositories.base import (
     execute_bulk_updater_partial,
     execute_creator,
     execute_dependent_creator,
-    execute_exists,
     execute_next_value_creator,
     execute_purger,
     execute_querier,
@@ -89,8 +88,17 @@ class ReadOps:
         return await execute_querier(self._sess, querier)
 
     async def exists[TRow: Base](self, querier: ExistsQuerier[TRow]) -> bool:
-        """Whether any row matches the querier's conditions (``SELECT EXISTS(...)``)."""
-        return await execute_exists(self._sess, querier)
+        """Whether any row matches the querier's conditions.
+
+        Runs ``SELECT EXISTS(SELECT 1 FROM table WHERE ...)``; does not count or fetch rows.
+        """
+        inner = (
+            sa.select(sa.literal(True))
+            .select_from(querier.row_class.__table__)
+            .where(*[condition() for condition in querier.conditions])
+        )
+        result = await self._sess.execute(sa.select(inner.exists()))
+        return bool(result.scalar_one())
 
     async def batch_query_in_global(
         self,

--- a/tests/unit/manager/repositories/app_config_allow_list/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_allow_list/test_repository.py
@@ -42,6 +42,7 @@ from ai.backend.manager.repositories.base import (
     Creator,
     CursorBackwardPagination,
     CursorForwardPagination,
+    ExistsQuerier,
     OffsetPagination,
     Purger,
 )
@@ -335,3 +336,39 @@ class TestSearch:
             )
         )
         assert {item.id for item in result.items} == {entry.id for entry in by_created_asc[1:]}
+
+
+class TestExists:
+    @staticmethod
+    def _querier(
+        config_name: str, scope_type: AppConfigScopeType
+    ) -> ExistsQuerier[AppConfigAllowListRow]:
+        return ExistsQuerier(
+            row_class=AppConfigAllowListRow,
+            conditions=[
+                AppConfigAllowListConditions.by_config_name_equals(
+                    StringMatchSpec(config_name, case_insensitive=False, negated=False)
+                ),
+                AppConfigAllowListConditions.by_scope_type_equals(scope_type),
+            ],
+        )
+
+    # existing_entry seeds a single ("theme", PUBLIC) row.
+    @pytest.mark.parametrize(
+        ("config_name", "scope_type", "expected"),
+        [
+            ("theme", AppConfigScopeType.PUBLIC, True),
+            ("theme", AppConfigScopeType.USER, False),
+            ("unregistered", AppConfigScopeType.PUBLIC, False),
+        ],
+    )
+    async def test_exists(
+        self,
+        repository: AppConfigAllowListRepository,
+        existing_entry: AppConfigAllowListData,
+        config_name: str,
+        scope_type: AppConfigScopeType,
+        expected: bool,
+    ) -> None:
+        querier = self._querier(config_name, scope_type)
+        assert await repository.exists(querier) is expected

--- a/tests/unit/manager/repositories/ops/test_provider.py
+++ b/tests/unit/manager/repositories/ops/test_provider.py
@@ -26,6 +26,7 @@ from ai.backend.manager.repositories.base import (
     Creator,
     CreatorSpec,
     DependentCreatorSpec,
+    ExistsQuerier,
     NoPagination,
     Purger,
     Querier,
@@ -190,6 +191,65 @@ class TestDependentCreate:
 
         assert child.parent_id == parent.id
         assert child.label == "solo"
+
+
+class TestExists:
+    async def test_matching_condition_is_true_absent_is_false(
+        self, provider: DBOpsProvider, ops_tables: None
+    ) -> None:
+        async with provider.write_ops() as w:
+            await w.create(Creator(spec=ParentCreatorSpec(name="p1", domain_name="d1")))
+
+        async with provider.read_ops() as r:
+            assert await r.exists(
+                ExistsQuerier(
+                    row_class=OpsTestParentRow,
+                    conditions=[lambda: OpsTestParentRow.name == "p1"],
+                )
+            )
+            assert not await r.exists(
+                ExistsQuerier(
+                    row_class=OpsTestParentRow,
+                    conditions=[lambda: OpsTestParentRow.name == "absent"],
+                )
+            )
+
+    async def test_conditions_are_anded(self, provider: DBOpsProvider, ops_tables: None) -> None:
+        async with provider.write_ops() as w:
+            await w.create(Creator(spec=ParentCreatorSpec(name="p1", domain_name="d1")))
+
+        async with provider.read_ops() as r:
+            assert await r.exists(
+                ExistsQuerier(
+                    row_class=OpsTestParentRow,
+                    conditions=[
+                        lambda: OpsTestParentRow.name == "p1",
+                        lambda: OpsTestParentRow.domain_name == "d1",
+                    ],
+                )
+            )
+            # name matches but domain_name does not — the AND must fail.
+            assert not await r.exists(
+                ExistsQuerier(
+                    row_class=OpsTestParentRow,
+                    conditions=[
+                        lambda: OpsTestParentRow.name == "p1",
+                        lambda: OpsTestParentRow.domain_name == "d2",
+                    ],
+                )
+            )
+
+    async def test_empty_conditions_check_any_row(
+        self, provider: DBOpsProvider, ops_tables: None
+    ) -> None:
+        async with provider.read_ops() as r:
+            assert not await r.exists(ExistsQuerier(row_class=OpsTestParentRow))
+
+        async with provider.write_ops() as w:
+            await w.create(Creator(spec=ParentCreatorSpec(name="p1", domain_name="d1")))
+
+        async with provider.read_ops() as r:
+            assert await r.exists(ExistsQuerier(row_class=OpsTestParentRow))
 
 
 class TestScopeFiltering:

--- a/tests/unit/manager/repositories/ops/test_provider.py
+++ b/tests/unit/manager/repositories/ops/test_provider.py
@@ -193,13 +193,20 @@ class TestDependentCreate:
         assert child.label == "solo"
 
 
+@pytest.fixture
+async def seeded_parent(
+    database_connection: ExtendedAsyncSAEngine,
+    ops_tables: None,
+) -> None:
+    """Seed a single ("p1", "d1") parent row directly, independent of the create op."""
+    async with database_connection.begin() as conn:
+        await conn.execute(sa.insert(OpsTestParentRow).values(name="p1", domain_name="d1"))
+
+
 class TestExists:
     async def test_matching_condition_is_true_absent_is_false(
-        self, provider: DBOpsProvider, ops_tables: None
+        self, provider: DBOpsProvider, seeded_parent: None
     ) -> None:
-        async with provider.write_ops() as w:
-            await w.create(Creator(spec=ParentCreatorSpec(name="p1", domain_name="d1")))
-
         async with provider.read_ops() as r:
             assert await r.exists(
                 ExistsQuerier(
@@ -214,10 +221,7 @@ class TestExists:
                 )
             )
 
-    async def test_conditions_are_anded(self, provider: DBOpsProvider, ops_tables: None) -> None:
-        async with provider.write_ops() as w:
-            await w.create(Creator(spec=ParentCreatorSpec(name="p1", domain_name="d1")))
-
+    async def test_conditions_are_anded(self, provider: DBOpsProvider, seeded_parent: None) -> None:
         async with provider.read_ops() as r:
             assert await r.exists(
                 ExistsQuerier(
@@ -239,15 +243,15 @@ class TestExists:
                 )
             )
 
-    async def test_empty_conditions_check_any_row(
+    async def test_empty_conditions_false_on_empty_table(
         self, provider: DBOpsProvider, ops_tables: None
     ) -> None:
         async with provider.read_ops() as r:
             assert not await r.exists(ExistsQuerier(row_class=OpsTestParentRow))
 
-        async with provider.write_ops() as w:
-            await w.create(Creator(spec=ParentCreatorSpec(name="p1", domain_name="d1")))
-
+    async def test_empty_conditions_true_when_any_row(
+        self, provider: DBOpsProvider, seeded_parent: None
+    ) -> None:
         async with provider.read_ops() as r:
             assert await r.exists(ExistsQuerier(row_class=OpsTestParentRow))
 


### PR DESCRIPTION
## Summary

Adds the existence-check repository primitive used by the AppConfig fragment write-gate, split out of #12358 to keep that PR small:

- **`ExistsQuerier`** dataclass + `execute_exists` in `repositories/base` — `SELECT EXISTS(SELECT 1 FROM table WHERE ...)`, no count/fetch.
- **`ReadOps.exists`** on the ops provider (so it is available inside `write_ops()` too — `WriteOps` extends `ReadOps`).
- **`AppConfigAllowListRepository.exists`** (+ db_source) built on `ExistsQuerier`.
- Real-DB repository tests for `exists`.

The fragment write-gate (#12358) consumes this; here it lands as reusable infrastructure at the base of the stack.

## 📚 Stacked PRs

Part of the AppConfigFragment / AppConfig stack under BEP-1052 (epic BA-5781). **Merge in order:**

1. ✅ #12306 — `feat(BA-6552): app_config_fragments DB model and Alembic migration`
2. ✅ #12307 — `feat(BA-6553): repository layer`
3. #12403 — `refactor(BA-6619): consolidate AppConfigScopeType into common.data`
4. 👉 **#12405 — `refactor(BA-6620): ExistsQuerier + AppConfigAllowList.exists`** ← you are here
5. #12358 — `feat(BA-6554): AppConfigFragment service layer`
6. #12401 — `feat(BA-6618): AppConfigFragment bulk CRUD service layer`
7. #12359 — `feat(BA-6555): app_config service layer`
8. #12377 — `feat(BA-6556): AppConfig REST v2 API`