### PR TITLE
refactor(BA-6630): move session-creation value types to the data layer

### DIFF
--- a/changes/12438.enhance.md
+++ b/changes/12438.enhance.md
@@ -1,0 +1,1 @@
+Move session-creation value types into the data layer so the scheduling-controller rule modules no longer import the scheduler repository.

--- a/src/ai/backend/manager/data/session/creation.py
+++ b/src/ai/backend/manager/data/session/creation.py
@@ -1,0 +1,99 @@
+"""Shared value objects for session creation and scheduling.
+
+These types are produced by the repository layer (from ORM rows) and
+consumed by the sokovan scheduling controller. They live in ``data/`` so
+neither side has to import the other's package.
+"""
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+from ai.backend.common.docker import ImageRef
+from ai.backend.common.types import AccessKey
+
+
+@dataclass
+class UserContext:
+    """User information for session creation."""
+
+    uuid: UUID
+    access_key: AccessKey
+    role: str  # UserRole as string
+    sudo_session_enabled: bool
+
+
+@dataclass
+class ContainerUserContext:
+    """Container user UID/GID information."""
+
+    uid: int | None
+    main_gid: int | None
+    supplementary_gids: list[int]
+
+
+@dataclass
+class ImageContext:
+    """Resolved image information."""
+
+    ref: ImageRef  # Image reference object
+    labels: dict[str, Any]
+
+
+@dataclass
+class ResolvedPresetValues:
+    """Resolved preset values ready for session injection."""
+
+    environ: dict[str, str]
+    args: list[str]
+
+
+@dataclass
+class DeploymentContext:
+    """Context data needed to create a session from deployment info.
+
+    Consumed by
+    :class:`ai.backend.manager.sokovan.deployment.deployment_draft_builder.DeploymentSessionDraftBuilder`
+    to assemble a :class:`SessionSpecDraft` for route-executor-driven
+    inference sessions.
+    """
+
+    created_user: UserContext
+    session_owner: UserContext
+    container_user: ContainerUserContext
+    group_id: UUID
+    resource_policy: dict[str, Any]
+    image: ImageContext
+    resolved_presets: ResolvedPresetValues | None = None
+
+
+@dataclass
+class ScalingGroupNetworkInfo:
+    """Network configuration from scaling group."""
+
+    use_host_network: bool
+    wsproxy_addr: str | None = None
+
+
+@dataclass
+class ImageInfo:
+    """Resolved image information."""
+
+    id: UUID
+    canonical: str
+    architecture: str
+    registry: str
+    labels: dict[str, Any]
+    # Resource spec maps slot names to {"min": value, "max": value}
+    # Values can be strings (for BinarySize), numbers, or None
+    resource_spec: dict[str, dict[str, str | int | Decimal | None]]
+
+
+@dataclass
+class ContainerUserInfo:
+    """User container UID/GID information."""
+
+    uid: int | None = None
+    main_gid: int | None = None
+    supplementary_gids: list[int] = field(default_factory=list)

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -89,6 +89,13 @@ from ai.backend.manager.data.image.types import ImageIdentifier
 from ai.backend.manager.data.model_serving.types import AppProxyRouteEntry
 from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.data.resource.types import ScalingGroupProxyTarget
