### PR TITLE
feat(BA-6738): add owner_id delegation to vfolder purge

### DIFF
--- a/changes/12590.feature.md
+++ b/changes/12590.feature.md
@@ -1,0 +1,1 @@
+Add an optional `owner_id` to `POST /v2/vfolders/{id}/purge` (`bai vfolder purge --owner-id`) so a caller can permanently purge a vfolder on behalf of another user.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -12095,7 +12095,7 @@ type Mutation
   deleteVfolderV2(vfolderId: UUID!): DeleteVFolderV2Payload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Permanently purge a virtual folder."""
-  purgeVfolderV2(vfolderId: UUID!, options: PurgeVFolderOptionsInput = null): PurgeVFolderV2Payload @join__field(graph: STRAWBERRY)
+  purgeVfolderV2(vfolderId: UUID!, options: PurgeVFolderOptionsInput = null, ownerId: UUID = null): PurgeVFolderV2Payload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.4. Restore a trashed virtual folder. RBAC enforced via scope chain.

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -7954,7 +7954,7 @@ type Mutation {
   deleteVfolderV2(vfolderId: UUID!): DeleteVFolderV2Payload
 
   """Added in 26.4.2. Permanently purge a virtual folder."""
-  purgeVfolderV2(vfolderId: UUID!, options: PurgeVFolderOptionsInput = null): PurgeVFolderV2Payload
+  purgeVfolderV2(vfolderId: UUID!, options: PurgeVFolderOptionsInput = null, ownerId: UUID = null): PurgeVFolderV2Payload
 
   """
   Added in 26.4.4. Restore a trashed virtual folder. RBAC enforced via scope chain.

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -27931,6 +27931,20 @@
           "options": {
             "$ref": "#/components/schemas/PurgeVFolderOptions",
             "description": "Optional behavior flags for the purge."
+          },
+          "owner_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Delegated owner user UUID. When set, the vfolder is purged on behalf of the specified user instead of the caller.",
+            "title": "Owner Id"
           }
         },
         "title": "PurgeVFolderInput",

--- a/src/ai/backend/client/cli/v2/vfolder/commands.py
+++ b/src/ai/backend/client/cli/v2/vfolder/commands.py
@@ -222,13 +222,23 @@ def delete(vfolder_id: UUID) -> None:
 
 @vfolder.command()
 @click.argument("vfolder_id", type=click.UUID)
-def purge(vfolder_id: UUID) -> None:
+@click.option(
+    "--owner-id",
+    default=None,
+    type=click.UUID,
+    help="Delegated owner user UUID. Purge the vfolder on behalf of this user.",
+)
+def purge(vfolder_id: UUID, owner_id: UUID | None) -> None:
     """Permanently delete a vfolder."""
+    from ai.backend.common.dto.manager.v2.vfolder.request import PurgeVFolderInput
+    from ai.backend.common.identifier.user import UserID
+
+    request = PurgeVFolderInput(owner_id=UserID(owner_id) if owner_id is not None else None)
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            result = await registry.vfolder.purge(vfolder_id)
+            result = await registry.vfolder.purge(vfolder_id, request)
             print_result(result)
         finally:
             await registry.close()

