### PR TITLE
fix(BA-6645): re-trigger image pulling for sessions stuck in PREPARING (#12455)

### DIFF
--- a/changes/12455.fix.md
+++ b/changes/12455.fix.md
@@ -1,0 +1,1 @@
+Re-trigger image pulling for sessions stuck in `PREPARING` by including `PREPARING` in `CheckPreconditionLifecycleHandler.target_statuses`, so a lost pull-completion event no longer leaves the session unable to progress.

--- a/src/ai/backend/manager/sokovan/scheduler/handlers/lifecycle/check_precondition.py
+++ b/src/ai/backend/manager/sokovan/scheduler/handlers/lifecycle/check_precondition.py
@@ -50,13 +50,26 @@ class CheckPreconditionLifecycleHandler(SessionLifecycleHandler):
 
     @classmethod
     def target_statuses(cls) -> list[SessionStatus]:
-        """Sessions in SCHEDULED state."""
-        return [SessionStatus.SCHEDULED]
+        """Sessions in SCHEDULED or PREPARING state.
+
+        PREPARING is included so the handler re-queries sessions that have
+        already started preparation and re-triggers the idempotent image
+        pull. This recovers sessions stuck in PREPARING when a pull-related
+        event (e.g. ImagePullFinished) was lost in transit, since nothing
+        else re-sends check_and_pull once the session leaves SCHEDULED.
+        """
+        return [SessionStatus.SCHEDULED, SessionStatus.PREPARING]
 
     @classmethod
     def target_kernel_statuses(cls) -> list[KernelStatus] | None:
-        """Include sessions where kernels are in SCHEDULED status."""
-        return [KernelStatus.SCHEDULED]
+        """Include sessions with kernels in SCHEDULED, PREPARING, or PULLING status.
+
+        PREPARING/PULLING cover kernels whose pull already finished on the
+        agent but were never updated to PREPARED because the ImagePullFinished
+        event was lost; re-triggering makes the agent re-emit the completion
+        event.
+        """
+        return [KernelStatus.SCHEDULED, KernelStatus.PREPARING, KernelStatus.PULLING]
 
     @classmethod
     def status_transitions(cls) -> StatusTransitions:
@@ -126,17 +139,22 @@ class CheckPreconditionLifecycleHandler(SessionLifecycleHandler):
             sessions_for_pull_data.image_configs,
         )
 
-        # Mark all sessions as success for status transition
+        # Report re-triggered PREPARING sessions as skipped so the coordinator
+        # does not re-apply the PREPARING transition (avoids racing against
+        # concurrent promotions and re-broadcasting the same status event).
         for session in sessions:
             session_info = session.session_info
-            result.successes.append(
-                SessionTransitionInfo(
-                    session_id=session_info.identity.id,
-                    from_status=session_info.lifecycle.status,
-                    reason="passed-preconditions",
-                    creation_id=session_info.identity.creation_id,
-                    access_key=AccessKey(session_info.metadata.access_key),
-                )
+            from_status = session_info.lifecycle.status
+            transition_info = SessionTransitionInfo(
+                session_id=session_info.identity.id,
+                from_status=from_status,
+                reason="passed-preconditions",
+                creation_id=session_info.identity.creation_id,
+                access_key=AccessKey(session_info.metadata.access_key),
             )
+            if from_status == SessionStatus.PREPARING:
+                result.skipped.append(transition_info)
+            else:
+                result.successes.append(transition_info)
 
         return result

--- a/tests/unit/manager/sokovan/scheduler/handlers/conftest.py
+++ b/tests/unit/manager/sokovan/scheduler/handlers/conftest.py
@@ -425,6 +425,15 @@ def scheduled_sessions_multiple() -> list[SessionWithKernels]:
     ]
 
 
+@pytest.fixture
+def preparing_session_with_pulling_kernel() -> SessionWithKernels:
+    """Re-triggered PREPARING session whose kernel is still PULLING."""
+    return _create_session(
+        status=SessionStatus.PREPARING,
+        kernel_status=KernelStatus.PULLING,
+    )
+
+
 # =============================================================================
 # Pre-created Session Fixtures for StartSessionsLifecycleHandler
 # =============================================================================

