### PR TITLE
feat(BA-6760): add DummyComputeBackend and refine ComputeBackend ABC

### DIFF
--- a/changes/12644.feature.md
+++ b/changes/12644.feature.md
@@ -1,0 +1,1 @@
+Add an in-memory dummy compute backend implementing the ComputeBackend instance-lifecycle interface for tests and local development.

--- a/src/ai/backend/agent/compute_backend/backend.py
+++ b/src/ai/backend/agent/compute_backend/backend.py
@@ -1,7 +1,9 @@
 """Container/VM-common interface for the instance lifecycle.
 
 The backend owns instances only; side resources (alloc/port/network/scratch) are
-acquired/released by separate managers. See proposals/BEP-1057-agent-re-architecture.md.
+acquired/released by separate managers. `destroy_instance` triggers instance
+teardown alone — the upper orchestration layer releases side resources in
+acquisition-reverse order. See proposals/BEP-1057-agent-re-architecture.md.
 """
 
 from __future__ import annotations
@@ -9,34 +11,34 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 
-from ai.backend.agent.compute_backend.types import (
-    InstanceHandle,
-    InstanceInfo,
-    InstanceSpec,
-    InstanceStat,
-)
+from ai.backend.agent.compute_backend.instance import ComputeInstance
+from ai.backend.agent.compute_backend.types import InstanceId, InstanceSpec
 
 
 class ComputeBackend(ABC):
     @abstractmethod
-    async def create_instance(self, spec: InstanceSpec) -> InstanceHandle:
+    async def create_instance(self, spec: InstanceSpec) -> ComputeInstance:
         raise NotImplementedError
 
     @abstractmethod
-    async def destroy_instance(self, handle: InstanceHandle) -> None:
-        """Idempotent: destroying an already-gone instance is a no-op."""
+    async def destroy_instance(self, instance_id: InstanceId) -> None:
+        """Trigger instance teardown only; idempotent. Side resources are released elsewhere."""
         raise NotImplementedError
 
     @abstractmethod
-    async def inspect_instance(self, handle: InstanceHandle) -> InstanceInfo:
+    async def load_instance(self, instance_id: InstanceId) -> ComputeInstance:
         """Raises InstanceNotFoundError when the instance no longer exists."""
         raise NotImplementedError
 
     @abstractmethod
-    async def list_instances(self) -> Sequence[InstanceInfo]:
-        """Each entry is self-described from labels, so kernel correlation survives a restart."""
+    async def list_instances(self) -> Sequence[ComputeInstance]:
+        """Instances the backend currently tracks."""
         raise NotImplementedError
 
     @abstractmethod
-    async def collect_stats(self, handle: InstanceHandle) -> InstanceStat:
+    async def recover(self) -> None:
+        """Rebuild the tracked set from substrate ground truth (labels) after registry loss.
+
+        A command: the recovered instances are read back via `list_instances`.
+        """
         raise NotImplementedError

