### PR TITLE
feat(BA-6810): AppConfigFragment visible-fragments query (repository layer)

### DIFF
--- a/changes/12706.feature.md
+++ b/changes/12706.feature.md
@@ -1,0 +1,1 @@
+Add the AppConfigFragment visible-fragments repository query: fetch the public / domain / user fragments visible to a (domain, user) principal for one or many config names, rank-ordered via the allow-list, in a single query.

--- a/src/ai/backend/manager/models/app_config_fragment/conditions.py
+++ b/src/ai/backend/manager/models/app_config_fragment/conditions.py
@@ -72,6 +72,19 @@ class AppConfigFragmentConditions:
 
     by_config_name_in = staticmethod(make_string_in_factory(AppConfigFragmentRow.config_name))
 
+    @staticmethod
+    def by_config_names(config_names: Sequence[str]) -> QueryCondition:
+        """Fragments whose ``config_name`` is one of ``config_names``.
+
+        The plain-name membership filter the merged read AND-combines with a visibility
+        filter — kept separate from the ``by_*_visibility`` scope builders.
+        """
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigFragmentRow.config_name.in_(list(config_names))
+
+        return inner
+
     # --- scope_type enum filters ---
 
     @staticmethod
@@ -108,6 +121,41 @@ class AppConfigFragmentConditions:
     def by_scope_id_equals(scope_id: str) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return AppConfigFragmentRow.scope_id == scope_id
+
+        return inner
+
+    # --- per-scope visibility filters (one scope_type each), independent of config_name ---
+
+    @staticmethod
+    def by_public_visibility() -> QueryCondition:
+        """The ``public`` scope (public has no per-entity scope_id)."""
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AppConfigFragmentRow.scope_type == AppConfigScopeType.PUBLIC
+
+        return inner
+
+    @staticmethod
+    def by_domain_visibility(domain: str) -> QueryCondition:
+        """The ``domain`` scope for ``domain``."""
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return sa.and_(
+                AppConfigFragmentRow.scope_type == AppConfigScopeType.DOMAIN,
+                AppConfigFragmentRow.scope_id == domain,
+            )
+
+        return inner
+
+    @staticmethod
+    def by_user_visibility(user_id: str) -> QueryCondition:
+        """The ``user`` scope for ``user_id``."""
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return sa.and_(
+                AppConfigFragmentRow.scope_type == AppConfigScopeType.USER,
+                AppConfigFragmentRow.scope_id == user_id,
+            )
 
         return inner
 

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -21,12 +21,18 @@ from ai.backend.manager.data.app_config_fragment.types import (
 from ai.backend.manager.errors.app_config import (
     AppConfigFragmentNotFound,
 )
+from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
+from ai.backend.manager.models.app_config_fragment.conditions import AppConfigFragmentConditions
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
 from ai.backend.manager.models.scopes import SearchScope
+from ai.backend.manager.repositories.app_config_fragment.types import (
+    AppConfigScopeArguments,
+)
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
     BulkCreator,
     Creator,
+    NoPagination,
     Purger,
     Querier,
     Updater,
@@ -193,3 +199,68 @@ class AppConfigFragmentDBSource:
                 has_next_page=result.has_next_page,
                 has_previous_page=result.has_previous_page,
             )
