### PR TITLE
refactor(BA-6805): delegate pagination total_count to polymorphic strategy methods

### DIFF
--- a/changes/12702.enhance.md
+++ b/changes/12702.enhance.md
@@ -1,0 +1,1 @@
+Delegate pagination `total_count` computation to polymorphic strategy methods, removing a redundant count query for unpaginated queries.

--- a/src/ai/backend/manager/repositories/base/pagination.py
+++ b/src/ai/backend/manager/repositories/base/pagination.py
@@ -24,17 +24,6 @@ class QueryPagination(ABC):
     select statement with appropriate pagination logic.
     """
 
-    @property
-    @abstractmethod
-    def uses_window_function(self) -> bool:
-        """Whether this pagination uses window function for total_count.
-
-        Returns:
-            True if window function should be added to main query (Offset),
-            False if separate count query should be used (Cursor).
-        """
-        raise NotImplementedError
-
     @abstractmethod
     def apply(self, query: sa.sql.Select[Any]) -> sa.sql.Select[Any]:
         """Apply pagination to a SQLAlchemy select statement."""
@@ -51,6 +40,25 @@ class QueryPagination(ABC):
 
         Returns:
             _PageInfoResult containing sliced rows and pagination flags
+        """
+
+        raise NotImplementedError
+
+    @abstractmethod
+    def attach_count(self, query: sa.sql.Select[Any]) -> sa.sql.Select[Any]:
+        """Attach a total_count column to the data query if this strategy folds
+        counting into the data query; otherwise return the query unchanged.
+        """
+
+        raise NotImplementedError
+
+    @abstractmethod
+    def count_from_rows(self, rows: list[Row[Any]]) -> int | None:
+        """Derive total_count from the fetched rows.
+
+        Returns:
+            The total count if derivable from the rows, or None to signal the
+            caller must execute a separate count query.
         """
 
         raise NotImplementedError
@@ -74,11 +82,6 @@ class NoPagination(QueryPagination):
     Useful for internal operations like scheduler batch processing.
     """
 
-    @property
-    @override
-    def uses_window_function(self) -> bool:
-        return False
-
     @override
     def apply(self, query: sa.sql.Select[Any]) -> sa.sql.Select[Any]:
         """No pagination applied - returns query unchanged."""
@@ -94,6 +97,16 @@ class NoPagination(QueryPagination):
             has_next_page=False,
             has_previous_page=False,
         )
+
+    @override
+    def attach_count(self, query: sa.sql.Select[Any]) -> sa.sql.Select[Any]:
+        """No count column needed - all rows are returned."""
+        return query
+
+    @override
+    def count_from_rows(self, rows: list[Row[Any]]) -> int | None:
+        """All matching rows are returned, so the count is simply len(rows)."""
+        return len(rows)
 
 
 @dataclass
@@ -111,11 +124,6 @@ class OffsetPagination(QueryPagination):
 
     offset: int = 0
     """Number of items to skip from the beginning (must be non-negative)."""
-
-    @property
-    @override
-    def uses_window_function(self) -> bool:
-        return True
 
     @override
     def apply(self, query: sa.sql.Select[Any]) -> sa.sql.Select[Any]:
@@ -138,9 +146,42 @@ class OffsetPagination(QueryPagination):
             has_previous_page=has_previous_page,
         )
 
+    @override
+    def attach_count(self, query: sa.sql.Select[Any]) -> sa.sql.Select[Any]:
+        """Fold the total count into the data query via a window function."""
+        return query.add_columns(sa.func.count().over().label("total_count"))
+
+    @override
+    def count_from_rows(self, rows: list[Row[Any]]) -> int | None:
+        """Read the window-function count from the rows.
+
+        Returns None when there are no rows (the window column is absent), so the
+        caller falls back to a separate count query.
+        """
+        if rows:
+            total_count: int = rows[0].total_count
+            return total_count
+        return None
+
+
+class CursorPagination(QueryPagination):
+    """Shared count strategy for cursor-based pagination.
+
+    total_count comes from a separate count query: a window count would be wrong
+    because the data query fetches LIMIT N+1 rows for page detection.
+    """
+
+    @override
+    def attach_count(self, query: sa.sql.Select[Any]) -> sa.sql.Select[Any]:
+        return query
+
+    @override
+    def count_from_rows(self, rows: list[Row[Any]]) -> int | None:
+        return None
+
 
 @dataclass
-class CursorForwardPagination(QueryPagination):
+class CursorForwardPagination(CursorPagination):
     """
     Cursor-based forward pagination using first and after.
 