--- a/src/ai/backend/agent/compute_backend/instance.py
+++ b/src/ai/backend/agent/compute_backend/instance.py
@@ -1,0 +1,23 @@
+"""Active handle to a created instance.
+
+A backend returns ComputeInstance objects rather than plain data so that
+observation (stats) rides on the object that already holds the backend-native
+reference. Lifecycle triggers stay on ComputeBackend.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ai.backend.agent.compute_backend.types import InstanceInfo, InstanceStat
+
+
+class ComputeInstance(ABC):
+    @property
+    @abstractmethod
+    def info(self) -> InstanceInfo:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def collect_stats(self) -> InstanceStat:
+        raise NotImplementedError

--- a/src/ai/backend/agent/dummy/compute_backend.py
+++ b/src/ai/backend/agent/dummy/compute_backend.py
@@ -1,0 +1,99 @@
+"""In-memory ComputeBackend for tests and local development.
+
+Fully satisfies the ComputeBackend/ComputeInstance ABCs without touching
+Docker/Kubernetes, so it can back service-glue unit tests. State is deterministic
+and held in memory, which doubles as this backend's ground truth for `recover`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from decimal import Decimal
+from typing import override
+
+from ai.backend.agent.compute_backend.backend import ComputeBackend
+from ai.backend.agent.compute_backend.instance import ComputeInstance
+from ai.backend.agent.compute_backend.types import (
+    InstanceHandle,
+    InstanceId,
+    InstanceInfo,
+    InstanceSpec,
+    InstanceStat,
+    InstanceState,
+)
+from ai.backend.agent.errors.backend import (
+    InstanceAlreadyExistsError,
+    InstanceNotFoundError,
+)
+from ai.backend.agent.stats import Measurement
+from ai.backend.common.docker import LabelName
+
+_DEFAULT_STATS: Mapping[str, Measurement] = {
+    "cpu_util": Measurement(value=Decimal("0"), capacity=Decimal("100")),
+    "mem": Measurement(value=Decimal("0"), capacity=Decimal("0")),
+}
+
+
+class DummyInstance(ComputeInstance):
+    _info: InstanceInfo
+    _stats_metrics: Mapping[str, Measurement]
+
+    def __init__(self, info: InstanceInfo, stats_metrics: Mapping[str, Measurement]) -> None:
+        self._info = info
+        self._stats_metrics = stats_metrics
+
+    @property
+    @override
+    def info(self) -> InstanceInfo:
+        return self._info
+
+    @override
+    async def collect_stats(self) -> InstanceStat:
+        return InstanceStat(
+            instance_id=self._info.handle.instance_id,
+            metrics=dict(self._stats_metrics),
+        )
+
+
+class DummyComputeBackend(ComputeBackend):
+    _instances: dict[InstanceId, DummyInstance]
+    _stats_metrics: Mapping[str, Measurement]
+
+    def __init__(self, *, stats_metrics: Mapping[str, Measurement] | None = None) -> None:
+        self._instances = {}
+        self._stats_metrics = dict(stats_metrics) if stats_metrics is not None else _DEFAULT_STATS
+
+    @override
+    async def create_instance(self, spec: InstanceSpec) -> ComputeInstance:
+        instance_id = InstanceId(f"dummy-{spec.kernel_id}")
+        if instance_id in self._instances:
+            raise InstanceAlreadyExistsError(f"instance {instance_id} already exists")
+        info = InstanceInfo(
+            handle=InstanceHandle(instance_id=instance_id, kernel_id=spec.kernel_id),
+            state=InstanceState.RUNNING,
+            image=spec.image,
+            labels={**spec.labels, LabelName.KERNEL_ID: str(spec.kernel_id)},
+        )
+        instance = DummyInstance(info, self._stats_metrics)
+        self._instances[instance_id] = instance
+        return instance
+
+    @override
+    async def destroy_instance(self, instance_id: InstanceId) -> None:
+        self._instances.pop(instance_id, None)
+
+    @override
+    async def load_instance(self, instance_id: InstanceId) -> ComputeInstance:
+        try:
+            return self._instances[instance_id]
+        except KeyError:
+            raise InstanceNotFoundError(f"instance {instance_id} not found") from None
+
+    @override
+    async def list_instances(self) -> Sequence[ComputeInstance]:
+        return list(self._instances.values())
+
+    @override
+    async def recover(self) -> None:
+        # Memory is this backend's ground truth; nothing external to reconcile.
+        return None

--- a/src/ai/backend/agent/errors/backend.py
+++ b/src/ai/backend/agent/errors/backend.py
@@ -30,3 +30,18 @@ class InstanceNotFoundError(BackendAIError, web.HTTPNotFound):
             operation=ErrorOperation.ACCESS,
             error_detail=ErrorDetail.NOT_FOUND,
         )
+
+
+class InstanceAlreadyExistsError(BackendAIError, web.HTTPConflict):
+    """Raised when creating an instance whose id is already tracked by the backend."""
+
+    error_type = "https://api.backend.ai/probs/agent/instance-already-exists"
+    error_title = "Instance already exists."
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.INSTANCE,
+            operation=ErrorOperation.CREATE,
+            error_detail=ErrorDetail.ALREADY_EXISTS,
+        )

--- a/tests/unit/agent/compute_backend/test_compute_backend.py
+++ b/tests/unit/agent/compute_backend/test_compute_backend.py
@@ -1,157 +1,40 @@
 from __future__ import annotations
 
