### PR TITLE
feat(BA-6729): add owner_id delegation to deployment create

### DIFF
--- a/changes/12594.feature.md
+++ b/changes/12594.feature.md
@@ -1,0 +1,1 @@
+Add an optional `owner_id` to `POST /v2/deployments/` (`bai deployment create --owner-id`) so a caller can create a deployment on behalf of another user, authorized against the owner's scope.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -3660,6 +3660,7 @@ input CreateDeploymentInput
   defaultDeploymentStrategy: DeploymentStrategyInput!
   replicaCount: Int!
   initialRevision: CreateRevisionInput = null
+  ownerId: UUID = null
 }
 
 """Added in 25.19.0. Payload for creating a model deployment."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -2390,6 +2390,7 @@ input CreateDeploymentInput {
   defaultDeploymentStrategy: DeploymentStrategyInput!
   replicaCount: Int!
   initialRevision: CreateRevisionInput = null
+  ownerId: UUID = null
 }
 
 """Added in 25.19.0. Payload for creating a model deployment."""

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -3755,6 +3755,20 @@
             ],
             "default": null,
             "description": "Initial revision configuration. If omitted, deployment is created without a revision and must be added later via add_revision."
+          },
+          "owner_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Delegated owner user UUID. When set, the deployment is created on behalf of the specified user (that user becomes the created_user / session_owner). Caller must have permission to act on behalf of the target user.",
+            "title": "Owner Id"
           }
         },
         "required": [

--- a/src/ai/backend/client/cli/v2/deployment/commands.py
+++ b/src/ai/backend/client/cli/v2/deployment/commands.py
@@ -132,6 +132,12 @@ def get(deployment_id: str) -> None:
     type=str,
     help="Initial revision as JSON string or @file path. If omitted, deployment starts without a revision.",
 )
+@click.option(
+    "--owner-id",
+    default=None,
+    type=click.UUID,
+    help="Delegated owner user UUID. Create the deployment on behalf of this user.",
+)
 def create(
     name: str,
     project_id: str,
@@ -141,6 +147,7 @@ def create(
     open_to_public: bool,
     strategy: str,
     initial_revision: str | None,
+    owner_id: UUID | None,
 ) -> None:
     """Create a deployment."""
 
@@ -155,6 +162,7 @@ def create(
         ModelDeploymentNetworkAccessInput,
     )
     from ai.backend.common.identifier.resource_group import ResourceGroupName
+    from ai.backend.common.identifier.user import UserID
 
     revision_dto: CreateRevisionInput | None = None
     if initial_revision is not None:
@@ -180,6 +188,7 @@ def create(
         ),
         replica_count=replicas,
         initial_revision=revision_dto,
+        owner_id=UserID(owner_id) if owner_id is not None else None,
     )
 
     async def _run() -> None:

--- a/src/ai/backend/common/dto/manager/v2/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/request.py
@@ -47,6 +47,7 @@ from ai.backend.common.identifier.deployment_preset import DeploymentPresetID
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.resource_group import ResourceGroupName
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import (
     AutoScalingMetricSource,
@@ -514,6 +515,14 @@ class CreateDeploymentInput(BaseRequestModel):
     initial_revision: CreateRevisionInput | None = Field(
         default=None,
         description="Initial revision configuration. If omitted, deployment is created without a revision and must be added later via add_revision.",
+    )
+    owner_id: UserID | None = Field(
+        default=None,
+        description=(
+            "Delegated owner user UUID. When set, the deployment is created on behalf of "
+            "the specified user (that user becomes the created_user / session_owner). "
+            "Caller must have permission to act on behalf of the target user."
+        ),
     )
 
 

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -664,14 +664,17 @@ class DeploymentAdapter(BaseAdapter):
                 strategy_spec=RollingUpdateSpec(),
             )
         meta = input.metadata
+        # Delegation: when owner_id is set, the deployment is owned by that user.
+        # The RBAC scope validator authorizes the caller against the owner's scope.
+        owner_id = input.owner_id if input.owner_id is not None else created_user_id
         creator = NewDeploymentCreator(
             metadata=DeploymentMetadata(
-                name=meta.name or f"deployment-{created_user_id.hex[:8]}",
+                name=meta.name or f"deployment-{owner_id.hex[:8]}",
                 domain=meta.domain_name,
                 project=meta.project_id,
                 resource_group=meta.resource_group_name,
-                created_user=created_user_id,
-                session_owner=created_user_id,
+                created_user=owner_id,
+                session_owner=owner_id,
                 created_at=None,
                 revision_history_limit=10,
                 tag=",".join(meta.tags) if meta.tags else None,

--- a/src/ai/backend/manager/api/gql/deployment/types/deployment.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/deployment.py
@@ -762,6 +762,8 @@ class CreateDeploymentInput(PydanticInputMixin[CreateDeploymentInputDTO]):
     default_deployment_strategy: DeploymentStrategyInputGQL
     replica_count: int
     initial_revision: CreateRevisionInput | None = None
+    owner_id: UUID | None = None
+    """Delegated owner user UUID. Create the deployment on behalf of this user."""
 
 
 @gql_pydantic_input(

--- a/src/ai/backend/manager/services/deployment/actions/create_deployment.py
+++ b/src/ai/backend/manager/services/deployment/actions/create_deployment.py
@@ -3,16 +3,22 @@
 from dataclasses import dataclass
 from typing import override
 
+from ai.backend.common.data.permission.types import RBACElementType, ScopeType
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.deployment.creator import NewDeploymentCreator
 from ai.backend.manager.data.deployment.types import ModelDeploymentData
-from ai.backend.manager.services.deployment.actions.base import DeploymentBaseAction
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.services.deployment.actions.base import DeploymentScopeAction
 
 
 @dataclass
-class CreateDeploymentAction(DeploymentBaseAction):
-    """Action to create a new deployment(Model Service)."""
+class CreateDeploymentAction(DeploymentScopeAction):
+    """Action to create a new deployment(Model Service).
+
+    RBAC is enforced against the owner's USER scope (the ``created_user`` on the
+    creator metadata), so delegation authorizes the caller against the owner.
+    """
 
     creator: NewDeploymentCreator
     auto_activate: bool
@@ -25,6 +31,23 @@ class CreateDeploymentAction(DeploymentBaseAction):
     @classmethod
     def operation_type(cls) -> ActionOperationType:
         return ActionOperationType.CREATE
+
+    @override
+    def scope_type(self) -> ScopeType:
+        return ScopeType.USER
+
+    @override
+    def scope_id(self) -> str:
+        return str(self.creator.metadata.created_user)
+
+    @override
+    def target_element(self) -> RBACElementRef:
+        # created_user is the effective owner (the caller, or the delegated
+        # owner_id). Authorize the caller against that user's USER scope.
+        return RBACElementRef(
+            element_type=RBACElementType.USER,
+            element_id=str(self.creator.metadata.created_user),
+        )
 
 
 @dataclass

--- a/src/ai/backend/manager/services/deployment/processors.py
+++ b/src/ai/backend/manager/services/deployment/processors.py
@@ -248,7 +248,11 @@ class DeploymentProcessors(AbstractProcessorPackage):
     ) -> None:
         # Deployment CRUD
         rbac_single_entity_validators = [validators.rbac.single_entity]
-        self.create_deployment = ActionProcessor(service.create_deployment, action_monitors)
+        self.create_deployment = ActionProcessor(
+            service.create_deployment,
+            action_monitors,
+            validators=[cast(ActionValidator, validators.rbac.scope)],
+        )
         self.create_legacy_deployment = ActionProcessor(
             service.create_legacy_deployment, action_monitors
         )

--- a/tests/unit/manager/services/deployment/test_create_deployment_action.py
+++ b/tests/unit/manager/services/deployment/test_create_deployment_action.py
@@ -1,0 +1,35 @@
+"""RBAC scope targeting for CreateDeploymentAction owner delegation.
+
+The deployment is created owned by ``created_user`` (the caller, or the
+delegated ``owner_id``). RBAC authorizes the caller against that user's USER
+scope, so the action's target must follow ``creator.metadata.created_user``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from ai.backend.common.data.permission.types import RBACElementType, ScopeType
+from ai.backend.manager.services.deployment.actions.create_deployment import (
+    CreateDeploymentAction,
+)
+
+
+def _make_action(created_user: uuid.UUID) -> CreateDeploymentAction:
+    creator = MagicMock()
+    creator.metadata.created_user = created_user
+    return CreateDeploymentAction(creator=creator, auto_activate=False)
+
+
+class TestCreateDeploymentActionScope:
+    def test_target_is_created_user_scope(self) -> None:
+        owner_id = uuid4()
+        action = _make_action(owner_id)
+
+        assert action.scope_type() == ScopeType.USER
+        assert action.scope_id() == str(owner_id)
+        target = action.target_element()
+        assert target.element_type == RBACElementType.USER
+        assert target.element_id == str(owner_id)


