### PR TITLE
fix(BA-6694): drop SAVEPOINT usage in sessionresult enum migration

### DIFF
--- a/changes/12536.fix.md
+++ b/changes/12536.fix.md
@@ -1,0 +1,1 @@
+Fix `alembic upgrade` failing on the first attempt with `SAVEPOINT can only be used in transaction blocks` while dropping the `sessionresult`/`sessionresults` enum types during a large-jump upgrade.

--- a/src/ai/backend/manager/models/alembic/versions/dec0deba5893_drop_sessionresult_enum_types.py
+++ b/src/ai/backend/manager/models/alembic/versions/dec0deba5893_drop_sessionresult_enum_types.py
@@ -11,6 +11,15 @@ states observed in the wild: the singular ``sessionresult`` may exist, the
 plural ``sessionresults`` may exist, both may coexist, or neither may exist
 (e.g. an environment that previously failed mid-migration).
 
+Idempotency is achieved with existence/type pre-checks (``information_schema``,
+``pg_type``, ``pg_attribute``) so that each DDL statement only runs when it is
+actually needed and is not expected to raise. The migration deliberately does
+NOT wrap individual statements in ``SAVEPOINT`` blocks: under the asyncpg
+driver, every DDL statement invalidates the driver's schema cache, and emitting
+a ``SAVEPOINT`` immediately after such a schema-invalidating DDL can leave the
+driver without an active transaction block, raising
+``NoActiveSQLTransactionError`` on the first upgrade attempt.
+
 Revision ID: dec0deba5893
 Revises: d1c0f1e2b3a4
 Create Date: 2026-04-29
@@ -21,7 +30,6 @@ Create Date: 2026-04-29
 
 import logging
 
-import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import text
 from sqlalchemy.engine import Connection
@@ -34,30 +42,12 @@ depends_on = None
 
 log = logging.getLogger(__name__)
 
