### PR TITLE
fix(BA-6811): scope ATOM/ATOM+ RSD group to assigned devices only

### DIFF
--- a/changes/12721.fix.md
+++ b/changes/12721.fix.md
@@ -1,0 +1,1 @@
+Scope the ATOM and ATOM+ RSD device group to only the devices assigned to a container, so creating a new session no longer resets the device context of other running containers on the same node.

--- a/src/ai/backend/accelerator/rebellions/atom/plugin.py
+++ b/src/ai/backend/accelerator/rebellions/atom/plugin.py
@@ -41,13 +41,16 @@ class ATOMPlugin(AbstractATOMPlugin[ATOMDevice]):
 
         return devices
 
-    async def group_npus(self, devices: list[ATOMDevice]) -> int:
+    async def _group_npus(self, devices: list[ATOMDevice]) -> int:
         non_zero_groups: set[int] = {int(d.rbln_stat_info.group_id) for d in devices} - {0}
         if len(non_zero_groups) > 0:
             await ATOMAPI.destroy_groups(self._rbln_stat_path, list(non_zero_groups))
 
+        assigned_device_ids = {d.device_id for d in devices}
         live_devices = await self._list_devices()
-        device_indexes = [d.rbln_stat_info.npu for d in live_devices]
+        device_indexes = [
+            d.rbln_stat_info.npu for d in live_devices if d.device_id in assigned_device_ids
+        ]
         return await ATOMAPI.create_group(self._rbln_stat_path, device_indexes)
 
     async def list_device_files(

--- a/src/ai/backend/accelerator/rebellions/atom_max/plugin.py
+++ b/src/ai/backend/accelerator/rebellions/atom_max/plugin.py
@@ -129,7 +129,7 @@ class ATOMMaxPlugin(AbstractATOMPlugin[ATOMMaxDevice]):
             ),
         ]
 
-    async def group_npus(
+    async def _group_npus(
         self,
         devices: Iterable[ATOMMaxDevice],
     ) -> int:

--- a/src/ai/backend/accelerator/rebellions/atom_plus/plugin.py
+++ b/src/ai/backend/accelerator/rebellions/atom_plus/plugin.py
@@ -51,7 +51,7 @@ class ATOMPlusPlugin(AbstractATOMPlugin[ATOMPlusDevice]):
 
         return devices
 
-    async def group_npus(
+    async def _group_npus(
         self,
         devices: Iterable[ATOMPlusDevice],
     ) -> int:
@@ -59,8 +59,11 @@ class ATOMPlusPlugin(AbstractATOMPlugin[ATOMPlusDevice]):
         if len(non_zero_groups) > 0:
             await ATOMAPI.destroy_groups(self._rbln_stat_path, list(non_zero_groups))
 
+        assigned_device_ids = {d.device_id for d in devices}
         live_devices = await self._list_devices()
-        device_indexes = [d.rbln_stat_info.npu for d in live_devices]
+        device_indexes = [
+            d.rbln_stat_info.npu for d in live_devices if d.device_id in assigned_device_ids
+        ]
         return await ATOMAPI.create_group(self._rbln_stat_path, device_indexes)
 
     async def list_device_files(

--- a/src/ai/backend/accelerator/rebellions/common/plugin.py
+++ b/src/ai/backend/accelerator/rebellions/common/plugin.py
@@ -302,7 +302,7 @@ class AbstractATOMPlugin[TATOMDevice: AbstractATOMDevice](AbstractComputePlugin,
 
         if self._enable_rsd:
             try:
-                group_idx = await self.group_npus(assigned_devices)
+                group_idx = await self._group_npus(assigned_devices)
                 log.debug("Created NPU Group {} with members {}", group_idx, assigned_devices)
                 device_files.append((Path(f"/dev/rsd{group_idx}"), Path("/dev/rsd0")))
             except LibraryError as e:
@@ -434,7 +434,7 @@ class AbstractATOMPlugin[TATOMDevice: AbstractATOMDevice](AbstractComputePlugin,
         return data
 
     @abstractmethod
-    async def group_npus(self, devices: list[TATOMDevice]) -> int:
+    async def _group_npus(self, devices: list[TATOMDevice]) -> int:
         raise NotImplementedError
 
     async def cleanup(self) -> None:


### PR DESCRIPTION
## Summary
- `_group_npus()` (renamed from `group_npus()`) built the RSD group from **all live NPUs** on the host instead of the devices actually assigned to the container. On a node running ATOM/ATOM+ containers, creating a new session regrouped every card, resetting device context and killing running processes.
- Filter live devices by the assigned device ids before `create_group`, so the RSD group contains only the assigned devices — matching the existing ATOM Max implementation.
- Fix applies to both the `atom` and `atom_plus` plugins (same root cause; `atom_max` was already correct).

## Test plan
- [ ] Allocate a single ATOM+ device to a session; verify the RSD group contains only that device.
- [ ] With a running ATOM+ container, create a new session on the same node; verify the existing container's device context is not reset and its processes survive.
- [ ] Repeat for the `atom` (non-Plus) plugin.

Resolves BA-6811