### PR TITLE
feat(BA-6628): conditional-bulk repository primitives

### DIFF
--- a/changes/12429.feature.md
+++ b/changes/12429.feature.md
@@ -1,0 +1,1 @@
+Add generic conditional-bulk repository primitives — `ConditionalCreator`/`Updater`/`Purger` (a write spec paired with an `only_if` existence gate) and `WriteOps.bulk_conditional_*_partial` for per-item partial-success gated bulk writes.

--- a/src/ai/backend/manager/errors/repository.py
+++ b/src/ai/backend/manager/errors/repository.py
@@ -15,6 +15,7 @@ from ai.backend.common.exception import (
     ErrorDomain,
     ErrorOperation,
 )
+from ai.backend.manager.errors.common import GenericForbidden
 
 
 class RepositoryError(BackendAIError):
@@ -192,3 +193,14 @@ class ExclusionViolationError(RepositoryIntegrityError):
             operation=ErrorOperation.GENERIC,
             error_detail=ErrorDetail.CONFLICT,
         )
+
+
+class ConditionalMutationForbidden(GenericForbidden):
+    """A gated bulk write item was rejected because its ``only_if`` gate did not pass.
+
+    Recorded as a per-item failure by the partial ``WriteOps.bulk_conditional_*_partial``
+    methods (the item is recorded in ``errors``, the rest proceed).
+    """
+
+    error_type = "https://api.backend.ai/probs/conditional-mutation-forbidden"
+    error_title = "Conditional mutation is forbidden (gate not satisfied)."