-# PostgreSQL SQLSTATE codes that we expect to encounter when an environment's
-# enum-type history has diverged from the migration chain. Anything else must
-# bubble up so a real failure is not silently masked.
-_EXPECTED_DIVERGENCE_SQLSTATES = frozenset([
-    "42710",  # duplicate_object               (e.g. CREATE TYPE on existing)
-    "42704",  # undefined_object               (e.g. DROP/ALTER on missing type)
-    "42P07",  # duplicate_table / index
-    "42P01",  # undefined_table
-    "42701",  # duplicate_column
-    "42703",  # undefined_column
-    "2BP01",  # dependent_objects_still_exist  (DROP TYPE blocked by deps)
-])
+# ``udt_name`` values that indicate the column is already a plain string type
+# and therefore needs no enum -> VARCHAR conversion.
+_VARCHAR_UDT_NAMES = frozenset(["varchar", "text", "bpchar"])
 
 
-def _sqlstate_of(exc: BaseException) -> str:
-    orig = getattr(exc, "orig", None)
-    return getattr(orig, "sqlstate", None) or "?"
-
-
-def _is_expected_divergence(exc: BaseException) -> bool:
-    return _sqlstate_of(exc) in _EXPECTED_DIVERGENCE_SQLSTATES
-
-
-def _column_type_name(conn: Connection, table: str, column: str) -> str | None:
+def _column_udt_name(conn: Connection, table: str, column: str) -> str | None:
     row = conn.execute(
         text(
             "SELECT udt_name FROM information_schema.columns"
@@ -69,155 +59,94 @@ def _column_type_name(conn: Connection, table: str, column: str) -> str | None:
     return row[0] if row is not None else None
 
 
-def _drop_column_default(conn: Connection, table: str, column: str) -> None:
-    try:
-        with conn.begin_nested():
-            conn.exec_driver_sql(f"ALTER TABLE {table} ALTER COLUMN {column} DROP DEFAULT")
-    except sa.exc.DBAPIError as e:
-        if not _is_expected_divergence(e):
-            raise
-        log.warning(
-            "Skipping DROP DEFAULT on %s.%s (sqlstate=%s): %s",
-            table,
-            column,
-            _sqlstate_of(e),
-            e,
-        )
+def _type_exists(conn: Connection, type_name: str) -> bool:
+    row = conn.execute(
+        text("SELECT 1 FROM pg_type WHERE typname = :type_name"),
+        {"type_name": type_name},
+    ).fetchone()
+    return row is not None
 
 
-def _alter_column_to_varchar(conn: Connection, table: str, column: str) -> None:
-    try:
-        with conn.begin_nested():
-            conn.exec_driver_sql(
-                f"ALTER TABLE {table} ALTER COLUMN {column} TYPE VARCHAR(64) USING {column}::text"
-            )
-    except sa.exc.DBAPIError as e:
-        if not _is_expected_divergence(e):
-            raise
-        log.warning(
-            "Skipping TYPE conversion of %s.%s to VARCHAR (sqlstate=%s): %s",
-            table,
-            column,
-            _sqlstate_of(e),
-            e,
-        )
+def _type_has_column_dependents(conn: Connection, type_name: str) -> bool:
+    """Return True if any live table column is still typed as ``type_name``.
+
+    Such a column blocks ``DROP TYPE`` (without CASCADE), so the drop is skipped
+    when this returns True.
+    """
+    row = conn.execute(
+        text(
+            "SELECT 1 FROM pg_attribute a"
+            " JOIN pg_type t ON a.atttypid = t.oid"
+            " WHERE t.typname = :type_name AND a.attnum > 0 AND NOT a.attisdropped"
+            " LIMIT 1"
+        ),
+        {"type_name": type_name},
+    ).fetchone()
+    return row is not None
 
 
-def _set_column_default_undefined(conn: Connection, table: str, column: str) -> None:
-    try:
-        with conn.begin_nested():
-            conn.exec_driver_sql(
-                f"ALTER TABLE {table} ALTER COLUMN {column} SET DEFAULT 'UNDEFINED'"
-            )
-    except sa.exc.DBAPIError as e:
-        if not _is_expected_divergence(e):
-            raise
-        log.warning(
-            "Skipping SET DEFAULT on %s.%s (sqlstate=%s): %s",
-            table,
-            column,
-            _sqlstate_of(e),
-            e,
-        )
-
-
-def _drop_enum_type(conn: Connection, type_name: str) -> None:
-    try:
-        with conn.begin_nested():
-            conn.exec_driver_sql(f"DROP TYPE IF EXISTS {type_name}")
-    except sa.exc.DBAPIError as e:
-        if not _is_expected_divergence(e):
-            raise
-        log.warning("Skipping DROP TYPE %s (sqlstate=%s): %s", type_name, _sqlstate_of(e), e)
-
-
-def _create_sessionresult_type_if_missing(conn: Connection) -> None:
-    try:
-        with conn.begin_nested():
-            conn.exec_driver_sql(
-                "DO $$ BEGIN"
-                " IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'sessionresult') THEN"
-                "   CREATE TYPE sessionresult AS ENUM ('UNDEFINED', 'SUCCESS', 'FAILURE');"
-                " END IF;"
-                " END $$;"
-            )
-    except sa.exc.DBAPIError as e:
-        if not _is_expected_divergence(e):
-            raise
-        log.warning("Skipping CREATE TYPE sessionresult (sqlstate=%s): %s", _sqlstate_of(e), e)
-
-
-def _alter_column_to_sessionresult(conn: Connection, table: str, column: str) -> None:
-    try:
-        with conn.begin_nested():
-            conn.exec_driver_sql(
-                f"ALTER TABLE {table} ALTER COLUMN {column}"
-                f" TYPE sessionresult USING {column}::text::sessionresult"
-            )
-    except sa.exc.DBAPIError as e:
-        if not _is_expected_divergence(e):
-            raise
-        log.warning(
-            "Skipping TYPE conversion of %s.%s to sessionresult (sqlstate=%s): %s",
-            table,
-            column,
-            _sqlstate_of(e),
-            e,
-        )
-
-
-def _set_column_default_undefined_sessionresult(conn: Connection, table: str, column: str) -> None:
-    try:
-        with conn.begin_nested():
-            conn.exec_driver_sql(
-                f"ALTER TABLE {table} ALTER COLUMN {column} SET DEFAULT 'UNDEFINED'::sessionresult"
-            )
-    except sa.exc.DBAPIError as e:
-        if not _is_expected_divergence(e):
-            raise
-        log.warning(
-            "Skipping SET DEFAULT on %s.%s (sqlstate=%s): %s",
-            table,
-            column,
-            _sqlstate_of(e),
-            e,
-        )
-
-
-def _convert_to_varchar(conn: Connection, table: str, column: str) -> None:
-    type_name = _column_type_name(conn, table, column)
-    if type_name is None:
+def _convert_column_to_varchar(conn: Connection, table: str, column: str) -> None:
+    udt_name = _column_udt_name(conn, table, column)
+    if udt_name is None:
         log.warning("Skipping conversion of %s.%s: column not found", table, column)
         return
-    if type_name not in ("varchar", "text", "bpchar"):
-        _drop_column_default(conn, table, column)
-        _alter_column_to_varchar(conn, table, column)
+    if udt_name not in _VARCHAR_UDT_NAMES:
+        # Column still uses the native enum type; convert it to VARCHAR.
+        # DROP DEFAULT is a no-op (never raises) when no default is set.
+        conn.exec_driver_sql(f"ALTER TABLE {table} ALTER COLUMN {column} DROP DEFAULT")
+        conn.exec_driver_sql(
+            f"ALTER TABLE {table} ALTER COLUMN {column} TYPE VARCHAR(64) USING {column}::text"
+        )
     # Repair the default unconditionally so it does not still reference the
     # (possibly stale) sessionresult enum type, which would otherwise block
     # DROP TYPE later in this migration on partially-migrated environments.
-    _set_column_default_undefined(conn, table, column)
+    conn.exec_driver_sql(f"ALTER TABLE {table} ALTER COLUMN {column} SET DEFAULT 'UNDEFINED'")
 
 
-def _convert_to_sessionresult(conn: Connection, table: str, column: str) -> None:
-    type_name = _column_type_name(conn, table, column)
-    if type_name is None:
+def _revert_column_to_sessionresult(conn: Connection, table: str, column: str) -> None:
+    udt_name = _column_udt_name(conn, table, column)
+    if udt_name is None:
         log.warning("Skipping revert of %s.%s: column not found", table, column)
         return
-    if type_name == "sessionresult":
+    if udt_name == "sessionresult":
         return
-    _drop_column_default(conn, table, column)
-    _alter_column_to_sessionresult(conn, table, column)
-    _set_column_default_undefined_sessionresult(conn, table, column)
+    conn.exec_driver_sql(f"ALTER TABLE {table} ALTER COLUMN {column} DROP DEFAULT")
+    conn.exec_driver_sql(
+        f"ALTER TABLE {table} ALTER COLUMN {column}"
+        f" TYPE sessionresult USING {column}::text::sessionresult"
+    )
+    conn.exec_driver_sql(
+        f"ALTER TABLE {table} ALTER COLUMN {column} SET DEFAULT 'UNDEFINED'::sessionresult"
+    )
+
+
+def _drop_enum_type_if_unused(conn: Connection, type_name: str) -> None:
+    if not _type_exists(conn, type_name):
+        return
+    if _type_has_column_dependents(conn, type_name):
+        log.warning("Skipping DROP TYPE %s: columns still depend on it", type_name)
+        return
+    conn.exec_driver_sql(f"DROP TYPE IF EXISTS {type_name}")
+
+
+def _create_sessionresult_type_if_missing(conn: Connection) -> None:
+    conn.exec_driver_sql(
+        "DO $$ BEGIN"
+        " IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'sessionresult') THEN"
+        "   CREATE TYPE sessionresult AS ENUM ('UNDEFINED', 'SUCCESS', 'FAILURE');"
+        " END IF;"
+        " END $$;"
+    )
 
 
 def upgrade() -> None:
     conn = op.get_bind()
 
-    _convert_to_varchar(conn, "kernels", "result")
-    _convert_to_varchar(conn, "sessions", "result")
+    _convert_column_to_varchar(conn, "kernels", "result")
+    _convert_column_to_varchar(conn, "sessions", "result")
 
     for type_name in ("sessionresult", "sessionresults"):
-        _drop_enum_type(conn, type_name)
+        _drop_enum_type_if_unused(conn, type_name)
 
 
 def downgrade() -> None:
@@ -225,4 +154,4 @@ def downgrade() -> None:
 
     _create_sessionresult_type_if_missing(conn)
     for table in ("kernels", "sessions"):
-        _convert_to_sessionresult(conn, table, "result")
+        _revert_column_to_sessionresult(conn, table, "result")


### PR DESCRIPTION
## Summary
- Migration `dec0deba5893` (drop `sessionresult`/`sessionresults` enum types → VARCHAR) wrapped each DDL step in `conn.begin_nested()` (SAVEPOINT). Under asyncpg, **every DDL statement invalidates the driver schema cache** (`sqlalchemy/dialects/postgresql/asyncpg.py:459-460`), and emitting a SAVEPOINT right after such a DDL can leave the driver with no active transaction block → `asyncpg.exceptions.NoActiveSQLTransactionError: SAVEPOINT can only be used in transaction blocks` (raised on `SAVEPOINT sa_savepoint_4`).
- The failure only surfaces on a **large-jump upgrade** (e.g. 25.15 → 26.4) where many prior migrations run in the same connection and accumulate schema-cache state; incremental dev upgrades don't hit it. The migration is idempotent, so a manual re-run succeeds — which is the reported symptom.
- Replaced the savepoint + exception-catch idempotency with **existence/type pre-checks** (`information_schema`, `pg_type`, `pg_attribute`) so each DDL runs only when needed and isn't expected to raise. No SAVEPOINT is emitted, structurally removing the failure mode while preserving idempotency and the enum→VARCHAR conversion (values, defaults, type drops).

## Test plan
- [x] `pants fmt` / `fix` / `lint` clean
- [x] Isolated scratch DB (native enum columns): `upgrade` converts `kernels.result`/`sessions.result` to `varchar(64)`, preserves values (`UNDEFINED,SUCCESS,FAILURE`), sets default `'UNDEFINED'`, drops both enum types
- [x] `downgrade` round-trips (columns back to `sessionresult`, values preserved)
- [ ] Verify on a real large-jump upgrade path (25.15 → 26.4) — could not be reproduced locally; needs a real baseline DB snapshot

Resolves BA-6694