### PR TITLE
fix(BA-6623): skip bind mount when optional runner binary is missing

### DIFF
--- a/changes/12409.fix.md
+++ b/changes/12409.fix.md
@@ -1,0 +1,1 @@
+Fix container creation failing with a bind-mount error when an optional runner binary (e.g. bssh-server) is absent from the agent's runner directory

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -615,7 +615,9 @@ class AbstractKernelCreationContext[KernelObjectType: AbstractKernel](aobject):
             skip_missing: bool = False,
         ) -> None:
             resolved_path = self.resolve_krunner_filepath("runner/" + filename)
-            if not skip_missing and not resolved_path.exists():
+            if not resolved_path.exists():
+                if skip_missing:
+                    return
                 raise FileNotFoundError(resolved_path)
             _mount(MountTypes.BIND, resolved_path, target_path)
 


### PR DESCRIPTION
## Summary
- `mount_static_binary(skip_missing=True)` only suppressed the `FileNotFoundError` but still added a bind mount for the absent path, so Docker rejected container creation with `bind source path does not exist`.
- This surfaced for `bssh-server.{arch}.bin` (added by #11136), which ships via the `import-bssh.yml` workflow and isn't present in every checkout.
- Return early when the file is missing so the mount is skipped entirely — the intended meaning of `skip_missing`.

## Test plan
- [ ] Create a session on an agent whose runner dir lacks `bssh-server.{arch}.bin`; container starts without the bind-mount error.
- [ ] Confirm required binaries still raise `FileNotFoundError` when absent (non-`skip_missing` path unchanged).

Resolves BA-6623