### PR TITLE
fix(BA-6695): chunk bulk INSERTs in RBAC backfill migrations

### DIFF
--- a/changes/12535.fix.md
+++ b/changes/12535.fix.md
@@ -1,0 +1,1 @@
+Fix `alembic upgrade` aborting on large deployments by chunking bulk INSERTs in RBAC backfill migrations so they stay within PostgreSQL's 32767 bind-parameter limit.

--- a/src/ai/backend/manager/models/alembic/README.md
+++ b/src/ai/backend/manager/models/alembic/README.md
@@ -153,3 +153,12 @@ See the following migrations in the codebase for reference:
   -- Checks multiple possible enum states and fixes whichever scenario it finds.
 - `src/ai/backend/manager/models/alembic/versions/c4ea15b77136_ensure_auditlogs_table_exist.py`
   -- Uses `inspector.get_table_names()` to skip table creation when it already exists.
+
+## Large Data Migrations
+
+Always chunk bulk `INSERT`s — never insert every row in one statement. A single
+statement binds at most **32,767** parameters (PostgreSQL Int16 limit), and a multi-row
+`INSERT` binds `rows × columns`, so unbounded backfills overflow on large sites. Use the
+shared `insert_skip_on_conflict` helper in
+`src/ai/backend/manager/models/rbac_models/migration/utils.py`, which chunks by column
+count.

--- a/src/ai/backend/manager/models/alembic/versions/2c9000848b6e_backfill_missing_user_system_roles.py
+++ b/src/ai/backend/manager/models/alembic/versions/2c9000848b6e_backfill_missing_user_system_roles.py
@@ -154,7 +154,7 @@ def _backfill_roles_and_permissions(db_conn: Connection, rows: Sequence[Row[Any]
 def upgrade() -> None:
     conn = op.get_bind()
     offset = 0
-    page_size = 1000
+    page_size = 100
     while True:
         rows = _query_users_without_system_roles(conn, offset, page_size)
         if not rows:

--- a/src/ai/backend/manager/models/alembic/versions/ad7acfe8aa1c_add_role_invitations_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/ad7acfe8aa1c_add_role_invitations_table.py
@@ -72,11 +72,19 @@ def _get_permissions_table() -> sa.Table:
     )
 
 
+_MAX_BIND_PARAMS = 16000
+
+
 def _insert_skip_on_conflict(
     db_conn: Connection, table: sa.Table, rows: list[dict[str, Any]]
 ) -> None:
-    if rows:
-        stmt = pg_insert(table).values(rows).on_conflict_do_nothing()
+    if not rows:
+        return
+    params_per_row = max(1, len(rows[0]))
+    chunk_size = max(1, _MAX_BIND_PARAMS // params_per_row)
+    for start in range(0, len(rows), chunk_size):
+        chunk = rows[start : start + chunk_size]
+        stmt = pg_insert(table).values(chunk).on_conflict_do_nothing()
         db_conn.execute(stmt)
 
 

--- a/src/ai/backend/manager/models/alembic/versions/d3683e2703ff_backfill_role_scope_mappings.py
+++ b/src/ai/backend/manager/models/alembic/versions/d3683e2703ff_backfill_role_scope_mappings.py
@@ -95,11 +95,19 @@ def _get_user_roles_table() -> sa.Table:
     )
 
 
+_MAX_BIND_PARAMS = 16000
+
+
 def _insert_skip_on_conflict(
     db_conn: Connection, table: sa.Table, rows: list[dict[str, Any]]
 ) -> None:
-    if rows:
-        stmt = pg_insert(table).values(rows).on_conflict_do_nothing()
+    if not rows:
+        return
+    params_per_row = max(1, len(rows[0]))
+    chunk_size = max(1, _MAX_BIND_PARAMS // params_per_row)
+    for start in range(0, len(rows), chunk_size):
+        chunk = rows[start : start + chunk_size]
+        stmt = pg_insert(table).values(chunk).on_conflict_do_nothing()
         db_conn.execute(stmt)
 
 

--- a/src/ai/backend/manager/models/rbac_models/migration/utils.py
+++ b/src/ai/backend/manager/models/rbac_models/migration/utils.py
@@ -28,11 +28,20 @@ def insert_if_data_exists(
         db_conn.execute(sa.insert(row_type), list(data))
 
 
+_MAX_BIND_PARAMS = 16000
+
+
 def insert_skip_on_conflict(
     db_conn: Connection, row_type: sa.Table, data: Collection[dict[str, Any]]
 ) -> None:
-    if data:
-        stmt = pg_insert(row_type).values(list(data)).on_conflict_do_nothing()
+    rows = list(data)
+    if not rows:
+        return
+    params_per_row = max(1, len(rows[0]))
+    chunk_size = max(1, _MAX_BIND_PARAMS // params_per_row)
+    for start in range(0, len(rows), chunk_size):
+        chunk = rows[start : start + chunk_size]
+        stmt = pg_insert(row_type).values(chunk).on_conflict_do_nothing()
         db_conn.execute(stmt)
 
 


### PR DESCRIPTION
## Summary
- RBAC backfill migrations built a single multi-row `INSERT` whose bind-parameter count (`rows × columns`) exceeded PostgreSQL's Int16 limit of 32767 on large sites, aborting `alembic upgrade` with a `DBAPIError`.
- Chunk the shared `insert_skip_on_conflict` helper (`rbac_models/migration/utils.py`) by column count, covering `2c9000848b6e` and the other migrations that use it; apply the same chunking to the local copies in `d3683e2703ff` and `ad7acfe8aa1c`.
- Reduce `2c9000848b6e` `page_size` to bound the in-memory batch.
- Document the "always chunk bulk INSERTs" rule in the alembic `README.md`.

## Test plan
- [x] Run the affected migrations against a DB seeded with enough users/projects to exceed 32767 bind parameters and confirm the upgrade completes.
- [x] Confirm re-running is idempotent (`ON CONFLICT DO NOTHING`).

Resolves BA-6695