### PR TITLE
feat(BA-6739): add owner_id delegation to vfolder delete

### DIFF
--- a/changes/12588.feature.md
+++ b/changes/12588.feature.md
@@ -1,0 +1,1 @@
+Add an optional `owner_id` query param to `DELETE /v2/vfolders/{id}` (`bai vfolder delete --owner-id`) so a caller can soft-delete a vfolder on behalf of another user.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -12092,7 +12092,7 @@ type Mutation
   createVFolderInProject(projectId: UUID!, input: CreateVFolderInScopeInput!): CreateVFolderV2Payload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Soft-delete a virtual folder (move to trash)."""
-  deleteVfolderV2(vfolderId: UUID!): DeleteVFolderV2Payload @join__field(graph: STRAWBERRY)
+  deleteVfolderV2(vfolderId: UUID!, ownerId: UUID = null): DeleteVFolderV2Payload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Permanently purge a virtual folder."""
   purgeVfolderV2(vfolderId: UUID!, options: PurgeVFolderOptionsInput = null): PurgeVFolderV2Payload @join__field(graph: STRAWBERRY)

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -7951,7 +7951,7 @@ type Mutation {
   createVFolderInProject(projectId: UUID!, input: CreateVFolderInScopeInput!): CreateVFolderV2Payload
 
   """Added in 26.4.2. Soft-delete a virtual folder (move to trash)."""
-  deleteVfolderV2(vfolderId: UUID!): DeleteVFolderV2Payload
+  deleteVfolderV2(vfolderId: UUID!, ownerId: UUID = null): DeleteVFolderV2Payload
 
   """Added in 26.4.2. Permanently purge a virtual folder."""
   purgeVfolderV2(vfolderId: UUID!, options: PurgeVFolderOptionsInput = null): PurgeVFolderV2Payload

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -48391,6 +48391,25 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "owner_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Delegated owner user UUID. When set, the vfolder is deleted on behalf of the specified user instead of the caller.",
+              "title": "Owner Id"
+            }
           }
         ],
         "description": "Soft-delete a vfolder.\n\n**Preconditions:**\n* User privilege required.\n"

--- a/src/ai/backend/client/cli/v2/vfolder/commands.py
+++ b/src/ai/backend/client/cli/v2/vfolder/commands.py
@@ -206,13 +206,22 @@ def project_create(
 
 @vfolder.command()
 @click.argument("vfolder_id", type=click.UUID)
-def delete(vfolder_id: UUID) -> None:
+@click.option(
+    "--owner-id",
+    default=None,
+    type=click.UUID,
+    help="Delegated owner user UUID. Delete the vfolder on behalf of this user.",
+)
+def delete(vfolder_id: UUID, owner_id: UUID | None) -> None:
     """Delete a vfolder (move to trash)."""
+    from ai.backend.common.identifier.user import UserID
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            result = await registry.vfolder.delete(vfolder_id)
+            result = await registry.vfolder.delete(
+                vfolder_id, owner_id=UserID(owner_id) if owner_id is not None else None
+            )
             print_result(result)
         finally:
             await registry.close()

--- a/src/ai/backend/client/v2/domains_v2/vfolder.py
+++ b/src/ai/backend/client/v2/domains_v2/vfolder.py
@@ -39,6 +39,7 @@ from ai.backend.common.dto.manager.v2.vfolder.response import (
     SearchVFoldersPayload,
     VFolderNode,
 )
+from ai.backend.common.identifier.user import UserID
 
 _PATH = "/v2/vfolders"
 
@@ -126,12 +127,16 @@ class V2VFolderClient(BaseDomainClient):
             response_model=VFolderNode,
         )
 
