### PR TITLE
fix: Restore 0-100 scale for vfolder list_hosts usage percentage

### DIFF
--- a/changes/12634.fix.md
+++ b/changes/12634.fix.md
@@ -1,0 +1,1 @@
+Fix vfolder host usage `percentage` returned by `vfolder/_/hosts` to be on the 0-100 scale again, so storage status indicators in WebUI and FastTrack reflect actual usage instead of always showing "Adequate"

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -1126,7 +1126,9 @@ class VFolderService:
                     volume_usage["total"] = storage_capacity_bytes
                 if show_percentage:
                     try:
-                        volume_usage["percentage"] = storage_used_bytes / storage_capacity_bytes
+                        volume_usage["percentage"] = (
+                            storage_used_bytes / storage_capacity_bytes
+                        ) * 100
                     except ZeroDivisionError:
                         volume_usage["percentage"] = 0.0
 

--- a/tests/unit/manager/services/vfolder/test_vfolder_storage_service.py
+++ b/tests/unit/manager/services/vfolder/test_vfolder_storage_service.py
@@ -279,6 +279,37 @@ class TestListHostsAction:
         assert "usage" in vol_info
         mock_storage_manager.get_manager_facing_client.return_value.get_fs_usage.assert_awaited_once()
 
+    async def test_usage_percentage_is_on_0_to_100_scale(
+        self,
+        vfolder_service: VFolderService,
+        mock_vfolder_repository: MagicMock,
+        mock_valkey_stat_client: MagicMock,
+        mock_storage_manager: MagicMock,
+        user_uuid: uuid.UUID,
+    ) -> None:
+        mock_valkey_stat_client.get_volume_usage = AsyncMock(return_value=None)
+        mock_storage_manager.get_manager_facing_client.return_value.get_fs_usage = AsyncMock(
+            return_value={"used_bytes": 50, "capacity_bytes": 200}
+        )
+
+        mock_vfolder_repository.get_allowed_hosts_for_listing = AsyncMock(
+            return_value=VFolderHostPermissionMap({
+                "proxy1:volume1": {VFolderHostPermission.CREATE},
+            })
+        )
+        action = ListHostsAction(
+            user_uuid=user_uuid,
+            domain_name="default",
+            group_id=None,
+            resource_policy={},
+        )
+        result = await vfolder_service.list_hosts(action)
+
+        usage = result.volume_info["proxy1:volume1"]["usage"]
+        assert usage["percentage"] == 25.0
+        assert usage["used"] == 50
+        assert usage["total"] == 200
+
 
 class TestGetQuotaAction:
     async def test_owner_returns_quota_bytes(


### PR DESCRIPTION
## Summary

- Restore the `* 100` multiplier in `VFolderService._fetch_exposed_volume_fields` so the `percentage` field of `GET /folders/_/hosts` (`vfolder/_/hosts`) is again on a 0-100 scale.
- The BA-4820 service-layer refactor (#9570, first released in 26.3.0) ported the legacy `api/vfolder.py::fetch_exposed_volume_fields` logic but dropped the `* 100`, silently changing the wire value to a 0-1 fraction.
- The `ZeroDivisionError` fallback (`0.0`) is kept as-is.

## Impact

Both first-party consumers threshold this value on a 0-100 scale (`< 70` → Adequate, `< 90` → Caution, else Insufficient):

- Backend.AI WebUI `StorageSelect` / storage status indicators
- Backend.AI FastTrack `VirtualFolderHostSelect`

With the fraction-scaled value (max 1.0), every storage host always renders as "Adequate" regardless of actual usage, hiding nearly-full volumes from users at folder-creation time.

## Cache interplay

`_fetch_exposed_volume_fields` first consults the Valkey stat cache via `get_volume_usage(proxy, volume)`. The corresponding writer `ValkeyStatClient.set_volume_usage` is defined in `src/ai/backend/common/clients/valkey_client/valkey_stat/client.py` but has **no call sites anywhere in this repository**, so the cache lookup always misses and the value is always recomputed from `get_fs_usage`. No stale fraction-scaled values can be served after this fix (unless an external component writes that key, which none in this repo does).

## Tests

- Added `test_usage_percentage_is_on_0_to_100_scale` to `tests/unit/manager/services/vfolder/test_vfolder_storage_service.py` (used=50, capacity=200 → `percentage == 25.0`), following the existing mock-based patterns in that file.
- `pants lint` / mypy / vfolder unit+component tests all pass locally (run by the pre-push hook).

Closes #12632

🤖 Generated with [Claude Code](https://claude.com/claude-code)
