### PR TITLE
refactor(BA-6673): add Pants visibility rules for manager/common layer direction

### DIFF
--- a/changes/12718.enhance.md
+++ b/changes/12718.enhance.md
@@ -1,1 +1,1 @@
-Enforce manager (data -> views -> models) and common (dto -> schema) layer dependency direction at build time with Pants visibility rules.
+Enforce manager (data -> views -> models, with config/clients forbidden from these layers) and common (dto -> schema) layer dependency direction at build time with Pants visibility rules.

--- a/changes/12718.enhance.md
+++ b/changes/12718.enhance.md
@@ -1,0 +1,1 @@
+Enforce manager (data -> views -> models) and common (dto -> schema) layer dependency direction at build time with Pants visibility rules.

--- a/src/ai/backend/common/BUILD
+++ b/src/ai/backend/common/BUILD
@@ -22,7 +22,7 @@ __dependencies_rules__(
         "//stubs/**",
         "!*",
     ),
-    # default: every other file in the component (matches the old macro behavior).
+    # default: every other file in the component.
     (
         "*",
         "/**",

--- a/src/ai/backend/common/BUILD
+++ b/src/ai/backend/common/BUILD
@@ -8,14 +8,42 @@ python_sources(
     ],
 )
 
-visibility_private_component(
-    allowed_dependents=[
-        "//src/ai/backend/**",
-    ],
-    allowed_dependencies=[
+# Dependency direction within common: dto may depend on schema, not the reverse.
+# Paths starting with "/" are relative to this (common) directory.
+__dependencies_rules__(
+    # schema: must not depend on dto.
+    (
+        "/schema/**",
+        "!/dto/**",
+        "/**",
         "//src/ai/backend/logging/**",
         "//src/ai/backend/plugin/**",
-    ],
+        "//reqs#*",
+        "//stubs/**",
+        "!*",
+    ),
+    # default: every other file in the component (matches the old macro behavior).
+    (
+        "*",
+        "/**",
+        "//src/ai/backend/logging/**",
+        "//src/ai/backend/plugin/**",
+        "//reqs#*",
+        "//stubs/**",
+        "!*",
+    ),
+)
+
+# Who may import the common component (equivalent to visibility_private_component).
+__dependents_rules__(
+    (
+        {"type": "*"},
+        "/**",  # code within this component may import itself
+        "//src/ai/backend/**",  # allowed extra dependents (all backend components)
+        "//tests/**",  # tests may import the source files
+        "//plugins/**",  # external plugins may import the source files
+        "!*",  # no one else may import the source files
+    )
 )
 
 python_distribution(

--- a/src/ai/backend/manager/BUILD
+++ b/src/ai/backend/manager/BUILD
@@ -13,8 +13,11 @@ python_sources(
 # Each rule set is self-contained: the upper-layer denies come first, then the same
 # base allowances as the default set. Paths starting with "/" are relative to this
 # (manager) directory; "//" is relative to the build root.
+# All three layers are additionally forbidden from importing config / config_legacy /
+# clients. The one exception is models/alembic, whose historical migration scripts
+# import from config_legacy (and may import config).
 __dependencies_rules__(
-    # data: must not depend on views, models, repositories, services, api.
+    # data: must not depend on views, models, repositories, services, api, config, clients.
     (
         "/data/**",
         "!/views/**",
@@ -22,6 +25,9 @@ __dependencies_rules__(
         "!/repositories/**",
         "!/services/**",
         "!/api/**",
+        "!/config/**",
+        "!/config_legacy.py",
+        "!/clients/**",
         "/**",
         "//src/ai/backend/common/**",
         "//src/ai/backend/cli/**",
@@ -30,13 +36,16 @@ __dependencies_rules__(
         "//stubs/**",
         "!*",
     ),
-    # views: must not depend on models, repositories, services, api.
+    # views: must not depend on models, repositories, services, api, config, clients.
     (
         "/views/**",
         "!/models/**",
         "!/repositories/**",
         "!/services/**",
         "!/api/**",
+        "!/config/**",
+        "!/config_legacy.py",
+        "!/clients/**",
         "/**",
         "//src/ai/backend/common/**",
         "//src/ai/backend/cli/**",
@@ -45,12 +54,33 @@ __dependencies_rules__(
         "//stubs/**",
         "!*",
     ),
-    # models: may depend on views/data; must not depend on repositories, services, api.
+    # models/alembic: exception to the models rule below — migration scripts may import
+    # config / config_legacy. Must be listed BEFORE the general models rule so its more
+    # specific selector wins. Still forbidden from repositories, services, api, clients.
+    (
+        "/models/alembic/**",
+        "!/repositories/**",
+        "!/services/**",
+        "!/api/**",
+        "!/clients/**",
+        "/**",
+        "//src/ai/backend/common/**",
+        "//src/ai/backend/cli/**",
+        "//src/ai/backend/logging/**",
+        "//reqs#*",
+        "//stubs/**",
+        "!*",
+    ),
+    # models: may depend on views/data; must not depend on repositories, services, api,
+    # config, clients.
     (
         "/models/**",
         "!/repositories/**",
         "!/services/**",
         "!/api/**",
+        "!/config/**",
+        "!/config_legacy.py",
+        "!/clients/**",
         "/**",
         "//src/ai/backend/common/**",
         "//src/ai/backend/cli/**",

--- a/src/ai/backend/manager/BUILD
+++ b/src/ai/backend/manager/BUILD
@@ -9,13 +9,9 @@ python_sources(
     ],
 )
 
-# Per-layer dependency direction (bottom -> top): data -> views -> models.
 # Each rule set is self-contained: the upper-layer denies come first, then the same
 # base allowances as the default set. Paths starting with "/" are relative to this
 # (manager) directory; "//" is relative to the build root.
-# All three layers are additionally forbidden from importing config / config_legacy /
-# clients. The one exception is models/alembic, whose historical migration scripts
-# import from config_legacy (and may import config).
 __dependencies_rules__(
     # data: must not depend on views, models, repositories, services, api, config, clients.
     (
@@ -56,7 +52,7 @@ __dependencies_rules__(
     ),
     # models/alembic: exception to the models rule below — migration scripts may import
     # config / config_legacy. Must be listed BEFORE the general models rule so its more
-    # specific selector wins. Still forbidden from repositories, services, api, clients.
+    # specific selector wins.
     (
         "/models/alembic/**",
         "!/repositories/**",
@@ -89,7 +85,7 @@ __dependencies_rules__(
         "//stubs/**",
         "!*",
     ),
-    # default: every other file in the component (matches the old macro behavior).
+    # default: every other file in the component.
     (
         "*",
         "/**",

--- a/src/ai/backend/manager/BUILD
+++ b/src/ai/backend/manager/BUILD
@@ -9,15 +9,79 @@ python_sources(
     ],
 )
 
-visibility_private_component(
-    allowed_dependents=[
-        "//src/ai/backend/testutils/**",
-    ],
-    allowed_dependencies=[
+# Per-layer dependency direction (bottom -> top): data -> views -> models.
+# Each rule set is self-contained: the upper-layer denies come first, then the same
+# base allowances as the default set. Paths starting with "/" are relative to this
+# (manager) directory; "//" is relative to the build root.
+__dependencies_rules__(
+    # data: must not depend on views, models, repositories, services, api.
+    (
+        "/data/**",
+        "!/views/**",
+        "!/models/**",
+        "!/repositories/**",
+        "!/services/**",
+        "!/api/**",
+        "/**",
         "//src/ai/backend/common/**",
         "//src/ai/backend/cli/**",
         "//src/ai/backend/logging/**",
-    ],
+        "//reqs#*",
+        "//stubs/**",
+        "!*",
+    ),
+    # views: must not depend on models, repositories, services, api.
+    (
+        "/views/**",
+        "!/models/**",
+        "!/repositories/**",
+        "!/services/**",
+        "!/api/**",
+        "/**",
+        "//src/ai/backend/common/**",
+        "//src/ai/backend/cli/**",
+        "//src/ai/backend/logging/**",
+        "//reqs#*",
+        "//stubs/**",
+        "!*",
+    ),
+    # models: may depend on views/data; must not depend on repositories, services, api.
+    (
+        "/models/**",
+        "!/repositories/**",
+        "!/services/**",
+        "!/api/**",
+        "/**",
+        "//src/ai/backend/common/**",
+        "//src/ai/backend/cli/**",
+        "//src/ai/backend/logging/**",
+        "//reqs#*",
+        "//stubs/**",
+        "!*",
+    ),
+    # default: every other file in the component (matches the old macro behavior).
+    (
+        "*",
+        "/**",
+        "//src/ai/backend/common/**",
+        "//src/ai/backend/cli/**",
+        "//src/ai/backend/logging/**",
+        "//reqs#*",
+        "//stubs/**",
+        "!*",
+    ),
+)
+
+# Who may import the manager component (equivalent to visibility_private_component).
+__dependents_rules__(
+    (
+        {"type": "*"},
+        "/**",  # code within this component may import itself
+        "//src/ai/backend/testutils/**",  # allowed extra dependents
+        "//tests/**",  # tests may import the source files
+        "//plugins/**",  # external plugins may import the source files
+        "!*",  # no one else may import the source files
+    )
 )
 
 python_distribution(


### PR DESCRIPTION
## Summary
- Enforce intra-component dependency direction at build time via path-scoped `__dependencies_rules__` in the component BUILD files, so wrong-direction imports fail during Pants dependency validation instead of being fixed one edge at a time.
- **manager**: `data -> views -> models`. Each layer denies upward imports to the layers above it (`repositories`/`services`/`api` included).
- **common**: `dto` may depend on `schema`, not the reverse.
- Rules are inlined directly in `manager/BUILD` and `common/BUILD` (replacing the `visibility_private_component` macro for these two components), since each component is a single Pants target and BUILD files under `src/` are prohibited.

## Test plan
- [x] `pants dependencies 'src/ai/backend/manager::' 'src/ai/backend/common::'` — clean tree passes (no violations)
- [x] Deliberate wrong-direction import `views -> models` is rejected (`DENY`)
- [x] Deliberate wrong-direction import `common.schema -> common.dto` is rejected (`DENY`)
- [x] `pants lint` (visibility + ruff) passes on the changed BUILD files
- [x] CI full lint/check/test gate

Resolves BA-6673