-import uuid
-from collections.abc import Mapping, Sequence
-from decimal import Decimal
 from typing import override
 
 import pytest
 
 from ai.backend.agent.compute_backend.backend import ComputeBackend
-from ai.backend.agent.compute_backend.types import (
-    InstanceHandle,
-    InstanceId,
-    InstanceInfo,
-    InstanceSpec,
-    InstanceStat,
-    InstanceState,
-)
-from ai.backend.agent.errors.backend import InstanceNotFoundError
-from ai.backend.agent.stats import Measurement
-from ai.backend.common.docker import LabelName
-from ai.backend.common.types import KernelId
+from ai.backend.agent.compute_backend.instance import ComputeInstance
+from ai.backend.agent.compute_backend.types import InstanceInfo, InstanceSpec
 
 
-class FakeComputeBackend(ComputeBackend):
-    _instances: dict[InstanceId, InstanceInfo]
-    _counter: int
-
-    def __init__(self) -> None:
-        self._instances = {}
-        self._counter = 0
-
-    @override
-    async def create_instance(self, spec: InstanceSpec) -> InstanceHandle:
-        self._counter += 1
-        instance_id = InstanceId(f"fake-{self._counter}")
-        labels = {**spec.labels, LabelName.KERNEL_ID: str(spec.kernel_id)}
-        handle = InstanceHandle(instance_id=instance_id, kernel_id=spec.kernel_id)
-        self._instances[instance_id] = InstanceInfo(
-            handle=handle,
-            state=InstanceState.RUNNING,
-            image=spec.image,
-            labels=labels,
-        )
-        return handle
-
-    @override
-    async def destroy_instance(self, handle: InstanceHandle) -> None:
-        self._instances.pop(handle.instance_id, None)
-
-    @override
-    async def inspect_instance(self, handle: InstanceHandle) -> InstanceInfo:
-        try:
-            return self._instances[handle.instance_id]
-        except KeyError:
-            raise InstanceNotFoundError(f"instance {handle.instance_id} not found") from None
-
-    @override
-    async def list_instances(self) -> Sequence[InstanceInfo]:
-        return [
-            self._from_labels(info.handle.instance_id, info) for info in self._instances.values()
-        ]
-
-    @override
-    async def collect_stats(self, handle: InstanceHandle) -> InstanceStat:
-        return InstanceStat(
-            instance_id=handle.instance_id,
-            metrics={"cpu_util": Measurement(value=Decimal("1"))},
-        )
-
-    @staticmethod
-    def _from_labels(instance_id: InstanceId, info: InstanceInfo) -> InstanceInfo:
-        labels = info.labels
-        kernel_id = KernelId(uuid.UUID(labels[LabelName.KERNEL_ID]))
-        return InstanceInfo(
-            handle=InstanceHandle(instance_id=instance_id, kernel_id=kernel_id),
-            state=info.state,
-            image=info.image,
-            labels=labels,
-        )
-
-
-def _make_spec(labels: Mapping[str, str] | None = None) -> InstanceSpec:
-    return InstanceSpec(
-        kernel_id=KernelId(uuid.uuid4()),
-        image="registry.example.com/base:latest",
-        labels=dict(labels or {}),
-    )
-
-
-def test_abc_cannot_be_instantiated() -> None:
+def test_backend_abc_cannot_be_instantiated() -> None:
     with pytest.raises(TypeError):
         ComputeBackend()  # type: ignore[abstract]
 
 
-def test_incomplete_subclass_cannot_be_instantiated() -> None:
+def test_instance_abc_cannot_be_instantiated() -> None:
+    with pytest.raises(TypeError):
+        ComputeInstance()  # type: ignore[abstract]
+
+
+def test_incomplete_backend_subclass_cannot_be_instantiated() -> None:
     class Incomplete(ComputeBackend):
         @override
-        async def create_instance(self, spec: InstanceSpec) -> InstanceHandle:
+        async def create_instance(self, spec: InstanceSpec) -> ComputeInstance:
             raise NotImplementedError(spec)
 
     with pytest.raises(TypeError):
         Incomplete()  # type: ignore[abstract]
 
 
