### PR TITLE
refactor(BA-6676): separate vfolder-mount resolution from spec-context fetch

### DIFF
--- a/changes/12495.enhance.md
+++ b/changes/12495.enhance.md
@@ -1,0 +1,1 @@
+Separate vfolder-mount resolution from the session spec-context fetch so scheduling callers that only need kernel resources can skip the storage-manager RPC.

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -1509,11 +1509,8 @@ class ScheduleDBSource:
     async def fetch_session_spec_contexts(
         self,
         draft: SessionSpecDraft,
-        *,
-        storage_manager: StorageSessionManager,
-        allowed_vfolder_types: list[str],
     ) -> SessionSpecContextFetch:
-        """Batch-fetch every DB read the draft-based preparer and validator
+        """Batch-fetch the DB reads the draft-based preparer and validator
         rules depend on, inside a single readonly transaction.
 
         Returns raw fetched data as :class:`SessionSpecContextFetch` — the
@@ -1613,7 +1610,6 @@ class ScheduleDBSource:
             )
 
             keypair_policy = None
-            resource_policy_dict: dict[str, Any] = {}
             if access_key is not None:
                 kp_row = (
                     await db_sess.scalars(
@@ -1624,50 +1620,6 @@ class ScheduleDBSource:
                 ).one_or_none()
                 if kp_row is not None and kp_row.resource_policy_row is not None:
                     keypair_policy = kp_row.resource_policy_row.to_dataclass()
-                    resource_policy_dict = {
-                        "allowed_vfolder_hosts": keypair_policy.allowed_vfolder_hosts,
-                    }
-
-            # Resolve mount requests per kernel group keyed by ``role``.
-            # Each group's request list resolves to a single
-            # ``VFolderMount`` tuple that every replica sharing the role
-            # copies verbatim. Task #33 (role-based mount override) can
-            # write distinct values per role without structural change.
-            vfolder_mounts_by_role: dict[str, tuple[VFolderMount, ...]] = {}
-            if domain_name is not None and user_uuid is not None:
-                user_scope_for_mounts = UserScope(
-                    domain_name=domain_name,
-                    group_id=project_id if project_id is not None else UUID(int=0),
-                    user_uuid=user_uuid,
-                    user_role="user",
-                )
-                for group in kernel_specs:
-                    per_group_requests: list[VFolderMountRequest] = []
-                    for entry in group.execution_spec.mounts:
-                        per_group_requests.append(
-                            VFolderMountRequest(
-                                ref=UUID(str(entry.vfolder_id)),
-                                dst_path=entry.mount_destination,
-                                options=VFolderMountOptions(
-                                    permission=entry.mount_perm,
-                                    subpath=entry.subpath,
-                                ),
-                            )
-                        )
-                    # Always resolve mounts even when the request list is
-                    # empty: ``prepare_vfolder_mounts`` injects dot-prefixed
-                    # auto-mount vfolders regardless of explicit requests, so
-                    # skipping here would silently drop them.
-                    vfolder_mounts_by_role[group.role] = tuple(
-                        await self._fetch_vfolder_mounts(
-                            db_sess,
-                            storage_manager,
-                            allowed_vfolder_types,
-                            user_scope_for_mounts,
-                            resource_policy_dict,
-                            per_group_requests,
-                        )
-                    )
 
             dotfile_bundle = DotfileBundle()
             if domain_name is not None and user_uuid is not None and access_key is not None:
@@ -1706,13 +1658,90 @@ class ScheduleDBSource:
             container_user_info=user_container,
             image_infos=image_infos,
             resource_group_allow_fractional=resource_group_allow_fractional,
-            vfolder_mounts_by_role=vfolder_mounts_by_role,
             dotfile_data=dotfile_bundle,
             active_session_count=active_session_count,
             keypair_resource_policy=keypair_policy,
             known_slot_types=known_slot_types,
             slot_type_policy=slot_type_policy,
         )
