### PR TITLE
fix(BA-6821): prevent event handler leak on legacy circuit init timeout

### DIFF
--- a/changes/12729.fix.md
+++ b/changes/12729.fix.md
@@ -1,0 +1,1 @@
+Fix app proxy coordinator event handler leak when legacy circuit initialization times out waiting for the proxy worker

--- a/src/ai/backend/appproxy/coordinator/types.py
+++ b/src/ai/backend/appproxy/coordinator/types.py
@@ -170,18 +170,19 @@ class CircuitManager:
             self,
             _event_handler,
         )
-        evt = AppProxyCircuitCreatedEvent(
-            authority,
-            [SerializableCircuit(**circuit.dump_model())],
-        )
-        await self.event_producer.broadcast_event(evt)
         try:
-            async with asyncio.timeout(15.0):
-                await worker_ready_evt.wait()
-        except TimeoutError as e:
-            raise ServiceUnavailable(
-                "E10001: Proxy worker not responding", extra_data={"worker": authority}
-            ) from e
+            evt = AppProxyCircuitCreatedEvent(
+                authority,
+                [SerializableCircuit(**circuit.dump_model())],
+            )
+            await self.event_producer.broadcast_event(evt)
+            try:
+                async with asyncio.timeout(15.0):
+                    await worker_ready_evt.wait()
+            except TimeoutError as e:
+                raise ServiceUnavailable(
+                    "E10001: Proxy worker not responding", extra_data={"worker": authority}
+                ) from e
         finally:
             self.event_dispatcher.unsubscribe(worker_ready_event_handler)
 

--- a/src/ai/backend/appproxy/coordinator/types.py
+++ b/src/ai/backend/appproxy/coordinator/types.py
@@ -182,8 +182,8 @@ class CircuitManager:
             raise ServiceUnavailable(
                 "E10001: Proxy worker not responding", extra_data={"worker": authority}
             ) from e
-
-        self.event_dispatcher.unsubscribe(worker_ready_event_handler)
+        finally:
+            self.event_dispatcher.unsubscribe(worker_ready_event_handler)
 
     async def update_circuit_routes(self, circuit: Circuit, old_routes: list[RouteInfo]) -> None:
         # Single-circuit entry point still exists for callers that don't


### PR DESCRIPTION
## Summary
- Move the worker-ready event handler unsubscribe into a `finally` block in `CircuitManager.initialize_legacy_circuit`, so the subscription is released even when waiting for the proxy worker times out.
- Previously, every timed-out legacy circuit initialization leaked an `AppProxyWorkerCircuitAddedEvent` subscription on the coordinator's event dispatcher.

## Test plan
- [ ] Existing appproxy coordinator unit tests pass (verified via pre-push hook: lint, mypy, pytest)
- [ ] Manually verify legacy circuit creation still succeeds against a live worker

Resolves BA-6821

🤖 Generated with [Claude Code](https://claude.com/claude-code)