### PR TITLE
chore: ignore single-host TUI installer DEVELOP-mode artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,14 @@ ENV/
 /loki-config.yaml
 /tempo-config.yaml
 
+# backend.ai-install (single-host TUI installer) writes these into the repo in
+# DEVELOP mode; harbor/* only appears when installing with --with-harbor.
+/etcd.config.json
+/etcd.installed.json
+/vfolder/
+/harbor/
+/harbor-offline-installer-*.tgz
+
 # Local temp and installer-generated directories
 /.tmp/
 /tmp/


### PR DESCRIPTION
## Summary
The single-host TUI installer (`src/ai/backend/install`) writes generated files
into the repo root in DEVELOP mode (`base_path = cwd`), but `.gitignore` only had
the old `install-dev.sh` `dev.*` names. So they showed up as untracked and blocked
repo updates.

## Changes
Ignore the TUI installer's DEVELOP-mode artifacts:

- `etcd.config.json`, `etcd.installed.json`, `vfolder/` — written on every install
- `harbor/`, `harbor-offline-installer-*.tgz` — only with `--with-harbor`

All patterns are root-anchored (don't touch the tracked `**/harbor.py` sources),
none of the paths are tracked, and there's no installer code change.