### PR TITLE
fix(BA-6773): isolate agent process metric collection from stuck containers

### DIFF
--- a/changes/12647.fix.md
+++ b/changes/12647.fix.md
@@ -1,0 +1,1 @@
+Isolate agent per-container process metric collection so a single unresponsive container (e.g. stuck in D-state) no longer stalls process metric collection for all other healthy containers on the agent

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -859,18 +859,31 @@ class StatContext:
                 await self.agent.valkey_stat_client.set_multiple_keys(key_value_map)
 
     async def _get_processes(
-        self, container_id: ContainerId, docker: aiodocker.Docker
+        self, container_id: ContainerId, docker: aiodocker.Docker, timeout: float
     ) -> list[PID]:
         """
         Get the list of PIDs for the given container ID.
+
+        The docker "top" query is bounded by ``timeout`` so that a single
+        unresponsive container (e.g. one stuck in D-state on a failing storage
+        backend, for which all docker queries hang) cannot block PID discovery
+        indefinitely. On timeout the container is skipped for this cycle.
         """
         return_val: list[PID] = []
         try:
-            result = await docker._query_json(f"containers/{container_id}/top", method="GET")
+            async with asyncio.timeout(timeout):
+                result = await docker._query_json(f"containers/{container_id}/top", method="GET")
             procs = result["Processes"]
         except (KeyError, aiodocker.exceptions.DockerError):
             log.debug(
                 "collect_per_container_process_stat(): cannot find container {}", container_id
+            )
+            return return_val
+        except TimeoutError:
+            log.warning(
+                "collect_per_container_process_stat(): timeout querying processes for "
+                "container {}; skipping it for this collection cycle",
+                container_id,
             )
             return return_val
 
@@ -911,14 +924,29 @@ class StatContext:
                 kernel_id_map[ContainerId(cid)] = kid
 
         pid_map: dict[PID, ContainerId] = {}
+        top_timeout = self._local_config.agent.utilization_metric.process.interval
         with self._stage_observer.measure_stage(
             stage=CollectionStage.DOCKER_TOP, upper_layer=CollectionLayer.PROCESS
         ):
             async with aiodocker.Docker() as docker:
-                for cid in container_ids:
-                    active_pids = await self._get_processes(cid, docker)
-                    for pid_ in active_pids:
-                        pid_map[pid_] = cid
+                # Query each container concurrently with a per-container timeout so that a
+                # single unresponsive container cannot stall PID discovery for the others.
+                proc_tasks = [
+                    asyncio.create_task(self._get_processes(cid, docker, top_timeout))
+                    for cid in container_ids
+                ]
+                proc_results = await asyncio.gather(*proc_tasks, return_exceptions=True)
+        for cid, active_pids in zip(container_ids, proc_results, strict=True):
+            if isinstance(active_pids, BaseException):
+                log.warning(
+                    "collect_per_container_process_stat(): failed to get processes for "
+                    "container {}",
+                    cid,
+                    exc_info=active_pids,
+                )
+                continue
+            for pid_ in active_pids:
+                pid_map[pid_] = cid
         # Here we use asyncio.gather() instead of aiotools.TaskGroup
         # to keep methods of other plugins running when a plugin raises an error
         # instead of cancelling them.

--- a/tests/unit/agent/test_stats.py
+++ b/tests/unit/agent/test_stats.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from decimal import Decimal
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 
-from ai.backend.agent.stats import MovingStatistics
+from ai.backend.agent.stats import MovingStatistics, StatContext
+from ai.backend.common.types import PID, ContainerId
 
 
 class TestMovingStatistics:
@@ -84,3 +87,59 @@ class TestMovingStatistics:
             stats.update(case.second_value)
 
         assert stats.rate == case.expected_rate
