### PR TITLE
refactor(BA-6610): introduce data-layer bulk failure types so data stops importing repositories

### DIFF
--- a/changes/12420.enhance.md
+++ b/changes/12420.enhance.md
@@ -1,0 +1,1 @@
+Introduce pure data-layer bulk failure types so the manager data layer no longer imports upward from the repositories layer

--- a/src/ai/backend/manager/api/adapters/user/adapter.py
+++ b/src/ai/backend/manager/api/adapters/user/adapter.py
@@ -584,8 +584,10 @@ class UserAdapter(BaseAdapter):
         failed = [
             BulkCreateUserV2Error(
                 index=error.index,
-                username=cast(UserCreatorSpec, error.spec).username,
-                email=cast(UserCreatorSpec, error.spec).email,
+                username=(
+                    spec := cast(UserCreatorSpec, action.items[error.index].creator.spec)
+                ).username,
+                email=spec.email,
                 message=str(error.exception),
             )
             for error in result.data.failures
@@ -610,8 +612,10 @@ class UserAdapter(BaseAdapter):
         failed = [
             BulkCreateUserV2Error(
                 index=error.index,
-                username=cast(UserCreatorSpec, error.spec).username,
-                email=cast(UserCreatorSpec, error.spec).email,
+                username=(
+                    spec := cast(UserCreatorSpec, action.items[error.index].creator.spec)
+                ).username,
+                email=spec.email,
                 message=str(error.exception),
             )
             for error in result.data.failures

--- a/src/ai/backend/manager/data/common/bulk.py
+++ b/src/ai/backend/manager/data/common/bulk.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BulkCreateFailure:
+    """A single failed item in a bulk create operation.
+
+    Pure data carrier for data-layer bulk result types. Repositories convert
+    their spec-carrying ``BulkCreatorError`` into this at the layer boundary, so
+    the data layer never imports from repositories. Upper layers re-derive the
+    failed item's identity from their original input via ``index``.
+    """
+
+    index: int
+    exception: Exception
+
+
+@dataclass(frozen=True)
+class BulkUpdateFailure:
+    """A single failed item in a bulk update operation.
+
+    Data-layer counterpart of the repository's ``BulkUpdaterError``; see
+    :class:`BulkCreateFailure` for the conversion contract.
+    """
+
+    index: int
+    exception: Exception
+
+
+@dataclass(frozen=True)
+class BulkPurgeFailure:
+    """A single failed item in a bulk purge operation.
+
+    Data-layer counterpart of the repository's ``BulkPurgerError``; see
+    :class:`BulkCreateFailure` for the conversion contract.
+    """
+
+    index: int
+    exception: Exception

--- a/src/ai/backend/manager/data/role_preset/types.py
+++ b/src/ai/backend/manager/data/role_preset/types.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import TYPE_CHECKING
 
 from ai.backend.common.data.permission.types import (
     EntityType,
@@ -11,15 +10,11 @@ from ai.backend.common.data.permission.types import (
 )
 from ai.backend.common.identifier.role_permission_preset import RolePermissionPresetID
 from ai.backend.common.identifier.role_preset import RolePresetID
-from ai.backend.manager.repositories.base.creator import BulkCreatorError
-from ai.backend.manager.repositories.base.purger import BulkPurgerError
-from ai.backend.manager.repositories.base.updater import BulkUpdaterError
-
-if TYPE_CHECKING:
-    from ai.backend.manager.models.rbac_models.role_permission_preset.row import (
-        RolePermissionPresetRow,
-    )
-    from ai.backend.manager.models.rbac_models.role_preset.row import RolePresetRow
+from ai.backend.manager.data.common.bulk import (
+    BulkCreateFailure,
+    BulkPurgeFailure,
+    BulkUpdateFailure,
+)
 
 
 @dataclass(frozen=True)
@@ -61,22 +56,22 @@ class RolePermissionPresetSearchResult:
 @dataclass(frozen=True)
 class RolePresetBulkPurgeResult:
     successes: list[RolePresetData] = field(default_factory=list)
-    failures: list[BulkPurgerError[RolePresetRow]] = field(default_factory=list)
+    failures: list[BulkPurgeFailure] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
 class RolePresetBulkUpdateResult:
     successes: list[RolePresetData] = field(default_factory=list)
-    failures: list[BulkUpdaterError[RolePresetRow]] = field(default_factory=list)
+    failures: list[BulkUpdateFailure] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
 class RolePermissionPresetBulkAddResult:
     successes: list[RolePermissionPresetData] = field(default_factory=list)
-    failures: list[BulkCreatorError[RolePermissionPresetRow]] = field(default_factory=list)
+    failures: list[BulkCreateFailure] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
 class RolePermissionPresetBulkRemoveResult:
     successes: list[RolePermissionPresetData] = field(default_factory=list)
-    failures: list[BulkPurgerError[RolePermissionPresetRow]] = field(default_factory=list)
+    failures: list[BulkPurgeFailure] = field(default_factory=list)

--- a/src/ai/backend/manager/data/user/types.py
+++ b/src/ai/backend/manager/data/user/types.py
@@ -4,7 +4,7 @@ import enum
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Self, override
+from typing import Any, Self, override
 from uuid import UUID
 
 from sqlalchemy.engine import Row
@@ -12,6 +12,7 @@ from sqlalchemy.engine import Row
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.types import AccessKey
+from ai.backend.manager.data.common.bulk import BulkCreateFailure, BulkUpdateFailure
 from ai.backend.manager.data.keypair.types import KeyPairData
 from ai.backend.manager.data.permission.id import ScopeId
 from ai.backend.manager.data.permission.types import (
@@ -20,11 +21,6 @@ from ai.backend.manager.data.permission.types import (
     ScopeType,
 )
 from ai.backend.manager.errors.resource import DataTransformationFailed
-
-if TYPE_CHECKING:
-    from ai.backend.manager.models.user import UserRow
-    from ai.backend.manager.repositories.base.creator import BulkCreatorError
-    from ai.backend.manager.repositories.base.updater import BulkUpdaterError
 
 
 class UserStatus(enum.StrEnum):
@@ -185,7 +181,7 @@ class BulkUserCreateResultData:
     """
 
     successes: list[UserCreateResultData] = field(default_factory=list)
-    failures: list[BulkCreatorError[UserRow]] = field(default_factory=list)
+    failures: list[BulkCreateFailure] = field(default_factory=list)
 
     def success_count(self) -> int:
         """Get count of successfully created users."""
@@ -206,7 +202,7 @@ class BulkUserUpdateResultData:
     """
 
     successes: list[UserData] = field(default_factory=list)
-    failures: list[BulkUpdaterError[UserRow]] = field(default_factory=list)
+    failures: list[BulkUpdateFailure] = field(default_factory=list)
 
     def success_count(self) -> int:
         """Get count of successfully updated users."""

--- a/src/ai/backend/manager/repositories/role_preset/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/role_preset/db_source/db_source.py
@@ -14,6 +14,11 @@ import sqlalchemy as sa
 from ai.backend.common.identifier.role_permission_preset import RolePermissionPresetID
 from ai.backend.common.identifier.role_preset import RolePresetID
 from ai.backend.logging.utils import BraceStyleAdapter
+from ai.backend.manager.data.common.bulk import (
+    BulkCreateFailure,
+    BulkPurgeFailure,
+    BulkUpdateFailure,
+)
 from ai.backend.manager.data.role_preset.types import (
     RolePermissionPresetBulkAddResult,
     RolePermissionPresetBulkRemoveResult,
@@ -115,7 +120,8 @@ class RolePresetDBSource:
         async with self._ops.write_ops() as w:
             result = await w.bulk_update_partial(updaters)
         successes = [row.to_data() for row in result.successes]
-        return RolePresetBulkUpdateResult(successes=successes, failures=result.errors)
+        failures = [BulkUpdateFailure(index=e.index, exception=e.exception) for e in result.errors]
+        return RolePresetBulkUpdateResult(successes=successes, failures=failures)
 
     async def purge(self, preset_id: RolePresetID) -> bool:
         async with self._ops.write_ops() as w:
@@ -130,7 +136,8 @@ class RolePresetDBSource:
         async with self._ops.write_ops() as w:
             result = await w.bulk_purge_partial(purgers)
         successes = [row.to_data() for row in result.successes]
-        return RolePresetBulkPurgeResult(successes=successes, failures=result.errors)
+        failures = [BulkPurgeFailure(index=e.index, exception=e.exception) for e in result.errors]
+        return RolePresetBulkPurgeResult(successes=successes, failures=failures)
 
     async def bulk_add_permissions(
         self,
@@ -141,7 +148,8 @@ class RolePresetDBSource:
         async with self._ops.write_ops() as w:
             result = await w.bulk_create_partial(bulk_creator)
         successes = [row.to_data() for row in result.successes]
-        return RolePermissionPresetBulkAddResult(successes=successes, failures=result.errors)
+        failures = [BulkCreateFailure(index=e.index, exception=e.exception) for e in result.errors]
+        return RolePermissionPresetBulkAddResult(successes=successes, failures=failures)
 
     async def bulk_remove_permissions(
         self,
@@ -151,4 +159,5 @@ class RolePresetDBSource:
         async with self._ops.write_ops() as w:
             result = await w.bulk_purge_partial(purgers)
         successes = [row.to_data() for row in result.successes]
-        return RolePermissionPresetBulkRemoveResult(successes=successes, failures=result.errors)
+        failures = [BulkPurgeFailure(index=e.index, exception=e.exception) for e in result.errors]
+        return RolePermissionPresetBulkRemoveResult(successes=successes, failures=failures)

--- a/src/ai/backend/manager/repositories/user/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/user/db_source/db_source.py
@@ -21,6 +21,7 @@ from ai.backend.common.identifier.project import ProjectID
 from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import AccessKey, VFolderID
 from ai.backend.logging.utils import BraceStyleAdapter
+from ai.backend.manager.data.common.bulk import BulkCreateFailure, BulkUpdateFailure
 from ai.backend.manager.data.common.types import SearchResult
 from ai.backend.manager.data.keypair.types import (
     GeneratedKeyPairData,
@@ -91,7 +92,6 @@ from ai.backend.manager.models.vfolder import (
     vfolders,
 )
 from ai.backend.manager.repositories.base.creator import (
-    BulkCreatorError,
     Creator,
     execute_creator,
 )
@@ -113,7 +113,7 @@ from ai.backend.manager.repositories.base.rbac.scope_binder import (
 from ai.backend.manager.repositories.base.rbac.scope_unbinder import (
     execute_rbac_scope_entity_unbinder,
 )
-from ai.backend.manager.repositories.base.updater import BulkUpdaterError, Updater, execute_updater
+from ai.backend.manager.repositories.base.updater import Updater, execute_updater
 from ai.backend.manager.repositories.group.creators import ProjectUserMembershipCreatorSpec
 from ai.backend.manager.repositories.group.scope_binders import UserProjectEntityUnbinder
 from ai.backend.manager.repositories.keypair.creators import KeyPairCreatorSpec
@@ -442,7 +442,7 @@ class UserDBSource:
             return BulkUserCreateResultData(successes=[], failures=[])
 
         successes: list[UserCreateResultData] = []
-        failures: list[BulkCreatorError[UserRow]] = []
+        failures: list[BulkCreateFailure] = []
 
         async with self._db.begin_session() as db_session:
             for idx, item in enumerate(items):
@@ -455,7 +455,7 @@ class UserDBSource:
                         successes.append(created)
                 except Exception as e:
                     log.warning("Failed to create user {}: {}", spec.email, str(e))
-                    failures.append(BulkCreatorError(spec=spec, exception=e, index=idx))
+                    failures.append(BulkCreateFailure(index=idx, exception=e))
 
         return BulkUserCreateResultData(successes=successes, failures=failures)
 
@@ -551,7 +551,7 @@ class UserDBSource:
             return BulkUserUpdateResultData(successes=[], failures=[])
 
         successes: list[UserData] = []
-        failures: list[BulkUpdaterError[UserRow]] = []
+        failures: list[BulkUpdateFailure] = []
 
         async with self._db.begin_session() as session:
             for idx, item in enumerate(items):
@@ -563,9 +563,7 @@ class UserDBSource:
                         successes.append(updated_user)
                 except Exception as e:
                     log.warning("Failed to update user {}: {}", item.user_id, str(e))
-                    failures.append(
-                        BulkUpdaterError(spec=item.updater_spec, exception=e, index=idx)
-                    )
+                    failures.append(BulkUpdateFailure(index=idx, exception=e))
 
         return BulkUserUpdateResultData(successes=successes, failures=failures)
 

--- a/src/ai/backend/manager/services/role_preset/actions/bulk_add_permissions.py
+++ b/src/ai/backend/manager/services/role_preset/actions/bulk_add_permissions.py
@@ -3,12 +3,12 @@ from typing import override
 
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.common.bulk import BulkCreateFailure
 from ai.backend.manager.data.role_preset.types import RolePermissionPresetData
 from ai.backend.manager.models.rbac_models.role_permission_preset.row import (
     RolePermissionPresetRow,
 )
 from ai.backend.manager.repositories.base import BulkCreator
-from ai.backend.manager.repositories.base.creator import BulkCreatorError
 from ai.backend.manager.services.role_preset.actions.base import RolePermissionPresetBulkAction
 
 
@@ -25,7 +25,7 @@ class BulkAddRolePermissionPresetsAction(RolePermissionPresetBulkAction):
 @dataclass
 class BulkAddRolePermissionPresetsActionResult(BaseActionResult):
     successes: list[RolePermissionPresetData] = field(default_factory=list)
-    failures: list[BulkCreatorError[RolePermissionPresetRow]] = field(default_factory=list)
+    failures: list[BulkCreateFailure] = field(default_factory=list)
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/role_preset/actions/bulk_remove_permissions.py
+++ b/src/ai/backend/manager/services/role_preset/actions/bulk_remove_permissions.py
@@ -5,11 +5,8 @@ from typing import override
 from ai.backend.common.identifier.role_permission_preset import RolePermissionPresetID
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.common.bulk import BulkPurgeFailure
 from ai.backend.manager.data.role_preset.types import RolePermissionPresetData
-from ai.backend.manager.models.rbac_models.role_permission_preset.row import (
-    RolePermissionPresetRow,
-)
-from ai.backend.manager.repositories.base.purger import BulkPurgerError
 from ai.backend.manager.services.role_preset.actions.base import RolePermissionPresetBulkAction
 
 
@@ -26,7 +23,7 @@ class BulkRemoveRolePermissionPresetsAction(RolePermissionPresetBulkAction):
 @dataclass
 class BulkRemoveRolePermissionPresetsActionResult(BaseActionResult):
     successes: list[RolePermissionPresetData] = field(default_factory=list)
-    failures: list[BulkPurgerError[RolePermissionPresetRow]] = field(default_factory=list)
+    failures: list[BulkPurgeFailure] = field(default_factory=list)
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/role_preset/actions/delete.py
+++ b/src/ai/backend/manager/services/role_preset/actions/delete.py
@@ -3,9 +3,10 @@ from typing import override
 
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.common.bulk import BulkUpdateFailure
 from ai.backend.manager.data.role_preset.types import RolePresetData
 from ai.backend.manager.models.rbac_models.role_preset.row import RolePresetRow
-from ai.backend.manager.repositories.base.updater import BulkUpdaterError, Updater
+from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.services.role_preset.actions.base import RolePresetBulkAction
 
 
@@ -22,7 +23,7 @@ class BulkDeleteRolePresetsAction(RolePresetBulkAction):
 @dataclass
 class BulkDeleteRolePresetsActionResult(BaseActionResult):
     successes: list[RolePresetData] = field(default_factory=list)
-    failures: list[BulkUpdaterError[RolePresetRow]] = field(default_factory=list)
+    failures: list[BulkUpdateFailure] = field(default_factory=list)
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/role_preset/actions/restore.py
+++ b/src/ai/backend/manager/services/role_preset/actions/restore.py
@@ -3,9 +3,10 @@ from typing import override
 
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.common.bulk import BulkUpdateFailure
 from ai.backend.manager.data.role_preset.types import RolePresetData
 from ai.backend.manager.models.rbac_models.role_preset.row import RolePresetRow
-from ai.backend.manager.repositories.base.updater import BulkUpdaterError, Updater
+from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.services.role_preset.actions.base import RolePresetBulkAction
 
 
@@ -22,7 +23,7 @@ class BulkRestoreRolePresetsAction(RolePresetBulkAction):
 @dataclass
 class BulkRestoreRolePresetsActionResult(BaseActionResult):
     successes: list[RolePresetData] = field(default_factory=list)
-    failures: list[BulkUpdaterError[RolePresetRow]] = field(default_factory=list)
+    failures: list[BulkUpdateFailure] = field(default_factory=list)
 
     @override
     def entity_id(self) -> str | None:

--- a/tests/unit/manager/services/user/test_user_service.py
+++ b/tests/unit/manager/services/user/test_user_service.py
@@ -18,6 +18,7 @@ from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.exception import InvalidAPIParameters
 from ai.backend.common.types import AccessKey, SecretKey
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
+from ai.backend.manager.data.common.bulk import BulkCreateFailure, BulkUpdateFailure
 from ai.backend.manager.data.keypair.types import KeyPairData
 from ai.backend.manager.data.user.types import (
     BulkUserCreateResultData,
@@ -30,11 +31,10 @@ from ai.backend.manager.data.user.types import (
 )
 from ai.backend.manager.errors.user import UserConflict, UserNotFound, UserPurgeFailure
 from ai.backend.manager.models.hasher.types import PasswordInfo
-from ai.backend.manager.models.user import UserRow
-from ai.backend.manager.repositories.base.creator import BulkCreatorError, Creator
+from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.pagination import OffsetPagination
 from ai.backend.manager.repositories.base.querier import BatchQuerier
-from ai.backend.manager.repositories.base.updater import BulkUpdaterError, Updater
+from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.user.creators import UserCreatorSpec
 from ai.backend.manager.repositories.user.repository import UserRepository
 from ai.backend.manager.repositories.user.types import (
@@ -303,17 +303,10 @@ class TestBulkCreateUser:
             )
             for i in [0, 1, 3, 4]
         ]
-        failures: list[BulkCreatorError[UserRow]] = [
-            BulkCreatorError(
-                spec=UserCreatorSpec(
-                    email="u2@example.com",
-                    username="u2",
-                    password=_make_password_info(),
-                    need_password_change=False,
-                    domain_name="default",
-                ),
-                exception=InvalidAPIParameters("Duplicate email"),
+        failures: list[BulkCreateFailure] = [
+            BulkCreateFailure(
                 index=2,
+                exception=InvalidAPIParameters("Duplicate email"),
             ),
         ]
         mock_user_repository.bulk_create_users_validated = AsyncMock(
@@ -438,13 +431,10 @@ class TestBulkModifyUser:
         successes = [
             _make_user_data(email=f"u{i}@example.com", username=f"u{i}") for i in [0, 1, 2, 4]
         ]
-        failures: list[BulkUpdaterError[UserRow]] = [
-            BulkUpdaterError(
-                spec=UserUpdaterSpec(
-                    full_name=TriState.update("User 3"),
-                ),
-                exception=UserNotFound("User not found"),
+        failures: list[BulkUpdateFailure] = [
+            BulkUpdateFailure(
                 index=3,
+                exception=UserNotFound("User not found"),
             ),
         ]
         mock_user_repository.bulk_update_users_validated = AsyncMock(


### PR DESCRIPTION
## Summary
- `data/user` and `data/role_preset` result types imported `BulkCreatorError` / `BulkUpdaterError` / `BulkPurgerError` from `repositories.base` — a `data → repositories` layering violation. Those repo error types carry an ORM-bound `CreatorSpec`/`UpdaterSpec`/`Purger`, so they cannot live in the data layer.
- Added pure `BulkCreateFailure` / `BulkUpdateFailure` / `BulkPurgeFailure` (`index` + `exception`) in `data/common/bulk.py`. Repositories convert their spec-carrying errors into these at the layer boundary — the pattern `permission_controller` already uses.
- Upper layers re-derive a failed item's identity from their own input via `index` (e.g. the user bulk-create adapter reads `action.items[error.index].creator.spec` instead of `error.spec`), so the repository spec no longer leaks up to the adapter.
- The repo-level `Bulk*Error` types stay in `repositories.base`; `permission_controller` and `execute_*` still read their `spec`/`purger` within the repository layer.

Success criterion: no `data/*` file imports from `repositories.*` (verified by grep); `pants fmt`/`fix`/`lint`/`check` pass.

## Test plan
- [x] `pants test tests/unit/manager/services/user/test_user_service.py`
- [x] `pants check --changed-since=origin/main` (mypy)
- [x] CI green

Resolves BA-6610