### PR TITLE
feat(BA-6628): assign scope-type default ranks to allow-list entries

### DIFF
--- a/changes/12516.feature.md
+++ b/changes/12516.feature.md
@@ -1,0 +1,1 @@
+Move the app config merge `rank` from `app_config_fragments` to the admin-owned `app_config_allow_list`, so a fragment owner can no longer re-order the merge

--- a/changes/12539.feature.md
+++ b/changes/12539.feature.md
@@ -1,0 +1,1 @@
+Default the app config allow-list merge `rank` by scope type (public=100, domain=200, user=300), so a user's own fragment wins the merge by default

--- a/proposals/BEP-1052-scoped-app-config-redesign.md
+++ b/proposals/BEP-1052-scoped-app-config-redesign.md
@@ -19,9 +19,9 @@ each managed independently.
 
 **Reads are the hot path.** A user's effective configuration for a
 `config_name` is the **deep merge of every fragment that applies to
-them**, taken
-straight from `app_config_fragments` in `rank` order — a single-table
-query with **no joins and no permission lookup**.
+them**, taken from `app_config_fragments` ordered by the `rank` of each
+fragment's allow-list entry — one indexed join, **no permission
+lookup**.
 
 **Write authorization is set up ahead of time.** Every config name is
 **explicitly registered** in `app_config_definitions`, and `app_config_allow_list`
@@ -68,18 +68,20 @@ Three scopes cover the use cases (`public` for the pre-login shell):
 - **Explicitly registered names.** Every config name lives in
   `app_config_definitions`; fragments and allow-list entries reference it by
   foreign key. No fragment may exist for an unregistered `config_name`.
-- **Reads are join-free and unconditional.** The merge reads
-  `app_config_fragments` alone, ordering the existing fragments by
-  `rank`. No allow-list or policy is consulted at read time — the hot
-  path stays a single indexed scan.
+- **Reads are unconditional.** The merge reads `app_config_fragments`
+  joined to `app_config_allow_list` only for each fragment's `rank` — an
+  indexed `(config_name, scope_type)` join. No permission or policy is
+  evaluated at read time.
 - **Allow-list = the write gate for every fragment.** `app_config_allow_list`
   holds **one record per `(config_name, scope_type)`**; a fragment at
   that scope may be created/updated/purged **only if** the record exists
   — through the admin mutations and the regular ones alike. What sets
   admins apart is that they alone manage the allow-list (and the
   `app_config_definitions`) itself. It governs **writes only** — never reads.
-- **`rank` lives on the fragment.** A fragment's `rank` is its merge
-  priority within a `config_name`; the read merge orders fragments by it.
+- **`rank` lives on the allow-list entry.** Merge priority is an
+  admin-owned policy: it sits on the (admin-managed) allow-list entry,
+  not on the fragment — a fragment owner editing their own fragment can
+  never re-order the merge (see §2).
 - **Single source-of-truth table.** One `app_config_fragments` table
   holds every scope; only the exposure layer is split.
 
@@ -109,9 +111,10 @@ Keyed by the natural composite `(scope_type, scope_id, config_name)`
 - `scope_id` — the scope's identifier (see convention below).
 - `config_name` — FK → `app_config_definitions.config_name`.
 - `config` — schema-less JSON payload.
-- `rank` — integer merge priority within the `config_name` (low → high;
-  higher wins). Assigned on create (see §2).
 - `created_at` / `updated_at`.
+
+The fragment carries no rank of its own — its merge priority is its
+allow-list entry's `rank` (see §2).
 
 ### `app_config_allow_list` — the per-`(config_name, scope_type)` write gate
 
@@ -125,12 +128,14 @@ advance.
   (`public | domain | user`). A user-overridable config carries a
   `(config_name, user)` row; an admin-only value carries
   `(config_name, domain)` and/or `(config_name, public)`.
+- `rank` — the merge priority every fragment under this entry carries
+  (low → high; higher wins). Defaults to a fixed rank (see §2); admins
+  may set it explicitly.
 - `created_at` / `updated_at`.
 
-A row's **presence** is the entire signal — there is no `rank` here,
-because the allow-list never participates in the merge. It gates **both**
-write paths; admins, unlike users, may also create/update/purge the
-allow-list rows themselves.
+A row's **presence** is the write grant, and its `rank` is the merge
+order of its fragments. It gates **both** write paths; admins, unlike
+users, may also create/update/purge the allow-list rows themselves.
 
 ### Scope-ID convention
 
@@ -185,7 +190,8 @@ boundary.
   merged value is the admin's (`public` / `domain` fragments only).
 - **Overridable**: the admin grants `(config_name, user)`. The admin
   sets the `domain` default; the user freely creates/updates/purges
-  their own `user` fragment, which (higher `rank`) wins on merge.
+  their own `user` fragment, which wins on merge when its allow-list
+  entry is ranked above the `domain` entry (see §2).
 - **User-only**: the grant exists and no admin fragment is published.
 
 To promote a fixed value to user-customizable, the admin adds a single
@@ -198,19 +204,24 @@ is already stored).
 
 ## 2. `rank` — merge priority
 
-`rank` is the integer priority a **fragment** carries within a
-`config_name`; the read merge applies fragments in `rank` order (low →
-high, higher wins).
+`rank` is the integer priority an **allow-list entry** carries; every
+fragment written under the entry merges at that priority (low → high,
+higher wins). It lives on the allow-list — not the fragment — because
+merge order is admin policy: fragment writes are partly user-owned, and
+a rank on the fragment would let a user re-order the merge by editing
+their own row.
 