-    async def delete(self, vfolder_id: UUID) -> DeleteVFolderPayload:
-        """Soft-delete a vfolder."""
+    async def delete(
+        self, vfolder_id: UUID, owner_id: UserID | None = None
+    ) -> DeleteVFolderPayload:
+        """Soft-delete a vfolder, optionally on behalf of ``owner_id``."""
+        params = {"owner_id": str(owner_id)} if owner_id is not None else None
         return await self._client.typed_request(
             "DELETE",
             f"{_PATH}/{vfolder_id}",
             response_model=DeleteVFolderPayload,
+            params=params,
         )
 
     async def purge(

--- a/src/ai/backend/common/dto/manager/v2/vfolder/request.py
+++ b/src/ai/backend/common/dto/manager/v2/vfolder/request.py
@@ -12,6 +12,7 @@ from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
 from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter
 from ai.backend.common.dto.manager.v2.deployment.request import DeploymentStrategyInput
 from ai.backend.common.identifier.deployment_preset import DeploymentPresetID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.typed_validators import VFolderName
 
 from .types import (
@@ -36,6 +37,7 @@ __all__ = (
     "DeleteFilesInput",
     "DeleteInvitationInput",
     "DeleteVFolderInput",
+    "DeleteVFolderQuery",
     "DeployVFolderInput",
     "InviteVFolderInput",
     "ListFilesInput",
@@ -146,6 +148,18 @@ class DeleteVFolderInput(BaseRequestModel):
     """Input for soft-deleting a virtual folder."""
 
     id: UUID = Field(description="VFolder ID to delete")
+
+
+class DeleteVFolderQuery(BaseRequestModel):
+    """Query parameters for the vfolder delete operation."""
+
+    owner_id: UserID | None = Field(
+        default=None,
+        description=(
+            "Delegated owner user UUID. When set, the vfolder is deleted on behalf of "
+            "the specified user instead of the caller."
+        ),
+    )
 
 
 class PurgeVFolderOptions(BaseRequestModel):

--- a/src/ai/backend/manager/api/adapters/vfolder/adapter.py
+++ b/src/ai/backend/manager/api/adapters/vfolder/adapter.py
@@ -58,6 +58,7 @@ from ai.backend.common.dto.manager.v2.vfolder.types import (
     VFolderUsageInfo as VFolderUsageInfoDTO,
 )
 from ai.backend.common.exception import BackendAIError, UnreachableError
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import BinarySize, MountPermission, VFolderUsageMode
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
@@ -434,9 +435,16 @@ class VFolderAdapter(BaseAdapter):
             used_bytes=_to_binary_size_info(usage.used_bytes),
         )
 
-    async def delete(self, vfolder_id: UUID) -> DeleteVFolderPayload:
-        """Soft-delete a vfolder (move to trash). RBAC enforced."""
-        action = DeleteVFolderV2Action(vfolder_id=vfolder_id)
+    async def delete(
+        self, vfolder_id: UUID, owner_id: UserID | None = None
+    ) -> DeleteVFolderPayload:
+        """Soft-delete a vfolder (move to trash). RBAC enforced.
+
+        When ``owner_id`` is set, the delete is performed on behalf of that user
+        (host permission is resolved from the owner). RBAC still authorizes the
+        caller against the target vfolder.
+        """
+        action = DeleteVFolderV2Action(vfolder_id=vfolder_id, owner_id=owner_id)
         await self._processors.vfolder.delete_v2.wait_for_complete(action)
         return DeleteVFolderPayload(id=vfolder_id)
 

--- a/src/ai/backend/manager/api/gql/vfolder_v2/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/resolver/mutation.py
@@ -10,6 +10,7 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
     PurgeVFolderInput,
     PurgeVFolderOptions,
 )
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.api.gql.decorators import BackendAIGQLMeta, gql_mutation
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.api.gql.vfolder_v2.types.mutations import (
@@ -66,8 +67,12 @@ async def create_vfolder_v2(
 async def delete_vfolder_v2(
     info: Info[StrawberryGQLContext],
     vfolder_id: UUID,
+    owner_id: UUID | None = None,
 ) -> DeleteVFolderPayloadGQL | None:
-    payload = await info.context.adapters.vfolder.delete(vfolder_id)
+    payload = await info.context.adapters.vfolder.delete(
+        vfolder_id,
+        owner_id=UserID(owner_id) if owner_id is not None else None,
+    )
     return DeleteVFolderPayloadGQL.from_pydantic(payload)
 
 

--- a/src/ai/backend/manager/api/rest/v2/vfolder/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/vfolder/handler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from http import HTTPStatus
 from typing import TYPE_CHECKING
 
-from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam
+from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam, QueryParam
 from ai.backend.common.dto.manager.v2.vfolder.request import (
     BulkDeleteVFoldersInput,
     BulkPurgeVFoldersInput,
@@ -15,6 +15,7 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
     CreateVFolderInput,
     CreateVFolderInScopeInput,
     DeleteFilesInput,
+    DeleteVFolderQuery,
     DeployVFolderInput,
     ListFilesInput,
     MkdirInput,
@@ -87,9 +88,10 @@ class V2VFolderHandler:
     async def delete(
         self,
         path: PathParam[VFolderIdPathParam],
+        query: QueryParam[DeleteVFolderQuery],
     ) -> APIResponse:
         """Soft-delete a vfolder."""
-        result = await self._adapter.delete(path.parsed.vfolder_id)
+        result = await self._adapter.delete(path.parsed.vfolder_id, owner_id=query.parsed.owner_id)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
     async def purge(

--- a/src/ai/backend/manager/services/vfolder/actions/vfolder_v2.py
+++ b/src/ai/backend/manager/services/vfolder/actions/vfolder_v2.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.services.vfolder.actions.base import (
@@ -18,6 +19,9 @@ class DeleteVFolderV2Action(VFolderSingleEntityAction):
     """Soft-delete a vfolder by ID with RBAC enforcement."""
 
     vfolder_id: uuid.UUID
+    owner_id: UserID | None = None
+    """Delegated owner user UUID. When set, the delete is performed on behalf of
+    that user (host permission is resolved from the owner)."""
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -1844,13 +1844,20 @@ class VFolderService:
         me = current_user()
         if me is None:
             raise UnreachableError("User context is not available")
+        acting_user_id = me.user_id
+        if action.owner_id is not None:
+            # Delegation: perform the delete on behalf of the target user, so the
+            # host permission is resolved from the owner. RBAC still authorizes
+            # the caller against the target vfolder.
+            owner = await self._user_repository.get_user_by_uuid(action.owner_id)
+            acting_user_id = owner.id
         vfolder_data = await self._vfolder_repository.get_by_id(action.vfolder_id)
 
-        # Host permission check — resolved from current user context
+        # Host permission check — resolved from the acting user context
         await self._vfolder_repository.ensure_host_permission_allowed_by_user(
             vfolder_data.host,
             permission=VFolderHostPermission.DELETE,
-            user_uuid=me.user_id,
+            user_uuid=acting_user_id,
         )
 
         await self._vfolder_repository.move_vfolders_to_trash([vfolder_data.id])

--- a/tests/unit/manager/api/adapters/test_vfolder_adapter.py
+++ b/tests/unit/manager/api/adapters/test_vfolder_adapter.py
@@ -14,6 +14,7 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
     SearchVFoldersInput,
     VFolderFilter,
 )
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import QuotaScopeID, VFolderUsageMode
 from ai.backend.manager.api.adapters.vfolder.adapter import VFolderAdapter
@@ -312,3 +313,43 @@ class TestVFolderAdapterGetFolderUsage:
         dto = await adapter.get_folder_usage(uuid4())
 
         assert dto is None
+
+
+class TestVFolderAdapterDelete:
+    """Tests for VFolderAdapter.delete() owner_id delegation."""
+
+    @pytest.fixture
+    def mock_processors(self) -> MagicMock:
+        processors = MagicMock()
+        processors.vfolder.delete_v2.wait_for_complete = AsyncMock()
+        return processors
+
+    @pytest.fixture
+    def adapter(self, mock_processors: MagicMock) -> VFolderAdapter:
+        return VFolderAdapter(mock_processors)
+
+    async def test_delete_without_owner(
+        self,
+        adapter: VFolderAdapter,
+        mock_processors: MagicMock,
+    ) -> None:
+        """Without owner_id, the action carries no delegated owner."""
+        vfolder_id = uuid4()
+        await adapter.delete(vfolder_id)
+
+        action = mock_processors.vfolder.delete_v2.wait_for_complete.call_args[0][0]
+        assert action.vfolder_id == vfolder_id
+        assert action.owner_id is None
+
+    async def test_delete_with_owner_forwards_owner(
+        self,
+        adapter: VFolderAdapter,
+        mock_processors: MagicMock,
+    ) -> None:
+        """With owner_id, the action carries the delegated owner."""
+        vfolder_id = uuid4()
+        owner_id = UserID(uuid4())
+        await adapter.delete(vfolder_id, owner_id=owner_id)
+
+        action = mock_processors.vfolder.delete_v2.wait_for_complete.call_args[0][0]
+        assert action.owner_id == owner_id


### PR DESCRIPTION
Implements **BA-6739** (under epic BA-6727).

## Summary

Add an optional `owner_id` (typed `UserID`) query param to `DELETE /v2/vfolders/{id}` (`bai vfolder delete --owner-id`) so a caller can soft-delete a vfolder **on behalf of another user**. The endpoint is bodyless, so `owner_id` is a query param.

## Behavior / Authorization

`delete_v2` resolves the acting user for the host-permission check via `current_user()`. When `owner_id` is set, the acting user becomes the resolved owner, so the host permission is checked against the owner. RBAC still authorizes the **caller** against the target vfolder (single-entity `VFOLDER` scope) — this endpoint already has an RBAC target, so no new scaffolding is added.

## Changes

| Layer | Change |
|---|---|
| DTO | `DeleteVFolderQuery.owner_id: UserID \| None` |
| Action | `DeleteVFolderV2Action.owner_id` |
| Handler | `QueryParam[DeleteVFolderQuery]` |
| Adapter / SDK | forward `owner_id` |
| Service | resolve owner as the acting user for the host permission check |
| CLI | `bai vfolder delete --owner-id` |

Adapter unit tests assert the action carries `owner_id` when set (and `None` otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12588.org.readthedocs.build/en/12588/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12588.org.readthedocs.build/ko/12588/

<!-- readthedocs-preview sorna-ko end -->