### PR TITLE
feat(BA-6700): add v2 GraphQL resourceAllocation resolver with allocated slots

### DIFF
--- a/changes/12546.feature.md
+++ b/changes/12546.feature.md
@@ -1,0 +1,1 @@
+Add a `resourceAllocation` field to the v2 GraphQL `SessionV2` and `KernelV2` types that reports requested / used / allocated resource slots aggregated from the `resource_allocations` table, where `allocated` persists after the session or kernel is freed or terminated (for post-termination statistics and billing).

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -8440,6 +8440,11 @@ type KernelV2 implements Node
   """Added in 26.2.0. The resource group this kernel is assigned to."""
   resourceGroup: ResourceGroup
 
+  """
+  Added in 26.8.0. Resource allocation (requested / used / allocated) computed on-demand from the resource_allocations table. Unlike the deprecated eager `resource.allocation`, `allocated` here persists after the kernel is freed or terminated (for statistics and billing).
+  """
+  resourceAllocation: ResourceAllocation!
+
   """Added in 26.3.0. The session this kernel belongs to."""
   session: SessionV2
 
@@ -15708,6 +15713,11 @@ type ResourceAllocation
   The resource slots currently used. Typed as Any because this field holds a nested GQL type (ResourceSlotGQL).
   """
   used: ResourceSlot
+
+  """
+  The resource slots actually allocated, computed from the resource_allocations table. Unlike `used`, this persists after the session/kernel is freed or terminated (for statistics and billing). Typed as Any because this field holds a nested GQL type (ResourceSlotGQL).
+  """
+  allocated: ResourceSlot
 }
 
 """
@@ -18453,6 +18463,11 @@ type SessionV2 implements Node
   Added in 26.4.4. The model deployment replica served by this session: a single replica instance of a model deployment that runs in this compute session and serves inference requests. Null for non-inference sessions.
   """
   replica: ModelReplica
+
+  """
+  Added in 26.8.0. Resource allocation (requested / used / allocated) computed on-demand from the resource_allocations table. Unlike the deprecated eager `resource.allocation`, `allocated` here persists after the session is freed or terminated (for statistics and billing).
+  """
+  resourceAllocation: ResourceAllocation!
 }
 
 """Added in 26.3.0. Connection type for paginated session results."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -5575,6 +5575,11 @@ type KernelV2 implements Node {
   """Added in 26.2.0. The resource group this kernel is assigned to."""
   resourceGroup: ResourceGroup
 
+  """
+  Added in 26.8.0. Resource allocation (requested / used / allocated) computed on-demand from the resource_allocations table. Unlike the deprecated eager `resource.allocation`, `allocated` here persists after the kernel is freed or terminated (for statistics and billing).
+  """
+  resourceAllocation: ResourceAllocation!
+
   """Added in 26.3.0. The session this kernel belongs to."""
   session: SessionV2
 
