### PR TITLE
fix(BA-6804): drop per-kernel keys from stream defaultdicts on termination

### DIFF
--- a/changes/12696.fix.md
+++ b/changes/12696.fix.md
@@ -1,0 +1,1 @@
+Fix a manager memory leak where the per-kernel stream handler dictionaries grew without bound as compute sessions were created and terminated.

--- a/src/ai/backend/manager/api/rest/stream/handler.py
+++ b/src/ai/backend/manager/api/rest/stream/handler.py
@@ -655,7 +655,7 @@ async def handle_kernel_terminating(
     """Cleanup callback invoked by StreamCleanupEventHandler."""
     stream_key = kernel.id
     cancelled_tasks: list[asyncio.Task[Any]] = []
-    for sock in app_ctx.stream_stdin_socks[stream_key]:
+    for sock in app_ctx.stream_stdin_socks.get(stream_key, ()):
         sock.close()
     for handler in list(app_ctx.stream_pty_handlers.get(stream_key, [])):
         handler.cancel()
@@ -668,6 +668,11 @@ async def handle_kernel_terminating(
         cancelled_tasks.append(handler)
     if cancelled_tasks:
         await asyncio.gather(*cancelled_tasks, return_exceptions=True)
+    # Drop the per-kernel entries so these defaultdicts stay bounded as kernels churn.
+    app_ctx.stream_pty_handlers.pop(stream_key, None)
+    app_ctx.stream_execute_handlers.pop(stream_key, None)
+    app_ctx.stream_proxy_handlers.pop(stream_key, None)
+    app_ctx.stream_stdin_socks.pop(stream_key, None)
 
 
 async def stream_conn_tracker_gc(

--- a/tests/unit/manager/api/rest/stream/BUILD
+++ b/tests/unit/manager/api/rest/stream/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/api/rest/stream/test_handle_kernel_terminating.py
+++ b/tests/unit/manager/api/rest/stream/test_handle_kernel_terminating.py
@@ -1,0 +1,63 @@
+"""Regression tests for BA-6804.
+
+The per-kernel stream defaultdicts must not accumulate outer keys across the kernel
+lifecycle. In particular ``handle_kernel_terminating`` must not auto-vivify a
+``stream_stdin_socks`` entry for a kernel that never opened a stream, and it must drop
+any existing per-kernel entries on termination.
+"""
+
+from __future__ import annotations
+
+import uuid
+import weakref
+from collections import defaultdict
+from types import SimpleNamespace
+from typing import cast
+
+from ai.backend.common.types import KernelId
+from ai.backend.manager.api.rest.stream.handler import PrivateContext, handle_kernel_terminating
+from ai.backend.manager.models.kernel import KernelRow
+
+
+def _make_app_ctx() -> PrivateContext:
+    return cast(
+        PrivateContext,
+        SimpleNamespace(
+            stream_pty_handlers=defaultdict(weakref.WeakSet),
+            stream_execute_handlers=defaultdict(weakref.WeakSet),
+            stream_proxy_handlers=defaultdict(weakref.WeakSet),
+            stream_stdin_socks=defaultdict(weakref.WeakSet),
+        ),
+    )
+
+
+def _make_kernel(kernel_id: KernelId) -> KernelRow:
+    return cast(KernelRow, SimpleNamespace(id=kernel_id))
+
+
+class TestHandleKernelTerminating:
+    async def test_terminating_kernel_without_streams_adds_no_keys(self) -> None:
+        app_ctx = _make_app_ctx()
+        kernel = _make_kernel(KernelId(uuid.uuid4()))
+
+        await handle_kernel_terminating(kernel, app_ctx=app_ctx)
+
+        assert len(app_ctx.stream_stdin_socks) == 0
+        assert len(app_ctx.stream_pty_handlers) == 0
+        assert len(app_ctx.stream_execute_handlers) == 0
+        assert len(app_ctx.stream_proxy_handlers) == 0
+
+    async def test_terminating_kernel_removes_existing_keys(self) -> None:
+        app_ctx = _make_app_ctx()
+        stream_key = KernelId(uuid.uuid4())
+        # Simulate streams having been opened for this kernel.
+        _ = app_ctx.stream_pty_handlers[stream_key]
+        _ = app_ctx.stream_stdin_socks[stream_key]
+        kernel = _make_kernel(stream_key)
+
+        await handle_kernel_terminating(kernel, app_ctx=app_ctx)
+
+        assert stream_key not in app_ctx.stream_pty_handlers
+        assert stream_key not in app_ctx.stream_execute_handlers
+        assert stream_key not in app_ctx.stream_proxy_handlers
+        assert stream_key not in app_ctx.stream_stdin_socks


### PR DESCRIPTION
## Summary
- The four per-kernel stream defaultdicts (`stream_pty_handlers`, `stream_execute_handlers`, `stream_proxy_handlers`, `stream_stdin_socks`) never deleted their outer keys. `handle_kernel_terminating()` also used a bare `stream_stdin_socks[stream_key]` access, so `defaultdict.__missing__` inserted an empty key on every kernel termination — including kernels that never opened a stream — growing the dicts unbounded across the session lifecycle.
- Verified on a live worker (Linux + memray): after real session create→terminate cycles, `stream/handler.py` and `defaultdict.__missing__` frames remained in the memray `--leaks` (un-freed) set.
- Use `.get()` in `handle_kernel_terminating` and pop all four per-kernel keys after cancelling the handlers.

Resolves BA-6804.

🤖 Generated with [Claude Code](https://claude.com/claude-code)