### PR TITLE
feat(BA-6833): support filtering audit logs by acted_as (UUID)

### DIFF
--- a/changes/12748.feature.md
+++ b/changes/12748.feature.md
@@ -1,0 +1,1 @@
+Support filtering audit logs by `acted_as` (the effective/acting user UUID) across the v2 GraphQL / REST DTOs, repository, adapter, and the `./bai audit-log search --acted-as` CLI option (BEP-1058)

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -1658,6 +1658,9 @@ input AuditLogFilter
   status: AuditLogStatusFilter = null
   createdAt: DateTimeFilter = null
   triggeredBy: StringFilter = null
+
+  """Added in 26.8.0. Filter by acted_as (the effective/acting user UUID)."""
+  actedAs: UUIDFilter = null
   AND: [AuditLogFilter!] = null
   OR: [AuditLogFilter!] = null
   NOT: [AuditLogFilter!] = null

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1205,6 +1205,9 @@ input AuditLogFilter {
   status: AuditLogStatusFilter = null
   createdAt: DateTimeFilter = null
   triggeredBy: StringFilter = null
+
+  """Added in 26.8.0. Filter by acted_as (the effective/acting user UUID)."""
+  actedAs: UUIDFilter = null
   AND: [AuditLogFilter!] = null
   OR: [AuditLogFilter!] = null
   NOT: [AuditLogFilter!] = null

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -1729,6 +1729,18 @@
             "default": null,
             "description": "Triggered-by filter"
           },
