### PR TITLE
fix(BA-6653): register image CLI ORM tables needed for mapper initialization

### DIFF
--- a/changes/12468.fix.md
+++ b/changes/12468.fix.md
@@ -1,0 +1,1 @@
+Register the ORM cluster the image CLI needs so its commands (`list`, `inspect`, `forget`, `purge`, `set-resource-limit`, `rescan`, `alias`, `dealias`, `validate-*`) no longer fail with a SQLAlchemy mapper initialization error.

--- a/src/ai/backend/manager/cli/image_impl.py
+++ b/src/ai/backend/manager/cli/image_impl.py
@@ -27,7 +27,19 @@ from .context import CLIContext, redis_ctx
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
+def _register_image_cli_orm_cluster() -> None:
+    """Register ORM rows reachable only via string relationships so the CLI can configure mappers (kept minimal, not all models)."""
+    from ai.backend.manager.models.agent.row import AgentRow
+    from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+        AssociationScopesEntitiesRow,
+    )
+    from ai.backend.manager.models.scaling_group.row import ScalingGroupForProjectRow
+
+    _ = (AgentRow, AssociationScopesEntitiesRow, ScalingGroupForProjectRow)
+
+
 async def list_images(cli_ctx: CLIContext, short: bool, installed_only: bool) -> None:
+    _register_image_cli_orm_cluster()
     # Connect to postgreSQL DB
     bootstrap_config = await cli_ctx.get_bootstrap_config()
     async with (
@@ -80,6 +92,7 @@ async def list_images(cli_ctx: CLIContext, short: bool, installed_only: bool) ->
 
 
 async def inspect_image(cli_ctx: CLIContext, canonical_or_alias: str, architecture: str) -> None:
+    _register_image_cli_orm_cluster()
     bootstrap_config = await cli_ctx.get_bootstrap_config()
     async with (
         connect_database(bootstrap_config.db) as db,
@@ -101,6 +114,7 @@ async def inspect_image(cli_ctx: CLIContext, canonical_or_alias: str, architectu
 
 
 async def forget_image(cli_ctx: CLIContext, canonical_or_alias: str, architecture: str) -> None:
+    _register_image_cli_orm_cluster()
     bootstrap_config = await cli_ctx.get_bootstrap_config()
     async with (
         connect_database(bootstrap_config.db) as db,
@@ -124,6 +138,7 @@ async def forget_image(cli_ctx: CLIContext, canonical_or_alias: str, architectur
 async def purge_image(
     cli_ctx: CLIContext, canonical_or_alias: str, architecture: str, remove_from_registry: bool
 ) -> None:
+    _register_image_cli_orm_cluster()
     bootstrap_config = await cli_ctx.get_bootstrap_config()
     async with (
         connect_database(bootstrap_config.db) as db,
@@ -164,6 +179,7 @@ async def set_image_resource_limit(
     range_value: tuple[Decimal | None, Decimal | None],
     architecture: str,
 ) -> None:
+    _register_image_cli_orm_cluster()
     bootstrap_config = await cli_ctx.get_bootstrap_config()
     async with (
         connect_database(bootstrap_config.db) as db,
@@ -189,14 +205,7 @@ async def rescan_images(
 ) -> None:
     if not registry_or_image:
         raise click.BadArgumentUsage("Please specify a valid registry or full image name.")
-    # Import AssociationScopesEntitiesRow to register it with the ORM metadata.
-    # Without this, the CLI rescan path doesn't load this table via the normal
-    # server bootstrap, causing SA to skip it during ORM queries.
-    from ai.backend.manager.models.rbac_models.association_scopes_entities import (
-        AssociationScopesEntitiesRow,
-    )
-
-    _ = AssociationScopesEntitiesRow
+    _register_image_cli_orm_cluster()
     bootstrap_config = await cli_ctx.get_bootstrap_config()
     async with (
         connect_database(bootstrap_config.db) as db,
@@ -210,6 +219,7 @@ async def rescan_images(
 
 
 async def alias(cli_ctx: CLIContext, alias: str, target: str, architecture: str) -> None:
+    _register_image_cli_orm_cluster()
     bootstrap_config = await cli_ctx.get_bootstrap_config()
     async with (
         connect_database(bootstrap_config.db) as db,
@@ -230,6 +240,7 @@ async def alias(cli_ctx: CLIContext, alias: str, target: str, architecture: str)
 
 
 async def dealias(cli_ctx: CLIContext, alias: str) -> None:
+    _register_image_cli_orm_cluster()
     bootstrap_config = await cli_ctx.get_bootstrap_config()
     async with (
         connect_database(bootstrap_config.db) as db,
@@ -245,6 +256,7 @@ async def dealias(cli_ctx: CLIContext, alias: str) -> None:
 
 
 async def validate_image_alias(cli_ctx: CLIContext, alias: str) -> None:
+    _register_image_cli_orm_cluster()
     bootstrap_config = await cli_ctx.get_bootstrap_config()
     async with (
         connect_database(bootstrap_config.db) as db,
@@ -273,6 +285,7 @@ def _resolve_architecture(current: bool, architecture: str | None) -> str:
 async def validate_image_canonical(
     cli_ctx: CLIContext, canonical: str, current: bool, architecture: str | None = None
 ) -> None:
+    _register_image_cli_orm_cluster()
     bootstrap_config = await cli_ctx.get_bootstrap_config()
     async with (
         connect_database(bootstrap_config.db) as db,


### PR DESCRIPTION
Resolves #12466 (BA-6653)

## Summary
- The image CLI commands (`list`, `inspect`, `forget`, `purge`, `set-resource-limit`, `rescan`, `alias`, `dealias`, `validate-image-alias`, `validate-image-canonical`) do not go through the normal server bootstrap, so ORM `Row` classes referenced only via string-based relationships are never imported. SQLAlchemy then fails to configure its mappers on each command's first ORM query, e.g. `Mapper[GroupRow(groups)]` cannot locate `'ScalingGroupForProjectRow'`. This surfaced during `install-dev.sh` at the image registry scan step.
- Extends the earlier BA-5033 fix (#9946), which guarded only `rescan` with `AssociationScopesEntitiesRow`. A `GroupRow -> ScalingGroupForProjectRow` relationship now goes unresolved on this path, and it affects every image subcommand that issues an ORM query — not just `rescan`.
- Registers the minimal ORM cluster (`AgentRow`, `AssociationScopesEntitiesRow`, `ScalingGroupForProjectRow`) inside each command handler, following the existing `_ =`/ORM-cluster registration pattern (cf. #12453).

## Verification
Confirmed against the live CLI on the current tree (before the fix), all failing with the identical `ScalingGroupForProjectRow` mapper error:
- `mgr image list` -> fails at `ImageRow.list`
- `mgr image inspect <name> <arch>` -> fails
- `mgr image dealias <alias>` -> fails
- `mgr image validate-image-alias <alias>` -> fails

After the fix, `configure_mappers()` succeeds once a handler's cluster imports run before its first query.

## Why no 26.4 backport is needed
This is a **main-only regression introduced by the import-graph change in BA-6632** ("move image scanning out of the models layer into the image repository"), not a defect in the ORM relationship itself.

The same `GroupRow -> "ScalingGroupForProjectRow"` relationship exists on both branches, but `image_impl` reaches the image scan through different imports:

| Branch | rescan import in `image_impl` | Effect on mapper config |
| --- | --- | --- |
| **26.4** | `from ...models.image import rescan_images` | that chain transitively loads `scaling_group`, so `ScalingGroupForProjectRow` is registered before `GroupRow` is configured -> OK |
| **main** | `from ...repositories.image.db_source import ImageDBSource` | that chain no longer loads `scaling_group.row`, so `GroupRow` configuration cannot resolve the string target -> fails |

Verified on a live 26.4 environment (v26.4.6): `mgr image list` runs cleanly, `configure_mappers()` succeeds, and `GroupRow`'s `sgroup_for_groups_rows` relationship resolves. The bug does not reproduce there, so no backport to 26.4 is required.

## Notes
- Deliberately does **not** use `ensure_all_tables_registered()`. Measured cost of importing every model on this CLI path is ~0.2-0.3s of extra startup per invocation (register+configure roughly doubles), and it does not reduce fragility enough to justify that. The minimal set was determined empirically by iteratively resolving each unresolved relationship name until `configure_mappers()` succeeds.

## Test plan
- [x] Live CLI: the four commands above fail before the fix, succeed (past mapper init) after
- [x] `configure_mappers()` succeeds in a fresh process once the cluster imports run before the first query
- [x] Confirmed on live 26.4 (v26.4.6) that the bug does not reproduce -> no backport needed
- [x] `pants fmt` / `pants lint` / `pants check` pass on the changed file