+
+
+class _FakeDocker:
+    """
+    Minimal aiodocker.Docker stand-in for ``StatContext._get_processes``.
+
+    ``responses`` maps a container id to either the ``Processes`` payload rows
+    or the literal string ``"hang"`` to simulate a container whose docker "top"
+    query never returns (e.g. a container stuck in D-state).
+    """
+
+    def __init__(self, responses: dict[str, Any]) -> None:
+        self._responses = responses
+
+    async def _query_json(self, path: str, method: str = "GET") -> dict[str, Any]:
+        # path looks like "containers/{container_id}/top"
+        container_id = path.split("/")[1]
+        resp = self._responses[container_id]
+        if resp == "hang":
+            await asyncio.Event().wait()  # never resolves
+        return {"Processes": resp}
+
+
+class TestGetProcessesTimeout:
+    """A single unresponsive container must not stall PID discovery for others."""
+
+    @pytest.fixture
+    def stat_ctx(self) -> StatContext:
+        # _get_processes does not touch instance state, so bypass __init__
+        # (which requires a full agent + config) and exercise the method directly.
+        return StatContext.__new__(StatContext)
+
+    async def test_returns_pids_for_healthy_container(self, stat_ctx: StatContext) -> None:
+        docker = _FakeDocker({"healthy": [["root", "1234"], ["root", "1235"]]})
+        pids = await stat_ctx._get_processes(ContainerId("healthy"), docker, timeout=1.0)  # type: ignore[arg-type]
+        assert pids == [PID(1234), PID(1235)]
+
+    async def test_timeout_returns_empty_without_hanging(self, stat_ctx: StatContext) -> None:
+        docker = _FakeDocker({"stuck": "hang"})
+        # Outer guard: if the per-call timeout were not honored, this would hang
+        # and the outer timeout would raise instead of returning [].
+        async with asyncio.timeout(5.0):
+            pids = await stat_ctx._get_processes(ContainerId("stuck"), docker, timeout=0.1)  # type: ignore[arg-type]
+        assert pids == []
+
+    async def test_stuck_container_does_not_block_healthy_ones(self, stat_ctx: StatContext) -> None:
+        docker = _FakeDocker({"stuck": "hang", "healthy": [["root", "42"]]})
+        # Mirror production: containers are queried concurrently. The stuck one
+        # must be skipped while the healthy one is still collected.
+        async with asyncio.timeout(5.0):
+            results = await asyncio.gather(
+                stat_ctx._get_processes(ContainerId("stuck"), docker, timeout=0.1),  # type: ignore[arg-type]
+                stat_ctx._get_processes(ContainerId("healthy"), docker, timeout=0.1),  # type: ignore[arg-type]
+            )
+        assert results[0] == []
+        assert results[1] == [PID(42)]


### PR DESCRIPTION
## Summary

A single container stuck in **D-state** (uninterruptible sleep — e.g. blocked on a failing storage backend) could stall **all** per-container process metric collection on an agent. Healthy containers on the same agent stopped reporting process metrics entirely until the stuck container went away.

This PR makes process-metric PID discovery **concurrent with a per-container timeout**, so one unresponsive container is skipped for that cycle while healthy containers keep being collected.

Resolves **BA-6773**.

> **Note for the reviewing agent**: this host is macOS and cannot reproduce the runtime behavior (`collect_per_container_process_stat` early-returns on `sys.platform == "darwin"`). Reproduction/verification must be done on a **Linux (Ubuntu) agent host**. See "Reproduction" below.

## Root cause

Observed in production from agent logs: one container's docker operations all hung — container log collection timed out, `container.delete(force=True)` returned `DockerError(500) "could not kill container: tried to kill container, but did not receive an exit event"`, and the scratch `umount` failed (`RuntimeError: umount failed`). The underlying loop-scratch storage (`/data2`) was faulting, which put the container's process into D-state → un-killable → mount held busy. The clean cycle then retried every ~60–90s.

The **agent-side defect** is the lack of isolation in `StatContext.collect_per_container_process_stat` (`src/ai/backend/agent/stats.py`):

- PID discovery iterated containers **sequentially** and called the docker `top` API (`_get_processes` → `GET containers/{cid}/top`) with **no timeout**.
- When `top` hung on the stuck container (same reason logs/delete hung), the loop never advanced → containers after it were never queried.
- The measurement gather and the Redis write happen **after** the loop, so even already-iterated healthy containers had nothing written for that cycle.
- The 5s timer uses `TimerDelayPolicy.CANCEL`: each tick cancels and restarts the hung task, but the fresh task re-hangs on the same container. Net effect: **process metrics stop for every container on the agent**.

By contrast, the container-stat path (`collect_container_stat`) was already resilient — it fans out per-container with `create_task` + `gather` and applies a per-plugin `wait_for` timeout. This PR brings the process-stat path in line with that pattern.

## The fix

`src/ai/backend/agent/stats.py`:

