### PR TITLE
feat(BA-6550): represent model service command as string

### DIFF
--- a/changes/12445.enhance.md
+++ b/changes/12445.enhance.md
@@ -1,0 +1,1 @@
+Represent model service start commands as single command strings internally while preserving deprecated list-form inputs.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -10395,7 +10395,9 @@ type ModelServiceConfig
   """
   startCommand: [String!] @deprecated(reason: "Use `command` instead.")
 
-  """Shell configured for the model service."""
+  """
+  Shell used to run the command. If set, the kernel runs `[shell, '-c', command]`; null or empty disables shell wrapping.
+  """
   shell: String
 
   """Port number for the model service."""
@@ -10424,7 +10426,9 @@ input ModelServiceConfigInput
   """
   startCommand: [String!] = null @deprecated(reason: "Use `command` instead.")
 
-  """Shell configured for the model service."""
+  """
+  Shell used to run the command. If set, the kernel runs `[shell, '-c', command]`; null or empty disables shell wrapping.
+  """
   shell: String = null
 
   """Port number for the model service."""
@@ -12936,7 +12940,9 @@ input PresetModelServiceConfigInput
   """
   startCommand: [String!] = null @deprecated(reason: "Use `command` instead.")
 
-  """Shell configured for the model service."""
+  """
+  Shell used to run the command. If set, the kernel runs `[shell, '-c', command]`; null or empty disables shell wrapping.
+  """
   shell: String = "/bin/bash"
 
   """Port number for the model service. Must be greater than 1."""

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -12937,7 +12937,7 @@ input PresetModelServiceConfigInput
   startCommand: [String!] = null @deprecated(reason: "Use `command` instead.")
 
   """Shell configured for the model service."""
-  shell: String! = "/bin/bash"
+  shell: String = "/bin/bash"
 
   """Port number for the model service. Must be greater than 1."""
   port: Int!

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -7092,7 +7092,9 @@ type ModelServiceConfig {
   """
   startCommand: [String!] @deprecated(reason: "Use `command` instead.")
 
-  """Shell configured for the model service."""
+  """
+  Shell used to run the command. If set, the kernel runs `[shell, '-c', command]`; null or empty disables shell wrapping.
+  """
   shell: String
 
   """Port number for the model service."""