### PR DESCRIPTION
Implements **BA-6729** (under epic BA-6727).

## Summary

Add an optional `owner_id` (typed `UserID`) to `POST /v2/deployments/` (`bai deployment create --owner-id`) so a caller can create a deployment **on behalf of another user** — that user becomes the `created_user` / `session_owner`.

## Authorization (⚠️ behavior change)

`CreateDeploymentAction` was a plain action with **no RBAC validator** (anyone could create). This PR converts it to a **scope action** targeting the effective owner's USER scope and wires the scope RBAC validator into its processor. So:

- Non-delegated create → authorized against the caller's own USER scope.
- Delegated create (`owner_id` set) → authorized against the **owner's** USER scope; a non-superadmin cannot create for arbitrary users unless permitted. Superadmin bypasses.

Because create was previously ungated, this introduces RBAC where there was none — **normal creates now require `CREATE` permission on `MODEL_DEPLOYMENT` in the user's own scope**. CI (component/integration) should confirm this is seeded; flagging for review.

## Changes

| Layer | Change |
|---|---|
| DTO | `CreateDeploymentInput.owner_id: UserID \| None` |
| Adapter | use `owner_id` as `created_user` / `session_owner` when set |
| Action | `DeploymentScopeAction`, target = `created_user`'s USER scope |
| Processor | `create_deployment` now runs the scope RBAC validator |
| CLI | `bai deployment create --owner-id` |

SDK needs no change (owner_id rides on the body). Action unit test asserts the target follows `created_user`.

## Deferred

Decision 3 (expose the owner on the response `DeploymentNode`) is **deferred** to a follow-up — it needs `ModelDeploymentData` to carry `session_owner` through the projection/adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12594.org.readthedocs.build/en/12594/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12594.org.readthedocs.build/ko/12594/

<!-- readthedocs-preview sorna-ko end -->