### PR TITLE
feat(BA-6701): expose allow-list rank on the v2 API surface

### DIFF
--- a/.claude/skills/bai-cli/SKILL.md
+++ b/.claude/skills/bai-cli/SKILL.md
@@ -104,6 +104,8 @@ Check options with `--help`.
 - **prometheus-query-definition**: user(get, search, execute) · admin(create, update, delete, preview)
 - **prometheus-query-definition-category**: user(get, search) · admin(create, delete)
 - **app-config**: user(get-domain, get-user, get-merged, delete-domain, delete-user)
+- **app-config-definition**: admin(create, get, search, purge)
+- **app-config-allow-list**: admin(create, get, search, update, purge)
 - **export**: admin(list-reports, get-report, audit-logs, keypairs, projects, sessions, sessions-by-project, users, users-by-domain) · my(keypairs, sessions)
 
 ### Utilities (not entities)

--- a/changes/12517.feature.md
+++ b/changes/12517.feature.md
@@ -1,1 +1,1 @@
-Expose the app config allow-list merge `rank` on the v2 REST/GraphQL APIs and CLI — optional create input (scope-type default when omitted), node field, and order field
+Expose the app config allow-list merge `rank` on the v2 REST/GraphQL APIs and CLI — optional create input (scope-type default when omitted), node field, order field, and a new admin update operation (`PATCH /v2/app-config-allow-list/{id}`, `adminUpdateAppConfigAllowList`, `./bai admin app-config-allow-list update --rank`) for re-ordering the merge

--- a/changes/12517.feature.md
+++ b/changes/12517.feature.md
@@ -1,0 +1,1 @@
+Expose the app config allow-list merge `rank` on the v2 REST/GraphQL APIs and CLI — optional create input (scope-type default when omitted), node field, and order field

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -11379,6 +11379,11 @@ type Mutation
   adminPurgeAppConfigAllowList(input: PurgeAppConfigAllowListInput!): PurgeAppConfigAllowListPayload @join__field(graph: STRAWBERRY)
 
   """
+  Added in 26.8.0. Update an app config allow-list entry's rank by id (super admin only).
+  """
+  adminUpdateAppConfigAllowList(input: UpdateAppConfigAllowListInput!): UpdateAppConfigAllowListPayload @join__field(graph: STRAWBERRY)
+
+  """
   Added in 25.14.0. Scan external registries to discover available artifacts. Searches HuggingFace or Reservoir registries for artifacts matching the specified criteria and registers them in the system with SCANNED status. The artifacts become available for import but are not downloaded until explicitly imported. This is the first step in the artifact workflow: Scan → Import → Use
   """
   scanArtifacts(input: ScanArtifactsInput!): ScanArtifactsPayload @join__field(graph: STRAWBERRY)
@@ -19185,6 +19190,29 @@ input UpdateAllowedResourceGroupsForProjectInput
 
   """Resource group names to disallow."""
   remove: [String!] = null
+}
+
+"""
+Added in 26.8.0. Input for updating an app config allow-list entry (rank only).
+"""
+input UpdateAppConfigAllowListInput
+  @join__type(graph: STRAWBERRY)
+{
+  """App config allow-list entry id to update."""
+  id: UUID!
+
+  """
+  New merge rank applied to fragments under this entry (low to high; higher wins). Omit to leave unchanged.
+  """
+  rank: Int = null
+}
+
+"""Added in 26.8.0. Payload for app config allow-list entry update."""
+type UpdateAppConfigAllowListPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Updated app config allow-list entry."""
+  appConfigAllowList: AppConfigAllowList!
 }
 
 """

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -903,6 +903,11 @@ type AppConfigAllowList implements Node
   """Scope type the entry permits writes at (public | domain | user)."""
   scopeType: AppConfigScopeType!
 
+  """
+  Added in 26.8.0. Merge rank applied to fragments under this entry (low to high; higher wins).
+  """
+  rank: Int!
+
   """Creation timestamp (UTC)."""
   createdAt: DateTime!
 
@@ -986,6 +991,7 @@ enum AppConfigAllowListOrderField
 {
   CONFIG_NAME @join__enumValue(graph: STRAWBERRY)
   SCOPE_TYPE @join__enumValue(graph: STRAWBERRY)
+  RANK @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   UPDATED_AT @join__enumValue(graph: STRAWBERRY)
 }
@@ -3448,6 +3454,11 @@ input CreateAppConfigAllowListInput
 
   """Scope at which fragments may be written (public | domain | user)."""
   scopeType: AppConfigScopeType!
+
+  """
+  Added in 26.8.0. Merge rank applied to fragments under this entry (low to high; higher wins). Defaults to the scope type's default rank (public=100, domain=200, user=300).
+  """
+  rank: Int = null
 }
 
 """Added in 26.7.0. Payload for app config allow-list entry creation."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -7238,6 +7238,11 @@ type Mutation {
   adminPurgeAppConfigAllowList(input: PurgeAppConfigAllowListInput!): PurgeAppConfigAllowListPayload
 
   """