@@ -7119,7 +7121,9 @@ input ModelServiceConfigInput {
   """
   startCommand: [String!] = null @deprecated(reason: "Use `command` instead.")
 
-  """Shell configured for the model service."""
+  """
+  Shell used to run the command. If set, the kernel runs `[shell, '-c', command]`; null or empty disables shell wrapping.
+  """
   shell: String = null
 
   """Port number for the model service."""
@@ -8639,7 +8643,9 @@ input PresetModelServiceConfigInput {
   """
   startCommand: [String!] = null @deprecated(reason: "Use `command` instead.")
 
-  """Shell configured for the model service."""
+  """
+  Shell used to run the command. If set, the kernel runs `[shell, '-c', command]`; null or empty disables shell wrapping.
+  """
   shell: String = "/bin/bash"
 
   """Port number for the model service. Must be greater than 1."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -8640,7 +8640,7 @@ input PresetModelServiceConfigInput {
   startCommand: [String!] = null @deprecated(reason: "Use `command` instead.")
 
   """Shell configured for the model service."""
-  shell: String! = "/bin/bash"
+  shell: String = "/bin/bash"
 
   """Port number for the model service. Must be greater than 1."""
   port: Int!

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -3462,6 +3462,7 @@
               }
             ],
             "default": null,
+            "description": "Shell used to run the command. If set, the kernel runs `[shell, '-c', command]`; null or empty disables shell wrapping.",
             "title": "Shell"
           },
           "port": {
@@ -7113,10 +7114,17 @@
             "title": "Start Command"
           },
           "shell": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "default": "/bin/bash",
-            "description": "Shell configured for the model service.",
-            "title": "Shell",
-            "type": "string"
+            "description": "Shell used to run the command. If set, the kernel runs `[shell, '-c', command]`; null or empty disables shell wrapping.",
+            "title": "Shell"
           },
           "port": {
             "description": "Port number for the model service. Must be greater than 1.",
@@ -7670,38 +7678,35 @@
           "start-command": {
             "anyOf": [
               {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
             "default": null,
-            "description": "Argv list to start the model service. ``{model_path}`` in any token is replaced per-token with the resolved ``model_path`` before launch. ``None`` falls back to the image's default CMD.",
+            "description": "Command string to start the model service. ``{model_path}`` is replaced with the resolved ``model_path`` before launch. ``None`` falls back to the image's default CMD.",
             "examples": [
-              [
-                "python",
-                "service.py"
-              ],
-              [
-                "vllm",
-                "serve",
-                "{model_path}"
-              ]
+              "python service.py",
+              "vllm serve {model_path}"
             ],
             "title": "Start-Command"
           },
           "shell": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "default": "/bin/bash",
-            "description": "Shell configured for the model service.",
+            "description": "Shell used to run the command. If set, the kernel runs `[shell, '-c', command]`; null or empty disables shell wrapping.",
             "examples": [
               "/bin/bash"
             ],
-            "title": "Shell",
-            "type": "string"
+            "title": "Shell"
           },
           "port": {
             "description": "Port number for the model service. Must be greater than 1.",
@@ -36424,10 +36429,7 @@
           "start-command": {
             "anyOf": [
               {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
+                "type": "string"
               },
               {
                 "type": "null"

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -6,6 +6,7 @@ import errno
 import logging
 import pickle
 import re
+import shlex
 import signal
 import sys
 import time
@@ -2505,7 +2506,7 @@ class AbstractAgent[
                 image_command_loaded = True
             if not image_command:
                 continue
-            model.service.start_command = list(image_command)
+            model.service.start_command = shlex.join(image_command)
         return models
 
     def _append_legacy_inference_env_args(
@@ -2521,7 +2522,7 @@ class AbstractAgent[
             service = model.service
             if service is None or not service.start_command:
                 continue
-            service.start_command = [*service.start_command, *extra_args]
+            service.start_command = f"{service.start_command} {shlex.join(extra_args)}"
         return models
 
     async def create_kernel(

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -150,14 +150,16 @@ def _resolve_start_command(service: Any) -> Any:
     if not isinstance(service, dict):
         return service
 
-    result = {k: v for k, v in service.items() if k not in ("command", "start-command")}
+    result = {
+        k: v for k, v in service.items() if k not in ("command", "start_command", "start-command")
+    }
     # Override deprecated ``start_command`` with the new ``command`` when supplied.
     start_command = service.get("command")
     if start_command is None:
         start_command = service.get("start_command", service.get("start-command"))
     if isinstance(start_command, list):
         start_command = shlex.join(start_command)
-    if start_command is not None or "start-command" in service:
+    if start_command is not None or "start_command" in service or "start-command" in service:
         result["start_command"] = start_command
     return result
 

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -20,6 +20,7 @@ from pydantic import (
 from . import validators as tx
 from .etcd import AsyncEtcd, ConfigScopes
 from .exception import BackendAIError, ConfigurationError, ModelDefinitionValidationError
+from .model_service_start_command_compat import resolve_model_service_start_command
 from .types import BackendAISchema, RedisHelperConfig, SchemaValidationFailureInfo
 
 __all__ = (
@@ -146,24 +147,6 @@ agent_selector_config_iv = t.Dict({}) | agent_selector_globalconfig_iv
 DEFAULT_SHELL = "/bin/bash"
 
 
-def _resolve_start_command(service: Any) -> Any:
-    if not isinstance(service, dict):
-        return service
-
-    result = {
-        k: v for k, v in service.items() if k not in ("command", "start_command", "start-command")
-    }
-    # Override deprecated ``start_command`` with the new ``command`` when supplied.
-    start_command = service.get("command")
-    if start_command is None:
-        start_command = service.get("start_command", service.get("start-command"))
-    if isinstance(start_command, list):
-        start_command = shlex.join(start_command)
-    if start_command is not None or "start_command" in service or "start-command" in service:
-        result["start_command"] = start_command
-    return result
-
-
 class PreStartAction(BaseConfigModel):
     action: str = Field(
         description="The name of the pre-start action to execute.",
@@ -267,7 +250,10 @@ class ModelServiceConfig(BaseConfigModel):
     )
     shell: str | None = Field(
         default=DEFAULT_SHELL,
-        description="Shell configured for the model service. Null or empty disables shell use.",
+        description=(
+            "Shell used to run the command. If set, the kernel runs "
+            "`[shell, '-c', command]`; null or empty disables shell wrapping."
+        ),
         examples=[DEFAULT_SHELL],
     )
     port: int = Field(
@@ -283,7 +269,7 @@ class ModelServiceConfig(BaseConfigModel):
     @model_validator(mode="before")
     @classmethod
     def _resolve_start_command(cls, data: Any) -> Any:
-        return _resolve_start_command(data)
+        return resolve_model_service_start_command(data)
 
 
 class ModelMetadata(BaseConfigModel):
@@ -578,7 +564,7 @@ class ModelServiceConfigDraft(BaseConfigModel):
     @model_validator(mode="before")
     @classmethod
     def _resolve_start_command(cls, data: Any) -> Any:
-        return _resolve_start_command(data)
+        return resolve_model_service_start_command(data)
 
     def to_resolved(self) -> ModelServiceConfig:
         # Drop unset (None) scalars so the strict type's ``Field(default=...)``

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import sys
 from collections.abc import Mapping, MutableMapping
 from pathlib import Path
@@ -145,21 +146,20 @@ agent_selector_config_iv = t.Dict({}) | agent_selector_globalconfig_iv
 DEFAULT_SHELL = "/bin/bash"
 
 
-def _wrap_str_start_command_into_argv(service: Any) -> Any:
+def _resolve_start_command(service: Any) -> Any:
     if not isinstance(service, dict):
         return service
-    # FIXME: temporary bridge — fold the single-string `command` into the str `start_command`
-    # so the ModelServiceConfigDraft validator wraps it.
-    command = service.get("command")
-    service = {k: v for k, v in service.items() if k != "command"}
-    # Override `start_command` with `command` if both are present as start_command is deprecated.
-    sc = command if command is not None else service.get("start_command")
-    if not isinstance(sc, str):
-        return service
-    shell = service.get("shell")
-    if shell:
-        return {**service, "start_command": [shell, "-c", sc]}
-    return {**service, "start_command": [sc]}
+
+    result = {k: v for k, v in service.items() if k not in ("command", "start-command")}
+    # Override deprecated ``start_command`` with the new ``command`` when supplied.
+    start_command = service.get("command")
+    if start_command is None:
+        start_command = service.get("start_command", service.get("start-command"))
+    if isinstance(start_command, list):
+        start_command = shlex.join(start_command)
+    if start_command is not None or "start-command" in service:
+        result["start_command"] = start_command
+    return result
 
 
 class PreStartAction(BaseConfigModel):
@@ -254,18 +254,18 @@ class ModelServiceConfig(BaseConfigModel):
         default_factory=list,
         description="List of pre-start actions to execute before starting the model service.",
     )
-    start_command: list[str] | None = Field(
+    start_command: str | None = Field(
         default=None,
         description=(
-            "Argv list to start the model service. ``{model_path}`` in any "
-            "token is replaced per-token with the resolved ``model_path`` "
-            "before launch. ``None`` falls back to the image's default CMD."
+            "Command string to start the model service. ``{model_path}`` is "
+            "replaced with the resolved ``model_path`` before launch. "
+            "``None`` falls back to the image's default CMD."
         ),
-        examples=[["python", "service.py"], ["vllm", "serve", "{model_path}"]],
+        examples=["python service.py", "vllm serve {model_path}"],
     )
-    shell: str = Field(
+    shell: str | None = Field(
         default=DEFAULT_SHELL,
-        description="Shell configured for the model service.",
+        description="Shell configured for the model service. Null or empty disables shell use.",
         examples=[DEFAULT_SHELL],
     )
     port: int = Field(
@@ -280,8 +280,8 @@ class ModelServiceConfig(BaseConfigModel):
 
     @model_validator(mode="before")
     @classmethod
-    def _wrap_str_start_command(cls, data: Any) -> Any:
-        return _wrap_str_start_command_into_argv(data)
+    def _resolve_start_command(cls, data: Any) -> Any:
+        return _resolve_start_command(data)
 
 
 class ModelMetadata(BaseConfigModel):
@@ -517,8 +517,7 @@ class ModelDefinition(BaseConfigModel):
         return None
 
     def with_args_appended(self, args: list[str]) -> ModelDefinition:
-        """Return a copy with ``args`` appended to each model's
-        ``service.start_command`` as separate argv tokens.
+        """Return a copy with ``args`` appended to each model's command string.
 
         Models with ``service is None`` are passed through unchanged;
         a model whose ``start_command`` is ``None`` receives ``args``
@@ -532,9 +531,11 @@ class ModelDefinition(BaseConfigModel):
             if model.service is None:
                 new_models.append(model)
                 continue
-            existing = model.service.start_command or []
+            suffix = shlex.join(args)
+            existing = model.service.start_command
+            start_command = f"{existing} {suffix}" if existing else suffix
             new_service = model.service.model_copy(
-                update={"start_command": existing + args},
+                update={"start_command": start_command},
             )
             new_models.append(model.model_copy(update={"service": new_service}))
         return self.model_copy(update={"models": new_models})
@@ -567,15 +568,15 @@ class ModelHealthCheckDraft(BaseConfigModel):
 
 class ModelServiceConfigDraft(BaseConfigModel):
     pre_start_actions: list[PreStartAction] | None = None
-    start_command: list[str] | None = None
+    start_command: str | None = None
     shell: str | None = None
     port: int | None = None
     health_check: ModelHealthCheckDraft | None = None
 
     @model_validator(mode="before")
     @classmethod
-    def _wrap_str_start_command(cls, data: Any) -> Any:
-        return _wrap_str_start_command_into_argv(data)
+    def _resolve_start_command(cls, data: Any) -> Any:
+        return _resolve_start_command(data)
 
     def to_resolved(self) -> ModelServiceConfig:
         # Drop unset (None) scalars so the strict type's ``Field(default=...)``
@@ -584,6 +585,8 @@ class ModelServiceConfigDraft(BaseConfigModel):
         # required fields (e.g. ``port``) surface as
         # ``BackendAISchemaValidationFailed``.
         payload = self.model_dump(exclude_none=True, exclude={"health_check"})
+        if "shell" in self.model_fields_set and self.shell is None:
+            payload["shell"] = None
         payload["health_check"] = self.health_check.to_resolved() if self.health_check else None
         return ModelServiceConfig.model_validate(payload)
 
@@ -601,9 +604,7 @@ class ModelConfigDraft(BaseConfigModel):
             # ``start_command`` are resolved here, at the same moment the
             # draft becomes a strict ``ModelConfig`` and ``model_path`` is
             # finalized. Placeholders therefore never propagate downstream.
-            service.start_command = [
-                token.replace("{model_path}", self.model_path) for token in service.start_command
-            ]
+            service.start_command = service.start_command.replace("{model_path}", self.model_path)
         payload = self.model_dump(exclude_none=True, exclude={"service"})
         payload["service"] = service
         return ModelConfig.model_validate(payload)

--- a/src/ai/backend/common/dto/manager/v2/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/request.py
@@ -152,7 +152,13 @@ class ModelServiceConfigInput(BaseRequestModel):
     pre_start_actions: list[PreStartAction] | None = None
     command: str | None = None
     start_command: list[str] | None = None
-    shell: str | None = None
+    shell: str | None = Field(
+        default=None,
+        description=(
+            "Shell used to run the command. If set, the kernel runs "
+            "`[shell, '-c', command]`; null or empty disables shell wrapping."
+        ),
+    )
     port: int | None = None
     health_check: ModelHealthCheckInput | None = None
 

--- a/src/ai/backend/common/dto/manager/v2/deployment/types.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/types.py
@@ -4,7 +4,6 @@ Common types for Deployment DTO v2.
 
 from __future__ import annotations
 
-import shlex
 from datetime import datetime
 from enum import StrEnum
 from typing import Any
@@ -318,31 +317,15 @@ class ModelServiceConfigInfoDTO(BaseResponseModel):
     )
     shell: str | None = Field(
         default="/bin/bash",
-        description="Shell configured for the model service.",
+        description=(
+            "Shell used to run the command. If set, the kernel runs "
+            "`[shell, '-c', command]`; null or empty disables shell wrapping."
+        ),
     )
     port: int = Field(description="Port number for the model service.")
     health_check: ModelHealthCheckInfoDTO | None = Field(
         default=None, description="Health check configuration for the model service."
     )
-
-    @model_validator(mode="before")
-    @classmethod
-    def _populate_command_from_internal_start_command(cls, data: Any) -> Any:
-        if not isinstance(data, dict):
-            return data
-        start_command = data.get("start_command")
-        if isinstance(start_command, str):
-            data = dict(data)
-            if data.get("command") is None:
-                data["command"] = start_command
-            try:
-                data["start_command"] = shlex.split(start_command)
-            except ValueError:
-                data["start_command"] = [start_command]
-        elif isinstance(start_command, list) and data.get("command") is None:
-            data = dict(data)
-            data["command"] = shlex.join(start_command)
-        return data
 
 
 class ModelMetadataInfoDTO(BaseResponseModel):

--- a/src/ai/backend/common/dto/manager/v2/deployment/types.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/types.py
@@ -4,6 +4,7 @@ Common types for Deployment DTO v2.
 
 from __future__ import annotations
 
+import shlex
 from datetime import datetime
 from enum import StrEnum
 from typing import Any
@@ -323,6 +324,25 @@ class ModelServiceConfigInfoDTO(BaseResponseModel):
     health_check: ModelHealthCheckInfoDTO | None = Field(
         default=None, description="Health check configuration for the model service."
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _populate_command_from_internal_start_command(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        start_command = data.get("start_command")
+        if isinstance(start_command, str):
+            data = dict(data)
+            if data.get("command") is None:
+                data["command"] = start_command
+            try:
+                data["start_command"] = shlex.split(start_command)
+            except ValueError:
+                data["start_command"] = [start_command]
+        elif isinstance(start_command, list) and data.get("command") is None:
+            data = dict(data)
+            data["command"] = shlex.join(start_command)
+        return data
 
 
 class ModelMetadataInfoDTO(BaseResponseModel):

--- a/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
@@ -75,7 +75,10 @@ class PresetModelServiceConfigInput(BaseRequestModel):
         default=None,
         description="Deprecated. Command to start the model service. Use `command` instead.",
     )
-    shell: str = Field(default=DEFAULT_SHELL, description="Shell configured for the model service.")
+    shell: str | None = Field(
+        default=DEFAULT_SHELL,
+        description="Shell configured for the model service. Null or empty disables shell use.",
+    )
     port: int = Field(
         gt=1, description="Port number for the model service. Must be greater than 1."
     )

--- a/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
@@ -77,7 +77,10 @@ class PresetModelServiceConfigInput(BaseRequestModel):
     )
     shell: str | None = Field(
         default=DEFAULT_SHELL,
-        description="Shell configured for the model service. Null or empty disables shell use.",
+        description=(
+            "Shell used to run the command. If set, the kernel runs "
+            "`[shell, '-c', command]`; null or empty disables shell wrapping."
+        ),
     )
     port: int = Field(
         gt=1, description="Port number for the model service. Must be greater than 1."

--- a/src/ai/backend/common/model_service_start_command_compat.py
+++ b/src/ai/backend/common/model_service_start_command_compat.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import shlex
 from collections.abc import Mapping
-from typing import Any, cast
+from typing import Any
 
 MODEL_SERVICE_COMMAND_KEYS = frozenset(("command", "start_command", "start-command"))
 
@@ -25,20 +25,13 @@ def _normalize_model_service_command_input(service: Mapping[str, Any]) -> dict[s
     return result
 
 
-def normalize_model_service_command_response(service: Mapping[str, Any]) -> dict[str, Any]:
-    result = dict(service)
-    command = result.get("command")
+def to_legacy_start_command(command: str | None) -> list[str] | None:
+    """Best-effort argv form of the internal command string for the deprecated
+    ``start_command`` response field."""
     if command is None:
-        command = result.get("start_command")
-        if isinstance(command, list) and all(isinstance(item, str) for item in command):
-            command = shlex.join(command)
-
-    if command is None:
-        result["start_command"] = None
-    else:
-        try:
-            result["start_command"] = shlex.split(cast(str, command))
-        except ValueError:
-            result["start_command"] = [command]
-    result["command"] = command
-    return result
+        return None
+    try:
+        return shlex.split(command)
+    except ValueError:
+        # Unparseable shell string (e.g. unclosed quote); keep it as a single argv item.
+        return [command]

--- a/src/ai/backend/common/model_service_start_command_compat.py
+++ b/src/ai/backend/common/model_service_start_command_compat.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import shlex
+from collections.abc import Mapping
+from typing import Any, cast
+
+MODEL_SERVICE_COMMAND_KEYS = frozenset(("command", "start_command", "start-command"))
+
+
+def resolve_model_service_start_command(service: Any) -> Any:
+    if not isinstance(service, Mapping):
+        return service
+    return _normalize_model_service_command_input(service)
+
+
+def _normalize_model_service_command_input(service: Mapping[str, Any]) -> dict[str, Any]:
+    result = {k: v for k, v in service.items() if k not in MODEL_SERVICE_COMMAND_KEYS}
+    command = service.get("command")
+    if command is None:
+        command = service.get("start_command", service.get("start-command"))
+        if isinstance(command, list) and all(isinstance(item, str) for item in command):
+            command = shlex.join(command)
+    if command is not None or "start_command" in service or "start-command" in service:
+        result["start_command"] = command
+    return result
+
+
+def normalize_model_service_command_response(service: Mapping[str, Any]) -> dict[str, Any]:
+    result = dict(service)
+    command = result.get("command")
+    if command is None:
+        command = result.get("start_command")
+        if isinstance(command, list) and all(isinstance(item, str) for item in command):
+            command = shlex.join(command)
+
+    if command is None:
+        result["start_command"] = None
+    else:
+        try:
+            result["start_command"] = shlex.split(cast(str, command))
+        except ValueError:
+            result["start_command"] = [command]
+    result["command"] = command
+    return result

--- a/src/ai/backend/kernel/service.py
+++ b/src/ai/backend/kernel/service.py
@@ -10,6 +10,7 @@ import enum
 import json
 import logging
 import re
+import shlex
 from collections.abc import (
     Collection,
     Iterator,
@@ -41,7 +42,7 @@ class Action(TypedDict):
 @attrs.define(auto_attribs=True, slots=True)
 class ServiceDefinition:
     command: str | list[str]
-    shell: str = "bash"
+    shell: str | None = "bash"
     noop: bool = False
     url_template: str = ""
     prestart_actions: list[Action] = attrs.Factory(list)
@@ -118,7 +119,10 @@ class ServiceParser:
         start_command = service.command
         if isinstance(start_command, str):
             shell = service.shell
-            start_command = [shell, "-c", start_command]
+            if shell:
+                start_command = [shell, "-c", start_command]
+            else:
+                start_command = shlex.split(start_command)
         cmdargs = [*start_command]
         env = {}
 

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from ai.backend.manager.sokovan.deployment.coordinator import DeploymentCoordinator
 
 from ai.backend.common.api_handlers import Sentinel
+from ai.backend.common.config import ModelDefinition
 from ai.backend.common.contexts.user import current_user
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.data.model_deployment.types import (
@@ -139,6 +140,9 @@ from ai.backend.common.dto.manager.v2.resource_slot.types import (
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
 from ai.backend.common.identifier.runtime_variant_preset import RuntimeVariantPresetID
+from ai.backend.common.model_service_start_command_compat import (
+    normalize_model_service_command_response,
+)
 from ai.backend.manager.api.adapter_options.deployment.options import (
     deployment_options_from_input,
     deployment_options_to_info,
@@ -336,6 +340,15 @@ def _tristate_from_input[T](value: T | Sentinel | None) -> TriState[T]:
     if value is None:
         return TriState[T].nullify()
     return TriState[T].update(value)
+
+
+def _model_definition_to_dto(model_definition: ModelDefinition) -> ModelDefinitionInfoDTO:
+    data = model_definition.model_dump(by_alias=False)
+    for model in data.get("models") or []:
+        service = model.get("service")
+        if service is not None:
+            model["service"] = normalize_model_service_command_response(service)
+    return ModelDefinitionInfoDTO.model_validate(data)
 
 
 @lru_cache(maxsize=1)
@@ -2355,9 +2368,7 @@ class DeploymentAdapter(BaseAdapter):
             ),
             model_mount_config=model_mount_config_dto,
             model_definition=(
-                ModelDefinitionInfoDTO.model_validate(
-                    data.model_definition.model_dump(by_alias=False)
-                )
+                _model_definition_to_dto(data.model_definition)
                 if data.model_definition is not None
                 else None
             ),

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -19,10 +19,7 @@ from ai.backend.common.api_handlers import Sentinel
 from ai.backend.common.config import (
     ModelConfig,
     ModelDefinition,
-    ModelHealthCheck,
-    ModelMetadata,
     ModelServiceConfig,
-    PreStartAction,
 )
 from ai.backend.common.contexts.user import current_user
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
@@ -352,63 +349,55 @@ def _tristate_from_input[T](value: T | Sentinel | None) -> TriState[T]:
     return TriState[T].update(value)
 
 
-def _pre_start_action_to_dto(action: PreStartAction) -> PreStartActionInfoDTO:
-    return PreStartActionInfoDTO(action=action.action, args=action.args)
-
-
-def _model_health_check_to_dto(check: ModelHealthCheck) -> ModelHealthCheckInfoDTO:
-    return ModelHealthCheckInfoDTO(
-        enable=check.enable,
-        interval=check.interval,
-        path=check.path,
-        max_retries=check.max_retries,
-        max_wait_time=check.max_wait_time,
-        expected_status_code=check.expected_status_code,
-        initial_delay=check.initial_delay,
-    )
-
-
 def _model_service_config_to_dto(service: ModelServiceConfig) -> ModelServiceConfigInfoDTO:
+    health_check = None
+    if service.health_check is not None:
+        health_check = ModelHealthCheckInfoDTO(
+            enable=service.health_check.enable,
+            interval=service.health_check.interval,
+            path=service.health_check.path,
+            max_retries=service.health_check.max_retries,
+            max_wait_time=service.health_check.max_wait_time,
+            expected_status_code=service.health_check.expected_status_code,
+            initial_delay=service.health_check.initial_delay,
+        )
     return ModelServiceConfigInfoDTO(
-        pre_start_actions=[_pre_start_action_to_dto(a) for a in service.pre_start_actions],
+        pre_start_actions=[
+            PreStartActionInfoDTO(action=a.action, args=a.args) for a in service.pre_start_actions
+        ],
         command=service.start_command,
         start_command=to_legacy_start_command(service.start_command),
         shell=service.shell,
         port=service.port,
-        health_check=(
-            _model_health_check_to_dto(service.health_check)
-            if service.health_check is not None
-            else None
-        ),
-    )
-
-
-def _model_metadata_to_dto(metadata: ModelMetadata) -> ModelMetadataInfoDTO:
-    return ModelMetadataInfoDTO(
-        author=metadata.author,
-        title=metadata.title,
-        version=metadata.version,
-        created=metadata.created,
-        last_modified=metadata.last_modified,
-        description=metadata.description,
-        task=metadata.task,
-        category=metadata.category,
-        architecture=metadata.architecture,
-        framework=metadata.framework,
-        label=metadata.label,
-        license=metadata.license,
-        min_resource=metadata.min_resource,
+        health_check=health_check,
     )
 
 
 def _model_config_to_dto(config: ModelConfig) -> ModelConfigInfoDTO:
+    metadata = None
+    if config.metadata is not None:
+        metadata = ModelMetadataInfoDTO(
+            author=config.metadata.author,
+            title=config.metadata.title,
+            version=config.metadata.version,
+            created=config.metadata.created,
+            last_modified=config.metadata.last_modified,
+            description=config.metadata.description,
+            task=config.metadata.task,
+            category=config.metadata.category,
+            architecture=config.metadata.architecture,
+            framework=config.metadata.framework,
+            label=config.metadata.label,
+            license=config.metadata.license,
+            min_resource=config.metadata.min_resource,
+        )
     return ModelConfigInfoDTO(
         name=config.name,
         model_path=config.model_path,
         service=(
             _model_service_config_to_dto(config.service) if config.service is not None else None
         ),
-        metadata=(_model_metadata_to_dto(config.metadata) if config.metadata is not None else None),
+        metadata=metadata,
     )
 
 

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -16,7 +16,14 @@ if TYPE_CHECKING:
     from ai.backend.manager.sokovan.deployment.coordinator import DeploymentCoordinator
 
 from ai.backend.common.api_handlers import Sentinel
-from ai.backend.common.config import ModelDefinition
+from ai.backend.common.config import (
+    ModelConfig,
+    ModelDefinition,
+    ModelHealthCheck,
+    ModelMetadata,
+    ModelServiceConfig,
+    PreStartAction,
+)
 from ai.backend.common.contexts.user import current_user
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.data.model_deployment.types import (
@@ -112,10 +119,15 @@ from ai.backend.common.dto.manager.v2.deployment.types import (
     EnvironmentVariableEntryInfoDTO,
     EnvironmentVariablesInfoDTO,
     ExtraVFolderMountGQLDTO,
+    ModelConfigInfoDTO,
     ModelDefinitionInfoDTO,
+    ModelHealthCheckInfoDTO,
+    ModelMetadataInfoDTO,
     ModelMountConfigInfoDTO,
     ModelRuntimeConfigInfoDTO,
+    ModelServiceConfigInfoDTO,
     OrderDirection,
+    PreStartActionInfoDTO,
     ReplicaOrderField,
     ReplicaStateInfo,
     ResourceConfigInfoDTO,
@@ -140,9 +152,7 @@ from ai.backend.common.dto.manager.v2.resource_slot.types import (
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
 from ai.backend.common.identifier.runtime_variant_preset import RuntimeVariantPresetID
-from ai.backend.common.model_service_start_command_compat import (
-    normalize_model_service_command_response,
-)
+from ai.backend.common.model_service_start_command_compat import to_legacy_start_command
 from ai.backend.manager.api.adapter_options.deployment.options import (
     deployment_options_from_input,
     deployment_options_to_info,
@@ -342,13 +352,74 @@ def _tristate_from_input[T](value: T | Sentinel | None) -> TriState[T]:
     return TriState[T].update(value)
 
 
-def _model_definition_to_dto(model_definition: ModelDefinition) -> ModelDefinitionInfoDTO:
-    data = model_definition.model_dump(by_alias=False)
-    for model in data.get("models") or []:
-        service = model.get("service")
-        if service is not None:
-            model["service"] = normalize_model_service_command_response(service)
-    return ModelDefinitionInfoDTO.model_validate(data)
+def _pre_start_action_to_dto(action: PreStartAction) -> PreStartActionInfoDTO:
+    return PreStartActionInfoDTO(action=action.action, args=action.args)
+
+
+def _model_health_check_to_dto(check: ModelHealthCheck) -> ModelHealthCheckInfoDTO:
+    return ModelHealthCheckInfoDTO(
+        enable=check.enable,
+        interval=check.interval,
+        path=check.path,
+        max_retries=check.max_retries,
+        max_wait_time=check.max_wait_time,
+        expected_status_code=check.expected_status_code,
+        initial_delay=check.initial_delay,
+    )
+
+
+def _model_service_config_to_dto(service: ModelServiceConfig) -> ModelServiceConfigInfoDTO:
+    return ModelServiceConfigInfoDTO(
+        pre_start_actions=[_pre_start_action_to_dto(a) for a in service.pre_start_actions],
+        command=service.start_command,
+        start_command=to_legacy_start_command(service.start_command),
+        shell=service.shell,
+        port=service.port,
+        health_check=(
+            _model_health_check_to_dto(service.health_check)
+            if service.health_check is not None
+            else None
+        ),
+    )
+
+
+def _model_metadata_to_dto(metadata: ModelMetadata) -> ModelMetadataInfoDTO:
+    return ModelMetadataInfoDTO(
+        author=metadata.author,
+        title=metadata.title,
+        version=metadata.version,
+        created=metadata.created,
+        last_modified=metadata.last_modified,
+        description=metadata.description,
+        task=metadata.task,
+        category=metadata.category,
+        architecture=metadata.architecture,
+        framework=metadata.framework,
+        label=metadata.label,
+        license=metadata.license,
+        min_resource=metadata.min_resource,
+    )
+
+
+def _model_config_to_dto(config: ModelConfig) -> ModelConfigInfoDTO:
+    return ModelConfigInfoDTO(
+        name=config.name,
+        model_path=config.model_path,
+        service=(
+            _model_service_config_to_dto(config.service) if config.service is not None else None
+        ),
+        metadata=(_model_metadata_to_dto(config.metadata) if config.metadata is not None else None),
+    )
+
+
+def _model_definition_to_dto(
+    definition: ModelDefinition | None,
+) -> ModelDefinitionInfoDTO | None:
+    if definition is None:
+        return None
+    return ModelDefinitionInfoDTO(
+        models=[_model_config_to_dto(m) for m in definition.models],
+    )
 
 
 @lru_cache(maxsize=1)
@@ -2367,11 +2438,7 @@ class DeploymentAdapter(BaseAdapter):
                 ],
             ),
             model_mount_config=model_mount_config_dto,
-            model_definition=(
-                _model_definition_to_dto(data.model_definition)
-                if data.model_definition is not None
-                else None
-            ),
+            model_definition=_model_definition_to_dto(data.model_definition),
             created_at=data.created_at,
             extra_mounts=[
                 ExtraVFolderMountGQLDTO(

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shlex
 from typing import Any
 from uuid import UUID
 
@@ -147,10 +148,20 @@ def _model_health_check_to_dto(check: ModelHealthCheck) -> ModelHealthCheckInfoD
     )
 
 
+def _legacy_start_command_to_dto(start_command: str | None) -> list[str] | None:
+    if start_command is None:
+        return None
+    try:
+        return shlex.split(start_command)
+    except ValueError:
+        return [start_command]
+
+
 def _model_service_config_to_dto(service: ModelServiceConfig) -> ModelServiceConfigInfoDTO:
     return ModelServiceConfigInfoDTO(
         pre_start_actions=[_pre_start_action_to_dto(a) for a in service.pre_start_actions],
-        start_command=service.start_command,
+        command=service.start_command,
+        start_command=_legacy_start_command_to_dto(service.start_command),
         shell=service.shell,
         port=service.port,
         health_check=(

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -54,9 +54,7 @@ from ai.backend.common.dto.manager.v2.resource_slot.response import (
     AllocatedResourceSlotNode,
     SearchAllocatedResourceSlotsPayload,
 )
-from ai.backend.common.model_service_start_command_compat import (
-    normalize_model_service_command_response,
-)
+from ai.backend.common.model_service_start_command_compat import to_legacy_start_command
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.deployment_revision_preset.types import (
@@ -151,13 +149,10 @@ def _model_health_check_to_dto(check: ModelHealthCheck) -> ModelHealthCheckInfoD
 
 
 def _model_service_config_to_dto(service: ModelServiceConfig) -> ModelServiceConfigInfoDTO:
-    command_fields = normalize_model_service_command_response({
-        "start_command": service.start_command,
-    })
     return ModelServiceConfigInfoDTO(
         pre_start_actions=[_pre_start_action_to_dto(a) for a in service.pre_start_actions],
-        command=command_fields["command"],
-        start_command=command_fields["start_command"],
+        command=service.start_command,
+        start_command=to_legacy_start_command(service.start_command),
         shell=service.shell,
         port=service.port,
         health_check=(

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import shlex
 from typing import Any
 from uuid import UUID
 
@@ -54,6 +53,9 @@ from ai.backend.common.dto.manager.v2.resource_slot.request import (
 from ai.backend.common.dto.manager.v2.resource_slot.response import (
     AllocatedResourceSlotNode,
     SearchAllocatedResourceSlotsPayload,
+)
+from ai.backend.common.model_service_start_command_compat import (
+    normalize_model_service_command_response,
 )
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
@@ -148,20 +150,14 @@ def _model_health_check_to_dto(check: ModelHealthCheck) -> ModelHealthCheckInfoD
     )
 
 
-def _legacy_start_command_to_dto(start_command: str | None) -> list[str] | None:
-    if start_command is None:
-        return None
-    try:
-        return shlex.split(start_command)
-    except ValueError:
-        return [start_command]
-
-
 def _model_service_config_to_dto(service: ModelServiceConfig) -> ModelServiceConfigInfoDTO:
+    command_fields = normalize_model_service_command_response({
+        "start_command": service.start_command,
+    })
     return ModelServiceConfigInfoDTO(
         pre_start_actions=[_pre_start_action_to_dto(a) for a in service.pre_start_actions],
-        command=service.start_command,
-        start_command=_legacy_start_command_to_dto(service.start_command),
+        command=command_fields["command"],
+        start_command=command_fields["start_command"],
         shell=service.shell,
         port=service.port,
         health_check=(

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -437,7 +437,11 @@ class ModelServiceConfigGQL:
         deprecation_reason="Use `command` instead.",
     )
     shell: str | None = gql_field(
-        description="Shell configured for the model service.", default="/bin/bash"
+        description=(
+            "Shell used to run the command. If set, the kernel runs "
+            "`[shell, '-c', command]`; null or empty disables shell wrapping."
+        ),
+        default="/bin/bash",
     )
     port: int = gql_field(description="Port number for the model service.")
     health_check: ModelHealthCheckGQL | None = gql_field(
@@ -998,7 +1002,11 @@ class ModelServiceConfigInputGQL(PydanticInputMixin[ModelServiceConfigInputDTO])
         deprecation_reason="Use `command` instead.",
     )
     shell: str | None = gql_field(
-        description="Shell configured for the model service.", default=None
+        description=(
+            "Shell used to run the command. If set, the kernel runs "
+            "`[shell, '-c', command]`; null or empty disables shell wrapping."
+        ),
+        default=None,
     )
     port: int | None = gql_field(description="Port number for the model service.", default=None)
     health_check: ModelHealthCheckInputGQL | None = gql_field(

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -551,7 +551,11 @@ class PresetModelServiceConfigInputGQL(PydanticInputMixin[PresetModelServiceConf
         deprecation_reason="Use `command` instead.",
     )
     shell: str | None = gql_field(
-        description="Shell configured for the model service.", default=DEFAULT_SHELL
+        description=(
+            "Shell used to run the command. If set, the kernel runs "
+            "`[shell, '-c', command]`; null or empty disables shell wrapping."
+        ),
+        default=DEFAULT_SHELL,
     )
     port: int = gql_field(
         description="Port number for the model service. Must be greater than 1.",

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -550,7 +550,7 @@ class PresetModelServiceConfigInputGQL(PydanticInputMixin[PresetModelServiceConf
         default=None,
         deprecation_reason="Use `command` instead.",
     )
-    shell: str = gql_field(
+    shell: str | None = gql_field(
         description="Shell configured for the model service.", default=DEFAULT_SHELL
     )
     port: int = gql_field(

--- a/src/ai/backend/manager/models/alembic/versions/ba6615a4d2f1_stringify_model_service_start_command.py
+++ b/src/ai/backend/manager/models/alembic/versions/ba6615a4d2f1_stringify_model_service_start_command.py
@@ -21,7 +21,7 @@ from sqlalchemy.engine import Connection
 # revision identifiers, used by Alembic.
 revision = "ba6615a4d2f1"
 down_revision = "e3b8d2a1c5f7"
-# Part of: {NEXT_RELEASE_VERSION}
+# Part of: 26.7.0 (main)
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/ba6615a4d2f1_stringify_model_service_start_command.py
+++ b/src/ai/backend/manager/models/alembic/versions/ba6615a4d2f1_stringify_model_service_start_command.py
@@ -1,0 +1,64 @@
+"""stringify model service start_command
+
+Convert stored model-definition ``service.start_command`` values from argv
+lists back to a single command string. This keeps persisted model definitions
+aligned with the internal model representation while accepting rows already
+converted by the previous compatibility migrations.
+
+Revision ID: ba6615a4d2f1
+Revises: e3b8d2a1c5f7
+Create Date: 2026-06-29
+
+"""
+
+import json
+import shlex
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Connection
+
+# revision identifiers, used by Alembic.
+revision = "ba6615a4d2f1"
+down_revision = "e3b8d2a1c5f7"
+# Part of: {NEXT_RELEASE_VERSION}
+branch_labels = None
+depends_on = None
+
+
+def _stringify_model_definition(conn: Connection, table: str, column: str) -> None:
+    rows = conn.execute(
+        sa.text(f"SELECT id, {column} FROM {table} WHERE {column} IS NOT NULL")
+    ).fetchall()
+
+    for row_id, model_definition in rows:
+        changed = False
+        models = model_definition.get("models") or []
+        for model in models:
+            try:
+                start_command = model["service"]["start_command"]
+            except (KeyError, TypeError):
+                continue
+            if isinstance(start_command, list):
+                model["service"]["start_command"] = shlex.join(start_command)
+                changed = True
+
+        if changed:
+            model_definition["models"] = models
+            conn.execute(
+                sa.text(f"UPDATE {table} SET {column} = CAST(:definition AS JSONB) WHERE id = :id"),
+                {"definition": json.dumps(model_definition), "id": row_id},
+            )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    _stringify_model_definition(conn, "deployment_revisions", "model_definition")
+    _stringify_model_definition(conn, "deployment_revision_presets", "model_definition")
+    _stringify_model_definition(conn, "runtime_variants", "default_model_definition")
+
+
+def downgrade() -> None:
+    # Data-only compatibility conversion. Reconstructing the previous argv
+    # representation would be lossy for shell scripts, so this is a no-op.
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/ba6615a4d2f1_stringify_model_service_start_command.py
+++ b/src/ai/backend/manager/models/alembic/versions/ba6615a4d2f1_stringify_model_service_start_command.py
@@ -6,7 +6,7 @@ aligned with the internal model representation while accepting rows already
 converted by the previous compatibility migrations.
 
 Revision ID: ba6615a4d2f1
-Revises: e3b8d2a1c5f7
+Revises: ada41cb881bb
 Create Date: 2026-06-29
 
 """
@@ -20,7 +20,7 @@ from sqlalchemy.engine import Connection
 
 # revision identifiers, used by Alembic.
 revision = "ba6615a4d2f1"
-down_revision = "e3b8d2a1c5f7"
+down_revision = "ada41cb881bb"
 # Part of: 26.7.0 (main)
 branch_labels = None
 depends_on = None

--- a/src/ai/backend/manager/sokovan/deployment/deployment_draft_builder.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_draft_builder.py
@@ -214,7 +214,7 @@ class DeploymentSessionDraftBuilder:
         ``service.start_command`` is taken as-is from the revision snapshot
         (the controller has already resolved any ``{model_path}`` placeholder
         against ``models[0].model_path`` at revision creation time). Preset
-        ARGS are appended as separate argv tokens via
+        ARGS are shell-quoted and appended to the command string via
         :meth:`ModelDefinition.with_args_appended` so the merge stays on
         typed objects up to the final ``model_dump``.
         """

--- a/tests/unit/agent/test_legacy_inference_env.py
+++ b/tests/unit/agent/test_legacy_inference_env.py
@@ -119,7 +119,7 @@ class TestLegacyInferenceEnvTranslatorToCliArgs:
         assert LegacyInferenceEnvTranslator.to_cli_args(scenario.environ) == scenario.expected
 
 
-def _model(name: str, start_command: list[str] | None) -> ModelConfig:
+def _model(name: str, start_command: str | None) -> ModelConfig:
     return ModelConfig.model_validate({
         "name": name,
         "model_path": f"/models/{name}",
@@ -133,7 +133,7 @@ def _model(name: str, start_command: list[str] | None) -> ModelConfig:
 
 class TestAppendLegacyInferenceEnvTranslator:
     def test_appends_to_existing_start_command(self) -> None:
-        models = [_model("vllm", ["vllm", "serve", "/models"])]
+        models = [_model("vllm", "vllm serve /models")]
         environ = {"VLLM_EXTRA_ARGS": "--trust-remote-code", "VLLM_TP_SIZE": "4"}
 
         result = AbstractAgent._append_legacy_inference_env_args(
@@ -145,17 +145,29 @@ class TestAppendLegacyInferenceEnvTranslator:
         assert result is models
         service = models[0].service
         assert service is not None
-        assert service.start_command == [
-            "vllm",
-            "serve",
-            "/models",
-            "--tensor-parallel-size",
-            "4",
-            "--trust-remote-code",
-        ]
+        assert service.start_command == (
+            "vllm serve /models --tensor-parallel-size 4 --trust-remote-code"
+        )
+
+    def test_appends_raw_dash_args_to_existing_start_command(self) -> None:
+        models = [_model("vllm", "vllm serve /models")]
+        environ = {"VLLM_EXTRA_ARGS": "--max-model-len 524288 --served-model-name 'llama 3'"}
+
+        result = AbstractAgent._append_legacy_inference_env_args(
+            cast(AbstractAgent[Any, Any], object()),
+            models,
+            environ,
+        )
+
+        assert result is models
+        service = models[0].service
+        assert service is not None
+        assert service.start_command == (
+            "vllm serve /models --max-model-len 524288 --served-model-name 'llama 3'"
+        )
 
     def test_noop_without_legacy_env(self) -> None:
-        models = [_model("vllm", ["vllm", "serve", "/models"])]
+        models = [_model("vllm", "vllm serve /models")]
 
         AbstractAgent._append_legacy_inference_env_args(
             cast(AbstractAgent[Any, Any], object()),
@@ -165,12 +177,12 @@ class TestAppendLegacyInferenceEnvTranslator:
 
         service = models[0].service
         assert service is not None
-        assert service.start_command == ["vllm", "serve", "/models"]
+        assert service.start_command == "vllm serve /models"
 
     def test_skips_model_without_service(self) -> None:
         models = [
             ModelConfig.model_validate({"name": "no-service", "model_path": "/models/x"}),
-            _model("vllm", ["vllm", "serve", "/models"]),
+            _model("vllm", "vllm serve /models"),
         ]
 
         AbstractAgent._append_legacy_inference_env_args(
@@ -182,4 +194,4 @@ class TestAppendLegacyInferenceEnvTranslator:
         assert models[0].service is None
         service = models[1].service
         assert service is not None
-        assert service.start_command == ["vllm", "serve", "/models", "--trust-remote-code"]
+        assert service.start_command == "vllm serve /models --trust-remote-code"

--- a/tests/unit/agent/test_model_service_start_command.py
+++ b/tests/unit/agent/test_model_service_start_command.py
@@ -17,7 +17,7 @@ class ModelServiceStartCommandScenario:
     id: str
     image_command: list[str] | None
     models: list[ModelConfig]
-    expected_start_commands: dict[str, list[str]]
+    expected_start_commands: dict[str, str]
     expected_image_command_calls: int = 1
     expected_unset_models: set[str] = field(default_factory=set)
 
@@ -43,7 +43,7 @@ class _ModelServiceCommandAgent:
 def _model(
     name: str,
     port: int,
-    start_command: list[str] | None = None,
+    start_command: str | None = None,
     shell: str = "/bin/bash",
 ) -> ModelConfig:
     return ModelConfig.model_validate({
@@ -84,11 +84,11 @@ class TestPopulateMissingModelServiceStartCommands:
                 image_command=["/etc/container/start-vllm.sh"],
                 models=[
                     _model("vllm", 8000),
-                    _model("explicit", 8001, ["python", "serve.py"]),
+                    _model("explicit", 8001, "python serve.py"),
                 ],
                 expected_start_commands={
-                    "vllm": ["/etc/container/start-vllm.sh"],
-                    "explicit": ["python", "serve.py"],
+                    "vllm": "/etc/container/start-vllm.sh",
+                    "explicit": "python serve.py",
                 },
             ),
             ModelServiceStartCommandScenario(
@@ -104,12 +104,12 @@ class TestPopulateMissingModelServiceStartCommands:
                 id="skips_image_command_lookup_when_all_commands_are_explicit",
                 image_command=["/etc/container/start-vllm.sh"],
                 models=[
-                    _model("explicit-a", 8000, ["python", "serve-a.py"]),
-                    _model("explicit-b", 8001, ["python", "serve-b.py"]),
+                    _model("explicit-a", 8000, "python serve-a.py"),
+                    _model("explicit-b", 8001, "python serve-b.py"),
                 ],
                 expected_start_commands={
-                    "explicit-a": ["python", "serve-a.py"],
-                    "explicit-b": ["python", "serve-b.py"],
+                    "explicit-a": "python serve-a.py",
+                    "explicit-b": "python serve-b.py",
                 },
                 expected_image_command_calls=0,
             ),

--- a/tests/unit/common/test_config.py
+++ b/tests/unit/common/test_config.py
@@ -107,7 +107,7 @@ class TestMergeFieldCoverage:
         base = ModelServiceConfig.model_construct(
             _fields_set=set(ModelServiceConfig.model_fields),
             pre_start_actions=[],
-            start_command=["base-cmd"],
+            start_command="base-cmd",
             shell="/bin/base",
             port=9999,
             health_check=None,
@@ -115,7 +115,7 @@ class TestMergeFieldCoverage:
         override = ModelServiceConfig.model_construct(
             _fields_set=set(),
             pre_start_actions=[],
-            start_command=[],
+            start_command="",
             shell="",
             port=2,
             health_check=None,
@@ -140,13 +140,13 @@ class TestMergeFieldCoverage:
         )
         base = ModelServiceConfig.model_construct(
             _fields_set={"health_check"},
-            start_command=[],
+            start_command="",
             port=2,
             health_check=base_hc,
         )
         override = ModelServiceConfig.model_construct(
             _fields_set={"health_check"},
-            start_command=[],
+            start_command="",
             port=2,
             health_check=override_hc,
         )
@@ -325,7 +325,7 @@ class TestHealthCheckEnable:
         """A disabled baseline is opted in when a higher-priority draft sets enable=True."""
         base = ModelServiceConfig.model_construct(
             _fields_set={"health_check"},
-            start_command=[],
+            start_command="",
             port=2,
             health_check=ModelHealthCheck.model_construct(
                 _fields_set=set(ModelHealthCheck.model_fields), enable=False, path="/health"
@@ -333,7 +333,7 @@ class TestHealthCheckEnable:
         )
         override = ModelServiceConfig.model_construct(
             _fields_set={"health_check"},
-            start_command=[],
+            start_command="",
             port=2,
             health_check=ModelHealthCheck.model_construct(_fields_set={"enable"}, enable=True),
         )
@@ -351,7 +351,7 @@ class TestModelDefinitionDraftMerge:
             model_path="/models",
             service=ModelServiceConfigDraft(
                 pre_start_actions=[],
-                start_command=["/models/start.sh"],
+                start_command="/models/start.sh",
                 shell="/bin/sh",
                 port=8000,
                 health_check=ModelHealthCheckDraft(
@@ -391,7 +391,7 @@ class TestModelDefinitionDraftMerge:
         assert merged.model_path == "/models"
         assert merged.service is not None
         assert merged.service.port == 8000
-        assert merged.service.start_command == ["/models/start.sh"]
+        assert merged.service.start_command == "/models/start.sh"
         assert merged.service.health_check is not None
         assert merged.service.health_check.enable is False
         assert merged.service.health_check.path == "/override"
@@ -480,6 +480,27 @@ class TestModelConfigs:
         assert service.start_command is None
         assert service.port == 8000
 
+    def test_to_resolved_preserves_explicit_null_shell(self) -> None:
+        draft = ModelDefinitionDraft.model_validate({
+            "models": [
+                {
+                    "name": "demo",
+                    "model_path": "/models/demo",
+                    "service": {
+                        "start_command": "python service.py",
+                        "shell": None,
+                        "port": 8000,
+                    },
+                }
+            ]
+        })
+
+        resolved = draft.to_resolved()
+
+        service = resolved.models[0].service
+        assert service is not None
+        assert service.shell is None
+
     def test_to_resolved_substitutes_model_path_placeholder(self) -> None:
         # The variant baseline keeps ``{model_path}`` so a single fixture
         # entry covers any mount destination; the placeholder is resolved
@@ -501,7 +522,7 @@ class TestModelConfigs:
 
         service = resolved.models[0].service
         assert service is not None
-        assert service.start_command == ["vllm", "serve", "/custom-mount"]
+        assert service.start_command == "vllm serve '/custom-mount'"
 
     def test_to_resolved_substitutes_placeholder_with_named_flag(self) -> None:
         # SGLang-style: ``{model_path}`` lands after a flag; the
@@ -529,13 +550,7 @@ class TestModelConfigs:
 
         service = resolved.models[0].service
         assert service is not None
-        assert service.start_command == [
-            "python",
-            "-m",
-            "sglang.launch_server",
-            "--model-path",
-            "/data",
-        ]
+        assert service.start_command == "python -m sglang.launch_server --model-path '/data'"
 
     def test_to_resolved_leaves_start_command_with_no_placeholder_unchanged(self) -> None:
         draft = ModelDefinitionDraft.model_validate({
@@ -555,7 +570,8 @@ class TestModelConfigs:
 
         service = resolved.models[0].service
         assert service is not None
-        assert service.start_command == ["my-server", "--bind", "0.0.0.0"]
+        # start command is changed to a string from a list, but the content is unchanged
+        assert service.start_command == "my-server --bind 0.0.0.0"
 
 
 class TestModelDefinitionWithArgsAppended:
@@ -568,7 +584,7 @@ class TestModelDefinitionWithArgsAppended:
                     model_path="/models",
                     service=ModelServiceConfig(
                         port=8000,
-                        start_command=["vllm", "serve", "/models"],
+                        start_command="vllm serve /models",
                     ),
                 )
             ]
@@ -599,12 +615,12 @@ class TestModelDefinitionWithArgsAppended:
                 ModelConfig(
                     name="a",
                     model_path="/models/a",
-                    service=ModelServiceConfig(port=8001, start_command=["a"]),
+                    service=ModelServiceConfig(port=8001, start_command="a"),
                 ),
                 ModelConfig(
                     name="b",
                     model_path="/models/b",
-                    service=ModelServiceConfig(port=8002, start_command=["b"]),
+                    service=ModelServiceConfig(port=8002, start_command="b"),
                 ),
             ]
         )
@@ -614,17 +630,17 @@ class TestModelDefinitionWithArgsAppended:
         [
             pytest.param(
                 ["--max-model-len", "4096"],
-                ["vllm", "serve", "/models", "--max-model-len", "4096"],
+                "vllm serve /models --max-model-len 4096",
                 id="single-flag-pair",
             ),
             pytest.param(
                 ["--port", "8000", "--max-model-len", "4096"],
-                ["vllm", "serve", "/models", "--port", "8000", "--max-model-len", "4096"],
+                "vllm serve /models --port 8000 --max-model-len 4096",
                 id="multiple-flag-pairs",
             ),
             pytest.param(
                 ["--trust-remote-code"],
-                ["vllm", "serve", "/models", "--trust-remote-code"],
+                "vllm serve /models --trust-remote-code",
                 id="bare-flag",
             ),
         ],
@@ -633,7 +649,7 @@ class TestModelDefinitionWithArgsAppended:
         self,
         vllm_definition: ModelDefinition,
         args: list[str],
-        expected: list[str],
+        expected: str,
     ) -> None:
         result = vllm_definition.with_args_appended(args)
 
@@ -660,7 +676,7 @@ class TestModelDefinitionWithArgsAppended:
 
         service = vllm_definition.models[0].service
         assert service is not None
-        assert service.start_command == ["vllm", "serve", "/models"]
+        assert service.start_command == "vllm serve /models"
 
     async def test_args_become_start_command_when_none(
         self,
@@ -670,7 +686,7 @@ class TestModelDefinitionWithArgsAppended:
 
         service = result.models[0].service
         assert service is not None
-        assert service.start_command == ["--port", "8000"]
+        assert service.start_command == "--port 8000"
 
     async def test_passes_through_models_without_service(
         self,
@@ -689,5 +705,5 @@ class TestModelDefinitionWithArgsAppended:
         first = result.models[0].service
         second = result.models[1].service
         assert first is not None and second is not None
-        assert first.start_command == ["a", "--shared", "true"]
-        assert second.start_command == ["b", "--shared", "true"]
+        assert first.start_command == "a --shared true"
+        assert second.start_command == "b --shared true"

--- a/tests/unit/common/test_model_service_start_command_compat.py
+++ b/tests/unit/common/test_model_service_start_command_compat.py
@@ -5,8 +5,8 @@ from typing import Any
 import pytest
 
 from ai.backend.common.model_service_start_command_compat import (
-    normalize_model_service_command_response,
     resolve_model_service_start_command,
+    to_legacy_start_command,
 )
 
 
@@ -56,51 +56,30 @@ class TestNormalizeModelServiceCommandInput:
         assert resolve_model_service_start_command(payload) is payload
 
 
-class TestNormalizeModelServiceCommandResponse:
+class TestToLegacyStartCommand:
     @pytest.mark.parametrize(
-        ("payload", "expected"),
+        ("command", "expected"),
         [
             pytest.param(
-                {
-                    "start_command": "python serve.py --name 'a b'",
-                    "port": 8080,
-                },
-                {
-                    "command": "python serve.py --name 'a b'",
-                    "start_command": ["python", "serve.py", "--name", "a b"],
-                    "port": 8080,
-                },
+                "python serve.py --name 'a b'",
+                ["python", "serve.py", "--name", "a b"],
                 id="internal-string",
             ),
             pytest.param(
-                {
-                    "start_command": ["python", "serve.py"],
-                    "port": 8080,
-                },
-                {
-                    "command": "python serve.py",
-                    "start_command": ["python", "serve.py"],
-                    "port": 8080,
-                },
-                id="legacy-list",
+                "python 'unterminated",
+                ["python 'unterminated"],
+                id="unparseable-string",
             ),
             pytest.param(
-                {
-                    "start_command": "python 'unterminated",
-                },
-                {
-                    "command": "python 'unterminated",
-                    "start_command": ["python 'unterminated"],
-                },
-                id="unparseable-string",
+                None,
+                None,
+                id="none",
             ),
         ],
     )
-    def test_normalizes_response_fields(
+    def test_derives_argv_form(
         self,
-        payload: dict[str, Any],
-        expected: dict[str, Any],
+        command: str | None,
+        expected: list[str] | None,
     ) -> None:
-        result = normalize_model_service_command_response(payload)
-
-        assert result == expected
+        assert to_legacy_start_command(command) == expected

--- a/tests/unit/common/test_model_service_start_command_compat.py
+++ b/tests/unit/common/test_model_service_start_command_compat.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ai.backend.common.model_service_start_command_compat import (
+    normalize_model_service_command_response,
+    resolve_model_service_start_command,
+)
+
+
+class TestNormalizeModelServiceCommandInput:
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            pytest.param(
+                {
+                    "command": "python new.py",
+                    "start_command": ["python", "old.py"],
+                    "port": 8080,
+                },
+                {"start_command": "python new.py", "port": 8080},
+                id="command-takes-precedence",
+            ),
+            pytest.param(
+                {
+                    "start-command": ["python", "serve.py", "--name", "a b"],
+                    "port": 8080,
+                },
+                {"start_command": "python serve.py --name 'a b'", "port": 8080},
+                id="hyphenated-start-command",
+            ),
+            pytest.param(
+                {
+                    "start-command": None,
+                    "port": 8080,
+                },
+                {"start_command": None, "port": 8080},
+                id="explicit-null",
+            ),
+        ],
+    )
+    def test_normalizes_mapping_input(
+        self,
+        payload: dict[str, Any],
+        expected: dict[str, Any],
+    ) -> None:
+        result = resolve_model_service_start_command(payload)
+
+        assert result == expected
+
+    def test_non_mapping_input_passes_through(self) -> None:
+        payload = ["not", "a", "service"]
+
+        assert resolve_model_service_start_command(payload) is payload
+
+
+class TestNormalizeModelServiceCommandResponse:
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            pytest.param(
+                {
+                    "start_command": "python serve.py --name 'a b'",
+                    "port": 8080,
+                },
+                {
+                    "command": "python serve.py --name 'a b'",
+                    "start_command": ["python", "serve.py", "--name", "a b"],
+                    "port": 8080,
+                },
+                id="internal-string",
+            ),
+            pytest.param(
+                {
+                    "start_command": ["python", "serve.py"],
+                    "port": 8080,
+                },
+                {
+                    "command": "python serve.py",
+                    "start_command": ["python", "serve.py"],
+                    "port": 8080,
+                },
+                id="legacy-list",
+            ),
+            pytest.param(
+                {
+                    "start_command": "python 'unterminated",
+                },
+                {
+                    "command": "python 'unterminated",
+                    "start_command": ["python 'unterminated"],
+                },
+                id="unparseable-string",
+            ),
+        ],
+    )
+    def test_normalizes_response_fields(
+        self,
+        payload: dict[str, Any],
+        expected: dict[str, Any],
+    ) -> None:
+        result = normalize_model_service_command_response(payload)
+
+        assert result == expected

--- a/tests/unit/kernel/test_service_variables.py
+++ b/tests/unit/kernel/test_service_variables.py
@@ -1,6 +1,49 @@
 from typing import Any
 
-from ai.backend.kernel.service import ServiceArgumentInterpolator
+import pytest
+
+from ai.backend.kernel.service import ServiceArgumentInterpolator, ServiceParser
+
+
+class TestModelServiceStringCommand:
+    @pytest.fixture
+    def service_parser(self) -> ServiceParser:
+        return ServiceParser({})
+
+    @pytest.mark.parametrize("shell", [None, ""])
+    async def test_without_shell_is_split(
+        self,
+        service_parser: ServiceParser,
+        shell: str | None,
+    ) -> None:
+        service_parser.add_model_service(
+            "model",
+            {
+                "start_command": "python service.py --flag 'a b'",
+                "shell": shell,
+                "pre_start_actions": [],
+            },
+        )
+
+        cmdargs, env = await service_parser.start_service("model", set(), {})
+
+        assert cmdargs == ["python", "service.py", "--flag", "a b"]
+        assert env == {}
+
+    async def test_with_shell_uses_shell_c(self, service_parser: ServiceParser) -> None:
+        service_parser.add_model_service(
+            "model",
+            {
+                "start_command": "python service.py && echo ok",
+                "shell": "/bin/bash",
+                "pre_start_actions": [],
+            },
+        )
+
+        cmdargs, env = await service_parser.start_service("model", set(), {})
+
+        assert cmdargs == ["/bin/bash", "-c", "python service.py && echo ok"]
+        assert env == {}
 
 
 def test_service_argument_interpolation_intrinsic_python_style() -> None:

--- a/tests/unit/manager/api/adapters/test_deployment_adapter.py
+++ b/tests/unit/manager/api/adapters/test_deployment_adapter.py
@@ -62,7 +62,7 @@ class TestRevisionDataToDTO:
                         name="demo-model",
                         model_path="/models/demo",
                         service=ModelServiceConfig(
-                            start_command=["python", "serve.py"],
+                            start_command="python serve.py",
                             port=8000,
                         ),
                     ),

--- a/tests/unit/manager/api/adapters/test_deployment_adapter.py
+++ b/tests/unit/manager/api/adapters/test_deployment_adapter.py
@@ -85,6 +85,7 @@ class TestRevisionDataToDTO:
         service = dto.model_definition.models[0].service
         assert service is not None
         assert service.port == 8000
+        assert service.command == "python serve.py"
         assert service.start_command == ["python", "serve.py"]
 
 

--- a/tests/unit/manager/api/gql/deployment/test_revision_preset_types.py
+++ b/tests/unit/manager/api/gql/deployment/test_revision_preset_types.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
-from ai.backend.common.config import DEFAULT_SHELL, ModelConfig, ModelDefinition
+from ai.backend.common.config import DEFAULT_SHELL, ModelConfig, ModelDefinition, ModelServiceConfig
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.dto.manager.v2.deployment.request import DeploymentStrategyInput
 from ai.backend.common.dto.manager.v2.deployment.types import (
@@ -111,7 +111,13 @@ class TestModelDefinitionToDTO:
 
     def test_converts_config_to_info_dto(self) -> None:
         config_model_def = ModelDefinition(
-            models=[ModelConfig(name="llama", model_path="/models/llama")],
+            models=[
+                ModelConfig(
+                    name="llama",
+                    model_path="/models/llama",
+                    service=ModelServiceConfig(start_command="python serve.py", port=8080),
+                )
+            ],
         )
 
         info_dto = _model_definition_to_dto(config_model_def)
@@ -120,6 +126,10 @@ class TestModelDefinitionToDTO:
         assert len(info_dto.models) == 1
         assert info_dto.models[0].name == "llama"
         assert info_dto.models[0].model_path == "/models/llama"
+        service = info_dto.models[0].service
+        assert service is not None
+        assert service.command == "python serve.py"
+        assert service.start_command == ["python", "serve.py"]
 
     def test_returns_none_for_none(self) -> None:
         assert _model_definition_to_dto(None) is None

--- a/tests/unit/manager/api/gql/deployment/test_revision_types.py
+++ b/tests/unit/manager/api/gql/deployment/test_revision_types.py
@@ -67,7 +67,7 @@ class TestModelDefinitionInputGQL:
         service = resolved.models[0].service
         assert service is not None
         assert service.port == 8000
-        assert service.start_command == ["/models/start.sh"]
+        assert service.start_command == "/models/start.sh"
         assert service.health_check is not None
         assert service.health_check.path == "1"
         assert service.health_check.expected_status_code == 101

--- a/tests/unit/manager/data/deployment/test_model_definition_start_command_compat.py
+++ b/tests/unit/manager/data/deployment/test_model_definition_start_command_compat.py
@@ -1,9 +1,8 @@
-"""``start_command`` input compatibility (str → list[str]).
+"""``start_command`` input compatibility (legacy list[str] → str).
 
-PR #11402 narrowed ``start_command`` to ``list[str] | None``. Legacy
-``str`` inputs are wrapped as ``[shell, "-c", str]`` only when the user
-sets ``shell``; otherwise they pass through as ``[str]`` so shell-less
-images stay launchable.
+Legacy ``start_command`` list inputs are converted with ``shlex.join``.
+The new ``command`` field takes precedence and is stored internally as the
+same single string.
 """
 
 from __future__ import annotations
@@ -26,25 +25,25 @@ START_COMMAND_CASES = [
     pytest.param(
         "python service.py",
         None,
-        ["python service.py"],
-        id="no-shell-single-argv",
+        "python service.py",
+        id="string-no-shell",
     ),
     pytest.param(
         'python -c "import x; x.run()"',
         None,
-        ['python -c "import x; x.run()"'],
-        id="no-shell-quoted-single-argv",
+        'python -c "import x; x.run()"',
+        id="string-quoted-no-shell",
     ),
     pytest.param(
         "echo $HOME && exec python serve.py",
         "/bin/zsh",
-        ["/bin/zsh", "-c", "echo $HOME && exec python serve.py"],
+        "echo $HOME && exec python serve.py",
         id="explicit-shell-custom",
     ),
     pytest.param(
         "python service.py --port 8080",
         "/bin/bash",
-        ["/bin/bash", "-c", "python service.py --port 8080"],
+        "python service.py --port 8080",
         id="explicit-shell-bash",
     ),
 ]
@@ -72,7 +71,7 @@ class TestPydanticInputCompat:
     """REST/GQL input → ``ModelServiceConfigDraft`` Pydantic validator."""
 
     @pytest.mark.parametrize(("raw", "shell", "expected"), START_COMMAND_CASES)
-    def test_str_input_is_wrapped(self, raw: str, shell: str | None, expected: list[str]) -> None:
+    def test_str_input_is_preserved(self, raw: str, shell: str | None, expected: str) -> None:
         payload: dict[str, Any] = {"start_command": raw, "port": 8080}
         if shell is not None:
             payload["shell"] = shell
@@ -81,16 +80,10 @@ class TestPydanticInputCompat:
 
 
 class TestCommandFoldsIntoStartCommand:
-    """``command`` (single string) folds into the argv ``start_command``.
-
-    PR #12418 adds ``command``, which supersedes the deprecated ``start_command``.
-    The shared ``_wrap_str_start_command_into_argv`` validator wraps it with the
-    same shell rules, lets it take precedence over ``start_command``, and strips it
-    so it is not persisted via ``extra="allow"``.
-    """
+    """``command`` supersedes the deprecated ``start_command``."""
 
     @pytest.mark.parametrize(("raw", "shell", "expected"), START_COMMAND_CASES)
-    def test_command_is_wrapped(self, raw: str, shell: str | None, expected: list[str]) -> None:
+    def test_command_is_resolved(self, raw: str, shell: str | None, expected: str) -> None:
         payload: dict[str, Any] = {"command": raw, "port": 8080}
         if shell is not None:
             payload["shell"] = shell
@@ -112,7 +105,7 @@ class TestCommandFoldsIntoStartCommand:
             "start_command": start_command,
             "port": 8080,
         })