+
+    async def _list_visible_fragments(
+        self,
+        config_names: Sequence[str],
+        scope: AppConfigScopeArguments,
+    ) -> list[AppConfigFragmentData]:
+        """Visible fragments for ``config_names`` in one query, ascending allow-list ``rank``.
+
+        Selects the requested names AND any one of the principal's visible scopes (public,
+        its domain, or its own user). The scope filter is name-independent, so it is a single
+        OR group AND-combined with the name membership. Merge priority (``rank``) lives on the
+        joined allow-list entry; the result is always ordered by ascending ``rank`` so the
+        caller can group by name and deep-merge each name's fragments in order (a global rank
+        sort keeps each name's subset rank-ordered too). Shared by the single- and bulk-name
+        public methods, which own the resilience policy.
+        """
+        scope_visibility = [
+            AppConfigFragmentConditions.by_public_visibility(),
+            AppConfigFragmentConditions.by_domain_visibility(str(scope.domain_id)),
+            AppConfigFragmentConditions.by_user_visibility(str(scope.user_id)),
+        ]
+        querier = BatchQuerier(
+            pagination=NoPagination(),
+            conditions=[
+                AppConfigFragmentConditions.by_config_names(config_names),
+                lambda: sa.or_(*(visibility() for visibility in scope_visibility)),
+            ],
+            orders=[AppConfigAllowListRow.rank.asc()],
+        )
+        # Join each fragment to its allow-list entry (indexed ``(config_name, scope_type)`` FK
+        # pair), which carries the merge ``rank`` the result is ordered by.
+        selector = sa.select(AppConfigFragmentRow).join(
+            AppConfigAllowListRow,
+            sa.and_(
+                AppConfigAllowListRow.config_name == AppConfigFragmentRow.config_name,
+                AppConfigAllowListRow.scope_type == AppConfigFragmentRow.scope_type,
+            ),
+        )
+        async with self._ops.read_ops() as r:
+            result = await r.batch_query_in_global(selector, querier)
+            return [row.AppConfigFragmentRow.to_data() for row in result.rows]
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def list_visible_fragments(
+        self, config_name: str, scope: AppConfigScopeArguments
+    ) -> list[AppConfigFragmentData]:
+        """Fragments visible to ``scope`` for one ``config_name``, rank-ordered, in one query.
+
+        Each ``(config_name, scope_type, scope_id)`` is unique, so the result is bounded
+        (one per scope_type), ready to deep-merge in ``rank`` order.
+        """
+        return await self._list_visible_fragments([config_name], scope)
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def list_visible_fragments_bulk(
+        self, config_names: list[str], scope: AppConfigScopeArguments
+    ) -> list[AppConfigFragmentData]:
+        """Visible fragments for several ``config_names`` at once, in a single query.
+
+        The bulk form of :meth:`list_visible_fragments`: rank-ordered, so the caller groups
+        by name (each name's subset stays rank-ordered) and deep-merges each in order.
+        """
+        if not config_names:
+            return []
+        return await self._list_visible_fragments(config_names, scope)

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -200,21 +200,21 @@ class AppConfigFragmentDBSource:
                 has_previous_page=result.has_previous_page,
             )
 
-    async def _list_visible_fragments(
-        self,
-        config_names: Sequence[str],
-        scope: AppConfigScopeArguments,
+    @app_config_fragment_db_source_resilience.apply()
+    async def list_visible_fragments_bulk(
+        self, config_names: list[str], scope: AppConfigScopeArguments
     ) -> list[AppConfigFragmentData]:
-        """Visible fragments for ``config_names`` in one query, ascending allow-list ``rank``.
+        """Visible fragments for several ``config_names`` at once, in a single query.
 
         Selects the requested names AND any one of the principal's visible scopes (public,
         its domain, or its own user). The scope filter is name-independent, so it is a single
         OR group AND-combined with the name membership. Merge priority (``rank``) lives on the
         joined allow-list entry; the result is always ordered by ascending ``rank`` so the