+
+    async def resolve_vfolder_mounts_by_role(
+        self,
+        draft: SessionSpecDraft,
+        *,
+        storage_manager: StorageSessionManager,
+        allowed_vfolder_types: list[str],
+    ) -> dict[str, tuple[VFolderMount, ...]]:
+        """Resolve each kernel group's vfolder mounts, keyed by ``role``.
+
+        Split out of :meth:`fetch_session_spec_contexts` because it is the only
+        part that needs the storage-manager RPC (and the etcd-sourced
+        ``allowed_vfolder_types``); kernel resource resolution does not depend on
+        it, so callers that only need slots/arch can skip this. Each group's
+        request list resolves to a single ``VFolderMount`` tuple that every
+        replica sharing the role copies verbatim.
+        """
+        user_uuid = draft.identity.user_uuid
+        domain_name = str(draft.scope.domain_name) if draft.scope.domain_name else None
+        project_id = draft.scope.project_id
+        access_key = draft.identity.access_key
+        kernel_specs = tuple(draft.options.kernel_groups or ())
+
+        vfolder_mounts_by_role: dict[str, tuple[VFolderMount, ...]] = {}
+        if domain_name is None or user_uuid is None:
+            return vfolder_mounts_by_role
+
+        async with self._begin_readonly_session_read_committed() as db_sess:
+            resource_policy_dict: dict[str, Any] = {}
+            if access_key is not None:
+                kp_row = (
+                    await db_sess.scalars(
+                        sa.select(KeyPairRow)
+                        .options(selectinload(KeyPairRow.resource_policy_row))
+                        .where(KeyPairRow.access_key == access_key)
+                    )
+                ).one_or_none()
+                if kp_row is not None and kp_row.resource_policy_row is not None:
+                    resource_policy_dict = {
+                        "allowed_vfolder_hosts": (
+                            kp_row.resource_policy_row.to_dataclass().allowed_vfolder_hosts
+                        ),
+                    }
+
+            user_scope_for_mounts = UserScope(
+                domain_name=domain_name,
+                group_id=project_id if project_id is not None else UUID(int=0),
+                user_uuid=user_uuid,
+                user_role="user",
+            )
+            for group in kernel_specs:
+                per_group_requests: list[VFolderMountRequest] = []
+                for entry in group.execution_spec.mounts:
+                    per_group_requests.append(
+                        VFolderMountRequest(
+                            ref=UUID(str(entry.vfolder_id)),
+                            dst_path=entry.mount_destination,
+                            options=VFolderMountOptions(
+                                permission=entry.mount_perm,
+                                subpath=entry.subpath,
+                            ),
+                        )
+                    )
+                # Always resolve mounts even when the request list is empty:
+                # ``prepare_vfolder_mounts`` injects dot-prefixed auto-mount
+                # vfolders regardless of explicit requests, so skipping here
+                # would silently drop them.
+                vfolder_mounts_by_role[group.role] = tuple(
+                    await self._fetch_vfolder_mounts(
+                        db_sess,
+                        storage_manager,
+                        allowed_vfolder_types,
+                        user_scope_for_mounts,
+                        resource_policy_dict,
+                        per_group_requests,
+                    )
+                )
+        return vfolder_mounts_by_role
 
     async def pick_default_resource_group(
         self,

--- a/src/ai/backend/manager/repositories/scheduler/repository.py
+++ b/src/ai/backend/manager/repositories/scheduler/repository.py
@@ -237,9 +237,6 @@ class SchedulerRepository:
     async def fetch_session_spec_contexts(
         self,
         draft: SessionSpecDraft,
-        *,
-        storage_manager: StorageSessionManager,
-        allowed_vfolder_types: list[str],
     ) -> SessionSpecContextFetch:
         """Batch-fetch raw data needed to assemble the draft-path
         preparation / validation contexts.
@@ -250,7 +247,22 @@ class SchedulerRepository:
         ``SessionSpecValidationContext`` pair — this split keeps the
         repository layer free of sokovan internals.
         """
-        return await self._db_source.fetch_session_spec_contexts(
+        return await self._db_source.fetch_session_spec_contexts(draft)
+
+    @scheduler_repository_resilience.apply()
+    async def resolve_vfolder_mounts_by_role(
+        self,
+        draft: SessionSpecDraft,
+        *,
+        storage_manager: StorageSessionManager,
+        allowed_vfolder_types: list[str],
+    ) -> dict[str, tuple[VFolderMount, ...]]:
+        """Resolve each kernel group's vfolder mounts, keyed by ``role``.
+
+        Separated from :meth:`fetch_session_spec_contexts` so callers that only
+        need kernel resource resolution can skip the storage-manager RPC.
+        """
+        return await self._db_source.resolve_vfolder_mounts_by_role(
             draft,
             storage_manager=storage_manager,
             allowed_vfolder_types=allowed_vfolder_types,

--- a/src/ai/backend/manager/repositories/scheduler/types/session_creation.py
+++ b/src/ai/backend/manager/repositories/scheduler/types/session_creation.py
@@ -9,7 +9,6 @@ from ai.backend.common.types import (
     SessionId,
     SlotName,
     SlotTypes,
-    VFolderMount,
 )
 from ai.backend.manager.data.dotfile.types import DotfileBundle
 from ai.backend.manager.data.resource.types import SlotTypePolicy
@@ -55,12 +54,6 @@ class SessionSpecContextFetch:
     container_user_info: ContainerUserInfo
     image_infos: dict[ImageID, ImageInfo]
     resource_group_allow_fractional: bool
-    # Resolved vfolder mounts keyed by ``KernelGroup.role``. Each value
-    # is the ``VFolderMount`` tuple the controller's batch fetch
-    # materialized for that group — identical replicas share one entry,
-    # and task #33 (role-based mount override) can write distinct values
-    # per role without structural changes.
-    vfolder_mounts_by_role: dict[str, tuple[VFolderMount, ...]]
     dotfile_data: DotfileBundle
     keypair_resource_policy: Any | None  # KeyPairResourcePolicyData
     known_slot_types: Mapping[SlotName, SlotTypes] = field(default_factory=dict)

--- a/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
@@ -146,21 +146,22 @@ class SchedulingController:
 
         Only input is the :class:`SessionSpecDraft` — request-envelope
         extras (sudo, model-definition overlay) ride on
-        ``draft.internal_data_extras``. Every validation-adjacent DB read
-        (image metadata, keypair policy, resource-group network,
-        container uid/gid, resolved vfolder mounts, dotfiles, active
-        session count) flows through
-        :meth:`SchedulerRepository.fetch_session_spec_contexts`.
+        ``draft.internal_data_extras``. Validation-adjacent DB reads (image
+        metadata, keypair policy, resource-group network, container uid/gid,
+        dotfiles, active session count) flow through
+        :meth:`SchedulerRepository.fetch_session_spec_contexts`; vfolder mounts
+        are resolved separately via
+        :meth:`SchedulerRepository.resolve_vfolder_mounts_by_role`.
 
         Flow:
 
-        1. Batch fetch — resolve prep / validation context bundles.
-        2. Preparer chain — draft → finalized ``SessionSpec``.
-        3. ``PRE_ENQUEUE_SESSION`` hook — rejected calls raise.
-        4. Validator chain — spec + context.
-        5. ``SchedulerRepository.enqueue_session_from_spec`` — writer tx.
-        6. Broadcast PENDING + ask the coordinator to schedule.
-        7. ``POST_ENQUEUE_SESSION`` hook notification.
+        1. Context fetch + vfolder-mount resolution + preparer chain →
+           finalized ``SessionSpec`` + validation context.
+        2. ``PRE_ENQUEUE_SESSION`` hook — rejected calls raise.
+        3. Validator chain — spec + context.
+        4. ``SchedulerRepository.enqueue_session_from_spec`` — writer tx.
+        5. Broadcast PENDING + ask the coordinator to schedule.
+        6. ``POST_ENQUEUE_SESSION`` hook notification.
         """
         rg_name = str(draft.scope.resource_group_name) if draft.scope.resource_group_name else ""
 
@@ -171,7 +172,14 @@ class SchedulingController:
         with self._metric_observer.measure_phase(
             "scheduling_controller", rg_name, "spec_fetch_contexts"
         ):
-            fetched = await self._repository.fetch_session_spec_contexts(
+            fetched = await self._repository.fetch_session_spec_contexts(draft)
+
+        # Vfolder mounts are resolved separately (storage-manager RPC / etcd),
+        # kept out of the context fetch so resource-only callers can skip them.
+        with self._metric_observer.measure_phase(
+            "scheduling_controller", rg_name, "vfolder_mount_resolution"
+        ):
+            vfolder_mounts_by_role = await self._repository.resolve_vfolder_mounts_by_role(
                 draft,
                 storage_manager=self._storage_manager,
                 allowed_vfolder_types=allowed_vfolder_types,
@@ -184,7 +192,7 @@ class SchedulingController:
             image_infos=fetched.image_infos,
             resource_group_allow_fractional=fetched.resource_group_allow_fractional,
             dotfile_data=fetched.dotfile_data,
-            vfolder_mounts_by_role=fetched.vfolder_mounts_by_role,
+            vfolder_mounts_by_role=vfolder_mounts_by_role,
         )
         val_ctx = SessionSpecValidationContext(
             keypair_resource_policy=fetched.keypair_resource_policy,

--- a/tests/unit/manager/repositories/scheduler/test_automount_vfolder_resolution.py
+++ b/tests/unit/manager/repositories/scheduler/test_automount_vfolder_resolution.py
@@ -1,8 +1,8 @@
 """Regression test for auto-mount (dot-prefixed) vfolder resolution.
 
-Exercised through ``SchedulerRepository.fetch_session_spec_contexts`` (the
-repository-layer entry point the scheduling controller calls) against a real
-test database.
+Exercised through ``SchedulerRepository.resolve_vfolder_mounts_by_role`` (the
+repository-layer entry point the scheduling controller calls for vfolder mount
+resolution) against a real test database.
 
 Reproduces the 26.4.4rc6 regression where the underlying db_source
 short-circuited a kernel group with no explicit mount requests::
@@ -294,8 +294,8 @@ class TestAutoMountVFolderResolution:
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> SchedulerRepository:
         """A real repository over the test DB. The cache client and config
-        provider are unused by ``fetch_session_spec_contexts`` (DB-only path),
-        so they are mocked.
+        provider are unused by ``resolve_vfolder_mounts_by_role``, so they are
+        mocked.
         """
         return SchedulerRepository(
             db_with_cleanup,
@@ -330,7 +330,7 @@ class TestAutoMountVFolderResolution:
             ),
         )
 
-        result = await scheduler_repository.fetch_session_spec_contexts(
+        result = await scheduler_repository.resolve_vfolder_mounts_by_role(
             draft,
             storage_manager=mock_storage_manager,
             allowed_vfolder_types=["user"],
@@ -338,11 +338,11 @@ class TestAutoMountVFolderResolution:
 
         # The "main" role must carry the auto-mount vfolder even though the
         # group requested no mounts explicitly.
-        assert "main" in result.vfolder_mounts_by_role
-        mounted_names = {mount.name for mount in result.vfolder_mounts_by_role["main"]}
+        assert "main" in result
+        mounted_names = {mount.name for mount in result["main"]}
         assert AUTOMOUNT_VFOLDER_NAME in mounted_names, (
             f"auto-mount vfolder {AUTOMOUNT_VFOLDER_NAME!r} must be resolved for a group "
             f"with no explicit mounts; got {mounted_names!r}"
         )
-        mounted_ids = {mount.vfid.folder_id for mount in result.vfolder_mounts_by_role["main"]}
+        mounted_ids = {mount.vfid.folder_id for mount in result["main"]}
         assert automount_vfolder_id in mounted_ids

--- a/tests/unit/manager/repositories/scheduler/test_owner_resource_group_access.py
+++ b/tests/unit/manager/repositories/scheduler/test_owner_resource_group_access.py
@@ -174,21 +174,13 @@ class TestOwnerOnlyResourceGroupForDelegation:
         ) as mock_query:
             if case.owner_has_access:
                 with pytest.raises(Exception) as exc_info:
-                    await db_source.fetch_session_spec_contexts(
-                        draft,
-                        storage_manager=AsyncMock(),
-                        allowed_vfolder_types=[],
-                    )
+                    await db_source.fetch_session_spec_contexts(draft)
                 assert not isinstance(exc_info.value, InvalidAPIParameters), (
                     f"RG access check must not raise when owner has access; got {exc_info.value!r}"
                 )
             else:
                 with pytest.raises(InvalidAPIParameters, match=RG_NAME):
-                    await db_source.fetch_session_spec_contexts(
-                        draft,
-                        storage_manager=AsyncMock(),
-                        allowed_vfolder_types=[],
-                    )
+                    await db_source.fetch_session_spec_contexts(draft)
 
         # Lookup MUST be scoped to the spec identity's access key — not
         # the requester's. This is the core invariant.

--- a/tests/unit/manager/sokovan/scheduling_controller/test_enqueue_session_from_draft.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/test_enqueue_session_from_draft.py
@@ -207,7 +207,6 @@ def _fetch_bundle(image_id: ImageID) -> SessionSpecContextFetch:
         container_user_info=ContainerUserInfo(uid=1000, main_gid=1000, supplementary_gids=[]),
         image_infos={image_id: _image_info(image_id)},
         resource_group_allow_fractional=False,
-        vfolder_mounts_by_role={"main": (_vfolder_mount(),)},
         dotfile_data=DotfileBundle(),
         keypair_resource_policy=_keypair_policy(),
         known_slot_types={
@@ -274,6 +273,7 @@ class TestEnqueueSessionFromDraft:
 
         repository = AsyncMock()
         repository.fetch_session_spec_contexts.return_value = _fetch_bundle(image_id)
+        repository.resolve_vfolder_mounts_by_role.return_value = {"main": (_vfolder_mount(),)}
         repository.enqueue_session_from_spec.return_value = expected_session_id
         repository.mark_scheduling_needed = AsyncMock()
 
@@ -286,11 +286,15 @@ class TestEnqueueSessionFromDraft:
 
         assert returned_id == expected_session_id
 
-        # Repository fetch got the draft + config-sourced knobs
+        # Repository fetch got the draft
         repository.fetch_session_spec_contexts.assert_awaited_once()
-        call_kwargs = repository.fetch_session_spec_contexts.await_args.kwargs
-        assert call_kwargs["allowed_vfolder_types"] == ["user"]
         assert repository.fetch_session_spec_contexts.await_args.args[0] is draft
+
+        # Vfolder mounts resolved separately with the config-sourced knob
+        repository.resolve_vfolder_mounts_by_role.assert_awaited_once()
+        vfolder_call_kwargs = repository.resolve_vfolder_mounts_by_role.await_args.kwargs
+        assert vfolder_call_kwargs["allowed_vfolder_types"] == ["user"]
+        assert repository.resolve_vfolder_mounts_by_role.await_args.args[0] is draft
 
         # enqueue_session_from_spec got the finalized SessionSpec
         repository.enqueue_session_from_spec.assert_awaited_once()
@@ -324,6 +328,7 @@ class TestEnqueueSessionFromDraft:
     ) -> None:
         repository = AsyncMock()
         repository.fetch_session_spec_contexts.return_value = _fetch_bundle(image_id)
+        repository.resolve_vfolder_mounts_by_role.return_value = {"main": (_vfolder_mount(),)}
         repository.enqueue_session_from_spec = AsyncMock()
 
         controller, _event_producer, _hook_plugin_ctx = _build_controller(
@@ -345,6 +350,7 @@ class TestEnqueueSessionFromDraft:
     ) -> None:
         repository = AsyncMock()
         repository.fetch_session_spec_contexts.return_value = _fetch_bundle(image_id)
+        repository.resolve_vfolder_mounts_by_role.return_value = {"main": (_vfolder_mount(),)}
         repository.enqueue_session_from_spec.return_value = SessionID(uuid.uuid4())
         repository.mark_scheduling_needed = AsyncMock()
 


### PR DESCRIPTION
## Summary
- Split vfolder-mount resolution out of `SchedulerRepository.fetch_session_spec_contexts` into a dedicated `resolve_vfolder_mounts_by_role` method.
- `SessionSpecContextFetch` no longer carries `vfolder_mounts_by_role`; the fetch signature drops the vfolder-only `storage_manager` / `allowed_vfolder_types` args.
- The enqueue path resolves vfolder mounts in a separate call and merges the result into the preparation context — behavior preserved.
- Lets resource-only callers (e.g. a scheduler dry-run) run the preparer chain without the storage-manager RPC and etcd vfolder-types lookup (the slowest part of the fetch).

## Test plan
- [x] `pants fmt/fix/lint/check`
- [x] `test_enqueue_session_from_draft`, `test_automount_vfolder_resolution`, `test_owner_resource_group_access`

Resolves BA-6676