-- **Assignment.** A new fragment is placed after the existing ones for
-  the same `config_name`, so a later-created fragment outranks earlier ones by
-  default. Admins re-order by setting `rank` explicitly. (Publishing the
-  `domain` default before a user writes their own copy naturally gives
-  the `user` fragment the higher rank, so the user value wins.)
-- **No tier defaults.** Priority is the fragment's `rank`, not derived
-  from `scope_type` — a `user` fragment outranks a `domain` fragment
-  only because its `rank` is higher, not because `user` is "above"
-  `domain`.
+- **Default rank.** A new entry defaults to a fixed `rank`; per-scope-type
+  defaults that order `public` < `domain` < `user` are introduced in a
+  follow-up. Until then the admin sets `rank` explicitly to order the
+  scopes.
+- **Admin override.** The admin may set `rank` explicitly when creating
+  the entry — e.g. a `domain` entry ranked above `user` yields a
+  domain-enforced value that user fragments cannot beat even where a
+  user grant exists.
+- **Per-caller totality.** For one caller and one `config_name`, at most
+  one fragment applies per scope type (§3), so the entry ranks totally
+  order every merge input.
 
 ---
 
@@ -219,7 +230,7 @@ high, higher wins).
 Two read shapes exist:
 
 - **`AppConfigFragment`** — one raw row, regardless of scope. Carries
-  `scopeType`, `scopeId`, `configName`, `rank`, and `config`. Callers
+  `scopeType`, `scopeId`, `configName`, and `config`. Callers
   disambiguate scope by reading `scopeType` (no per-scope wrapper
   types).
 - **`AppConfig`** — the merged per-user view for a `config_name`: the
