### PR TITLE
chore(BA-6625): Bump pygments to ~=2.17 for Sphinx 7.4 compatibility

### DIFF
--- a/changes/12422.fix.md
+++ b/changes/12422.fix.md
@@ -1,0 +1,1 @@
+Fix the Read the Docs build failing with a dependency conflict by bumping the docs `pygments` pin to `~=2.17`, satisfying Sphinx 7.4's `Pygments>=2.17` requirement.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,6 +5,6 @@ sphinx-intl>=2.1
 sphinx-rtd-theme~=1.3
 sphinxcontrib-mermaid~=0.7.1
 rtds-action~=1.1.0
-pygments~=2.16.1
+pygments~=2.17
 # replace the following line with native support of Sphinx in Pants
 -r ../requirements.txt


### PR DESCRIPTION
resolve #12423  (BA-6625)

## Summary

`docs/requirements.txt` pinned `pygments~=2.16.1` (i.e. `<2.17`) while `Sphinx~=7.2`
resolves to the latest 7.4.x. **Sphinx 7.4.0 raised its floor to `Pygments>=2.17`**, so
pip cannot satisfy both constraints and the Read the Docs builds fail with a
dependency-resolution error.

This is a pre-existing latent conflict (unrelated to any feature change): the
`Sphinx~=7.2` upper bound allows 7.4.x, and it surfaces whenever the docs env is
resolved cleanly.

```
ERROR: Cannot install -r docs/requirements.txt (line 1) and pygments~=2.16.1
because these package versions have conflicting dependencies.
    The user requested pygments~=2.16.1
    sphinx 7.4.7 depends on Pygments>=2.17
```

## Fix

Bump the floor: `pygments~=2.16.1` → `pygments~=2.17` (`>=2.17, <3.0`), which satisfies
Sphinx 7.4's requirement while keeping an explicit pin within Pygments 2.x.

## References

- Sphinx v7.4.0 `pyproject.toml` declares `Pygments>=2.17` — https://github.com/sphinx-doc/sphinx/blob/v7.4.0/pyproject.toml
- PyPI Sphinx 7.4.0 `requires_dist: Pygments>=2.17`, released 2024-07-15 — https://pypi.org/pypi/Sphinx/7.4.0/json

## Test plan

- [ ] Read the Docs builds (`sorna`, `sorna-ko`) resolve dependencies and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12422.org.readthedocs.build/en/12422/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12422.org.readthedocs.build/ko/12422/

<!-- readthedocs-preview sorna-ko end -->