### PR TITLE
refactor(BA-6630): move remaining scheduler/fair-share value types to the data layer

### DIFF
--- a/changes/12444.enhance.md
+++ b/changes/12444.enhance.md
@@ -1,0 +1,1 @@
+Move the remaining scheduler and fair-share value types into the data layer, removing all repository imports of the sokovan package.

--- a/src/ai/backend/manager/data/fair_share/__init__.py
+++ b/src/ai/backend/manager/data/fair_share/__init__.py
@@ -1,20 +1,30 @@
 from .types import (
+    BucketDelta,
+    DomainFactorResult,
     DomainFairShareData,
     DomainFairShareSearchResult,
+    DomainUsageBucketKey,
     FairShareCalculationContext,
     FairShareCalculationSnapshot,
     FairShareData,
+    FairShareFactorCalculationResult,
     FairShareMetadata,
     FairSharesByLevel,
     FairShareSpec,
+    ProjectFactorResult,
     ProjectFairShareData,
     ProjectFairShareSearchResult,
+    ProjectUsageBucketKey,
     ProjectUserIds,
     RawUsageBucketsByLevel,
+    UsageBucketAggregationResult,
+    UserFactorResult,
     UserFairShareData,
     UserFairShareFactors,
     UserFairShareSearchResult,
     UserProjectKey,
+    UserSchedulingRank,
+    UserUsageBucketKey,
 )
 
 __all__ = (
@@ -39,4 +49,16 @@ __all__ = (
     # User-level
     "UserFairShareData",
     "UserFairShareSearchResult",
+    # Factor calculation results
+    "DomainFactorResult",
+    "ProjectFactorResult",
+    "UserFactorResult",
+    "UserSchedulingRank",
+    "FairShareFactorCalculationResult",
+    # Usage bucket aggregation results
+    "UserUsageBucketKey",
+    "ProjectUsageBucketKey",
+    "DomainUsageBucketKey",
+    "BucketDelta",
+    "UsageBucketAggregationResult",
 )

--- a/src/ai/backend/manager/data/fair_share/types.py
+++ b/src/ai/backend/manager/data/fair_share/types.py
@@ -308,3 +308,127 @@ class FairShareCalculationContext:
     """Mapping from project_id to domain_name.
     Used as fallback when fair_shares.project doesn't contain the project
     (new projects with usage but no fair share record yet)."""
+
+
+# =============================================================================
+# Fair share factor calculation results
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class DomainFactorResult:
+    """Factor calculation result for a domain."""
+
+    domain_name: str
+    total_decayed_usage: ResourceSlot
+    normalized_usage: Decimal
+    fair_share_factor: Decimal
+
+
+@dataclass(frozen=True)
+class ProjectFactorResult:
+    """Factor calculation result for a project."""
+
+    project_id: uuid.UUID
+    domain_name: str
+    total_decayed_usage: ResourceSlot
+    normalized_usage: Decimal
+    fair_share_factor: Decimal
+
+
+@dataclass(frozen=True)
+class UserFactorResult:
+    """Factor calculation result for a user."""
+
+    user_uuid: uuid.UUID
+    project_id: uuid.UUID
+    domain_name: str
+    total_decayed_usage: ResourceSlot
+    normalized_usage: Decimal
+    fair_share_factor: Decimal
+
+
+@dataclass(frozen=True)
+class UserSchedulingRank:
+    """Scheduling rank for a user within a project."""
+
+    user_uuid: uuid.UUID
+    project_id: uuid.UUID
+    rank: int  # 1 = highest priority
+
+
+@dataclass
+class FairShareFactorCalculationResult:
+    """Result of fair share factor calculation for all levels."""
+
+    domain_results: dict[str, DomainFactorResult] = field(default_factory=dict)
+    project_results: dict[uuid.UUID, ProjectFactorResult] = field(default_factory=dict)
+    user_results: dict[UserProjectKey, UserFactorResult] = field(default_factory=dict)
+    scheduling_ranks: list[UserSchedulingRank] = field(default_factory=list)
+
+
+# =============================================================================
+# Usage bucket aggregation results
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class UserUsageBucketKey:
+    """Key for user usage bucket aggregation.
+
+    Uniquely identifies a user's usage bucket within a resource group and time period.
+    """
+
+    user_uuid: uuid.UUID
+    project_id: uuid.UUID
+    domain_name: str
+    resource_group: str
+    period_date: date
+
+
+@dataclass(frozen=True)
+class ProjectUsageBucketKey:
+    """Key for project usage bucket aggregation.
+
+    Uniquely identifies a project's usage bucket within a resource group and time period.
+    """
+
+    project_id: uuid.UUID
+    domain_name: str
+    resource_group: str
+    period_date: date
+
+
+@dataclass(frozen=True)
+class DomainUsageBucketKey:
+    """Key for domain usage bucket aggregation.
+
+    Uniquely identifies a domain's usage bucket within a resource group and time period.
+    """
+
+    domain_name: str
+    resource_group: str
+    period_date: date
+
+
+@dataclass
+class BucketDelta:
+    """Separated resource amount and duration for a usage bucket.
+
+    Stores raw resource amounts and duration separately instead of
+    pre-multiplied resource-seconds.  The product ``amount * duration_seconds``
+    is computed at SQL query time where PostgreSQL auto-extends NUMERIC precision,
+    eliminating overflow risk for large memory values.
+    """
+
+    slots: ResourceSlot = field(default_factory=ResourceSlot)
+    duration_seconds: int = 0
+
+
+@dataclass
+class UsageBucketAggregationResult:
+    """Result of aggregating kernel usage into daily buckets."""
+
+    user_usage_deltas: dict[UserUsageBucketKey, BucketDelta] = field(default_factory=dict)
+    project_usage_deltas: dict[ProjectUsageBucketKey, BucketDelta] = field(default_factory=dict)
+    domain_usage_deltas: dict[DomainUsageBucketKey, BucketDelta] = field(default_factory=dict)

--- a/src/ai/backend/manager/data/sokovan/__init__.py
+++ b/src/ai/backend/manager/data/sokovan/__init__.py
@@ -1,5 +1,6 @@
 """Data types for Sokovan scheduler."""
 
+from .agent import AgentInfo
 from .allocation import (
     AgentAllocation,
     AllocationBatch,
@@ -9,6 +10,7 @@ from .allocation import (
     SessionAllocation,
 )
 from .config import NetworkSetup, ScalingGroupInfo, SchedulingConfig
+from .handler import HandlerKernelData, HandlerSessionData
 from .image import ImageConfigData, ImageIdentifier
 from .lifecycle import (
     KernelBindingData,
@@ -54,6 +56,8 @@ from .workload import (
 )
 
 __all__ = [
+    # agent
+    "AgentInfo",
     # allocation
     "AgentAllocation",
     "AllocationBatch",
@@ -65,6 +69,9 @@ __all__ = [
     "NetworkSetup",
     "ScalingGroupInfo",
     "SchedulingConfig",
+    # handler
+    "HandlerKernelData",
+    "HandlerSessionData",
     # image
     "ImageConfigData",
     "ImageIdentifier",

--- a/src/ai/backend/manager/data/sokovan/agent.py
+++ b/src/ai/backend/manager/data/sokovan/agent.py
@@ -1,0 +1,27 @@
+"""Agent data types for scheduling and agent selection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ai.backend.common.types import AgentId, ResourceSlot
+
+
+@dataclass
+class AgentInfo:
+    """Essential information about an agent for selection."""
+
+    # Unique identifier of the agent
+    agent_id: AgentId
+    # Network address of the agent
+    agent_addr: str
+    # Architecture of the agent (e.g., "x86_64", "aarch64")
+    architecture: str
+    # Available resource slots on the agent
+    available_slots: ResourceSlot
+    # Currently occupied resource slots
+    occupied_slots: ResourceSlot
+    # Scaling group the agent belongs to
+    scaling_group: str
+    # Number of containers currently running on the agent
+    container_count: int

--- a/src/ai/backend/manager/data/sokovan/handler.py
+++ b/src/ai/backend/manager/data/sokovan/handler.py
@@ -1,0 +1,48 @@
+"""Session/kernel data passed to scheduler lifecycle handlers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from uuid import UUID
+
+from ai.backend.common.types import (
+    AccessKey,
+    AgentId,
+    ResourceSlot,
+    SessionId,
+    SessionTypes,
+)
+from ai.backend.manager.data.kernel.types import KernelStatus
+from ai.backend.manager.models.session import SessionStatus
+
+
+@dataclass
+class HandlerKernelData:
+    """Kernel data for handler execution.
+
+    Contains minimal kernel information needed by handlers.
+    """
+
+    kernel_id: UUID
+    agent_id: AgentId | None
+    status: KernelStatus
+    container_id: str | None = None
+    occupied_slots: ResourceSlot | None = None
+
+
+@dataclass
+class HandlerSessionData:
+    """Session data passed to handlers by coordinator.
+
+    Contains all necessary information for handler execution
+    without requiring additional database queries for basic operations.
+    """
+
+    session_id: SessionId
+    creation_id: str
+    access_key: AccessKey
+    status: SessionStatus
+    scaling_group: str
+    session_type: SessionTypes
+    status_info: str | None = None
+    kernels: list[HandlerKernelData] = field(default_factory=list)

--- a/src/ai/backend/manager/repositories/fair_share/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/fair_share/db_source/db_source.py
@@ -18,6 +18,7 @@ from ai.backend.manager.data.fair_share import (
     FairShareCalculationContext,
     FairShareCalculationSnapshot,
     FairShareData,
+    FairShareFactorCalculationResult,
     FairSharesByLevel,
     FairShareSpec,
     ProjectFairShareData,
@@ -73,7 +74,6 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
     from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
-    from ai.backend.manager.sokovan.scheduler.fair_share import FairShareFactorCalculationResult
 
 
 __all__ = ("FairShareDBSource",)

--- a/src/ai/backend/manager/repositories/fair_share/repository.py
+++ b/src/ai/backend/manager/repositories/fair_share/repository.py
@@ -20,6 +20,7 @@ from ai.backend.manager.data.fair_share import (
     DomainFairShareData,
     DomainFairShareSearchResult,
     FairShareCalculationContext,
+    FairShareFactorCalculationResult,
     ProjectFairShareData,
     ProjectFairShareSearchResult,
     ProjectUserIds,
@@ -53,7 +54,6 @@ if TYPE_CHECKING:
         UserFairShareRow,
     )
     from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
-    from ai.backend.manager.sokovan.scheduler.fair_share import FairShareFactorCalculationResult
 
 
 __all__ = ("FairShareRepository",)

--- a/src/ai/backend/manager/repositories/resource_usage_history/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/resource_usage_history/db_source/db_source.py
@@ -50,14 +50,14 @@ from ai.backend.manager.repositories.resource_usage_history.types import (
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
-    from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
-    from ai.backend.manager.sokovan.scheduler.fair_share import (
+    from ai.backend.manager.data.fair_share import (
         BucketDelta,
         DomainUsageBucketKey,
         ProjectUsageBucketKey,
         UsageBucketAggregationResult,
         UserUsageBucketKey,
     )
+    from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 

--- a/src/ai/backend/manager/repositories/resource_usage_history/repository.py
+++ b/src/ai/backend/manager/repositories/resource_usage_history/repository.py
@@ -36,6 +36,7 @@ from .types import (
 )
 
 if TYPE_CHECKING:
+    from ai.backend.manager.data.fair_share import UsageBucketAggregationResult
     from ai.backend.manager.models.resource_usage_history import (
         DomainUsageBucketRow,
         KernelUsageRecordRow,
@@ -43,7 +44,6 @@ if TYPE_CHECKING:
         UserUsageBucketRow,
     )
     from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
-    from ai.backend.manager.sokovan.scheduler.fair_share import UsageBucketAggregationResult
 
 
 __all__ = ("ResourceUsageHistoryRepository",)

--- a/src/ai/backend/manager/repositories/scheduler/types/context.py
+++ b/src/ai/backend/manager/repositories/scheduler/types/context.py
@@ -3,12 +3,12 @@
 from dataclasses import dataclass
 
 from ai.backend.manager.data.sokovan import (
+    AgentInfo,
     ScalingGroupInfo,
     SchedulingConfig,
     SessionWorkload,
     SystemSnapshot,
 )
-from ai.backend.manager.sokovan.scheduler.provisioner.selectors.selector import AgentInfo
 
 
 @dataclass

--- a/src/ai/backend/manager/repositories/scheduler/types/search.py
+++ b/src/ai/backend/manager/repositories/scheduler/types/search.py
@@ -3,17 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
 from uuid import UUID
 
 from ai.backend.manager.data.sokovan import (
+    HandlerSessionData,
     ImageConfigData,
     SessionDataForPull,
     SessionDataForStart,
 )
-
-if TYPE_CHECKING:
-    from ai.backend.manager.sokovan.scheduler.results import HandlerSessionData
 
 
 @dataclass

--- a/src/ai/backend/manager/sokovan/scheduler/fair_share/__init__.py
+++ b/src/ai/backend/manager/sokovan/scheduler/fair_share/__init__.py
@@ -4,38 +4,11 @@ This module provides components for tracking kernel resource usage
 and calculating fair share scheduling ranks.
 """
 
-from .aggregator import (
-    BucketDelta,
-    DomainUsageBucketKey,
-    FairShareAggregator,
-    KernelUsagePreparationResult,
-    ProjectUsageBucketKey,
-    UsageBucketAggregationResult,
-    UserUsageBucketKey,
-)
-from .calculator import (
-    DomainFactorResult,
-    FairShareFactorCalculationResult,
-    FairShareFactorCalculator,
-    ProjectFactorResult,
-    UserFactorResult,
-    UserSchedulingRank,
-)
+from .aggregator import FairShareAggregator, KernelUsagePreparationResult
+from .calculator import FairShareFactorCalculator
 
 __all__ = [
-    # Aggregator
-    "BucketDelta",
-    "DomainUsageBucketKey",
     "FairShareAggregator",
     "KernelUsagePreparationResult",
-    "ProjectUsageBucketKey",
-    "UsageBucketAggregationResult",
-    "UserUsageBucketKey",
-    # Calculator
-    "DomainFactorResult",
-    "FairShareFactorCalculationResult",
     "FairShareFactorCalculator",
-    "ProjectFactorResult",
-    "UserFactorResult",
-    "UserSchedulingRank",
 ]

--- a/src/ai/backend/manager/sokovan/scheduler/fair_share/aggregator.py
+++ b/src/ai/backend/manager/sokovan/scheduler/fair_share/aggregator.py
@@ -22,6 +22,13 @@ from uuid import UUID
 
 from ai.backend.common.types import ResourceSlot
 from ai.backend.logging.utils import BraceStyleAdapter
+from ai.backend.manager.data.fair_share import (
+    BucketDelta,
+    DomainUsageBucketKey,
+    ProjectUsageBucketKey,
+    UsageBucketAggregationResult,
+    UserUsageBucketKey,
+)
 from ai.backend.manager.repositories.resource_usage_history import (
     KernelUsageRecordCreatorSpec,
 )
@@ -33,50 +40,6 @@ SLICE_DURATION_SECONDS = 300
 
 if TYPE_CHECKING:
     from ai.backend.manager.data.kernel.types import KernelInfo
-
-
-# =============================================================================
-# Bucket Key Types
-# =============================================================================
-
-
-@dataclass(frozen=True)
-class UserUsageBucketKey:
-    """Key for user usage bucket aggregation.
-
-    Uniquely identifies a user's usage bucket within a resource group and time period.
-    """
-
-    user_uuid: UUID
-    project_id: UUID
-    domain_name: str
-    resource_group: str
-    period_date: date
-
-
-@dataclass(frozen=True)
-class ProjectUsageBucketKey:
-    """Key for project usage bucket aggregation.
-
-    Uniquely identifies a project's usage bucket within a resource group and time period.
-    """
-
-    project_id: UUID
-    domain_name: str
-    resource_group: str
-    period_date: date
-
-
-@dataclass(frozen=True)
-class DomainUsageBucketKey:
-    """Key for domain usage bucket aggregation.
-
-    Uniquely identifies a domain's usage bucket within a resource group and time period.
-    """
-
-    domain_name: str
-    resource_group: str
-    period_date: date
 
 
 # =============================================================================
@@ -97,39 +60,6 @@ class KernelUsagePreparationResult:
     specs: list[KernelUsageRecordCreatorSpec] = field(default_factory=list)
     kernel_observation_times: dict[UUID, datetime] = field(default_factory=dict)
     observed_count: int = 0
-
-
-@dataclass
-class BucketDelta:
-    """Separated resource amount and duration for a usage bucket.
-
-    Stores raw resource amounts and duration separately instead of
-    pre-multiplied resource-seconds.  The product ``amount * duration_seconds``
-    is computed at SQL query time where PostgreSQL auto-extends NUMERIC precision,
-    eliminating overflow risk for large memory values.
-
-    Attributes:
-        slots: Raw resource amounts (e.g., {"cpu": 2, "mem": 4096000000})
-        duration_seconds: Total usage duration in seconds
-    """
-
-    slots: ResourceSlot = field(default_factory=ResourceSlot)
-    duration_seconds: int = 0
-
-
-@dataclass
-class UsageBucketAggregationResult:
-    """Result of aggregating kernel usage into daily buckets.
-
-    Attributes:
-        user_usage_deltas: Aggregated usage deltas by user for bucket updates
-        project_usage_deltas: Aggregated usage deltas by project for bucket updates
-        domain_usage_deltas: Aggregated usage deltas by domain for bucket updates
-    """
-
-    user_usage_deltas: dict[UserUsageBucketKey, BucketDelta] = field(default_factory=dict)
-    project_usage_deltas: dict[ProjectUsageBucketKey, BucketDelta] = field(default_factory=dict)
-    domain_usage_deltas: dict[DomainUsageBucketKey, BucketDelta] = field(default_factory=dict)
 
 
 class FairShareAggregator:

--- a/src/ai/backend/manager/sokovan/scheduler/fair_share/calculator.py
+++ b/src/ai/backend/manager/sokovan/scheduler/fair_share/calculator.py
@@ -17,7 +17,7 @@ The decay formula is:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
 from typing import TYPE_CHECKING, TypedDict
@@ -34,7 +34,14 @@ if TYPE_CHECKING:
         UserFairShareData,
     )
 
-from ai.backend.manager.data.fair_share import UserProjectKey
+from ai.backend.manager.data.fair_share import (
+    DomainFactorResult,
+    FairShareFactorCalculationResult,
+    ProjectFactorResult,
+    UserFactorResult,
+    UserProjectKey,
+    UserSchedulingRank,
+)
 
 
 class DecayedUsagesByLevel(TypedDict):
@@ -58,48 +65,6 @@ SECONDS_PER_DAY = Decimal("86400")
 
 
 @dataclass(frozen=True)
-class DomainFactorResult:
-    """Factor calculation result for a domain."""
-
-    domain_name: str
-    total_decayed_usage: ResourceSlot
-    normalized_usage: Decimal
-    fair_share_factor: Decimal
-
-
-@dataclass(frozen=True)
-class ProjectFactorResult:
-    """Factor calculation result for a project."""
-
-    project_id: UUID
-    domain_name: str
-    total_decayed_usage: ResourceSlot
-    normalized_usage: Decimal
-    fair_share_factor: Decimal
-
-
-@dataclass(frozen=True)
-class UserFactorResult:
-    """Factor calculation result for a user."""
-
-    user_uuid: UUID
-    project_id: UUID
-    domain_name: str
-    total_decayed_usage: ResourceSlot
-    normalized_usage: Decimal
-    fair_share_factor: Decimal
-
-
-@dataclass(frozen=True)
-class UserSchedulingRank:
-    """Scheduling rank for a user within a project."""
-
-    user_uuid: UUID
-    project_id: UUID
-    rank: int  # 1 = highest priority
-
-
-@dataclass(frozen=True)
 class _UserFactorForRanking:
     """Internal dataclass for sorting users by hierarchical factors."""
 
@@ -112,16 +77,6 @@ class _UserFactorForRanking:
     def sort_key(self) -> tuple[Decimal, Decimal, Decimal]:
         """Return sort key for descending order (higher factor = higher priority)."""
         return (-self.domain_factor, -self.project_factor, -self.user_factor)
-
-
-@dataclass
-class FairShareFactorCalculationResult:
-    """Result of fair share factor calculation for all levels."""
-
-    domain_results: dict[str, DomainFactorResult] = field(default_factory=dict)
-    project_results: dict[UUID, ProjectFactorResult] = field(default_factory=dict)
-    user_results: dict[UserProjectKey, UserFactorResult] = field(default_factory=dict)
-    scheduling_ranks: list[UserSchedulingRank] = field(default_factory=list)
 
 
 class FairShareFactorCalculator:

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/provisioner.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/provisioner.py
@@ -11,6 +11,7 @@ from ai.backend.common.clients.valkey_client.valkey_schedule.client import Valke
 from ai.backend.common.types import (
     AgentId,
     AgentSelectionStrategy,
+    ResourceSlot,
     SessionId,
     SlotQuantity,
 )
@@ -18,6 +19,8 @@ from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.sokovan import (
     AgentAllocation,
+    AgentInfo,
+    AgentOccupancy,
     AllocationBatch,
     KernelAllocation,
     KeypairOccupancy,
@@ -39,6 +42,7 @@ from ai.backend.manager.repositories.scheduler import (
     SchedulerRepository,
     SchedulingData,
 )
+from ai.backend.manager.repositories.scheduler.types.agent import AgentMeta
 from ai.backend.manager.sokovan.recorder import (
     ExecutionRecord,
     RecorderContext,
@@ -52,7 +56,6 @@ from .selectors.dispersed import DispersedAgentSelector
 from .selectors.legacy import LegacyAgentSelector
 from .selectors.roundrobin import RoundRobinAgentSelector
 from .selectors.selector import (
-    AgentInfo,
     AgentSelection,
     AgentSelectionConfig,
     AgentSelectionCriteria,
@@ -233,8 +236,7 @@ class SessionProvisioner:
             else {}
         )
         mutable_agents = [
-            AgentInfo.from_meta_and_occupancy(agent, agent_occupancy)
-            for agent in scheduling_data.agents
+            self._build_agent_info(agent, agent_occupancy) for agent in scheduling_data.agents
         ]
         session_allocations: list[SessionAllocation] = []
         scheduling_failures: list[SchedulingFailure] = []
@@ -479,6 +481,27 @@ class SessionProvisioner:
             session_workload,
             selections,
             scaling_group,
+        )
+
+    @staticmethod
+    def _build_agent_info(
+        meta: AgentMeta,
+        occupancy_map: Mapping[AgentId, AgentOccupancy],
+    ) -> AgentInfo:
+        """Create an AgentInfo from agent metadata and occupancy mapping."""
+        occupancy = occupancy_map.get(meta.id)
+        if occupancy:
+            occupied = ResourceSlot({sq.slot_name: sq.quantity for sq in occupancy.occupied_slots})
+        else:
+            occupied = ResourceSlot()
+        return AgentInfo(
+            agent_id=meta.id,
+            agent_addr=meta.addr,
+            architecture=meta.architecture,
+            scaling_group=meta.scaling_group,
+            available_slots=meta.available_slots,
+            occupied_slots=occupied,
+            container_count=occupancy.container_count if occupancy else 0,
         )
 
     @staticmethod

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/__init__.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/__init__.py
@@ -1,6 +1,8 @@
 """Agent selector interfaces and implementations for sokovan scheduler."""
 
 # Import exceptions first (they don't have dependencies)
+from ai.backend.manager.data.sokovan import AgentInfo
+
 from .exceptions import (
     AgentSelectionError,
     NoAvailableAgentError,
@@ -10,7 +12,6 @@ from .exceptions import (
 # Then import selector which depends on exceptions
 from .selector import (
     AbstractAgentSelector,
-    AgentInfo,
     AgentSelection,
     AgentSelectionConfig,
     AgentSelectionCriteria,

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/selector.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/selector.py
@@ -11,7 +11,6 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
 from uuid import UUID
 
 from ai.backend.common.types import (
@@ -24,6 +23,7 @@ from ai.backend.common.types import (
     SessionTypes,
 )
 from ai.backend.logging.utils import BraceStyleAdapter
+from ai.backend.manager.data.sokovan import AgentInfo
 
 from .exceptions import (
     ContainerLimitExceededError,
@@ -34,62 +34,7 @@ from .exceptions import (
     TrackerCompatibilityError,
 )
 
-if TYPE_CHECKING:
-    from ai.backend.manager.data.sokovan import AgentOccupancy
-    from ai.backend.manager.repositories.scheduler.types.agent import AgentMeta
-
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
-
-
-@dataclass
-class AgentInfo:
-    """Essential information about an agent for selection."""
-
-    # Unique identifier of the agent
-    agent_id: AgentId
-    # Network address of the agent
-    agent_addr: str
-    # Architecture of the agent (e.g., "x86_64", "aarch64")
-    architecture: str
-    # Available resource slots on the agent
-    available_slots: ResourceSlot
-    # Currently occupied resource slots
-    occupied_slots: ResourceSlot
-    # Scaling group the agent belongs to
-    scaling_group: str
-    # Number of containers currently running on the agent
-    container_count: int
-
-    @classmethod
-    def from_meta_and_occupancy(
-        cls,
-        meta: AgentMeta,
-        occupancy_map: Mapping[AgentId, AgentOccupancy],
-    ) -> AgentInfo:
-        """
-        Create an AgentInfo from agent metadata and occupancy mapping.
-
-        Args:
-            meta: Agent metadata containing static information
-            occupancy_map: Mapping of agent IDs to occupancy data
-
-        Returns:
-            AgentInfo instance with occupancy data looked up by agent ID
-        """
-        occupancy = occupancy_map.get(meta.id)
-        if occupancy:
-            occupied = ResourceSlot({sq.slot_name: sq.quantity for sq in occupancy.occupied_slots})
-        else:
-            occupied = ResourceSlot()
-        return cls(
-            agent_id=meta.id,
-            agent_addr=meta.addr,
-            architecture=meta.architecture,
-            scaling_group=meta.scaling_group,
-            available_slots=meta.available_slots,
-            occupied_slots=occupied,
-            container_count=occupancy.container_count if occupancy else 0,
-        )
 
 
 @dataclass

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/utils.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/utils.py
@@ -5,8 +5,7 @@ Utility functions for agent selectors.
 from decimal import Decimal
 
 from ai.backend.common.types import ResourceSlot
-
-from .selector import AgentInfo
+from ai.backend.manager.data.sokovan import AgentInfo
 
 
 def count_unutilized_capabilities(agent_info: AgentInfo, requested_slots: ResourceSlot) -> int:

--- a/src/ai/backend/manager/sokovan/scheduler/results.py
+++ b/src/ai/backend/manager/sokovan/scheduler/results.py
@@ -5,15 +5,11 @@ Result type for scheduling operations.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from uuid import UUID
 
 from ai.backend.common.types import (
     AccessKey,
-    AgentId,
     KernelId,
-    ResourceSlot,
     SessionId,
-    SessionTypes,
 )
 from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.sokovan.allocation import SchedulingFailure
@@ -58,38 +54,6 @@ class SessionTransitionInfo:
     error_code: str | None = None
     creation_id: str | None = None
     access_key: AccessKey | None = None
-
-
-@dataclass
-class HandlerKernelData:
-    """Kernel data for handler execution.
-
-    Contains minimal kernel information needed by handlers.
-    """
-
-    kernel_id: UUID
-    agent_id: AgentId | None
-    status: KernelStatus
-    container_id: str | None = None
-    occupied_slots: ResourceSlot | None = None
-
-
-@dataclass
-class HandlerSessionData:
-    """Session data passed to handlers by coordinator.
-
-    Contains all necessary information for handler execution
-    without requiring additional database queries for basic operations.
-    """
-
-    session_id: SessionId
-    creation_id: str
-    access_key: AccessKey
-    status: SessionStatus
-    scaling_group: str
-    session_type: SessionTypes
-    status_info: str | None = None
-    kernels: list[HandlerKernelData] = field(default_factory=list)
 
 
 @dataclass

--- a/tests/unit/manager/repositories/fair_share/BUILD
+++ b/tests/unit/manager/repositories/fair_share/BUILD
@@ -1,1 +1,3 @@
+python_test_utils()
+
 python_tests(name="tests")

--- a/tests/unit/manager/repositories/fair_share/conftest.py
+++ b/tests/unit/manager/repositories/fair_share/conftest.py
@@ -1,0 +1,94 @@
+"""Shared setup for fair-share repository tests.
+
+A few tests here instantiate ORM rows (``DomainFairShareRow`` and friends) and
+call ``to_data()`` directly. Instantiating a mapped class makes SQLAlchemy
+configure every imported mapper and resolve string-based ``relationship()``
+targets. Those targets are imported only under ``TYPE_CHECKING`` in the model
+modules, so they have to be imported (and registered) here.
+
+Following the repository test convention, the related rows are imported in FK
+order and handed to ``with_tables`` via the ``fair_share_row_tables`` fixture;
+tests that build rows in-memory request that fixture so the mappers are
+configured before construction.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.fair_share import (
+    DomainFairShareRow,
+    ProjectFairShareRow,
+    UserFairShareRow,
+)
+from ai.backend.manager.models.group import AssocGroupUserRow, GroupRow
+from ai.backend.manager.models.image import ImageRow
+from ai.backend.manager.models.kernel import KernelRow
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.rbac_models import RoleRow, UserRoleRow
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.resource_preset import ResourcePresetRow
+from ai.backend.manager.models.resource_slot import AgentResourceRow, ResourceSlotTypeRow
+from ai.backend.manager.models.scaling_group import (
+    ScalingGroupForDomainRow,
+    ScalingGroupForProjectRow,
+    ScalingGroupRow,
+)
+from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.user import UserRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.testutils.db import with_tables
+
+
+@pytest.fixture
+async def fair_share_row_tables(
+    database_connection: ExtendedAsyncSAEngine,
+) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+    """Create the fair-share tables and register the related ORM mappers.
+
+    Rows are listed in FK dependency order (parents before children); the
+    relationship targets (e.g. ``ScalingGroupForDomainRow``) must be present so
+    SQLAlchemy can configure the ``DomainFairShareRow`` / ``ProjectFairShareRow``
+    / ``UserFairShareRow`` mappers.
+    """
+    async with with_tables(
+        database_connection,
+        [
+            # Base rows in FK dependency order (parents before children)
+            DomainRow,
+            ScalingGroupRow,
+            ScalingGroupForDomainRow,
+            UserResourcePolicyRow,
+            ProjectResourcePolicyRow,
+            KeyPairResourcePolicyRow,
+            RoleRow,
+            UserRoleRow,
+            UserRow,
+            KeyPairRow,
+            GroupRow,
+            ScalingGroupForProjectRow,
+            AssocGroupUserRow,
+            AgentRow,
+            ContainerRegistryRow,
+            ImageRow,
+            SessionRow,
+            KernelRow,
+            ResourcePresetRow,
+            ResourceSlotTypeRow,
+            AgentResourceRow,
+            # Fair Share rows (no FK constraints but need mapper registration)
+            DomainFairShareRow,
+            ProjectFairShareRow,
+            UserFairShareRow,
+        ],
+    ):
+        yield database_connection

--- a/tests/unit/manager/repositories/fair_share/test_db_source_resource_weights.py
+++ b/tests/unit/manager/repositories/fair_share/test_db_source_resource_weights.py
@@ -17,12 +17,15 @@ from ai.backend.manager.models.fair_share.row import (
     ProjectFairShareRow,
     UserFairShareRow,
 )
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
 
 class TestDomainFairShareRowToData:
     """Test DomainFairShareRow.to_data() with resource weight merging."""
 
-    def test_partial_explicit_weights_with_null_weight(self) -> None:
+    async def test_partial_explicit_weights_with_null_weight(
+        self, fair_share_row_tables: ExtendedAsyncSAEngine
+    ) -> None:
         """Scenario 2.2: Domain fair share with NULL weight and partial resource weights."""
         # Given: Create a DomainFairShareRow with partial resource weights
         row = DomainFairShareRow(
@@ -69,7 +72,9 @@ class TestDomainFairShareRowToData:
         assert "mem" in result.data.uses_default_resources
         assert "cuda.device" not in result.data.uses_default_resources
 
-    def test_explicit_weight_with_all_default_resource_weights(self) -> None:
+    async def test_explicit_weight_with_all_default_resource_weights(
+        self, fair_share_row_tables: ExtendedAsyncSAEngine
+    ) -> None:
         """Scenario 2.3: Explicit entity weight but all resource weights use defaults."""
         # Given
         row = DomainFairShareRow(
@@ -115,7 +120,9 @@ class TestDomainFairShareRowToData:
 class TestProjectFairShareRowToData:
     """Test ProjectFairShareRow.to_data() with resource weight merging."""
 
-    def test_partial_resource_weights(self) -> None:
+    async def test_partial_resource_weights(
+        self, fair_share_row_tables: ExtendedAsyncSAEngine
+    ) -> None:
         """Scenario 2.4: Project fair share with partial resource weights."""
         # Given
         row = ProjectFairShareRow(
@@ -158,7 +165,9 @@ class TestProjectFairShareRowToData:
 class TestUserFairShareRowToData:
     """Test UserFairShareRow.to_data() with resource weight merging."""
 
-    def test_empty_resource_weights(self) -> None:
+    async def test_empty_resource_weights(
+        self, fair_share_row_tables: ExtendedAsyncSAEngine
+    ) -> None:
         """Scenario 2.5: User fair share with empty resource weights (all defaults)."""
         # Given
         row = UserFairShareRow(
@@ -202,7 +211,9 @@ class TestUserFairShareRowToData:
 class TestResourceWeightMergingEdgeCases:
     """Test edge cases for resource weight merging."""
 
-    def test_new_resource_type_fallback_to_one(self) -> None:
+    async def test_new_resource_type_fallback_to_one(
+        self, fair_share_row_tables: ExtendedAsyncSAEngine
+    ) -> None:
         """Test fallback to 1.0 for new resource types not in defaults."""
         # Given
         row = DomainFairShareRow(

--- a/tests/unit/manager/repositories/resource_usage_history/test_usage_bucket_entries.py
+++ b/tests/unit/manager/repositories/resource_usage_history/test_usage_bucket_entries.py
@@ -15,6 +15,12 @@ import pytest
 import sqlalchemy as sa
 
 from ai.backend.common.types import ResourceSlot
+from ai.backend.manager.data.fair_share import (
+    BucketDelta,
+    DomainUsageBucketKey,
+    UsageBucketAggregationResult,
+    UserUsageBucketKey,
+)
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
@@ -41,12 +47,6 @@ from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.resource_usage_history.db_source.db_source import (
     ResourceUsageHistoryDBSource,
-)
-from ai.backend.manager.sokovan.scheduler.fair_share.aggregator import (
-    BucketDelta,
-    DomainUsageBucketKey,
-    UsageBucketAggregationResult,
-    UserUsageBucketKey,
 )
 from ai.backend.testutils.db import with_tables
 

--- a/tests/unit/manager/sokovan/scheduler/fair_share/test_aggregator_bucket_aggregation.py
+++ b/tests/unit/manager/sokovan/scheduler/fair_share/test_aggregator_bucket_aggregation.py
@@ -15,14 +15,16 @@ from uuid import UUID, uuid4
 import pytest
 
 from ai.backend.common.types import ResourceSlot
+from ai.backend.manager.data.fair_share import (
+    DomainUsageBucketKey,
+    ProjectUsageBucketKey,
+    UserUsageBucketKey,
+)
 from ai.backend.manager.repositories.resource_usage_history import (
     KernelUsageRecordCreatorSpec,
 )
 from ai.backend.manager.sokovan.scheduler.fair_share.aggregator import (
-    DomainUsageBucketKey,
     FairShareAggregator,
-    ProjectUsageBucketKey,
-    UserUsageBucketKey,
 )
 
 

--- a/tests/unit/manager/sokovan/scheduler/fair_share/test_calculator.py
+++ b/tests/unit/manager/sokovan/scheduler/fair_share/test_calculator.py
@@ -21,6 +21,7 @@ from ai.backend.manager.data.fair_share import (
     FairShareCalculationContext,
     FairShareCalculationSnapshot,
     FairShareData,
+    FairShareFactorCalculationResult,
     FairShareMetadata,
     FairSharesByLevel,
     FairShareSpec,
@@ -30,7 +31,6 @@ from ai.backend.manager.data.fair_share import (
     UserProjectKey,
 )
 from ai.backend.manager.sokovan.scheduler.fair_share.calculator import (
-    FairShareFactorCalculationResult,
     FairShareFactorCalculator,
 )
 

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/conftest.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/conftest.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 import pytest
 
 from ai.backend.common.types import AgentId, ResourceSlot
-from ai.backend.manager.sokovan.scheduler.provisioner.selectors.selector import AgentInfo
+from ai.backend.manager.data.sokovan import AgentInfo
 
 
 def _create_agent_info(

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_agent_selection_with_resources.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_agent_selection_with_resources.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 import pytest
 
 from ai.backend.common.types import AgentId, ClusterMode, ResourceSlot, SessionId, SessionTypes
+from ai.backend.manager.data.sokovan import AgentInfo
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.concentrated import (
     ConcentratedAgentSelector,
 )
@@ -18,7 +19,6 @@ from ai.backend.manager.sokovan.scheduler.provisioner.selectors.exceptions impor
     NoAvailableAgentError,
 )
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.selector import (
-    AgentInfo,
     AgentSelectionConfig,
     AgentSelectionCriteria,
     AgentSelector,

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_concentrated_selector.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_concentrated_selector.py
@@ -15,11 +15,11 @@ from ai.backend.common.types import (
     SessionId,
     SessionTypes,
 )
+from ai.backend.manager.data.sokovan import AgentInfo
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.concentrated import (
     ConcentratedAgentSelector,
 )
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.selector import (
-    AgentInfo,
     AgentSelectionConfig,
     AgentSelectionCriteria,
     AgentStateTracker,

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_dispersed_selector.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_dispersed_selector.py
@@ -15,6 +15,7 @@ from ai.backend.common.types import (
     SessionId,
     SessionTypes,
 )
+from ai.backend.manager.data.sokovan import AgentInfo
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.concentrated import (
     ConcentratedAgentSelector,
 )
@@ -22,7 +23,6 @@ from ai.backend.manager.sokovan.scheduler.provisioner.selectors.dispersed import
     DispersedAgentSelector,
 )
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.selector import (
-    AgentInfo,
     AgentSelectionConfig,
     AgentSelectionCriteria,
     AgentStateTracker,

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_failed_agent_filtering.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_failed_agent_filtering.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 import pytest
 
 from ai.backend.common.types import AgentId, ClusterMode, ResourceSlot, SessionId, SessionTypes
+from ai.backend.manager.data.sokovan import AgentInfo
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.concentrated import (
     ConcentratedAgentSelector,
 )
@@ -15,7 +16,6 @@ from ai.backend.manager.sokovan.scheduler.provisioner.selectors.dispersed import
     DispersedAgentSelector,
 )
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.selector import (
-    AgentInfo,
     AgentSelectionConfig,
     AgentSelectionCriteria,
     AgentSelector,

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_failure_message_format.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_failure_message_format.py
@@ -22,6 +22,7 @@ from ai.backend.common.types import (
     SessionId,
     SessionTypes,
 )
+from ai.backend.manager.data.sokovan import AgentInfo
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.concentrated import (
     ConcentratedAgentSelector,
 )
@@ -33,7 +34,6 @@ from ai.backend.manager.sokovan.scheduler.provisioner.selectors.exceptions impor
     NoAvailableAgentError,
 )
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.selector import (
-    AgentInfo,
     AgentSelectionConfig,
     AgentSelectionCriteria,
     AgentSelector,

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_legacy_selector.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_legacy_selector.py
@@ -15,6 +15,7 @@ from ai.backend.common.types import (
     SessionId,
     SessionTypes,
 )
+from ai.backend.manager.data.sokovan import AgentInfo
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.concentrated import (
     ConcentratedAgentSelector,
 )
@@ -23,7 +24,6 @@ from ai.backend.manager.sokovan.scheduler.provisioner.selectors.dispersed import
 )
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.legacy import LegacyAgentSelector
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.selector import (
-    AgentInfo,
     AgentSelectionConfig,
     AgentSelectionCriteria,
     AgentStateTracker,

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_roundrobin_selector.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_roundrobin_selector.py
@@ -15,11 +15,11 @@ from ai.backend.common.types import (
     SessionId,
     SessionTypes,
 )
+from ai.backend.manager.data.sokovan import AgentInfo
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.roundrobin import (
     RoundRobinAgentSelector,
 )
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.selector import (
-    AgentInfo,
     AgentSelectionConfig,
     AgentSelectionCriteria,
     AgentStateTracker,

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_selector_edge_cases.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_selector_edge_cases.py
@@ -15,6 +15,7 @@ from ai.backend.common.types import (
     SessionId,
     SessionTypes,
 )
+from ai.backend.manager.data.sokovan import AgentInfo
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.concentrated import (
     ConcentratedAgentSelector,
 )
@@ -26,7 +27,6 @@ from ai.backend.manager.sokovan.scheduler.provisioner.selectors.roundrobin impor
     RoundRobinAgentSelector,
 )
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.selector import (
-    AgentInfo,
     AgentSelectionConfig,
     AgentSelectionCriteria,
     AgentStateTracker,

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_selector_integration.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_selector_integration.py
@@ -15,6 +15,7 @@ from ai.backend.common.types import (
     SessionId,
     SessionTypes,
 )
+from ai.backend.manager.data.sokovan import AgentInfo
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.concentrated import (
     ConcentratedAgentSelector,
 )
@@ -26,7 +27,6 @@ from ai.backend.manager.sokovan.scheduler.provisioner.selectors.roundrobin impor
     RoundRobinAgentSelector,
 )
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.selector import (
-    AgentInfo,
     AgentSelectionConfig,
     AgentSelectionCriteria,
     AgentStateTracker,

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_utils.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from decimal import Decimal
 
 from ai.backend.common.types import ResourceSlot
-from ai.backend.manager.sokovan.scheduler.provisioner.selectors.selector import AgentInfo
+from ai.backend.manager.data.sokovan import AgentInfo
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.utils import (
     count_unutilized_capabilities,
     order_slots_by_priority,

--- a/tests/unit/manager/sokovan/scheduler/test_scheduler.py
+++ b/tests/unit/manager/sokovan/scheduler/test_scheduler.py
@@ -16,6 +16,7 @@ from ai.backend.common.types import (
     SessionTypes,
 )
 from ai.backend.manager.data.sokovan import (
+    AgentInfo,
     KernelWorkload,
     SchedulingConfig,
     SessionWorkload,
@@ -29,7 +30,6 @@ from ai.backend.manager.sokovan.scheduler.provisioner.selectors.exceptions impor
     NoCompatibleAgentError,
 )
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.selector import (
-    AgentInfo,
     AgentSelection,
     AgentSelectionConfig,
     AgentSelectionCriteria,


### PR DESCRIPTION
## Summary
Cuts the **remaining `repositories/* → sokovan` back-edges**, finishing the cross-layer cleanup so no repository imports the `sokovan` package for its value objects. Two commits, same principle throughout — **data modules hold types only; logic moves to its caller**:

1. **AgentInfo + handler session data → `data/sokovan`**
   - Relocate `AgentInfo` and `HandlerSessionData`/`HandlerKernelData` out of the selector / results logic modules into `data/sokovan`.
   - Drop `AgentInfo.from_meta_and_occupancy`; move it into its only caller, `SessionProvisioner._build_agent_info`.
   - Removes `repositories/scheduler/types/{context,search}` → sokovan edges.

2. **fair-share result types → `data/fair_share`**
   - Relocate `FairShareFactorCalculationResult`, `UsageBucketAggregationResult` and their nested factor/key/delta types from the sokovan `calculator`/`aggregator` modules into the existing `data/fair_share` package.
   - Removes `repositories/fair_share` and `repositories/resource_usage_history` → sokovan edges.

After this PR, `repositories → sokovan` (logic) import edges = **0**.

## Notes
- Builds on #12438 (session-creation types) and #12441 (`sokovan.data` package), both merged to main.
- The relocated fair-share result types keep their existing non-frozen `@dataclass` form (they are builder-style results); this is a deliberate deviation from the `data/` frozen convention, scoped to these result containers.

## Test plan
- [x] `pants fmt` / `fix` / `lint` (incl. visibility) pass
- [x] `pants check` (mypy, full repo — 6282 files) passes

Relates to BA-6630
