### PR TITLE
release: 26.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ Fixed rescan serialization failures, preserved API failure categories in action 
 
 ### Test Updates
 * Import the ORM relationship cluster in the manager unit tests that register it so they configure SQLAlchemy mappers when run as isolated targets. ([#12453](https://github.com/lablup/backend.ai/issues/12453))
+* Set scaling_group_name in session inserts across tests to satisfy the non-null scaling_group_name constraint ([#12502](https://github.com/lablup/backend.ai/issues/12502))
 
 
 ## 26.4.4 (2026-06-18)

--- a/changes/12502.fix.md
+++ b/changes/12502.fix.md
@@ -1,1 +1,0 @@
-Set scaling_group_name in session inserts across tests to satisfy the non-null scaling_group_name constraint


### PR DESCRIPTION
## Summary
- Re-release 26.7.0 to include the post-tag fix #12502 (`fix(BA-6677): add scaling_group_name to session inserts in tests`).
- Merge the #12502 changelog entry into the existing `## 26.7.0` section under `### Test Updates`, consuming the `changes/12502.fix.md` fragment.
- `NEXT_RELEASE_VERSION` stays at `26.8.0` — re-releases do not advance the dev version.

## Post-merge checklist
- [ ] Move the `26.7.0` tag from 8fe0238c1f to the new merge commit and force-push the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)