-async def test_create_stamps_kernel_id_and_returns_handle() -> None:
-    backend = FakeComputeBackend()
-    spec = _make_spec()
+def test_incomplete_instance_subclass_cannot_be_instantiated() -> None:
+    class Incomplete(ComputeInstance):
+        @property
+        @override
+        def info(self) -> InstanceInfo:
+            raise NotImplementedError
 
-    handle = await backend.create_instance(spec)
-
-    assert handle.kernel_id == spec.kernel_id
-    info = await backend.inspect_instance(handle)
-    assert info.labels[LabelName.KERNEL_ID] == str(spec.kernel_id)
-
-
-async def test_list_instances_self_describes_from_labels() -> None:
-    backend = FakeComputeBackend()
-    spec = _make_spec()
-    handle = await backend.create_instance(spec)
-
-    listed = await backend.list_instances()
-
-    assert len(listed) == 1
-    assert listed[0].handle.kernel_id == spec.kernel_id
-    assert listed[0].handle.instance_id == handle.instance_id
-
-
-async def test_destroy_is_idempotent() -> None:
-    backend = FakeComputeBackend()
-    handle = await backend.create_instance(_make_spec())
-
-    await backend.destroy_instance(handle)
-    await backend.destroy_instance(handle)
-
-    assert await backend.list_instances() == []
-
-
-async def test_inspect_missing_instance_raises() -> None:
-    backend = FakeComputeBackend()
-    handle = InstanceHandle(
-        instance_id=InstanceId("does-not-exist"),
-        kernel_id=KernelId(uuid.uuid4()),
-    )
-
-    with pytest.raises(InstanceNotFoundError):
-        await backend.inspect_instance(handle)
-
-
-async def test_collect_stats_returns_measurements() -> None:
-    backend = FakeComputeBackend()
-    handle = await backend.create_instance(_make_spec())
-
-    stat = await backend.collect_stats(handle)
-
-    assert stat.instance_id == handle.instance_id
-    assert "cpu_util" in stat.metrics
+    with pytest.raises(TypeError):
+        Incomplete()  # type: ignore[abstract]

