### PR TITLE
fix(BA-6699): route webserver auth paths through HealthyEndpointPool (#12543)

### DIFF
--- a/changes/12543.fix.md
+++ b/changes/12543.fix.md
@@ -1,0 +1,1 @@
+Fix web server login, logout, edu-launcher token login, and no-auth password reset failing when the first configured Manager endpoint is down by routing them through the healthy-endpoint pool instead of pinning to `api.endpoint[0]`.

--- a/src/ai/backend/web/errors.py
+++ b/src/ai/backend/web/errors.py
@@ -55,3 +55,18 @@ class ManagerConnectionUnavailable(BackendAIError, web.HTTPServiceUnavailable):
             operation=ErrorOperation.REQUEST,
             error_detail=ErrorDetail.UNAVAILABLE,
         )
+
+
+class UnexpectedAuthResponseError(BackendAIError, web.HTTPInternalServerError):
+    """Raised when the Manager returns an unrecognized authorization response type."""
+
+    error_type = "https://api.backend.ai/probs/webserver/unexpected-auth-response"
+    error_title = "Unexpected authorization response from the Manager."
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.API,
+            operation=ErrorOperation.AUTH,
+            error_detail=ErrorDetail.INTERNAL_ERROR,
+        )

--- a/src/ai/backend/web/errors.py
+++ b/src/ai/backend/web/errors.py
@@ -63,7 +63,6 @@ class UnexpectedAuthResponseError(BackendAIError, web.HTTPInternalServerError):
     error_type = "https://api.backend.ai/probs/webserver/unexpected-auth-response"
     error_title = "Unexpected authorization response from the Manager."
 