+  Added in 26.8.0. Update an app config allow-list entry's rank by id (super admin only).
+  """
+  adminUpdateAppConfigAllowList(input: UpdateAppConfigAllowListInput!): UpdateAppConfigAllowListPayload
+
+  """
   Added in 25.14.0. Scan external registries to discover available artifacts. Searches HuggingFace or Reservoir registries for artifacts matching the specified criteria and registers them in the system with SCANNED status. The artifacts become available for import but are not downloaded until explicitly imported. This is the first step in the artifact workflow: Scan → Import → Use
   """
   scanArtifacts(input: ScanArtifactsInput!): ScanArtifactsPayload
@@ -13376,6 +13381,25 @@ input UpdateAllowedResourceGroupsForProjectInput {
 
   """Resource group names to disallow."""
   remove: [String!] = null
+}
+
+"""
+Added in 26.8.0. Input for updating an app config allow-list entry (rank only).
+"""
+input UpdateAppConfigAllowListInput {
+  """App config allow-list entry id to update."""
+  id: UUID!
+
+  """
+  New merge rank applied to fragments under this entry (low to high; higher wins). Omit to leave unchanged.
+  """
+  rank: Int = null
+}
+
+"""Added in 26.8.0. Payload for app config allow-list entry update."""
+type UpdateAppConfigAllowListPayload {
+  """Updated app config allow-list entry."""
+  appConfigAllowList: AppConfigAllowList!
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -622,6 +622,11 @@ type AppConfigAllowList implements Node {
   """Scope type the entry permits writes at (public | domain | user)."""
   scopeType: AppConfigScopeType!
 
+  """
+  Added in 26.8.0. Merge rank applied to fragments under this entry (low to high; higher wins).
+  """
+  rank: Int!
+
   """Creation timestamp (UTC)."""
   createdAt: DateTime!
 
@@ -695,6 +700,7 @@ Added in 26.7.0. Fields available for ordering app config allow-list results.
 enum AppConfigAllowListOrderField {
   CONFIG_NAME
   SCOPE_TYPE
+  RANK
   CREATED_AT
   UPDATED_AT
 }
@@ -2277,6 +2283,11 @@ input CreateAppConfigAllowListInput {
 
   """Scope at which fragments may be written (public | domain | user)."""
   scopeType: AppConfigScopeType!
+
+  """
+  Added in 26.8.0. Merge rank applied to fragments under this entry (low to high; higher wins). Defaults to the scope type's default rank (public=100, domain=200, user=300).
+  """
+  rank: Int = null
 }
 
 """Added in 26.7.0. Payload for app config allow-list entry creation."""

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -570,6 +570,19 @@
           "scope_type": {
             "$ref": "#/components/schemas/AppConfigScopeType",
             "description": "Scope at which fragments may be written (public | domain | user)."
+          },
+          "rank": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Merge rank applied to fragments under this entry (low to high; higher wins). Defaults to the scope type's default rank (public=100, domain=200, user=300).",
+            "title": "Rank"
           }
         },
         "required": [
@@ -705,6 +718,7 @@
         "enum": [
           "config_name",
           "scope_type",
+          "rank",
           "created_at",
           "updated_at"
         ],
@@ -952,6 +966,35 @@
           }
         },
         "title": "SearchAppConfigAllowListInput",
+        "type": "object"
+      },
+      "UpdateAppConfigAllowListInput": {
+        "description": "Input for updating an app config allow-list entry.\n\nOnly ``rank`` is updatable — the identity pair (``config_name``, ``scope_type``)\nis immutable (purge and recreate to change it).",
+        "properties": {
+          "id": {
+            "description": "App config allow-list entry id to update.",
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "rank": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "New merge rank applied to fragments under this entry (low to high; higher wins). Omit to leave unchanged.",
+            "title": "Rank"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "UpdateAppConfigAllowListInput",
         "type": "object"
       },
       "CreateAppConfigDefinitionInput": {
@@ -38612,6 +38655,42 @@
           }
         ],
         "description": "Get an app config allow-list entry by id (superadmin only).\n\n**Preconditions:**\n* Superadmin privilege required.\n"
+      },
+      "patch": {
+        "operationId": "v2/app-config-allow-list.admin_update",
+        "tags": [
+          "v2/app-config-allow-list"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAppConfigAllowListInput"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "app_config_allow_list_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "description": "Update an app config allow-list entry's rank by id (superadmin only).\n\n**Preconditions:**\n* Superadmin privilege required.\n"
       },
       "delete": {
         "operationId": "v2/app-config-allow-list.admin_purge",

--- a/src/ai/backend/client/cli/v2/admin/app_config_allow_list.py
+++ b/src/ai/backend/client/cli/v2/admin/app_config_allow_list.py
@@ -158,6 +158,34 @@ def search(
 
 @app_config_allow_list.command()
 @click.argument("app_config_allow_list_id", type=click.UUID)
+@click.option(
+    "--rank",
+    required=True,
+    type=int,
+    help=("New merge rank applied to fragments under this entry (low to high; higher wins)."),
+)
+def update(app_config_allow_list_id: uuid.UUID, rank: int) -> None:
+    """Update an app config allow-list entry's rank by ID."""
+    from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
+        UpdateAppConfigAllowListInput,
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_allow_list.admin_update(
+                app_config_allow_list_id,
+                UpdateAppConfigAllowListInput(id=app_config_allow_list_id, rank=rank),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@app_config_allow_list.command()
+@click.argument("app_config_allow_list_id", type=click.UUID)
 def purge(app_config_allow_list_id: uuid.UUID) -> None:
     """Purge an app config allow-list entry by ID."""
 

--- a/src/ai/backend/client/cli/v2/admin/app_config_allow_list.py
+++ b/src/ai/backend/client/cli/v2/admin/app_config_allow_list.py
@@ -29,7 +29,16 @@ def app_config_allow_list() -> None:
     type=click.Choice([scope_type.value for scope_type in AppConfigScopeType]),
     help="Scope type the entry permits writes at.",
 )
-def create(config_name: str, scope_type: str) -> None:
+@click.option(
+    "--rank",
+    default=None,
+    type=int,
+    help=(
+        "Merge rank applied to fragments under this entry (low to high; higher wins). "
+        "Defaults to the scope type's default rank (public=100, domain=200, user=300)."
+    ),
+)
+def create(config_name: str, scope_type: str, rank: int | None) -> None:
     """Register a new app config allow-list entry."""
     from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
         CreateAppConfigAllowListInput,
@@ -42,6 +51,7 @@ def create(config_name: str, scope_type: str) -> None:
                 CreateAppConfigAllowListInput(
                     config_name=config_name,
                     scope_type=AppConfigScopeType(scope_type),
+                    rank=rank,
                 )
             )
             print_result(result)

--- a/src/ai/backend/client/v2/domains_v2/app_config_allow_list.py
+++ b/src/ai/backend/client/v2/domains_v2/app_config_allow_list.py
@@ -9,12 +9,14 @@ from ai.backend.client.v2.base_domain import BaseDomainClient
 from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
     CreateAppConfigAllowListInput,
     SearchAppConfigAllowListInput,
+    UpdateAppConfigAllowListInput,
 )
 from ai.backend.common.dto.manager.v2.app_config_allow_list.response import (
     AppConfigAllowListNode,
     CreateAppConfigAllowListPayload,
     PurgeAppConfigAllowListPayload,
     SearchAppConfigAllowListPayload,
+    UpdateAppConfigAllowListPayload,
 )
 
 _PATH: Final = "/v2/app-config-allow-list"