@@ -10720,6 +10725,11 @@ type ResourceAllocation {
   The resource slots currently used. Typed as Any because this field holds a nested GQL type (ResourceSlotGQL).
   """
   used: ResourceSlot
+
+  """
+  The resource slots actually allocated, computed from the resource_allocations table. Unlike `used`, this persists after the session/kernel is freed or terminated (for statistics and billing). Typed as Any because this field holds a nested GQL type (ResourceSlotGQL).
+  """
+  allocated: ResourceSlot
 }
 
 """
@@ -12813,6 +12823,11 @@ type SessionV2 implements Node {
   Added in 26.4.4. The model deployment replica served by this session: a single replica instance of a model deployment that runs in this compute session and serves inference requests. Null for non-inference sessions.
   """
   replica: ModelReplica
+
+  """
+  Added in 26.8.0. Resource allocation (requested / used / allocated) computed on-demand from the resource_allocations table. Unlike the deprecated eager `resource.allocation`, `allocated` here persists after the session is freed or terminated (for statistics and billing).
+  """
+  resourceAllocation: ResourceAllocation!
 }
 
 """Added in 26.3.0. Connection type for paginated session results."""

--- a/src/ai/backend/common/dto/manager/v2/kernel/response.py
+++ b/src/ai/backend/common/dto/manager/v2/kernel/response.py
@@ -254,6 +254,15 @@ class ResourceAllocationGQLDTO(BaseResponseModel):
             "Typed as Any because this field holds a nested GQL type (ResourceSlotGQL)."
         ),
     )
+    allocated: Any = Field(
+        default=None,
+        description=(
+            "The resource slots actually allocated, computed from the "
+            "resource_allocations table. Unlike `used`, this persists after the "
+            "session/kernel is freed or terminated (for statistics and billing). "
+            "Typed as Any because this field holds a nested GQL type (ResourceSlotGQL)."
+        ),
+    )
 
 
 class KernelResourceInfoGQLDTO(BaseResponseModel):

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -74,12 +74,14 @@ from ai.backend.common.types import (
     KernelId,
     MountInfoEntry,
     MountPermission,
+    ResourceSlot,
     SessionId,
     SessionTypes,
 )
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.kernel.types import KernelInfo, KernelStatus, KernelStatusInMatchSpec
+from ai.backend.manager.data.resource_slot.types import ResourceAllocationAggregate
 from ai.backend.manager.data.session.types import SessionData, SessionStatus
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.models.kernel.conditions import KernelConditions
@@ -117,6 +119,12 @@ from ai.backend.manager.repositories.base import (
     negate_conditions,
 )
 from ai.backend.manager.repositories.session.types import ProjectSessionSearchScope
+from ai.backend.manager.services.session.actions.batch_get_kernel_resource_allocation import (
+    BatchGetKernelResourceAllocationAction,
+)
+from ai.backend.manager.services.session.actions.batch_get_session_resource_allocation import (
+    BatchGetSessionResourceAllocationAction,
+)
 from ai.backend.manager.services.session.actions.enqueue_session import (
     EnqueueSessionAction,
     ResourceSlotEntry,
@@ -363,6 +371,66 @@ class SessionAdapter(BaseAdapter):
             info.id: self._kernel_info_to_node(info) for info in action_result.data
         }
         return [kernel_map.get(kernel_id) for kernel_id in kernel_ids]
+
+    @staticmethod
+    def _aggregate_to_allocation_dto(
+        aggregate: ResourceAllocationAggregate | None,
+    ) -> ResourceAllocationGQLDTO:
+        """Convert a per-owner resource-allocation aggregate to the shared GQL DTO.
+
+        A missing aggregate (owner with no resource_allocations rows) maps to empty
+        slot sets rather than null.
+        """
+
+        def _to_info(slots: ResourceSlot | None) -> ResourceSlotInfo:
+            return ResourceSlotInfo(
+                entries=[
+                    ResourceSlotEntryInfo(resource_type=k, quantity=Decimal(str(v)))
+                    for k, v in (slots or {}).items()
+                ]
+            )
+
+        return ResourceAllocationGQLDTO(
+            requested=_to_info(aggregate.requested if aggregate else None),
+            used=_to_info(aggregate.used if aggregate else None),
+            allocated=_to_info(aggregate.allocated if aggregate else None),
+        )
+
+    async def batch_resource_allocation_by_session(
+        self, session_ids: Sequence[SessionId]
+    ) -> list[ResourceAllocationGQLDTO]:
+        """Batch-aggregate resource_allocations per session for DataLoader use.
+
+        Returns one DTO per input session id, in the same order.
+        """
+        if not session_ids:
+            return []
+        action_result = (
+            await self._processors.session.batch_get_session_resource_allocation.wait_for_complete(
+                BatchGetSessionResourceAllocationAction(session_ids=list(session_ids))
+            )
+        )
+        return [
+            self._aggregate_to_allocation_dto(action_result.data.get(sid)) for sid in session_ids
+        ]
+
+    async def batch_resource_allocation_by_kernel(
+        self, kernel_ids: Sequence[KernelId]
+    ) -> list[ResourceAllocationGQLDTO]:
+        """Batch-aggregate resource_allocations per kernel for DataLoader use.
+
+        Returns one DTO per input kernel id, in the same order.
+        """
+        if not kernel_ids:
+            return []
+        action_result = (
+            await self._processors.session.batch_get_kernel_resource_allocation.wait_for_complete(
+                BatchGetKernelResourceAllocationAction(kernel_ids=list(kernel_ids))
+            )
+        )
+        return [
+            self._aggregate_to_allocation_dto(action_result.data.get(kid)) for kid in kernel_ids
+        ]
 
     # -------------------------------------------------------------------------
     # Session search

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -62,7 +62,10 @@ if TYPE_CHECKING:
         ImageV2AliasGQL,
         ImageV2GQL,
     )
-    from ai.backend.manager.api.gql.kernel.types import KernelV2GQL  # pants: no-infer-dep
+    from ai.backend.manager.api.gql.kernel.types import (  # pants: no-infer-dep
+        KernelV2GQL,
+        ResourceAllocationGQL,
+    )
     from ai.backend.manager.api.gql.notification.types import (  # pants: no-infer-dep
         NotificationChannel,
         NotificationRule,
@@ -535,6 +538,38 @@ class DataLoaders:
 
             dtos = await adapter.batch_load_by_ids(session_ids)
             return [SG.from_pydantic(dto) if dto is not None else None for dto in dtos]
+
+        return DataLoader(load_fn=load_fn)
+
+    @cached_property
+    def session_resource_allocation_loader(
+        self,
+    ) -> DataLoader[SessionId, ResourceAllocationGQL]:
+        adapter = self._adapters.session
+
+        async def load_fn(session_ids: list[SessionId]) -> list[ResourceAllocationGQL]:
+            from ai.backend.manager.api.gql.kernel.types import (  # pants: no-infer-dep
+                ResourceAllocationGQL as RA,
+            )
+
+            dtos = await adapter.batch_resource_allocation_by_session(session_ids)
+            return [RA.from_pydantic(dto) for dto in dtos]
+
+        return DataLoader(load_fn=load_fn)
+
+    @cached_property
+    def kernel_resource_allocation_loader(
+        self,
+    ) -> DataLoader[KernelId, ResourceAllocationGQL]:
+        adapter = self._adapters.session
+
+        async def load_fn(kernel_ids: list[KernelId]) -> list[ResourceAllocationGQL]:
+            from ai.backend.manager.api.gql.kernel.types import (  # pants: no-infer-dep
+                ResourceAllocationGQL as RA,
+            )
+
+            dtos = await adapter.batch_resource_allocation_by_kernel(kernel_ids)
+            return [RA.from_pydantic(dto) for dto in dtos]
 
         return DataLoader(load_fn=load_fn)
 

--- a/src/ai/backend/manager/api/gql/kernel/types.py
+++ b/src/ai/backend/manager/api/gql/kernel/types.py
@@ -26,6 +26,7 @@ from ai.backend.common.dto.manager.v2.kernel.response import (
 from ai.backend.common.dto.manager.v2.kernel.types import (
     KernelStatusFilter,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.common.types import AgentId, KernelId, SessionTypes
 from ai.backend.manager.api.gql.base import OrderDirection, UUIDFilter
 from ai.backend.manager.api.gql.decorators import (
@@ -59,7 +60,7 @@ from ai.backend.manager.api.gql.domain_v2.types.node import DomainV2GQL
 from ai.backend.manager.api.gql.fair_share.types.common import ResourceSlotGQL
 from ai.backend.manager.api.gql.image.types import ImageV2GQL
 from ai.backend.manager.api.gql.project_v2.types.node import ProjectV2GQL
-from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
+from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
 from ai.backend.manager.api.gql.resource_group.types import ResourceGroupGQL
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.api.gql.user.types.node import UserV2GQL
@@ -207,12 +208,22 @@ class KernelV2UserInfoGQL:
     model=ResourceAllocationGQLDTO,
     name="ResourceAllocation",
 )
-class ResourceAllocationGQL:
+class ResourceAllocationGQL(PydanticOutputMixin[ResourceAllocationGQLDTO]):
     requested: ResourceSlotGQL = gql_field(
         description="The resource slots originally requested for this kernel."
     )
     used: ResourceSlotGQL | None = gql_field(
         description="The resource slots currently used by this kernel. May be null if not yet allocated."
+    )
+    allocated: ResourceSlotGQL | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "The resource slots actually allocated, computed from the "
+                "resource_allocations table. Unlike `used`, this persists after the "
+                "session/kernel is freed or terminated (for statistics and billing)."
+            ),
+        )
     )
 
 
@@ -396,6 +407,22 @@ class KernelV2GQL(PydanticNodeMixin[KernelNode]):
         if resource_group_data is None:
             return None
         return resource_group_data
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Resource allocation (requested / used / allocated) computed on-demand "
+                "from the resource_allocations table. Unlike the deprecated eager "
+                "`resource.allocation`, `allocated` here persists after the kernel is "
+                "freed or terminated (for statistics and billing)."
+            ),
+        )
+    )  # type: ignore[misc]
+    async def resource_allocation(self, info: Info[StrawberryGQLContext]) -> ResourceAllocationGQL:
+        return await info.context.data_loaders.kernel_resource_allocation_loader.load(
+            KernelId(UUID(str(self.id)))
+        )
 
     @gql_added_field(
         BackendAIGQLMeta(added_version="26.3.0", description="The session this kernel belongs to.")

--- a/src/ai/backend/manager/api/gql/session/types.py
+++ b/src/ai/backend/manager/api/gql/session/types.py
@@ -466,6 +466,22 @@ class SessionV2GQL(PydanticNodeMixin[SessionNode]):
             return None
         return await info.context.data_loaders.replica_loader.load(UUID(str(self.replica_id)))
 
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Resource allocation (requested / used / allocated) computed on-demand "
+                "from the resource_allocations table. Unlike the deprecated eager "
+                "`resource.allocation`, `allocated` here persists after the session is "
+                "freed or terminated (for statistics and billing)."
+            ),
+        )
+    )  # type: ignore[misc]
+    async def resource_allocation(self, info: Info[StrawberryGQLContext]) -> ResourceAllocationGQL:
+        return await info.context.data_loaders.session_resource_allocation_loader.load(
+            SessionId(UUID(str(self.id)))
+        )
+
     # TODO: Add `vfolder_mounts` dynamic field (VFolder connection type needed)
 
     @classmethod

--- a/src/ai/backend/manager/data/resource_slot/types.py
+++ b/src/ai/backend/manager/data/resource_slot/types.py
@@ -4,7 +4,23 @@ import uuid
 from dataclasses import dataclass
 from decimal import Decimal
 
-from ai.backend.common.types import SlotQuantity
+from ai.backend.common.types import ResourceSlot, SlotQuantity
+
+
+@dataclass(frozen=True)
+class ResourceAllocationAggregate:
+    """Per-owner (session or kernel) resource allocation aggregated from the
+    ``resource_allocations`` table.
+
+    - ``requested``: SUM(requested) over the owner's slots.
+    - ``used``: currently occupying resources (``free_at IS NULL``); empties after free.
+    - ``allocated``: resources ever actually allocated (``used_at IS NOT NULL``);
+      persists after the owner is freed/terminated (for statistics/billing).
+    """
+
+    requested: ResourceSlot
+    used: ResourceSlot
+    allocated: ResourceSlot
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/repositories/session/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/session/db_source/db_source.py
@@ -12,9 +12,17 @@ from sqlalchemy.orm.strategy_options import _AbstractLoad
 
 from ai.backend.common.docker import ImageRef
 from ai.backend.common.identifier.session import SessionID
-from ai.backend.common.types import AccessKey, AgentId, ImageAlias, SessionId
+from ai.backend.common.types import (
+    AccessKey,
+    AgentId,
+    ImageAlias,
+    KernelId,
+    ResourceSlot,
+    SessionId,
+)
 from ai.backend.manager.data.image.types import ImageIdentifier, ImageStatus
 from ai.backend.manager.data.kernel.types import KernelListResult
+from ai.backend.manager.data.resource_slot.types import ResourceAllocationAggregate
 from ai.backend.manager.data.session.types import (
     SessionData,
     SessionListResult,
@@ -35,6 +43,7 @@ from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.resource_policy import KeyPairResourcePolicyRow
+from ai.backend.manager.models.resource_slot import ResourceAllocationRow
 from ai.backend.manager.models.scaling_group import scaling_groups
 from ai.backend.manager.models.session import (
     DEAD_SESSION_STATUSES,
@@ -688,6 +697,105 @@ class SessionDBSource:
                 has_next_page=result.has_next_page,
                 has_previous_page=result.has_previous_page,
             )
+
+    @staticmethod
+    def _resource_allocation_aggregates() -> tuple[Any, Any, Any]:
+        """Build the three per-slot aggregate expressions over resource_allocations.
+
+        - requested: SUM(requested)
+        - used: currently occupying (free_at IS NULL), coalesced with requested
+        - allocated: ever actually allocated (used_at IS NOT NULL), persists after free
+        """
+        ra = ResourceAllocationRow.__table__
+        requested_expr = sa.func.sum(ra.c.requested).label("requested")
+        used_expr = (
+            sa.func.sum(sa.func.coalesce(ra.c.used, ra.c.requested))
+            .filter(ra.c.free_at.is_(None))
+            .label("used")
+        )
+        allocated_expr = sa.func.sum(ra.c.used).filter(ra.c.used_at.isnot(None)).label("allocated")
+        return requested_expr, used_expr, allocated_expr
+
+    @staticmethod
+    def _rows_to_aggregates(
+        rows: Sequence[Any], key_attr: str
+    ) -> dict[Any, ResourceAllocationAggregate]:
+        requested: dict[Any, ResourceSlot] = {}
+        used: dict[Any, ResourceSlot] = {}
+        allocated: dict[Any, ResourceSlot] = {}
+        for r in rows:
+            key = getattr(r, key_attr)
+            if r.requested is not None:
+                requested.setdefault(key, ResourceSlot())[r.slot_name] = r.requested
+            if r.used is not None:
+                used.setdefault(key, ResourceSlot())[r.slot_name] = r.used
+            if r.allocated is not None:
+                allocated.setdefault(key, ResourceSlot())[r.slot_name] = r.allocated
+        keys = set(requested) | set(used) | set(allocated)
+        return {
+            key: ResourceAllocationAggregate(
+                requested=requested.get(key, ResourceSlot()),
+                used=used.get(key, ResourceSlot()),
+                allocated=allocated.get(key, ResourceSlot()),
+            )
+            for key in keys
+        }
+
+    async def batch_get_resource_allocation_by_session(
+        self,
+        session_ids: Sequence[SessionId],
+    ) -> dict[SessionId, ResourceAllocationAggregate]:
+        """Aggregate resource_allocations per session (grouped by slot).
+
+        Values are computed live from the resource_allocations table; the deprecated
+        JSONB columns are never read.
+        """
+        if not session_ids:
+            return {}
+        ra = ResourceAllocationRow.__table__
+        kernels = KernelRow.__table__
+        requested_expr, used_expr, allocated_expr = self._resource_allocation_aggregates()
+        stmt = (
+            sa.select(
+                kernels.c.session_id.label("session_id"),
+                ra.c.slot_name,
+                requested_expr,
+                used_expr,
+                allocated_expr,
+            )
+            .select_from(ra.join(kernels, ra.c.kernel_id == kernels.c.id))
+            .where(kernels.c.session_id.in_(session_ids))
+            .group_by(kernels.c.session_id, ra.c.slot_name)
+        )
+        async with self._db.begin_readonly_session() as db_sess:
+            rows = (await db_sess.execute(stmt)).all()
+        aggregates = self._rows_to_aggregates(rows, "session_id")
+        return {SessionId(key): agg for key, agg in aggregates.items()}
+
+    async def batch_get_resource_allocation_by_kernel(
+        self,
+        kernel_ids: Sequence[KernelId],
+    ) -> dict[KernelId, ResourceAllocationAggregate]:
+        """Aggregate resource_allocations per kernel (grouped by slot)."""
+        if not kernel_ids:
+            return {}
+        ra = ResourceAllocationRow.__table__
+        requested_expr, used_expr, allocated_expr = self._resource_allocation_aggregates()
+        stmt = (
+            sa.select(
+                ra.c.kernel_id.label("kernel_id"),
+                ra.c.slot_name,
+                requested_expr,
+                used_expr,
+                allocated_expr,
+            )
+            .where(ra.c.kernel_id.in_(kernel_ids))
+            .group_by(ra.c.kernel_id, ra.c.slot_name)
+        )
+        async with self._db.begin_readonly_session() as db_sess:
+            rows = (await db_sess.execute(stmt)).all()
+        aggregates = self._rows_to_aggregates(rows, "kernel_id")
+        return {KernelId(key): agg for key, agg in aggregates.items()}
 
     async def resolve_image_by_id(
         self,

--- a/src/ai/backend/manager/repositories/session/repository.py
+++ b/src/ai/backend/manager/repositories/session/repository.py
@@ -14,9 +14,10 @@ from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
 from ai.backend.common.resilience.resilience import Resilience
-from ai.backend.common.types import AccessKey, ImageAlias, SessionId
+from ai.backend.common.types import AccessKey, ImageAlias, KernelId, SessionId
 from ai.backend.manager.data.image.types import ImageIdentifier
 from ai.backend.manager.data.kernel.types import KernelListResult
+from ai.backend.manager.data.resource_slot.types import ResourceAllocationAggregate
 from ai.backend.manager.data.session.types import (
     SessionData,
     SessionListResult,
@@ -324,6 +325,22 @@ class SessionRepository:
             KernelListResult with items, total count, and pagination info
         """
         return await self._db_source.search_kernels(querier)
+
+    @session_repository_resilience.apply()
+    async def batch_get_resource_allocation_by_session(
+        self,
+        session_ids: Sequence[SessionId],
+    ) -> dict[SessionId, ResourceAllocationAggregate]:
+        """Aggregate resource_allocations per session (requested/used/allocated)."""
+        return await self._db_source.batch_get_resource_allocation_by_session(session_ids)
+
+    @session_repository_resilience.apply()
+    async def batch_get_resource_allocation_by_kernel(
+        self,
+        kernel_ids: Sequence[KernelId],
+    ) -> dict[KernelId, ResourceAllocationAggregate]:
+        """Aggregate resource_allocations per kernel (requested/used/allocated)."""
+        return await self._db_source.batch_get_resource_allocation_by_kernel(kernel_ids)
 
     @session_repository_resilience.apply()
     async def resolve_image_by_id(

--- a/src/ai/backend/manager/services/session/actions/batch_get_kernel_resource_allocation.py
+++ b/src/ai/backend/manager/services/session/actions/batch_get_kernel_resource_allocation.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import EntityType, RBACElementType
+from ai.backend.common.types import KernelId
+from ai.backend.manager.actions.action.bulk import BaseBulkAction, BaseBulkActionResult
+from ai.backend.manager.actions.action.types import ActionTarget
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.data.resource_slot.types import ResourceAllocationAggregate
+
+
+@dataclass(frozen=True)
+class KernelResourceAllocationTarget(ActionTarget):
+    """Bulk-action target identifying a single kernel by ID."""
+
+    kernel_id: KernelId
+
+    @override
+    def to_rbac_element_ref(self) -> RBACElementRef:
+        return RBACElementRef(
+            element_type=RBACElementType.KERNEL,
+            element_id=str(self.kernel_id),
+        )
+
+
+@dataclass
+class BatchGetKernelResourceAllocationAction(BaseBulkAction[KernelResourceAllocationTarget]):
+    """Batch-aggregate resource allocations for one or more kernels.
+
+    Used by the GraphQL DataLoader backing ``KernelV2.resourceAllocation``; the
+    kernel ids originate from already-authorized kernel nodes.
+    """
+
+    kernel_ids: list[KernelId]
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.KERNEL
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.SEARCH
+
+    @override
+    def targets(self) -> Sequence[KernelResourceAllocationTarget]:
+        return [KernelResourceAllocationTarget(kernel_id=kid) for kid in self.kernel_ids]
+
+
+@dataclass
+class BatchGetKernelResourceAllocationActionResult(BaseBulkActionResult):
+    data: dict[KernelId, ResourceAllocationAggregate]
+
+    @override
+    def element_refs(self) -> list[RBACElementRef]:
+        return [
+            RBACElementRef(element_type=RBACElementType.KERNEL, element_id=str(kid))
+            for kid in self.data
+        ]

--- a/src/ai/backend/manager/services/session/actions/batch_get_session_resource_allocation.py
+++ b/src/ai/backend/manager/services/session/actions/batch_get_session_resource_allocation.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import EntityType, RBACElementType
+from ai.backend.common.types import SessionId
+from ai.backend.manager.actions.action.bulk import BaseBulkAction, BaseBulkActionResult
+from ai.backend.manager.actions.action.types import ActionTarget
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.data.resource_slot.types import ResourceAllocationAggregate
+
+
+@dataclass(frozen=True)
+class SessionResourceAllocationTarget(ActionTarget):
+    """Bulk-action target identifying a single session by ID."""
+
+    session_id: SessionId
+
+    @override
+    def to_rbac_element_ref(self) -> RBACElementRef:
+        return RBACElementRef(
+            element_type=RBACElementType.SESSION,
+            element_id=str(self.session_id),
+        )
+
+
+@dataclass
+class BatchGetSessionResourceAllocationAction(BaseBulkAction[SessionResourceAllocationTarget]):
+    """Batch-aggregate resource allocations for one or more sessions.
+
+    Used by the GraphQL DataLoader backing ``SessionV2.resourceAllocation``; the
+    session ids originate from already-authorized session nodes.
+    """
+
+    session_ids: list[SessionId]
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.SESSION
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.SEARCH
+
+    @override
+    def targets(self) -> Sequence[SessionResourceAllocationTarget]:
+        return [SessionResourceAllocationTarget(session_id=sid) for sid in self.session_ids]
+
+
+@dataclass
+class BatchGetSessionResourceAllocationActionResult(BaseBulkActionResult):
+    data: dict[SessionId, ResourceAllocationAggregate]
+
+    @override
+    def element_refs(self) -> list[RBACElementRef]:
+        return [
+            RBACElementRef(element_type=RBACElementType.SESSION, element_id=str(sid))
+            for sid in self.data
+        ]

--- a/src/ai/backend/manager/services/session/processors.py
+++ b/src/ai/backend/manager/services/session/processors.py
@@ -7,6 +7,14 @@ from ai.backend.manager.actions.processor.single_entity import SingleEntityActio
 from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validator.base import ActionValidator
 from ai.backend.manager.actions.validators import ActionValidators
+from ai.backend.manager.services.session.actions.batch_get_kernel_resource_allocation import (
+    BatchGetKernelResourceAllocationAction,
+    BatchGetKernelResourceAllocationActionResult,
+)
+from ai.backend.manager.services.session.actions.batch_get_session_resource_allocation import (
+    BatchGetSessionResourceAllocationAction,
+    BatchGetSessionResourceAllocationActionResult,
+)
 from ai.backend.manager.services.session.actions.commit_session import (
     CommitSessionAction,
     CommitSessionActionResult,
@@ -178,6 +186,12 @@ class SessionProcessors(AbstractProcessorPackage):
     resolve_session: ActionProcessor[ResolveSessionAction, ResolveSessionActionResult]
     resolve_session_name: ActionProcessor[ResolveSessionNameAction, ResolveSessionNameActionResult]
     search_kernels: ActionProcessor[SearchKernelsAction, SearchKernelsActionResult]
+    batch_get_session_resource_allocation: BulkActionProcessor[
+        BatchGetSessionResourceAllocationAction, BatchGetSessionResourceAllocationActionResult
+    ]
+    batch_get_kernel_resource_allocation: BulkActionProcessor[
+        BatchGetKernelResourceAllocationAction, BatchGetKernelResourceAllocationActionResult
+    ]
     search_sessions: ActionProcessor[SearchSessionsAction, SearchSessionsActionResult]
     search_sessions_in_project: ActionProcessor[
         SearchSessionsInProjectAction, SearchSessionsInProjectActionResult
@@ -253,6 +267,16 @@ class SessionProcessors(AbstractProcessorPackage):
             action_monitors,
             validators=[cast(ActionValidator, scope_validator)],
         )
+        # Bulk read for GraphQL DataLoaders; ids come from already-authorized
+        # session/kernel nodes, so no per-target RBAC re-validation is applied.
+        self.batch_get_session_resource_allocation = BulkActionProcessor(
+            service.batch_get_session_resource_allocation,
+            monitors=action_monitors,
+        )
+        self.batch_get_kernel_resource_allocation = BulkActionProcessor(
+            service.batch_get_kernel_resource_allocation,
+            monitors=action_monitors,
+        )
         self.search_sessions = ActionProcessor(
             service.search, action_monitors, validators=[cast(ActionValidator, scope_validator)]
         )
@@ -318,6 +342,8 @@ class SessionProcessors(AbstractProcessorPackage):
             ResolveSessionAction.spec(),
             ResolveSessionNameAction.spec(),
             SearchKernelsAction.spec(),
+            BatchGetSessionResourceAllocationAction.spec(),
+            BatchGetKernelResourceAllocationAction.spec(),
             SearchSessionsAction.spec(),
             SearchSessionsInProjectAction.spec(),
             ShutdownServiceAction.spec(),

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -101,6 +101,14 @@ from ai.backend.manager.repositories.scheduler.repository import SchedulerReposi
 from ai.backend.manager.repositories.session.repository import SessionRepository
 from ai.backend.manager.repositories.session.updaters import SessionUpdaterSpec
 from ai.backend.manager.repositories.user.repository import UserRepository
+from ai.backend.manager.services.session.actions.batch_get_kernel_resource_allocation import (
+    BatchGetKernelResourceAllocationAction,
+    BatchGetKernelResourceAllocationActionResult,
+)
+from ai.backend.manager.services.session.actions.batch_get_session_resource_allocation import (
+    BatchGetSessionResourceAllocationAction,
+    BatchGetSessionResourceAllocationActionResult,
+)
 from ai.backend.manager.services.session.actions.commit_session import (
     CommitSessionAction,
     CommitSessionActionResult,
@@ -1514,6 +1522,24 @@ class SessionService:
             has_next_page=result.has_next_page,
             has_previous_page=result.has_previous_page,
         )
+
+    async def batch_get_session_resource_allocation(
+        self, action: BatchGetSessionResourceAllocationAction
+    ) -> BatchGetSessionResourceAllocationActionResult:
+        """Aggregate resource_allocations per session (requested/used/allocated)."""
+        data = await self._session_repository.batch_get_resource_allocation_by_session(
+            action.session_ids
+        )
+        return BatchGetSessionResourceAllocationActionResult(data=data)
+
+    async def batch_get_kernel_resource_allocation(
+        self, action: BatchGetKernelResourceAllocationAction
+    ) -> BatchGetKernelResourceAllocationActionResult:
+        """Aggregate resource_allocations per kernel (requested/used/allocated)."""
+        data = await self._session_repository.batch_get_resource_allocation_by_kernel(
+            action.kernel_ids
+        )
+        return BatchGetKernelResourceAllocationActionResult(data=data)
 
     async def enqueue_session(self, action: EnqueueSessionAction) -> EnqueueSessionActionResult:
         """Enqueue a new compute session (PENDING) through the scheduler.


### PR DESCRIPTION
## Summary
- Add a DataLoader-backed `resourceAllocation` resolver field to `SessionV2` and `KernelV2` returning requested / used / **allocated** resource slots, aggregated on-demand from the `resource_allocations` table via bulk actions.
- The new `allocated` slot reports resources actually allocated and **persists after the session/kernel is freed or terminated** (`SUM(used) WHERE used_at IS NOT NULL`, no `free_at` filter), unlike `used` which empties once freed — enabling post-termination statistics/billing without client-side summing of kernel slots.
- Values are sourced solely from `resource_allocations`; the deprecated `kernels.occupied_slots` / `requested_slots` JSONB columns are not read. The released eager `resource.allocation` (used/requested) is left unchanged for compatibility.

## Test plan
- [x] `pants fmt / fix / lint / check` (mypy) pass
- [x] `pants test` for session service/repository, adapter, and GraphQL types
- [x] GraphQL schema builds; `SessionV2.resourceAllocation` and `KernelV2.resourceAllocation` exposed
- [x] Verified aggregation against a live halfstack DB: a TERMINATED session/kernel returns non-empty `requested`/`allocated` matching `SUM(used)` while `used` is empty; a cancelled-before-running session returns empty `allocated`
- [ ] Verify end-to-end via `./bai gql` against a running manager

Resolves BA-6700