-        assert resolved.start_command == ["python new.py"]
+        assert resolved.start_command == "python new.py"
 
     def test_command_is_not_persisted_as_extra(self) -> None:
         resolved = ModelServiceConfig.model_validate({
@@ -121,14 +114,22 @@ class TestCommandFoldsIntoStartCommand:
         })
         assert "command" not in resolved.model_dump()
 
+    def test_hyphenated_start_command_alias_is_canonicalized(self) -> None:
+        resolved = ModelServiceConfig.model_validate({
+            "start-command": ["python", "old.py", "--flag", "a b"],
+            "port": 8080,
+        })
+        assert resolved.start_command == "python old.py --flag 'a b'"
+        dumped = resolved.model_dump()
+        assert dumped["start_command"] == "python old.py --flag 'a b'"
+        assert "start-command" not in dumped
+
 
 class TestModelDefinitionInputCompat:
     """vfolder YAML scan → ``ModelDefinition.model_validate``."""
 
     @pytest.mark.parametrize(("raw", "shell", "expected"), START_COMMAND_CASES)
-    def test_str_input_is_normalized(
-        self, raw: str, shell: str | None, expected: list[str]
-    ) -> None:
+    def test_str_input_is_normalized(self, raw: str, shell: str | None, expected: str) -> None:
         result = ModelDefinition.model_validate(_wrap_definition(raw, shell))
         assert result.models[0].service is not None
         assert result.models[0].service.start_command == expected
