### PR TITLE
fix(BA-6769): expose BinarySizeInfo byte count as string field 'expr'

### DIFF
--- a/changes/12638.breaking.md
+++ b/changes/12638.breaking.md
@@ -1,0 +1,1 @@
+The GraphQL and REST v2 `BinarySizeInfo` type now returns the exact byte count as a string field `expr` (replacing the integer `value`), lifting the 2 GiB GraphQL `Int` limit that made larger sizes fail to serialize; clients must read `expr` as a string on resource policy `maxQuotaScopeSize`, vfolder `usedBytes`/`maxSize`, and resource preset/allocation `sharedMemory`.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -2048,8 +2048,10 @@ Added in 26.4.2. Binary size with both raw bytes and human-readable format.
 type BinarySizeInfo
   @join__type(graph: STRAWBERRY)
 {
-  """Size in bytes."""
-  value: Int!
+  """
+  Exact size in bytes as a decimal string (e.g., '1073741824'); accepted as BinarySizeInput.expr.
+  """
+  expr: String!
 
   """Size in human-readable format (e.g., '1g', '512m')."""
   display: String!

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1436,8 +1436,10 @@ enum BgtaskEventType {
 Added in 26.4.2. Binary size with both raw bytes and human-readable format.
 """
 type BinarySizeInfo {
-  """Size in bytes."""
-  value: Int!
+  """
+  Exact size in bytes as a decimal string (e.g., '1073741824'); accepted as BinarySizeInput.expr.
+  """
+  expr: String!
 
   """Size in human-readable format (e.g., '1g', '512m')."""
   display: String!

--- a/src/ai/backend/common/dto/manager/v2/common.py
+++ b/src/ai/backend/common/dto/manager/v2/common.py
@@ -48,9 +48,16 @@ class BinarySizeInput(BaseRequestModel):
 
 
 class BinarySizeInfo(BaseResponseModel):
-    """Binary size output with both raw bytes and human-readable format."""
+    """Binary size output with both the exact byte count and a human-readable form.
 
-    value: int = Field(description="Size in bytes.")
+    ``expr`` mirrors the ``expr`` input field: an exact decimal byte-count string
+    (e.g. '1073741824') that can be fed back into any ``BinarySizeInput``. It is a
+    string so sizes beyond the GraphQL ``Int`` range (2 GiB) serialize correctly.
+    """
+
+    expr: str = Field(
+        description="Exact size in bytes as a decimal string (e.g., '1073741824'); accepted as BinarySizeInput.expr.",
+    )
     display: str = Field(description="Size in human-readable format (e.g., '1g', '512m').")
 
 

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -177,6 +177,7 @@ __all__ = (
 if TYPE_CHECKING:
     from ai.backend.common.configs.redis import RedisConfig
     from ai.backend.common.data.vfolder.types import VFolderMountData
+    from ai.backend.common.dto.manager.v2.common import BinarySizeInfo
 
     from .docker import ImageRef
 
@@ -1077,6 +1078,21 @@ class BinarySize(int):
             raise ValueError("Unsupported scale unit.", suffix)
         value = self._quantize(self, maybe_multiplier)
         return f"{value:f}{suffix.lower()}".strip()
+
+    def to_bytes_str(self) -> str:
+        """Exact byte count as a base-10 string (e.g. '1073741824').
+
+        Distinct from ``str()`` ('1 GiB') and ``format(_, 's')`` ('1g'), which humanize.
+        """
+        return str(int(self))
+
+    @classmethod
+    def to_size_info(cls, value: int) -> BinarySizeInfo:
+        """Build the BinarySizeInfo DTO from a byte count (exact string + humanized display)."""
+        from ai.backend.common.dto.manager.v2.common import BinarySizeInfo
+
+        size = cls(value)
+        return BinarySizeInfo(expr=size.to_bytes_str(), display=f"{size:s}")
 
 
 def _validate_binary_size(v: Any) -> BinarySize:

--- a/src/ai/backend/manager/api/adapters/resource_allocation/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_allocation/adapter.py
@@ -8,7 +8,6 @@ from uuid import UUID
 
 from ai.backend.common.contexts.user import current_user
 from ai.backend.common.dto.manager.v2.common import (
-    BinarySizeInfo,
     ResourceLimitEntryInfo,
     ResourceSlotEntryInfo,
 )
@@ -60,16 +59,6 @@ from ai.backend.manager.services.resource_allocation.actions.get_resource_group_
 from ai.backend.manager.services.resource_allocation.actions.resolve_keypair_context import (
     ResolveKeypairContextAction,
 )
-
-
-def _humanize_bytes(value: int) -> str:
-    """Convert bytes integer to human-readable string (e.g., 1073741824 -> '1g')."""
-    return f"{BinarySize(value):s}"
-
-
-def _to_binary_size_info(value: int) -> BinarySizeInfo:
-    """Convert bytes integer to BinarySizeInfo DTO."""
-    return BinarySizeInfo(value=value, display=_humanize_bytes(value))
 
 
 class ResourceAllocationAdapter(BaseAdapter):
@@ -398,7 +387,9 @@ def _preset_availability_to_node(data: PresetAvailabilityData) -> PresetAvailabi
             for k, v in data.preset.resource_slots.items()
         ],
         shared_memory=(
-            _to_binary_size_info(data.preset.shared_memory) if data.preset.shared_memory else None
+            BinarySize.to_size_info(data.preset.shared_memory)
+            if data.preset.shared_memory is not None
+            else None
         ),
         resource_group_name=data.preset.scaling_group_name,
         available=data.available,

--- a/src/ai/backend/manager/api/adapters/resource_policy/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_policy/adapter.py
@@ -11,7 +11,6 @@ from typing import Any
 from ai.backend.common.api_handlers import Sentinel
 from ai.backend.common.contexts.user import current_user
 from ai.backend.common.dto.manager.v2.common import (
-    BinarySizeInfo,
     BinarySizeInput,
     ResourceLimitEntryInfo,
     ResourceSlotEntryInfo,
@@ -165,17 +164,6 @@ from ai.backend.manager.services.user_resource_policy.actions.search_user_resour
     SearchUserResourcePoliciesAction,
 )
 from ai.backend.manager.types import OptionalState, TriState
-
-
-def _humanize_bytes(value: int) -> str:
-    """Convert bytes integer to human-readable string (e.g., 1073741824 -> '1g')."""
-    return f"{BinarySize(value):s}"
-
-
-def _to_binary_size_info(value: int) -> BinarySizeInfo:
-    """Convert bytes integer to BinarySizeInfo DTO."""
-    return BinarySizeInfo(value=value, display=_humanize_bytes(value))
-
 
 _KEYPAIR_RP_PAGINATION_SPEC = PaginationSpec(
     forward_order=KeypairResourcePolicyOrders.created_at(ascending=False),
@@ -651,7 +639,7 @@ class ResourcePolicyAdapter(BaseAdapter):
             name=data.name,
             max_vfolder_count=data.max_vfolder_count,
             max_concurrent_logins=data.max_concurrent_logins,
-            max_quota_scope_size=_to_binary_size_info(data.max_quota_scope_size),
+            max_quota_scope_size=BinarySize.to_size_info(data.max_quota_scope_size),
             max_session_count_per_model_session=data.max_session_count_per_model_session,
             max_customized_image_count=data.max_customized_image_count,
         )
@@ -664,7 +652,7 @@ class ResourcePolicyAdapter(BaseAdapter):
             id=data.name,
             name=data.name,
             max_vfolder_count=data.max_vfolder_count,
-            max_quota_scope_size=_to_binary_size_info(data.max_quota_scope_size),
+            max_quota_scope_size=BinarySize.to_size_info(data.max_quota_scope_size),
             max_network_count=data.max_network_count,
         )
 

--- a/src/ai/backend/manager/api/adapters/resource_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_preset/adapter.py
@@ -8,7 +8,6 @@ from uuid import UUID
 
 from ai.backend.common.api_handlers import SENTINEL
 from ai.backend.common.dto.manager.v2.common import (
-    BinarySizeInfo,
     BinarySizeInput,
     ResourceSlotEntryInfo,
 )
@@ -63,21 +62,11 @@ from ai.backend.manager.services.resource_preset.actions.search_presets import (
 from ai.backend.manager.types import OptionalState, TriState
 
 
-def _humanize_bytes(value: int) -> str:
-    """Convert bytes integer to human-readable string (e.g., 1073741824 → '1g')."""
-    return f"{BinarySize(value):s}"
-
-
 def _resolve_binary_size_input(input: BinarySizeInput | None) -> int | None:
     """Resolve BinarySizeInput to bytes integer."""
     if input is None:
         return None
     return input.bytes
-
-
-def _to_binary_size_info(value: int) -> BinarySizeInfo:
-    """Convert bytes integer to BinarySizeInfo DTO."""
-    return BinarySizeInfo(value=value, display=_humanize_bytes(value))
 
 
 def _resource_slot_entries_to_slot(
@@ -274,7 +263,9 @@ class ResourcePresetAdapter(BaseAdapter):
                 for k, v in data.resource_slots.items()
             ],
             shared_memory=(
-                _to_binary_size_info(data.shared_memory) if data.shared_memory else None
+                BinarySize.to_size_info(data.shared_memory)
+                if data.shared_memory is not None
+                else None
             ),
             resource_group_name=data.scaling_group_name,
         )

--- a/src/ai/backend/manager/api/adapters/vfolder/adapter.py
+++ b/src/ai/backend/manager/api/adapters/vfolder/adapter.py
@@ -7,7 +7,6 @@ from uuid import UUID
 
 from ai.backend.common.contexts.user import current_user
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
-from ai.backend.common.dto.manager.v2.common import BinarySizeInfo
 from ai.backend.common.dto.manager.v2.deployment.request import DeploymentStrategyInput
 from ai.backend.common.dto.manager.v2.vfolder.request import (
     BulkDeleteVFoldersInput,
@@ -148,11 +147,6 @@ _VFOLDER_PAGINATION_SPEC = PaginationSpec(
 )
 
 
-def _to_binary_size_info(value: int) -> BinarySizeInfo:
-    """Convert bytes integer to BinarySizeInfo DTO."""
-    return BinarySizeInfo(value=value, display=f"{BinarySize(value):s}")
-
-
 def _build_policy_from_strategy_input(
     strategy_input: DeploymentStrategyInput | None,
 ) -> DeploymentPolicyConfig | None:
@@ -218,7 +212,9 @@ class VFolderAdapter(BaseAdapter):
                 creator_email=data.creator,
             ),
             quota=VFolderQuotaInfo(
-                max_size=_to_binary_size_info(data.max_size) if data.max_size is not None else None,
+                max_size=BinarySize.to_size_info(data.max_size)
+                if data.max_size is not None
+                else None,
                 max_files=data.max_files,
             ),
             unmanaged_path=data.unmanaged_path,
@@ -431,7 +427,7 @@ class VFolderAdapter(BaseAdapter):
             return None
         return VFolderUsageInfoDTO(
             num_files=usage.num_files,
-            used_bytes=_to_binary_size_info(usage.used_bytes),
+            used_bytes=BinarySize.to_size_info(usage.used_bytes),
         )
 
     async def delete(self, vfolder_id: UUID) -> DeleteVFolderPayload:

--- a/tests/component/resource_policy/test_user_resource_policy_crud.py
+++ b/tests/component/resource_policy/test_user_resource_policy_crud.py
@@ -38,7 +38,7 @@ class TestUserResourcePolicyCreate:
         policy = result.user_resource_policy
         assert policy.name == name
         assert policy.max_vfolder_count == 20
-        assert policy.max_quota_scope_size.value == 1073741824
+        assert policy.max_quota_scope_size.expr == "1073741824"
         assert policy.max_session_count_per_model_session == 5
         assert policy.max_customized_image_count == 10
 

--- a/tests/unit/common/dto/manager/v2/common/BUILD
+++ b/tests/unit/common/dto/manager/v2/common/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/common/dto/manager/v2/common/test_common.py
+++ b/tests/unit/common/dto/manager/v2/common/test_common.py
@@ -1,0 +1,44 @@
+"""Tests for ai.backend.common.dto.manager.v2.common shared DTOs."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from ai.backend.common.dto.manager.v2.common import BinarySizeInfo
+
+# Byte sizes that overflow GraphQL Int (32-bit signed, max 2,147,483,647)
+# and JSON-number-safe integers (2^53). These must serialize as strings.
+_OVER_2GIB = "1234000000000"
+_OVER_2POW53 = str(2**53 + 1)
+
+
+class TestBinarySizeInfo:
+    """BinarySizeInfo.expr is a decimal byte-count string, unbounded by Int range."""
+
+    def test_expr_is_string(self) -> None:
+        info = BinarySizeInfo(expr="1073741824", display="1g")
+        assert info.expr == "1073741824"
+
+    def test_rejects_int_expr(self) -> None:
+        int_value: Any = 1073741824
+        with pytest.raises(ValidationError):
+            BinarySizeInfo(expr=int_value, display="1g")
+
+    @pytest.mark.parametrize("byte_str", [_OVER_2GIB, _OVER_2POW53])
+    def test_serializes_large_values_as_json_string(self, byte_str: str) -> None:
+        info = BinarySizeInfo(expr=byte_str, display="humanized")
+        payload = json.loads(info.model_dump_json())
+        assert payload["expr"] == byte_str
+        assert isinstance(payload["expr"], str)
+
+    @pytest.mark.parametrize("byte_str", [_OVER_2GIB, _OVER_2POW53])
+    def test_round_trip_preserves_large_values(self, byte_str: str) -> None:
+        info = BinarySizeInfo(expr=byte_str, display="humanized")
+        restored = BinarySizeInfo.model_validate_json(info.model_dump_json())
+        assert restored.expr == byte_str
+        # Exact byte count is recoverable as an arbitrary-precision int.
+        assert int(restored.expr) == int(byte_str)

--- a/tests/unit/common/dto/manager/v2/resource_policy/test_response.py
+++ b/tests/unit/common/dto/manager/v2/resource_policy/test_response.py
@@ -56,7 +56,7 @@ def _make_user_policy_node(name: str = "user-policy") -> UserResourcePolicyNode:
         name=name,
         created_at=datetime(2024, 1, 1, tzinfo=UTC),
         max_vfolder_count=10,
-        max_quota_scope_size=BinarySizeInfo(value=1073741824, display="1g"),
+        max_quota_scope_size=BinarySizeInfo(expr="1073741824", display="1g"),
         max_session_count_per_model_session=5,
         max_customized_image_count=3,
     )
@@ -68,7 +68,7 @@ def _make_project_policy_node(name: str = "project-policy") -> ProjectResourcePo
         name=name,
         created_at=datetime(2024, 1, 1, tzinfo=UTC),
         max_vfolder_count=20,
-        max_quota_scope_size=BinarySizeInfo(value=10737418240, display="10g"),
+        max_quota_scope_size=BinarySizeInfo(expr="10737418240", display="10g"),
         max_network_count=5,
     )
 
