### PR TITLE
feat(BA-6814): expose UserUsageBucket user/project/domain/resourceGroup nested fields

### DIFF
--- a/changes/12714.feature.md
+++ b/changes/12714.feature.md
@@ -1,0 +1,1 @@
+Add DataLoader-backed `user`, `project`, `domain`, and `resourceGroup` nested fields to the `UserUsageBucket` GraphQL type so related entities can be fetched in one query, mirroring the sibling `UserFairShare` type.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -21032,6 +21032,26 @@ type UserUsageBucket implements Node
   Added in 26.2.0. Usage ratio against total available capacity for each resource. Calculated as resource_usage divided by capacity_snapshot. Represents the fraction of total capacity consumed (resource-seconds / resource). The result is in seconds, where 86400 means full utilization for one day. Values can exceed this if usage exceeds capacity.
   """
   usageCapacityRatio: ResourceSlot
+
+  """
+  Added in 26.8.0. The user entity this usage bucket belongs to.
+  """
+  user: UserV2
+
+  """
+  Added in 26.8.0. The project entity this usage bucket belongs to.
+  """
+  project: ProjectV2
+
+  """
+  Added in 26.8.0. The domain entity this usage bucket belongs to.
+  """
+  domain: DomainV2
+
+  """
+  Added in 26.8.0. The resource group this usage was recorded in.
+  """
+  resourceGroup: ResourceGroup
 }
 
 """

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -21033,24 +21033,16 @@ type UserUsageBucket implements Node
   """
   usageCapacityRatio: ResourceSlot
 
-  """
-  Added in 26.8.0. The user entity this usage bucket belongs to.
-  """
+  """Added in 26.8.0. The user entity this usage bucket belongs to."""
   user: UserV2
 
-  """
-  Added in 26.8.0. The project entity this usage bucket belongs to.
-  """
+  """Added in 26.8.0. The project entity this usage bucket belongs to."""
   project: ProjectV2
 
-  """
-  Added in 26.8.0. The domain entity this usage bucket belongs to.
-  """
+  """Added in 26.8.0. The domain entity this usage bucket belongs to."""
   domain: DomainV2
 
-  """
-  Added in 26.8.0. The resource group this usage was recorded in.
-  """
+  """Added in 26.8.0. The resource group this usage was recorded in."""
   resourceGroup: ResourceGroup
 }
 

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -14815,24 +14815,16 @@ type UserUsageBucket implements Node {
   """
   usageCapacityRatio: ResourceSlot
 
-  """
-  Added in 26.8.0. The user entity this usage bucket belongs to.
-  """
+  """Added in 26.8.0. The user entity this usage bucket belongs to."""
   user: UserV2
 
-  """
-  Added in 26.8.0. The project entity this usage bucket belongs to.
-  """
+  """Added in 26.8.0. The project entity this usage bucket belongs to."""
   project: ProjectV2
 
-  """
-  Added in 26.8.0. The domain entity this usage bucket belongs to.
-  """
+  """Added in 26.8.0. The domain entity this usage bucket belongs to."""
   domain: DomainV2
 
