### PR TITLE
fix: render tuple-typed config examples as TOML arrays in generated samples

### DIFF
--- a/changes/12747.fix.md
+++ b/changes/12747.fix.md
@@ -1,0 +1,1 @@
+Fix tuple-typed config examples (agent `port-range`, app-proxy worker port ranges and `api_port_pool`) being rendered as quoted strings in the generated `sample.toml` files, which failed validation when copied into an actual configuration; they are now emitted as proper TOML arrays.

--- a/configs/agent/sample.toml
+++ b/configs/agent/sample.toml
@@ -300,7 +300,7 @@
   # Jupyter, and other services. In multi-agent mode, ensure non-overlapping
   # ranges.
   # Added in 25.12.0
-  port-range = "[30000, 32000]"
+  port-range = [30000, 32000]
   # Minimum seconds between releasing a host port and reallocating it to a new
   # container. Mitigates TCP TIME_WAIT and stale firewall/monitoring state by
   # ensuring recently freed ports are not immediately reused. Set to 0 to

--- a/configs/app-proxy-worker/sample.toml
+++ b/configs/app-proxy-worker/sample.toml
@@ -169,11 +169,6 @@
   # production to prevent information disclosure.
   # Added in 25.9.0
   metric_access_allowed_hosts = "10.0.0.0/8"
-  # The interval in seconds between collecting metrics from inference model
-  # endpoints. Metrics include request counts, latencies, and throughput. Lower
-  # values provide more granular data but increase overhead on model services.
-  # Added in 25.9.0
-  inference_metric_collection_interval = 5.0
   # The interval in seconds for cleaning up idle HTTP client sessions. The
   # worker maintains a pool of aiohttp.ClientSession instances for backend
   # connections. Periodic cleanup prevents resource leaks from accumulated idle
@@ -185,6 +180,14 @@
   # defaults to api_bind_addr. Required when behind NAT or containers.
   # Added in 25.9.0
   ## announce_addr = { host = "worker.example.com", port = 10201 }
+  # CIDR blocks (or bare IP addresses) of load balancers / reverse proxies that
+  # sit in front of this worker and may be trusted to set the 'X-Forwarded-For'
+  # header. Client-IP allowlist checks honor 'X-Forwarded-For' only when the
+  # immediate peer matches one of these networks; otherwise the direct
+  # connection address is used, so a directly-exposed worker cannot be spoofed
+  # by a forged header. Leave empty when clients connect directly to the worker.
+  # Added in 26.4.5
+  trusted_proxies = ["10.0.0.0/8"]
 
   # Configuration for wildcard domain routing. Required when frontend_mode is
   # 'wildcard'. Defines the bind address, base domain, and port settings for
@@ -228,12 +231,12 @@
     # Ensure the range is large enough for your expected concurrent sessions and
     # firewall rules allow access.
     # Added in 25.9.0
-    bind_port_range = "10205,10300"
+    bind_port_range = [10205, 10300]
     # The externally accessible port range when the worker is behind NAT or port
     # mapping. Required when external ports differ from bind_port_range. Must be
     # the same size as bind_port_range for correct port mapping.
     # Added in 25.9.0
-    ## advertised_port_range = "10205,10300"
+    ## advertised_port_range = [10205, 10300]
 
   # Configuration for Traefik-delegated routing. Required when frontend_mode is
   # 'traefik'. The worker configures Traefik dynamically instead of handling
@@ -297,7 +300,7 @@
       # proxied application. Configure corresponding Traefik entrypoints for
       # each port in this range.
       # Added in 25.9.0
-      port_range = "10205,10300"
+      port_range = [10205, 10300]
 
   # Configuration for HTTP/2 protocol support using nghttpx. Required when
   # protocol is 'h2'. Defines the nghttpx binary path and API port pool for
@@ -313,7 +316,7 @@
     # ports are used for the worker to communicate with nghttpx instances.
     # Should not overlap with other service ports on the same host.
     # Added in 25.9.0
-    api_port_pool = "50000,60000"
+    api_port_pool = [50000, 60000]
 
   # Filter rules to route specific applications to this worker. Each filter
   # matches applications by key-value pairs. Useful for routing specific
@@ -529,6 +532,15 @@
   # OTLP receiver.
   # Added in 25.7.0
   endpoint = "http://otel-collector:4317"
+  # Maximum number of spans queued for export. Spans are dropped when the queue
+  # is full. The default (65536) accommodates burst traffic from GraphQL
+  # workloads.
+  # Added in 26.2.0
+  max-queue-size = 65536
+  # Maximum number of spans exported in a single batch. Larger batches reduce
+  # export overhead but increase memory usage.
+  # Added in 26.2.0
+  max-export-batch-size = 4096
 
 # Service discovery configuration for locating the coordinator and other
 # Backend.AI components. Supports Redis-based or etcd-based service registration
@@ -538,6 +550,46 @@
   # Type of service discovery to use. Supported types are 'etcd' and 'redis'.
   # Added in 25.9.0
   type = "redis"
