### PR TITLE
fix(BA-6770): serialize GPFS quota limit as plain int

### DIFF
--- a/changes/12641.fix.md
+++ b/changes/12641.fix.md
@@ -1,0 +1,1 @@
+Fix GPFS quota unset failing with `GPFSJobFailedError` by serializing the quota limit as a plain integer instead of a human-readable `BinarySize` string.

--- a/src/ai/backend/storage/volumes/gpfs/gpfs_client.py
+++ b/src/ai/backend/storage/volumes/gpfs/gpfs_client.py
@@ -17,7 +17,6 @@ from tenacity import (
     wait_fixed,
 )
 
-from ai.backend.common.types import BinarySize
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.storage.errors import ExternalStorageServiceError
 
@@ -258,7 +257,7 @@ class GPFSAPIClient:
         fileset_name: str,
         limit_bytes: int,
     ) -> None:
-        limit_str = str(limit_bytes)
+        limit_str = str(int(limit_bytes))
         body = {
             "operationType": "setQuota",
             "quotaType": GPFSQuotaType.FILESET,
@@ -277,7 +276,7 @@ class GPFSAPIClient:
             await self._wait_for_job_done([GPFSJob.from_dict(x) for x in data["jobs"]])
 
     async def remove_quota(self, fs_name: str, fileset_name: str) -> None:
-        await self.set_quota(fs_name, fileset_name, BinarySize(0))
+        await self.set_quota(fs_name, fileset_name, 0)
 
     async def create_fileset(
         self,


### PR DESCRIPTION
## Summary
- `remove_quota` passed `BinarySize(0)` into `set_quota`, whose `str()` yields `"0 bytes"` (`BinarySize` is an `int` subclass with a human-readable `__str__`). GPFS `mmsetquota` rejects that value (`EFSSP1101C`, exitCode 6), so unset quota failed with `GPFSJobFailedError` and a 500 error.
- Coerce the limit to a plain `int` before serialization in `set_quota` (`str(int(limit_bytes))`), guarding all callers against the `BinarySize`/`int` subclass trap.
- Pass a plain `0` from `remove_quota`; drop the now-unused `BinarySize` import.

## Test plan
- [x] `DELETE /quota-scope/quota` on a GPFS volume succeeds (body carries `blockSoftLimit="0"` / `blockHardLimit="0"`, no `EFSSP1101C`).
- [x] `update_quota_scope` with a positive limit still sets the quota correctly.

Resolves BA-6770