### PR TITLE
chore(BA-6822): drop "resolved via DataLoader" implementation detail from GQL descriptions

### DIFF
--- a/changes/12726.misc.md
+++ b/changes/12726.misc.md
@@ -1,0 +1,1 @@
+Remove the "resolved via DataLoader" implementation detail from GraphQL nested-field descriptions so the schema documents the interface, not how values are fetched.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -9908,19 +9908,15 @@ type ModelDeployment implements Node
   """
   scalingState: ScalingState!
 
-  """
-  Added in 26.4.3. The current active revision of this deployment, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The current active revision of this deployment."""
   currentRevision: ModelRevision
 
   """
-  Added in 26.4.3. The revision currently being deployed (in progress, not yet active), resolved via DataLoader.
+  Added in 26.4.3. The revision currently being deployed (in progress, not yet active).
   """
   deployingRevision: ModelRevision
 
-  """
-  Added in 26.4.3. The user who created this deployment, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The user who created this deployment."""
   creator: UserV2
 
   """Added in 25.19.0. Deployment policy configuration."""
@@ -9968,25 +9964,19 @@ Added in 25.19.0. Contains metadata information for a model deployment including
 type ModelDeploymentMetadata
   @join__type(graph: STRAWBERRY)
 {
-  """
-  Added in 26.4.4. The resource group this deployment runs in, resolved via DataLoader.
-  """
+  """Added in 26.4.4. The resource group this deployment runs in."""
   resourceGroup: ResourceGroup
 
   """The project of this entity."""
   project: GroupNode @deprecated(reason: "Use project_v2 instead.")
 
-  """
-  Added in 26.4.3. The project this deployment belongs to, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The project this deployment belongs to."""
   projectV2: ProjectV2
 
   """The domain of this entity."""
   domain: DomainNode @deprecated(reason: "Use domain_v2 instead.")
 
-  """
-  Added in 26.4.3. The domain this deployment belongs to, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The domain this deployment belongs to."""
   domainV2: DomainV2
   projectId: ID!
   domainName: String!
@@ -10249,9 +10239,7 @@ type ModelReplica implements Node
   """
   session: ComputeSessionNode @deprecated(reason: "Use session_v2 instead.")
 
-  """
-  Added in 26.4.3. The compute session running this replica, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The compute session running this replica."""
   sessionV2: SessionV2
 
   """The revision of this entity."""
@@ -10336,19 +10324,15 @@ type ModelRevision implements Node
   """The image of this entity."""
   image: ImageNode @deprecated(reason: "Use image_v2 instead.")
 
-  """
-  Added in 26.4.3. The container image used by this revision, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The container image used by this revision."""
   imageV2: ImageV2
 
   """
-  Added in 26.4.4. The deployment-level preset that produced this revision, resolved via DataLoader. ``None`` when the revision was created without a preset, when the originating preset row has since been deleted (SET NULL FK), or for legacy rows that predate this field.
+  Added in 26.4.4. The deployment-level preset that produced this revision. ``None`` when the revision was created without a preset, when the originating preset row has since been deleted (SET NULL FK), or for legacy rows that predate this field.
   """
   revisionPreset: DeploymentRevisionPreset
 
-  """
-  Added in 26.4.4. The parent deployment owning this revision, resolved via DataLoader.
-  """
+  """Added in 26.4.4. The parent deployment owning this revision."""
   deployment: ModelDeployment
 
   """Added in 26.4.2. Resource slot allocations for this revision."""
@@ -17284,9 +17268,7 @@ type Route implements Node
   """
   session: ID @deprecated(reason: "Use session_v2 instead.")
 
-  """
-  Added in 26.4.3. The compute session associated with this route, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The compute session associated with this route."""
   sessionV2: SessionV2
 
   """The revision associated with the route."""
@@ -17649,7 +17631,7 @@ type RuntimeVariantPreset implements Node
   updatedAt: DateTime
 
   """
