### PR TITLE
feat(BA-6813): expose ProjectUsageBucket project/domain/resourceGroup nested fields

### DIFF
--- a/changes/12713.feature.md
+++ b/changes/12713.feature.md
@@ -1,0 +1,1 @@
+Add DataLoader-backed `project`, `domain`, and `resourceGroup` nested fields to the `ProjectUsageBucket` GraphQL type so related entities can be fetched in one query, mirroring the sibling `ProjectFairShare` type.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -13636,19 +13636,13 @@ type ProjectUsageBucket implements Node
   """
   usageCapacityRatio: ResourceSlot
 
-  """
-  Added in 26.8.0. The project entity this usage bucket belongs to.
-  """
+  """Added in 26.8.0. The project entity this usage bucket belongs to."""
   project: ProjectV2
 
-  """
-  Added in 26.8.0. The domain entity this usage bucket belongs to.
-  """
+  """Added in 26.8.0. The domain entity this usage bucket belongs to."""
   domain: DomainV2
 
-  """
-  Added in 26.8.0. The resource group this usage was recorded in.
-  """
+  """Added in 26.8.0. The resource group this usage was recorded in."""
   resourceGroup: ResourceGroup
 
   """

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -13637,6 +13637,21 @@ type ProjectUsageBucket implements Node
   usageCapacityRatio: ResourceSlot
 
   """
+  Added in 26.8.0. The project entity this usage bucket belongs to.
+  """
+  project: ProjectV2
+
+  """
+  Added in 26.8.0. The domain entity this usage bucket belongs to.
+  """
+  domain: DomainV2
+
+  """
+  Added in 26.8.0. The resource group this usage was recorded in.
+  """
+  resourceGroup: ResourceGroup
+
+  """
   Added in 26.1.0. User usage buckets belonging to this project. Returns paginated user-level usage history for all users in this project within the same scaling group.
   """
   userUsageBuckets(filter: UserUsageBucketFilter = null, orderBy: [UserUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserUsageBucketConnection

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -9211,6 +9211,21 @@ type ProjectUsageBucket implements Node {
   usageCapacityRatio: ResourceSlot
 
   """
+  Added in 26.8.0. The project entity this usage bucket belongs to.
+  """
+  project: ProjectV2
+
+  """
+  Added in 26.8.0. The domain entity this usage bucket belongs to.
+  """
+  domain: DomainV2
+
+  """
+  Added in 26.8.0. The resource group this usage was recorded in.
+  """
+  resourceGroup: ResourceGroup
+
+  """
   Added in 26.1.0. User usage buckets belonging to this project. Returns paginated user-level usage history for all users in this project within the same scaling group.
   """
   userUsageBuckets(filter: UserUsageBucketFilter = null, orderBy: [UserUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserUsageBucketConnection

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -9210,19 +9210,13 @@ type ProjectUsageBucket implements Node {
   """
   usageCapacityRatio: ResourceSlot
 
-  """
-  Added in 26.8.0. The project entity this usage bucket belongs to.
-  """
+  """Added in 26.8.0. The project entity this usage bucket belongs to."""
   project: ProjectV2
 
-  """
-  Added in 26.8.0. The domain entity this usage bucket belongs to.
-  """
+  """Added in 26.8.0. The domain entity this usage bucket belongs to."""
   domain: DomainV2
 
-  """
-  Added in 26.8.0. The resource group this usage was recorded in.
-  """
+  """Added in 26.8.0. The resource group this usage was recorded in."""
   resourceGroup: ResourceGroup
 
   """

--- a/src/ai/backend/manager/api/gql/resource_usage/types/project_usage.py
+++ b/src/ai/backend/manager/api/gql/resource_usage/types/project_usage.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any, Self
+from typing import TYPE_CHECKING, Annotated, Any, Self
 from uuid import UUID
 
+import strawberry
 from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID
 
@@ -18,6 +19,7 @@ from ai.backend.common.dto.manager.v2.resource_usage.request import (
 from ai.backend.common.dto.manager.v2.resource_usage.response import (
     ProjectUsageBucketNode,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import (
     DateFilter,
     OrderDirection,
@@ -51,6 +53,11 @@ from .user_usage import (
     UserUsageBucketGQL,
     UserUsageBucketOrderBy,
 )
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.domain_v2.types.node import DomainV2GQL
+    from ai.backend.manager.api.gql.project_v2.types.node import ProjectV2GQL
+    from ai.backend.manager.api.gql.resource_group.types import ResourceGroupGQL
 
 
 @gql_node_type(
@@ -107,6 +114,60 @@ class ProjectUsageBucketGQL(PydanticNodeMixin[ProjectUsageBucketNode]):
             self.resource_usage,
             self.capacity_snapshot,
         )
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The project entity this usage bucket belongs to.",
+        )
+    )  # type: ignore[misc]
+    async def project(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            ProjectV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.project_v2.types.node"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.project_loader.load(self.project_id)
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The domain entity this usage bucket belongs to.",
+        )
+    )  # type: ignore[misc]
+    async def domain(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            DomainV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.domain_v2.types.node"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.domain_loader.load(self.domain_name)
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The resource group this usage was recorded in.",
+        )
+    )  # type: ignore[misc]
+    async def resource_group(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            ResourceGroupGQL,
+            strawberry.lazy("ai.backend.manager.api.gql.resource_group.types"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.resource_group_loader.load(self.resource_group_name)
 
     @gql_added_field(
         BackendAIGQLMeta(


### PR DESCRIPTION
## Summary

Adds DataLoader-backed nested entity fields to the `ProjectUsageBucket` GraphQL type: `project: ProjectV2`, `domain: Domain`, `resourceGroup: ResourceGroup`.

Previously the type exposed only the scalar `projectId`, `domainName`, and `resourceGroupName`, so clients had to run separate queries to resolve the related entities. The sibling `ProjectFairShare` type already exposes these exact nested resolvers; this mirrors that pattern.

Part of the nested-field audit spun off from BA-6809.

## Changes

- `ProjectUsageBucket` gains `project`/`domain`/`resourceGroup` async resolvers via the existing `project_loader`/`domain_loader`/`resource_group_loader` (no N+1).
- Regenerated `v2-schema.graphql` and `supergraph.graphql`.

## Verification

- `pants lint / check (mypy) / fix` pass.
- `dump-gql-schema --v2` and `generate-supergraph` build the full schema with the new fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12713.org.readthedocs.build/en/12713/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12713.org.readthedocs.build/ko/12713/

<!-- readthedocs-preview sorna-ko end -->