+from ai.backend.manager.data.session.creation import (
+    ContainerUserContext,
+    DeploymentContext,
+    ImageContext,
+    ResolvedPresetValues,
+    UserContext,
+)
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.data.vfolder.types import VFolderLocation
 from ai.backend.manager.errors.deployment import (
@@ -181,13 +188,6 @@ from ai.backend.manager.repositories.deployment.types import (
     RouteServiceDiscoveryInfo,
     RouteSessionInfo,
     RouteSessionKernelInfo,
-)
-from ai.backend.manager.repositories.scheduler.types.session_creation import (
-    ContainerUserContext,
-    DeploymentContext,
-    ImageContext,
-    ResolvedPresetValues,
-    UserContext,
 )
 from ai.backend.manager.repositories.scheduling_history.creators import (
     DeploymentHistoryCreatorSpec,

--- a/src/ai/backend/manager/repositories/deployment/repository.py
+++ b/src/ai/backend/manager/repositories/deployment/repository.py
@@ -82,6 +82,7 @@ from ai.backend.manager.data.deployment.types import (
 from ai.backend.manager.data.image.types import ImageIdentifier
 from ai.backend.manager.data.model_serving.types import AppProxyRouteEntry
 from ai.backend.manager.data.resource.types import ScalingGroupProxyTarget
+from ai.backend.manager.data.session.creation import DeploymentContext
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.errors.service import EndpointNotFound
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
@@ -103,7 +104,6 @@ from ai.backend.manager.repositories.base.updater import (
     Updater,
 )
 from ai.backend.manager.repositories.base.upserter import Upserter
-from ai.backend.manager.repositories.scheduler.types.session_creation import DeploymentContext
 from ai.backend.manager.repositories.scheduling_history.creators import DeploymentHistoryCreatorSpec
 
 from .db_source import DeploymentDBSource

--- a/src/ai/backend/manager/repositories/scheduler/creators.py
+++ b/src/ai/backend/manager/repositories/scheduler/creators.py
@@ -36,12 +36,12 @@ from uuid import UUID
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.types import ClusterMode, ResourceSlot, ResourceSlotEntry
 from ai.backend.manager.data.kernel.types import KernelStatus
+from ai.backend.manager.data.session.creation import ImageInfo
 from ai.backend.manager.data.session.spec import KernelSpec, SessionSpec
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.repositories.base.creator import CreatorSpec
-from ai.backend.manager.repositories.scheduler.types.session_creation import ImageInfo
 
 __all__ = (
     "KernelRowFromSpec",

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -53,6 +53,11 @@ from ai.backend.manager.data.image.types import ImageIdentifier
 from ai.backend.manager.data.kernel.types import KernelListResult, KernelStatus
 from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.data.resource.types import SlotTypePolicy
+from ai.backend.manager.data.session.creation import (
+    ContainerUserInfo,
+    ImageInfo,
+    ScalingGroupNetworkInfo,
+)
 from ai.backend.manager.data.session.options import DefaultSessionOptions
 from ai.backend.manager.data.session.types import SchedulingResult, SessionInfo, SessionStatus
 from ai.backend.manager.errors.api import InvalidAPIParameters
@@ -137,9 +142,6 @@ from ai.backend.manager.repositories.scheduler.types.session import (
 )
 from ai.backend.manager.repositories.scheduler.types.session_creation import (
     AllowedScalingGroup,
-    ContainerUserInfo,
-    ImageInfo,
-    ScalingGroupNetworkInfo,
     SessionSpecContextFetch,
 )
 from ai.backend.manager.repositories.scheduler.types.snapshot import ResourcePolicies, SnapshotData

--- a/src/ai/backend/manager/repositories/scheduler/types/session_creation.py
+++ b/src/ai/backend/manager/repositories/scheduler/types/session_creation.py
@@ -2,14 +2,10 @@
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from decimal import Decimal
 from typing import Any
-from uuid import UUID
 
-from ai.backend.common.docker import ImageRef
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.types import (
-    AccessKey,
     SessionId,
     SlotName,
     SlotTypes,
@@ -17,61 +13,12 @@ from ai.backend.common.types import (
 )
 from ai.backend.manager.data.dotfile.types import DotfileBundle
 from ai.backend.manager.data.resource.types import SlotTypePolicy
+from ai.backend.manager.data.session.creation import (
+    ContainerUserInfo,
+    ImageInfo,
+    ScalingGroupNetworkInfo,
+)
 from ai.backend.manager.models.scaling_group import ScalingGroupOpts
-
-
-@dataclass
-class UserContext:
-    """User information for session creation."""
-
-    uuid: UUID
-    access_key: AccessKey
-    role: str  # UserRole as string
-    sudo_session_enabled: bool
-
-
-@dataclass
-class ContainerUserContext:
-    """Container user UID/GID information."""
-
-    uid: int | None
-    main_gid: int | None
-    supplementary_gids: list[int]
-
-
-@dataclass
-class ImageContext:
-    """Resolved image information."""
-
-    ref: ImageRef  # Image reference object
-    labels: dict[str, Any]
-
-
-@dataclass
-class ResolvedPresetValues:
-    """Resolved preset values ready for session injection."""
-
-    environ: dict[str, str]
-    args: list[str]
-
-
-@dataclass
-class DeploymentContext:
-    """Context data needed to create a session from deployment info.
-
-    Consumed by
-    :class:`ai.backend.manager.sokovan.deployment.deployment_draft_builder.DeploymentSessionDraftBuilder`
-    to assemble a :class:`SessionSpecDraft` for route-executor-driven
-    inference sessions.
-    """
-
-    created_user: UserContext
-    session_owner: UserContext
-    container_user: ContainerUserContext
-    group_id: UUID
-    resource_policy: dict[str, Any]
-    image: ImageContext
-    resolved_presets: ResolvedPresetValues | None = None
 
 
 @dataclass
@@ -83,43 +30,12 @@ class SessionDependencyData:
 
 
 @dataclass
-class ScalingGroupNetworkInfo:
-    """Network configuration from scaling group."""
-
-    use_host_network: bool
-    wsproxy_addr: str | None = None
-
-
-@dataclass
-class ImageInfo:
-    """Resolved image information."""
-
-    id: UUID
-    canonical: str
-    architecture: str
-    registry: str
-    labels: dict[str, Any]
-    # Resource spec maps slot names to {"min": value, "max": value}
-    # Values can be strings (for BinarySize), numbers, or None
-    resource_spec: dict[str, dict[str, str | int | Decimal | None]]
-
-
-@dataclass
 class AllowedScalingGroup:
     """Allowed scaling group for a user."""
 
     name: str
     is_private: bool
     scheduler_opts: ScalingGroupOpts
-
-
-@dataclass
-class ContainerUserInfo:
-    """User container UID/GID information."""
-
-    uid: int | None = None
-    main_gid: int | None = None
-    supplementary_gids: list[int] = field(default_factory=list)
 
 
 @dataclass

--- a/src/ai/backend/manager/sokovan/deployment/deployment_draft_builder.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_draft_builder.py
@@ -27,6 +27,7 @@ from ai.backend.common.types import (
     SessionTypes,
 )
 from ai.backend.manager.data.deployment.types import DeploymentInfo, ModelRevisionData
+from ai.backend.manager.data.session.creation import DeploymentContext
 from ai.backend.manager.data.session.draft import (
     KernelExecutionSpecDraft,
     KernelGroupDraft,
@@ -45,7 +46,6 @@ from ai.backend.manager.data.session.options import (
 )
 from ai.backend.manager.defs import DEFAULT_ROLE
 from ai.backend.manager.errors.deployment import RevisionMissingModelVFolder
-from ai.backend.manager.repositories.scheduler.types.session_creation import DeploymentContext
 
 
 class DeploymentSessionDraftBuilder:

--- a/src/ai/backend/manager/sokovan/scheduling_controller/preparers/compute_kernel_resources_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/preparers/compute_kernel_resources_rule.py
@@ -27,13 +27,13 @@ from decimal import Decimal
 from typing import Any
 
 from ai.backend.common.types import BinarySize, ResourceSlotEntry
+from ai.backend.manager.data.session.creation import ImageInfo
 from ai.backend.manager.data.session.draft import (
     KernelExecutionSpecDraft,
     SessionSpecDraft,
 )
 from ai.backend.manager.data.session.options import ResourceOpts
 from ai.backend.manager.defs import DEFAULT_SHARED_MEMORY_SIZE, INTRINSIC_SLOTS
-from ai.backend.manager.repositories.scheduler.types.session_creation import ImageInfo
 from ai.backend.manager.sokovan.scheduling_controller.preparers.draft_rule import (
     SessionSpecDraftRule,
     SessionSpecPreparationContext,

--- a/src/ai/backend/manager/sokovan/scheduling_controller/preparers/draft_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/preparers/draft_rule.py
@@ -23,13 +23,13 @@ from dataclasses import dataclass, field
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.types import VFolderMount
 from ai.backend.manager.data.dotfile.types import DotfileBundle
-from ai.backend.manager.data.session.draft import SessionSpecDraft
-from ai.backend.manager.data.session.options import DefaultSessionOptions
-from ai.backend.manager.repositories.scheduler.types.session_creation import (
+from ai.backend.manager.data.session.creation import (
     ContainerUserInfo,
     ImageInfo,
     ScalingGroupNetworkInfo,
 )
+from ai.backend.manager.data.session.draft import SessionSpecDraft
+from ai.backend.manager.data.session.options import DefaultSessionOptions
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/sokovan/scheduling_controller/resource_parse.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/resource_parse.py
@@ -18,7 +18,7 @@ from decimal import Decimal
 from typing import Any
 
 from ai.backend.common.types import BinarySize
-from ai.backend.manager.repositories.scheduler.types.session_creation import ImageInfo
+from ai.backend.manager.data.session.creation import ImageInfo
 
 
 def parse_quantity(raw: Any) -> Decimal:

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/resource_limit_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/resource_limit_rule.py
@@ -20,9 +20,9 @@ from ai.backend.common.types import (
     SlotTypes,
 )
 from ai.backend.manager.data.resource.types import SlotTypePolicy
+from ai.backend.manager.data.session.creation import ImageInfo
 from ai.backend.manager.data.session.spec import KernelSpec, SessionSpec
 from ai.backend.manager.errors.api import InvalidAPIParameters
-from ai.backend.manager.repositories.scheduler.types.session_creation import ImageInfo
 from ai.backend.manager.sokovan.scheduling_controller.resource_parse import (
     image_min_slots,
     parse_quantity,

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/session_spec_base.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/session_spec_base.py
@@ -20,8 +20,8 @@ from ai.backend.common.types import SlotName, SlotTypes
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.data.dotfile.types import DotfileBundle
 from ai.backend.manager.data.resource.types import KeyPairResourcePolicyData, SlotTypePolicy
+from ai.backend.manager.data.session.creation import ImageInfo
 from ai.backend.manager.data.session.spec import SessionSpec
-from ai.backend.manager.repositories.scheduler.types.session_creation import ImageInfo
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 

--- a/tests/unit/manager/sokovan/deployment/test_deployment_draft_builder.py
+++ b/tests/unit/manager/sokovan/deployment/test_deployment_draft_builder.py
@@ -14,12 +14,12 @@ from ai.backend.common.config import (
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import MountPermission
 from ai.backend.manager.data.deployment.types import ModelRevisionData
-from ai.backend.manager.data.session.draft import KernelExecutionSpecDraft
-from ai.backend.manager.defs import DEFAULT_ROLE
-from ai.backend.manager.repositories.scheduler.types.session_creation import (
+from ai.backend.manager.data.session.creation import (
     DeploymentContext,
     ResolvedPresetValues,
 )
+from ai.backend.manager.data.session.draft import KernelExecutionSpecDraft
+from ai.backend.manager.defs import DEFAULT_ROLE
 from ai.backend.manager.sokovan.deployment.deployment_draft_builder import (
     DeploymentSessionDraftBuilder,
 )

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_assign_container_user_mapping_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_assign_container_user_mapping_rule.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 import pytest
 
+from ai.backend.manager.data.session.creation import (
+    ContainerUserInfo,
+)
 from ai.backend.manager.data.session.draft import (
     KernelSpecDraft,
     SessionSpecDraft,
 )
 from ai.backend.manager.data.session.options import DefaultSessionOptions
-from ai.backend.manager.repositories.scheduler.types.session_creation import (
-    ContainerUserInfo,
-)
 from ai.backend.manager.sokovan.scheduling_controller.preparers.assign_container_user_mapping_rule import (
     AssignContainerUserMappingRule,
 )

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_assign_network_config_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_assign_network_config_rule.py
@@ -14,15 +14,15 @@ from __future__ import annotations
 
 import pytest
 
+from ai.backend.manager.data.session.creation import (
+    ScalingGroupNetworkInfo,
+)
 from ai.backend.manager.data.session.draft import (
     SessionNetworkDraft,
     SessionSpecDraft,
 )
 from ai.backend.manager.data.session.options import DefaultSessionOptions
 from ai.backend.manager.models.network import NetworkType
-from ai.backend.manager.repositories.scheduler.types.session_creation import (
-    ScalingGroupNetworkInfo,
-)
 from ai.backend.manager.sokovan.scheduling_controller.preparers.assign_network_config_rule import (
     AssignNetworkConfigRule,
 )

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_compute_kernel_resources_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_compute_kernel_resources_rule.py
@@ -19,6 +19,7 @@ import pytest
 
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.types import BinarySize, ResourceSlotEntry
+from ai.backend.manager.data.session.creation import ImageInfo
 from ai.backend.manager.data.session.draft import (
     KernelExecutionSpecDraft,
     KernelGroupDraft,
@@ -26,7 +27,6 @@ from ai.backend.manager.data.session.draft import (
     SessionSpecDraft,
 )
 from ai.backend.manager.data.session.options import DefaultSessionOptions, ResourceOpts
-from ai.backend.manager.repositories.scheduler.types.session_creation import ImageInfo
 from ai.backend.manager.sokovan.scheduling_controller.preparers.compute_kernel_resources_rule import (
     ComputeKernelResourcesRule,
 )

--- a/tests/unit/manager/sokovan/scheduling_controller/test_enqueue_session_from_draft.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/test_enqueue_session_from_draft.py
@@ -54,6 +54,11 @@ from ai.backend.common.types import (
 )
 from ai.backend.manager.data.dotfile.types import DotfileBundle
 from ai.backend.manager.data.resource.types import KeyPairResourcePolicyData, SlotTypePolicy
+from ai.backend.manager.data.session.creation import (
+    ContainerUserInfo,
+    ImageInfo,
+    ScalingGroupNetworkInfo,
+)
 from ai.backend.manager.data.session.draft import (
     KernelExecutionSpecDraft,
     KernelGroupDraft,
@@ -74,9 +79,6 @@ from ai.backend.manager.data.session.spec import SessionSpec
 from ai.backend.manager.errors.common import RejectedByHook
 from ai.backend.manager.models.network import NetworkType
 from ai.backend.manager.repositories.scheduler.types.session_creation import (
-    ContainerUserInfo,
-    ImageInfo,
-    ScalingGroupNetworkInfo,
     SessionSpecContextFetch,
 )
 from ai.backend.manager.sokovan.scheduling_controller.scheduling_controller import (

--- a/tests/unit/manager/sokovan/scheduling_controller/validators/test_session_spec_rules.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/validators/test_session_spec_rules.py
@@ -32,6 +32,7 @@ from ai.backend.common.types import (
 )
 from ai.backend.manager.data.dotfile.types import DotfileBundle, DotfileEntry
 from ai.backend.manager.data.resource.types import KeyPairResourcePolicyData, SlotTypePolicy
+from ai.backend.manager.data.session.creation import ImageInfo
 from ai.backend.manager.data.session.options import (
     KernelExecutionSpec,
     ResourceOpts,
@@ -51,7 +52,6 @@ from ai.backend.manager.errors.api import InvalidAPIParameters
 from ai.backend.manager.errors.kernel import QuotaExceeded
 from ai.backend.manager.errors.storage import DotfileVFolderPathConflict
 from ai.backend.manager.models.network import NetworkType
-from ai.backend.manager.repositories.scheduler.types.session_creation import ImageInfo
 from ai.backend.manager.sokovan.scheduling_controller.validators.container_limit_rule import (
     ContainerLimitRule,
 )


### PR DESCRIPTION
## Summary
Moves the session-creation **value types** out of `repositories/scheduler/types/session_creation` into `data/session/creation`, so the sokovan scheduling-controller rule modules depend on `data/` instead of `repositories/` and leave the cross-layer import cycle.

Relocated types: `ImageInfo`, `ContainerUserInfo`, `ScalingGroupNetworkInfo`, and `DeploymentContext` (with its `UserContext` / `ContainerUserContext` / `ImageContext` / `ResolvedPresetValues` helpers). The helpers move alongside `DeploymentContext` so `data/` stays free of upward imports.

The pure rule modules (preparers / validators / `resource_parse` / `deployment_draft_builder`) only ever imported these value objects — not the repository itself — so relocating the types takes them fully out of the `sokovan` ⇄ `repositories.scheduler` cycle.

## Scope
This PR is the first of a series. Follow-ups (separate branches/PRs):
- `sokovan.data` package → `data.sokovan`
- relocate `AgentInfo` + handler session data, cutting the remaining `repositories/scheduler → sokovan` back-edges

## Test plan
- [x] `pants fmt` / `fix` / `lint` (incl. visibility) pass
- [x] `pants check` (mypy) passes

Resolves BA-6630