@@ -137,9 +138,8 @@ class TestModelDefinitionInputCompat:
 class TestYAMLInputCompat:
     """End-to-end vfolder scan path: a user-authored ``model-definition.yaml``
     is parsed by ruamel.yaml and fed to ``ModelDefinition.model_validate``.
-    Confirms that every YAML notation a user might write — legacy shell string,
-    inline flow sequence, hyphenated block sequence — resolves to the same
-    canonical ``list[str]``.
+    Confirms that every YAML notation a user might write resolves to the same
+    canonical command string.
     """
 
     @pytest.mark.parametrize(
@@ -154,7 +154,7 @@ class TestYAMLInputCompat:
                         start_command: python service.py
                         port: 8080
                 """),
-                ["python service.py"],
+                "python service.py",
                 id="legacy-shell-string-no-shell-key",
             ),
             pytest.param(
@@ -167,7 +167,7 @@ class TestYAMLInputCompat:
                         shell: /bin/zsh
                         port: 8080
                 """),
-                ["/bin/zsh", "-c", "echo $HOME | tee /tmp/out"],
+                "echo $HOME | tee /tmp/out",
                 id="legacy-shell-string-explicit-shell",
             ),
             pytest.param(
@@ -179,7 +179,7 @@ class TestYAMLInputCompat:
                         start_command: ["/bin/bash", "/models/start.sh"]
                         port: 8080
                 """),
-                ["/bin/bash", "/models/start.sh"],
+                "/bin/bash /models/start.sh",
                 id="flow-sequence",
             ),
             pytest.param(
@@ -193,12 +193,12 @@ class TestYAMLInputCompat:
                         - /models/start.sh
                         port: 8080
                 """),
