### PR TITLE
fix(BA-6678): add pool_pre_ping/pool_recycle to appproxy-coordinator DB engine

### DIFF
--- a/changes/12507.fix.md
+++ b/changes/12507.fix.md
@@ -1,0 +1,1 @@
+Add `pool_pre_ping` and `pool_recycle` to the appproxy-coordinator database engine so a dropped/stale pooled Postgres connection is transparently reconnected at checkout instead of poisoning the pool with `SAVEPOINT can only be used in transaction blocks` errors until a restart.

--- a/src/ai/backend/appproxy/coordinator/config.py
+++ b/src/ai/backend/appproxy/coordinator/config.py
@@ -29,7 +29,12 @@ from ai.backend.common.configs import (
     PyroscopeConfig,
     ServiceDiscoveryConfig,
 )
-from ai.backend.common.meta import BackendAIConfigMeta, CompositeType, ConfigExample
+from ai.backend.common.meta import (
+    NEXT_RELEASE_VERSION,
+    BackendAIConfigMeta,
+    CompositeType,
+    ConfigExample,
+)
 from ai.backend.common.types import ServiceDiscoveryType
 from ai.backend.logging import LogLevel
 from ai.backend.logging.config import LoggingConfig
@@ -174,7 +179,7 @@ class DBConfig(BaseSchema):
                 "Useful for handling database connections closed by the server after inactivity "
                 "or by network equipment with idle timeouts."
             ),
-            added_version="26.5.0",
+            added_version=NEXT_RELEASE_VERSION,
             example=ConfigExample(local="-1", prod="3600"),
         ),
     ]
@@ -189,7 +194,7 @@ class DBConfig(BaseSchema):
                 "used in transaction blocks' errors after a Postgres connection drop or failover. "
                 "Adds a small overhead per checkout but is recommended for production."
             ),
-            added_version="26.5.0",
+            added_version=NEXT_RELEASE_VERSION,
             example=ConfigExample(local="true", prod="true"),
         ),
     ]

--- a/src/ai/backend/appproxy/coordinator/config.py
+++ b/src/ai/backend/appproxy/coordinator/config.py
@@ -164,6 +164,35 @@ class DBConfig(BaseSchema):
             example=ConfigExample(local="64", prod="128"),
         ),
     ]
+    pool_recycle: Annotated[
+        float,
+        Field(default=-1, ge=-1),
+        BackendAIConfigMeta(
+            description=(
+                "Maximum lifetime of a connection in seconds before it's recycled. "
+                "Set to -1 to disable connection recycling. "
+                "Useful for handling database connections closed by the server after inactivity "
+                "or by network equipment with idle timeouts."
+            ),
+            added_version="26.5.0",
+            example=ConfigExample(local="-1", prod="3600"),
+        ),
+    ]
+    pool_pre_ping: Annotated[
+        bool,
+        Field(default=True),
+        BackendAIConfigMeta(
+            description=(
+                "Whether to test connections with a lightweight ping before using them. "
+                "Detects stale or disconnected connections at pool checkout and transparently "
+                "reconnects them with clean transaction state, preventing 'SAVEPOINT can only be "
+                "used in transaction blocks' errors after a Postgres connection drop or failover. "
+                "Adds a small overhead per checkout but is recommended for production."
+            ),
+            added_version="26.5.0",
+            example=ConfigExample(local="true", prod="true"),
+        ),
+    ]
 
 
 class ClientIPStrategyConfig(BaseSchema):

--- a/src/ai/backend/appproxy/coordinator/models/utils.py
+++ b/src/ai/backend/appproxy/coordinator/models/utils.py
@@ -357,6 +357,8 @@ async def connect_database(
         str(db_url),
         connect_args=pgsql_connect_opts,
         pool_size=db_config.pool_size,
+        pool_recycle=db_config.pool_recycle,
+        pool_pre_ping=db_config.pool_pre_ping,
         max_overflow=db_config.max_overflow,
         json_serializer=functools.partial(json.dumps, cls=ExtendedJSONEncoder),
         isolation_level=isolation_level,

--- a/tests/unit/appproxy/coordinator/dependencies/infrastructure/test_database.py
+++ b/tests/unit/appproxy/coordinator/dependencies/infrastructure/test_database.py
@@ -36,6 +36,8 @@ class TestDatabaseProvider:
             user="postgres",
             password="develove",
             pool_size=8,
+            pool_recycle=-1,
+            pool_pre_ping=True,
             max_overflow=64,
         )
 


### PR DESCRIPTION
## Summary
The appproxy-coordinator SQLAlchemy engine is created **without** `pool_pre_ping` (and without `pool_recycle`), unlike the manager and account-manager engines. This ports the robust-connection handling the manager received in #1991 to the coordinator.

## Problem
When a pooled Postgres connection is dropped underneath SQLAlchemy (server-side termination, failover, network blip, or `idle_in_transaction_session_timeout`), asyncpg transparently reconnects the socket with a clean no-transaction state, but SQLAlchemy's pooled connection keeps stale transaction state. The next query is then issued as a nested SAVEPOINT, which the fresh connection rejects:

```
asyncpg.exceptions.NoActiveSQLTransactionError: SAVEPOINT can only be used in transaction blocks
```

Without `pool_pre_ping` the poisoned connection is never revalidated at checkout, so it stays in the pool and every subsequent request reusing it fails the same way — the coordinator is effectively down until a process restart, with no automatic recovery. Observed as a ~24h outage in a production deployment where every `PATCH /api/worker/{id}` heartbeat returned 500, causing workers to be marked stale and app/SSH endpoint creation to fail with `AppLaunchError: Worker not available`.

The first error is already the SAVEPOINT error with **no preceding SQLSTATE 40001 serialization failure** — the trigger is a dropped connection, not a serialization conflict. (`pgsql_connect_opts` sets `idle_in_transaction_session_timeout = 60s`, one concrete way a pooled connection gets terminated server-side.)

## Fix
- Add `pool_recycle` and `pool_pre_ping` fields to appproxy-coordinator `DBConfig` (previously only `pool_size` / `max_overflow` existed).
- Pass both to `create_async_engine`, mirroring manager (#1991) and account-manager.
- `pool_pre_ping` defaults to `True` here so the resilience is on by default. (manager/account-manager default it to `False`; consider flipping those or enabling in deployment config in a follow-up so they benefit too.)

## Notes
- Secondary hardening (not in this PR): `execute_with_txn_retry` reuses one caller-provided connection across retry attempts, so a poisoned connection cannot recover mid-loop. Running each attempt on a fresh transaction would harden the retry path further. Aggravator, not root cause.

Jira: BA-6678

🤖 Generated with [Claude Code](https://claude.com/claude-code)