### PR TITLE
fix(BA-6623): skip bind mount when optional runner binary is missing (#12409)

### DIFF
--- a/changes/12409.fix.md
+++ b/changes/12409.fix.md
@@ -1,0 +1,1 @@
+Fix container creation failing with a bind-mount error when an optional runner binary (e.g. bssh-server) is absent from the agent's runner directory

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -615,7 +615,9 @@ class AbstractKernelCreationContext[KernelObjectType: AbstractKernel](aobject):
             skip_missing: bool = False,
         ) -> None:
             resolved_path = self.resolve_krunner_filepath("runner/" + filename)
-            if not skip_missing and not resolved_path.exists():
+            if not resolved_path.exists():
+                if skip_missing:
+                    return
                 raise FileNotFoundError(resolved_path)
             _mount(MountTypes.BIND, resolved_path, target_path)
 


### PR DESCRIPTION
This is an auto-generated backport PR of #12409 to the 26.4 release.