### PR TITLE
fix(BA-6679): send session download files as query params in v1 client (#12509)

### DIFF
--- a/changes/12509.fix.md
+++ b/changes/12509.fix.md
@@ -1,0 +1,1 @@
+Fix `session download` and `session ssh` failing with HTTP 400 by sending the file list as query parameters to match the manager endpoint contract.

--- a/src/ai/backend/client/func/session.py
+++ b/src/ai/backend/client/func/session.py
@@ -1097,7 +1097,9 @@ class ComputeSession(BaseFunction):
         :param dest: The destination directory in the client-side.
         :param show_progress: Displays a progress bar during downloads.
         """
-        params = {}
+        params: dict[str, str | list[str]] = {
+            "files": [*map(str, files)],
+        }
         if self.owner_access_key:
             params["owner_access_key"] = self.owner_access_key
         prefix = get_naming(api_session.get().api_version, "path")
@@ -1106,9 +1108,6 @@ class ComputeSession(BaseFunction):
             f"/{prefix}/{self.session_identifier}/download",
             params=params,
         )
-        rqst.set_json({
-            "files": [*map(str, files)],
-        })
         file_names = []
         async with rqst.fetch() as resp:
             loop = current_loop()

--- a/src/ai/backend/client/request.py
+++ b/src/ai/backend/client/request.py
@@ -126,7 +126,7 @@ class Request:
         content: RequestContent | None = None,
         *,
         content_type: str | None = None,
-        params: Mapping[str, str | int] | None = None,
+        params: Mapping[str, str | int | list[str]] | None = None,
         reporthook: Callable[..., Any] | None = None,
         override_api_version: str | None = None,
         session_mode: SessionMode = SessionMode.CLIENT,


### PR DESCRIPTION
This is an auto-generated backport PR of #12509 to the 26.4 release.