@@ -24,8 +26,8 @@ class V2AppConfigAllowListClient(BaseDomainClient):
     """SDK client for app config allow-list operations.
 
     Mirrors the REST v2 surface introduced in BA-6546. All calls require
-    super-admin privileges; the entity supports create, get, search, and
-    purge (no update or delete).
+    super-admin privileges; the entity supports create, get, search, update
+    (rank only), and purge.
     """
 
     async def admin_create(
@@ -58,6 +60,19 @@ class V2AppConfigAllowListClient(BaseDomainClient):
             "GET",
             f"{_PATH}/{app_config_allow_list_id}",
             response_model=AppConfigAllowListNode,
+        )
+
+    async def admin_update(
+        self,
+        app_config_allow_list_id: UUID,
+        request: UpdateAppConfigAllowListInput,
+    ) -> UpdateAppConfigAllowListPayload:
+        """Update an app config allow-list entry's rank by ID (superadmin only)."""
+        return await self._client.typed_request(
+            "PATCH",
+            f"{_PATH}/{app_config_allow_list_id}",
+            request=request,
+            response_model=UpdateAppConfigAllowListPayload,
         )
 
     async def admin_purge(

--- a/src/ai/backend/common/dto/manager/v2/app_config_allow_list/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_allow_list/request.py
@@ -22,6 +22,7 @@ __all__ = (
     "CreateAppConfigAllowListInput",
     "PurgeAppConfigAllowListInput",
     "SearchAppConfigAllowListInput",
+    "UpdateAppConfigAllowListInput",
 )
 
 
@@ -41,6 +42,23 @@ class CreateAppConfigAllowListInput(BaseRequestModel):
         description=(
             "Merge rank applied to fragments under this entry (low to high; higher wins). "
             "Defaults to the scope type's default rank (public=100, domain=200, user=300)."
+        ),
+    )
+
+
+class UpdateAppConfigAllowListInput(BaseRequestModel):
+    """Input for updating an app config allow-list entry.
+
+    Only ``rank`` is updatable — the identity pair (``config_name``, ``scope_type``)
+    is immutable (purge and recreate to change it).
+    """
+
+    id: UUID = Field(description="App config allow-list entry id to update.")
+    rank: int | None = Field(
+        default=None,
+        description=(
+            "New merge rank applied to fragments under this entry (low to high; "
+            "higher wins). Omit to leave unchanged."
         ),
     )
 

--- a/src/ai/backend/common/dto/manager/v2/app_config_allow_list/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_allow_list/request.py
@@ -36,6 +36,13 @@ class CreateAppConfigAllowListInput(BaseRequestModel):
     scope_type: AppConfigScopeType = Field(
         description="Scope at which fragments may be written (public | domain | user)."
     )