-    @override
     def error_code(self) -> ErrorCode:
         return ErrorCode(
             domain=ErrorDomain.API,

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -56,6 +56,7 @@ from ai.backend.common.dto.internal.health import (
 )
 from ai.backend.common.dto.manager.auth.request import UpdatePasswordNoAuthRequest
 from ai.backend.common.dto.manager.auth.types import (
+    AuthResponse,
     AuthSuccessResponse,
     RequireTwoFactorAuthResponse,
     RequireTwoFactorRegistrationResponse,
@@ -80,6 +81,7 @@ from ai.backend.web.clients.apollo_router_pool import (
     ApolloRouterPoolGateHealthChecker,
 )
 from ai.backend.web.clients.endpoint_pool import (
+    AcquiredEndpoint,
     EndpointPoolSpec,
     HealthyEndpointPool,
     build_endpoint_selection_strategy,
@@ -93,7 +95,7 @@ from ai.backend.web.security import SecurityPolicy, csp_nonce_var, security_poli
 
 from . import __version__, user_agent
 from .auth import build_forwarding_headers, fill_forwarding_hdrs_to_api_session, get_client_ip
-from .errors import InvalidAPIConfigurationError
+from .errors import InvalidAPIConfigurationError, UnexpectedAuthResponseError
 from .proxy import (
     decrypt_payload,
     web_handler,
@@ -263,17 +265,23 @@ async def update_password_no_auth(request: web.Request) -> web.Response:
         "password_changed_at": None,
     }
 
+    manager_pool = cast(HealthyEndpointPool, request.app["manager_pool"])
+    registries = cast(
+        Mapping[str, BackendAIClientRegistry], request.app["no_auth_client_registries"]
+    )
     try:
-        registry: BackendAIClientRegistry = request.app["no_auth_client_registry"]
-        resp = await registry.auth.update_password_no_auth(
-            UpdatePasswordNoAuthRequest(
-                domain=config.api.domain,
-                username=creds["username"],
-                current_password=creds["current_password"],
-                new_password=creds["new_password"],
-            ),
-            extra_headers=build_forwarding_headers(request),
-        )
+        # Pick a healthy endpoint from the pool and use its pre-built no-auth
+        # registry, instead of pinning to endpoint[0].
+        async with manager_pool.acquire() as acquired:
+            resp = await registries[acquired.endpoint].auth.update_password_no_auth(
+                UpdatePasswordNoAuthRequest(
+                    domain=config.api.domain,
+                    username=creds["username"],
+                    current_password=creds["current_password"],
+                    new_password=creds["new_password"],
+                ),
+                extra_headers=build_forwarding_headers(request),
+            )
         result["password_changed_at"] = resp.password_changed_at
         log.info(
             "UPDATE_PASSWORD_NO_AUTH: Authorization succeeded for (email:{}, ip:{})",
@@ -334,6 +342,40 @@ async def login_check_handler(request: web.Request) -> web.Response:
         "data": public_data,
         "session_id": session.identity,  # temporary wsproxy interop patch
     })
+
+
+async def _authorize_via_anonymous_session(
+    request: web.Request,
+    acquired_endpoint: AcquiredEndpoint,
+    config: WebServerUnifiedConfig,
+    *,
+    username: str,
+    password: str,
+    extra_args: Mapping[str, Any],
+    forward_cookies: bool = False,
+) -> AuthResponse:
+    """Authorize anonymously against the given (pool-acquired) Manager endpoint.
+
+    Endpoint selection stays with the caller, which acquires ``acquired_endpoint``
+    from ``manager_pool`` and keeps this call inside the acquire context.
+    """
+    anon_api_config = APIConfig(
+        domain=config.api.domain,
+        endpoint=acquired_endpoint.endpoint,
+        access_key="",
+        secret_key="",  # anonymous session
+        user_agent=user_agent,
+        skip_sslcert_validation=not config.api.ssl_verify,
+    )
+    if not anon_api_config.is_anonymous:
+        raise InvalidAPIConfigurationError(
+            "Anonymous API configuration is not properly initialized."
+        )
+    async with APISession(config=anon_api_config) as api_session:
+        fill_forwarding_hdrs_to_api_session(request, api_session)
+        if forward_cookies:
+            api_session.aiohttp_session.cookie_jar.update_cookies(request.cookies)
+        return await api_session.User.authorize(username, password, extra_args=extra_args)
 
 
 async def login_handler(request: web.Request) -> web.Response:
@@ -437,72 +479,69 @@ async def login_handler(request: web.Request) -> web.Response:
             content_type="application/problem+json",
         )
 
+    manager_pool = cast(HealthyEndpointPool, request.app["manager_pool"])
     try:
-        anon_api_config = APIConfig(
-            domain=config.api.domain,
-            endpoint=str(config.api.endpoint[0]),
-            access_key="",
-            secret_key="",  # anonymous session
-            user_agent=user_agent,
-            skip_sslcert_validation=not config.api.ssl_verify,
-        )
-        if not anon_api_config.is_anonymous:
-            raise InvalidAPIConfigurationError(
-                "Anonymous API configuration is not properly initialized."
+        extra_args = {}
+        extra_keys = set(creds.keys()) ^ {"username", "password"}
+        for extra_key in extra_keys:
+            extra_args[extra_key] = creds[extra_key]
+        async with manager_pool.acquire() as acquired_endpoint:
+            auth_result = await _authorize_via_anonymous_session(
+                request,
+                acquired_endpoint,
+                config,
+                username=creds["username"],
+                password=creds["password"],
+                extra_args=extra_args,
             )
-        async with APISession(config=anon_api_config) as api_session:
-            fill_forwarding_hdrs_to_api_session(request, api_session)
-            extra_args = {}
-            extra_keys = set(creds.keys()) ^ {"username", "password"}
-            for extra_key in extra_keys:
-                extra_args[extra_key] = creds[extra_key]
-            auth_result = await api_session.User.authorize(
-                creds["username"], creds["password"], extra_args=extra_args
-            )
-            match auth_result:
-                case AuthSuccessResponse():
-                    token = auth_result
-                    stored_token = {
-                        "type": "keypair",
-                        "access_key": token.access_key,
-                        "secret_key": token.secret_key,
-                        "role": token.role,
-                        "status": token.status,
-                    }
-                    public_return = {
-                        "access_key": token.access_key,
-                        "role": token.role,
-                        "status": token.status,
-                    }
-                    _bind_session_to_manager_token(session, token.session_token)
-                    session["authenticated"] = True
-                    session["token"] = stored_token  # store full token
-                    result["authenticated"] = True
-                    result["data"] = public_return  # store public info from token
-                    login_fail_count = 0
-                    await _set_login_history(last_login_attempt, login_fail_count)
-                    log.info(
-                        "LOGIN_HANDLER: Authorization succeeded for (email:{}, ip:{})",
-                        creds["username"],
-                        client_ip,
-                    )
-                case RequireTwoFactorRegistrationResponse():
-                    result["authenticated"] = False
-                    result["data"] = {
-                        "type": "https://api.backend.ai/probs/require-totp-registration",
-                        "title": "Two-Factor Authentication registration required.",
-                        "details": "You must register Two-Factor Authentication.",
-                        "two_factor_registration_token": auth_result.token,
-                    }
-                    return web.json_response(result)
-                case RequireTwoFactorAuthResponse():
-                    result["authenticated"] = False
-                    result["data"] = {
-                        "type": "https://api.backend.ai/probs/require-totp-authentication",
-                        "title": "Two-Factor Authentication needed.",
-                        "details": "You must authenticate using Two-Factor Authentication.",
-                    }
-                    return web.json_response(result)
+        match auth_result:
+            case AuthSuccessResponse():
+                token = auth_result
+                stored_token = {
+                    "type": "keypair",
+                    "access_key": token.access_key,
+                    "secret_key": token.secret_key,
+                    "role": token.role,
+                    "status": token.status,
+                }
+                public_return = {
+                    "access_key": token.access_key,
+                    "role": token.role,
+                    "status": token.status,
+                }
+                _bind_session_to_manager_token(session, token.session_token)
+                session["authenticated"] = True
+                session["token"] = stored_token  # store full token
+                result["authenticated"] = True
+                result["data"] = public_return  # store public info from token
+                login_fail_count = 0
+                await _set_login_history(last_login_attempt, login_fail_count)
+                log.info(
+                    "LOGIN_HANDLER: Authorization succeeded for (email:{}, ip:{})",
+                    creds["username"],
+                    client_ip,
+                )
+            case RequireTwoFactorRegistrationResponse():
+                result["authenticated"] = False
+                result["data"] = {
+                    "type": "https://api.backend.ai/probs/require-totp-registration",
+                    "title": "Two-Factor Authentication registration required.",
+                    "details": "You must register Two-Factor Authentication.",
+                    "two_factor_registration_token": auth_result.token,
+                }
+                return web.json_response(result)
+            case RequireTwoFactorAuthResponse():
+                result["authenticated"] = False
+                result["data"] = {
+                    "type": "https://api.backend.ai/probs/require-totp-authentication",
+                    "title": "Two-Factor Authentication needed.",
+                    "details": "You must authenticate using Two-Factor Authentication.",
+                }
+                return web.json_response(result)
+            case _:
+                raise UnexpectedAuthResponseError(
+                    f"Unexpected auth result type: {type(auth_result)}"
+                )
     except BackendClientError as e:
         # This is error, not failed login, so we should not update login history.
         return web.HTTPBadGateway(
@@ -544,14 +583,15 @@ async def logout_handler(request: web.Request) -> web.Response:
     # Invalidate login session in Manager DB
     if session_token:
         config = cast(WebServerUnifiedConfig, request.app["config"])
+        manager_pool = cast(HealthyEndpointPool, request.app["manager_pool"])
         try:
-            endpoint = str(config.api.endpoint[0])
-            async with aiohttp.ClientSession() as http_session:
-                await http_session.post(
-                    f"{endpoint}/auth/logout",
-                    json={"session_token": session_token},
-                    ssl=config.api.ssl_verify,
-                )
+            async with manager_pool.acquire() as acquired:
+                async with aiohttp.ClientSession() as http_session:
+                    await http_session.post(
+                        f"{acquired.endpoint}/auth/logout",
+                        json={"session_token": session_token},
+                        ssl=config.api.ssl_verify,
+                    )
         except Exception:
             log.exception(
                 "Failed to invalidate login session in Manager DB (token={})", session_token
@@ -673,73 +713,68 @@ async def token_login_handler(request: web.Request) -> web.Response:
         "authenticated": False,
         "data": None,
     }
+    manager_pool = cast(HealthyEndpointPool, request.app["manager_pool"])
+    # Instead of email and password, token will be used for user auth.
+    # The purpose of token login is to authenticate a client, typically a browser, using a
+    # separate token referred to as `sToken`, rather than using user's email and password.
+    # However, the `api_session.User.authorize` SDK requires email and password as
+    # parameters, so we just pass fake (arbitrary) email and password which are placeholders
+    # in token-based login. Each authorize hook plugin will deal with various type of
+    # `sToken` and related parameters to authorize a user. In this process, email and
+    # password do not play any role.
+    extra_args = {**rqst_data, auth_token_name: auth_token}
     try:
-        anon_api_config = APIConfig(
-            domain=config.api.domain,
-            endpoint=str(config.api.endpoint[0]),
-            access_key="",
-            secret_key="",  # anonymous session
-            user_agent=user_agent,
-            skip_sslcert_validation=not config.api.ssl_verify,
-        )
-        if not anon_api_config.is_anonymous:
-            raise InvalidAPIConfigurationError(
-                "Anonymous API configuration is not properly initialized."
+        async with manager_pool.acquire() as acquired_endpoint:
+            auth_result = await _authorize_via_anonymous_session(
+                request,
+                acquired_endpoint,
+                config,
+                username="fake-email",
+                password="fake-pwd",
+                extra_args=extra_args,
+                forward_cookies=True,
             )
-        async with APISession(config=anon_api_config) as api_session:
-            fill_forwarding_hdrs_to_api_session(request, api_session)
-            # Instead of email and password, token will be used for user auth.
-            api_session.aiohttp_session.cookie_jar.update_cookies(request.cookies)
-            extra_args = {**rqst_data, auth_token_name: auth_token}
-            # The purpose of token login is to authenticate a client, typically a browser, using a
-            # separate token referred to as `sToken`, rather than using user's email and password.
-            # However, the `api_session.User.authorize` SDK requires email and password as
-            # parameters, so we just pass fake (arbitrary) email and password which are placeholders
-            # in token-based login. Each authorize hook plugin will deal with various type of
-            # `sToken` and related parameters to authorize a user. In this process, email and
-            # password do not play any role.
-            auth_result = await api_session.User.authorize(
-                "fake-email", "fake-pwd", extra_args=extra_args
-            )
-            match auth_result:
-                case AuthSuccessResponse():
-                    token = auth_result
-                case RequireTwoFactorRegistrationResponse():
-                    result["authenticated"] = False
-                    result["data"] = {
-                        "type": "https://api.backend.ai/probs/require-totp-registration",
-                        "title": "Two-Factor Authentication registration required.",
-                        "details": "You must register Two-Factor Authentication.",
-                        "two_factor_registration_token": auth_result.token,
-                    }
-                    return web.json_response(result)
-                case RequireTwoFactorAuthResponse():
-                    result["authenticated"] = False
-                    result["data"] = {
-                        "type": "https://api.backend.ai/probs/require-totp-authentication",
-                        "title": "Two-Factor Authentication needed.",
-                        "details": "You must authenticate using Two-Factor Authentication.",
-                    }
-                    return web.json_response(result)
-                case _:
-                    raise RuntimeError(f"Unexpected auth result type: {type(auth_result)}")
-            stored_token = {
-                "type": "keypair",
-                "access_key": token.access_key,
-                "secret_key": token.secret_key,
-                "role": token.role,
-                "status": token.status,
-            }
-            public_return = {
-                "access_key": token.access_key,
-                "role": token.role,
-                "status": token.status,
-            }
-            _bind_session_to_manager_token(session, token.session_token)
-            session["authenticated"] = True
-            session["token"] = stored_token  # store full token
-            result["authenticated"] = True
-            result["data"] = public_return  # store public info from token
+        match auth_result:
+            case AuthSuccessResponse():
+                token = auth_result
+            case RequireTwoFactorRegistrationResponse():
+                result["authenticated"] = False
+                result["data"] = {
+                    "type": "https://api.backend.ai/probs/require-totp-registration",
+                    "title": "Two-Factor Authentication registration required.",
+                    "details": "You must register Two-Factor Authentication.",
+                    "two_factor_registration_token": auth_result.token,
+                }
+                return web.json_response(result)
+            case RequireTwoFactorAuthResponse():
+                result["authenticated"] = False
+                result["data"] = {
+                    "type": "https://api.backend.ai/probs/require-totp-authentication",
+                    "title": "Two-Factor Authentication needed.",
+                    "details": "You must authenticate using Two-Factor Authentication.",
+                }
+                return web.json_response(result)
+            case _:
+                raise UnexpectedAuthResponseError(
+                    f"Unexpected auth result type: {type(auth_result)}"
+                )
+        stored_token = {
+            "type": "keypair",
+            "access_key": token.access_key,
+            "secret_key": token.secret_key,
+            "role": token.role,
+            "status": token.status,
+        }
+        public_return = {
+            "access_key": token.access_key,
+            "role": token.role,
+            "status": token.status,
+        }
+        _bind_session_to_manager_token(session, token.session_token)
+        session["authenticated"] = True
+        session["token"] = stored_token  # store full token
+        result["authenticated"] = True
+        result["data"] = public_return  # store public info from token
     except BackendClientError as e:
         return web.HTTPBadGateway(
             text=json.dumps({
@@ -939,18 +974,33 @@ async def apollo_router_pool_ctx(
 
 
 @asynccontextmanager
-async def no_auth_client_registry_ctx(
-    config: WebServerUnifiedConfig,
-) -> AsyncGenerator[BackendAIClientRegistry]:
-    client_config = V2ClientConfig(
-        endpoint=URL(str(config.api.endpoint[0])),
-        skip_ssl_verification=not config.api.ssl_verify,
-    )
-    registry = await BackendAIClientRegistry.create(client_config, NoAuth())
+async def no_auth_client_registries_ctx(
+    manager_pool: HealthyEndpointPool,
+    ssl_verify: bool,
+) -> AsyncGenerator[Mapping[str, BackendAIClientRegistry]]:
+    """Build one no-auth v2 client registry per Manager endpoint in the pool.
+
+    Keyed by the same endpoint strings ``manager_pool`` hands out, so the
+    no-auth password reset path can use the registry of a pool-selected
+    healthy endpoint instead of pinning to ``config.api.endpoint[0]``.
+    """
+    registries: dict[str, BackendAIClientRegistry] = {}
     try:
-        yield registry
+        for endpoint in manager_pool.all_endpoints():
+            registries[endpoint] = await BackendAIClientRegistry.create(
+                V2ClientConfig(
+                    endpoint=URL(endpoint),
+                    skip_ssl_verification=not ssl_verify,
+                ),
+                NoAuth(),
+            )
+        yield registries
     finally:
-        await registry.close()
+        # Best-effort close so one failing registry does not leak the others.
+        await asyncio.gather(
+            *(registry.close() for registry in registries.values()),
+            return_exceptions=True,
+        )
 
 
 @asynccontextmanager
@@ -1160,8 +1210,8 @@ async def server_main(
             app["apollo_router_pool"] = await web_init_stack.enter_async_context(
                 apollo_router_pool_ctx(config, app)
             )
-        app["no_auth_client_registry"] = await web_init_stack.enter_async_context(
-            no_auth_client_registry_ctx(config)
+        app["no_auth_client_registries"] = await web_init_stack.enter_async_context(
+            no_auth_client_registries_ctx(app["manager_pool"], config.api.ssl_verify)
         )
         await web_init_stack.enter_async_context(redis_ctx(config, app, pidx))
 

--- a/tests/unit/webserver/conftest.py
+++ b/tests/unit/webserver/conftest.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import yarl
+
+
+class DummyApiConfig:
+    """Stand-in for the SDK ``APIConfig`` used across webserver unit tests."""
+
+    def __init__(
+        self,
+        *,
+        endpoint: list[yarl.URL],
+        domain: str = "default",
+        ssl_verify: bool = False,
+    ) -> None:
+        self.domain = domain
+        self.endpoint = endpoint
+        self.ssl_verify = ssl_verify
+
+
+class DummyConfig:
+    def __init__(self, api: DummyApiConfig) -> None:
+        self.api = api

--- a/tests/unit/webserver/test_auth.py
+++ b/tests/unit/webserver/test_auth.py
@@ -13,17 +13,7 @@ from ai.backend.common.clients.http_client.client_pool import ClientPool, tcp_cl
 from ai.backend.web.auth import get_anonymous_session, get_api_session
 from ai.backend.web.clients.endpoint_pool import AcquiredEndpoint
 
-
-class DummyApiConfig:
-    def __init__(self, domain: str, endpoint: list[yarl.URL], ssl_verify: bool) -> None:
-        self.domain = domain
-        self.endpoint = endpoint
-        self.ssl_verify = ssl_verify
-
-
-class DummyConfig:
-    def __init__(self, api_config: DummyApiConfig) -> None:
-        self.api = api_config
+from .conftest import DummyApiConfig, DummyConfig
 
 
 class DummyRequest:

--- a/tests/unit/webserver/test_server.py
+++ b/tests/unit/webserver/test_server.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yarl
+from aiohttp import web
+from pytest_mock import MockerFixture
+
+from ai.backend.web import server
+from ai.backend.web.clients.endpoint_pool import AcquiredEndpoint, HealthyEndpointPool
+from ai.backend.web.config.unified import WebServerUnifiedConfig
+
+from .conftest import DummyApiConfig, DummyConfig
+
+
+class _FakeAPISession:
+    """Stand-in for the SDK ``AsyncSession`` used inside the anonymous-auth helper."""
+
+    def __init__(self, *, config: Any) -> None:
+        self.config = config
+        self.aiohttp_session = MagicMock()
+        self.User = MagicMock()
+        self.User.authorize = AsyncMock()
+
+    async def __aenter__(self) -> _FakeAPISession:
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+
+def _web_config(endpoints: list[str]) -> WebServerUnifiedConfig:
+    config = DummyConfig(DummyApiConfig(endpoint=[yarl.URL(e) for e in endpoints]))
+    return cast(WebServerUnifiedConfig, config)
+
+
+class _FakePool:
+    """Stand-in for ``HealthyEndpointPool`` exposing only ``all_endpoints``."""
+
+    def __init__(self, endpoints: list[str]) -> None:
+        self._endpoints = endpoints
+
+    def all_endpoints(self) -> list[str]:
+        return list(self._endpoints)
+
+
+def _pool(endpoints: list[str]) -> HealthyEndpointPool:
+    return cast(HealthyEndpointPool, _FakePool(endpoints))
+
+
+@pytest.fixture
+def acquired_endpoint() -> AcquiredEndpoint:
+    """A healthy endpoint the caller acquired from the pool."""
+    return AcquiredEndpoint(endpoint="https://m2")
+
+
+def _patch_apisession(mocker: MockerFixture, *, auth_result: object) -> dict[str, Any]:
+    """Patch ``server.APISession`` with a capturing fake and return the capture dict."""
+    captured: dict[str, Any] = {}
+
+    def _factory(*, config: Any) -> _FakeAPISession:
+        session = _FakeAPISession(config=config)
+        session.User.authorize.return_value = auth_result
+        captured["config"] = config
+        captured["session"] = session
+        return session
+
+    mocker.patch.object(server, "APISession", _factory)
+    mocker.patch.object(server, "fill_forwarding_hdrs_to_api_session")
+    return captured
+
+
+class TestAuthorizeViaAnonymousSession:
+    async def test_uses_acquired_endpoint(
+        self, mocker: MockerFixture, acquired_endpoint: AcquiredEndpoint
+    ) -> None:
+        auth_result = object()
+        captured = _patch_apisession(mocker, auth_result=auth_result)
+
+        result = await server._authorize_via_anonymous_session(
+            cast(web.Request, MagicMock()),
+            acquired_endpoint,
+            _web_config(["https://m1", "https://m2"]),
+            username="user",
+            password="pass",
+            extra_args={"otp": "123"},
+        )
+
+        assert result is auth_result
+        # The anonymous config targets the acquired endpoint, not endpoint[0].
+        assert str(captured["config"].endpoint) == "https://m2"
+        assert captured["config"].is_anonymous
+        captured["session"].User.authorize.assert_awaited_once_with(
+            "user", "pass", extra_args={"otp": "123"}
+        )
+
+    async def test_forwards_cookies_when_requested(
+        self, mocker: MockerFixture, acquired_endpoint: AcquiredEndpoint
+    ) -> None:
+        captured = _patch_apisession(mocker, auth_result=object())
+        request = MagicMock()
+        request.cookies = {"sToken": "abc"}
+
+        await server._authorize_via_anonymous_session(
+            cast(web.Request, request),
+            acquired_endpoint,
+            _web_config(["https://m1"]),
+            username="fake",
+            password="fake",
+            extra_args={},
+            forward_cookies=True,
+        )
+
+        captured["session"].aiohttp_session.cookie_jar.update_cookies.assert_called_once_with(
+            request.cookies
+        )
+
+    async def test_does_not_forward_cookies_by_default(
+        self, mocker: MockerFixture, acquired_endpoint: AcquiredEndpoint
+    ) -> None:
+        captured = _patch_apisession(mocker, auth_result=object())
+
+        await server._authorize_via_anonymous_session(
+            cast(web.Request, MagicMock()),
+            acquired_endpoint,
+            _web_config(["https://m1"]),
+            username="user",
+            password="pass",
+            extra_args={},
+        )
+
+        captured["session"].aiohttp_session.cookie_jar.update_cookies.assert_not_called()
+
+
+class TestNoAuthClientRegistriesCtx:
+    def _patch_create(self, mocker: MockerFixture) -> dict[str, MagicMock]:
+        registries_by_endpoint: dict[str, MagicMock] = {}
+
+        def _create(config: Any, auth: Any) -> MagicMock:
+            registry = MagicMock()
+            registry.close = AsyncMock()
+            registries_by_endpoint[str(config.endpoint)] = registry
+            return registry
+
+        mocker.patch(
+            "ai.backend.web.server.BackendAIClientRegistry.create",
+            AsyncMock(side_effect=_create),
+        )
+        return registries_by_endpoint
+
+    async def test_builds_one_registry_per_endpoint(self, mocker: MockerFixture) -> None:
+        registries_by_endpoint = self._patch_create(mocker)
+
+        endpoints = ["https://m1", "https://m2", "https://m3"]
+        async with server.no_auth_client_registries_ctx(
+            _pool(endpoints), ssl_verify=False
+        ) as registries:
+            assert set(registries.keys()) == {"https://m1", "https://m2", "https://m3"}
+            assert len(registries_by_endpoint) == 3
+            # Each registry is keyed by the endpoint it was built for, so the
+            # handler can look it up by the endpoint the pool hands out.
+            for key, registry in registries.items():
+                assert registry is registries_by_endpoint[key]
+
+    async def test_closes_all_registries_on_exit(self, mocker: MockerFixture) -> None:
+        registries_by_endpoint = self._patch_create(mocker)
+
+        endpoints = ["https://m1", "https://m2"]
+        async with server.no_auth_client_registries_ctx(_pool(endpoints), ssl_verify=False):
+            pass
+
+        assert len(registries_by_endpoint) == 2
+        for registry in registries_by_endpoint.values():
+            registry.close.assert_awaited_once()


### PR DESCRIPTION
This is an auto-generated backport PR of #12543 to the 26.4 release.