### PR TITLE
fix(BA-6726): enforce in-use guard on vfolder purge paths

### DIFF
--- a/changes/12621.fix.md
+++ b/changes/12621.fix.md
@@ -1,0 +1,1 @@
+Guard vfolder purge against in-use folders: reject purging a vfolder that is mounted by a live session/kernel, referenced by an active model-service endpoint, or not in a purgable status, unless an explicit `force` flag is set.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -14029,6 +14029,11 @@ input PurgeVFolderOptionsInput
   If true, also delete model card record(s) referencing the vfolder. If false, the request is rejected when any model card still references it.
   """
   cascadeModelCard: Boolean! = false
+
+  """
+  Added in 26.8.0. If true, bypass the in-use guards and purge the vfolder even when it is mounted by a live session, referenced by an active model-service endpoint, or not in a purgable status. Irreversible — use with caution. If false (default), the request is rejected in those cases.
+  """
+  force: Boolean! = false
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -9454,6 +9454,11 @@ input PurgeVFolderOptionsInput {
   If true, also delete model card record(s) referencing the vfolder. If false, the request is rejected when any model card still references it.
   """
   cascadeModelCard: Boolean! = false
+
+  """
+  Added in 26.8.0. If true, bypass the in-use guards and purge the vfolder even when it is mounted by a live session, referenced by an active model-service endpoint, or not in a purgable status. Irreversible — use with caution. If false (default), the request is rejected in those cases.
+  """
+  force: Boolean! = false
 }
 
 """

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -27846,6 +27846,12 @@
             "description": "If true, also delete model card record(s) referencing the vfolder. If false, the request is rejected when any model card still references it.",
             "title": "Cascade Model Card",
             "type": "boolean"
+          },
+          "force": {
+            "default": false,
+            "description": "If true, bypass the in-use guards and purge the vfolder even when it is mounted by a live session, referenced by an active model-service endpoint, or not in a purgable status. Irreversible — use with caution. If false (default), the request is rejected in those cases.",
+            "title": "Force",
+            "type": "boolean"
           }
         },
         "title": "PurgeVFolderOptions",

--- a/src/ai/backend/client/cli/v2/vfolder/commands.py
+++ b/src/ai/backend/client/cli/v2/vfolder/commands.py
@@ -222,13 +222,30 @@ def delete(vfolder_id: UUID) -> None:
 
 @vfolder.command()
 @click.argument("vfolder_id", type=click.UUID)
-def purge(vfolder_id: UUID) -> None:
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help=(
+        "Bypass the in-use guards and purge even when the vfolder is mounted by a "
+        "live session, referenced by an active model-service endpoint, or not in a "
+        "purgable status. Irreversible."
+    ),
+)
+def purge(vfolder_id: UUID, force: bool) -> None:
     """Permanently delete a vfolder."""
+
+    from ai.backend.common.dto.manager.v2.vfolder.request import (
+        PurgeVFolderInput,
+        PurgeVFolderOptions,
+    )
+
+    input_dto = PurgeVFolderInput(options=PurgeVFolderOptions(force=force))
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            result = await registry.vfolder.purge(vfolder_id)
+            result = await registry.vfolder.purge(vfolder_id, input_dto)
             print_result(result)
         finally:
             await registry.close()
@@ -482,12 +499,25 @@ def bulk_delete(ids: tuple[UUID, ...]) -> None:
 
 @vfolder.command(name="bulk-purge")
 @click.argument("ids", nargs=-1, required=True, type=click.UUID)
-def bulk_purge(ids: tuple[UUID, ...]) -> None:
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help=(
+        "Bypass the in-use guards for every vfolder in the batch and purge even when "
+        "mounted by a live session, referenced by an active model-service endpoint, or "
+        "not in a purgable status. Irreversible."
+    ),
+)
+def bulk_purge(ids: tuple[UUID, ...], force: bool) -> None:
     """Permanently purge multiple vfolders."""
 
-    from ai.backend.common.dto.manager.v2.vfolder.request import BulkPurgeVFoldersInput
+    from ai.backend.common.dto.manager.v2.vfolder.request import (
+        BulkPurgeVFoldersInput,
+        PurgeVFolderOptions,
+    )
 
-    input_dto = BulkPurgeVFoldersInput(ids=list(ids))
+    input_dto = BulkPurgeVFoldersInput(ids=list(ids), options=PurgeVFolderOptions(force=force))
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())

--- a/src/ai/backend/common/dto/manager/v2/vfolder/request.py
+++ b/src/ai/backend/common/dto/manager/v2/vfolder/request.py
@@ -162,6 +162,15 @@ class PurgeVFolderOptions(BaseRequestModel):
             "If false, the request is rejected when any model card still references it."
         ),
     )
+    force: bool = Field(
+        default=False,
+        description=(
+            "If true, bypass the in-use guards and purge the vfolder even when it is "
+            "mounted by a live session, referenced by an active model-service endpoint, "
+            "or not in a purgable status. Irreversible — use with caution. "
+            "If false (default), the request is rejected in those cases."
+        ),
+    )
 
 
 class PurgeVFolderInput(BaseRequestModel):

--- a/src/ai/backend/manager/api/adapters/vfolder/adapter.py
+++ b/src/ai/backend/manager/api/adapters/vfolder/adapter.py
@@ -457,6 +457,7 @@ class VFolderAdapter(BaseAdapter):
         action = PurgeVFolderV2Action(
             vfolder_id=vfolder_id,
             cascade_model_card=input.options.cascade_model_card,
+            force=input.options.force,
         )
         await self._processors.vfolder.purge_v2.wait_for_complete(action)
         return PurgeVFolderPayload(id=vfolder_id)
@@ -561,6 +562,7 @@ class VFolderAdapter(BaseAdapter):
             action = PurgeVFolderV2Action(
                 vfolder_id=vfolder_id,
                 cascade_model_card=input.options.cascade_model_card,
+                force=input.options.force,
             )
             try:
                 await self._processors.vfolder.purge_v2.wait_for_complete(action)

--- a/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
@@ -91,6 +91,7 @@ from ai.backend.common.dto.manager.v2.vfolder.response import (
 from ai.backend.common.dto.manager.v2.vfolder.response import (
     RestoreVFolderPayload as RestorePayloadDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
@@ -458,6 +459,18 @@ class PurgeVFolderOptionsInputGQL(PydanticInputMixin[PurgeVFolderOptionsDTO]):
             "If true, also delete model card record(s) referencing the vfolder. "
             "If false, the request is rejected when any model card still references it."
         ),
+    )
+    force: bool = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "If true, bypass the in-use guards and purge the vfolder even when it is "
+                "mounted by a live session, referenced by an active model-service endpoint, "
+                "or not in a purgable status. Irreversible — use with caution. "
+                "If false (default), the request is rejected in those cases."
+            ),
+        ),
+        default=False,
     )
 
 

--- a/src/ai/backend/manager/repositories/vfolder/purge_guards.py
+++ b/src/ai/backend/manager/repositories/vfolder/purge_guards.py
@@ -1,0 +1,158 @@
+"""Registry of active vfolder references consulted by the purge in-use guard.
+
+``vfolders.id`` is referenced in two forms:
+
+- **Hard FK columns** — discoverable from the schema and (partly) enforced by
+  the DB: ``model_cards.vfolder`` (RESTRICT), ``deployment_revisions.model``
+  (SET NULL), and the ``vfolder_*`` CASCADE child tables.
+- **Soft JSONB references** that embed a vfolder id but are *not* foreign keys,
+  so schema metadata and the DB cannot see them:
+  ``sessions.vfolder_mounts`` / ``kernels.vfolder_mounts`` (``VFolderMount``)
+  and ``deployment_revisions.extra_mounts`` (``MountInfoEntry``).
+
+The purge in-use guard must reject a purge while any *active* reference exists,
+but the DB cannot enforce that for the soft references (and ``SET NULL`` FKs are
+silently nulled rather than blocked). Both categories are therefore checked
+explicitly through the registry below.
+
+TEMPORARY — the soft references should eventually be normalized into FK junction
+tables; once that lands, the guard can enumerate FKs and this hand-maintained
+list can shrink to the checks that need per-entity "active" semantics.
+``tests/unit/manager/repositories/vfolder/test_vfolder_purge_guard_completeness.py``
+introspects the ORM and fails if any ``VFolderMount`` / ``MountInfoEntry`` column
+or non-CASCADE FK to ``vfolders.id`` is not represented here, so the list cannot
+silently rot as the schema evolves.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession as SASession
+
+from ai.backend.common.data.endpoint.types import EndpointLifecycle
+from ai.backend.common.identifier.deployment import DeploymentID
+from ai.backend.common.types import VFolderID
+from ai.backend.manager.models.deployment_revision.row import DeploymentRevisionRow
+from ai.backend.manager.models.endpoint.row import EndpointRow
+from ai.backend.manager.models.kernel.row import DEAD_KERNEL_STATUSES, KernelRow
+from ai.backend.manager.models.vfolder.row import VFolderRow, get_sessions_by_mounted_folder
+
+__all__ = (
+    "VFolderReferenceCheck",
+    "VFolderReferenceHit",
+    "VFOLDER_REFERENCE_CHECKS",
+    "find_active_vfolder_references",
+)
+
+
+@dataclass(frozen=True)
+class VFolderReferenceCheck:
+    """A single "is this vfolder actively referenced here?" probe.
+
+    ``source`` is the ``"<table>.<column>"`` the reference lives in; the
+    completeness test matches on it so every referencing column must appear as
+    the ``source`` of exactly one check.
+    """
+
+    source: str
+    describe: str
+    query: Callable[[SASession, VFolderRow], Awaitable[Sequence[uuid.UUID]]]
+
+
+@dataclass(frozen=True)
+class VFolderReferenceHit:
+    source: str
+    describe: str
+    referrer_ids: list[str]
+
+
+async def _sessions_mounting(session: SASession, vfolder_row: VFolderRow) -> Sequence[uuid.UUID]:
+    return list(await get_sessions_by_mounted_folder(session, VFolderID.from_row(vfolder_row)))
+
+
+async def _kernels_mounting(session: SASession, vfolder_row: VFolderRow) -> Sequence[uuid.UUID]:
+    stmt = sa.select(KernelRow.id).where(
+        KernelRow.status.not_in(DEAD_KERNEL_STATUSES)
+        & KernelRow.vfolder_mounts.contains([{"vfid": str(VFolderID.from_row(vfolder_row))}])
+    )
+    return list((await session.scalars(stmt)).all())
+
+
+def _active_endpoint_ids_stmt(
+    where_clause: sa.sql.expression.ColumnElement[bool],
+) -> sa.Select[tuple[DeploymentID]]:
+    return (
+        sa.select(EndpointRow.id)
+        .join(DeploymentRevisionRow, DeploymentRevisionRow.endpoint == EndpointRow.id)
+        .where(EndpointRow.lifecycle_stage.in_(EndpointLifecycle.active_states()) & where_clause)
+        .distinct()
+    )
+
+
+async def _active_endpoints_by_model(
+    session: SASession, vfolder_row: VFolderRow
+) -> Sequence[uuid.UUID]:
+    stmt = _active_endpoint_ids_stmt(DeploymentRevisionRow.model == vfolder_row.id)
+    return list((await session.scalars(stmt)).all())
+
+
+async def _active_endpoints_by_extra_mount(
+    session: SASession, vfolder_row: VFolderRow
+) -> Sequence[uuid.UUID]:
+    # ``extra_mounts`` stores ``MountInfoEntry.model_dump(mode="json")`` where
+    # ``vfolder_id`` is the dashed UUID string (``str(uuid)``).
+    stmt = _active_endpoint_ids_stmt(
+        DeploymentRevisionRow.extra_mounts.contains([{"vfolder_id": str(vfolder_row.id)}])
+    )
+    return list((await session.scalars(stmt)).all())
+
+
+# Order matters only for which reference is reported first in the error message.
+VFOLDER_REFERENCE_CHECKS: list[VFolderReferenceCheck] = [
+    VFolderReferenceCheck(
+        source="sessions.vfolder_mounts",
+        describe="mounted on live session(s)",
+        query=_sessions_mounting,
+    ),
+    VFolderReferenceCheck(
+        source="kernels.vfolder_mounts",
+        describe="mounted on live kernel(s)",
+        query=_kernels_mounting,
+    ),
+    VFolderReferenceCheck(
+        source="deployment_revisions.model",
+        describe="referenced as the model by active endpoint(s)",
+        query=_active_endpoints_by_model,
+    ),
+    VFolderReferenceCheck(
+        source="deployment_revisions.extra_mounts",
+        describe="mounted as an extra mount by active endpoint(s)",
+        query=_active_endpoints_by_extra_mount,
+    ),
+]
+
+
+async def find_active_vfolder_references(
+    session: SASession, vfolder_row: VFolderRow
+) -> list[VFolderReferenceHit]:
+    """Return every active reference to the vfolder across the registry.
+
+    Empty when nothing actively references it (i.e. purge is safe w.r.t.
+    in-use guards).
+    """
+    hits: list[VFolderReferenceHit] = []
+    for check in VFOLDER_REFERENCE_CHECKS:
+        referrer_ids = await check.query(session, vfolder_row)
+        if referrer_ids:
+            hits.append(
+                VFolderReferenceHit(
+                    source=check.source,
+                    describe=check.describe,
+                    referrer_ids=[str(rid) for rid in referrer_ids],
+                )
+            )
+    return hits

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -142,6 +142,7 @@ from ai.backend.manager.repositories.base.rbac.revoker import (
 )
 from ai.backend.manager.repositories.base.updater import Updater, execute_updater
 from ai.backend.manager.repositories.vfolder.creators import VFolderCreatorSpec
