### PR TITLE
fix(BA-6776): stringify unified_devices SlotName before JSON serialization (#12649)

### DIFF
--- a/changes/12649.fix.md
+++ b/changes/12649.fix.md
@@ -1,0 +1,1 @@
+Fix `create_kernel` crashing with a JSON serialization error when a kernel is allocated a unified-memory accelerator device

--- a/src/ai/backend/agent/resources.py
+++ b/src/ai/backend/agent/resources.py
@@ -173,7 +173,9 @@ class KernelResourceSpec:
     def write_to_string(self) -> str:
         mounts_str = ",".join(map(str, self.mounts))
         slots_str = dump_json_str({k: str(v) for k, v in self.slots.items()})
-        unified_devices_str = dump_json_str(self.unified_devices)
+        unified_devices_str = dump_json_str([
+            (str(device_name), str(slot_name)) for device_name, slot_name in self.unified_devices
+        ])
 
         resource_str = ""
         resource_str += f"SCRATCH_SIZE={BinarySize(self.scratch_disk_size):m}\n"
@@ -281,6 +283,9 @@ class KernelResourceSpec:
             serialized_allocations[str(dev_name)] = serialized_dev_alloc
         o["allocations"] = serialized_allocations
         o["mounts"] = list(map(str, self.mounts))
+        o["unified_devices"] = [
+            (str(device_name), str(slot_name)) for device_name, slot_name in self.unified_devices
+        ]
         return o
 
     def to_json(self) -> str:


### PR DESCRIPTION
This is an auto-generated backport PR of #12649 to the 26.4 release.