+    rank: int | None = Field(
+        default=None,
+        description=(
+            "Merge rank applied to fragments under this entry (low to high; higher wins). "
+            "Defaults to the scope type's default rank (public=100, domain=200, user=300)."
+        ),
+    )
 
 
 class PurgeAppConfigAllowListInput(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/app_config_allow_list/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_allow_list/response.py
@@ -24,6 +24,9 @@ class AppConfigAllowListNode(BaseResponseModel):
     id: UUID = Field(description="App config allow-list entry UUID.")
     config_name: str = Field(description="Gated config name.")
     scope_type: AppConfigScopeType = Field(description="Scope type the entry permits writes at.")
+    rank: int = Field(
+        description=("Merge rank applied to fragments under this entry (low to high; higher wins).")
+    )
     created_at: datetime = Field(description="Creation timestamp (UTC).")
     updated_at: datetime = Field(description="Last update timestamp (UTC).")
 

--- a/src/ai/backend/common/dto/manager/v2/app_config_allow_list/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_allow_list/response.py
@@ -15,6 +15,7 @@ __all__ = (
     "CreateAppConfigAllowListPayload",
     "PurgeAppConfigAllowListPayload",
     "SearchAppConfigAllowListPayload",
+    "UpdateAppConfigAllowListPayload",
 )
 
 
@@ -36,6 +37,14 @@ class CreateAppConfigAllowListPayload(BaseResponseModel):
 
     app_config_allow_list: AppConfigAllowListNode = Field(
         description="Created app config allow-list entry."
+    )
+
+
+class UpdateAppConfigAllowListPayload(BaseResponseModel):
+    """Payload for app config allow-list entry update."""
+
+    app_config_allow_list: AppConfigAllowListNode = Field(
+        description="Updated app config allow-list entry."
     )
 
 

--- a/src/ai/backend/common/dto/manager/v2/app_config_allow_list/types.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_allow_list/types.py
@@ -33,5 +33,6 @@ class AppConfigScopeTypeFilter(BaseRequestModel):
 class AppConfigAllowListOrderField(StrEnum):
     CONFIG_NAME = "config_name"
     SCOPE_TYPE = "scope_type"
+    RANK = "rank"
     CREATED_AT = "created_at"
     UPDATED_AT = "updated_at"

--- a/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
@@ -13,12 +13,14 @@ from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
     CreateAppConfigAllowListInput,
     PurgeAppConfigAllowListInput,
     SearchAppConfigAllowListInput,
+    UpdateAppConfigAllowListInput,
 )
 from ai.backend.common.dto.manager.v2.app_config_allow_list.response import (
     AppConfigAllowListNode,
     CreateAppConfigAllowListPayload,
     PurgeAppConfigAllowListPayload,
     SearchAppConfigAllowListPayload,
+    UpdateAppConfigAllowListPayload,
 )
 from ai.backend.common.dto.manager.v2.app_config_allow_list.types import (
     AppConfigAllowListOrderField,
@@ -40,8 +42,12 @@ from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.repositories.app_config_allow_list.creators import (
     AppConfigAllowListCreatorSpec,
 )
+from ai.backend.manager.repositories.app_config_allow_list.updaters import (
+    AppConfigAllowListUpdaterSpec,
+)
 from ai.backend.manager.repositories.base import (
     Purger,
+    Updater,
     combine_conditions_or,
     negate_conditions,
 )
@@ -58,6 +64,10 @@ from ai.backend.manager.services.app_config_allow_list.actions.purge import (
 from ai.backend.manager.services.app_config_allow_list.actions.search import (
     SearchAppConfigAllowListAction,
 )
+from ai.backend.manager.services.app_config_allow_list.actions.update import (
+    UpdateAppConfigAllowListAction,
+)
+from ai.backend.manager.types import OptionalState
 
 
 @lru_cache(maxsize=1)
@@ -142,6 +152,26 @@ class AppConfigAllowListAdapter(BaseAdapter):
             total_count=action_result.total_count,
             has_next_page=action_result.has_next_page,
             has_previous_page=action_result.has_previous_page,
+        )
+
+    async def admin_update(
+        self, input: UpdateAppConfigAllowListInput
+    ) -> UpdateAppConfigAllowListPayload:
+        updater = Updater(
+            spec=AppConfigAllowListUpdaterSpec(
+                rank=(
+                    OptionalState.update(input.rank)
+                    if input.rank is not None
+                    else OptionalState.nop()
+                ),
+            ),
+            pk_value=AppConfigAllowListID(input.id),
+        )
+        action_result = await self._processors.app_config_allow_list.update.wait_for_complete(
+            UpdateAppConfigAllowListAction(updater=updater)
+        )
+        return UpdateAppConfigAllowListPayload(
+            app_config_allow_list=self._data_to_node(action_result.allow_list),
         )
 
     async def admin_purge(

--- a/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
@@ -81,6 +81,7 @@ class AppConfigAllowListAdapter(BaseAdapter):
             spec=AppConfigAllowListCreatorSpec(
                 config_name=input.config_name,
                 scope_type=AppConfigScopeType(input.scope_type.value),
+                rank=input.rank,
             )
         )
         action_result = await self._processors.app_config_allow_list.create.wait_for_complete(
@@ -158,6 +159,7 @@ class AppConfigAllowListAdapter(BaseAdapter):
             id=data.id,
             config_name=data.config_name,
             scope_type=AppConfigScopeTypeDTO(data.scope_type.value),
+            rank=data.rank,
             created_at=data.created_at,
             updated_at=data.updated_at,
         )
@@ -248,6 +250,8 @@ class AppConfigAllowListAdapter(BaseAdapter):
                     result.append(AppConfigAllowListOrders.config_name(ascending))
                 case AppConfigAllowListOrderField.SCOPE_TYPE:
                     result.append(AppConfigAllowListOrders.scope_type(ascending))
+                case AppConfigAllowListOrderField.RANK:
+                    result.append(AppConfigAllowListOrders.rank(ascending))
                 case AppConfigAllowListOrderField.CREATED_AT:
                     result.append(AppConfigAllowListOrders.created_at(ascending))
                 case AppConfigAllowListOrderField.UPDATED_AT:

--- a/src/ai/backend/manager/api/gql/app_config_allow_list/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config_allow_list/__init__.py
@@ -5,6 +5,7 @@ from .resolver import (
     admin_app_config_allow_lists,
     admin_create_app_config_allow_list,
     admin_purge_app_config_allow_list,
+    admin_update_app_config_allow_list,
 )
 from .types import (
     AppConfigAllowListConnection,
@@ -37,4 +38,5 @@ __all__ = (
     # Mutation resolvers
     "admin_create_app_config_allow_list",
     "admin_purge_app_config_allow_list",
+    "admin_update_app_config_allow_list",
 )

--- a/src/ai/backend/manager/api/gql/app_config_allow_list/resolver.py
+++ b/src/ai/backend/manager/api/gql/app_config_allow_list/resolver.py
@@ -11,6 +11,7 @@ from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
     SearchAppConfigAllowListInput,
 )
 from ai.backend.common.identifier.app_config_allow_list import AppConfigAllowListID
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import encode_cursor
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -30,6 +31,8 @@ from .types import (
     CreateAppConfigAllowListPayloadGQL,
     PurgeAppConfigAllowListInputGQL,
     PurgeAppConfigAllowListPayloadGQL,
+    UpdateAppConfigAllowListInputGQL,
+    UpdateAppConfigAllowListPayloadGQL,
 )
 
 
@@ -115,6 +118,21 @@ async def admin_create_app_config_allow_list(
     check_admin_only()
     payload = await info.context.adapters.app_config_allow_list.admin_create(input.to_pydantic())
     return CreateAppConfigAllowListPayloadGQL.from_pydantic(payload)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Update an app config allow-list entry's rank by id (super admin only).",
+    )
+)
+async def admin_update_app_config_allow_list(
+    info: Info[StrawberryGQLContext],
+    input: UpdateAppConfigAllowListInputGQL,
+) -> UpdateAppConfigAllowListPayloadGQL | None:
+    check_admin_only()
+    payload = await info.context.adapters.app_config_allow_list.admin_update(input.to_pydantic())
+    return UpdateAppConfigAllowListPayloadGQL.from_pydantic(payload)
 
 
 @gql_mutation(

--- a/src/ai/backend/manager/api/gql/app_config_allow_list/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_allow_list/types.py
@@ -24,6 +24,9 @@ from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
 from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
     PurgeAppConfigAllowListInput as PurgeAppConfigAllowListInputDTO,
 )
+from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
+    UpdateAppConfigAllowListInput as UpdateAppConfigAllowListInputDTO,
+)
 from ai.backend.common.dto.manager.v2.app_config_allow_list.response import (
     AppConfigAllowListNode,
 )