+  # Unique instance identifier for this service instance.
+  # Added in 26.3.0
+  ## instance-id = "..."
+  # Logical group name for this service (e.g., 'manager', 'agent', 'storage-
+  # proxy').
+  # Added in 26.3.0
+  ## service-group = "..."
+  # Human-readable display name for this service instance.
+  # Added in 26.3.0
+  ## display-name = "..."
+
+  # Additional labels for service categorization and filtering.
+  # Added in 26.3.0
+  # Replace <name> with your actual key (e.g., 'default', 'local')
+  [service_discovery.extra-labels.<name>]
+
+  # List of endpoints exposed by this service instance.
+  # Added in 26.3.0
+  [[service_discovery.endpoints]]
+  # Add multiple [[service_discovery.endpoints]] sections as needed
+    # Role of this endpoint (e.g., 'main', 'health', 'internal').
+    # Added in 26.3.0
+    role = "main"
+    # Network scope of this endpoint (e.g., 'public', 'private', 'internal').
+    # Added in 26.3.0
+    scope = "public"
+    # Hostname or IP address of the endpoint.
+    # Added in 26.3.0
+    address = "manager.example.com"
+    # Port number of the endpoint.
+    # Added in 26.3.0
+    port = 443
+    # Protocol used by the endpoint (e.g., 'grpc', 'http', 'https').
+    # Added in 26.3.0
+    protocol = "https"
+
+    # Additional metadata for the endpoint.
+    # Added in 26.3.0
+    # Replace <name> with your actual key (e.g., 'default', 'local')
+    [service_discovery.endpoints.metadata.<name>]
 
 # etcd connection configuration for distributed coordination. Used for service
 # discovery (if etcd-based) and shared configuration management.

--- a/src/ai/backend/appproxy/worker/config.py
+++ b/src/ai/backend/appproxy/worker/config.py
@@ -171,7 +171,7 @@ class PortProxyConfig(BaseSchema):
                 "enough for your expected concurrent sessions and firewall rules allow access."
             ),
             added_version="25.9.0",
-            example=ConfigExample(local="10205,10300", prod="10205,10300"),
+            example=ConfigExample(local="[10205, 10300]", prod="[10205, 10300]"),
         ),
     ]
     advertised_port_range: Annotated[
@@ -184,7 +184,7 @@ class PortProxyConfig(BaseSchema):
                 "Must be the same size as bind_port_range for correct port mapping."
             ),
             added_version="25.9.0",
-            example=ConfigExample(local="", prod="10205,10300"),
+            example=ConfigExample(local="", prod="[10205, 10300]"),
         ),
     ]
 
@@ -213,7 +213,7 @@ class H2Config(BaseSchema):
                 "Should not overlap with other service ports on the same host."
             ),
             added_version="25.9.0",
-            example=ConfigExample(local="50000,60000", prod="50000,60000"),
+            example=ConfigExample(local="[50000, 60000]", prod="[50000, 60000]"),
         ),
     ]
 
@@ -242,7 +242,7 @@ class TraefikPortProxyConfig(BaseSchema):
                 "Configure corresponding Traefik entrypoints for each port in this range."
             ),
             added_version="25.9.0",
-            example=ConfigExample(local="10205,10300", prod="10205,10300"),
+            example=ConfigExample(local="[10205, 10300]", prod="[10205, 10300]"),
         ),
     ]
 

--- a/src/ai/backend/common/configs/generator/toml.py
+++ b/src/ai/backend/common/configs/generator/toml.py
@@ -388,8 +388,8 @@ class TOMLGenerator:
         """
         type_lower = type_name.lower()
 
-        # List conversion - parse JSON array string like '["a", "b"]'
-        if "list" in type_lower or "sequence" in type_lower:
+        # List/tuple conversion - parse JSON array string like '["a", "b"]'
+        if "list" in type_lower or "sequence" in type_lower or "tuple" in type_lower:
             if example.startswith("["):
                 try:
                     return json.loads(example)


### PR DESCRIPTION
## Summary

Tuple-typed config fields (port ranges etc.) were rendered into the generated `sample.toml` files as **quoted strings**, producing examples that fail validation against their own schema:

```toml
# before (agent sample.toml)
port-range = "[30000, 32000]"     # agent's validator: "port_range must be a tuple of two integers"
# before (app-proxy-worker sample.toml)
port_range = "10205,10300"        # pydantic: tuple_type error
```

Found while implementing #12744 — copying the sample's `port_range = "10205,10300"` into a worker config fails to load.

## Root cause

Two layers:
1. `_convert_example_to_type` in `src/ai/backend/common/configs/generator/toml.py` handles list/dict/bool/int/float but **not tuple**, so example strings for tuple fields are emitted as-is (quoted).
2. The four appproxy-worker examples additionally used a bare `"10205,10300"` format that could never parse as an array (`bind_port_range`, `advertised_port_range`, `api_port_pool`, `[proxy_worker.traefik.port_proxy].port_range`).

## Changes

- Generator: treat `tuple` like `list`/`sequence` (parse JSON-array example strings).
- `src/ai/backend/appproxy/worker/config.py`: normalize the four examples to the `"[a, b]"` form.
- Regenerated `configs/agent/sample.toml` and `configs/app-proxy-worker/sample.toml` via `config generate-sample --env prod --unmask-secrets`. The agent diff is the single `port-range` line; the worker sample also picks up schema fields added since it was last regenerated (`trusted_proxies`, service-discovery/OTel additions from 26.3.0–26.4.5) — the sample is a generated artifact, so this brings it back in sync with the schema.

## Verification

- Rendered array values validate against the actual pydantic models (e.g. `TraefikPortProxyConfig(port_range=[10205, 10300])` → OK; the previous string forms raise `tuple_type` / validator errors).
- `pants lint check` clean on the two touched Python files.
- Note: the `[service-discovery.extra-labels.<name>]` placeholder section appearing in the regenerated worker sample follows the existing convention already present in the agent/manager/storage/webserver samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)