### PR TITLE
feat(BA-1982): add `--app-proxy-frontend=traefik` option to install-dev.sh

### DIFF
--- a/changes/12744.feature.md
+++ b/changes/12744.feature.md
@@ -1,0 +1,1 @@
+Add the `--app-proxy-frontend=traefik` option to `install-dev.sh`, automating the traefik-mode App Proxy setup: Traefik runs as a halfstack compose service (profile `traefik`) with the appproxy Traefik plugin, and the coordinator/worker halfstack configurations are generated accordingly.

--- a/configs/traefik/traefik.halfstack.yml
+++ b/configs/traefik/traefik.halfstack.yml
@@ -1,16 +1,32 @@
 # Traefik static configuration for halfstack Docker Compose.
 #
-# Coordinator (`feat/appproxy-traefik-reconcile`) writes router/service/middleware
-# definitions into etcd under the namespace `traefik/worker_{authority}/...`,
-# so the etcd provider's `rootKey` must point at that worker-specific subtree.
+# The app-proxy coordinator writes router/service/middleware definitions into
+# etcd under the namespace `traefik/worker_{authority}/...`, so the etcd
+# provider's `rootKey` must point at that worker-specific subtree.
 #
-# Traefik runs as a Docker container in the halfstack and reaches the host etcd
-# (exposed on port 8121) via the shared `half` network using the
-# `backendai-half-etcd` service hostname.
+# Traefik runs as a Docker container in the halfstack (see the
+# `backendai-half-traefik` service in docker-compose.halfstack-main.yml) and
+# reaches the host etcd via the shared `half` network using the
+# `backendai-half-etcd` service hostname. `install-dev.sh
+# --app-proxy-frontend=traefik` copies this file to
+# `traefik.halfstack.current.yml` and substitutes the "APPPROXY_MARKER_DIR"
+# placeholder below with the actual last-used-time marker directory.
 
 api:
   dashboard: true
   insecure: true
+
+ping: {}
+
+experimental:
+  localPlugins:
+    appproxy-traefik-plugin:
+      moduleName: backend.ai/appproxy-traefik-plugin
+      settings:
+        mounts:
+          - "/__APPPROXY_MARKER_DIR__:/appproxy-traefik"
+    appproxy-traefik-plugin-go:
+      moduleName: backend.ai/appproxy-traefik-plugin-go
 
 entryPoints:
   traefik:

--- a/docker-compose.halfstack-main.yml
+++ b/docker-compose.halfstack-main.yml
@@ -268,6 +268,33 @@ services:
       timeout: 3s
       retries: 10
 
