### PR TITLE
fix(BA-6844): backfill admin-page read for runtime-created admin roles

### DIFF
--- a/changes/12771.fix.md
+++ b/changes/12771.fix.md
@@ -1,0 +1,1 @@
+Backfill the missing admin-page read permission for project and domain admin roles created at runtime, which an earlier migration skipped due to a role-name pattern mismatch.

--- a/src/ai/backend/manager/models/alembic/versions/2d6443ac0d4a_create_app_config_allow_list_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/2d6443ac0d4a_create_app_config_allow_list_table.py
@@ -8,7 +8,7 @@ foreign key into ``app_config_definitions`` so an entry may only reference a
 registered config name.
 
 Revision ID: 2d6443ac0d4a
-Revises: c7e1a9d4f6b2
+Revises: f2b9a4c7e103
 Create Date: 2026-06-18
 
 """
@@ -20,7 +20,7 @@ from ai.backend.manager.models.base import IDColumn
 
 # revision identifiers, used by Alembic.
 revision = "2d6443ac0d4a"
-down_revision = "c7e1a9d4f6b2"
+down_revision = "f2b9a4c7e103"
 # Part of: 26.5.0
 branch_labels = None
 depends_on = None

--- a/src/ai/backend/manager/models/alembic/versions/a3c1d8e5b294_backfill_admin_page_read_for_runtime_admin_roles_followup.py
+++ b/src/ai/backend/manager/models/alembic/versions/a3c1d8e5b294_backfill_admin_page_read_for_runtime_admin_roles_followup.py
@@ -1,0 +1,55 @@
+"""backfill admin page read permission for runtime-created admin roles (followup)
+
+Idempotent duplicate of f2b9a4c7e103 appended on top of the main head so that
+databases already at the main head — which never applied f2b9a4c7e103 (it was
+spliced in earlier on the chain) — still receive the backfill. It is a no-op on
+databases that already applied f2b9a4c7e103, via ``ON CONFLICT DO NOTHING``.
+
+Revision ID: a3c1d8e5b294
+Revises: c05f9465a9cd
+Create Date: 2026-07-11 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a3c1d8e5b294"
+down_revision = "c05f9465a9cd"
+# Part of: 26.4.8 (backport), 26.8.0 (main)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Same backfill as f2b9a4c7e103, written idempotently.
+    conn.execute(
+        sa.text("""
+        INSERT INTO permissions (role_id, scope_type, scope_id, entity_type, operation)
+        SELECT DISTINCT p.role_id, p.scope_type, p.scope_id, 'project_admin_page', 'read'
+        FROM permissions p
+        JOIN roles r ON r.id = p.role_id
+        WHERE r.name LIKE 'project-%-admin'
+          AND p.scope_type = 'project'
+        ON CONFLICT DO NOTHING
+    """)
+    )
+    conn.execute(
+        sa.text("""
+        INSERT INTO permissions (role_id, scope_type, scope_id, entity_type, operation)
+        SELECT DISTINCT p.role_id, p.scope_type, p.scope_id, 'domain_admin_page', 'read'
+        FROM permissions p
+        JOIN roles r ON r.id = p.role_id
+        WHERE r.name LIKE 'domain-%-admin'
+          AND p.scope_type = 'domain'
+        ON CONFLICT DO NOTHING
+    """)
+    )
+
+
+def downgrade() -> None:
+    # The corresponding downgrade is handled by f2b9a4c7e103.
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/f2b9a4c7e103_backfill_admin_page_read_for_runtime_admin_roles.py
+++ b/src/ai/backend/manager/models/alembic/versions/f2b9a4c7e103_backfill_admin_page_read_for_runtime_admin_roles.py
@@ -1,0 +1,68 @@
+"""backfill admin page read permission for runtime-created admin roles
+
+The earlier backfill (3b6297b1bd75) matched admin roles only by the
+data-migration naming scheme ``role_project_<id>_admin`` /
+``role_domain_<name>_admin``. Admin roles created at runtime use a different
+naming scheme (``project-<id8>-admin`` / ``domain-<name>-admin``) and were
+therefore skipped, leaving them without the ``*_admin_page`` READ permission.
+
+This migration backfills the missed READ permission for those runtime-named
+admin roles. It is idempotent via ``ON CONFLICT DO NOTHING``.
+
+Revision ID: f2b9a4c7e103
+Revises: c7e1a9d4f6b2
+Create Date: 2026-07-11 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f2b9a4c7e103"
+down_revision = "c7e1a9d4f6b2"
+# Part of: 26.4.8 (backport), 26.8.0 (main)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Insert READ permission for project_admin_page for every runtime-created
+    # project admin role (named 'project-<id8>-admin'). Derive scope_type and
+    # scope_id from existing permissions already held by each role.
+    conn.execute(
+        sa.text("""
+        INSERT INTO permissions (role_id, scope_type, scope_id, entity_type, operation)
+        SELECT DISTINCT p.role_id, p.scope_type, p.scope_id, 'project_admin_page', 'read'
+        FROM permissions p
+        JOIN roles r ON r.id = p.role_id
+        WHERE r.name LIKE 'project-%-admin'
+          AND p.scope_type = 'project'
+        ON CONFLICT DO NOTHING
+    """)
+    )
+
+    # Insert READ permission for domain_admin_page for every runtime-created
+    # domain admin role (named 'domain-<name>-admin').
+    conn.execute(
+        sa.text("""
+        INSERT INTO permissions (role_id, scope_type, scope_id, entity_type, operation)
+        SELECT DISTINCT p.role_id, p.scope_type, p.scope_id, 'domain_admin_page', 'read'
+        FROM permissions p
+        JOIN roles r ON r.id = p.role_id
+        WHERE r.name LIKE 'domain-%-admin'
+          AND p.scope_type = 'domain'
+        ON CONFLICT DO NOTHING
+    """)
+    )
+
+
+def downgrade() -> None:
+    # No-op: the admin-page READ permission is part of each admin role's intended
+    # permission set (granted natively at role creation for roles created after the
+    # fix). A pattern-based DELETE here cannot distinguish rows inserted by this
+    # backfill from those granted at creation, so it would strip permissions the
+    # roles legitimately hold. Leaving the backfilled rows in place is safe.
+    pass


### PR DESCRIPTION
## Summary
- Some project/domain admin roles were missing the `*_admin_page` READ permission because the earlier backfill (`3b6297b1bd75`) matched only the data-migration role naming scheme (`role_project_<id>_admin` / `role_domain_<name>_admin`), skipping runtime-created roles (`project-<id8>-admin` / `domain-<name>-admin`).
- Add a corrective backfill migration (`f2b9a4c7e103`) matching the runtime naming scheme, spliced into the main chain right after the current 26.4 head (`c7e1a9d4f6b2`); update `2d6443ac0d4a`'s `down_revision` accordingly.
- Append an idempotent duplicate (`a3c1d8e5b294`) at the main head so databases already at the main head also receive the backfill. Both backfills use `ON CONFLICT DO NOTHING`; downgrade is a no-op to avoid stripping permissions that newly created roles hold natively.
- The same `f2b9a4c7e103` migration will be added to the `26.4` branch (as its new head) via a separate backport PR.

## Test plan
- [ ] `alembic downgrade` to `c7e1a9d4f6b2`, seed both `role_*_admin` and runtime `project-/domain-` admin roles, `alembic upgrade head`, verify `permissions` contains `project_admin_page`/`domain_admin_page` read for the runtime-named roles
- [ ] Re-run `upgrade` to confirm idempotency (no duplicate rows / no error)

Resolves BA-6844