--- a/src/ai/backend/common/dto/manager/v2/vfolder/request.py
+++ b/src/ai/backend/common/dto/manager/v2/vfolder/request.py
@@ -12,6 +12,7 @@ from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
 from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter
 from ai.backend.common.dto.manager.v2.deployment.request import DeploymentStrategyInput
 from ai.backend.common.identifier.deployment_preset import DeploymentPresetID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.typed_validators import VFolderName
 
 from .types import (
@@ -175,6 +176,13 @@ class PurgeVFolderInput(BaseRequestModel):
     options: PurgeVFolderOptions = Field(
         default_factory=PurgeVFolderOptions,
         description="Optional behavior flags for the purge.",
+    )
+    owner_id: UserID | None = Field(
+        default=None,
+        description=(
+            "Delegated owner user UUID. When set, the vfolder is purged on behalf of "
+            "the specified user instead of the caller."
+        ),
     )
 
 

--- a/src/ai/backend/manager/api/adapters/vfolder/adapter.py
+++ b/src/ai/backend/manager/api/adapters/vfolder/adapter.py
@@ -457,6 +457,7 @@ class VFolderAdapter(BaseAdapter):
         action = PurgeVFolderV2Action(
             vfolder_id=vfolder_id,
             cascade_model_card=input.options.cascade_model_card,
+            owner_id=input.owner_id,
         )
         await self._processors.vfolder.purge_v2.wait_for_complete(action)
         return PurgeVFolderPayload(id=vfolder_id)

--- a/src/ai/backend/manager/api/gql/vfolder_v2/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/resolver/mutation.py
@@ -10,6 +10,7 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
     PurgeVFolderInput,
     PurgeVFolderOptions,
 )
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.api.gql.decorators import BackendAIGQLMeta, gql_mutation
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.api.gql.vfolder_v2.types.mutations import (
@@ -81,11 +82,15 @@ async def purge_vfolder_v2(
     info: Info[StrawberryGQLContext],
     vfolder_id: UUID,
     options: PurgeVFolderOptionsInputGQL | None = None,
+    owner_id: UUID | None = None,
 ) -> PurgeVFolderPayloadGQL | None:
     options_dto = options.to_pydantic() if options is not None else PurgeVFolderOptions()
     payload = await info.context.adapters.vfolder.purge(
         vfolder_id,
-        PurgeVFolderInput(options=options_dto),
+        PurgeVFolderInput(
+            options=options_dto,
+            owner_id=UserID(owner_id) if owner_id is not None else None,
+        ),
     )
     return PurgeVFolderPayloadGQL.from_pydantic(payload)
 

--- a/src/ai/backend/manager/services/vfolder/actions/vfolder_v2.py
+++ b/src/ai/backend/manager/services/vfolder/actions/vfolder_v2.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.services.vfolder.actions.base import (
@@ -64,6 +65,9 @@ class PurgeVFolderV2Action(VFolderSingleEntityAction):
 
     vfolder_id: uuid.UUID
     cascade_model_card: bool = False
+    owner_id: UserID | None = None
+    """Delegated owner user UUID. When set, the purge is performed on behalf of
+    that user (host permission is resolved from the owner)."""
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -1866,13 +1866,20 @@ class VFolderService:
         me = current_user()
         if me is None:
             raise UnreachableError("User context is not available")
+        acting_user_id = me.user_id
+        if action.owner_id is not None:
+            # Delegation: perform the purge on behalf of the target user, so the
+            # host permission is resolved from the owner. RBAC still authorizes
+            # the caller against the target vfolder.
+            owner = await self._user_repository.get_user_by_uuid(action.owner_id)
+            acting_user_id = owner.id
         vfolder_data = await self._vfolder_repository.get_by_id(action.vfolder_id)
 
-        # Host permission check — resolved from current user context
+        # Host permission check — resolved from the acting user context
         await self._vfolder_repository.ensure_host_permission_allowed_by_user(
             vfolder_data.host,
             permission=VFolderHostPermission.DELETE,
-            user_uuid=me.user_id,
+            user_uuid=acting_user_id,
         )
 
         result = await self._vfolder_repository.delete_vfolders_forever(

--- a/tests/unit/manager/api/adapters/test_vfolder_adapter.py
+++ b/tests/unit/manager/api/adapters/test_vfolder_adapter.py
@@ -14,6 +14,7 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
     SearchVFoldersInput,
     VFolderFilter,
 )
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import QuotaScopeID, VFolderUsageMode
 from ai.backend.manager.api.adapters.vfolder.adapter import VFolderAdapter
@@ -312,3 +313,47 @@ class TestVFolderAdapterGetFolderUsage:
         dto = await adapter.get_folder_usage(uuid4())
 
         assert dto is None
+
+
+class TestVFolderAdapterPurge:
+    """Tests for VFolderAdapter.purge() owner_id delegation."""
+
+    @pytest.fixture
+    def mock_processors(self) -> MagicMock:
+        processors = MagicMock()
+        processors.vfolder.purge_v2.wait_for_complete = AsyncMock()
+        return processors
+
+    @pytest.fixture
+    def adapter(self, mock_processors: MagicMock) -> VFolderAdapter:
+        return VFolderAdapter(mock_processors)
+
+    async def test_purge_without_owner(
+        self,
+        adapter: VFolderAdapter,
+        mock_processors: MagicMock,
+    ) -> None:
+        """Without owner_id, the action carries no delegated owner."""
+        from ai.backend.common.dto.manager.v2.vfolder.request import PurgeVFolderInput
+
+        vfolder_id = uuid4()
+        await adapter.purge(vfolder_id, PurgeVFolderInput())
+
+        action = mock_processors.vfolder.purge_v2.wait_for_complete.call_args[0][0]
+        assert action.vfolder_id == vfolder_id
+        assert action.owner_id is None
+
+    async def test_purge_with_owner_forwards_owner(
+        self,
+        adapter: VFolderAdapter,
+        mock_processors: MagicMock,
+    ) -> None:
+        """With owner_id, the action carries the delegated owner."""
+        from ai.backend.common.dto.manager.v2.vfolder.request import PurgeVFolderInput
+
+        vfolder_id = uuid4()
+        owner_id = UserID(uuid4())
+        await adapter.purge(vfolder_id, PurgeVFolderInput(owner_id=owner_id))
+
+        action = mock_processors.vfolder.purge_v2.wait_for_complete.call_args[0][0]
+        assert action.owner_id == owner_id

--- a/tests/unit/manager/api/adapters/test_vfolder_adapter.py
+++ b/tests/unit/manager/api/adapters/test_vfolder_adapter.py
@@ -11,6 +11,7 @@ import pytest
 
 from ai.backend.common.data.user.types import UserData
 from ai.backend.common.dto.manager.v2.vfolder.request import (
+    PurgeVFolderInput,
     SearchVFoldersInput,
     VFolderFilter,
 )
@@ -334,8 +335,6 @@ class TestVFolderAdapterPurge:
         mock_processors: MagicMock,
     ) -> None:
         """Without owner_id, the action carries no delegated owner."""
-        from ai.backend.common.dto.manager.v2.vfolder.request import PurgeVFolderInput
-
         vfolder_id = uuid4()
         await adapter.purge(vfolder_id, PurgeVFolderInput())
 
@@ -349,8 +348,6 @@ class TestVFolderAdapterPurge:
         mock_processors: MagicMock,
     ) -> None:
         """With owner_id, the action carries the delegated owner."""