-  """
-  Added in 26.8.0. The resource group this usage was recorded in.
-  """
+  """Added in 26.8.0. The resource group this usage was recorded in."""
   resourceGroup: ResourceGroup
 }
 

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -14814,6 +14814,26 @@ type UserUsageBucket implements Node {
   Added in 26.2.0. Usage ratio against total available capacity for each resource. Calculated as resource_usage divided by capacity_snapshot. Represents the fraction of total capacity consumed (resource-seconds / resource). The result is in seconds, where 86400 means full utilization for one day. Values can exceed this if usage exceeds capacity.
   """
   usageCapacityRatio: ResourceSlot
+
+  """
+  Added in 26.8.0. The user entity this usage bucket belongs to.
+  """
+  user: UserV2
+
+  """
+  Added in 26.8.0. The project entity this usage bucket belongs to.
+  """
+  project: ProjectV2
+
+  """
+  Added in 26.8.0. The domain entity this usage bucket belongs to.
+  """
+  domain: DomainV2
+
+  """
+  Added in 26.8.0. The resource group this usage was recorded in.
+  """
+  resourceGroup: ResourceGroup
 }
 
 """

--- a/src/ai/backend/manager/api/gql/resource_usage/types/user_usage.py
+++ b/src/ai/backend/manager/api/gql/resource_usage/types/user_usage.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Self
+from typing import TYPE_CHECKING, Annotated, Any, Self
 from uuid import UUID
 
+import strawberry
+from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID
 
 from ai.backend.common.dto.manager.v2.resource_usage.request import (
@@ -16,6 +18,7 @@ from ai.backend.common.dto.manager.v2.resource_usage.request import (
 from ai.backend.common.dto.manager.v2.resource_usage.response import (
     UserUsageBucketNode,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import (
     DateFilter,
     OrderDirection,
@@ -32,13 +35,19 @@ from ai.backend.manager.api.gql.decorators import (
 )
 from ai.backend.manager.api.gql.fair_share.types import ResourceSlotGQL
 from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin, PydanticNodeMixin
-from ai.backend.manager.api.gql.types import GQLFilter, GQLOrderBy
+from ai.backend.manager.api.gql.types import GQLFilter, GQLOrderBy, StrawberryGQLContext
 
 from .common import UsageBucketMetadataGQL, UsageBucketOrderField
 from .common_calculations import (
     calculate_average_daily_usage,
     calculate_usage_capacity_ratio,
 )
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.domain_v2.types.node import DomainV2GQL
+    from ai.backend.manager.api.gql.project_v2.types.node import ProjectV2GQL
+    from ai.backend.manager.api.gql.resource_group.types import ResourceGroupGQL
+    from ai.backend.manager.api.gql.user.types.node import UserV2GQL
 
 
 @gql_node_type(
@@ -95,6 +104,78 @@ class UserUsageBucketGQL(PydanticNodeMixin[UserUsageBucketNode]):
             self.resource_usage,
             self.capacity_snapshot,
         )
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The user entity this usage bucket belongs to.",
+        )
+    )  # type: ignore[misc]
+    async def user(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            UserV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.user.types.node"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.user_loader.load(self.user_uuid)
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The project entity this usage bucket belongs to.",
+        )
+    )  # type: ignore[misc]
+    async def project(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            ProjectV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.project_v2.types.node"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.project_loader.load(self.project_id)
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The domain entity this usage bucket belongs to.",
+        )
+    )  # type: ignore[misc]
+    async def domain(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            DomainV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.domain_v2.types.node"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.domain_loader.load(self.domain_name)
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The resource group this usage was recorded in.",
+        )
+    )  # type: ignore[misc]
+    async def resource_group(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            ResourceGroupGQL,
+            strawberry.lazy("ai.backend.manager.api.gql.resource_group.types"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.resource_group_loader.load(self.resource_group_name)
 
 
 UserUsageBucketEdge = Edge[UserUsageBucketGQL]


### PR DESCRIPTION
## Summary

Adds DataLoader-backed nested entity fields to the `UserUsageBucket` GraphQL type: `user: User`, `project: ProjectV2`, `domain: Domain`, `resourceGroup: ResourceGroup`.

Previously the type exposed only the scalar `userUuid`, `projectId`, `domainName`, and `resourceGroupName`, so clients had to run separate queries to resolve the related entities. The sibling `UserFairShare` type already exposes these exact nested resolvers; this mirrors that pattern.

Part of the nested-field audit spun off from BA-6809.

## Changes

- `UserUsageBucket` gains `user`/`project`/`domain`/`resourceGroup` async resolvers via the existing `user_loader`/`project_loader`/`domain_loader`/`resource_group_loader` (no N+1).
- Regenerated `v2-schema.graphql` and `supergraph.graphql`.

## Verification

- `pants lint / check (mypy) / fix` pass.
- `dump-gql-schema --v2` and `generate-supergraph` build the full schema with the new fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12714.org.readthedocs.build/en/12714/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12714.org.readthedocs.build/ko/12714/

<!-- readthedocs-preview sorna-ko end -->