### PR TITLE
fix(BA-6795): detect client disconnect in bgtask SSE event handler

### DIFF
--- a/changes/12686.fix.md
+++ b/changes/12686.fix.md
@@ -1,0 +1,1 @@
+Fix a manager memory leak where the background-task event stream (`GET /events/background-task`) leaked an asyncio task and a registered event propagator when a client disconnected before the task finished.

--- a/src/ai/backend/manager/api/rest/events/handler.py
+++ b/src/ai/backend/manager/api/rest/events/handler.py
@@ -209,6 +209,20 @@ class EventsHandler:
             self.event_hub.register_event_propagator(
                 propagator, [(EventDomain.BGTASK, str(task_id))]
             )
+
+            async def close_on_disconnect() -> None:
+                # resp.wait() returns once the SSE connection is closed by the
+                # client. Closing the propagator then unblocks receive() below,
+                # so the handler exits and the finally: cleanup runs. Without
+                # this, receive() blocks forever when a client disconnects
+                # before the terminal (close) event arrives, leaking the task,
+                # the registered propagator, and its per-alias metric series.
+                try:
+                    await resp.wait()
+                finally:
+                    await propagator.close()
+
+            disconnect_task = asyncio.create_task(close_on_disconnect())
             try:
                 cache_id = EventCacheDomain.BGTASK.cache_id(str(task_id))
                 async for event in propagator.receive(cache_id):
@@ -230,9 +244,19 @@ class EventsHandler:
                             user_event.event_name(),
                         )
                         break
-                await resp.send(dump_json_str({}), event="server_close")
+                # Skip the trailing send if the client already disconnected
+                # (receive() then ended via close_on_disconnect()).
+                if not disconnect_task.done():
+                    await resp.send(dump_json_str({}), event="server_close")
             finally:
                 self.event_hub.unregister_event_propagator(propagator.id())
+                await propagator.close()
+                if not disconnect_task.done():
+                    disconnect_task.cancel()
+                    try:
+                        await disconnect_task
+                    except asyncio.CancelledError:
+                        pass
         return resp
 
 

--- a/tests/unit/manager/api/events/BUILD
+++ b/tests/unit/manager/api/events/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/api/events/test_handler.py
+++ b/tests/unit/manager/api/events/test_handler.py
@@ -150,3 +150,4 @@ class TestPushBackgroundTaskEvents:
 
         sse.send.assert_awaited()  # the event was streamed to the client
         event_hub.unregister_event_propagator.assert_called_once()
+        assert propagator._closed is True  # the propagator was closed on exit

