### PR TITLE
feat(BA-6603): define Virtual Scope domain types

### DIFF
--- a/changes/12419.feature.md
+++ b/changes/12419.feature.md
@@ -1,0 +1,1 @@
+Add Virtual Scope domain types for the generalized RBAC ownership layer (scope → virtual_scope → entity), with per-edge permission caps.

--- a/src/ai/backend/common/data/permission/virtual_scope.py
+++ b/src/ai/backend/common/data/permission/virtual_scope.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ai.backend.common.data.permission.types import Permission
+from ai.backend.common.entity.types import EntityType, ScopeType
+from ai.backend.common.identifier.virtual_scope import VirtualScopeID
+
+__all__ = (
+    "VirtualScopeData",
+    "AssociationScopeData",
+    "AssociationEntityData",
+)
+
+
+@dataclass(frozen=True)
+class VirtualScopeData:
+    virtual_scope_id: VirtualScopeID
+
+
+@dataclass(frozen=True)
+class AssociationScopeData:
+    """Inbound edge ``real scope -> virtual_scope``: a traditional scope
+    (domain/project/user/...) bound to a virtual scope so it can reach
+    everything the VS owns. Many scopes may bind to the same VS.
+
+    ``is_origin`` marks the single scope the VS fundamentally represents (the
+    scope it was created for); the rest are additional bindings. It drives
+    reverse identity lookup and cascade lifecycle (removing the origin tears
+    down the VS, removing another binding only detaches that scope).
+
+    ``permission_cap`` is the ceiling this hop grants (``None`` = no ceiling);
+    effective permission is clipped by a bitwise AND with the cap.
+    """
+
+    scope_type: ScopeType
+    scope_id: str
+    virtual_scope_id: VirtualScopeID
+    permission_cap: Permission | None
+    is_origin: bool
+
+
+@dataclass(frozen=True)
+class AssociationEntityData:
+    """Outbound edge ``virtual_scope -> entity``: an entity owned by a virtual
+    scope. Attaching one entity here exposes it to every scope bound to the
+    same VS.
+
+    ``permission_cap`` is the ceiling this hop grants (``None`` = no ceiling);
+    effective permission is clipped by a bitwise AND with the cap.
+    """
+
+    virtual_scope_id: VirtualScopeID
+    entity_type: EntityType
+    entity_id: str
+    permission_cap: Permission | None

--- a/src/ai/backend/common/data/permission/virtual_scope.py
+++ b/src/ai/backend/common/data/permission/virtual_scope.py
@@ -15,7 +15,7 @@ __all__ = (
 
 @dataclass(frozen=True)
 class VirtualScopeData:
-    virtual_scope_id: VirtualScopeID
+    id: VirtualScopeID
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/common/identifier/virtual_scope.py
+++ b/src/ai/backend/common/identifier/virtual_scope.py
@@ -1,0 +1,7 @@
+from typing import NewType
+from uuid import UUID
+
+__all__ = ("VirtualScopeID",)
+
+
+VirtualScopeID = NewType("VirtualScopeID", UUID)


### PR DESCRIPTION
## Summary
- Add the domain-level building blocks for the Virtual Scope (VS) RBAC ownership layer, built on the identifier/NewType layer instead of the legacy RBAC enums.
- `VirtualScopeID` identifier (UUID NewType); `VirtualScopeRef` / `VirtualScopeData` for a VS and its backing element.
- `ScopeVirtualBinding` (scope → VS) and `VirtualEntityOwnership` (VS → entity) edges, each carrying a `permission_cap` (`Permission | None`, NULL = no ceiling) in place of a relation type.
- Types only — no ORM, migration, or behavior changes.

## Test plan
- [x] N/A — pure type definitions; covered by `pants check`/`lint` (CI).

Resolves BA-6603