### PR TITLE
chore(BA-6845): lower kernel.execute/attach_output_queue logs to debug level

### DIFF
--- a/changes/12777.misc.md
+++ b/changes/12777.misc.md
@@ -1,0 +1,1 @@
+Lower per-execution agent logs `kernel.execute` and `CodeRunner.attach_output_queue` from INFO to DEBUG to reduce log noise.

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -437,7 +437,7 @@ class AbstractKernel(UserDict[str, Any], aobject, metaclass=ABCMeta):
         if self.runner is None:
             raise KernelRunnerNotInitializedError("Kernel runner is not initialized")
         try:
-            log.info(
+            log.debug(
                 "kernel.execute(k:{0}, run_id:{1}, mode:{2}, opts:{3})",
                 self.kernel_id,
                 run_id,
@@ -1182,7 +1182,7 @@ class AbstractCodeRunner(aobject, metaclass=ABCMeta):
             self.pending_queues[run_id] = (activated, q)
         else:
             activated, q = self.pending_queues[run_id]
-        log.info(
+        log.debug(
             "CodeRunner.attach_output_queue(k:{0}, run_id:{1}, is running event set:{2})",
             self.kernel_id,
             run_id,


### PR DESCRIPTION
## Summary
- Lower two per-execution agent logs in `agent/kernel.py` from INFO to DEBUG: `kernel.execute(...)` and `CodeRunner.attach_output_queue(...)`.
- These are diagnostic logs that fire on every code run and clutter log output at INFO level.

## Test plan
- [x] Run a session and confirm the two messages no longer appear at INFO level (visible only with DEBUG logging).

Resolves BA-6845

🤖 Generated with [Claude Code](https://claude.com/claude-code)