--- a/src/ai/backend/manager/repositories/base/__init__.py
+++ b/src/ai/backend/manager/repositories/base/__init__.py
@@ -4,10 +4,12 @@ Re-exports all public APIs for backward compatibility.
 """
 
 from .creator import (
+    BulkConditionalCreator,
     BulkCreator,
     BulkCreatorError,
     BulkCreatorResult,
     BulkCreatorResultWithFailures,
+    ConditionalCreator,
     Creator,
     CreatorResult,
     CreatorSpec,
@@ -47,8 +49,10 @@ from .purger import (
     BatchPurger,
     BatchPurgerResult,
     BatchPurgerSpec,
+    BulkConditionalPurger,
     BulkPurgerError,
     BulkPurgerResultWithFailures,
+    ConditionalPurger,
     Purger,
     PurgerResult,
     execute_batch_purger,
@@ -72,8 +76,10 @@ from .updater import (
     BatchUpdater,
     BatchUpdaterResult,
     BatchUpdaterSpec,
+    BulkConditionalUpdater,
     BulkUpdaterError,
     BulkUpdaterResult,
+    ConditionalUpdater,
     Updater,
     UpdaterResult,
     UpdaterSpec,
@@ -148,11 +154,17 @@ __all__ = [
     "BulkCreatorResultWithFailures",
     "execute_bulk_creator",
     "execute_bulk_creator_partial",
+    # ConditionalCreator
+    "ConditionalCreator",
+    "BulkConditionalCreator",
     # Updater
     "UpdaterSpec",
     "Updater",
     "UpdaterResult",
     "execute_updater",
+    # ConditionalUpdater
+    "ConditionalUpdater",
+    "BulkConditionalUpdater",
     # BatchUpdater
     "BatchUpdaterSpec",
     "BatchUpdater",
@@ -175,6 +187,9 @@ __all__ = [
     "Purger",
     "PurgerResult",
     "execute_purger",
+    # ConditionalPurger
+    "ConditionalPurger",
+    "BulkConditionalPurger",
     # BulkPurger
     "BulkPurgerError",
     "BulkPurgerResultWithFailures",

--- a/src/ai/backend/manager/repositories/base/creator.py
+++ b/src/ai/backend/manager/repositories/base/creator.py
@@ -13,6 +13,7 @@ from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.clauses import QueryCondition
 
 from .integrity import match_integrity_error, parse_integrity_error
+from .querier import ExistsQuerier
 from .types import IntegrityErrorCheck
 
 if TYPE_CHECKING:
@@ -317,6 +318,38 @@ async def execute_bulk_creator_partial[TRow: Base](
                 )
 
     return BulkCreatorResultWithFailures(successes=successes, errors=errors)
+
+
+@dataclass
+class ConditionalCreator[TRow: Base, TGateRow: Base]:
+    """A creator spec paired with the existence gate (``only_if``) that authorizes it.
+
+    The gate is checked (``SELECT EXISTS``) inside the same write transaction as the insert,
+    so the authorization and the write commit atomically — no check-then-write race. One item
+    of a :class:`BulkConditionalCreator`.
+
+    Attributes:
+        spec: What to insert.
+        only_if: Existence check that must hold for the insert to proceed.
+    """
+
+    spec: CreatorSpec[TRow]
+    only_if: ExistsQuerier[TGateRow]
+
+
+@dataclass
+class BulkConditionalCreator[TRow: Base, TGateRow: Base]:
+    """Bundles gated creator specs for a partial-success conditional bulk insert.
+
+    Each item carries its own ``only_if`` gate and runs in its own savepoint: a rejected gate
+    (or a failed insert) is reported as a per-item failure and skips only that item, while the
+    rest proceed. See ``WriteOps.bulk_conditional_create_partial``.
+
+    Attributes:
+        specs: Gated creator specs to insert, each independently.
+    """
+
+    specs: Sequence[ConditionalCreator[TRow, TGateRow]]
 
 
 async def execute_dependent_creator[TDependency, TRow: Base](

--- a/src/ai/backend/manager/repositories/base/purger.py
+++ b/src/ai/backend/manager/repositories/base/purger.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 from uuid import UUID
@@ -14,6 +15,7 @@ from ai.backend.manager.errors.repository import UnsupportedCompositePrimaryKeyE
 from ai.backend.manager.models.base import Base
 
 from .integrity import parse_integrity_error
+from .querier import ExistsQuerier
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession as SASession
@@ -44,6 +46,38 @@ class PurgerResult[TRow: Base]:
     """Result of executing a single-row delete operation."""
 
     row: TRow
+
+
+@dataclass
+class ConditionalPurger[TRow: Base, TGateRow: Base]:
+    """A purger paired with the existence gate (``only_if``) that authorizes it.
+
+    The gate is checked (``SELECT EXISTS``) inside the same write transaction as the delete,
+    so the authorization and the write commit atomically. One item of a
+    :class:`BulkConditionalPurger`.
+
+    Attributes:
+        purger: The single-row delete to apply.
+        only_if: Existence check that must hold for the delete to proceed.
+    """
+
+    purger: Purger[TRow]
+    only_if: ExistsQuerier[TGateRow]
+
+
+@dataclass
+class BulkConditionalPurger[TRow: Base, TGateRow: Base]:
+    """Bundles gated purgers for a partial-success conditional bulk delete.
+
+    Each item carries its own ``only_if`` gate and runs in its own savepoint: a rejected gate,
+    a missing target, or a failed delete is reported as a per-item failure and skips only that
+    item, while the rest proceed. See ``WriteOps.bulk_conditional_purge_partial``.
+
+    Attributes:
+        purgers: Gated purgers to apply, each independently.
+    """
+
+    purgers: Sequence[ConditionalPurger[TRow, TGateRow]]
 
 
 @dataclass

--- a/src/ai/backend/manager/repositories/base/updater.py
+++ b/src/ai/backend/manager/repositories/base/updater.py
@@ -16,6 +16,7 @@ from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.clauses import QueryCondition
 
 from .integrity import match_integrity_error, parse_integrity_error
+from .querier import ExistsQuerier
 from .types import IntegrityErrorCheck
 
 if TYPE_CHECKING:
@@ -116,6 +117,38 @@ class Updater[TRow: Base]:
 
     spec: UpdaterSpec[TRow]
     pk_value: UUID | str | int
+
+
+@dataclass
+class ConditionalUpdater[TRow: Base, TGateRow: Base]:
+    """An updater paired with the existence gate (``only_if``) that authorizes it.
+
+    The gate is checked (``SELECT EXISTS``) inside the same write transaction as the update,
+    so the authorization and the write commit atomically. One item of a
+    :class:`BulkConditionalUpdater`.
+
+    Attributes:
+        updater: The single-row update to apply.
+        only_if: Existence check that must hold for the update to proceed.
+    """
+
+    updater: Updater[TRow]
+    only_if: ExistsQuerier[TGateRow]
+
+
+@dataclass
+class BulkConditionalUpdater[TRow: Base, TGateRow: Base]:
+    """Bundles gated updaters for a partial-success conditional bulk update.
+
+    Each item carries its own ``only_if`` gate and runs in its own savepoint: a rejected gate,
+    a missing target, or a failed update is reported as a per-item failure and skips only that
+    item, while the rest proceed. See ``WriteOps.bulk_conditional_update_partial``.
+
+    Attributes:
+        updaters: Gated updaters to apply, each independently.
+    """
+
+    updaters: Sequence[ConditionalUpdater[TRow, TGateRow]]
 
 
 @dataclass

--- a/src/ai/backend/manager/repositories/ops/base/provider.py
+++ b/src/ai/backend/manager/repositories/ops/base/provider.py
@@ -15,7 +15,12 @@ from typing import TYPE_CHECKING, Any
 
 import sqlalchemy as sa
 
-from ai.backend.manager.errors.repository import EmptySearchScopeError
+from ai.backend.manager.errors.common import ObjectNotFound
+from ai.backend.manager.errors.repository import (
+    ConditionalMutationForbidden,
+    EmptySearchScopeError,
+    UnsupportedCompositePrimaryKeyError,
+)
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.scopes import SearchScope
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
@@ -26,10 +31,16 @@ from ai.backend.manager.repositories.base import (
     BatchQuerierResult,
     BatchUpdater,
     BatchUpdaterResult,
+    BulkConditionalCreator,
+    BulkConditionalPurger,
+    BulkConditionalUpdater,
     BulkCreator,
+    BulkCreatorError,
     BulkCreatorResult,
     BulkCreatorResultWithFailures,
+    BulkPurgerError,
     BulkPurgerResultWithFailures,
+    BulkUpdaterError,
     BulkUpdaterResult,
     Creator,
     CreatorResult,
@@ -55,10 +66,10 @@ from ai.backend.manager.repositories.base import (
     execute_creator,
     execute_dependent_creator,
     execute_next_value_creator,
-    execute_purger,
     execute_querier,
-    execute_updater,
     execute_upserter,
+    match_integrity_error,
+    parse_integrity_error,
 )
 
 if TYPE_CHECKING:
@@ -153,6 +164,147 @@ class WriteOps(ReadOps):
         """Insert multiple rows, isolating each via a savepoint for partial success."""
         return await execute_bulk_creator_partial(self._sess, bulk)
 
+    async def bulk_conditional_create_partial[TRow: Base, TGateRow: Base](
+        self,
+        bulk: BulkConditionalCreator[TRow, TGateRow],
+    ) -> BulkCreatorResultWithFailures[TRow]:
+        """Insert each gated item independently — partial success.
+
+        Per item: the ``only_if`` gate is checked (``SELECT EXISTS``), then the row is inserted
+        inside a savepoint. A rejected gate (``ConditionalMutationForbidden``) or a failed insert
+        records a failure and rolls back only that item; the rest proceed. Must be used inside
+        ``write_ops()``.
+        """
+        successes: list[TRow] = []
+        errors: list[BulkCreatorError[TRow]] = []
+        for index, conditional in enumerate(bulk.specs):
+            if not await self.exists(conditional.only_if):
+                errors.append(
+                    BulkCreatorError(
+                        spec=conditional.spec,
+                        exception=ConditionalMutationForbidden(
+                            f"Conditional create rejected: gate failed for item at index {index}."
+                        ),
+                        index=index,
+                    )
+                )
+                continue
+            async with self._sess.begin_nested():
+                try:
+                    row = conditional.spec.build_row()
+                    self._sess.add(row)
+                    await self._sess.flush()
+                    successes.append(row)
+                except sa.exc.IntegrityError as e:
+                    parsed = parse_integrity_error(e)
+                    checks = conditional.spec.integrity_error_checks
+                    if checks:
+                        try:
+                            match_integrity_error(parsed, checks)
+                        except Exception as domain_error:
+                            errors.append(
+                                BulkCreatorError(
+                                    spec=conditional.spec, exception=domain_error, index=index
+                                )
+                            )
+                    else:
+                        errors.append(
+                            BulkCreatorError(spec=conditional.spec, exception=parsed, index=index)
+                        )
+                except Exception as e:
+                    errors.append(BulkCreatorError(spec=conditional.spec, exception=e, index=index))
+        return BulkCreatorResultWithFailures(successes=successes, errors=errors)
+
+    async def bulk_conditional_update_partial[TRow: Base, TGateRow: Base](
+        self,
+        bulk: BulkConditionalUpdater[TRow, TGateRow],
+    ) -> BulkUpdaterResult[TRow]:
+        """Update each gated item independently — partial success.
+
+        Per item: the ``only_if`` gate is checked, then the row is updated by primary key inside
+        a savepoint. A rejected gate, a missing target (recorded as ``ObjectNotFound``), or a
+        failed update records a failure and rolls back only that item; the rest proceed. Must be
+        used inside ``write_ops()``.
+        """
+        successes: list[TRow] = []
+        errors: list[BulkUpdaterError[TRow]] = []
+        for index, conditional in enumerate(bulk.updaters):
+            if not await self.exists(conditional.only_if):
+                errors.append(
+                    BulkUpdaterError(
+                        spec=conditional.updater.spec,
+                        exception=ConditionalMutationForbidden(
+                            f"Conditional update rejected: gate failed for item at index {index}."
+                        ),
+                        index=index,
+                    )
+                )
+                continue
+            try:
+                async with self._sess.begin_nested():
+                    result = await self._execute_updater(conditional.updater)
+                    if result is None:
+                        errors.append(
+                            BulkUpdaterError(
+                                spec=conditional.updater.spec,
+                                exception=ObjectNotFound(
+                                    f"Update target not found for item at index {index}."
+                                ),
+                                index=index,
+                            )
+                        )
+                    else:
+                        successes.append(result.row)
+            except Exception as e:
+                errors.append(
+                    BulkUpdaterError(spec=conditional.updater.spec, exception=e, index=index)
+                )
+        return BulkUpdaterResult(successes=successes, errors=errors)
+
+    async def bulk_conditional_purge_partial[TRow: Base, TGateRow: Base](
+        self,
+        bulk: BulkConditionalPurger[TRow, TGateRow],
+    ) -> BulkPurgerResultWithFailures[TRow]:
+        """Delete each gated item independently — partial success.
+
+        Per item: the ``only_if`` gate is checked, then the row is deleted by primary key inside
+        a savepoint. A rejected gate, a missing target (recorded as ``ObjectNotFound``), or a
+        failed delete records a failure and rolls back only that item; the rest proceed. Must be
+        used inside ``write_ops()``.
+        """
+        successes: list[TRow] = []
+        errors: list[BulkPurgerError[TRow]] = []
+        for index, conditional in enumerate(bulk.purgers):
+            if not await self.exists(conditional.only_if):
+                errors.append(
+                    BulkPurgerError(
+                        purger=conditional.purger,
+                        exception=ConditionalMutationForbidden(
+                            f"Conditional purge rejected: gate failed for item at index {index}."
+                        ),
+                        index=index,
+                    )
+                )
+                continue
+            try:
+                async with self._sess.begin_nested():
+                    result = await self._execute_purger(conditional.purger)
+                    if result is None:
+                        errors.append(
+                            BulkPurgerError(
+                                purger=conditional.purger,
+                                exception=ObjectNotFound(
+                                    f"Purge target not found for item at index {index}."
+                                ),
+                                index=index,
+                            )
+                        )
+                    else:
+                        successes.append(result.row)
+            except Exception as e:
+                errors.append(BulkPurgerError(purger=conditional.purger, exception=e, index=index))
+        return BulkPurgerResultWithFailures(successes=successes, errors=errors)
+
     async def create_dependent[TDependency, TRow: Base](
         self,
         spec: DependentCreatorSpec[TDependency, TRow],
@@ -191,9 +343,46 @@ class WriteOps(ReadOps):
         """
         return await execute_next_value_creator(self._sess, policy, spec)
 
