### PR TITLE
fix(BA-6651): run container registry rescan under READ COMMITTED to avoid serialization failures (#12464)

### DIFF
--- a/changes/12464.fix.md
+++ b/changes/12464.fix.md
@@ -1,0 +1,1 @@
+Fix container registry rescan task failing with SerializationError (SQLSTATE 40001) by running the rescan upsert under READ COMMITTED instead of SERIALIZABLE isolation

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -181,7 +181,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
             log.info("No images found in registry {0}", self.registry_url)
         else:
             image_identifiers = [(k.canonical, k.architecture) for k in _all_updates.keys()]
-            async with self.db.begin_session() as session:
+            async with self.db.begin_session_read_committed() as session:
                 existing_images = await session.scalars(
                     sa.select(ImageRow).where(
                         sa.func.ROW(ImageRow.name, ImageRow.architecture).in_(image_identifiers),


### PR DESCRIPTION
This is an auto-generated backport PR of #12464 to the 26.4 release.