@@ -160,7 +160,7 @@ class TestUserResourcePolicyNode:
         node = _make_user_policy_node()
         assert node.name == "user-policy"
         assert node.max_vfolder_count == 10
-        assert node.max_quota_scope_size.value == 1073741824
+        assert node.max_quota_scope_size.expr == "1073741824"
         assert node.max_session_count_per_model_session == 5
         assert node.max_customized_image_count == 3
 
@@ -212,7 +212,7 @@ class TestProjectResourcePolicyNode:
         node = _make_project_policy_node()
         assert node.name == "project-policy"
         assert node.max_vfolder_count == 20
-        assert node.max_quota_scope_size.value == 10737418240
+        assert node.max_quota_scope_size.expr == "10737418240"
         assert node.max_network_count == 5
 
     def test_round_trip(self) -> None:

--- a/tests/unit/common/dto/manager/v2/vfolder/test_types.py
+++ b/tests/unit/common/dto/manager/v2/vfolder/test_types.py
@@ -188,16 +188,16 @@ class TestVFolderUsageInfo:
     def test_creation(self) -> None:
         info = VFolderUsageInfo(
             num_files=10,
-            used_bytes=BinarySizeInfo(value=1024, display="1024"),
+            used_bytes=BinarySizeInfo(expr="1024", display="1024"),
         )
         assert info.num_files == 10
