### PR TITLE
feat(BA-6815): expose ContainerRegistry.images nested connection

### DIFF
--- a/changes/12716.feature.md
+++ b/changes/12716.feature.md
@@ -1,0 +1,1 @@
+Add a nested `images: ImageV2Connection` paginated field to the `ContainerRegistryV2` GraphQL type, making the one-to-many registry->images relationship graph-navigable directly on the node instead of only via the standalone `containerRegistryImagesV2` root query.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -3382,6 +3382,11 @@ type ContainerRegistryV2 implements Node
 
   """Extra metadata for the container registry"""
   extra: JSON
+
+  """
+  Added in 26.8.0. Container images stored in this registry. Returns a paginated connection scoped to this registry, so the registry->images relationship can be traversed directly on the node instead of a separate containerRegistryImagesV2 query.
+  """
+  images(filter: ImageV2Filter = null, orderBy: [ImageV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2Connection
 }
 
 """Added in 26.4.2. Paginated connection for container registries."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -2243,6 +2243,11 @@ type ContainerRegistryV2 implements Node {
 
   """Extra metadata for the container registry"""
   extra: JSON
+
+  """
+  Added in 26.8.0. Container images stored in this registry. Returns a paginated connection scoped to this registry, so the registry->images relationship can be traversed directly on the node instead of a separate containerRegistryImagesV2 query.
+  """
+  images(filter: ImageV2Filter = null, orderBy: [ImageV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2Connection
 }
 
 """Added in 26.4.2. Paginated connection for container registries."""

--- a/src/ai/backend/manager/api/gql/container_registry/types.py
+++ b/src/ai/backend/manager/api/gql/container_registry/types.py
@@ -8,18 +8,30 @@ from typing import Any, Self, cast, override
 from uuid import UUID
 
 from strawberry import Info
-from strawberry.relay import Connection, Edge, NodeID
+from strawberry.relay import Connection, Edge, NodeID, PageInfo
 from strawberry.scalars import JSON
 
+from ai.backend.common.dto.manager.v2.image.request import AdminSearchImagesInput
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.base import encode_cursor
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
+    gql_added_field,
     gql_connection_type,
     gql_enum,
     gql_field,
     gql_node_type,
 )
+from ai.backend.manager.api.gql.image.types import (
+    ImageV2ConnectionGQL,
+    ImageV2EdgeGQL,
+    ImageV2FilterGQL,
+    ImageV2GQL,
+    ImageV2OrderByGQL,
+)
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
+from ai.backend.manager.models.image.conditions import ImageConditions
 
 
 @gql_enum(
@@ -70,6 +82,53 @@ class ContainerRegistryGQL(PydanticNodeMixin[Any]):
     extra: JSON | None = gql_field(
         description="Extra metadata for the container registry", default=None
     )
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Container images stored in this registry. Returns a paginated connection scoped to this registry, so the registry->images relationship can be traversed directly on the node instead of a separate containerRegistryImagesV2 query.",
+        )
+    )  # type: ignore[misc]
+    async def images(
+        self,
+        info: Info[StrawberryGQLContext],
+        filter: ImageV2FilterGQL | None = None,
+        order_by: list[ImageV2OrderByGQL] | None = None,
+        before: str | None = None,
+        after: str | None = None,
+        first: int | None = None,
+        last: int | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> ImageV2ConnectionGQL | None:
+        base_conditions = [ImageConditions.by_registry_id(UUID(self.id))]
+        payload = await info.context.adapters.image.admin_search_images_gql(
+            AdminSearchImagesInput(
+                filter=filter.to_pydantic() if filter else None,
+                order=[o.to_pydantic() for o in order_by] if order_by else None,
+                first=first,
+                after=after,
+                last=last,
+                before=before,
+                limit=limit,
+                offset=offset,
+            ),
+            base_conditions=base_conditions,
+        )
+        edges = [
+            ImageV2EdgeGQL(
+                node=ImageV2GQL.from_pydantic(node),
+                cursor=encode_cursor(node.id),
+            )
+            for node in payload.items
+        ]
+        page_info = PageInfo(
+            has_next_page=payload.has_next_page,
+            has_previous_page=payload.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        )
+        return ImageV2ConnectionGQL(count=payload.total_count, edges=edges, page_info=page_info)
 
     @classmethod
     @override


### PR DESCRIPTION
## Summary

Adds a nested `images: ImageV2Connection` paginated field to the `ContainerRegistryV2` GraphQL type, so the one-to-many registry → images relationship can be traversed directly on the node.

### Why

`images.registry_id` is a `NOT NULL` FK to `container_registries.id` (one registry : many images). The forward direction `ImageV2.registry` was added in BA-6812. The reverse was reachable only through the standalone root query `containerRegistryImagesV2(scope: { registryId })` — not as a nested field — so the relationship was not graph-navigable. This exposes it where it belongs, on the node.

## Changes

- `ContainerRegistryV2` gains an async `images` connection resolver (filter, orderBy, cursor + offset pagination) scoped to the registry via `ImageConditions.by_registry_id(self.id)`, reusing `admin_search_images_gql` — the same logic as the existing `containerRegistryImagesV2` root query and the `ImageV2.aliases` nested-connection pattern.
- Regenerated `v2-schema.graphql` and `supergraph.graphql`.

## Example

```graphql
query {
  # (whatever query returns a ContainerRegistryV2 node)
  ... on ContainerRegistryV2 {
    registryName
    images(first: 20) { count edges { node { id identity { canonicalName } } } }
  }
}
```

## Verification

- `pants lint / check (mypy) / fix` pass. No circular import (image/types.py does not import container_registry at runtime).
- `dump-gql-schema --v2` and `generate-supergraph` build the full schema with the new connection field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12716.org.readthedocs.build/en/12716/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12716.org.readthedocs.build/ko/12716/

<!-- readthedocs-preview sorna-ko end -->