### PR TITLE
feat: Enable external event-dispatcher plugins to observe session lifecycle results

### DIFF
--- a/changes/12529.feature.md
+++ b/changes/12529.feature.md
@@ -1,0 +1,1 @@
+Forward session result and termination events to manager event-dispatcher plugins and initialize them with a standard dependency context, so externally installed plugins can react to session lifecycle outcomes without manager source changes.

--- a/src/ai/backend/common/plugin/event.py
+++ b/src/ai/backend/common/plugin/event.py
@@ -14,6 +14,32 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class AbstractEventDispatcherPlugin(AbstractPlugin, metaclass=ABCMeta):
+    """Base class for event-dispatcher plugins.
+
+    Lifecycle contract for implementations (in-tree or externally installed):
+
+    - ``init(context=None)`` is called once at plugin discovery time, before
+      the host's dependency graph exists. Implementations must tolerate a
+      ``None`` context (typically by staying disabled).
+    - The host calls ``init`` again with a context mapping after its
+      dependencies are ready and **before** any event is delivered, so
+      ``init`` must be safely re-entrant. The manager provides at least the
+      following keys and may add more; implementations must pick the keys
+      they need and tolerate extra ones:
+
+      - ``etcd``: the shared :class:`~ai.backend.common.etcd.AsyncEtcd` client
+      - ``config_provider``: the manager configuration provider
+      - ``repositories``: the manager repositories container
+      - ``processors``: the manager service-layer processors container
+      - ``error_log_repository``: shortcut kept for backward compatibility
+
+    - ``handle_event`` receives every event the host forwards and must filter
+      by event type (``isinstance``) and return quickly for events it does
+      not care about. Exceptions raised here are logged and suppressed by the
+      host so that one plugin cannot disturb event handling or sibling
+      plugins — do not rely on exceptions for control flow.
+    """
+
     @override
     async def init(self, context: Any | None = None) -> None:
         pass
