### PR TITLE
chore: pin federation versions to stop supergraph.graphql drift (#12462)

### DIFF
--- a/changes/12462.misc.md
+++ b/changes/12462.misc.md
@@ -1,0 +1,1 @@
+Pin the GraphQL federation versions so `docs/manager/graphql-reference/supergraph.graphql` no longer drifts on CI regeneration: set `federation_version: "=2.14.0"` in `configs/graphql/supergraph.yaml` (rover's latest floating plugin `v2.15.0` reformats the SDL) and pin the graphene subgraph to `FederationVersion.VERSION_2_7` instead of `LATEST_VERSION`.

--- a/configs/graphql/supergraph.yaml
+++ b/configs/graphql/supergraph.yaml
@@ -13,6 +13,11 @@
 #   - configs/graphql/README.md
 #   - https://www.apollographql.com/docs/rover/commands/supergraphs
 
+# Pin the composition (supergraph) plugin version. Without this, `rover supergraph
+# compose` floats to the latest Federation 2 plugin; v2.15.0 changed the SDL printer
+# layout and rewrites the whole dump. 2.14.0 keeps the existing committed format.
+federation_version: "=2.14.0"
+
 subgraphs:
   # Legacy GraphQL API (Graphene-based)
   graphene:

--- a/src/ai/backend/manager/api/gql_legacy/schema.py
+++ b/src/ai/backend/manager/api/gql_legacy/schema.py
@@ -3452,5 +3452,7 @@ graphene_schema = graphene_federation.build_schema(
     query=Query,
     mutation=Mutation,
     auto_camelcase=False,
-    federation_version=graphene_federation.LATEST_VERSION,
+    # Pin the federation version so the emitted subgraph SDL (and thus the composed
+    # supergraph) stays stable; LATEST_VERSION floats as graphene_federation upgrades.
+    federation_version=graphene_federation.FederationVersion.VERSION_2_7,
 )


### PR DESCRIPTION
This is an auto-generated backport PR of #12462 to the 26.4 release.

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12499.org.readthedocs.build/en/12499/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12499.org.readthedocs.build/ko/12499/

<!-- readthedocs-preview sorna-ko end -->