### PR TITLE
fix(BA-6861): disable auto_assign for admin roles [26.4 backport]

### DIFF
--- a/changes/12810.fix.md
+++ b/changes/12810.fix.md
@@ -1,0 +1,1 @@
+Stop auto-assigning admin roles to users joining a scope by clearing `auto_assign` for roles whose name ends with `admin`, which the system-role backfill had wrongly enabled.

--- a/src/ai/backend/manager/models/alembic/versions/daf20413acda_disable_auto_assign_for_admin_roles.py
+++ b/src/ai/backend/manager/models/alembic/versions/daf20413acda_disable_auto_assign_for_admin_roles.py
@@ -1,0 +1,42 @@
+"""disable auto_assign for admin roles
+
+An earlier backfill (eb9d9c018e85) set ``auto_assign = true`` for every
+system-sourced role (``WHERE source = 'system'``). Admin roles are
+system-sourced and were therefore swept into that backfill, which made them
+auto-granted to every user who joins the owning scope — an unintended and
+privilege-escalating behavior. Admin roles must never be auto-assigned.
+
+This migration clears ``auto_assign`` for every role whose name ends with
+``admin``. It is naturally idempotent: rows already at ``false`` are left
+untouched by the ``auto_assign = true`` guard.
+
+Revision ID: daf20413acda
+Revises: f2b9a4c7e103
+Create Date: 2026-07-13 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "daf20413acda"
+down_revision = "f2b9a4c7e103"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE roles SET auto_assign = false WHERE name LIKE :pattern AND auto_assign = true"
+        ).bindparams(pattern="%admin")
+    )
+
+
+def downgrade() -> None:
+    # No-op: re-enabling auto_assign for admin roles would reintroduce the
+    # privilege-escalation behavior this migration fixes, and the pre-migration
+    # value cannot be reconstructed. Leaving auto_assign = false is safe.
+    pass


### PR DESCRIPTION
## Summary

Backport to 26.4 of the admin-role `auto_assign` fix (BA-6861).

Admin roles were incorrectly marked `auto_assign = true` and were therefore auto-granted to every user who joins the owning scope — an unintended, privilege-escalating behavior.

**Root cause:** the `eb9d9c018e85` backfill set `auto_assign = true` for every system-sourced role (`WHERE source = 'system'`). Admin roles are system-sourced and were swept into that backfill.

**Fix:** clear `auto_assign` for every role whose name ends with `admin`.

## Migration

| revision | down_revision |
|---|---|
| `daf20413acda` | `f2b9a4c7e103` (26.4 head) |

`UPDATE roles SET auto_assign = false WHERE name LIKE '%admin' AND auto_assign = true` — idempotent; the `auto_assign = true` guard makes re-runs a no-op. Downgrade is intentionally a no-op.

## Verification

- Non-destructive dry-run against the local DB (transaction + rollback): the UPDATE targets exactly the 12 admin-named roles currently at `auto_assign = true`; re-run affects 0 rows.
- `pants fmt lint check` pass.

## Related

- Jira: BA-6861
- main PR: (linked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