+from ai.backend.manager.repositories.vfolder.purge_guards import find_active_vfolder_references
 from ai.backend.manager.repositories.vfolder.types import (
     BulkVFolderPurgeResult,
     ProjectVFolderSearchScope,
@@ -693,12 +694,44 @@ class VfolderRepository:
                 record.model_card_rows.append(card_row)
         return list(grouped.values())
 
+    async def _ensure_vfolder_purgeable(
+        self, session: SASession, vfolder_row: VFolderRow, *, force: bool
+    ) -> None:
+        """Raise when the vfolder must not be purged; return normally otherwise.
+
+        Enforces a purgable-status precondition and rejects the purge while the
+        vfolder is actively referenced anywhere in
+        :data:`VFOLDER_REFERENCE_CHECKS` (live session/kernel mounts, active
+        model-service endpoints via ``model`` or ``extra_mounts``). All checks
+        are skipped when ``force`` is True.
+
+        Raises:
+            VFolderFilterStatusFailed: The vfolder status is not purgable.
+            VFolderDeletionNotAllowed: The vfolder is still actively referenced.
+        """
+        if force:
+            return
+        if vfolder_row.status not in vfolder_status_map[VFolderStatusSet.PURGABLE]:
+            raise VFolderFilterStatusFailed(
+                f"Cannot purge the vfolder(id: {vfolder_row.id}). Its status "
+                f"({vfolder_row.status.value}) is not purgable. Soft-delete it "
+                "first or set force=True."
+            )
+        hits = await find_active_vfolder_references(session, vfolder_row)
+        if hits:
+            details = "; ".join(f"{hit.describe} {hit.referrer_ids}" for hit in hits)
+            raise VFolderDeletionNotAllowed(
+                f"Cannot purge the vfolder(id: {vfolder_row.id}); it is still in use: "
+                f"{details}. Remove the reference(s) first or set force=True."
+            )
+
     @vfolder_repository_resilience.apply()
     async def delete_vfolders_forever(
         self,
         vfolder_ids: list[uuid.UUID],
         *,
         cascade_model_card: bool = False,
+        force: bool = False,
     ) -> BulkVFolderPurgeResult:
         """
         Delete VFolders forever with partial-success semantics.
@@ -708,6 +741,11 @@ class VfolderRepository:
         ``VFolderHasLinkedModelCard``) when ``cascade_model_card`` is False;
         otherwise the cards are deleted and the vfolder transitions to
         ``DELETE_ONGOING`` like any other success.
+
+        Unless ``force`` is True, a vfolder that is mounted by a live session,
+        referenced by an active model-service endpoint, or not in a purgable
+        status also becomes a failure (carrying the blocking error) and is
+        skipped — its storage is left intact.
         """
 
         result = BulkVFolderPurgeResult()
@@ -720,6 +758,17 @@ class VfolderRepository:
                 succeeded_ids: list[uuid.UUID] = []
                 succeeded_rows: list[VFolderRow] = []
                 for rec in records:
+                    # Partial-success semantics: a per-vfolder blocker becomes a
+                    # failure entry rather than aborting the whole batch.
+                    try:
+                        await self._ensure_vfolder_purgeable(
+                            db_session, rec.vfolder_row, force=force
+                        )
+                    except BackendAIError as e:
+                        result.failures.append(
+                            VFolderPurgeFailure(vfolder_id=rec.vfolder_row.id, exception=e)
+                        )
+                        continue
                     if rec.model_card_rows and not cascade_model_card:
                         result.failures.append(
                             VFolderPurgeFailure(
@@ -767,24 +816,30 @@ class VfolderRepository:
             return result
 
     @vfolder_repository_resilience.apply()
-    async def purge_vfolder(self, purger: RBACEntityPurger[VFolderRow]) -> VFolderData:
+    async def purge_vfolder(
+        self, purger: RBACEntityPurger[VFolderRow], *, force: bool = False
+    ) -> VFolderData:
         """
         Permanently delete a VFolder from DB.
         Only VFolders with purgable status (DELETE_PENDING, DELETE_COMPLETE) can be purged.
 
+        Unless ``force`` is True, the purge is rejected when the vfolder is
+        mounted by a live session, referenced by an active model-service
+        endpoint, or not in a purgable status.
+
         Raises:
             VFolderNotFound: If the vfolder doesn't exist.
             VFolderFilterStatusFailed: If the vfolder status is not purgable.
+            VFolderDeletionNotAllowed: If the vfolder is mounted or endpoint-referenced.
             VFolderHasLinkedModelCard: If a model card still references the vfolder.
         """
         vfolder_uuid = cast(uuid.UUID, purger.pk_value)
         async with self._db.begin_session() as session:
-            # Fetch vfolder first to validate status before purging.
+            # Fetch vfolder first to validate status/in-use before purging.
             vfolder_row = await self._get_vfolder_by_id(session, vfolder_uuid)
             if vfolder_row is None:
                 raise VFolderNotFound(extra_data=str(vfolder_uuid))
-            if vfolder_row.status not in vfolder_status_map[VFolderStatusSet.PURGABLE]:
-                raise VFolderFilterStatusFailed
+            await self._ensure_vfolder_purgeable(session, vfolder_row, force=force)
             try:
                 await execute_rbac_entity_purger(session, purger)
             except RepositoryIntegrityError as e:

--- a/src/ai/backend/manager/services/vfolder/actions/vfolder_v2.py
+++ b/src/ai/backend/manager/services/vfolder/actions/vfolder_v2.py
@@ -60,10 +60,15 @@ class PurgeVFolderV2Action(VFolderSingleEntityAction):
     By default the call is rejected when any model card references the
     vfolder. Set ``cascade_model_card=True`` to also remove the linked
     model card row(s) atomically.
+
+    By default the call is also rejected when the vfolder is mounted by a
+    live session, referenced by an active model-service endpoint, or not in
+    a purgable status. Set ``force=True`` to bypass those in-use guards.
     """
 
     vfolder_id: uuid.UUID
     cascade_model_card: bool = False
+    force: bool = False
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -730,7 +730,10 @@ class VFolderService:
         vfolder_data = await self._vfolder_repository.get_by_id_validated(
             action.vfolder_uuid, user.id, user.domain_name
         )
-        result = await self._vfolder_repository.delete_vfolders_forever([action.vfolder_uuid])
+        # Explicit escape hatch: bypass the in-use / status guards.
+        result = await self._vfolder_repository.delete_vfolders_forever(
+            [action.vfolder_uuid], force=True
+        )
         if result.failures:
             raise result.failures[0].exception
         await self._remove_vfolder_from_storage(vfolder_data)
@@ -1878,6 +1881,7 @@ class VFolderService:
         result = await self._vfolder_repository.delete_vfolders_forever(
             [action.vfolder_id],
             cascade_model_card=action.cascade_model_card,
+            force=action.force,
         )
         if result.failures:
             raise result.failures[0].exception

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_purge_guard_completeness.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_purge_guard_completeness.py
@@ -1,0 +1,103 @@
+"""Guarantee the purge in-use guard sees every vfolder reference in the schema.
+
+``vfolders.id`` is referenced two ways: hard FK columns and soft JSONB
+references (``VFolderMount`` / ``MountInfoEntry``) that embed a vfolder id but
+are invisible to the DB and to schema metadata. The purge guard consults
+:data:`VFOLDER_REFERENCE_CHECKS` for the soft references (and the SET NULL FK
+``deployment_revisions.model``); this test fails the build when a new
+referencing column is added without registering it, so the hand-maintained
+registry cannot silently rot as the schema evolves.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+
+import ai.backend.manager.models
+from ai.backend.common.types import MountInfoEntry, VFolderMount
+from ai.backend.manager.models.base import (
+    PydanticListColumn,
+    StructuredJSONObjectListColumn,
+    metadata,
+)
+from ai.backend.manager.repositories.vfolder.purge_guards import VFOLDER_REFERENCE_CHECKS
+
+# Same discovery rule alembic's env.py uses to register every table on
+# ``metadata`` (top-level modules + Row-bearing subpackages).
+_SKIP_SUBPACKAGES = {"alembic", "hasher", "minilang", "rbac"}
+
+# FK columns to vfolders.id handled outside the reference registry. Each entry
+# needs an explicit justification so adding one is a deliberate decision.
+_FK_HANDLED_ELSEWHERE = {
+    # RESTRICT FK: the DB blocks row deletion and delete_vfolders_forever
+    # surfaces it as VFolderHasLinkedModelCard (with the cascade_model_card opt).
+    "model_cards.vfolder",
+}
+
+
+def _load_all_models() -> None:
+    for module_info in pkgutil.iter_modules(ai.backend.manager.models.__path__):
+        if module_info.ispkg and module_info.name in _SKIP_SUBPACKAGES:
+            continue
+        importlib.import_module(f"ai.backend.manager.models.{module_info.name}")
+
+
+def _registered_sources() -> set[str]:
+    return {check.source for check in VFOLDER_REFERENCE_CHECKS}
+
+
+def test_registry_sources_are_unique() -> None:
+    sources = [check.source for check in VFOLDER_REFERENCE_CHECKS]
+    assert len(sources) == len(set(sources)), f"Duplicate reference sources: {sources}"
+
+
+def test_all_soft_vfolder_reference_columns_are_registered() -> None:
+    """Every JSONB column embedding a vfolder id must have a registry entry."""
+    _load_all_models()
+    registered = _registered_sources()
+
+    soft_columns: set[str] = set()
+    for table in metadata.tables.values():
+        for column in table.columns:
+            col_type = column.type
+            if (
+                isinstance(col_type, StructuredJSONObjectListColumn)
+                and col_type._schema is VFolderMount
+            ) or (isinstance(col_type, PydanticListColumn) and col_type._schema is MountInfoEntry):
+                soft_columns.add(f"{table.name}.{column.name}")
+
+    missing = soft_columns - registered
+    assert not missing, (
+        f"Unregistered vfolder soft-reference column(s): {sorted(missing)}. "
+        "Add a VFolderReferenceCheck for each in repositories/vfolder/purge_guards.py "
+        "so the purge in-use guard covers it."
+    )
+
+
+def test_all_fk_references_to_vfolders_are_accounted_for() -> None:
+    """Every non-CASCADE FK to vfolders.id must be registered or handled."""
+    _load_all_models()
+    accounted = _registered_sources() | _FK_HANDLED_ELSEWHERE
+
+    unaccounted: list[tuple[str, str | None]] = []
+    for table in metadata.tables.values():
+        for column in table.columns:
+            for fk in column.foreign_keys:
+                # ``target_fullname`` is the declared "<table>.<column>" string;
+                # reading it does not resolve the FK (so unrelated unresolved
+                # FKs elsewhere in the schema cannot break this check).
+                if fk.target_fullname != "vfolders.id":
+                    continue
+                source = f"{table.name}.{column.name}"
+                # CASCADE children are deleted together with the vfolder.
+                if (fk.ondelete or "").upper() == "CASCADE":
+                    continue
+                if source not in accounted:
+                    unaccounted.append((source, fk.ondelete))
+
+    assert not unaccounted, (
+        f"FK column(s) referencing vfolders.id not covered by the purge guard: {unaccounted}. "
+        "Register a VFolderReferenceCheck in purge_guards.py, or add to _FK_HANDLED_ELSEWHERE "
+        "with justification."
+    )

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_repository.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_repository.py
@@ -7,20 +7,31 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncGenerator
+from pathlib import PurePosixPath
 
 import pytest
 import sqlalchemy as sa
 
+from ai.backend.common.config import ModelDefinitionDraft
+from ai.backend.common.container_registry import ContainerRegistryType
+from ai.backend.common.data.endpoint.types import EndpointLifecycle
+from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import (
     BinarySize,
+    ClusterMode,
     DefaultForUnspecified,
+    MountInfoEntry,
+    MountPermission,
     ResourceSlot,
     VFolderHostPermission,
     VFolderHostPermissionMap,
+    VFolderID,
+    VFolderMount,
     VFolderUsageMode,
 )
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.group.types import ProjectType
+from ai.backend.manager.data.image.types import ImageType
 from ai.backend.manager.data.permission.types import RoleSource
 from ai.backend.manager.data.vfolder.types import (
     VFolderCreateParams,
@@ -28,7 +39,9 @@ from ai.backend.manager.data.vfolder.types import (
     VFolderOperationStatus,
     VFolderOwnershipType,
 )
+from ai.backend.manager.defs import DEFAULT_ROLE
 from ai.backend.manager.errors.storage import (
+    VFolderDeletionNotAllowed,
     VFolderFilterStatusFailed,
     VFolderHasLinkedModelCard,
     VFolderNotFound,
@@ -69,8 +82,8 @@ from ai.backend.manager.models.resource_slot.row import (
 )
 from ai.backend.manager.models.routing import RoutingRow
 from ai.backend.manager.models.runtime_variant import RuntimeVariantRow
-from ai.backend.manager.models.scaling_group import ScalingGroupRow
-from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.scaling_group import ScalingGroupOpts, ScalingGroupRow
+from ai.backend.manager.models.session import SessionRow, SessionStatus
 from ai.backend.manager.models.user import (
     UserRole,
     UserRow,
@@ -618,6 +631,7 @@ class TestVfolderRepositoryPurge:
             database_connection,
             [
                 DomainRow,
+                ScalingGroupRow,
                 UserResourcePolicyRow,
                 ProjectResourcePolicyRow,
                 KeyPairResourcePolicyRow,
@@ -626,7 +640,22 @@ class TestVfolderRepositoryPurge:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
+                ImageRow,
                 VFolderRow,
+                # Endpoint / session tables — required by the purge in-use guards
+                # (get_sessions_by_mounted_folder + active-endpoint reference check).
+                EndpointRow,
+                DeploymentPolicyRow,
+                DeploymentAutoScalingPolicyRow,
+                RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
+                DeploymentRevisionRow,
+                SessionRow,
+                AgentRow,
+                KernelRow,
+                ReplicaGroupRow,
+                RoutingRow,
                 ModelCardRow,
                 EntityFieldRow,
                 AssociationScopesEntitiesRow,
@@ -988,6 +1017,7 @@ class TestVfolderRepositoryDeleteForever:
             database_connection,
             [
                 DomainRow,
+                ScalingGroupRow,
                 UserResourcePolicyRow,
                 ProjectResourcePolicyRow,
                 KeyPairResourcePolicyRow,
@@ -996,10 +1026,25 @@ class TestVfolderRepositoryDeleteForever:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
+                ContainerRegistryRow,
+                ImageRow,
                 VFolderRow,
                 VFolderInvitationRow,
                 VFolderPermissionRow,
                 ResourceSlotTypeRow,
+                # Endpoint / session tables — required by the purge in-use guards
+                # (get_sessions_by_mounted_folder + active-endpoint reference check).
+                EndpointRow,
+                DeploymentPolicyRow,
+                DeploymentAutoScalingPolicyRow,
+                RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
+                DeploymentRevisionRow,
+                SessionRow,
+                AgentRow,
+                KernelRow,
+                ReplicaGroupRow,
+                RoutingRow,
                 ModelCardRow,
                 ModelCardResourceRequirementRow,
                 EntityFieldRow,
@@ -1330,6 +1375,535 @@ class TestVfolderRepositoryDeleteForever:
             == VFolderOperationStatus.DELETE_PENDING
         )
         assert await self._model_card_exists(db_with_cleanup, card_id)
+
+    # ------------------------------------------------------------------
+    # In-use guards: purgable-status precondition, live-session mount,
+    # active-endpoint reference, and the force bypass for all three.
+    # ------------------------------------------------------------------
+
+    @pytest.fixture
+    async def test_scaling_group(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> tuple[uuid.UUID, str]:
+        sgroup_name = f"test-sgroup-{uuid.uuid4().hex[:8]}"
+        async with db_with_cleanup.begin_session() as db_sess:
+            sgroup = ScalingGroupRow(
+                name=sgroup_name,
+                description="Test scaling group",
+                is_active=True,
+                driver="static",
+                driver_opts={},
+                scheduler="fifo",
+                scheduler_opts=ScalingGroupOpts(),
+            )
+            db_sess.add(sgroup)
+            await db_sess.flush()
+            sgroup_id = sgroup.id
+        return sgroup_id, sgroup_name
+
+    @pytest.fixture
+    async def test_image_id(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> uuid.UUID:
+        registry_id = uuid.uuid4()
+        async with db_with_cleanup.begin_session() as db_sess:
+            db_sess.add(
+                ContainerRegistryRow(
+                    id=registry_id,
+                    url="https://docker.io",
+                    registry_name=f"reg-{uuid.uuid4().hex[:8]}",
+                    type=ContainerRegistryType.DOCKER,
+                )
+            )
+            await db_sess.flush()
+            image = ImageRow(
+                name="test-image:latest",
+                project=str(uuid.uuid4()),
+                image="test-image",
+                registry="docker.io",
+                registry_id=registry_id,
+                architecture="x86_64",
+                is_local=False,
+                config_digest="sha256:abc123",
+                size_bytes=1000000,
+                type=ImageType.COMPUTE,
+                labels={},
+            )
+            db_sess.add(image)
+            await db_sess.flush()
+            return image.id
+
+    @pytest.fixture
+    async def test_runtime_variant_id(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> uuid.UUID:
+        async with db_with_cleanup.begin_session() as db_sess:
+            variant = RuntimeVariantRow(
+                name=f"test-variant-{uuid.uuid4().hex[:8]}",
+                description="Test runtime variant",
+                default_model_definition=ModelDefinitionDraft(),
+            )
+            db_sess.add(variant)
+            await db_sess.flush()
+            return variant.id
+
+    async def _domain_id(
+        self,
+        db: ExtendedAsyncSAEngine,
+        domain_name: str,
+    ) -> uuid.UUID:
+        async with db.begin_readonly_session() as session:
+            return (
+                await session.execute(sa.select(DomainRow.id).where(DomainRow.name == domain_name))
+            ).scalar_one()
+
+    async def _create_live_session_mounting(
+        self,
+        db: ExtendedAsyncSAEngine,
+        *,
+        vfolder_id: uuid.UUID,
+        quota_scope_id: str,
+        domain_name: str,
+        domain_id: uuid.UUID,
+        group_id: uuid.UUID,
+        user_id: uuid.UUID,
+        sgroup_id: uuid.UUID,
+        sgroup_name: str,
+    ) -> uuid.UUID:
+        session_id = uuid.uuid4()
+        mount = VFolderMount(
+            name="mnt",
+            vfid=VFolderID(quota_scope_id, vfolder_id),
+            vfsubpath=PurePosixPath("."),
+            host_path=PurePosixPath("/vfroot/local/mnt"),
+            kernel_path=PurePosixPath("/home/work/mnt"),
+            mount_perm=MountPermission.READ_WRITE,
+            usage_mode=VFolderUsageMode.GENERAL,
+        )
+        async with db.begin_session() as db_sess:
+            db_sess.add(
+                SessionRow(
+                    id=session_id,
+                    cluster_size=1,
+                    domain_name=domain_name,
+                    domain_id=domain_id,
+                    resource_group_id=sgroup_id,
+                    scaling_group_name=sgroup_name,
+                    group_id=group_id,
+                    user_uuid=user_id,
+                    occupying_slots=ResourceSlot(),
+                    requested_slots=ResourceSlot(),
+                    status=SessionStatus.RUNNING,
+                    vfolder_mounts=[mount],
+                )
+            )
+            await db_sess.flush()
+        return session_id
+
+    async def _create_endpoint_with_model(
+        self,
+        db: ExtendedAsyncSAEngine,
+        *,
+        model_vfolder_id: uuid.UUID | None,
+        domain_name: str,
+        project_id: uuid.UUID,
+        user_id: uuid.UUID,
+        sgroup_name: str,
+        image_id: uuid.UUID,
+        runtime_variant_id: uuid.UUID,
+        lifecycle: EndpointLifecycle,
+        extra_mount_vfolder_ids: list[uuid.UUID] | None = None,
+    ) -> uuid.UUID:
+        extra_mounts = [
+            MountInfoEntry(vfolder_id=VFolderUUID(vfid)) for vfid in (extra_mount_vfolder_ids or [])
+        ]
+        async with db.begin_session() as db_sess:
+            endpoint = EndpointRow(
+                name=f"ep-{uuid.uuid4().hex[:8]}",
+                created_user=user_id,
+                session_owner=user_id,
+                replicas=1,
+                domain=domain_name,
+                project=project_id,
+                resource_group=sgroup_name,
+                url=f"https://{uuid.uuid4().hex[:8]}.example.com",
+                lifecycle_stage=lifecycle,
+            )
+            db_sess.add(endpoint)
+            await db_sess.flush()
+            revision = DeploymentRevisionRow(
+                endpoint=endpoint.id,
+                revision_number=1,
+                image=image_id,
+                model=model_vfolder_id,
+                model_mount_destination="/models",
+                resource_group=sgroup_name,
+                resource_opts={},
+                cluster_mode=ClusterMode.SINGLE_NODE.name,
+                cluster_size=1,
+                runtime_variant_id=runtime_variant_id,
+                environ={},
+                extra_mounts=extra_mounts,
+            )
+            db_sess.add(revision)
+            await db_sess.flush()
+            return endpoint.id
+
+    async def _create_live_kernel_mounting(
+        self,
+        db: ExtendedAsyncSAEngine,
+        *,
+        vfolder_id: uuid.UUID,
+        quota_scope_id: str,
+        domain_name: str,
+        domain_id: uuid.UUID,
+        group_id: uuid.UUID,
+        user_id: uuid.UUID,
+        sgroup_id: uuid.UUID,
+        sgroup_name: str,
+    ) -> uuid.UUID:
+        # A live kernel mounts the vfolder while its parent session does NOT,
+        # isolating the kernel-level mount guard from the session-level one.
+        session_id = uuid.uuid4()
+        kernel_id = uuid.uuid4()
+        mount = VFolderMount(
+            name="mnt",
+            vfid=VFolderID(quota_scope_id, vfolder_id),
+            vfsubpath=PurePosixPath("."),
+            host_path=PurePosixPath("/vfroot/local/mnt"),
+            kernel_path=PurePosixPath("/home/work/mnt"),
+            mount_perm=MountPermission.READ_WRITE,
+            usage_mode=VFolderUsageMode.GENERAL,
+        )
+        async with db.begin_session() as db_sess:
+            db_sess.add(
+                SessionRow(
+                    id=session_id,
+                    cluster_size=1,
+                    domain_name=domain_name,
+                    domain_id=domain_id,
+                    resource_group_id=sgroup_id,
+                    scaling_group_name=sgroup_name,
+                    group_id=group_id,
+                    user_uuid=user_id,
+                    occupying_slots=ResourceSlot(),
+                    requested_slots=ResourceSlot(),
+                    status=SessionStatus.RUNNING,
+                    vfolder_mounts=[],
+                )
+            )
+            db_sess.add(
+                KernelRow(
+                    id=kernel_id,
+                    session_id=session_id,
+                    domain_name=domain_name,
+                    group_id=group_id,
+                    user_uuid=user_id,
+                    scaling_group=sgroup_name,
+                    resource_group_id=sgroup_id,
+                    cluster_role=DEFAULT_ROLE,
+                    occupied_slots=ResourceSlot(),
+                    requested_slots=ResourceSlot(),
+                    repl_in_port=0,
+                    repl_out_port=0,
+                    stdin_port=0,
+                    stdout_port=0,
+                    vfolder_mounts=[mount],
+                )
+            )
+            await db_sess.flush()
+        return kernel_id
+
+    async def test_non_purgable_status_returns_failure(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        vfolder_repository: VfolderRepository,
+        test_domain_name: str,
+        test_user: uuid.UUID,
+    ) -> None:
+        vfolder_id = await self._create_vfolder(
+            db_with_cleanup,
+            domain_name=test_domain_name,
+            user_id=test_user,
+            status=VFolderOperationStatus.READY,
+        )
+
+        result = await vfolder_repository.delete_vfolders_forever([vfolder_id])
+
+        assert result.succeeded == []
+        assert len(result.failures) == 1
+        assert isinstance(result.failures[0].exception, VFolderFilterStatusFailed)
+        # Storage-status untouched: still READY.
+        assert (
+            await self._vfolder_status(db_with_cleanup, vfolder_id) == VFolderOperationStatus.READY
+        )
+
+    async def test_force_purges_non_purgable_status(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        vfolder_repository: VfolderRepository,
+        test_domain_name: str,
+        test_user: uuid.UUID,
+    ) -> None:
+        vfolder_id = await self._create_vfolder(
+            db_with_cleanup,
+            domain_name=test_domain_name,
+            user_id=test_user,
+            status=VFolderOperationStatus.READY,
+        )
+
+        result = await vfolder_repository.delete_vfolders_forever([vfolder_id], force=True)
+
+        assert result.failures == []
+        assert [d.id for d in result.succeeded] == [vfolder_id]
+        assert (
+            await self._vfolder_status(db_with_cleanup, vfolder_id)
+            == VFolderOperationStatus.DELETE_ONGOING
+        )
+
+    async def test_mounted_by_live_session_returns_failure(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        vfolder_repository: VfolderRepository,
+        test_domain_name: str,
+        test_user: uuid.UUID,
+        test_project_id: uuid.UUID,
+        test_scaling_group: tuple[uuid.UUID, str],
+    ) -> None:
+        vfolder_id = await self._create_vfolder(
+            db_with_cleanup, domain_name=test_domain_name, user_id=test_user
+        )
+        sgroup_id, sgroup_name = test_scaling_group
+        await self._create_live_session_mounting(
+            db_with_cleanup,
+            vfolder_id=vfolder_id,
+            quota_scope_id=f"user:{test_user}",
+            domain_name=test_domain_name,
+            domain_id=await self._domain_id(db_with_cleanup, test_domain_name),
+            group_id=test_project_id,
+            user_id=test_user,
+            sgroup_id=sgroup_id,
+            sgroup_name=sgroup_name,
+        )
+
+        result = await vfolder_repository.delete_vfolders_forever([vfolder_id])
+
+        assert result.succeeded == []
+        assert len(result.failures) == 1
+        assert isinstance(result.failures[0].exception, VFolderDeletionNotAllowed)
+        assert (
+            await self._vfolder_status(db_with_cleanup, vfolder_id)
+            == VFolderOperationStatus.DELETE_PENDING
+        )
+
+    async def test_force_purges_mounted_vfolder(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        vfolder_repository: VfolderRepository,
+        test_domain_name: str,
+        test_user: uuid.UUID,
+        test_project_id: uuid.UUID,
+        test_scaling_group: tuple[uuid.UUID, str],
+    ) -> None:
+        vfolder_id = await self._create_vfolder(
+            db_with_cleanup, domain_name=test_domain_name, user_id=test_user
+        )
+        sgroup_id, sgroup_name = test_scaling_group
+        await self._create_live_session_mounting(
+            db_with_cleanup,
+            vfolder_id=vfolder_id,
+            quota_scope_id=f"user:{test_user}",
+            domain_name=test_domain_name,
+            domain_id=await self._domain_id(db_with_cleanup, test_domain_name),
+            group_id=test_project_id,
+            user_id=test_user,
+            sgroup_id=sgroup_id,
+            sgroup_name=sgroup_name,
+        )
+
+        result = await vfolder_repository.delete_vfolders_forever([vfolder_id], force=True)
+
+        assert result.failures == []
+        assert [d.id for d in result.succeeded] == [vfolder_id]
+
+    async def test_active_endpoint_reference_returns_failure(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        vfolder_repository: VfolderRepository,
+        test_domain_name: str,
+        test_user: uuid.UUID,
+        test_project_id: uuid.UUID,
+        test_scaling_group: tuple[uuid.UUID, str],
+        test_image_id: uuid.UUID,
+        test_runtime_variant_id: uuid.UUID,
+    ) -> None:
+        vfolder_id = await self._create_vfolder(
+            db_with_cleanup, domain_name=test_domain_name, user_id=test_user
+        )
+        _sgroup_id, sgroup_name = test_scaling_group
+        await self._create_endpoint_with_model(
+            db_with_cleanup,
+            model_vfolder_id=vfolder_id,
+            domain_name=test_domain_name,
+            project_id=test_project_id,
+            user_id=test_user,
+            sgroup_name=sgroup_name,
+            image_id=test_image_id,
+            runtime_variant_id=test_runtime_variant_id,
+            lifecycle=EndpointLifecycle.READY,
+        )
+
+        result = await vfolder_repository.delete_vfolders_forever([vfolder_id])
+
+        assert result.succeeded == []
+        assert len(result.failures) == 1
+        assert isinstance(result.failures[0].exception, VFolderDeletionNotAllowed)
+        assert (
+            await self._vfolder_status(db_with_cleanup, vfolder_id)
+            == VFolderOperationStatus.DELETE_PENDING
+        )
+
+    async def test_destroyed_endpoint_reference_succeeds(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        vfolder_repository: VfolderRepository,
+        test_domain_name: str,
+        test_user: uuid.UUID,
+        test_project_id: uuid.UUID,
+        test_scaling_group: tuple[uuid.UUID, str],
+        test_image_id: uuid.UUID,
+        test_runtime_variant_id: uuid.UUID,
+    ) -> None:
+        vfolder_id = await self._create_vfolder(
+            db_with_cleanup, domain_name=test_domain_name, user_id=test_user
+        )
+        _sgroup_id, sgroup_name = test_scaling_group
+        # A destroyed endpoint no longer mounts the model — must not block purge.
+        await self._create_endpoint_with_model(
+            db_with_cleanup,
+            model_vfolder_id=vfolder_id,
+            domain_name=test_domain_name,
+            project_id=test_project_id,
+            user_id=test_user,
+            sgroup_name=sgroup_name,
+            image_id=test_image_id,
+            runtime_variant_id=test_runtime_variant_id,
+            lifecycle=EndpointLifecycle.DESTROYED,
+        )
+
+        result = await vfolder_repository.delete_vfolders_forever([vfolder_id])
+
+        assert result.failures == []
+        assert [d.id for d in result.succeeded] == [vfolder_id]
+
+    async def test_force_purges_endpoint_referenced_vfolder(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        vfolder_repository: VfolderRepository,
+        test_domain_name: str,
+        test_user: uuid.UUID,
+        test_project_id: uuid.UUID,
+        test_scaling_group: tuple[uuid.UUID, str],
+        test_image_id: uuid.UUID,
+        test_runtime_variant_id: uuid.UUID,
+    ) -> None:
+        vfolder_id = await self._create_vfolder(
+            db_with_cleanup, domain_name=test_domain_name, user_id=test_user
+        )
+        _sgroup_id, sgroup_name = test_scaling_group
+        await self._create_endpoint_with_model(
+            db_with_cleanup,
+            model_vfolder_id=vfolder_id,
+            domain_name=test_domain_name,
+            project_id=test_project_id,
+            user_id=test_user,
+            sgroup_name=sgroup_name,
+            image_id=test_image_id,
+            runtime_variant_id=test_runtime_variant_id,
+            lifecycle=EndpointLifecycle.READY,
+        )
+
+        result = await vfolder_repository.delete_vfolders_forever([vfolder_id], force=True)
+
+        assert result.failures == []
+        assert [d.id for d in result.succeeded] == [vfolder_id]
+
+    async def test_active_endpoint_extra_mount_returns_failure(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        vfolder_repository: VfolderRepository,
+        test_domain_name: str,
+        test_user: uuid.UUID,
+        test_project_id: uuid.UUID,
+        test_scaling_group: tuple[uuid.UUID, str],
+        test_image_id: uuid.UUID,
+        test_runtime_variant_id: uuid.UUID,
+    ) -> None:
+        vfolder_id = await self._create_vfolder(
+            db_with_cleanup, domain_name=test_domain_name, user_id=test_user
+        )
+        _sgroup_id, sgroup_name = test_scaling_group
+        # vfolder referenced as an EXTRA mount (not the model) of an active endpoint.
+        await self._create_endpoint_with_model(
+            db_with_cleanup,
+            model_vfolder_id=None,
+            domain_name=test_domain_name,
+            project_id=test_project_id,
+            user_id=test_user,
+            sgroup_name=sgroup_name,
+            image_id=test_image_id,
+            runtime_variant_id=test_runtime_variant_id,
+            lifecycle=EndpointLifecycle.READY,
+            extra_mount_vfolder_ids=[vfolder_id],
+        )
+
+        result = await vfolder_repository.delete_vfolders_forever([vfolder_id])
+
+        assert result.succeeded == []
+        assert len(result.failures) == 1
+        assert isinstance(result.failures[0].exception, VFolderDeletionNotAllowed)
+        assert (
+            await self._vfolder_status(db_with_cleanup, vfolder_id)
+            == VFolderOperationStatus.DELETE_PENDING
+        )
+
+    async def test_mounted_by_live_kernel_returns_failure(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        vfolder_repository: VfolderRepository,
+        test_domain_name: str,
+        test_user: uuid.UUID,
+        test_project_id: uuid.UUID,
+        test_scaling_group: tuple[uuid.UUID, str],
+    ) -> None:
+        vfolder_id = await self._create_vfolder(
+            db_with_cleanup, domain_name=test_domain_name, user_id=test_user
+        )
+        sgroup_id, sgroup_name = test_scaling_group
+        await self._create_live_kernel_mounting(
+            db_with_cleanup,
+            vfolder_id=vfolder_id,
+            quota_scope_id=f"user:{test_user}",
+            domain_name=test_domain_name,
+            domain_id=await self._domain_id(db_with_cleanup, test_domain_name),
+            group_id=test_project_id,
+            user_id=test_user,
+            sgroup_id=sgroup_id,
+            sgroup_name=sgroup_name,
+        )
+
+        result = await vfolder_repository.delete_vfolders_forever([vfolder_id])
+
+        assert result.succeeded == []
+        assert len(result.failures) == 1
+        assert isinstance(result.failures[0].exception, VFolderDeletionNotAllowed)
+        assert (
+            await self._vfolder_status(db_with_cleanup, vfolder_id)
+            == VFolderOperationStatus.DELETE_PENDING
+        )
 
 
 class TestVFolderRepositoryTrashAndRestore:

--- a/tests/unit/manager/services/vfolder/test_vfolder_crud_service.py
+++ b/tests/unit/manager/services/vfolder/test_vfolder_crud_service.py
@@ -950,7 +950,10 @@ class TestForceDeleteVFolderAction:
 
         assert isinstance(result, ForceDeleteVFolderActionResult)
         assert result.vfolder_uuid == vfolder_uuid
-        mock_vfolder_repository.delete_vfolders_forever.assert_called_once_with([vfolder_uuid])
+        # force_delete is the explicit escape hatch: it must bypass the in-use guards.
+        mock_vfolder_repository.delete_vfolders_forever.assert_called_once_with(
+            [vfolder_uuid], force=True
+        )
         mock_client = mock_storage_manager.get_manager_facing_client.return_value
         mock_client.delete_folder.assert_called_once()
 


### PR DESCRIPTION
## Summary
- Soft delete blocks removing a vfolder mounted by a live session, but **purge had no such guard** — a `ready` / mounted / model-service vfolder could be physically destroyed, causing irreversible data loss and dangling endpoints (hit in QA on a model-service model vfolder).
- Add an in-use guard to **both** purge paths (v1 `purge_vfolder`, v2 `delete_vfolders_forever`): reject when the vfolder is mounted by a live session/kernel, referenced as `model` or `extra_mounts` by an active endpoint, or not in a purgable status. Gated by an explicit `force` flag (default off).
- **v1 schema is unchanged** — `force` is surfaced only on the v2 surface (DTO / GraphQL / action / SDK / CLI `--force`); v1's `force_delete` endpoint stays the escape hatch.
- Centralize every vfolder reference in a purge-guard registry (`repositories/vfolder/purge_guards.py`) and add a schema-introspection **completeness test** so a newly added referencing column (FK or `VFolderMount`/`MountInfoEntry` JSONB) cannot silently bypass the guard. TEMPORARY until the soft references are normalized into FK junction tables.

## Test plan
- [ ] Repository guard tests: live-session mount / live-kernel mount / active-endpoint `model` / active-endpoint `extra_mounts` / non-purgable status are all rejected; `force=True` bypasses each; destroyed endpoint & unreferenced delete-complete vfolder succeed (no regression).
- [ ] Completeness test asserts every FK to `vfolders.id` and every `VFolderMount`/`MountInfoEntry` column is registered (verified it fails when a registration is removed).
- [ ] Service test: `force_delete` forwards `force=True`; `purge_v2` forwards `action.force`.
- [ ] CI: `pants check` + `pants test`.

Resolves BA-6726

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12621.org.readthedocs.build/en/12621/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12621.org.readthedocs.build/ko/12621/

<!-- readthedocs-preview sorna-ko end -->