### PR TITLE
feat(BA-6849): support nested replica deployment filters

### DIFF
--- a/changes/12805.feature.md
+++ b/changes/12805.feature.md
@@ -1,0 +1,1 @@
+Support some, every, and none nested replica filters for deployments.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -5653,6 +5653,9 @@ input DeploymentFilter
   Added in 26.4.3. Filter by deployment destruction datetime. Supports IS NULL / IS NOT NULL.
   """
   destroyedAt: NullableDateTimeFilter = null
+
+  """Added in 26.8.0. Filter by conditions on deployment replicas."""
+  replicas: ReplicaNestedFilter = null
   AND: [DeploymentFilter!] = null
   OR: [DeploymentFilter!] = null
   NOT: [DeploymentFilter!] = null
@@ -15675,6 +15678,9 @@ input ReplicaFilter
   @join__type(graph: STRAWBERRY)
 {
   status: ReplicaStatusFilter = null
+
+  """Added in 26.8.0. Filter by replica health status."""
+  healthStatus: ReplicaHealthStatusFilter = null
   trafficStatus: TrafficStatusFilter = null
   AND: [ReplicaFilter!] = null
   OR: [ReplicaFilter!] = null
@@ -15691,6 +15697,37 @@ enum ReplicaHealthStatus
   HEALTHY @join__enumValue(graph: STRAWBERRY)
   UNHEALTHY @join__enumValue(graph: STRAWBERRY)
   DEGRADED @join__enumValue(graph: STRAWBERRY)
+}
+
+"""Added in 26.8.0. Filter for replica health status."""
+input ReplicaHealthStatusFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Health status is in the list."""
+  in: [ReplicaHealthStatus!] = null
+  equals: ReplicaHealthStatus = null
+
+  """Excludes health statuses in the list."""
+  notIn: [ReplicaHealthStatus!] = null
+
+  """Excludes exact health status match."""
+  notEquals: ReplicaHealthStatus = null
+}
+
+"""Added in 26.8.0. Filter deployments by conditions on their replicas."""
+input ReplicaNestedFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Matches parents with at least one replica satisfying all conditions."""
+  some: ReplicaFilter = null
+
+  """
+  Matches parents where every replica satisfies all conditions (also true when the parent has no replica).
+  """
+  every: ReplicaFilter = null
+
+  """Matches parents with no replica satisfying all conditions."""
+  none: ReplicaFilter = null
 }
 
 """Added in 25.19.0. """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -3870,6 +3870,9 @@ input DeploymentFilter {
   Added in 26.4.3. Filter by deployment destruction datetime. Supports IS NULL / IS NOT NULL.
   """
   destroyedAt: NullableDateTimeFilter = null
+
+  """Added in 26.8.0. Filter by conditions on deployment replicas."""
+  replicas: ReplicaNestedFilter = null
   AND: [DeploymentFilter!] = null
   OR: [DeploymentFilter!] = null
   NOT: [DeploymentFilter!] = null
