### PR TITLE
feat(BA-6832): add allow_theme_mode webserver.conf flag for WebUI allowThemeMode

### DIFF
--- a/changes/12745.feature.md
+++ b/changes/12745.feature.md
@@ -1,0 +1,1 @@
+Add the `allow_theme_mode` webserver config option to expose the WebUI `allowThemeMode` flag, which gates the theme (family) selector and primary color customization in user settings

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -65,6 +65,9 @@ force_2FA = false
 directory_based_usage = false
 # If true, display the custom allocation on the session launcher.
 # allow_custom_resource_allocation = true
+# If true, users can select a theme (family) and customize its primary color in user settings.
+# The light/dark theme mode selector is always available regardless of this flag.
+# allow_theme_mode = false
 is_directory_size_visible = true
 # edu_appname_prefix = "" 
 # If false, the model store will be disabled.

--- a/configs/webserver/sample.toml
+++ b/configs/webserver/sample.toml
@@ -153,7 +153,7 @@
   # Allow users to select a theme (family) and customize its primary color in
   # user settings. The light/dark theme mode selector is always available
   # regardless of this flag.
-  # Added in 26.7.0
+  # Added in 26.8.0
   allow-theme-mode = false
   # Prefix for educational application names. Used to identify and filter
   # applications meant for educational environments. Leave empty to disable

--- a/configs/webserver/sample.toml
+++ b/configs/webserver/sample.toml
@@ -150,6 +150,11 @@
   # templates. Disable for simplified user experience.
   # Added in 25.12.0
   allow-custom-resource-allocation = true
+  # Allow users to select a theme (family) and customize its primary color in
+  # user settings. The light/dark theme mode selector is always available
+  # regardless of this flag.
+  # Added in 26.7.0
+  allow-theme-mode = false
   # Prefix for educational application names. Used to identify and filter
   # applications meant for educational environments. Leave empty to disable
   # educational app filtering.

--- a/src/ai/backend/web/config/unified.py
+++ b/src/ai/backend/web/config/unified.py
@@ -568,7 +568,7 @@ class ServiceConfig(BaseConfigSchema):
                 "in user settings. The light/dark theme mode selector is always available "
                 "regardless of this flag."
             ),
-            added_version="26.7.0",
+            added_version="26.8.0",
             example=ConfigExample(local="false", prod="false"),
         ),
     ]

--- a/src/ai/backend/web/config/unified.py
+++ b/src/ai/backend/web/config/unified.py
@@ -555,6 +555,23 @@ class ServiceConfig(BaseConfigSchema):
             example=ConfigExample(local="true", prod="true"),
         ),
     ]
+    allow_theme_mode: Annotated[
+        bool,
+        Field(
+            default=False,
+            validation_alias=AliasChoices("allow_theme_mode", "allow-theme-mode"),
+            serialization_alias="allow-theme-mode",
+        ),
+        BackendAIConfigMeta(
+            description=(
+                "Allow users to select a theme (family) and customize its primary color "
+                "in user settings. The light/dark theme mode selector is always available "
+                "regardless of this flag."
+            ),
+            added_version="26.7.0",
+            example=ConfigExample(local="false", prod="false"),
+        ),
+    ]
     edu_appname_prefix: Annotated[
         str,
         Field(

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -26,6 +26,7 @@ connectionMode = "SESSION"
 {% toml_field "directoryBasedUsage" config["service"]["directory-based-usage"] %}
 {% toml_field "maxCountForPreopenPorts" config["session"]["max-count-for-preopen-ports"] %}
 {% toml_field "allowCustomResourceAllocation" config["service"]["allow-custom-resource-allocation"] %}
+{% toml_field "allowThemeMode" config["service"]["allow-theme-mode"] %}
 {% toml_field "isDirectorySizeVisible" config["service"]["is-directory-size-visible"] %}
 {% toml_field "eduAppNamePrefix" config["service"]["edu-appname-prefix"] %}
 {% toml_field "enableExtendLoginSession" config["service"]["enable-extend-login-session"] %}


### PR DESCRIPTION
## Summary
- Expose the WebUI `config.toml` flag `allowThemeMode` (introduced in lablup/backend.ai-webui#8104, FR-3239) as a `webserver.conf` `[service]` option `allow_theme_mode` (default `false`)
- Render `allowThemeMode` in the `[general]` section of the webserver-generated `config.toml` (`templates/config.toml.j2`)
- Update `configs/webserver/sample.conf` (hand-maintained) and regenerate the `allow-theme-mode` block in `configs/webserver/sample.toml`

## Test plan
- [x] `pants fmt / fix / lint / check` pass
- [x] `tests/unit/webserver` and `tests/unit/common/configs/test_config_field_validation.py` pass
- [x] Template smoke test: default config renders `allowThemeMode = false`; setting `allow_theme_mode = true` (or `allow-theme-mode = true`) in `[service]` renders `allowThemeMode = true`

Resolves BA-6832

🤖 Generated with [Claude Code](https://claude.com/claude-code)