### PR TITLE
fix(BA-6861): disable auto_assign for admin roles

### DIFF
--- a/changes/12809.fix.md
+++ b/changes/12809.fix.md
@@ -1,0 +1,1 @@
+Stop auto-assigning admin roles to users joining a scope by clearing `auto_assign` for roles whose name ends with `admin`, which the system-role backfill had wrongly enabled.

--- a/src/ai/backend/manager/models/alembic/versions/2d6443ac0d4a_create_app_config_allow_list_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/2d6443ac0d4a_create_app_config_allow_list_table.py
@@ -20,7 +20,7 @@ from ai.backend.manager.models.base import IDColumn
 
 # revision identifiers, used by Alembic.
 revision = "2d6443ac0d4a"
-down_revision = "f2b9a4c7e103"
+down_revision = "daf20413acda"
 # Part of: 26.5.0
 branch_labels = None
 depends_on = None

--- a/src/ai/backend/manager/models/alembic/versions/45d3064b95c9_disable_auto_assign_for_admin_roles_followup.py
+++ b/src/ai/backend/manager/models/alembic/versions/45d3064b95c9_disable_auto_assign_for_admin_roles_followup.py
@@ -1,0 +1,39 @@
+"""disable auto_assign for admin roles (main-head follow-up)
+
+Duplicate of daf20413acda for the main branch. daf20413acda is inserted into
+the chain right after f2b9a4c7e103, so databases already migrated past that
+point (i.e. at the current main head) would never replay it. This follow-up
+re-applies the same correction at the main head so those databases also get
+it. It performs the identical, idempotent UPDATE and is a no-op on databases
+that already ran daf20413acda.
+
+Revision ID: 45d3064b95c9
+Revises: 2ec0aa5a19cf
+Create Date: 2026-07-13 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "45d3064b95c9"
+down_revision = "2ec0aa5a19cf"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE roles SET auto_assign = false WHERE name LIKE :pattern AND auto_assign = true"
+        ).bindparams(pattern="%admin")
+    )
+
+
+def downgrade() -> None:
+    # No-op: re-enabling auto_assign for admin roles would reintroduce the
+    # privilege-escalation behavior this migration fixes, and the pre-migration
+    # value cannot be reconstructed. Leaving auto_assign = false is safe.
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/daf20413acda_disable_auto_assign_for_admin_roles.py
+++ b/src/ai/backend/manager/models/alembic/versions/daf20413acda_disable_auto_assign_for_admin_roles.py
@@ -1,0 +1,42 @@
+"""disable auto_assign for admin roles
+
+An earlier backfill (eb9d9c018e85) set ``auto_assign = true`` for every
+system-sourced role (``WHERE source = 'system'``). Admin roles are
+system-sourced and were therefore swept into that backfill, which made them
+auto-granted to every user who joins the owning scope — an unintended and
+privilege-escalating behavior. Admin roles must never be auto-assigned.
+
+This migration clears ``auto_assign`` for every role whose name ends with
+``admin``. It is naturally idempotent: rows already at ``false`` are left
+untouched by the ``auto_assign = true`` guard.
+
+Revision ID: daf20413acda
+Revises: f2b9a4c7e103
+Create Date: 2026-07-13 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "daf20413acda"
+down_revision = "f2b9a4c7e103"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE roles SET auto_assign = false WHERE name LIKE :pattern AND auto_assign = true"
+        ).bindparams(pattern="%admin")
+    )
+
+
+def downgrade() -> None:
+    # No-op: re-enabling auto_assign for admin roles would reintroduce the
+    # privilege-escalation behavior this migration fixes, and the pre-migration
+    # value cannot be reconstructed. Leaving auto_assign = false is safe.
+    pass


### PR DESCRIPTION
## Summary

Admin roles were incorrectly marked `auto_assign = true` and were therefore auto-granted to every user who joins the owning scope — an unintended, privilege-escalating behavior.

**Root cause:** the `eb9d9c018e85` backfill set `auto_assign = true` for every system-sourced role (`WHERE source = 'system'`). Admin roles are system-sourced and were swept into that backfill.

**Fix:** clear `auto_assign` for every role whose name ends with `admin`.

## Migrations (main-side backport reconciliation)

This is the main-side counterpart of the 26.4 backport (BA-6861). The backport migration `d` is inserted into the main chain and a duplicate `d'` is appended at the main head:

| revision | down_revision | role |
|---|---|---|
| `daf20413acda` | `f2b9a4c7e103` | `d` — same file as the 26.4 backport, inserted after `f2b9a4c7e103` |
| `2d6443ac0d4a` | `daf20413acda` (was `f2b9a4c7e103`) | existing migration repointed onto `d` |
| `45d3064b95c9` | `2ec0aa5a19cf` | `d'` — re-applies the same idempotent UPDATE at the main head so DBs already past the insertion point still get the fix |

Resulting chain: `f2b9a4c7e103 → daf20413acda → 2d6443ac0d4a → … → 2ec0aa5a19cf → 45d3064b95c9` (single head).

## Idempotency

`UPDATE roles SET auto_assign = false WHERE name LIKE '%admin' AND auto_assign = true` — safe to re-apply; the `auto_assign = true` guard makes re-runs a no-op. Downgrade is intentionally a no-op (the prior value cannot be reconstructed and restoring `true` would reintroduce the bug).

## Verification

- Non-destructive dry-run against the local DB (transaction + rollback): the UPDATE targets exactly the 12 admin-named roles currently at `auto_assign = true`; re-run affects 0 rows.
- `scripts/check-multiple-alembic-heads.py` → single head `45d3064b95c9`.
- `pants fmt lint check` pass.

## Related

- Jira: BA-6861
- 26.4 backport PR: (linked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