@@ -10717,6 +10720,9 @@ type ReplaceRolePermissionsPayload {
 """Added in 25.19.0. """
 input ReplicaFilter {
   status: ReplicaStatusFilter = null
+
+  """Added in 26.8.0. Filter by replica health status."""
+  healthStatus: ReplicaHealthStatusFilter = null
   trafficStatus: TrafficStatusFilter = null
   AND: [ReplicaFilter!] = null
   OR: [ReplicaFilter!] = null
@@ -10731,6 +10737,33 @@ enum ReplicaHealthStatus {
   HEALTHY
   UNHEALTHY
   DEGRADED
+}
+
+"""Added in 26.8.0. Filter for replica health status."""
+input ReplicaHealthStatusFilter {
+  """Health status is in the list."""
+  in: [ReplicaHealthStatus!] = null
+  equals: ReplicaHealthStatus = null
+
+  """Excludes health statuses in the list."""
+  notIn: [ReplicaHealthStatus!] = null
+
+  """Excludes exact health status match."""
+  notEquals: ReplicaHealthStatus = null
+}
+
+"""Added in 26.8.0. Filter deployments by conditions on their replicas."""
+input ReplicaNestedFilter {
+  """Matches parents with at least one replica satisfying all conditions."""
+  some: ReplicaFilter = null
+
+  """
+  Matches parents where every replica satisfies all conditions (also true when the parent has no replica).
+  """
+  every: ReplicaFilter = null
+
+  """Matches parents with no replica satisfying all conditions."""
+  none: ReplicaFilter = null
 }
 
 """Added in 25.19.0. """

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -4082,6 +4082,375 @@
         "title": "NullableDateTimeFilter",
         "type": "object"
       },
+      "ReplicaFilter": {
+        "description": "Filter for deployment replicas.",
+        "properties": {
+          "deployment_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by deployment ID",
+            "title": "Deployment Id"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReplicaStatusFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Replica status filter"
+          },
+          "health_status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReplicaHealthStatusFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Replica health status filter"
+          },
+          "traffic_status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReplicaTrafficStatusFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Replica traffic status filter"
+          },
+          "AND": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ReplicaFilter"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "AND conjunction",
+            "title": "And"
+          },
+          "OR": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ReplicaFilter"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "OR conjunction",
+            "title": "Or"
+          },
+          "NOT": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ReplicaFilter"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "NOT negation",
+            "title": "Not"
+          }
+        },
+        "title": "ReplicaFilter",
+        "type": "object"
+      },
+      "ReplicaHealthStatusFilter": {
+        "description": "Filter for replica health status.",
+        "properties": {
+          "equals": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RouteHealthStatus"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Exact health status match"
+          },
+          "in": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/RouteHealthStatus"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Health status is in list",
+            "title": "In"
+          },
+          "not_equals": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RouteHealthStatus"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Excludes exact health status match"
+          },
+          "not_in": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/RouteHealthStatus"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Health status is not in list",
+            "title": "Not In"
+          }
+        },
+        "title": "ReplicaHealthStatusFilter",
+        "type": "object"
+      },
+      "ReplicaNestedFilter": {
+        "description": "Filter deployments by conditions on their replicas.",
+        "properties": {
+          "some": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReplicaFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Matches parents with at least one replica satisfying all conditions."
+          },
+          "every": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReplicaFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Matches parents where every replica satisfies all conditions (also true when the parent has no replica)."
+          },
+          "none": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReplicaFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Matches parents with no replica satisfying all conditions."
+          }
+        },
+        "title": "ReplicaNestedFilter",
+        "type": "object"
+      },
+      "ReplicaStatusFilter": {
+        "description": "Filter for replica (route) status.",
+        "properties": {
+          "equals": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RouteStatus"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Exact status match"
+          },
+          "in": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/RouteStatus"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Status is in list",
+            "title": "In"
+          },
+          "not_equals": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RouteStatus"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Excludes exact status match"
+          },
+          "not_in": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/RouteStatus"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Status is not in list",
+            "title": "Not In"
+          }
+        },
+        "title": "ReplicaStatusFilter",
+        "type": "object"
+      },
+      "ReplicaTrafficStatusFilter": {
+        "description": "Filter for replica traffic status.",
+        "properties": {
+          "equals": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RouteTrafficStatus"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Exact traffic status match"
+          },
+          "in": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/RouteTrafficStatus"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Traffic status is in list",
+            "title": "In"
+          },
+          "not_equals": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RouteTrafficStatus"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Excludes exact traffic status match"
+          },
+          "not_in": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/RouteTrafficStatus"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Traffic status is not in list",
+            "title": "Not In"
+          }
+        },
+        "title": "ReplicaTrafficStatusFilter",
+        "type": "object"
+      },
+      "RouteHealthStatus": {
+        "description": "Health check status of a route.",
+        "enum": [
+          "not_checked",
+          "healthy",
+          "unhealthy",
+          "degraded"
+        ],
+        "title": "RouteHealthStatus",
+        "type": "string"
+      },
+      "RouteStatus": {
+        "description": "Lifecycle status of a route in the deployment.",
+        "enum": [
+          "provisioning",
+          "running",
+          "terminating",
+          "terminated",
+          "failed_to_start"
+        ],
+        "title": "RouteStatus",
+        "type": "string"
+      },
+      "RouteTrafficStatus": {
+        "description": "Traffic routing status for a route.\n\nControls whether traffic should be sent to this route.\nActual traffic delivery depends on health being HEALTHY.\n\n- ACTIVE: Traffic enabled (will receive traffic when health is HEALTHY)\n- INACTIVE: Traffic disabled (will not receive traffic regardless of health)",
+        "enum": [
+          "active",
+          "inactive"
+        ],
+        "title": "RouteTrafficStatus",
+        "type": "string"
+      },
       "AdminSearchDeploymentsInput": {
         "description": "Input for searching deployments (admin, no scope).",
         "properties": {
@@ -5070,99 +5439,6 @@
         "title": "SearchAllocatedResourceSlotsInput",
         "type": "object"
       },
-      "ReplicaFilter": {
-        "description": "Filter for deployment replicas.",
-        "properties": {
-          "deployment_id": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Filter by deployment ID",
-            "title": "Deployment Id"
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ReplicaStatusFilter"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Replica status filter"
-          },
-          "traffic_status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ReplicaTrafficStatusFilter"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Replica traffic status filter"
-          },
-          "AND": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/ReplicaFilter"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "AND conjunction",
-            "title": "And"
-          },
-          "OR": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/ReplicaFilter"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "OR conjunction",
-            "title": "Or"
-          },
-          "NOT": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/ReplicaFilter"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "NOT negation",
-            "title": "Not"
-          }
-        },
-        "title": "ReplicaFilter",
-        "type": "object"
-      },
       "ReplicaOrder": {
         "description": "Ordering specification for deployment replicas.",
         "properties": {
@@ -5187,153 +5463,6 @@
           "id"
         ],
         "title": "ReplicaOrderField",
-        "type": "string"
-      },
-      "ReplicaStatusFilter": {
-        "description": "Filter for replica (route) status.",
-        "properties": {
-          "equals": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/RouteStatus"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Exact status match"
-          },
-          "in": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/RouteStatus"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Status is in list",
-            "title": "In"
-          },
-          "not_equals": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/RouteStatus"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Excludes exact status match"
-          },
-          "not_in": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/RouteStatus"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Status is not in list",
-            "title": "Not In"
-          }
-        },
-        "title": "ReplicaStatusFilter",
-        "type": "object"
-      },
-      "ReplicaTrafficStatusFilter": {
-        "description": "Filter for replica traffic status.",
-        "properties": {
-          "equals": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/RouteTrafficStatus"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Exact traffic status match"
-          },
-          "in": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/RouteTrafficStatus"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Traffic status is in list",
-            "title": "In"
-          },
-          "not_equals": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/RouteTrafficStatus"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Excludes exact traffic status match"
-          },
-          "not_in": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/RouteTrafficStatus"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Traffic status is not in list",
-            "title": "Not In"
-          }
-        },
-        "title": "ReplicaTrafficStatusFilter",
-        "type": "object"
-      },
-      "RouteStatus": {
-        "description": "Lifecycle status of a route in the deployment.",
-        "enum": [
-          "provisioning",
-          "running",
-          "terminating",
-          "terminated",
-          "failed_to_start"
-        ],
-        "title": "RouteStatus",
-        "type": "string"
-      },
-      "RouteTrafficStatus": {
-        "description": "Traffic routing status for a route.\n\nControls whether traffic should be sent to this route.\nActual traffic delivery depends on health being HEALTHY.\n\n- ACTIVE: Traffic enabled (will receive traffic when health is HEALTHY)\n- INACTIVE: Traffic disabled (will not receive traffic regardless of health)",
-        "enum": [
-          "active",
-          "inactive"
-        ],
-        "title": "RouteTrafficStatus",
         "type": "string"
       },
       "SearchReplicasInput": {
@@ -5521,17 +5650,6 @@
         },
         "title": "RouteFilter",
         "type": "object"