-  Added in 26.8.0. The runtime variant this preset belongs to, resolved via DataLoader. Fetch its name and other attributes in a single query alongside the preset list.
+  Added in 26.8.0. The runtime variant this preset belongs to. Fetch its name and other attributes in a single query alongside the preset list.
   """
   runtimeVariant: RuntimeVariant
 }
@@ -17723,9 +17705,7 @@ Added in 26.4.4. A runtime variant preset value materialised on a revision.
 type RuntimeVariantPresetValue
   @join__type(graph: STRAWBERRY)
 {
-  """
-  The runtime variant preset this value is bound to, resolved via DataLoader.
-  """
+  """The runtime variant preset this value is bound to."""
   preset: RuntimeVariantPreset
 
   """Runtime variant preset ID."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -6647,19 +6647,15 @@ type ModelDeployment implements Node {
   """
   scalingState: ScalingState!
 
-  """
-  Added in 26.4.3. The current active revision of this deployment, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The current active revision of this deployment."""
   currentRevision: ModelRevision
 
   """
-  Added in 26.4.3. The revision currently being deployed (in progress, not yet active), resolved via DataLoader.
+  Added in 26.4.3. The revision currently being deployed (in progress, not yet active).
   """
   deployingRevision: ModelRevision
 
-  """
-  Added in 26.4.3. The user who created this deployment, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The user who created this deployment."""
   creator: UserV2
 
   """Added in 25.19.0. Deployment policy configuration."""
@@ -6701,25 +6697,19 @@ type ModelDeploymentEdge {
 Added in 25.19.0. Contains metadata information for a model deployment including its name, status, tags, and timestamps. Also provides access to the associated project and domain.
 """
 type ModelDeploymentMetadata {
-  """
-  Added in 26.4.4. The resource group this deployment runs in, resolved via DataLoader.
-  """
+  """Added in 26.4.4. The resource group this deployment runs in."""
   resourceGroup: ResourceGroup
 
   """The project of this entity."""
   project: GroupNode @deprecated(reason: "Use project_v2 instead.")
 
-  """
-  Added in 26.4.3. The project this deployment belongs to, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The project this deployment belongs to."""
   projectV2: ProjectV2
 
   """The domain of this entity."""
   domain: DomainNode @deprecated(reason: "Use domain_v2 instead.")
 
-  """
-  Added in 26.4.3. The domain this deployment belongs to, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The domain this deployment belongs to."""
   domainV2: DomainV2
   projectId: ID!
   domainName: String!
@@ -6961,9 +6951,7 @@ type ModelReplica implements Node {
   """
   session: ComputeSessionNode @deprecated(reason: "Use session_v2 instead.")
 
-  """
-  Added in 26.4.3. The compute session running this replica, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The compute session running this replica."""
   sessionV2: SessionV2
 
   """The revision of this entity."""
@@ -7041,19 +7029,15 @@ type ModelRevision implements Node {
   """The image of this entity."""
   image: ImageNode @deprecated(reason: "Use image_v2 instead.")
 
-  """
-  Added in 26.4.3. The container image used by this revision, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The container image used by this revision."""
   imageV2: ImageV2
 
   """
-  Added in 26.4.4. The deployment-level preset that produced this revision, resolved via DataLoader. ``None`` when the revision was created without a preset, when the originating preset row has since been deleted (SET NULL FK), or for legacy rows that predate this field.
+  Added in 26.4.4. The deployment-level preset that produced this revision. ``None`` when the revision was created without a preset, when the originating preset row has since been deleted (SET NULL FK), or for legacy rows that predate this field.
   """
   revisionPreset: DeploymentRevisionPreset
 
-  """
-  Added in 26.4.4. The parent deployment owning this revision, resolved via DataLoader.
-  """
+  """Added in 26.4.4. The parent deployment owning this revision."""
   deployment: ModelDeployment
 
   """Added in 26.4.2. Resource slot allocations for this revision."""
@@ -11976,9 +11960,7 @@ type Route implements Node {
   """
   session: ID @deprecated(reason: "Use session_v2 instead.")
 
-  """
-  Added in 26.4.3. The compute session associated with this route, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The compute session associated with this route."""
   sessionV2: SessionV2
 
   """The revision associated with the route."""
@@ -12258,7 +12240,7 @@ type RuntimeVariantPreset implements Node {
   updatedAt: DateTime
 
   """
-  Added in 26.8.0. The runtime variant this preset belongs to, resolved via DataLoader. Fetch its name and other attributes in a single query alongside the preset list.
+  Added in 26.8.0. The runtime variant this preset belongs to. Fetch its name and other attributes in a single query alongside the preset list.
   """
   runtimeVariant: RuntimeVariant
 }
@@ -12320,9 +12302,7 @@ enum RuntimeVariantPresetOrderField {
 Added in 26.4.4. A runtime variant preset value materialised on a revision.
 """
 type RuntimeVariantPresetValue {
-  """
-  The runtime variant preset this value is bound to, resolved via DataLoader.
-  """
+  """The runtime variant preset this value is bound to."""
   preset: RuntimeVariantPreset
 
   """Runtime variant preset ID."""

--- a/src/ai/backend/manager/api/gql/deployment/types/deployment.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/deployment.py
@@ -239,7 +239,7 @@ class ModelDeploymentMetadata:
     @gql_added_field(
         BackendAIGQLMeta(
             added_version="26.4.4",
-            description="The resource group this deployment runs in, resolved via DataLoader.",
+            description="The resource group this deployment runs in.",
         )
     )  # type: ignore[misc]
     async def resource_group(
@@ -265,7 +265,7 @@ class ModelDeploymentMetadata:
     @gql_added_field(
         BackendAIGQLMeta(
             added_version="26.4.3",
-            description="The project this deployment belongs to, resolved via DataLoader.",
+            description="The project this deployment belongs to.",
         )
     )  # type: ignore[misc]
     async def project_v2(
@@ -291,7 +291,7 @@ class ModelDeploymentMetadata:
     @gql_added_field(
         BackendAIGQLMeta(
             added_version="26.4.3",
-            description="The domain this deployment belongs to, resolved via DataLoader.",
+            description="The domain this deployment belongs to.",
         )
     )  # type: ignore[misc]
     async def domain_v2(
@@ -352,7 +352,7 @@ class ModelDeployment(PydanticNodeMixin[DeploymentNodeDTO]):
     @gql_added_field(
         BackendAIGQLMeta(
             added_version="26.4.3",
-            description="The current active revision of this deployment, resolved via DataLoader.",
+            description="The current active revision of this deployment.",
         )
     )  # type: ignore[misc]
     async def current_revision(self, info: Info[StrawberryGQLContext]) -> ModelRevision | None:
@@ -365,7 +365,7 @@ class ModelDeployment(PydanticNodeMixin[DeploymentNodeDTO]):
     @gql_added_field(
         BackendAIGQLMeta(
             added_version="26.4.3",
-            description="The revision currently being deployed (in progress, not yet active), resolved via DataLoader.",
+            description="The revision currently being deployed (in progress, not yet active).",
         )
     )  # type: ignore[misc]
     async def deploying_revision(self, info: Info[StrawberryGQLContext]) -> ModelRevision | None:
@@ -378,7 +378,7 @@ class ModelDeployment(PydanticNodeMixin[DeploymentNodeDTO]):
     @gql_added_field(
         BackendAIGQLMeta(
             added_version="26.4.3",
-            description="The user who created this deployment, resolved via DataLoader.",
+            description="The user who created this deployment.",
         )
     )  # type: ignore[misc]
     async def creator(

--- a/src/ai/backend/manager/api/gql/deployment/types/replica.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/replica.py
@@ -239,7 +239,7 @@ class ModelReplica(PydanticNodeMixin[ReplicaNodeDTO]):
     @gql_added_field(
         BackendAIGQLMeta(
             added_version="26.4.3",
-            description="The compute session running this replica, resolved via DataLoader.",
+            description="The compute session running this replica.",
         )
     )  # type: ignore[misc]
     async def session_v2(

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -243,9 +243,7 @@ class RuntimeVariantPresetValueGQL:
     preset_id: UUID = gql_field(description="The preset this value is bound to.")
     value: str = gql_field(description="Value bound to the preset.")
 
-    @gql_field(
-        description="The runtime variant preset this value is bound to, resolved via DataLoader."
-    )  # type: ignore[misc]
+    @gql_field(description="The runtime variant preset this value is bound to.")  # type: ignore[misc]
     async def preset(
         self, info: Info[StrawberryGQLContext]
     ) -> (
@@ -592,7 +590,7 @@ class ModelRevision(PydanticNodeMixin[RevisionNodeDTO]):
     @gql_added_field(
         BackendAIGQLMeta(
             added_version="26.4.3",
-            description="The container image used by this revision, resolved via DataLoader.",
+            description="The container image used by this revision.",
         )
     )  # type: ignore[misc]
     async def image_v2(
@@ -612,8 +610,8 @@ class ModelRevision(PydanticNodeMixin[RevisionNodeDTO]):
         BackendAIGQLMeta(
             added_version="26.4.4",
             description=(
-                "The deployment-level preset that produced this revision, "
-                "resolved via DataLoader. ``None`` when the revision was "
+                "The deployment-level preset that produced this revision. "
+                "``None`` when the revision was "
                 "created without a preset, when the originating preset row "
                 "has since been deleted (SET NULL FK), or for legacy rows "
                 "that predate this field."
@@ -636,7 +634,7 @@ class ModelRevision(PydanticNodeMixin[RevisionNodeDTO]):
     @gql_added_field(
         BackendAIGQLMeta(
             added_version="26.4.4",
-            description="The parent deployment owning this revision, resolved via DataLoader.",
+            description="The parent deployment owning this revision.",
         )
     )  # type: ignore[misc]
     async def deployment(

--- a/src/ai/backend/manager/api/gql/deployment/types/route.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/route.py
@@ -145,7 +145,7 @@ class Route(PydanticNodeMixin[RouteNodeDTO]):
     @gql_added_field(
         BackendAIGQLMeta(
             added_version="26.4.3",
-            description="The compute session associated with this route, resolved via DataLoader.",
+            description="The compute session associated with this route.",
         )
     )  # type: ignore[misc]
     async def session_v2(

--- a/src/ai/backend/manager/api/gql/runtime_variant_preset/types.py
+++ b/src/ai/backend/manager/api/gql/runtime_variant_preset/types.py
@@ -239,7 +239,7 @@ class RuntimeVariantPresetGQL(PydanticNodeMixin[NodeDTO]):
     @gql_added_field(
         BackendAIGQLMeta(
             added_version=NEXT_RELEASE_VERSION,
-            description="The runtime variant this preset belongs to, resolved via DataLoader. Fetch its name and other attributes in a single query alongside the preset list.",
+            description="The runtime variant this preset belongs to. Fetch its name and other attributes in a single query alongside the preset list.",
         )
     )  # type: ignore[misc]
     async def runtime_variant(


### PR DESCRIPTION
**Jira:** [BA-6822](https://lablup.atlassian.net/browse/BA-6822)

GraphQL field descriptions should describe the interface/contract, not how the value is fetched internally.

## What
Remove only the `resolved via DataLoader` phrasing from nested-field descriptions across the GQL types. **Other explanations in the same descriptions are kept as-is** (e.g. the `None`-condition note on `revision_preset`, the single-query note on `runtime_variant`).

Affected types:
- `deployment` (resource group, project, domain, active/target revision, created-by user)
- `revision` (runtime variant preset binding, container image, revision preset, parent deployment)
- `replica` (compute session)
- `route` (compute session)
- `runtime_variant_preset` (runtime variant)

Regenerated `v2-schema.graphql` and `supergraph.graphql` dumps accordingly.

## Not included
Internal docstrings (e.g. `"""Resolve revision using dataloader."""`) are left untouched — they are not part of the exposed schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12726.org.readthedocs.build/en/12726/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12726.org.readthedocs.build/ko/12726/

<!-- readthedocs-preview sorna-ko end -->

[BA-6822]: https://lablup.atlassian.net/browse/BA-6822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