### PR TITLE
feat(BA-6740): add owner_id delegation to vfolder restore

### DIFF
--- a/changes/12587.feature.md
+++ b/changes/12587.feature.md
@@ -1,0 +1,1 @@
+Add an optional `owner_id` query param to `POST /v2/vfolders/{id}/restore` (`bai vfolder restore --owner-id`) so a caller can restore a trashed vfolder on behalf of another user.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -12100,7 +12100,7 @@ type Mutation
   """
   Added in 26.4.4. Restore a trashed virtual folder. RBAC enforced via scope chain.
   """
-  restoreVFolder(vfolderId: UUID!, ownerId: UUID = null): RestoreVFolderPayload @join__field(graph: STRAWBERRY)
+  restoreVFolder(vfolderId: UUID!, options: RestoreVFolderOptions = null): RestoreVFolderPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Deploy a deployment directly from a model VFolder."""
   deployVfolderV2(vfolderId: UUID!, input: DeployVFolderV2Input!): DeployVFolderV2Payload @join__field(graph: STRAWBERRY)
@@ -16362,6 +16362,14 @@ type RestoreArtifactsPayload
 {
   """List of restored artifacts."""
   artifacts: [Artifact!]!
+}
+
+"""Added in 26.8.0. Options for restoring a virtual folder from trash."""
+input RestoreVFolderOptions
+  @join__type(graph: STRAWBERRY)
+{
+  """Delegated owner user UUID. Restore the vfolder on behalf of this user."""
+  ownerId: UUID = null
 }
 
 """

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -12100,7 +12100,7 @@ type Mutation
   """
   Added in 26.4.4. Restore a trashed virtual folder. RBAC enforced via scope chain.
   """
