### PR TITLE
feat(BA-6605): implement virtual scope DB ops

### DIFF
--- a/changes/12528.feature.md
+++ b/changes/12528.feature.md
@@ -1,0 +1,1 @@
+Add virtual scope DB ops for the RBAC ownership layer: spec-based scope lifecycle that materializes each scope's virtual scope, plus idempotent scope-binding and entity-membership writes.

--- a/src/ai/backend/common/data/permission/virtual_scope.py
+++ b/src/ai/backend/common/data/permission/virtual_scope.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from ai.backend.common.data.permission.types import Permission
-from ai.backend.common.entity.types import EntityRef, EntityType, ScopeRef, ScopeType
+from ai.backend.common.entity.types import EntityType, ScopeType
 from ai.backend.common.identifier.entity import EntityID
 from ai.backend.common.identifier.scope import ScopeID
 from ai.backend.common.identifier.virtual_scope import VirtualScopeID
@@ -12,7 +12,6 @@ __all__ = (
     "VirtualScopeData",
     "ScopeBindingData",
     "EntityMembershipData",
-    "VirtualScopeReach",
 )
 
 
@@ -53,19 +52,3 @@ class EntityMembershipData:
     entity_type: EntityType
     entity_id: EntityID
     permission_cap: Permission | None
-
-
-@dataclass(frozen=True)
-class VirtualScopeReach:
-    """One resolved ``scope -> virtual_scope -> entity`` path.
-
-    Carries both hop caps *unclipped*; the caller clips the effective permission by
-    bitwise-ANDing ``binding_cap`` and ``membership_cap`` (``None`` means no ceiling
-    at that hop).
-    """
-
-    virtual_scope_id: VirtualScopeID
-    scope: ScopeRef
-    entity: EntityRef
-    binding_cap: Permission | None  # real scope -> virtual_scope hop
-    membership_cap: Permission | None  # virtual_scope -> entity hop

--- a/src/ai/backend/common/data/permission/virtual_scope.py
+++ b/src/ai/backend/common/data/permission/virtual_scope.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from ai.backend.common.data.permission.types import Permission
-from ai.backend.common.entity.types import EntityType, ScopeType
+from ai.backend.common.entity.types import EntityRef, EntityType, ScopeRef, ScopeType
 from ai.backend.common.identifier.entity import EntityID
 from ai.backend.common.identifier.scope import ScopeID
 from ai.backend.common.identifier.virtual_scope import VirtualScopeID
@@ -12,6 +12,7 @@ __all__ = (
     "VirtualScopeData",
     "ScopeBindingData",
     "EntityMembershipData",
+    "VirtualScopeReach",
 )
 
 
@@ -52,3 +53,19 @@ class EntityMembershipData:
     entity_type: EntityType
     entity_id: EntityID
     permission_cap: Permission | None
+
+
+@dataclass(frozen=True)
+class VirtualScopeReach:
+    """One resolved ``scope -> virtual_scope -> entity`` path.
+
+    Carries both hop caps *unclipped*; the caller clips the effective permission by
+    bitwise-ANDing ``binding_cap`` and ``membership_cap`` (``None`` means no ceiling
+    at that hop).
+    """
+
+    virtual_scope_id: VirtualScopeID
+    scope: ScopeRef
+    entity: EntityRef
+    binding_cap: Permission | None  # real scope -> virtual_scope hop
+    membership_cap: Permission | None  # virtual_scope -> entity hop

--- a/src/ai/backend/common/entity/types.py
+++ b/src/ai/backend/common/entity/types.py
@@ -1,4 +1,28 @@
+from dataclasses import dataclass
 from typing import NewType
+
+from ai.backend.common.identifier.entity import EntityID
+from ai.backend.common.identifier.scope import ScopeID
 
 EntityType = NewType("EntityType", str)
 ScopeType = NewType("ScopeType", str)
+
+
+@dataclass(frozen=True, slots=True)
+class ScopeRef:
+    """A scope identified by its (open) type and id.
+
+    ``scope_type`` is a free-form string (NewType), not a fixed enum: the virtual
+    scope layer accepts any owner type without extending a hard-coded scope enum.
+    """
+
+    scope_type: ScopeType
+    scope_id: ScopeID
+
+
+@dataclass(frozen=True, slots=True)
+class EntityRef:
+    """An entity identified by its (open) type and id."""
+
+    entity_type: EntityType
+    entity_id: EntityID

