### PR TITLE
fix(BA-758): gate model-service health check on enable flag

### DIFF
--- a/changes/12412.fix.md
+++ b/changes/12412.fix.md
@@ -1,0 +1,1 @@
+Start the model service health check only when health_check.enable is true, instead of whenever a health_check block is present

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -928,7 +928,8 @@ class AbstractCodeRunner(aobject, metaclass=ABCMeta):
             b"start-model-service",
             _dump_json_bytes(model_info),
         ])
-        if health_check_info := model_info.get("service", {}).get("health_check"):
+        health_check_info = model_info.get("service", {}).get("health_check")
+        if health_check_info and health_check_info.get("enable"):
             timeout_seconds = (
                 health_check_info["max_retries"] * health_check_info["max_wait_time"] + 10
             )

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -789,7 +789,8 @@ class BaseRunner(metaclass=ABCMeta):
                 if model_service_info is None:
                     raise RuntimeError("model_service_info is None despite service being started")
                 model_service_info = cast(Mapping[str, Any], model_service_info)
-                if model_service_info.get("health_check"):
+                health_check_info = model_service_info.get("health_check")
+                if health_check_info and health_check_info.get("enable"):
                     self._health_check_task = asyncio.create_task(
                         self.check_model_health(model_info["name"], model_service_info)
                     )


### PR DESCRIPTION
## Summary
- Start the model-service health check only when `health_check.enable` is `true`, instead of whenever a `health_check` block is merely present.
- Applied symmetrically in both the agent side (`agent/kernel.py`, which derives the wait timeout) and the kernel runner side (`kernel/base.py`, which spawns the health-check task).

## Test plan
- [ ] Model service with `health_check.enable: false` (block present) does NOT start a health-check task
- [ ] Model service with `health_check.enable: true` starts the health-check task and computes the timeout
- [ ] Model service with no `health_check` block behaves as before

Resolves BA-758