-        caller can group by name and deep-merge each name's fragments in order (a global rank
-        sort keeps each name's subset rank-ordered too). Shared by the single- and bulk-name
-        public methods, which own the resilience policy.
+        caller can group by name (each name's subset stays rank-ordered) and deep-merge each
+        name's fragments in order.
         """
+        if not config_names:
+            return []
         scope_visibility = [
             AppConfigFragmentConditions.by_public_visibility(),
             AppConfigFragmentConditions.by_domain_visibility(str(scope.domain_id)),
@@ -240,27 +240,3 @@ class AppConfigFragmentDBSource:
         async with self._ops.read_ops() as r:
             result = await r.batch_query_in_global(selector, querier)
             return [row.AppConfigFragmentRow.to_data() for row in result.rows]
-
-    @app_config_fragment_db_source_resilience.apply()
-    async def list_visible_fragments(
-        self, config_name: str, scope: AppConfigScopeArguments
-    ) -> list[AppConfigFragmentData]:
-        """Fragments visible to ``scope`` for one ``config_name``, rank-ordered, in one query.
-
-        Each ``(config_name, scope_type, scope_id)`` is unique, so the result is bounded
-        (one per scope_type), ready to deep-merge in ``rank`` order.
-        """
-        return await self._list_visible_fragments([config_name], scope)
-
-    @app_config_fragment_db_source_resilience.apply()
-    async def list_visible_fragments_bulk(
-        self, config_names: list[str], scope: AppConfigScopeArguments
-    ) -> list[AppConfigFragmentData]:
-        """Visible fragments for several ``config_names`` at once, in a single query.
-
-        The bulk form of :meth:`list_visible_fragments`: rank-ordered, so the caller groups
-        by name (each name's subset stays rank-ordered) and deep-merges each in order.
-        """
-        if not config_names:
-            return []
-        return await self._list_visible_fragments(config_names, scope)

--- a/src/ai/backend/manager/repositories/app_config_fragment/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repository.py
@@ -18,6 +18,9 @@ from ai.backend.manager.models.scopes import SearchScope
 from ai.backend.manager.repositories.app_config_fragment.db_source import (
     AppConfigFragmentDBSource,
 )
+from ai.backend.manager.repositories.app_config_fragment.types import (
+    AppConfigScopeArguments,
+)
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
     BulkCreator,
@@ -103,3 +106,15 @@ class AppConfigFragmentRepository:
         purgers: Sequence[Purger[AppConfigFragmentRow]],
     ) -> AppConfigFragmentBulkResult:
         return await self._db_source.bulk_purge(purgers)
+
+    @app_config_fragment_repository_resilience.apply()
+    async def list_visible_fragments(
+        self, config_name: str, scope: AppConfigScopeArguments
+    ) -> list[AppConfigFragmentData]:
+        return await self._db_source.list_visible_fragments(config_name, scope)
+
+    @app_config_fragment_repository_resilience.apply()
+    async def list_visible_fragments_bulk(
+        self, config_names: list[str], scope: AppConfigScopeArguments
+    ) -> list[AppConfigFragmentData]:
+        return await self._db_source.list_visible_fragments_bulk(config_names, scope)

--- a/src/ai/backend/manager/repositories/app_config_fragment/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repository.py
@@ -108,12 +108,6 @@ class AppConfigFragmentRepository:
         return await self._db_source.bulk_purge(purgers)
 
     @app_config_fragment_repository_resilience.apply()
-    async def list_visible_fragments(
-        self, config_name: str, scope: AppConfigScopeArguments
-    ) -> list[AppConfigFragmentData]:
-        return await self._db_source.list_visible_fragments(config_name, scope)
-
-    @app_config_fragment_repository_resilience.apply()
     async def list_visible_fragments_bulk(
         self, config_names: list[str], scope: AppConfigScopeArguments
     ) -> list[AppConfigFragmentData]:

--- a/src/ai/backend/manager/repositories/app_config_fragment/types.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/types.py
@@ -1,4 +1,4 @@
-"""Types for app config fragment repository operations (search scopes)."""
+"""Types for app config fragment repository operations (search scopes, resolve arguments)."""
 
 from __future__ import annotations
 
@@ -16,9 +16,23 @@ from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.scopes import ExistenceCheck, SearchScope
 
 __all__ = (
+    "AppConfigScopeArguments",
     "DomainAppConfigFragmentSearchScope",
     "UserAppConfigFragmentSearchScope",
 )
+
+
+@dataclass(frozen=True)
+class AppConfigScopeArguments:
+    """The principal an ``AppConfig`` is resolved for: the resolving user and its domain.
+
+    Bundles the scope-identifying arguments so they travel together (add new principal
+    dimensions here rather than growing method signatures). Plain value object — not a
+    :class:`SearchScope`.
+    """
+
+    domain_id: DomainID
+    user_id: UserID
 
 
 @dataclass(frozen=True)

--- a/tests/unit/manager/repositories/app_config_fragment/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_repository.py
@@ -633,8 +633,8 @@ class TestApplicableFragments:
         repository: AppConfigFragmentRepository,
         fragments_across_scopes: list[AppConfigFragmentData],
     ) -> None:
-        applicable = await repository.list_visible_fragments(
-            "theme",
+        applicable = await repository.list_visible_fragments_bulk(
+            ["theme"],
             AppConfigScopeArguments(domain_id=DomainID(_DOMAIN_UUID), user_id=UserID(_USER_UUID)),
         )
         # public + the caller's domain + the caller's own user fragment, ordered by the
@@ -661,8 +661,8 @@ class TestApplicableFragments:
         repository: AppConfigFragmentRepository,
         fragments_across_scopes: list[AppConfigFragmentData],
     ) -> None:
-        applicable = await repository.list_visible_fragments(
-            "unregistered",
+        applicable = await repository.list_visible_fragments_bulk(
+            ["unregistered"],
             AppConfigScopeArguments(domain_id=DomainID(_DOMAIN_UUID), user_id=UserID(_USER_UUID)),
         )
         assert applicable == []

--- a/tests/unit/manager/repositories/app_config_fragment/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_repository.py
@@ -31,6 +31,7 @@ from ai.backend.manager.repositories.app_config_fragment.repository import (
     AppConfigFragmentRepository,
 )
 from ai.backend.manager.repositories.app_config_fragment.types import (
+    AppConfigScopeArguments,
     DomainAppConfigFragmentSearchScope,
     UserAppConfigFragmentSearchScope,
 )
@@ -569,3 +570,137 @@ class TestBulkPurge:
         assert [f.index for f in result.failed] == [1]
         with pytest.raises(AppConfigFragmentNotFound):
             await repository.get_by_id(two_fragments[0].id)
+
+
+class TestVisibilityConditions:
+    async def test_public_visibility_selects_only_public(
+        self,
+        repository: AppConfigFragmentRepository,
+        fragments_across_scopes: list[AppConfigFragmentData],
+    ) -> None:
+        result = await repository.admin_search(
+            BatchQuerier(
+                pagination=OffsetPagination(limit=10, offset=0),
+                conditions=[AppConfigFragmentConditions.by_public_visibility()],
+            )
+        )
+        # Visibility is scope-only (name-independent): every public fragment, any name.
+        expected = {
+            f.id for f in fragments_across_scopes if f.scope_type is AppConfigScopeType.PUBLIC
+        }
+        assert {item.id for item in result.items} == expected
+
+    async def test_domain_visibility_selects_only_that_domain(
+        self,
+        repository: AppConfigFragmentRepository,
+        fragments_across_scopes: list[AppConfigFragmentData],
+    ) -> None:
+        result = await repository.admin_search(
+            BatchQuerier(
+                pagination=OffsetPagination(limit=10, offset=0),
+                conditions=[AppConfigFragmentConditions.by_domain_visibility(_DOMAIN_ID)],
+            )
+        )
+        expected = {
+            f.id
+            for f in fragments_across_scopes
+            if f.scope_type is AppConfigScopeType.DOMAIN and f.scope_id == _DOMAIN_ID
+        }
+        assert {item.id for item in result.items} == expected
+
+    async def test_user_visibility_selects_only_that_user(
+        self,
+        repository: AppConfigFragmentRepository,
+        fragments_across_scopes: list[AppConfigFragmentData],
+    ) -> None:
+        result = await repository.admin_search(
+            BatchQuerier(
+                pagination=OffsetPagination(limit=10, offset=0),
+                conditions=[AppConfigFragmentConditions.by_user_visibility(_USER_ID)],
+            )
+        )
+        expected = {
+            f.id
+            for f in fragments_across_scopes
+            if f.scope_type is AppConfigScopeType.USER and f.scope_id == _USER_ID
+        }
+        assert {item.id for item in result.items} == expected
+
+
+class TestApplicableFragments:
+    async def test_one_query_returns_public_domain_user_rank_ordered(
+        self,
+        repository: AppConfigFragmentRepository,
+        fragments_across_scopes: list[AppConfigFragmentData],
+    ) -> None:
+        applicable = await repository.list_visible_fragments(
+            "theme",
+            AppConfigScopeArguments(domain_id=DomainID(_DOMAIN_UUID), user_id=UserID(_USER_UUID)),
+        )
+        # public + the caller's domain + the caller's own user fragment, ordered by the
+        # allow-list entries' ranks (scope-type defaults: public < domain < user).
+        expected = [
+            f
+            for f in fragments_across_scopes
+            if f.config_name == "theme"
+            and (
+                f.scope_type is AppConfigScopeType.PUBLIC
+                or (f.scope_type is AppConfigScopeType.DOMAIN and f.scope_id == _DOMAIN_ID)
+                or (f.scope_type is AppConfigScopeType.USER and f.scope_id == _USER_ID)
+            )
+        ]
+        assert [f.id for f in applicable] == [f.id for f in expected]
+        assert [f.scope_type for f in applicable] == [
+            AppConfigScopeType.PUBLIC,
+            AppConfigScopeType.DOMAIN,
+            AppConfigScopeType.USER,
+        ]
+
+    async def test_unknown_config_name_returns_empty(
+        self,
+        repository: AppConfigFragmentRepository,
+        fragments_across_scopes: list[AppConfigFragmentData],
+    ) -> None:
+        applicable = await repository.list_visible_fragments(
+            "unregistered",
+            AppConfigScopeArguments(domain_id=DomainID(_DOMAIN_UUID), user_id=UserID(_USER_UUID)),
+        )
+        assert applicable == []
+
+    async def test_bulk_returns_visible_fragments_for_all_names_ordered(
+        self,
+        repository: AppConfigFragmentRepository,
+        fragments_across_scopes: list[AppConfigFragmentData],
+    ) -> None:
+        applicable = await repository.list_visible_fragments_bulk(
+            ["theme", "menu"],
+            AppConfigScopeArguments(domain_id=DomainID(_DOMAIN_UUID), user_id=UserID(_USER_UUID)),
+        )
+        # public + the caller's domain + the caller's own user fragment, for both names.
+        expected = {
+            f.id
+            for f in fragments_across_scopes
+            if f.config_name in ("theme", "menu")
+            and (
+                f.scope_type is AppConfigScopeType.PUBLIC
+                or (f.scope_type is AppConfigScopeType.DOMAIN and f.scope_id == _DOMAIN_ID)
+                or (f.scope_type is AppConfigScopeType.USER and f.scope_id == _USER_ID)
+            )
+        }
+        assert {f.id for f in applicable} == expected
+        # Rank-ordered globally, so each config_name's subset stays rank-ordered
+        # (public < domain < user) for the caller to group by name and deep-merge in order.
+        for name in ("theme", "menu"):
+            ranks = [f.scope_type.default_rank() for f in applicable if f.config_name == name]
+            assert ranks == sorted(ranks)
+
+    async def test_bulk_empty_names_returns_empty(
+        self,
+        repository: AppConfigFragmentRepository,
+        fragments_across_scopes: list[AppConfigFragmentData],
+    ) -> None:
+        applicable = await repository.list_visible_fragments_bulk(
+            [],
+            AppConfigScopeArguments(domain_id=DomainID(_DOMAIN_UUID), user_id=UserID(_USER_UUID)),
+        )
+        assert applicable == []


### PR DESCRIPTION
## 📚 Stacked PRs

Part of the AppConfigFragment / AppConfig stack under BEP-1052 (epic BA-5781). **Merge in order:**

1. ✅ #12306 — `feat(BA-6552): app_config_fragments DB model and Alembic migration`
2. ✅ #12307 — `feat(BA-6553): repository layer`
3. ✅ #12403 — `refactor(BA-6619): consolidate AppConfigScopeType into common.data`
4. ✅ #12405 — `refactor(BA-6620): ExistsQuerier + AppConfigAllowList.exists`
5. ✅ #12358 — `feat(BA-6554): AppConfigFragment service layer`
6. ✅ #12516 — `feat(BA-6702): move fragment rank to the allow list with scope defaults`
7. ✅ #12517 — `feat(BA-6701): expose allow-list rank on the v2 API surface`
8. ✅ #12518 — `feat(BA-6704): cascade app config subtree deletion from the definition`
9. ✅ #12426 — `feat(BA-6626): app_config_fragment bulk repository layer`
10. ✅ #12401 — `feat(BA-6618): app_config_fragment bulk CRUD service layer`
11. 👉 **#12706 — `feat(BA-6810): AppConfigFragment visible-fragments query (repository layer)`** ← you are here
12. #12359 — `feat(BA-6555): AppConfig merge engine + resolve service (service layer)`
13. #12377 — `feat(BA-6556): AppConfig REST v2 API`

## Summary

Split out of #12359 (BA-6555). This is the **repository read layer** the merged-AppConfig service (#12359) builds on; the merge engine + resolve service follows in #12359 (stacked on this).

## What's included

- **Visibility conditions** (`models/app_config_fragment/conditions.py`): `by_config_names` (name membership) plus scope-only `by_public_visibility` / `by_domain_visibility` / `by_user_visibility` — kept separate so the merged read AND-combines `config_name IN (...)` with `(public OR domain OR user)`.
- **`AppConfigScopeArguments`** (`repositories/app_config_fragment/types.py`): the resolving `(domain, user)` principal, bundled so it travels together.
- **`list_visible_fragments` / `list_visible_fragments_bulk`** (`db_source.py` + `repository.py`): per name, the `public` OR the scope's `domain` OR its `user` fragment, joined to the allow-list for the merge `rank`, fetched in a single query (rank-ordered, ready to deep-merge).
- **Real-DB repository tests**: the visibility conditions and the merged read.

No service/merge logic here — that is #12359.