@@ -32,6 +35,9 @@ from ai.backend.common.dto.manager.v2.app_config_allow_list.response import (
 )
 from ai.backend.common.dto.manager.v2.app_config_allow_list.response import (
     PurgeAppConfigAllowListPayload as PurgeAppConfigAllowListPayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_allow_list.response import (
+    UpdateAppConfigAllowListPayload as UpdateAppConfigAllowListPayloadDTO,
 )
 from ai.backend.common.dto.manager.v2.app_config_allow_list.types import (
     AppConfigScopeTypeFilter as AppConfigScopeTypeFilterDTO,
@@ -65,6 +71,8 @@ __all__ = (
     "CreateAppConfigAllowListPayloadGQL",
     "PurgeAppConfigAllowListInputGQL",
     "PurgeAppConfigAllowListPayloadGQL",
+    "UpdateAppConfigAllowListInputGQL",
+    "UpdateAppConfigAllowListPayloadGQL",
 )
 
 
@@ -259,6 +267,38 @@ class CreateAppConfigAllowListInputGQL(PydanticInputMixin[CreateAppConfigAllowLi
 class CreateAppConfigAllowListPayloadGQL(PydanticOutputMixin[CreateAppConfigAllowListPayloadDTO]):
     app_config_allow_list: AppConfigAllowListGQL = gql_field(
         description="The created app config allow-list entry."
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Input for updating an app config allow-list entry (rank only).",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="UpdateAppConfigAllowListInput",
+)
+class UpdateAppConfigAllowListInputGQL(PydanticInputMixin[UpdateAppConfigAllowListInputDTO]):
+    id: UUID = gql_field(description="App config allow-list entry id to update.")
+    rank: int | None = gql_field(
+        description=(
+            "New merge rank applied to fragments under this entry (low to high; higher "
+            "wins). Omit to leave unchanged."
+        ),
+        default=None,
+    )
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for app config allow-list entry update.",
+    ),
+    model=UpdateAppConfigAllowListPayloadDTO,
+    name="UpdateAppConfigAllowListPayload",
+)
+class UpdateAppConfigAllowListPayloadGQL(PydanticOutputMixin[UpdateAppConfigAllowListPayloadDTO]):
+    app_config_allow_list: AppConfigAllowListGQL = gql_field(
+        description="The updated app config allow-list entry."
     )
 
 

--- a/src/ai/backend/manager/api/gql/app_config_allow_list/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_allow_list/types.py
@@ -37,6 +37,7 @@ from ai.backend.common.dto.manager.v2.app_config_allow_list.types import (
     AppConfigScopeTypeFilter as AppConfigScopeTypeFilterDTO,
 )
 from ai.backend.common.identifier.app_config_allow_list import AppConfigAllowListID
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection, StringFilter
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -86,6 +87,14 @@ class AppConfigAllowListGQL(PydanticNodeMixin[AppConfigAllowListNode]):
     config_name: str = gql_field(description="The config name this entry permits writes for.")
     scope_type: AppConfigScopeType = gql_field(
         description="Scope type the entry permits writes at (public | domain | user)."
+    )
+    rank: int = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Merge rank applied to fragments under this entry (low to high; higher wins)."
+            ),
+        ),
     )
     created_at: datetime = gql_field(description="Creation timestamp (UTC).")
     updated_at: datetime = gql_field(description="Last update timestamp (UTC).")
