### PR TITLE
fix(alembic): populate NOT NULL permission column in admin-page backfill

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/f2b9a4c7e103_backfill_admin_page_read_for_runtime_admin_roles.py
+++ b/src/ai/backend/manager/models/alembic/versions/f2b9a4c7e103_backfill_admin_page_read_for_runtime_admin_roles.py
@@ -34,8 +34,8 @@ def upgrade() -> None:
     # scope_id from existing permissions already held by each role.
     conn.execute(
         sa.text("""
-        INSERT INTO permissions (role_id, scope_type, scope_id, entity_type, operation)
-        SELECT DISTINCT p.role_id, p.scope_type, p.scope_id, 'project_admin_page', 'read'
+        INSERT INTO permissions (role_id, scope_type, scope_id, entity_type, operation, permission)
+        SELECT DISTINCT p.role_id, p.scope_type, p.scope_id, 'project_admin_page', 'read', 1
         FROM permissions p
         JOIN roles r ON r.id = p.role_id
         WHERE r.name LIKE 'project-%-admin'
@@ -48,8 +48,8 @@ def upgrade() -> None:
     # domain admin role (named 'domain-<name>-admin').
     conn.execute(
         sa.text("""
-        INSERT INTO permissions (role_id, scope_type, scope_id, entity_type, operation)
-        SELECT DISTINCT p.role_id, p.scope_type, p.scope_id, 'domain_admin_page', 'read'
+        INSERT INTO permissions (role_id, scope_type, scope_id, entity_type, operation, permission)
+        SELECT DISTINCT p.role_id, p.scope_type, p.scope_id, 'domain_admin_page', 'read', 1
         FROM permissions p
         JOIN roles r ON r.id = p.role_id
         WHERE r.name LIKE 'domain-%-admin'


### PR DESCRIPTION
## Summary
- The admin-page READ backfill migration (`f2b9a4c7e103`) inserts into `permissions` without the `permission` bitmask column, which `c6648c039bd4` made NOT NULL earlier in the chain.
- A fresh `alembic upgrade head` fails with `NotNullViolationError`.
- Add `permission = 1` (the `READ` bit) to the INSERT column list.

## Test plan
- [x] `alembic downgrade` below `c6648c039bd4`, then `alembic upgrade head` on a fresh DB completes without NotNull violation
- [x] Backfilled rows have `operation = 'read'` and `permission = 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)