+    async def _execute_updater[TRow: Base](
+        self, updater: Updater[TRow]
+    ) -> UpdaterResult[TRow] | None:
+        """Update a single row by primary key (shared by ``update`` and the bulk paths)."""
+        row_class = updater.spec.row_class
+        table = row_class.__table__
+        pk_columns = list(table.primary_key.columns)
+        if len(pk_columns) != 1:
+            raise UnsupportedCompositePrimaryKeyError(
+                "Updater only supports single-column primary keys",
+            )
+        values = updater.spec.build_values()
+        if not values:
+            # No columns to update: return the current row if it exists so callers can tell
+            # "nothing to change" apart from "row not found". None means not found only.
+            existing = await self._sess.execute(
+                sa.select(row_class).where(pk_columns[0] == updater.pk_value)
+            )
+            current_row = existing.scalar_one_or_none()
+            return UpdaterResult(row=current_row) if current_row is not None else None
+        update_stmt = (
+            sa.update(table)
+            .values(values)
+            .where(pk_columns[0] == updater.pk_value)
+            .returning(*table.columns)
+        )
+        select_stmt = sa.select(row_class).from_statement(update_stmt)
+        try:
+            result = await self._sess.execute(select_stmt)
+        except sa.exc.IntegrityError as e:
+            parsed = parse_integrity_error(e)
+            match_integrity_error(parsed, updater.spec.integrity_error_checks)
+        updated_row = result.scalar_one_or_none()
+        if updated_row is None:
+            return None
+        return UpdaterResult(row=updated_row)
+
     async def update[TRow: Base](self, updater: Updater[TRow]) -> UpdaterResult[TRow] | None:
         """Update a single row by primary key."""