@@ -193,6 +202,7 @@ class AppConfigAllowListFilterGQL(PydanticInputMixin[AppConfigAllowListFilterDTO
 class AppConfigAllowListOrderFieldGQL(StrEnum):
     CONFIG_NAME = "config_name"
     SCOPE_TYPE = "scope_type"
+    RANK = "rank"
     CREATED_AT = "created_at"
     UPDATED_AT = "updated_at"
 
@@ -225,6 +235,16 @@ class CreateAppConfigAllowListInputGQL(PydanticInputMixin[CreateAppConfigAllowLi
     config_name: str = gql_field(description="Registered config name to gate.")
     scope_type: AppConfigScopeType = gql_field(
         description="Scope at which fragments may be written (public | domain | user)."
+    )
+    rank: int | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Merge rank applied to fragments under this entry (low to high; higher wins). "
+                "Defaults to the scope type's default rank (public=100, domain=200, user=300)."
+            ),
+        ),
+        default=None,
     )
 
 

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -23,6 +23,7 @@ from .app_config_allow_list import (
     admin_app_config_allow_lists,
     admin_create_app_config_allow_list,
     admin_purge_app_config_allow_list,
+    admin_update_app_config_allow_list,
 )
 from .app_config_definition import (
     admin_app_config_definition,
@@ -708,6 +709,7 @@ class Query:
 class Mutation:
     admin_create_app_config_allow_list = admin_create_app_config_allow_list
     admin_purge_app_config_allow_list = admin_purge_app_config_allow_list
+    admin_update_app_config_allow_list = admin_update_app_config_allow_list
     scan_artifacts = scan_artifacts
     scan_artifact_models = scan_artifact_models
     import_artifacts = import_artifacts

--- a/src/ai/backend/manager/api/rest/v2/app_config_allow_list/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_allow_list/handler.py
@@ -11,6 +11,7 @@ from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
     CreateAppConfigAllowListInput,
     PurgeAppConfigAllowListInput,
     SearchAppConfigAllowListInput,
+    UpdateAppConfigAllowListInput,
 )
 from ai.backend.common.identifier.app_config_allow_list import AppConfigAllowListID
 from ai.backend.logging import BraceStyleAdapter
@@ -54,6 +55,16 @@ class V2AppConfigAllowListHandler:
         result = await self._adapter.admin_get(
             AppConfigAllowListID(path.parsed.app_config_allow_list_id)
         )
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def admin_update(
+        self,
+        path: PathParam[AppConfigAllowListIdPathParam],
+        body: BodyParam[UpdateAppConfigAllowListInput],
+    ) -> APIResponse:
+        """Update an app config allow-list entry's rank by id (superadmin only)."""
+        merged = body.parsed.model_copy(update={"id": path.parsed.app_config_allow_list_id})
+        result = await self._adapter.admin_update(merged)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
     async def admin_purge(

--- a/src/ai/backend/manager/api/rest/v2/app_config_allow_list/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_allow_list/registry.py
@@ -23,6 +23,7 @@ def register_v2_app_config_allow_list_routes(
         POST   /                            register an allow-list entry
         POST   /search                      paginated search
         GET    /{app_config_allow_list_id}  get by id
+        PATCH  /{app_config_allow_list_id}  update (rank) by id
         DELETE /{app_config_allow_list_id}  purge by id
     """
     registry = RouteRegistry.create("app-config-allow-list", route_deps.cors_options)
@@ -33,6 +34,12 @@ def register_v2_app_config_allow_list_routes(
         "GET",
         "/{app_config_allow_list_id}",
         handler.admin_get,
+        middlewares=[superadmin_required],
+    )
+    registry.add(
+        "PATCH",
+        "/{app_config_allow_list_id}",
+        handler.admin_update,
         middlewares=[superadmin_required],
     )
     registry.add(

--- a/src/ai/backend/manager/repositories/app_config_allow_list/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_allow_list/db_source/db_source.py
@@ -27,6 +27,7 @@ from ai.backend.manager.repositories.base import (
     ExistsQuerier,
     Purger,
     Querier,
+    Updater,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider
 
@@ -73,6 +74,16 @@ class AppConfigAllowListDBSource:
             if result is None:
                 raise AppConfigAllowListNotFound(
                     f"App config allow-list entry {allow_list_id} not found"
+                )
+            return result.row.to_data()
+
+    @app_config_allow_list_db_source_resilience.apply()
+    async def update(self, updater: Updater[AppConfigAllowListRow]) -> AppConfigAllowListData:
+        async with self._ops.write_ops() as w:
+            result = await w.update(updater)
+            if result is None:
+                raise AppConfigAllowListNotFound(
+                    f"App config allow-list entry {updater.pk_value} not found"
                 )
             return result.row.to_data()
 

--- a/src/ai/backend/manager/repositories/app_config_allow_list/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_allow_list/repository.py
@@ -14,7 +14,13 @@ from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowLi
 from ai.backend.manager.repositories.app_config_allow_list.db_source import (
     AppConfigAllowListDBSource,
 )
-from ai.backend.manager.repositories.base import BatchQuerier, Creator, ExistsQuerier, Purger
+from ai.backend.manager.repositories.base import (
+    BatchQuerier,
+    Creator,
+    ExistsQuerier,
+    Purger,
+    Updater,
+)
 from ai.backend.manager.repositories.ops import DBOpsProvider
 
 __all__ = ("AppConfigAllowListRepository",)
@@ -61,6 +67,10 @@ class AppConfigAllowListRepository:
     @app_config_allow_list_repository_resilience.apply()
     async def search(self, querier: BatchQuerier) -> AppConfigAllowListSearchResult:
         return await self._db_source.search(querier)
+
+    @app_config_allow_list_repository_resilience.apply()
+    async def update(self, updater: Updater[AppConfigAllowListRow]) -> AppConfigAllowListData:
+        return await self._db_source.update(updater)
 
     @app_config_allow_list_repository_resilience.apply()
     async def purge(self, purger: Purger[AppConfigAllowListRow]) -> AppConfigAllowListData:

--- a/src/ai/backend/manager/repositories/app_config_allow_list/updaters.py
+++ b/src/ai/backend/manager/repositories/app_config_allow_list/updaters.py
@@ -1,0 +1,34 @@
+"""UpdaterSpec implementations for app config allow-list repository."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, override
+
+from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
+from ai.backend.manager.repositories.base.updater import UpdaterSpec
+from ai.backend.manager.types import OptionalState
+
+
+@dataclass
+class AppConfigAllowListUpdaterSpec(UpdaterSpec[AppConfigAllowListRow]):
+    """UpdaterSpec for app config allow-list entries.
+
+    Only ``rank`` is updatable — re-ordering the merge is the one post-create
+    adjustment an entry supports. The identity pair (``config_name``, ``scope_type``)
+    is immutable: changing it means purging the entry (which cascades to its
+    fragments) and creating a new one.
+    """
+
+    rank: OptionalState[int] = field(default_factory=OptionalState[int].nop)
+
+    @property
+    @override
+    def row_class(self) -> type[AppConfigAllowListRow]:
+        return AppConfigAllowListRow
+
+    @override
+    def build_values(self) -> dict[str, Any]:
+        to_update: dict[str, Any] = {}
+        self.rank.update_dict(to_update, "rank")
+        return to_update

--- a/src/ai/backend/manager/services/app_config_allow_list/actions/update.py
+++ b/src/ai/backend/manager/services/app_config_allow_list/actions/update.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.app_config_allow_list.types import AppConfigAllowListData
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
+from ai.backend.manager.repositories.base import Updater
+from ai.backend.manager.services.app_config_allow_list.actions.base import (
+    AppConfigAllowListSingleEntityAction,
+    AppConfigAllowListSingleEntityActionResult,
+)
+
+
+@dataclass
+class UpdateAppConfigAllowListAction(AppConfigAllowListSingleEntityAction):
+    """Update an allow-list entry's ``rank`` (admin-only re-ordering of the merge).
+
+    The identity pair (``config_name``, ``scope_type``) is immutable — changing it
+    means purging the entry (which cascades to its fragments) and creating a new one.
+    """
+
+    updater: Updater[AppConfigAllowListRow]
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.UPDATE
+
+    @override
+    def target_entity_id(self) -> str:
+        return str(self.updater.pk_value)
+
+    @override
+    def target_element(self) -> RBACElementRef:
+        return RBACElementRef(RBACElementType.APP_CONFIG_ALLOW_LIST, str(self.updater.pk_value))
+
+
+@dataclass
+class UpdateAppConfigAllowListActionResult(AppConfigAllowListSingleEntityActionResult):
+    allow_list: AppConfigAllowListData
+
+    @override
+    def target_entity_id(self) -> str:
+        return str(self.allow_list.id)

--- a/src/ai/backend/manager/services/app_config_allow_list/processors.py
+++ b/src/ai/backend/manager/services/app_config_allow_list/processors.py
@@ -22,6 +22,10 @@ from ai.backend.manager.services.app_config_allow_list.actions.search import (
     SearchAppConfigAllowListAction,
     SearchAppConfigAllowListActionResult,
 )
+from ai.backend.manager.services.app_config_allow_list.actions.update import (
+    UpdateAppConfigAllowListAction,
+    UpdateAppConfigAllowListActionResult,
+)
 from ai.backend.manager.services.app_config_allow_list.service import (
     AppConfigAllowListService,
 )
@@ -35,6 +39,9 @@ class AppConfigAllowListProcessors(AbstractProcessorPackage):
     search: ScopeActionProcessor[
         SearchAppConfigAllowListAction, SearchAppConfigAllowListActionResult
     ]
+    update: SingleEntityActionProcessor[
+        UpdateAppConfigAllowListAction, UpdateAppConfigAllowListActionResult
+    ]
     purge: SingleEntityActionProcessor[
         PurgeAppConfigAllowListAction, PurgeAppConfigAllowListActionResult
     ]
@@ -47,6 +54,7 @@ class AppConfigAllowListProcessors(AbstractProcessorPackage):
         self.create = ScopeActionProcessor(service.create, action_monitors)
         self.get = SingleEntityActionProcessor(service.get, action_monitors)
         self.search = ScopeActionProcessor(service.search, action_monitors)
+        self.update = SingleEntityActionProcessor(service.update, action_monitors)
         self.purge = SingleEntityActionProcessor(service.purge, action_monitors)
 
     @override
@@ -55,5 +63,6 @@ class AppConfigAllowListProcessors(AbstractProcessorPackage):
             CreateAppConfigAllowListAction.spec(),
             GetAppConfigAllowListAction.spec(),
             SearchAppConfigAllowListAction.spec(),
+            UpdateAppConfigAllowListAction.spec(),
             PurgeAppConfigAllowListAction.spec(),
         ]

--- a/src/ai/backend/manager/services/app_config_allow_list/service.py
+++ b/src/ai/backend/manager/services/app_config_allow_list/service.py
@@ -19,6 +19,10 @@ from ai.backend.manager.services.app_config_allow_list.actions.search import (
     SearchAppConfigAllowListAction,
     SearchAppConfigAllowListActionResult,
 )
+from ai.backend.manager.services.app_config_allow_list.actions.update import (
+    UpdateAppConfigAllowListAction,
+    UpdateAppConfigAllowListActionResult,
+)
 
 __all__ = ("AppConfigAllowListService",)
 
@@ -49,6 +53,12 @@ class AppConfigAllowListService:
             has_next_page=result.has_next_page,
             has_previous_page=result.has_previous_page,
         )
+
+    async def update(
+        self, action: UpdateAppConfigAllowListAction
+    ) -> UpdateAppConfigAllowListActionResult:
+        data = await self._repository.update(action.updater)
+        return UpdateAppConfigAllowListActionResult(allow_list=data)
 
     async def purge(
         self, action: PurgeAppConfigAllowListAction

--- a/tests/unit/client_v2/test_app_config_allow_list.py
+++ b/tests/unit/client_v2/test_app_config_allow_list.py
@@ -12,12 +12,14 @@ from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.dto.manager.v2.app_config_allow_list.request import (
     CreateAppConfigAllowListInput,
     SearchAppConfigAllowListInput,
+    UpdateAppConfigAllowListInput,
 )
 from ai.backend.common.dto.manager.v2.app_config_allow_list.response import (
     AppConfigAllowListNode,
     CreateAppConfigAllowListPayload,
     PurgeAppConfigAllowListPayload,
     SearchAppConfigAllowListPayload,
+    UpdateAppConfigAllowListPayload,
 )
 
 from .conftest import MockAuth
@@ -118,6 +120,29 @@ class TestAdminGet:
         assert str(call_args[0][1]).endswith(f"/v2/app-config-allow-list/{entry_id}")
         assert isinstance(result, AppConfigAllowListNode)
         assert result.config_name == "preferences"
+
+
+class TestAdminUpdate:
+    async def test_happy_path(self) -> None:
+        entry_id = uuid4()
+        payload = _node_payload(str(entry_id), "theme")
+        payload["rank"] = 250
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"app_config_allow_list": payload})
+        mock_session = _make_request_session(mock_resp)
+        client = _make_client(mock_session)
+
+        result = await client.admin_update(
+            entry_id,
+            UpdateAppConfigAllowListInput(id=entry_id, rank=250),
+        )
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "PATCH"
+        assert str(call_args[0][1]).endswith(f"/v2/app-config-allow-list/{entry_id}")
+        assert isinstance(result, UpdateAppConfigAllowListPayload)
+        assert result.app_config_allow_list.rank == 250
 
 
 class TestAdminPurge:

--- a/tests/unit/client_v2/test_app_config_allow_list.py
+++ b/tests/unit/client_v2/test_app_config_allow_list.py
@@ -39,11 +39,12 @@ def _make_client(mock_session: MagicMock) -> V2AppConfigAllowListClient:
     return V2AppConfigAllowListClient(auth_client)
 
 
-def _node_payload(entry_id: str, config_name: str) -> dict[str, str]:
+def _node_payload(entry_id: str, config_name: str) -> dict[str, str | int]:
     return {
         "id": entry_id,
         "config_name": config_name,
         "scope_type": "domain",
+        "rank": 200,
         "created_at": "2026-01-01T00:00:00+00:00",
         "updated_at": "2026-01-02T00:00:00+00:00",
     }
@@ -73,6 +74,7 @@ class TestAdminCreate:
         assert isinstance(result, CreateAppConfigAllowListPayload)
         assert result.app_config_allow_list.config_name == "theme"
         assert result.app_config_allow_list.scope_type == AppConfigScopeType.DOMAIN
+        assert result.app_config_allow_list.rank == 200
 
 
 class TestAdminSearch:

--- a/tests/unit/manager/api/gql/test_app_config_allow_list_types.py
+++ b/tests/unit/manager/api/gql/test_app_config_allow_list_types.py
@@ -30,6 +30,7 @@ class TestAppConfigAllowListGQL:
             id=uuid.uuid4(),
             config_name="theme",
             scope_type=AppConfigScopeType.DOMAIN,
+            rank=200,
             created_at=created,
             updated_at=updated,
         )
@@ -38,6 +39,7 @@ class TestAppConfigAllowListGQL:
 
         assert gql.config_name == "theme"
         assert gql.scope_type == AppConfigScopeType.DOMAIN
+        assert gql.rank == 200
         assert gql.created_at == created
         assert gql.updated_at == updated
 