-        assert info.used_bytes.value == 1024
+        assert info.used_bytes.expr == "1024"
 
     def test_round_trip(self) -> None:
         info = VFolderUsageInfo(
             num_files=5,
-            used_bytes=BinarySizeInfo(value=512, display="512"),
+            used_bytes=BinarySizeInfo(expr="512", display="512"),
         )
         restored = VFolderUsageInfo.model_validate_json(info.model_dump_json())
         assert restored.num_files == 5
-        assert restored.used_bytes.value == 512
+        assert restored.used_bytes.expr == "512"

--- a/tests/unit/common/test_binary_size_parse.py
+++ b/tests/unit/common/test_binary_size_parse.py
@@ -44,3 +44,53 @@ class TestBinarySizeFractionalZeroParsing:
         # Sanity check: regular integer strings continue to parse normally.
         assert int(BinarySize.from_str("1024")) == 1024
         assert int(BinarySize.from_str("1G")) == 1024 * 1024 * 1024
+
+
+class TestBinarySizeToBytesStr:
+    """to_bytes_str returns the exact byte count, bypassing the humanizing str()/format."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (0, "0"),
+            (1024, "1024"),
+            (1073741824, "1073741824"),
+            (1234000000000, "1234000000000"),  # > 2 GiB
+            (2**53 + 1, "9007199254740993"),  # > JSON-safe int
+        ],
+    )
+    def test_returns_exact_decimal_bytes(self, value: int, expected: str) -> None:
+        assert BinarySize(value).to_bytes_str() == expected
+
+    def test_does_not_humanize(self) -> None:
+        # str()/format humanize; to_bytes_str must not.
+        size = BinarySize(1073741824)
+        assert str(size) == "1 GiB"
+        assert f"{size:s}" == "1g"
+        assert size.to_bytes_str() == "1073741824"
+
+
+class TestBinarySizeToSizeInfo:
+    """to_size_info builds a BinarySizeInfo (exact-bytes expr + humanized display)."""
+
+    def test_zero_is_a_real_value(self) -> None:
+        # A byte count of 0 must produce a DTO, not be mistaken for absent.
+        info = BinarySize.to_size_info(0)
+        assert info.expr == "0"
+        assert info.display == "0"
+
+    @pytest.mark.parametrize(
+        ("value", "expected_expr"),
+        [
+            (1073741824, "1073741824"),
+            (1234000000000, "1234000000000"),  # > 2 GiB
+            (2**53 + 1, "9007199254740993"),  # > JSON-safe int
+        ],
+    )
+    def test_expr_is_exact_decimal_bytes(self, value: int, expected_expr: str) -> None:
+        assert BinarySize.to_size_info(value).expr == expected_expr
+
+    def test_display_is_humanized(self) -> None:
+        info = BinarySize.to_size_info(1073741824)
+        assert info.expr == "1073741824"
+        assert info.display == "1g"

--- a/tests/unit/manager/api/adapters/test_vfolder_adapter.py
+++ b/tests/unit/manager/api/adapters/test_vfolder_adapter.py
@@ -293,7 +293,7 @@ class TestVFolderAdapterGetFolderUsage:
 
         assert dto is not None
         assert dto.num_files == 2
-        assert dto.used_bytes.value == 524308
+        assert dto.used_bytes.expr == "524308"
 
     async def test_unmanaged_vfolder_returns_none(
         self,

--- a/tests/unit/manager/api/gql/test_common_types.py
+++ b/tests/unit/manager/api/gql/test_common_types.py
@@ -1,0 +1,27 @@
+"""Tests for shared GQL types in ai.backend.manager.api.gql.common_types."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from ai.backend.common.dto.manager.v2.common import BinarySizeInfo
+from ai.backend.manager.api.gql.common_types import BinarySizeInfoGQL
+
+
+class TestBinarySizeInfoGQL:
+    """BinarySizeInfoGQL.expr must map to GraphQL String, not the 32-bit Int scalar.
+
+    Regression guard: exposing the byte count as Int made sizes over 2 GiB fail
+    response serialization with "Int cannot represent non 32-bit signed integer".
+    Strawberry maps a ``str`` field to String and an ``int`` field to Int, so the
+    field's Python type is the invariant that decides the GraphQL scalar.
+    """
+
+    def test_expr_field_maps_to_string(self) -> None:
+        definition = cast(Any, BinarySizeInfoGQL).__strawberry_definition__
+        fields = {f.name: f for f in definition.fields}
+        assert fields["expr"].type is str
+
+    def test_from_pydantic_preserves_string_expr(self) -> None:
+        gql = BinarySizeInfoGQL.from_pydantic(BinarySizeInfo(expr="1234000000000", display="1.1t"))
+        assert cast(Any, gql).expr == "1234000000000"


