### PR TITLE
feat(BA-6745): add PreemptionConfig.enabled toggle and preemption_min_runtime

### DIFF
--- a/changes/12627.feature.md
+++ b/changes/12627.feature.md
@@ -1,0 +1,1 @@
+Add an `enabled` toggle and a `preemption_min_runtime` duration to resource group preemption configuration, exposed via GraphQL and REST v2.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -12690,6 +12690,9 @@ type PredefinedAtomicPermission
 type PreemptionConfig
   @join__type(graph: STRAWBERRY)
 {
+  """Whether preemption is enabled for this resource group (opt-in)."""
+  enabled: Boolean!
+
   """Sessions with priority <= this value are eligible for preemption."""
   preemptiblePriority: Int!
 
@@ -12698,12 +12701,22 @@ type PreemptionConfig
 
   """How to preempt a session when preemption is triggered."""
   mode: PreemptionMode!
+
+  """
+  Minimum session runtime in seconds before it becomes preemptible (0 = disabled).
+  """
+  preemptionMinRuntime: Float!
 }
 
 """Added in 26.3.0. Input for preemption configuration."""
 input PreemptionConfigInput
   @join__type(graph: STRAWBERRY)
 {
+  """
+  Added in 26.8.0. Whether preemption is enabled for this resource group (opt-in). Default is false.
+  """
+  enabled: Boolean! = false
+
   """Sessions with priority <= this value are preemptible. Default is 5."""
   preemptiblePriority: Int! = 5
 
@@ -12714,6 +12727,11 @@ input PreemptionConfigInput
 
   """How to preempt sessions (TERMINATE, RESCHEDULE). Default is TERMINATE."""
   mode: PreemptionMode! = TERMINATE
+
+  """
+  Added in 26.8.0. Minimum session runtime in seconds before it becomes preemptible (0 = disabled). Default is 0.
+  """
+  preemptionMinRuntime: Float! = 0
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -8427,6 +8427,9 @@ input PreStartActionInput {
 
 """Added in 26.3.0. Preemption configuration for a resource group."""
 type PreemptionConfig {
+  """Whether preemption is enabled for this resource group (opt-in)."""
+  enabled: Boolean!
+
   """Sessions with priority <= this value are eligible for preemption."""
   preemptiblePriority: Int!
 
@@ -8435,10 +8438,20 @@ type PreemptionConfig {
 
   """How to preempt a session when preemption is triggered."""
   mode: PreemptionMode!
+
+  """
+  Minimum session runtime in seconds before it becomes preemptible (0 = disabled).
+  """
+  preemptionMinRuntime: Float!
 }
 
 """Added in 26.3.0. Input for preemption configuration."""
 input PreemptionConfigInput {
+  """
+  Added in 26.8.0. Whether preemption is enabled for this resource group (opt-in). Default is false.
+  """
+  enabled: Boolean! = false
+
   """Sessions with priority <= this value are preemptible. Default is 5."""
   preemptiblePriority: Int! = 5
 
@@ -8449,6 +8462,11 @@ input PreemptionConfigInput {
 
   """How to preempt sessions (TERMINATE, RESCHEDULE). Default is TERMINATE."""
   mode: PreemptionMode! = TERMINATE
+
+  """
+  Added in 26.8.0. Minimum session runtime in seconds before it becomes preemptible (0 = disabled). Default is 0.
+  """
+  preemptionMinRuntime: Float! = 0
 }
 
 """

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -19065,6 +19065,12 @@
       "PreemptionConfigInputDTO": {
         "description": "Input for preemption configuration.",
         "properties": {
+          "enabled": {
+            "default": false,
+            "description": "Whether preemption is enabled for this resource group (opt-in).",
+            "title": "Enabled",
+            "type": "boolean"
+          },
           "preemptible_priority": {
             "default": 5,
             "description": "Sessions with priority <= this value are eligible for preemption.",
@@ -19082,6 +19088,13 @@
             "description": "How to preempt sessions (terminate/reschedule).",
             "title": "Mode",
             "type": "string"
+          },
+          "preemption_min_runtime": {
+            "default": 0.0,
+            "description": "Minimum session runtime in seconds before it becomes preemptible (0 = disabled).",
+            "minimum": 0.0,
+            "title": "Preemption Min Runtime",
+            "type": "number"
           }
         },
         "title": "PreemptionConfigInputDTO",

--- a/src/ai/backend/common/dto/manager/v2/resource_group/request.py
+++ b/src/ai/backend/common/dto/manager/v2/resource_group/request.py
@@ -186,6 +186,10 @@ class ResourceWeightEntryInput(BaseRequestModel):
 class PreemptionConfigInputDTO(BaseRequestModel):
     """Input for preemption configuration."""
 
+    enabled: bool = Field(
+        default=False,
+        description="Whether preemption is enabled for this resource group (opt-in).",
+    )
     preemptible_priority: int = Field(
         default=5,
         description="Sessions with priority <= this value are eligible for preemption.",
@@ -197,6 +201,13 @@ class PreemptionConfigInputDTO(BaseRequestModel):
     mode: str = Field(
         default="terminate",
         description="How to preempt sessions (terminate/reschedule).",
+    )
+    preemption_min_runtime: float = Field(
+        default=0.0,
+        ge=0.0,
+        description=(
+            "Minimum session runtime in seconds before it becomes preemptible (0 = disabled)."
+        ),
     )
 
 

--- a/src/ai/backend/common/dto/manager/v2/resource_group/response.py
+++ b/src/ai/backend/common/dto/manager/v2/resource_group/response.py
@@ -117,6 +117,9 @@ class AdminSearchResourceGroupsPayload(BaseResponseModel):
 class PreemptionConfigInfo(BaseResponseModel):
     """Preemption configuration DTO."""
 
+    enabled: bool = Field(
+        description="Whether preemption is enabled for this resource group (opt-in)."
+    )
     preemptible_priority: int = Field(
         description="Sessions with priority <= this value are eligible for preemption."
     )
@@ -125,6 +128,11 @@ class PreemptionConfigInfo(BaseResponseModel):
     )
     mode: PreemptionModeDTO = Field(
         description="How to preempt a session when preemption is triggered."
+    )
+    preemption_min_runtime: float = Field(
+        description=(
+            "Minimum session runtime in seconds before it becomes preemptible (0 = disabled)."
+        )
     )
 
 

--- a/src/ai/backend/common/dto/manager/v2/scaling_group/request.py
+++ b/src/ai/backend/common/dto/manager/v2/scaling_group/request.py
@@ -19,6 +19,10 @@ __all__ = (
 class PreemptionConfigInput(BaseRequestModel):
     """Input for preemption configuration."""
 
+    enabled: bool = Field(
+        default=False,
+        description="Whether preemption is enabled for this scaling group (opt-in). Default is false.",
+    )
     preemptible_priority: int = Field(
         default=5,
         ge=1,
@@ -32,6 +36,14 @@ class PreemptionConfigInput(BaseRequestModel):
     mode: PreemptionMode = Field(
         default=PreemptionMode.TERMINATE,
         description="Preemption mode (terminate or reschedule).",
+    )
+    preemption_min_runtime: float = Field(
+        default=0.0,
+        ge=0.0,
+        description=(
+            "Minimum session runtime in seconds before it becomes preemptible "
+            "(0 = disabled). Default is 0."
+        ),
     )
 
 

--- a/src/ai/backend/common/dto/manager/v2/scaling_group/response.py
+++ b/src/ai/backend/common/dto/manager/v2/scaling_group/response.py
@@ -61,6 +61,9 @@ class ScalingGroupNetworkInfo(BaseResponseModel):
 class PreemptionConfigInfo(BaseResponseModel):
     """Preemption configuration for a scaling group."""
 
+    enabled: bool = Field(
+        description="Whether preemption is enabled for this scaling group (opt-in).",
+    )
     preemptible_priority: int = Field(
         description="Priority of preemptible sessions (1=lowest, 10=highest).",
     )
@@ -69,6 +72,11 @@ class PreemptionConfigInfo(BaseResponseModel):
     )
     mode: PreemptionMode = Field(
         description="How to preempt a session when preemption is triggered.",
+    )
+    preemption_min_runtime: float = Field(
+        description=(
+            "Minimum session runtime in seconds before it becomes preemptible (0 = disabled)."
+        ),
     )
 
 

--- a/src/ai/backend/manager/api/adapters/resource_group/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_group/adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
@@ -611,9 +612,13 @@ class ResourceGroupAdapter(BaseAdapter):
         if input.preemption is not None:
             preemption_config_state = OptionalState.update(
                 DataPreemptionConfig(
+                    enabled=input.preemption.enabled,
                     preemptible_priority=input.preemption.preemptible_priority,
                     order=PreemptionOrder(input.preemption.order),
                     mode=PreemptionMode(input.preemption.mode),
+                    preemption_min_runtime=timedelta(
+                        seconds=input.preemption.preemption_min_runtime
+                    ),
                 )
             )
 
@@ -787,9 +792,11 @@ class ResourceGroupAdapter(BaseAdapter):
             scheduler=ResourceGroupSchedulerConfigInfo(
                 type=SchedulerTypeDTO(data.scheduler.name.value),
                 preemption=PreemptionConfigInfo(
+                    enabled=data.scheduler.options.preemption.enabled,
                     preemptible_priority=data.scheduler.options.preemption.preemptible_priority,
                     order=PreemptionOrderDTO(data.scheduler.options.preemption.order.value),
                     mode=PreemptionModeDTO(data.scheduler.options.preemption.mode.value),
+                    preemption_min_runtime=data.scheduler.options.preemption.preemption_min_runtime.total_seconds(),
                 ),
             ),
             default_deployment_options=deployment_options_to_info(data.default_deployment_options),

--- a/src/ai/backend/manager/api/gql/resource_group/types.py
+++ b/src/ai/backend/manager/api/gql/resource_group/types.py
@@ -80,6 +80,7 @@ from ai.backend.common.dto.manager.v2.resource_group.response import (
 from ai.backend.common.dto.manager.v2.resource_group.response import (
     ReplaceResourceGroupDefaultSessionOptionsPayload as ReplaceResourceGroupDefaultSessionOptionsPayloadDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import OrderDirection, StringFilter
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -185,6 +186,12 @@ class PreemptionOrderGQL(StrEnum):
 class PreemptionConfigGQL(PydanticOutputMixin[PreemptionConfigInfo]):
     """Preemption configuration for GraphQL."""
 
+    enabled: bool = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Whether preemption is enabled for this resource group (opt-in).",
+        )
+    )
     preemptible_priority: int = gql_field(
         description="Sessions with priority <= this value are eligible for preemption."
     )
@@ -193,6 +200,14 @@ class PreemptionConfigGQL(PydanticOutputMixin[PreemptionConfigInfo]):
     )
     mode: PreemptionModeGQL = gql_field(
         description="How to preempt a session when preemption is triggered."
+    )
+    preemption_min_runtime: float = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Minimum session runtime in seconds before it becomes preemptible (0 = disabled)."
+            ),
+        )
     )
 
 
@@ -449,6 +464,13 @@ class ResourceGroupOrderByGQL(PydanticInputMixin[ResourceGroupOrderDTO]):
 class PreemptionConfigInput(PydanticInputMixin[PreemptionConfigInputDTO]):
     """Input for preemption configuration. Replaces entire preemption config when provided."""
 
+    enabled: bool = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Whether preemption is enabled for this resource group (opt-in). Default is false.",
+        ),
+        default=False,
+    )
     preemptible_priority: int = gql_field(
         description="Sessions with priority <= this value are preemptible. Default is 5.", default=5
     )
@@ -459,6 +481,16 @@ class PreemptionConfigInput(PydanticInputMixin[PreemptionConfigInputDTO]):
     mode: PreemptionModeGQL = gql_field(
         description="How to preempt sessions (TERMINATE, RESCHEDULE). Default is TERMINATE.",
         default=PreemptionModeGQL.TERMINATE,
+    )
+    preemption_min_runtime: float = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Minimum session runtime in seconds before it becomes preemptible "
+                "(0 = disabled). Default is 0."
+            ),
+        ),
+        default=0.0,
     )
 
 

--- a/src/ai/backend/manager/data/scaling_group/types.py
+++ b/src/ai/backend/manager/data/scaling_group/types.py
@@ -68,9 +68,11 @@ class ScalingGroupDriverConfig:
 class PreemptionConfig:
     """Preemption configuration for a scaling group."""
 
+    enabled: bool = False
     preemptible_priority: int = 5
     order: PreemptionOrder = PreemptionOrder.OLDEST
     mode: PreemptionMode = PreemptionMode.TERMINATE
+    preemption_min_runtime: timedelta = timedelta(seconds=0)
 
 
 @dataclass
@@ -99,9 +101,11 @@ class ScalingGroupSchedulerOptions:
             "allow_fractional_resource_fragmentation": self.allow_fractional_resource_fragmentation,
             "route_cleanup_target_statuses": self.route_cleanup_target_statuses,
             "preemption": {
+                "enabled": self.preemption.enabled,
                 "preemptible_priority": self.preemption.preemptible_priority,
                 "order": self.preemption.order.value,
                 "mode": self.preemption.mode.value,
+                "preemption_min_runtime": self.preemption.preemption_min_runtime.total_seconds(),
             },
         }
 

--- a/src/ai/backend/manager/models/scaling_group/row.py
+++ b/src/ai/backend/manager/models/scaling_group/row.py
@@ -89,6 +89,9 @@ __all__: Sequence[str] = (
 class PreemptionConfig(BackendAISchema):
     model_config = ConfigDict(frozen=True)
 
+    enabled: bool = False
+    """Whether preemption is enabled for this resource group (opt-in)"""
+
     preemptible_priority: int = 5
     """Sessions with priority <= this value are preemptible"""
 
@@ -98,6 +101,9 @@ class PreemptionConfig(BackendAISchema):
     mode: PreemptionMode = PreemptionMode.TERMINATE
     """How to preempt sessions"""
 
+    preemption_min_runtime: timedelta = timedelta(seconds=0)
+    """Minimum session runtime before it becomes preemptible (0 = disabled)"""
+
     @field_serializer("order", mode="plain")
     def serialize_order(self, value: PreemptionOrder) -> str:
         return value.value
@@ -105,6 +111,10 @@ class PreemptionConfig(BackendAISchema):
     @field_serializer("mode", mode="plain")
     def serialize_mode(self, value: PreemptionMode) -> str:
         return value.value
+
+    @field_serializer("preemption_min_runtime", mode="plain")
+    def serialize_preemption_min_runtime(self, value: timedelta) -> float:
+        return value.total_seconds()
 
 
 class ScalingGroupOpts(BackendAISchema):
@@ -402,9 +412,11 @@ class ScalingGroupRow(Base):  # type: ignore[misc]
                     allow_fractional_resource_fragmentation=self.scheduler_opts.allow_fractional_resource_fragmentation,
                     route_cleanup_target_statuses=self.scheduler_opts.route_cleanup_target_statuses,
                     preemption=DataPreemptionConfig(
+                        enabled=self.scheduler_opts.preemption.enabled,
                         preemptible_priority=self.scheduler_opts.preemption.preemptible_priority,
                         order=self.scheduler_opts.preemption.order,
                         mode=self.scheduler_opts.preemption.mode,
+                        preemption_min_runtime=self.scheduler_opts.preemption.preemption_min_runtime,
                     ),
                 ),
             ),

--- a/src/ai/backend/manager/repositories/scaling_group/updaters.py
+++ b/src/ai/backend/manager/repositories/scaling_group/updaters.py
@@ -143,9 +143,11 @@ class ScalingGroupSchedulerConfigUpdaterSpec(UpdaterSpec[ScalingGroupRow]):
             to_update["scheduler_opts"] = scheduler_opts
         if (preemption := self.preemption_config.optional_value()) is not None:
             preemption_dict = {
+                "enabled": preemption.enabled,
                 "preemptible_priority": preemption.preemptible_priority,
                 "order": preemption.order.value,
                 "mode": preemption.mode.value,
+                "preemption_min_runtime": preemption.preemption_min_runtime.total_seconds(),
             }
             to_update["scheduler_opts"] = func.jsonb_set(
                 sa.literal_column("scheduler_opts"),

--- a/tests/unit/common/dto/manager/v2/resource_group/test_response.py
+++ b/tests/unit/common/dto/manager/v2/resource_group/test_response.py
@@ -70,9 +70,11 @@ def _make_resource_group_detail_node(name: str = "test-group") -> ResourceGroupD
         scheduler=ResourceGroupSchedulerConfigInfo(
             type=SchedulerTypeDTO.FIFO,
             preemption=PreemptionConfigInfo(
+                enabled=False,
                 preemptible_priority=5,
                 order=PreemptionOrderDTO.OLDEST,
                 mode=PreemptionModeDTO.TERMINATE,
+                preemption_min_runtime=0.0,
             ),
         ),
         default_deployment_options=DeploymentOptionsInfo(

--- a/tests/unit/common/dto/manager/v2/scaling_group/test_request.py
+++ b/tests/unit/common/dto/manager/v2/scaling_group/test_request.py
@@ -23,19 +23,29 @@ class TestPreemptionConfigInput:
 
     def test_defaults_are_valid(self) -> None:
         req = PreemptionConfigInput()
+        assert req.enabled is False
         assert req.preemptible_priority == 5
         assert req.order == PreemptionOrder.OLDEST
         assert req.mode == PreemptionMode.TERMINATE
+        assert req.preemption_min_runtime == 0.0
 
     def test_valid_creation_with_all_fields(self) -> None:
         req = PreemptionConfigInput(
+            enabled=True,
             preemptible_priority=3,
             order=PreemptionOrder.NEWEST,
             mode=PreemptionMode.RESCHEDULE,
+            preemption_min_runtime=300.0,
         )
+        assert req.enabled is True
         assert req.preemptible_priority == 3
         assert req.order == PreemptionOrder.NEWEST
         assert req.mode == PreemptionMode.RESCHEDULE
+        assert req.preemption_min_runtime == 300.0
+
+    def test_negative_min_runtime_raises_validation_error(self) -> None:
+        with pytest.raises((BackendAISchemaValidationFailed, ValidationError)):
+            PreemptionConfigInput(preemption_min_runtime=-1.0)
 
     def test_min_priority_is_valid(self) -> None:
         req = PreemptionConfigInput(preemptible_priority=1)
@@ -55,15 +65,19 @@ class TestPreemptionConfigInput:
 
     def test_round_trip(self) -> None:
         req = PreemptionConfigInput(
+            enabled=True,
             preemptible_priority=7,
             order=PreemptionOrder.NEWEST,
             mode=PreemptionMode.RESCHEDULE,
+            preemption_min_runtime=120.0,
         )
         json_data = req.model_dump_json()
         restored = PreemptionConfigInput.model_validate_json(json_data)
+        assert restored.enabled == req.enabled
         assert restored.preemptible_priority == req.preemptible_priority
         assert restored.order == req.order
         assert restored.mode == req.mode
+        assert restored.preemption_min_runtime == req.preemption_min_runtime
 
 
 class TestUpdateScalingGroupInput:

--- a/tests/unit/common/dto/manager/v2/scaling_group/test_response.py
+++ b/tests/unit/common/dto/manager/v2/scaling_group/test_response.py
@@ -22,9 +22,11 @@ from ai.backend.common.dto.manager.v2.scaling_group.types import (
 
 def _make_preemption_config() -> PreemptionConfigInfo:
     return PreemptionConfigInfo(
+        enabled=False,
         preemptible_priority=5,
         order=PreemptionOrder.OLDEST,
         mode=PreemptionMode.TERMINATE,
+        preemption_min_runtime=0.0,
     )
 
 
@@ -90,9 +92,22 @@ class TestPreemptionConfigInfo:
 
     def test_valid_creation(self) -> None:
         info = _make_preemption_config()
+        assert info.enabled is False
         assert info.preemptible_priority == 5
         assert info.order == PreemptionOrder.OLDEST
         assert info.mode == PreemptionMode.TERMINATE
+        assert info.preemption_min_runtime == 0.0
+
+    def test_enabled_with_min_runtime(self) -> None:
+        info = PreemptionConfigInfo(
+            enabled=True,
+            preemptible_priority=5,
+            order=PreemptionOrder.OLDEST,
+            mode=PreemptionMode.TERMINATE,
+            preemption_min_runtime=300.0,
+        )
+        assert info.enabled is True
+        assert info.preemption_min_runtime == 300.0
 
 
 class TestScalingGroupSchedulerInfo:

--- a/tests/unit/manager/api/gql/resource_group/test_resource_info.py
+++ b/tests/unit/manager/api/gql/resource_group/test_resource_info.py
@@ -260,9 +260,11 @@ class TestResourceGroupGQLResourceInfoResolver:
                 ResourceGroupSchedulerConfigInfo(
                     type=SchedulerTypeDTO.FIFO,
                     preemption=PreemptionConfigInfo(
+                        enabled=False,
                         preemptible_priority=5,
                         order=PreemptionOrderDTO.OLDEST,
                         mode=PreemptionModeDTO.TERMINATE,
+                        preemption_min_runtime=0.0,
                     ),
                 )
             ),

--- a/tests/unit/manager/models/scaling_group/test_row.py
+++ b/tests/unit/manager/models/scaling_group/test_row.py
@@ -8,8 +8,13 @@ import pytest
 from pydantic import ValidationError
 
 from ai.backend.common.exception import BackendAISchemaValidationFailed
-from ai.backend.common.types import AgentSelectionStrategy, SessionTypes
-from ai.backend.manager.models.scaling_group.row import ScalingGroupOpts
+from ai.backend.common.types import (
+    AgentSelectionStrategy,
+    PreemptionMode,
+    PreemptionOrder,
+    SessionTypes,
+)
+from ai.backend.manager.models.scaling_group.row import PreemptionConfig, ScalingGroupOpts
 
 
 class TestScalingGroupOptsDefaults:
@@ -193,3 +198,96 @@ class TestScalingGroupOptsBackwardCompatibility:
         assert opts.agent_selection_strategy == AgentSelectionStrategy.DISPERSED
         assert opts.enforce_spreading_endpoint_replica is False
         assert opts.allow_fractional_resource_fragmentation is True
+
+
+class TestPreemptionConfig:
+    """Test PreemptionConfig defaults, serialization, and backward compatibility."""
+
+    def test_defaults(self) -> None:
+        config = PreemptionConfig()
+        assert config.enabled is False
+        assert config.preemptible_priority == 5
+        assert config.order == PreemptionOrder.OLDEST
+        assert config.mode == PreemptionMode.TERMINATE
+        assert config.preemption_min_runtime == timedelta(seconds=0)
+
+    def test_scaling_group_opts_default_preemption(self) -> None:
+        opts = ScalingGroupOpts()
+        assert opts.preemption == PreemptionConfig()
+        assert opts.preemption.enabled is False
+        assert opts.preemption.preemption_min_runtime == timedelta(seconds=0)
+
+    def test_serialize_json_mode_types(self) -> None:
+        config = PreemptionConfig(
+            enabled=True,
+            preemptible_priority=3,
+            order=PreemptionOrder.NEWEST,
+            mode=PreemptionMode.RESCHEDULE,
+            preemption_min_runtime=timedelta(seconds=300),
+        )
+        dumped = config.model_dump(mode="json")
+        assert dumped["enabled"] is True
+        assert dumped["preemptible_priority"] == 3
+        assert dumped["order"] == PreemptionOrder.NEWEST.value
+        assert dumped["mode"] == PreemptionMode.RESCHEDULE.value
+        # preemption_min_runtime → float seconds
+        assert isinstance(dumped["preemption_min_runtime"], float)
+        assert dumped["preemption_min_runtime"] == 300.0
+
+    def test_validate_min_runtime_from_int(self) -> None:
+        config = PreemptionConfig.model_validate({"preemption_min_runtime": 120})
+        assert config.preemption_min_runtime == timedelta(seconds=120)
+
+    def test_validate_min_runtime_from_float(self) -> None:
+        config = PreemptionConfig.model_validate({"preemption_min_runtime": 90.5})
+        assert config.preemption_min_runtime == timedelta(seconds=90.5)
+
+    def test_roundtrip_custom_values(self) -> None:
+        original = PreemptionConfig(
+            enabled=True,
+            preemptible_priority=1,
+            order=PreemptionOrder.NEWEST,
+            mode=PreemptionMode.RESCHEDULE,
+            preemption_min_runtime=timedelta(minutes=5),
+        )
+        restored = PreemptionConfig.model_validate(original.model_dump(mode="json"))
+        assert restored == original
+
+    def test_backward_compat_missing_new_keys(self) -> None:
+        """Legacy preemption JSON without enabled/preemption_min_runtime loads defaults."""
+        legacy_data = {
+            "preemptible_priority": 5,
+            "order": "oldest",
+            "mode": "terminate",
+        }
+        config = PreemptionConfig.model_validate(legacy_data)
+        assert config.enabled is False
+        assert config.preemption_min_runtime == timedelta(seconds=0)
+        assert config.preemptible_priority == 5
+
+    def test_backward_compat_via_scaling_group_opts(self) -> None:
+        """A legacy scheduler_opts JSONB row without the new preemption keys loads defaults."""
+        legacy_opts = {
+            "preemption": {
+                "preemptible_priority": 3,
+                "order": "newest",
+                "mode": "reschedule",
+            },
+        }
+        opts = ScalingGroupOpts.model_validate(legacy_opts)
+        assert opts.preemption.enabled is False
+        assert opts.preemption.preemption_min_runtime == timedelta(seconds=0)
+        assert opts.preemption.preemptible_priority == 3
+        assert opts.preemption.order == PreemptionOrder.NEWEST
+        assert opts.preemption.mode == PreemptionMode.RESCHEDULE
+
+    def test_scaling_group_opts_roundtrip_with_preemption(self) -> None:
+        original = ScalingGroupOpts(
+            preemption=PreemptionConfig(
+                enabled=True,
+                preemption_min_runtime=timedelta(seconds=300),
+            ),
+        )
+        restored = ScalingGroupOpts.model_validate(original.model_dump(mode="json"))
+        assert restored.preemption.enabled is True
+        assert restored.preemption.preemption_min_runtime == timedelta(seconds=300)


### PR DESCRIPTION
## Summary
- Add two fields to resource-group `PreemptionConfig` (stored in `scaling_groups.scheduler_opts` JSONB — no DB migration):
  - `enabled: bool` (default `false`, opt-in master switch for preemption)
  - `preemption_min_runtime: duration` (default `0`, i.e. disabled; minimum session runtime before it becomes preemptible)
- Exposed across the full stack following the existing `preemptible_priority`/`order`/`mode` pattern: Model (`PreemptionConfig`), Data type, DTO v2 (`resource_group` + `scaling_group`), Adapter, Repository updater (JSONB write), and GraphQL input/output types (tagged `NEXT_RELEASE_VERSION`).
- Internally `preemption_min_runtime` is a `timedelta`; on the wire (DTO/GraphQL) it is `float` seconds, matching the repo's duration convention (`pending_timeout`).
- Backward compatible: existing rows without the new JSONB keys load to defaults (`enabled=False`, `preemption_min_runtime=0`).

This Story unblocks BA-6747 (snapshot conditional load) and BA-6748 (planner); `preemption.enabled` gates that conditional load. Epic BA-3056 / BEP-1055.

## Test plan
- [x] `pants fmt / fix / lint / check` (mypy) pass
- [x] DTO round-trip + validation (`resource_group`, `scaling_group` request/response)
- [x] GraphQL adapter output construction (`test_resource_info`)
- [x] Model-level defaults, JSON serialization (`timedelta`↔seconds), and backward-compat loading of legacy JSONB without the new keys (`TestPreemptionConfig`)
- [ ] Live-server `./bai` create/update round-trip (admin + non-admin) — deferred to CI / local dev

Resolves BA-6745