### PR TITLE
feat(BA-6809): expose RuntimeVariantPreset.runtimeVariant nested field

### DIFF
--- a/changes/12708.feature.md
+++ b/changes/12708.feature.md
@@ -1,0 +1,1 @@
+Add a DataLoader-backed `runtimeVariant: RuntimeVariant` nested field to the `RuntimeVariantPreset` GraphQL type so the runtime variant name can be fetched in one query alongside a preset list, instead of firing a separate `runtimeVariants` query.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -17638,6 +17638,11 @@ type RuntimeVariantPreset implements Node
 
   """Timestamp of the last modification to this preset."""
   updatedAt: DateTime
+
+  """
+  Added in 26.8.0. The runtime variant this preset belongs to, resolved via DataLoader. Fetch its name and other attributes in a single query alongside the preset list.
+  """
+  runtimeVariant: RuntimeVariant
 }
 
 """Added in 26.4.2. Paginated list of runtime variant presets."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -12247,6 +12247,11 @@ type RuntimeVariantPreset implements Node {
 
   """Timestamp of the last modification to this preset."""
   updatedAt: DateTime
+
+  """
+  Added in 26.8.0. The runtime variant this preset belongs to, resolved via DataLoader. Fetch its name and other attributes in a single query alongside the preset list.
+  """
+  runtimeVariant: RuntimeVariant
 }
 
 """Added in 26.4.2. Paginated list of runtime variant presets."""

--- a/src/ai/backend/manager/api/gql/runtime_variant_preset/types.py
+++ b/src/ai/backend/manager/api/gql/runtime_variant_preset/types.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
-from typing import Self
+from typing import TYPE_CHECKING, Annotated, Self
 from uuid import UUID
 
+import strawberry
+from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID
 
 from ai.backend.common.dto.manager.v2.runtime_variant_preset.request import (
@@ -52,6 +54,7 @@ from ai.backend.common.dto.manager.v2.runtime_variant_preset.types import (
 from ai.backend.common.dto.manager.v2.runtime_variant_preset.types import (
     UIOption as UIOptionDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import StringFilter as StringFilterGQL
 from ai.backend.manager.api.gql.base import UUIDFilter as UUIDFilterGQL
 from ai.backend.manager.api.gql.decorators import (
@@ -66,6 +69,10 @@ from ai.backend.manager.api.gql.decorators import (
     gql_pydantic_type,
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.runtime_variant.types import RuntimeVariantGQL
 
 
 @gql_enum(
@@ -228,6 +235,24 @@ class RuntimeVariantPresetGQL(PydanticNodeMixin[NodeDTO]):
     updated_at: datetime | None = gql_field(
         description="Timestamp of the last modification to this preset."
     )
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The runtime variant this preset belongs to, resolved via DataLoader. Fetch its name and other attributes in a single query alongside the preset list.",
+        )
+    )  # type: ignore[misc]
+    async def runtime_variant(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            RuntimeVariantGQL,
+            strawberry.lazy("ai.backend.manager.api.gql.runtime_variant.types"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.runtime_variant_loader.load(self.runtime_variant_id)
 
 
 RuntimeVariantPresetEdge = Edge[RuntimeVariantPresetGQL]


### PR DESCRIPTION
## Summary

Adds a DataLoader-backed `runtimeVariant: RuntimeVariant` nested field to the `RuntimeVariantPreset` GraphQL type.

Previously the type only exposed `runtimeVariantId: UUID!`, so to display the runtime variant name in a preset list the client had to fire a separate `runtimeVariants` query and build an `id -> name` map itself (see `AdminRuntimeVariantPreset.tsx` in webui). This mirrors the existing `DeploymentRevisionPreset.runtimeVariant` field so the name can be fetched in a single query alongside the preset list.

Resolves BA-6809. Unblocks FR-3256.

## Changes

- `RuntimeVariantPreset` GQL type gains an async `runtimeVariant: RuntimeVariant` resolver, resolved via the already-registered `runtime_variant_loader` DataLoader (no N+1).
- Regenerated `v2-schema.graphql` and `supergraph.graphql` references.

## Implementation notes

- Reuses the existing `runtime_variant_loader` and `RuntimeVariantAdapter.batch_load_by_ids` — no new loader/adapter code required.
- Uses `strawberry.lazy()` + `TYPE_CHECKING` import to avoid a circular import between the preset and runtime-variant GQL modules.
- `added_version = NEXT_RELEASE_VERSION` per the version-metadata rule.

## Example

```graphql
query {
  runtimeVariantPresets(first: 50) {
    edges { node {
      id
      runtimeVariantId
      runtimeVariant { id name }   # newly available in one round-trip
    } }
  }
}
```

## Verification

- `pants lint / check (mypy) / fix` pass on the changed file.
- `dump-gql-schema --v2` and `generate-supergraph` build the full Strawberry schema successfully with the new field exposed.
- Existing `runtime_variant_preset` gql tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12708.org.readthedocs.build/en/12708/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12708.org.readthedocs.build/ko/12708/

<!-- readthedocs-preview sorna-ko end -->