-      },
-      "RouteHealthStatus": {
-        "description": "Health check status of a route.",
-        "enum": [
-          "not_checked",
-          "healthy",
-          "unhealthy",
-          "degraded"
-        ],
-        "title": "RouteHealthStatus",
-        "type": "string"
       },
       "RouteOrder": {
         "description": "Order specification for routes.",

--- a/src/ai/backend/common/dto/manager/v2/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/request.py
@@ -94,6 +94,8 @@ __all__ = (
     "ModelServiceConfigInput",
     "PresetValueInput",
     "ReplicaFilter",
+    "ReplicaHealthStatusFilter",
+    "ReplicaNestedFilter",
     "ReplicaOrder",
     "ReplicaStatusFilter",
     "ReplicaTrafficStatusFilter",
@@ -630,6 +632,60 @@ class ReplicaTrafficStatusFilter(BaseRequestModel):
     )
 
 
+class ReplicaHealthStatusFilter(BaseRequestModel):
+    """Filter for replica health status."""
+
+    equals: RouteHealthStatus | None = Field(default=None, description="Exact health status match")
+    in_: list[RouteHealthStatus] | None = Field(
+        default=None, alias="in", description="Health status is in list"
+    )
+    not_equals: RouteHealthStatus | None = Field(
+        default=None, description="Excludes exact health status match"
+    )
+    not_in: list[RouteHealthStatus] | None = Field(
+        default=None, description="Health status is not in list"
+    )
+
+
+class ReplicaFilter(BaseRequestModel):
+    """Filter for deployment replicas."""
+
+    deployment_id: UUID | None = Field(default=None, description="Filter by deployment ID")
+    status: ReplicaStatusFilter | None = Field(default=None, description="Replica status filter")
+    health_status: ReplicaHealthStatusFilter | None = Field(
+        default=None, description="Replica health status filter"
+    )
+    traffic_status: ReplicaTrafficStatusFilter | None = Field(
+        default=None, description="Replica traffic status filter"
+    )
+    AND: list[ReplicaFilter] | None = Field(default=None, description="AND conjunction")
+    OR: list[ReplicaFilter] | None = Field(default=None, description="OR conjunction")
+    NOT: list[ReplicaFilter] | None = Field(default=None, description="NOT negation")
+
+
+ReplicaFilter.model_rebuild()
+
+
+class ReplicaNestedFilter(BaseRequestModel):
+    """Filter deployments by conditions on their replicas."""
+
+    some: ReplicaFilter | None = Field(
+        default=None,
+        description="Matches parents with at least one replica satisfying all conditions.",
+    )
+    every: ReplicaFilter | None = Field(
+        default=None,
+        description=(
+            "Matches parents where every replica satisfies all conditions "
+            "(also true when the parent has no replica)."
+        ),
+    )
+    none: ReplicaFilter | None = Field(
+        default=None,
+        description="Matches parents with no replica satisfying all conditions.",
+    )
+
+
 class DeploymentFilter(BaseRequestModel):
     """Filter for deployments."""
 
@@ -649,6 +705,9 @@ class DeploymentFilter(BaseRequestModel):
     created_at: DateTimeFilter | None = Field(default=None, description="Creation datetime filter")
     destroyed_at: NullableDateTimeFilter | None = Field(
         default=None, description="Destruction datetime filter (supports is_null)"
+    )
+    replicas: ReplicaNestedFilter | None = Field(
+        default=None, description="Filter by conditions on deployment replicas"
     )
     AND: list[DeploymentFilter] | None = Field(default=None, description="AND conjunction")
     OR: list[DeploymentFilter] | None = Field(default=None, description="OR conjunction")
@@ -732,22 +791,6 @@ class AutoScalingRuleFilter(BaseRequestModel):
 
 
 AutoScalingRuleFilter.model_rebuild()
-
-
-class ReplicaFilter(BaseRequestModel):
-    """Filter for deployment replicas."""
-
-    deployment_id: UUID | None = Field(default=None, description="Filter by deployment ID")
-    status: ReplicaStatusFilter | None = Field(default=None, description="Replica status filter")
-    traffic_status: ReplicaTrafficStatusFilter | None = Field(
-        default=None, description="Replica traffic status filter"
-    )
-    AND: list[ReplicaFilter] | None = Field(default=None, description="AND conjunction")
-    OR: list[ReplicaFilter] | None = Field(default=None, description="OR conjunction")
-    NOT: list[ReplicaFilter] | None = Field(default=None, description="NOT negation")
-
-
-ReplicaFilter.model_rebuild()
 
 
 class DeploymentPolicyFilter(BaseRequestModel):

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -1717,6 +1717,21 @@ class DeploymentAdapter(BaseAdapter):
             )
             if dt_condition is not None:
                 conditions.append(dt_condition)
