### PR TITLE
fix: pass required resource_group_id in sequencer test make_workload

### DIFF
--- a/changes/12697.misc.md
+++ b/changes/12697.misc.md
@@ -1,0 +1,1 @@
+Fix a typecheck regression where the sequencer test omitted the now-required `resource_group_id` when constructing `SessionWorkload`.

--- a/tests/unit/manager/sokovan/scheduler/provisioner/sequencers/test_sequencer.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/sequencers/test_sequencer.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 
 import pytest
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import AccessKey, ResourceSlot, SessionId
 from ai.backend.manager.data.sokovan import (
     ConcurrencySnapshot,
@@ -28,6 +29,7 @@ def make_workload(access_key: str, priority: int) -> SessionWorkload:
         group_id=uuid.uuid4(),
         domain_name="default",
         scaling_group="default",
+        resource_group_id=ResourceGroupID(uuid.uuid4()),
         priority=priority,
     )
 


### PR DESCRIPTION
## Summary

Fixes a typecheck regression on `main`: `SessionWorkload.resource_group_id` became a **required** field in #12655 (BA-6709), but the `make_workload` helper added later in #12668 (BA-6788) does not pass it, so `mypy` fails on `main` — and on every open PR whose CI typechecks the merge with `main`.

```
tests/unit/manager/sokovan/scheduler/provisioner/sequencers/test_sequencer.py:23:
  error: Missing positional argument "resource_group_id" in call to "SessionWorkload"  [call-arg]
```

## Change

Pass `resource_group_id=ResourceGroupID(uuid.uuid4())` in `make_workload`, matching the pattern already used in `tests/unit/manager/sokovan/scheduler/conftest.py`.

## Verification

- `pants check tests/unit/manager/sokovan/scheduler/provisioner/sequencers/test_sequencer.py` → mypy clean
- `pants test  tests/unit/manager/sokovan/scheduler/provisioner/sequencers/test_sequencer.py` → passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