@@ -40,5 +66,15 @@ class EventDispatcherPluginContext(BasePluginContext[AbstractEventDispatcherPlug
         source: AgentId,
         event: AbstractEvent,
     ) -> None:
-        for plugin_instance in self.plugins.values():
-            await plugin_instance.handle_event(source, event)
+        for plugin_name, plugin_instance in self.plugins.items():
+            try:
+                await plugin_instance.handle_event(source, event)
+            except Exception:
+                # A misbehaving plugin must not disturb the surrounding event
+                # handler (which would leave the message un-acked and cause
+                # redelivery) nor starve sibling plugins of the event.
+                log.exception(
+                    "event-dispatcher plugin {} failed to handle event {}",
+                    plugin_name,
+                    event.event_name(),
+                )

--- a/src/ai/backend/manager/dependencies/composer.py
+++ b/src/ai/backend/manager/dependencies/composer.py
@@ -8,7 +8,6 @@ from typing import override
 
 from ai.backend.common.dependencies import DependencyComposer, DependencyStack
 from ai.backend.logging.types import LogLevel
-from ai.backend.manager.plugin.error_monitor import ErrorEventDispatcher
 from ai.backend.manager.plugin.monitor import ManagerErrorPluginContext, ManagerStatsPluginContext
 
 from .agents import AgentsComposer, AgentsInput, AgentsResources
@@ -187,16 +186,10 @@ class ManagerDependencyComposer(DependencyComposer[DependencyInput, DependencyRe
             ),
         )
 
-        # Stage 6.5: Re-initialize ErrorEventDispatcher plugin with repository.
-        # The plugin was disabled during Stage 4 (Plugins) because
-        # error_log_repository was not yet available.
-        for plugin_instance in plugins.event_dispatcher_plugin_ctx.plugins.values():
-            if isinstance(plugin_instance, ErrorEventDispatcher):
-                await plugin_instance.init(
-                    context={
-                        "error_log_repository": domain.repositories.error_log.repository,
-                    },
-                )
+        # Event-dispatcher plugins (disabled since Stage 4 for lack of
+        # dependencies) are re-initialized inside the Processing stage with
+        # the standard manager plugin context, right before the event
+        # dispatcher starts delivering events.
 
         # Stage 6.5: Monitoring (error_monitor, stats_monitor)
         # Must run after Domain so that error_log_repository is available.

--- a/src/ai/backend/manager/dependencies/composer.py
+++ b/src/ai/backend/manager/dependencies/composer.py
@@ -186,9 +186,9 @@ class ManagerDependencyComposer(DependencyComposer[DependencyInput, DependencyRe
             ),
         )
 
-        # Event-dispatcher plugins (disabled since Stage 4 for lack of
-        # dependencies) are re-initialized inside the Processing stage with
-        # the standard manager plugin context, right before the event
+        # Note: event-dispatcher plugins (disabled since Stage 4 for lack of
+        # dependencies) are re-initialized by ProcessingComposer (Stage 10)
+        # with the standard manager plugin context, right before the event
         # dispatcher starts delivering events.
 
         # Stage 6.5: Monitoring (error_monitor, stats_monitor)

--- a/src/ai/backend/manager/dependencies/processing/composer.py
+++ b/src/ai/backend/manager/dependencies/processing/composer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -77,6 +78,8 @@ from .log_cleanup_timer import LogCleanupTimerDependency, LogCleanupTimerInput
 from .manager_status_watcher import ManagerStatusWatcherDependency, ManagerStatusWatcherInput
 from .processors import ProcessorsDependency, ProcessorsProviderInput
 from .stats_reporter import StatsReporterDependency, StatsReporterInput
+
+log = logging.getLogger(__spec__.name)
 
 
 @dataclass
@@ -291,25 +294,32 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
 
         # Step 2.5: Re-initialize event-dispatcher plugins with the standard
         # manager plugin context, now that repositories and processors exist
-        # and before the event dispatcher starts delivering events. These
-        # context keys are the contract for `backendai_event_dispatcher_v20`
-        # plugins (in-tree or externally installed); each plugin picks the
-        # keys it needs and must tolerate extra ones.
+        # and before the event dispatcher starts delivering events. The
+        # context keys are documented as the plugin-facing contract on
+        # `AbstractEventDispatcherPlugin` (ai.backend.common.plugin.event).
         event_dispatcher_plugin_context = {
             "etcd": setup_input.etcd,
             "config_provider": setup_input.config_provider,
             "repositories": setup_input.repositories,
             "processors": processors,
+            # Shortcut kept for backward compatibility with the intrinsic
+            # ErrorEventDispatcher plugin.
             "error_log_repository": setup_input.repositories.error_log.repository,
-            "session_repository": setup_input.repositories.session.repository,
-            "user_repository": setup_input.repositories.user.repository,
-            "keypair_resource_policy_repository": (
-                setup_input.repositories.keypair_resource_policy.repository
-            ),
-            "session_processors": processors.session,
         }
-        for plugin_instance in setup_input.event_dispatcher_plugin_ctx.plugins.values():
-            await plugin_instance.init(context=event_dispatcher_plugin_context)
+        for (
+            plugin_name,
+            plugin_instance,
+        ) in setup_input.event_dispatcher_plugin_ctx.plugins.items():
+            try:
+                await plugin_instance.init(context=event_dispatcher_plugin_context)
+            except Exception:
+                # A plugin that fails to initialize must not abort manager
+                # startup; it is left in whatever (typically disabled) state
+                # its failed init produced.
+                log.exception(
+                    "Failed to re-initialize event-dispatcher plugin %r; skipping it",
+                    plugin_name,
+                )
 
         # Step 3: Register Dispatchers and start EventDispatcher
         dispatchers = Dispatchers(

--- a/src/ai/backend/manager/dependencies/processing/composer.py
+++ b/src/ai/backend/manager/dependencies/processing/composer.py
@@ -289,6 +289,28 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
             ),
         )
 