--- a/tests/unit/agent/dummy/BUILD
+++ b/tests/unit/agent/dummy/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/agent/dummy/test_compute_backend.py
+++ b/tests/unit/agent/dummy/test_compute_backend.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping
+from decimal import Decimal
+
+import pytest
+
+from ai.backend.agent.compute_backend.types import (
+    InstanceId,
+    InstanceSpec,
+    InstanceState,
+)
+from ai.backend.agent.dummy.compute_backend import DummyComputeBackend
+from ai.backend.agent.errors.backend import (
+    InstanceAlreadyExistsError,
+    InstanceNotFoundError,
+)
+from ai.backend.agent.stats import Measurement
+from ai.backend.common.docker import LabelName
+from ai.backend.common.types import KernelId
+
+
+def _make_spec(labels: Mapping[str, str] | None = None) -> InstanceSpec:
+    return InstanceSpec(
+        kernel_id=KernelId(uuid.uuid4()),
+        image="registry.example.com/base:latest",
+        labels=dict(labels or {}),
+    )
+
+
+async def test_create_returns_instance_stamped_with_kernel_id() -> None:
+    backend = DummyComputeBackend()
+    spec = _make_spec()
+
+    instance = await backend.create_instance(spec)
+
+    info = instance.info
+    assert info.handle.kernel_id == spec.kernel_id
+    assert info.handle.instance_id == InstanceId(f"dummy-{spec.kernel_id}")
+    assert info.state == InstanceState.RUNNING
+    assert info.image == spec.image
+    assert info.labels[LabelName.KERNEL_ID] == str(spec.kernel_id)
+
+
+async def test_create_preserves_caller_labels() -> None:
+    backend = DummyComputeBackend()
+    spec = _make_spec(labels={"ai.backend.session-id": "abc"})
+
+    instance = await backend.create_instance(spec)
+
+    assert instance.info.labels["ai.backend.session-id"] == "abc"
+
+
+async def test_create_twice_for_same_kernel_raises() -> None:
+    backend = DummyComputeBackend()
+    spec = _make_spec()
+    await backend.create_instance(spec)
+
+    with pytest.raises(InstanceAlreadyExistsError):
+        await backend.create_instance(spec)
+
+
+async def test_create_after_destroy_succeeds() -> None:
+    backend = DummyComputeBackend()
+    spec = _make_spec()
+    instance = await backend.create_instance(spec)
+
+    await backend.destroy_instance(instance.info.handle.instance_id)
+    recreated = await backend.create_instance(spec)
+
+    assert recreated.info.handle.kernel_id == spec.kernel_id
+
+
+async def test_load_returns_created_instance() -> None:
+    backend = DummyComputeBackend()
+    spec = _make_spec()
+    created = await backend.create_instance(spec)
+
+    loaded = await backend.load_instance(created.info.handle.instance_id)
+
+    assert loaded.info.handle.kernel_id == spec.kernel_id
+
+
+async def test_load_missing_instance_raises() -> None:
+    backend = DummyComputeBackend()
+
+    with pytest.raises(InstanceNotFoundError):
+        await backend.load_instance(InstanceId("does-not-exist"))
+
+
+async def test_list_instances_returns_current_instances() -> None:
+    backend = DummyComputeBackend()
+    spec = _make_spec()
+    created = await backend.create_instance(spec)
+
+    listed = await backend.list_instances()
+
+    assert len(listed) == 1
+    assert listed[0].info.handle.instance_id == created.info.handle.instance_id
+    assert listed[0].info.labels[LabelName.KERNEL_ID] == str(spec.kernel_id)
+
+
+async def test_destroy_removes_instance_and_is_idempotent() -> None:
+    backend = DummyComputeBackend()
+    created = await backend.create_instance(_make_spec())
+    instance_id = created.info.handle.instance_id
+
+    await backend.destroy_instance(instance_id)
+    await backend.destroy_instance(instance_id)
+
+    assert await backend.list_instances() == []
+    with pytest.raises(InstanceNotFoundError):
+        await backend.load_instance(instance_id)
+
+
+async def test_recover_preserves_tracked_instances() -> None:
+    backend = DummyComputeBackend()
+    created = await backend.create_instance(_make_spec())
+
+    await backend.recover()
+
+    listed = await backend.list_instances()
+    assert [i.info.handle.instance_id for i in listed] == [created.info.handle.instance_id]
+
+
+async def test_collect_stats_on_instance() -> None:
+    metrics = {"cpu_util": Measurement(value=Decimal("42"), capacity=Decimal("100"))}
+    backend = DummyComputeBackend(stats_metrics=metrics)
+    instance = await backend.create_instance(_make_spec())
+
+    stat = await instance.collect_stats()
+
+    assert stat.instance_id == instance.info.handle.instance_id
+    assert stat.metrics["cpu_util"].value == Decimal("42")
+
+
+async def test_create_load_destroy_roundtrip_as_service_backend() -> None:
+    backend = DummyComputeBackend()
+    spec = _make_spec()
+
+    instance = await backend.create_instance(spec)
+    instance_id = instance.info.handle.instance_id
+    assert (await backend.load_instance(instance_id)).info.state == InstanceState.RUNNING
+
+    await backend.destroy_instance(instance_id)
+    with pytest.raises(InstanceNotFoundError):
+        await backend.load_instance(instance_id)


### PR DESCRIPTION
## Summary
- Add an in-memory `DummyComputeBackend`/`DummyInstance` that fully satisfies the `ComputeBackend` ABC without Docker/Kubernetes, so it can back service-glue unit tests.
- Refine the ABC to return active `ComputeInstance` objects: new `ComputeInstance` ABC (`info` + `collect_stats`), `create_instance` returns it, `inspect`→`load`, addressing by `InstanceId`, and a `recover()` command (side-resource release stays in the upper orchestration layer).
- Guard duplicate creation per kernel with a new `InstanceAlreadyExistsError` instead of silently overwriting.

## Test plan
- [x] `pants test tests/unit/agent/dummy:: tests/unit/agent/compute_backend::`
- [x] `pants lint` / `pants check` on changed files
- [ ] CI green

Resolves BA-6760