### PR TITLE
fix(BA-6844): backfill admin-page read for runtime-created admin roles (backport to 26.4)

### DIFF
--- a/changes/12772.fix.md
+++ b/changes/12772.fix.md
@@ -1,0 +1,1 @@
+Backfill the missing admin-page read permission for project and domain admin roles created at runtime, which an earlier migration skipped due to a role-name pattern mismatch.

--- a/src/ai/backend/manager/models/alembic/versions/f2b9a4c7e103_backfill_admin_page_read_for_runtime_admin_roles.py
+++ b/src/ai/backend/manager/models/alembic/versions/f2b9a4c7e103_backfill_admin_page_read_for_runtime_admin_roles.py
@@ -1,0 +1,68 @@
+"""backfill admin page read permission for runtime-created admin roles
+
+The earlier backfill (3b6297b1bd75) matched admin roles only by the
+data-migration naming scheme ``role_project_<id>_admin`` /
+``role_domain_<name>_admin``. Admin roles created at runtime use a different
+naming scheme (``project-<id8>-admin`` / ``domain-<name>-admin``) and were
+therefore skipped, leaving them without the ``*_admin_page`` READ permission.
+
+This migration backfills the missed READ permission for those runtime-named
+admin roles. It is idempotent via ``ON CONFLICT DO NOTHING``.
+
+Revision ID: f2b9a4c7e103
+Revises: c7e1a9d4f6b2
+Create Date: 2026-07-11 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f2b9a4c7e103"
+down_revision = "c7e1a9d4f6b2"
+# Part of: 26.4.8 (backport), 26.8.0 (main)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Insert READ permission for project_admin_page for every runtime-created
+    # project admin role (named 'project-<id8>-admin'). Derive scope_type and
+    # scope_id from existing permissions already held by each role.
+    conn.execute(
+        sa.text("""
+        INSERT INTO permissions (role_id, scope_type, scope_id, entity_type, operation)
+        SELECT DISTINCT p.role_id, p.scope_type, p.scope_id, 'project_admin_page', 'read'
+        FROM permissions p
+        JOIN roles r ON r.id = p.role_id
+        WHERE r.name LIKE 'project-%-admin'
+          AND p.scope_type = 'project'
+        ON CONFLICT DO NOTHING
+    """)
+    )
+
+    # Insert READ permission for domain_admin_page for every runtime-created
+    # domain admin role (named 'domain-<name>-admin').
+    conn.execute(
+        sa.text("""
+        INSERT INTO permissions (role_id, scope_type, scope_id, entity_type, operation)
+        SELECT DISTINCT p.role_id, p.scope_type, p.scope_id, 'domain_admin_page', 'read'
+        FROM permissions p
+        JOIN roles r ON r.id = p.role_id
+        WHERE r.name LIKE 'domain-%-admin'
+          AND p.scope_type = 'domain'
+        ON CONFLICT DO NOTHING
+    """)
+    )
+
+
+def downgrade() -> None:
+    # No-op: the admin-page READ permission is part of each admin role's intended
+    # permission set (granted natively at role creation for roles created after the
+    # fix). A pattern-based DELETE here cannot distinguish rows inserted by this
+    # backfill from those granted at creation, so it would strip permissions the
+    # roles legitimately hold. Leaving the backfilled rows in place is safe.
+    pass


### PR DESCRIPTION
Backport of #12771 to `26.4`.

## Summary
- Adds the corrective admin-page backfill migration `f2b9a4c7e103` as the new `26.4` head (on top of `c7e1a9d4f6b2`).
- Backfills the `*_admin_page` READ permission for runtime-created admin roles (`project-<id8>-admin` / `domain-<name>-admin`) that the earlier `3b6297b1bd75` migration skipped due to its role-name pattern.
- Same revision id as the one spliced into the `main` chain; idempotent via `ON CONFLICT DO NOTHING`; downgrade is a no-op.

## Test plan
- [ ] `alembic downgrade` to `c7e1a9d4f6b2`, seed runtime `project-/domain-` admin roles, `alembic upgrade head`, verify `permissions` gains `project_admin_page`/`domain_admin_page` read for those roles
- [ ] Re-run `upgrade` to confirm idempotency

Backport of #12771
Resolves BA-6844