### PR TITLE
fix(BA-6776): stringify unified_devices SlotName before JSON serialization

### DIFF
--- a/changes/12649.fix.md
+++ b/changes/12649.fix.md
@@ -1,0 +1,1 @@
+Fix `create_kernel` crashing with a JSON serialization error when a kernel is allocated a unified-memory accelerator device

--- a/src/ai/backend/agent/resources.py
+++ b/src/ai/backend/agent/resources.py
@@ -174,7 +174,9 @@ class KernelResourceSpec:
     def write_to_string(self) -> str:
         mounts_str = ",".join(map(str, self.mounts))
         slots_str = dump_json_str({k: str(v) for k, v in self.slots.items()})
-        unified_devices_str = dump_json_str(self.unified_devices)
+        unified_devices_str = dump_json_str([
+            [str(device_name), str(slot_name)] for device_name, slot_name in self.unified_devices
+        ])
 
         resource_str = ""
         resource_str += f"SCRATCH_SIZE={BinarySize(self.scratch_disk_size):m}\n"
@@ -282,6 +284,9 @@ class KernelResourceSpec:
             serialized_allocations[str(dev_name)] = serialized_dev_alloc
         o["allocations"] = serialized_allocations
         o["mounts"] = list(map(str, self.mounts))
+        o["unified_devices"] = [
+            [str(device_name), str(slot_name)] for device_name, slot_name in self.unified_devices
+        ]
         return o
 
     def to_json(self) -> str:

--- a/src/ai/backend/agent/resources.py
+++ b/src/ai/backend/agent/resources.py
@@ -175,7 +175,7 @@ class KernelResourceSpec:
         mounts_str = ",".join(map(str, self.mounts))
         slots_str = dump_json_str({k: str(v) for k, v in self.slots.items()})
         unified_devices_str = dump_json_str([
-            [str(device_name), str(slot_name)] for device_name, slot_name in self.unified_devices
+            (str(device_name), str(slot_name)) for device_name, slot_name in self.unified_devices
         ])
 
         resource_str = ""
@@ -285,7 +285,7 @@ class KernelResourceSpec:
         o["allocations"] = serialized_allocations
         o["mounts"] = list(map(str, self.mounts))
         o["unified_devices"] = [
-            [str(device_name), str(slot_name)] for device_name, slot_name in self.unified_devices
+            (str(device_name), str(slot_name)) for device_name, slot_name in self.unified_devices
         ]
         return o
 


### PR DESCRIPTION
## Summary
- `KernelResourceSpec.to_json_serializable_dict()` normalized `slots`, `allocations`, and `mounts` to strings but left `unified_devices` as the raw `attrs.asdict()` output — a list of `(DeviceName, SlotName)` tuples. `SlotName` is a `collections.UserString` subclass that orjson cannot serialize, so `to_json()` crashed `create_kernel` with `TypeError: Type is not JSON serializable: SlotName`.
- This only triggered on agents running an accelerator plugin that reports a `SlotTypes.UNIFIED` slot (e.g. arm64/unified-memory CUDA devices), since that is the only path that populates `unified_devices`.
- Convert each `(DeviceName, SlotName)` tuple to `[str, str]` before `dump_json_str()` in both `to_json_serializable_dict()` and `write_to_string()` (which had the same latent bug). The read path already parsed `UNIFIED_DEVICES` as JSON arrays, so the shape round-trips unchanged.

## Test plan
- [x] `KernelResourceSpec.to_json()` with a non-empty `unified_devices` no longer raises and produces valid JSON
- [x] `write_to_string()` / `read_from_string()` round-trips `unified_devices` correctly
- [x] Session creation succeeds on an agent with a UNIFIED-slot accelerator plugin

Resolves BA-6776