+  backendai-half-traefik:
+    # Traefik dataplane for the app-proxy worker's traefik frontend mode.
+    # Enabled only via `install-dev.sh --app-proxy-frontend=traefik`
+    # (docker compose --profile traefik). The static configuration and the
+    # appproxy traefik plugin are prepared by install-dev.sh before `up`.
+    image: traefik:v3.7
+    restart: unless-stopped
+    profiles: ["traefik"]
+    networks:
+      - half
+    ports:
+      - "8080:8080"                # traefik API entrypoint (worker calls 127.0.0.1:8080)
+      - "10205-10300:10205-10300"  # portproxy_* entrypoints
+    volumes:
+      - "./traefik.halfstack.current.yml:/etc/traefik/traefik.yml:ro"
+      - "./volumes/traefik/plugins-local:/plugins-local:ro"
+      # The coordinator hands the worker's marker path verbatim to the traefik
+      # plugin, so the directory must be visible inside the container at the
+      # same absolute path as on the host. install-dev.sh substitutes the
+      # placeholder with the actual repository path.
+      - "./volumes/traefik/marker:/__APPPROXY_MARKER_DIR__"
+    healthcheck:
+      test: ["CMD", "traefik", "healthcheck", "--ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
 networks:
   half:
 

--- a/scripts/delete-dev.sh
+++ b/scripts/delete-dev.sh
@@ -138,8 +138,9 @@ fi
 if [ $REMOVE_CONTAINERS -eq 1 ]; then
   show_info "Removing Docker containers..."
   if [ -f "docker-compose.halfstack.current.yml" ]; then
-    $docker_sudo $DOCKER_COMPOSE -f "docker-compose.halfstack.current.yml" --profile observability --profile storage down
+    $docker_sudo $DOCKER_COMPOSE -f "docker-compose.halfstack.current.yml" --profile observability --profile storage --profile traefik down
     rm "docker-compose.halfstack.current.yml"
+    rm -f "traefik.halfstack.current.yml"
   else
     show_warning "The halfstack containers are already removed."
   fi

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -191,6 +191,14 @@ usage() {
   echo "  ${LWHITE}--configure-ha${NC}"
   echo "    Configure HA dev environment."
   echo "    (default: false)"
+  echo ""
+  echo "  ${LWHITE}--app-proxy-frontend MODE${NC}"
+  echo "    The frontend dataplane of the app-proxy worker."
+  echo "    \"port\" serves proxied apps directly from the worker process, while"
+  echo "    \"traefik\" delegates them to a Traefik container in the halfstack"
+  echo "    (started via the \"traefik\" compose profile with the appproxy"
+  echo "    Traefik plugin). Not supported together with --configure-ha."
+  echo "    (default: port)"
 }
 
 show_error() {
@@ -240,6 +248,11 @@ show_guide() {
   show_note "How to run Backend.AI app-proxy:"
   echo "  > ${WHITE}./backend.ai app-proxy-coordinator start-server --debug${NC}"
   echo "  > ${WHITE}./backend.ai app-proxy-worker start-server --debug${NC}"
+  if [ "$APPPROXY_FRONTEND" = "traefik" ]; then
+    echo "  The app-proxy worker is configured with the traefik frontend."
+    echo "  The Traefik container already runs as part of the halfstack"
+    echo "  (compose profile \"traefik\"); its dashboard is at ${WHITE}http://127.0.0.1:${TRAEFIK_API_PORT}${NC}."
+  fi
   echo "  ${LRED}DO NOT source env-local-*.sh in the shell where you run the web server"
   echo "  to prevent misbehavior of the client used inside the web server.${NC}"
   show_info "How to run your first code:"
@@ -391,7 +404,9 @@ ACCOUNT_MANAGER_PORT="8099"
 WEBSERVER_PORT="8090"
 APPPROXY_COORDINATOR_PORT="10200"
 APPPROXY_WORKER_PORT="10201"
-APPPROXY_IMPL="port"  # frontend server mode ("port" or "traefik")
+APPPROXY_FRONTEND="port"  # frontend server mode ("port" or "traefik")
+APPPROXY_TRAEFIK_PLUGIN_VERSION="0.0.5"
+TRAEFIK_API_PORT="8080"
 WSPROXY_PORT="5050"
 AGENT_RPC_PORT="6011"
 AGENT_WATCHER_PORT="6019"
@@ -444,8 +459,11 @@ while [ $# -gt 0 ]; do
     --app-proxy-coordinator-port=*)  APPPROXY_COORDINATOR_PORT="${1#*=}" ;;
     --app-proxy-worker-port)         APPPROXY_WORKER_PORT=$2; shift ;;
     --app-proxy-worker-port=*)       APPPROXY_WORKER_PORT="${1#*=}" ;;
-    --app-proxy-impl)                APPPROXY_IMPL=$2; shift ;;
-    --app-proxy-impl=*)              APPPROXY_IMPL="${1#*=}" ;;
+    --app-proxy-frontend)            APPPROXY_FRONTEND=$2; shift ;;
+    --app-proxy-frontend=*)          APPPROXY_FRONTEND="${1#*=}" ;;
+    # legacy alias of --app-proxy-frontend
+    --app-proxy-impl)                APPPROXY_FRONTEND=$2; shift ;;
+    --app-proxy-impl=*)              APPPROXY_FRONTEND="${1#*=}" ;;
     --agent-rpc-port)       AGENT_RPC_PORT=$2; shift ;;
     --agent-rpc-port=*)     AGENT_RPC_PORT="${1#*=}" ;;
     --agent-watcher-port)   AGENT_WATCHER_PORT=$2; shift ;;
@@ -467,6 +485,18 @@ while [ $# -gt 0 ]; do
   shift
 done
 
+case $APPPROXY_FRONTEND in
+  port|traefik) ;;
+  *)
+    echo "Invalid --app-proxy-frontend value: ${APPPROXY_FRONTEND} (must be \"port\" or \"traefik\")"
+    echo "Run '$0 --help' for usage."
+    exit 1
+esac
+if [ "$APPPROXY_FRONTEND" = "traefik" ] && [ $CONFIGURE_HA -eq 1 ]; then
+  echo "--app-proxy-frontend=traefik is not supported together with --configure-ha yet."
+  exit 1
+fi
+
 # Build the docker compose --profile flags from the ENABLE_* booleans now,
 # right after argument parsing, so every code path (including Codespaces
 # post-create that skips setup_environment) sees a consistent value.
@@ -479,6 +509,9 @@ elif [ $ENABLE_TELEMETRY -eq 1 ]; then
 fi
 if [ $ENABLE_STORAGE -eq 1 ]; then
   HALFSTACK_PROFILE_ARGS="${HALFSTACK_PROFILE_ARGS} --profile storage"
