### PR TITLE
feat(BA-6602): add compute-schedule GraphQL schema

### DIFF
--- a/changes/12629.feature.md
+++ b/changes/12629.feature.md
@@ -1,1 +1,1 @@
-Add the dry-run schedule GraphQL schema (DTOs, types, and the `dryRunSchedule` query) for probing resource-group admission without provisioning.
+Add the compute-schedule GraphQL schema (DTOs, types, and the `computeSchedule` query) for probing resource-group admission without provisioning.

--- a/changes/12629.feature.md
+++ b/changes/12629.feature.md
@@ -1,0 +1,1 @@
+Add the dry-run schedule GraphQL schema (DTOs, types, and the `dryRunSchedule` query) for probing resource-group admission without provisioning.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -2985,6 +2985,56 @@ type ComputePlugins
   entries: [ComputePluginEntry!]!
 }
 
+"""
+Added in 26.8.0. Compute a session's scheduling against a resource group without provisioning.
+"""
+input ComputeScheduleInput
+  @join__type(graph: STRAWBERRY)
+{
+  kernels: [ComputeScheduleKernelResourceInput!]!
+  clusterMode: SessionClusterMode!
+  resourceGroupId: ID!
+}
+
+"""
+Added in 26.8.0. Per-kernel resource request for a compute-schedule. The image is optional when a resource-group default supplies it downstream.
+"""
+input ComputeScheduleKernelResourceInput
+  @join__type(graph: STRAWBERRY)
+{
+  imageId: ID = null
+  resources: [ResourceSlotEntryInput!] = null
+}
+
+"""
+Added in 26.8.0. Compute-schedule outcome for a single kernel. Results correspond positionally to the requested kernels.
+"""
+type ComputeScheduleKernelResult
+  @join__type(graph: STRAWBERRY)
+{
+  """Resource slots resolved for this kernel after applying defaults."""
+  requestedSlots: [ResourceSlotEntry!]!
+
+  """Architecture resolved for this kernel."""
+  requestedArchitecture: String!
+
+  """Whether this kernel could be scheduled onto a target node."""
+  success: Boolean!
+
+  """What to change so the kernel would fit. Null when success is True."""
+  reasonHint: UnschedulableReasonHint
+}
+
+"""Added in 26.8.0. Result of a compute-schedule request."""
+type ComputeSchedulePayload
+  @join__type(graph: STRAWBERRY)
+{
+  """
+  Per-kernel compute-schedule outcomes, correlated to the request by list index.
+  """
+  results: [ComputeScheduleKernelResult!]!
+}
+
 type ComputeSession implements Item
   @join__implements(graph: GRAPHENE, interface: "Item")
   @join__type(graph: GRAPHENE)
@@ -6724,35 +6774,6 @@ input DomainWeightInputItem
   weight: Decimal = null
 }
 
-"""
-Added in 26.8.0. Per-kernel resource request for a scheduling dry-run. The image is optional when a resource-group default supplies it downstream.
-"""
-input DryRunKernelResourceInput
-  @join__type(graph: STRAWBERRY)
-{
-  imageId: ID = null
-  resources: [ResourceSlotEntryInput!] = null
-}
-
-"""
-Added in 26.8.0. Dry-run a session's scheduling against a resource group without provisioning.
-"""
-input DryRunScheduleInput
-  @join__type(graph: STRAWBERRY)
-{
-  kernels: [DryRunKernelResourceInput!]!
-  clusterMode: SessionClusterMode!
-  resourceGroupId: ID!
-}
-
-"""Added in 26.8.0. Result of a dry-run schedule request."""
-type DryRunSchedulePayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Per-kernel dry-run outcomes, correlated to the request by list index."""
-  dryRunResults: [KernelDryRunResult!]!
-}
-
 """Added in 26.4.2. Breakdown of resource allocation by scope."""
 type EffectiveBreakdownV2
   @join__type(graph: STRAWBERRY)
@@ -8308,25 +8329,6 @@ type KernelConnection
 
   """Total count of the GQL nodes of the query."""
   count: Int
-}
-
-"""
-Added in 26.8.0. Dry-run outcome for a single kernel. Results correspond positionally to the requested kernels.
-"""
-type KernelDryRunResult
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource slots resolved for this kernel after applying defaults."""
-  requestedSlots: [ResourceSlotEntry!]!
-
-  """Architecture resolved for this kernel."""
-  requestedArchitecture: String!
-
-  """Whether this kernel could be scheduled onto a target node."""
-  success: Boolean!
-
-  """What to change so the kernel would fit. Null when success is True."""
-  reasonHint: UnschedulableReasonHint
 }
 
 """Added in 24.09.0. A Relay edge containing a `Kernel` and its cursor."""
@@ -14603,9 +14605,9 @@ type Query
   schedulingHandlers: [SchedulingHandlerNode!] @join__field(graph: STRAWBERRY)
 
   """
-  Added in 26.8.0. Dry-run a session's scheduling against a resource group without provisioning. Returns per-kernel admission outcomes and, for kernels that do not fit, hints on what to reduce.
+  Added in 26.8.0. Compute whether a session could be created on a resource group, without actually provisioning it. Checks each kernel's resource request against the group's agents and returns per-kernel admission outcomes, with hints on what to reduce for kernels that do not fit.
   """
