### PR TITLE
chore: pin federation versions to stop supergraph.graphql drift

### DIFF
--- a/changes/12462.misc.md
+++ b/changes/12462.misc.md
@@ -1,0 +1,1 @@
+Pin the GraphQL federation versions so `docs/manager/graphql-reference/supergraph.graphql` no longer drifts on CI regeneration: set `federation_version: "=2.14.0"` in `configs/graphql/supergraph.yaml` (rover's latest floating plugin `v2.15.0` reformats the SDL) and pin the graphene subgraph to `FederationVersion.VERSION_2_7` instead of `LATEST_VERSION`.

--- a/configs/graphql/supergraph.yaml
+++ b/configs/graphql/supergraph.yaml
@@ -13,6 +13,11 @@
 #   - configs/graphql/README.md
 #   - https://www.apollographql.com/docs/rover/commands/supergraphs
 
+# Pin the composition (supergraph) plugin version. Without this, `rover supergraph
+# compose` floats to the latest Federation 2 plugin; v2.15.0 changed the SDL printer
+# layout and rewrites the whole dump. 2.14.0 keeps the existing committed format.
+federation_version: "=2.14.0"
+
 subgraphs:
   # Legacy GraphQL API (Graphene-based)
   graphene:

--- a/src/ai/backend/manager/api/gql_legacy/schema.py
+++ b/src/ai/backend/manager/api/gql_legacy/schema.py
@@ -3456,5 +3456,7 @@ graphene_schema = graphene_federation.build_schema(
     query=Query,
     mutation=Mutation,
     auto_camelcase=False,
-    federation_version=graphene_federation.LATEST_VERSION,
+    # Pin the federation version so the emitted subgraph SDL (and thus the composed
+    # supergraph) stays stable; LATEST_VERSION floats as graphene_federation upgrades.
+    federation_version=graphene_federation.FederationVersion.VERSION_2_7,
 )


### PR DESCRIPTION
## Summary
Stop `docs/manager/graphql-reference/supergraph.graphql` from being rewritten on every CI regeneration. **No schema file changes** — only version pins.

## Problem
Two floating version sources rewrote the composed schema even when the GraphQL schema was unchanged:

1. **rover composition plugin** — `configs/graphql/supergraph.yaml` pinned no `federation_version`, so `rover supergraph compose` fetched the latest Federation 2 plugin. **v2.15.0 changed the SDL printer layout** (inline `@join__*` directives, no blank lines), rewriting ~5k lines with no semantic change.
2. **graphene subgraph** — declared `federation_version=graphene_federation.LATEST_VERSION`, which bumps as the library upgrades.

## Fix
| Pin | Location | Value |
|-----|----------|-------|
| Composition plugin | `configs/graphql/supergraph.yaml` | `federation_version: "=2.14.0"` |
| Graphene subgraph | `gql_legacy/schema.py` | `FederationVersion.VERSION_2_7` (was `LATEST_VERSION`) |

`2.14.0` is the newest composition plugin that preserves the currently committed format (v2.9.0–v2.14.0 all produce identical output; v2.15.0 is the first to reformat).

## Verification
- Tested plugin versions v2.9.0–v2.15.0 against `main`'s committed SDL: **v2.14.0 and below are byte-for-byte identical to `main`**; v2.15.0 reformats.
- With both pins, `rover supergraph compose` output is **byte-for-byte identical** to the committed `supergraph.graphql` — regeneration yields zero diff.
- `graphene_federation.LATEST_VERSION == FederationVersion.VERSION_2_7` today, so the emitted subgraph SDL is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12462.org.readthedocs.build/en/12462/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12462.org.readthedocs.build/ko/12462/

<!-- readthedocs-preview sorna-ko end -->