@@ -235,10 +246,10 @@ those whose scope applies to them:
 - the user's `user` fragment (`scope_id = the user's id`).
 
 A single `app_config_fragments` query selects exactly those rows (the
-user's domain is known from the session — **no join, no allow-list
-lookup**), orders them by `rank` (low → high), and deep-merges: nested
-objects recurse, scalars and lists are wholesale-replaced, and the
-higher `rank` wins on conflict.
+user's domain is known from the session — no permission check), joins
+each to its allow-list entry for the `rank`, orders by it (low → high),
+and deep-merges: nested objects recurse, scalars and lists are
+wholesale-replaced, and the higher `rank` wins on conflict.
 
 **Null projection.** A stored `config` of `{}` reads back as `null`, and
 a merged `config` that is empty after combining every fragment is
@@ -276,7 +287,8 @@ likewise `null` — clients fall back to their built-in defaults.
   be written only after its scope's row exists.
 - **Pre-login public config** — anonymous read of `public` `theme`.
 - **Bootstrap after login** — read merged `AppConfig`s in one round of
-  queries; each is a single-table rank merge, no per-scope stitching.
+  queries; each is a rank merge over the fragments joined to their
+  allow-list entries, no per-scope stitching.
 - **User edits a config** — a regular create/update/purge on the
   caller's own `user` row (only where the grant exists); the response is
   the recomputed merge.
@@ -289,7 +301,8 @@ likewise `null` — clients fall back to their built-in defaults.
 - **Admin locks a value back down** — remove the `(config_name, user)`
   grant **and** purge existing `user` fragments (the grant gates writes,
   not reads).
-- **Admin reorders contributions** — adjust fragment `rank`s.
+- **Admin reorders contributions** — set the allow-list entries'
+  `rank`s (per `(config_name, scope_type)`, not per fragment).
 - **Admin retires a config name** — purge the fragments, then the
   allow-list entries, then the `app_config_definitions` row (purge is rejected
   while references remain).

--- a/proposals/BEP-1052-scoped-app-config-redesign.md
+++ b/proposals/BEP-1052-scoped-app-config-redesign.md
@@ -129,7 +129,7 @@ advance.
   `(config_name, user)` row; an admin-only value carries
   `(config_name, domain)` and/or `(config_name, public)`.
 - `rank` — the merge priority every fragment under this entry carries
-  (low → high; higher wins). Defaults to a fixed rank (see §2); admins
+  (low → high; higher wins). Defaults per scope type (see §2); admins
   may set it explicitly.
 - `created_at` / `updated_at`.
 
@@ -190,8 +190,8 @@ boundary.
   merged value is the admin's (`public` / `domain` fragments only).
 - **Overridable**: the admin grants `(config_name, user)`. The admin
   sets the `domain` default; the user freely creates/updates/purges
-  their own `user` fragment, which wins on merge when its allow-list
-  entry is ranked above the `domain` entry (see §2).
+  their own `user` fragment, which wins on merge (the `user` entry's
+  default `rank` is the highest).
 - **User-only**: the grant exists and no admin fragment is published.
 
 To promote a fixed value to user-customizable, the admin adds a single
@@ -211,10 +211,11 @@ merge order is admin policy: fragment writes are partly user-owned, and
 a rank on the fragment would let a user re-order the merge by editing
 their own row.
 
-- **Default rank.** A new entry defaults to a fixed `rank`; per-scope-type
-  defaults that order `public` < `domain` < `user` are introduced in a
-  follow-up. Until then the admin sets `rank` explicitly to order the
-  scopes.
+- **Scope-type defaults.** A new entry defaults its `rank` from its
+  `scope_type`: `public` = 100, `domain` = 200, `user` = 300. The
+  defaults order the scopes so a user's own fragment overrides the
+  domain default, which overrides the public value; the 100 gap leaves
+  room for custom placement in between.
 - **Admin override.** The admin may set `rank` explicitly when creating
   the entry — e.g. a `domain` entry ranked above `user` yields a
   domain-enforced value that user fragments cannot beat even where a

--- a/src/ai/backend/common/data/app_config/types.py
+++ b/src/ai/backend/common/data/app_config/types.py
@@ -41,3 +41,19 @@ class AppConfigScopeType(enum.StrEnum):
         their own ``scope_id``.
         """
         return "" if self is AppConfigScopeType.PUBLIC else scope_id
+
+    def default_rank(self) -> int:
+        """Default merge rank for an allow-list entry at this scope type (BEP-1052).
+
+        The merge applies fragments in rank order (low → high; higher wins), so the
+        defaults order the scopes as ``public`` < ``domain`` < ``user`` — a user's own
+        fragment overrides the domain default, which overrides the public value. The
+        100 gap leaves room for admins to place custom ranks in between.
+        """
+        match self:
+            case AppConfigScopeType.PUBLIC:
+                return 100
+            case AppConfigScopeType.DOMAIN:
+                return 200
+            case AppConfigScopeType.USER:
+                return 300

--- a/src/ai/backend/manager/data/app_config_allow_list/types.py
+++ b/src/ai/backend/manager/data/app_config_allow_list/types.py
@@ -9,11 +9,16 @@ from ai.backend.common.identifier.app_config_allow_list import AppConfigAllowLis
 
 @dataclass(frozen=True)
 class AppConfigAllowListData:
-    """Domain data for one app config allow-list entry — a per-``(config_name, scope_type)`` write gate."""
+    """Domain data for one app config allow-list entry — a per-``(config_name, scope_type)`` write gate.
+
+    ``rank`` is the merge priority applied to every fragment written under the entry
+    (low → high; higher wins).
+    """
 
     id: AppConfigAllowListID
     config_name: str
     scope_type: AppConfigScopeType
+    rank: int
     created_at: datetime
     updated_at: datetime
 

--- a/src/ai/backend/manager/data/app_config_fragment/types.py
+++ b/src/ai/backend/manager/data/app_config_fragment/types.py
@@ -16,7 +16,6 @@ class AppConfigFragmentData:
     config_name: str
     scope_type: AppConfigScopeType
     scope_id: str
-    rank: int
     config: dict[str, Any]
     created_at: datetime
     updated_at: datetime

--- a/src/ai/backend/manager/models/alembic/versions/66d0f891ed20_move_fragment_rank_to_app_config_allow_list.py
+++ b/src/ai/backend/manager/models/alembic/versions/66d0f891ed20_move_fragment_rank_to_app_config_allow_list.py
@@ -4,8 +4,8 @@ Move the merge-priority ``rank`` from ``app_config_fragments`` to
 ``app_config_allow_list`` (BEP-1052). Fragment writes are partly user-owned, so
 a rank on the fragment would let a fragment owner re-order the merge; the
 allow-list entry is admin-owned, making it the right carrier for merge
-priority. Existing allow-list rows are backfilled with a fixed default rank
-(per-scope-type defaults follow in a later revision).
+priority. Existing allow-list rows are backfilled with the per-scope-type
+default ranks (public=100, domain=200, user=300).
 
 Revision ID: 66d0f891ed20
 Revises: a379b72f1206
@@ -25,13 +25,17 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Allow-list entries carry the merge rank; backfill existing rows with the default.
+    # Allow-list entries carry the merge rank; backfill by scope-type default.
     op.add_column("app_config_allow_list", sa.Column("rank", sa.Integer(), nullable=True))
     op.execute(
         sa.text(
             """
             UPDATE app_config_allow_list
-            SET rank = 100
+            SET rank = CASE scope_type
+                WHEN 'public' THEN 100
+                WHEN 'domain' THEN 200
+                WHEN 'user' THEN 300
+            END
             WHERE rank IS NULL
             """
         )
@@ -43,7 +47,7 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.add_column("app_config_fragments", sa.Column("rank", sa.Integer(), nullable=True))
     # Restore each fragment's rank from its allow-list entry. Fragments whose entry
-    # was removed fall back to the default rank; fragments sharing a
+    # was removed fall back to the scope-type default; fragments sharing a
     # ``(config_name, scope_type)`` end up with equal ranks — the pre-move
     # per-fragment next-value ranks are not recoverable.
     op.execute(
@@ -61,7 +65,11 @@ def downgrade() -> None:
         sa.text(
             """
             UPDATE app_config_fragments
-            SET rank = 100
+            SET rank = CASE scope_type
+                WHEN 'public' THEN 100
+                WHEN 'domain' THEN 200
+                WHEN 'user' THEN 300
+            END
             WHERE rank IS NULL
             """
         )

--- a/src/ai/backend/manager/models/alembic/versions/66d0f891ed20_move_fragment_rank_to_app_config_allow_list.py
+++ b/src/ai/backend/manager/models/alembic/versions/66d0f891ed20_move_fragment_rank_to_app_config_allow_list.py
@@ -1,0 +1,70 @@
+"""move fragment rank to app_config_allow_list
+
+Move the merge-priority ``rank`` from ``app_config_fragments`` to
+``app_config_allow_list`` (BEP-1052). Fragment writes are partly user-owned, so
+a rank on the fragment would let a fragment owner re-order the merge; the
+allow-list entry is admin-owned, making it the right carrier for merge
+priority. Existing allow-list rows are backfilled with a fixed default rank
+(per-scope-type defaults follow in a later revision).
+
+Revision ID: 66d0f891ed20
+Revises: a379b72f1206
+Create Date: 2026-07-03
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "66d0f891ed20"
+down_revision = "a379b72f1206"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Allow-list entries carry the merge rank; backfill existing rows with the default.
+    op.add_column("app_config_allow_list", sa.Column("rank", sa.Integer(), nullable=True))
+    op.execute(
+        sa.text(
+            """
+            UPDATE app_config_allow_list
+            SET rank = 100
+            WHERE rank IS NULL
+            """
+        )
+    )
+    op.alter_column("app_config_allow_list", "rank", nullable=False)
+    op.drop_column("app_config_fragments", "rank")
+
+
+def downgrade() -> None:
+    op.add_column("app_config_fragments", sa.Column("rank", sa.Integer(), nullable=True))
+    # Restore each fragment's rank from its allow-list entry. Fragments whose entry
+    # was removed fall back to the default rank; fragments sharing a
+    # ``(config_name, scope_type)`` end up with equal ranks — the pre-move
+    # per-fragment next-value ranks are not recoverable.
+    op.execute(
+        sa.text(
+            """
+            UPDATE app_config_fragments f
+            SET rank = al.rank
+            FROM app_config_allow_list al
+            WHERE al.config_name = f.config_name
+              AND al.scope_type = f.scope_type
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE app_config_fragments
+            SET rank = 100
+            WHERE rank IS NULL
+            """
+        )
+    )
+    op.alter_column("app_config_fragments", "rank", nullable=False)
+    op.drop_column("app_config_allow_list", "rank")

--- a/src/ai/backend/manager/models/app_config_allow_list/orders.py
+++ b/src/ai/backend/manager/models/app_config_allow_list/orders.py
@@ -28,6 +28,12 @@ class AppConfigAllowListOrders:
         return AppConfigAllowListRow.scope_type.desc()
 
     @staticmethod
+    def rank(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AppConfigAllowListRow.rank.asc()
+        return AppConfigAllowListRow.rank.desc()
+
+    @staticmethod
     def created_at(ascending: bool = True) -> QueryOrder:
         if ascending:
             return AppConfigAllowListRow.created_at.asc()

--- a/src/ai/backend/manager/models/app_config_allow_list/row.py
+++ b/src/ai/backend/manager/models/app_config_allow_list/row.py
@@ -19,9 +19,10 @@ class AppConfigAllowListRow(Base):  # type: ignore[misc]
     """Permission to write config fragments for one config name at one scope type.
 
     A config fragment may be created, updated, or purged only when a matching row
-    exists here; without one, the write is rejected. Reads never consult this table.
-    There is at most one row per ``(config_name, scope_type)``, and only admins
-    create or remove these rows.
+    exists here; without one, the write is rejected. ``rank`` is the merge priority
+    the entry's fragments carry (low → high; higher wins) — admin-owned here so
+    fragment owners cannot re-order the merge. There is at most one row per
+    ``(config_name, scope_type)``, and only admins create or remove these rows.
     """
 
     __tablename__ = "app_config_allow_list"
@@ -48,6 +49,11 @@ class AppConfigAllowListRow(Base):  # type: ignore[misc]
         StrEnumType(AppConfigScopeType),
         nullable=False,
     )
+    rank: Mapped[int] = mapped_column(
+        "rank",
+        sa.Integer,
+        nullable=False,
+    )
     created_at: Mapped[datetime] = mapped_column(
         "created_at",
         sa.DateTime(timezone=True),
@@ -67,6 +73,7 @@ class AppConfigAllowListRow(Base):  # type: ignore[misc]
             id=self.id,
             config_name=self.config_name,
             scope_type=self.scope_type,
+            rank=self.rank,
             created_at=self.created_at,
             updated_at=self.updated_at,
         )

--- a/src/ai/backend/manager/models/app_config_fragment/orders.py
+++ b/src/ai/backend/manager/models/app_config_fragment/orders.py
@@ -34,12 +34,6 @@ class AppConfigFragmentOrders:
         return AppConfigFragmentRow.scope_id.desc()
 
     @staticmethod
-    def rank(ascending: bool = True) -> QueryOrder:
-        if ascending:
-            return AppConfigFragmentRow.rank.asc()
-        return AppConfigFragmentRow.rank.desc()
-
-    @staticmethod
     def created_at(ascending: bool = True) -> QueryOrder:
         if ascending:
             return AppConfigFragmentRow.created_at.asc()

--- a/src/ai/backend/manager/models/app_config_fragment/row.py
+++ b/src/ai/backend/manager/models/app_config_fragment/row.py
@@ -18,7 +18,11 @@ __all__ = ("AppConfigFragmentRow",)
 
 
 class AppConfigFragmentRow(Base):  # type: ignore[misc]
-    """One scoped app config fragment — a single JSON document at ``(config_name, scope_type, scope_id)``."""
+    """One scoped app config fragment — a single JSON document at ``(config_name, scope_type, scope_id)``.
+
+    The fragment carries no merge priority of its own — its rank is the ``rank`` of
+    the allow-list entry for its ``(config_name, scope_type)``.
+    """
 
     __tablename__ = "app_config_fragments"
     __table_args__ = (
@@ -52,11 +56,6 @@ class AppConfigFragmentRow(Base):  # type: ignore[misc]
         sa.String(length=255),
         nullable=False,
     )
-    rank: Mapped[int] = mapped_column(
-        "rank",
-        sa.Integer,
-        nullable=False,
-    )
     config: Mapped[dict[str, Any]] = mapped_column(
         "config",
         JSONB,
@@ -82,7 +81,6 @@ class AppConfigFragmentRow(Base):  # type: ignore[misc]
             config_name=self.config_name,
             scope_type=self.scope_type,
             scope_id=self.scope_id,
-            rank=self.rank,
             config=self.config,
             created_at=self.created_at,
             updated_at=self.updated_at,

--- a/src/ai/backend/manager/repositories/app_config_allow_list/creators.py
+++ b/src/ai/backend/manager/repositories/app_config_allow_list/creators.py
@@ -9,18 +9,14 @@ from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
 from ai.backend.manager.repositories.base import CreatorSpec
 
-# Default merge rank for a new allow-list entry when the caller does not pass one.
-# Per-scope-type defaults are introduced in a follow-up; for now every scope shares
-# this fixed rank.
-DEFAULT_RANK = 100
-
 
 @dataclass
 class AppConfigAllowListCreatorSpec(CreatorSpec[AppConfigAllowListRow]):
     """CreatorSpec for an app config allow-list entry.
 
     ``rank`` is the merge priority every fragment under the entry carries; when not
-    given, it falls back to ``DEFAULT_RANK``.
+    given, it falls back to the scope type's default (public=100, domain=200,
+    user=300), which orders the scopes so a user's own fragment wins the merge.
     """
 
     config_name: str
@@ -29,7 +25,7 @@ class AppConfigAllowListCreatorSpec(CreatorSpec[AppConfigAllowListRow]):
 
     @override
     def build_row(self) -> AppConfigAllowListRow:
-        rank = self.rank if self.rank is not None else DEFAULT_RANK
+        rank = self.rank if self.rank is not None else self.scope_type.default_rank()
         return AppConfigAllowListRow(
             config_name=self.config_name,
             scope_type=self.scope_type,

--- a/src/ai/backend/manager/repositories/app_config_allow_list/creators.py
+++ b/src/ai/backend/manager/repositories/app_config_allow_list/creators.py
@@ -9,14 +9,29 @@ from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
 from ai.backend.manager.repositories.base import CreatorSpec
 
+# Default merge rank for a new allow-list entry when the caller does not pass one.
+# Per-scope-type defaults are introduced in a follow-up; for now every scope shares
+# this fixed rank.
+DEFAULT_RANK = 100
+
 
 @dataclass
 class AppConfigAllowListCreatorSpec(CreatorSpec[AppConfigAllowListRow]):
-    """CreatorSpec for an app config allow-list entry."""
+    """CreatorSpec for an app config allow-list entry.
+
+    ``rank`` is the merge priority every fragment under the entry carries; when not
+    given, it falls back to ``DEFAULT_RANK``.
+    """
 
     config_name: str
     scope_type: AppConfigScopeType
+    rank: int | None = None
 
     @override
     def build_row(self) -> AppConfigAllowListRow:
-        return AppConfigAllowListRow(config_name=self.config_name, scope_type=self.scope_type)
+        rank = self.rank if self.rank is not None else DEFAULT_RANK
+        return AppConfigAllowListRow(
+            config_name=self.config_name,
+            scope_type=self.scope_type,
+            rank=rank,
+        )

--- a/src/ai/backend/manager/repositories/app_config_fragment/creators.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/creators.py
@@ -7,15 +7,15 @@ from typing import Any, override
 
 from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
-from ai.backend.manager.repositories.base.creator import DependentCreatorSpec
+from ai.backend.manager.repositories.base import CreatorSpec
 
 
 @dataclass
-class AppConfigFragmentCreatorSpec(DependentCreatorSpec[int, AppConfigFragmentRow]):
-    """Fragment creator whose ``rank`` is assigned by the ops layer (next-value) at execution.
+class AppConfigFragmentCreatorSpec(CreatorSpec[AppConfigFragmentRow]):
+    """CreatorSpec for one app config fragment.
 
-    ``build_row`` receives the computed next rank, so a newly created fragment is placed
-    after the existing fragments for the same ``config_name``.
+    The fragment carries no merge priority of its own — its rank is the ``rank`` of
+    the allow-list entry for its ``(config_name, scope_type)``.
     """
 
     config_name: str
@@ -24,11 +24,10 @@ class AppConfigFragmentCreatorSpec(DependentCreatorSpec[int, AppConfigFragmentRo
     config: dict[str, Any]
 
     @override
-    def build_row(self, next_rank: int) -> AppConfigFragmentRow:
+    def build_row(self) -> AppConfigFragmentRow:
         return AppConfigFragmentRow(
             config_name=self.config_name,
             scope_type=self.scope_type,
             scope_id=self.scope_id,
-            rank=next_rank,
             config=self.config,
         )

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -21,7 +21,6 @@ from ai.backend.manager.errors.app_config import (
     AppConfigFragmentWriteNotAllowed,
 )
 from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
-from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
 from ai.backend.manager.models.scopes import SearchScope
 from ai.backend.manager.repositories.app_config_fragment.creators import (
@@ -29,18 +28,15 @@ from ai.backend.manager.repositories.app_config_fragment.creators import (
 )
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
+    Creator,
     ExistsQuerier,
     Purger,
     Querier,
     Updater,
 )
-from ai.backend.manager.repositories.base.creator import NextValuePolicy
 from ai.backend.manager.repositories.ops import DBOpsProvider
 
 __all__ = ("AppConfigFragmentDBSource",)
-
-# Gap between successive ranks, leaving room to re-order fragments without renumbering.
-RANK_GAP = 100
 
 app_config_fragment_db_source_resilience = Resilience(
     policies=[
@@ -76,14 +72,6 @@ class AppConfigFragmentDBSource:
         spec: AppConfigFragmentCreatorSpec,
         only_if: ExistsQuerier[AppConfigAllowListRow],
     ) -> AppConfigFragmentData:
-        policy = NextValuePolicy(
-            column=AppConfigFragmentRow.rank,
-            scope_condition=lambda: AppConfigFragmentRow.config_name == spec.config_name,
-            lock_selector=sa.select(AppConfigDefinitionRow).where(
-                AppConfigDefinitionRow.config_name == spec.config_name
-            ),
-            gap=RANK_GAP,
-        )
         # ``only_if`` (built by the caller) and the write run in one transaction, so the gate
         # check and the write commit atomically — no check-then-write race.
         async with self._ops.write_ops() as w:
@@ -92,7 +80,7 @@ class AppConfigFragmentDBSource:
                     f"Writing app config {spec.config_name!r} at scope "
                     f"{spec.scope_type.value!r} is not allowed."
                 )
-            created = await w.create_with_next_value(policy, spec)
+            created = await w.create(Creator(spec=spec))
             return created.row.to_data()
 
     @app_config_fragment_db_source_resilience.apply()

--- a/src/ai/backend/manager/repositories/app_config_fragment/updaters.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/updaters.py
@@ -14,8 +14,8 @@ from ai.backend.manager.types import OptionalState
 class AppConfigFragmentUpdaterSpec(UpdaterSpec[AppConfigFragmentRow]):
     """UpdaterSpec for app config fragment updates.
 
-    Only ``config`` is updatable (replaced wholesale). ``rank`` is assigned at create and is
-    never updatable — re-ordering is not exposed through the update path.
+    Only ``config`` is updatable (replaced wholesale). Merge priority lives on the
+    fragment's allow-list entry, so re-ordering is not a fragment update.
     """
 
     config: OptionalState[dict[str, Any]] = field(default_factory=OptionalState[dict[str, Any]].nop)

--- a/src/ai/backend/manager/services/app_config_fragment/actions/update.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/update.py
@@ -18,7 +18,7 @@ from ai.backend.manager.services.app_config_fragment.actions.base import (
 
 @dataclass
 class UpdateAppConfigFragmentAction(AppConfigFragmentSingleEntityAction):
-    """Update a fragment's ``config`` (replaced wholesale); ``rank`` is not updatable.
+    """Update a fragment's ``config`` (replaced wholesale).
 
     Not admin-only: an allow-listed user may update their own ``user``-scope fragment. The
     allow-list write-gate (``only_if``) authorizes the write against the fragment's

--- a/tests/unit/manager/repositories/app_config_allow_list/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_allow_list/test_repository.py
@@ -26,7 +26,6 @@ from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowLi
 from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.app_config_allow_list.creators import (
-    DEFAULT_RANK,
     AppConfigAllowListCreatorSpec,
 )
 from ai.backend.manager.repositories.app_config_allow_list.repository import (
@@ -156,14 +155,24 @@ class TestCreateAndGet:
 
 
 class TestRankAssignment:
-    async def test_rank_defaults_to_fixed_value(
+    @pytest.mark.parametrize(
+        ("scope_type", "expected_rank"),
+        [
+            (AppConfigScopeType.PUBLIC, 100),
+            (AppConfigScopeType.DOMAIN, 200),
+            (AppConfigScopeType.USER, 300),
+        ],
+    )
+    async def test_rank_defaults_by_scope_type(
         self,
         repository: AppConfigAllowListRepository,
         definition_repository: AppConfigDefinitionRepository,
+        scope_type: AppConfigScopeType,
+        expected_rank: int,
     ) -> None:
         await _register(definition_repository, "theme")
-        created = await _create_entry(repository, "theme", AppConfigScopeType.DOMAIN)
-        assert created.rank == DEFAULT_RANK
+        created = await _create_entry(repository, "theme", scope_type)
+        assert created.rank == expected_rank
 
     async def test_explicit_rank_overrides_default(
         self,
@@ -313,6 +322,20 @@ class TestSearch:
             )
         )
         assert [item.id for item in result.items] == [target.id]
+
+    async def test_search_orders_by_rank_asc(
+        self,
+        repository: AppConfigAllowListRepository,
+        seeded_entries: list[AppConfigAllowListData],
+    ) -> None:
+        result = await repository.search(
+            BatchQuerier(
+                pagination=OffsetPagination(limit=10, offset=0),
+                orders=[AppConfigAllowListOrders.rank(ascending=True)],
+            )
+        )
+        expected = [entry.id for entry in sorted(seeded_entries, key=lambda e: e.rank)]
+        assert [item.id for item in result.items] == expected
 
     async def test_search_orders_by_created_at(
         self,

--- a/tests/unit/manager/repositories/app_config_allow_list/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_allow_list/test_repository.py
@@ -26,6 +26,7 @@ from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowLi
 from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.app_config_allow_list.creators import (
+    DEFAULT_RANK,
     AppConfigAllowListCreatorSpec,
 )
 from ai.backend.manager.repositories.app_config_allow_list.repository import (
@@ -80,9 +81,14 @@ async def _create_entry(
     repository: AppConfigAllowListRepository,
     config_name: str,
     scope_type: AppConfigScopeType,
+    rank: int | None = None,
 ) -> AppConfigAllowListData:
     return await repository.create(
-        Creator(spec=AppConfigAllowListCreatorSpec(config_name=config_name, scope_type=scope_type))
+        Creator(
+            spec=AppConfigAllowListCreatorSpec(
+                config_name=config_name, scope_type=scope_type, rank=rank
+            )
+        )
     )
 
 
@@ -147,6 +153,27 @@ class TestCreateAndGet:
     ) -> None:
         with pytest.raises(UniqueConstraintViolationError):
             await _create_entry(repository, existing_entry.config_name, existing_entry.scope_type)
+
+
+class TestRankAssignment:
+    async def test_rank_defaults_to_fixed_value(
+        self,
+        repository: AppConfigAllowListRepository,
+        definition_repository: AppConfigDefinitionRepository,
+    ) -> None:
+        await _register(definition_repository, "theme")
+        created = await _create_entry(repository, "theme", AppConfigScopeType.DOMAIN)
+        assert created.rank == DEFAULT_RANK
+
+    async def test_explicit_rank_overrides_default(
+        self,
+        repository: AppConfigAllowListRepository,
+        definition_repository: AppConfigDefinitionRepository,
+    ) -> None:
+        await _register(definition_repository, "theme")
+        created = await _create_entry(repository, "theme", AppConfigScopeType.DOMAIN, rank=250)
+        assert created.rank == 250
+        assert (await repository.get_by_id(created.id)).rank == 250
 
 
 class TestPurge:

--- a/tests/unit/manager/repositories/app_config_fragment/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_repository.py
@@ -8,7 +8,6 @@ from collections.abc import AsyncGenerator
 import pytest
 
 from ai.backend.common.data.app_config.types import AppConfigScopeType
-from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.user import UserID
@@ -23,7 +22,6 @@ from ai.backend.manager.errors.repository import UniqueConstraintViolationError
 from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
 from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
 from ai.backend.manager.models.app_config_fragment.conditions import AppConfigFragmentConditions
-from ai.backend.manager.models.app_config_fragment.orders import AppConfigFragmentOrders
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.app_config_fragment.creators import (
@@ -74,6 +72,14 @@ def repository(database: ExtendedAsyncSAEngine) -> AppConfigFragmentRepository:
     return AppConfigFragmentRepository(DBOpsProvider(database))
 
 
+def _allow_list_row(config_name: str, scope_type: AppConfigScopeType) -> AppConfigAllowListRow:
+    return AppConfigAllowListRow(
+        config_name=config_name,
+        scope_type=scope_type,
+        rank=100,
+    )
+
+
 @pytest.fixture
 async def theme_registered(database: ExtendedAsyncSAEngine) -> None:
     """Situation: ``theme`` is registered and allow-listed at every scope; no fragments yet."""
@@ -81,9 +87,9 @@ async def theme_registered(database: ExtendedAsyncSAEngine) -> None:
         db_sess.add(AppConfigDefinitionRow(config_name="theme"))
         await db_sess.flush()
         db_sess.add_all([
-            AppConfigAllowListRow(config_name="theme", scope_type=AppConfigScopeType.PUBLIC),
-            AppConfigAllowListRow(config_name="theme", scope_type=AppConfigScopeType.DOMAIN),
-            AppConfigAllowListRow(config_name="theme", scope_type=AppConfigScopeType.USER),
+            _allow_list_row("theme", AppConfigScopeType.PUBLIC),
+            _allow_list_row("theme", AppConfigScopeType.DOMAIN),
+            _allow_list_row("theme", AppConfigScopeType.USER),
         ])
         await db_sess.flush()
 
@@ -102,14 +108,11 @@ async def domain_scoped_fragment(database: ExtendedAsyncSAEngine) -> AppConfigFr
     async with database.begin_session() as db_sess:
         db_sess.add(AppConfigDefinitionRow(config_name="theme"))
         await db_sess.flush()
-        db_sess.add(
-            AppConfigAllowListRow(config_name="theme", scope_type=AppConfigScopeType.DOMAIN)
-        )
+        db_sess.add(_allow_list_row("theme", AppConfigScopeType.DOMAIN))
         row = AppConfigFragmentRow(
             config_name="theme",
             scope_type=AppConfigScopeType.DOMAIN,
             scope_id=_DOMAIN_ID,
-            rank=100,
             config={"k": "v"},
         )
         db_sess.add(row)
@@ -130,7 +133,6 @@ async def fragment_not_allow_listed(database: ExtendedAsyncSAEngine) -> AppConfi
             config_name="theme",
             scope_type=AppConfigScopeType.DOMAIN,
             scope_id=_DOMAIN_ID,
-            rank=100,
             config={"k": "v"},
         )
         db_sess.add(row)
@@ -142,8 +144,7 @@ async def fragment_not_allow_listed(database: ExtendedAsyncSAEngine) -> AppConfi
 async def fragments_across_scopes(database: ExtendedAsyncSAEngine) -> list[AppConfigFragmentData]:
     """Situation: fragments across every scope_type, two domains, two users, two config_names.
 
-    Returned in creation order so search filters and rank ordering can derive their
-    expectations from it.
+    Returned in creation order so search filters can derive their expectations from it.
     """
     async with database.begin_session() as db_sess:
         db_sess.add_all([
@@ -151,47 +152,48 @@ async def fragments_across_scopes(database: ExtendedAsyncSAEngine) -> list[AppCo
             AppConfigDefinitionRow(config_name="menu"),
         ])
         await db_sess.flush()
+        db_sess.add_all([
+            _allow_list_row("theme", AppConfigScopeType.PUBLIC),
+            _allow_list_row("theme", AppConfigScopeType.DOMAIN),
+            _allow_list_row("theme", AppConfigScopeType.USER),
+            _allow_list_row("menu", AppConfigScopeType.PUBLIC),
+        ])
+        await db_sess.flush()
         rows = [
             AppConfigFragmentRow(
                 config_name="theme",
                 scope_type=AppConfigScopeType.PUBLIC,
                 scope_id="public",
-                rank=100,
                 config={"k": "v"},
             ),
             AppConfigFragmentRow(
                 config_name="theme",
                 scope_type=AppConfigScopeType.DOMAIN,
                 scope_id=_DOMAIN_ID,
-                rank=200,
                 config={"k": "v"},
             ),
             AppConfigFragmentRow(
                 config_name="theme",
                 scope_type=AppConfigScopeType.DOMAIN,
                 scope_id="other",
-                rank=300,
                 config={"k": "v"},
             ),
             AppConfigFragmentRow(
                 config_name="theme",
                 scope_type=AppConfigScopeType.USER,
                 scope_id=_USER_ID,
-                rank=400,
                 config={"k": "v"},
             ),
             AppConfigFragmentRow(
                 config_name="theme",
                 scope_type=AppConfigScopeType.USER,
                 scope_id=_OTHER_USER_ID,
-                rank=500,
                 config={"k": "v"},
             ),
             AppConfigFragmentRow(
                 config_name="menu",
                 scope_type=AppConfigScopeType.PUBLIC,
                 scope_id="public",
-                rank=100,
                 config={"k": "v"},
             ),
         ]
@@ -252,40 +254,6 @@ class TestCreateAndGet:
                 ),
                 ExistsQuerier(row_class=AppConfigAllowListRow),
             )
-
-
-class TestRankAssignment:
-    async def test_rank_increases_per_config_name(
-        self, repository: AppConfigFragmentRepository, theme_registered: None
-    ) -> None:
-        first = await repository.create(
-            AppConfigFragmentCreatorSpec(
-                config_name="theme",
-                scope_type=AppConfigScopeType.PUBLIC,
-                scope_id="public",
-                config={"k": "v"},
-            ),
-            ExistsQuerier(row_class=AppConfigAllowListRow),
-        )
-        second = await repository.create(
-            AppConfigFragmentCreatorSpec(
-                config_name="theme",
-                scope_type=AppConfigScopeType.DOMAIN,
-                scope_id=_DOMAIN_ID,
-                config={"k": "v"},
-            ),
-            ExistsQuerier(row_class=AppConfigAllowListRow),
-        )
-        third = await repository.create(
-            AppConfigFragmentCreatorSpec(
-                config_name="theme",
-                scope_type=AppConfigScopeType.USER,
-                scope_id=_USER_ID,
-                config={"k": "v"},
-            ),
-            ExistsQuerier(row_class=AppConfigAllowListRow),
-        )
-        assert first.rank < second.rank < third.rank
 
 
 class TestUpdate:
@@ -416,27 +384,6 @@ class TestSearch:
         )
         expected = {f.id for f in fragments_across_scopes if f.scope_id == _USER_ID}
         assert {item.id for item in result.items} == expected
-
-    async def test_order_by_rank_desc(
-        self,
-        repository: AppConfigFragmentRepository,
-        fragments_across_scopes: list[AppConfigFragmentData],
-    ) -> None:
-        # Rank is monotonic per config_name, so scope to one config_name for a total order.
-        theme_fragments = [f for f in fragments_across_scopes if f.config_name == "theme"]
-        result = await repository.admin_search(
-            BatchQuerier(
-                pagination=OffsetPagination(limit=10, offset=0),
-                conditions=[
-                    AppConfigFragmentConditions.by_config_name_equals(
-                        StringMatchSpec("theme", case_insensitive=False, negated=False)
-                    )
-                ],
-                orders=[AppConfigFragmentOrders.rank(ascending=False)],
-            )
-        )
-        expected = [f.id for f in sorted(theme_fragments, key=lambda f: f.rank, reverse=True)]
-        assert [item.id for item in result.items] == expected
 
 
 class TestScopedSearch:

--- a/tests/unit/manager/repositories/app_config_fragment/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_repository.py
@@ -76,7 +76,7 @@ def _allow_list_row(config_name: str, scope_type: AppConfigScopeType) -> AppConf
     return AppConfigAllowListRow(
         config_name=config_name,
         scope_type=scope_type,
-        rank=100,
+        rank=scope_type.default_rank(),
     )
 
 

--- a/tests/unit/manager/services/app_config_allow_list/test_service.py
+++ b/tests/unit/manager/services/app_config_allow_list/test_service.py
@@ -52,6 +52,7 @@ class TestAppConfigAllowListService:
             id=AppConfigAllowListID(uuid.uuid4()),
             config_name="theme",
             scope_type=AppConfigScopeType.USER,
+            rank=100,
             created_at=datetime.now(UTC),
             updated_at=datetime.now(UTC),
         )

--- a/tests/unit/manager/services/app_config_allow_list/test_service.py
+++ b/tests/unit/manager/services/app_config_allow_list/test_service.py
@@ -52,7 +52,7 @@ class TestAppConfigAllowListService:
             id=AppConfigAllowListID(uuid.uuid4()),
             config_name="theme",
             scope_type=AppConfigScopeType.USER,
-            rank=100,
+            rank=AppConfigScopeType.USER.default_rank(),
             created_at=datetime.now(UTC),
             updated_at=datetime.now(UTC),
         )

--- a/tests/unit/manager/services/app_config_fragment/test_service.py
+++ b/tests/unit/manager/services/app_config_fragment/test_service.py
@@ -75,7 +75,6 @@ def _fragment(
         config_name=config_name,
         scope_type=scope_type,
         scope_id=scope_id,
-        rank=100,
         config={"k": "v"},
         created_at=now,
         updated_at=now,


### PR DESCRIPTION
## Summary

Second half of the AppConfigFragment rank redesign (BA-6628), split out of #12516. #12516 moves the merge `rank` from `app_config_fragments` to the admin-owned `app_config_allow_list` with a single fixed default; **this PR makes that default depend on the scope type.**

- **`AppConfigScopeType.default_rank()`** — a new allow-list entry defaults its `rank` from its scope type: `public`=100, `domain`=200, `user`=300. The defaults order the scopes so a user's own fragment overrides the domain default, which overrides the public value; the 100 gap leaves room for admins to place custom ranks in between. An explicit `rank` still overrides the default.
- **Migration `66d0f891ed20`** — the backfill (added in #12516) switches from the fixed default to the per-scope-type defaults for existing allow-list rows.
- **BEP-1052** — documents the scope-type defaults and the "user fragment wins by default" behavior.

## 📚 Stacked PRs

Part of the AppConfigFragment / AppConfig stack under BEP-1052 (epic BA-5781). **Merge in order:**

1. ✅ #12306 — `feat(BA-6552): app_config_fragments DB model and Alembic migration`
2. ✅ #12307 — `feat(BA-6553): repository layer`
3. ✅ #12403 — `refactor(BA-6619): consolidate AppConfigScopeType into common.data`
4. ✅ #12405 — `refactor(BA-6620): ExistsQuerier + AppConfigAllowList.exists`
5. ✅ #12358 — `feat(BA-6554): AppConfigFragment service layer`
6. #12516 — `feat(BA-6628): move fragment rank to the allow list`
7. 👉 **#12539 — `feat(BA-6628): assign scope-type default ranks to allow-list entries`** ← you are here
8. #12517 — `feat(BA-6628): expose allow-list rank on the v2 API surface`
9. #12518 — `feat(BA-6628): cascade fragment deletion from the allow list`
10. #12426 — `feat(BA-6626): app_config_fragment bulk repository layer`
11. #12401 — `feat(BA-6618): AppConfigFragment bulk CRUD service layer`
12. #12359 — `feat(BA-6555): app_config service layer (merge engine)`
13. #12377 — `feat(BA-6556): AppConfig REST v2 API`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

