### PR TITLE
feat(BA-6655): add dry-run schedule action and value types

### DIFF
--- a/changes/12496.feature.md
+++ b/changes/12496.feature.md
@@ -1,0 +1,1 @@
+Add scheduler dry-run schedule action and value types.

--- a/src/ai/backend/manager/api/adapter_options/session/options.py
+++ b/src/ai/backend/manager/api/adapter_options/session/options.py
@@ -59,6 +59,7 @@ from ai.backend.manager.data.session.options import (
     FailurePolicy,
     HandlerOptions,
     KernelExecutionSpec,
+    KernelResourceConfig,
     ResourceOpts,
     SessionHandlerOptions,
 )
@@ -223,9 +224,11 @@ def _kernel_execution_spec_from_input(
     if input.resources is None:
         raise InvalidAPIParameters("default_kernel_execution_spec.resources is required when set")
     return KernelExecutionSpec(
-        image_id=ImageID(input.image_id),
-        resources=_resource_entry_list_from_input(input.resources),
-        resource_opts=_resource_opts_from_input(input.resource_opts),
+        resource_input=KernelResourceConfig(
+            image_id=ImageID(input.image_id),
+            resources=_resource_entry_list_from_input(input.resources),
+            resource_opts=_resource_opts_from_input(input.resource_opts),
+        ),
         environ=dict(input.environ or {}),
         mounts=_mount_items_to_entries(input.mounts or ()),
         startup_command=input.startup_command,
@@ -239,15 +242,15 @@ def _kernel_execution_spec_to_info(
     spec: KernelExecutionSpec,
 ) -> KernelExecutionSpecInfo:
     return KernelExecutionSpecInfo(
-        image_id=spec.image_id,
+        image_id=spec.resource_input.image_id,
         resources=[
             ResourceSlotEntryInfo(
                 resource_type=entry.resource_type,
                 quantity=Decimal(entry.quantity),
             )
-            for entry in spec.resources
+            for entry in spec.resource_input.resources
         ],
-        resource_opts=_resource_opts_to_info(spec.resource_opts),
+        resource_opts=_resource_opts_to_info(spec.resource_input.resource_opts),
         environ=dict(spec.environ),
         startup_command=spec.startup_command,
         bootstrap_script=spec.bootstrap_script,

--- a/src/ai/backend/manager/data/session/draft.py
+++ b/src/ai/backend/manager/data/session/draft.py
@@ -77,17 +77,7 @@ class _DraftBaseModel(BackendAISchema):
 class KernelResourceDraft(_DraftBaseModel):
     """Minimal per-kernel resource inputs for requested-slots resolution.
 
-    The subset of ``KernelExecutionSpecDraft`` that slot computation reads: the
-    image (min slots / shmem label / architecture), the caller's partial
-    resource request, and the shmem override. Factored out so slot resolution
-    can consume a kernel's resource view without the execution-only fields
-    (environ, mounts, commands, timeouts). ``KernelExecutionSpecDraft`` extends
-    this, so ``KernelSpecDraft.execution_spec`` is usable directly as a
-    ``KernelResourceDraft``.
-
-    ``image_id`` may be ``None`` when a resource-group default supplies it
-    downstream; zero / absent ``resources`` entries are filled from the image
-    minimums during computation.
+    ``image_id`` may be ``None`` when a resource-group default supplies it downstream.
     """
 
     image_id: ImageID | None = None

--- a/src/ai/backend/manager/data/session/draft.py
+++ b/src/ai/backend/manager/data/session/draft.py
@@ -74,12 +74,30 @@ class _DraftBaseModel(BackendAISchema):
     model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
 
 
-class KernelExecutionSpecDraft(_DraftBaseModel):
-    """Optional-heavy mirror of ``KernelExecutionSpec``."""
+class KernelResourceDraft(_DraftBaseModel):
+    """Minimal per-kernel resource inputs for requested-slots resolution.
+
+    The subset of ``KernelExecutionSpecDraft`` that slot computation reads: the
+    image (min slots / shmem label / architecture), the caller's partial
+    resource request, and the shmem override. Factored out so slot resolution
+    can consume a kernel's resource view without the execution-only fields
+    (environ, mounts, commands, timeouts). ``KernelExecutionSpecDraft`` extends
+    this, so ``KernelSpecDraft.execution_spec`` is usable directly as a
+    ``KernelResourceDraft``.
+
+    ``image_id`` may be ``None`` when a resource-group default supplies it
+    downstream; zero / absent ``resources`` entries are filled from the image
+    minimums during computation.
+    """
 
     image_id: ImageID | None = None
     resources: tuple[ResourceSlotEntry, ...] = ()
     resource_opts: ResourceOpts | None = None
+
+
+class KernelExecutionSpecDraft(KernelResourceDraft):
+    """Optional-heavy mirror of ``KernelExecutionSpec``."""
+
     environ: Mapping[str, str] = Field(default_factory=dict)
     mounts: tuple[MountInfoEntry, ...] = ()
     startup_command: str | None = None

--- a/src/ai/backend/manager/data/session/draft.py
+++ b/src/ai/backend/manager/data/session/draft.py
@@ -74,10 +74,11 @@ class _DraftBaseModel(BackendAISchema):
     model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
 
 
-class KernelResourceDraft(_DraftBaseModel):
+class KernelResourceInput(_DraftBaseModel):
     """Minimal per-kernel resource inputs for requested-slots resolution.
 
-    ``image_id`` may be ``None`` when a resource-group default supplies it downstream.
+    A standalone input consumed by the scheduler dry-run; ``image_id`` may be
+    ``None`` when a resource-group default supplies it downstream.
     """
 
     image_id: ImageID | None = None
@@ -85,9 +86,14 @@ class KernelResourceDraft(_DraftBaseModel):
     resource_opts: ResourceOpts | None = None
 
 
-class KernelExecutionSpecDraft(KernelResourceDraft):
-    """Optional-heavy mirror of ``KernelExecutionSpec``."""
+class KernelExecutionSpecDraft(_DraftBaseModel):
+    """Optional-heavy mirror of ``KernelExecutionSpec``.
 
+    ``resource_input`` groups the slot-resolution inputs (image + resource
+    slots) shared with the scheduler dry-run.
+    """
+
+    resource_input: KernelResourceInput = Field(default_factory=KernelResourceInput)
     environ: Mapping[str, str] = Field(default_factory=dict)
     mounts: tuple[MountInfoEntry, ...] = ()
     startup_command: str | None = None

--- a/src/ai/backend/manager/data/session/dry_run.py
+++ b/src/ai/backend/manager/data/session/dry_run.py
@@ -2,22 +2,18 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from ai.backend.common.types import AgentId, KernelId, ResourceSlot
+from ai.backend.common.types import AgentId, KernelId, ResourceSlotEntry
 from ai.backend.manager.data.session.draft import KernelResourceDraft
 
 
 @dataclass(frozen=True)
 class KernelDryRunSpec:
-    """Per-kernel request for a scheduler dry-run.
+    """Per-kernel request for a scheduler dry-run (one spec = one kernel).
 
-    One spec corresponds to exactly one kernel; kernel count is not aggregated.
     ``kernel_id`` is a caller-supplied correlation handle (a dry-run does not
-    enqueue, so there is no persisted ``KernelRow.id``); it matches the input
-    spec to its result through the selector's ``kernel_ids``.
-    ``resource`` carries the request in its pre-resolution form (image + partial
-    slots + shmem); the service resolves it to the selector's requested_slots
-    and architecture from image minimums and resource-group defaults, so a
-    dry-run reflects what a real enqueue would actually schedule.
+    enqueue, so there is no persisted ``KernelRow.id``) used to match the result.
+    ``resource`` is the pre-resolution request; the service resolves it to the
+    selector's requested_slots and architecture.
     """
 
     kernel_id: KernelId
@@ -28,21 +24,15 @@ class KernelDryRunSpec:
 class KernelDryRunRemediation:
     """What the caller could change so an unschedulable kernel would fit.
 
-    Data-layer mirror of the scheduler selector's ``RemediationHint`` (mirrored
-    here rather than imported, so the data layer stays free of a sokovan
-    dependency and can be converted to a DTO). There is no discriminator: any
-    subset of fields may be populated, and each non-None field is an
-    independently actionable remediation.
+    Data-layer mirror of the selector's ``RemediationHint``.
 
-    - ``required_reduction`` — subtract these slots to fit the best-fitting node,
-      i.e. the candidate node needing the smallest reduction, compared as whole
-      deficit vectors (NOT a per-slot min across different nodes).
-    - ``required_container_reduction`` — free this many containers to admit the kernel.
-    - ``available_archs`` — architectures that actually exist (change the request arch).
-    - ``available_agent_ids`` — agents that are actually available (revise designation).
+    - ``required_reduction`` — subtract these slots to fit the best-fitting node.
+    - ``required_container_reduction`` — free this many containers.
+    - ``available_archs`` — architectures that actually exist.
+    - ``available_agent_ids`` — agents that are actually available.
     """
 
-    required_reduction: ResourceSlot | None = None
+    required_reduction: tuple[ResourceSlotEntry, ...] | None = None
     required_container_reduction: int | None = None
     available_archs: list[str] | None = None
     available_agent_ids: list[AgentId] | None = None
@@ -58,7 +48,7 @@ class KernelDryRunResult:
     """
 
     spec: KernelDryRunSpec
-    resolved_slots: ResourceSlot
+    resolved_slots: tuple[ResourceSlotEntry, ...]
     resolved_architecture: str
     schedulable: bool
     remediation: KernelDryRunRemediation | None = None

--- a/src/ai/backend/manager/data/session/dry_run.py
+++ b/src/ai/backend/manager/data/session/dry_run.py
@@ -2,22 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from ai.backend.common.types import KernelId, ResourceSlotEntry
-from ai.backend.manager.data.session.draft import KernelResourceDraft
-
-
-@dataclass(frozen=True)
-class KernelDryRunSpec:
-    """Per-kernel request for a scheduler dry-run (one spec = one kernel).
-
-    ``kernel_id`` is a caller-supplied correlation handle (a dry-run does not
-    enqueue, so there is no persisted ``KernelRow.id``) used to match the result.
-    ``resource`` is the pre-resolution request; the service resolves it to the
-    selector's requested_slots and architecture.
-    """
-
-    kernel_id: KernelId
-    resource: KernelResourceDraft
+from ai.backend.common.types import ResourceSlotEntry
 
 
 @dataclass(frozen=True)
@@ -41,12 +26,15 @@ class UnschedulableReasonHint:
 class KernelDryRunResult:
     """Dry-run outcome for a single kernel.
 
+    Results correspond positionally to the requested kernels: the caller
+    matches each result to its input by list index, so no correlation handle
+    is carried here.
+
     ``remediation`` is populated only when ``schedulable`` is False; it
     describes what to change so the kernel would fit on one of the
     scheduling-target nodes.
     """
 
-    spec: KernelDryRunSpec
     resolved_slots: tuple[ResourceSlotEntry, ...]
     resolved_architecture: str
     schedulable: bool

--- a/src/ai/backend/manager/data/session/dry_run.py
+++ b/src/ai/backend/manager/data/session/dry_run.py
@@ -30,12 +30,12 @@ class KernelDryRunResult:
     matches each result to its input by list index, so no correlation handle
     is carried here.
 
-    ``remediation`` is populated only when ``schedulable`` is False; it
+    ``reason_hint`` is populated only when ``success`` is False; it
     describes what to change so the kernel would fit on one of the
     scheduling-target nodes.
     """
 
-    resolved_slots: tuple[ResourceSlotEntry, ...]
-    resolved_architecture: str
-    schedulable: bool
-    remediation: UnschedulableReasonHint | None = None
+    requested_slots: tuple[ResourceSlotEntry, ...]
+    requested_architecture: str
+    success: bool
+    reason_hint: UnschedulableReasonHint | None = None

--- a/src/ai/backend/manager/data/session/dry_run.py
+++ b/src/ai/backend/manager/data/session/dry_run.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from ai.backend.common.types import AgentId, KernelId, ResourceSlotEntry
+from ai.backend.common.types import KernelId, ResourceSlotEntry
 from ai.backend.manager.data.session.draft import KernelResourceDraft
 
 
@@ -21,21 +21,20 @@ class KernelDryRunSpec:
 
 
 @dataclass(frozen=True)
-class KernelDryRunRemediation:
+class UnschedulableReasonHint:
     """What the caller could change so an unschedulable kernel would fit.
 
-    Data-layer mirror of the selector's ``RemediationHint``.
+    Surfaces only the user-actionable subset of the selector's
+    ``RemediationHint``.
 
     - ``required_reduction`` — subtract these slots to fit the best-fitting node.
     - ``required_container_reduction`` — free this many containers.
     - ``available_archs`` — architectures that actually exist.
-    - ``available_agent_ids`` — agents that are actually available.
     """
 
     required_reduction: tuple[ResourceSlotEntry, ...] | None = None
     required_container_reduction: int | None = None
     available_archs: list[str] | None = None
-    available_agent_ids: list[AgentId] | None = None
 
 
 @dataclass(frozen=True)
@@ -51,4 +50,4 @@ class KernelDryRunResult:
     resolved_slots: tuple[ResourceSlotEntry, ...]
     resolved_architecture: str
     schedulable: bool
-    remediation: KernelDryRunRemediation | None = None
+    remediation: UnschedulableReasonHint | None = None

--- a/src/ai/backend/manager/data/session/dry_run.py
+++ b/src/ai/backend/manager/data/session/dry_run.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ai.backend.common.types import AgentId, KernelId, ResourceSlot
+from ai.backend.manager.data.session.draft import KernelResourceDraft
+
+
+@dataclass(frozen=True)
+class KernelDryRunSpec:
+    """Per-kernel request for a scheduler dry-run.
+
+    One spec corresponds to exactly one kernel; kernel count is not aggregated.
+    ``kernel_id`` is a caller-supplied correlation handle (a dry-run does not
+    enqueue, so there is no persisted ``KernelRow.id``); it matches the input
+    spec to its result through the selector's ``kernel_ids``.
+    ``resource`` carries the request in its pre-resolution form (image + partial
+    slots + shmem); the service resolves it to the selector's requested_slots
+    and architecture from image minimums and resource-group defaults, so a
+    dry-run reflects what a real enqueue would actually schedule.
+    """
+
+    kernel_id: KernelId
+    resource: KernelResourceDraft
+
+
+@dataclass(frozen=True)
+class KernelDryRunRemediation:
+    """What the caller could change so an unschedulable kernel would fit.
+
+    Data-layer mirror of the scheduler selector's ``RemediationHint`` (mirrored
+    here rather than imported, so the data layer stays free of a sokovan
+    dependency and can be converted to a DTO). There is no discriminator: any
+    subset of fields may be populated, and each non-None field is an
+    independently actionable remediation.
+
+    - ``required_reduction`` — subtract these slots to fit the best-fitting node,
+      i.e. the candidate node needing the smallest reduction, compared as whole
+      deficit vectors (NOT a per-slot min across different nodes).
+    - ``required_container_reduction`` — free this many containers to admit the kernel.
+    - ``available_archs`` — architectures that actually exist (change the request arch).
+    - ``available_agent_ids`` — agents that are actually available (revise designation).
+    """
+
+    required_reduction: ResourceSlot | None = None
+    required_container_reduction: int | None = None
+    available_archs: list[str] | None = None
+    available_agent_ids: list[AgentId] | None = None
+
+
+@dataclass(frozen=True)
+class KernelDryRunResult:
+    """Dry-run outcome for a single kernel.
+
+    ``remediation`` is populated only when ``schedulable`` is False; it
+    describes what to change so the kernel would fit on one of the
+    scheduling-target nodes.
+    """
+
+    spec: KernelDryRunSpec
+    resolved_slots: ResourceSlot
+    resolved_architecture: str
+    schedulable: bool
+    remediation: KernelDryRunRemediation | None = None

--- a/src/ai/backend/manager/data/session/options.py
+++ b/src/ai/backend/manager/data/session/options.py
@@ -259,15 +259,11 @@ class SchedulingTarget(_OptionsBaseModel):
     )
 
 
-class KernelExecutionSpec(_OptionsBaseModel):
-    """Per-kernel execution spec.
+class KernelResourceConfig(_OptionsBaseModel):
+    """Resolved per-kernel resource inputs (image + slots).
 
-    Used both as the shared baseline in
-    ``DefaultSessionOptions.default_kernel_execution_spec`` (merged
-    into every group unless overridden) and as the per-group override on
-    ``KernelGroup.execution_spec``. All fields are resolved; ``None`` on the
-    optional fields carries real meaning (for example ``starts_at=None``
-    = "start immediately on schedule").
+    The resolved counterpart of the draft's ``KernelResourceInput``; grouped as
+    a single field so the same shape is shared with the scheduler dry-run.
     """
 
     image_id: ImageID = Field(
@@ -288,6 +284,22 @@ class KernelExecutionSpec(_OptionsBaseModel):
     resource_opts: ResourceOpts = Field(
         default_factory=ResourceOpts,
         description="Qualitative resource hints such as shared memory.",
+    )
+
+
+class KernelExecutionSpec(_OptionsBaseModel):
+    """Per-kernel execution spec.
+
+    Used both as the shared baseline in
+    ``DefaultSessionOptions.default_kernel_execution_spec`` (merged
+    into every group unless overridden) and as the per-group override on
+    ``KernelGroup.execution_spec``. All fields are resolved; ``None`` on the
+    optional fields carries real meaning (for example ``starts_at=None``
+    = "start immediately on schedule").
+    """
+
+    resource_input: KernelResourceConfig = Field(
+        description="Resolved image + resource-slot inputs for this kernel.",
     )
     environ: Mapping[str, str] = Field(
         default_factory=dict,

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -109,6 +109,7 @@ from ai.backend.manager.data.model_serving.types import EndpointData
 from ai.backend.manager.data.session.draft import (
     KernelExecutionSpecDraft,
     KernelGroupDraft,
+    KernelResourceInput,
     SchedulingTargetDraft,
     SessionClassificationDraft,
     SessionIdentityDraft,
@@ -1068,9 +1069,11 @@ class AgentRegistry:
             kernel: KernelEnqueueingConfig,
         ) -> KernelExecutionSpecDraft:
             return KernelExecutionSpecDraft(
-                image_id=image_id_by_ref[kernel["image_ref"]],
-                resources=resource_entries,
-                resource_opts=resource_opts,
+                resource_input=KernelResourceInput(
+                    image_id=image_id_by_ref[kernel["image_ref"]],
+                    resources=resource_entries,
+                    resource_opts=resource_opts,
+                ),
                 environ=environ_dict,
                 mounts=mount_entries,
                 startup_command=kernel.get("startup_command") or startup_command,

--- a/src/ai/backend/manager/repositories/scheduler/creators.py
+++ b/src/ai/backend/manager/repositories/scheduler/creators.py
@@ -68,9 +68,11 @@ class KernelRowFromSpec(CreatorSpec[KernelRow]):
         execution = self.kernel_spec.execution_spec
         image_info = self.image_info
         environ_payload = [f"{k}={v}" for k, v in (execution.environ or {}).items()]
-        resource_opts_payload = execution.resource_opts.model_dump(exclude_none=True)
+        resource_opts_payload = execution.resource_input.resource_opts.model_dump(exclude_none=True)
         resolved_mounts = list(self.kernel_spec.vfolder_mounts)
-        requested_slots = ResourceSlotEntry.inputs_to_resource_slot(execution.resources)
+        requested_slots = ResourceSlotEntry.inputs_to_resource_slot(
+            execution.resource_input.resources
+        )
 
         return KernelRow(
             session_id=self.spec.identity.session_id,
@@ -152,7 +154,7 @@ class SessionRowFromSpec(CreatorSpec[SessionRow]):
         session_image_ids: list[UUID] = []
         requested_slots = ResourceSlot()
         for kernel in kernel_specs:
-            image_id = kernel.execution_spec.image_id
+            image_id = kernel.execution_spec.resource_input.image_id
             image_info = self.image_infos.get(image_id) if image_id is not None else None
             if image_info is not None:
                 session_image_ids.append(image_info.id)
@@ -162,7 +164,7 @@ class SessionRowFromSpec(CreatorSpec[SessionRow]):
                     else:
                         session_images.append(image_info.canonical)
             requested_slots += ResourceSlotEntry.inputs_to_resource_slot(
-                kernel.execution_spec.resources
+                kernel.execution_spec.resource_input.resources
             )
 
         main_mounts = list(main_kernel.vfolder_mounts) if main_kernel else []

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -1382,9 +1382,9 @@ class ScheduleDBSource:
 
         async with self._begin_session_read_committed() as db_sess:
             image_ids = {
-                kernel.execution_spec.image_id
+                kernel.execution_spec.resource_input.image_id
                 for kernel in spec.kernel_specs
-                if kernel.execution_spec.image_id is not None
+                if kernel.execution_spec.resource_input.image_id is not None
             }
             image_metadata: dict[ImageID, ImageInfo] = {}
             if image_ids:
@@ -1406,7 +1406,7 @@ class ScheduleDBSource:
                 }
 
             for kernel in spec.kernel_specs:
-                image_id = kernel.execution_spec.image_id
+                image_id = kernel.execution_spec.resource_input.image_id
                 if image_id is not None and image_id not in image_metadata:
                     raise ImageNotFound(
                         f"Image {image_id} referenced by kernel "
@@ -1436,8 +1436,8 @@ class ScheduleDBSource:
                     spec=spec,
                     kernel_spec=kernel,
                     image_info=(
-                        image_metadata.get(kernel.execution_spec.image_id)
-                        if kernel.execution_spec.image_id is not None
+                        image_metadata.get(kernel.execution_spec.resource_input.image_id)
+                        if kernel.execution_spec.resource_input.image_id is not None
                         else None
                     ),
                     enqueue_time=enqueue_time,
@@ -1580,7 +1580,7 @@ class ScheduleDBSource:
             image_ids: list[UUID] = []
             seen_ids: set[UUID] = set()
             for group in kernel_specs:
-                img = group.execution_spec.image_id
+                img = group.execution_spec.resource_input.image_id
                 if img is None:
                     continue
                 img_uuid = UUID(str(img))

--- a/src/ai/backend/manager/services/model_serving/services/model_serving.py
+++ b/src/ai/backend/manager/services/model_serving/services/model_serving.py
@@ -69,6 +69,7 @@ from ai.backend.manager.data.model_serving.types import (
 from ai.backend.manager.data.session.draft import (
     KernelExecutionSpecDraft,
     KernelGroupDraft,
+    KernelResourceInput,
     SchedulingTargetDraft,
     SessionClassificationDraft,
     SessionIdentityDraft,
@@ -442,9 +443,11 @@ class ModelServingService:
         kernel_groups = await self._resolve_kernel_groups(
             cluster_size=action.cluster_size,
             execution_spec=KernelExecutionSpecDraft(
-                image_id=ImageID(image_data.id),
-                resources=resource_entries,
-                resource_opts=resource_opts,
+                resource_input=KernelResourceInput(
+                    image_id=ImageID(image_data.id),
+                    resources=resource_entries,
+                    resource_opts=resource_opts,
+                ),
                 environ=environ,
                 mounts=mount_entries,
                 startup_command=action.startup_command,

--- a/src/ai/backend/manager/services/session/actions/dry_run_schedule.py
+++ b/src/ai/backend/manager/services/session/actions/dry_run_schedule.py
@@ -8,7 +8,7 @@ from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import ClusterMode
 from ai.backend.manager.actions.action import BaseAction, BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.data.session.draft import KernelResourceDraft
+from ai.backend.manager.data.session.draft import KernelResourceInput
 from ai.backend.manager.data.session.dry_run import KernelDryRunResult
 
 
@@ -20,22 +20,22 @@ class DryRunScheduleAction(BaseAction):
     be driven directly: ``cluster_mode`` decides whether kernel slots are summed
     onto a single node (SINGLE_NODE) or placed individually (MULTI_NODE).
 
-    Each kernel is an unresolved ``KernelResourceDraft``; the result list
+    Each kernel is an unresolved ``KernelResourceInput``; the result list
     corresponds positionally, so callers match results to kernels by index.
     """
 
-    kernels: list[KernelResourceDraft]
+    kernels: list[KernelResourceInput]
     cluster_mode: ClusterMode
     resource_group_id: ResourceGroupID
 
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EntityType.SESSION
+        return EntityType.RESOURCE_GROUP
 
     @override
     def entity_id(self) -> str | None:
-        return None
+        return str(self.resource_group_id)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/actions/dry_run_schedule.py
+++ b/src/ai/backend/manager/services/session/actions/dry_run_schedule.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import EntityType
+from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.types import ClusterMode
+from ai.backend.manager.actions.action import BaseAction, BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.session.dry_run import KernelDryRunResult, KernelDryRunSpec
+
+
+@dataclass(frozen=True)
+class DryRunScheduleAction(BaseAction):
+    """Dry-run a session's scheduling against a resource group without provisioning.
+
+    The fields mirror the scheduler's selection criteria so the real selector can
+    be driven directly: ``cluster_mode`` decides whether kernel slots are summed
+    onto a single node (SINGLE_NODE) or placed individually (MULTI_NODE).
+    """
+
+    kernels: list[KernelDryRunSpec]
+    cluster_mode: ClusterMode
+    resource_group_id: ResourceGroupID
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.SESSION
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+
+@dataclass(frozen=True)
+class DryRunScheduleActionResult(BaseActionResult):
+    kernel_results: list[KernelDryRunResult]
+
+    @override
+    def entity_id(self) -> str | None:
+        return None

--- a/src/ai/backend/manager/services/session/actions/dry_run_schedule.py
+++ b/src/ai/backend/manager/services/session/actions/dry_run_schedule.py
@@ -8,7 +8,8 @@ from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import ClusterMode
 from ai.backend.manager.actions.action import BaseAction, BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.data.session.dry_run import KernelDryRunResult, KernelDryRunSpec
+from ai.backend.manager.data.session.draft import KernelResourceDraft
+from ai.backend.manager.data.session.dry_run import KernelDryRunResult
 
 
 @dataclass(frozen=True)
@@ -18,9 +19,12 @@ class DryRunScheduleAction(BaseAction):
     The fields mirror the scheduler's selection criteria so the real selector can
     be driven directly: ``cluster_mode`` decides whether kernel slots are summed
     onto a single node (SINGLE_NODE) or placed individually (MULTI_NODE).
+
+    Each kernel is an unresolved ``KernelResourceDraft``; the result list
+    corresponds positionally, so callers match results to kernels by index.
     """
 
-    kernels: list[KernelDryRunSpec]
+    kernels: list[KernelResourceDraft]
     cluster_mode: ClusterMode
     resource_group_id: ResourceGroupID
 

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -54,6 +54,7 @@ from ai.backend.manager.data.image.types import ImageIdentifier
 from ai.backend.manager.data.session.draft import (
     KernelExecutionSpecDraft,
     KernelGroupDraft,
+    KernelResourceInput,
     SchedulingTargetDraft,
     SessionClassificationDraft,
     SessionIdentityDraft,
@@ -1627,9 +1628,11 @@ class SessionService:
             cluster_size=action.resource.cluster_size,
             preopen_ports=preopen_ports,
             execution_spec=KernelExecutionSpecDraft(
-                image_id=ImageID(action.image_id),
-                resources=resource_entries,
-                resource_opts=resource_opts,
+                resource_input=KernelResourceInput(
+                    image_id=ImageID(action.image_id),
+                    resources=resource_entries,
+                    resource_opts=resource_opts,
+                ),
                 environ=environ,
                 mounts=mount_entries,
                 startup_command=startup_command,

--- a/src/ai/backend/manager/sokovan/deployment/deployment_draft_builder.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_draft_builder.py
@@ -31,6 +31,7 @@ from ai.backend.manager.data.session.creation import DeploymentContext
 from ai.backend.manager.data.session.draft import (
     KernelExecutionSpecDraft,
     KernelGroupDraft,
+    KernelResourceInput,
     SchedulingTargetDraft,
     SessionClassificationDraft,
     SessionIdentityDraft,
@@ -83,9 +84,11 @@ class DeploymentSessionDraftBuilder:
         kernel_groups = cls._resolve_kernel_groups(
             cluster_size=target_revision.cluster_config.size,
             execution_spec=KernelExecutionSpecDraft(
-                image_id=target_revision.image_id,
-                resources=resource_entries,
-                resource_opts=resource_opts,
+                resource_input=KernelResourceInput(
+                    image_id=target_revision.image_id,
+                    resources=resource_entries,
+                    resource_opts=resource_opts,
+                ),
                 environ=environ,
                 mounts=mounts,
                 startup_command=startup_command,

--- a/src/ai/backend/manager/sokovan/scheduling_controller/preparers/compute_kernel_resources_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/preparers/compute_kernel_resources_rule.py
@@ -64,7 +64,7 @@ class ComputeKernelResourcesRule(SessionSpecDraftRule):
 
         new_groups = []
         for group in draft.options.kernel_groups:
-            image_id = group.execution_spec.image_id
+            image_id = group.execution_spec.resource_input.image_id
             image_info = context.image_infos.get(image_id) if image_id is not None else None
             if image_info is None:
                 new_groups.append(group)
@@ -82,13 +82,19 @@ class ComputeKernelResourcesRule(SessionSpecDraftRule):
         image_info: ImageInfo,
     ) -> KernelExecutionSpecDraft:
         raw_min_slots = image_min_slots(image_info)
-        resolved_opts = cls._resolve_resource_opts(draft.resource_opts, image_info.labels)
+        resolved_opts = cls._resolve_resource_opts(
+            draft.resource_input.resource_opts, image_info.labels
+        )
         min_slots = cls._apply_shmem_to_mem_min(raw_min_slots, resolved_opts.shmem)
-        resolved_resources = cls._fill_intrinsic_slots(draft.resources, min_slots)
+        resolved_resources = cls._fill_intrinsic_slots(draft.resource_input.resources, min_slots)
         return draft.model_copy(
             update={
-                "resources": resolved_resources,
-                "resource_opts": resolved_opts,
+                "resource_input": draft.resource_input.model_copy(
+                    update={
+                        "resources": resolved_resources,
+                        "resource_opts": resolved_opts,
+                    }
+                ),
             }
         )
 

--- a/src/ai/backend/manager/sokovan/scheduling_controller/preparers/merge_resource_group_defaults_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/preparers/merge_resource_group_defaults_rule.py
@@ -106,16 +106,24 @@ class MergeResourceGroupDefaultsRule(SessionSpecDraftRule):
     ) -> KernelExecutionSpecDraft:
         return draft_exec.model_copy(
             update={
-                "image_id": (
-                    draft_exec.image_id if draft_exec.image_id is not None else rg_exec.image_id
-                ),
-                "resources": (
-                    draft_exec.resources if draft_exec.resources else tuple(rg_exec.resources)
-                ),
-                "resource_opts": (
-                    draft_exec.resource_opts
-                    if draft_exec.resource_opts is not None
-                    else rg_exec.resource_opts
+                "resource_input": draft_exec.resource_input.model_copy(
+                    update={
+                        "image_id": (
+                            draft_exec.resource_input.image_id
+                            if draft_exec.resource_input.image_id is not None
+                            else rg_exec.resource_input.image_id
+                        ),
+                        "resources": (
+                            draft_exec.resource_input.resources
+                            if draft_exec.resource_input.resources
+                            else tuple(rg_exec.resource_input.resources)
+                        ),
+                        "resource_opts": (
+                            draft_exec.resource_input.resource_opts
+                            if draft_exec.resource_input.resource_opts is not None
+                            else rg_exec.resource_input.resource_opts
+                        ),
+                    }
                 ),
                 "environ": (draft_exec.environ if draft_exec.environ else dict(rg_exec.environ)),
                 "mounts": (draft_exec.mounts if draft_exec.mounts else tuple(rg_exec.mounts)),

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/image_slot_type_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/image_slot_type_rule.py
@@ -51,7 +51,7 @@ class ImageSlotTypeRule(SessionSpecValidatorRule):
             )
         errors: list[str] = []
         for idx, kernel in enumerate(spec.kernel_specs):
-            image_info = context.image_infos.get(kernel.execution_spec.image_id)
+            image_info = context.image_infos.get(kernel.execution_spec.resource_input.image_id)
             if image_info is None:
                 continue
             min_slots = image_min_slots(image_info)

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/requested_slot_type_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/requested_slot_type_rule.py
@@ -52,7 +52,7 @@ class RequestedSlotTypeRule(SessionSpecValidatorRule):
         for idx, kernel in enumerate(spec.kernel_specs):
             unknown = sorted({
                 entry.resource_type
-                for entry in kernel.execution_spec.resources
+                for entry in kernel.execution_spec.resource_input.resources
                 if entry.resource_type not in rg_slot_types
                 and parse_quantity(entry.quantity) > Decimal(0)
             })

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/required_resource_slot_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/required_resource_slot_rule.py
@@ -40,7 +40,7 @@ class RequiredResourceSlotRule(SessionSpecValidatorRule):
         for idx, kernel in enumerate(spec.kernel_specs):
             requested = {
                 entry.resource_type: parse_quantity(entry.quantity)
-                for entry in kernel.execution_spec.resources
+                for entry in kernel.execution_spec.resource_input.resources
             }
             missing = sorted(
                 str(slot_name)

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/resource_limit_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/resource_limit_rule.py
@@ -47,7 +47,7 @@ class ResourceLimitRule(SessionSpecValidatorRule):
         context: SessionSpecValidationContext,
     ) -> None:
         for idx, kernel in enumerate(spec.kernel_specs):
-            image_info = context.image_infos.get(kernel.execution_spec.image_id)
+            image_info = context.image_infos.get(kernel.execution_spec.resource_input.image_id)
             if image_info is None:
                 continue
             self._validate_kernel(
@@ -68,13 +68,13 @@ class ResourceLimitRule(SessionSpecValidatorRule):
         policy: SlotTypePolicy,
     ) -> None:
         min_slots = image_min_slots(image_info)
-        shmem = kernel.execution_spec.resource_opts.shmem
+        shmem = kernel.execution_spec.resource_input.resource_opts.shmem
         if shmem is not None:
             min_slots["mem"] = min_slots.get("mem", Decimal(0)) + Decimal(int(shmem))
 
         requested = {
             entry.resource_type: parse_quantity(entry.quantity)
-            for entry in kernel.execution_spec.resources
+            for entry in kernel.execution_spec.resource_input.resources
         }
         for slot_name, min_value in min_slots.items():
             if Decimal(min_value) <= Decimal(0):

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/service_port_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/service_port_rule.py
@@ -40,7 +40,7 @@ class ServicePortRule(SessionSpecValidatorRule):
                         f"collide with reserved ports ({sorted(_RESERVED_PORTS)})."
                     ),
                 )
-            image_info = context.image_infos.get(kernel.execution_spec.image_id)
+            image_info = context.image_infos.get(kernel.execution_spec.resource_input.image_id)
             if image_info is None:
                 continue
             image_service_ports = self._image_service_ports(image_info.labels)

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_compute_kernel_resources_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_compute_kernel_resources_rule.py
@@ -23,6 +23,7 @@ from ai.backend.manager.data.session.creation import ImageInfo
 from ai.backend.manager.data.session.draft import (
     KernelExecutionSpecDraft,
     KernelGroupDraft,
+    KernelResourceInput,
     SessionOptionsDraft,
     SessionSpecDraft,
 )
@@ -83,7 +84,9 @@ class TestComputeKernelResourcesRule:
             KernelGroupDraft(
                 role="main",
                 replica_count=1,
-                execution_spec=KernelExecutionSpecDraft(image_id=image_id),
+                execution_spec=KernelExecutionSpecDraft(
+                    resource_input=KernelResourceInput(image_id=image_id),
+                ),
             ),
         )
         ctx = _context({
@@ -97,7 +100,7 @@ class TestComputeKernelResourcesRule:
         result = await rule.prepare(draft, ctx)
 
         assert result.options.kernel_groups is not None
-        resources = result.options.kernel_groups[0].execution_spec.resources
+        resources = result.options.kernel_groups[0].execution_spec.resource_input.resources
         resource_map = {entry.resource_type: Decimal(entry.quantity) for entry in resources}
         assert resource_map["cpu"] == Decimal("2")
         # mem must include shmem so the result clears ResourceLimitRule's
@@ -114,7 +117,9 @@ class TestComputeKernelResourcesRule:
             KernelGroupDraft(
                 role="main",
                 replica_count=1,
-                execution_spec=KernelExecutionSpecDraft(image_id=image_id),
+                execution_spec=KernelExecutionSpecDraft(
+                    resource_input=KernelResourceInput(image_id=image_id),
+                ),
             ),
         )
         ctx = _context({
@@ -129,10 +134,11 @@ class TestComputeKernelResourcesRule:
         assert result.options.kernel_groups is not None
         exec_spec = result.options.kernel_groups[0].execution_spec
         resource_map = {
-            entry.resource_type: Decimal(entry.quantity) for entry in exec_spec.resources
+            entry.resource_type: Decimal(entry.quantity)
+            for entry in exec_spec.resource_input.resources
         }
-        assert exec_spec.resource_opts is not None
-        shmem = exec_spec.resource_opts.shmem
+        assert exec_spec.resource_input.resource_opts is not None
+        shmem = exec_spec.resource_input.resource_opts.shmem
         assert shmem is not None
         image_min_mem = Decimal(256 * 1024 * 1024)
         assert resource_map["mem"] >= image_min_mem + Decimal(int(shmem))
@@ -145,8 +151,10 @@ class TestComputeKernelResourcesRule:
                 role="main",
                 replica_count=1,
                 execution_spec=KernelExecutionSpecDraft(
-                    image_id=image_id,
-                    resources=(ResourceSlotEntry(resource_type="cpu", quantity="8"),),
+                    resource_input=KernelResourceInput(
+                        image_id=image_id,
+                        resources=(ResourceSlotEntry(resource_type="cpu", quantity="8"),),
+                    ),
                 ),
             ),
         )
@@ -154,7 +162,7 @@ class TestComputeKernelResourcesRule:
         result = await rule.prepare(draft, ctx)
 
         assert result.options.kernel_groups is not None
-        resources = result.options.kernel_groups[0].execution_spec.resources
+        resources = result.options.kernel_groups[0].execution_spec.resource_input.resources
         resource_map = {entry.resource_type: Decimal(entry.quantity) for entry in resources}
         assert resource_map["cpu"] == Decimal("8")
 
@@ -165,7 +173,9 @@ class TestComputeKernelResourcesRule:
             KernelGroupDraft(
                 role="main",
                 replica_count=1,
-                execution_spec=KernelExecutionSpecDraft(image_id=image_id),
+                execution_spec=KernelExecutionSpecDraft(
+                    resource_input=KernelResourceInput(image_id=image_id),
+                ),
             ),
         )
         ctx = _context({
@@ -177,7 +187,7 @@ class TestComputeKernelResourcesRule:
         result = await rule.prepare(draft, ctx)
 
         assert result.options.kernel_groups is not None
-        opts = result.options.kernel_groups[0].execution_spec.resource_opts
+        opts = result.options.kernel_groups[0].execution_spec.resource_input.resource_opts
         assert opts is not None
         assert opts.shmem is not None
         # 2g == 2 * 1024 MiB
@@ -192,8 +202,10 @@ class TestComputeKernelResourcesRule:
                 role="main",
                 replica_count=1,
                 execution_spec=KernelExecutionSpecDraft(
-                    image_id=image_id,
-                    resource_opts=ResourceOpts(shmem=caller_shmem),
+                    resource_input=KernelResourceInput(
+                        image_id=image_id,
+                        resource_opts=ResourceOpts(shmem=caller_shmem),
+                    ),
                 ),
             ),
         )
@@ -206,7 +218,7 @@ class TestComputeKernelResourcesRule:
         result = await rule.prepare(draft, ctx)
 
         assert result.options.kernel_groups is not None
-        opts = result.options.kernel_groups[0].execution_spec.resource_opts
+        opts = result.options.kernel_groups[0].execution_spec.resource_input.resource_opts
         assert opts is not None
         assert opts.shmem == caller_shmem
 
@@ -217,7 +229,9 @@ class TestComputeKernelResourcesRule:
             KernelGroupDraft(
                 role="main",
                 replica_count=1,
-                execution_spec=KernelExecutionSpecDraft(image_id=image_id),
+                execution_spec=KernelExecutionSpecDraft(
+                    resource_input=KernelResourceInput(image_id=image_id),
+                ),
             ),
         )
         ctx = _context({})  # no image infos supplied
@@ -225,8 +239,8 @@ class TestComputeKernelResourcesRule:
 
         assert result.options.kernel_groups is not None
         merged = result.options.kernel_groups[0].execution_spec
-        assert merged.resources == ()
-        assert merged.resource_opts is None
+        assert merged.resource_input.resources == ()
+        assert merged.resource_input.resource_opts is None
 
     async def test_noop_when_kernel_groups_unset(self, rule: ComputeKernelResourcesRule) -> None:
         """With no ``kernel_groups``, the draft is returned unchanged."""

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_expand_kernel_groups_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_expand_kernel_groups_rule.py
@@ -18,6 +18,7 @@ from ai.backend.common.types import ResourceSlotEntry
 from ai.backend.manager.data.session.draft import (
     KernelExecutionSpecDraft,
     KernelGroupDraft,
+    KernelResourceInput,
     SessionOptionsDraft,
     SessionSpecDraft,
 )
@@ -44,8 +45,10 @@ def context() -> SessionSpecPreparationContext:
 
 def _make_execution_spec(image_id: ImageID, cpu: str = "1") -> KernelExecutionSpecDraft:
     return KernelExecutionSpecDraft(
-        image_id=image_id,
-        resources=(ResourceSlotEntry(resource_type="cpu", quantity=cpu),),
+        resource_input=KernelResourceInput(
+            image_id=image_id,
+            resources=(ResourceSlotEntry(resource_type="cpu", quantity=cpu),),
+        ),
     )
 
 
@@ -167,8 +170,8 @@ class TestExpandKernelGroupsRule:
         result = await rule.prepare(draft, context)
 
         for kernel in result.kernel_specs:
-            assert kernel.execution_spec.image_id == image_id
-            assert kernel.execution_spec.resources == (
+            assert kernel.execution_spec.resource_input.image_id == image_id
+            assert kernel.execution_spec.resource_input.resources == (
                 ResourceSlotEntry(resource_type="cpu", quantity="4"),
             )
 

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_merge_resource_group_defaults_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_merge_resource_group_defaults_rule.py
@@ -23,6 +23,7 @@ from ai.backend.common.types import ClusterMode, ResourceSlotEntry
 from ai.backend.manager.data.session.draft import (
     KernelExecutionSpecDraft,
     KernelGroupDraft,
+    KernelResourceInput,
     SchedulingTargetDraft,
     SessionOptionsDraft,
     SessionSpecDraft,
@@ -33,6 +34,7 @@ from ai.backend.manager.data.session.options import (
     FailurePolicy,
     HandlerOptions,
     KernelExecutionSpec,
+    KernelResourceConfig,
     ResourceOpts,
     SessionHandlerOptions,
 )
@@ -64,9 +66,11 @@ def rg_defaults(rg_image_id: ImageID) -> DefaultSessionOptions:
         handler_options=SessionHandlerOptions(default=HandlerOptions(timeout=60), by_handler={}),
         agent_selection_policy=AgentSelectionPolicy.STRICT,
         default_kernel_execution_spec=KernelExecutionSpec(
-            image_id=rg_image_id,
-            resources=[ResourceSlotEntry(resource_type="cpu", quantity="2")],
-            resource_opts=ResourceOpts(),
+            resource_input=KernelResourceConfig(
+                image_id=rg_image_id,
+                resources=[ResourceSlotEntry(resource_type="cpu", quantity="2")],
+                resource_opts=ResourceOpts(),
+            ),
             environ={"RG_BASE": "1"},
             startup_command="rg-start",
             bootstrap_script="rg-bootstrap",
@@ -133,8 +137,10 @@ class TestMergeResourceGroupDefaultsRule:
         result = await rule.prepare(draft, _context(rg_defaults))
         assert result.options.kernel_groups is not None
         merged = result.options.kernel_groups[0].execution_spec
-        assert merged.image_id == rg_image_id
-        assert merged.resources == (ResourceSlotEntry(resource_type="cpu", quantity="2"),)
+        assert merged.resource_input.image_id == rg_image_id
+        assert merged.resource_input.resources == (
+            ResourceSlotEntry(resource_type="cpu", quantity="2"),
+        )
         assert merged.environ == {"RG_BASE": "1"}
         assert merged.startup_command == "rg-start"
         assert merged.bootstrap_script == "rg-bootstrap"
@@ -153,7 +159,9 @@ class TestMergeResourceGroupDefaultsRule:
                         role="main",
                         replica_count=1,
                         execution_spec=KernelExecutionSpecDraft(
-                            image_id=caller_image,
+                            resource_input=KernelResourceInput(
+                                image_id=caller_image,
+                            ),
                             environ={"CALLER": "yes"},
                         ),
                     ),
@@ -163,10 +171,12 @@ class TestMergeResourceGroupDefaultsRule:
         result = await rule.prepare(draft, _context(rg_defaults))
         assert result.options.kernel_groups is not None
         merged = result.options.kernel_groups[0].execution_spec
-        assert merged.image_id == caller_image
+        assert merged.resource_input.image_id == caller_image
         assert merged.environ == {"CALLER": "yes"}
         # Unset fields still picked up from RG.
-        assert merged.resources == (ResourceSlotEntry(resource_type="cpu", quantity="2"),)
+        assert merged.resource_input.resources == (
+            ResourceSlotEntry(resource_type="cpu", quantity="2"),
+        )
         assert merged.startup_command == "rg-start"
 
     async def test_noop_group_merge_when_rg_has_no_default(
@@ -183,4 +193,4 @@ class TestMergeResourceGroupDefaultsRule:
         result = await rule.prepare(draft, _context(rg))
         assert result.options.priority == 7
         assert result.options.kernel_groups is not None
-        assert result.options.kernel_groups[0].execution_spec.image_id is None
+        assert result.options.kernel_groups[0].execution_spec.resource_input.image_id is None

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_session_spec_preparer.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_session_spec_preparer.py
@@ -31,6 +31,7 @@ from ai.backend.common.types import AccessKey, ClusterMode, ResourceSlotEntry, S
 from ai.backend.manager.data.session.draft import (
     KernelExecutionSpecDraft,
     KernelGroupDraft,
+    KernelResourceInput,
     KernelSpecDraft,
     SessionClassificationDraft,
     SessionIdentityDraft,
@@ -102,8 +103,10 @@ def minimal_kernel_group(image_id: ImageID) -> KernelGroupDraft:
         role="main",
         replica_count=1,
         execution_spec=KernelExecutionSpecDraft(
-            image_id=image_id,
-            resources=(ResourceSlotEntry(resource_type="cpu", quantity="1"),),
+            resource_input=KernelResourceInput(
+                image_id=image_id,
+                resources=(ResourceSlotEntry(resource_type="cpu", quantity="1"),),
+            ),
         ),
     )
 
@@ -147,8 +150,10 @@ def complete_draft(image_id: ImageID, minimal_kernel_group: KernelGroupDraft) ->
                 cluster_hostname="main1",
                 local_rank=0,
                 execution_spec=KernelExecutionSpecDraft(
-                    image_id=image_id,
-                    resources=(ResourceSlotEntry(resource_type="cpu", quantity="1"),),
+                    resource_input=KernelResourceInput(
+                        image_id=image_id,
+                        resources=(ResourceSlotEntry(resource_type="cpu", quantity="1"),),
+                    ),
                 ),
             ),
         ),
@@ -338,8 +343,10 @@ class TestFinalization:
             cluster_hostname="main1",
             local_rank=0,
             execution_spec=KernelExecutionSpecDraft(
-                image_id=image_id,
-                resources=(ResourceSlotEntry(resource_type="cpu", quantity="1"),),
+                resource_input=KernelResourceInput(
+                    image_id=image_id,
+                    resources=(ResourceSlotEntry(resource_type="cpu", quantity="1"),),
+                ),
             ),
         )
         draft = complete_draft.model_copy(update={"kernel_specs": (broken_kernel,)})
@@ -363,8 +370,10 @@ class TestFinalization:
             cluster_hostname="main1",
             local_rank=0,
             execution_spec=KernelExecutionSpecDraft(
-                # image_id intentionally unset
-                resources=(ResourceSlotEntry(resource_type="cpu", quantity="1"),),
+                resource_input=KernelResourceInput(
+                    # image_id intentionally unset
+                    resources=(ResourceSlotEntry(resource_type="cpu", quantity="1"),),
+                ),
             ),
         )
         draft = complete_draft.model_copy(update={"kernel_specs": (broken_kernel,)})
@@ -373,4 +382,4 @@ class TestFinalization:
         extra_data = exc_info.value.extra_data
         assert extra_data is not None
         missing: list[str] = extra_data["missing"]
-        assert "kernel_specs[0].execution_spec.image_id" in missing
+        assert "kernel_specs[0].execution_spec.resource_input.image_id" in missing

--- a/tests/unit/manager/sokovan/scheduling_controller/test_enqueue_session_from_draft.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/test_enqueue_session_from_draft.py
@@ -62,6 +62,7 @@ from ai.backend.manager.data.session.creation import (
 from ai.backend.manager.data.session.draft import (
     KernelExecutionSpecDraft,
     KernelGroupDraft,
+    KernelResourceInput,
     SchedulingTargetDraft,
     SessionClassificationDraft,
     SessionIdentityDraft,
@@ -122,15 +123,17 @@ def draft(image_id: ImageID) -> SessionSpecDraft:
                     role="main",
                     replica_count=1,
                     execution_spec=KernelExecutionSpecDraft(
-                        image_id=image_id,
-                        resources=(
-                            ResourceSlotEntry(resource_type="cpu", quantity=str(Decimal(2))),
-                            ResourceSlotEntry(
-                                resource_type="mem",
-                                quantity=str(Decimal(2 * 1024 * 1024 * 1024)),
+                        resource_input=KernelResourceInput(
+                            image_id=image_id,
+                            resources=(
+                                ResourceSlotEntry(resource_type="cpu", quantity=str(Decimal(2))),
+                                ResourceSlotEntry(
+                                    resource_type="mem",
+                                    quantity=str(Decimal(2 * 1024 * 1024 * 1024)),
+                                ),
                             ),
+                            resource_opts=ResourceOpts(),
                         ),
-                        resource_opts=ResourceOpts(),
                         mounts=(
                             MountInfoEntry(
                                 vfolder_id=VFolderUUID(
@@ -308,7 +311,7 @@ class TestEnqueueSessionFromDraft:
         assert len(enqueued_spec.kernel_specs) == 1
         kernel = enqueued_spec.kernel_specs[0]
         assert kernel.cluster_role == "main"
-        assert kernel.execution_spec.image_id == image_id
+        assert kernel.execution_spec.resource_input.image_id == image_id
         # vfolder mounts flowed through context → resolved on the kernel spec
         assert len(kernel.vfolder_mounts) == 1
         assert kernel.vfolder_mounts[0].kernel_path == PurePosixPath("/home/work/data")

--- a/tests/unit/manager/sokovan/scheduling_controller/validators/test_session_spec_rules.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/validators/test_session_spec_rules.py
@@ -35,6 +35,7 @@ from ai.backend.manager.data.resource.types import KeyPairResourcePolicyData, Sl
 from ai.backend.manager.data.session.creation import ImageInfo
 from ai.backend.manager.data.session.options import (
     KernelExecutionSpec,
+    KernelResourceConfig,
     ResourceOpts,
     SchedulingTarget,
     SessionHandlerOptions,
@@ -115,12 +116,16 @@ def _kernel(
         local_rank=0,
         preopen_ports=preopen_ports,
         execution_spec=KernelExecutionSpec(
-            image_id=image_id,
-            resources=[
-                ResourceSlotEntry(resource_type="cpu", quantity=str(Decimal(cpu))),
-                ResourceSlotEntry(resource_type="mem", quantity=str(Decimal(1024 * 1024 * 1024))),
-            ],
-            resource_opts=ResourceOpts(shmem=shmem),
+            resource_input=KernelResourceConfig(
+                image_id=image_id,
+                resources=[
+                    ResourceSlotEntry(resource_type="cpu", quantity=str(Decimal(cpu))),
+                    ResourceSlotEntry(
+                        resource_type="mem", quantity=str(Decimal(1024 * 1024 * 1024))
+                    ),
+                ],
+                resource_opts=ResourceOpts(shmem=shmem),
+            ),
         ),
     )
 
@@ -474,9 +479,11 @@ def _kernel_with_resources(
         cluster_hostname="main1",
         local_rank=0,
         execution_spec=KernelExecutionSpec(
-            image_id=image_id,
-            resources=[ResourceSlotEntry(resource_type=k, quantity=q) for k, q in resources],
-            resource_opts=ResourceOpts(),
+            resource_input=KernelResourceConfig(
+                image_id=image_id,
+                resources=[ResourceSlotEntry(resource_type=k, quantity=q) for k, q in resources],
+                resource_opts=ResourceOpts(),
+            ),
         ),
     )
 


### PR DESCRIPTION
## Summary
- Add the scheduler dry-run scaffolding types:
  - `data/session/dry_run.py`: `KernelDryRunSpec`, `KernelDryRunResult`, and `KernelDryRunRemediation` (a data-layer mirror of the selector's `RemediationHint` — `required_reduction` / `required_container_reduction` / `available_archs` / `available_agent_ids`).
  - `services/session/actions/dry_run_schedule.py`: `DryRunScheduleAction` (frozen, `EntityType.SESSION`, GET) and `DryRunScheduleActionResult`.

## Test plan
- [x] `pants fmt/fix/lint/check` on the new files

Resolves BA-6655