### PR TITLE
fix: skip bind-mount for missing optional runner binaries

### DIFF
--- a/changes/12413.fix.md
+++ b/changes/12413.fix.md
@@ -1,0 +1,1 @@
+Fix sessions terminating immediately when an optional runner binary (e.g. `bssh-server`) is absent: `mount_static_binary(skip_missing=True)` now skips the bind-mount instead of passing a non-existent source path to Docker.

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -615,7 +615,9 @@ class AbstractKernelCreationContext[KernelObjectType: AbstractKernel](aobject):
             skip_missing: bool = False,
         ) -> None:
             resolved_path = self.resolve_krunner_filepath("runner/" + filename)
-            if not skip_missing and not resolved_path.exists():
+            if not resolved_path.exists():
+                if skip_missing:
+                    return
                 raise FileNotFoundError(resolved_path)
             _mount(MountTypes.BIND, resolved_path, target_path)
 


### PR DESCRIPTION
## Summary

A freshly enqueued session went `CREATING` → `TERMINATING` → `TERMINATED` immediately, with the kernel `container_id` staying `null`. Root cause is in the agent's `mount_static_binary()`.

`mount_static_binary(..., skip_missing=True)` only suppressed the Python `FileNotFoundError` but **still called `_mount()`**, so an absent optional binary was added to the container config as a bind mount anyway. Docker then rejects container creation:

```
DockerError: [400] invalid mount config for type "bind":
bind source path does not exist: .../src/ai/backend/runner/bssh-server.x86_64.bin
```

→ `ContainerCreationFailedError` → kernel `FAILED_TO_CREATE` → session instantly `TERMINATED`.

This triggers whenever a `skip_missing=True` artifact is not present on the agent host — e.g. `bssh-server.{arch}.bin` / `bssh-server.1` when only `bssh.{arch}.bin` is distributed.

## Fix

Return early when the source file is missing and `skip_missing` is set, so the optional binary/man-page is genuinely skipped instead of mounted.

```python
resolved_path = self.resolve_krunner_filepath("runner/" + filename)
if not resolved_path.exists():
    if skip_missing:
        return
    raise FileNotFoundError(resolved_path)
_mount(MountTypes.BIND, resolved_path, target_path)
```

## Verification

- Reproduced on local halfstack: every session with `bssh-server.x86_64.bin` absent terminated instantly.
- After the fix + `./dev restart agent`, enqueued a `python:3.9` session → reaches **RUNNING** normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)