-  dryRunSchedule(input: DryRunScheduleInput!): DryRunSchedulePayload @join__field(graph: STRAWBERRY)
+  computeSchedule(input: ComputeScheduleInput!): ComputeSchedulePayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Get allowed resource groups for a domain (admin only).
@@ -19218,16 +19220,13 @@ type UnregisterStorageNamespacePayload
 }
 
 """
-Added in 26.8.0. What the caller could change so an unschedulable kernel would fit. Present only when the kernel's dry-run did not succeed.
+Added in 26.8.0. What the caller could change so an unschedulable kernel would fit. Present only when the kernel could not be scheduled.
 """
 type UnschedulableReasonHint
   @join__type(graph: STRAWBERRY)
 {
   """Subtract these slots to fit the best-fitting node."""
   requiredReduction: [ResourceSlotEntry!]
-
-  """Number of containers that must be freed to fit."""
-  requiredContainerReduction: Int
 
   """Architectures that actually exist among the scheduling targets."""
   availableArchs: [String!]

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -6724,6 +6724,35 @@ input DomainWeightInputItem
   weight: Decimal = null
 }
 
+"""
+Added in 26.8.0. Per-kernel resource request for a scheduling dry-run. The image is optional when a resource-group default supplies it downstream.
+"""
+input DryRunKernelResourceInput
+  @join__type(graph: STRAWBERRY)
+{
+  imageId: ID = null
+  resources: [ResourceSlotEntryInput!] = null
+}
+
+"""
+Added in 26.8.0. Dry-run a session's scheduling against a resource group without provisioning.
+"""
+input DryRunScheduleInput
+  @join__type(graph: STRAWBERRY)
+{
+  kernels: [DryRunKernelResourceInput!]!
+  clusterMode: SessionClusterMode!
+  resourceGroupId: ID!
+}
+
+"""Added in 26.8.0. Result of a dry-run schedule request."""
+type DryRunSchedulePayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Per-kernel dry-run outcomes, correlated to the request by list index."""
+  dryRunResults: [KernelDryRunResult!]!
+}
+
 """Added in 26.4.2. Breakdown of resource allocation by scope."""
 type EffectiveBreakdownV2
   @join__type(graph: STRAWBERRY)
@@ -8279,6 +8308,25 @@ type KernelConnection
 
   """Total count of the GQL nodes of the query."""
   count: Int
+}
+
+"""
+Added in 26.8.0. Dry-run outcome for a single kernel. Results correspond positionally to the requested kernels.
+"""
+type KernelDryRunResult
+  @join__type(graph: STRAWBERRY)
+{
+  """Resource slots resolved for this kernel after applying defaults."""
+  requestedSlots: [ResourceSlotEntry!]!
+
+  """Architecture resolved for this kernel."""
+  requestedArchitecture: String!
+
+  """Whether this kernel could be scheduled onto a target node."""
+  success: Boolean!
+
+  """What to change so the kernel would fit. Null when success is True."""
+  reasonHint: UnschedulableReasonHint
 }
 
 """Added in 24.09.0. A Relay edge containing a `Kernel` and its cursor."""
@@ -14555,6 +14603,11 @@ type Query
   schedulingHandlers: [SchedulingHandlerNode!] @join__field(graph: STRAWBERRY)
 
   """
+  Added in 26.8.0. Dry-run a session's scheduling against a resource group without provisioning. Returns per-kernel admission outcomes and, for kernels that do not fit, hints on what to reduce.
+  """
+  dryRunSchedule(input: DryRunScheduleInput!): DryRunSchedulePayload @join__field(graph: STRAWBERRY)
+
+  """
   Added in 26.4.2. Get allowed resource groups for a domain (admin only).
   """
   adminAllowedResourceGroupsForDomainV2(domainName: String!): AllowedResourceGroupsPayload @join__field(graph: STRAWBERRY)
@@ -19162,6 +19215,22 @@ type UnregisterStorageNamespacePayload
 {
   """ID of the unregistered storage namespace"""
   id: UUID!
+}
+
+"""
+Added in 26.8.0. What the caller could change so an unschedulable kernel would fit. Present only when the kernel's dry-run did not succeed.
+"""
+type UnschedulableReasonHint
+  @join__type(graph: STRAWBERRY)
+{
+  """Subtract these slots to fit the best-fitting node."""
+  requiredReduction: [ResourceSlotEntry!]
+
+  """Number of containers that must be freed to fit."""
+  requiredContainerReduction: Int
+
+  """Architectures that actually exist among the scheduling targets."""
+  availableArchs: [String!]
 }
 
 type UnsetQuotaScope

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -4604,6 +4604,29 @@ input DomainWeightInputItem {
   weight: Decimal = null
 }
 
+"""
+Added in 26.8.0. Per-kernel resource request for a scheduling dry-run. The image is optional when a resource-group default supplies it downstream.
+"""
+input DryRunKernelResourceInput {
+  imageId: ID = null
+  resources: [ResourceSlotEntryInput!] = null
+}
+
+"""
+Added in 26.8.0. Dry-run a session's scheduling against a resource group without provisioning.
+"""
+input DryRunScheduleInput {
+  kernels: [DryRunKernelResourceInput!]!
+  clusterMode: SessionClusterMode!
+  resourceGroupId: ID!
+}
+
+"""Added in 26.8.0. Result of a dry-run schedule request."""
+type DryRunSchedulePayload {
+  """Per-kernel dry-run outcomes, correlated to the request by list index."""
+  dryRunResults: [KernelDryRunResult!]!
+}
+
 """Added in 26.4.2. Breakdown of resource allocation by scope."""
 type EffectiveBreakdownV2 {
   """Keypair resource policy limits."""
@@ -5482,6 +5505,23 @@ type IssueMyKeypairPayload {
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf).
 """
 scalar JSON @specifiedBy(url: "https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf")
