### PR TITLE
feat(BA-6741): add owner_id delegation to session terminate

### DIFF
--- a/changes/12592.feature.md
+++ b/changes/12592.feature.md
@@ -1,0 +1,1 @@
+Add an optional `owner_id` to `POST /v2/sessions/terminate` (`bai session terminate --owner-id`) so a caller can terminate sessions on behalf of another user; every target session must be owned by that user.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -12138,7 +12138,7 @@ type Mutation
   """
   Added in 26.4.4. Terminate one or more sessions by ID. Per-session RBAC permission is enforced by the bulk validator; any denial fails the whole request.
   """
-  terminateSessionsV2(sessionIds: [ID!]!, forced: Boolean! = false): TerminateSessionsPayload @join__field(graph: STRAWBERRY)
+  terminateSessionsV2(sessionIds: [ID!]!, forced: Boolean! = false, ownerId: ID = null): TerminateSessionsPayload @join__field(graph: STRAWBERRY)
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -7997,7 +7997,7 @@ type Mutation {
   """
   Added in 26.4.4. Terminate one or more sessions by ID. Per-session RBAC permission is enforced by the bulk validator; any denial fails the whole request.
   """
-  terminateSessionsV2(sessionIds: [ID!]!, forced: Boolean! = false): TerminateSessionsPayload
+  terminateSessionsV2(sessionIds: [ID!]!, forced: Boolean! = false, ownerId: ID = null): TerminateSessionsPayload
 }
 
 """

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -26279,6 +26279,20 @@
             "description": "Force-terminate without waiting for cleanup.",
             "title": "Forced",
             "type": "boolean"
+          },
+          "owner_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Delegated owner user UUID. When set, the sessions are terminated on behalf of the specified user; all target sessions must be owned by that user.",
+            "title": "Owner Id"
           }
         },
         "required": [

--- a/src/ai/backend/client/cli/v2/session/commands.py
+++ b/src/ai/backend/client/cli/v2/session/commands.py
@@ -89,14 +89,22 @@ def project_search(project_id: str, limit: int, offset: int) -> None:
 @session.command()
 @click.argument("session_ids", nargs=-1, required=True)
 @click.option("--forced", is_flag=True, default=False, help="Force-terminate without cleanup.")
-def terminate(session_ids: tuple[str, ...], forced: bool) -> None:
+@click.option(
+    "--owner-id",
+    default=None,
+    type=click.UUID,
+    help="Delegated owner user UUID. Terminate the owner's sessions on their behalf.",
+)
+def terminate(session_ids: tuple[str, ...], forced: bool, owner_id: UUID | None) -> None:
     """Terminate one or more sessions by ID."""
 
     from ai.backend.common.dto.manager.v2.session.request import TerminateSessionsInput
+    from ai.backend.common.identifier.user import UserID
 
     body = TerminateSessionsInput(
         session_ids=[UUID(sid) for sid in session_ids],
         forced=forced,
+        owner_id=UserID(owner_id) if owner_id is not None else None,
     )
 
     async def _run() -> None:

--- a/src/ai/backend/common/dto/manager/v2/session/request.py
+++ b/src/ai/backend/common/dto/manager/v2/session/request.py
@@ -23,6 +23,7 @@ from ai.backend.common.dto.manager.v2.session.types import (
     SessionStatusFilter,
 )
 from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 
 __all__ = (
@@ -382,6 +383,13 @@ class TerminateSessionsInput(BaseRequestModel):
 
     session_ids: list[UUID] = Field(description="Session UUIDs to terminate.")
     forced: bool = Field(default=False, description="Force-terminate without waiting for cleanup.")
+    owner_id: UserID | None = Field(
+        default=None,
+        description=(
+            "Delegated owner user UUID. When set, the sessions are terminated on behalf "
+            "of the specified user; all target sessions must be owned by that user."
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -873,6 +873,7 @@ class SessionAdapter(BaseAdapter):
         action = TerminateSessionsAction(
             session_ids=[SessionId(sid) for sid in input.session_ids],
             forced=input.forced,
+            owner_id=input.owner_id,
         )
         result = await self._processors.session.terminate_sessions.wait_for_complete(action)
         return TerminateSessionsPayload(

--- a/src/ai/backend/manager/api/gql/session/resolver/session.py
+++ b/src/ai/backend/manager/api/gql/session/resolver/session.py
@@ -10,6 +10,7 @@ from ai.backend.common.dto.manager.v2.session.request import (
     AdminSearchSessionsInput,
     TerminateSessionsInput,
 )
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import SessionId
 from ai.backend.manager.api.gql.base import encode_cursor
 from ai.backend.manager.api.gql.decorators import (
@@ -179,12 +180,14 @@ async def terminate_sessions_v2(
     info: Info[StrawberryGQLContext],
     session_ids: list[ID],
     forced: bool = False,
+    owner_id: ID | None = None,
 ) -> TerminateSessionsPayloadGQL | None:
     """Terminate one or more sessions identified by ID."""
     payload = await info.context.adapters.session.terminate(
         TerminateSessionsInput(
             session_ids=[UUID(str(sid)) for sid in session_ids],
             forced=forced,
+            owner_id=UserID(UUID(str(owner_id))) if owner_id is not None else None,
         )
     )
     return TerminateSessionsPayloadGQL(

--- a/src/ai/backend/manager/services/session/actions/terminate_sessions.py
+++ b/src/ai/backend/manager/services/session/actions/terminate_sessions.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import override
 
 from ai.backend.common.data.permission.types import EntityType, RBACElementType
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import SessionId
 from ai.backend.manager.actions.action.bulk import BaseBulkAction, BaseBulkActionResult
 from ai.backend.manager.actions.action.types import ActionTarget
@@ -36,6 +37,9 @@ class TerminateSessionsAction(BaseBulkAction[SessionTerminationTarget]):
 
     session_ids: list[SessionId]
     forced: bool
+    owner_id: UserID | None = None
+    """Delegated owner user UUID. When set, the service verifies that every
+    target session is owned by that user before terminating."""
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -70,6 +70,7 @@ from ai.backend.manager.data.session.options import (
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.defs import DEFAULT_ROLE
 from ai.backend.manager.errors.common import (
+    Forbidden,
     InternalServerError,
     ServiceUnavailable,
 )
@@ -861,6 +862,17 @@ class SessionService:
         self, action: TerminateSessionsAction
     ) -> TerminateSessionsActionResult:
         """Terminate multiple sessions by their IDs."""
+        if action.owner_id is not None:
+            # Delegation: verify every target session is owned by the delegated
+            # owner before terminating on their behalf.
+            owner = await self._user_repository.get_user_by_uuid(action.owner_id)
+            for session_id in action.session_ids:
+                session_owner = await self._session_repository.get_session_owner(session_id)
+                if session_owner.id != owner.id:
+                    raise Forbidden(
+                        f"Session {session_id} is not owned by the delegated owner "
+                        f"{action.owner_id}."
+                    )
         reason = (
             KernelLifecycleEventReason.FORCE_TERMINATED
             if action.forced

--- a/tests/unit/manager/services/session/test_session_service.py
+++ b/tests/unit/manager/services/session/test_session_service.py
@@ -18,6 +18,7 @@ from ai.backend.common.dto.agent.response import CodeCompletionResp, CodeComplet
 from ai.backend.common.exception import InvalidAPIParameters
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import (
     AccessKey,
     ClusterMode,
@@ -43,6 +44,7 @@ from ai.backend.manager.data.kernel.types import (
     UserPermission,
 )
 from ai.backend.manager.data.session.types import SessionData, SessionListResult, SessionStatus
+from ai.backend.manager.errors.common import Forbidden
 from ai.backend.manager.errors.kernel import SessionNotFound
 from ai.backend.manager.errors.storage import VFolderBadRequest
 from ai.backend.manager.models.network import NetworkType
@@ -110,6 +112,9 @@ from ai.backend.manager.services.session.actions.shutdown_service import (
     ShutdownServiceAction,
     ShutdownServiceActionResult,
 )
+from ai.backend.manager.services.session.actions.terminate_sessions import (
+    TerminateSessionsAction,
+)
 from ai.backend.manager.services.session.actions.upload_files import (
     UploadFilesAction,
     UploadFilesActionResult,
@@ -176,6 +181,12 @@ def mock_scheduler_repository() -> MagicMock:
 
 
 @pytest.fixture
+def mock_user_repository() -> MagicMock:
+    """Create mocked user repository."""
+    return MagicMock()
+
+
+@pytest.fixture
 def mock_appproxy_client_pool() -> MagicMock:
     """Create mocked AppProxy client pool."""
     return MagicMock()
@@ -193,6 +204,7 @@ async def session_service(
     mock_scheduling_controller: MagicMock,
     mock_scheduler_repository: MagicMock,
     mock_appproxy_client_pool: MagicMock,
+    mock_user_repository: MagicMock,
 ) -> SessionService:
     """Create SessionService with mocked dependencies."""
     args = SessionServiceArgs(
@@ -206,7 +218,7 @@ async def session_service(
         scheduler_repository=mock_scheduler_repository,
         scheduling_controller=mock_scheduling_controller,
         appproxy_client_pool=mock_appproxy_client_pool,
-        user_repository=MagicMock(),
+        user_repository=mock_user_repository,
     )
     return SessionService(args)
 
@@ -1904,3 +1916,58 @@ class TestEnqueueSession:
         draft = mock_scheduling_controller.enqueue_session_from_draft.await_args.args[0]
         assert draft.scope.resource_group_id == requested_resource_group_id
         assert draft.scope.resource_group_name == ResourceGroupName("requested-rg")
+
+
+class TestTerminateSessionsDelegation:
+    """owner_id delegation in SessionService.terminate_sessions()."""
+
+    async def test_rejects_session_not_owned_by_owner(
+        self,
+        session_service: SessionService,
+        mock_session_repository: MagicMock,
+        mock_scheduling_controller: MagicMock,
+        mock_user_repository: MagicMock,
+    ) -> None:
+        """Terminating on behalf of an owner rejects sessions the owner does not own."""
+        owner_id = uuid4()
+        session_id = SessionId(uuid4())
+        mock_user_repository.get_user_by_uuid = AsyncMock(return_value=MagicMock(id=owner_id))
+        # The session is owned by a different user.
+        mock_session_repository.get_session_owner = AsyncMock(return_value=MagicMock(id=uuid4()))
+        mock_scheduling_controller.mark_sessions_for_termination = AsyncMock()
+        action = TerminateSessionsAction(
+            session_ids=[session_id], forced=False, owner_id=UserID(owner_id)
+        )
+
+        with pytest.raises(Forbidden):
+            await session_service.terminate_sessions(action)
+        mock_scheduling_controller.mark_sessions_for_termination.assert_not_called()
+
+    async def test_terminates_when_all_sessions_owned(
+        self,
+        session_service: SessionService,
+        mock_session_repository: MagicMock,
+        mock_scheduling_controller: MagicMock,
+        mock_user_repository: MagicMock,
+    ) -> None:
+        """Terminating on behalf of an owner proceeds when the owner owns the sessions."""
+        owner_id = uuid4()
+        session_id = SessionId(uuid4())
+        mock_user_repository.get_user_by_uuid = AsyncMock(return_value=MagicMock(id=owner_id))
+        mock_session_repository.get_session_owner = AsyncMock(return_value=MagicMock(id=owner_id))
+        mock_scheduling_controller.mark_sessions_for_termination = AsyncMock(
+            return_value=MagicMock(
+                cancelled_sessions=[],
+                terminating_sessions=[session_id],
+                force_terminated_sessions=[],
+                skipped_sessions=[],
+            )
+        )
+        action = TerminateSessionsAction(
+            session_ids=[session_id], forced=False, owner_id=UserID(owner_id)
+        )
+
+        result = await session_service.terminate_sessions(action)
+
+        mock_scheduling_controller.mark_sessions_for_termination.assert_called_once()
+        assert result.terminating == [session_id]


### PR DESCRIPTION
Implements **BA-6741** (under epic BA-6727).

## Summary

Add an optional `owner_id` (typed `UserID`) to `POST /v2/sessions/terminate` (`bai session terminate --owner-id`) so a caller can terminate sessions **on behalf of another user**. `owner_id` is carried in the request body.

## Behavior / Authorization

Unlike the vfolder endpoints, `terminate` has no acting-user context — it marks sessions for termination by ID, with per-session RBAC via the bulk validator. So `owner_id` is enforced as an **ownership check**: the service resolves the owner and verifies every target session is owned by that user, rejecting the request with `Forbidden` otherwise. RBAC still authorizes the caller per session.

## Changes

| Layer | Change |
|---|---|
| DTO | `TerminateSessionsInput.owner_id: UserID \| None` |
| Action | `TerminateSessionsAction.owner_id` |
| Adapter | forward `owner_id` |
| Service | verify every target session is owned by the resolved owner (`Forbidden` on mismatch) |
| CLI | `bai session terminate --owner-id` |

Handler and SDK need no change (owner_id rides on the body). Service unit tests cover reject-on-mismatch and proceed-when-owned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12592.org.readthedocs.build/en/12592/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12592.org.readthedocs.build/ko/12592/

<!-- readthedocs-preview sorna-ko end -->