### PR TITLE
feat(BA-6723): add mapped-scope filter to role search

### DIFF
--- a/changes/12563.feature.md
+++ b/changes/12563.feature.md
@@ -1,0 +1,1 @@
+Add a mapped-scope filter to the role search API so roles can be queried by the scope (domain / project / user) they are registered in.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -16660,6 +16660,7 @@ input RoleFilter
   source: RoleSourceFilter = null
   status: RoleStatusFilter = null
   assignedUser: RoleUserNestedFilter = null
+  mappedScope: RoleMappedScopeNestedFilter = null
   AND: [RoleFilter!] = null
   OR: [RoleFilter!] = null
   NOT: [RoleFilter!] = null
@@ -16801,6 +16802,19 @@ input RoleInvitationUserNestedFilter
   @join__type(graph: STRAWBERRY)
 {
   email: StringFilter = null
+}
+
+"""
+Added in 26.8.0. Filter roles by the scope they are mapped (registered) to.
+"""
+input RoleMappedScopeNestedFilter
+  @join__type(graph: STRAWBERRY)
+{
+  scopeType: RBACElementTypeFilter = null
+  scopeId: StringFilter = null
+  AND: [RoleMappedScopeNestedFilter!] = null
+  OR: [RoleMappedScopeNestedFilter!] = null
+  NOT: [RoleMappedScopeNestedFilter!] = null
 }
 
 """Added in 26.3.0. Order by specification for roles"""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -11430,6 +11430,7 @@ input RoleFilter {
   source: RoleSourceFilter = null
   status: RoleStatusFilter = null
   assignedUser: RoleUserNestedFilter = null
+  mappedScope: RoleMappedScopeNestedFilter = null
   AND: [RoleFilter!] = null
   OR: [RoleFilter!] = null
   NOT: [RoleFilter!] = null
@@ -11550,6 +11551,17 @@ Added in 26.4.4. Nested filter for a user (inviter or invitee) of an invitation.
 """
 input RoleInvitationUserNestedFilter {
   email: StringFilter = null
+}
+
+"""
+Added in 26.8.0. Filter roles by the scope they are mapped (registered) to.
+"""
+input RoleMappedScopeNestedFilter {
+  scopeType: RBACElementTypeFilter = null
+  scopeId: StringFilter = null
+  AND: [RoleMappedScopeNestedFilter!] = null
+  OR: [RoleMappedScopeNestedFilter!] = null
+  NOT: [RoleMappedScopeNestedFilter!] = null
 }
 
 """Added in 26.3.0. Order by specification for roles"""

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -16648,6 +16648,80 @@
         "title": "CreateRoleInput",
         "type": "object"
       },
+      "MappedScopeNestedFilter": {
+        "description": "Filter roles by the scope they are mapped (registered) to.",
+        "properties": {
+          "scope_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RBACElementTypeFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "scope_id": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StringFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "AND": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/MappedScopeNestedFilter"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "And"
+          },
+          "OR": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/MappedScopeNestedFilter"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Or"
+          },
+          "NOT": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/MappedScopeNestedFilter"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Not"
+          }
+        },
+        "title": "MappedScopeNestedFilter",
+        "type": "object"
+      },
       "RoleFilter": {
         "description": "Filter for roles.",
         "properties": {

--- a/src/ai/backend/client/cli/v2/rbac/role.py
+++ b/src/ai/backend/client/cli/v2/rbac/role.py
@@ -49,6 +49,18 @@ def role() -> None:
     default=None,
     help="Filter by role status.",
 )
+@click.option(
+    "--scope-type",
+    type=click.Choice(["domain", "project", "user"], case_sensitive=False),
+    default=None,
+    help="Filter by the type of scope the role is mapped to.",
+)
+@click.option(
+    "--scope-id",
+    type=str,
+    default=None,
+    help="Filter by the id of the scope the role is mapped to (exact match).",
+)
 def search(
     limit: int | None,
     offset: int | None,
@@ -56,27 +68,48 @@ def search(
     name_contains: str | None,
     source: str | None,
     status: str | None,
+    scope_type: str | None,
+    scope_id: str | None,
 ) -> None:
     """Search roles."""
     from ai.backend.common.dto.manager.query import StringFilter
     from ai.backend.common.dto.manager.v2.rbac.request import (
+        MappedScopeNestedFilter,
         RoleFilter,
         RoleOrderBy,
         SearchRolesInput,
     )
     from ai.backend.common.dto.manager.v2.rbac.types import (
+        RBACElementTypeDTO,
+        RBACElementTypeFilter,
         RoleOrderField,
         RoleSourceFilter,
         RoleStatusFilter,
     )
 
+    # Build mapped-scope nested filter only if any scope option is provided
+    mapped_scope_dto: MappedScopeNestedFilter | None = None
+    if scope_type is not None or scope_id is not None:
+        mapped_scope_dto = MappedScopeNestedFilter(
+            scope_type=RBACElementTypeFilter(equals=RBACElementTypeDTO(scope_type))
+            if scope_type is not None
+            else None,
+            scope_id=StringFilter(equals=scope_id) if scope_id is not None else None,
+        )
+
     # Build filter only if any filter option is provided
     filter_dto: RoleFilter | None = None
-    if any([name_contains is not None, source is not None, status is not None]):
+    if any([
+        name_contains is not None,
+        source is not None,
+        status is not None,
+        mapped_scope_dto is not None,
+    ]):
         filter_dto = RoleFilter(
             name=StringFilter(contains=name_contains) if name_contains is not None else None,
             source=RoleSourceFilter(equals=source) if source is not None else None,
             status=RoleStatusFilter(equals=status) if status is not None else None,
+            mapped_scope=mapped_scope_dto,
         )
 
     # Build order only if --order-by is provided

--- a/src/ai/backend/client/cli/v2/rbac/role.py
+++ b/src/ai/backend/client/cli/v2/rbac/role.py
@@ -61,6 +61,12 @@ def role() -> None:
     default=None,
     help="Filter by the id of the scope the role is mapped to (exact match).",
 )
+@click.option(
+    "--assigned-user-id",
+    type=str,
+    default=None,
+    help="Filter roles assigned to this user id.",
+)
 def search(
     limit: int | None,
     offset: int | None,
@@ -70,14 +76,16 @@ def search(
     status: str | None,
     scope_type: str | None,
     scope_id: str | None,
+    assigned_user_id: str | None,
 ) -> None:
     """Search roles."""
-    from ai.backend.common.dto.manager.query import StringFilter
+    from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
     from ai.backend.common.dto.manager.v2.rbac.request import (
         MappedScopeNestedFilter,
         RoleFilter,
         RoleOrderBy,
         SearchRolesInput,
+        UserNestedFilter,
     )
     from ai.backend.common.dto.manager.v2.rbac.types import (
         RBACElementTypeDTO,
@@ -97,6 +105,11 @@ def search(
             scope_id=StringFilter(equals=scope_id) if scope_id is not None else None,
         )
 
+    # Build assigned-user nested filter only if the option is provided
+    assigned_user_dto: UserNestedFilter | None = None
+    if assigned_user_id is not None:
+        assigned_user_dto = UserNestedFilter(user_id=UUIDFilter(equals=UUID(assigned_user_id)))
+
     # Build filter only if any filter option is provided
     filter_dto: RoleFilter | None = None
     if any([
@@ -104,12 +117,14 @@ def search(
         source is not None,
         status is not None,
         mapped_scope_dto is not None,
+        assigned_user_dto is not None,
     ]):
         filter_dto = RoleFilter(
             name=StringFilter(contains=name_contains) if name_contains is not None else None,
             source=RoleSourceFilter(equals=source) if source is not None else None,
             status=RoleStatusFilter(equals=status) if status is not None else None,
             mapped_scope=mapped_scope_dto,
+            assigned_user=assigned_user_dto,
         )
 
     # Build order only if --order-by is provided

--- a/src/ai/backend/common/dto/manager/v2/rbac/request.py
+++ b/src/ai/backend/common/dto/manager/v2/rbac/request.py
@@ -228,6 +228,19 @@ class UserNestedFilter(BaseRequestModel):
 UserNestedFilter.model_rebuild()
 
 
+class MappedScopeNestedFilter(BaseRequestModel):
+    """Filter roles by the scope they are mapped (registered) to."""
+
+    scope_type: RBACElementTypeFilter | None = None
+    scope_id: StringFilter | None = None
+    AND: list[MappedScopeNestedFilter] | None = None
+    OR: list[MappedScopeNestedFilter] | None = None
+    NOT: list[MappedScopeNestedFilter] | None = None
+
+
+MappedScopeNestedFilter.model_rebuild()
+
+
 class RoleFilter(BaseRequestModel):
     """Filter for roles."""
 
@@ -235,6 +248,7 @@ class RoleFilter(BaseRequestModel):
     source: RoleSourceFilter | None = None
     status: RoleStatusFilter | None = None
     assigned_user: UserNestedFilter | None = None
+    mapped_scope: MappedScopeNestedFilter | None = None
     AND: list[RoleFilter] | None = None
     OR: list[RoleFilter] | None = None
     NOT: list[RoleFilter] | None = None

--- a/src/ai/backend/manager/api/adapters/rbac/adapter.py
+++ b/src/ai/backend/manager/api/adapters/rbac/adapter.py
@@ -86,6 +86,9 @@ from ai.backend.common.dto.manager.v2.rbac.request import (
     EntityOrderBy as EntityOrderByDTO,
 )
 from ai.backend.common.dto.manager.v2.rbac.request import (
+    MappedScopeNestedFilter as MappedScopeNestedFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.rbac.request import (
     PermissionFilter as PermissionFilterDTO,
 )
 from ai.backend.common.dto.manager.v2.rbac.request import (
@@ -1404,6 +1407,8 @@ class RBACAdapter(BaseAdapter):
                 )
         if f.assigned_user is not None:
             conditions.extend(self._convert_user_nested_filter(f.assigned_user))
+        if f.mapped_scope is not None:
+            conditions.extend(self._convert_mapped_scope_nested_filter(f.mapped_scope))
         if f.AND:
             for sub in f.AND:
                 conditions.extend(self._convert_role_filter_gql(sub))
@@ -1447,6 +1452,61 @@ class RBACAdapter(BaseAdapter):
             not_conditions: list[QueryCondition] = []
             for sub in f.NOT:
                 not_conditions.extend(self._convert_user_nested_filter(sub))
+            if not_conditions:
+                conditions.append(negate_conditions(not_conditions))
+        return conditions
+
+    def _convert_mapped_scope_nested_filter(
+        self, f: MappedScopeNestedFilterDTO
+    ) -> list[QueryCondition]:
+        raw_conditions: list[QueryCondition] = []
+        if f.scope_type is not None:
+            st = f.scope_type
+            if st.equals is not None:
+                raw_conditions.append(
+                    EntityScopeConditions.by_scope_type_equals(RBACElementType(st.equals))
+                )
+            if st.in_ is not None and st.in_:
+                raw_conditions.append(
+                    EntityScopeConditions.by_scope_type_in([RBACElementType(s) for s in st.in_])
+                )
+            if st.not_equals is not None:
+                raw_conditions.append(
+                    EntityScopeConditions.by_scope_type_not_equals(RBACElementType(st.not_equals))
+                )
+            if st.not_in is not None and st.not_in:
+                raw_conditions.append(
+                    EntityScopeConditions.by_scope_type_not_in([
+                        RBACElementType(s) for s in st.not_in
+                    ])
+                )
+        if f.scope_id is not None:
+            condition = self.convert_string_filter(
+                f.scope_id,
+                contains_factory=EntityScopeConditions.by_scope_id_contains,
+                equals_factory=EntityScopeConditions.by_scope_id_equals,
+                starts_with_factory=EntityScopeConditions.by_scope_id_starts_with,
+                ends_with_factory=EntityScopeConditions.by_scope_id_ends_with,
+                in_factory=EntityScopeConditions.by_scope_id_in,
+            )
+            if condition is not None:
+                raw_conditions.append(condition)
+        conditions: list[QueryCondition] = []
+        if raw_conditions:
+            conditions.append(RoleConditions.by_mapped_scope(raw_conditions))
+        if f.AND:
+            for sub in f.AND:
+                conditions.extend(self._convert_mapped_scope_nested_filter(sub))
+        if f.OR:
+            or_conditions: list[QueryCondition] = []
+            for sub in f.OR:
+                or_conditions.extend(self._convert_mapped_scope_nested_filter(sub))
+            if or_conditions:
+                conditions.append(combine_conditions_or(or_conditions))
+        if f.NOT:
+            not_conditions: list[QueryCondition] = []
+            for sub in f.NOT:
+                not_conditions.extend(self._convert_mapped_scope_nested_filter(sub))
             if not_conditions:
                 conditions.append(negate_conditions(not_conditions))
         return conditions

--- a/src/ai/backend/manager/api/gql/rbac/types/role.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/role.py
@@ -34,6 +34,9 @@ from ai.backend.common.dto.manager.v2.rbac.request import (
     DeleteRoleInput as DeleteRoleInputDTO,
 )
 from ai.backend.common.dto.manager.v2.rbac.request import (
+    MappedScopeNestedFilter as MappedScopeNestedFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.rbac.request import (
     PurgeRoleInput as PurgeRoleInputDTO,
 )
 from ai.backend.common.dto.manager.v2.rbac.request import (
@@ -91,6 +94,7 @@ from ai.backend.common.dto.manager.v2.rbac.types import (
 from ai.backend.common.dto.manager.v2.rbac.types import (
     RoleStatusFilter as RoleStatusFilterDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import OrderDirection, StringFilter, UUIDFilter, encode_cursor
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -104,7 +108,7 @@ from ai.backend.manager.api.gql.decorators import (
     gql_pydantic_type,
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
-from ai.backend.manager.api.gql.rbac.types.scope import ScopeInputGQL
+from ai.backend.manager.api.gql.rbac.types.scope import RBACElementTypeFilterGQL, ScopeInputGQL
 from ai.backend.manager.api.gql.types import GQLFilter, GQLOrderBy, StrawberryGQLContext
 
 if TYPE_CHECKING:
@@ -532,6 +536,22 @@ class RoleUserNestedFilterGQL(PydanticInputMixin[UserNestedFilterDTO]):
 
 
 @gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Filter roles by the scope they are mapped (registered) to.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="RoleMappedScopeNestedFilter",
+)
+class RoleMappedScopeNestedFilterGQL(PydanticInputMixin[MappedScopeNestedFilterDTO]):
+    scope_type: RBACElementTypeFilterGQL | None = None
+    scope_id: StringFilter | None = None
+
+    AND: list[Self] | None = None
+    OR: list[Self] | None = None
+    NOT: list[Self] | None = None
+
+
+@gql_pydantic_input(
     BackendAIGQLMeta(description="Filter for roles", added_version="26.3.0"),
     name="RoleFilter",
 )
@@ -540,6 +560,7 @@ class RoleFilter(PydanticInputMixin[RoleFilterDTO], GQLFilter):
     source: RoleSourceFilterGQL | None = None
     status: RoleStatusFilterGQL | None = None
     assigned_user: RoleUserNestedFilterGQL | None = None
+    mapped_scope: RoleMappedScopeNestedFilterGQL | None = None
 
     AND: list[Self] | None = None
     OR: list[Self] | None = None

--- a/src/ai/backend/manager/models/rbac_models/conditions.py
+++ b/src/ai/backend/manager/models/rbac_models/conditions.py
@@ -219,6 +219,32 @@ class RoleConditions:
 
         return inner
 
+    @staticmethod
+    def by_mapped_scope(
+        scope_conditions: list[QueryCondition],
+    ) -> QueryCondition:
+        """Match roles registered in a scope satisfying ``scope_conditions`` (correlated EXISTS).
+
+        The role-to-scope binding lives in ``association_scopes_entities`` as a row with
+        ``entity_type == ROLE`` and ``entity_id == role.id``. All ``scope_conditions`` must be
+        satisfied by the same association row.
+        """
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            subq = (
+                sa.select(sa.literal(1))
+                .where(
+                    AssociationScopesEntitiesRow.entity_type == EntityType.ROLE,
+                    AssociationScopesEntitiesRow.entity_id == sa.cast(RoleRow.id, sa.String),
+                )
+                .correlate(RoleRow)
+            )
+            for cond in scope_conditions:
+                subq = subq.where(cond())
+            return sa.exists(subq)
+
+        return inner
+
 
 class PermissionConditions:
     """Query conditions for permissions."""
@@ -745,6 +771,94 @@ class EntityScopeConditions:
             return AssociationScopesEntitiesRow.scope_id == scope_id
 
         return inner
+
+    @staticmethod
+    def by_scope_type_equals(element_type: RBACElementType) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AssociationScopesEntitiesRow.scope_type == element_type.to_scope_type()
+
+        return inner
+
+    @staticmethod
+    def by_scope_type_not_equals(element_type: RBACElementType) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AssociationScopesEntitiesRow.scope_type != element_type.to_scope_type()
+
+        return inner
+
+    @staticmethod
+    def by_scope_type_in(element_types: Collection[RBACElementType]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AssociationScopesEntitiesRow.scope_type.in_([
+                et.to_scope_type() for et in element_types
+            ])
+
+        return inner
+
+    @staticmethod
+    def by_scope_type_not_in(element_types: Collection[RBACElementType]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AssociationScopesEntitiesRow.scope_type.not_in([
+                et.to_scope_type() for et in element_types
+            ])
+
+        return inner
+
+    @staticmethod
+    def by_scope_id_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AssociationScopesEntitiesRow.scope_id.ilike(f"%{spec.value}%")
+            else:
+                condition = AssociationScopesEntitiesRow.scope_id.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_scope_id_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = (
+                    sa.func.lower(AssociationScopesEntitiesRow.scope_id) == spec.value.lower()
+                )
+            else:
+                condition = AssociationScopesEntitiesRow.scope_id == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_scope_id_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AssociationScopesEntitiesRow.scope_id.ilike(f"{spec.value}%")
+            else:
+                condition = AssociationScopesEntitiesRow.scope_id.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_scope_id_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AssociationScopesEntitiesRow.scope_id.ilike(f"%{spec.value}")
+            else:
+                condition = AssociationScopesEntitiesRow.scope_id.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    by_scope_id_in = staticmethod(make_string_in_factory(AssociationScopesEntitiesRow.scope_id))
 
     @staticmethod
     def by_entity_type(element_type: RBACElementType) -> QueryCondition:

--- a/tests/unit/manager/repositories/permission_controller/test_search_element_associations.py
+++ b/tests/unit/manager/repositories/permission_controller/test_search_element_associations.py
@@ -20,6 +20,7 @@ from ai.backend.manager.models.agent import AgentRow
 # registry. These rows are reachable via relationships but are not otherwise
 # imported/registered by this test; _ORM_CLUSTER keeps them live.
 from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac_models import UserRoleRow
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
@@ -45,6 +46,7 @@ from ai.backend.testutils.db import with_tables
 _ORM_CLUSTER = (
     AgentRow,
     ScalingGroupForDomainRow,
+    ImageRow,
 )
 
 

--- a/tests/unit/manager/repositories/permission_controller/test_search_permissions.py
+++ b/tests/unit/manager/repositories/permission_controller/test_search_permissions.py
@@ -25,6 +25,7 @@ from ai.backend.manager.models.agent import AgentRow
 # registry. These rows are reachable via relationships but are not otherwise
 # imported/registered by this test; _ORM_CLUSTER keeps them live.
 from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac_models import UserRoleRow
 from ai.backend.manager.models.rbac_models.conditions import (
@@ -52,6 +53,7 @@ from ai.backend.testutils.db import with_tables
 _ORM_CLUSTER = (
     AgentRow,
     ScalingGroupForDomainRow,
+    ImageRow,
 )
 
 

--- a/tests/unit/manager/repositories/permission_controller/test_search_roles.py
+++ b/tests/unit/manager/repositories/permission_controller/test_search_roles.py
@@ -16,7 +16,12 @@ from ai.backend.common.data.filter_specs import (
     StringMatchSpec,
     UUIDEqualMatchSpec,
 )
-from ai.backend.common.data.permission.types import EntityType, OperationType
+from ai.backend.common.data.permission.types import (
+    EntityType,
+    OperationType,
+    RBACElementType,
+    ScopeType,
+)
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.models.agent import AgentRow
@@ -29,8 +34,12 @@ from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac_models import UserRoleRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
 from ai.backend.manager.models.rbac_models.conditions import (
     AssignedUserConditions,
+    EntityScopeConditions,
     RoleConditions,
 )
 from ai.backend.manager.models.rbac_models.orders import RoleOrders
@@ -87,6 +96,7 @@ class TestSearchRoles:
                 KeyPairRow,
                 PermissionRow,
                 ObjectPermissionRow,
+                AssociationScopesEntitiesRow,
             ],
         ):
             yield database_connection
@@ -312,6 +322,60 @@ class TestSearchRoles:
 
         assert result.total_count == 0
         assert result.items == []
+
+    @pytest.fixture
+    async def roles_mapped_to_scope(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+        created_roles: list[CreatedRole],
+    ) -> tuple[str, list[CreatedRole]]:
+        """Map the first role to a project scope via ``association_scopes_entities``.
+
+        Returns ``(project_scope_id, created_roles)``.
+        """
+        project_scope_id = str(uuid.uuid4())
+
+        async with db_with_rbac_tables.begin_session() as db_sess:
+            db_sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=project_scope_id,
+                    entity_type=EntityType.ROLE,
+                    entity_id=str(created_roles[0].role_id),
+                )
+            )
+            await db_sess.flush()
+
+        return project_scope_id, created_roles
+
+    async def test_by_mapped_scope_returns_roles_in_scope(
+        self,
+        repository: PermissionControllerRepository,
+        roles_mapped_to_scope: tuple[str, list[CreatedRole]],
+    ) -> None:
+        """``RoleConditions.by_mapped_scope`` should restrict results to roles
+        registered in the given scope via the correlated EXISTS subquery."""
+        project_scope_id, created_roles = roles_mapped_to_scope
+
+        querier = BatchQuerier(
+            conditions=[
+                RoleConditions.by_mapped_scope([
+                    EntityScopeConditions.by_scope_type_equals(RBACElementType.PROJECT),
+                    EntityScopeConditions.by_scope_id_equals(
+                        StringMatchSpec(
+                            value=project_scope_id, case_insensitive=False, negated=False
+                        )
+                    ),
+                ]),
+            ],
+            orders=[],
+            pagination=OffsetPagination(limit=10, offset=0),
+        )
+
+        result = await repository.search_roles(querier)
+
+        assert result.total_count == 1
+        assert [item.id for item in result.items] == [created_roles[0].role_id]
 
 
 class TestSearchRolesTotalCountNotInflated:

--- a/tests/unit/manager/repositories/permission_controller/test_search_roles.py
+++ b/tests/unit/manager/repositories/permission_controller/test_search_roles.py
@@ -32,6 +32,7 @@ from ai.backend.manager.models.agent import AgentRow
 # imported/registered by this test; _ORM_CLUSTER keeps them live.
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.hasher.types import PasswordInfo
+from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac_models import UserRoleRow
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
@@ -66,6 +67,7 @@ from ai.backend.testutils.db import with_tables
 _ORM_CLUSTER = (
     AgentRow,
     ScalingGroupForDomainRow,
+    ImageRow,
 )
 
 

--- a/tests/unit/manager/repositories/permission_controller/test_search_users_assigned_to_role.py
+++ b/tests/unit/manager/repositories/permission_controller/test_search_users_assigned_to_role.py
@@ -20,6 +20,7 @@ from ai.backend.manager.models.agent import AgentRow
 # registry. These rows are reachable via relationships but are not otherwise
 # imported/registered by this test; _ORM_CLUSTER keeps them live.
 from ai.backend.manager.models.domain.row import DomainRow
+from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac_models import UserRoleRow
 from ai.backend.manager.models.rbac_models.conditions import AssignedUserConditions
@@ -41,6 +42,7 @@ from ai.backend.testutils.db import with_tables
 _ORM_CLUSTER = (
     AgentRow,
     ScalingGroupForDomainRow,
+    ImageRow,
 )
 
 


### PR DESCRIPTION
## Summary
- Add a `mapped_scope` nested filter to the role search `RoleFilter`, letting roles be queried by the scope they are registered in (domain / project / user) via the `association_scopes_entities` binding.
- Implemented across the full v2 stack: DTO, model conditions (correlated `EXISTS`, no join added to `db_source`), adapter, GraphQL input type, and admin CLI options (`--scope-type` / `--scope-id`).
- Mirrors the existing `assigned_user` nested-filter pattern; SDK and REST handler pass `SearchRolesInput` through unchanged.

## Test plan
- [x] `pants fmt / fix / lint` pass
- [x] `test_by_mapped_scope_returns_roles_in_scope` (repository unit, real DB) — verifies only the role bound to the given scope is returned via the correlated EXISTS subquery
- [x] CI: `pants check` / `pants test`

Resolves BA-6723

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12563.org.readthedocs.build/en/12563/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12563.org.readthedocs.build/ko/12563/

<!-- readthedocs-preview sorna-ko end -->