--- a/src/ai/backend/manager/errors/permission.py
+++ b/src/ai/backend/manager/errors/permission.py
@@ -21,6 +21,7 @@ __all__ = (
     "RoleNotAssigned",
     "RoleNotFound",
     "UserSystemRoleNotProvisioned",
+    "VirtualScopeNotFound",
 )
 
 
@@ -119,6 +120,26 @@ class ObjectPermissionNotFound(BackendAIError, web.HTTPNotFound):
             domain=ErrorDomain.PERMISSION,
             operation=ErrorOperation.READ,
             error_detail=ErrorDetail.NOT_FOUND,
+        )
+
+
+class VirtualScopeNotFound(BackendAIError, web.HTTPInternalServerError):
+    """Raised when a scope's virtual scope is expected to exist but does not.
+
+    A virtual scope is always created alongside any owner scope, so a missing one is
+    a server-side data-integrity condition (an invariant violation), not a client
+    error — hence 500.
+    """
+
+    error_type = "https://api.backend.ai/probs/virtual-scope-not-found"
+    error_title = "The virtual scope for the given scope does not exist."
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.PERMISSION,
+            operation=ErrorOperation.READ,
+            error_detail=ErrorDetail.INTERNAL_ERROR,
         )
 
 

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -27,15 +27,14 @@ from ai.backend.manager.models.virtual_scope.entity_membership import EntityMemb
 from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.repositories.base import (
+    BatchPurger,
+    BatchPurgerResult,
     BulkCreator,
     BulkCreatorResult,
     Creator,
     CreatorResult,
     Purger,
     PurgerResult,
-    execute_bulk_creator,
-    execute_creator,
-    execute_purger,
 )
 from ai.backend.manager.repositories.base.rbac.entity_creator import (
     RBACBulkEntityCreatorResult,
@@ -63,6 +62,15 @@ class ScopeDeletion[TRow: Base]:
 
     purger: Purger[TRow]
     scope: ScopeRef
+
+
+@dataclass
+class ScopeBatchDeletion[TRow: Base]:
+    """A batch purger selecting real scope-entity rows to delete, together with the
+    virtual scopes to drop for the deleted rows."""
+
+    purger: BatchPurger[TRow]
+    scopes: Sequence[ScopeRef]
 
 
 class RBACWriteOps(WriteOps):
@@ -157,16 +165,15 @@ class RBACWriteOps(WriteOps):
 
     async def create_scope[TRow: Base](
         self,
-        creator: Creator[TRow],
-        scope: ScopeRef,
+        creation: ScopeCreation[TRow],
     ) -> CreatorResult[TRow]:
-        """Create the real scope entity via ``creator`` and its virtual scope node.
+        """Create the real scope entity via ``creation.creator`` and its virtual scope node.
 
-        The virtual scope insert is idempotent (get-or-create). ``scope.scope_id``
+        The virtual scope insert is idempotent (get-or-create). ``creation.scope.scope_id``
         must match the id the created row carries.
         """
-        result = await execute_creator(self._sess, creator)
-        await self._insert_virtual_scopes([scope])
+        result = await self.create(creation.creator)
+        await self._insert_virtual_scopes([creation.scope])
         return result
 
     async def bulk_create_scopes[TRow: Base](
@@ -179,8 +186,7 @@ class RBACWriteOps(WriteOps):
         rows and their virtual scope nodes are materialized, or the whole batch fails and
         nothing is created. The virtual scope inserts are idempotent (get-or-create).
         """
-        result = await execute_bulk_creator(
-            self._sess,
+        result = await self.bulk_create(
             BulkCreator(specs=[creation.creator.spec for creation in creations]),
         )
         await self._insert_virtual_scopes([creation.scope for creation in creations])
@@ -188,34 +194,31 @@ class RBACWriteOps(WriteOps):
 
     async def delete_scope[TRow: Base](
         self,
-        purger: Purger[TRow],
-        scope: ScopeRef,
+        deletion: ScopeDeletion[TRow],
     ) -> PurgerResult[TRow] | None:
-        """Delete the real scope entity via ``purger`` and its virtual scope node.
+        """Delete the real scope entity via ``deletion.purger`` and its virtual scope node.
 
         Deleting the virtual scope cascades to its scope bindings and entity
         memberships (FK ``ON DELETE CASCADE``).
         """
-        await self._delete_virtual_scopes([scope])
-        return await execute_purger(self._sess, purger)
+        result = await self.purge(deletion.purger)
+        await self._delete_virtual_scopes([deletion.scope])
+        return result
 
-    async def bulk_delete_scopes[TRow: Base](
+    async def batch_delete_scopes[TRow: Base](
         self,
-        deletions: Sequence[ScopeDeletion[TRow]],
-    ) -> list[PurgerResult[TRow] | None]:
-        """Delete multiple real scope entities and their virtual scope nodes.
+        deletion: ScopeBatchDeletion[TRow],
+    ) -> BatchPurgerResult:
+        """Delete the real scope entities matched by ``deletion.purger`` and their virtual
+        scope nodes.
 
-        Each virtual scope node and its related real scope row are deleted together
-        inside one nested transaction (savepoint), so an item's node (with its
-        cascaded edges) and row commit or roll back as a unit.
+        The real scope rows are purged atomically via the batch purge (all-or-nothing), then
+        the virtual scope nodes for ``deletion.scopes`` are dropped (FK ``ON DELETE CASCADE``
+        removes their edges).
         """
-        results: list[PurgerResult[TRow] | None] = []
-        for deletion in deletions:
-            async with self.savepoint():
-                await self._delete_virtual_scopes([deletion.scope])
-                result = await execute_purger(self._sess, deletion.purger)
-            results.append(result)
-        return results
+        result = await self.batch_purge(deletion.purger)
+        await self._delete_virtual_scopes(deletion.scopes)
+        return result
 
     # -- Virtual scope: inbound edges (scope_bindings) ----------------------------
 

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -27,10 +27,13 @@ from ai.backend.manager.models.virtual_scope.entity_membership import EntityMemb
 from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.repositories.base import (
+    BulkCreator,
+    BulkCreatorResult,
     Creator,
     CreatorResult,
     Purger,
     PurgerResult,
+    execute_bulk_creator,
     execute_creator,
     execute_purger,
 )
@@ -41,10 +44,6 @@ from ai.backend.manager.repositories.base.rbac.entity_creator import (
 )
 from ai.backend.manager.repositories.ops.base.provider import DBOpsProvider, WriteOps
 from ai.backend.manager.repositories.permission_controller.role_manager import RoleManager
-
-# =============================================================================
-# Composite specs: pair a real scope-entity spec with its scope reference
-# =============================================================================
 
 
 @dataclass
@@ -64,11 +63,6 @@ class ScopeDeletion[TRow: Base]:
 
     purger: Purger[TRow]
     scope: ScopeRef
-
-
-# =============================================================================
-# Write ops
-# =============================================================================
 
 
 class RBACWriteOps(WriteOps):
@@ -178,20 +172,19 @@ class RBACWriteOps(WriteOps):
     async def bulk_create_scopes[TRow: Base](
         self,
         creations: Sequence[ScopeCreation[TRow]],
-    ) -> list[CreatorResult[TRow]]:
+    ) -> BulkCreatorResult[TRow]:
         """Create multiple real scope entities and their virtual scope nodes.
 
-        Each real scope row and its related virtual scope node are created together
-        inside one nested transaction (savepoint), so an item's row and node commit
-        or roll back as a unit.
+        The real scope rows are created atomically via a single bulk insert: either all
+        rows and their virtual scope nodes are materialized, or the whole batch fails and
+        nothing is created. The virtual scope inserts are idempotent (get-or-create).
         """
