### PR TITLE
feat(BA-6681): accept resource_group_id in session creation APIs

### DIFF
--- a/changes/12513.feature.md
+++ b/changes/12513.feature.md
@@ -1,0 +1,1 @@
+Add resource_group_id input to session creation APIs, deprecating the name-based resource_group field

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -6950,7 +6950,7 @@ input EnqueueSessionInput
   resourceEntries: [SessionResourceSlotEntryInput!]!
 
   """
-  Deprecated since 26.8.0. Use resource_group_id instead. Scaling group name.
+  Deprecated since 26.8.0. Use resource_group_id instead. Resource group name.
   """
   resourceGroup: String = null @deprecated(reason: "Use resource_group_id instead.")
 

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -6949,8 +6949,13 @@ input EnqueueSessionInput
   """Resource slot allocations."""
   resourceEntries: [SessionResourceSlotEntryInput!]!
 
-  """Scaling group name."""
-  resourceGroup: String = null
+  """
+  Deprecated since 26.8.0. Use resource_group_id instead. Scaling group name.
+  """
+  resourceGroup: String = null @deprecated(reason: "Use resource_group_id instead.")
+
+  """Added in 26.8.0. Resource group UUID. Auto-selected if omitted."""
+  resourceGroupId: ID = null
 
   """Additional resource options."""
   resourceOpts: SessionResourceOptsInput = null

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -4657,7 +4657,7 @@ input EnqueueSessionInput {
   resourceEntries: [SessionResourceSlotEntryInput!]!
 
   """
-  Deprecated since 26.8.0. Use resource_group_id instead. Scaling group name.
+  Deprecated since 26.8.0. Use resource_group_id instead. Resource group name.
   """
   resourceGroup: String = null @deprecated(reason: "Use resource_group_id instead.")
 

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -4656,8 +4656,13 @@ input EnqueueSessionInput {
   """Resource slot allocations."""
   resourceEntries: [SessionResourceSlotEntryInput!]!
 
-  """Scaling group name."""
-  resourceGroup: String = null
+  """
+  Deprecated since 26.8.0. Use resource_group_id instead. Scaling group name.
+  """
+  resourceGroup: String = null @deprecated(reason: "Use resource_group_id instead.")
+
+  """Added in 26.8.0. Resource group UUID. Auto-selected if omitted."""
+  resourceGroupId: ID = null
 
   """Additional resource options."""
   resourceOpts: SessionResourceOptsInput = null

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -25245,8 +25245,22 @@
               }
             ],
             "default": null,
-            "description": "Scaling group name. Auto-selected if omitted.",
+            "description": "Deprecated since 26.8.0. Use resource_group_id instead. Resource group name.",
             "title": "Resource Group"