@@ -160,11 +201,6 @@ class CursorForwardPagination(QueryPagination):
 
     cursor_condition: QueryCondition | None = None
     """Optional QueryCondition for cursor position. If None, starts from the beginning."""
-
-    @property
-    @override
-    def uses_window_function(self) -> bool:
-        return False
 
     @override
     def apply(self, query: sa.sql.Select[Any]) -> sa.sql.Select[Any]:
@@ -197,7 +233,7 @@ class CursorForwardPagination(QueryPagination):
 
 
 @dataclass
-class CursorBackwardPagination(QueryPagination):
+class CursorBackwardPagination(CursorPagination):
     """
     Cursor-based backward pagination using last and before.
 
@@ -217,11 +253,6 @@ class CursorBackwardPagination(QueryPagination):
 
     cursor_condition: QueryCondition | None = None
     """Optional QueryCondition for cursor position. If None, starts from the end."""
-
-    @property
-    @override
-    def uses_window_function(self) -> bool:
-        return False
 
     @override
     def apply(self, query: sa.sql.Select[Any]) -> sa.sql.Select[Any]:

--- a/src/ai/backend/manager/repositories/base/querier.py
+++ b/src/ai/backend/manager/repositories/base/querier.py
@@ -234,20 +234,15 @@ async def execute_batch_querier(
         await _validate_scope(db_sess, aggregated_checks)
 
     query_pair = _apply_batch_querier(query, querier, or_conditions)
-    data_query = query_pair.query
     count_query = query_pair.count_query
 
-    if querier.pagination.uses_window_function:
-        data_query = data_query.add_columns(sa.func.count().over().label("total_count"))
+    data_query = querier.pagination.attach_count(query_pair.query)
     result = await db_sess.execute(data_query)
     rows = list(result.all())
 
-    total_count: int
-    if querier.pagination.uses_window_function and rows:
-        # Offset pagination with results: use window function from rows
-        total_count = rows[0].total_count
-    else:
-        # Cursor pagination or offset fallback (rows empty): separate count query
+    total_count = querier.pagination.count_from_rows(rows)
+    if total_count is None:
+        # Strategy could not derive the count from rows: run a separate count query.
         count_result = await db_sess.execute(count_query)
         total_count = count_result.scalar() or 0
 

--- a/tests/unit/manager/repositories/base/test_pagination_classes.py
+++ b/tests/unit/manager/repositories/base/test_pagination_classes.py
@@ -12,6 +12,7 @@ from sqlalchemy import Row
 from ai.backend.manager.repositories.base import (
     CursorBackwardPagination,
     CursorForwardPagination,
+    NoPagination,
     OffsetPagination,
     PageInfoResult,
 )
@@ -285,3 +286,83 @@ class TestCursorBackwardPagination:
 
         # When using backward cursor, there's always a next page (we came from somewhere ahead)
         assert result.has_next_page is True
+
+
+class TestCountStrategyMethods:
+    """Tests for the polymorphic count strategy: attach_count() and count_from_rows()."""
+
+    def test_offset_attach_count_adds_column(self) -> None:
+        """OffsetPagination.attach_count() folds a count column into the query."""
+        pagination = OffsetPagination(limit=10)
+        mock_query = MagicMock()
+        mock_query.add_columns.return_value = mock_query
+
+        result = pagination.attach_count(mock_query)
+
+        mock_query.add_columns.assert_called_once()
+        assert result is mock_query
+
+    def test_offset_count_from_rows_reads_window_value(self) -> None:
+        """OffsetPagination.count_from_rows() reads total_count from the first row."""
+        pagination = OffsetPagination(limit=10)
+        rows = [MagicMock(total_count=42) for _ in range(3)]
+
+        assert pagination.count_from_rows(cast(list[Row[Any]], rows)) == 42
+
+    def test_offset_count_from_rows_empty_returns_none(self) -> None:
+        """OffsetPagination.count_from_rows() returns None on empty rows (fallback)."""
+        pagination = OffsetPagination(limit=10)
+
+        assert pagination.count_from_rows([]) is None
+
+    def test_no_pagination_attach_count_is_identity(self) -> None:
+        """NoPagination.attach_count() leaves the query unchanged."""
+        pagination = NoPagination()
+        mock_query = MagicMock()
+
+        result = pagination.attach_count(mock_query)
+
+        mock_query.add_columns.assert_not_called()
+        assert result is mock_query
+
+    def test_no_pagination_count_from_rows_is_len(self) -> None:
+        """NoPagination.count_from_rows() returns len(rows), never None."""
+        pagination = NoPagination()
+        rows = [MagicMock() for _ in range(7)]
+
+        assert pagination.count_from_rows(cast(list[Row[Any]], rows)) == 7
+        assert pagination.count_from_rows([]) == 0
+
+    def test_cursor_forward_attach_count_is_identity(self) -> None:
+        """CursorForwardPagination.attach_count() leaves the query unchanged."""
+        pagination = CursorForwardPagination(first=10, cursor_order=MagicMock())
+        mock_query = MagicMock()
+
+        result = pagination.attach_count(mock_query)
+
+        mock_query.add_columns.assert_not_called()
+        assert result is mock_query
+
+    def test_cursor_forward_count_from_rows_returns_none(self) -> None:
+        """CursorForwardPagination.count_from_rows() always signals a count query."""
+        pagination = CursorForwardPagination(first=10, cursor_order=MagicMock())
+        rows = [MagicMock() for _ in range(11)]
+
+        assert pagination.count_from_rows(cast(list[Row[Any]], rows)) is None
+
+    def test_cursor_backward_attach_count_is_identity(self) -> None:
+        """CursorBackwardPagination.attach_count() leaves the query unchanged."""
+        pagination = CursorBackwardPagination(last=10, cursor_order=MagicMock())
+        mock_query = MagicMock()
+
+        result = pagination.attach_count(mock_query)
+
+        mock_query.add_columns.assert_not_called()
+        assert result is mock_query
+
+    def test_cursor_backward_count_from_rows_returns_none(self) -> None:
+        """CursorBackwardPagination.count_from_rows() always signals a count query."""
+        pagination = CursorBackwardPagination(last=10, cursor_order=MagicMock())
+        rows = [MagicMock() for _ in range(11)]
+
+        assert pagination.count_from_rows(cast(list[Row[Any]], rows)) is None

--- a/tests/unit/manager/repositories/base/test_pagination_integration.py
+++ b/tests/unit/manager/repositories/base/test_pagination_integration.py
@@ -14,6 +14,7 @@ from ai.backend.manager.repositories.base import (
     BatchQuerier,
     CursorBackwardPagination,
     CursorForwardPagination,
+    NoPagination,
     OffsetPagination,
     execute_batch_querier,
 )
@@ -84,6 +85,25 @@ def _make_cursor_condition_backward(table: sa.Table, cursor_id: int) -> QueryCon
         return table.c.id < cursor_id
 
     return condition
+
+
+class _ExecuteCountingSession:
+    """Wraps a session/connection to count execute() calls.
+
+    execute_batch_querier only ever calls db_sess.execute(), so counting those
+    calls lets us assert how many round-trips (data query, count query) run.
+    """
+
+    inner: Any
+    execute_count: int
+
+    def __init__(self, inner: Any) -> None:
+        self.inner = inner
+        self.execute_count = 0
+
+    async def execute(self, *args: Any, **kwargs: Any) -> Any:
+        self.execute_count += 1
+        return await self.inner.execute(*args, **kwargs)
 
 
 class TestOffsetPagination:
@@ -409,3 +429,105 @@ class TestEdgeCases:
         assert result.total_count == 100
         assert result.has_previous_page is False
         assert result.has_next_page is False
+
+
+class TestNoPagination:
+    """Tests for NoPagination - returns all rows, total_count == len(rows)."""
+
+    async def test_returns_all_rows_without_count_query(
+        self,
+        pagination_test_db: tuple[AsyncConnection, sa.Table],
+    ) -> None:
+        """total_count equals len(rows) and no separate count query is executed."""
+        conn, test_items = pagination_test_db
+
+        query = _make_base_query(test_items).order_by(test_items.c.id.asc())
+        querier = BatchQuerier(pagination=NoPagination())
+        spy = _ExecuteCountingSession(conn)
+
+        result = await execute_batch_querier(spy, query, querier)  # type: ignore[arg-type]
+
+        assert len(result.rows) == 100
+        assert result.total_count == 100  # == len(rows)
+        assert result.has_previous_page is False
+        assert result.has_next_page is False
+        assert spy.execute_count == 1  # data query only, zero count queries
+
+    async def test_with_filter_counts_only_matching_rows(
+        self,
+        pagination_test_db: tuple[AsyncConnection, sa.Table],
+    ) -> None:
+        """With a filter, total_count still equals len(rows) and runs no count query."""
+        conn, test_items = pagination_test_db
+
+        def filter_condition() -> sa.sql.expression.ColumnElement[bool]:
+            return test_items.c.id > 50
+
+        query = _make_base_query(test_items).order_by(test_items.c.id.asc())
+        querier = BatchQuerier(pagination=NoPagination(), conditions=[filter_condition])
+        spy = _ExecuteCountingSession(conn)
+
+        result = await execute_batch_querier(spy, query, querier)  # type: ignore[arg-type]
+
+        assert len(result.rows) == 50
+        assert result.total_count == 50
+        assert spy.execute_count == 1  # zero count queries
+
+
+class TestCountQueryExecution:
+    """Verify how many DB round-trips each strategy makes for total_count."""
+
+    async def test_offset_with_results_uses_window_no_count_query(
+        self,
+        pagination_test_db: tuple[AsyncConnection, sa.Table],
+    ) -> None:
+        """Offset with rows folds the count into the data query (single round-trip)."""
+        conn, test_items = pagination_test_db
+
+        query = _make_base_query(test_items).order_by(test_items.c.id.asc())
+        querier = BatchQuerier(pagination=OffsetPagination(limit=10, offset=0))
+        spy = _ExecuteCountingSession(conn)
+
+        result = await execute_batch_querier(spy, query, querier)  # type: ignore[arg-type]
+
+        assert result.total_count == 100
+        assert spy.execute_count == 1  # window function, no separate count query
+
+    async def test_offset_empty_falls_back_to_count_query(
+        self,
+        pagination_test_db: tuple[AsyncConnection, sa.Table],
+    ) -> None:
+        """Offset with empty rows falls back to a separate count query."""
+        conn, test_items = pagination_test_db
+
+        query = _make_base_query(test_items).order_by(test_items.c.id.asc())
+        querier = BatchQuerier(pagination=OffsetPagination(limit=10, offset=200))
+        spy = _ExecuteCountingSession(conn)
+
+        result = await execute_batch_querier(spy, query, querier)  # type: ignore[arg-type]
+
+        assert result.rows == []
+        assert result.total_count == 100  # resolved via the fallback count query
+        assert spy.execute_count == 2  # empty data query + count query
+
+    async def test_cursor_forward_runs_separate_count_query(
+        self,
+        pagination_test_db: tuple[AsyncConnection, sa.Table],
+    ) -> None:
+        """Cursor pagination always runs a separate count query."""
+        conn, test_items = pagination_test_db
+
+        query = _make_base_query(test_items)
+        querier = BatchQuerier(
+            pagination=CursorForwardPagination(
+                first=10,
+                cursor_order=test_items.c.id.asc(),
+                cursor_condition=None,
+            )
+        )
+        spy = _ExecuteCountingSession(conn)
+
+        result = await execute_batch_querier(spy, query, querier)  # type: ignore[arg-type]
+
+        assert result.total_count == 100
+        assert spy.execute_count == 2  # data query + separate count query


### PR DESCRIPTION
## Summary
- Remove the binary `uses_window_function` flag; replace it with two polymorphic methods on `QueryPagination`: `attach_count(query)` (folds a count column into the data query) and `count_from_rows(rows) -> int | None` (derives `total_count` from fetched rows, or `None` to signal a separate count query).
- `execute_batch_querier` stops branching on the flag and delegates: attach count → execute → resolve `total_count`, running the fallback count query only when `count_from_rows` returns `None`.
- `NoPagination` now returns `len(rows)` and runs **zero** count queries; `OffsetPagination` uses the window function (fallback to count query on empty rows); the two cursor strategies share the separate-count behavior via a `CursorPagination` intermediate base.

## Test plan
- [x] Offset: window-function `total_count`, no separate count query; empty result falls back to count query (`total_count=0`/full count)
- [x] NoPagination: `total_count == len(rows)`, zero count queries
- [x] Cursor forward/backward: behavior and `total_count` unchanged (separate count query retained)
- [x] `uses_window_function` fully removed (grep clean)
- [x] `pants fmt/fix/lint/check` pass; `test_pagination_classes` / `test_pagination_integration` / `test_querier` pass

Resolves BA-6805