+          "acted_as": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UUIDFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Acted-as (effective/acting user UUID) filter"
+          },
           "created_at": {
             "anyOf": [
               {
@@ -1893,6 +1905,75 @@
           }
         },
         "title": "AuditLogStatusFilter",
+        "type": "object"
+      },
+      "UUIDFilter": {
+        "description": "Filter for UUID fields supporting equality and set operations.\n\nProvides UUID matching with equals/not_equals and in/not_in operations.",
+        "properties": {
+          "equals": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Exact UUID match",
+            "title": "Equals"
+          },
+          "in": {
+            "anyOf": [
+              {
+                "items": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "UUID is in list",
+            "title": "In"
+          },
+          "not_equals": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Not equals UUID",
+            "title": "Not Equals"
+          },
+          "not_in": {
+            "anyOf": [
+              {
+                "items": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "UUID is not in list",
+            "title": "Not In"
+          }
+        },
+        "title": "UUIDFilter",
         "type": "object"
       },
       "AdminSearchAuditLogsInput": {
@@ -3999,75 +4080,6 @@
           }
         },
         "title": "NullableDateTimeFilter",
-        "type": "object"
-      },
-      "UUIDFilter": {
-        "description": "Filter for UUID fields supporting equality and set operations.\n\nProvides UUID matching with equals/not_equals and in/not_in operations.",
-        "properties": {
-          "equals": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Exact UUID match",
-            "title": "Equals"
-          },
-          "in": {
-            "anyOf": [
-              {
-                "items": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "UUID is in list",
-            "title": "In"
-          },
-          "not_equals": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Not equals UUID",
-            "title": "Not Equals"
-          },
-          "not_in": {
-            "anyOf": [
-              {
-                "items": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "UUID is not in list",
-            "title": "Not In"
-          }
-        },
-        "title": "UUIDFilter",
         "type": "object"
       },
       "AdminSearchDeploymentsInput": {

--- a/src/ai/backend/client/cli/v2/audit_log/commands.py
+++ b/src/ai/backend/client/cli/v2/audit_log/commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import uuid
 
 import click
 
@@ -47,6 +48,12 @@ def audit_log() -> None:
     help="Filter by triggered-by user (contains).",
 )
 @click.option(
+    "--acted-as",
+    type=click.UUID,
+    default=None,
+    help="Filter by acted-as (effective/acting user UUID, exact match).",
+)
+@click.option(
     "--order-by",
     multiple=True,
     help=(
@@ -61,10 +68,11 @@ def search(
     operation: str | None,
     status: str | None,
     triggered_by: str | None,
+    acted_as: uuid.UUID | None,
     order_by: tuple[str, ...],
 ) -> None:
     """Search audit logs."""
-    from ai.backend.common.dto.manager.query import StringFilter
+    from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
     from ai.backend.common.dto.manager.v2.audit_log.request import (
         AdminSearchAuditLogsInput,
         AuditLogFilter,
@@ -78,7 +86,7 @@ def search(
 
     # Build filter only if any filter option is provided
     filter_dto: AuditLogFilter | None = None
-    if any(opt is not None for opt in (entity_type, operation, status, triggered_by)):
+    if any(opt is not None for opt in (entity_type, operation, status, triggered_by, acted_as)):
         filter_dto = AuditLogFilter(
             entity_type=(StringFilter(contains=entity_type) if entity_type is not None else None),
             operation=StringFilter(contains=operation) if operation is not None else None,
@@ -88,6 +96,7 @@ def search(
             triggered_by=(
                 StringFilter(contains=triggered_by) if triggered_by is not None else None
             ),
+            acted_as=(UUIDFilter(equals=acted_as) if acted_as is not None else None),
         )
 
     # Build order only if --order-by is provided

--- a/src/ai/backend/common/dto/manager/v2/audit_log/request.py
+++ b/src/ai/backend/common/dto/manager/v2/audit_log/request.py
@@ -7,7 +7,7 @@ from typing import Self
 from pydantic import Field, model_validator
 
 from ai.backend.common.api_handlers import BaseRequestModel
-from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter
+from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter, UUIDFilter
 from ai.backend.common.dto.manager.v2.rbac.types import EntityTypeScope, UUIDScope
 
 from .types import AuditLogOrderField, AuditLogStatus, OrderDirection
@@ -43,6 +43,9 @@ class AuditLogFilter(BaseRequestModel):
     operation: StringFilter | None = Field(default=None, description="Operation filter")
     status: AuditLogStatusFilter | None = Field(default=None, description="Status filter")
     triggered_by: StringFilter | None = Field(default=None, description="Triggered-by filter")
+    acted_as: UUIDFilter | None = Field(
+        default=None, description="Acted-as (effective/acting user UUID) filter"
+    )
     created_at: DateTimeFilter | None = Field(
         default=None, description="Filter logs by created_at datetime"
     )

--- a/src/ai/backend/manager/api/adapters/audit_log/adapter.py
+++ b/src/ai/backend/manager/api/adapters/audit_log/adapter.py
@@ -175,6 +175,14 @@ class AuditLogAdapter(BaseAdapter):
             )
             if condition is not None:
                 conditions.append(condition)
+        if f.acted_as is not None:
+            condition = self.convert_uuid_filter(
+                f.acted_as,
+                equals_factory=AuditLogConditions.by_acted_as_equals,
+                in_factory=AuditLogConditions.by_acted_as_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
         if f.status is not None:
             self._apply_status_filter(f.status, conditions)
         if f.created_at is not None:

--- a/src/ai/backend/manager/api/gql/audit_log/types/filter.py
+++ b/src/ai/backend/manager/api/gql/audit_log/types/filter.py
@@ -8,9 +8,11 @@ from ai.backend.common.dto.manager.v2.audit_log.request import (
     AuditLogFilter,
     AuditLogStatusFilter,
 )
-from ai.backend.manager.api.gql.base import DateTimeFilter, StringFilter
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.base import DateTimeFilter, StringFilter, UUIDFilter
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
+    gql_added_field,
     gql_field,
     gql_pydantic_input,
 )
@@ -47,6 +49,13 @@ class AuditLogFilterGQL(PydanticInputMixin[AuditLogFilter]):
     status: AuditLogStatusFilterGQL | None = None
     created_at: DateTimeFilter | None = None
     triggered_by: StringFilter | None = None
+    acted_as: UUIDFilter | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Filter by acted_as (the effective/acting user UUID).",
+        ),
+        default=None,
+    )
 
     AND: list[Self] | None = None
     OR: list[Self] | None = None

--- a/src/ai/backend/manager/repositories/audit_log/options.py
+++ b/src/ai/backend/manager/repositories/audit_log/options.py
@@ -13,7 +13,11 @@ from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.models.condition_utils import make_string_in_factory
 
 if TYPE_CHECKING:
-    from ai.backend.common.data.filter_specs import StringMatchSpec
+    from ai.backend.common.data.filter_specs import (
+        StringMatchSpec,
+        UUIDEqualMatchSpec,
+        UUIDInMatchSpec,
+    )
 
 
 class AuditLogConditions:
@@ -232,6 +236,29 @@ class AuditLogConditions:
         return inner
 
     by_triggered_by_in = staticmethod(make_string_in_factory(AuditLogRow.triggered_by))
+
+    # --- acted_as UUID filters ---
+    # acted_as is stored as a stringified UUID, so compare against str(value).
+
+    @staticmethod
+    def by_acted_as_equals(spec: UUIDEqualMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = AuditLogRow.acted_as == str(spec.value)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_acted_as_in(spec: UUIDInMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = AuditLogRow.acted_as.in_([str(v) for v in spec.values])
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
 
     # --- cursor pagination conditions ---
 

--- a/tests/unit/manager/repositories/audit_log/test_audit_log_repository.py
+++ b/tests/unit/manager/repositories/audit_log/test_audit_log_repository.py
@@ -13,10 +13,12 @@ from typing import TYPE_CHECKING
 import pytest
 import sqlalchemy as sa
 
+from ai.backend.common.data.filter_specs import UUIDEqualMatchSpec
 from ai.backend.manager.actions.types import OperationStatus
 from ai.backend.manager.data.audit_log.types import AuditLogData
 from ai.backend.manager.models.audit_log import AuditLogRow
 from ai.backend.manager.repositories.audit_log import AuditLogCreatorSpec, AuditLogRepository
+from ai.backend.manager.repositories.audit_log.options import AuditLogConditions
 from ai.backend.manager.repositories.base import BatchQuerier, Creator, OffsetPagination
 from ai.backend.testutils.db import with_tables
 
@@ -243,6 +245,59 @@ class TestAuditLogRepository:
 
         assert len(result.items) == 1
         assert result.items[0].operation == "alpha-op"
+
+    @pytest.fixture
+    async def sample_audit_logs_by_acted_as(
+        self,
+        audit_log_repository: AuditLogRepository,
+    ) -> AsyncGenerator[dict[uuid.UUID, uuid.UUID], None]:
+        """Seed audit logs with two distinct acted_as UUIDs; returns {acted_as: row_id}."""
+        now = datetime.now(UTC)
+        ids: dict[uuid.UUID, uuid.UUID] = {}
+        for _ in range(2):
+            acted_as = uuid.uuid4()
+            creator = Creator(
+                spec=AuditLogCreatorSpec(
+                    action_id=uuid.uuid4(),
+                    entity_type="session",
+                    operation="update",
+                    created_at=now,
+                    description=f"acted by {acted_as}",
+                    status=OperationStatus.SUCCESS,
+                    entity_id=None,
+                    request_id=None,
+                    triggered_by="super-admin",
+                    acted_as=str(acted_as),
+                    duration=None,
+                )
+            )
+            result = await audit_log_repository.create(creator)
+            ids[acted_as] = result.id
+        yield ids
+
+    async def test_search_filter_by_acted_as_equals(
+        self,
+        audit_log_repository: AuditLogRepository,
+        sample_audit_logs_by_acted_as: dict[uuid.UUID, uuid.UUID],
+    ) -> None:
+        """Filtering by acted_as returns only rows that ran as that effective user UUID."""
+        target_acted_as, other_acted_as = sample_audit_logs_by_acted_as.keys()
+        querier = BatchQuerier(
+            pagination=OffsetPagination(limit=10, offset=0),
+            conditions=[
+                AuditLogConditions.by_acted_as_equals(
+                    UUIDEqualMatchSpec(value=target_acted_as, negated=False)
+                ),
+            ],
+            orders=[],
+        )
+
+        result = await audit_log_repository.search(querier=querier)
+
+        result_ids = [log.id for log in result.items]
+        assert sample_audit_logs_by_acted_as[target_acted_as] in result_ids
+        assert sample_audit_logs_by_acted_as[other_acted_as] not in result_ids
+        assert all(log.acted_as == str(target_acted_as) for log in result.items)
 
     # =========================================================================
     # Tests - Search with ordering


### PR DESCRIPTION
## 📚 Stacked PRs

- #12704 — feat(BA-6783): add `acted_as` column and split trigger vs effective audit identity
- #12732 — feat(BA-6823): expose `acted_as` on audit-log read APIs
- #12748 — feat(BA-6833): filter audit logs by `acted_as` ← you are here

Stacked on #12732 — review/merge that first.

---

resolves BA-6833 (Epic BA-6778 / BEP-1058)

## Summary

Follow-up to BA-6823 (which made `acted_as` **readable**). This makes `acted_as` — the effective/acting user a request ran as, which differs from `triggered_by` only during super-admin impersonation (BEP-1058) — usable as a **filter (by UUID)**, and surfaces it in the CLI.

`acted_as` is a UUID, so it is **filter-only** — there is no ordering (ordering by a random UUID is meaningless).

## Changes

| Layer | Change |
|-------|--------|
| DTO (`common/dto/manager/v2/audit_log`) | `AuditLogFilter.acted_as: UUIDFilter` |
| Repository (`repositories/audit_log/options.py`) | `AuditLogConditions.by_acted_as_{equals,in}` (UUID compared as `str` against the String column) |
| Adapter (`api/adapters/audit_log`) | `convert_uuid_filter` for `acted_as` |
| GraphQL v2 | `AuditLogFilter.actedAs: UUIDFilter` (`gql_added_field`, `added_version=NEXT_RELEASE_VERSION`) |
| CLI | `./bai audit-log search --acted-as <uuid>` (exact match) |
| SDK | no change (generic; the DTO change propagates) |

- `acted_as` is a **new (unreleased)** filter field, so UUID-typing it is **not** a breaking change; `triggered_by` stays `StringFilter` (already released).
- The response node `acted_as` remains a UUID **string** — only the filter is UUID-typed.
- Regenerated GraphQL (`v2-schema.graphql`, `supergraph.graphql`) and REST (`openapi.json`) dumps. Legacy graphene `schema.graphql` is unchanged — new fields go on v2 only.

## Out of scope

- `AuditLogScope` (scoped_search) `acted_as` scope — the scoped/RBAC path is a separate concern.
- Legacy graphene audit-log type.

## Verification

- `pants test tests/unit/manager/repositories/audit_log:: tests/unit/manager/api/adapters/test_audit_log_adapter.py` — pass
  - a new repository test filters by `acted_as` (UUID) against a real DB (`with_tables`)
- `pants --changed-since fmt lint check` — clean (ruff, mypy, visibility)
- All schema dumps regenerated and consistent with the code; `actedAs` filter carries an `Added in 26.8.0` description (graphql-inspector requirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12748.org.readthedocs.build/en/12748/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12748.org.readthedocs.build/ko/12748/

<!-- readthedocs-preview sorna-ko end -->