- `_get_processes(...)` now takes a `timeout` and wraps the docker `top` query in `asyncio.timeout(...)`; on `TimeoutError` it logs and returns `[]` (container skipped for this cycle).
- `collect_per_container_process_stat` now issues all `_get_processes` calls **concurrently** via `asyncio.gather(..., return_exceptions=True)` instead of a sequential `await` loop, and builds `pid_map` from the results. A per-container failure is logged and skipped, not fatal.
- The per-container timeout is derived from the configured process metric interval (`agent.utilization_metric.process.interval`).

## Tests

`tests/unit/agent/test_stats.py` — added `TestGetProcessesTimeout`:

- healthy container → returns its PIDs;
- a container whose `top` never returns → times out and returns `[]` without hanging;
- a stuck container queried **concurrently** with a healthy one → stuck is skipped, healthy is still collected.

These are deterministic and do not require a Linux host (they exercise `_get_processes` directly with a fake docker client).

```
pants test tests/unit/agent/test_stats.py
```

## Reproduction (Ubuntu VM — for the reviewing agent)

Goal: on a Linux agent, show that **before** this branch one stuck container freezes process metrics for all sessions, and **after** it only the stuck one is affected.

### 0. Context / where to look
- Code path: `src/ai/backend/agent/stats.py` → `collect_per_container_process_stat` → `_get_processes` (docker `top`).
- Timer: `src/ai/backend/agent/agent.py` `collect_process_stat`, 5s interval, `TimerDelayPolicy.CANCEL`.
- Process metrics land in Valkey/Redis keyed by container id; the WebUI/live-stat reads from there.

### 1. Bring up a Linux dev agent
- Standard Backend.AI dev env on the VM (halfstack + manager + agent). Start at least **two** sessions so there is a healthy container and a victim container.
- Confirm process metrics flow for both (check the agent's Valkey stat writes, or live-stat via the manager) before injecting the fault.

### 2. Induce the stall — pick one

**(A) Deterministic (recommended, no kernel fault): hang the docker `top` call.**
Interpose a tiny proxy between the agent and the docker socket that forwards everything **except** `GET /containers/<victim-cid>/top`, which it holds open indefinitely. Point the agent's docker client at the proxy socket. This reproduces exactly the code-level failure (a `top` call that never returns) without needing real storage failure — cleanest for confirming the before/after behavior.

**(B) Realistic (matches the incident): force a genuine D-state.**
Back a mount the container does I/O on with a hangable device and then block it, so the in-container process enters uninterruptible sleep and docker operations on it hang:
- e.g. a FUSE mount whose daemon you then `kill -STOP`/kill, or a hard NFS mount to a black-holed server, or a `dmsetup` delay/suspended device under the container scratch. Do I/O to it from inside the container, then block the backing store.
- Expect: `docker top <victim>` hangs, `docker rm -f <victim>` returns the "did not receive an exit event" 500, and `umount` of the scratch fails — same signature as the incident.
- ⚠️ A D-state process cannot be killed; you may need to reboot the VM to clean up. Snapshot first.

> Note: `SIGSTOP` alone is **not** sufficient — it yields `T` (stopped) state, and `docker top` still returns. You need a real I/O block (A or B).

### 3. Observe the bug (on `origin/main`, before this branch)
- After the fault, **all** sessions' process metrics stop updating (stale/absent in Valkey / live-stat), not just the victim's.
- Agent log shows the process-stat task being cancelled/restarted each cycle with no progress.

### 4. Verify the fix (this branch)
- Check out `fix/ba-6773-process-stat-isolation`, restart the agent.
- The victim container is skipped each cycle with a log line:
  `collect_per_container_process_stat(): timeout querying processes for container <cid>; skipping it for this collection cycle`
- **Healthy sessions keep reporting process metrics** every interval.

### 5. Verification checklist
- [ ] Repro confirmed on `origin/main`: one stuck container ⇒ all process metrics stall.
- [ ] With this branch: healthy containers keep reporting; only the stuck one is skipped + logged.
- [ ] `pants test tests/unit/agent/test_stats.py` passes.
- [ ] `pants lint check src/ai/backend/agent/stats.py tests/unit/agent/test_stats.py` clean.

## Out of scope / follow-up
- Secondary risk (separate issue candidate): container-stat cgroup/proc reads (`read_sysfs` / `Path.read_text`) run synchronously on the event loop; a read that blocks uninterruptibly can freeze the whole agent event loop, which `asyncio.timeout` cannot interrupt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