+        # Step 2.5: Re-initialize event-dispatcher plugins with the standard
+        # manager plugin context, now that repositories and processors exist
+        # and before the event dispatcher starts delivering events. These
+        # context keys are the contract for `backendai_event_dispatcher_v20`
+        # plugins (in-tree or externally installed); each plugin picks the
+        # keys it needs and must tolerate extra ones.
+        event_dispatcher_plugin_context = {
+            "etcd": setup_input.etcd,
+            "config_provider": setup_input.config_provider,
+            "repositories": setup_input.repositories,
+            "processors": processors,
+            "error_log_repository": setup_input.repositories.error_log.repository,
+            "session_repository": setup_input.repositories.session.repository,
+            "user_repository": setup_input.repositories.user.repository,
+            "keypair_resource_policy_repository": (
+                setup_input.repositories.keypair_resource_policy.repository
+            ),
+            "session_processors": processors.session,
+        }
+        for plugin_instance in setup_input.event_dispatcher_plugin_ctx.plugins.values():
+            await plugin_instance.init(context=event_dispatcher_plugin_context)
+
         # Step 3: Register Dispatchers and start EventDispatcher
         dispatchers = Dispatchers(
             DispatcherArgs(

--- a/src/ai/backend/manager/event_dispatcher/handlers/session.py
+++ b/src/ai/backend/manager/event_dispatcher/handlers/session.py
@@ -100,7 +100,7 @@ class SessionEventHandler:
         await self._idle_checker_host.dispatch_session_status_event(
             event.session_id, SessionStatus.RUNNING
         )
-        await self._event_dispatcher_plugin_ctx.handle_event(context, source, event)
+        await self._event_dispatcher_plugin_ctx.handle_event(None, source, event)
 
     async def handle_session_cancelled(
         self,
@@ -114,6 +114,7 @@ class SessionEventHandler:
         """
         log.info("handle_session_cancelled: ev:{} s:{}", event.event_name(), event.session_id)
         await self._handle_started_or_cancelled(None, source, event)
+        await self._event_dispatcher_plugin_ctx.handle_event(None, source, event)
 
     async def handle_session_terminating(
         self,
@@ -126,6 +127,7 @@ class SessionEventHandler:
         published by the manager.
         """
         await self.invoke_session_callback(None, source, event)
+        await self._event_dispatcher_plugin_ctx.handle_event(None, source, event)
 
     async def handle_session_terminated(
         self,

--- a/src/ai/backend/manager/event_dispatcher/handlers/session.py
+++ b/src/ai/backend/manager/event_dispatcher/handlers/session.py
@@ -135,6 +135,7 @@ class SessionEventHandler:
     ) -> None:
         await self._registry.clean_session(event.session_id)
         await self.invoke_session_callback(None, source, event)
+        await self._event_dispatcher_plugin_ctx.handle_event(None, source, event)
 
     async def handle_destroy_session(
         self,
@@ -173,6 +174,7 @@ class SessionEventHandler:
         )
 
         await self.invoke_session_callback(None, source, event)
+        await self._event_dispatcher_plugin_ctx.handle_event(None, source, event)
 
     async def invoke_session_callback(
         self,

--- a/tests/unit/common/plugin/BUILD
+++ b/tests/unit/common/plugin/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/tests/unit/common/plugin/test_event.py
+++ b/tests/unit/common/plugin/test_event.py
@@ -1,0 +1,72 @@
+"""Tests for EventDispatcherPluginContext plugin isolation."""
+
+from __future__ import annotations
+
+from typing import Any, override
+from unittest.mock import MagicMock
+
+from ai.backend.common.events.types import AbstractEvent
+from ai.backend.common.plugin.event import (
+    AbstractEventDispatcherPlugin,
+    EventDispatcherPluginContext,
+)
+from ai.backend.common.types import AgentId
+
+
+class _RecordingPlugin(AbstractEventDispatcherPlugin):
+    received: list[AbstractEvent]
+
+    def __init__(self) -> None:
+        super().__init__(plugin_config={}, local_config={})
+        self.received = []
+
+    @override
+    async def update_plugin_config(self, plugin_config: Any) -> None:
+        pass
+
+    @override
+    async def handle_event(self, source: AgentId, event: AbstractEvent) -> None:
+        self.received.append(event)
+
+
+class _RaisingPlugin(AbstractEventDispatcherPlugin):
+    @override
+    async def update_plugin_config(self, plugin_config: Any) -> None:
+        pass
+
+    @override
+    async def handle_event(self, source: AgentId, event: AbstractEvent) -> None:
+        raise RuntimeError("broken plugin")
+
+
+def _make_context(
+    plugins: dict[str, AbstractEventDispatcherPlugin],
+) -> EventDispatcherPluginContext:
+    ctx = EventDispatcherPluginContext(etcd=MagicMock(), local_config={})
+    ctx.plugins = plugins
+    return ctx
+
+
+def _make_event() -> AbstractEvent:
+    event = MagicMock(spec=AbstractEvent)
+    event.event_name.return_value = "test_event"
+    return event
+
+
+class TestEventDispatcherPluginContextIsolation:
+    """A misbehaving plugin must not disturb the caller or sibling plugins."""
+
+    async def test_plugin_exception_does_not_propagate(self) -> None:
+        ctx = _make_context({"broken": _RaisingPlugin(plugin_config={}, local_config={})})
+        # Must not raise into the surrounding event handler.
+        await ctx.handle_event(None, AgentId("i-test"), _make_event())
+
+    async def test_sibling_plugins_still_receive_the_event(self) -> None:
+        recording = _RecordingPlugin()
+        ctx = _make_context({
+            "broken": _RaisingPlugin(plugin_config={}, local_config={}),
+            "healthy": recording,
+        })
+        event = _make_event()
+        await ctx.handle_event(None, AgentId("i-test"), event)
+        assert recording.received == [event]

--- a/tests/unit/manager/dependencies/processing/test_composer.py
+++ b/tests/unit/manager/dependencies/processing/test_composer.py
@@ -197,3 +197,67 @@ class TestProcessingComposer:
                     "dispatcher.start",
                     "BgtaskRegistry",
                 ]
+
+    @patch(
+        "ai.backend.manager.dependencies.processing.bgtask_registry.BackgroundTaskHandlerRegistry"
+    )
+    @patch("ai.backend.manager.dependencies.processing.bgtask_registry.CommitSessionHandler")
+    @patch("ai.backend.manager.dependencies.processing.bgtask_registry.RescanGPUAllocMapsHandler")
+    @patch("ai.backend.manager.dependencies.processing.bgtask_registry.PurgeImagesHandler")
+    @patch("ai.backend.manager.dependencies.processing.bgtask_registry.RescanImagesHandler")
+    @patch("ai.backend.manager.dependencies.processing.composer.Dispatchers")
+    @patch("ai.backend.manager.dependencies.processing.processors.create_processors")
+    @patch("ai.backend.manager.dependencies.processing.event_dispatcher.EventDispatcher")
+    async def test_event_dispatcher_plugins_reinitialized_before_start(
+        self,
+        mock_dispatcher_class: MagicMock,
+        mock_create_processors: MagicMock,
+        mock_dispatchers_class: MagicMock,
+        mock_rescan_images: MagicMock,
+        mock_purge_images: MagicMock,
+        mock_rescan_gpu: MagicMock,
+        mock_commit_session: MagicMock,
+        mock_registry_class: MagicMock,
+    ) -> None:
+        """Event-dispatcher plugins must receive the standard manager context
+        before the event dispatcher starts delivering events."""
+        call_order: list[str] = []
+
+        mock_event_dispatcher = MagicMock()
+        mock_event_dispatcher.start = AsyncMock(side_effect=lambda: call_order.append("start"))
+        mock_event_dispatcher.close = AsyncMock()
+        mock_dispatcher_class.return_value = mock_event_dispatcher
+
+        mock_processors = MagicMock()
+        mock_create_processors.return_value = mock_processors
+        mock_dispatchers_class.return_value = MagicMock()
+        mock_registry_class.return_value = MagicMock()
+
+        stub_plugin = MagicMock()
+        stub_plugin.init = AsyncMock(side_effect=lambda context: call_order.append("plugin_init"))
+        setup_input = _make_processing_input()
+        setup_input.event_dispatcher_plugin_ctx.plugins = {"stub": stub_plugin}
+
+        composer = ProcessingComposer()
+        stack = DependencyBuilderStack()
+
+        async with stack:
+            async with composer.compose(stack, setup_input):
+                pass
+
+        stub_plugin.init.assert_awaited_once()
+        context = stub_plugin.init.await_args.kwargs["context"]
+        expected_keys = {
+            "etcd",
+            "config_provider",
+            "repositories",
+            "processors",
+            "error_log_repository",
+            "session_repository",
+            "user_repository",
+            "keypair_resource_policy_repository",
+            "session_processors",
+        }
+        assert expected_keys <= set(context.keys())
+        assert context["processors"] is mock_processors
+        assert call_order == ["plugin_init", "start"]

--- a/tests/unit/manager/dependencies/processing/test_composer.py
+++ b/tests/unit/manager/dependencies/processing/test_composer.py
@@ -253,11 +253,59 @@ class TestProcessingComposer:
             "repositories",
             "processors",
             "error_log_repository",
-            "session_repository",
-            "user_repository",
-            "keypair_resource_policy_repository",
-            "session_processors",
         }
         assert expected_keys <= set(context.keys())
         assert context["processors"] is mock_processors
         assert call_order == ["plugin_init", "start"]
+
+    @patch(
+        "ai.backend.manager.dependencies.processing.bgtask_registry.BackgroundTaskHandlerRegistry"
+    )
+    @patch("ai.backend.manager.dependencies.processing.bgtask_registry.CommitSessionHandler")
+    @patch("ai.backend.manager.dependencies.processing.bgtask_registry.RescanGPUAllocMapsHandler")
+    @patch("ai.backend.manager.dependencies.processing.bgtask_registry.PurgeImagesHandler")
+    @patch("ai.backend.manager.dependencies.processing.bgtask_registry.RescanImagesHandler")
+    @patch("ai.backend.manager.dependencies.processing.composer.Dispatchers")
+    @patch("ai.backend.manager.dependencies.processing.processors.create_processors")
+    @patch("ai.backend.manager.dependencies.processing.event_dispatcher.EventDispatcher")
+    async def test_plugin_init_failure_does_not_abort_composition(
+        self,
+        mock_dispatcher_class: MagicMock,
+        mock_create_processors: MagicMock,
+        mock_dispatchers_class: MagicMock,
+        mock_rescan_images: MagicMock,
+        mock_purge_images: MagicMock,
+        mock_rescan_gpu: MagicMock,
+        mock_commit_session: MagicMock,
+        mock_registry_class: MagicMock,
+    ) -> None:
+        """A plugin whose re-init raises must be skipped, not abort startup."""
+        mock_event_dispatcher = MagicMock()
+        mock_event_dispatcher.start = AsyncMock()
+        mock_event_dispatcher.close = AsyncMock()
+        mock_dispatcher_class.return_value = mock_event_dispatcher
+
+        mock_create_processors.return_value = MagicMock()
+        mock_dispatchers_class.return_value = MagicMock()
+        mock_registry_class.return_value = MagicMock()
+
+        broken_plugin = MagicMock()
+        broken_plugin.init = AsyncMock(side_effect=RuntimeError("broken plugin config"))
+        healthy_plugin = MagicMock()
+        healthy_plugin.init = AsyncMock()
+        setup_input = _make_processing_input()
+        setup_input.event_dispatcher_plugin_ctx.plugins = {
+            "broken": broken_plugin,
+            "healthy": healthy_plugin,
+        }
+
+        composer = ProcessingComposer()
+        stack = DependencyBuilderStack()
+
+        async with stack:
+            async with composer.compose(stack, setup_input) as resources:
+                assert isinstance(resources, ProcessingResources)
+
+        broken_plugin.init.assert_awaited_once()
+        healthy_plugin.init.assert_awaited_once()
+        mock_event_dispatcher.start.assert_awaited_once()

--- a/tests/unit/manager/event_dispatcher/handlers/test_session.py
+++ b/tests/unit/manager/event_dispatcher/handlers/test_session.py
@@ -13,9 +13,11 @@ import yarl
 
 from ai.backend.common.events.event_types.kernel.types import KernelLifecycleEventReason
 from ai.backend.common.events.event_types.session.anycast import (
+    SessionCancelledAnycastEvent,
     SessionFailureAnycastEvent,
     SessionSuccessAnycastEvent,
     SessionTerminatedAnycastEvent,
+    SessionTerminatingAnycastEvent,
 )
 from ai.backend.common.types import (
     AgentId,
@@ -332,4 +334,33 @@ class TestEventDispatcherPluginForwarding:
             side_effect=SessionNotFound("gone"),
         ):
             await handler.handle_session_terminated(None, AgentId("i-test"), event)
+        plugin_ctx.handle_event.assert_awaited_once_with(None, AgentId("i-test"), event)
+
+    async def test_session_cancelled_is_forwarded_to_plugins(
+        self,
+        handler: SessionEventHandler,
+        plugin_ctx: MagicMock,
+        session_id: SessionId,
+    ) -> None:
+        event = SessionCancelledAnycastEvent(
+            session_id,
+            "test-creation-id",
+            reason=KernelLifecycleEventReason.FAILED_TO_START,
+        )
+        await handler.handle_session_cancelled(None, AgentId("i-test"), event)
+        plugin_ctx.handle_event.assert_awaited_once_with(None, AgentId("i-test"), event)
+
+    async def test_session_terminating_is_forwarded_to_plugins(
+        self,
+        handler: SessionEventHandler,
+        plugin_ctx: MagicMock,
+        session_id: SessionId,
+    ) -> None:
+        event = SessionTerminatingAnycastEvent(session_id, "user-requested")
+        with patch(
+            "ai.backend.manager.event_dispatcher.handlers.session.SessionRow.get_session",
+            new_callable=AsyncMock,
+            side_effect=SessionNotFound("gone"),
+        ):
+            await handler.handle_session_terminating(None, AgentId("i-test"), event)
         plugin_ctx.handle_event.assert_awaited_once_with(None, AgentId("i-test"), event)

--- a/tests/unit/manager/event_dispatcher/handlers/test_session.py
+++ b/tests/unit/manager/event_dispatcher/handlers/test_session.py
@@ -11,7 +11,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import yarl
 
+from ai.backend.common.events.event_types.kernel.types import KernelLifecycleEventReason
 from ai.backend.common.events.event_types.session.anycast import (
+    SessionFailureAnycastEvent,
+    SessionSuccessAnycastEvent,
     SessionTerminatedAnycastEvent,
 )
 from ai.backend.common.types import (
@@ -20,6 +23,7 @@ from ai.backend.common.types import (
     SessionResult,
     SessionTypes,
 )
+from ai.backend.manager.errors.kernel import SessionNotFound
 from ai.backend.manager.event_dispatcher.handlers.session import SessionEventHandler
 
 
@@ -234,3 +238,98 @@ class TestInvokeSessionCallbackPayload:
             await handler.invoke_session_callback(None, AgentId("i-test"), event)
 
         mock_callback.assert_not_called()
+
+
+class TestEventDispatcherPluginForwarding:
+    """Session result/termination events must be forwarded to event-dispatcher plugins."""
+
+    @pytest.fixture
+    def plugin_ctx(self) -> MagicMock:
+        ctx = MagicMock()
+        ctx.handle_event = AsyncMock()
+        return ctx
+
+    @pytest.fixture
+    def handler(self, plugin_ctx: MagicMock) -> SessionEventHandler:
+        registry = MagicMock()
+        registry.clean_session = AsyncMock()
+        scheduling_controller = MagicMock()
+        scheduling_controller.mark_sessions_for_termination = AsyncMock()
+        return SessionEventHandler(
+            registry=registry,
+            db=_make_mock_db(AsyncMock()),
+            event_dispatcher_plugin_ctx=plugin_ctx,
+            idle_checker_host=MagicMock(),
+            scheduling_controller=scheduling_controller,
+        )
+
+    @pytest.fixture
+    def session_id(self) -> SessionId:
+        return SessionId(uuid.uuid4())
+
+    async def test_batch_failure_is_forwarded_to_plugins(
+        self,
+        handler: SessionEventHandler,
+        plugin_ctx: MagicMock,
+        session_id: SessionId,
+    ) -> None:
+        event = SessionFailureAnycastEvent(
+            session_id,
+            reason=KernelLifecycleEventReason.TASK_FAILED,
+            exit_code=1,
+        )
+        with (
+            patch(
+                "ai.backend.manager.event_dispatcher.handlers.session"
+                ".SessionRow.set_session_result",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "ai.backend.manager.event_dispatcher.handlers.session.SessionRow.get_session",
+                new_callable=AsyncMock,
+                side_effect=SessionNotFound("gone"),
+            ),
+        ):
+            await handler.handle_batch_result(None, AgentId("i-test"), event)
+        plugin_ctx.handle_event.assert_awaited_once_with(None, AgentId("i-test"), event)
+
+    async def test_batch_success_is_forwarded_to_plugins(
+        self,
+        handler: SessionEventHandler,
+        plugin_ctx: MagicMock,
+        session_id: SessionId,
+    ) -> None:
+        event = SessionSuccessAnycastEvent(
+            session_id,
+            reason=KernelLifecycleEventReason.TASK_FINISHED,
+            exit_code=0,
+        )
+        with (
+            patch(
+                "ai.backend.manager.event_dispatcher.handlers.session"
+                ".SessionRow.set_session_result",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "ai.backend.manager.event_dispatcher.handlers.session.SessionRow.get_session",
+                new_callable=AsyncMock,
+                side_effect=SessionNotFound("gone"),
+            ),
+        ):
+            await handler.handle_batch_result(None, AgentId("i-test"), event)
+        plugin_ctx.handle_event.assert_awaited_once_with(None, AgentId("i-test"), event)
+
+    async def test_session_terminated_is_forwarded_to_plugins(
+        self,
+        handler: SessionEventHandler,
+        plugin_ctx: MagicMock,
+        session_id: SessionId,
+    ) -> None:
+        event = SessionTerminatedAnycastEvent(session_id, "task-failed")
+        with patch(
+            "ai.backend.manager.event_dispatcher.handlers.session.SessionRow.get_session",
+            new_callable=AsyncMock,
+            side_effect=SessionNotFound("gone"),
+        ):
+            await handler.handle_session_terminated(None, AgentId("i-test"), event)
+        plugin_ctx.handle_event.assert_awaited_once_with(None, AgentId("i-test"), event)


### PR DESCRIPTION
## Summary

- Forward session lifecycle events (`SessionSuccess/FailureAnycastEvent`, `SessionTerminatedAnycastEvent`, `SessionCancelledAnycastEvent`, `SessionTerminatingAnycastEvent`) to `backendai_event_dispatcher_v20` plugins in `SessionEventHandler`, mirroring the existing `session_started` forwarding — previously plugins could observe that a session started but never how it ended.
- Replace the `isinstance(ErrorEventDispatcher)` special-case re-initialization in `dependencies/composer.py` with a generic late re-init of **all** event-dispatcher plugins inside `ProcessingComposer`, using a standard context dict (`etcd`, `config_provider`, `repositories`, `processors`, plus `error_log_repository` for compatibility). It runs after processors creation and **before** `event_dispatcher.start()`, so every plugin is fully wired before the first event can be delivered.
- Harden the extension point for third-party code: a plugin whose `init` raises is skipped (manager startup is never aborted), and a plugin raising in `handle_event` is logged and suppressed per-plugin — so it can neither leave the message un-acked (which would cause redelivery with duplicate side effects) nor starve sibling plugins.
- Document the plugin lifecycle and the standard context-key contract on `AbstractEventDispatcherPlugin`, where plugin authors will actually find it.
- Together these make the event-dispatcher plugin group a real extension point for externally installed (package-metadata-discovered) plugins: core no longer imports any concrete plugin class.

**Behavioral note:** with per-plugin exception isolation, an exception in the intrinsic `ErrorEventDispatcher`'s `handle_event` (e.g. a transient DB failure while writing an error log) is now logged and dropped instead of leaving the message un-ACKed for auto-claim retry. This trades best-effort error-log telemetry for eliminating poison-message redelivery loops (which previously re-ran the whole handler, including duplicate webhooks).

## Test plan

- [x] `tests/unit/manager/event_dispatcher/handlers/test_session.py::TestEventDispatcherPluginForwarding` — batch success, batch failure, terminated, cancelled, and terminating events reach the plugin context with the original source/event.
- [x] `tests/unit/common/plugin/test_event.py` — a raising plugin does not propagate into the caller and sibling plugins still receive the event.
- [x] `tests/unit/manager/dependencies/processing/test_composer.py` — plugins receive the standard context keys, `init` is awaited before `event_dispatcher.start()`, and a plugin whose `init` raises does not abort composition.
- [x] `pants fmt/fix/lint/check --changed-since=origin/main` clean; existing handler/composer/plugin suites pass.
- [x] Verified locally with an externally pip-installed test plugin: discovered via `scan_entrypoint_from_package_metadata`, receives failure events, and gets the standard context (no core modification).

Resolves #12526

🤖 Generated with [Claude Code](https://claude.com/claude-code)