-  restoreVFolder(vfolderId: UUID!): RestoreVFolderPayload @join__field(graph: STRAWBERRY)
+  restoreVFolder(vfolderId: UUID!, ownerId: UUID = null): RestoreVFolderPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Deploy a deployment directly from a model VFolder."""
   deployVfolderV2(vfolderId: UUID!, input: DeployVFolderV2Input!): DeployVFolderV2Payload @join__field(graph: STRAWBERRY)

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -7959,7 +7959,7 @@ type Mutation {
   """
   Added in 26.4.4. Restore a trashed virtual folder. RBAC enforced via scope chain.
   """
-  restoreVFolder(vfolderId: UUID!, ownerId: UUID = null): RestoreVFolderPayload
+  restoreVFolder(vfolderId: UUID!, options: RestoreVFolderOptions = null): RestoreVFolderPayload
 
   """Added in 26.4.2. Deploy a deployment directly from a model VFolder."""
   deployVfolderV2(vfolderId: UUID!, input: DeployVFolderV2Input!): DeployVFolderV2Payload
@@ -11252,6 +11252,12 @@ Added in 25.15.0. Response payload for artifact restoration operations. Contains
 type RestoreArtifactsPayload {
   """List of restored artifacts."""
   artifacts: [Artifact!]!
+}
+
+"""Added in 26.8.0. Options for restoring a virtual folder from trash."""
+input RestoreVFolderOptions {
+  """Delegated owner user UUID. Restore the vfolder on behalf of this user."""
+  ownerId: UUID = null
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -7959,7 +7959,7 @@ type Mutation {
   """
   Added in 26.4.4. Restore a trashed virtual folder. RBAC enforced via scope chain.
   """
-  restoreVFolder(vfolderId: UUID!): RestoreVFolderPayload
+  restoreVFolder(vfolderId: UUID!, ownerId: UUID = null): RestoreVFolderPayload
 
   """Added in 26.4.2. Deploy a deployment directly from a model VFolder."""
   deployVfolderV2(vfolderId: UUID!, input: DeployVFolderV2Input!): DeployVFolderV2Payload

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -48384,6 +48384,25 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "owner_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Delegated owner user UUID. When set, the vfolder is restored on behalf of the specified user instead of the caller.",
+              "title": "Owner Id"
+            }
           }
         ],
         "description": "Restore a trashed vfolder.\n\n**Preconditions:**\n* User privilege required.\n"

--- a/src/ai/backend/client/cli/v2/vfolder/commands.py
+++ b/src/ai/backend/client/cli/v2/vfolder/commands.py
@@ -238,13 +238,22 @@ def purge(vfolder_id: UUID) -> None:
 
 @vfolder.command()
 @click.argument("vfolder_id", type=click.UUID)
-def restore(vfolder_id: UUID) -> None:
+@click.option(
+    "--owner-id",
+    default=None,
+    type=click.UUID,
+    help="Delegated owner user UUID. Restore the vfolder on behalf of this user.",
+)
+def restore(vfolder_id: UUID, owner_id: UUID | None) -> None:
     """Restore a trashed vfolder."""
+    from ai.backend.common.identifier.user import UserID
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            result = await registry.vfolder.restore(vfolder_id)
+            result = await registry.vfolder.restore(
+                vfolder_id, owner_id=UserID(owner_id) if owner_id is not None else None
+            )
             print_result(result)
         finally:
             await registry.close()

--- a/src/ai/backend/client/cli/v2/vfolder/commands.py
+++ b/src/ai/backend/client/cli/v2/vfolder/commands.py
@@ -246,14 +246,15 @@ def purge(vfolder_id: UUID) -> None:
 )
 def restore(vfolder_id: UUID, owner_id: UUID | None) -> None:
     """Restore a trashed vfolder."""
+    from ai.backend.common.dto.manager.v2.vfolder.request import RestoreVFolderOptions
     from ai.backend.common.identifier.user import UserID
+
+    options = RestoreVFolderOptions(owner_id=UserID(owner_id) if owner_id is not None else None)
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            result = await registry.vfolder.restore(
-                vfolder_id, owner_id=UserID(owner_id) if owner_id is not None else None
-            )
+            result = await registry.vfolder.restore(vfolder_id, options)
             print_result(result)
         finally:
             await registry.close()

--- a/src/ai/backend/client/v2/domains_v2/vfolder.py
+++ b/src/ai/backend/client/v2/domains_v2/vfolder.py
@@ -39,6 +39,7 @@ from ai.backend.common.dto.manager.v2.vfolder.response import (
     SearchVFoldersPayload,
     VFolderNode,
 )
+from ai.backend.common.identifier.user import UserID
 
 _PATH = "/v2/vfolders"
 
@@ -149,12 +150,16 @@ class V2VFolderClient(BaseDomainClient):
             response_model=PurgeVFolderPayload,
         )
 
-    async def restore(self, vfolder_id: UUID) -> RestoreVFolderPayload:
-        """Restore a trashed vfolder."""
+    async def restore(
+        self, vfolder_id: UUID, owner_id: UserID | None = None
+    ) -> RestoreVFolderPayload:
+        """Restore a trashed vfolder, optionally on behalf of ``owner_id``."""
+        params = {"owner_id": str(owner_id)} if owner_id is not None else None
         return await self._client.typed_request(
             "POST",
             f"{_PATH}/{vfolder_id}/restore",
             response_model=RestoreVFolderPayload,
+            params=params,
         )
 
     async def deploy(

--- a/src/ai/backend/client/v2/domains_v2/vfolder.py
+++ b/src/ai/backend/client/v2/domains_v2/vfolder.py
@@ -19,6 +19,7 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
     MkdirInput,
     MoveFileInput,
     PurgeVFolderInput,
+    RestoreVFolderOptions,
     SearchVFoldersInput,
 )
 from ai.backend.common.dto.manager.v2.vfolder.response import (
@@ -39,7 +40,6 @@ from ai.backend.common.dto.manager.v2.vfolder.response import (
     SearchVFoldersPayload,
     VFolderNode,
 )
-from ai.backend.common.identifier.user import UserID
 
 _PATH = "/v2/vfolders"
 
@@ -151,10 +151,12 @@ class V2VFolderClient(BaseDomainClient):
         )
 
     async def restore(
-        self, vfolder_id: UUID, owner_id: UserID | None = None
+        self, vfolder_id: UUID, options: RestoreVFolderOptions | None = None
     ) -> RestoreVFolderPayload:
-        """Restore a trashed vfolder, optionally on behalf of ``owner_id``."""
-        params = {"owner_id": str(owner_id)} if owner_id is not None else None
+        """Restore a trashed vfolder, optionally on behalf of ``options.owner_id``."""
+        params = None
+        if options is not None and options.owner_id is not None:
+            params = {"owner_id": str(options.owner_id)}
         return await self._client.typed_request(
             "POST",
             f"{_PATH}/{vfolder_id}/restore",

--- a/src/ai/backend/common/dto/manager/v2/vfolder/request.py
+++ b/src/ai/backend/common/dto/manager/v2/vfolder/request.py
@@ -12,6 +12,7 @@ from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
 from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter
 from ai.backend.common.dto.manager.v2.deployment.request import DeploymentStrategyInput
 from ai.backend.common.identifier.deployment_preset import DeploymentPresetID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.typed_validators import VFolderName
 
 from .types import (
@@ -45,6 +46,7 @@ __all__ = (
     "PurgeVFolderOptions",
     "RenameFileInput",
     "RestoreVFolderInput",
+    "RestoreVFolderQuery",
     "ShareVFolderInput",
     "UnshareVFolderInput",
     "UpdateVFolderInput",
@@ -198,6 +200,18 @@ class RestoreVFolderInput(BaseRequestModel):
     """Input for restoring a virtual folder from trash."""
 
     id: UUID = Field(description="VFolder ID to restore")
+
+
+class RestoreVFolderQuery(BaseRequestModel):
+    """Query parameters for the vfolder restore operation."""
+
+    owner_id: UserID | None = Field(
+        default=None,
+        description=(
+            "Delegated owner user UUID. When set, the vfolder is restored on behalf of "
+            "the specified user instead of the caller."
+        ),
+    )
 
 
 class CloneVFolderInput(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/vfolder/request.py
+++ b/src/ai/backend/common/dto/manager/v2/vfolder/request.py
@@ -46,7 +46,7 @@ __all__ = (
     "PurgeVFolderOptions",
     "RenameFileInput",
     "RestoreVFolderInput",
-    "RestoreVFolderQuery",
+    "RestoreVFolderOptions",
     "ShareVFolderInput",
     "UnshareVFolderInput",
     "UpdateVFolderInput",
@@ -202,8 +202,12 @@ class RestoreVFolderInput(BaseRequestModel):
     id: UUID = Field(description="VFolder ID to restore")
 
 
-class RestoreVFolderQuery(BaseRequestModel):
-    """Query parameters for the vfolder restore operation."""
+class RestoreVFolderOptions(BaseRequestModel):
+    """Options for the vfolder restore operation.
+
+    Shared by the REST query parameters and the GraphQL ``options`` input so the
+    delegation flag lives in one place instead of a bare mutation argument.
+    """
 
     owner_id: UserID | None = Field(
         default=None,

--- a/src/ai/backend/manager/api/adapters/vfolder/adapter.py
+++ b/src/ai/backend/manager/api/adapters/vfolder/adapter.py
@@ -23,6 +23,7 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
     MkdirInput,
     MoveFileInput,
     PurgeVFolderInput,
+    RestoreVFolderOptions,
     SearchVFoldersInput,
     VFolderFilter,
     VFolderOrder,
@@ -58,7 +59,6 @@ from ai.backend.common.dto.manager.v2.vfolder.types import (
     VFolderUsageInfo as VFolderUsageInfoDTO,
 )
 from ai.backend.common.exception import BackendAIError, UnreachableError
-from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import BinarySize, MountPermission, VFolderUsageMode
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
@@ -442,19 +442,19 @@ class VFolderAdapter(BaseAdapter):
         return DeleteVFolderPayload(id=vfolder_id)
 
     async def restore(
-        self, vfolder_id: UUID, owner_id: UserID | None = None
+        self, vfolder_id: UUID, options: RestoreVFolderOptions
     ) -> RestoreVFolderPayload:
         """Restore a trashed vfolder. RBAC enforced.
 
