### PR TITLE
feat(BA-6737): add owner_id delegation to vfolder project-create

### DIFF
--- a/changes/12586.feature.md
+++ b/changes/12586.feature.md
@@ -1,0 +1,1 @@
+Add an optional `owner_id` to `POST /v2/vfolders/projects/{project_id}/create` (`bai vfolder project-create --owner-id`) so a caller can create a project vfolder on behalf of another user.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -4692,6 +4692,9 @@ input CreateVFolderInScopeInput
 
   """Whether the vfolder is cloneable."""
   cloneable: Boolean! = false
+
+  """Delegated owner user UUID. Create the vfolder on behalf of this user."""
+  ownerId: UUID = null
 }
 
 """Added in 26.4.2. Input for creating a new virtual folder."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -3122,6 +3122,9 @@ input CreateVFolderInScopeInput {
 
   """Whether the vfolder is cloneable."""
   cloneable: Boolean! = false
+
+  """Delegated owner user UUID. Create the vfolder on behalf of this user."""
+  ownerId: UUID = null
 }
 
 """Added in 26.4.2. Input for creating a new virtual folder."""

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -28240,6 +28240,20 @@
             "description": "Whether the vfolder is cloneable",
             "title": "Cloneable",
             "type": "boolean"
+          },
+          "owner_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Delegated owner user UUID. When set, the vfolder is created on behalf of the specified user instead of the caller. Authorization stays scoped to the project.",
+            "title": "Owner Id"
           }
         },
         "required": [

--- a/src/ai/backend/client/cli/v2/vfolder/commands.py
+++ b/src/ai/backend/client/cli/v2/vfolder/commands.py
@@ -192,13 +192,14 @@ def project_create(
 
     from ai.backend.common.dto.manager.v2.vfolder.request import CreateVFolderInScopeInput
     from ai.backend.common.dto.manager.v2.vfolder.types import VFolderUsageMode
+    from ai.backend.common.identifier.user import UserID
 
     input_dto = CreateVFolderInScopeInput(
         name=name,
         usage_mode=VFolderUsageMode(usage_mode),
         host=host,
         cloneable=cloneable,
-        owner_id=owner_id,
+        owner_id=UserID(owner_id) if owner_id is not None else None,
     )
 
     async def _run() -> None:

--- a/src/ai/backend/client/cli/v2/vfolder/commands.py
+++ b/src/ai/backend/client/cli/v2/vfolder/commands.py
@@ -174,12 +174,19 @@ def get(vfolder_id: UUID) -> None:
 )
 @click.option("--host", default=None, type=str, help="Storage host.")
 @click.option("--cloneable", is_flag=True, default=False, help="Allow cloning.")
+@click.option(
+    "--owner-id",
+    default=None,
+    type=click.UUID,
+    help="Delegated owner user UUID. Create the vfolder on behalf of this user.",
+)
 def project_create(
     project_id: UUID,
     name: str,
     usage_mode: str,
     host: str | None,
     cloneable: bool,
+    owner_id: UUID | None,
 ) -> None:
     """Create a vfolder owned by a project."""
 
@@ -191,6 +198,7 @@ def project_create(
         usage_mode=VFolderUsageMode(usage_mode),
         host=host,
         cloneable=cloneable,
+        owner_id=owner_id,
     )
 
     async def _run() -> None:

--- a/src/ai/backend/common/dto/manager/v2/vfolder/request.py
+++ b/src/ai/backend/common/dto/manager/v2/vfolder/request.py
@@ -12,6 +12,7 @@ from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
 from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter
 from ai.backend.common.dto.manager.v2.deployment.request import DeploymentStrategyInput
 from ai.backend.common.identifier.deployment_preset import DeploymentPresetID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.typed_validators import VFolderName
 
 from .types import (
@@ -107,7 +108,7 @@ class CreateVFolderInScopeInput(BaseRequestModel):
         description="Default permission of the vfolder",
     )
     cloneable: bool = Field(default=False, description="Whether the vfolder is cloneable")
-    owner_id: UUID | None = Field(
+    owner_id: UserID | None = Field(
         default=None,
         description=(
             "Delegated owner user UUID. When set, the vfolder is created on behalf of "

--- a/src/ai/backend/common/dto/manager/v2/vfolder/request.py
+++ b/src/ai/backend/common/dto/manager/v2/vfolder/request.py
@@ -107,6 +107,14 @@ class CreateVFolderInScopeInput(BaseRequestModel):
         description="Default permission of the vfolder",
     )
     cloneable: bool = Field(default=False, description="Whether the vfolder is cloneable")
+    owner_id: UUID | None = Field(
+        default=None,
+        description=(
+            "Delegated owner user UUID. When set, the vfolder is created on behalf of "
+            "the specified user instead of the caller. Authorization stays scoped to "
+            "the project."
+        ),
+    )
 
     @field_validator("name", mode="before")
     @classmethod

--- a/src/ai/backend/manager/api/adapters/vfolder/adapter.py
+++ b/src/ai/backend/manager/api/adapters/vfolder/adapter.py
@@ -388,6 +388,7 @@ class VFolderAdapter(BaseAdapter):
             usage_mode=VFolderUsageMode(input.usage_mode.value),
             permission=VFolderPermission(input.permission.value),
             cloneable=input.cloneable,
+            owner_id=input.owner_id,
         )
         result = await self._processors.vfolder.create_vfolder_in_project.wait_for_complete(action)
         return CreateVFolderPayload(vfolder=self._vfolder_data_to_node(result.vfolder))

--- a/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
@@ -157,6 +157,10 @@ class CreateVFolderInScopeInputGQL(PydanticInputMixin[CreateInScopeInputDTO]):
         description="Default mount permission of the vfolder.",
     )
     cloneable: bool = gql_field(default=False, description="Whether the vfolder is cloneable.")
+    owner_id: UUID | None = gql_field(
+        default=None,
+        description="Delegated owner user UUID. Create the vfolder on behalf of this user.",
+    )
 
 
 @gql_pydantic_input(

--- a/src/ai/backend/manager/services/vfolder/actions/vfolder_in_project.py
+++ b/src/ai/backend/manager/services/vfolder/actions/vfolder_in_project.py
@@ -38,6 +38,10 @@ class CreateVFolderInProjectAction(VFolderScopeAction):
     usage_mode: VFolderUsageMode
     permission: VFolderPermission
     cloneable: bool
+    owner_id: uuid.UUID | None = None
+    """Delegated owner user UUID. When set, the service records the vfolder as
+    created by that user instead of the caller. Authorization stays
+    PROJECT-scoped (the caller needs CREATE on the project)."""
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/vfolder/actions/vfolder_in_project.py
+++ b/src/ai/backend/manager/services/vfolder/actions/vfolder_in_project.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.permission.types import RBACElementType, ScopeType
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import VFolderUsageMode
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.permission.types import RBACElementRef
@@ -38,7 +39,7 @@ class CreateVFolderInProjectAction(VFolderScopeAction):
     usage_mode: VFolderUsageMode
     permission: VFolderPermission
     cloneable: bool
-    owner_id: uuid.UUID | None = None
+    owner_id: UserID | None = None
     """Delegated owner user UUID. When set, the service records the vfolder as
     created by that user instead of the caller. Authorization stays
     PROJECT-scoped (the caller needs CREATE on the project)."""

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -41,7 +41,7 @@ from ai.backend.manager.data.vfolder.types import (
 )
 from ai.backend.manager.errors.common import Forbidden, InternalServerError, ObjectNotFound
 from ai.backend.manager.errors.kernel import BackendAgentError
-from ai.backend.manager.errors.resource import ProjectNotFound
+from ai.backend.manager.errors.resource import DomainNotFound, ProjectNotFound
 from ai.backend.manager.errors.storage import (
     TooManyVFoldersFound,
     UnexpectedStorageProxyResponseError,

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -1767,6 +1767,15 @@ class VFolderService:
         user_uuid = action.user_id
         domain_name = action.domain_name
         project_id = action.project_id
+        if action.owner_id is not None:
+            # Delegation: record the vfolder as created by the target user.
+            # Authorization stays PROJECT-scoped (validated above), so this only
+            # swaps the creating user's identity.
+            owner = await self._user_repository.get_user_by_uuid(action.owner_id)
+            if owner.domain_name is None:
+                raise DomainNotFound()
+            user_uuid = owner.id
+            domain_name = owner.domain_name
 
         user_with_hosts = await self._vfolder_repository.get_user_with_keypair_policy_vfolder_hosts(
             user_uuid

--- a/tests/unit/manager/services/vfolder/test_create_in_project_action.py
+++ b/tests/unit/manager/services/vfolder/test_create_in_project_action.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import uuid
 
 from ai.backend.common.data.permission.types import RBACElementType, ScopeType
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import VFolderUsageMode
 from ai.backend.manager.models.vfolder import VFolderPermission
 from ai.backend.manager.services.vfolder.actions.vfolder_in_project import (
@@ -17,7 +18,7 @@ from ai.backend.manager.services.vfolder.actions.vfolder_in_project import (
 )
 
 
-def _make_action(*, owner_id: uuid.UUID | None) -> CreateVFolderInProjectAction:
+def _make_action(*, owner_id: UserID | None) -> CreateVFolderInProjectAction:
     return CreateVFolderInProjectAction(
         project_id=uuid.uuid4(),
         user_id=uuid.uuid4(),
@@ -42,7 +43,7 @@ class TestCreateVFolderInProjectActionScope:
         assert target.element_id == str(action.project_id)
 
     def test_target_stays_project_with_owner(self) -> None:
-        action = _make_action(owner_id=uuid.uuid4())
+        action = _make_action(owner_id=UserID(uuid.uuid4()))
 
         # Delegation must not move the RBAC target off the project.
         assert action.scope_id() == str(action.project_id)

--- a/tests/unit/manager/services/vfolder/test_create_in_project_action.py
+++ b/tests/unit/manager/services/vfolder/test_create_in_project_action.py
@@ -1,0 +1,51 @@
+"""RBAC scope targeting for CreateVFolderInProjectAction owner delegation.
+
+Project-owned vfolder creation is authorized against the PROJECT scope. The
+optional ``owner_id`` only swaps the creating user's identity in the service and
+must NOT change the RBAC target (which stays the project).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from ai.backend.common.data.permission.types import RBACElementType, ScopeType
+from ai.backend.common.types import VFolderUsageMode
+from ai.backend.manager.models.vfolder import VFolderPermission
+from ai.backend.manager.services.vfolder.actions.vfolder_in_project import (
+    CreateVFolderInProjectAction,
+)
+
+
+def _make_action(*, owner_id: uuid.UUID | None) -> CreateVFolderInProjectAction:
+    return CreateVFolderInProjectAction(
+        project_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        domain_name="default",
+        name="test-vfolder",
+        host=None,
+        usage_mode=VFolderUsageMode.GENERAL,
+        permission=VFolderPermission.READ_WRITE,
+        cloneable=False,
+        owner_id=owner_id,
+    )
+
+
+class TestCreateVFolderInProjectActionScope:
+    def test_target_is_project_without_owner(self) -> None:
+        action = _make_action(owner_id=None)
+
+        assert action.scope_type() == ScopeType.PROJECT
+        assert action.scope_id() == str(action.project_id)
+        target = action.target_element()
+        assert target.element_type == RBACElementType.PROJECT
+        assert target.element_id == str(action.project_id)
+
+    def test_target_stays_project_with_owner(self) -> None:
+        action = _make_action(owner_id=uuid.uuid4())
+
+        # Delegation must not move the RBAC target off the project.
+        assert action.scope_id() == str(action.project_id)
+        target = action.target_element()
+        assert target.element_type == RBACElementType.PROJECT
+        assert target.element_id == str(action.project_id)


### PR DESCRIPTION
Implements **BA-6737** (under epic BA-6727).

## Summary

Add an optional `owner_id` to `POST /v2/vfolders/projects/{project_id}/create` (`bai vfolder project-create`) so a caller can create a project-owned vfolder **on behalf of another user**. The resolved owner becomes the creating user.

## Authorization

Project vfolder creation is authorized against the **PROJECT** scope (the caller needs CREATE on the project). `owner_id` only swaps the creating user's identity — the RBAC target stays the project, so this does **not** open a user-scope delegation path.

## Changes

| Layer | Change |
|---|---|
| DTO | `CreateVFolderInScopeInput.owner_id` |
| Action | `CreateVFolderInProjectAction.owner_id` (RBAC target unchanged = PROJECT) |
| Adapter | forward `owner_id` |
| Service | resolve owner (`get_user_by_uuid`), record vfolder under the owner |
| CLI | `bai vfolder project-create --owner-id` |

Unit test asserts the RBAC target stays PROJECT even when `owner_id` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12586.org.readthedocs.build/en/12586/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12586.org.readthedocs.build/ko/12586/

<!-- readthedocs-preview sorna-ko end -->