+
+"""
+Added in 26.8.0. Dry-run outcome for a single kernel. Results correspond positionally to the requested kernels.
+"""
+type KernelDryRunResult {
+  """Resource slots resolved for this kernel after applying defaults."""
+  requestedSlots: [ResourceSlotEntry!]!
+
+  """Architecture resolved for this kernel."""
+  requestedArchitecture: String!
+
+  """Whether this kernel could be scheduled onto a target node."""
+  success: Boolean!
+
+  """What to change so the kernel would fit. Null when success is True."""
+  reasonHint: UnschedulableReasonHint
+}
 
 """
 Added in 26.3.0. Per-slot resource allocation entry for a kernel.
@@ -9610,6 +9650,11 @@ type Query {
   schedulingHandlers: [SchedulingHandlerNode!]
 
   """
+  Added in 26.8.0. Dry-run a session's scheduling against a resource group without provisioning. Returns per-kernel admission outcomes and, for kernels that do not fit, hints on what to reduce.
+  """
+  dryRunSchedule(input: DryRunScheduleInput!): DryRunSchedulePayload
+
+  """
   Added in 26.4.2. Get allowed resource groups for a domain (admin only).
   """
   adminAllowedResourceGroupsForDomainV2(domainName: String!): AllowedResourceGroupsPayload
@@ -13378,6 +13423,20 @@ Added in 25.15.0. Payload returned after storage namespace unregistration.
 type UnregisterStorageNamespacePayload {
   """ID of the unregistered storage namespace"""
   id: UUID!
+}
+
+"""
+Added in 26.8.0. What the caller could change so an unschedulable kernel would fit. Present only when the kernel's dry-run did not succeed.
+"""
+type UnschedulableReasonHint {
+  """Subtract these slots to fit the best-fitting node."""
+  requiredReduction: [ResourceSlotEntry!]
+
+  """Number of containers that must be freed to fit."""
+  requiredContainerReduction: Int
+
+  """Architectures that actually exist among the scheduling targets."""
+  availableArchs: [String!]
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -2131,6 +2131,48 @@ type ComputePlugins {
   entries: [ComputePluginEntry!]!
 }
 
+"""
+Added in 26.8.0. Compute a session's scheduling against a resource group without provisioning.
+"""
+input ComputeScheduleInput {
+  kernels: [ComputeScheduleKernelResourceInput!]!
+  clusterMode: SessionClusterMode!
+  resourceGroupId: ID!
+}
+
+"""
+Added in 26.8.0. Per-kernel resource request for a compute-schedule. The image is optional when a resource-group default supplies it downstream.
+"""
+input ComputeScheduleKernelResourceInput {
+  imageId: ID = null
+  resources: [ResourceSlotEntryInput!] = null
+}
+
+"""
+Added in 26.8.0. Compute-schedule outcome for a single kernel. Results correspond positionally to the requested kernels.
+"""
+type ComputeScheduleKernelResult {
+  """Resource slots resolved for this kernel after applying defaults."""
+  requestedSlots: [ResourceSlotEntry!]!
+
+  """Architecture resolved for this kernel."""
+  requestedArchitecture: String!
+
+  """Whether this kernel could be scheduled onto a target node."""
+  success: Boolean!
+
+  """What to change so the kernel would fit. Null when success is True."""
+  reasonHint: UnschedulableReasonHint
+}
+
+"""Added in 26.8.0. Result of a compute-schedule request."""
+type ComputeSchedulePayload {
+  """
+  Per-kernel compute-schedule outcomes, correlated to the request by list index.
+  """
+  results: [ComputeScheduleKernelResult!]!
+}
+
 extend type ComputeSessionNode implements Node @key(fields: "id") {
   """The Globally Unique ID of this object"""
   id: ID!
@@ -4604,29 +4646,6 @@ input DomainWeightInputItem {
   weight: Decimal = null
 }
 
-"""
-Added in 26.8.0. Per-kernel resource request for a scheduling dry-run. The image is optional when a resource-group default supplies it downstream.
-"""
-input DryRunKernelResourceInput {
-  imageId: ID = null
-  resources: [ResourceSlotEntryInput!] = null
-}
-
-"""
-Added in 26.8.0. Dry-run a session's scheduling against a resource group without provisioning.
-"""
-input DryRunScheduleInput {
-  kernels: [DryRunKernelResourceInput!]!
-  clusterMode: SessionClusterMode!
-  resourceGroupId: ID!
-}
-
-"""Added in 26.8.0. Result of a dry-run schedule request."""
-type DryRunSchedulePayload {
-  """Per-kernel dry-run outcomes, correlated to the request by list index."""
-  dryRunResults: [KernelDryRunResult!]!
-}
-
 """Added in 26.4.2. Breakdown of resource allocation by scope."""
 type EffectiveBreakdownV2 {
   """Keypair resource policy limits."""
@@ -5505,23 +5524,6 @@ type IssueMyKeypairPayload {
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf).
 """
 scalar JSON @specifiedBy(url: "https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf")
-
-"""
-Added in 26.8.0. Dry-run outcome for a single kernel. Results correspond positionally to the requested kernels.
-"""
-type KernelDryRunResult {
-  """Resource slots resolved for this kernel after applying defaults."""
-  requestedSlots: [ResourceSlotEntry!]!
-
-  """Architecture resolved for this kernel."""
-  requestedArchitecture: String!
-
-  """Whether this kernel could be scheduled onto a target node."""
-  success: Boolean!
-
-  """What to change so the kernel would fit. Null when success is True."""
-  reasonHint: UnschedulableReasonHint
-}
 
 """
 Added in 26.3.0. Per-slot resource allocation entry for a kernel.
@@ -9650,9 +9652,9 @@ type Query {
   schedulingHandlers: [SchedulingHandlerNode!]
 
   """