--- a/tests/unit/manager/sokovan/scheduler/handlers/test_lifecycle_handlers.py
+++ b/tests/unit/manager/sokovan/scheduler/handlers/test_lifecycle_handlers.py
@@ -18,7 +18,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from ai.backend.manager.data.session.types import SessionStatus
-from ai.backend.manager.data.sokovan import (
+from ai.backend.manager.repositories.scheduler.types.session import (
+    TerminatingSessionData,
+)
+from ai.backend.manager.sokovan.data import (
     SessionsForPullWithImages,
     SessionsForStartWithImages,
     SessionWithKernels,

--- a/tests/unit/manager/sokovan/scheduler/handlers/test_lifecycle_handlers.py
+++ b/tests/unit/manager/sokovan/scheduler/handlers/test_lifecycle_handlers.py
@@ -4,7 +4,7 @@ Based on BEP-1033 test scenarios for handler-level testing.
 
 Test Scenarios:
 - SC-SS-001 ~ SC-SS-005: ScheduleSessionsLifecycleHandler
-- SC-CP-001 ~ SC-CP-004: CheckPreconditionLifecycleHandler
+- SC-CP-001 ~ SC-CP-006: CheckPreconditionLifecycleHandler
 - SC-ST-001 ~ SC-ST-005: StartSessionsLifecycleHandler
 - SC-TE-001 ~ SC-TE-005: TerminateSessionsLifecycleHandler
 """
@@ -17,10 +17,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from ai.backend.manager.repositories.scheduler.types.session import (
-    TerminatingSessionData,
-)
-from ai.backend.manager.sokovan.data import (
+from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.data.sokovan import (
     SessionsForPullWithImages,
     SessionsForStartWithImages,
     SessionWithKernels,
@@ -304,15 +302,16 @@ class TestScheduleSessionsLifecycleHandler:
 
 
 # =============================================================================
-# CheckPreconditionLifecycleHandler Tests (SC-CP-001 ~ SC-CP-004)
+# CheckPreconditionLifecycleHandler Tests (SC-CP-001 ~ SC-CP-006)
 # =============================================================================
 
 
 class TestCheckPreconditionLifecycleHandler:
     """Tests for CheckPreconditionLifecycleHandler.
 
-    Verifies the handler correctly triggers image pulling via launcher
-    and marks all sessions as successful.
+    Verifies the handler correctly triggers image pulling via launcher,
+    marks SCHEDULED sessions as successful, and reports re-triggered
+    PREPARING sessions as skipped.
     """
 
     @pytest.fixture
@@ -433,6 +432,80 @@ class TestCheckPreconditionLifecycleHandler:
 
         # Assert
         expected_ids = [s.session_info.identity.id for s in scheduled_sessions_multiple]
+        mock_repository.get_sessions_for_pull_by_ids.assert_awaited_once_with(expected_ids)
+
+    async def test_retriggered_preparing_session_reported_as_skipped(
+        self,
+        handler: CheckPreconditionLifecycleHandler,
+        mock_launcher: AsyncMock,
+        mock_repository: AsyncMock,
+        preparing_session_with_pulling_kernel: SessionWithKernels,
+        sessions_for_pull_factory: Callable[..., SessionsForPullWithImages],
+    ) -> None:
+        """SC-CP-005: Re-triggered PREPARING session is skipped, not success.
+
+        Given: A PREPARING session (re-triggered for a potentially stuck pull)
+        When: Handler is invoked
+        Then: Image pulling is re-triggered but the session is reported as
+              skipped so the coordinator does not re-apply the PREPARING
+              transition
+        """
+        # Arrange
+        sessions = [preparing_session_with_pulling_kernel]
+        sessions_for_pull = sessions_for_pull_factory(sessions)
+        mock_repository.get_sessions_for_pull_by_ids.return_value = sessions_for_pull
+
+        # Act
+        result = await handler.execute("default", sessions)
+
+        # Assert
+        assert len(result.successes) == 0
+        assert len(result.failures) == 0
+        assert len(result.skipped) == 1
+        assert result.skipped[0].from_status == SessionStatus.PREPARING
+
+        # Image pulling is still re-triggered for the skipped session
+        mock_launcher.trigger_image_pulling.assert_awaited_once_with(
+            sessions_for_pull.sessions,
+            sessions_for_pull.image_configs,
+        )
+
+    async def test_mixed_scheduled_and_preparing_sessions_categorized(
+        self,
+        handler: CheckPreconditionLifecycleHandler,
+        mock_launcher: AsyncMock,
+        mock_repository: AsyncMock,
+        scheduled_session: SessionWithKernels,
+        preparing_session_with_pulling_kernel: SessionWithKernels,
+        sessions_for_pull_factory: Callable[..., SessionsForPullWithImages],
+    ) -> None:
+        """SC-CP-006: SCHEDULED sessions succeed while PREPARING ones are skipped.
+
+        Given: A SCHEDULED session and a re-triggered PREPARING session
+        When: Handler is invoked
+        Then: The SCHEDULED session is reported as success and the PREPARING
+              session as skipped, with image pulling triggered for both
+        """
+        # Arrange
+        sessions = [scheduled_session, preparing_session_with_pulling_kernel]
+        sessions_for_pull = sessions_for_pull_factory(sessions)
+        mock_repository.get_sessions_for_pull_by_ids.return_value = sessions_for_pull
+
+        # Act
+        result = await handler.execute("default", sessions)
+
+        # Assert
+        assert len(result.successes) == 1
+        assert result.successes[0].session_id == scheduled_session.session_info.identity.id
+        assert len(result.skipped) == 1
+        assert (
+            result.skipped[0].session_id
+            == preparing_session_with_pulling_kernel.session_info.identity.id
+        )
+        assert len(result.failures) == 0
+
+        # Image pulling is triggered for both sessions
+        expected_ids = [s.session_info.identity.id for s in sessions]
         mock_repository.get_sessions_for_pull_by_ids.assert_awaited_once_with(expected_ids)
 
 


### PR DESCRIPTION
This is an auto-generated backport PR of #12455 to the 26.4 release.