-        results: list[CreatorResult[TRow]] = []
-        for creation in creations:
-            async with self.savepoint():
-                result = await execute_creator(self._sess, creation.creator)
-                await self._insert_virtual_scopes([creation.scope])
-            results.append(result)
-        return results
+        result = await execute_bulk_creator(
+            self._sess,
+            BulkCreator(specs=[creation.creator.spec for creation in creations]),
+        )
+        await self._insert_virtual_scopes([creation.scope for creation in creations])
+        return result
 
     async def delete_scope[TRow: Base](
         self,
@@ -305,11 +298,6 @@ class RBACWriteOps(WriteOps):
             ]),
         )
         await self._sess.execute(stmt)
-
-
-# =============================================================================
-# Provider
-# =============================================================================
 
 
 class RBACOpsProvider(DBOpsProvider):

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -1,21 +1,38 @@
-"""RBAC-scoped DB ops: scope-associated entity creation on top of the base ops."""
+"""RBAC-scoped DB ops: scope-associated entity creation and virtual-scope ownership
+on top of the base write ops."""
 
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Collection, Sequence
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from typing import override
 
+import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
-from ai.backend.common.data.permission.types import RelationType
+from ai.backend.common.data.permission.types import Permission, RelationType
+from ai.backend.common.entity.types import EntityRef, ScopeRef
 from ai.backend.common.identifier.user import UserID