-        When ``owner_id`` is set, the vfolder is restored on behalf of that user
-        (the restore is validated against the owner's ownership). RBAC still
-        authorizes the caller against the target vfolder.
+        When ``options.owner_id`` is set, the vfolder is restored on behalf of
+        that user (the restore is validated against the owner's ownership). RBAC
+        still authorizes the caller against the target vfolder.
         """
         me = current_user()
         if me is None:
             raise UnreachableError("User context is not available")
         action = RestoreVFolderFromTrashAction(
-            user_uuid=owner_id if owner_id is not None else me.user_id,
+            user_uuid=options.owner_id if options.owner_id is not None else me.user_id,
             vfolder_uuid=vfolder_id,
         )
         await self._processors.vfolder.restore_vfolder_from_trash.wait_for_complete(action)

--- a/src/ai/backend/manager/api/adapters/vfolder/adapter.py
+++ b/src/ai/backend/manager/api/adapters/vfolder/adapter.py
@@ -58,6 +58,7 @@ from ai.backend.common.dto.manager.v2.vfolder.types import (
     VFolderUsageInfo as VFolderUsageInfoDTO,
 )
 from ai.backend.common.exception import BackendAIError, UnreachableError
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import BinarySize, MountPermission, VFolderUsageMode
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
@@ -440,13 +441,20 @@ class VFolderAdapter(BaseAdapter):
         await self._processors.vfolder.delete_v2.wait_for_complete(action)
         return DeleteVFolderPayload(id=vfolder_id)
 
-    async def restore(self, vfolder_id: UUID) -> RestoreVFolderPayload:
-        """Restore a trashed vfolder. RBAC enforced."""
+    async def restore(
+        self, vfolder_id: UUID, owner_id: UserID | None = None
+    ) -> RestoreVFolderPayload:
+        """Restore a trashed vfolder. RBAC enforced.
+
+        When ``owner_id`` is set, the vfolder is restored on behalf of that user
+        (the restore is validated against the owner's ownership). RBAC still
+        authorizes the caller against the target vfolder.
+        """
         me = current_user()
         if me is None:
             raise UnreachableError("User context is not available")
         action = RestoreVFolderFromTrashAction(
-            user_uuid=me.user_id,
+            user_uuid=owner_id if owner_id is not None else me.user_id,
             vfolder_uuid=vfolder_id,
         )
         await self._processors.vfolder.restore_vfolder_from_trash.wait_for_complete(action)

--- a/src/ai/backend/manager/api/gql/vfolder_v2/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/resolver/mutation.py
@@ -9,6 +9,7 @@ from strawberry import Info
 from ai.backend.common.dto.manager.v2.vfolder.request import (
     PurgeVFolderInput,
     PurgeVFolderOptions,
+    RestoreVFolderOptions,
 )
 from ai.backend.manager.api.gql.decorators import BackendAIGQLMeta, gql_mutation
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
@@ -104,8 +105,8 @@ async def restore_vfolder_v2(
     options: RestoreVFolderOptionsInputGQL | None = None,
 ) -> RestoreVFolderPayloadGQL | None:
     """Restore a virtual folder from trash."""
-    owner_id = options.to_pydantic().owner_id if options is not None else None
-    payload = await info.context.adapters.vfolder.restore(vfolder_id, owner_id=owner_id)
+    options_dto = options.to_pydantic() if options is not None else RestoreVFolderOptions()
+    payload = await info.context.adapters.vfolder.restore(vfolder_id, options_dto)
     return RestoreVFolderPayloadGQL.from_pydantic(payload)
 
 

--- a/src/ai/backend/manager/api/gql/vfolder_v2/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/resolver/mutation.py
@@ -10,6 +10,7 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
     PurgeVFolderInput,
     PurgeVFolderOptions,
 )
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.api.gql.decorators import BackendAIGQLMeta, gql_mutation
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.api.gql.vfolder_v2.types.mutations import (
@@ -100,9 +101,13 @@ async def purge_vfolder_v2(
 async def restore_vfolder_v2(
     info: Info[StrawberryGQLContext],
     vfolder_id: UUID,
+    owner_id: UUID | None = None,
 ) -> RestoreVFolderPayloadGQL | None:
     """Restore a virtual folder from trash."""
-    payload = await info.context.adapters.vfolder.restore(vfolder_id)
+    payload = await info.context.adapters.vfolder.restore(
+        vfolder_id,
+        owner_id=UserID(owner_id) if owner_id is not None else None,
+    )
     return RestoreVFolderPayloadGQL.from_pydantic(payload)
 
 

--- a/src/ai/backend/manager/api/gql/vfolder_v2/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/resolver/mutation.py
@@ -10,7 +10,6 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
     PurgeVFolderInput,
     PurgeVFolderOptions,
 )
-from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.api.gql.decorators import BackendAIGQLMeta, gql_mutation
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.api.gql.vfolder_v2.types.mutations import (
@@ -38,6 +37,7 @@ from ai.backend.manager.api.gql.vfolder_v2.types.mutations import (
     MoveFilePayloadGQL,
     PurgeVFolderOptionsInputGQL,
     PurgeVFolderPayloadGQL,
+    RestoreVFolderOptionsInputGQL,
     RestoreVFolderPayloadGQL,
     UploadSessionInputGQL,
     UploadSessionPayloadGQL,
@@ -101,13 +101,11 @@ async def purge_vfolder_v2(
 async def restore_vfolder_v2(
     info: Info[StrawberryGQLContext],
     vfolder_id: UUID,
-    owner_id: UUID | None = None,
+    options: RestoreVFolderOptionsInputGQL | None = None,
 ) -> RestoreVFolderPayloadGQL | None:
     """Restore a virtual folder from trash."""
-    payload = await info.context.adapters.vfolder.restore(
-        vfolder_id,
-        owner_id=UserID(owner_id) if owner_id is not None else None,
-    )
+    owner_id = options.to_pydantic().owner_id if options is not None else None
+    payload = await info.context.adapters.vfolder.restore(vfolder_id, owner_id=owner_id)
     return RestoreVFolderPayloadGQL.from_pydantic(payload)
 
 

--- a/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
@@ -43,6 +43,9 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
 from ai.backend.common.dto.manager.v2.vfolder.request import (
     PurgeVFolderOptions as PurgeVFolderOptionsDTO,
 )
+from ai.backend.common.dto.manager.v2.vfolder.request import (
+    RestoreVFolderOptions as RestoreVFolderOptionsDTO,
+)
 from ai.backend.common.dto.manager.v2.vfolder.response import (
     BulkDeleteVFoldersPayload as BulkDeletePayloadDTO,
 )
@@ -91,6 +94,7 @@ from ai.backend.common.dto.manager.v2.vfolder.response import (
 from ai.backend.common.dto.manager.v2.vfolder.response import (
     RestoreVFolderPayload as RestorePayloadDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
@@ -458,6 +462,20 @@ class PurgeVFolderOptionsInputGQL(PydanticInputMixin[PurgeVFolderOptionsDTO]):
             "If true, also delete model card record(s) referencing the vfolder. "
             "If false, the request is rejected when any model card still references it."
         ),
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Options for restoring a virtual folder from trash.",
+    ),
+    name="RestoreVFolderOptions",
+)
+class RestoreVFolderOptionsInputGQL(PydanticInputMixin[RestoreVFolderOptionsDTO]):
+    owner_id: UUID | None = gql_field(
+        default=None,
+        description="Delegated owner user UUID. Restore the vfolder on behalf of this user.",
     )
 
 

--- a/src/ai/backend/manager/api/rest/v2/vfolder/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/vfolder/handler.py
@@ -108,9 +108,7 @@ class V2VFolderHandler:
         query: QueryParam[RestoreVFolderQuery],
     ) -> APIResponse:
         """Restore a trashed vfolder."""
-        result = await self._adapter.restore(
-            path.parsed.vfolder_id, owner_id=query.parsed.owner_id
-        )
+        result = await self._adapter.restore(path.parsed.vfolder_id, owner_id=query.parsed.owner_id)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
     async def project_create(

--- a/src/ai/backend/manager/api/rest/v2/vfolder/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/vfolder/handler.py
@@ -108,7 +108,7 @@ class V2VFolderHandler:
         query: QueryParam[RestoreVFolderOptions],
     ) -> APIResponse:
         """Restore a trashed vfolder."""
-        result = await self._adapter.restore(path.parsed.vfolder_id, owner_id=query.parsed.owner_id)
+        result = await self._adapter.restore(path.parsed.vfolder_id, query.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
     async def project_create(

--- a/src/ai/backend/manager/api/rest/v2/vfolder/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/vfolder/handler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from http import HTTPStatus
 from typing import TYPE_CHECKING
 
-from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam
+from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam, QueryParam
 from ai.backend.common.dto.manager.v2.vfolder.request import (
     BulkDeleteVFoldersInput,
     BulkPurgeVFoldersInput,
@@ -20,6 +20,7 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
     MkdirInput,
     MoveFileInput,
     PurgeVFolderInput,
+    RestoreVFolderQuery,
     SearchVFoldersInput,
 )
 from ai.backend.manager.api.rest.v2.path_params import ProjectIdPathParam, VFolderIdPathParam
@@ -104,9 +105,12 @@ class V2VFolderHandler:
     async def restore(
         self,
         path: PathParam[VFolderIdPathParam],
+        query: QueryParam[RestoreVFolderQuery],
     ) -> APIResponse:
         """Restore a trashed vfolder."""
-        result = await self._adapter.restore(path.parsed.vfolder_id)
+        result = await self._adapter.restore(
+            path.parsed.vfolder_id, owner_id=query.parsed.owner_id
+        )
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
     async def project_create(

--- a/src/ai/backend/manager/api/rest/v2/vfolder/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/vfolder/handler.py
@@ -20,7 +20,7 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
     MkdirInput,
     MoveFileInput,
     PurgeVFolderInput,
-    RestoreVFolderQuery,
+    RestoreVFolderOptions,
     SearchVFoldersInput,
 )
 from ai.backend.manager.api.rest.v2.path_params import ProjectIdPathParam, VFolderIdPathParam
@@ -105,7 +105,7 @@ class V2VFolderHandler:
     async def restore(
         self,
         path: PathParam[VFolderIdPathParam],
-        query: QueryParam[RestoreVFolderQuery],
+        query: QueryParam[RestoreVFolderOptions],
     ) -> APIResponse:
         """Restore a trashed vfolder."""
         result = await self._adapter.restore(path.parsed.vfolder_id, owner_id=query.parsed.owner_id)

--- a/tests/unit/manager/api/adapters/test_vfolder_adapter.py
+++ b/tests/unit/manager/api/adapters/test_vfolder_adapter.py
@@ -11,6 +11,7 @@ import pytest
 
 from ai.backend.common.data.user.types import UserData
 from ai.backend.common.dto.manager.v2.vfolder.request import (
+    RestoreVFolderOptions,
     SearchVFoldersInput,
     VFolderFilter,
 )
@@ -357,7 +358,7 @@ class TestVFolderAdapterRestore:
             "ai.backend.manager.api.adapters.vfolder.adapter.current_user",
             return_value=user_data,
         ):
-            await adapter.restore(vfolder_id, owner_id=owner_id)
+            await adapter.restore(vfolder_id, RestoreVFolderOptions(owner_id=owner_id))
 
         restore_mock = mock_processors.vfolder.restore_vfolder_from_trash.wait_for_complete
         action = restore_mock.call_args[0][0]

--- a/tests/unit/manager/api/adapters/test_vfolder_adapter.py
+++ b/tests/unit/manager/api/adapters/test_vfolder_adapter.py
@@ -339,34 +339,20 @@ class TestVFolderAdapterRestore:
     def adapter(self, mock_processors: MagicMock) -> VFolderAdapter:
         return VFolderAdapter(mock_processors)
 
-    async def test_restore_without_owner_uses_caller(
+    @pytest.mark.parametrize(
+        "with_owner",
+        [pytest.param(False, id="no-owner"), pytest.param(True, id="with-owner")],
+    )
+    async def test_restore_acting_user_follows_owner_id(
         self,
         adapter: VFolderAdapter,
         mock_processors: MagicMock,
         user_data: UserData,
+        with_owner: bool,
     ) -> None:
-        """Without owner_id, the acting user is the caller."""
+        """Without owner_id the acting user is the caller; with owner_id it is the owner."""
         vfolder_id = uuid4()
-        with patch(
-            "ai.backend.manager.api.adapters.vfolder.adapter.current_user",
-            return_value=user_data,
-        ):
-            await adapter.restore(vfolder_id)
-
-        restore_mock = mock_processors.vfolder.restore_vfolder_from_trash.wait_for_complete
-        action = restore_mock.call_args[0][0]
-        assert action.user_uuid == user_data.user_id
-        assert action.vfolder_uuid == vfolder_id
-
-    async def test_restore_with_owner_uses_owner(
-        self,
-        adapter: VFolderAdapter,
-        mock_processors: MagicMock,
-        user_data: UserData,
-    ) -> None:
-        """With owner_id, the acting user is the owner, not the caller."""
-        vfolder_id = uuid4()
-        owner_id = UserID(uuid4())
+        owner_id = UserID(uuid4()) if with_owner else None
         with patch(
             "ai.backend.manager.api.adapters.vfolder.adapter.current_user",
             return_value=user_data,
@@ -375,5 +361,8 @@ class TestVFolderAdapterRestore:
 
         restore_mock = mock_processors.vfolder.restore_vfolder_from_trash.wait_for_complete
         action = restore_mock.call_args[0][0]
-        assert action.user_uuid == owner_id
-        assert action.user_uuid != user_data.user_id
+        expected_user = owner_id if with_owner else user_data.user_id
+        assert action.user_uuid == expected_user
+        assert action.vfolder_uuid == vfolder_id
+        if with_owner:
+            assert action.user_uuid != user_data.user_id

--- a/tests/unit/manager/api/adapters/test_vfolder_adapter.py
+++ b/tests/unit/manager/api/adapters/test_vfolder_adapter.py
@@ -14,6 +14,7 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
     SearchVFoldersInput,
     VFolderFilter,
 )
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import QuotaScopeID, VFolderUsageMode
 from ai.backend.manager.api.adapters.vfolder.adapter import VFolderAdapter
@@ -312,3 +313,67 @@ class TestVFolderAdapterGetFolderUsage:
         dto = await adapter.get_folder_usage(uuid4())
 
         assert dto is None
+
+
+class TestVFolderAdapterRestore:
+    """Tests for VFolderAdapter.restore() owner_id delegation."""
+
+    @pytest.fixture
+    def user_data(self) -> UserData:
+        return UserData(
+            user_id=uuid4(),
+            is_authorized=True,
+            is_admin=False,
+            is_superadmin=False,
+            role=UserRole.USER,
+            domain_name="default",
+        )
+
+    @pytest.fixture
+    def mock_processors(self) -> MagicMock:
+        processors = MagicMock()
+        processors.vfolder.restore_vfolder_from_trash.wait_for_complete = AsyncMock()
+        return processors
+
+    @pytest.fixture
+    def adapter(self, mock_processors: MagicMock) -> VFolderAdapter:
+        return VFolderAdapter(mock_processors)
+
+    async def test_restore_without_owner_uses_caller(
+        self,
+        adapter: VFolderAdapter,
+        mock_processors: MagicMock,
+        user_data: UserData,
+    ) -> None:
+        """Without owner_id, the acting user is the caller."""
+        vfolder_id = uuid4()
+        with patch(
+            "ai.backend.manager.api.adapters.vfolder.adapter.current_user",
+            return_value=user_data,
+        ):
+            await adapter.restore(vfolder_id)
+
+        restore_mock = mock_processors.vfolder.restore_vfolder_from_trash.wait_for_complete
+        action = restore_mock.call_args[0][0]
+        assert action.user_uuid == user_data.user_id
+        assert action.vfolder_uuid == vfolder_id
+
+    async def test_restore_with_owner_uses_owner(
+        self,
+        adapter: VFolderAdapter,
+        mock_processors: MagicMock,
+        user_data: UserData,
+    ) -> None:
+        """With owner_id, the acting user is the owner, not the caller."""
+        vfolder_id = uuid4()
+        owner_id = UserID(uuid4())
+        with patch(
+            "ai.backend.manager.api.adapters.vfolder.adapter.current_user",
+            return_value=user_data,
+        ):
+            await adapter.restore(vfolder_id, owner_id=owner_id)
+
+        restore_mock = mock_processors.vfolder.restore_vfolder_from_trash.wait_for_complete
+        action = restore_mock.call_args[0][0]
+        assert action.user_uuid == owner_id
+        assert action.user_uuid != user_data.user_id


### PR DESCRIPTION
Implements **BA-6740** (under epic BA-6727).

## Summary

Add an optional `owner_id` (typed `UserID`) query param to `POST /v2/vfolders/{id}/restore` (`bai vfolder restore --owner-id`) so a caller can restore a trashed vfolder **on behalf of another user**. The endpoint is bodyless, so `owner_id` is a query param.

## Behavior / Authorization

The restore service resolves the acting user via `get_user_by_uuid` and validates the vfolder against that user's ownership. When `owner_id` is set it becomes the acting user, so the restore runs in the owner's context. RBAC still authorizes the **caller** against the target vfolder (single-entity `VFOLDER` scope) — this endpoint already has an RBAC target, so no new scaffolding is added.

## Changes

| Layer | Change |
|---|---|
| DTO | `RestoreVFolderQuery.owner_id: UserID \| None` |
| Handler | `QueryParam[RestoreVFolderQuery]` |
| Adapter | use `owner_id` as the acting `user_uuid` when set |
| SDK | `restore(owner_id)` → query param |
| CLI | `bai vfolder restore --owner-id` |

No action/service change — the restore service already parameterizes on the acting `user_uuid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12587.org.readthedocs.build/en/12587/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12587.org.readthedocs.build/ko/12587/

<!-- readthedocs-preview sorna-ko end -->