-        from ai.backend.common.dto.manager.v2.vfolder.request import PurgeVFolderInput
-
         vfolder_id = uuid4()
         owner_id = UserID(uuid4())
         await adapter.purge(vfolder_id, PurgeVFolderInput(owner_id=owner_id))


### PR DESCRIPTION
Implements **BA-6738** (under epic BA-6727).

## Summary

Add an optional `owner_id` (typed `UserID`) to `POST /v2/vfolders/{id}/purge` (`bai vfolder purge --owner-id`) so a caller can permanently purge a vfolder **on behalf of another user**. `owner_id` is carried in the request body.

## Behavior / Authorization

`purge_v2` resolves the acting user for the host-permission check via `current_user()`. When `owner_id` is set, the acting user becomes the resolved owner, so the host permission is checked against the owner. RBAC still authorizes the **caller** against the target vfolder (single-entity `VFOLDER` scope).

## Changes

| Layer | Change |
|---|---|
| DTO | `PurgeVFolderInput.owner_id: UserID \| None` |
| Action | `PurgeVFolderV2Action.owner_id` |
| Adapter | forward `owner_id` |
| Service | resolve owner as the acting user for the host permission check |
| CLI | `bai vfolder purge --owner-id` |

Handler and SDK need no change (owner_id rides on the `PurgeVFolderInput` body). Adapter unit tests assert the action carries `owner_id` when set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12590.org.readthedocs.build/en/12590/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12590.org.readthedocs.build/ko/12590/

<!-- readthedocs-preview sorna-ko end -->