--- a/tests/unit/manager/api/events/test_handler.py
+++ b/tests/unit/manager/api/events/test_handler.py
@@ -1,0 +1,152 @@
+"""Regression tests for the background-task SSE event handler."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager, suppress
+from dataclasses import dataclass
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp_sse import EventSourceResponse
+
+from ai.backend.common.api_handlers import QueryParam
+from ai.backend.common.dto.manager.events.request import PushBackgroundTaskEventsRequest
+from ai.backend.common.events.event_types.bgtask.broadcast import BgtaskDoneEvent
+from ai.backend.common.events.hub.propagators.cache import WithCachePropagator
+from ai.backend.manager.api.rest.events import handler as events_handler
+from ai.backend.manager.api.rest.events.handler import EventsHandler, PrivateContext
+from ai.backend.manager.dto.context import RequestCtx, UserContext
+
+
+@pytest.fixture
+def propagator() -> WithCachePropagator:
+    """The propagator the handler registers (patched in via WithCachePropagator)."""
+    fetcher = MagicMock()
+    # No cached event -> receive() yields nothing and blocks on its queue,
+    # exactly the condition under which the handler used to hang.
+    fetcher.fetch_cached_event = AsyncMock(return_value=None)
+    return WithCachePropagator(fetcher)
+
+
+@asynccontextmanager
+async def yield_response(response: EventSourceResponse) -> AsyncIterator[EventSourceResponse]:
+    """``sse_response(request)`` returns an async CM that yields the response."""
+    yield response
+
+
+@dataclass
+class SSEStreamHarness:
+    """Handles to a running ``push_background_task_events`` call.
+
+    - ``task``: the handler coroutine, started and blocked in ``receive()``.
+    - ``sse``: the response mock; set ``sse.disconnect_event`` to end ``wait()``
+      (as a real client disconnect would), assert on ``sse.send``.
+    - ``event_hub``: the mock hub, to assert register/unregister calls.
+    """
+
+    task: asyncio.Task[web.StreamResponse]
+    sse: MagicMock
+    event_hub: MagicMock
+
+
+@pytest.fixture
+async def bgtask_event_stream(
+    monkeypatch: pytest.MonkeyPatch, propagator: WithCachePropagator
+) -> AsyncIterator[SSEStreamHarness]:
+    """Start the handler against a mocked SSE response, blocked in receive()."""
+    event_hub = MagicMock()
+    handler = EventsHandler(
+        private_ctx=PrivateContext(),
+        events_processors=MagicMock(),
+        event_hub=event_hub,
+        event_fetcher=MagicMock(),  # unused: WithCachePropagator is patched to `propagator`
+    )
+    monkeypatch.setattr(events_handler, "WithCachePropagator", lambda _fetcher: propagator)
+
+    # The handler only uses two things on the response: wait() (which returns
+    # when the client disconnects) and send(). Model wait() as blocking until we
+    # set disconnect_event, i.e. until the client "disconnects".
+    sse = MagicMock(spec=EventSourceResponse)
+    sse.disconnect_event = asyncio.Event()
+    sse.wait.side_effect = sse.disconnect_event.wait
+    monkeypatch.setattr(events_handler, "sse_response", lambda _request: yield_response(sse))
+
+    query = MagicMock(spec=QueryParam)
+    query.parsed.task_id = uuid.uuid4()
+    ctx = MagicMock(spec=RequestCtx)
+    ctx.request = MagicMock(spec=web.Request)
+    user_ctx = MagicMock(spec=UserContext)
+    user_ctx.access_key = "AKIATEST"
+
+    task = asyncio.create_task(
+        handler.push_background_task_events(
+            cast(QueryParam[PushBackgroundTaskEventsRequest], query),
+            cast(RequestCtx, ctx),
+            cast(UserContext, user_ctx),
+        )
+    )
+    # Wait until the handler has registered the propagator and is blocked.
+    for _ in range(200):
+        if event_hub.register_event_propagator.called:
+            break
+        await asyncio.sleep(0.01)
+
+    try:
+        yield SSEStreamHarness(task=task, sse=sse, event_hub=event_hub)
+    finally:
+        if not task.done():
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+
+
+class TestPushBackgroundTaskEvents:
+    async def test_client_disconnect_unregisters_propagator(
+        self, bgtask_event_stream: SSEStreamHarness, propagator: WithCachePropagator
+    ) -> None:
+        """A client disconnecting before the terminal event must not leak.
+
+        The handler blocked forever in ``receive()`` because nothing detected the
+        disconnect, so the ``finally`` cleanup never ran and the request task, the
+        registered propagator, and its per-alias metric series were never
+        released. It must now exit and unregister the propagator once the SSE
+        connection closes.
+        """
+        task = bgtask_event_stream.task
+        sse = bgtask_event_stream.sse
+        event_hub = bgtask_event_stream.event_hub
+        assert not event_hub.unregister_event_propagator.called
+
+        sse.disconnect_event.set()  # the client closes the SSE connection
+
+        try:
+            await asyncio.wait_for(task, timeout=5.0)
+        except TimeoutError:
+            raise AssertionError(
+                "handler did not exit after client disconnect (leak regression)"
+            ) from None
+
+        event_hub.unregister_event_propagator.assert_called_once_with(propagator.id())
+
+    async def test_terminal_event_completes_and_unregisters(
+        self, bgtask_event_stream: SSEStreamHarness, propagator: WithCachePropagator
+    ) -> None:
+        """The normal path still works: a terminal event ends the stream cleanly."""
+        task = bgtask_event_stream.task
+        sse = bgtask_event_stream.sse
+        event_hub = bgtask_event_stream.event_hub
+
+        # a terminal (done) event arrives -> the handler streams it and stops
+        await propagator.propagate_event(BgtaskDoneEvent(task_id=uuid.uuid4(), message="done"))
+        try:
+            await asyncio.wait_for(task, timeout=5.0)
+        except TimeoutError:
+            raise AssertionError("handler did not complete after a terminal event") from None
+
+        sse.send.assert_awaited()  # the event was streamed to the client
+        event_hub.unregister_event_propagator.assert_called_once()


### PR DESCRIPTION
## Summary

Fixes a manager memory leak: the background-task SSE event handler blocks
forever when a client disconnects before the task's terminal event, leaking an
asyncio task, the registered event propagator (and its queue), and a per-alias
metric series — one leak per abandoned stream.

Jira: BA-6795 (part of epic BA-6792)

### Root cause
`manager/api/rest/events/handler.py` · `push_background_task_events`

`async for event in propagator.receive(...)` only wakes on an event, so a client
disconnect before the terminal (close) event — tab close, navigation, network
blip, or subscribing to an already-finished task — is never detected and the
handler blocks indefinitely.

### Fix
Race `receive()` against `resp.wait()` via a `close_on_disconnect()` task that
closes the propagator on disconnect (the same pattern `push_session_events`
already uses), and close the propagator in `finally`. Skip the trailing
`server_close` send when the client is already gone.

### Verification
Reproduced live: opening + immediately closing 1000 distinct bgtask SSE streams
left `propagator_count=1000` and `async_task_count` elevated indefinitely on the
running manager; after the fix both drain to baseline within the SSE ping
interval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