+fi
+if [ "$APPPROXY_FRONTEND" = "traefik" ]; then
+  HALFSTACK_PROFILE_ARGS="${HALFSTACK_PROFILE_ARGS} --profile traefik"
 fi
 
 if [ "$CURRENT_BRANCH" = "main" ]; then
@@ -1067,6 +1100,40 @@ setup_environment() {
   mkdir -p "${HALFSTACK_VOLUME_PATH}/etcd-data"
   mkdir -p "${HALFSTACK_VOLUME_PATH}/redis-data"
 
+  if [ "$APPPROXY_FRONTEND" = "traefik" ]; then
+    # Prepare the Traefik container assets before `compose up` starts the
+    # "traefik" profile: the static configuration, the appproxy Traefik
+    # plugin, and the last-used-time marker directory. The marker directory
+    # must be mounted into the container at the same absolute path as on the
+    # host because the coordinator hands the worker's marker path verbatim to
+    # the Traefik plugin.
+    show_info "Preparing Traefik assets for the app-proxy traefik frontend..."
+    APPPROXY_MARKER_DIR="${ROOT_PATH}/volumes/traefik/marker"
+    mkdir -p "${APPPROXY_MARKER_DIR}"
+    cp configs/traefik/traefik.halfstack.yml ./traefik.halfstack.current.yml
+    sed_inplace "s@/__APPPROXY_MARKER_DIR__@${APPPROXY_MARKER_DIR}@g" ./traefik.halfstack.current.yml
+    sed_inplace "s@/__APPPROXY_MARKER_DIR__@${APPPROXY_MARKER_DIR}@g" "docker-compose.halfstack.current.yml"
+    APPPROXY_TRAEFIK_PLUGIN_URL="https://github.com/lablup/backend.ai-appproxy-worker-traefik/releases/download/${APPPROXY_TRAEFIK_PLUGIN_VERSION}/appproxy-traefik-plugin.tar.gz"
+    if ! curl -fsSL "${APPPROXY_TRAEFIK_PLUGIN_URL}" | tar xz -C "${HALFSTACK_VOLUME_PATH}/traefik" 2>/dev/null; then
+      # The plugin repository currently requires authenticated access;
+      # fall back to the GitHub CLI which uses the developer's credentials.
+      if command -v gh >/dev/null 2>&1 \
+        && gh release download "${APPPROXY_TRAEFIK_PLUGIN_VERSION}" \
+             --repo lablup/backend.ai-appproxy-worker-traefik \
+             --pattern "appproxy-traefik-plugin.tar.gz" --output - 2>/dev/null \
+           | tar xz -C "${HALFSTACK_VOLUME_PATH}/traefik"; then
+        :
+      else
+        show_error "Failed to download the appproxy Traefik plugin."
+        echo "The plugin repository may require access permission. Download"
+        echo "appproxy-traefik-plugin.tar.gz from"
+        echo "  https://github.com/lablup/backend.ai-appproxy-worker-traefik/releases/tag/${APPPROXY_TRAEFIK_PLUGIN_VERSION}"
+        echo "and extract it into ${HALFSTACK_VOLUME_PATH}/traefik/, then re-run."
+        exit 1
+      fi
+    fi
+  fi
+
   $docker_sudo docker compose -f "docker-compose.halfstack.current.yml" $HALFSTACK_PROFILE_ARGS pull
 
   show_info "Pre-pulling frequently used kernel images..."
@@ -1166,6 +1233,36 @@ configure_backendai() {
   sed_inplace "s/api_secret = \"some_api_secret\"/api_secret = \"${APPPROXY_API_SECRET}\"/" ./app-proxy-worker.toml
   sed_inplace "s/jwt_secret = \"some_jwt_secret\"/jwt_secret = \"${APPPROXY_JWT_SECRET}\"/" ./app-proxy-worker.toml
   sed_inplace "s/secret = \"some_permit_hash_secret\"/secret = \"${APPPROXY_PERMIT_HASH_SECRET}\"/" ./app-proxy-worker.toml
+
+  if [ "$APPPROXY_FRONTEND" = "traefik" ]; then
+    # Delegate the worker dataplane to the halfstack Traefik container
+    # (started above via the "traefik" compose profile). The coordinator
+    # publishes routing rules to etcd (namespace "traefik") which the Traefik
+    # etcd provider watches; the worker only reconciles routes through the
+    # Traefik API published at 127.0.0.1:${TRAEFIK_API_PORT}.
+    APPPROXY_MARKER_DIR="${ROOT_PATH}/volumes/traefik/marker"
+    sed_inplace "s/^allow_unauthorized_configure_request = true/allow_unauthorized_configure_request = true\\
+enable_traefik = true/" ./app-proxy-coordinator.toml
+    cat >> ./app-proxy-coordinator.toml <<EOF
+
+[proxy_coordinator.traefik.etcd]
+namespace = "traefik"
+addr = { host = "127.0.0.1", port = ${ETCD_PORT} }
+EOF
+    # The leftover [proxy_worker.port_proxy] table is ignored in traefik mode.
+    sed_inplace "s/^frontend_mode = \"port\"/frontend_mode = \"traefik\"/" ./app-proxy-worker.toml
+    cat >> ./app-proxy-worker.toml <<EOF
+
+[proxy_worker.traefik]
+api_port = ${TRAEFIK_API_PORT}
+frontend_mode = "port"
+last_used_time_marker_directory = "${APPPROXY_MARKER_DIR}"
+
+[proxy_worker.traefik.port_proxy]
+advertised_host = "127.0.0.1"
+port_range = [10205, 10300]
+EOF
+  fi
 
   # In HA mode the app-proxy components must reach Redis through Sentinel (nothing
   # listens on the standalone REDIS_PORT). Comment out the standalone `addr` and


### PR DESCRIPTION
Resolves #5319 (BA-1982)

## Summary

Automates the manual traefik-mode App Proxy setup (`docs/app-proxy/traefik-integration.md`) behind a new installer option:

```
./scripts/install-dev.sh --app-proxy-frontend=traefik
```

**Approach: Traefik runs as a halfstack compose service** (not a host binary), gated behind the `traefik` compose profile so default installs are untouched.

## Changes

| File | Change |
|---|---|
| `docker-compose.halfstack-main.yml` | New `backendai-half-traefik` service (`traefik:v3.7`, `profiles: ["traefik"]`): publishes the API entrypoint `8080` (the worker reconciles routes against `http://127.0.0.1:{api_port}`) and `10205-10300` portproxy entrypoints; healthcheck via `traefik healthcheck --ping` |
| `configs/traefik/traefik.halfstack.yml` | Completed with `experimental.localPlugins` (appproxy Traefik plugin wasm + go) and `ping: {}`; marker-directory placeholder substituted by the installer |
| `scripts/install-dev.sh` | Option parsing/validation + usage docs (`--app-proxy-impl` kept as a legacy alias — it was parsed but never consumed before); Traefik asset preparation **before** `compose up` (static config copy + marker path substitution, plugin download from `backend.ai-appproxy-worker-traefik` releases with a `gh` CLI fallback while that repository is private); `--profile traefik` via the existing `HALFSTACK_PROFILE_ARGS` mechanism; coordinator/worker TOML generation; run-guide note. Aborts when combined with `--configure-ha` (left as the existing separate TODO) |
| `scripts/delete-dev.sh` | `--profile traefik` on compose down + removal of the generated `traefik.halfstack.current.yml` |

### Generated configuration

Coordinator: `enable_traefik = true` + `[proxy_coordinator.traefik.etcd]` (`namespace = "traefik"`, halfstack etcd port). Worker: `frontend_mode = "traefik"` + `[proxy_worker.traefik]` (`api_port`, sub-mode `port`, marker directory) + `[proxy_worker.traefik.port_proxy]` (`port_range = [10205, 10300]` — note the tuple form; the string form shown in sample.toml does not validate).

The last-used-time marker directory is bind-mounted into the container **at the same absolute path as on the host**, because the coordinator hands the worker's marker path verbatim to the Traefik plugin (`circuit.py` → `lastusedmarkerpath`).

## Verification

- `bash -n` both scripts; `docker compose config` valid with and without the profile (placeholder mount target validates in both).
- Generated coordinator/worker TOMLs validated against the actual pydantic config models (this caught `port_range` requiring a tuple).
- Isolated compose run (etcd + traefik with the prepared assets): both plugins load (`Plugins loaded: appproxy-traefik-plugin, appproxy-traefik-plugin-go`), `/ping` + dashboard 200, healthcheck healthy, and a router written under `traefik/worker_worker-1/...` in etcd appears via the etcd provider (`placeholder@etcd`). The initial "key not found in store" retry loop settles once the coordinator writes the first key — benign bootstrap behavior.
- Not yet exercised: a full fresh `install-dev.sh --app-proxy-frontend=traefik` run with a real session app end-to-end (requires a clean dev box); reviewer validation welcome.

## Notes

- The plugin repository is currently **private**, so the anonymous `curl` path 404s; the installer falls back to `gh release download` (developer credentials) and otherwise fails with clear manual instructions. If/when the repo goes public the `curl` path takes over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)