### PR TITLE
fix(BA-6843): register RBAC admin-page GET actions in the action registry

### DIFF
--- a/changes/12769.fix.md
+++ b/changes/12769.fix.md
@@ -1,1 +1,1 @@
-Allow `PROJECT_ADMIN_PAGE` and `DOMAIN_ADMIN_PAGE` permissions to be granted to custom RBAC roles by registering their admin-page actions in the permission matrix.
+Allow the `PROJECT_ADMIN_PAGE` permission to be granted to custom RBAC roles by registering its admin-page action in the permission matrix.

--- a/changes/12769.fix.md
+++ b/changes/12769.fix.md
@@ -1,0 +1,1 @@
+Allow `PROJECT_ADMIN_PAGE` and `DOMAIN_ADMIN_PAGE` permissions to be granted to custom RBAC roles by registering their admin-page actions in the permission matrix.

--- a/src/ai/backend/manager/actions/action/__init__.py
+++ b/src/ai/backend/manager/actions/action/__init__.py
@@ -19,7 +19,6 @@ from .rbac import (
     build_operation_description,
 )
 from .rbac_admin_page import (
-    DomainAdminPageGetRBACAction,
     ProjectAdminPageGetRBACAction,
 )
 from .rbac_model_deployment import (
@@ -94,7 +93,6 @@ RBAC_ACTION_REGISTRY: tuple[type[BaseRBACAction], ...] = (
     ProjectSoftDeleteRBACAction,
     ProjectHardDeleteRBACAction,
     ProjectAdminPageGetRBACAction,
-    DomainAdminPageGetRBACAction,
     SessionCreateRBACAction,
     SessionGetRBACAction,
     SessionSearchRBACAction,

--- a/src/ai/backend/manager/actions/action/__init__.py
+++ b/src/ai/backend/manager/actions/action/__init__.py
@@ -18,6 +18,10 @@ from .rbac import (
     RBACRequiredPermission,
     build_operation_description,
 )
+from .rbac_admin_page import (
+    DomainAdminPageGetRBACAction,
+    ProjectAdminPageGetRBACAction,
+)
 from .rbac_model_deployment import (
     ModelDeploymentCreateRBACAction,
     ModelDeploymentGetRBACAction,
@@ -89,6 +93,8 @@ RBAC_ACTION_REGISTRY: tuple[type[BaseRBACAction], ...] = (
     ProjectUpdateRBACAction,
     ProjectSoftDeleteRBACAction,
     ProjectHardDeleteRBACAction,
+    ProjectAdminPageGetRBACAction,
+    DomainAdminPageGetRBACAction,
     SessionCreateRBACAction,
     SessionGetRBACAction,
     SessionSearchRBACAction,

--- a/src/ai/backend/manager/actions/action/rbac_admin_page.py
+++ b/src/ai/backend/manager/actions/action/rbac_admin_page.py
@@ -1,8 +1,8 @@
 """RBAC action declarations for admin-page access control element types.
 
-These are pseudo-entities that gate visibility of the project/domain admin
-pages. They carry only a READ operation and are not enforced at runtime like
-CRUD actions; they exist so that the permission matrix exposes an assignable
+These are pseudo-entities that gate visibility of the project admin page.
+They carry only a READ operation and are not enforced at runtime like CRUD
+actions; they exist so that the permission matrix exposes an assignable
 operation for custom roles.
 """
 
@@ -31,20 +31,3 @@ class ProjectAdminPageGetRBACAction(BaseRBACAction):
     @override
     def permission_scope(cls) -> RBACElementType:
         return RBACElementType.PROJECT
-
-
-class DomainAdminPageGetRBACAction(BaseRBACAction):
-    @classmethod
-    @override
-    def action_name(cls) -> RBACActionName:
-        return RBACActionName.GET
-
-    @classmethod
-    @override
-    def required_permission(cls) -> RBACRequiredPermission:
-        return RBACRequiredPermission(RBACElementType.DOMAIN_ADMIN_PAGE, OperationType.READ)
-
-    @classmethod
-    @override
-    def permission_scope(cls) -> RBACElementType:
-        return RBACElementType.DOMAIN

--- a/src/ai/backend/manager/actions/action/rbac_admin_page.py
+++ b/src/ai/backend/manager/actions/action/rbac_admin_page.py
@@ -1,0 +1,50 @@
+"""RBAC action declarations for admin-page access control element types.
+
+These are pseudo-entities that gate visibility of the project/domain admin
+pages. They carry only a READ operation and are not enforced at runtime like
+CRUD actions; they exist so that the permission matrix exposes an assignable
+operation for custom roles.
+"""
+
+from typing import override
+
+from ai.backend.common.data.permission.types import OperationType, RBACElementType
+from ai.backend.manager.actions.action.rbac import (
+    BaseRBACAction,
+    RBACActionName,
+    RBACRequiredPermission,
+)
+
+
+class ProjectAdminPageGetRBACAction(BaseRBACAction):
+    @classmethod
+    @override
+    def action_name(cls) -> RBACActionName:
+        return RBACActionName.GET
+
+    @classmethod
+    @override
+    def required_permission(cls) -> RBACRequiredPermission:
+        return RBACRequiredPermission(RBACElementType.PROJECT_ADMIN_PAGE, OperationType.READ)
+
+    @classmethod
+    @override
+    def permission_scope(cls) -> RBACElementType:
+        return RBACElementType.PROJECT
+
+
+class DomainAdminPageGetRBACAction(BaseRBACAction):
+    @classmethod
+    @override
+    def action_name(cls) -> RBACActionName:
+        return RBACActionName.GET
+
+    @classmethod
+    @override
+    def required_permission(cls) -> RBACRequiredPermission:
+        return RBACRequiredPermission(RBACElementType.DOMAIN_ADMIN_PAGE, OperationType.READ)
+
+    @classmethod
+    @override
+    def permission_scope(cls) -> RBACElementType:
+        return RBACElementType.DOMAIN


### PR DESCRIPTION
## Summary
- `PROJECT_ADMIN_PAGE` is declared as a valid scope-entity combination (`VALID_SCOPE_ENTITY_COMBINATIONS`) but had **no registered RBAC action**, so `rbacEntityOperationCombinations` and `rbacPermissionMatrix` returned **zero assignable operations** for it — making the permission un-assignable to custom project-scoped roles even though the default project-admin system role carries `PROJECT_ADMIN_PAGE: {READ}`.
- Add `ProjectAdminPageGetRBACAction` (PROJECT scope, GET → READ) as a declaration-only `BaseRBACAction` and register it in `RBAC_ACTION_REGISTRY`.
- All three RBAC matrix queries (`rbacScopeEntityCombinations`, `rbacEntityOperationCombinations`, `rbacPermissionMatrix`) now surface this entity consistently. No processor/service/handler needed — this is a metadata-only pseudo-entity gating admin-page visibility.

Resolves BA-6843

🤖 Generated with [Claude Code](https://claude.com/claude-code)
