### PR TITLE
fix(BA-6642): reject Harbor webhook when configured secret is missing or mismatched

### DIFF
--- a/changes/12480.fix.md
+++ b/changes/12480.fix.md
@@ -1,0 +1,1 @@
+Reject Harbor container registry webhook requests that omit or mismatch a configured authorization secret

--- a/src/ai/backend/manager/services/container_registry/service.py
+++ b/src/ai/backend/manager/services/container_registry/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import secrets
 from typing import TYPE_CHECKING, Final
 
 from ai.backend.logging import BraceStyleAdapter
@@ -207,10 +208,13 @@ class ContainerRegistryService:
                     ),
                 )
 
-            # Validate webhook authorization
-            if action.auth_header:
-                extra = registry_row.extra or {}
-                if extra.get("webhook_auth_header") != action.auth_header:
+            # Validate webhook authorization: if the registry configured a secret,
+            # the request MUST present a matching header (omitting it must fail).
+            expected_auth = (registry_row.extra or {}).get("webhook_auth_header")
+            if expected_auth:
+                if not action.auth_header or not secrets.compare_digest(
+                    action.auth_header, expected_auth
+                ):
                     raise ContainerRegistryWebhookAuthorizationFailed(
                         extra_msg=(
                             f"Unauthorized webhook request"

--- a/src/ai/backend/manager/services/container_registry/service.py
+++ b/src/ai/backend/manager/services/container_registry/service.py
@@ -213,7 +213,7 @@ class ContainerRegistryService:
             expected_auth = (registry_row.extra or {}).get("webhook_auth_header")
             if expected_auth:
                 if not action.auth_header or not secrets.compare_digest(
-                    action.auth_header, expected_auth
+                    action.auth_header.encode(), expected_auth.encode()
                 ):
                     raise ContainerRegistryWebhookAuthorizationFailed(
                         extra_msg=(

--- a/tests/unit/manager/services/container_registry/test_container_registry_service.py
+++ b/tests/unit/manager/services/container_registry/test_container_registry_service.py
@@ -956,6 +956,34 @@ class TestHandleHarborWebhook:
         with pytest.raises(ContainerRegistryWebhookAuthorizationFailed):
             await container_registry_service.handle_harbor_webhook(action)
 
+    async def test_missing_auth_header_raises_when_required(
+        self,
+        container_registry_service: ContainerRegistryService,
+        mock_container_registry_repository: MagicMock,
+        sample_registry_row: MagicMock,
+    ) -> None:
+        """Omitting the auth header must not bypass a configured secret."""
+        sample_registry_row.extra = {"webhook_auth_header": "Bearer correct-token"}
+        sample_registry_row.registry_name = "registry.example.com"
+        mock_container_registry_repository.get_registry_by_url_and_project = AsyncMock(
+            return_value=sample_registry_row
+        )
+
+        action = HandleHarborWebhookAction(
+            event_type="PUSH_ARTIFACT",
+            resources=[
+                HarborWebhookResourceInput(
+                    resource_url="registry.example.com/project/img", tag="latest"
+                )
+            ],
+            project="project",
+            img_name="img",
+            auth_header=None,
+        )
+
+        with pytest.raises(ContainerRegistryWebhookAuthorizationFailed):
+            await container_registry_service.handle_harbor_webhook(action)
+
     async def test_non_push_artifact_event_ignored(
         self,
         container_registry_service: ContainerRegistryService,

--- a/tests/unit/manager/services/container_registry/test_container_registry_service.py
+++ b/tests/unit/manager/services/container_registry/test_container_registry_service.py
@@ -984,6 +984,34 @@ class TestHandleHarborWebhook:
         with pytest.raises(ContainerRegistryWebhookAuthorizationFailed):
             await container_registry_service.handle_harbor_webhook(action)
 
+    async def test_non_ascii_auth_header_raises_authorization_failed(
+        self,
+        container_registry_service: ContainerRegistryService,
+        mock_container_registry_repository: MagicMock,
+        sample_registry_row: MagicMock,
+    ) -> None:
+        """A non-ASCII header must fail cleanly, not raise TypeError from compare_digest."""
+        sample_registry_row.extra = {"webhook_auth_header": "Bearer correct-token"}
+        sample_registry_row.registry_name = "registry.example.com"
+        mock_container_registry_repository.get_registry_by_url_and_project = AsyncMock(
+            return_value=sample_registry_row
+        )
+
+        action = HandleHarborWebhookAction(
+            event_type="PUSH_ARTIFACT",
+            resources=[
+                HarborWebhookResourceInput(
+                    resource_url="registry.example.com/project/img", tag="latest"
+                )
+            ],
+            project="project",
+            img_name="img",
+            auth_header="Bearer \x80\xff",
+        )
+
+        with pytest.raises(ContainerRegistryWebhookAuthorizationFailed):
+            await container_registry_service.handle_harbor_webhook(action)
+
     async def test_non_push_artifact_event_ignored(
         self,
         container_registry_service: ContainerRegistryService,


### PR DESCRIPTION
## Summary
- Harbor webhook authorization was only enforced when the request carried an `Authorization` header. A registry with a configured `webhook_auth_header` secret could be bypassed simply by **omitting** the header, letting an unauthenticated request reach the `PUSH_ARTIFACT` scan path.
- Validate against the registry's expected secret instead: if a secret is configured, a missing **or** mismatched header is rejected. Comparison uses `secrets.compare_digest` (constant-time).
- Registries with no configured secret keep the existing opt-in behavior (unchanged).

## Test plan
- [x] `test_missing_auth_header_raises_when_required` — configured secret + no header → `ContainerRegistryWebhookAuthorizationFailed`
- [x] Existing webhook tests still pass (valid auth, invalid auth, no-secret proceeds, non-PUSH ignored)
- [x] `pants test` / `lint` / `check` (mypy) on changed files

Resolves BA-6642