### PR TITLE
feat(BA-6606): add virtual-scope-chain permission check

### DIFF
--- a/changes/12814.feature.md
+++ b/changes/12814.feature.md
@@ -1,0 +1,1 @@
+Add a repository function to verify a user's effective permission on an entity through the virtual-scope chain, clipping by the `permission_cap` on each hop.

--- a/src/ai/backend/manager/data/permission/virtual_scope.py
+++ b/src/ai/backend/manager/data/permission/virtual_scope.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ai.backend.common.entity.types import EntityRef
+from ai.backend.common.identifier.user import UserID
+
+
+@dataclass(frozen=True)
+class VirtualScopePermissionCheckKey:
+    """Identifies a ``(user, entity)`` target for virtual-scope-chain
+    permission resolution.
+    """
+
+    user_id: UserID
+    entity: EntityRef

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -13,6 +13,9 @@ from ai.backend.common.data.permission.types import (
     RBACElementType,
     RelationType,
 )
+from ai.backend.common.entity.types import EntityRef
+from ai.backend.common.identifier.entity import EntityID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.actions.action.rbac_role_invitation import (
     CreateRoleInvitationResult,
@@ -52,11 +55,13 @@ from ai.backend.manager.data.permission.status import (
 from ai.backend.manager.data.permission.types import (
     EntityType,
     OperationType,
+    Permission,
     RBACElementRef,
     ScopeData,
     ScopeListResult,
     ScopeType,
 )
+from ai.backend.manager.data.permission.virtual_scope import VirtualScopePermissionCheckKey
 from ai.backend.manager.data.role_invitation.types import (
     RoleInvitationData,
     RoleInvitationState,
@@ -81,6 +86,8 @@ from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
 from ai.backend.manager.models.role_invitation.row import RoleInvitationRow
 from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.repositories.base.creator import (
     BulkCreator,
     BulkCreatorResultWithFailures,
@@ -143,6 +150,20 @@ class _PermissionGroupKey:
     user_id: uuid.UUID
     element_type: RBACElementType
     subject_entity_type: RBACElementType
+
+
+@dataclass(frozen=True)
+class _VirtualScopePermissionGroupKey:
+    """Group key for batching virtual-scope-chain resolution inputs.
+
+    Keys sharing the same ``(user_id, entity_type)`` are resolved by a single
+    SQL round-trip differing only in the per-target ``entity_id`` IN-list.
+    ``entity_type`` is the DB-facing :class:`EntityType` enum (converted from the
+    open ``EntityRef.entity_type``) so it binds against the permission columns.
+    """
+
+    user_id: uuid.UUID
+    entity_type: EntityType
 
 
 class PermissionDBSource:
@@ -1160,6 +1181,136 @@ class PermissionDBSource:
         that received no grant map to an empty frozenset.
         """
         return await self._resolve_permissions_via_direct_scope_walk(keys)
+
+    # ------------------------------------------------ virtual-scope-chain checks
+
+    async def check_permission_via_virtual_scope(
+        self,
+        user_id: UserID,
+        entity: EntityRef,
+        permission: Permission,
+    ) -> bool:
+        """Return whether the user holds *permission* on the entity via a virtual scope.
+
+        Resolves the effective permission through the virtual-scope chain and tests
+        it bitwise (``effective & permission != NONE``).
+        """
+        key = VirtualScopePermissionCheckKey(user_id=user_id, entity=entity)
+        resolved = await self.resolve_effective_permissions_via_virtual_scope([key])
+        return bool(resolved.get(key, Permission.NONE) & permission)
+
+    async def check_bulk_permission_via_virtual_scope(
+        self,
+        keys: Collection[VirtualScopePermissionCheckKey],
+        permission: Permission,
+    ) -> Mapping[VirtualScopePermissionCheckKey, bool]:
+        """Check *permission* on each target key through the virtual-scope chain in one go.
+
+        Returns a mapping from each input key to whether the permission is granted.
+        """
+        if not keys:
+            return {}
+        resolved = await self.resolve_effective_permissions_via_virtual_scope(keys)
+        return {key: bool(resolved.get(key, Permission.NONE) & permission) for key in keys}
+
+    async def resolve_effective_permissions_via_virtual_scope(
+        self,
+        keys: Collection[VirtualScopePermissionCheckKey],
+    ) -> Mapping[VirtualScopePermissionCheckKey, Permission]:
+        """Resolve each target's effective :class:`Permission` through the virtual-scope chain.
+
+        Walks ``entity -> entity_memberships -> scope_bindings -> scope`` and
+        OR-combines the granted bitmask at each resolved scope, clipping every
+        path by both hop caps (``granted & scope_cap & entity_cap``; ``None`` = no
+        ceiling). Keys sharing ``(user_id, entity_type)`` share one round-trip;
+        keys with no reachable grant map to :attr:`Permission.NONE`.
+        """
+        if not keys:
+            return {}
+
+        groups: defaultdict[
+            _VirtualScopePermissionGroupKey, list[VirtualScopePermissionCheckKey]
+        ] = defaultdict(list)
+        for key in keys:
+            groups[
+                _VirtualScopePermissionGroupKey(
+                    user_id=key.user_id,
+                    entity_type=EntityType(key.entity.entity_type),
+                )
+            ].append(key)
+
+        result: dict[VirtualScopePermissionCheckKey, Permission] = {}
+        async with self._db.begin_readonly_session_read_committed() as db_session:
+            for group_key, members in groups.items():
+                entity_ids = [k.entity.entity_id for k in members]
+                granted = await self._resolve_permissions_for_virtual_scope_group(
+                    db_session=db_session,
+                    group_key=group_key,
+                    entity_ids=entity_ids,
+                )
+                for key in members:
+                    result[key] = granted.get(key.entity.entity_id, Permission.NONE)
+        return result
+
+    async def _resolve_permissions_for_virtual_scope_group(
+        self,
+        *,
+        db_session: SASession,
+        group_key: _VirtualScopePermissionGroupKey,
+        entity_ids: Sequence[EntityID],
+    ) -> Mapping[EntityID, Permission]:
+        """Run the virtual-scope-chain query for a single ``(user_id, entity_type)``
+        group with N entity_ids.
+
+        Returns a mapping from entity_id to its effective (cap-clipped, OR-combined)
+        :class:`Permission`. Entities with no reachable grant are absent from the map.
+        """
+        em = EntityMembershipRow.__table__
+        sb = ScopeBindingRow.__table__
+        perm = PermissionRow.__table__
+        roles = RoleRow.__table__
+        user_roles = UserRoleRow.__table__
+
+        query = (
+            sa.select(
+                em.c.entity_id,
+                perm.c.permission,
+                sb.c.permission_cap.label("scope_cap"),
+                em.c.permission_cap.label("entity_cap"),
+            )
+            .select_from(
+                em.join(sb, sb.c.virtual_scope_id == em.c.virtual_scope_id)
+                .join(
+                    perm,
+                    sa.and_(
+                        perm.c.scope_type == sb.c.scope_type,
+                        # scope_bindings.scope_id is a native UUID; permissions.scope_id
+                        # stores its canonical string form. Cast to compare.
+                        perm.c.scope_id == sa.cast(sb.c.scope_id, sa.String),
+                        perm.c.entity_type == group_key.entity_type,
+                    ),
+                )
+                .join(roles, roles.c.id == perm.c.role_id)
+                .join(user_roles, user_roles.c.role_id == roles.c.id)
+            )
+            .where(
+                sa.and_(
+                    em.c.entity_type == group_key.entity_type,
+                    em.c.entity_id.in_(entity_ids),
+                    user_roles.c.user_id == group_key.user_id,
+                    roles.c.status == RoleStatus.ACTIVE,
+                )
+            )
+        )
+
+        full_cap = Permission.full()
+        granted: defaultdict[EntityID, Permission] = defaultdict(lambda: Permission.NONE)
+        result = await db_session.execute(query)
+        for row in result:
+            scope_cap = row.scope_cap if row.scope_cap is not None else full_cap
+            entity_cap = row.entity_cap if row.entity_cap is not None else full_cap
+            granted[row.entity_id] |= row.permission & scope_cap & entity_cap
+        return granted
 
     async def bulk_assign_role(
         self, bulk_creator: BulkCreator[UserRoleRow]

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -13,9 +13,7 @@ from ai.backend.common.data.permission.types import (
     RBACElementType,
     RelationType,
 )
-from ai.backend.common.entity.types import EntityRef
 from ai.backend.common.identifier.entity import EntityID
-from ai.backend.common.identifier.user import UserID
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.actions.action.rbac_role_invitation import (
     CreateRoleInvitationResult,
@@ -1186,16 +1184,14 @@ class PermissionDBSource:
 
     async def check_permission_via_virtual_scope(
         self,
-        user_id: UserID,
-        entity: EntityRef,
+        key: VirtualScopePermissionCheckKey,
         permission: Permission,
     ) -> bool:
-        """Return whether the user holds *permission* on the entity via a virtual scope.
+        """Return whether the user holds *permission* on the key's entity via a virtual scope.
 
         Resolves the effective permission through the virtual-scope chain and tests
         it bitwise (``effective & permission != NONE``).
         """
-        key = VirtualScopePermissionCheckKey(user_id=user_id, entity=entity)
         resolved = await self.resolve_effective_permissions_via_virtual_scope([key])
         return bool(resolved.get(key, Permission.NONE) & permission)
 
@@ -1294,12 +1290,10 @@ class PermissionDBSource:
                 .join(user_roles, user_roles.c.role_id == roles.c.id)
             )
             .where(
-                sa.and_(
-                    em.c.entity_type == group_key.entity_type,
-                    em.c.entity_id.in_(entity_ids),
-                    user_roles.c.user_id == group_key.user_id,
-                    roles.c.status == RoleStatus.ACTIVE,
-                )
+                em.c.entity_type == group_key.entity_type,
+                em.c.entity_id.in_(entity_ids),
+                user_roles.c.user_id == group_key.user_id,
+                roles.c.status == RoleStatus.ACTIVE,
             )
         )
 

--- a/tests/unit/manager/repositories/permission_controller/test_check_permission_via_virtual_scope.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_permission_via_virtual_scope.py
@@ -361,7 +361,7 @@ class TestCheckPermissionViaVirtualScope:
         )
         unreachable = VirtualScopePermissionCheckKey(
             user_id=chain.user_id,
-            entity=EntityRef(entity_type=_TARGET_ENTITY_TYPE, entity_id=EntityID(uuid.uuid4())),
+            entity=EntityRef(entity_type=_TARGET_ENTITY_TYPE, entity_id=uuid.uuid4()),
         )
         result = await db_source.check_bulk_permission_via_virtual_scope(
             [reachable, unreachable], Permission.READ

--- a/tests/unit/manager/repositories/permission_controller/test_check_permission_via_virtual_scope.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_permission_via_virtual_scope.py
@@ -305,11 +305,11 @@ class TestCheckPermissionViaVirtualScope:
         permission: Permission,
         expected: bool,
     ) -> None:
-        result = await db_source.check_permission_via_virtual_scope(
+        key = VirtualScopePermissionCheckKey(
             user_id=chain.user_id,
             entity=EntityRef(entity_type=_TARGET_ENTITY_TYPE, entity_id=chain.entity_id),
-            permission=permission,
         )
+        result = await db_source.check_permission_via_virtual_scope(key, permission)
         assert result is expected
 
     @pytest.mark.parametrize(
@@ -378,9 +378,9 @@ class TestCheckPermissionViaVirtualScope:
         db_source: PermissionDBSource,
         chain: VSChainFixture,
     ) -> None:
-        result = await db_source.check_permission_via_virtual_scope(
+        key = VirtualScopePermissionCheckKey(
             user_id=UserID(uuid.uuid4()),
             entity=EntityRef(entity_type=_TARGET_ENTITY_TYPE, entity_id=chain.entity_id),
-            permission=Permission.READ,
         )
+        result = await db_source.check_permission_via_virtual_scope(key, Permission.READ)
         assert result is False

--- a/tests/unit/manager/repositories/permission_controller/test_check_permission_via_virtual_scope.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_permission_via_virtual_scope.py
@@ -1,0 +1,386 @@
+"""
+Tests for PermissionDBSource virtual-scope-chain permission checks.
+
+Covers resolution through the ``entity -> virtual_scope -> scope`` chain with
+per-hop ``permission_cap`` clipping, parallel to the direct scope-walk check.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass, field
+
+import pytest
+
+from ai.backend.common.data.permission.types import Permission
+from ai.backend.common.entity.types import EntityRef, EntityType, ScopeType
+from ai.backend.common.identifier.entity import EntityID
+from ai.backend.common.identifier.user import UserID
+from ai.backend.common.identifier.virtual_scope import VirtualScopeID
+from ai.backend.manager.data.permission.status import RoleStatus
+from ai.backend.manager.data.permission.types import (
+    EntityType as PermEntityType,
+)
+from ai.backend.manager.data.permission.types import (
+    OperationType,
+)
+from ai.backend.manager.data.permission.types import (
+    ScopeType as PermScopeType,
+)
+from ai.backend.manager.data.permission.virtual_scope import VirtualScopePermissionCheckKey
+from ai.backend.manager.data.user.types import UserStatus
+from ai.backend.manager.models.agent import AgentRow
+
+# ORM cluster registration: configure_mappers() (triggered when this isolated
+# test registers a domain-cluster row) resolves string relationships against the
+# registry. These rows are reachable via relationships but are not otherwise
+# imported/registered by this test; _ORM_CLUSTER keeps them live.
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.rbac_models import UserRoleRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.rbac_models.permission.object_permission import ObjectPermissionRow
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
+from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.scaling_group import ScalingGroupForDomainRow
+from ai.backend.manager.models.user import UserRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
+from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
+from ai.backend.manager.repositories.permission_controller.db_source.db_source import (
+    PermissionDBSource,
+)
+from ai.backend.testutils.db import with_tables
+
+_ORM_CLUSTER = (
+    AgentRow,
+    ScalingGroupForDomainRow,
+)
+
+_TARGET_ENTITY_TYPE = EntityType("vfolder")
+
+
+@dataclass
+class VSChainFixture:
+    """Identifiers for a virtual-scope chain test."""
+
+    user_id: UserID = field(default_factory=lambda: UserID(uuid.uuid4()))
+    role_id: uuid.UUID = field(default_factory=uuid.uuid4)
+    virtual_scope_id: VirtualScopeID = field(default_factory=lambda: VirtualScopeID(uuid.uuid4()))
+    owner_scope_id: uuid.UUID = field(default_factory=uuid.uuid4)
+    bound_scope_id: uuid.UUID = field(default_factory=uuid.uuid4)
+    entity_id: EntityID = field(default_factory=uuid.uuid4)
+
+
+@dataclass
+class VSChainSpec:
+    """Declarative description of the virtual-scope chain to materialize."""
+
+    granted: Permission
+    scope_cap: Permission | None = None
+    entity_cap: Permission | None = None
+    attach_membership: bool = True
+    role_status: RoleStatus = RoleStatus.ACTIVE
+
+
+class TestCheckPermissionViaVirtualScope:
+    @pytest.fixture
+    async def db_with_rbac_tables(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                DomainRow,
+                UserResourcePolicyRow,
+                KeyPairResourcePolicyRow,
+                RoleRow,
+                UserRoleRow,
+                UserRow,
+                KeyPairRow,
+                PermissionRow,
+                ObjectPermissionRow,
+                AssociationScopesEntitiesRow,
+                VirtualScopeRow,
+                ScopeBindingRow,
+                EntityMembershipRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    def db_source(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+    ) -> PermissionDBSource:
+        return PermissionDBSource(db_with_rbac_tables)
+
+    @pytest.fixture
+    def fixture_ids(self) -> VSChainFixture:
+        return VSChainFixture()
+
+    async def _create_user_and_role(
+        self,
+        db: ExtendedAsyncSAEngine,
+        ids: VSChainFixture,
+        role_status: RoleStatus,
+    ) -> None:
+        async with db.begin_session() as db_sess:
+            policy = UserResourcePolicyRow(
+                name="test-rbac-policy",
+                max_vfolder_count=0,
+                max_quota_scope_size=-1,
+                max_session_count_per_model_session=0,
+                max_customized_image_count=0,
+            )
+            db_sess.add(policy)
+            user = UserRow(
+                uuid=ids.user_id,
+                email="testuser@test.com",
+                resource_policy="test-rbac-policy",
+                status=UserStatus.ACTIVE,
+                need_password_change=False,
+                sudo_session_enabled=False,
+            )
+            db_sess.add(user)
+            await db_sess.flush()
+
+            role = RoleRow(id=ids.role_id, name="test-role", status=role_status)
+            db_sess.add(role)
+            await db_sess.flush()
+
+            db_sess.add(UserRoleRow(user_id=ids.user_id, role_id=ids.role_id))
+            await db_sess.flush()
+
+    async def _build_chain(
+        self,
+        db: ExtendedAsyncSAEngine,
+        ids: VSChainFixture,
+        spec: VSChainSpec,
+    ) -> None:
+        """Materialize: virtual scope, scope binding, entity membership, and a
+        permission granting ``spec.granted`` at the bound scope."""
+        async with db.begin_session() as db_sess:
+            db_sess.add(
+                VirtualScopeRow(
+                    id=ids.virtual_scope_id,
+                    scope_type=ScopeType("project"),
+                    scope_id=ids.owner_scope_id,
+                )
+            )
+            await db_sess.flush()
+
+            db_sess.add(
+                ScopeBindingRow(
+                    virtual_scope_id=ids.virtual_scope_id,
+                    scope_type=ScopeType("project"),
+                    scope_id=ids.bound_scope_id,
+                    permission_cap=spec.scope_cap,
+                )
+            )
+            if spec.attach_membership:
+                db_sess.add(
+                    EntityMembershipRow(
+                        virtual_scope_id=ids.virtual_scope_id,
+                        entity_type=_TARGET_ENTITY_TYPE,
+                        entity_id=ids.entity_id,
+                        permission_cap=spec.entity_cap,
+                    )
+                )
+            db_sess.add(
+                PermissionRow(
+                    role_id=ids.role_id,
+                    scope_type=PermScopeType.PROJECT,
+                    scope_id=str(ids.bound_scope_id),
+                    entity_type=PermEntityType.VFOLDER,
+                    operation=OperationType.READ,
+                    permission=spec.granted,
+                )
+            )
+            await db_sess.flush()
+
+    @pytest.fixture
+    async def chain(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+        fixture_ids: VSChainFixture,
+        request: pytest.FixtureRequest,
+    ) -> VSChainFixture:
+        spec: VSChainSpec = request.param
+        await self._create_user_and_role(db_with_rbac_tables, fixture_ids, spec.role_status)
+        await self._build_chain(db_with_rbac_tables, fixture_ids, spec)
+        return fixture_ids
+
+    @pytest.mark.parametrize(
+        ("chain", "permission", "expected"),
+        [
+            pytest.param(
+                VSChainSpec(granted=Permission.READ),
+                Permission.READ,
+                True,
+                id="permitted",
+            ),
+            pytest.param(
+                VSChainSpec(granted=Permission.READ),
+                Permission.UPDATE,
+                False,
+                id="denied-operation-mismatch",
+            ),
+            pytest.param(
+                VSChainSpec(granted=Permission.READ | Permission.UPDATE | Permission.CREATE),
+                Permission.CREATE,
+                True,
+                id="multi-level-chain-flows-through",
+            ),
+            pytest.param(
+                VSChainSpec(
+                    granted=Permission.READ | Permission.UPDATE,
+                    scope_cap=Permission.READ,
+                ),
+                Permission.UPDATE,
+                False,
+                id="clip-at-scope-to-vs-hop",
+            ),
+            pytest.param(
+                VSChainSpec(
+                    granted=Permission.READ | Permission.UPDATE,
+                    scope_cap=Permission.READ,
+                ),
+                Permission.READ,
+                True,
+                id="scope-cap-keeps-read",
+            ),
+            pytest.param(
+                VSChainSpec(
+                    granted=Permission.READ | Permission.UPDATE,
+                    entity_cap=Permission.READ,
+                ),
+                Permission.UPDATE,
+                False,
+                id="clip-at-vs-to-entity-hop",
+            ),
+            pytest.param(
+                VSChainSpec(
+                    granted=Permission.READ | Permission.UPDATE,
+                    entity_cap=Permission.READ,
+                ),
+                Permission.READ,
+                True,
+                id="entity-cap-keeps-read",
+            ),
+            pytest.param(
+                VSChainSpec(granted=Permission.READ | Permission.UPDATE),
+                Permission.UPDATE,
+                True,
+                id="null-cap-no-clip",
+            ),
+            pytest.param(
+                VSChainSpec(granted=Permission.READ, attach_membership=False),
+                Permission.READ,
+                False,
+                id="no-vs-fallback",
+            ),
+            pytest.param(
+                VSChainSpec(granted=Permission.READ, role_status=RoleStatus.INACTIVE),
+                Permission.READ,
+                False,
+                id="inactive-role-denied",
+            ),
+        ],
+        indirect=["chain"],
+    )
+    async def test_check_permission(
+        self,
+        db_source: PermissionDBSource,
+        chain: VSChainFixture,
+        permission: Permission,
+        expected: bool,
+    ) -> None:
+        result = await db_source.check_permission_via_virtual_scope(
+            user_id=chain.user_id,
+            entity=EntityRef(entity_type=_TARGET_ENTITY_TYPE, entity_id=chain.entity_id),
+            permission=permission,
+        )
+        assert result is expected
+
+    @pytest.mark.parametrize(
+        ("chain", "expected"),
+        [
+            pytest.param(
+                VSChainSpec(granted=Permission.READ | Permission.UPDATE),
+                Permission.READ | Permission.UPDATE,
+                id="both-caps-null",
+            ),
+            pytest.param(
+                VSChainSpec(
+                    granted=Permission.full(),
+                    scope_cap=Permission.READ | Permission.UPDATE,
+                    entity_cap=Permission.READ,
+                ),
+                Permission.READ,
+                id="clipped-by-both-hops",
+            ),
+        ],
+        indirect=["chain"],
+    )
+    async def test_resolve_effective_permission_bitmask(
+        self,
+        db_source: PermissionDBSource,
+        chain: VSChainFixture,
+        expected: Permission,
+    ) -> None:
+        key = VirtualScopePermissionCheckKey(
+            user_id=chain.user_id,
+            entity=EntityRef(entity_type=_TARGET_ENTITY_TYPE, entity_id=chain.entity_id),
+        )
+        resolved = await db_source.resolve_effective_permissions_via_virtual_scope([key])
+        assert resolved[key] == expected
+
+    @pytest.mark.parametrize(
+        ("chain",),
+        [pytest.param(VSChainSpec(granted=Permission.READ), id="bulk")],
+        indirect=["chain"],
+    )
+    async def test_bulk_check_maps_each_key(
+        self,
+        db_source: PermissionDBSource,
+        chain: VSChainFixture,
+    ) -> None:
+        reachable = VirtualScopePermissionCheckKey(
+            user_id=chain.user_id,
+            entity=EntityRef(entity_type=_TARGET_ENTITY_TYPE, entity_id=chain.entity_id),
+        )
+        unreachable = VirtualScopePermissionCheckKey(
+            user_id=chain.user_id,
+            entity=EntityRef(entity_type=_TARGET_ENTITY_TYPE, entity_id=EntityID(uuid.uuid4())),
+        )
+        result = await db_source.check_bulk_permission_via_virtual_scope(
+            [reachable, unreachable], Permission.READ
+        )
+        assert result == {reachable: True, unreachable: False}
+
+    @pytest.mark.parametrize(
+        ("chain",),
+        [pytest.param(VSChainSpec(granted=Permission.READ), id="isolation")],
+        indirect=["chain"],
+    )
+    async def test_other_user_is_isolated(
+        self,
+        db_source: PermissionDBSource,
+        chain: VSChainFixture,
+    ) -> None:
+        result = await db_source.check_permission_via_virtual_scope(
+            user_id=UserID(uuid.uuid4()),
+            entity=EntityRef(entity_type=_TARGET_ENTITY_TYPE, entity_id=chain.entity_id),
+            permission=Permission.READ,
+        )
+        assert result is False


### PR DESCRIPTION
## Summary
- Add virtual-scope-chain permission resolution to `PermissionDBSource`, parallel to the existing direct scope-walk check.
- Resolve a user's effective `Permission` on an entity by walking `entity → entity_memberships → scope_bindings → scope`, evaluating the granted bitmask at each resolved scope and clipping each path by **both** hop caps (`granted & scope_cap & entity_cap`; `None` = no ceiling). Contributions are OR-combined.
- Public surface: `check_permission_via_virtual_scope` (single), `check_bulk_permission_via_virtual_scope` (bulk), `resolve_effective_permissions_via_virtual_scope` (key → `Permission` bitmask). Keys are built on the canonical open types (`EntityRef` / `UserID` / `Permission`), not `RBACElementType` / `RelationType`.

## Test plan
- [x] Unit tests (real DB, `with_tables`): permitted / denied (operation mismatch) / multi-level chain / cap clipping at scope→VS hop / cap clipping at VS→entity hop / NULL-cap (no clip) / no-VS fallback / inactive-role denied / bulk mapping / effective-bitmask resolve (both-hop clipping) / user isolation.

## Performance

Benchmarked the **actual** `PermissionDBSource.resolve_effective_permissions_via_virtual_scope()` code path (SQLAlchemy + asyncpg, via `begin_readonly_session_read_committed`) against synthetic, production-scale data on Postgres 16.3 (80 reps after warmup). Two query strategies were compared, each with and without **covering indexes** (`INCLUDE` the selected columns so the em / perm / sb scans go index-only):
- **(1)** the current single 4-join,
- **(3)** a virtual-scope-centric 2-query split (`entity_memberships ⋈ scope_bindings`, then `permissions ⋈ roles ⋈ user_roles`, joined in memory).

Each cell is **p50 / p95 ms**.

### Low fan-out — ~1 resolved row per entity
1M `entity_memberships` / 100k `virtual_scopes` / 100k `scopes` (scope:vs = 1:1).

| batch | (1) 4-join | (1) +covering | (3) split | (3) split +covering |
|------:|:---:|:---:|:---:|:---:|
| 1 | 1.01 / 1.16 | 1.14 / 1.77 | 1.83 / 2.29 | 1.00 / 1.10 |
| 10 | 1.66 / 1.81 | 1.97 / 2.49 | 2.82 / 3.52 | 1.24 / 1.32 |
| 100 | 7.72 / 11.56 | 2.58 / 3.04 | 8.69 / 15.10 | 7.77 / 12.10 |
| 1000 | 17.54 / 19.07 | 17.67 / 19.15 | 30.38 / 34.49 | 30.46 / 33.25 |

### High fan-out — ~10 resolved rows per entity
scope:vs = 10:1, vs:entity = 1:100 (1M entities / 10k `virtual_scopes` / 100k `scopes`; a batch of 1000 yields ~10k joined rows).

| batch | (1) 4-join | (1) +covering | (3) split | (3) split +covering |
|------:|:---:|:---:|:---:|:---:|
| 1 | 1.59 / 1.96 | 1.42 / 1.78 | 1.71 / 2.18 | 2.01 / 2.87 |
| 10 | 3.30 / 4.36 | 3.59 / 5.07 | 6.00 / 7.45 | 6.35 / 8.23 |
| 100 | 10.10 / 15.67 | 9.71 / 13.65 | 21.35 / 22.99 | 17.77 / 22.11 |
| 1000 | 124.33 / 147.52 | **87.30 / 110.66** | 145.26 / 183.75 | 144.31 / 182.66 |

**Findings**
- **The single 4-join is the right default in both regimes.** At batch 1000 it beats the split at low fan-out (17.5 vs 30 ms) and at high fan-out (87 vs 144 ms with covering indexes). `EXPLAIN ANALYZE` confirms the `permissions` CAST join (`perm.scope_id = CAST(sb.scope_id AS varchar)`) uses `ix_permissions_scope_entity` and the `roles`/`user_roles` join uses the `(user_id, role_id)` unique index.
- **The 2-query split does not pay off in the real code path.** A raw-`asyncpg` microbenchmark suggested it wins at high fan-out (35 vs 81 ms at batch 1000), but that gain vanished when measured through the real SQLAlchemy path: the split issues two queries and materializes Q1's `entity × scope` rows plus a large `IN`-list, and that client-side overhead outweighs the DB-side savings. It is slower-or-equal at every size — a useful caution that raw-driver microbenchmarks do not represent the ORM code path.
- **Covering indexes help the 4-join where the query is DB-bound**: low-fan-out mid batches (batch 100: 7.7 → 2.6 ms) and high-fan-out large batches (batch 1000: 124 → 87 ms), with no query change. At batch 1000 low fan-out the per-call session + row-materialization overhead dominates, so the index effect is neutral there.

**Takeaway:** keep the single 4-join and add the covering indexes; the virtual-scope-centric split was validated against the real code and does not help. Follow-ups tracked separately.

Resolves BA-6606
