### PR TITLE
fix(BA-6821): prevent event handler leak on legacy circuit init timeout (#12729)

### DIFF
--- a/changes/12729.fix.md
+++ b/changes/12729.fix.md
@@ -1,0 +1,1 @@
+Fix app proxy coordinator event handler leak when legacy circuit initialization times out waiting for the proxy worker

--- a/src/ai/backend/appproxy/coordinator/types.py
+++ b/src/ai/backend/appproxy/coordinator/types.py
@@ -170,20 +170,21 @@ class CircuitManager:
             self,
             _event_handler,
         )
-        evt = AppProxyCircuitCreatedEvent(
-            authority,
-            [SerializableCircuit(**circuit.dump_model())],
-        )
-        await self.event_producer.broadcast_event(evt)
         try:
-            async with asyncio.timeout(15.0):
-                await worker_ready_evt.wait()
-        except TimeoutError as e:
-            raise ServiceUnavailable(
-                "E10001: Proxy worker not responding", extra_data={"worker": authority}
-            ) from e
-
-        self.event_dispatcher.unsubscribe(worker_ready_event_handler)
+            evt = AppProxyCircuitCreatedEvent(
+                authority,
+                [SerializableCircuit(**circuit.dump_model())],
+            )
+            await self.event_producer.broadcast_event(evt)
+            try:
+                async with asyncio.timeout(15.0):
+                    await worker_ready_evt.wait()
+            except TimeoutError as e:
+                raise ServiceUnavailable(
+                    "E10001: Proxy worker not responding", extra_data={"worker": authority}
+                ) from e
+        finally:
+            self.event_dispatcher.unsubscribe(worker_ready_event_handler)
 
     async def update_circuit_routes(self, circuit: Circuit, old_routes: list[RouteInfo]) -> None:
         # Single-circuit entry point still exists for callers that don't


### PR DESCRIPTION
This is an auto-generated backport PR of #12729 to the 26.4 release.