### PR TITLE
feat(BA-6787): add scope filtering to Role.scopes GraphQL filter

### DIFF
--- a/changes/12670.feature.md
+++ b/changes/12670.feature.md
@@ -1,0 +1,1 @@
+Support filtering a role's scopes by scope type and scope id in the `Role.scopes` GraphQL field.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -7056,6 +7056,16 @@ input EntityFilter
 {
   entityType: RBACElementTypeFilter = null
   entityId: StringFilter = null
+
+  """
+  Added in 26.8.0. Filter by the type of scope the entity is registered in.
+  """
+  scopeType: RBACElementTypeFilter = null
+
+  """
+  Added in 26.8.0. Filter by the id of scope the entity is registered in.
+  """
+  scopeId: StringFilter = null
   AND: [EntityFilter!] = null
   OR: [EntityFilter!] = null
   NOT: [EntityFilter!] = null

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -4755,6 +4755,16 @@ type EntityConnection {
 input EntityFilter {
   entityType: RBACElementTypeFilter = null
   entityId: StringFilter = null
+
+  """
+  Added in 26.8.0. Filter by the type of scope the entity is registered in.
+  """
+  scopeType: RBACElementTypeFilter = null
+
+  """
+  Added in 26.8.0. Filter by the id of scope the entity is registered in.
+  """
+  scopeId: StringFilter = null
   AND: [EntityFilter!] = null
   OR: [EntityFilter!] = null
   NOT: [EntityFilter!] = null

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -18014,6 +18014,28 @@
             ],
             "default": null
           },
+          "scope_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RBACElementTypeFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "scope_id": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StringFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
           "AND": {
             "anyOf": [
               {

--- a/src/ai/backend/common/dto/manager/v2/rbac/request.py
+++ b/src/ai/backend/common/dto/manager/v2/rbac/request.py
@@ -307,6 +307,8 @@ class EntityFilter(BaseRequestModel):
 
     entity_type: RBACElementTypeFilter | None = None
     entity_id: StringFilter | None = None
+    scope_type: RBACElementTypeFilter | None = None
+    scope_id: StringFilter | None = None
     AND: list[EntityFilter] | None = None
     OR: list[EntityFilter] | None = None
     NOT: list[EntityFilter] | None = None

--- a/src/ai/backend/manager/api/adapters/rbac/adapter.py
+++ b/src/ai/backend/manager/api/adapters/rbac/adapter.py
@@ -1747,6 +1747,27 @@ class RBACAdapter(BaseAdapter):
             )
             if condition is not None:
                 conditions.append(condition)
+        if f.scope_type is not None:
+            conditions.extend(
+                self._convert_rbac_element_type_filter(
+                    f.scope_type,
+                    equals_factory=EntityScopeConditions.by_scope_type_equals,
+                    not_equals_factory=EntityScopeConditions.by_scope_type_not_equals,
+                    in_factory=EntityScopeConditions.by_scope_type_in,
+                    not_in_factory=EntityScopeConditions.by_scope_type_not_in,
+                )
+            )
+        if f.scope_id is not None:
+            condition = self.convert_string_filter(
+                f.scope_id,
+                contains_factory=EntityScopeConditions.by_scope_id_contains,
+                equals_factory=EntityScopeConditions.by_scope_id_equals,
+                starts_with_factory=EntityScopeConditions.by_scope_id_starts_with,
+                ends_with_factory=EntityScopeConditions.by_scope_id_ends_with,
+                in_factory=EntityScopeConditions.by_scope_id_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
         if f.AND:
             for sub in f.AND:
                 conditions.extend(self._convert_entity_filter(sub))

--- a/src/ai/backend/manager/api/gql/rbac/types/entity.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/entity.py
@@ -21,6 +21,7 @@ from ai.backend.common.dto.manager.v2.rbac.request import (
 from ai.backend.common.dto.manager.v2.rbac.response import (
     AssociationScopesEntitiesNode,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import OrderDirection, StringFilter
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -153,6 +154,20 @@ class EntityRefGQL(PydanticNodeMixin[AssociationScopesEntitiesNode]):
 class EntityFilter(PydanticInputMixin[EntityFilterDTO], GQLFilter):
     entity_type: RBACElementTypeFilterGQL | None = None
     entity_id: StringFilter | None = None
+    scope_type: RBACElementTypeFilterGQL | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Filter by the type of scope the entity is registered in.",
+        ),
+        default=None,
+    )
+    scope_id: StringFilter | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Filter by the id of scope the entity is registered in.",
+        ),
+        default=None,
+    )
     AND: list[Self] | None = None
     OR: list[Self] | None = None
     NOT: list[Self] | None = None


### PR DESCRIPTION
## Summary
- Add `scopeType` and `scopeId` fields to the `EntityFilter` GraphQL input so a role's scopes can be filtered by the **scope side** of the association (e.g. only the projects a role is mapped to).
- Previously `EntityFilter` exposed only `entity_type`/`entity_id`, which `search_role_scopes` already pins to `ROLE`/`<role_id>` — so the filter could not narrow results at all.
- Wire the new fields in the adapter's `_convert_entity_filter` to the existing `EntityScopeConditions.by_scope_type_*` / `by_scope_id_*` factories (model layer already implemented). New GQL fields are version-tagged via `gql_added_field(NEXT_RELEASE_VERSION)`.

## Test plan
- [x] `pants fmt / fix / lint / check` (incl. mypy) pass
- [x] Live manager (direct API, `./bai gql --v2`) verified:
  - `scopeType {equals/in}` filters by scope type (PROJECT vs USER)
  - `scopeId {equals/startsWith}` filters by scope id
  - `AND` / `NOT` compose correctly; no filter returns all scopes unchanged
- [x] v2-schema & supergraph snapshots regenerated with `Added in` version annotation
- [x] CI green

Resolves BA-6787

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12670.org.readthedocs.build/en/12670/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12670.org.readthedocs.build/ko/12670/

<!-- readthedocs-preview sorna-ko end -->