### PR TITLE
feat(BA-2325): Allow v2 client registries to borrow a shared aiohttp session

### DIFF
--- a/changes/5820.enhance.md
+++ b/changes/5820.enhance.md
@@ -1,0 +1,1 @@
+Allow the v2 async client registries (`BackendAIClientRegistry`, `V2ClientRegistry`) to borrow a caller-owned `aiohttp.ClientSession` so repeated Manager calls can reuse a shared connection pool; `close()` leaves an injected session open.

--- a/src/ai/backend/client/v2/base_client.py
+++ b/src/ai/backend/client/v2/base_client.py
@@ -61,21 +61,30 @@ class BackendAIAuthClient:
 
     Prefer ``create()`` for production use; ``__init__`` accepts a pre-built
     session so tests can inject a mock directly.
+
+    Pass ``owns_session=False`` when injecting a caller-owned session (e.g. a
+    shared connection pool): ``close()`` will then leave the session open so the
+    caller can keep reusing it. Sessions built by ``create()`` are owned and
+    closed normally.
     """
 
     _config: ClientConfig
     _auth: AuthStrategy
     _session: aiohttp.ClientSession
+    _owns_session: bool
 
     def __init__(
         self,
         config: ClientConfig,
         auth: AuthStrategy,
         session: aiohttp.ClientSession,
+        *,
+        owns_session: bool = True,
     ) -> None:
         self._config = config
         self._auth = auth
         self._session = session
+        self._owns_session = owns_session
 
     @classmethod
     async def create(
@@ -95,7 +104,8 @@ class BackendAIAuthClient:
         return self._config
 
     async def close(self) -> None:
-        await self._session.close()
+        if self._owns_session:
+            await self._session.close()
 
     def _build_url(self, path: str) -> str:
         base = str(self._config.endpoint).rstrip("/")
@@ -378,14 +388,18 @@ class BackendAIAnonymousClient:
 
     _config: ClientConfig
     _session: aiohttp.ClientSession
+    _owns_session: bool
 
     def __init__(
         self,
         config: ClientConfig,
         session: aiohttp.ClientSession,
+        *,
+        owns_session: bool = True,
     ) -> None:
         self._config = config
         self._session = session
+        self._owns_session = owns_session
 
     @classmethod
     async def create(
@@ -396,7 +410,8 @@ class BackendAIAnonymousClient:
         return cls(config, session)
 
     async def close(self) -> None:
-        await self._session.close()
+        if self._owns_session:
+            await self._session.close()
 
     def _build_url(self, path: str) -> str:
         base = str(self._config.endpoint).rstrip("/")

--- a/src/ai/backend/client/v2/registry.py
+++ b/src/ai/backend/client/v2/registry.py
@@ -8,6 +8,8 @@ from .base_client import BackendAIAnonymousClient, BackendAIAuthClient
 from .config import ClientConfig
 
 if TYPE_CHECKING:
+    import aiohttp
+
     from .domains.acl import ACLClient
     from .domains.agent import AgentClient
     from .domains.artifact import ArtifactClient
@@ -62,9 +64,22 @@ class BackendAIClientRegistry:
         cls,
         config: ClientConfig,
         auth: AuthStrategy,
+        *,
+        session: aiohttp.ClientSession | None = None,
     ) -> BackendAIClientRegistry:
-        client = await BackendAIAuthClient.create(config, auth)
-        anon_client = await BackendAIAnonymousClient.create(config)
+        """Build a registry.
+
+        When ``session`` is given, both the authenticated and anonymous clients
+        borrow that caller-owned session (a shared connection pool) and
+        ``close()`` leaves it open. When omitted, each client creates and owns
+        its own session, as before.
+        """
+        if session is not None:
+            client = BackendAIAuthClient(config, auth, session, owns_session=False)
+            anon_client = BackendAIAnonymousClient(config, session, owns_session=False)
+        else:
+            client = await BackendAIAuthClient.create(config, auth)
+            anon_client = await BackendAIAnonymousClient.create(config)
         return cls(client, anon_client)
 
     async def close(self) -> None:

--- a/src/ai/backend/client/v2/v2_registry.py
+++ b/src/ai/backend/client/v2/v2_registry.py
@@ -15,6 +15,8 @@ from .base_client import BackendAIAuthClient
 from .config import ClientConfig
 
 if TYPE_CHECKING:
+    import aiohttp
+
     from .domains_v2.agent import V2AgentClient
     from .domains_v2.app_config_allow_list import V2AppConfigAllowListClient
     from .domains_v2.app_config_definition import V2AppConfigDefinitionClient
@@ -76,8 +78,19 @@ class V2ClientRegistry:
         cls,
         config: ClientConfig,
         auth: AuthStrategy,
+        *,
+        session: aiohttp.ClientSession | None = None,
     ) -> V2ClientRegistry:
-        client = await BackendAIAuthClient.create(config, auth)
+        """Build a registry.
+
+        When ``session`` is given, the client borrows that caller-owned session
+        (a shared connection pool) and ``close()`` leaves it open. When omitted,
+        the client creates and owns its own session, as before.
+        """
+        if session is not None:
+            client = BackendAIAuthClient(config, auth, session, owns_session=False)
+        else:
+            client = await BackendAIAuthClient.create(config, auth)
         return cls(client)
 
     async def close(self) -> None:

--- a/tests/unit/client_v2/test_base_client.py
+++ b/tests/unit/client_v2/test_base_client.py
@@ -56,6 +56,34 @@ def _make_request_session(resp: AsyncMock) -> MagicMock:
     return mock_session
 
 
+class TestSessionOwnership:
+    """close() must close an owned session but leave an injected one open."""
+
+    async def test_owned_auth_session_is_closed(self) -> None:
+        session = AsyncMock()
+        client = BackendAIAuthClient(_DEFAULT_CONFIG, MockAuth(), session)
+        await client.close()
+        session.close.assert_awaited_once()
+
+    async def test_injected_auth_session_is_not_closed(self) -> None:
+        session = AsyncMock()
+        client = BackendAIAuthClient(_DEFAULT_CONFIG, MockAuth(), session, owns_session=False)
+        await client.close()
+        session.close.assert_not_awaited()
+
+    async def test_owned_anon_session_is_closed(self) -> None:
+        session = AsyncMock()
+        client = BackendAIAnonymousClient(_DEFAULT_CONFIG, session)
+        await client.close()
+        session.close.assert_awaited_once()
+
+    async def test_injected_anon_session_is_not_closed(self) -> None:
+        session = AsyncMock()
+        client = BackendAIAnonymousClient(_DEFAULT_CONFIG, session, owns_session=False)
+        await client.close()
+        session.close.assert_not_awaited()
+
+
 class _RecordingAuth(MockAuth):
     """MockAuth that records the rel_url it was asked to sign."""
 

--- a/tests/unit/client_v2/test_registry.py
+++ b/tests/unit/client_v2/test_registry.py
@@ -26,6 +26,7 @@ from ai.backend.client.v2.domains.template import TemplateClient
 from ai.backend.client.v2.domains.user import UserClient
 from ai.backend.client.v2.domains.vfolder import VFolderClient
 from ai.backend.client.v2.registry import BackendAIClientRegistry
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
 
 from .conftest import MockAuth
 
@@ -91,3 +92,34 @@ class TestBackendAIClientRegistry:
         await registry.close()
         mock_session.close.assert_awaited_once()
         mock_anon_session.close.assert_awaited_once()
+
+    async def test_create_with_injected_session_shares_it(self) -> None:
+        config = ClientConfig(endpoint=URL("https://api.example.com"))
+        shared_session = AsyncMock()
+        registry = await BackendAIClientRegistry.create(config, MockAuth(), session=shared_session)
+        # Both the authenticated and anonymous clients borrow the same session.
+        assert registry._client.session is shared_session
+        assert registry._anon_client._session is shared_session
+
+    async def test_close_preserves_injected_session(self) -> None:
+        config = ClientConfig(endpoint=URL("https://api.example.com"))
+        shared_session = AsyncMock()
+        registry = await BackendAIClientRegistry.create(config, MockAuth(), session=shared_session)
+        await registry.close()
+        # A borrowed pool must survive registry.close().
+        shared_session.close.assert_not_awaited()
+
+
+class TestV2ClientRegistry:
+    async def test_create_with_injected_session_shares_it(self) -> None:
+        config = ClientConfig(endpoint=URL("https://api.example.com"))
+        shared_session = AsyncMock()
+        registry = await V2ClientRegistry.create(config, MockAuth(), session=shared_session)
+        assert registry._client.session is shared_session
+
+    async def test_close_preserves_injected_session(self) -> None:
+        config = ClientConfig(endpoint=URL("https://api.example.com"))
+        shared_session = AsyncMock()
+        registry = await V2ClientRegistry.create(config, MockAuth(), session=shared_session)
+        await registry.close()
+        shared_session.close.assert_not_awaited()


### PR DESCRIPTION
Resolves #5820 (BA-2325). Supersedes #5841.

## Problem

The v2 async client opens **and closes** a fresh `aiohttp.ClientSession` for every registry: `BackendAIClientRegistry.create` builds a session (`base_client.py:86`) and `registry.close()` tears it down (`base_client.py:98`). Callers that make repeated Manager calls — especially synchronous callers wrapping the client in `async_to_sync`, and any long-lived service — therefore pay a new TCP + TLS handshake on every request and cannot pool connections.

(The original BA-2325 framing — pooling the *synchronous* `Session` — was a dead end: that path is CLI-only and has no long-lived consumer to pool. See #5841.)

## Change

A minimal session-injection seam on the v2 async client:

- `BackendAIAuthClient` / `BackendAIAnonymousClient` gain `owns_session` (default `True`). `close()` closes the session only when owned.
- `BackendAIClientRegistry.create` / `V2ClientRegistry.create` accept an optional `session=`. When given, the clients **borrow** it (`owns_session=False`), so `close()` leaves the shared pool open. When omitted, behavior is unchanged (each client creates and owns its own session).

Because the aiohttp session is auth-agnostic transport (HMAC signing is per-request, `base_client.py:112`), a single shared session can serve **all** credentials against a given endpoint — one connection pool, not one-per-keypair.

## Caller pattern (out of scope here, for downstream)

Callers own the pool lifecycle. Recommended: one shared session **per event loop** (keyed by the running loop) so sessions created under `async_to_sync` are never used across loops, then pass it as `session=` and drop the per-call `registry.close()`; close the pool on worker shutdown.

## Tests

- `close()` closes an owned session but leaves an injected one open (auth + anon clients).
- `create(..., session=shared)` shares one session across both clients and preserves it across `registry.close()` (both registries).

## Checklist
- [x] News fragment (`changes/5820.enhance.md`)
- [x] `pants fmt/fix/lint/check/test` pass on changed files
- [ ] Draft — downstream per-loop pool wiring to follow separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12457.org.readthedocs.build/en/12457/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12457.org.readthedocs.build/ko/12457/

<!-- readthedocs-preview sorna-ko end -->