-                ["/bin/bash", "/models/start.sh"],
+                "/bin/bash /models/start.sh",
                 id="block-sequence",
             ),
         ],
     )
-    def test_yaml_forms_are_normalized(self, yaml_text: str, expected: list[str]) -> None:
+    def test_yaml_forms_are_normalized(self, yaml_text: str, expected: str) -> None:
         loaded = YAML().load(yaml_text)
         result = ModelDefinition.model_validate(loaded)
         assert result.models[0].service is not None
@@ -209,7 +209,7 @@ class TestPydanticColumnReadCompat:
     """DB read path → ``PydanticColumn(ModelDefinition).process_result_value``."""
 
     @pytest.mark.parametrize(("raw", "shell", "expected"), START_COMMAND_CASES)
-    def test_legacy_str_is_wrapped(self, raw: str, shell: str | None, expected: list[str]) -> None:
+    def test_legacy_str_is_preserved(self, raw: str, shell: str | None, expected: str) -> None:
         column = PydanticColumn(ModelDefinition)
         resolved = column.process_result_value(_wrap_definition(raw, shell), DefaultDialect())
         assert resolved is not None

--- a/tests/unit/manager/repositories/deployment_revision_preset/test_repository.py
+++ b/tests/unit/manager/repositories/deployment_revision_preset/test_repository.py
@@ -19,6 +19,7 @@ from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.manager.data.deployment_revision_preset.types import ResourceSlotEntryData
 from ai.backend.manager.errors.resource import DeploymentRevisionPresetNotFound
