### PR TITLE
refactor(BA-6667): move session/kernel/network status enums down from models to data

### DIFF
--- a/changes/12505.enhance.md
+++ b/changes/12505.enhance.md
@@ -1,0 +1,1 @@
+Move session/kernel/network status enums down into the manager data layer to cut cyclic `data`->`models` import edges.

--- a/src/ai/backend/manager/data/network/types.py
+++ b/src/ai/backend/manager/data/network/types.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import enum
+from typing import Final
+
+__all__: Final[tuple[str, ...]] = ("NetworkType",)
+
+
+class NetworkType(enum.StrEnum):
+    VOLATILE = "volatile"
+    PERSISTENT = "persistent"
+    HOST = "host"

--- a/src/ai/backend/manager/data/session/draft.py
+++ b/src/ai/backend/manager/data/session/draft.py
@@ -52,6 +52,7 @@ from ai.backend.common.types import (
     SessionTypes,
     VFolderMount,
 )
+from ai.backend.manager.data.network.types import NetworkType
 from ai.backend.manager.data.session.options import (
     AgentSelectionPolicy,
     FailurePolicy,
@@ -59,7 +60,6 @@ from ai.backend.manager.data.session.options import (
     ResourceOpts,
     SessionHandlerOptions,
 )
-from ai.backend.manager.models.network import NetworkType
 
 
 class _DraftBaseModel(BackendAISchema):

--- a/src/ai/backend/manager/data/session/spec.py
+++ b/src/ai/backend/manager/data/session/spec.py
@@ -35,13 +35,13 @@ from ai.backend.common.types import (
     SessionTypes,
     VFolderMount,
 )
+from ai.backend.manager.data.network.types import NetworkType
 from ai.backend.manager.data.session.options import (
     InternalDataExtras,
     KernelExecutionSpec,
     SessionOptions,
 )
 from ai.backend.manager.errors.kernel import IncompleteSessionSpec
-from ai.backend.manager.models.network import NetworkType
 
 
 class _SpecBaseModel(BackendAISchema):

--- a/src/ai/backend/manager/data/session/types.py
+++ b/src/ai/backend/manager/data/session/types.py
@@ -25,8 +25,8 @@ from ai.backend.manager.data.user.types import UserData
 
 if TYPE_CHECKING:
     from ai.backend.manager.data.kernel.types import KernelStatus
+    from ai.backend.manager.data.network.types import NetworkType
     from ai.backend.manager.data.session.options import SessionHandlerOptions
-    from ai.backend.manager.models.network import NetworkType
 
 
 class SessionStatus(CIStrEnum):

--- a/src/ai/backend/manager/data/sokovan/handler.py
+++ b/src/ai/backend/manager/data/sokovan/handler.py
@@ -13,7 +13,7 @@ from ai.backend.common.types import (
     SessionTypes,
 )
 from ai.backend.manager.data.kernel.types import KernelStatus
-from ai.backend.manager.models.session import SessionStatus
+from ai.backend.manager.data.session.types import SessionStatus
 
 
 @dataclass

--- a/src/ai/backend/manager/data/sokovan/lifecycle.py
+++ b/src/ai/backend/manager/data/sokovan/lifecycle.py
@@ -18,12 +18,11 @@ from ai.backend.common.types import (
     SessionId,
     SessionTypes,
 )
-from ai.backend.manager.data.kernel.types import KernelInfo
+from ai.backend.manager.data.kernel.types import KernelInfo, KernelStatus
+from ai.backend.manager.data.network.types import NetworkType
 from ai.backend.manager.data.session.types import SessionInfo
 from ai.backend.manager.defs import DEFAULT_ROLE
 from ai.backend.manager.errors.kernel import MainKernelNotFound, TooManyKernelsFound
-from ai.backend.manager.models.kernel import KernelStatus
-from ai.backend.manager.models.network import NetworkType
 
 from .image import ImageConfigData
 

--- a/src/ai/backend/manager/data/sokovan/result.py
+++ b/src/ai/backend/manager/data/sokovan/result.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from ai.backend.common.types import KernelId, SessionId
-from ai.backend.manager.data.session.types import KernelMatchType
+from ai.backend.manager.data.kernel.types import KernelStatus
+from ai.backend.manager.data.session.types import KernelMatchType, SessionStatus
 from ai.backend.manager.exceptions import ErrorStatusInfo
-from ai.backend.manager.models.kernel import KernelStatus
-from ai.backend.manager.models.session import SessionStatus
 
 from .lifecycle import SessionWithKernels
 

--- a/src/ai/backend/manager/data/sokovan/workload.py
+++ b/src/ai/backend/manager/data/sokovan/workload.py
@@ -15,7 +15,7 @@ from ai.backend.common.types import (
     SessionResult,
     SessionTypes,
 )
-from ai.backend.manager.models.session import SessionStatus
+from ai.backend.manager.data.session.types import SessionStatus
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/models/network/row.py
+++ b/src/ai/backend/manager/models/network/row.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import enum
 import uuid
 from collections.abc import Mapping
 from datetime import datetime
@@ -12,6 +11,7 @@ from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship, selectinload
 
+from ai.backend.manager.data.network.types import NetworkType
 from ai.backend.manager.models.base import (
     GUID,
     Base,
@@ -26,12 +26,6 @@ __all__: Final[tuple[str, ...]] = (
     "NetworkRow",
     "NetworkType",
 )
-
-
-class NetworkType(enum.StrEnum):
-    VOLATILE = "volatile"
-    PERSISTENT = "persistent"
-    HOST = "host"
 
 
 def _get_project_join_condition() -> sa.ColumnElement[bool]:


### PR DESCRIPTION
## Summary
- Move `NetworkType` out of `models/network/row.py` into a new pure-leaf `data/network/types.py`; `models/network/row.py` re-exports it for backward compatibility.
- Redirect the data-layer imports of `SessionStatus`/`KernelStatus` (already defined under `data/`) so `data/sokovan/*` and `data/session/*` import directly from `data` instead of routing through `models`.
- Net effect: removes 7 of the `data -> models` back-edges that feed the `models <-> data` cyclic hub dependency (19 → 12), part of epic BA-6666.

## Test plan
- [x] `pants test --changed-since=main` (data/session, data/sokovan, models/network)
- [x] CI: mypy + visibility rules (verified locally, all pass)

Resolves BA-6667