### PR DESCRIPTION
## Summary
- `BinarySizeInfo` exposed the byte count as `value: int`, which GraphQL maps to the 32-bit `Int` scalar — byte sizes over 2 GiB failed response serialization (`Int cannot represent non 32-bit signed integer value`). Input/DB paths were already fine; only the response scalar was narrowed.
- Replace `value: int` with `expr: str` (exact decimal byte string, mirroring `BinarySizeInput.expr`) so arbitrarily large sizes serialize as strings across GraphQL and REST v2. Adds `BinarySize.to_size_info()` to build the DTO from the source type.
- Also fixes a falsy-zero guard that dropped an explicit `shared_memory` of `0`, and regenerates the GraphQL reference schemas.

**BREAKING**: `BinarySizeInfo.value` (Int) is now `expr` (String). Affects resource policy `maxQuotaScopeSize`, vfolder `usedBytes`/`maxSize`, and resource preset/allocation `sharedMemory`. Clients that read these as numbers must read `expr` as a string (parse to int where needed). WebUI consumers need a coordinated migration.

## Test plan
- [x] `BinarySizeInfo` serializes byte counts over 2 GiB and 2^53 as JSON strings (round-trip)
- [x] `BinarySizeInfoGQL.expr` maps to GraphQL `String`, not `Int`
- [x] `BinarySize.to_size_info()` returns exact `expr` (not humanized) incl. `BinarySize` inputs and `0`
- [x] `shared_memory == 0` is emitted, not dropped as unset
- [x] Input path unchanged: policy create with `expr="1073741824"` still succeeds
- [x] GraphQL reference schemas (`v2-schema.graphql`, `supergraph.graphql`) show `expr: String!`
- [x] `pants fmt/fix/lint/check/test` pass

Resolves BA-6769

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12638.org.readthedocs.build/en/12638/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12638.org.readthedocs.build/ko/12638/

<!-- readthedocs-preview sorna-ko end -->