+from ai.backend.manager.models.base import ensure_all_tables_registered
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
 from ai.backend.manager.models.resource_slot.row import PresetResourceSlotRow, ResourceSlotTypeRow
 from ai.backend.manager.models.runtime_variant.row import RuntimeVariantRow
@@ -37,6 +38,8 @@ from ai.backend.manager.repositories.deployment_revision_preset.updaters import 
 from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.manager.types import OptionalState
 from ai.backend.testutils.db import with_tables
+
+ensure_all_tables_registered()
 
 # Shared runtime variant id; the preset's rank scope and the FOR UPDATE lock target it.
 _VARIANT_ID = RuntimeVariantID(uuid4())

--- a/tests/unit/manager/sokovan/deployment/test_deployment_draft_builder.py
+++ b/tests/unit/manager/sokovan/deployment/test_deployment_draft_builder.py
@@ -60,7 +60,7 @@ class TestModelDefinitionPayload:
                         model_path="/models",
                         service=ModelServiceConfig(
                             port=8000,
-                            start_command=["vllm", "serve", "/models"],
+                            start_command="vllm serve /models",
                         ),
                     )
                 ]
@@ -78,11 +78,11 @@ class TestModelDefinitionPayload:
     @pytest.mark.parametrize(
         ("args", "expected_start_command"),
         [
-            pytest.param(None, ["vllm", "serve", "/models"], id="presets-absent"),
-            pytest.param([], ["vllm", "serve", "/models"], id="presets-empty"),
+            pytest.param(None, "vllm serve /models", id="presets-absent"),
+            pytest.param([], "vllm serve /models", id="presets-empty"),
             pytest.param(
                 ["--max-model-len", "4096"],
-                ["vllm", "serve", "/models", "--max-model-len", "4096"],
+                "vllm serve /models --max-model-len 4096",
                 id="presets-with-args",
             ),
         ],
@@ -91,7 +91,7 @@ class TestModelDefinitionPayload:
         self,
         vllm_revision: ModelRevisionData,
         args: list[str] | None,
-        expected_start_command: list[str],
+        expected_start_command: str,
     ) -> None:
         # Builder wiring contract: pulls args from ``context.resolved_presets``
         # (handling both ``None`` and empty-list shapes) and returns a dict
