### PR TITLE
fix(BA-6717): apply resource group default_session_options to enqueued sessions (#12559)

### DIFF
--- a/changes/12559.fix.md
+++ b/changes/12559.fix.md
@@ -1,0 +1,1 @@
+Apply resource group `default_session_options` (handler_options and resource_opts) to enqueued sessions instead of silently ignoring them.

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -120,7 +120,6 @@ from ai.backend.manager.data.session.draft import (
 from ai.backend.manager.data.session.options import (
     InternalDataExtras,
     ResourceOpts,
-    SessionHandlerOptions,
 )
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.models.resource_slot import ResourceAllocationRow
@@ -1019,7 +1018,10 @@ class AgentRegistry:
         resource_entries = self._resource_entries_from_legacy_dict(
             creation_config.get("resources") or {}
         )
-        resource_opts = ResourceOpts.model_validate(creation_config.get("resource_opts") or {})
+        resource_opts_payload = creation_config.get("resource_opts") or {}
+        resource_opts = (
+            ResourceOpts.model_validate(resource_opts_payload) if resource_opts_payload else None
+        )
         environ_dict = dict(creation_config.get("environ") or {})
         preopen_ports = tuple(creation_config.get("preopen_ports") or ())
         # Session-level fields (callback, dependencies, etc.) flow onto
@@ -1157,7 +1159,7 @@ class AgentRegistry:
                     designated_agents=tuple(AgentId(a) for a in (agent_list or ())),
                 ),
                 kernel_groups=tuple(groups_by_role.values()),
-                handler_options=SessionHandlerOptions(),
+                handler_options=None,
             ),
             internal_data_extras=InternalDataExtras(
                 sudo_session_enabled=sudo_session_enabled,

--- a/src/ai/backend/manager/services/model_serving/services/model_serving.py
+++ b/src/ai/backend/manager/services/model_serving/services/model_serving.py
@@ -80,7 +80,6 @@ from ai.backend.manager.data.session.draft import (
 from ai.backend.manager.data.session.options import (
     InternalDataExtras,
     ResourceOpts,
-    SessionHandlerOptions,
 )
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.data.vfolder.types import VFolderOwnershipType
@@ -438,7 +437,10 @@ class ModelServingService:
             service_prepare_ctx.extra_mounts,
         )
         resource_entries = self._resource_entries_from_config(action.config.resources)
-        resource_opts = ResourceOpts.model_validate(action.config.resource_opts or {})
+        resource_opts_payload = action.config.resource_opts or {}
+        resource_opts = (
+            ResourceOpts.model_validate(resource_opts_payload) if resource_opts_payload else None
+        )
         environ = dict(action.config.environ or {})
         callback_url = URL(action.callback_url.unicode_string()) if action.callback_url else None
         kernel_groups = await self._resolve_kernel_groups(
@@ -489,7 +491,7 @@ class ModelServingService:
                 cluster_size=action.cluster_size,
                 scheduling_target=SchedulingTargetDraft(),
                 kernel_groups=kernel_groups,
-                handler_options=SessionHandlerOptions(),
+                handler_options=None,
             ),
             internal_data_extras=InternalDataExtras(
                 sudo_session_enabled=sudo_session_enabled,

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -65,7 +65,6 @@ from ai.backend.manager.data.session.draft import (
 from ai.backend.manager.data.session.options import (
     InternalDataExtras,
     ResourceOpts,
-    SessionHandlerOptions,
 )
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.defs import DEFAULT_ROLE
@@ -1557,7 +1556,9 @@ class SessionService:
         resource_opts_payload: dict[str, Any] = {}
         if action.resource.shmem is not None:
             resource_opts_payload["shmem"] = BinarySize.from_str(action.resource.shmem)
-        resource_opts = ResourceOpts.model_validate(resource_opts_payload)
+        resource_opts = (
+            ResourceOpts.model_validate(resource_opts_payload) if resource_opts_payload else None
+        )
 
         mount_entries = tuple(action.mounts or ())
 
@@ -1638,7 +1639,7 @@ class SessionService:
                     ),
                 ),
                 kernel_groups=kernel_groups,
-                handler_options=SessionHandlerOptions(),
+                handler_options=None,
             ),
             internal_data_extras=InternalDataExtras(
                 sudo_session_enabled=False,

--- a/src/ai/backend/manager/sokovan/deployment/deployment_draft_builder.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_draft_builder.py
@@ -41,7 +41,6 @@ from ai.backend.manager.data.session.draft import (
 from ai.backend.manager.data.session.options import (
     InternalDataExtras,
     ResourceOpts,
-    SessionHandlerOptions,
 )
 from ai.backend.manager.defs import DEFAULT_ROLE
 from ai.backend.manager.errors.deployment import RevisionMissingModelVFolder
@@ -71,8 +70,9 @@ class DeploymentSessionDraftBuilder:
         startup_command = target_revision.execution.startup_command
         mounts = cls._resolve_mounts(target_revision)
         resource_entries = cls._resource_entries(target_revision)
-        resource_opts = ResourceOpts.model_validate(
-            dict(target_revision.resource_config.resource_opts) or {}
+        resource_opts_payload = dict(target_revision.resource_config.resource_opts) or {}
+        resource_opts = (
+            ResourceOpts.model_validate(resource_opts_payload) if resource_opts_payload else None
         )
         model_definition_payload = cls._model_definition_payload(target_revision, context)
 
@@ -119,7 +119,7 @@ class DeploymentSessionDraftBuilder:
                 cluster_size=target_revision.cluster_config.size,
                 scheduling_target=SchedulingTargetDraft(),
                 kernel_groups=kernel_groups,
-                handler_options=SessionHandlerOptions(),
+                handler_options=None,
             ),
             internal_data_extras=InternalDataExtras(
                 sudo_session_enabled=context.session_owner.sudo_session_enabled,

--- a/tests/unit/manager/services/session/test_session_service.py
+++ b/tests/unit/manager/services/session/test_session_service.py
@@ -19,6 +19,7 @@ from ai.backend.common.exception import InvalidAPIParameters
 from ai.backend.common.identifier.resource_group import ResourceGroupName
 from ai.backend.common.types import (
     AccessKey,
+    BinarySize,
     ClusterMode,
     KernelId,
     ResourceSlot,
@@ -1830,4 +1831,103 @@ class TestEnqueueSession:
 
         mock_scheduler_repository.pick_default_resource_group.assert_not_called()
         draft = mock_scheduling_controller.enqueue_session_from_draft.await_args.args[0]
-        assert str(draft.scope.resource_group_name) == "user-picked-rg"
+        assert draft.scope.resource_group_id == requested_resource_group_id
+        assert draft.scope.resource_group_name == ResourceGroupName("requested-rg")
+
+    async def test_uses_user_supplied_resource_group_id(
+        self,
+        configured_session_service: SessionService,
+        mock_scheduler_repository: MagicMock,
+        mock_scheduling_controller: MagicMock,
+        enqueue_action_without_rg: EnqueueSessionAction,
+        requested_resource_group_id: ResourceGroupID,
+    ) -> None:
+        """When the caller supplies a resource group id, only its name is
+        looked up: no auto-picking.
+        """
+        action = EnqueueSessionAction(
+            session_name=enqueue_action_without_rg.session_name,
+            session_type=enqueue_action_without_rg.session_type,
+            image_id=enqueue_action_without_rg.image_id,
+            resource=SessionResourceSpec(
+                entries=enqueue_action_without_rg.resource.entries,
+                resource_group_id=requested_resource_group_id,
+            ),
+            scheduling=enqueue_action_without_rg.scheduling,
+            user_id=enqueue_action_without_rg.user_id,
+            access_key=enqueue_action_without_rg.access_key,
+            domain_name=enqueue_action_without_rg.domain_name,
+            group_id=enqueue_action_without_rg.group_id,
+        )
+
+        await configured_session_service.enqueue_session(action)
+
+        mock_scheduler_repository.pick_default_resource_group.assert_not_called()
+        mock_scheduler_repository.get_resource_group_id_by_name.assert_not_called()
+        mock_scheduler_repository.get_resource_group_name_by_id.assert_awaited_once_with(
+            requested_resource_group_id
+        )
+        draft = mock_scheduling_controller.enqueue_session_from_draft.await_args.args[0]
+        assert draft.scope.resource_group_id == requested_resource_group_id
+        assert draft.scope.resource_group_name == ResourceGroupName("requested-rg")
+
+    async def test_leaves_handler_options_unset_for_rg_defaults(
+        self,
+        configured_session_service: SessionService,
+        mock_scheduling_controller: MagicMock,
+        enqueue_action_without_rg: EnqueueSessionAction,
+    ) -> None:
+        """The enqueue draft leaves handler_options unset so the resource-group
+        default can fill it downstream instead of being shadowed by a default.
+        """
+        await configured_session_service.enqueue_session(enqueue_action_without_rg)
+
+        draft = mock_scheduling_controller.enqueue_session_from_draft.await_args.args[0]
+        assert draft.options.handler_options is None
+
+    async def test_leaves_resource_opts_unset_when_shmem_omitted(
+        self,
+        configured_session_service: SessionService,
+        mock_scheduling_controller: MagicMock,
+        enqueue_action_without_rg: EnqueueSessionAction,
+    ) -> None:
+        """The execution spec leaves resource_opts unset when the caller gives
+        no shmem, so the resource-group default can fill it.
+        """
+        await configured_session_service.enqueue_session(enqueue_action_without_rg)
+
+        draft = mock_scheduling_controller.enqueue_session_from_draft.await_args.args[0]
+        assert draft.options.kernel_groups is not None
+        assert draft.options.kernel_groups[0].execution_spec.resource_input.resource_opts is None
+
+    async def test_keeps_resource_opts_when_shmem_supplied(
+        self,
+        configured_session_service: SessionService,
+        mock_scheduling_controller: MagicMock,
+        enqueue_action_without_rg: EnqueueSessionAction,
+    ) -> None:
+        """A caller-supplied shmem is preserved on the execution spec's
+        resource_opts rather than being dropped to None.
+        """
+        action = EnqueueSessionAction(
+            session_name=enqueue_action_without_rg.session_name,
+            session_type=enqueue_action_without_rg.session_type,
+            image_id=enqueue_action_without_rg.image_id,
+            resource=SessionResourceSpec(
+                entries=enqueue_action_without_rg.resource.entries,
+                shmem="256m",
+            ),
+            scheduling=enqueue_action_without_rg.scheduling,
+            user_id=enqueue_action_without_rg.user_id,
+            access_key=enqueue_action_without_rg.access_key,
+            domain_name=enqueue_action_without_rg.domain_name,
+            group_id=enqueue_action_without_rg.group_id,
+        )
+
+        await configured_session_service.enqueue_session(action)
+
+        draft = mock_scheduling_controller.enqueue_session_from_draft.await_args.args[0]
+        assert draft.options.kernel_groups is not None
+        resource_opts = draft.options.kernel_groups[0].execution_spec.resource_input.resource_opts
+        assert resource_opts is not None
+        assert resource_opts.shmem == BinarySize.from_str("256m")

--- a/tests/unit/manager/services/session/test_session_service.py
+++ b/tests/unit/manager/services/session/test_session_service.py
@@ -1831,45 +1831,7 @@ class TestEnqueueSession:
 
         mock_scheduler_repository.pick_default_resource_group.assert_not_called()
         draft = mock_scheduling_controller.enqueue_session_from_draft.await_args.args[0]
-        assert draft.scope.resource_group_id == requested_resource_group_id
-        assert draft.scope.resource_group_name == ResourceGroupName("requested-rg")
-
-    async def test_uses_user_supplied_resource_group_id(
-        self,
-        configured_session_service: SessionService,
-        mock_scheduler_repository: MagicMock,
-        mock_scheduling_controller: MagicMock,
-        enqueue_action_without_rg: EnqueueSessionAction,
-        requested_resource_group_id: ResourceGroupID,
-    ) -> None:
-        """When the caller supplies a resource group id, only its name is
-        looked up: no auto-picking.
-        """
-        action = EnqueueSessionAction(
-            session_name=enqueue_action_without_rg.session_name,
-            session_type=enqueue_action_without_rg.session_type,
-            image_id=enqueue_action_without_rg.image_id,
-            resource=SessionResourceSpec(
-                entries=enqueue_action_without_rg.resource.entries,
-                resource_group_id=requested_resource_group_id,
-            ),
-            scheduling=enqueue_action_without_rg.scheduling,
-            user_id=enqueue_action_without_rg.user_id,
-            access_key=enqueue_action_without_rg.access_key,
-            domain_name=enqueue_action_without_rg.domain_name,
-            group_id=enqueue_action_without_rg.group_id,
-        )
-
-        await configured_session_service.enqueue_session(action)
-
-        mock_scheduler_repository.pick_default_resource_group.assert_not_called()
-        mock_scheduler_repository.get_resource_group_id_by_name.assert_not_called()
-        mock_scheduler_repository.get_resource_group_name_by_id.assert_awaited_once_with(
-            requested_resource_group_id
-        )
-        draft = mock_scheduling_controller.enqueue_session_from_draft.await_args.args[0]
-        assert draft.scope.resource_group_id == requested_resource_group_id
-        assert draft.scope.resource_group_name == ResourceGroupName("requested-rg")
+        assert str(draft.scope.resource_group_name) == "user-picked-rg"
 
     async def test_leaves_handler_options_unset_for_rg_defaults(
         self,
@@ -1898,7 +1860,7 @@ class TestEnqueueSession:
 
         draft = mock_scheduling_controller.enqueue_session_from_draft.await_args.args[0]
         assert draft.options.kernel_groups is not None
-        assert draft.options.kernel_groups[0].execution_spec.resource_input.resource_opts is None
+        assert draft.options.kernel_groups[0].execution_spec.resource_opts is None
 
     async def test_keeps_resource_opts_when_shmem_supplied(
         self,
@@ -1928,6 +1890,6 @@ class TestEnqueueSession:
 
         draft = mock_scheduling_controller.enqueue_session_from_draft.await_args.args[0]
         assert draft.options.kernel_groups is not None
-        resource_opts = draft.options.kernel_groups[0].execution_spec.resource_input.resource_opts
+        resource_opts = draft.options.kernel_groups[0].execution_spec.resource_opts
         assert resource_opts is not None
         assert resource_opts.shmem == BinarySize.from_str("256m")

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_merge_resource_group_defaults_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_merge_resource_group_defaults_rule.py
@@ -67,11 +67,9 @@ def rg_defaults(rg_image_id: ImageID) -> DefaultSessionOptions:
         ),
         agent_selection_policy=AgentSelectionPolicy.STRICT,
         default_kernel_execution_spec=KernelExecutionSpec(
-            resource_input=KernelResourceConfig(
-                image_id=rg_image_id,
-                resources=[ResourceSlotEntry(resource_type="cpu", quantity="2")],
-                resource_opts=ResourceOpts(shmem=BinarySize(128 * 1024 * 1024)),
-            ),
+            image_id=rg_image_id,
+            resources=[ResourceSlotEntry(resource_type="cpu", quantity="2")],
+            resource_opts=ResourceOpts(shmem=BinarySize(128 * 1024 * 1024)),
             environ={"RG_BASE": "1"},
             startup_command="rg-start",
             bootstrap_script="rg-bootstrap",
@@ -144,9 +142,7 @@ class TestMergeResourceGroupDefaultsRule:
         assert merged.environ == {"RG_BASE": "1"}
         assert merged.startup_command == "rg-start"
         assert merged.bootstrap_script == "rg-bootstrap"
-        assert merged.resource_input.resource_opts == ResourceOpts(
-            shmem=BinarySize(128 * 1024 * 1024)
-        )
+        assert merged.resource_opts == ResourceOpts(shmem=BinarySize(128 * 1024 * 1024))
 
     async def test_preserves_caller_execution_spec_over_rg(
         self,

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_merge_resource_group_defaults_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_merge_resource_group_defaults_rule.py
@@ -19,7 +19,7 @@ import uuid
 import pytest
 
 from ai.backend.common.identifier.image import ImageID
-from ai.backend.common.types import ClusterMode, ResourceSlotEntry
+from ai.backend.common.types import BinarySize, ClusterMode, ResourceSlotEntry
 from ai.backend.manager.data.session.draft import (
     KernelExecutionSpecDraft,
     KernelGroupDraft,
@@ -61,12 +61,17 @@ def rg_defaults(rg_image_id: ImageID) -> DefaultSessionOptions:
         is_preemptible=False,
         cluster_mode=ClusterMode.MULTI_NODE,
         default_failure_policy=FailurePolicy.STRICT,
-        handler_options=SessionHandlerOptions(default=HandlerOptions(timeout=60), by_handler={}),
+        handler_options=SessionHandlerOptions(
+            default=HandlerOptions(timeout=60),
+            by_handler={"schedule-sessions": HandlerOptions(max_retry_count=1)},
+        ),
         agent_selection_policy=AgentSelectionPolicy.STRICT,
         default_kernel_execution_spec=KernelExecutionSpec(
-            image_id=rg_image_id,
-            resources=[ResourceSlotEntry(resource_type="cpu", quantity="2")],
-            resource_opts=ResourceOpts(),
+            resource_input=KernelResourceConfig(
+                image_id=rg_image_id,
+                resources=[ResourceSlotEntry(resource_type="cpu", quantity="2")],
+                resource_opts=ResourceOpts(shmem=BinarySize(128 * 1024 * 1024)),
+            ),
             environ={"RG_BASE": "1"},
             startup_command="rg-start",
             bootstrap_script="rg-bootstrap",
@@ -91,7 +96,8 @@ class TestMergeResourceGroupDefaultsRule:
         assert opts.is_preemptible is False
         assert opts.cluster_mode == ClusterMode.MULTI_NODE
         assert opts.handler_options == SessionHandlerOptions(
-            default=HandlerOptions(timeout=60), by_handler={}
+            default=HandlerOptions(timeout=60),
+            by_handler={"schedule-sessions": HandlerOptions(max_retry_count=1)},
         )
         assert opts.scheduling_target.agent_selection_policy == AgentSelectionPolicy.STRICT
 
@@ -138,6 +144,9 @@ class TestMergeResourceGroupDefaultsRule:
         assert merged.environ == {"RG_BASE": "1"}
         assert merged.startup_command == "rg-start"
         assert merged.bootstrap_script == "rg-bootstrap"
+        assert merged.resource_input.resource_opts == ResourceOpts(
+            shmem=BinarySize(128 * 1024 * 1024)
+        )
 
     async def test_preserves_caller_execution_spec_over_rg(
         self,


### PR DESCRIPTION
This is an auto-generated backport PR of #12559 to the 26.4 release.