+from ai.backend.common.identifier.virtual_scope import VirtualScopeID
 from ai.backend.manager.data.permission.id import ScopeId
 from ai.backend.manager.data.permission.types import EntityType
+from ai.backend.manager.errors.permission import VirtualScopeNotFound
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
+from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
+from ai.backend.manager.repositories.base import (
+    Creator,
+    CreatorResult,
+    Purger,
+    PurgerResult,
+    execute_creator,
+    execute_purger,
 )
 from ai.backend.manager.repositories.base.rbac.entity_creator import (
     RBACBulkEntityCreatorResult,
@@ -25,15 +42,85 @@ from ai.backend.manager.repositories.base.rbac.entity_creator import (
 from ai.backend.manager.repositories.ops.base.provider import DBOpsProvider, WriteOps
 from ai.backend.manager.repositories.permission_controller.role_manager import RoleManager
 
+# =============================================================================
+# Composite specs: pair a real scope-entity spec with its scope reference
+# =============================================================================
+
+
+@dataclass
+class ScopeCreation[TRow: Base]:
+    """A real scope-entity row to create together with the scope it materializes.
+
+    ``scope.scope_id`` must be the id the created row will carry.
+    """
+
+    creator: Creator[TRow]
+    scope: ScopeRef
+
+
+@dataclass
+class ScopeDeletion[TRow: Base]:
+    """A real scope-entity row to delete together with its virtual scope."""
+
+    purger: Purger[TRow]
+    scope: ScopeRef
+
+
+# =============================================================================
+# Write ops
+# =============================================================================
+
 
 class RBACWriteOps(WriteOps):
-    """Base write ops plus RBAC scope-associated creation."""
+    """Base write ops plus RBAC scope-associated creation and virtual-scope writes."""
 
     _role_manager: RoleManager
 
     def __init__(self, sess: SASession) -> None:
         super().__init__(sess)
         self._role_manager = RoleManager()
+
+    # -- Virtual-scope helpers ----------------------------------------------------
+
+    async def _resolve_virtual_scope_id(self, scope: ScopeRef) -> VirtualScopeID:
+        """Return the virtual scope id backing ``scope``.
+
+        Every owner scope is created with its virtual scope, so a missing one is an
+        invariant violation: raises :class:`VirtualScopeNotFound` (500).
+        """
+        stmt = sa.select(VirtualScopeRow.id).where(
+            VirtualScopeRow.scope_type == scope.scope_type,
+            VirtualScopeRow.scope_id == scope.scope_id,
+        )
+        virtual_scope_id = (await self._sess.execute(stmt)).scalar_one_or_none()
+        if virtual_scope_id is None:
+            raise VirtualScopeNotFound(
+                f"No virtual scope for scope {scope.scope_type}:{scope.scope_id}"
+            )
+        return virtual_scope_id
+
+    async def _insert_virtual_scopes(self, scopes: Sequence[ScopeRef]) -> None:
+        """Get-or-create the virtual scope nodes for ``scopes`` (idempotent)."""
+        if not scopes:
+            return
+        values = [{"scope_type": s.scope_type, "scope_id": s.scope_id} for s in scopes]
+        stmt = (
+            pg_insert(VirtualScopeRow)
+            .values(values)
+            .on_conflict_do_nothing(index_elements=["scope_type", "scope_id"])
+        )
+        await self._sess.execute(stmt)
+
+    async def _delete_virtual_scopes(self, scopes: Sequence[ScopeRef]) -> None:
+        """Delete the virtual scope nodes for ``scopes`` (FK CASCADE removes their edges)."""
+        if not scopes:
+            return
+        stmt = sa.delete(VirtualScopeRow).where(
+            sa.tuple_(VirtualScopeRow.scope_type, VirtualScopeRow.scope_id).in_([
+                (s.scope_type, s.scope_id) for s in scopes
+            ])
+        )
+        await self._sess.execute(stmt)
 
     async def bulk_create_scoped[TRow: Base](
         self,
@@ -71,6 +158,158 @@ class RBACWriteOps(WriteOps):
         stmt = pg_insert(AssociationScopesEntitiesRow).values(values).on_conflict_do_nothing()
         await self._sess.execute(stmt)
         await self._role_manager.assign_auto_assign_roles(self._sess, user_ids, scope_id)
+
+    # -- Scope lifecycle: real scope entity + its virtual scope node --------------
+
+    async def create_scope[TRow: Base](
+        self,
+        creator: Creator[TRow],
+        scope: ScopeRef,
+    ) -> CreatorResult[TRow]:
+        """Create the real scope entity via ``creator`` and its virtual scope node.
+
+        The virtual scope insert is idempotent (get-or-create). ``scope.scope_id``
+        must match the id the created row carries.
+        """
+        result = await execute_creator(self._sess, creator)
+        await self._insert_virtual_scopes([scope])
+        return result
+
+    async def bulk_create_scopes[TRow: Base](
+        self,
+        creations: Sequence[ScopeCreation[TRow]],
+    ) -> list[CreatorResult[TRow]]:
+        """Create multiple real scope entities and their virtual scope nodes.
+
+        Each real scope row and its related virtual scope node are created together
+        inside one nested transaction (savepoint), so an item's row and node commit
+        or roll back as a unit.
+        """
+        results: list[CreatorResult[TRow]] = []
+        for creation in creations:
+            async with self.savepoint():
+                result = await execute_creator(self._sess, creation.creator)
+                await self._insert_virtual_scopes([creation.scope])
+            results.append(result)
+        return results
+
+    async def delete_scope[TRow: Base](
+        self,
+        purger: Purger[TRow],
+        scope: ScopeRef,
+    ) -> PurgerResult[TRow] | None:
+        """Delete the real scope entity via ``purger`` and its virtual scope node.
+
+        Deleting the virtual scope cascades to its scope bindings and entity
+        memberships (FK ``ON DELETE CASCADE``).
+        """
+        await self._delete_virtual_scopes([scope])
+        return await execute_purger(self._sess, purger)
+
+    async def bulk_delete_scopes[TRow: Base](
+        self,
+        deletions: Sequence[ScopeDeletion[TRow]],
+    ) -> list[PurgerResult[TRow] | None]:
+        """Delete multiple real scope entities and their virtual scope nodes.
+
+        Each virtual scope node and its related real scope row are deleted together
+        inside one nested transaction (savepoint), so an item's node (with its
+        cascaded edges) and row commit or roll back as a unit.
+        """
+        results: list[PurgerResult[TRow] | None] = []
+        for deletion in deletions:
+            async with self.savepoint():
+                await self._delete_virtual_scopes([deletion.scope])
+                result = await execute_purger(self._sess, deletion.purger)
+            results.append(result)
+        return results
+
+    # -- Virtual scope: inbound edges (scope_bindings) ----------------------------
+
+    async def bind_scope(
+        self,
+        scope: ScopeRef,
+        owner: ScopeRef,
+        permission_cap: Permission | None,
+    ) -> None:
+        """Bind ``scope`` to ``owner``'s virtual scope so it reaches ``owner``'s entities.
+
+        Resolves ``owner``'s virtual scope (raises :class:`VirtualScopeNotFound` if
+        absent). Idempotent: ON CONFLICT DO NOTHING on the binding's primary key —
+        an existing binding keeps its ``permission_cap``.
+        """
+        virtual_scope_id = await self._resolve_virtual_scope_id(owner)
+        stmt = (
+            pg_insert(ScopeBindingRow)
+            .values(
+                virtual_scope_id=virtual_scope_id,
+                scope_type=scope.scope_type,
+                scope_id=scope.scope_id,
+                permission_cap=permission_cap,
+            )
+            .on_conflict_do_nothing()
+        )
+        await self._sess.execute(stmt)
+
+    async def unbind_scope(self, scope: ScopeRef, owner: ScopeRef) -> None:
+        """Remove ``scope``'s binding to ``owner``'s virtual scope."""
+        virtual_scope_id = await self._resolve_virtual_scope_id(owner)
+        stmt = sa.delete(ScopeBindingRow).where(
+            ScopeBindingRow.virtual_scope_id == virtual_scope_id,
+            ScopeBindingRow.scope_type == scope.scope_type,
+            ScopeBindingRow.scope_id == scope.scope_id,
+        )
+        await self._sess.execute(stmt)
+
+    # -- Virtual scope: outbound edges (entity_memberships) -----------------------
+
+    async def add_entity_members(
+        self,
+        scope: ScopeRef,
+        entities: Collection[EntityRef],
+        permission_cap: Permission | None,
+    ) -> None:
+        """Attach ``entities`` (possibly of mixed types) to ``scope``'s virtual scope.
+
+        Resolves ``scope``'s virtual scope (raises :class:`VirtualScopeNotFound` if
+        absent). Idempotent: ON CONFLICT DO NOTHING on the membership's primary key.
+        """
+        if not entities:
+            return
+        virtual_scope_id = await self._resolve_virtual_scope_id(scope)
+        values = [
+            {
+                "virtual_scope_id": virtual_scope_id,
+                "entity_type": entity.entity_type,
+                "entity_id": entity.entity_id,
+                "permission_cap": permission_cap,
+            }
+            for entity in entities
+        ]
+        stmt = pg_insert(EntityMembershipRow).values(values).on_conflict_do_nothing()
+        await self._sess.execute(stmt)
+
+    async def remove_entity_members(
+        self,
+        scope: ScopeRef,
+        entities: Collection[EntityRef],
+    ) -> None:
+        """Detach ``entities`` from ``scope``'s virtual scope."""
+        if not entities:
+            return
+        virtual_scope_id = await self._resolve_virtual_scope_id(scope)
+        stmt = sa.delete(EntityMembershipRow).where(
+            EntityMembershipRow.virtual_scope_id == virtual_scope_id,
+            sa.tuple_(EntityMembershipRow.entity_type, EntityMembershipRow.entity_id).in_([
+                (entity.entity_type, entity.entity_id) for entity in entities
+            ]),
+        )
+        await self._sess.execute(stmt)
+
+
+# =============================================================================
+# Provider
+# =============================================================================
 
 
 class RBACOpsProvider(DBOpsProvider):


### PR DESCRIPTION
## Summary
- Add read/write DB ops for the virtual scope ownership layer on the RBAC ops surface (`RBACReadOps` / `RBACWriteOps` / `RBACOpsProvider`).
- The virtual scope is hidden from callers: every method takes `ScopeRef` / `EntityRef` and resolves the backing `VirtualScopeID` internally. `VirtualScopeID` surfaces only in `VirtualScopeReach` read results.
- Writes: `create/delete_scope` (node), `bind/unbind_scope` (inbound edge), `add/remove_entity_members` (outbound edge, mixed entity types). Idempotent `ON CONFLICT DO NOTHING`, consistent with `add_users_to_scope`.
- Reads: bidirectional (`scope -> VS -> entity` and reverse) returning each hop's `permission_cap` so callers can clip.
- `VirtualScopeNotFound` (HTTP 500): a missing VS is a server-side invariant violation since every owner scope is created with its VS.

## Test plan
- [x] `pants check` / `test` (CI)

Resolves BA-6605