@@ -108,11 +108,8 @@ class TestModelDefinitionPayload:
         self,
         vllm_revision: ModelRevisionData,
     ) -> None:
-        # Regression guard for BA-5891 at the highest layer where the bug
-        # surfaced: tokens must arrive split, so each value lands as its
-        # own argv entry rather than ``"--port 8000"``. The same invariant
-        # is implied by the parametrized expected lists above, but this
-        # test makes it an explicit assertion at the kernel-payload boundary.
+        # Regression guard for argument appending: preset tokens are shell-quoted
+        # before they are appended to the command string.
         tokens = ["--port", "8000", "--max-model-len", "4096"]
 
         payload = DeploymentSessionDraftBuilder._model_definition_payload(
@@ -121,8 +118,7 @@ class TestModelDefinitionPayload:
 
         assert payload is not None
         cmd = payload["models"][0]["service"]["start_command"]
-        assert cmd == ["vllm", "serve", "/models", *tokens]
-        assert all(" " not in token for token in cmd)
+        assert cmd == "vllm serve /models --port 8000 --max-model-len 4096"
 
 
 class TestKernelGroups:

--- a/tests/unit/manager/test_registry.py
+++ b/tests/unit/manager/test_registry.py
@@ -206,7 +206,7 @@ class TestResolveHealthCheck:
                         name="m",
                         model_path="/models/m",
                         service=ModelServiceConfig(
-                            start_command=["run"],
+                            start_command="run",
                             port=8000,
                             health_check=ModelHealthCheck(
                                 enable=True,
@@ -242,7 +242,7 @@ class TestResolveHealthCheck:
                     ModelConfig(
                         name="m",
                         model_path="/models/m",
-                        service=ModelServiceConfig(start_command=["run"], port=8000),
+                        service=ModelServiceConfig(start_command="run", port=8000),
                     )
                 ]
             )


### PR DESCRIPTION
## Summary
- Refactor model service `start_command` to use a single internal command string while preserving deprecated list input compatibility.
- Keep `/bin/bash` as the default shell, allow explicit null/empty shell for direct argv execution, and update kernel-side command resolution accordingly.
- Add an idempotent Alembic data migration for stored model definitions in revisions, revision presets, and runtime variant defaults.

## Test plan
- [x] `pants fmt --changed-since=HEAD`
- [x] `pants fix --changed-since=HEAD`
- [x] `pants lint --changed-since=HEAD`
- [x] `pants check --changed-since=HEAD`
- [x] `pants test --changed-since=HEAD`
- [x] `pants lint --changed-since=origin/main`
- [x] Push hook: lint/check/test on `origin/main..HEAD@603d0918f`
- [x] Live manager/web API verification for explicit `command`, deprecated list `start_command`, vLLM default model definition, and revision preset storage

Resolves BA-6550


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12445.org.readthedocs.build/en/12445/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12445.org.readthedocs.build/ko/12445/

<!-- readthedocs-preview sorna-ko end -->