### PR TITLE
feat(BA-6857): add --shell option to deployment revision add CLI

### DIFF
--- a/changes/12797.feature.md
+++ b/changes/12797.feature.md
@@ -1,1 +1,1 @@
-Add `--use-shell` and `--no-use-shell` options to the `deployment revision add` v2 CLI to control model service shell wrapping
+Add `--shell` and `--no-shell` options to the `deployment revision add` v2 CLI to control model service shell wrapping

--- a/changes/12797.feature.md
+++ b/changes/12797.feature.md
@@ -1,0 +1,1 @@
+Add `--use-shell` and `--no-use-shell` options to the `deployment revision add` v2 CLI to control model service shell wrapping

--- a/src/ai/backend/client/cli/v2/deployment/revision.py
+++ b/src/ai/backend/client/cli/v2/deployment/revision.py
@@ -35,19 +35,19 @@ def revision() -> None:
     "--auto-activate", is_flag=True, default=False, help="Activate immediately after creation."
 )
 @click.option(
-    "--use-shell",
-    "use_shell",
+    "--shell",
+    "shell",
     is_flag=False,
     flag_value=DEFAULT_SHELL,
     default=None,
     type=str,
     help=(
         "Shell to wrap the model service command with (`[shell, '-c', command]`). "
-        f"Bare --use-shell uses {DEFAULT_SHELL}. Omit to keep the config/baseline as-is."
+        f"Bare --shell uses {DEFAULT_SHELL}. Omit to keep the config/baseline as-is."
     ),
 )
 @click.option(
-    "--no-use-shell",
+    "--no-shell",
     is_flag=True,
     default=False,
     help="Disable shell wrapping.",
@@ -57,8 +57,8 @@ def add(
     config: str,
     preset_id: str | None,
     auto_activate: bool,
-    use_shell: str | None,
-    no_use_shell: bool,
+    shell: str | None,
+    no_shell: bool,
 ) -> None:
     """Add a new revision to a deployment."""
 
@@ -77,12 +77,12 @@ def add(
         data["revision_preset_id"] = preset_id
     if auto_activate:
         data.setdefault("options", {})["auto_activate"] = True
-    if no_use_shell and use_shell is not None:
-        raise click.UsageError("--use-shell and --no-use-shell are mutually exclusive.")
-    if no_use_shell or use_shell is not None:
+    if no_shell and shell is not None:
+        raise click.UsageError("--shell and --no-shell are mutually exclusive.")
+    if no_shell or shell is not None:
         # Explicit null disables shell wrapping over any baseline in the draft merge.
         # `or {}` also normalizes containers present as explicit null in the config.
-        shell = None if no_use_shell else use_shell
+        shell_value = None if no_shell else shell
         model_def = data.get("model_definition") or {}
         data["model_definition"] = model_def
         models = model_def.get("models") or [{}]
@@ -92,7 +92,7 @@ def add(
                 continue  # let DTO validation report invalid entries
             service = model.get("service") or {}
             model["service"] = service
-            service["shell"] = shell
+            service["shell"] = shell_value
     body = AddRevisionInput.model_validate(data)
 
     async def _run() -> None:

--- a/src/ai/backend/client/cli/v2/deployment/revision.py
+++ b/src/ai/backend/client/cli/v2/deployment/revision.py
@@ -81,12 +81,18 @@ def add(
         raise click.UsageError("--use-shell and --no-use-shell are mutually exclusive.")
     if no_use_shell or use_shell is not None:
         # Explicit null disables shell wrapping over any baseline in the draft merge.
+        # `or {}` also normalizes containers present as explicit null in the config.
         shell = None if no_use_shell else use_shell
-        model_def = data.setdefault("model_definition", {})
+        model_def = data.get("model_definition") or {}
+        data["model_definition"] = model_def
         models = model_def.get("models") or [{}]
         model_def["models"] = models
         for model in models:
-            model.setdefault("service", {})["shell"] = shell
+            if not isinstance(model, dict):
+                continue  # let DTO validation report invalid entries
+            service = model.get("service") or {}
+            model["service"] = service
+            service["shell"] = shell
     body = AddRevisionInput.model_validate(data)
 
     async def _run() -> None:

--- a/src/ai/backend/client/cli/v2/deployment/revision.py
+++ b/src/ai/backend/client/cli/v2/deployment/revision.py
@@ -14,6 +14,7 @@ from ai.backend.client.cli.v2.helpers import (
     load_v2_config,
     print_result,
 )
+from ai.backend.common.config import DEFAULT_SHELL
 
 
 @click.group()
@@ -33,7 +34,32 @@ def revision() -> None:
 @click.option(
     "--auto-activate", is_flag=True, default=False, help="Activate immediately after creation."
 )
-def add(deployment_id: str, config: str, preset_id: str | None, auto_activate: bool) -> None:
+@click.option(
+    "--use-shell",
+    "use_shell",
+    is_flag=False,
+    flag_value=DEFAULT_SHELL,
+    default=None,
+    type=str,
+    help=(
+        "Shell to wrap the model service command with (`[shell, '-c', command]`). "
+        f"Bare --use-shell uses {DEFAULT_SHELL}. Omit to keep the config/baseline as-is."
+    ),
+)
+@click.option(
+    "--no-use-shell",
+    is_flag=True,
+    default=False,
+    help="Disable shell wrapping.",
+)
+def add(
+    deployment_id: str,
+    config: str,
+    preset_id: str | None,
+    auto_activate: bool,
+    use_shell: str | None,
+    no_use_shell: bool,
+) -> None:
     """Add a new revision to a deployment."""
 
     from ai.backend.common.dto.manager.v2.deployment.request import (
@@ -51,6 +77,16 @@ def add(deployment_id: str, config: str, preset_id: str | None, auto_activate: b
         data["revision_preset_id"] = preset_id
     if auto_activate:
         data.setdefault("options", {})["auto_activate"] = True
+    if no_use_shell and use_shell is not None:
+        raise click.UsageError("--use-shell and --no-use-shell are mutually exclusive.")
+    if no_use_shell or use_shell is not None:
+        # Explicit null disables shell wrapping over any baseline in the draft merge.
+        shell = None if no_use_shell else use_shell
+        model_def = data.setdefault("model_definition", {})
+        models = model_def.get("models") or [{}]
+        model_def["models"] = models
+        for model in models:
+            model.setdefault("service", {})["shell"] = shell
     body = AddRevisionInput.model_validate(data)
 
     async def _run() -> None:


### PR DESCRIPTION
## Summary
- Add `--shell [SHELL]` / `--no-shell` options to `./bai deployment revision add` so shell wrapping can be controlled without hand-editing the `--config` JSON.
- The option injects `shell` into `model_definition.models[*].service` of the request config; an explicit `null` from `--no-shell` disables shell wrapping.
- If the config has no `model_definition` (or has it as explicit `null`), a single-model entry is created/normalized so the value still merges by index over the baseline.

## Behavior matrix

| Input | Injected value |
|-------|----------------|
| (omitted) | config/baseline untouched |
| `--shell` | `service.shell = "/bin/bash"` (`DEFAULT_SHELL`) |
| `--shell /bin/zsh` | `service.shell = "/bin/zsh"` |
| `--no-shell` | `service.shell = null` (disables shell wrapping) |
| `--shell … --no-shell` | `UsageError` (mutually exclusive) |

## Notes
- Overriding a preset/vfolder **baseline** shell with the explicit `null` depends on the draft-merge fix in #12665; until that lands, `--no-shell` only takes effect when no baseline provides a shell.

## Test plan
- [x] `pants fmt/lint/check` pass on the changed file
- [x] All behavior-matrix cases plus null-container configs (`model_definition: null`, `service: null`) verified via Click `CliRunner`
- [x] Explicit `shell: null` survives `AddRevisionInput` → `to_draft()` with `shell` in `model_fields_set`
- [ ] Live-server verification with a real deployment

Resolves BA-6857

🤖 Generated with [Claude Code](https://claude.com/claude-code)