### PR TITLE
feat(BA-6812): expose ImageV2.registry nested field

### DIFF
--- a/changes/12712.feature.md
+++ b/changes/12712.feature.md
@@ -1,0 +1,1 @@
+Add a DataLoader-backed `registry: ContainerRegistryV2` nested field to the `ImageV2` GraphQL type so the container registry can be fetched in one query instead of a separate `containerRegistries` lookup.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -7889,6 +7889,11 @@ type ImageV2 implements Node
   registryId: UUID!
 
   """
+  Added in 26.8.0. The container registry where this image is stored, resolved via DataLoader. Fetch the registry's attributes in a single query instead of a separate containerRegistries lookup.
+  """
+  registry: ContainerRegistryV2
+
+  """
   Added in 26.3.0. Timestamp of the most recent session created with this image. Returns null if the image has never been used.
   """
   lastUsed: DateTime

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -7888,9 +7888,7 @@ type ImageV2 implements Node
   """UUID of the container registry where this image is stored."""
   registryId: UUID!
 
-  """
-  Added in 26.8.0. The container registry where this image is stored, resolved via DataLoader. Fetch the registry's attributes in a single query instead of a separate containerRegistries lookup.
-  """
+  """Added in 26.8.0. The container registry where this image is stored."""
   registry: ContainerRegistryV2
 
   """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -5197,6 +5197,11 @@ type ImageV2 implements Node {
   registryId: UUID!
 
   """
+  Added in 26.8.0. The container registry where this image is stored, resolved via DataLoader. Fetch the registry's attributes in a single query instead of a separate containerRegistries lookup.
+  """
+  registry: ContainerRegistryV2
+
+  """
   Added in 26.3.0. Timestamp of the most recent session created with this image. Returns null if the image has never been used.
   """
   lastUsed: DateTime

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -5196,9 +5196,7 @@ type ImageV2 implements Node {
   """UUID of the container registry where this image is stored."""
   registryId: UUID!
 
-  """
-  Added in 26.8.0. The container registry where this image is stored, resolved via DataLoader. Fetch the registry's attributes in a single query instead of a separate containerRegistries lookup.
-  """
+  """Added in 26.8.0. The container registry where this image is stored."""
   registry: ContainerRegistryV2
 
   """

--- a/src/ai/backend/manager/api/gql/image/types.py
+++ b/src/ai/backend/manager/api/gql/image/types.py
@@ -286,7 +286,7 @@ class ImageV2GQL(PydanticNodeMixin[ImageNode]):
     @gql_added_field(
         BackendAIGQLMeta(
             added_version=NEXT_RELEASE_VERSION,
-            description="The container registry where this image is stored, resolved via DataLoader. Fetch the registry's attributes in a single query instead of a separate containerRegistries lookup.",
+            description="The container registry where this image is stored.",
         )
     )  # type: ignore[misc]
     async def registry(

--- a/src/ai/backend/manager/api/gql/image/types.py
+++ b/src/ai/backend/manager/api/gql/image/types.py
@@ -11,7 +11,7 @@ import uuid
 from collections.abc import Iterable
 from datetime import datetime
 from enum import StrEnum
-from typing import Any, Self, cast, override
+from typing import TYPE_CHECKING, Annotated, Any, Self, cast, override
 
 import strawberry
 from strawberry import Info
@@ -41,6 +41,7 @@ from ai.backend.common.dto.manager.v2.image.types import (
     ImageResourceLimitGQLInfo,
     ImageTagInfo,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.common.types import ImageID
 from ai.backend.manager.api.gql.base import (
     DateTimeFilter,
@@ -66,6 +67,9 @@ from ai.backend.manager.api.gql.pydantic_compat import (
 )
 from ai.backend.manager.api.gql.types import GQLFilter, GQLOrderBy, StrawberryGQLContext
 from ai.backend.manager.models.image.conditions import ImageAliasConditions
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.container_registry.types import ContainerRegistryGQL
 
 # =============================================================================
 # Enums
@@ -275,10 +279,27 @@ class ImageV2GQL(PydanticNodeMixin[ImageNode]):
         description="Permission info for the current user. May be null.", default=None
     )
 
-    # Registry (ContainerRegistryNode connection to be added later)
     registry_id: uuid.UUID = gql_field(
         description="UUID of the container registry where this image is stored."
     )
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The container registry where this image is stored, resolved via DataLoader. Fetch the registry's attributes in a single query instead of a separate containerRegistries lookup.",
+        )
+    )  # type: ignore[misc]
+    async def registry(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            ContainerRegistryGQL,
+            strawberry.lazy("ai.backend.manager.api.gql.container_registry.types"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.container_registry_loader.load(self.registry_id)
 
     @gql_added_field(
         BackendAIGQLMeta(


### PR DESCRIPTION
## Summary

Adds a DataLoader-backed `registry: ContainerRegistryV2` nested field to the `ImageV2` GraphQL type.

Previously the type exposed only `registryId: UUID` (with an inline `# ContainerRegistryNode connection to be added later` placeholder), forcing clients to run a separate `containerRegistries` query and join by id to display registry attributes. This exposes the registry object in a single query.

Part of the nested-field audit spun off from BA-6809.

## Changes

- `ImageV2` gains an async `registry: ContainerRegistryV2` resolver via the already-registered `container_registry_loader` (no N+1). Removes the placeholder comment.
- Regenerated `v2-schema.graphql` and `supergraph.graphql`.

## Verification

- `pants lint / check (mypy) / fix` pass.
- `dump-gql-schema --v2` and `generate-supergraph` build the full schema with the new field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12712.org.readthedocs.build/en/12712/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12712.org.readthedocs.build/ko/12712/

<!-- readthedocs-preview sorna-ko end -->