--- a/tests/unit/manager/repositories/app_config_allow_list/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_allow_list/test_repository.py
@@ -31,6 +31,9 @@ from ai.backend.manager.repositories.app_config_allow_list.creators import (
 from ai.backend.manager.repositories.app_config_allow_list.repository import (
     AppConfigAllowListRepository,
 )
+from ai.backend.manager.repositories.app_config_allow_list.updaters import (
+    AppConfigAllowListUpdaterSpec,
+)
 from ai.backend.manager.repositories.app_config_definition.creators import (
     AppConfigDefinitionCreatorSpec,
 )
@@ -45,8 +48,10 @@ from ai.backend.manager.repositories.base import (
     ExistsQuerier,
     OffsetPagination,
     Purger,
+    Updater,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider
+from ai.backend.manager.types import OptionalState
 from ai.backend.testutils.db import with_tables
 
 
@@ -183,6 +188,34 @@ class TestRankAssignment:
         created = await _create_entry(repository, "theme", AppConfigScopeType.DOMAIN, rank=250)
         assert created.rank == 250
         assert (await repository.get_by_id(created.id)).rank == 250
+
+
+class TestUpdate:
+    async def test_update_changes_rank(
+        self,
+        repository: AppConfigAllowListRepository,
+        existing_entry: AppConfigAllowListData,
+    ) -> None:
+        updated = await repository.update(
+            Updater(
+                spec=AppConfigAllowListUpdaterSpec(rank=OptionalState.update(250)),
+                pk_value=existing_entry.id,
+            )
+        )
+        assert updated.rank == 250
+        assert (await repository.get_by_id(existing_entry.id)).rank == 250
+        # identity fields are untouched
+        assert updated.config_name == existing_entry.config_name
+        assert updated.scope_type is existing_entry.scope_type
+
+    async def test_update_missing_raises(self, repository: AppConfigAllowListRepository) -> None:
+        with pytest.raises(AppConfigAllowListNotFound):
+            await repository.update(
+                Updater(
+                    spec=AppConfigAllowListUpdaterSpec(rank=OptionalState.update(250)),
+                    pk_value=_missing_id(),
+                )
+            )
 
 
 class TestPurge:

--- a/tests/unit/manager/services/app_config_allow_list/test_service.py
+++ b/tests/unit/manager/services/app_config_allow_list/test_service.py
@@ -22,11 +22,15 @@ from ai.backend.manager.repositories.app_config_allow_list.creators import (
 from ai.backend.manager.repositories.app_config_allow_list.repository import (
     AppConfigAllowListRepository,
 )
+from ai.backend.manager.repositories.app_config_allow_list.updaters import (
+    AppConfigAllowListUpdaterSpec,
+)
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
     Creator,
     OffsetPagination,
     Purger,
+    Updater,
 )
 from ai.backend.manager.services.app_config_allow_list.actions.create import (
     CreateAppConfigAllowListAction,
@@ -40,9 +44,13 @@ from ai.backend.manager.services.app_config_allow_list.actions.purge import (
 from ai.backend.manager.services.app_config_allow_list.actions.search import (
     SearchAppConfigAllowListAction,
 )
+from ai.backend.manager.services.app_config_allow_list.actions.update import (
+    UpdateAppConfigAllowListAction,
+)
 from ai.backend.manager.services.app_config_allow_list.service import (
     AppConfigAllowListService,
 )
+from ai.backend.manager.types import OptionalState
 
 
 class TestAppConfigAllowListService:
@@ -130,6 +138,23 @@ class TestAppConfigAllowListService:
         assert result.data == [allow_list_data]
         assert result.total_count == 1
         mock_repository.search.assert_called_once_with(querier)
+
+    async def test_update(
+        self,
+        service: AppConfigAllowListService,
+        mock_repository: MagicMock,
+        allow_list_data: AppConfigAllowListData,
+    ) -> None:
+        mock_repository.update = AsyncMock(return_value=allow_list_data)
+        updater = Updater(
+            spec=AppConfigAllowListUpdaterSpec(rank=OptionalState.update(250)),
+            pk_value=allow_list_data.id,
+        )
+
+        result = await service.update(UpdateAppConfigAllowListAction(updater=updater))
+
+        assert result.allow_list == allow_list_data
+        mock_repository.update.assert_called_once_with(updater)
 
     async def test_purge(
         self,


### PR DESCRIPTION
## Summary

Exposes the allow-list `rank` (introduced in #12516) on the v2 API surface. Pure API-layer change — no schema or behavior change beyond the new field:

- **DTO** (`common/dto/manager/v2/app_config_allow_list`): optional `rank` on `CreateAppConfigAllowListInput` (defaults to the scope type's default rank when omitted), required `rank` on `AppConfigAllowListNode`, and a `RANK` order field.
- **Adapter**: maps `rank` between the DTO and the creator spec / domain data, and handles the `RANK` ordering.
- **GraphQL**: `rank` on the `AppConfigAllowList` node and `CreateAppConfigAllowListInput` (version-tagged with `NEXT_RELEASE_VERSION`), `RANK` in `AppConfigAllowListOrderField`; supergraph / v2 schema regenerated.
- **CLI**: `./bai admin app-config-allow-list create --rank`.
- **New `update` operation (rank only)** — with rank on the allow list, re-ordering the merge needs a post-create adjustment (purge now cascades to fragments, so purge+recreate is not a substitute): `AppConfigAllowListUpdaterSpec` + service action/processor, `PATCH /v2/app-config-allow-list/{id}`, `adminUpdateAppConfigAllowList` GQL mutation, SDK `admin_update`, and `./bai admin app-config-allow-list update <id> --rank`. The identity pair (`config_name`, `scope_type`) stays immutable.
- The SDK create/get/search need no code change (they share the DTOs).

Verified against the live server: REST/GQL/CLI create with default (user=300) and explicit (`--rank 250`) ranks, `rank` ordering in both directions, and rank update via both the CLI (`update --rank 275`) and the GQL mutation.

## 📚 Stacked PRs

Part of the AppConfigFragment / AppConfig stack under BEP-1052 (epic BA-5781). **Merge in order:**

1. ✅ #12306 — `feat(BA-6552): app_config_fragments DB model and Alembic migration`
2. ✅ #12307 — `feat(BA-6553): repository layer`
3. ✅ #12403 — `refactor(BA-6619): consolidate AppConfigScopeType into common.data`
4. ✅ #12405 — `refactor(BA-6620): ExistsQuerier + AppConfigAllowList.exists`
5. ✅ #12358 — `feat(BA-6554): AppConfigFragment service layer`
6. #12516 — `feat(BA-6628): move fragment rank to the allow list with scope defaults` (replaces #12429)
7. 👉 **#12517 — `feat(BA-6701): expose allow-list rank on the v2 API surface`** ← you are here
8. #12518 — `feat(BA-6628): cascade fragment deletion from the allow list`
9. #12426 — `feat(BA-6626): app_config_fragment bulk repository layer`
10. #12401 — `feat(BA-6618): AppConfigFragment bulk CRUD service layer`
11. #12359 — `feat(BA-6555): app_config service layer (merge engine)`
12. #12377 — `feat(BA-6556): AppConfig REST v2 API`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12517.org.readthedocs.build/en/12517/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12517.org.readthedocs.build/ko/12517/

<!-- readthedocs-preview sorna-ko end -->



<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12517.org.readthedocs.build/en/12517/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12517.org.readthedocs.build/ko/12517/

<!-- readthedocs-preview sorna-ko end -->


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12517.org.readthedocs.build/en/12517/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12517.org.readthedocs.build/ko/12517/

<!-- readthedocs-preview sorna-ko end -->


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12517.org.readthedocs.build/en/12517/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12517.org.readthedocs.build/ko/12517/

<!-- readthedocs-preview sorna-ko end -->


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12517.org.readthedocs.build/en/12517/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12517.org.readthedocs.build/ko/12517/

<!-- readthedocs-preview sorna-ko end -->
