### PR TITLE
refactor(BA-6790): move DB engine utilities from models to repository layer

### DIFF
--- a/changes/12677.enhance.md
+++ b/changes/12677.enhance.md
@@ -1,0 +1,1 @@
+Move the database engine creation and lifecycle utilities from the manager models layer into the repository layer, decoupling models from database configuration.

--- a/src/ai/backend/manager/cli/__main__.py
+++ b/src/ai/backend/manager/cli/__main__.py
@@ -268,7 +268,7 @@ def clear_history(cli_ctx: CLIContext, retention: str, vacuum_full: bool) -> Non
     from ai.backend.manager.models.error_logs import error_logs
     from ai.backend.manager.models.kernel import kernels
     from ai.backend.manager.models.session import SessionRow
-    from ai.backend.manager.models.utils import connect_database, vacuum_db
+    from ai.backend.manager.repositories.db.engine import connect_database, vacuum_db
 
     from .context import redis_ctx
 

--- a/src/ai/backend/manager/cli/agent.py
+++ b/src/ai/backend/manager/cli/agent.py
@@ -57,7 +57,7 @@ def ping(cli_ctx: CLIContext, agent_id: str, alembic_config: str, timeout: float
 
     from ai.backend.common.auth import PublicKey, SecretKey
     from ai.backend.manager.agent_cache import AgentRPCCache
-    from ai.backend.manager.models.utils import create_async_engine
+    from ai.backend.manager.repositories.db.engine import create_async_engine
 
     async def _impl() -> None:
         bootstrap_config = await cli_ctx.get_bootstrap_config()

--- a/src/ai/backend/manager/cli/dbschema.py
+++ b/src/ai/backend/manager/cli/dbschema.py
@@ -53,7 +53,7 @@ def show(_cli_ctx: CLIContext, alembic_config: str) -> None:
     from alembic.script import ScriptDirectory
     from sqlalchemy.engine import Connection
 
-    from ai.backend.manager.models.utils import create_async_engine
+    from ai.backend.manager.repositories.db.engine import create_async_engine
 
     def _get_current_rev_sync(connection: Connection) -> str | None:
         context = MigrationContext.configure(connection)
@@ -224,7 +224,7 @@ def oneshot(_cli_ctx: CLIContext, alembic_config: str) -> None:
     from sqlalchemy.engine import Connection, Engine
 
     from ai.backend.manager.models.base import ensure_all_tables_registered, metadata
-    from ai.backend.manager.models.utils import create_async_engine
+    from ai.backend.manager.repositories.db.engine import create_async_engine
 
     ensure_all_tables_registered()
 

--- a/src/ai/backend/manager/cli/image_impl.py
+++ b/src/ai/backend/manager/cli/image_impl.py
@@ -19,7 +19,7 @@ from ai.backend.manager.container_registry.harbor import HarborRegistry_v2
 from ai.backend.manager.data.image.types import ImageStatus
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.image import ImageAliasRow, ImageIdentifier, ImageRow
-from ai.backend.manager.models.utils import connect_database
+from ai.backend.manager.repositories.db.engine import connect_database
 from ai.backend.manager.repositories.image.db_source.db_source import ImageDBSource
 
 from .context import CLIContext, redis_ctx

--- a/src/ai/backend/manager/dependencies/infrastructure/database.py
+++ b/src/ai/backend/manager/dependencies/infrastructure/database.py
@@ -7,7 +7,8 @@ from typing import override
 from ai.backend.common.health_checker import ServiceHealthChecker
 from ai.backend.manager.config.unified import ManagerUnifiedConfig
 from ai.backend.manager.health.database import DatabaseHealthChecker
-from ai.backend.manager.models.utils import ExtendedAsyncSAEngine, connect_database
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.db.engine import connect_database
 
 from .base import InfrastructureDependency
 

--- a/src/ai/backend/manager/models/utils.py
+++ b/src/ai/backend/manager/models/utils.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 import asyncio
-import functools
-import json
 import logging
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from contextlib import AbstractAsyncContextManager as AbstractAsyncCtxMgr
 from contextlib import asynccontextmanager as actxmgr
 from typing import (
-    TYPE_CHECKING,
     Any,
     Concatenate,
     ParamSpec,
@@ -19,7 +16,6 @@ from typing import (
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as psql
-from sqlalchemy.engine import create_engine as _create_engine
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
 from sqlalchemy.ext.asyncio import AsyncEngine as SAEngine
@@ -34,19 +30,12 @@ from tenacity import (
     stop_after_attempt,
     wait_exponential,
 )
-from yarl import URL
 
 from ai.backend.common.exception import DatabaseError
-from ai.backend.common.json import ExtendedJSONEncoder
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.defs import LockID
 from ai.backend.manager.errors.resource import DBOperationFailed
 from ai.backend.manager.types import Sentinel
-
-if TYPE_CHECKING:
-    from ai.backend.manager.config.bootstrap import BootstrapConfig
-    from ai.backend.manager.config.unified import DatabaseConfig
-
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 column_constraints = ["nullable", "index", "unique", "primary_key"]
@@ -387,67 +376,6 @@ async def execute_with_txn_retry(
     return result
 
 
-def create_async_engine(
-    *args: Any,
-    _txn_concurrency_threshold: int = 0,
-    _lock_conn_timeout: int = 0,
-    **kwargs: Any,
-) -> ExtendedAsyncSAEngine:
-    kwargs["future"] = True
-    sync_engine = _create_engine(*args, **kwargs)
-    return ExtendedAsyncSAEngine(
-        sync_engine,
-        _txn_concurrency_threshold=_txn_concurrency_threshold,
-        _lock_conn_timeout=_lock_conn_timeout,
-    )
-
-
-@actxmgr
-async def connect_database(
-    db_config: DatabaseConfig,
-    isolation_level: str = "SERIALIZABLE",
-) -> AsyncIterator[ExtendedAsyncSAEngine]:
-    from .base import pgsql_connect_opts
-
-    db_url = (
-        URL(f"postgresql+asyncpg://{db_config.addr.host}/{db_config.name}")
-        .with_port(db_config.addr.port)
-        .with_user(db_config.user)
-    )
-    if db_config.password is not None:
-        db_url = db_url.with_password(db_config.password)
-
-    version_check_db = create_async_engine(str(db_url))
-    async with version_check_db.begin() as conn:
-        result = await conn.execute(sa.text("show server_version"))
-        version_str = result.scalar()
-        if version_str is None:
-            raise DatabaseError("Failed to retrieve PostgreSQL server version")
-        major, minor, *_ = map(int, version_str.partition(" ")[0].split("."))
-        if (major, minor) < (11, 0):
-            pgsql_connect_opts["server_settings"].pop("jit")
-    await version_check_db.dispose()
-
-    db = create_async_engine(
-        str(db_url),
-        connect_args=pgsql_connect_opts,
-        pool_size=db_config.pool_size,
-        pool_recycle=db_config.pool_recycle,
-        pool_pre_ping=db_config.pool_pre_ping,
-        max_overflow=db_config.max_overflow,
-        json_serializer=functools.partial(json.dumps, cls=ExtendedJSONEncoder),
-        isolation_level=isolation_level,
-        future=True,
-        _txn_concurrency_threshold=max(
-            int(db_config.pool_size + max(0, db_config.max_overflow) * 0.5),
-            2,
-        ),
-        _lock_conn_timeout=int(db_config.lock_conn_timeout),
-    )
-    yield db
-    await db.dispose()
-
-
 @actxmgr
 async def reenter_txn_session(
     pool: ExtendedAsyncSAEngine,
@@ -618,11 +546,3 @@ def agg_to_array(
 
 def is_db_retry_error(e: Exception) -> bool:
     return isinstance(e, DBAPIError) and getattr(e.orig, "pgcode", None) == "40001"
-
-
-async def vacuum_db(bootstrap_config: BootstrapConfig, vacuum_full: bool = False) -> None:
-    async with connect_database(bootstrap_config.db, isolation_level="AUTOCOMMIT") as db:
-        async with db.begin() as conn:
-            vacuum_sql = "VACUUM FULL" if vacuum_full else "VACUUM"
-            log.info("Performing {} operation...", vacuum_sql)
-            await conn.exec_driver_sql(vacuum_sql)

--- a/src/ai/backend/manager/repositories/db/engine.py
+++ b/src/ai/backend/manager/repositories/db/engine.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import functools
+import json
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager as actxmgr
+from typing import TYPE_CHECKING, Any
+
+import sqlalchemy as sa
+from sqlalchemy.engine import create_engine as _create_engine
+from yarl import URL
+
+from ai.backend.common.exception import DatabaseError
+from ai.backend.common.json import ExtendedJSONEncoder
+from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.models.base import pgsql_connect_opts
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+
+if TYPE_CHECKING:
+    from ai.backend.manager.config.bootstrap import BootstrapConfig
+    from ai.backend.manager.config.unified import DatabaseConfig
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+def create_async_engine(
+    *args: Any,
+    _txn_concurrency_threshold: int = 0,
+    _lock_conn_timeout: int = 0,
+    **kwargs: Any,
+) -> ExtendedAsyncSAEngine:
+    kwargs["future"] = True
+    sync_engine = _create_engine(*args, **kwargs)
+    return ExtendedAsyncSAEngine(
+        sync_engine,
+        _txn_concurrency_threshold=_txn_concurrency_threshold,
+        _lock_conn_timeout=_lock_conn_timeout,
+    )
+
+
+@actxmgr
+async def connect_database(
+    db_config: DatabaseConfig,
+    isolation_level: str = "SERIALIZABLE",
+) -> AsyncIterator[ExtendedAsyncSAEngine]:
+    db_url = (
+        URL(f"postgresql+asyncpg://{db_config.addr.host}/{db_config.name}")
+        .with_port(db_config.addr.port)
+        .with_user(db_config.user)
+    )
+    if db_config.password is not None:
+        db_url = db_url.with_password(db_config.password)
+
+    version_check_db = create_async_engine(str(db_url))
+    async with version_check_db.begin() as conn:
+        result = await conn.execute(sa.text("show server_version"))
+        version_str = result.scalar()
+        if version_str is None:
+            raise DatabaseError("Failed to retrieve PostgreSQL server version")
+        major, minor, *_ = map(int, version_str.partition(" ")[0].split("."))
+        if (major, minor) < (11, 0):
+            pgsql_connect_opts["server_settings"].pop("jit")
+    await version_check_db.dispose()
+
+    db = create_async_engine(
+        str(db_url),
+        connect_args=pgsql_connect_opts,
+        pool_size=db_config.pool_size,
+        pool_recycle=db_config.pool_recycle,
+        pool_pre_ping=db_config.pool_pre_ping,
+        max_overflow=db_config.max_overflow,
+        json_serializer=functools.partial(json.dumps, cls=ExtendedJSONEncoder),
+        isolation_level=isolation_level,
+        future=True,
+        _txn_concurrency_threshold=max(
+            int(db_config.pool_size + max(0, db_config.max_overflow) * 0.5),
+            2,
+        ),
+        _lock_conn_timeout=int(db_config.lock_conn_timeout),
+    )
+    yield db
+    await db.dispose()
+
+
+async def vacuum_db(bootstrap_config: BootstrapConfig, vacuum_full: bool = False) -> None:
+    async with connect_database(bootstrap_config.db, isolation_level="AUTOCOMMIT") as db:
+        async with db.begin() as conn:
+            vacuum_sql = "VACUUM FULL" if vacuum_full else "VACUUM"
+            log.info("Performing {} operation...", vacuum_sql)
+            await conn.exec_driver_sql(vacuum_sql)

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -130,16 +130,16 @@ from ai.backend.manager.models.scaling_group.row import ScalingGroupOpts
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.session_template import session_templates
 from ai.backend.manager.models.user import users
-from ai.backend.manager.models.utils import (
-    ExtendedAsyncSAEngine,
-    connect_database,
-    create_async_engine,
-)
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import vfolders
 from ai.backend.manager.notification.notification_center import NotificationCenter
 from ai.backend.manager.plugin.network import NetworkPluginContext
 from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.repositories.auth.repository import AuthRepository
+from ai.backend.manager.repositories.db.engine import (
+    connect_database,
+    create_async_engine,
+)
 from ai.backend.manager.repositories.group.repository import GroupRepository
 from ai.backend.manager.repositories.user.repository import UserRepository
 from ai.backend.manager.repositories.user_resource_policy.repository import (

--- a/tests/component/openid/conftest.py
+++ b/tests/component/openid/conftest.py
@@ -58,10 +58,11 @@ from ai.backend.manager.models.resource_policy import (
     user_resource_policies,
 )
 from ai.backend.manager.models.user import UserRole, UserStatus, users
-from ai.backend.manager.models.utils import ExtendedAsyncSAEngine, connect_database
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.plugin.openid.hook import OIDCHookPlugin
 from ai.backend.manager.plugin.openid.valkey_client import ValkeyOpenIDClient
 from ai.backend.manager.plugin.openid.webapp import OIDCWebAppPlugin
+from ai.backend.manager.repositories.db.engine import connect_database
 from ai.backend.testutils.bootstrap import (  # noqa: F401
     postgres_container,
     redis_container,

--- a/tests/unit/manager/actions/validators/conftest.py
+++ b/tests/unit/manager/actions/validators/conftest.py
@@ -5,7 +5,8 @@ from collections.abc import AsyncIterator
 import pytest
 
 from ai.backend.common.typed_validators import HostPortPair as HostPortPairModel
-from ai.backend.manager.models.utils import ExtendedAsyncSAEngine, create_async_engine
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.db.engine import create_async_engine
 from ai.backend.testutils.bootstrap import postgres_container  # noqa: F401
 
 

--- a/tests/unit/manager/health/test_database.py
+++ b/tests/unit/manager/health/test_database.py
@@ -10,7 +10,8 @@ from ai.backend.common.typed_validators import HostPortPair
 from ai.backend.common.typed_validators import HostPortPair as HostPortPairModel
 from ai.backend.manager.config.unified import DatabaseConfig
 from ai.backend.manager.health.database import DatabaseHealthChecker
-from ai.backend.manager.models.utils import ExtendedAsyncSAEngine, connect_database
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.db.engine import connect_database
 
 
 @pytest.fixture

--- a/tests/unit/manager/models/conftest.py
+++ b/tests/unit/manager/models/conftest.py
@@ -9,7 +9,8 @@ from ai.backend.common.typed_validators import HostPortPair as HostPortPairModel
 # Register all models so SQLAlchemy's global configure_mappers() can resolve every
 # row's string relationships regardless of which models a test module happens to import.
 from ai.backend.manager.models.base import ensure_all_tables_registered
-from ai.backend.manager.models.utils import ExtendedAsyncSAEngine, create_async_engine
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.db.engine import create_async_engine
 from ai.backend.testutils.bootstrap import postgres_container  # noqa: F401
 
 ensure_all_tables_registered()

--- a/tests/unit/manager/repositories/conftest.py
+++ b/tests/unit/manager/repositories/conftest.py
@@ -9,7 +9,8 @@ from ai.backend.common.typed_validators import HostPortPair as HostPortPairModel
 # Register all models so SQLAlchemy's global configure_mappers() can resolve every
 # row's string relationships regardless of which models a test shard happens to import.
 from ai.backend.manager.models.base import ensure_all_tables_registered
-from ai.backend.manager.models.utils import ExtendedAsyncSAEngine, create_async_engine
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.db.engine import create_async_engine
 
 ensure_all_tables_registered()
 

--- a/tests/unit/manager/services/scaling_group/conftest.py
+++ b/tests/unit/manager/services/scaling_group/conftest.py
@@ -49,7 +49,8 @@ from ai.backend.manager.models.scaling_group import (
     ScalingGroupRow,
 )
 from ai.backend.manager.models.user.row import UserRow
-from ai.backend.manager.models.utils import ExtendedAsyncSAEngine, create_async_engine
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.db.engine import create_async_engine
 from ai.backend.manager.repositories.scaling_group.repository import ScalingGroupRepository
 from ai.backend.manager.services.scaling_group.processors import ScalingGroupProcessors
 from ai.backend.manager.services.scaling_group.service import ScalingGroupService

--- a/tests/unit/manager/test_query_userinfo.py
+++ b/tests/unit/manager/test_query_userinfo.py
@@ -47,8 +47,9 @@ from ai.backend.manager.models.runtime_variant import RuntimeVariantRow
 from ai.backend.manager.models.scaling_group import ScalingGroupRow
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.user import UserRole, UserRow
-from ai.backend.manager.models.utils import ExtendedAsyncSAEngine, create_async_engine
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import VFolderRow
+from ai.backend.manager.repositories.db.engine import create_async_engine
 from ai.backend.manager.utils import query_userinfo, query_userinfo_from_session
 from ai.backend.testutils.db import with_tables
 

--- a/tests/unit/manager/test_reconcile_agent_resources.py
+++ b/tests/unit/manager/test_reconcile_agent_resources.py
@@ -37,8 +37,9 @@ from ai.backend.manager.models.resource_slot import (
 )
 from ai.backend.manager.models.scaling_group import ScalingGroupOpts, ScalingGroupRow
 from ai.backend.manager.models.session import SessionRow
-from ai.backend.manager.models.utils import ExtendedAsyncSAEngine, create_async_engine
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.registry import AgentRegistry
+from ai.backend.manager.repositories.db.engine import create_async_engine
 from ai.backend.testutils.db import with_tables
 
 

--- a/tests/unit/testutils/conftest.py
+++ b/tests/unit/testutils/conftest.py
@@ -6,7 +6,8 @@ from collections.abc import Iterator
 import pytest
 
 from ai.backend.common.typed_validators import HostPortPair as HostPortPairModel
-from ai.backend.manager.models.utils import ExtendedAsyncSAEngine, create_async_engine
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.db.engine import create_async_engine
 from ai.backend.testutils.bootstrap import postgres_container  # noqa: F401
 
 


### PR DESCRIPTION
## Summary
- Move engine creation/lifecycle functions (`create_async_engine`, `connect_database`, `vacuum_db`) out of `models/utils.py` into a new `repositories/db/engine.py`, relocating engine ownership to the repository layer.
- This removes the models layer's dependency on `BootstrapConfig`/`DatabaseConfig` — models no longer imports config for the DB engine.
- `ExtendedAsyncSAEngine` and the config-free transaction retry helpers (`execute_with_retry`, `execute_with_txn_retry`, etc.) stay in `models/utils.py`, since models row classes use them directly and must not import from the higher repository layer.
- Update all manager-scope consumers (dependencies, CLI, tests) to import from the new location.

## Test plan
- [x] CI: unit + component tests pass (dependents of `models.utils` are broad)
- [x] `pants check` (mypy) passes
- [x] `pants lint` incl. visibility rules passes (no layer/cycle violation)

Resolves BA-6790