+        if f.replicas is not None:
+            if f.replicas.some is not None:
+                replica_conditions = self._convert_replica_filter(f.replicas.some)
+                conditions.append(DeploymentConditions.by_replica_exists(replica_conditions))
+            if f.replicas.none is not None:
+                replica_conditions = self._convert_replica_filter(f.replicas.none)
+                conditions.append(
+                    negate_conditions([DeploymentConditions.by_replica_exists(replica_conditions)])
+                )
+            if f.replicas.every is not None:
+                replica_conditions = self._convert_replica_filter(f.replicas.every)
+                violating_replica = negate_conditions(replica_conditions)
+                conditions.append(
+                    negate_conditions([DeploymentConditions.by_replica_exists([violating_replica])])
+                )
         if f.AND:
             for sub in f.AND:
                 conditions.extend(self._convert_deployment_filter(sub))
@@ -2100,6 +2115,37 @@ class DeploymentAdapter(BaseAdapter):
                 conditions.append(
                     RouteConditions.by_status_not_in([
                         ManagerRouteStatus(s.value) for s in st.not_in
+                    ])
+                )
+        if f.health_status is not None:
+            health_status = f.health_status
+            if health_status.equals is not None:
+                conditions.append(
+                    RouteConditions.by_health_statuses([
+                        ManagerRouteHealthStatus(health_status.equals.value)
+                    ])
+                )
+            if health_status.in_ is not None:
+                conditions.append(
+                    RouteConditions.by_health_statuses([
+                        ManagerRouteHealthStatus(status.value) for status in health_status.in_
+                    ])
+                )
+            if health_status.not_equals is not None:
+                conditions.append(
+                    negate_conditions([
+                        RouteConditions.by_health_statuses([
+                            ManagerRouteHealthStatus(health_status.not_equals.value)
+                        ])
+                    ])
+                )
+            if health_status.not_in is not None:
+                conditions.append(
+                    negate_conditions([
+                        RouteConditions.by_health_statuses([
+                            ManagerRouteHealthStatus(status.value)
+                            for status in health_status.not_in
+                        ])
                     ])
                 )
         if f.traffic_status is not None:

