### PR TITLE
feat(BA-6648): make session scaling group name non-null

### DIFF
--- a/changes/12459.feature.md
+++ b/changes/12459.feature.md
@@ -1,0 +1,1 @@
+Make compute session scaling group names non-nullable by backfilling them from kernel scaling group data.

--- a/src/ai/backend/manager/models/alembic/versions/b4c5d6e7f8a9_make_session_scaling_group_name_non_nullable.py
+++ b/src/ai/backend/manager/models/alembic/versions/b4c5d6e7f8a9_make_session_scaling_group_name_non_nullable.py
@@ -1,0 +1,78 @@
+"""make session scaling_group_name non-nullable
+
+Revision ID: b4c5d6e7f8a9
+Revises: e3b8d2a1c5f7
+Create Date: 2026-07-01
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b4c5d6e7f8a9"
+down_revision = "e3b8d2a1c5f7"
+# Part of: 26.7.0
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text("""
+        WITH session_scaling_groups AS (
+          SELECT DISTINCT kernels.session_id, kernels.scaling_group
+          FROM kernels
+          WHERE kernels.scaling_group IS NOT NULL
+            AND NOT EXISTS (
+              SELECT 1
+              FROM kernels AS other_kernels
+              WHERE other_kernels.session_id = kernels.session_id
+                AND other_kernels.scaling_group IS NOT NULL
+                AND other_kernels.scaling_group <> kernels.scaling_group
+            )
+        )
+        UPDATE sessions
+        SET scaling_group_name = session_scaling_groups.scaling_group
+        FROM session_scaling_groups
+        WHERE sessions.id = session_scaling_groups.session_id
+          AND sessions.scaling_group_name IS NULL
+        """)
+    )
+    op.execute(
+        sa.text("""
+        DELETE FROM routings
+        USING sessions
+        WHERE routings.session = sessions.id
+          AND sessions.scaling_group_name IS NULL
+        """)
+    )
+    op.execute(
+        sa.text("""
+        DELETE FROM kernels
+        USING sessions
+        WHERE kernels.session_id = sessions.id
+          AND sessions.scaling_group_name IS NULL
+        """)
+    )
+    op.execute(
+        sa.text("""
+        DELETE FROM sessions
+        WHERE scaling_group_name IS NULL
+        """)
+    )
+    op.alter_column(
+        "sessions",
+        "scaling_group_name",
+        existing_type=sa.String(length=64),
+        nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "sessions",
+        "scaling_group_name",
+        existing_type=sa.String(length=64),
+        nullable=True,
+    )

--- a/src/ai/backend/manager/models/session/row.py
+++ b/src/ai/backend/manager/models/session/row.py
@@ -453,10 +453,10 @@ class SessionRow(Base):  # type: ignore[misc]
     kernels: Mapped[list[KernelRow]] = relationship("KernelRow", back_populates="session")
 
     # Resource ownership
-    scaling_group_name: Mapped[str | None] = mapped_column(
-        "scaling_group_name", sa.ForeignKey("scaling_groups.name"), index=True, nullable=True
+    scaling_group_name: Mapped[str] = mapped_column(
+        "scaling_group_name", sa.ForeignKey("scaling_groups.name"), index=True, nullable=False
     )
-    scaling_group: Mapped[ScalingGroupRow | None] = relationship(
+    scaling_group: Mapped[ScalingGroupRow] = relationship(
         "ScalingGroupRow", back_populates="sessions"
     )
     target_sgroup_names: Mapped[list[str] | None] = mapped_column(

--- a/tests/component/session/test_session_execution.py
+++ b/tests/component/session/test_session_execution.py
@@ -22,7 +22,6 @@ from ai.backend.common.dto.manager.session.response import (
 )
 from ai.backend.manager.models.kernel import kernels
 from ai.backend.manager.models.scaling_group import scaling_groups
-from ai.backend.manager.models.session.row import SessionRow
 
 from .conftest import SessionSeedData
 
@@ -732,26 +731,6 @@ class TestSessionStartServiceFailures:
             await admin_registry.session.start_service(
                 session_seed.session_name,
                 StartServiceRequest(app="ttyd", port=9999),
-            )
-
-    async def test_start_with_no_scaling_group(
-        self,
-        admin_registry: BackendAIClientRegistry,
-        session_seed: SessionSeedData,
-        db_engine: SAEngine,
-    ) -> None:
-        """F-BIZ-4: Session has no scaling_group → ServerError (ServiceUnavailable)."""
-        async with db_engine.begin() as conn:
-            await conn.execute(
-                sa.update(SessionRow.__table__)
-                .where(SessionRow.__table__.c.id == session_seed.session_id)
-                .values(scaling_group_name=None)
-            )
-
-        with pytest.raises(ServerError):
-            await admin_registry.session.start_service(
-                session_seed.session_name,
-                StartServiceRequest(app="ttyd"),
             )
 
     async def test_start_with_no_wsproxy_addr(


### PR DESCRIPTION
resolve #12458 (BA-6648)
## Summary
- Backfill sessions.scaling_group_name from kernels when all kernels in a session agree on one scaling group.
- Make sessions.scaling_group_name non-nullable.
- Update SessionRow typing/nullability and remove the component test case that created an impossible NULL scaling group state.

## Validation
- pants fmt --changed-since=HEAD~1
- pants fix --changed-since=HEAD~1
- pants lint --changed-since=HEAD~1
- pants check --changed-since=HEAD~1
- pants test --changed-since=HEAD~1
- pre-push hook on origin/main..HEAD

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12459.org.readthedocs.build/en/12459/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12459.org.readthedocs.build/ko/12459/

<!-- readthedocs-preview sorna-ko end -->