### PR TITLE
feat(BA-6788): process all workloads in a single tick by priority order in sequencer (#12668)

### DIFF
--- a/changes/12668.breaking.md
+++ b/changes/12668.breaking.md
@@ -1,0 +1,1 @@
+Schedule all workloads within a single tick in priority order instead of dropping lower-priority workloads

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/sequencers/sequencer.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/sequencers/sequencer.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from collections.abc import Sequence
 
 from ai.backend.manager.sokovan.data import SessionWorkload, SystemSnapshot
@@ -71,10 +72,14 @@ class SchedulingSequencer:
         :param workloads: A sequence of SessionWorkload objects to order.
         :return: A sequence of SessionWorkload objects ordered by priority and the sequencer's logic.
         """
-        priorities = {s.priority for s in workloads}
-        top_priority = max(priorities)
-        filtered_workloads = [*filter(lambda s: s.priority == top_priority, workloads)]
+        priority_workloads: defaultdict[int, list[SessionWorkload]] = defaultdict(list)
+        for workload in workloads:
+            priority_workloads[workload.priority].append(workload)
 
-        return await self._workload_sequencer.sequence(
-            resource_group, system_snapshot, filtered_workloads
-        )
+        result: list[SessionWorkload] = []
+        for priority in sorted(priority_workloads.keys(), reverse=True):
+            sequenced = await self._workload_sequencer.sequence(
+                resource_group, system_snapshot, priority_workloads[priority]
+            )
+            result.extend(sequenced)
+        return result

--- a/tests/unit/manager/sokovan/scheduler/provisioner/sequencers/test_sequencer.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/sequencers/test_sequencer.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 import pytest
 
 from ai.backend.common.types import AccessKey, ResourceSlot, SessionId
-from ai.backend.manager.data.sokovan import (
+from ai.backend.manager.sokovan.data import (
     ConcurrencySnapshot,
     PendingSessionSnapshot,
     ResourceOccupancySnapshot,

--- a/tests/unit/manager/sokovan/scheduler/provisioner/sequencers/test_sequencer.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/sequencers/test_sequencer.py
@@ -1,0 +1,132 @@
+import uuid
+from decimal import Decimal
+
+import pytest
+
+from ai.backend.common.types import AccessKey, ResourceSlot, SessionId
+from ai.backend.manager.data.sokovan import (
+    ConcurrencySnapshot,
+    PendingSessionSnapshot,
+    ResourceOccupancySnapshot,
+    ResourcePolicySnapshot,
+    SessionDependencySnapshot,
+    SessionWorkload,
+    SystemSnapshot,
+)
+from ai.backend.manager.sokovan.scheduler.provisioner.sequencers.fifo import FIFOSequencer
+from ai.backend.manager.sokovan.scheduler.provisioner.sequencers.sequencer import (
+    SchedulingSequencer,
+)
+
+
+def make_workload(access_key: str, priority: int) -> SessionWorkload:
+    return SessionWorkload(
+        session_id=SessionId(uuid.uuid4()),
+        access_key=AccessKey(access_key),
+        requested_slots=ResourceSlot(cpu=Decimal("10"), mem=Decimal("10")),
+        user_uuid=uuid.uuid4(),
+        group_id=uuid.uuid4(),
+        domain_name="default",
+        scaling_group="default",
+        priority=priority,
+    )
+
+
+class TestSchedulingSequencer:
+    @pytest.fixture
+    def scaling_group(self) -> str:
+        return "default"
+
+    @pytest.fixture
+    def sequencer(self) -> SchedulingSequencer:
+        return SchedulingSequencer(FIFOSequencer())
+
+    @pytest.fixture
+    def system_snapshot(self) -> SystemSnapshot:
+        return SystemSnapshot(
+            total_capacity=ResourceSlot(cpu=Decimal("100"), mem=Decimal("100")),
+            resource_occupancy=ResourceOccupancySnapshot(
+                by_keypair={},
+                by_user={},
+                by_group={},
+                by_domain={},
+                by_agent={},
+            ),
+            resource_policy=ResourcePolicySnapshot(
+                keypair_policies={},
+                user_policies={},
+                group_limits={},
+                domain_limits={},
+            ),
+            concurrency=ConcurrencySnapshot(
+                sessions_by_keypair={},
+                sftp_sessions_by_keypair={},
+            ),
+            pending_sessions=PendingSessionSnapshot(
+                by_keypair={},
+            ),
+            session_dependencies=SessionDependencySnapshot(
+                by_session={},
+            ),
+            known_slot_types={},
+        )
+
+    async def test_empty_workloads(
+        self,
+        scaling_group: str,
+        sequencer: SchedulingSequencer,
+        system_snapshot: SystemSnapshot,
+    ) -> None:
+        result = await sequencer.sequence(scaling_group, system_snapshot, [])
+        assert result == []
+
+    async def test_keeps_all_workloads_across_priorities(
+        self,
+        scaling_group: str,
+        sequencer: SchedulingSequencer,
+        system_snapshot: SystemSnapshot,
+    ) -> None:
+        workloads = [
+            make_workload("high", priority=10),
+            make_workload("mid", priority=5),
+            make_workload("low", priority=0),
+        ]
+
+        result = await sequencer.sequence(scaling_group, system_snapshot, workloads)
+
+        assert {w.access_key for w in result} == {AccessKey(k) for k in ("high", "mid", "low")}
+
+    async def test_orders_by_descending_priority(
+        self,
+        scaling_group: str,
+        sequencer: SchedulingSequencer,
+        system_snapshot: SystemSnapshot,
+    ) -> None:
+        workloads = [
+            make_workload("low", priority=0),
+            make_workload("high", priority=10),
+            make_workload("mid", priority=5),
+        ]
+
+        result = await sequencer.sequence(scaling_group, system_snapshot, workloads)
+
+        assert [w.access_key for w in result] == [AccessKey(k) for k in ("high", "mid", "low")]
+
+    async def test_preserves_order_within_same_priority(
+        self,
+        scaling_group: str,
+        sequencer: SchedulingSequencer,
+        system_snapshot: SystemSnapshot,
+    ) -> None:
+        workloads = [
+            make_workload("high-first", priority=10),
+            make_workload("low-first", priority=0),
+            make_workload("high-second", priority=10),
+            make_workload("low-second", priority=0),
+        ]
+
+        result = await sequencer.sequence(scaling_group, system_snapshot, workloads)
+
+        assert [w.access_key for w in result] == [
+            AccessKey(k) for k in ("high-first", "high-second", "low-first", "low-second")
+        ]


### PR DESCRIPTION
This is an auto-generated backport PR of #12668 to the 26.4 release.