### PR TITLE
fix(BA-6842): query project membership from association_scopes_entities

### DIFF
--- a/changes/12766.fix.md
+++ b/changes/12766.fix.md
@@ -1,0 +1,1 @@
+Fix resource preset check failing for project members whose membership is recorded only in `association_scopes_entities`

--- a/src/ai/backend/manager/repositories/resource_preset/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/resource_preset/db_source/db_source.py
@@ -23,6 +23,7 @@ from ai.backend.common.types import (
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.data.agent.types import AgentStatus
 from ai.backend.manager.data.kernel.types import KernelStatus
+from ai.backend.manager.data.permission.types import EntityType, ScopeType
 from ai.backend.manager.data.resource_preset.types import (
     ResourcePresetData,
     ResourcePresetSearchResult,
@@ -36,8 +37,11 @@ from ai.backend.manager.errors.resource import (
 )
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.domain import domains
-from ai.backend.manager.models.group import association_groups_users, groups
+from ai.backend.manager.models.group import groups
 from ai.backend.manager.models.kernel import KernelRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
 from ai.backend.manager.models.resource_preset import ResourcePresetRow
 from ai.backend.manager.models.resource_slot import (
     AgentResourceRow,
@@ -251,14 +255,18 @@ class ResourcePresetDBSource:
         """
         j = sa.join(
             groups,
-            association_groups_users,
-            association_groups_users.c.group_id == groups.c.id,
+            AssociationScopesEntitiesRow,
+            sa.and_(
+                AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                AssociationScopesEntitiesRow.scope_id == sa.cast(groups.c.id, sa.String),
+            ),
         )
         query = (
             sa.select(groups.c.id, groups.c.total_resource_slots)
             .select_from(j)
             .where(
-                (association_groups_users.c.user_id == user_id)
+                (AssociationScopesEntitiesRow.entity_id == str(user_id))
                 & (groups.c.name == group_name)
                 & (groups.c.domain_name == domain_name),
             )


### PR DESCRIPTION
## Summary
- `ResourcePresetDBSource._get_group_info` resolved a user's project membership by joining `groups` against the legacy `association_groups_users` table.
- Project membership is migrating to the RBAC `association_scopes_entities` (ASE) table, so members recorded only in ASE were not found — a valid member hit `ProjectNotFound` during the resource preset check flow (`check_presets_data → _fetch_all_check_presets_data → _get_group_info`).
- Rewrote the lookup to join `groups` against `association_scopes_entities` (`scope_type=PROJECT`, `entity_type=USER`), matching the established RBAC query pattern.

## Test plan
- [x] Check resource presets as a member whose project membership exists only in `association_scopes_entities`; verify no `ProjectNotFound`.
- [x] Verify group id and total_resource_slots resolve correctly for existing members.

Resolves BA-6842

🤖 Generated with [Claude Code](https://claude.com/claude-code)