### PR TITLE
fix(BA-6651): run container registry rescan under READ COMMITTED to avoid serialization failures

### DIFF
--- a/changes/12464.fix.md
+++ b/changes/12464.fix.md
@@ -1,0 +1,1 @@
+Fix container registry rescan task failing with SerializationError (SQLSTATE 40001) by running the rescan upsert under READ COMMITTED instead of SERIALIZABLE isolation

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -181,7 +181,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
             log.info("No images found in registry {0}", self.registry_url)
         else:
             image_identifiers = [(k.canonical, k.architecture) for k in _all_updates.keys()]
-            async with self.db.begin_session() as session:
+            async with self.db.begin_session_read_committed() as session:
                 existing_images = await session.scalars(
                     sa.select(ImageRow).where(
                         sa.func.ROW(ImageRow.name, ImageRow.architecture).in_(image_identifiers),


### PR DESCRIPTION
## Problem

The container registry rescan task (`_rescan_task`) repeatedly fails with an unhandled asyncpg `SerializationError` (PostgreSQL SQLSTATE 40001), spamming the manager logs:

```
Task <id> (_rescan_task): unhandled error: (sqlalchemy.dialects.postgresql.asyncpg.Error)
<class 'asyncpg.exceptions.SerializationError'>: could not serialize access due to
read/write dependencies among transactions
DETAIL:  Reason code: Canceled on identification as a pivot, during conflict out checking.
HINT:  The transaction might succeed if retried.
[SQL: UPDATE images SET config_digest=$1::VARCHAR WHERE images.id = $2::UUID]
```

The whole rescan task aborts with no retry, and the error recurs continuously.

## Root cause

The rescan upsert in `container_registry/base.py` ran inside a session using the engine-default **SERIALIZABLE** isolation level. Concurrent rescans over overlapping image sets create read/write dependencies, and PostgreSQL cancels one transaction as a pivot (SQLSTATE 40001).

Rescan upserts are keyed by `(name, architecture)` and are idempotent, so they do not require serializable isolation.

## Fix

Run the rescan session under **READ COMMITTED** (the repository-layer standard) via `begin_session_read_committed()`.

## Related

- Jira: BA-6651

🤖 Generated with [Claude Code](https://claude.com/claude-code)