### PR TITLE
fix(BA-758): gate model-service health check on enable flag (#12412)

### DIFF
--- a/changes/12412.fix.md
+++ b/changes/12412.fix.md
@@ -1,0 +1,1 @@
+Start the model service health check only when health_check.enable is true, instead of whenever a health_check block is present

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -928,7 +928,8 @@ class AbstractCodeRunner(aobject, metaclass=ABCMeta):
             b"start-model-service",
             _dump_json_bytes(model_info),
         ])
-        if health_check_info := model_info.get("service", {}).get("health_check"):
+        health_check_info = model_info.get("service", {}).get("health_check")
+        if health_check_info and health_check_info.get("enable"):
             timeout_seconds = (
                 health_check_info["max_retries"] * health_check_info["max_wait_time"] + 10
             )

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -789,7 +789,8 @@ class BaseRunner(metaclass=ABCMeta):
                 if model_service_info is None:
                     raise RuntimeError("model_service_info is None despite service being started")
                 model_service_info = cast(Mapping[str, Any], model_service_info)
-                if model_service_info.get("health_check"):
+                health_check_info = model_service_info.get("health_check")
+                if health_check_info and health_check_info.get("enable"):
                     self._health_check_task = asyncio.create_task(
                         self.check_model_health(model_info["name"], model_service_info)
                     )


### PR DESCRIPTION
This is an auto-generated backport PR of #12412 to the 26.4 release.