### PR TITLE
feat(BA-6600): define dry-run schedule action and input/output types

### DIFF
--- a/changes/12434.feature.md
+++ b/changes/12434.feature.md
@@ -1,0 +1,1 @@
+Add scheduler dry-run action and input/output types for the session launcher pre-check.

--- a/src/ai/backend/manager/data/session/dry_run.py
+++ b/src/ai/backend/manager/data/session/dry_run.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ai.backend.common.types import ResourceSlot
+
+
+@dataclass(frozen=True)
+class KernelDryRunSpec:
+    """Per-kernel resource requirement for a scheduler dry-run.
+
+    One spec corresponds to exactly one kernel; kernel count is not aggregated.
+    ``architecture`` is used as a pre-filter so that architecture-incompatible
+    nodes are not miscounted as a slot shortage.
+    """
+
+    requested_slots: ResourceSlot
+    architecture: str
+
+
+@dataclass(frozen=True)
+class KernelDryRunResult:
+    """Dry-run outcome for a single kernel.
+
+    ``required_reduction`` is the per-slot amount to reduce so this kernel becomes
+    schedulable on its best-fitting node, i.e. the candidate node that requires the
+    smallest reduction. It is selected by comparing candidate nodes as whole deficit
+    vectors (NOT a per-slot min across different nodes) and reporting that node's
+    deficit. It is an empty ``ResourceSlot`` when ``schedulable`` is True.
+    """
+
+    spec: KernelDryRunSpec
+    schedulable: bool
+    required_reduction: ResourceSlot

--- a/src/ai/backend/manager/services/session/actions/dry_run_schedule.py
+++ b/src/ai/backend/manager/services/session/actions/dry_run_schedule.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import EntityType
+from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.types import ClusterMode
+from ai.backend.manager.actions.action import BaseAction, BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.session.dry_run import KernelDryRunResult, KernelDryRunSpec
+
+
+@dataclass(frozen=True)
+class DryRunScheduleAction(BaseAction):
+    """Dry-run a session's scheduling against a resource group without provisioning.
+
+    The fields mirror the scheduler's selection criteria so the real selector can
+    be driven directly: ``cluster_mode`` decides whether kernel slots are summed
+    onto a single node (SINGLE_NODE) or placed individually (MULTI_NODE).
+    """
+
+    # One spec per kernel; results are mapped back by list order.
+    kernels: list[KernelDryRunSpec]
+    cluster_mode: ClusterMode
+    resource_group_id: ResourceGroupID
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.SESSION
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+
+@dataclass(frozen=True)
+class DryRunScheduleActionResult(BaseActionResult):
+    # Per-kernel results, in the same order as the action's ``kernels``.
+    kernels: list[KernelDryRunResult]
+
+    @override
+    def entity_id(self) -> str | None:
+        return None


### PR DESCRIPTION
## Summary
- `data/session/dry_run.py`: `KernelDryRunSpec` (per-kernel `requested_slots` + `architecture`) and `KernelDryRunResult` (`spec` + `schedulable` + `required_reduction` — the minimum per-slot reduction to fit on the best-fitting node).
- `services/session/actions/dry_run_schedule.py`: `DryRunScheduleAction` (frozen, `EntityType.SESSION`, `GET`, carries `kernels` / `cluster_mode` / `resource_group_id`) and `DryRunScheduleActionResult`.

## Test plan
- [x] `pants check` / `pants test` pass in CI.

Resolves BA-6600