### PR TITLE
fix(BA-6693): isolate frozen migration table metadata (#12537)

### DIFF
--- a/changes/12537.fix.md
+++ b/changes/12537.fix.md
@@ -1,0 +1,1 @@
+Fix `alembic upgrade` failing when upgrading from older versions, caused by RBAC migration helpers leaking production ORM columns into their frozen table definitions

--- a/src/ai/backend/manager/models/rbac_models/migration/models.py
+++ b/src/ai/backend/manager/models/rbac_models/migration/models.py
@@ -14,9 +14,10 @@ define tables inline or use raw SQL instead of calling these shared helpers.
 import sqlalchemy as sa
 from sqlalchemy.orm import registry
 
-from ai.backend.manager.models.base import GUID, IDColumn, metadata
+from ai.backend.manager.models.base import GUID, IDColumn
 
-mapper_registry = registry(metadata=metadata)
+# Use an isolated metadata so the frozen table definitions in this module stay frozen.
+mapper_registry = registry(metadata=sa.MetaData())
 
 
 def get_user_roles_table() -> sa.Table:


### PR DESCRIPTION
This is an auto-generated backport PR of #12537 to the 26.4 release.