### PR TITLE
test: register ImageRow in RBAC validator/permission mapper clusters

### DIFF
--- a/changes/12533.test.md
+++ b/changes/12533.test.md
@@ -1,0 +1,1 @@
+Register `ImageRow` in the RBAC validator and bulk role-permission test ORM clusters so the SQLAlchemy mapper registry can resolve `KernelRow`'s `relationship("ImageRow")`.

--- a/tests/unit/manager/actions/validators/test_rbac_validators.py
+++ b/tests/unit/manager/actions/validators/test_rbac_validators.py
@@ -56,6 +56,7 @@ from ai.backend.manager.models.agent import AgentRow
 # registry. These rows are reachable via relationships but are not otherwise
 # imported/registered by this test; _ORM_CLUSTER keeps them live.
 from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac_models import UserRoleRow
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
@@ -78,6 +79,7 @@ from ai.backend.testutils.db import with_tables
 
 _ORM_CLUSTER = (
     AgentRow,
+    ImageRow,
     ScalingGroupForDomainRow,
 )
 

--- a/tests/unit/manager/repositories/permission_controller/test_role_permissions_bulk.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_permissions_bulk.py
@@ -26,6 +26,7 @@ from ai.backend.manager.errors.permission import RoleNotFound
 # registry. These rows are reachable via relationships but are not otherwise
 # imported/registered by this test; _ORM_CLUSTER keeps them live.
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.scaling_group import ScalingGroupForDomainRow
@@ -61,6 +62,7 @@ ALL_OWNER_OPS = (
 
 _ORM_CLUSTER = (
     AgentRow,
+    ImageRow,
     ScalingGroupForDomainRow,
 )
 


### PR DESCRIPTION
## Summary
- `KernelRow` declares `relationship("ImageRow")`. When these isolated tests configure the SQLAlchemy mapper registry, resolving the string `'ImageRow'` fails with `InvalidRequestError` unless the class has been imported.
- `ImageRow` stopped being pulled in transitively (after image scanning moved out of the models layer), so add it to each test's `_ORM_CLUSTER`.
- Fixes the 11 errored RBAC validator tests and the bulk role-permission tests; both files now pass.

## Test plan
- [x] `pants test tests/unit/manager/actions/validators/test_rbac_validators.py`
- [x] `pants test tests/unit/manager/repositories/permission_controller/test_role_permissions_bulk.py`