### PR TITLE
fix(BA-6693): isolate frozen migration table metadata

### DIFF
--- a/changes/12537.fix.md
+++ b/changes/12537.fix.md
@@ -1,1 +1,1 @@
-Fix `alembic upgrade` failing with `column roles.auto_assign does not exist` when upgrading from older versions, caused by RBAC migration helpers leaking production ORM columns into their frozen table definitions
+Fix `alembic upgrade` failing when upgrading from older versions, caused by RBAC migration helpers leaking production ORM columns into their frozen table definitions

--- a/changes/12537.fix.md
+++ b/changes/12537.fix.md
@@ -1,0 +1,1 @@
+Fix `alembic upgrade` failing with `column roles.auto_assign does not exist` when upgrading from older versions, caused by RBAC migration helpers leaking production ORM columns into their frozen table definitions

--- a/src/ai/backend/manager/models/rbac_models/migration/models.py
+++ b/src/ai/backend/manager/models/rbac_models/migration/models.py
@@ -14,9 +14,10 @@ define tables inline or use raw SQL instead of calling these shared helpers.
 import sqlalchemy as sa
 from sqlalchemy.orm import registry
 
-from ai.backend.manager.models.base import GUID, IDColumn, metadata
+from ai.backend.manager.models.base import GUID, IDColumn
 
-mapper_registry = registry(metadata=metadata)
+# Use an isolated metadata so the frozen table definitions in this module stay frozen.
+mapper_registry = registry(metadata=sa.MetaData())
 
 
 def get_user_roles_table() -> sa.Table:


### PR DESCRIPTION
## Summary
- RBAC migration helpers (`models/rbac_models/migration/models.py`) shared the production ORM `metadata`, so `extend_existing=True` merged live model columns into the intended *frozen* table definitions.
- As a result, `get_roles_table()` returned the full production `roles` table (including later-added columns like `auto_assign`), and historical data migration `09206ac04fd3` selected columns that do not exist yet at that point in the chain — breaking `alembic upgrade` from older versions (e.g. 25.15 → 26.4) with `column roles.auto_assign does not exist`.
- Fix: give the migration helpers an isolated `MetaData()` so the frozen definitions stay frozen regardless of which production models are loaded during an alembic run.

## Test plan
- [x] Compiled the exact `SELECT get_roles_table()` query after loading production models: now references only the 4 frozen columns (`id, name, source, description`); `auto_assign` no longer present.
- [x] End-to-end alembic reproduction with a temporary `roles.test` ORM column + throwaway revisions: **without** the fix the migration failed with `column roles.test does not exist` (same shape as the reported bug); **with** the fix it passed. Temp artifacts fully reverted.
- [x] CI: type check + tests.

Resolves BA-6693