### PR TITLE
fix(BA-6617): align session service endpoints with client param placement

### DIFF
--- a/changes/12411.fix.md
+++ b/changes/12411.fix.md
@@ -1,0 +1,1 @@
+Fix `400 Malformed body` errors when shutting down a session service (e.g. Tensorboard), downloading files, or imagifying a session by restoring the request parameter placement the WebUI expects on the legacy `/session/` endpoints.

--- a/src/ai/backend/client/v2/domains/session.py
+++ b/src/ai/backend/client/v2/domains/session.py
@@ -224,7 +224,7 @@ class SessionClient(BaseDomainClient):
         await self._client.typed_request_no_content(
             "POST",
             f"{_BASE_PATH}/{session_name}/shutdown-service",
-            request=request,
+            params=request.model_dump(mode="json", exclude_none=True),
         )
 
     # -----------------------------------------------------------------------
@@ -265,7 +265,7 @@ class SessionClient(BaseDomainClient):
             "POST",
             f"{_BASE_PATH}/{session_name}/imagify",
             response_model=ConvertSessionToImageResponse,
-            params=request.model_dump(mode="json", exclude_none=True),
+            request=request,
         )
 
     # -----------------------------------------------------------------------
@@ -409,7 +409,7 @@ class SessionClient(BaseDomainClient):
     ) -> bytes:
         return await self._client.download(
             f"{_BASE_PATH}/{session_name}/download",
-            json=request.model_dump(exclude_none=True),
+            params=request.model_dump(mode="json", exclude_none=True),
         )
 
     async def download_single(

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -1113,11 +1113,11 @@ class SessionHandler:
 
     async def shutdown_service(
         self,
-        body: BodyParam[ShutdownServiceRequest],
+        query: QueryParam[ShutdownServiceRequest],
         ctx: RequestCtx,
     ) -> web.Response:
         request = ctx.request
-        params = body.parsed
+        params = query.parsed
         session_name = request.match_info["session_name"]
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
@@ -1189,11 +1189,11 @@ class SessionHandler:
 
     async def download_files(
         self,
-        body: BodyParam[DownloadFilesRequest],
+        query: QueryParam[DownloadFilesRequest],
         ctx: RequestCtx,
     ) -> web.Response:
         request = ctx.request
-        params = body.parsed
+        params = query.parsed
         session_name = request.match_info["session_name"]
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
@@ -1380,11 +1380,11 @@ class SessionHandler:
 
     async def convert_session_to_image(
         self,
-        query: QueryParam[ConvertSessionToImageRequest],
+        body: BodyParam[ConvertSessionToImageRequest],
         ctx: RequestCtx,
     ) -> APIResponse:
         request = ctx.request
-        params = query.parsed
+        params = body.parsed
         session_name: str = request.match_info["session_name"]
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(

--- a/tests/unit/client_v2/test_session.py
+++ b/tests/unit/client_v2/test_session.py
@@ -297,8 +297,9 @@ class TestServices:
         method, url, body = _last_request_call(mock_session)
         assert method == "POST"
         assert "/session/my-sess/shutdown-service" in url
-        assert body is not None
-        assert body["service_name"] == "jupyter"
+        assert body is None
+        _, kwargs = mock_session.request.call_args
+        assert kwargs["params"]["service_name"] == "jupyter"
 
 
 # ---------------------------------------------------------------------------
@@ -343,9 +344,13 @@ class TestCommitAndImage:
 
         assert isinstance(result, ConvertSessionToImageResponse)
         assert result.task_id == "task-abc"
-        method, url, _ = _last_request_call(mock_session)
+        method, url, body = _last_request_call(mock_session)
         assert method == "POST"
         assert "/session/my-sess/imagify" in url
+        # imagify is a body endpoint (manager reads BodyParam), so image_name
+        # must travel in the JSON body, not the query string.
+        assert body is not None
+        assert body["image_name"] == "my-custom-img"
 
 
 # ---------------------------------------------------------------------------
@@ -505,7 +510,10 @@ class TestBinaryOperations:
         mock_download.assert_awaited_once()
         call_args = mock_download.call_args
         assert "/session/my-sess/download" in call_args.args[0]
-        assert call_args.kwargs["json"]["files"] == ["a.txt", "b.txt"]
+        # download is a query-string endpoint (manager reads QueryParam), so the
+        # files list must travel in the query string, not the JSON body.
+        assert call_args.kwargs.get("json") is None
+        assert call_args.kwargs["params"]["files"] == ["a.txt", "b.txt"]
 
     async def test_download_single(self) -> None:
         mock_client = BackendAIAuthClient(_DEFAULT_CONFIG, MockAuth(), MagicMock())


### PR DESCRIPTION
## Summary
- The legacy `/session/` handlers were rewritten to read parameters from a single fixed source (`BodyParam` or `QueryParam`), diverging from how the WebUI has always called them. Clicking Tensorboard (→ `shutdown-service`) raised `400 Malformed body`.
- Restore compatibility by matching each handler to the source the WebUI sends, and align the SDK v2 client to the same contract:
  - `shutdown-service`: `BodyParam` → `QueryParam`
  - `download`: `BodyParam` → `QueryParam` (matches legacy `MultiKey` `getall` semantics)
  - `imagify`: `QueryParam` → `BodyParam`
- WebUI requires no change; the Python SDK v2 client is updated to the restored contract.

## Test plan
- [x] `pants test tests/unit/client_v2/test_session.py` (updated to assert new param placement)
- [x] `pants test tests/component/session/test_session_execution.py` (`TestSessionShutdownService` exercises SDK → real handler end-to-end)

Resolves BA-6617

🤖 Generated with [Claude Code](https://claude.com/claude-code)