### PR TITLE
docs(alembic): use NEXT_RELEASE_VERSION placeholder for revision version comment

### DIFF
--- a/changes/12770.doc.md
+++ b/changes/12770.doc.md
@@ -1,0 +1,1 @@
+Change the alembic revision version comment convention to use the `NEXT_RELEASE_VERSION` placeholder instead of a hardcoded version.

--- a/src/ai/backend/manager/models/alembic/AGENTS.md
+++ b/src/ai/backend/manager/models/alembic/AGENTS.md
@@ -7,15 +7,13 @@
 - **Backport = fixes only** — do NOT backport feature-level schema changes.
 - **Idempotency** — every backport migration (both `d` and `d'`) must be safe to re-apply by using existence checks
   (`IF NOT EXISTS`, `IF EXISTS`, `inspector`).
-- **Release version comment** — every migration file places a
-  `# Part of: <major>.<minor>.<patch>` comment next to the revision identifier. For backports: `# Part of: 26.2.1 (backport), 26.3.0 (main)`.
+- **Release version comment** — every migration file places a `# Part of: NEXT_RELEASE_VERSION` comment next to the
+  revision identifier. Do NOT hardcode a version; the `NEXT_RELEASE_VERSION` placeholder is frozen to the actual version. For backports the placeholder freezes per branch, so both `d` and `d'` keep the same placeholder.
 - **Do NOT edit the revision of a released migration** — do not modify the `revision`/`down_revision` of an
   already-released migration. Editing `down_revision` is allowed only when inserting a backport into the main chain before merge.
 
 ## Forward direction (under consideration)
 
-- Use `{NEXT_RELEASE_VERSION}` in the version comment so it auto-freezes at release time — do not hardcode the next version
-  (the same mechanism as the GQL `added_version`; `scripts/freeze_release_version.py` substitutes across `src/**/*.py`).
 - Avoid adding alembic migrations in a backport where possible. If you must, place the corresponding version on the backport
   branch, and afterwards reconcile so that main also includes that downgrade.
 

--- a/src/ai/backend/manager/models/alembic/README.md
+++ b/src/ai/backend/manager/models/alembic/README.md
@@ -64,24 +64,21 @@ a  -->  d  -->  b  -->  c  -->  d'
 
 ### Release Version Comment
 
-Every migration file must include a comment indicating which release version
-(including the minor version, e.g., `26.3.0`) it belongs to. Place the comment
-next to the revision identifiers:
+Every migration file includes a comment marking which release it belongs to,
+placed next to the revision identifiers. Use the `NEXT_RELEASE_VERSION`
+placeholder instead of a hardcoded version:
 
 ```python
 # revision identifiers, used by Alembic.
 revision = "1cc9b47e0a8e"
 down_revision = "ffcf0ed13a26"
-# Part of: 26.3.0
+# Part of: NEXT_RELEASE_VERSION
 branch_labels = None
 depends_on = None
 ```
 
-For backport migrations, note both the target release branch and the main branch:
-
-```python
-# Part of: 26.2.1 (backport), 26.3.0 (main)
-```
+For backport migrations the placeholder freezes **per branch**: the backport migration `d` on the release branch freezes to the backport target version when that release is cut,
+and its main-branch duplicate `d'` freezes to the main release version.
 
 ### Idempotent Writing Rules
 


### PR DESCRIPTION
## Summary

Change the alembic revision version-comment convention to use the `NEXT_RELEASE_VERSION` placeholder instead of a hardcoded version. At release time `scripts/release.sh` (via `scripts/freeze_release_version.py`) freezes it to the actual version — the same mechanism as the GraphQL `added_version`.

## Changes

- `models/alembic/README.md` — rewrite the **"Release Version Comment"** section to recommend `# Part of: NEXT_RELEASE_VERSION`. For backports the placeholder freezes **per branch**: `d` on the release branch → backport target version, `d'` on main → main release version, so the old `(backport)/(main)` dual annotation is no longer needed.
- `models/alembic/AGENTS.md` — update the **"Release version comment"** rule to the placeholder form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