-        return await execute_updater(self._sess, updater)
+        return await self._execute_updater(updater)
 
     async def batch_update[TRow: Base](self, updater: BatchUpdater[TRow]) -> BatchUpdaterResult:
         """Update all rows matching the updater conditions."""
@@ -214,9 +403,29 @@ class WriteOps(ReadOps):
         """Insert or update a single row on conflict."""
         return await execute_upserter(self._sess, upserter, index_elements=index_elements)
 
+    async def _execute_purger[TRow: Base](self, purger: Purger[TRow]) -> PurgerResult[TRow] | None:
+        """Delete a single row by primary key (shared by ``purge`` and the bulk paths)."""
+        row_class = purger.row_class
+        table = row_class.__table__
+        pk_columns = list(table.primary_key.columns)
+        if len(pk_columns) != 1:
+            raise UnsupportedCompositePrimaryKeyError(
+                f"Purger only supports single-column primary keys (table: {table.name})",
+            )
+        stmt = sa.delete(table).where(pk_columns[0] == purger.pk_value).returning(*table.columns)
+        try:
+            result = await self._sess.execute(stmt)
+        except sa.exc.IntegrityError as e:
+            raise parse_integrity_error(e) from e
+        row_data = result.fetchone()
+        if row_data is None:
+            return None
+        deleted_row: TRow = row_class(**dict(row_data._mapping))
+        return PurgerResult(row=deleted_row)
+
     async def purge[TRow: Base](self, purger: Purger[TRow]) -> PurgerResult[TRow] | None:
         """Delete a single row by primary key."""
