### PR TITLE
feat(BA-6639): add AND/OR/NOT combinators to v2 GraphQL search filters

### DIFF
--- a/changes/12446.feature.md
+++ b/changes/12446.feature.md
@@ -1,0 +1,1 @@
+Add AND/OR/NOT boolean combinators to v2 GraphQL search filters that were missing them (resource policies, container registry, runtime variants, app config, and more).

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -956,6 +956,15 @@ input AppConfigAllowListFilter
 
   """Filter by last update datetime."""
   updatedAt: DateTimeFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [AppConfigAllowListFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [AppConfigAllowListFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [AppConfigAllowListFilter!] = null
 }
 
 """Added in 26.7.0. Specifies ordering for app config allow-list results."""
@@ -1040,6 +1049,15 @@ input AppConfigDefinitionFilter
 
   """Filter by last update datetime."""
   updatedAt: DateTimeFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [AppConfigDefinitionFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [AppConfigDefinitionFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [AppConfigDefinitionFilter!] = null
 }
 
 """Added in 26.7.0. Specifies ordering for app config definition results."""
@@ -2692,6 +2710,15 @@ input CategoryFilter
 {
   """Filter by name."""
   name: StringFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [CategoryFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [CategoryFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [CategoryFilter!] = null
 }
 
 """Added in 26.3.0. Specifies ordering for query preset category results."""
@@ -3331,6 +3358,15 @@ input ContainerRegistryV2Filter
   registryName: StringFilter = null
   type: ContainerRegistryTypeFilter = null
   isGlobal: Boolean = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [ContainerRegistryV2Filter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [ContainerRegistryV2Filter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [ContainerRegistryV2Filter!] = null
 }
 
 """Added in 26.4.2. Ordering specification for container registries."""
@@ -5816,6 +5852,15 @@ input DeploymentRevisionPresetFilter
 
   """Variant ID filter."""
   runtimeVariantId: UUIDFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [DeploymentRevisionPresetFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [DeploymentRevisionPresetFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [DeploymentRevisionPresetFilter!] = null
 }
 
 """Added in 26.4.2. Order specification for deployment revision presets."""
@@ -8841,6 +8886,15 @@ input KeypairResourcePolicyV2Filter
   Added in 26.4.4. Filter policies by their assigned keypairs. A policy matches if at least one of its keypairs satisfies the conditions.
   """
   keypair: KeypairResourcePolicyKeypairNestedFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [KeypairResourcePolicyV2Filter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [KeypairResourcePolicyV2Filter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [KeypairResourcePolicyV2Filter!] = null
 }
 
 """Added in 26.4.2. Ordering specification for keypair resource policies."""
@@ -9125,6 +9179,15 @@ input LoginClientTypeFilter
 
   """Filter by last modification datetime."""
   modifiedAt: DateTimeFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [LoginClientTypeFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [LoginClientTypeFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [LoginClientTypeFilter!] = null
 }
 
 """Added in 26.4.2. Specifies ordering for login client type results."""
@@ -13340,6 +13403,15 @@ input ProjectResourcePolicyV2Filter
   maxVfolderCount: IntFilter = null
   maxQuotaScopeSize: IntFilter = null
   maxNetworkCount: IntFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [ProjectResourcePolicyV2Filter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [ProjectResourcePolicyV2Filter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [ProjectResourcePolicyV2Filter!] = null
 }
 
 """Added in 26.4.2. Ordering specification for project resource policies."""
@@ -17335,6 +17407,15 @@ input RuntimeVariantFilter
 {
   """Name filter."""
   name: StringFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [RuntimeVariantFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [RuntimeVariantFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [RuntimeVariantFilter!] = null
 }
 
 """Added in 24.03.5."""
@@ -17450,6 +17531,15 @@ input RuntimeVariantPresetFilter
 
   """Variant ID filter."""
   runtimeVariantId: UUIDFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [RuntimeVariantPresetFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [RuntimeVariantPresetFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [RuntimeVariantPresetFilter!] = null
 }
 
 """Added in 26.4.2. Order specification."""
@@ -20628,6 +20718,15 @@ input UserResourcePolicyV2Filter
   maxQuotaScopeSize: IntFilter = null
   maxSessionCountPerModelSession: IntFilter = null
   maxCustomizedImageCount: IntFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [UserResourcePolicyV2Filter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [UserResourcePolicyV2Filter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [UserResourcePolicyV2Filter!] = null
 }
 
 """Added in 26.4.2. Ordering specification for user resource policies."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -669,6 +669,15 @@ input AppConfigAllowListFilter {
 
   """Filter by last update datetime."""
   updatedAt: DateTimeFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [AppConfigAllowListFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [AppConfigAllowListFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [AppConfigAllowListFilter!] = null
 }
 
 """Added in 26.7.0. Specifies ordering for app config allow-list results."""
@@ -740,6 +749,15 @@ input AppConfigDefinitionFilter {
 
   """Filter by last update datetime."""
   updatedAt: DateTimeFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [AppConfigDefinitionFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [AppConfigDefinitionFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [AppConfigDefinitionFilter!] = null
 }
 
 """Added in 26.7.0. Specifies ordering for app config definition results."""
@@ -1961,6 +1979,15 @@ input CancelRoleInvitationInput {
 input CategoryFilter {
   """Filter by name."""
   name: StringFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [CategoryFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [CategoryFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [CategoryFilter!] = null
 }
 
 """Added in 26.3.0. Specifies ordering for query preset category results."""
@@ -2194,6 +2221,15 @@ input ContainerRegistryV2Filter {
   registryName: StringFilter = null
   type: ContainerRegistryTypeFilter = null
   isGlobal: Boolean = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [ContainerRegistryV2Filter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [ContainerRegistryV2Filter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [ContainerRegistryV2Filter!] = null
 }
 
 """Added in 26.4.2. Ordering specification for container registries."""
@@ -4002,6 +4038,15 @@ input DeploymentRevisionPresetFilter {
 
   """Variant ID filter."""
   runtimeVariantId: UUIDFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [DeploymentRevisionPresetFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [DeploymentRevisionPresetFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [DeploymentRevisionPresetFilter!] = null
 }
 
 """Added in 26.4.2. Order specification for deployment revision presets."""
@@ -5909,6 +5954,15 @@ input KeypairResourcePolicyV2Filter {
   Added in 26.4.4. Filter policies by their assigned keypairs. A policy matches if at least one of its keypairs satisfies the conditions.
   """
   keypair: KeypairResourcePolicyKeypairNestedFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [KeypairResourcePolicyV2Filter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [KeypairResourcePolicyV2Filter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [KeypairResourcePolicyV2Filter!] = null
 }
 
 """Added in 26.4.2. Ordering specification for keypair resource policies."""
@@ -6022,6 +6076,15 @@ input LoginClientTypeFilter {
 
   """Filter by last modification datetime."""
   modifiedAt: DateTimeFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [LoginClientTypeFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [LoginClientTypeFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [LoginClientTypeFilter!] = null
 }
 
 """Added in 26.4.2. Specifies ordering for login client type results."""
@@ -8937,6 +9000,15 @@ input ProjectResourcePolicyV2Filter {
   maxVfolderCount: IntFilter = null
   maxQuotaScopeSize: IntFilter = null
   maxNetworkCount: IntFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [ProjectResourcePolicyV2Filter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [ProjectResourcePolicyV2Filter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [ProjectResourcePolicyV2Filter!] = null
 }
 
 """Added in 26.4.2. Ordering specification for project resource policies."""
@@ -11969,6 +12041,15 @@ type RuntimeVariantEdge {
 input RuntimeVariantFilter {
   """Name filter."""
   name: StringFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [RuntimeVariantFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [RuntimeVariantFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [RuntimeVariantFilter!] = null
 }
 
 """Added in 26.4.2. Order specification."""
@@ -12063,6 +12144,15 @@ input RuntimeVariantPresetFilter {
 
   """Variant ID filter."""
   runtimeVariantId: UUIDFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [RuntimeVariantPresetFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [RuntimeVariantPresetFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [RuntimeVariantPresetFilter!] = null
 }
 
 """Added in 26.4.2. Order specification."""
@@ -14441,6 +14531,15 @@ input UserResourcePolicyV2Filter {
   maxQuotaScopeSize: IntFilter = null
   maxSessionCountPerModelSession: IntFilter = null
   maxCustomizedImageCount: IntFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [UserResourcePolicyV2Filter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [UserResourcePolicyV2Filter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [UserResourcePolicyV2Filter!] = null
 }
 
 """Added in 26.4.2. Ordering specification for user resource policies."""

--- a/src/ai/backend/common/dto/manager/v2/app_config_allow_list/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_allow_list/request.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Self
 from uuid import UUID
 
 from pydantic import Field
@@ -56,6 +57,12 @@ class AppConfigAllowListFilter(BaseRequestModel):
     updated_at: DateTimeFilter | None = Field(
         default=None, description="Filter by last update datetime."
     )
+    AND: list[Self] | None = Field(default=None, description="Match all of the given sub-filters.")
+    OR: list[Self] | None = Field(default=None, description="Match any of the given sub-filters.")
+    NOT: list[Self] | None = Field(default=None, description="Negate the given sub-filters.")
+
+
+AppConfigAllowListFilter.model_rebuild()
 
 
 class AppConfigAllowListOrder(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/app_config_definition/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_definition/request.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Self
 from uuid import UUID
 
 from pydantic import Field
@@ -48,6 +49,12 @@ class AppConfigDefinitionFilter(BaseRequestModel):
     updated_at: DateTimeFilter | None = Field(
         default=None, description="Filter by last update datetime."
     )
+    AND: list[Self] | None = Field(default=None, description="Match all of the given sub-filters.")
+    OR: list[Self] | None = Field(default=None, description="Match any of the given sub-filters.")
+    NOT: list[Self] | None = Field(default=None, description="Negate the given sub-filters.")
+
+
+AppConfigDefinitionFilter.model_rebuild()
 
 
 class AppConfigDefinitionOrder(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/container_registry/request.py
+++ b/src/ai/backend/common/dto/manager/v2/container_registry/request.py
@@ -4,7 +4,7 @@ Request DTOs for container registry DTO v2.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Self
 from uuid import UUID
 
 from pydantic import Field, field_validator
@@ -154,6 +154,12 @@ class ContainerRegistryFilter(BaseRequestModel):
         default=None, description="Filter by registry type."
     )
     is_global: bool | None = Field(default=None, description="Filter by global accessibility.")
+    AND: list[Self] | None = Field(default=None, description="Match all of the given sub-filters.")
+    OR: list[Self] | None = Field(default=None, description="Match any of the given sub-filters.")
+    NOT: list[Self] | None = Field(default=None, description="Negate the given sub-filters.")
+
+
+ContainerRegistryFilter.model_rebuild()
 
 
 class ContainerRegistryOrder(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/login_client_type/request.py
+++ b/src/ai/backend/common/dto/manager/v2/login_client_type/request.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Self
+
 from pydantic import Field
 
 from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
@@ -64,6 +66,12 @@ class LoginClientTypeFilter(BaseRequestModel):
     modified_at: DateTimeFilter | None = Field(
         default=None, description="Filter by last modification datetime."
     )
+    AND: list[Self] | None = None
+    OR: list[Self] | None = None
+    NOT: list[Self] | None = None
+
+
+LoginClientTypeFilter.model_rebuild()
 
 
 class LoginClientTypeOrder(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/prometheus_query_preset_category/request.py
+++ b/src/ai/backend/common/dto/manager/v2/prometheus_query_preset_category/request.py
@@ -4,6 +4,7 @@ Request DTOs for prometheus_query_preset_category DTO v2.
 
 from __future__ import annotations
 
+from typing import Self
 from uuid import UUID
 
 from pydantic import Field, field_validator
@@ -49,6 +50,12 @@ class CategoryFilter(BaseRequestModel):
     """Filter for prometheus query preset category search."""
 
     name: StringFilter | None = Field(default=None, description="Filter by name")
+    AND: list[Self] | None = None
+    OR: list[Self] | None = None
+    NOT: list[Self] | None = None
+
+
+CategoryFilter.model_rebuild()
 
 
 class CategoryOrder(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/resource_policy/request.py
+++ b/src/ai/backend/common/dto/manager/v2/resource_policy/request.py
@@ -4,6 +4,8 @@ Request DTOs for resource policy DTO v2.
 
 from __future__ import annotations
 
+from typing import Self
+
 from pydantic import Field, field_validator
 
 from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
@@ -321,6 +323,9 @@ class KeypairResourcePolicyFilter(BaseRequestModel):
     max_pending_session_count: IntFilter | None = Field(
         default=None, description="Filter by max pending session count."
     )
+    AND: list[Self] | None = Field(default=None, description="Match all of the given sub-filters.")
+    OR: list[Self] | None = Field(default=None, description="Match any of the given sub-filters.")
+    NOT: list[Self] | None = Field(default=None, description="Negate the given sub-filters.")
 
 
 class UserResourcePolicyFilter(BaseRequestModel):
@@ -343,6 +348,9 @@ class UserResourcePolicyFilter(BaseRequestModel):
     max_customized_image_count: IntFilter | None = Field(
         default=None, description="Filter by max customized image count."
     )
+    AND: list[Self] | None = Field(default=None, description="Match all of the given sub-filters.")
+    OR: list[Self] | None = Field(default=None, description="Match any of the given sub-filters.")
+    NOT: list[Self] | None = Field(default=None, description="Negate the given sub-filters.")
 
 
 class ProjectResourcePolicyFilter(BaseRequestModel):
@@ -359,6 +367,14 @@ class ProjectResourcePolicyFilter(BaseRequestModel):
     max_network_count: IntFilter | None = Field(
         default=None, description="Filter by max network count."
     )
+    AND: list[Self] | None = Field(default=None, description="Match all of the given sub-filters.")
+    OR: list[Self] | None = Field(default=None, description="Match any of the given sub-filters.")
+    NOT: list[Self] | None = Field(default=None, description="Negate the given sub-filters.")
+
+
+KeypairResourcePolicyFilter.model_rebuild()
+UserResourcePolicyFilter.model_rebuild()
+ProjectResourcePolicyFilter.model_rebuild()
 
 
 class KeypairResourcePolicyOrder(BaseRequestModel):

--- a/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
@@ -40,7 +40,11 @@ from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.repositories.app_config_allow_list.creators import (
     AppConfigAllowListCreatorSpec,
 )
-from ai.backend.manager.repositories.base import Purger
+from ai.backend.manager.repositories.base import (
+    Purger,
+    combine_conditions_or,
+    negate_conditions,
+)
 from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.services.app_config_allow_list.actions.create import (
     CreateAppConfigAllowListAction,
@@ -189,6 +193,21 @@ class AppConfigAllowListAdapter(BaseAdapter):
             )
             if condition:
                 conditions.append(condition)
+        if filter_.AND:
+            for sub_filter in filter_.AND:
+                conditions.extend(self._convert_filter(sub_filter))
+        if filter_.OR:
+            or_conditions: list[QueryCondition] = []
+            for sub_filter in filter_.OR:
+                or_conditions.extend(self._convert_filter(sub_filter))
+            if or_conditions:
+                conditions.append(combine_conditions_or(or_conditions))
+        if filter_.NOT:
+            not_conditions: list[QueryCondition] = []
+            for sub_filter in filter_.NOT:
+                not_conditions.extend(self._convert_filter(sub_filter))
+            if not_conditions:
+                conditions.append(negate_conditions(not_conditions))
         return conditions
 
     @staticmethod

--- a/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
@@ -35,7 +35,11 @@ from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.repositories.app_config_definition.creators import (
     AppConfigDefinitionCreatorSpec,
 )
-from ai.backend.manager.repositories.base import Purger
+from ai.backend.manager.repositories.base import (
+    Purger,
+    combine_conditions_or,
+    negate_conditions,
+)
 from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.services.app_config_definition.actions.create import (
     CreateAppConfigDefinitionAction,
@@ -176,6 +180,21 @@ class AppConfigDefinitionAdapter(BaseAdapter):
             )
             if condition:
                 conditions.append(condition)
+        if filter_.AND:
+            for sub_filter in filter_.AND:
+                conditions.extend(self._convert_filter(sub_filter))
+        if filter_.OR:
+            or_conditions: list[QueryCondition] = []
+            for sub_filter in filter_.OR:
+                or_conditions.extend(self._convert_filter(sub_filter))
+            if or_conditions:
+                conditions.append(combine_conditions_or(or_conditions))
+        if filter_.NOT:
+            not_conditions: list[QueryCondition] = []
+            for sub_filter in filter_.NOT:
+                not_conditions.extend(self._convert_filter(sub_filter))
+            if not_conditions:
+                conditions.append(negate_conditions(not_conditions))
         return conditions
 
     def _convert_orders(self, orders: list[AppConfigDefinitionOrder]) -> list[QueryOrder]:

--- a/src/ai/backend/manager/api/adapters/container_registry/adapter.py
+++ b/src/ai/backend/manager/api/adapters/container_registry/adapter.py
@@ -33,7 +33,12 @@ from ai.backend.manager.models.container_registry.orders import (
     TIEBREAKER_ORDER,
     resolve_order,
 )
-from ai.backend.manager.repositories.base import BatchQuerier, OffsetPagination
+from ai.backend.manager.repositories.base import (
+    BatchQuerier,
+    OffsetPagination,
+    combine_conditions_or,
+    negate_conditions,
+)
 from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.purger import Purger
 from ai.backend.manager.repositories.base.updater import Updater
@@ -206,6 +211,21 @@ class ContainerRegistryAdapter(BaseAdapter):
             conditions.extend(self._convert_type_filter(filter.type))
         if filter.is_global is not None:
             conditions.append(ContainerRegistryConditions.by_is_global(filter.is_global))
+        if filter.AND:
+            for sub_filter in filter.AND:
+                conditions.extend(self._convert_filter(sub_filter))
+        if filter.OR:
+            or_conditions: list[QueryCondition] = []
+            for sub_filter in filter.OR:
+                or_conditions.extend(self._convert_filter(sub_filter))
+            if or_conditions:
+                conditions.append(combine_conditions_or(or_conditions))
+        if filter.NOT:
+            not_conditions: list[QueryCondition] = []
+            for sub_filter in filter.NOT:
+                not_conditions.extend(self._convert_filter(sub_filter))
+            if not_conditions:
+                conditions.append(negate_conditions(not_conditions))
         return conditions
 
     def _convert_string_filter(self, sf: StringFilter) -> QueryCondition | None:

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -80,7 +80,11 @@ from ai.backend.manager.models.resource_slot.orders import (
 from ai.backend.manager.models.runtime_variant_preset.types import (
     RuntimeVariantPresetValueEntry,
 )
-from ai.backend.manager.repositories.base import BatchQuerier, combine_conditions_or
+from ai.backend.manager.repositories.base import (
+    BatchQuerier,
+    combine_conditions_or,
+    negate_conditions,
+)
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.deployment_revision_preset.creators import (
     DeploymentRevisionPresetCreatorSpec,
@@ -502,6 +506,12 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
                 or_conds.extend(self._convert_filter(sub))
             if or_conds:
                 conditions.append(combine_conditions_or(or_conds))
+        if filter_.NOT:
+            not_conds: list[QueryCondition] = []
+            for sub in filter_.NOT:
+                not_conds.extend(self._convert_filter(sub))
+            if not_conds:
+                conditions.append(negate_conditions(not_conds))
         return conditions
 
     def _convert_orders(self, orders: list[DeploymentRevisionPresetOrder]) -> list[QueryOrder]:

--- a/src/ai/backend/manager/api/adapters/login_client_type/adapter.py
+++ b/src/ai/backend/manager/api/adapters/login_client_type/adapter.py
@@ -29,7 +29,12 @@ from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.models.login_client_type.conditions import LoginClientTypeConditions
 from ai.backend.manager.models.login_client_type.orders import LoginClientTypeOrders
 from ai.backend.manager.models.login_client_type.row import LoginClientTypeRow
-from ai.backend.manager.repositories.base import BatchQuerier, OffsetPagination
+from ai.backend.manager.repositories.base import (
+    BatchQuerier,
+    OffsetPagination,
+    combine_conditions_or,
+    negate_conditions,
+)
 from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.login_client_type.creators import (
@@ -214,5 +219,21 @@ class LoginClientTypeAdapter(BaseAdapter):
             )
             if condition is not None:
                 conditions.append(condition)
+
+        if filter.AND:
+            for sub_filter in filter.AND:
+                conditions.extend(self._convert_filter(sub_filter))
+        if filter.OR:
+            or_conditions: list[QueryCondition] = []
+            for sub_filter in filter.OR:
+                or_conditions.extend(self._convert_filter(sub_filter))
+            if or_conditions:
+                conditions.append(combine_conditions_or(or_conditions))
+        if filter.NOT:
+            not_conditions: list[QueryCondition] = []
+            for sub_filter in filter.NOT:
+                not_conditions.extend(self._convert_filter(sub_filter))
+            if not_conditions:
+                conditions.append(negate_conditions(not_conditions))
 
         return conditions

--- a/src/ai/backend/manager/api/adapters/prometheus_query_preset_category/adapter.py
+++ b/src/ai/backend/manager/api/adapters/prometheus_query_preset_category/adapter.py
@@ -37,7 +37,13 @@ from ai.backend.manager.models.prometheus_query_preset_category.conditions impor
 from ai.backend.manager.models.prometheus_query_preset_category.orders import (
     PrometheusQueryPresetCategoryOrders,
 )
-from ai.backend.manager.repositories.base import BatchQuerier, Creator, OffsetPagination
+from ai.backend.manager.repositories.base import (
+    BatchQuerier,
+    Creator,
+    OffsetPagination,
+    combine_conditions_or,
+    negate_conditions,
+)
 from ai.backend.manager.repositories.prometheus_query_preset_category.creators import (
     PrometheusQueryPresetCategoryCreatorSpec,
 )
@@ -155,6 +161,22 @@ class PrometheusQueryPresetCategoryAdapter(BaseAdapter):
             )
             if condition is not None:
                 conditions.append(condition)
+
+        if filter.AND:
+            for sub_filter in filter.AND:
+                conditions.extend(self._convert_filter(sub_filter))
+        if filter.OR:
+            or_conditions: list[QueryCondition] = []
+            for sub_filter in filter.OR:
+                or_conditions.extend(self._convert_filter(sub_filter))
+            if or_conditions:
+                conditions.append(combine_conditions_or(or_conditions))
+        if filter.NOT:
+            not_conditions: list[QueryCondition] = []
+            for sub_filter in filter.NOT:
+                not_conditions.extend(self._convert_filter(sub_filter))
+            if not_conditions:
+                conditions.append(negate_conditions(not_conditions))
 
         return conditions
 

--- a/src/ai/backend/manager/api/adapters/resource_policy/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_policy/adapter.py
@@ -89,6 +89,10 @@ from ai.backend.manager.models.resource_policy.orders import (
     ProjectResourcePolicyOrders,
     UserResourcePolicyOrders,
 )
+from ai.backend.manager.repositories.base import (
+    combine_conditions_or,
+    negate_conditions,
+)
 from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.keypair_resource_policy.creators import (
@@ -733,6 +737,21 @@ class ResourcePolicyAdapter(BaseAdapter):
             cond = self._convert_keypair_nested_filter(filter.keypair)
             if cond is not None:
                 conditions.append(cond)
+        if filter.AND:
+            for sub_filter in filter.AND:
+                conditions.extend(self._convert_keypair_filter(sub_filter))
+        if filter.OR:
+            or_conditions: list[QueryCondition] = []
+            for sub_filter in filter.OR:
+                or_conditions.extend(self._convert_keypair_filter(sub_filter))
+            if or_conditions:
+                conditions.append(combine_conditions_or(or_conditions))
+        if filter.NOT:
+            not_conditions: list[QueryCondition] = []
+            for sub_filter in filter.NOT:
+                not_conditions.extend(self._convert_keypair_filter(sub_filter))
+            if not_conditions:
+                conditions.append(negate_conditions(not_conditions))
         return conditions
 
     def _convert_keypair_nested_filter(
@@ -810,6 +829,21 @@ class ResourcePolicyAdapter(BaseAdapter):
             )
             if cond is not None:
                 conditions.append(cond)
+        if filter.AND:
+            for sub_filter in filter.AND:
+                conditions.extend(self._convert_user_filter(sub_filter))
+        if filter.OR:
+            or_conditions: list[QueryCondition] = []
+            for sub_filter in filter.OR:
+                or_conditions.extend(self._convert_user_filter(sub_filter))
+            if or_conditions:
+                conditions.append(combine_conditions_or(or_conditions))
+        if filter.NOT:
+            not_conditions: list[QueryCondition] = []
+            for sub_filter in filter.NOT:
+                not_conditions.extend(self._convert_user_filter(sub_filter))
+            if not_conditions:
+                conditions.append(negate_conditions(not_conditions))
         return conditions
 
     def _convert_project_filter(self, filter: ProjectResourcePolicyFilter) -> list[QueryCondition]:
@@ -854,6 +888,21 @@ class ResourcePolicyAdapter(BaseAdapter):
             )
             if cond is not None:
                 conditions.append(cond)
+        if filter.AND:
+            for sub_filter in filter.AND:
+                conditions.extend(self._convert_project_filter(sub_filter))
+        if filter.OR:
+            or_conditions: list[QueryCondition] = []
+            for sub_filter in filter.OR:
+                or_conditions.extend(self._convert_project_filter(sub_filter))
+            if or_conditions:
+                conditions.append(combine_conditions_or(or_conditions))
+        if filter.NOT:
+            not_conditions: list[QueryCondition] = []
+            for sub_filter in filter.NOT:
+                not_conditions.extend(self._convert_project_filter(sub_filter))
+            if not_conditions:
+                conditions.append(negate_conditions(not_conditions))
         return conditions
 
     # ── Order resolvers ──

--- a/src/ai/backend/manager/api/gql/app_config_allow_list/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_allow_list/types.py
@@ -42,6 +42,7 @@ from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection, Stri
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
+    gql_added_field,
     gql_connection_type,
     gql_enum,
     gql_field,
@@ -167,6 +168,24 @@ class AppConfigAllowListFilterGQL(PydanticInputMixin[AppConfigAllowListFilterDTO
     )
     updated_at: DateTimeFilter | None = gql_field(
         description="Filter by last update datetime.", default=None
+    )
+    AND: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match all of the given sub-filters."
+        ),
+        default=None,
+    )
+    OR: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match any of the given sub-filters."
+        ),
+        default=None,
+    )
+    NOT: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Negate the given sub-filters."
+        ),
+        default=None,
     )
 
 

--- a/src/ai/backend/manager/api/gql/app_config_definition/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_definition/types.py
@@ -38,6 +38,7 @@ from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection, Stri
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
+    gql_added_field,
     gql_connection_type,
     gql_enum,
     gql_field,
@@ -134,6 +135,24 @@ class AppConfigDefinitionFilterGQL(PydanticInputMixin[AppConfigDefinitionFilterD
     )
     updated_at: DateTimeFilter | None = gql_field(
         description="Filter by last update datetime.", default=None
+    )
+    AND: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match all of the given sub-filters."
+        ),
+        default=None,
+    )
+    OR: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match any of the given sub-filters."
+        ),
+        default=None,
+    )
+    NOT: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Negate the given sub-filters."
+        ),
+        default=None,
     )
 
 

--- a/src/ai/backend/manager/api/gql/container_registry/filters.py
+++ b/src/ai/backend/manager/api/gql/container_registry/filters.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Self
 
 from ai.backend.common.dto.manager.v2.container_registry.request import (
     ContainerRegistryFilter as ContainerRegistryFilterDTO,
@@ -13,6 +14,7 @@ from ai.backend.common.dto.manager.v2.container_registry.request import (
 from ai.backend.common.dto.manager.v2.container_registry.types import (
     ContainerRegistryTypeFilter as ContainerRegistryTypeFilterDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import (
     OrderDirection,
     StringFilter,
@@ -20,6 +22,7 @@ from ai.backend.manager.api.gql.base import (
 from ai.backend.manager.api.gql.container_registry.types import ContainerRegistryTypeGQL
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
+    gql_added_field,
     gql_enum,
     gql_field,
     gql_pydantic_input,
@@ -52,6 +55,24 @@ class ContainerRegistryV2Filter(PydanticInputMixin[ContainerRegistryFilterDTO]):
     registry_name: StringFilter | None = None
     type: ContainerRegistryTypeFilterGQL | None = None
     is_global: bool | None = None
+    AND: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match all of the given sub-filters."
+        ),
+        default=None,
+    )
+    OR: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match any of the given sub-filters."
+        ),
+        default=None,
+    )
+    NOT: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Negate the given sub-filters."
+        ),
+        default=None,
+    )
 
 
 @gql_enum(

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, Self
 from uuid import UUID
 
 import strawberry
@@ -413,6 +413,24 @@ class DeploymentRevisionPresetFilterGQL(PydanticInputMixin[FilterDTO]):
     name: StringFilterGQL | None = gql_field(default=None, description="Name filter.")
     runtime_variant_id: UUIDFilterGQL | None = gql_field(
         default=None, description="Variant ID filter."
+    )
+    AND: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match all of the given sub-filters."
+        ),
+        default=None,
+    )
+    OR: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match any of the given sub-filters."
+        ),
+        default=None,
+    )
+    NOT: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Negate the given sub-filters."
+        ),
+        default=None,
     )
 
 

--- a/src/ai/backend/manager/api/gql/login_client_type/types.py
+++ b/src/ai/backend/manager/api/gql/login_client_type/types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import Any
+from typing import Any, Self
 
 from strawberry.relay import Connection, Edge, NodeID
 
@@ -31,10 +31,12 @@ from ai.backend.common.dto.manager.v2.login_client_type.response import (
 from ai.backend.common.dto.manager.v2.login_client_type.response import (
     UpdateLoginClientTypePayload as UpdateLoginClientTypePayloadDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection, StringFilter
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
+    gql_added_field,
     gql_connection_type,
     gql_enum,
     gql_field,
@@ -118,6 +120,24 @@ class LoginClientTypeFilterGQL(PydanticInputMixin[LoginClientTypeFilterDTO]):
     )
     modified_at: DateTimeFilter | None = gql_field(
         description="Filter by last modification datetime.", default=None
+    )
+    AND: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match all of the given sub-filters."
+        ),
+        default=None,
+    )
+    OR: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match any of the given sub-filters."
+        ),
+        default=None,
+    )
+    NOT: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Negate the given sub-filters."
+        ),
+        default=None,
     )
 
 

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/types/category.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/types/category.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
+from typing import Self
 from uuid import UUID
 
 from ai.backend.common.dto.manager.v2.prometheus_query_preset_category.request import (
@@ -24,12 +25,14 @@ from ai.backend.common.dto.manager.v2.prometheus_query_preset_category.response 
 from ai.backend.common.dto.manager.v2.prometheus_query_preset_category.response import (
     DeleteCategoryPayload as DeleteCategoryPayloadDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import (
     OrderDirection,
     StringFilter,
 )
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
+    gql_added_field,
     gql_enum,
     gql_field,
     gql_pydantic_input,
@@ -68,6 +71,24 @@ class CategoryGQL(PydanticOutputMixin[CategoryNode]):
 )
 class CategoryFilterGQL(PydanticInputMixin[CategoryFilterDTO]):
     name: StringFilter | None = gql_field(description="Filter by name.", default=None)
+    AND: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match all of the given sub-filters."
+        ),
+        default=None,
+    )
+    OR: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match any of the given sub-filters."
+        ),
+        default=None,
+    )
+    NOT: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Negate the given sub-filters."
+        ),
+        default=None,
+    )
 
 
 @gql_enum(

--- a/src/ai/backend/manager/api/gql/resource_policy_v2/types/filters.py
+++ b/src/ai/backend/manager/api/gql/resource_policy_v2/types/filters.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Self
 
 from ai.backend.common.dto.manager.v2.resource_policy.request import (
     KeypairResourcePolicyFilter as KeypairResourcePolicyFilterDTO,
@@ -25,6 +26,7 @@ from ai.backend.common.dto.manager.v2.resource_policy.request import (
 from ai.backend.common.dto.manager.v2.resource_policy.request import (
     UserResourcePolicyOrder as UserResourcePolicyOrderDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import (
     DateTimeFilter,
     IntFilter,
@@ -86,6 +88,24 @@ class KeypairResourcePolicyV2Filter(PydanticInputMixin[KeypairResourcePolicyFilt
         ),
         default=None,
     )
+    AND: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match all of the given sub-filters."
+        ),
+        default=None,
+    )
+    OR: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match any of the given sub-filters."
+        ),
+        default=None,
+    )
+    NOT: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Negate the given sub-filters."
+        ),
+        default=None,
+    )
 
 
 @gql_enum(
@@ -140,6 +160,24 @@ class UserResourcePolicyV2Filter(PydanticInputMixin[UserResourcePolicyFilterDTO]
     max_quota_scope_size: IntFilter | None = None
     max_session_count_per_model_session: IntFilter | None = None
     max_customized_image_count: IntFilter | None = None
+    AND: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match all of the given sub-filters."
+        ),
+        default=None,
+    )
+    OR: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match any of the given sub-filters."
+        ),
+        default=None,
+    )
+    NOT: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Negate the given sub-filters."
+        ),
+        default=None,
+    )
 
 
 @gql_enum(
@@ -191,6 +229,24 @@ class ProjectResourcePolicyV2Filter(PydanticInputMixin[ProjectResourcePolicyFilt
     max_vfolder_count: IntFilter | None = None
     max_quota_scope_size: IntFilter | None = None
     max_network_count: IntFilter | None = None
+    AND: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match all of the given sub-filters."
+        ),
+        default=None,
+    )
+    OR: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match any of the given sub-filters."
+        ),
+        default=None,
+    )
+    NOT: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Negate the given sub-filters."
+        ),
+        default=None,
+    )
 
 
 @gql_enum(

--- a/src/ai/backend/manager/api/gql/runtime_variant/types.py
+++ b/src/ai/backend/manager/api/gql/runtime_variant/types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
+from typing import Self
 from uuid import UUID
 
 from strawberry import UNSET
@@ -37,10 +38,12 @@ from ai.backend.common.dto.manager.v2.runtime_variant.response import (
 from ai.backend.common.dto.manager.v2.runtime_variant.response import (
     UpdateRuntimeVariantPayload as UpdateRuntimeVariantPayloadDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import StringFilter as StringFilterGQL
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
+    gql_added_field,
     gql_connection_type,
     gql_enum,
     gql_field,
@@ -103,6 +106,24 @@ class RuntimeVariantConnection(Connection[RuntimeVariantGQL]):
 )
 class RuntimeVariantFilterGQL(PydanticInputMixin[RuntimeVariantFilterDTO]):
     name: StringFilterGQL | None = gql_field(default=None, description="Name filter.")
+    AND: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match all of the given sub-filters."
+        ),
+        default=None,
+    )
+    OR: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match any of the given sub-filters."
+        ),
+        default=None,
+    )
+    NOT: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Negate the given sub-filters."
+        ),
+        default=None,
+    )
 
 
 @gql_pydantic_input(

--- a/src/ai/backend/manager/api/gql/runtime_variant_preset/types.py
+++ b/src/ai/backend/manager/api/gql/runtime_variant_preset/types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
+from typing import Self
 from uuid import UUID
 
 from strawberry.relay import Connection, Edge, NodeID
@@ -51,6 +52,7 @@ from ai.backend.common.dto.manager.v2.runtime_variant_preset.types import (
 from ai.backend.common.dto.manager.v2.runtime_variant_preset.types import (
     UIOption as UIOptionDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import StringFilter as StringFilterGQL
 from ai.backend.manager.api.gql.base import UUIDFilter as UUIDFilterGQL
 from ai.backend.manager.api.gql.decorators import (
@@ -254,6 +256,24 @@ class RuntimeVariantPresetFilterGQL(PydanticInputMixin[FilterDTO]):
     name: StringFilterGQL | None = gql_field(default=None, description="Name filter.")
     runtime_variant_id: UUIDFilterGQL | None = gql_field(
         default=None, description="Variant ID filter."
+    )
+    AND: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match all of the given sub-filters."
+        ),
+        default=None,
+    )
+    OR: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Match any of the given sub-filters."
+        ),
+        default=None,
+    )
+    NOT: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Negate the given sub-filters."
+        ),
+        default=None,
     )
 
 

--- a/tests/unit/manager/api/gql/app_config_allow_list/BUILD
+++ b/tests/unit/manager/api/gql/app_config_allow_list/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/api/gql/app_config_allow_list/test_filters.py
+++ b/tests/unit/manager/api/gql/app_config_allow_list/test_filters.py
@@ -1,0 +1,49 @@
+"""Tests for AND/OR/NOT combinators on the app config allow-list GQL filter."""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
+    AppConfigAllowListFilter as AppConfigAllowListFilterDTO,
+)
+from ai.backend.manager.api.gql.app_config_allow_list.types import (
+    AppConfigAllowListFilterGQL,
+)
+from ai.backend.manager.api.gql.base import StringFilter
+
+
+class TestAppConfigAllowListFilterCombinators:
+    """Tests for AND/OR/NOT combinators on AppConfigAllowListFilterGQL."""
+
+    def test_empty(self) -> None:
+        dto = AppConfigAllowListFilterGQL().to_pydantic()
+        assert dto.AND is None
+        assert dto.OR is None
+        assert dto.NOT is None
+
+    def test_and(self) -> None:
+        f = AppConfigAllowListFilterGQL(
+            AND=[
+                AppConfigAllowListFilterGQL(config_name=StringFilter(contains="a")),
+                AppConfigAllowListFilterGQL(config_name=StringFilter(contains="b")),
+            ]
+        )
+        dto = f.to_pydantic()
+        assert isinstance(dto, AppConfigAllowListFilterDTO)
+        assert dto.AND is not None
+        assert len(dto.AND) == 2
+
+    def test_or(self) -> None:
+        f = AppConfigAllowListFilterGQL(
+            OR=[AppConfigAllowListFilterGQL(config_name=StringFilter(contains="a"))]
+        )
+        dto = f.to_pydantic()
+        assert dto.OR is not None
+        assert len(dto.OR) == 1
+
+    def test_not(self) -> None:
+        f = AppConfigAllowListFilterGQL(
+            NOT=[AppConfigAllowListFilterGQL(config_name=StringFilter(equals="x"))]
+        )
+        dto = f.to_pydantic()
+        assert dto.NOT is not None
+        assert len(dto.NOT) == 1

--- a/tests/unit/manager/api/gql/app_config_definition/BUILD
+++ b/tests/unit/manager/api/gql/app_config_definition/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/api/gql/app_config_definition/test_filters.py
+++ b/tests/unit/manager/api/gql/app_config_definition/test_filters.py
@@ -1,0 +1,49 @@
+"""Tests for AND/OR/NOT combinators on the app config definition GQL filter."""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.app_config_definition.request import (
+    AppConfigDefinitionFilter as AppConfigDefinitionFilterDTO,
+)
+from ai.backend.manager.api.gql.app_config_definition.types import (
+    AppConfigDefinitionFilterGQL,
+)
+from ai.backend.manager.api.gql.base import StringFilter
+
+
+class TestAppConfigDefinitionFilterCombinators:
+    """Tests for AND/OR/NOT combinators on AppConfigDefinitionFilterGQL."""
+
+    def test_empty(self) -> None:
+        dto = AppConfigDefinitionFilterGQL().to_pydantic()
+        assert dto.AND is None
+        assert dto.OR is None
+        assert dto.NOT is None
+
+    def test_and(self) -> None:
+        f = AppConfigDefinitionFilterGQL(
+            AND=[
+                AppConfigDefinitionFilterGQL(config_name=StringFilter(contains="a")),
+                AppConfigDefinitionFilterGQL(config_name=StringFilter(contains="b")),
+            ]
+        )
+        dto = f.to_pydantic()
+        assert isinstance(dto, AppConfigDefinitionFilterDTO)
+        assert dto.AND is not None
+        assert len(dto.AND) == 2
+
+    def test_or(self) -> None:
+        f = AppConfigDefinitionFilterGQL(
+            OR=[AppConfigDefinitionFilterGQL(config_name=StringFilter(contains="a"))]
+        )
+        dto = f.to_pydantic()
+        assert dto.OR is not None
+        assert len(dto.OR) == 1
+
+    def test_not(self) -> None:
+        f = AppConfigDefinitionFilterGQL(
+            NOT=[AppConfigDefinitionFilterGQL(config_name=StringFilter(equals="x"))]
+        )
+        dto = f.to_pydantic()
+        assert dto.NOT is not None
+        assert len(dto.NOT) == 1

--- a/tests/unit/manager/api/gql/container_registry/BUILD
+++ b/tests/unit/manager/api/gql/container_registry/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/api/gql/container_registry/test_filters.py
+++ b/tests/unit/manager/api/gql/container_registry/test_filters.py
@@ -1,0 +1,54 @@
+"""Tests for the AND/OR/NOT combinators on container registry GQL filter types."""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.container_registry.request import (
+    ContainerRegistryFilter as ContainerRegistryFilterDTO,
+)
+from ai.backend.manager.api.gql.base import StringFilter
+from ai.backend.manager.api.gql.container_registry.filters import ContainerRegistryV2Filter
+
+
+class TestContainerRegistryFilterCombinators:
+    """Tests for AND/OR/NOT combinators on ContainerRegistryV2Filter."""
+
+    def test_to_pydantic_empty(self) -> None:
+        dto = ContainerRegistryV2Filter().to_pydantic()
+        assert dto.AND is None
+        assert dto.OR is None
+        assert dto.NOT is None
+
+    def test_to_pydantic_and(self) -> None:
+        filter_gql = ContainerRegistryV2Filter(
+            AND=[
+                ContainerRegistryV2Filter(registry_name=StringFilter(contains="a")),
+                ContainerRegistryV2Filter(registry_name=StringFilter(contains="b")),
+            ]
+        )
+        dto = filter_gql.to_pydantic()
+        assert isinstance(dto, ContainerRegistryFilterDTO)
+        assert dto.AND is not None
+        assert len(dto.AND) == 2
+        assert dto.AND[0].registry_name is not None
+        assert dto.AND[0].registry_name.contains == "a"
+
+    def test_to_pydantic_or(self) -> None:
+        filter_gql = ContainerRegistryV2Filter(
+            OR=[
+                ContainerRegistryV2Filter(registry_name=StringFilter(contains="a")),
+                ContainerRegistryV2Filter(registry_name=StringFilter(contains="b")),
+            ]
+        )
+        dto = filter_gql.to_pydantic()
+        assert dto.OR is not None
+        assert len(dto.OR) == 2
+
+    def test_to_pydantic_not(self) -> None:
+        filter_gql = ContainerRegistryV2Filter(
+            NOT=[ContainerRegistryV2Filter(registry_name=StringFilter(equals="x"))]
+        )
+        dto = filter_gql.to_pydantic()
+        assert dto.NOT is not None
+        assert len(dto.NOT) == 1
+        assert dto.NOT[0].registry_name is not None
+        assert dto.NOT[0].registry_name.equals == "x"

--- a/tests/unit/manager/api/gql/deployment/test_revision_preset_filters.py
+++ b/tests/unit/manager/api/gql/deployment/test_revision_preset_filters.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from ai.backend.manager.api.gql.base import StringFilter as StringFilterGQL
+from ai.backend.manager.api.gql.deployment.types.revision_preset import (
+    DeploymentRevisionPresetFilterGQL,
+)
+
+
+class TestDeploymentRevisionPresetFilterCombinators:
+    def test_empty(self) -> None:
+        dto = DeploymentRevisionPresetFilterGQL().to_pydantic()
+        assert dto.AND is None and dto.OR is None and dto.NOT is None
+
+    def test_and(self) -> None:
+        f = DeploymentRevisionPresetFilterGQL(
+            AND=[
+                DeploymentRevisionPresetFilterGQL(name=StringFilterGQL(contains="a")),
+                DeploymentRevisionPresetFilterGQL(name=StringFilterGQL(contains="b")),
+            ]
+        )
+        dto = f.to_pydantic()
+        assert dto.AND is not None
+        assert len(dto.AND) == 2
+
+    def test_or(self) -> None:
+        f = DeploymentRevisionPresetFilterGQL(
+            OR=[DeploymentRevisionPresetFilterGQL(name=StringFilterGQL(contains="a"))]
+        )
+        assert f.to_pydantic().OR is not None
+
+    def test_not(self) -> None:
+        f = DeploymentRevisionPresetFilterGQL(
+            NOT=[DeploymentRevisionPresetFilterGQL(name=StringFilterGQL(equals="x"))]
+        )
+        assert f.to_pydantic().NOT is not None

--- a/tests/unit/manager/api/gql/login_client_type/BUILD
+++ b/tests/unit/manager/api/gql/login_client_type/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/api/gql/login_client_type/test_filters.py
+++ b/tests/unit/manager/api/gql/login_client_type/test_filters.py
@@ -1,0 +1,45 @@
+"""Tests for the AND/OR/NOT combinators on the login client type GQL filter."""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.login_client_type.request import (
+    LoginClientTypeFilter as LoginClientTypeFilterDTO,
+)
+from ai.backend.manager.api.gql.base import StringFilter
+from ai.backend.manager.api.gql.login_client_type.types import LoginClientTypeFilterGQL
+
+
+class TestLoginClientTypeFilterCombinators:
+    """Tests for AND/OR/NOT combinators on LoginClientTypeFilterGQL."""
+
+    def test_empty(self) -> None:
+        dto = LoginClientTypeFilterGQL().to_pydantic()
+        assert isinstance(dto, LoginClientTypeFilterDTO)
+        assert dto.AND is None and dto.OR is None and dto.NOT is None
+
+    def test_and(self) -> None:
+        f = LoginClientTypeFilterGQL(
+            AND=[
+                LoginClientTypeFilterGQL(name=StringFilter(contains="a")),
+                LoginClientTypeFilterGQL(name=StringFilter(contains="b")),
+            ]
+        )
+        dto = f.to_pydantic()
+        assert dto.AND is not None
+        assert len(dto.AND) == 2
+        assert dto.AND[0].name is not None
+        assert dto.AND[0].name.contains == "a"
+
+    def test_or(self) -> None:
+        f = LoginClientTypeFilterGQL(OR=[LoginClientTypeFilterGQL(name=StringFilter(contains="a"))])
+        dto = f.to_pydantic()
+        assert dto.OR is not None
+        assert len(dto.OR) == 1
+
+    def test_not(self) -> None:
+        f = LoginClientTypeFilterGQL(NOT=[LoginClientTypeFilterGQL(name=StringFilter(equals="x"))])
+        dto = f.to_pydantic()
+        assert dto.NOT is not None
+        assert len(dto.NOT) == 1
+        assert dto.NOT[0].name is not None
+        assert dto.NOT[0].name.equals == "x"

--- a/tests/unit/manager/api/gql/prometheus_query_preset/BUILD
+++ b/tests/unit/manager/api/gql/prometheus_query_preset/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/api/gql/prometheus_query_preset/test_category_filters.py
+++ b/tests/unit/manager/api/gql/prometheus_query_preset/test_category_filters.py
@@ -1,0 +1,45 @@
+"""Tests for the AND/OR/NOT combinators on the query preset category GQL filter."""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.prometheus_query_preset_category.request import (
+    CategoryFilter as CategoryFilterDTO,
+)
+from ai.backend.manager.api.gql.base import StringFilter
+from ai.backend.manager.api.gql.prometheus_query_preset.types.category import CategoryFilterGQL
+
+
+class TestCategoryFilterCombinators:
+    """Tests for AND/OR/NOT combinators on CategoryFilterGQL."""
+
+    def test_empty(self) -> None:
+        dto = CategoryFilterGQL().to_pydantic()
+        assert isinstance(dto, CategoryFilterDTO)
+        assert dto.AND is None and dto.OR is None and dto.NOT is None
+
+    def test_and(self) -> None:
+        f = CategoryFilterGQL(
+            AND=[
+                CategoryFilterGQL(name=StringFilter(contains="a")),
+                CategoryFilterGQL(name=StringFilter(contains="b")),
+            ]
+        )
+        dto = f.to_pydantic()
+        assert dto.AND is not None
+        assert len(dto.AND) == 2
+        assert dto.AND[0].name is not None
+        assert dto.AND[0].name.contains == "a"
+
+    def test_or(self) -> None:
+        f = CategoryFilterGQL(OR=[CategoryFilterGQL(name=StringFilter(contains="a"))])
+        dto = f.to_pydantic()
+        assert dto.OR is not None
+        assert len(dto.OR) == 1
+
+    def test_not(self) -> None:
+        f = CategoryFilterGQL(NOT=[CategoryFilterGQL(name=StringFilter(equals="x"))])
+        dto = f.to_pydantic()
+        assert dto.NOT is not None
+        assert len(dto.NOT) == 1
+        assert dto.NOT[0].name is not None
+        assert dto.NOT[0].name.equals == "x"

--- a/tests/unit/manager/api/gql/resource_policy_v2/test_nested_filters.py
+++ b/tests/unit/manager/api/gql/resource_policy_v2/test_nested_filters.py
@@ -7,10 +7,18 @@ import uuid
 from ai.backend.common.dto.manager.v2.resource_policy.request import (
     KeypairResourcePolicyFilter as KeypairResourcePolicyFilterDTO,
 )
-from ai.backend.manager.api.gql.base import UUIDFilter
+from ai.backend.common.dto.manager.v2.resource_policy.request import (
+    ProjectResourcePolicyFilter as ProjectResourcePolicyFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.resource_policy.request import (
+    UserResourcePolicyFilter as UserResourcePolicyFilterDTO,
+)
+from ai.backend.manager.api.gql.base import StringFilter, UUIDFilter
 from ai.backend.manager.api.gql.resource_policy_v2.types.filters import (
     KeypairResourcePolicyKeypairNestedFilterGQL,
     KeypairResourcePolicyV2Filter,
+    ProjectResourcePolicyV2Filter,
+    UserResourcePolicyV2Filter,
 )
 
 
@@ -45,3 +53,130 @@ class TestKeypairResourcePolicyKeypairNestedFilter:
         assert dto.keypair is not None
         assert dto.keypair.user_id is not None
         assert dto.keypair.user_id.equals == owner_id
+
+
+class TestKeypairResourcePolicyFilterCombinators:
+    """Tests for AND/OR/NOT combinators on KeypairResourcePolicyV2Filter."""
+
+    def test_to_pydantic_empty(self) -> None:
+        dto = KeypairResourcePolicyV2Filter().to_pydantic()
+        assert dto.AND is None
+        assert dto.OR is None
+        assert dto.NOT is None
+
+    def test_to_pydantic_and(self) -> None:
+        filter_gql = KeypairResourcePolicyV2Filter(
+            AND=[
+                KeypairResourcePolicyV2Filter(name=StringFilter(contains="gpu")),
+                KeypairResourcePolicyV2Filter(name=StringFilter(contains="prod")),
+            ]
+        )
+        dto = filter_gql.to_pydantic()
+        assert isinstance(dto, KeypairResourcePolicyFilterDTO)
+        assert dto.AND is not None
+        assert len(dto.AND) == 2
+        assert dto.AND[0].name is not None
+        assert dto.AND[0].name.contains == "gpu"
+
+    def test_to_pydantic_or(self) -> None:
+        filter_gql = KeypairResourcePolicyV2Filter(
+            OR=[
+                KeypairResourcePolicyV2Filter(name=StringFilter(contains="a")),
+                KeypairResourcePolicyV2Filter(name=StringFilter(contains="b")),
+            ]
+        )
+        dto = filter_gql.to_pydantic()
+        assert dto.OR is not None
+        assert len(dto.OR) == 2
+
+    def test_to_pydantic_not(self) -> None:
+        filter_gql = KeypairResourcePolicyV2Filter(
+            NOT=[KeypairResourcePolicyV2Filter(name=StringFilter(equals="default"))]
+        )
+        dto = filter_gql.to_pydantic()
+        assert dto.NOT is not None
+        assert len(dto.NOT) == 1
+        assert dto.NOT[0].name is not None
+        assert dto.NOT[0].name.equals == "default"
+
+
+class TestUserResourcePolicyFilterCombinators:
+    """Tests for AND/OR/NOT combinators on UserResourcePolicyV2Filter."""
+
+    def test_to_pydantic_empty(self) -> None:
+        dto = UserResourcePolicyV2Filter().to_pydantic()
+        assert dto.AND is None
+        assert dto.OR is None
+        assert dto.NOT is None
+
+    def test_to_pydantic_and(self) -> None:
+        filter_gql = UserResourcePolicyV2Filter(
+            AND=[
+                UserResourcePolicyV2Filter(name=StringFilter(contains="gpu")),
+                UserResourcePolicyV2Filter(name=StringFilter(contains="prod")),
+            ]
+        )
+        dto = filter_gql.to_pydantic()
+        assert isinstance(dto, UserResourcePolicyFilterDTO)
+        assert dto.AND is not None
+        assert len(dto.AND) == 2
+
+    def test_to_pydantic_or(self) -> None:
+        filter_gql = UserResourcePolicyV2Filter(
+            OR=[
+                UserResourcePolicyV2Filter(name=StringFilter(contains="a")),
+                UserResourcePolicyV2Filter(name=StringFilter(contains="b")),
+            ]
+        )
+        dto = filter_gql.to_pydantic()
+        assert dto.OR is not None
+        assert len(dto.OR) == 2
+
+    def test_to_pydantic_not(self) -> None:
+        filter_gql = UserResourcePolicyV2Filter(
+            NOT=[UserResourcePolicyV2Filter(name=StringFilter(equals="default"))]
+        )
+        dto = filter_gql.to_pydantic()
+        assert dto.NOT is not None
+        assert len(dto.NOT) == 1
+
+
+class TestProjectResourcePolicyFilterCombinators:
+    """Tests for AND/OR/NOT combinators on ProjectResourcePolicyV2Filter."""
+
+    def test_to_pydantic_empty(self) -> None:
+        dto = ProjectResourcePolicyV2Filter().to_pydantic()
+        assert dto.AND is None
+        assert dto.OR is None
+        assert dto.NOT is None
+
+    def test_to_pydantic_and(self) -> None:
+        filter_gql = ProjectResourcePolicyV2Filter(
+            AND=[
+                ProjectResourcePolicyV2Filter(name=StringFilter(contains="gpu")),
+                ProjectResourcePolicyV2Filter(name=StringFilter(contains="prod")),
+            ]
+        )
+        dto = filter_gql.to_pydantic()
+        assert isinstance(dto, ProjectResourcePolicyFilterDTO)
+        assert dto.AND is not None
+        assert len(dto.AND) == 2
+
+    def test_to_pydantic_or(self) -> None:
+        filter_gql = ProjectResourcePolicyV2Filter(
+            OR=[
+                ProjectResourcePolicyV2Filter(name=StringFilter(contains="a")),
+                ProjectResourcePolicyV2Filter(name=StringFilter(contains="b")),
+            ]
+        )
+        dto = filter_gql.to_pydantic()
+        assert dto.OR is not None
+        assert len(dto.OR) == 2
+
+    def test_to_pydantic_not(self) -> None:
+        filter_gql = ProjectResourcePolicyV2Filter(
+            NOT=[ProjectResourcePolicyV2Filter(name=StringFilter(equals="default"))]
+        )
+        dto = filter_gql.to_pydantic()
+        assert dto.NOT is not None
+        assert len(dto.NOT) == 1

--- a/tests/unit/manager/api/gql/runtime_variant/BUILD
+++ b/tests/unit/manager/api/gql/runtime_variant/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/api/gql/runtime_variant/test_filters.py
+++ b/tests/unit/manager/api/gql/runtime_variant/test_filters.py
@@ -1,0 +1,50 @@
+"""Tests for AND/OR/NOT combinators on the RuntimeVariant GQL filter."""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.runtime_variant.request import (
+    RuntimeVariantFilter as RuntimeVariantFilterDTO,
+)
+from ai.backend.manager.api.gql.base import StringFilter as StringFilterGQL
+from ai.backend.manager.api.gql.runtime_variant.types import RuntimeVariantFilterGQL
+
+
+class TestRuntimeVariantFilterCombinators:
+    """Tests for AND/OR/NOT combinators on RuntimeVariantFilterGQL."""
+
+    def test_empty(self) -> None:
+        dto = RuntimeVariantFilterGQL().to_pydantic()
+        assert isinstance(dto, RuntimeVariantFilterDTO)
+        assert dto.AND is None
+        assert dto.OR is None
+        assert dto.NOT is None
+
+    def test_and(self) -> None:
+        f = RuntimeVariantFilterGQL(
+            AND=[
+                RuntimeVariantFilterGQL(name=StringFilterGQL(contains="a")),
+                RuntimeVariantFilterGQL(name=StringFilterGQL(contains="b")),
+            ]
+        )
+        dto = f.to_pydantic()
+        assert isinstance(dto, RuntimeVariantFilterDTO)
+        assert dto.AND is not None
+        assert len(dto.AND) == 2
+        assert dto.AND[0].name is not None
+        assert dto.AND[0].name.contains == "a"
+
+    def test_or(self) -> None:
+        f = RuntimeVariantFilterGQL(
+            OR=[RuntimeVariantFilterGQL(name=StringFilterGQL(contains="a"))]
+        )
+        dto = f.to_pydantic()
+        assert dto.OR is not None
+        assert len(dto.OR) == 1
+
+    def test_not(self) -> None:
+        f = RuntimeVariantFilterGQL(NOT=[RuntimeVariantFilterGQL(name=StringFilterGQL(equals="x"))])
+        dto = f.to_pydantic()
+        assert dto.NOT is not None
+        assert len(dto.NOT) == 1
+        assert dto.NOT[0].name is not None
+        assert dto.NOT[0].name.equals == "x"

--- a/tests/unit/manager/api/gql/runtime_variant_preset/BUILD
+++ b/tests/unit/manager/api/gql/runtime_variant_preset/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/api/gql/runtime_variant_preset/test_filters.py
+++ b/tests/unit/manager/api/gql/runtime_variant_preset/test_filters.py
@@ -1,0 +1,58 @@
+"""Tests for AND/OR/NOT combinators on the RuntimeVariantPreset GQL filter."""
+
+from __future__ import annotations
+
+import uuid
+
+from ai.backend.common.dto.manager.v2.runtime_variant_preset.request import (
+    RuntimeVariantPresetFilter as RuntimeVariantPresetFilterDTO,
+)
+from ai.backend.manager.api.gql.base import StringFilter as StringFilterGQL
+from ai.backend.manager.api.gql.base import UUIDFilter as UUIDFilterGQL
+from ai.backend.manager.api.gql.runtime_variant_preset.types import RuntimeVariantPresetFilterGQL
+
+
+class TestRuntimeVariantPresetFilterCombinators:
+    """Tests for AND/OR/NOT combinators on RuntimeVariantPresetFilterGQL."""
+
+    def test_empty(self) -> None:
+        dto = RuntimeVariantPresetFilterGQL().to_pydantic()
+        assert isinstance(dto, RuntimeVariantPresetFilterDTO)
+        assert dto.AND is None
+        assert dto.OR is None
+        assert dto.NOT is None
+
+    def test_and(self) -> None:
+        f = RuntimeVariantPresetFilterGQL(
+            AND=[
+                RuntimeVariantPresetFilterGQL(name=StringFilterGQL(contains="a")),
+                RuntimeVariantPresetFilterGQL(name=StringFilterGQL(contains="b")),
+            ]
+        )
+        dto = f.to_pydantic()
+        assert isinstance(dto, RuntimeVariantPresetFilterDTO)
+        assert dto.AND is not None
+        assert len(dto.AND) == 2
+        assert dto.AND[0].name is not None
+        assert dto.AND[0].name.contains == "a"
+
+    def test_or(self) -> None:
+        variant_id = uuid.uuid4()
+        f = RuntimeVariantPresetFilterGQL(
+            OR=[RuntimeVariantPresetFilterGQL(runtime_variant_id=UUIDFilterGQL(equals=variant_id))]
+        )
+        dto = f.to_pydantic()
+        assert dto.OR is not None
+        assert len(dto.OR) == 1
+        assert dto.OR[0].runtime_variant_id is not None
+        assert dto.OR[0].runtime_variant_id.equals == variant_id
+
+    def test_not(self) -> None:
+        f = RuntimeVariantPresetFilterGQL(
+            NOT=[RuntimeVariantPresetFilterGQL(name=StringFilterGQL(equals="x"))]
+        )
+        dto = f.to_pydantic()
+        assert dto.NOT is not None
+        assert len(dto.NOT) == 1
+        assert dto.NOT[0].name is not None
+        assert dto.NOT[0].name.equals == "x"


### PR DESCRIPTION
## Summary
- Add `AND`/`OR`/`NOT` boolean combinators to the 11 v2 GraphQL **root search filters** that were missing them, aligning them with the rest of the v2 filter inputs (e.g. `SessionV2Filter`, `AgentFilter`).
- Wired uniformly across all three layers: DTO (`list[Self]` self-referential fields + `model_rebuild()`), GraphQL (`gql_added_field` with `NEXT_RELEASE_VERSION`), and the adapter `_convert_*_filter` (recursive combination via `combine_conditions_or` / `negate_conditions`).
- Filters covered: `KeypairResourcePolicyV2`, `UserResourcePolicyV2`, `ProjectResourcePolicyV2`, `ContainerRegistryV2`, `RuntimeVariant`, `RuntimeVariantPreset`, `DeploymentRevisionPreset`, `AppConfigAllowList`, `AppConfigDefinition`, `Category`, `LoginClientType`.
- Regenerated GraphQL schema artifacts (`v2-schema.graphql`, `supergraph.graphql`); v1 schema unchanged. Diff is exactly 33 added field lines (11 × 3).

## Test plan
- [x] `pants fmt :: && pants fix :: && pants lint --changed-since=origin/main` pass
- [x] `pants check --changed-since=HEAD` (mypy) passes, no `# type: ignore` / `# noqa`
- [x] `pants test --changed-since=HEAD` — per-filter `to_pydantic` unit tests (empty/AND/OR/NOT) pass for all 11 filters
- [x] Schema regenerated; all 11 `input *Filter` blocks now expose `AND`/`OR`/`NOT`
- [ ] (optional) Live verification: run an `OR`/`NOT` search against an affected entity and confirm boolean logic

Resolves BA-6639