--- a/src/ai/backend/manager/api/gql/deployment/types/deployment.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/deployment.py
@@ -49,6 +49,9 @@ from ai.backend.common.dto.manager.v2.deployment.request import (
     ReplaceDeploymentOptionsGQLInput as ReplaceDeploymentOptionsGQLInputDTO,
 )
 from ai.backend.common.dto.manager.v2.deployment.request import (
+    ReplicaNestedFilter as ReplicaNestedFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.deployment.request import (
     SyncReplicaInput as SyncReplicaInputDTO,
 )
 from ai.backend.common.dto.manager.v2.deployment.request import (
@@ -91,6 +94,7 @@ from ai.backend.common.dto.manager.v2.deployment.types import (
 from ai.backend.common.dto.manager.v2.deployment.types import (
     ProjectDeploymentScope as ProjectDeploymentScopeDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import (
     DateTimeFilter,
     NullableDateTimeFilter,
@@ -616,6 +620,31 @@ class ProjectDeploymentScopeGQL(PydanticInputMixin[ProjectDeploymentScopeDTO]):
 
 
 @gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Filter deployments by conditions on their replicas.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="ReplicaNestedFilter",
+)
+class ReplicaNestedFilterGQL(PydanticInputMixin[ReplicaNestedFilterDTO]):
+    some: ReplicaFilter | None = gql_field(
+        description="Matches parents with at least one replica satisfying all conditions.",
+        default=None,
+    )
+    every: ReplicaFilter | None = gql_field(
+        description=(
+            "Matches parents where every replica satisfies all conditions "
+            "(also true when the parent has no replica)."
+        ),
+        default=None,
+    )
+    none: ReplicaFilter | None = gql_field(
+        description="Matches parents with no replica satisfying all conditions.",
+        default=None,
+    )
+
+
+@gql_pydantic_input(
     BackendAIGQLMeta(description="", added_version="25.19.0"),
     name="DeploymentFilter",
 )
@@ -655,6 +684,13 @@ class DeploymentFilter(PydanticInputMixin[DeploymentFilterDTO]):
         BackendAIGQLMeta(
             added_version="26.4.3",
             description="Filter by deployment destruction datetime. Supports IS NULL / IS NOT NULL.",
+        ),
+        default=None,
+    )
+    replicas: ReplicaNestedFilterGQL | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Filter by conditions on deployment replicas.",
         ),
         default=None,
     )

--- a/src/ai/backend/manager/api/gql/deployment/types/replica.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/replica.py
@@ -18,6 +18,9 @@ from ai.backend.common.dto.manager.v2.deployment.request import (
     ReplicaFilter as ReplicaFilterDTO,
 )
 from ai.backend.common.dto.manager.v2.deployment.request import (
+    ReplicaHealthStatusFilter as ReplicaHealthStatusFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.deployment.request import (
     ReplicaOrder as ReplicaOrderDTO,
 )
 from ai.backend.common.dto.manager.v2.deployment.request import (
@@ -35,6 +38,7 @@ from ai.backend.common.dto.manager.v2.deployment.response import (
 from ai.backend.common.dto.manager.v2.deployment.types import (
     ReplicaOrderField,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import (
     OrderDirection,
 )
@@ -156,6 +160,26 @@ class TrafficStatusFilter(PydanticInputMixin[ReplicaTrafficStatusFilterDTO]):
     )
 
 
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Filter for replica health status.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="ReplicaHealthStatusFilter",
+)
+class ReplicaHealthStatusFilterGQL(PydanticInputMixin[ReplicaHealthStatusFilterDTO]):
+    in_: list[ReplicaHealthStatusGQL] | None = gql_field(
+        description="Health status is in the list.", name="in", default=None
+    )
+    equals: ReplicaHealthStatusGQL | None = None
+    not_in: list[ReplicaHealthStatusGQL] | None = gql_field(
+        description="Excludes health statuses in the list.", name="notIn", default=None
+    )
+    not_equals: ReplicaHealthStatusGQL | None = gql_field(
+        description="Excludes exact health status match.", name="notEquals", default=None
+    )
+
+
 # ========== ModelReplica Types ==========
 
 
@@ -165,6 +189,13 @@ class TrafficStatusFilter(PydanticInputMixin[ReplicaTrafficStatusFilterDTO]):
 )
 class ReplicaFilter(PydanticInputMixin[ReplicaFilterDTO]):
     status: ReplicaStatusFilter | None = None
+    health_status: ReplicaHealthStatusFilterGQL | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Filter by replica health status.",
+        ),
+        default=None,
+    )
     traffic_status: TrafficStatusFilter | None = None
 
     AND: list[Self] | None = None