+          },
+          "resource_group_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Resource group UUID. Auto-selected if omitted.",
+            "title": "Resource Group Id"
           },
           "resource_opts": {
             "anyOf": [

--- a/src/ai/backend/common/dto/manager/v2/session/request.py
+++ b/src/ai/backend/common/dto/manager/v2/session/request.py
@@ -22,6 +22,8 @@ from ai.backend.common.dto.manager.v2.session.types import (
     SessionOrderField,
     SessionStatusFilter,
 )
+from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 
 __all__ = (
     "AdminSearchSessionsInput",
@@ -300,7 +302,11 @@ class EnqueueSessionInput(BaseRequestModel):
         description="Resource slot allocations.",
     )
     resource_group: str | None = Field(
-        default=None, description="Scaling group name. Auto-selected if omitted."
+        default=None,
+        description=f"Deprecated since {NEXT_RELEASE_VERSION}. Use resource_group_id instead. Resource group name.",
+    )
+    resource_group_id: ResourceGroupID | None = Field(
+        default=None, description="Resource group UUID. Auto-selected if omitted."
     )
     resource_opts: ResourceOptsInput | None = Field(
         default=None, description="Additional resource options."

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -273,6 +273,7 @@ class SessionAdapter(BaseAdapter):
                     for e in input.resource_entries
                 ],
                 resource_group=input.resource_group,
+                resource_group_id=input.resource_group_id,
                 shmem=input.resource_opts.shmem.expr
                 if input.resource_opts and input.resource_opts.shmem
                 else None,

--- a/src/ai/backend/manager/api/gql/session/types.py
+++ b/src/ai/backend/manager/api/gql/session/types.py
@@ -51,6 +51,7 @@ from ai.backend.common.dto.manager.v2.session.types import (
     ProjectSessionScope,
     SessionStatusFilter,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.common.types import ImageID, SessionId
 from ai.backend.manager.api.gql.base import OrderDirection, StringFilter, UUIDFilter, encode_cursor
 from ai.backend.manager.api.gql.common.types import (
@@ -603,7 +604,18 @@ class EnqueueSessionInputGQL(PydanticInputMixin[EnqueueSessionInputDTO]):
     resource_entries: list[SessionResourceSlotEntryInputGQL] = gql_field(
         description="Resource slot allocations."
     )
-    resource_group: str | None = gql_field(default=None, description="Scaling group name.")
+    resource_group: str | None = gql_field(
+        default=None,
+        description=f"Deprecated since {NEXT_RELEASE_VERSION}. Use resource_group_id instead. Resource group name.",
+        deprecation_reason="Use resource_group_id instead.",
+    )
+    resource_group_id: ID | None = gql_added_field(
+        BackendAIGQLMeta(
+            description="Resource group UUID. Auto-selected if omitted.",
+            added_version=NEXT_RELEASE_VERSION,
+        ),
+        default=None,
+    )
     resource_opts: SessionResourceOptsInputGQL | None = gql_field(
         default=None, description="Additional resource options."
     )

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1122,10 +1122,13 @@ class AgentRegistry:
         if scaling_group:
             resource_group_name = ResourceGroupName(scaling_group)
         else:
-            resource_group_name = await self._scheduler_repository.pick_default_resource_group(
+            resource_group_id = await self._scheduler_repository.pick_default_resource_group(
                 access_key=access_key,
                 domain_name=user_scope.domain_name,
                 project_id=ProjectID(user_scope.group_id),
+            )
+            resource_group_name = await self._scheduler_repository.get_resource_group_name_by_id(
+                resource_group_id
             )
 
         draft = SessionSpecDraft(

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -31,7 +31,10 @@ from ai.backend.common.data.permission.types import (
 from ai.backend.common.docker import ImageRef
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.project import ProjectID
-from ai.backend.common.identifier.resource_group import ResourceGroupName
+from ai.backend.common.identifier.resource_group import (
+    ResourceGroupID,
+    ResourceGroupName,
+)
 from ai.backend.common.resource.types import TotalResourceData
 from ai.backend.common.types import (
     AccessKey,
@@ -1720,7 +1723,7 @@ class ScheduleDBSource:
         access_key: AccessKey,
         domain_name: str,
         project_id: ProjectID,
-    ) -> ResourceGroupName:
+    ) -> ResourceGroupID:
         """Return the first resource group from the owner's allowlist."""
         async with self._begin_readonly_session_read_committed() as db_sess:
             allowed_rgs = await self._query_allowed_scaling_groups(
@@ -1728,7 +1731,18 @@ class ScheduleDBSource:
             )
         if not allowed_rgs:
             raise InvalidAPIParameters("No accessible scaling group available")
-        return ResourceGroupName(allowed_rgs[0].name)
+        return allowed_rgs[0].id
+
+    async def get_resource_group_name_by_id(
+        self, resource_group_id: ResourceGroupID
+    ) -> ResourceGroupName:
+        async with self._begin_readonly_session_read_committed() as db_sess:
+            resource_group_name = await db_sess.scalar(
+                sa.select(ScalingGroupRow.name).where(ScalingGroupRow.id == resource_group_id)
+            )
+        if resource_group_name is None:
+            raise ScalingGroupNotFound(f"Resource group not found (id:{resource_group_id})")
+        return ResourceGroupName(resource_group_name)
 
     async def _get_scaling_group_network_info(
         self, db_sess: SASession, scaling_group_name: str
@@ -1954,7 +1968,8 @@ class ScheduleDBSource:
 
         return [
             AllowedScalingGroup(
-                name=sg.name,
+                id=ResourceGroupID(sg.id),
+                name=ResourceGroupName(sg.name),
                 is_private=not sg.is_public,  # Convert is_public to is_private
                 scheduler_opts=sg.scheduler_opts,
             )

--- a/src/ai/backend/manager/repositories/scheduler/repository.py
+++ b/src/ai/backend/manager/repositories/scheduler/repository.py
@@ -17,7 +17,7 @@ from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeySta
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.project import ProjectID
-from ai.backend.common.identifier.resource_group import ResourceGroupName
+from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
@@ -263,13 +263,19 @@ class SchedulerRepository:
         access_key: AccessKey,
         domain_name: str,
         project_id: ProjectID,
-    ) -> ResourceGroupName:
+    ) -> ResourceGroupID:
         """Return the first resource group from the owner's allowlist."""
         return await self._db_source.pick_default_resource_group(
             access_key=access_key,
             domain_name=domain_name,
             project_id=project_id,
         )
+
+    @scheduler_repository_resilience.apply()
+    async def get_resource_group_name_by_id(
+        self, resource_group_id: ResourceGroupID
+    ) -> ResourceGroupName:
+        return await self._db_source.get_resource_group_name_by_id(resource_group_id)
 
     @scheduler_repository_resilience.apply()
     async def prepare_vfolder_mounts(

--- a/src/ai/backend/manager/repositories/scheduler/types/session_creation.py
+++ b/src/ai/backend/manager/repositories/scheduler/types/session_creation.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from ai.backend.common.identifier.image import ImageID
+from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
 from ai.backend.common.types import (
     SessionId,
     SlotName,
@@ -33,7 +34,8 @@ class SessionDependencyData:
 class AllowedScalingGroup:
     """Allowed scaling group for a user."""
 
-    name: str
+    id: ResourceGroupID
+    name: ResourceGroupName
     is_private: bool
     scheduler_opts: ScalingGroupOpts
 

--- a/src/ai/backend/manager/services/model_serving/services/model_serving.py
+++ b/src/ai/backend/manager/services/model_serving/services/model_serving.py
@@ -455,10 +455,13 @@ class ModelServingService:
         if service_prepare_ctx.scaling_group:
             resource_group_name = ResourceGroupName(service_prepare_ctx.scaling_group)
         else:
-            resource_group_name = await self._scheduler_repository.pick_default_resource_group(
+            resource_group_id = await self._scheduler_repository.pick_default_resource_group(
                 access_key=AccessKey(service_prepare_ctx.owner_access_key),
                 domain_name=action.domain_name,
                 project_id=ProjectID(service_prepare_ctx.group_id),
+            )
+            resource_group_name = await self._scheduler_repository.get_resource_group_name_by_id(
+                resource_group_id
             )
 
         draft = SessionSpecDraft(

--- a/src/ai/backend/manager/services/session/actions/enqueue_session.py
+++ b/src/ai/backend/manager/services/session/actions/enqueue_session.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from typing import override
 
 from ai.backend.common.data.permission.types import RBACElementType, ScopeType
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import AccessKey, ClusterMode, MountInfoEntry, SessionTypes
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
@@ -29,6 +30,7 @@ class SessionResourceSpec:
 
     entries: list[ResourceSlotEntry]
     resource_group: str | None = None
+    resource_group_id: ResourceGroupID | None = None
     shmem: str | None = None
     cluster_mode: ClusterMode = ClusterMode.SINGLE_NODE
     cluster_size: int = 1

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -1577,13 +1577,20 @@ class SessionService:
         dependencies = tuple(SessionID(dep_id) for dep_id in (action.scheduling.dependencies or ()))
         callback_url = yarl.URL(action.callback_url) if action.callback_url else None
 
-        if action.resource.resource_group:
+        if action.resource.resource_group_id is not None:
+            resource_group_name = await self._scheduler_repository.get_resource_group_name_by_id(
+                action.resource.resource_group_id
+            )
+        elif action.resource.resource_group:
             resource_group_name = ResourceGroupName(action.resource.resource_group)
         else:
-            resource_group_name = await self._scheduler_repository.pick_default_resource_group(
+            resource_group_id = await self._scheduler_repository.pick_default_resource_group(
                 access_key=access_key,
                 domain_name=domain_name,
                 project_id=ProjectID(action.group_id),
+            )
+            resource_group_name = await self._scheduler_repository.get_resource_group_name_by_id(
+                resource_group_id
             )
         kernel_groups = await self._resolve_kernel_groups(
             cluster_size=action.resource.cluster_size,

--- a/tests/unit/manager/repositories/scheduler/test_owner_resource_group_access.py
+++ b/tests/unit/manager/repositories/scheduler/test_owner_resource_group_access.py
@@ -24,7 +24,7 @@ import pytest
 
 from ai.backend.common.identifier.domain import DomainName
 from ai.backend.common.identifier.project import ProjectID
-from ai.backend.common.identifier.resource_group import ResourceGroupName
+from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
 from ai.backend.common.identifier.session import SessionID
 from ai.backend.common.types import AccessKey
 from ai.backend.manager.data.session.draft import (
@@ -91,7 +91,8 @@ class TestOwnerOnlyResourceGroupForDelegation:
     @pytest.fixture
     def sample_accessible_rg(self) -> AllowedScalingGroup:
         return AllowedScalingGroup(
-            name=RG_NAME,
+            id=ResourceGroupID(uuid.uuid4()),
+            name=ResourceGroupName(RG_NAME),
             is_private=False,
             scheduler_opts=ScalingGroupOpts(
                 allowed_session_types=[],

--- a/tests/unit/manager/services/session/test_session_service.py
+++ b/tests/unit/manager/services/session/test_session_service.py
@@ -16,7 +16,7 @@ from dateutil.tz import tzutc
 
 from ai.backend.common.dto.agent.response import CodeCompletionResp, CodeCompletionResult
 from ai.backend.common.exception import InvalidAPIParameters
-from ai.backend.common.identifier.resource_group import ResourceGroupName
+from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
 from ai.backend.common.types import (
     AccessKey,
     ClusterMode,
@@ -1724,8 +1724,14 @@ class TestEnqueueSession:
         return uuid4()
 
     @pytest.fixture
-    def picked_resource_group(self) -> ResourceGroupName:
-        return ResourceGroupName("auto-picked-rg")
+    def picked_resource_group_id(self) -> ResourceGroupID:
+        """Resource group id returned by the default auto-picker."""
+        return ResourceGroupID(uuid4())
+
+    @pytest.fixture
+    def requested_resource_group_id(self) -> ResourceGroupID:
+        """Resource group id supplied directly by the caller."""
+        return ResourceGroupID(uuid4())
 
     @pytest.fixture
     def enqueue_action_without_rg(
@@ -1766,7 +1772,7 @@ class TestEnqueueSession:
             image_id=enqueue_action_without_rg.image_id,
             resource=SessionResourceSpec(
                 entries=enqueue_action_without_rg.resource.entries,
-                resource_group="user-picked-rg",
+                resource_group="requested-rg",
             ),
             scheduling=enqueue_action_without_rg.scheduling,
             user_id=enqueue_action_without_rg.user_id,
@@ -1784,7 +1790,8 @@ class TestEnqueueSession:
         mock_scheduler_repository: MagicMock,
         sample_session_id: SessionId,
         sample_session_data: SessionData,
-        picked_resource_group: ResourceGroupName,
+        picked_resource_group_id: ResourceGroupID,
+        requested_resource_group_id: ResourceGroupID,
     ) -> SessionService:
         """Wire async mocks every ``enqueue_session`` exercise needs."""
         mock_session_repository.resolve_image_by_id = AsyncMock()
@@ -1793,7 +1800,14 @@ class TestEnqueueSession:
             return_value=sample_session_id
         )
         mock_scheduler_repository.pick_default_resource_group = AsyncMock(
-            return_value=picked_resource_group
+            return_value=picked_resource_group_id
+        )
+        rg_names = {
+            picked_resource_group_id: ResourceGroupName("picked-rg"),
+            requested_resource_group_id: ResourceGroupName("requested-rg"),
+        }
+        mock_scheduler_repository.get_resource_group_name_by_id = AsyncMock(
+            side_effect=lambda resource_group_id: rg_names[resource_group_id]
         )
         return session_service
 
@@ -1803,18 +1817,19 @@ class TestEnqueueSession:
         mock_scheduler_repository: MagicMock,
         mock_scheduling_controller: MagicMock,
         enqueue_action_without_rg: EnqueueSessionAction,
-        picked_resource_group: ResourceGroupName,
+        picked_resource_group_id: ResourceGroupID,
     ) -> None:
-        """BA-5917: when ``action.resource.resource_group`` is None, the
-        service calls ``pick_default_resource_group`` and feeds the
-        picked name onto the draft handed to the controller — restoring
-        the legacy ``ScalingGroupResolver`` behavior.
+        """BA-5917: when no resource group is given, the default is auto-picked
+        by id and the draft carries the name resolved from that id.
         """
         await configured_session_service.enqueue_session(enqueue_action_without_rg)
 
         mock_scheduler_repository.pick_default_resource_group.assert_awaited_once()
+        mock_scheduler_repository.get_resource_group_name_by_id.assert_awaited_once_with(
+            picked_resource_group_id
+        )
         draft = mock_scheduling_controller.enqueue_session_from_draft.await_args.args[0]
-        assert draft.scope.resource_group_name == picked_resource_group
+        assert draft.scope.resource_group_name == ResourceGroupName("picked-rg")
 
     async def test_uses_user_supplied_resource_group(
         self,
@@ -1823,11 +1838,47 @@ class TestEnqueueSession:
         mock_scheduling_controller: MagicMock,
         enqueue_action_with_rg: EnqueueSessionAction,
     ) -> None:
-        """When the caller supplies a scaling group, the auto-picker
-        must not run and the draft carries the user-supplied name.
+        """When the caller supplies a scaling group name, it is used as-is:
+        no lookups and no auto-picking.
         """
         await configured_session_service.enqueue_session(enqueue_action_with_rg)
 
         mock_scheduler_repository.pick_default_resource_group.assert_not_called()
+        mock_scheduler_repository.get_resource_group_name_by_id.assert_not_called()
         draft = mock_scheduling_controller.enqueue_session_from_draft.await_args.args[0]
-        assert str(draft.scope.resource_group_name) == "user-picked-rg"
+        assert draft.scope.resource_group_name == ResourceGroupName("requested-rg")
+
+    async def test_uses_user_supplied_resource_group_id(
+        self,
+        configured_session_service: SessionService,
+        mock_scheduler_repository: MagicMock,
+        mock_scheduling_controller: MagicMock,
+        enqueue_action_without_rg: EnqueueSessionAction,
+        requested_resource_group_id: ResourceGroupID,
+    ) -> None:
+        """When the caller supplies a resource group id, only its name is
+        looked up: no auto-picking.
+        """
+        action = EnqueueSessionAction(
+            session_name=enqueue_action_without_rg.session_name,
+            session_type=enqueue_action_without_rg.session_type,
+            image_id=enqueue_action_without_rg.image_id,
+            resource=SessionResourceSpec(
+                entries=enqueue_action_without_rg.resource.entries,
+                resource_group_id=requested_resource_group_id,
+            ),
+            scheduling=enqueue_action_without_rg.scheduling,
+            user_id=enqueue_action_without_rg.user_id,
+            access_key=enqueue_action_without_rg.access_key,
+            domain_name=enqueue_action_without_rg.domain_name,
+            group_id=enqueue_action_without_rg.group_id,
+        )
+
+        await configured_session_service.enqueue_session(action)
+
+        mock_scheduler_repository.pick_default_resource_group.assert_not_called()
+        mock_scheduler_repository.get_resource_group_name_by_id.assert_awaited_once_with(
+            requested_resource_group_id
+        )
+        draft = mock_scheduling_controller.enqueue_session_from_draft.await_args.args[0]
+        assert draft.scope.resource_group_name == ResourceGroupName("requested-rg")


### PR DESCRIPTION
## Summary
- Add an optional `resource_group_id` input to session enqueue (REST v2 DTO / GraphQL / adapter) and deprecate the name-based `resource_group` field.
- Resolve the resource group by id when supplied; a user-supplied name is used as-is with no extra lookup, and the auto-picked default is now selected by id and resolved back to its canonical name.
- `pick_default_resource_group` returns `ResourceGroupID` and `AllowedScalingGroup` carries the resource group `id`, laying the groundwork for BA-6644 (persisting `domain_id` / `resource_group_id` on sessions) without any schema change.

## Test plan
- [x] `TestEnqueueSession` covers all three resolution paths: explicit id (name looked up by id), explicit name (no lookups), omitted (auto-pick by id).
- [x] Full `tests/unit` + `tests/component` suites pass locally (1017 targets).
- [ ] CI green.

Resolves BA-6681

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12513.org.readthedocs.build/en/12513/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12513.org.readthedocs.build/ko/12513/

<!-- readthedocs-preview sorna-ko end -->