### PR TITLE
fix(BA-6646): recover sessions stuck in CREATING by re-sending idempotent create_kernel

### DIFF
--- a/changes/12481.fix.md
+++ b/changes/12481.fix.md
@@ -1,0 +1,1 @@
+Recover sessions stuck in `CREATING` due to a lost `KernelStarted` event by making the agent's `create_kernel` idempotent (re-emitting the event for an already-running kernel and skipping in-flight creations) and re-sending it from the periodic session-start sweep.

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2522,6 +2522,57 @@ class AbstractAgent[
             service.start_command = [*service.start_command, *extra_args]
         return models
 
+    async def _replay_kernel_started_event(
+        self,
+        kernel_obj: AbstractKernel,
+        kernel_config: KernelCreationConfig,
+    ) -> KernelCreationResult:
+        """
+        Rebuild the creation result of an already-running kernel and re-emit the
+        KernelStarted events, so that a manager which missed the original event
+        can still transition the kernel to RUNNING.
+        """
+        kernel_id = kernel_obj.kernel_id
+        session_id = kernel_obj.session_id
+        attached_devices = {}
+        for dev_name, device_alloc in kernel_obj.resource_spec.allocations.items():
+            computer_ctx = self.computers[dev_name]
+            attached_devices[dev_name] = await computer_ctx.instance.get_attached_devices(
+                device_alloc
+            )
+        kernel_creation_info: KernelCreationResult = {
+            "id": kernel_id,
+            "kernel_host": str(kernel_obj["kernel_host"]),
+            "repl_in_port": kernel_obj["repl_in_port"],
+            "repl_out_port": kernel_obj["repl_out_port"],
+            "stdin_port": kernel_obj["stdin_port"],  # legacy
+            "stdout_port": kernel_obj["stdout_port"],  # legacy
+            "service_ports": self.get_public_service_ports(kernel_obj.service_ports),
+            "container_id": kernel_obj["container_id"],
+            "resource_spec": attrs.asdict(kernel_obj.resource_spec),
+            "scaling_group": kernel_config["scaling_group"],
+            "agent_addr": kernel_config["agent_addr"],
+            "attached_devices": attached_devices,
+        }
+        replayed_creation_info = {
+            **kernel_creation_info,
+            "id": str(kernel_id),
+            "container_id": str(kernel_obj["container_id"]),
+        }
+        await self.anycast_and_broadcast_event(
+            KernelStartedAnycastEvent(
+                kernel_id,
+                session_id,
+                creation_info=replayed_creation_info,
+            ),
+            KernelStartedBroadcastEvent(
+                kernel_id,
+                session_id,
+                creation_info=replayed_creation_info,
+            ),
+        )
+        return kernel_creation_info
+
     async def create_kernel(
         self,
         ownership_data: KernelOwnershipData,
@@ -2531,18 +2582,47 @@ class AbstractAgent[
         *,
         restarting: bool = False,
         throttle_sema: asyncio.Semaphore | None = None,
-    ) -> KernelCreationResult:
+    ) -> KernelCreationResult | None:
         """
         Create a new kernel.
+
+        This method is idempotent for non-restarting calls so that the manager
+        may safely re-send ``create_kernels`` for sessions stuck in CREATING:
+
+        - If the kernel is already running, the KernelStarted events are
+          re-emitted (recovering a lost event) without creating a new container.
+        - If a creation is already in flight (or the kernel exists in the
+          registry but has not reached RUNNING yet), the call is skipped and
+          returns ``None``; the in-flight creation emits the events itself.
         """
         kernel_id = ownership_data.kernel_id
         session_id = ownership_data.session_id
+
+        if not restarting and kernel_id not in self._active_creates:
+            existing_kernel = self.kernel_registry.get(kernel_id)
+            if existing_kernel is not None:
+                if existing_kernel.state == KernelLifecycleStatus.RUNNING:
+                    log.info(
+                        "create_kernel(kernel:{}, session:{}) kernel is already running;"
+                        " re-emitting KernelStarted events",
+                        kernel_id,
+                        session_id,
+                    )
+                    return await self._replay_kernel_started_event(existing_kernel, kernel_config)
+                log.debug(
+                    "create_kernel(kernel:{}, session:{}) kernel already exists in the registry"
+                    " (state: {}); skipping duplicate creation",
+                    kernel_id,
+                    session_id,
+                    existing_kernel.state,
+                )
+                return None
 
         # Track kernel creation for health monitoring
         with self.track_create(kernel_id, session_id) as should_proceed:
             if not should_proceed:
                 log.debug("Kernel {} is already being created, skipping", kernel_id)
-                raise ResourceError("Kernel creation already in progress")
+                return None
 
             if throttle_sema is None:
                 # make a local semaphore

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -858,6 +858,10 @@ class AgentRPCServer(aobject):
             match result:
                 case BaseException():
                     errors.append(result)
+                case None:
+                    # Creation skipped: another creation for the kernel is
+                    # already in flight and will emit the lifecycle events.
+                    pass
                 case _:
                     raw_results.append({
                         "id": str(result["id"]),

--- a/src/ai/backend/manager/sokovan/scheduler/handlers/lifecycle/start_sessions.py
+++ b/src/ai/backend/manager/sokovan/scheduler/handlers/lifecycle/start_sessions.py
@@ -52,13 +52,27 @@ class StartSessionsLifecycleHandler(SessionLifecycleHandler):
 
     @classmethod
     def target_statuses(cls) -> list[SessionStatus]:
-        """Sessions in PREPARED state."""
-        return [SessionStatus.PREPARED]
+        """Sessions in PREPARED or CREATING state.
+
+        CREATING is included so the handler re-queries sessions that have
+        already started kernel creation and re-sends the idempotent
+        ``create_kernels`` RPC. This recovers sessions stuck in CREATING when
+        the KernelStarted event was lost in transit: the agent re-emits the
+        event for an already-running kernel and skips kernels whose creation
+        is still in flight, so no duplicate container is created.
+        """
+        return [SessionStatus.PREPARED, SessionStatus.CREATING]
 
     @classmethod
     def target_kernel_statuses(cls) -> list[KernelStatus] | None:
-        """Include sessions where kernels are in PREPARED status."""
-        return [KernelStatus.PREPARED]
+        """Include sessions with kernels in PREPARED or CREATING status.
+
+        CREATING is included so that a session stuck in CREATING whose
+        kernels have already advanced to CREATING (but whose KernelStarted
+        event was lost) is still picked up and has kernel creation
+        re-triggered.
+        """
+        return [KernelStatus.PREPARED, KernelStatus.CREATING]
 
     @classmethod
     def status_transitions(cls) -> StatusTransitions:

--- a/tests/unit/agent/test_create_kernel_idempotency.py
+++ b/tests/unit/agent/test_create_kernel_idempotency.py
@@ -1,0 +1,187 @@
+"""
+Tests for create_kernel idempotency (BA-6646).
+
+The manager re-sends ``create_kernels`` for sessions stuck in CREATING, so
+``AbstractAgent.create_kernel`` must not raise nor create a duplicate
+container when called again for the same kernel:
+
+- already-running kernel  -> re-emit KernelStarted events and return the
+  reconstructed creation info
+- kernel in the registry but not RUNNING yet -> skip (return None)
+- creation in flight (tracked by ``_active_creates``) -> skip (return None)
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+
+from ai.backend.agent.agent import AbstractAgent
+from ai.backend.agent.kernel import AbstractKernel
+from ai.backend.agent.resources import KernelResourceSpec
+from ai.backend.agent.types import KernelLifecycleStatus, KernelOwnershipData
+from ai.backend.common.events.event_types.kernel.anycast import KernelStartedAnycastEvent
+from ai.backend.common.events.event_types.kernel.broadcast import KernelStartedBroadcastEvent
+from ai.backend.common.types import (
+    AgentId,
+    ClusterInfo,
+    KernelCreationConfig,
+    KernelId,
+    ResourceSlot,
+    SessionId,
+)
+
+KERNEL_ID = KernelId(uuid.uuid4())
+SESSION_ID = SessionId(uuid.uuid4())
+AGENT_ID = AgentId("i-test")
+CONTAINER_ID = "c-0123456789abcdef"
+
+
+@pytest.fixture
+def ownership_data() -> KernelOwnershipData:
+    return KernelOwnershipData(KERNEL_ID, SESSION_ID, AGENT_ID)
+
+
+@pytest.fixture
+def kernel_config() -> KernelCreationConfig:
+    return cast(
+        KernelCreationConfig,
+        {
+            "scaling_group": "default",
+            "agent_addr": "tcp://127.0.0.1:6011",
+        },
+    )
+
+
+@pytest.fixture
+def running_kernel_obj() -> MagicMock:
+    kernel_obj = MagicMock(spec=AbstractKernel)
+    kernel_obj.state = KernelLifecycleStatus.RUNNING
+    kernel_obj.kernel_id = KERNEL_ID
+    kernel_obj.session_id = SESSION_ID
+    kernel_obj.resource_spec = KernelResourceSpec(
+        slots=ResourceSlot(),
+        allocations={},
+        scratch_disk_size=0,
+    )
+    kernel_obj.service_ports = []
+    data = {
+        "kernel_host": "127.0.0.1",
+        "repl_in_port": 2000,
+        "repl_out_port": 2001,
+        "stdin_port": 2002,
+        "stdout_port": 2003,
+        "container_id": CONTAINER_ID,
+    }
+    kernel_obj.__getitem__.side_effect = data.__getitem__
+    return kernel_obj
+
+
+@pytest.fixture
+def stub_agent() -> Mock:
+    """A stub standing in for an AbstractAgent instance.
+
+    The real ``create_kernel`` / ``track_create`` / ``_replay_kernel_started_event``
+    implementations are exercised unbound against this stub.
+    """
+    agent = Mock(spec=AbstractAgent)
+    agent._active_creates = {}
+    agent.kernel_registry = {}
+    agent.computers = {}
+    agent.get_public_service_ports = Mock(side_effect=lambda service_ports: service_ports)
+    agent.anycast_and_broadcast_event = AsyncMock()
+    agent.track_create = lambda kernel_id, session_id: AbstractAgent.track_create(
+        agent, kernel_id, session_id
+    )
+    agent._replay_kernel_started_event = (
+        lambda kernel_obj, kernel_config: AbstractAgent._replay_kernel_started_event(
+            agent, kernel_obj, kernel_config
+        )
+    )
+    return agent
+
+
+async def _call_create_kernel(
+    stub_agent: Mock,
+    ownership_data: KernelOwnershipData,
+    kernel_config: KernelCreationConfig,
+) -> Any:
+    return await AbstractAgent.create_kernel(
+        stub_agent,
+        ownership_data,
+        MagicMock(),  # kernel_image
+        kernel_config,
+        cast(ClusterInfo, {}),
+    )
+
+
+class TestCreateKernelIdempotency:
+    async def test_running_kernel_reemits_started_events(
+        self,
+        stub_agent: Mock,
+        running_kernel_obj: MagicMock,
+        ownership_data: KernelOwnershipData,
+        kernel_config: KernelCreationConfig,
+    ) -> None:
+        """A re-sent create for an already-running kernel re-emits the
+        KernelStarted events (recovering a lost event) and returns the
+        reconstructed creation info without creating a new container."""
+        stub_agent.kernel_registry[KERNEL_ID] = running_kernel_obj
+
+        result = await _call_create_kernel(stub_agent, ownership_data, kernel_config)
+
+        assert result is not None
+        assert result["id"] == KERNEL_ID
+        assert result["container_id"] == CONTAINER_ID
+        assert result["kernel_host"] == "127.0.0.1"
+        assert result["scaling_group"] == "default"
+        assert result["agent_addr"] == "tcp://127.0.0.1:6011"
+
+        stub_agent.anycast_and_broadcast_event.assert_awaited_once()
+        anycast_event, broadcast_event = stub_agent.anycast_and_broadcast_event.await_args.args
+        assert isinstance(anycast_event, KernelStartedAnycastEvent)
+        assert isinstance(broadcast_event, KernelStartedBroadcastEvent)
+        assert anycast_event.kernel_id == KERNEL_ID
+        assert anycast_event.session_id == SESSION_ID
+        assert anycast_event.creation_info["id"] == str(KERNEL_ID)
+        assert anycast_event.creation_info["container_id"] == CONTAINER_ID
+
+        # No creation was tracked; the call short-circuited.
+        assert KERNEL_ID not in stub_agent._active_creates
+
+    async def test_registered_but_not_running_kernel_is_skipped(
+        self,
+        stub_agent: Mock,
+        running_kernel_obj: MagicMock,
+        ownership_data: KernelOwnershipData,
+        kernel_config: KernelCreationConfig,
+    ) -> None:
+        """A kernel present in the registry but not RUNNING yet must not be
+        re-created nor have its events replayed."""
+        running_kernel_obj.state = KernelLifecycleStatus.PREPARING
+        stub_agent.kernel_registry[KERNEL_ID] = running_kernel_obj
+
+        result = await _call_create_kernel(stub_agent, ownership_data, kernel_config)
+
+        assert result is None
+        stub_agent.anycast_and_broadcast_event.assert_not_awaited()
+
+    async def test_inflight_creation_is_skipped_without_raising(
+        self,
+        stub_agent: Mock,
+        ownership_data: KernelOwnershipData,
+        kernel_config: KernelCreationConfig,
+    ) -> None:
+        """A re-sent create while another creation is in flight returns None
+        instead of raising, so the manager's periodic re-send is harmless."""
+        stub_agent._active_creates[KERNEL_ID] = Mock()
+
+        result = await _call_create_kernel(stub_agent, ownership_data, kernel_config)
+
+        assert result is None
+        stub_agent.anycast_and_broadcast_event.assert_not_awaited()
+        # The in-flight tracking entry must be left intact.
+        assert KERNEL_ID in stub_agent._active_creates

--- a/tests/unit/manager/sokovan/scheduler/handlers/test_lifecycle_handlers.py
+++ b/tests/unit/manager/sokovan/scheduler/handlers/test_lifecycle_handlers.py
@@ -17,6 +17,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ai.backend.manager.data.kernel.types import KernelStatus
+from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.data.sokovan import (
     SessionsForPullWithImages,
     SessionsForStartWithImages,
@@ -600,6 +602,23 @@ class TestStartSessionsLifecycleHandler:
         # Assert
         assert len(result.successes) == 1
         assert result.successes[0].session_id == prepared_session.session_info.identity.id
+
+    def test_target_statuses_include_creating_for_reconciliation(self) -> None:
+        """SC-ST-006: CREATING sessions/kernels are re-targeted.
+
+        Given: The handler's target status declarations
+        When: The periodic START sweep queries target sessions
+        Then: Sessions/kernels stuck in CREATING (lost KernelStarted event)
+              are re-picked so the idempotent create_kernels RPC is re-sent
+        """
+        assert StartSessionsLifecycleHandler.target_statuses() == [
+            SessionStatus.PREPARED,
+            SessionStatus.CREATING,
+        ]
+        assert StartSessionsLifecycleHandler.target_kernel_statuses() == [
+            KernelStatus.PREPARED,
+            KernelStatus.CREATING,
+        ]
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- A session could remain stuck in `CREATING` indefinitely when the `KernelStarted` gate event was lost in transit, since nothing re-queried the CREATING zone (same class of gap as BA-6645 / #12455 for PREPARING).
- Make the agent's `create_kernel` idempotent for non-restarting calls: if the kernel is already running, it re-emits the `KernelStarted` anycast/broadcast events (reconstructing the creation info from the kernel registry) instead of creating a duplicate container; if a creation is already in flight (or the kernel exists in the registry but has not reached RUNNING yet), the call is skipped and returns `None` instead of raising `ResourceError`.
- Include `CREATING` in `StartSessionsLifecycleHandler.target_statuses()` / `target_kernel_statuses()` so the periodic START sweep re-sends the now-idempotent `create_kernels` RPC for stuck sessions, recovering them without manual intervention.

Note: the Jira issue suggested a read-only reconciliation via `check_creating`/`check_running` RPCs. This PR instead re-sends `create_kernels` after making it idempotent, which reuses the original event path (including the full `creation_info` payload) and also covers the manager-side `WHERE status IN (PREPARED, CREATING)` guard for duplicate events.

## Test plan

- [x] `tests/unit/agent/test_create_kernel_idempotency.py`: re-emit for a RUNNING kernel, skip for a registered-but-not-running kernel, skip (no raise) for an in-flight creation
- [x] `test_lifecycle_handlers.py` SC-ST-006: `CREATING` included in the handler's target statuses
- [x] `pants fmt/fix/lint/check` and affected unit tests pass locally
- [ ] Live verification: kill the KernelStarted event delivery and confirm a CREATING-stuck session recovers within one sweep interval

Resolves BA-6646

🤖 Generated with [Claude Code](https://claude.com/claude-code)