-        return await execute_purger(self._sess, purger)
+        return await self._execute_purger(purger)
 
     async def batch_purge[TRow: Base](self, purger: BatchPurger[TRow]) -> BatchPurgerResult:
         """Delete rows in batches matching the purger subquery."""

--- a/tests/unit/manager/repositories/ops/test_conditional_provider.py
+++ b/tests/unit/manager/repositories/ops/test_conditional_provider.py
@@ -1,0 +1,315 @@
+"""Tests for the conditional-bulk WriteOps primitives.
+
+``bulk_conditional_{create,update,purge}_partial`` apply a per-item ``only_if`` existence gate
+before each write, with partial success: an item whose gate is not satisfied is reported as
+``ConditionalMutationForbidden`` (and a missing update/purge target as a not-found error) while
+the rest of the batch proceeds.
+
+The gate models an authorization check: each write carries a *scope*, and an ``_AllowListRow``
+entry authorizes writes to that scope. Writes to a non-allow-listed scope are forbidden — this
+is the shape a real caller (e.g. a permission/visibility check) would use ``only_if`` for.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ai.backend.manager.errors.repository import ConditionalMutationForbidden
+from ai.backend.manager.models.base import Base
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.base import (
+    BatchQuerier,
+    BulkConditionalCreator,
+    BulkConditionalPurger,
+    BulkConditionalUpdater,
+    ConditionalCreator,
+    ConditionalPurger,
+    ConditionalUpdater,
+    CreatorSpec,
+    ExistsQuerier,
+    NoPagination,
+    Purger,
+    Querier,
+    Updater,
+    UpdaterSpec,
+)
+from ai.backend.manager.repositories.ops import DBOpsProvider
+from ai.backend.testutils.db import with_tables
+
+
+class _ConfigRow(Base):  # type: ignore[misc]
+    """A scoped config row — the entity a conditional bulk write creates / updates / deletes."""
+
+    __tablename__ = "test_cond_config"
+    __table_args__ = {"extend_existing": True}
+
+    id: Mapped[int] = mapped_column(sa.Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    scope: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
+
+class _AllowListRow(Base):  # type: ignore[misc]
+    """Allow-list of scopes a conditional write may touch — the ``only_if`` gate's table.
+
+    An entry for a scope authorizes writes to that scope; a scope with no entry is not
+    authorized, so writes targeting it are reported as ``ConditionalMutationForbidden`` while
+    the rest of the batch proceeds. Stands in for a real permission / visibility check.
+    """
+
+    __tablename__ = "test_cond_allowlist"
+    __table_args__ = {"extend_existing": True}
+
+    id: Mapped[int] = mapped_column(sa.Integer, primary_key=True, autoincrement=True)
+    scope: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
+
+@dataclass
+class _ConfigCreatorSpec(CreatorSpec[_ConfigRow]):
+    name: str
+    scope: str
+
+    def build_row(self) -> _ConfigRow:
+        return _ConfigRow(name=self.name, scope=self.scope)
+
+
+@dataclass
+class _ConfigRenameSpec(UpdaterSpec[_ConfigRow]):
+    new_name: str
+
+    @property
+    def row_class(self) -> type[_ConfigRow]:
+        return _ConfigRow
+
+    def build_values(self) -> dict[str, Any]:
+        return {"name": self.new_name}
+
+
+@pytest.fixture
+async def tables(database_connection: ExtendedAsyncSAEngine) -> AsyncGenerator[None, None]:
+    async with with_tables(database_connection, [_ConfigRow, _AllowListRow]):
+        yield
+
+
+@pytest.fixture
+def provider(database_connection: ExtendedAsyncSAEngine) -> DBOpsProvider:
+    return DBOpsProvider(database_connection)
+
+
+@pytest.fixture
+async def allow_list(
+    database_connection: ExtendedAsyncSAEngine,
+    tables: None,
+) -> None:
+    """Allow-list scope "d1": writes targeting "d1" are authorized, any other scope is not."""
+    async with database_connection.begin() as conn:
+        await conn.execute(sa.insert(_AllowListRow).values(scope="d1"))
+
+
+@pytest.fixture
+async def seeded_configs(
+    database_connection: ExtendedAsyncSAEngine,
+    tables: None,
+) -> dict[str, int]:
+    """Seed one config row per scope — "d1" (allow-listed) and "d2" (not) — to update / purge.
+
+    Returns ``{scope: row id}`` so a test can target the authorized vs. unauthorized row.
+    """
+    async with database_connection.begin() as conn:
+        await conn.execute(
+            sa.insert(_ConfigRow).values([
+                {"name": "cfg-d1", "scope": "d1"},
+                {"name": "cfg-d2", "scope": "d2"},
+            ])
+        )
+        result = await conn.execute(
+            sa.select(_ConfigRow.id, _ConfigRow.scope).where(
+                _ConfigRow.name.in_(["cfg-d1", "cfg-d2"])
+            )
+        )
+        return {row.scope: row.id for row in result}
+
+
+class TestBulkConditionalCreate:
+    async def test_all_authorized_inserts_every_row(
+        self, provider: DBOpsProvider, allow_list: None
+    ) -> None:
+        # Both configs target the allow-listed scope "d1", so every gate is authorized.
+        async with provider.write_ops() as w:
+            result = await w.bulk_conditional_create_partial(
+                BulkConditionalCreator(
+                    specs=[
+                        ConditionalCreator(
+                            spec=_ConfigCreatorSpec(name="cfg-a", scope="d1"),
+                            only_if=ExistsQuerier(
+                                row_class=_AllowListRow,
+                                conditions=[lambda: _AllowListRow.scope == "d1"],
+                            ),
+                        ),
+                        ConditionalCreator(
+                            spec=_ConfigCreatorSpec(name="cfg-b", scope="d1"),
+                            only_if=ExistsQuerier(
+                                row_class=_AllowListRow,
+                                conditions=[lambda: _AllowListRow.scope == "d1"],
+                            ),
+                        ),
+                    ]
+                )
+            )
+
+        assert {row.name for row in result.successes} == {"cfg-a", "cfg-b"}
+        assert result.errors == []
+
+    async def test_unauthorized_scope_is_forbidden(
+        self, provider: DBOpsProvider, allow_list: None
+    ) -> None:
+        # "d1" is allow-listed so it is written; "d2" is not, so that item alone is forbidden.
+        async with provider.write_ops() as w:
+            result = await w.bulk_conditional_create_partial(
+                BulkConditionalCreator(
+                    specs=[
+                        ConditionalCreator(
+                            spec=_ConfigCreatorSpec(name="cfg-d1", scope="d1"),
+                            only_if=ExistsQuerier(
+                                row_class=_AllowListRow,
+                                conditions=[lambda: _AllowListRow.scope == "d1"],
+                            ),
+                        ),
+                        ConditionalCreator(
+                            spec=_ConfigCreatorSpec(name="cfg-d2", scope="d2"),
+                            only_if=ExistsQuerier(
+                                row_class=_AllowListRow,
+                                conditions=[lambda: _AllowListRow.scope == "d2"],
+                            ),
+                        ),
+                    ]
+                )
+            )
+
+        # partial: the "d1" config is inserted; the "d2" item (index 1) is forbidden.
+        assert {row.name for row in result.successes} == {"cfg-d1"}
+        assert [e.index for e in result.errors] == [1]
+        assert isinstance(result.errors[0].exception, ConditionalMutationForbidden)
+        async with provider.read_ops() as r:
+            written = await r.batch_query_in_global(
+                sa.select(_ConfigRow), BatchQuerier(pagination=NoPagination())
+            )
+        assert {row[0].name for row in written.rows} == {"cfg-d1"}
+
+    async def test_empty_specs_returns_empty(self, provider: DBOpsProvider, tables: None) -> None:
+        empty: BulkConditionalCreator[_ConfigRow, _AllowListRow] = BulkConditionalCreator(specs=[])
+        async with provider.write_ops() as w:
+            result = await w.bulk_conditional_create_partial(empty)
+        assert result.successes == []
+        assert result.errors == []
+
+
+class TestBulkConditionalUpdate:
+    async def test_updates_only_authorized_scopes(
+        self, provider: DBOpsProvider, allow_list: None, seeded_configs: dict[str, int]
+    ) -> None:
+        # Each updater is gated on its config's scope: "d1" is authorized, "d2" is not.
+        async with provider.write_ops() as w:
+            result = await w.bulk_conditional_update_partial(
+                BulkConditionalUpdater(
+                    updaters=[
+                        ConditionalUpdater(
+                            updater=Updater(
+                                spec=_ConfigRenameSpec(new_name="cfg-d1-v2"),
+                                pk_value=seeded_configs["d1"],
+                            ),
+                            only_if=ExistsQuerier(
+                                row_class=_AllowListRow,
+                                conditions=[lambda: _AllowListRow.scope == "d1"],
+                            ),
+                        ),
+                        ConditionalUpdater(
+                            updater=Updater(
+                                spec=_ConfigRenameSpec(new_name="cfg-d2-v2"),
+                                pk_value=seeded_configs["d2"],
+                            ),
+                            only_if=ExistsQuerier(
+                                row_class=_AllowListRow,
+                                conditions=[lambda: _AllowListRow.scope == "d2"],
+                            ),
+                        ),
+                    ]
+                )
+            )
+
+        # partial: the "d1" config is updated; the "d2" item (index 1) is forbidden and left as-is.
+        assert [row.name for row in result.successes] == ["cfg-d1-v2"]
+        assert [e.index for e in result.errors] == [1]
+        assert isinstance(result.errors[0].exception, ConditionalMutationForbidden)
+        async with provider.read_ops() as r:
+            unauthorized = await r.query(
+                Querier(row_class=_ConfigRow, pk_value=seeded_configs["d2"])
+            )
+        assert unauthorized is not None
+        assert unauthorized.row.name == "cfg-d2"
+
+    async def test_missing_target_is_reported(
+        self, provider: DBOpsProvider, allow_list: None
+    ) -> None:
+        # The gate is authorized ("d1") but no such row exists -> reported, not a silent success.
+        async with provider.write_ops() as w:
+            result = await w.bulk_conditional_update_partial(
+                BulkConditionalUpdater(
+                    updaters=[
+                        ConditionalUpdater(
+                            updater=Updater(
+                                spec=_ConfigRenameSpec(new_name="nope"), pk_value=999_999
+                            ),
+                            only_if=ExistsQuerier(
+                                row_class=_AllowListRow,
+                                conditions=[lambda: _AllowListRow.scope == "d1"],
+                            ),
+                        ),
+                    ]
+                )
+            )
+        assert result.successes == []
+        assert [e.index for e in result.errors] == [0]
+
+
+class TestBulkConditionalPurge:
+    async def test_purges_only_authorized_scopes(
+        self, provider: DBOpsProvider, allow_list: None, seeded_configs: dict[str, int]
+    ) -> None:
+        # Each purger is gated on its config's scope: "d1" is authorized (deleted), "d2" is not (kept).
+        async with provider.write_ops() as w:
+            result = await w.bulk_conditional_purge_partial(
+                BulkConditionalPurger(
+                    purgers=[
+                        ConditionalPurger(
+                            purger=Purger(row_class=_ConfigRow, pk_value=seeded_configs["d1"]),
+                            only_if=ExistsQuerier(
+                                row_class=_AllowListRow,
+                                conditions=[lambda: _AllowListRow.scope == "d1"],
+                            ),
+                        ),
+                        ConditionalPurger(
+                            purger=Purger(row_class=_ConfigRow, pk_value=seeded_configs["d2"]),
+                            only_if=ExistsQuerier(
+                                row_class=_AllowListRow,
+                                conditions=[lambda: _AllowListRow.scope == "d2"],
+                            ),
+                        ),
+                    ]
+                )
+            )
+
+        # partial: the "d1" config is deleted; the "d2" item (index 1) is forbidden and kept.
+        assert {row.id for row in result.successes} == {seeded_configs["d1"]}
+        assert [e.index for e in result.errors] == [1]
+        assert isinstance(result.errors[0].exception, ConditionalMutationForbidden)
+        async with provider.read_ops() as r:
+            deleted = await r.query(Querier(row_class=_ConfigRow, pk_value=seeded_configs["d1"]))
+            kept = await r.query(Querier(row_class=_ConfigRow, pk_value=seeded_configs["d2"]))
+        assert deleted is None
+        assert kept is not None


### PR DESCRIPTION
## Summary

Generic, domain-agnostic repository primitives for **gated bulk writes**, split out of #12426 (BA-6626) so app_config_fragment — and future domains — build on them. No app_config-specific code.

- `repositories/base`: `ConditionalCreator` / `ConditionalUpdater` / `ConditionalPurger` and `BulkConditional{Creator,Updater,Purger}` — a write spec paired with an `only_if` existence gate.
- `WriteOps.bulk_conditional_create_partial` / `_update_partial` / `_purge_partial` — each item runs in its own savepoint for **partial success** (gate-rejected / missing / failed items reported per-item; the rest proceed). Implemented directly in `WriteOps` with private `_update_one`/`_purge_one` row helpers (not delegating to the standalone `execute_*` functions).
- Repository errors `ConditionalWriteNotAllowed` / `ConditionalWriteTargetNotFound`.
- Ops-provider unit tests.

## 📚 Stacked PRs

Part of the AppConfigFragment / AppConfig stack under BEP-1052 (epic BA-5781). **Merge in order:**

1. ✅ #12306 — `feat(BA-6552): app_config_fragments DB model and Alembic migration`
2. ✅ #12307 — `feat(BA-6553): repository layer`
3. ✅ #12403 — `refactor(BA-6619): consolidate AppConfigScopeType into common.data`
4. ✅ #12405 — `refactor(BA-6620): ExistsQuerier + AppConfigAllowList.exists`
5. ✅ #12358 — `feat(BA-6554): AppConfigFragment service layer`
6. 👉 **#12429 — `feat(BA-6628): conditional-bulk repository primitives`** ← you are here
7. #12426 — `feat(BA-6626): app_config_fragment bulk repository layer`
8. #12401 — `feat(BA-6618): AppConfigFragment bulk CRUD service layer`
9. #12359 — `feat(BA-6555): app_config service layer`
10. #12377 — `feat(BA-6556): AppConfig REST v2 API`
