### PR TITLE
fix(BA-6856): preserve resource policy creation timestamps

### DIFF
--- a/changes/12791.fix.md
+++ b/changes/12791.fix.md
@@ -1,0 +1,1 @@
+Return creation timestamps for user and project resource policies in v2 API responses.

--- a/src/ai/backend/manager/api/adapters/resource_policy/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_policy/adapter.py
@@ -637,6 +637,7 @@ class ResourcePolicyAdapter(BaseAdapter):
         return UserResourcePolicyNode(
             id=data.name,
             name=data.name,
+            created_at=data.created_at,
             max_vfolder_count=data.max_vfolder_count,
             max_concurrent_logins=data.max_concurrent_logins,
             max_quota_scope_size=BinarySize.to_size_info(data.max_quota_scope_size),
@@ -651,6 +652,7 @@ class ResourcePolicyAdapter(BaseAdapter):
         return ProjectResourcePolicyNode(
             id=data.name,
             name=data.name,
+            created_at=data.created_at,
             max_vfolder_count=data.max_vfolder_count,
             max_quota_scope_size=BinarySize.to_size_info(data.max_quota_scope_size),
             max_network_count=data.max_network_count,

--- a/src/ai/backend/manager/models/resource_policy/row.py
+++ b/src/ai/backend/manager/models/resource_policy/row.py
@@ -167,6 +167,7 @@ class UserResourcePolicyRow(Base):  # type: ignore[misc]
     def to_dataclass(self) -> UserResourcePolicyData:
         return UserResourcePolicyData(
             name=self.name,
+            created_at=self.created_at,
             max_vfolder_count=self.max_vfolder_count,
             max_quota_scope_size=self.max_quota_scope_size,
             max_session_count_per_model_session=self.max_session_count_per_model_session,
@@ -225,6 +226,7 @@ class ProjectResourcePolicyRow(Base):  # type: ignore[misc]
     def to_dataclass(self) -> ProjectResourcePolicyData:
         return ProjectResourcePolicyData(
             name=self.name,
+            created_at=self.created_at,
             max_vfolder_count=self.max_vfolder_count,
             max_quota_scope_size=self.max_quota_scope_size,
             max_network_count=self.max_network_count,

--- a/tests/component/resource_policy/test_project_resource_policy_crud.py
+++ b/tests/component/resource_policy/test_project_resource_policy_crud.py
@@ -36,6 +36,7 @@ class TestProjectResourcePolicyCreate:
         assert isinstance(result, CreateProjectResourcePolicyPayload)
         policy = result.project_resource_policy
         assert policy.name == name
+        assert policy.created_at is not None
         assert policy.max_vfolder_count == 20
         assert policy.max_network_count == 10
 
@@ -63,6 +64,7 @@ class TestProjectResourcePolicyGet:
 
         result = await admin_v2_registry.resource_policy.admin_get_project_resource_policy(name)
         assert result.name == name
+        assert result.created_at is not None
         assert result.max_vfolder_count == created.project_resource_policy.max_vfolder_count
 
 

--- a/tests/component/resource_policy/test_user_resource_policy_crud.py
+++ b/tests/component/resource_policy/test_user_resource_policy_crud.py
@@ -37,6 +37,7 @@ class TestUserResourcePolicyCreate:
         assert isinstance(result, CreateUserResourcePolicyPayload)
         policy = result.user_resource_policy
         assert policy.name == name
+        assert policy.created_at is not None
         assert policy.max_vfolder_count == 20
         assert policy.max_quota_scope_size.expr == "1073741824"
         assert policy.max_session_count_per_model_session == 5
@@ -57,6 +58,7 @@ class TestUserResourcePolicyGet:
 
         result = await admin_v2_registry.resource_policy.admin_get_user_resource_policy(name)
         assert result.name == name
+        assert result.created_at is not None
         assert result.max_vfolder_count == created.user_resource_policy.max_vfolder_count
 
 


### PR DESCRIPTION
## Summary

- Preserve `created_at` when converting user and project resource policy rows into data objects and v2 response DTOs.
- Return the database-generated creation timestamp from create, get, and search APIs instead of `null`.
- Add component regression coverage for user and project resource policy create and get responses.

## Root cause

The timestamp existed in the database, but both the ORM row-to-data conversion and the data-to-response conversion omitted `created_at`.

## Test plan

- [x] `pants fmt ::`
- [x] `pants fix ::`
- [x] `pants lint --changed-since=origin/main`
- [x] Push-hook MyPy checks
- [x] User resource policy component tests
- [x] Project resource policy component tests

Resolves BA-6856