-  Added in 26.8.0. Dry-run a session's scheduling against a resource group without provisioning. Returns per-kernel admission outcomes and, for kernels that do not fit, hints on what to reduce.
+  Added in 26.8.0. Compute whether a session could be created on a resource group, without actually provisioning it. Checks each kernel's resource request against the group's agents and returns per-kernel admission outcomes, with hints on what to reduce for kernels that do not fit.
   """
-  dryRunSchedule(input: DryRunScheduleInput!): DryRunSchedulePayload
+  computeSchedule(input: ComputeScheduleInput!): ComputeSchedulePayload
 
   """
   Added in 26.4.2. Get allowed resource groups for a domain (admin only).
@@ -13426,14 +13428,11 @@ type UnregisterStorageNamespacePayload {
 }
 
 """
-Added in 26.8.0. What the caller could change so an unschedulable kernel would fit. Present only when the kernel's dry-run did not succeed.
+Added in 26.8.0. What the caller could change so an unschedulable kernel would fit. Present only when the kernel could not be scheduled.
 """
 type UnschedulableReasonHint {
   """Subtract these slots to fit the best-fitting node."""
   requiredReduction: [ResourceSlotEntry!]
-
-  """Number of containers that must be freed to fit."""
-  requiredContainerReduction: Int
 
   """Architectures that actually exist among the scheduling targets."""
   availableArchs: [String!]

--- a/src/ai/backend/common/dto/manager/v2/scheduler/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/scheduler/__init__.py
@@ -2,9 +2,24 @@
 Scheduler DTOs v2 for Manager API.
 """
 
+from ai.backend.common.dto.manager.v2.scheduler.request import (
+    DryRunKernelResourceInput,
+    DryRunScheduleInput,
+)
 from ai.backend.common.dto.manager.v2.scheduler.response import (
+    DryRunSchedulePayload,
+    KernelDryRunResultInfo,
     SchedulingBroadcastEventPayloadNode,
     SchedulingStatusDTO,
+    UnschedulableReasonHintInfo,
 )
 
-__all__ = ("SchedulingBroadcastEventPayloadNode", "SchedulingStatusDTO")
+__all__ = (
+    "DryRunKernelResourceInput",
+    "DryRunScheduleInput",
+    "DryRunSchedulePayload",
+    "KernelDryRunResultInfo",
+    "SchedulingBroadcastEventPayloadNode",
+    "SchedulingStatusDTO",
+    "UnschedulableReasonHintInfo",
+)

--- a/src/ai/backend/common/dto/manager/v2/scheduler/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/scheduler/__init__.py
@@ -3,22 +3,22 @@ Scheduler DTOs v2 for Manager API.
 """
 
 from ai.backend.common.dto.manager.v2.scheduler.request import (
-    DryRunKernelResourceInput,
-    DryRunScheduleInput,
+    ComputeScheduleInput,
+    ComputeScheduleKernelResourceInput,
 )
 from ai.backend.common.dto.manager.v2.scheduler.response import (
-    DryRunSchedulePayload,
-    KernelDryRunResultInfo,
+    ComputeScheduleKernelResultInfo,
+    ComputeSchedulePayload,
     SchedulingBroadcastEventPayloadNode,
     SchedulingStatusDTO,
     UnschedulableReasonHintInfo,
 )
 
 __all__ = (
-    "DryRunKernelResourceInput",
-    "DryRunScheduleInput",
-    "DryRunSchedulePayload",
-    "KernelDryRunResultInfo",
+    "ComputeScheduleInput",
+    "ComputeScheduleKernelResourceInput",
+    "ComputeScheduleKernelResultInfo",
+    "ComputeSchedulePayload",
     "SchedulingBroadcastEventPayloadNode",
     "SchedulingStatusDTO",
     "UnschedulableReasonHintInfo",

--- a/src/ai/backend/common/dto/manager/v2/scheduler/request.py
+++ b/src/ai/backend/common/dto/manager/v2/scheduler/request.py
@@ -1,0 +1,58 @@
+"""
+Request DTOs for the dry-run schedule v2 API.
+"""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from ai.backend.common.api_handlers import BaseRequestModel
+from ai.backend.common.dto.manager.v2.common import ResourceSlotEntryInput
+from ai.backend.common.dto.manager.v2.session.types import ClusterModeEnum
+from ai.backend.common.identifier.image import ImageID
+from ai.backend.common.identifier.resource_group import ResourceGroupID
+
+__all__ = (
+    "DryRunKernelResourceInput",
+    "DryRunScheduleInput",
+)
+
+
+class DryRunKernelResourceInput(BaseRequestModel):
+    """Per-kernel resource inputs for a scheduling dry-run.
+
+    Mirrors the scheduler's ``KernelResourceInput``: the requested resource
+    slots plus an optional image whose architecture and resource-group
+    defaults are resolved downstream. Results are correlated to kernels by
+    list index, so no identifier is carried here.
+    """
+
+    image_id: ImageID | None = Field(
+        default=None,
+        description=(
+            "Image to schedule this kernel against. May be null when a "
+            "resource-group default supplies the image downstream."
+        ),
+    )
+    resources: list[ResourceSlotEntryInput] = Field(
+        default_factory=list,
+        description="Requested resource slots (cpu, mem, accelerators) for this kernel.",
+    )
+
+
+class DryRunScheduleInput(BaseRequestModel):
+    """Dry-run a session's scheduling against a resource group without provisioning.
+
+    ``cluster_mode`` decides whether kernel slots are summed onto a single
+    node (SINGLE_NODE) or placed individually (MULTI_NODE).
+    """
+
+    kernels: list[DryRunKernelResourceInput] = Field(
+        description="Per-kernel resource requests to test against the resource group.",
+    )
+    cluster_mode: ClusterModeEnum = Field(
+        description="Cluster networking mode governing how kernel slots are placed.",
+    )
+    resource_group_id: ResourceGroupID = Field(
+        description="Target resource group to dry-run the scheduling against.",
+    )

--- a/src/ai/backend/common/dto/manager/v2/scheduler/request.py
+++ b/src/ai/backend/common/dto/manager/v2/scheduler/request.py
@@ -1,5 +1,5 @@
 """
-Request DTOs for the dry-run schedule v2 API.
+Request DTOs for the compute-schedule v2 API.
 """
 
 from __future__ import annotations
@@ -13,13 +13,13 @@ from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
 
 __all__ = (
-    "DryRunKernelResourceInput",
-    "DryRunScheduleInput",
+    "ComputeScheduleInput",
+    "ComputeScheduleKernelResourceInput",
 )
 
 
-class DryRunKernelResourceInput(BaseRequestModel):
-    """Per-kernel resource inputs for a scheduling dry-run.
+class ComputeScheduleKernelResourceInput(BaseRequestModel):
+    """Per-kernel resource inputs for a compute-schedule request.
 
     Mirrors the scheduler's ``KernelResourceInput``: the requested resource
     slots plus an optional image whose architecture and resource-group
@@ -40,19 +40,19 @@ class DryRunKernelResourceInput(BaseRequestModel):
     )
 
 
-class DryRunScheduleInput(BaseRequestModel):
-    """Dry-run a session's scheduling against a resource group without provisioning.
+class ComputeScheduleInput(BaseRequestModel):
+    """Compute a session's scheduling against a resource group without provisioning.
 
     ``cluster_mode`` decides whether kernel slots are summed onto a single
     node (SINGLE_NODE) or placed individually (MULTI_NODE).
     """
 
-    kernels: list[DryRunKernelResourceInput] = Field(
+    kernels: list[ComputeScheduleKernelResourceInput] = Field(
         description="Per-kernel resource requests to test against the resource group.",
     )
     cluster_mode: ClusterModeEnum = Field(
         description="Cluster networking mode governing how kernel slots are placed.",
     )
     resource_group_id: ResourceGroupID = Field(
-        description="Target resource group to dry-run the scheduling against.",
+        description="Target resource group to compute the scheduling against.",
     )

--- a/src/ai/backend/common/dto/manager/v2/scheduler/response.py
+++ b/src/ai/backend/common/dto/manager/v2/scheduler/response.py
@@ -9,8 +9,14 @@ from enum import StrEnum
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.dto.manager.v2.common import ResourceSlotEntryInfo
 
-__all__ = ("SchedulingBroadcastEventPayloadNode",)
+__all__ = (
+    "DryRunSchedulePayload",
+    "KernelDryRunResultInfo",
+    "SchedulingBroadcastEventPayloadNode",
+    "UnschedulableReasonHintInfo",
+)
 
 
 class SchedulingStatusDTO(StrEnum):
@@ -37,3 +43,55 @@ class SchedulingBroadcastEventPayloadNode(BaseResponseModel):
         description="Status transition that occurred during session scheduling."
     )
     reason: str = Field(description="Human-readable reason for this status transition.")
+
+
+class UnschedulableReasonHintInfo(BaseResponseModel):
+    """What the caller could change so an unschedulable kernel would fit.
+
+    Populated only when the kernel's dry-run ``success`` is False. Surfaces
+    the user-actionable subset of the selector's remediation hint.
+    """
+
+    required_reduction: list[ResourceSlotEntryInfo] | None = Field(
+        default=None,
+        description="Subtract these slots to fit the best-fitting node.",
+    )
+    required_container_reduction: int | None = Field(
+        default=None,
+        description="Number of containers that must be freed to fit.",
+    )
+    available_archs: list[str] | None = Field(
+        default=None,
+        description="Architectures that actually exist among the scheduling targets.",
+    )
+
+
+class KernelDryRunResultInfo(BaseResponseModel):
+    """Dry-run outcome for a single kernel.
+
+    Results correspond positionally to the requested kernels: the caller
+    matches each result to its input by list index. ``reason_hint`` is
+    populated only when ``success`` is False.
+    """
+
+    requested_slots: list[ResourceSlotEntryInfo] = Field(
+        description="Resource slots resolved for this kernel after applying defaults.",
+    )
+    requested_architecture: str = Field(
+        description="Architecture resolved for this kernel.",
+    )
+    success: bool = Field(
+        description="Whether this kernel could be scheduled onto a target node.",
+    )
+    reason_hint: UnschedulableReasonHintInfo | None = Field(
+        default=None,
+        description="What to change so the kernel would fit. Null when success is True.",
+    )
+
+
+class DryRunSchedulePayload(BaseResponseModel):
+    """Result of a dry-run schedule request."""
+
+    dry_run_results: list[KernelDryRunResultInfo] = Field(
+        description="Per-kernel dry-run outcomes, correlated to the request by list index.",
+    )

--- a/src/ai/backend/common/dto/manager/v2/scheduler/response.py
+++ b/src/ai/backend/common/dto/manager/v2/scheduler/response.py
@@ -12,8 +12,8 @@ from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.v2.common import ResourceSlotEntryInfo
 
 __all__ = (
-    "DryRunSchedulePayload",
-    "KernelDryRunResultInfo",
+    "ComputeScheduleKernelResultInfo",
+    "ComputeSchedulePayload",
     "SchedulingBroadcastEventPayloadNode",
     "UnschedulableReasonHintInfo",
 )
@@ -48,7 +48,7 @@ class SchedulingBroadcastEventPayloadNode(BaseResponseModel):
 class UnschedulableReasonHintInfo(BaseResponseModel):
     """What the caller could change so an unschedulable kernel would fit.
 
-    Populated only when the kernel's dry-run ``success`` is False. Surfaces
+    Populated only when the kernel's ``success`` is False. Surfaces
     the user-actionable subset of the selector's remediation hint.
     """
 
@@ -62,8 +62,8 @@ class UnschedulableReasonHintInfo(BaseResponseModel):
     )
 
 
-class KernelDryRunResultInfo(BaseResponseModel):
-    """Dry-run outcome for a single kernel.
+class ComputeScheduleKernelResultInfo(BaseResponseModel):
+    """Compute-schedule outcome for a single kernel.
 
     Results correspond positionally to the requested kernels: the caller
     matches each result to its input by list index. ``reason_hint`` is
@@ -85,9 +85,9 @@ class KernelDryRunResultInfo(BaseResponseModel):
     )
 
 
-class DryRunSchedulePayload(BaseResponseModel):
-    """Result of a dry-run schedule request."""
+class ComputeSchedulePayload(BaseResponseModel):
+    """Result of a compute-schedule request."""
 
-    dry_run_results: list[KernelDryRunResultInfo] = Field(
-        description="Per-kernel dry-run outcomes, correlated to the request by list index.",
+    results: list[ComputeScheduleKernelResultInfo] = Field(
+        description="Per-kernel compute-schedule outcomes, correlated to the request by list index.",
     )

--- a/src/ai/backend/common/dto/manager/v2/scheduler/response.py
+++ b/src/ai/backend/common/dto/manager/v2/scheduler/response.py
@@ -56,10 +56,6 @@ class UnschedulableReasonHintInfo(BaseResponseModel):
         default=None,
         description="Subtract these slots to fit the best-fitting node.",
     )
-    required_container_reduction: int | None = Field(
-        default=None,
-        description="Number of containers that must be freed to fit.",
-    )
     available_archs: list[str] | None = Field(
         default=None,
         description="Architectures that actually exist among the scheduling targets.",

--- a/src/ai/backend/manager/api/gql/scheduler.py
+++ b/src/ai/backend/manager/api/gql/scheduler.py
@@ -9,22 +9,37 @@ import strawberry
 from strawberry import Info
 
 from ai.backend.common.dto.manager.v2.scheduler import (
+    DryRunKernelResourceInput,
+    DryRunScheduleInput,
+    DryRunSchedulePayload,
+    KernelDryRunResultInfo,
     SchedulingBroadcastEventPayloadNode,
     SchedulingStatusDTO,
+    UnschedulableReasonHintInfo,
 )
 from ai.backend.common.events.event_types.session.broadcast import SchedulingBroadcastEvent
 from ai.backend.common.events.hub.propagators.bypass import AsyncBypassPropagator
 from ai.backend.common.events.types import EventDomain
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.common.types import SessionId
 from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.api.gql.common_types import (
+    ResourceSlotEntryGQL,
+    ResourceSlotEntryInputGQL,
+)
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
+    PydanticInputMixin,
     gql_enum,
     gql_field,
+    gql_pydantic_input,
     gql_pydantic_type,
+    gql_root_field,
     gql_subscription,
 )
+from ai.backend.manager.api.gql.session.types import SessionClusterModeGQL
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
+from ai.backend.manager.errors.common import ServiceUnavailable
 from ai.backend.manager.errors.kernel import InvalidSessionId
 
 from .session_federation import Session
@@ -141,3 +156,103 @@ async def scheduling_events_by_session(
     finally:
         # Unregister propagator when subscription ends
         event_hub.unregister_event_propagator(propagator.id())
+
+
+# ---------------------------------------------------------------------------
+# Dry-run schedule — probe a resource group's admission for a session's
+# kernels without provisioning. Powers the session-launcher live feedback,
+# so the query stays lightweight.
+# ---------------------------------------------------------------------------
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Per-kernel resource request for a scheduling dry-run. The image is "
+            "optional when a resource-group default supplies it downstream."
+        ),
+    ),
+    name="DryRunKernelResourceInput",
+)
+class DryRunKernelResourceInputGQL(PydanticInputMixin[DryRunKernelResourceInput]):
+    image_id: strawberry.ID | None = None
+    resources: list[ResourceSlotEntryInputGQL] | None = None
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Dry-run a session's scheduling against a resource group without provisioning.",
+    ),
+    name="DryRunScheduleInput",
+)
+class DryRunScheduleInputGQL(PydanticInputMixin[DryRunScheduleInput]):
+    kernels: list[DryRunKernelResourceInputGQL]
+    cluster_mode: SessionClusterModeGQL
+    resource_group_id: strawberry.ID
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "What the caller could change so an unschedulable kernel would fit. "
+            "Present only when the kernel's dry-run did not succeed."
+        ),
+    ),
+    model=UnschedulableReasonHintInfo,
+    name="UnschedulableReasonHint",
+)
+class UnschedulableReasonHintGQL:
+    required_reduction: list[ResourceSlotEntryGQL] | None
+    required_container_reduction: int | None
+    available_archs: list[str] | None
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Dry-run outcome for a single kernel. Results correspond positionally "
+            "to the requested kernels."
+        ),
+    ),
+    model=KernelDryRunResultInfo,
+    name="KernelDryRunResult",
+)
+class KernelDryRunResultGQL:
+    requested_slots: list[ResourceSlotEntryGQL]
+    requested_architecture: str
+    success: bool
+    reason_hint: UnschedulableReasonHintGQL | None
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Result of a dry-run schedule request.",
+    ),
+    model=DryRunSchedulePayload,
+    name="DryRunSchedulePayload",
+)
+class DryRunSchedulePayloadGQL:
+    dry_run_results: list[KernelDryRunResultGQL]
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Dry-run a session's scheduling against a resource group without "
+            "provisioning. Returns per-kernel admission outcomes and, for kernels "
+            "that do not fit, hints on what to reduce."
+        ),
+    )
+)  # type: ignore[misc]
+async def dry_run_schedule(
+    input: DryRunScheduleInputGQL,
+    info: Info[StrawberryGQLContext],
+) -> DryRunSchedulePayloadGQL:
+    # Schema-only surface: the adapter wiring lands in a follow-up.
+    raise ServiceUnavailable("Dry-run schedule is not yet available.")

--- a/src/ai/backend/manager/api/gql/scheduler.py
+++ b/src/ai/backend/manager/api/gql/scheduler.py
@@ -158,13 +158,6 @@ async def scheduling_events_by_session(
         event_hub.unregister_event_propagator(propagator.id())
 
 
-# ---------------------------------------------------------------------------
-# Dry-run schedule — probe a resource group's admission for a session's
-# kernels without provisioning. Powers the session-launcher live feedback,
-# so the query stays lightweight.
-# ---------------------------------------------------------------------------
-
-
 @gql_pydantic_input(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
@@ -206,7 +199,6 @@ class DryRunScheduleInputGQL(PydanticInputMixin[DryRunScheduleInput]):
 )
 class UnschedulableReasonHintGQL:
     required_reduction: list[ResourceSlotEntryGQL] | None
-    required_container_reduction: int | None
     available_archs: list[str] | None
 
 

--- a/src/ai/backend/manager/api/gql/scheduler.py
+++ b/src/ai/backend/manager/api/gql/scheduler.py
@@ -253,6 +253,6 @@ class DryRunSchedulePayloadGQL:
 async def dry_run_schedule(
     input: DryRunScheduleInputGQL,
     info: Info[StrawberryGQLContext],
-) -> DryRunSchedulePayloadGQL:
+) -> DryRunSchedulePayloadGQL | None:
     # Schema-only surface: the adapter wiring lands in a follow-up.
     raise ServiceUnavailable("Dry-run schedule is not yet available.")

--- a/src/ai/backend/manager/api/gql/scheduler.py
+++ b/src/ai/backend/manager/api/gql/scheduler.py
@@ -9,10 +9,10 @@ import strawberry
 from strawberry import Info
 
 from ai.backend.common.dto.manager.v2.scheduler import (
-    DryRunKernelResourceInput,
-    DryRunScheduleInput,
-    DryRunSchedulePayload,
-    KernelDryRunResultInfo,
+    ComputeScheduleInput,
+    ComputeScheduleKernelResourceInput,
+    ComputeScheduleKernelResultInfo,
+    ComputeSchedulePayload,
     SchedulingBroadcastEventPayloadNode,
     SchedulingStatusDTO,
     UnschedulableReasonHintInfo,
@@ -162,13 +162,13 @@ async def scheduling_events_by_session(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
         description=(
-            "Per-kernel resource request for a scheduling dry-run. The image is "
+            "Per-kernel resource request for a compute-schedule. The image is "
             "optional when a resource-group default supplies it downstream."
         ),
     ),
-    name="DryRunKernelResourceInput",
+    name="ComputeScheduleKernelResourceInput",
 )
-class DryRunKernelResourceInputGQL(PydanticInputMixin[DryRunKernelResourceInput]):
+class ComputeScheduleKernelResourceInputGQL(PydanticInputMixin[ComputeScheduleKernelResourceInput]):
     image_id: strawberry.ID | None = None
     resources: list[ResourceSlotEntryInputGQL] | None = None
 
@@ -176,12 +176,12 @@ class DryRunKernelResourceInputGQL(PydanticInputMixin[DryRunKernelResourceInput]
 @gql_pydantic_input(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
-        description="Dry-run a session's scheduling against a resource group without provisioning.",
+        description="Compute a session's scheduling against a resource group without provisioning.",
     ),
-    name="DryRunScheduleInput",
+    name="ComputeScheduleInput",
 )
-class DryRunScheduleInputGQL(PydanticInputMixin[DryRunScheduleInput]):
-    kernels: list[DryRunKernelResourceInputGQL]
+class ComputeScheduleInputGQL(PydanticInputMixin[ComputeScheduleInput]):
+    kernels: list[ComputeScheduleKernelResourceInputGQL]
     cluster_mode: SessionClusterModeGQL
     resource_group_id: strawberry.ID
 
@@ -191,7 +191,7 @@ class DryRunScheduleInputGQL(PydanticInputMixin[DryRunScheduleInput]):
         added_version=NEXT_RELEASE_VERSION,
         description=(
             "What the caller could change so an unschedulable kernel would fit. "
-            "Present only when the kernel's dry-run did not succeed."
+            "Present only when the kernel could not be scheduled."
         ),
     ),
     model=UnschedulableReasonHintInfo,
@@ -206,14 +206,14 @@ class UnschedulableReasonHintGQL:
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
         description=(
-            "Dry-run outcome for a single kernel. Results correspond positionally "
+            "Compute-schedule outcome for a single kernel. Results correspond positionally "
             "to the requested kernels."
         ),
     ),
-    model=KernelDryRunResultInfo,
-    name="KernelDryRunResult",
+    model=ComputeScheduleKernelResultInfo,
+    name="ComputeScheduleKernelResult",
 )
-class KernelDryRunResultGQL:
+class ComputeScheduleKernelResultGQL:
     requested_slots: list[ResourceSlotEntryGQL]
     requested_architecture: str
     success: bool
@@ -223,28 +223,29 @@ class KernelDryRunResultGQL:
 @gql_pydantic_type(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
-        description="Result of a dry-run schedule request.",
+        description="Result of a compute-schedule request.",
     ),
-    model=DryRunSchedulePayload,
-    name="DryRunSchedulePayload",
+    model=ComputeSchedulePayload,
+    name="ComputeSchedulePayload",
 )
-class DryRunSchedulePayloadGQL:
-    dry_run_results: list[KernelDryRunResultGQL]
+class ComputeSchedulePayloadGQL:
+    results: list[ComputeScheduleKernelResultGQL]
 
 
 @gql_root_field(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
         description=(
-            "Dry-run a session's scheduling against a resource group without "
-            "provisioning. Returns per-kernel admission outcomes and, for kernels "
-            "that do not fit, hints on what to reduce."
+            "Compute whether a session could be created on a resource group, "
+            "without actually provisioning it. Checks each kernel's resource "
+            "request against the group's agents and returns per-kernel admission "
+            "outcomes, with hints on what to reduce for kernels that do not fit."
         ),
     )
 )  # type: ignore[misc]
-async def dry_run_schedule(
-    input: DryRunScheduleInputGQL,
+async def compute_schedule(
+    input: ComputeScheduleInputGQL,
     info: Info[StrawberryGQLContext],
-) -> DryRunSchedulePayloadGQL | None:
+) -> ComputeSchedulePayloadGQL | None:
     # Schema-only surface: the adapter wiring lands in a follow-up.
-    raise ServiceUnavailable("Dry-run schedule is not yet available.")
+    raise ServiceUnavailable("Compute schedule is not yet available.")

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -411,6 +411,7 @@ from .runtime_variant_preset import (
     runtime_variant_presets,
 )
 from .scheduler import (
+    dry_run_schedule,
     scheduling_events_by_session,
 )
 from .scheduling_handler import scheduling_handlers
@@ -526,6 +527,7 @@ class Query:
     admin_resource_groups = admin_resource_groups
     admin_resource_group_v2 = admin_resource_group_v2
     scheduling_handlers = scheduling_handlers
+    dry_run_schedule = dry_run_schedule
     admin_allowed_resource_groups_for_domain_v2 = admin_allowed_resource_groups_for_domain_v2
     admin_allowed_resource_groups_for_project_v2 = admin_allowed_resource_groups_for_project_v2
     admin_allowed_domains_for_resource_group_v2 = admin_allowed_domains_for_resource_group_v2

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -411,7 +411,7 @@ from .runtime_variant_preset import (
     runtime_variant_presets,
 )
 from .scheduler import (
-    dry_run_schedule,
+    compute_schedule,
     scheduling_events_by_session,
 )
 from .scheduling_handler import scheduling_handlers
@@ -527,7 +527,7 @@ class Query:
     admin_resource_groups = admin_resource_groups
     admin_resource_group_v2 = admin_resource_group_v2
     scheduling_handlers = scheduling_handlers
-    dry_run_schedule = dry_run_schedule
+    compute_schedule = compute_schedule
     admin_allowed_resource_groups_for_domain_v2 = admin_allowed_resource_groups_for_domain_v2
     admin_allowed_resource_groups_for_project_v2 = admin_allowed_resource_groups_for_project_v2
     admin_allowed_domains_for_resource_group_v2 = admin_allowed_domains_for_resource_group_v2


### PR DESCRIPTION
## Summary
- Add the compute-schedule GraphQL surface as **schema-only** work: shared v2 DTOs plus the Strawberry GQL types and the `computeSchedule` root query.
- DTOs (`common/dto/manager/v2/scheduler`): `ComputeScheduleInput` / `ComputeScheduleKernelResourceInput` requests and `ComputeSchedulePayload` / `ComputeScheduleKernelResultInfo` / `UnschedulableReasonHintInfo` responses, referencing the existing scheduling action/value types and using `ImageID` / `ResourceGroupID` identifiers.
- GQL (`manager/api/gql/scheduler`): input/output types and the `computeSchedule` root query registered on the `Query` type. Reuses `SessionClusterModeGQL` (values match `ClusterModeEnum` for `to_pydantic`).
- The resolver is a placeholder pending adapter wiring; the generated committed `.graphql` files are intentionally **not** regenerated in this PR.

## Test plan
- [x] `pants check` (mypy) passes for the changed DTO/GQL files
- [x] `./backend.ai mgr api dump-gql-schema --v2` composes and emits the `computeSchedule` query with the expected input/output types
- [x] Follow-up: adapter/service wiring + committed schema regeneration

Resolves BA-6602

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12629.org.readthedocs.build/en/12629/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12629.org.readthedocs.build/ko/12629/

<!-- readthedocs-preview sorna-ko end -->
