### PR TITLE
feat(BA-6742): default model service shell to /bin/bash in revision inputs

### DIFF
--- a/changes/12622.feature.md
+++ b/changes/12622.feature.md
@@ -1,0 +1,1 @@
+Default the model service `shell` to `/bin/bash` in deployment revision inputs so string start commands run under a shell when `shell` is omitted

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -10445,7 +10445,7 @@ input ModelServiceConfigInput
   """
   Shell used to run the command. If set, the kernel runs `[shell, '-c', command]`; null or empty disables shell wrapping.
   """
-  shell: String = null
+  shell: String = "/bin/bash"
 
   """Port number for the model service."""
   port: Int = null

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -7140,7 +7140,7 @@ input ModelServiceConfigInput {
   """
   Shell used to run the command. If set, the kernel runs `[shell, '-c', command]`; null or empty disables shell wrapping.
   """
-  shell: String = null
+  shell: String = "/bin/bash"
 
   """Port number for the model service."""
   port: Int = null

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -3504,7 +3504,7 @@
                 "type": "null"
               }
             ],
-            "default": null,
+            "default": "/bin/bash",
             "description": "Shell used to run the command. If set, the kernel runs `[shell, '-c', command]`; null or empty disables shell wrapping.",
             "title": "Shell"
           },

--- a/src/ai/backend/common/dto/manager/v2/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/request.py
@@ -13,6 +13,7 @@ from pydantic import Field, field_validator
 
 from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
 from ai.backend.common.config import (
+    DEFAULT_SHELL,
     ModelDefinitionDraft,
     PreStartAction,
 )
@@ -153,7 +154,7 @@ class ModelServiceConfigInput(BaseRequestModel):
     command: str | None = None
     start_command: list[str] | None = None
     shell: str | None = Field(
-        default=None,
+        default=DEFAULT_SHELL,
         description=(
             "Shell used to run the command. If set, the kernel runs "
             "`[shell, '-c', command]`; null or empty disables shell wrapping."

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -14,6 +14,9 @@ from strawberry.relay import Connection, Edge, NodeID
 from strawberry.scalars import JSON
 
 from ai.backend.common.config import (
+    DEFAULT_SHELL,
+)
+from ai.backend.common.config import (
     PreStartAction as PreStartActionDTO,
 )
 from ai.backend.common.dto.manager.v2.deployment.request import (
@@ -1006,7 +1009,7 @@ class ModelServiceConfigInputGQL(PydanticInputMixin[ModelServiceConfigInputDTO])
             "Shell used to run the command. If set, the kernel runs "
             "`[shell, '-c', command]`; null or empty disables shell wrapping."
         ),
-        default=None,
+        default=DEFAULT_SHELL,
     )
     port: int | None = gql_field(description="Port number for the model service.", default=None)
     health_check: ModelHealthCheckInputGQL | None = gql_field(

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -444,7 +444,7 @@ class ModelServiceConfigGQL:
             "Shell used to run the command. If set, the kernel runs "
             "`[shell, '-c', command]`; null or empty disables shell wrapping."
         ),
-        default="/bin/bash",
+        default=None,
     )
     port: int = gql_field(description="Port number for the model service.")
     health_check: ModelHealthCheckGQL | None = gql_field(


### PR DESCRIPTION
## Summary
- Omitting `shell` in `CreateRevisionInput.model_definition` resolved to an explicit `null` (the GQL layer materializes omitted optional fields as `null`), so string start-commands were shlex-split instead of run under a shell — multiline and shell-syntax commands silently broke (the first token swallowed the rest as literal argv).
- Set the documented default `/bin/bash` on `ModelServiceConfigInput.shell` (v2 DTO + GQL input), so omission now means "run under /bin/bash" while an explicit `null` still disables shell wrapping.
- Regenerated `supergraph.graphql` / `v2-schema.graphql` / `openapi.json` snapshots.

## Test plan
- [x] GQL omission path: `ModelServiceConfigInputGQL(command=...)` → DTO → draft merge → resolved `shell == "/bin/bash"`
- [x] GQL explicit-null path still resolves to `null` (shell wrapping disabled)
- [x] Live e2e: deployment with a multiline string `command` and no `shell` starts the server, setup lines run in order, `/health` returns 200
- [x] `pants lint check test` on touched targets

Part of BA-6742

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12622.org.readthedocs.build/en/12622/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12622.org.readthedocs.build/ko/12622/

<!-- readthedocs-preview sorna-ko end -->