--- a/src/ai/backend/manager/models/condition_utils.py
+++ b/src/ai/backend/manager/models/condition_utils.py
@@ -11,6 +11,30 @@ from ai.backend.common.data.filter_specs import StringInMatchSpec
 from ai.backend.manager.models.clauses import QueryCondition
 
 
+def make_correlated_exists(
+    child_row: type[Any],
+    correlate_row: type[Any],
+    join_predicate: sa.sql.expression.ColumnElement[bool],
+) -> Callable[[list[QueryCondition]], QueryCondition]:
+    """Create a factory for positive correlated ``EXISTS`` conditions."""
+
+    def factory(child_conditions: list[QueryCondition]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            subquery = (
+                sa.select(sa.literal(1))
+                .select_from(child_row)
+                .where(join_predicate)
+                .correlate(correlate_row)
+            )
+            for condition in child_conditions:
+                subquery = subquery.where(condition())
+            return sa.exists(subquery)
+
+        return inner
+
+    return factory
+
+
 def make_string_in_factory(
     column: sa.orm.InstrumentedAttribute[Any],
 ) -> Callable[[StringInMatchSpec], QueryCondition]:

--- a/src/ai/backend/manager/models/endpoint/conditions.py
+++ b/src/ai/backend/manager/models/endpoint/conditions.py
@@ -17,16 +17,25 @@ from ai.backend.common.data.filter_specs import (
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.manager.data.deployment.types import DeploymentLifecycleSubStep
 from ai.backend.manager.models.clauses import QueryCondition
-from ai.backend.manager.models.condition_utils import make_string_in_factory
+from ai.backend.manager.models.condition_utils import make_correlated_exists, make_string_in_factory
 from ai.backend.manager.models.endpoint import (
     EndpointAutoScalingRuleRow,
     EndpointRow,
     EndpointTokenRow,
 )
+from ai.backend.manager.models.routing import RoutingRow
 
 
 class DeploymentConditions:
     """Query conditions for deployments."""
+
+    by_replica_exists = staticmethod(
+        make_correlated_exists(
+            child_row=RoutingRow,
+            correlate_row=EndpointRow,
+            join_predicate=RoutingRow.endpoint == EndpointRow.id,
+        )
+    )
 
     @staticmethod
     def by_ids(deployment_ids: Collection[DeploymentID]) -> QueryCondition:

--- a/tests/component/deployment/test_deployment.py
+++ b/tests/component/deployment/test_deployment.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncEngine as SAEngine
 
 from ai.backend.client.v2.exceptions import NotFoundError
 from ai.backend.client.v2.registry import BackendAIClientRegistry
@@ -20,6 +22,9 @@ from ai.backend.common.config import ModelDefinitionDraft
 from ai.backend.common.contexts.user import with_user
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy, ModelDeploymentStatus
+from ai.backend.common.data.model_deployment.types import (
+    RouteHealthStatus as CommonRouteHealthStatus,
+)
 from ai.backend.common.data.user.types import UserData, UserRole
 from ai.backend.common.dto.manager.deployment import (
     CreateDeploymentRequest,
@@ -44,6 +49,9 @@ from ai.backend.common.dto.manager.deployment.request import ClusterConfigInput
 from ai.backend.common.dto.manager.query import StringFilter
 from ai.backend.common.dto.manager.v2.deployment.request import (
     AdminSearchDeploymentsInput,
+    ReplicaFilter,
+    ReplicaHealthStatusFilter,
+    ReplicaNestedFilter,
 )
 from ai.backend.common.dto.manager.v2.deployment.request import (
     DeploymentFilter as DeploymentFilterV2,
@@ -53,6 +61,12 @@ from ai.backend.common.identifier.resource_group import ResourceGroupName
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import ClusterMode
 from ai.backend.manager.api.adapters.deployment.adapter import DeploymentAdapter
+from ai.backend.manager.data.deployment.types import (
+    RouteHealthStatus,
+    RouteStatus,
+    RouteTrafficStatus,
+)
+from ai.backend.manager.models.routing import RoutingRow
 from ai.backend.manager.services.deployment.processors import DeploymentProcessors
 from ai.backend.manager.services.deployment.service import _map_lifecycle_to_status
 from ai.backend.manager.services.processors import Processors
@@ -400,6 +414,147 @@ class TestDeploymentAdapterFilter:
         )
         response = await admin_registry.deployment.create_deployment(request)
         return response.deployment.id
+
+    @pytest.fixture
+    async def replica_filter_deployments(
+        self,
+        admin_registry: BackendAIClientRegistry,
+        admin_user_fixture: UserFixtureData,
+        db_engine: SAEngine,
+        group_fixture: uuid.UUID,
+        domain_fixture: DomainFixtureData,
+        scaling_group_name: ResourceGroupName,
+        deployment_seed_data: tuple[ImageID, VFolderUUID],
+    ) -> dict[str, uuid.UUID]:
+        deployment_ids = {
+            name: await self._create_deployment_with_tags(
+                admin_registry,
+                group_fixture,
+                domain_fixture.domain_name,
+                scaling_group_name,
+                deployment_seed_data,
+                [name],
+            )
+            for name in ("zero", "healthy", "unhealthy", "mixed")
+        }
+        route_specs = (
+            (deployment_ids["healthy"], RouteHealthStatus.HEALTHY),
+            (deployment_ids["unhealthy"], RouteHealthStatus.UNHEALTHY),
+            (deployment_ids["mixed"], RouteHealthStatus.HEALTHY),
+            (deployment_ids["mixed"], RouteHealthStatus.UNHEALTHY),
+        )
+        async with db_engine.begin() as conn:
+            await conn.execute(
+                sa.insert(RoutingRow),
+                [
+                    {
+                        "id": uuid.uuid4(),
+                        "endpoint": deployment_id,
+                        "session": None,
+                        "session_owner": admin_user_fixture.user_uuid,
+                        "domain": domain_fixture.domain_name,
+                        "project": group_fixture,
+                        "status": RouteStatus.RUNNING,
+                        "health_status": health_status,
+                        "traffic_ratio": 1.0,
+                        "revision": uuid.uuid4(),
+                        "traffic_status": RouteTrafficStatus.ACTIVE,
+                    }
+                    for deployment_id, health_status in route_specs
+                ],
+            )
+        return deployment_ids
+
+    @pytest.mark.parametrize(
+        ("replicas_filter", "expected_names"),
+        [
+            pytest.param(
+                ReplicaNestedFilter(
+                    some=ReplicaFilter(
+                        health_status=ReplicaHealthStatusFilter(
+                            equals=CommonRouteHealthStatus.HEALTHY
+                        )
+                    )
+                ),
+                ("healthy", "mixed"),
+                id="some-matches-any-replica",
+            ),
+            pytest.param(
+                ReplicaNestedFilter(
+                    none=ReplicaFilter(
+                        health_status=ReplicaHealthStatusFilter(
+                            equals=CommonRouteHealthStatus.HEALTHY
+                        )
+                    )
+                ),
+                ("zero", "unhealthy"),
+                id="none-matches-no-replica",
+            ),
+            pytest.param(
+                ReplicaNestedFilter(
+                    every=ReplicaFilter(
+                        health_status=ReplicaHealthStatusFilter(
+                            equals=CommonRouteHealthStatus.HEALTHY
+                        )
+                    )
+                ),
+                ("zero", "healthy"),
+                id="every-includes-zero-replica",
+            ),
+        ],
+    )
+    async def test_replica_nested_filter_modes(
+        self,
+        deployment_adapter: DeploymentAdapter,
+        admin_user_fixture: UserFixtureData,
+        domain_fixture: DomainFixtureData,
+        replica_filter_deployments: dict[str, uuid.UUID],
+        replicas_filter: ReplicaNestedFilter,
+        expected_names: tuple[str, ...],
+    ) -> None:
+        with with_user(
+            self._admin_user_data(admin_user_fixture.user_uuid, domain_fixture.domain_name)
+        ):
+            payload = await deployment_adapter.my_search(
+                AdminSearchDeploymentsInput(
+                    filter=DeploymentFilterV2(
+                        replicas=replicas_filter,
+                    ),
+                    limit=50,
+                )
+            )
+
+        assert {item.id for item in payload.items} == {
+            replica_filter_deployments[name] for name in expected_names
+        }
+
+    async def test_replica_some_and_every_require_nonempty_all_match(
+        self,
+        deployment_adapter: DeploymentAdapter,
+        admin_user_fixture: UserFixtureData,
+        domain_fixture: DomainFixtureData,
+        replica_filter_deployments: dict[str, uuid.UUID],
+    ) -> None:
+        with with_user(
+            self._admin_user_data(admin_user_fixture.user_uuid, domain_fixture.domain_name)
+        ):
+            payload = await deployment_adapter.my_search(
+                AdminSearchDeploymentsInput(
+                    filter=DeploymentFilterV2(
+                        replicas=ReplicaNestedFilter(
+                            some=ReplicaFilter(),
+                            every=ReplicaFilter(
+                                health_status=ReplicaHealthStatusFilter(
+                                    equals=CommonRouteHealthStatus.HEALTHY
+                                )
+                            ),
+                        )
+                    ),
+                    limit=50,
+                )
+            )
+
+        assert {item.id for item in payload.items} == {replica_filter_deployments["healthy"]}
 
     async def test_my_search_and_filter_returns_intersection(
         self,

--- a/tests/unit/manager/models/test_correlated_exists.py
+++ b/tests/unit/manager/models/test_correlated_exists.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from ai.backend.manager.models.condition_utils import make_correlated_exists
+from ai.backend.manager.models.endpoint import EndpointRow
+from ai.backend.manager.models.routing import RoutingRow
+
+
+class TestMakeCorrelatedExists:
+    def test_correlates_child_query_with_parent(self) -> None:
+        correlated_exists = make_correlated_exists(
+            child_row=RoutingRow,
+            correlate_row=EndpointRow,
+            join_predicate=RoutingRow.endpoint == EndpointRow.id,
+        )
+        condition = correlated_exists([
+            lambda: RoutingRow.traffic_ratio > 0,
+        ])
+        query = sa.select(EndpointRow.id).where(condition())
+
+        sql = str(query.compile(compile_kwargs={"literal_binds": True}))
+
+        assert sql.count("EXISTS") == 1
+        assert "routings.endpoint = endpoints.id" in sql
+        assert "routings.traffic_ratio > 0" in sql
+        assert "FROM routings, endpoints" not in sql
+        assert "NOT" not in sql


### PR DESCRIPTION
## Summary

- Add `some`, `every`, and `none` nested replica filters for deployments.
- Add a shared correlated `EXISTS` condition builder.
- Expose structured replica health-status filtering through REST v2 and GraphQL.

## Test plan

- [x] Run related unit tests.
- [x] Run deployment component and repository tests.
- [x] Verify REST v2 and GraphQL `some`, `every`, and `none` queries on the live server.
- [x] Run Pants format, fix, lint, and type checks.

Resolves BA-6849

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12805.org.readthedocs.build/en/12805/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12805.org.readthedocs.build/ko/12805/

<!-- readthedocs-preview sorna-ko end -->