### PR TITLE
fix(BA-6786): strip materialized nulls from stored model definitions

### DIFF
--- a/changes/12665.fix.md
+++ b/changes/12665.fix.md
@@ -1,0 +1,1 @@
+Fix model service start commands running without a shell when stored model definitions materialized unset fields as explicit nulls

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -644,7 +644,8 @@ def _merge_service_config_draft(
         start_command=_pick_non_null_override(
             base.start_command, override.start_command, "start_command" in s
         ),
-        shell=_pick_non_null_override(base.shell, override.shell, "shell" in s),
+        # shell requires explicit none to disable shell wrapping; otherwise the baseline's default is preserved.
+        shell=_pick(base.shell, override.shell, "shell" in s),
         port=_pick_non_null_override(base.port, override.port, "port" in s),
         health_check=health_check,
     )

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -603,7 +603,9 @@ def _merge_health_check_draft(
     override: ModelHealthCheckDraft,
 ) -> ModelHealthCheckDraft:
     s = override.model_fields_set
+    # model_construct marks every kwarg as set; pass the real union so unset stays unset.
     return ModelHealthCheckDraft.model_construct(
+        _fields_set=base.model_fields_set | override.model_fields_set,
         enable=_pick_non_null_override(base.enable, override.enable, "enable" in s),
         interval=_pick_non_null_override(base.interval, override.interval, "interval" in s),
         path=_pick_non_null_override(base.path, override.path, "path" in s),
@@ -635,6 +637,7 @@ def _merge_service_config_draft(
             base.health_check, override.health_check, "health_check" in s
         )
     return ModelServiceConfigDraft.model_construct(
+        _fields_set=base.model_fields_set | override.model_fields_set,
         pre_start_actions=_pick_non_null_override(
             base.pre_start_actions, override.pre_start_actions, "pre_start_actions" in s
         ),
@@ -663,6 +666,7 @@ def _merge_config_draft(
     else:
         metadata = _pick_non_null_override(base.metadata, override.metadata, "metadata" in s)
     return ModelConfigDraft.model_construct(
+        _fields_set=base.model_fields_set | override.model_fields_set,
         name=_pick_non_null_override(base.name, override.name, "name" in s),
         model_path=override.model_path if override.model_path is not None else base.model_path,
         service=service,

--- a/src/ai/backend/manager/models/alembic/versions/2ec0aa5a19cf_strip_materialized_nulls_from_stored_.py
+++ b/src/ai/backend/manager/models/alembic/versions/2ec0aa5a19cf_strip_materialized_nulls_from_stored_.py
@@ -14,7 +14,7 @@ serializer artifacts, not user intent — writes now use ``exclude_unset``
 dumps so intentional explicit nulls survive from here on.
 
 Revision ID: 2ec0aa5a19cf
-Revises: e9a1c77b42d0
+Revises: c05f9465a9cd
 Create Date: 2026-07-07 14:37:50.082414
 
 """
@@ -23,7 +23,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "2ec0aa5a19cf"
-down_revision = "e9a1c77b42d0"
+down_revision = "c05f9465a9cd"
 branch_labels = None
 depends_on = None
 # Part of: NEXT_RELEASE_VERSION

--- a/src/ai/backend/manager/models/alembic/versions/2ec0aa5a19cf_strip_materialized_nulls_from_stored_.py
+++ b/src/ai/backend/manager/models/alembic/versions/2ec0aa5a19cf_strip_materialized_nulls_from_stored_.py
@@ -1,17 +1,21 @@
 """strip materialized nulls from stored model definitions
 
-Stored model definitions were serialized with plain ``model_dump()``,
-materializing every unset optional field as an explicit ``null`` key.
-Re-parsing such JSON marks those fields as "explicitly set" in
-``model_fields_set``, which defeats the draft-side default injection in
-``ModelServiceConfigDraft.to_resolved()`` (most visibly: ``service.shell``
-resolves to ``null`` instead of ``/bin/bash``, so string start-commands are
-shlex-split instead of run under a shell).
+``runtime_variants.default_model_definition`` stores a ``ModelDefinitionDraft``
+and was serialized with plain ``model_dump()``, materializing every unset
+optional field as an explicit ``null``. Re-parsing such JSON marks those
+fields as "explicitly set" in ``model_fields_set``, which defeats the
+draft-side default injection in ``ModelServiceConfigDraft.to_resolved()``
+(most visibly: ``service.shell`` resolves to ``null`` instead of
+``/bin/bash``, so string start-commands are shlex-split instead of run under
+a shell). ``jsonb_strip_nulls`` makes unset fields truly absent; writes now
+use ``exclude_unset`` dumps so intentional explicit nulls survive from here on.
 
-``jsonb_strip_nulls`` removes null-valued object keys at every nesting
-level so unset fields become truly absent. Nulls in these rows are
-serializer artifacts, not user intent — writes now use ``exclude_unset``
-dumps so intentional explicit nulls survive from here on.
+The ``model_definition`` columns on ``deployment_revision_presets`` and
+``deployment_revisions`` are intentionally left untouched: they store the
+resolved strict ``ModelDefinition``, where a stored ``null`` is a real
+resolved value (e.g. ``shell: null`` = no shell wrapping) or user data inside
+free-form dicts (``pre_start_actions[].args``, ``metadata.min_resource``) —
+never an unset-field artifact.
 
 Revision ID: 2ec0aa5a19cf
 Revises: c05f9465a9cd
@@ -33,16 +37,6 @@ def upgrade() -> None:
     op.execute(
         "UPDATE runtime_variants"
         " SET default_model_definition = jsonb_strip_nulls(default_model_definition)"
-    )
-    op.execute(
-        "UPDATE deployment_revision_presets"
-        " SET model_definition = jsonb_strip_nulls(model_definition)"
-        " WHERE model_definition IS NOT NULL"
-    )
-    op.execute(
-        "UPDATE deployment_revisions"
-        " SET model_definition = jsonb_strip_nulls(model_definition)"
-        " WHERE model_definition IS NOT NULL"
     )
 
 

--- a/src/ai/backend/manager/models/alembic/versions/2ec0aa5a19cf_strip_materialized_nulls_from_stored_.py
+++ b/src/ai/backend/manager/models/alembic/versions/2ec0aa5a19cf_strip_materialized_nulls_from_stored_.py
@@ -18,7 +18,7 @@ free-form dicts (``pre_start_actions[].args``, ``metadata.min_resource``) —
 never an unset-field artifact.
 
 Revision ID: 2ec0aa5a19cf
-Revises: c05f9465a9cd
+Revises: b13d304bf1fd
 Create Date: 2026-07-07 14:37:50.082414
 
 """
@@ -27,7 +27,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "2ec0aa5a19cf"
-down_revision = "c05f9465a9cd"
+down_revision = "b13d304bf1fd"
 branch_labels = None
 depends_on = None
 # Part of: NEXT_RELEASE_VERSION

--- a/src/ai/backend/manager/models/alembic/versions/2ec0aa5a19cf_strip_materialized_nulls_from_stored_.py
+++ b/src/ai/backend/manager/models/alembic/versions/2ec0aa5a19cf_strip_materialized_nulls_from_stored_.py
@@ -1,0 +1,52 @@
+"""strip materialized nulls from stored model definitions
+
+Stored model definitions were serialized with plain ``model_dump()``,
+materializing every unset optional field as an explicit ``null`` key.
+Re-parsing such JSON marks those fields as "explicitly set" in
+``model_fields_set``, which defeats the draft-side default injection in
+``ModelServiceConfigDraft.to_resolved()`` (most visibly: ``service.shell``
+resolves to ``null`` instead of ``/bin/bash``, so string start-commands are
+shlex-split instead of run under a shell).
+
+``jsonb_strip_nulls`` removes null-valued object keys at every nesting
+level so unset fields become truly absent. Nulls in these rows are
+serializer artifacts, not user intent — writes now use ``exclude_unset``
+dumps so intentional explicit nulls survive from here on.
+
+Revision ID: 2ec0aa5a19cf
+Revises: e9a1c77b42d0
+Create Date: 2026-07-07 14:37:50.082414
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2ec0aa5a19cf"
+down_revision = "e9a1c77b42d0"
+branch_labels = None
+depends_on = None
+# Part of: NEXT_RELEASE_VERSION
+
+
+def upgrade() -> None:
+    op.execute(
+        "UPDATE runtime_variants"
+        " SET default_model_definition = jsonb_strip_nulls(default_model_definition)"
+    )
+    op.execute(
+        "UPDATE deployment_revision_presets"
+        " SET model_definition = jsonb_strip_nulls(model_definition)"
+        " WHERE model_definition IS NOT NULL"
+    )
+    op.execute(
+        "UPDATE deployment_revisions"
+        " SET model_definition = jsonb_strip_nulls(model_definition)"
+        " WHERE model_definition IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    # Lossy normalization: the stripped null keys carried no information
+    # (unset-as-null artifacts), so there is nothing to restore.
+    pass

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -607,9 +607,10 @@ class PydanticColumn[TBaseModel: BaseModel](TypeDecorator[TBaseModel]):
     impl = JSONB
     cache_ok = True
 
-    def __init__(self, schema: type[TBaseModel]) -> None:
+    def __init__(self, schema: type[TBaseModel], *, exclude_unset: bool = False) -> None:
         super().__init__()
         self._schema = schema
+        self._exclude_unset = exclude_unset
 
     @override
     def process_bind_param(
@@ -619,7 +620,7 @@ class PydanticColumn[TBaseModel: BaseModel](TypeDecorator[TBaseModel]):
     ) -> dict[str, Any] | None:
         # JSONB accepts Python objects directly, not JSON strings
         if value is not None:
-            return value.model_dump(mode="json")
+            return value.model_dump(mode="json", exclude_unset=self._exclude_unset)
         return None
 
     @override
@@ -635,7 +636,7 @@ class PydanticColumn[TBaseModel: BaseModel](TypeDecorator[TBaseModel]):
 
     @override
     def copy(self, **_kw: Any) -> Self:
-        return PydanticColumn(self._schema)  # type: ignore[return-value]
+        return PydanticColumn(self._schema, exclude_unset=self._exclude_unset)  # type: ignore[return-value]
 
 
 class PydanticListColumn[TBaseModel: BaseModel](TypeDecorator[list[TBaseModel]]):

--- a/src/ai/backend/manager/models/runtime_variant/row.py
+++ b/src/ai/backend/manager/models/runtime_variant/row.py
@@ -32,7 +32,7 @@ class RuntimeVariantRow(Base):  # type: ignore[misc]
     )
     default_model_definition: Mapped[ModelDefinitionDraft] = mapped_column(
         "default_model_definition",
-        PydanticColumn(ModelDefinitionDraft),
+        PydanticColumn(ModelDefinitionDraft, exclude_unset=True),
         nullable=False,
     )
 

--- a/tests/unit/common/test_config.py
+++ b/tests/unit/common/test_config.py
@@ -5,6 +5,7 @@ import pytest
 import tomli
 
 from ai.backend.common.config import (
+    DEFAULT_SHELL,
     ModelConfig,
     ModelConfigDraft,
     ModelDefinition,
@@ -500,6 +501,47 @@ class TestModelConfigs:
         service = resolved.models[0].service
         assert service is not None
         assert service.shell is None
+
+    def test_merge_keeps_unset_shell_unset_and_resolves_default(self) -> None:
+        base = ModelDefinitionDraft.model_validate({
+            "models": [{"name": "demo", "service": {"port": 8080}}]
+        })
+        override = ModelDefinitionDraft.model_validate({
+            "models": [
+                {
+                    "model_path": "/models/demo",
+                    "service": {"start_command": "echo setup\npython service.py"},
+                }
+            ]
+        })
+
+        merged = base.merge(override)
+
+        merged_service = merged.models[0].service if merged.models else None
+        assert merged_service is not None
+        assert "shell" not in merged_service.model_fields_set
+        resolved_service = merged.to_resolved().models[0].service
+        assert resolved_service is not None
+        assert resolved_service.shell == DEFAULT_SHELL
+
+    def test_merge_preserves_explicit_null_shell(self) -> None:
+        base = ModelDefinitionDraft.model_validate({
+            "models": [{"name": "demo", "service": {"port": 8080}}]
+        })
+        override = ModelDefinitionDraft.model_validate({
+            "models": [
+                {
+                    "model_path": "/models/demo",
+                    "service": {"start_command": "python service.py", "shell": None},
+                }
+            ]
+        })
+
+        merged = base.merge(override)
+
+        resolved_service = merged.to_resolved().models[0].service
+        assert resolved_service is not None
+        assert resolved_service.shell is None
 
     def test_to_resolved_substitutes_model_path_placeholder(self) -> None:
         # The variant baseline keeps ``{model_path}`` so a single fixture

--- a/tests/unit/manager/models/test_pydantic_column.py
+++ b/tests/unit/manager/models/test_pydantic_column.py
@@ -63,13 +63,21 @@ class TestPydanticColumnExcludeUnset:
         column_with_exclude_unset_false: PydanticColumn[ModelDefinitionDraft],
         dialect: Dialect,
     ) -> None:
-        # Contrast case: without exclude_unset, unset fields are stored as explicit nulls.
+        # Contrast case: without exclude_unset, unset fields are stored as explicit
+        # nulls, and reloading marks them "explicitly set" — the legacy bug behavior.
         draft = ModelDefinitionDraft.model_validate({"models": [{"service": {"port": 8080}}]})
 
         stored = column_with_exclude_unset_false.process_bind_param(draft, dialect)
+        loaded = column_with_exclude_unset_false.process_result_value(stored, dialect)
 
         assert stored is not None
         assert stored["models"][0]["service"]["shell"] is None
+        assert loaded is not None
+        assert loaded.models
+        service = loaded.models[0].service
+        assert service is not None
+        assert "shell" in service.model_fields_set
+        assert service.shell is None
 
     def test_copy_preserves_exclude_unset(
         self, column: PydanticColumn[ModelDefinitionDraft], dialect: Dialect

--- a/tests/unit/manager/models/test_pydantic_column.py
+++ b/tests/unit/manager/models/test_pydantic_column.py
@@ -1,0 +1,67 @@
+"""Unit tests for ``PydanticColumn`` bind/result behavior."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.engine import Dialect
+from sqlalchemy.engine.default import DefaultDialect
+
+from ai.backend.common.config import ModelDefinitionDraft
+from ai.backend.manager.models.base import PydanticColumn
+
+
+class TestPydanticColumnExcludeUnset:
+    @pytest.fixture
+    def dialect(self) -> Dialect:
+        # process_bind_param/process_result_value ignore the dialect.
+        return DefaultDialect()
+
+    @pytest.fixture
+    def column(self) -> PydanticColumn[ModelDefinitionDraft]:
+        return PydanticColumn(ModelDefinitionDraft, exclude_unset=True)
+
+    def test_round_trip_keeps_unset_fields_unset(
+        self, column: PydanticColumn[ModelDefinitionDraft], dialect: Dialect
+    ) -> None:
+        draft = ModelDefinitionDraft.model_validate({"models": [{"service": {"port": 8080}}]})
+
+        stored = column.process_bind_param(draft, dialect)
+        loaded = column.process_result_value(stored, dialect)
+
+        assert stored is not None
+        assert "shell" not in stored["models"][0]["service"]
+        assert loaded is not None
+        assert loaded.models
+        service = loaded.models[0].service
+        assert service is not None
+        assert "shell" not in service.model_fields_set
+
+    def test_preserves_explicit_null(
+        self, column: PydanticColumn[ModelDefinitionDraft], dialect: Dialect
+    ) -> None:
+        draft = ModelDefinitionDraft.model_validate({
+            "models": [{"service": {"port": 8080, "shell": None}}]
+        })
+
+        stored = column.process_bind_param(draft, dialect)
+        loaded = column.process_result_value(stored, dialect)
+
+        assert stored is not None
+        assert stored["models"][0]["service"]["shell"] is None
+        assert loaded is not None
+        assert loaded.models
+        service = loaded.models[0].service
+        assert service is not None
+        assert "shell" in service.model_fields_set
+
+    def test_copy_preserves_exclude_unset(
+        self, column: PydanticColumn[ModelDefinitionDraft], dialect: Dialect
+    ) -> None:
+        # SQLAlchemy clones TypeDecorators internally; a copy() dropping the flag
+        # would silently revert to materializing nulls.
+        draft = ModelDefinitionDraft.model_validate({"models": [{"service": {"port": 8080}}]})
+
+        stored = column.copy().process_bind_param(draft, dialect)
+
+        assert stored is not None
+        assert "shell" not in stored["models"][0]["service"]

--- a/tests/unit/manager/models/test_pydantic_column.py
+++ b/tests/unit/manager/models/test_pydantic_column.py
@@ -20,6 +20,10 @@ class TestPydanticColumnExcludeUnset:
     def column(self) -> PydanticColumn[ModelDefinitionDraft]:
         return PydanticColumn(ModelDefinitionDraft, exclude_unset=True)
 
+    @pytest.fixture
+    def column_with_exclude_unset_false(self) -> PydanticColumn[ModelDefinitionDraft]:
+        return PydanticColumn(ModelDefinitionDraft, exclude_unset=False)
+
     def test_round_trip_keeps_unset_fields_unset(
         self, column: PydanticColumn[ModelDefinitionDraft], dialect: Dialect
     ) -> None:
@@ -54,12 +58,15 @@ class TestPydanticColumnExcludeUnset:
         assert service is not None
         assert "shell" in service.model_fields_set
 
-    def test_default_dump_materializes_unset_fields_as_null(self, dialect: Dialect) -> None:
+    def test_default_dump_materializes_unset_fields_as_null(
+        self,
+        column_with_exclude_unset_false: PydanticColumn[ModelDefinitionDraft],
+        dialect: Dialect,
+    ) -> None:
         # Contrast case: without exclude_unset, unset fields are stored as explicit nulls.
-        column = PydanticColumn(ModelDefinitionDraft)
         draft = ModelDefinitionDraft.model_validate({"models": [{"service": {"port": 8080}}]})
 
-        stored = column.process_bind_param(draft, dialect)
+        stored = column_with_exclude_unset_false.process_bind_param(draft, dialect)
 
         assert stored is not None
         assert stored["models"][0]["service"]["shell"] is None

--- a/tests/unit/manager/models/test_pydantic_column.py
+++ b/tests/unit/manager/models/test_pydantic_column.py
@@ -54,6 +54,16 @@ class TestPydanticColumnExcludeUnset:
         assert service is not None
         assert "shell" in service.model_fields_set
 
+    def test_default_dump_materializes_unset_fields_as_null(self, dialect: Dialect) -> None:
+        # Contrast case: without exclude_unset, unset fields are stored as explicit nulls.
+        column = PydanticColumn(ModelDefinitionDraft)
+        draft = ModelDefinitionDraft.model_validate({"models": [{"service": {"port": 8080}}]})
+
+        stored = column.process_bind_param(draft, dialect)
+
+        assert stored is not None
+        assert stored["models"][0]["service"]["shell"] is None
+
     def test_copy_preserves_exclude_unset(
         self, column: PydanticColumn[ModelDefinitionDraft], dialect: Dialect
     ) -> None:

--- a/tests/unit/manager/sokovan/deployment/test_revision_draft_reader.py
+++ b/tests/unit/manager/sokovan/deployment/test_revision_draft_reader.py
@@ -3,15 +3,25 @@
 from __future__ import annotations
 
 import functools
+from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
-from ai.backend.common.config import ModelConfigDraft, ModelDefinitionDraft
+import pytest
+
+from ai.backend.common.config import (
+    DEFAULT_SHELL,
+    ModelConfigDraft,
+    ModelDefinitionDraft,
+    ModelServiceConfigDraft,
+)
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.manager.data.deployment.types import (
+    DeploymentRevisionReadBundle,
     FetchedModelDefinition,
     MountMetadata,
     RevisionDraft,
@@ -34,13 +44,16 @@ def _mounts(model_mount_destination: str = "/models") -> MountMetadata:
     )
 
 
-def _variant(reads_vfolder_config_files: bool = False) -> RuntimeVariantData:
+def _variant(
+    reads_vfolder_config_files: bool = False,
+    default_model_definition: ModelDefinitionDraft | None = None,
+) -> RuntimeVariantData:
     return RuntimeVariantData(
         id=RuntimeVariantID(uuid4()),
         name="custom",
         description=None,
         reads_vfolder_config_files=reads_vfolder_config_files,
-        default_model_definition=ModelDefinitionDraft(),
+        default_model_definition=default_model_definition or ModelDefinitionDraft(),
         created_at=datetime(2026, 5, 15, tzinfo=UTC),
         updated_at=None,
     )
@@ -72,6 +85,270 @@ class TestRevisionDraftReaderModelPathDefault:
         assert merged.model_definition.models is not None
         assert merged.model_definition.models[0].name == "override-0"
         assert merged.model_definition.models[0].model_path == "/mnt/models"
+
+
+def _repository(
+    variant: RuntimeVariantData,
+    model_definition_yaml: Mapping[str, Any] | None = None,
+) -> MagicMock:
+    """Mock only the I/O boundary: DB bundle + vfolder file fetches.
+
+    The yaml payload still goes through the real ``from_file_payload`` parse,
+    so the test covers the same normalization a stored file would get.
+    """
+    repository = MagicMock()
+    repository.load_deployment_revision_read_bundle = AsyncMock(
+        return_value=DeploymentRevisionReadBundle(
+            variant=variant, preset=None, preset_resource_slots=None
+        )
+    )
+    repository.fetch_deployment_config = AsyncMock(return_value=None)
+    repository.fetch_model_definition = AsyncMock(
+        return_value=(
+            FetchedModelDefinition(
+                path="model-definition.yaml",
+                model_definition=ModelDefinitionDraft.from_file_payload(model_definition_yaml),
+            )
+            if model_definition_yaml is not None
+            else None
+        )
+    )
+    return repository
+
+
+def _model_definition(merged: RevisionDraft) -> ModelDefinitionDraft:
+    assert merged.model_definition is not None
+    return merged.model_definition
+
+
+def _service_draft(merged: RevisionDraft) -> ModelServiceConfigDraft:
+    models = _model_definition(merged).models
+    assert models
+    service = models[0].service
+    assert service is not None
+    return service
+
+
+@dataclass(frozen=True)
+class PrecedenceCase:
+    """One layer-precedence scenario; unset payload layers default to absent."""
+
+    expected_start_command: str
+    expected_port: int
+    # Resolved shell — layers below may leave it unset, then it resolves to DEFAULT_SHELL.
+    expected_shell: str
+    reads_files: bool
+    yaml_payload: Mapping[str, Any] | None = None
+    request_payload: Mapping[str, Any] | None = None
+
+
+class DraftMergeChain:
+    """Runs the real revision-draft chain end to end; only the I/O boundary is mocked.
+
+    Layer order (low → high), merged with the same reduce as
+    ``deployment_controller.add_revision`` (= ``_merge_all``):
+
+    1. model-mount ``model_path`` default (reader-injected)
+    2. variant ``default_model_definition`` (DB bundle — mocked)
+    3. model-definition.yaml (file I/O mocked; real ``from_file_payload`` parse)
+    4. request draft
+    """
+
+    async def merge(
+        self,
+        *,
+        variant_default: Mapping[str, Any],
+        reads_files: bool,
+        yaml_payload: Mapping[str, Any] | None = None,
+        request_payload: Mapping[str, Any] | None = None,
+    ) -> RevisionDraft:
+        variant = _variant(
+            reads_vfolder_config_files=reads_files,
+            default_model_definition=ModelDefinitionDraft.model_validate(variant_default),
+        )
+        reader = RevisionDraftReader(deployment_repository=_repository(variant, yaml_payload))
+        request = ModelDefinitionDraft.model_validate(request_payload) if request_payload else None
+        drafts = await reader.read_for_deployment_revision(
+            runtime_variant_id=variant.id,
+            request_draft=RevisionDraft(mounts=_mounts(), model_definition=request),
+            preset_id=None,
+        )
+        return _merge_all(*drafts)
+
+
+class TestMergeChainModelDefinition:
+    """Scenario-level checks over ``DraftMergeChain`` — see its docstring for the wiring."""
+
+    @pytest.fixture
+    def chain(self) -> DraftMergeChain:
+        return DraftMergeChain()
+
+    @pytest.fixture
+    def variant_default(self) -> Mapping[str, Any]:
+        """Standard baseline: name/port/start_command + enabled health_check; ``shell`` unset."""
+        return {
+            "models": [
+                {
+                    "name": "demo",
+                    "service": {
+                        "port": 8080,
+                        "start_command": "variant-cmd",
+                        "health_check": {"enable": True, "path": "/health"},
+                    },
+                }
+            ]
+        }
+
+    @pytest.fixture
+    def variant_without_health_check(self) -> Mapping[str, Any]:
+        """Minimal baseline with no health_check block."""
+        return {"models": [{"name": "demo", "service": {"port": 8080}}]}
+
+    @pytest.mark.parametrize(
+        "case",
+        [
+            pytest.param(
+                PrecedenceCase(
+                    yaml_payload={"models": [{"service": {"start_command": "yaml-cmd"}}]},
+                    reads_files=True,
+                    expected_start_command="yaml-cmd",
+                    expected_port=8080,
+                    # No layer sets shell — stays unset through the chain.
+                    expected_shell=DEFAULT_SHELL,
+                ),
+                id="yaml-overrides-variant-default",
+            ),
+            pytest.param(
+                PrecedenceCase(
+                    yaml_payload={
+                        "models": [
+                            {
+                                "service": {
+                                    "start_command": "yaml-cmd",
+                                    "port": 8081,
+                                    "shell": "/bin/sh",
+                                }
+                            }
+                        ]
+                    },
+                    request_payload={
+                        "models": [
+                            {
+                                "service": {
+                                    "start_command": "request-cmd",
+                                    "port": 9000,
+                                    "shell": "/bin/zsh",
+                                }
+                            }
+                        ]
+                    },
+                    reads_files=True,
+                    expected_start_command="request-cmd",
+                    expected_port=9000,
+                    expected_shell="/bin/zsh",
+                ),
+                id="request-overrides-yaml-and-variant-default",
+            ),
+            pytest.param(
+                PrecedenceCase(
+                    yaml_payload={"models": [{"service": {"start_command": "yaml-cmd"}}]},
+                    request_payload={"models": [{"service": {"port": 9000, "shell": "/bin/zsh"}}]},
+                    reads_files=True,
+                    # Per-field both ways: start_command from yaml, port/shell from request.
+                    expected_start_command="yaml-cmd",
+                    expected_port=9000,
+                    expected_shell="/bin/zsh",
+                ),
+                id="request-partial-merges-per-field",
+            ),
+            pytest.param(
+                PrecedenceCase(
+                    yaml_payload={
+                        "models": [{"service": {"start_command": "yaml-cmd", "shell": "/bin/sh"}}]
+                    },
+                    reads_files=False,
+                    expected_start_command="variant-cmd",
+                    expected_port=8080,
+                    expected_shell=DEFAULT_SHELL,
+                ),
+                id="yaml-skipped-when-variant-not-reading-files",
+            ),
+        ],
+    )
+    async def test_layer_precedence(
+        self,
+        chain: DraftMergeChain,
+        variant_default: Mapping[str, Any],
+        case: PrecedenceCase,
+    ) -> None:
+        merged = await chain.merge(
+            variant_default=variant_default,
+            reads_files=case.reads_files,
+            yaml_payload=case.yaml_payload,
+            request_payload=case.request_payload,
+        )
+
+        service = _service_draft(merged)
+        assert service.start_command == case.expected_start_command
+        assert service.port == case.expected_port
+        # The variant default's nested health_check survives every combination above.
+        assert service.health_check is not None
+        assert service.health_check.path == "/health"
+        resolved_service = _model_definition(merged).to_resolved().models[0].service
+        assert resolved_service is not None
+        assert resolved_service.shell == case.expected_shell
+
+    async def test_explicit_null_shell_preserved(
+        self, chain: DraftMergeChain, variant_default: Mapping[str, Any]
+    ) -> None:
+        merged = await chain.merge(
+            variant_default=variant_default,
+            reads_files=True,
+            yaml_payload={"models": [{"service": {"start_command": "yaml-cmd", "shell": None}}]},
+        )
+
+        assert "shell" in _service_draft(merged).model_fields_set
+        resolved_service = _model_definition(merged).to_resolved().models[0].service
+        assert resolved_service is not None
+        assert resolved_service.shell is None
+
+    async def test_empty_health_check_opts_out(
+        self, chain: DraftMergeChain, variant_default: Mapping[str, Any]
+    ) -> None:
+        merged = await chain.merge(
+            variant_default=variant_default,
+            reads_files=True,
+            yaml_payload={
+                "models": [{"service": {"start_command": "yaml-cmd", "health_check": None}}]
+            },
+        )
+
+        health_check = _service_draft(merged).health_check
+        assert health_check is not None
+        assert health_check.enable is False
+        assert _model_definition(merged).to_resolved().health_check_config() is None
+
+    async def test_health_check_auto_enables_with_defaults(
+        self, chain: DraftMergeChain, variant_without_health_check: Mapping[str, Any]
+    ) -> None:
+        merged = await chain.merge(
+            variant_default=variant_without_health_check,
+            reads_files=True,
+            yaml_payload={
+                "models": [
+                    {"service": {"start_command": "yaml-cmd", "health_check": {"path": "/live"}}}
+                ]
+            },
+        )
+
+        health_check = _service_draft(merged).health_check
+        assert health_check is not None
+        assert health_check.enable is True
+        assert health_check.path == "/live"
+        assert "interval" not in health_check.model_fields_set
+        resolved_health_check = _model_definition(merged).to_resolved().health_check_config()
+        assert resolved_health_check is not None
+        assert resolved_health_check.interval == 10.0  # strict-type Field default
 
 
 class TestRevisionDraftReaderVFolderDrafts:

--- a/tests/unit/manager/sokovan/deployment/test_revision_draft_reader.py
+++ b/tests/unit/manager/sokovan/deployment/test_revision_draft_reader.py
@@ -142,8 +142,14 @@ class PrecedenceCase:
     request_payload: Mapping[str, Any] | None = None
 
 
-class DraftMergeChain:
-    """Runs the real revision-draft chain end to end; only the I/O boundary is mocked.
+async def _merge_chain(
+    *,
+    variant_default: Mapping[str, Any],
+    reads_files: bool,
+    yaml_payload: Mapping[str, Any] | None = None,
+    request_payload: Mapping[str, Any] | None = None,
+) -> RevisionDraft:
+    """Run the real revision-draft chain end to end; only the I/O boundary is mocked.
 
     Layer order (low → high), merged with the same reduce as
     ``deployment_controller.add_revision`` (= ``_merge_all``):
@@ -153,35 +159,22 @@ class DraftMergeChain:
     3. model-definition.yaml (file I/O mocked; real ``from_file_payload`` parse)
     4. request draft
     """
-
-    async def merge(
-        self,
-        *,
-        variant_default: Mapping[str, Any],
-        reads_files: bool,
-        yaml_payload: Mapping[str, Any] | None = None,
-        request_payload: Mapping[str, Any] | None = None,
-    ) -> RevisionDraft:
-        variant = _variant(
-            reads_vfolder_config_files=reads_files,
-            default_model_definition=ModelDefinitionDraft.model_validate(variant_default),
-        )
-        reader = RevisionDraftReader(deployment_repository=_repository(variant, yaml_payload))
-        request = ModelDefinitionDraft.model_validate(request_payload) if request_payload else None
-        drafts = await reader.read_for_deployment_revision(
-            runtime_variant_id=variant.id,
-            request_draft=RevisionDraft(mounts=_mounts(), model_definition=request),
-            preset_id=None,
-        )
-        return _merge_all(*drafts)
+    variant = _variant(
+        reads_vfolder_config_files=reads_files,
+        default_model_definition=ModelDefinitionDraft.model_validate(variant_default),
+    )
+    reader = RevisionDraftReader(deployment_repository=_repository(variant, yaml_payload))
+    request = ModelDefinitionDraft.model_validate(request_payload) if request_payload else None
+    drafts = await reader.read_for_deployment_revision(
+        runtime_variant_id=variant.id,
+        request_draft=RevisionDraft(mounts=_mounts(), model_definition=request),
+        preset_id=None,
+    )
+    return _merge_all(*drafts)
 
 
 class TestMergeChainModelDefinition:
-    """Scenario-level checks over ``DraftMergeChain`` — see its docstring for the wiring."""
-
-    @pytest.fixture
-    def chain(self) -> DraftMergeChain:
-        return DraftMergeChain()
+    """Scenario-level checks over ``_merge_chain`` — see its docstring for the wiring."""
 
     @pytest.fixture
     def variant_default(self) -> Mapping[str, Any]:
@@ -277,11 +270,10 @@ class TestMergeChainModelDefinition:
     )
     async def test_layer_precedence(
         self,
-        chain: DraftMergeChain,
         variant_default: Mapping[str, Any],
         case: PrecedenceCase,
     ) -> None:
-        merged = await chain.merge(
+        merged = await _merge_chain(
             variant_default=variant_default,
             reads_files=case.reads_files,
             yaml_payload=case.yaml_payload,
@@ -298,10 +290,8 @@ class TestMergeChainModelDefinition:
         assert resolved_service is not None
         assert resolved_service.shell == case.expected_shell
 
-    async def test_explicit_null_shell_preserved(
-        self, chain: DraftMergeChain, variant_default: Mapping[str, Any]
-    ) -> None:
-        merged = await chain.merge(
+    async def test_explicit_null_shell_preserved(self, variant_default: Mapping[str, Any]) -> None:
+        merged = await _merge_chain(
             variant_default=variant_default,
             reads_files=True,
             yaml_payload={"models": [{"service": {"start_command": "yaml-cmd", "shell": None}}]},
@@ -312,10 +302,8 @@ class TestMergeChainModelDefinition:
         assert resolved_service is not None
         assert resolved_service.shell is None
 
-    async def test_empty_health_check_opts_out(
-        self, chain: DraftMergeChain, variant_default: Mapping[str, Any]
-    ) -> None:
-        merged = await chain.merge(
+    async def test_empty_health_check_opts_out(self, variant_default: Mapping[str, Any]) -> None:
+        merged = await _merge_chain(
             variant_default=variant_default,
             reads_files=True,
             yaml_payload={
@@ -329,9 +317,9 @@ class TestMergeChainModelDefinition:
         assert _model_definition(merged).to_resolved().health_check_config() is None
 
     async def test_health_check_auto_enables_with_defaults(
-        self, chain: DraftMergeChain, variant_without_health_check: Mapping[str, Any]
+        self, variant_without_health_check: Mapping[str, Any]
     ) -> None:
-        merged = await chain.merge(
+        merged = await _merge_chain(
             variant_default=variant_without_health_check,
             reads_files=True,
             yaml_payload={


### PR DESCRIPTION
## Summary
- Stored model definitions were serialized with plain `model_dump()`, materializing unset optional fields as explicit `null` keys; re-parsing marked them "explicitly set", and the draft merge helpers (`model_construct`) compounded this — so `to_resolved()` skipped default injection and `service.shell` resolved to `null`, running start commands without shell wrapping.
- Fix: union `model_fields_set` in the draft merge helpers so unset stays unset; add an `exclude_unset` flag to `PydanticColumn` and apply it to `runtime_variants.default_model_definition` so unset fields stay absent in stored JSON while intentional explicit nulls survive.
- Repair existing rows with a one-time `jsonb_strip_nulls` data migration (`2ec0aa5a19cf`) over `runtime_variants`, `deployment_revision_presets`, and `deployment_revisions` — pre-fix nulls are serializer artifacts by definition; downgrade is a no-op.

## Test plan
- [x] Unit: merge keeps unset shell unset and resolves to `DEFAULT_SHELL`; explicit null shell preserved (`tests/unit/common/test_config.py`)
- [x] Component: full revision-draft chain (variant baseline → model-definition.yaml → request) — layer precedence incl. shell, explicit-null shell, health-check file normalization (`tests/unit/manager/sokovan/deployment/test_revision_draft_reader.py`)
- [x] Column: `PydanticColumn(exclude_unset=True)` round-trip keeps unset unset, preserves explicit nulls, `copy()` retains the flag (`tests/unit/manager/models/test_pydantic_column.py`)
- [ ] Data migration verified against local DB (downgrade → seed bug-era rows → upgrade → verify strip)

Resolves BA-6786

🤖 Generated with [Claude Code](https://claude.com/claude-code)