### PR TITLE
fix(BA-6789): stringify start_command in runtime variant fixtures

### DIFF
--- a/changes/12671.fix.md
+++ b/changes/12671.fix.md
@@ -1,0 +1,1 @@
+Align runtime variant fixture start_command with the stored string format so fresh installs seed the same data as migrated databases

--- a/fixtures/manager/example-runtime-variants.json
+++ b/fixtures/manager/example-runtime-variants.json
@@ -9,7 +9,7 @@
           {
             "name": "vllm-model",
             "service": {
-              "start_command": ["vllm", "serve", "{model_path}"],
+              "start_command": "vllm serve '{model_path}'",
               "port": 8000,
               "health_check": {
                 "enable": true,
@@ -69,7 +69,7 @@
           {
             "name": "tgi-model",
             "service": {
-              "start_command": ["text-generation-launcher", "--model-id", "{model_path}"],
+              "start_command": "text-generation-launcher --model-id '{model_path}'",
               "port": 3000,
               "health_check": {
                 "enable": true,
@@ -92,13 +92,7 @@
           {
             "name": "sglang-model",
             "service": {
-              "start_command": [
-                "python",
-                "-m",
-                "sglang.launch_server",
-                "--model-path",
-                "{model_path}"
-              ],
+              "start_command": "python -m sglang.launch_server --model-path '{model_path}'",
               "port": 9001,
               "health_check": {
                 "enable": true,
@@ -121,7 +115,7 @@
           {
             "name": "max-model",
             "service": {
-              "start_command": ["max", "serve", "--model", "{model_path}"],
+              "start_command": "max serve --model '{model_path}'",
               "port": 8000,
               "health_check": {
                 "enable": true,
@@ -144,12 +138,7 @@
           {
             "name": "llamacpp-model",
             "service": {
-              "start_command": [
-                "sh",
-                "-c",
-                "llama-server -m \"$(ls /models/*.gguf | head -n1)\" \"$@\"",
-                "llama-cpp"
-              ],
+              "start_command": "sh -c 'llama-server -m \"$(ls /models/*.gguf | head -n1)\" \"$@\"' llama-cpp",
               "port": 8080,
               "health_check": {
                 "path": "/health",

--- a/src/ai/backend/install/fixtures/example-runtime-variants.json
+++ b/src/ai/backend/install/fixtures/example-runtime-variants.json
@@ -9,7 +9,7 @@
           {
             "name": "vllm-model",
             "service": {
-              "start_command": ["vllm", "serve", "{model_path}"],
+              "start_command": "vllm serve '{model_path}'",
               "port": 8000,
               "health_check": {
                 "enable": true,
@@ -69,7 +69,7 @@
           {
             "name": "tgi-model",
             "service": {
-              "start_command": ["text-generation-launcher", "--model-id", "{model_path}"],
+              "start_command": "text-generation-launcher --model-id '{model_path}'",
               "port": 3000,
               "health_check": {
                 "enable": true,
@@ -92,13 +92,7 @@
           {
             "name": "sglang-model",
             "service": {
-              "start_command": [
-                "python",
-                "-m",
-                "sglang.launch_server",
-                "--model-path",
-                "{model_path}"
-              ],
+              "start_command": "python -m sglang.launch_server --model-path '{model_path}'",
               "port": 9001,
               "health_check": {
                 "enable": true,
@@ -121,7 +115,7 @@
           {
             "name": "max-model",
             "service": {
-              "start_command": ["max", "serve", "--model", "{model_path}"],
+              "start_command": "max serve --model '{model_path}'",
               "port": 8000,
               "health_check": {
                 "enable": true,
@@ -144,12 +138,7 @@
           {
             "name": "llamacpp-model",
             "service": {
-              "start_command": [
-                "sh",
-                "-c",
-                "llama-server -m \"$(ls /models/*.gguf | head -n1)\" \"$@\"",
-                "llama-cpp"
-              ],
+              "start_command": "sh -c 'llama-server -m \"$(ls /models/*.gguf | head -n1)\" \"$@\"' llama-cpp",
               "port": 8080,
               "health_check": {
                 "path": "/health",


### PR DESCRIPTION
## Summary
- The stored format for model-definition `start_command` is now a single command string (migration `ba6615a4d2f1` shlex-joins existing argv-list rows), but the install fixtures still shipped argv lists — so fresh installs re-seeded the legacy form and relied on read-time normalization.
- Convert `start_command` in both fixture copies (`fixtures/manager/` and `src/ai/backend/install/fixtures/`) using the same `shlex.join` rule as the migration, so seeded rows match migrated rows byte-for-byte (`{model_path}` ends up single-quoted per shlex quoting, which plain-`str.replace` substitution handles unchanged).

## Test plan
- [x] Each converted string equals `shlex.join(<original argv>)` and `shlex.split` round-trips back to the original argv
- [x] Both fixture copies are byte-identical (`diff`)
- [x] All 8 variant definitions parse through `ModelDefinitionDraft.model_validate`

Resolves BA-6789

🤖 Generated with [Claude Code](https://claude.com/claude-code)