### PR TITLE
refactor(BA-6780): use resource group IDs in fair-share internals

### DIFF
--- a/changes/12818.enhance.md
+++ b/changes/12818.enhance.md
@@ -1,0 +1,1 @@
+Use stable resource group IDs for fair-share scheduling and usage aggregation.

--- a/src/ai/backend/manager/api/adapters/fair_share/adapter.py
+++ b/src/ai/backend/manager/api/adapters/fair_share/adapter.py
@@ -154,9 +154,12 @@ class FairShareAdapter(BaseAdapter):
 
     async def get_domain(self, input: GetDomainFairShareInput) -> GetDomainFairSharePayload:
         """Get a single domain fair share record."""
+        resource_group_id_result = await self._processors.scaling_group.resolve_resource_group_id_by_name.wait_for_complete(
+            ResolveResourceGroupIDByNameAction(name=ResourceGroupName(input.resource_group))
+        )
         result = await self._processors.fair_share.get_domain_fair_share.wait_for_complete(
             GetDomainFairShareAction(
-                resource_group=input.resource_group,
+                resource_group_id=resource_group_id_result.resource_group_id,
                 domain_name=input.domain_name,
             )
         )
@@ -200,6 +203,9 @@ class FairShareAdapter(BaseAdapter):
         resource_group: str,
     ) -> SearchDomainFairSharesPayload:
         """Search domain fair shares within a resource group (entity-based, cursor/offset)."""
+        resource_group_id_result = await self._processors.scaling_group.resolve_resource_group_id_by_name.wait_for_complete(
+            ResolveResourceGroupIDByNameAction(name=ResourceGroupName(resource_group))
+        )
         conditions = self._convert_domain_filter_rg(input.filter) if input.filter else []
         orders = self._convert_domain_orders_rg(input.order) if input.order else []
         querier = self._build_querier(
@@ -216,7 +222,9 @@ class FairShareAdapter(BaseAdapter):
 
         result = await self._processors.fair_share.search_rg_domain_fair_shares.wait_for_complete(
             SearchRGDomainFairSharesAction(
-                scope=DomainFairShareSearchScope(resource_group=resource_group),
+                scope=DomainFairShareSearchScope(
+                    resource_group_id=resource_group_id_result.resource_group_id,
+                ),
                 querier=querier,
             )
         )
@@ -271,9 +279,12 @@ class FairShareAdapter(BaseAdapter):
 
     async def get_project(self, input: GetProjectFairShareInput) -> GetProjectFairSharePayload:
         """Get a single project fair share record."""
+        resource_group_id_result = await self._processors.scaling_group.resolve_resource_group_id_by_name.wait_for_complete(
+            ResolveResourceGroupIDByNameAction(name=ResourceGroupName(input.resource_group))
+        )
         result = await self._processors.fair_share.get_project_fair_share.wait_for_complete(
             GetProjectFairShareAction(
-                resource_group=input.resource_group,
+                resource_group_id=resource_group_id_result.resource_group_id,
                 project_id=input.project_id,
             )
         )
@@ -316,6 +327,9 @@ class FairShareAdapter(BaseAdapter):
         domain_name: str,
     ) -> SearchProjectFairSharesPayload:
         """Search project fair shares within a resource group scope (entity-based, cursor/offset)."""
+        resource_group_id_result = await self._processors.scaling_group.resolve_resource_group_id_by_name.wait_for_complete(
+            ResolveResourceGroupIDByNameAction(name=ResourceGroupName(resource_group))
+        )
         conditions = self._convert_project_filter_rg(input.filter) if input.filter else []
         orders = self._convert_project_orders_rg(input.order) if input.order else []
         querier = self._build_querier(
@@ -333,8 +347,8 @@ class FairShareAdapter(BaseAdapter):
         result = await self._processors.fair_share.search_rg_project_fair_shares.wait_for_complete(
             SearchRGProjectFairSharesAction(
                 scope=ProjectFairShareSearchScope(
-                    resource_group=resource_group,
                     domain_name=domain_name,
+                    resource_group_id=resource_group_id_result.resource_group_id,
                 ),
                 querier=querier,
             )
@@ -395,9 +409,12 @@ class FairShareAdapter(BaseAdapter):
 
     async def get_user(self, input: GetUserFairShareInput) -> GetUserFairSharePayload:
         """Get a single user fair share record."""
+        resource_group_id_result = await self._processors.scaling_group.resolve_resource_group_id_by_name.wait_for_complete(
+            ResolveResourceGroupIDByNameAction(name=ResourceGroupName(input.resource_group))
+        )
         result = await self._processors.fair_share.get_user_fair_share.wait_for_complete(
             GetUserFairShareAction(
-                resource_group=input.resource_group,
+                resource_group_id=resource_group_id_result.resource_group_id,
                 project_id=input.project_id,
                 user_uuid=input.user_uuid,
             )
@@ -440,6 +457,9 @@ class FairShareAdapter(BaseAdapter):
         project_id: UUID,
     ) -> SearchUserFairSharesPayload:
         """Search user fair shares within a resource group scope (entity-based, cursor/offset)."""
+        resource_group_id_result = await self._processors.scaling_group.resolve_resource_group_id_by_name.wait_for_complete(
+            ResolveResourceGroupIDByNameAction(name=ResourceGroupName(resource_group))
+        )
         conditions = self._convert_user_filter_rg(input.filter) if input.filter else []
         orders = self._convert_user_orders_rg(input.order) if input.order else []
         querier = self._build_querier(
@@ -457,9 +477,9 @@ class FairShareAdapter(BaseAdapter):
         result = await self._processors.fair_share.search_rg_user_fair_shares.wait_for_complete(
             SearchRGUserFairSharesAction(
                 scope=UserFairShareSearchScope(
-                    resource_group=resource_group,
                     domain_name=domain_name,
                     project_id=project_id,
+                    resource_group_id=resource_group_id_result.resource_group_id,
                 ),
                 querier=querier,
             )

--- a/src/ai/backend/manager/api/rest/fair_share/handler.py
+++ b/src/ai/backend/manager/api/rest/fair_share/handler.py
@@ -68,7 +68,7 @@ from ai.backend.common.dto.manager.fair_share import (
     UserUsageBucketFilter,
 )
 from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
-from ai.backend.common.identifier.resource_group import ResourceGroupName
+from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
 from ai.backend.manager.models.scaling_group.conditions import ScalingGroupConditions
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
@@ -138,6 +138,12 @@ class FairShareAPIHandler:
         self._scaling_group = scaling_group
         self._adapter = FairShareAdapter()
 
+    async def _resolve_resource_group_id(self, resource_group: str) -> ResourceGroupID:
+        result = await self._scaling_group.resolve_resource_group_id_by_name.wait_for_complete(
+            ResolveResourceGroupIDByNameAction(name=ResourceGroupName(resource_group))
+        )
+        return result.resource_group_id
+
     # Domain Fair Share
 
     async def get_domain_fair_share(
@@ -145,9 +151,10 @@ class FairShareAPIHandler:
         path: PathParam[GetDomainFairSharePathParam],
     ) -> APIResponse:
         """Get a single domain fair share."""
+        resource_group_id = await self._resolve_resource_group_id(path.parsed.resource_group)
         action_result = await self._fair_share.get_domain_fair_share.wait_for_complete(
             GetDomainFairShareAction(
-                resource_group=path.parsed.resource_group, domain_name=path.parsed.domain_name
+                resource_group_id=resource_group_id, domain_name=path.parsed.domain_name
             )
         )
 
@@ -192,9 +199,10 @@ class FairShareAPIHandler:
         path: PathParam[GetProjectFairSharePathParam],
     ) -> APIResponse:
         """Get a single project fair share."""
+        resource_group_id = await self._resolve_resource_group_id(path.parsed.resource_group)
         action_result = await self._fair_share.get_project_fair_share.wait_for_complete(
             GetProjectFairShareAction(
-                resource_group=path.parsed.resource_group, project_id=path.parsed.project_id
+                resource_group_id=resource_group_id, project_id=path.parsed.project_id
             )
         )
 
@@ -239,9 +247,10 @@ class FairShareAPIHandler:
         path: PathParam[GetUserFairSharePathParam],
     ) -> APIResponse:
         """Get a single user fair share."""
+        resource_group_id = await self._resolve_resource_group_id(path.parsed.resource_group)
         action_result = await self._fair_share.get_user_fair_share.wait_for_complete(
             GetUserFairShareAction(
-                resource_group=path.parsed.resource_group,
+                resource_group_id=resource_group_id,
                 project_id=path.parsed.project_id,
                 user_uuid=path.parsed.user_uuid,
             )
@@ -534,9 +543,10 @@ class FairShareAPIHandler:
         path: PathParam[RGDomainFairSharePathParam],
     ) -> APIResponse:
         """Get a single domain fair share within RG scope."""
+        resource_group_id = await self._resolve_resource_group_id(path.parsed.resource_group)
         action_result = await self._fair_share.get_domain_fair_share.wait_for_complete(
             GetDomainFairShareAction(
-                resource_group=path.parsed.resource_group, domain_name=path.parsed.domain_name
+                resource_group_id=resource_group_id, domain_name=path.parsed.domain_name
             )
         )
 
@@ -555,7 +565,8 @@ class FairShareAPIHandler:
         """Search domain fair shares within RG scope."""
 
         querier = self._adapter.build_domain_fair_share_querier_rg(body.parsed)
-        scope = DomainFairShareSearchScope(resource_group=path.parsed.resource_group)
+        resource_group_id = await self._resolve_resource_group_id(path.parsed.resource_group)
+        scope = DomainFairShareSearchScope(resource_group_id=resource_group_id)
 
         action_result = await self._fair_share.search_rg_domain_fair_shares.wait_for_complete(
             SearchRGDomainFairSharesAction(
@@ -583,9 +594,10 @@ class FairShareAPIHandler:
         path: PathParam[RGProjectFairSharePathParam],
     ) -> APIResponse:
         """Get a single project fair share within RG scope."""
+        resource_group_id = await self._resolve_resource_group_id(path.parsed.resource_group)
         action_result = await self._fair_share.get_project_fair_share.wait_for_complete(
             GetProjectFairShareAction(
-                resource_group=path.parsed.resource_group, project_id=path.parsed.project_id
+                resource_group_id=resource_group_id, project_id=path.parsed.project_id
             )
         )
 
@@ -604,9 +616,10 @@ class FairShareAPIHandler:
         """Search project fair shares within RG scope."""
 
         querier = self._adapter.build_project_fair_share_querier_rg(body.parsed)
+        resource_group_id = await self._resolve_resource_group_id(path.parsed.resource_group)
         scope = ProjectFairShareSearchScope(
-            resource_group=path.parsed.resource_group,
             domain_name=path.parsed.domain_name,
+            resource_group_id=resource_group_id,
         )
 
         action_result = await self._fair_share.search_rg_project_fair_shares.wait_for_complete(
@@ -635,9 +648,10 @@ class FairShareAPIHandler:
         path: PathParam[RGUserFairSharePathParam],
     ) -> APIResponse:
         """Get a single user fair share within RG scope."""
+        resource_group_id = await self._resolve_resource_group_id(path.parsed.resource_group)
         action_result = await self._fair_share.get_user_fair_share.wait_for_complete(
             GetUserFairShareAction(
-                resource_group=path.parsed.resource_group,
+                resource_group_id=resource_group_id,
                 project_id=path.parsed.project_id,
                 user_uuid=path.parsed.user_uuid,
             )
@@ -658,10 +672,11 @@ class FairShareAPIHandler:
         """Search user fair shares within RG scope."""
 
         querier = self._adapter.build_user_fair_share_querier_rg(body.parsed)
+        resource_group_id = await self._resolve_resource_group_id(path.parsed.resource_group)
         scope = UserFairShareSearchScope(
-            resource_group=path.parsed.resource_group,
             domain_name=path.parsed.domain_name,
             project_id=path.parsed.project_id,
+            resource_group_id=resource_group_id,
         )
 
         action_result = await self._fair_share.search_rg_user_fair_shares.wait_for_complete(

--- a/src/ai/backend/manager/data/fair_share/types.py
+++ b/src/ai/backend/manager/data/fair_share/types.py
@@ -144,6 +144,7 @@ class DomainFairShareData:
     """Domain-level fair share data."""
 
     resource_group: str
+    resource_group_id: ResourceGroupID
     domain_name: str
     data: FairShareData
     """Nested fair share data structure."""
@@ -154,6 +155,7 @@ class ProjectFairShareData:
     """Project-level fair share data."""
 
     resource_group: str
+    resource_group_id: ResourceGroupID
     project_id: uuid.UUID
     domain_name: str
     data: FairShareData
@@ -165,6 +167,7 @@ class UserFairShareData:
     """User-level fair share data."""
 
     resource_group: str
+    resource_group_id: ResourceGroupID
     user_uuid: uuid.UUID
     project_id: uuid.UUID
     domain_name: str

--- a/src/ai/backend/manager/models/alembic/versions/b988f01b17a1_use_resource_group_id_for_fair_share_uniqueness.py
+++ b/src/ai/backend/manager/models/alembic/versions/b988f01b17a1_use_resource_group_id_for_fair_share_uniqueness.py
@@ -1,0 +1,114 @@
+"""use resource group IDs for fair-share uniqueness
+
+Revision ID: b988f01b17a1
+Revises: 3f9a1c7b2e04
+Create Date: 2026-07-20
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b988f01b17a1"
+down_revision = "3f9a1c7b2e04"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint(
+        "uq_domain_fair_share_rg_id",
+        "domain_fair_shares",
+        ["resource_group_id", "domain_name"],
+    )
+    op.create_unique_constraint(
+        "uq_project_fair_share_rg_id",
+        "project_fair_shares",
+        ["resource_group_id", "project_id"],
+    )
+    op.create_unique_constraint(
+        "uq_user_fair_share_rg_id",
+        "user_fair_shares",
+        ["resource_group_id", "user_uuid", "project_id"],
+    )
+    op.create_unique_constraint(
+        "uq_domain_usage_bucket_rg_id",
+        "domain_usage_buckets",
+        ["domain_name", "resource_group_id", "period_start"],
+    )
+    op.create_unique_constraint(
+        "uq_project_usage_bucket_rg_id",
+        "project_usage_buckets",
+        ["project_id", "resource_group_id", "period_start"],
+    )
+    op.create_unique_constraint(
+        "uq_user_usage_bucket_rg_id",
+        "user_usage_buckets",
+        ["user_uuid", "project_id", "resource_group_id", "period_start"],
+    )
+    op.create_index(
+        "ix_kernel_usage_rg_id_period",
+        "kernel_usage_records",
+        ["resource_group_id", "period_start"],
+    )
+
+    op.drop_constraint("uq_domain_fair_share", "domain_fair_shares", type_="unique")
+    op.drop_constraint("uq_project_fair_share", "project_fair_shares", type_="unique")
+    op.drop_constraint("uq_user_fair_share", "user_fair_shares", type_="unique")
+    op.drop_constraint("uq_domain_usage_bucket", "domain_usage_buckets", type_="unique")
+    op.drop_constraint("uq_project_usage_bucket", "project_usage_buckets", type_="unique")
+    op.drop_constraint("uq_user_usage_bucket", "user_usage_buckets", type_="unique")
+
+
+def downgrade() -> None:
+    op.create_unique_constraint(
+        "uq_domain_fair_share",
+        "domain_fair_shares",
+        ["resource_group", "domain_name"],
+    )
+    op.create_unique_constraint(
+        "uq_project_fair_share",
+        "project_fair_shares",
+        ["resource_group", "project_id"],
+    )
+    op.create_unique_constraint(
+        "uq_user_fair_share",
+        "user_fair_shares",
+        ["resource_group", "user_uuid", "project_id"],
+    )
+    op.create_unique_constraint(
+        "uq_domain_usage_bucket",
+        "domain_usage_buckets",
+        ["domain_name", "resource_group", "period_start"],
+    )
+    op.create_unique_constraint(
+        "uq_project_usage_bucket",
+        "project_usage_buckets",
+        ["project_id", "resource_group", "period_start"],
+    )
+    op.create_unique_constraint(
+        "uq_user_usage_bucket",
+        "user_usage_buckets",
+        ["user_uuid", "project_id", "resource_group", "period_start"],
+    )
+
+    op.drop_index("ix_kernel_usage_rg_id_period", table_name="kernel_usage_records")
+    op.drop_constraint("uq_domain_fair_share_rg_id", "domain_fair_shares", type_="unique")
+    op.drop_constraint("uq_project_fair_share_rg_id", "project_fair_shares", type_="unique")
+    op.drop_constraint("uq_user_fair_share_rg_id", "user_fair_shares", type_="unique")
+    op.drop_constraint(
+        "uq_domain_usage_bucket_rg_id",
+        "domain_usage_buckets",
+        type_="unique",
+    )
+    op.drop_constraint(
+        "uq_project_usage_bucket_rg_id",
+        "project_usage_buckets",
+        type_="unique",
+    )
+    op.drop_constraint(
+        "uq_user_usage_bucket_rg_id",
+        "user_usage_buckets",
+        type_="unique",
+    )

--- a/src/ai/backend/manager/models/fair_share/row.py
+++ b/src/ai/backend/manager/models/fair_share/row.py
@@ -235,7 +235,7 @@ class DomainFairShareRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     )
 
     __table_args__ = (
-        sa.UniqueConstraint("resource_group", "domain_name", name="uq_domain_fair_share"),
+        sa.UniqueConstraint("resource_group_id", "domain_name", name="uq_domain_fair_share_rg_id"),
         sa.Index("ix_domain_fair_share_lookup", "resource_group", "domain_name"),
     )
 
@@ -272,6 +272,7 @@ class DomainFairShareRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
 
         return DomainFairShareData(
             resource_group=self.resource_group,
+            resource_group_id=self.resource_group_id,
             domain_name=self.domain_name,
             data=FairShareData(
                 spec=FairShareSpec(
@@ -442,7 +443,7 @@ class ProjectFairShareRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     )
 
     __table_args__ = (
-        sa.UniqueConstraint("resource_group", "project_id", name="uq_project_fair_share"),
+        sa.UniqueConstraint("resource_group_id", "project_id", name="uq_project_fair_share_rg_id"),
         sa.Index("ix_project_fair_share_lookup", "resource_group", "project_id"),
     )
 
@@ -479,6 +480,7 @@ class ProjectFairShareRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
 
         return ProjectFairShareData(
             resource_group=self.resource_group,
+            resource_group_id=self.resource_group_id,
             project_id=self.project_id,
             domain_name=self.domain_name,
             data=FairShareData(
@@ -676,10 +678,10 @@ class UserFairShareRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
 
     __table_args__ = (
         sa.UniqueConstraint(
-            "resource_group",
+            "resource_group_id",
             "user_uuid",
             "project_id",
-            name="uq_user_fair_share",
+            name="uq_user_fair_share_rg_id",
         ),
         sa.Index("ix_user_fair_share_lookup", "resource_group", "user_uuid", "project_id"),
     )
@@ -717,6 +719,7 @@ class UserFairShareRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
 
         return UserFairShareData(
             resource_group=self.resource_group,
+            resource_group_id=self.resource_group_id,
             user_uuid=self.user_uuid,
             project_id=self.project_id,
             domain_name=self.domain_name,

--- a/src/ai/backend/manager/models/resource_usage_history/row.py
+++ b/src/ai/backend/manager/models/resource_usage_history/row.py
@@ -165,6 +165,7 @@ class KernelUsageRecordRow(Base):  # type: ignore[misc]
 
     __table_args__ = (
         sa.Index("ix_kernel_usage_rg_period", "resource_group", "period_start"),
+        sa.Index("ix_kernel_usage_rg_id_period", "resource_group_id", "period_start"),
         sa.Index("ix_kernel_usage_user_period", "user_uuid", "period_start"),
     )
 
@@ -233,9 +234,9 @@ class DomainUsageBucketRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc
     __table_args__ = (
         sa.UniqueConstraint(
             "domain_name",
-            "resource_group",
+            "resource_group_id",
             "period_start",
-            name="uq_domain_usage_bucket",
+            name="uq_domain_usage_bucket_rg_id",
         ),
         sa.Index("ix_domain_usage_bucket_lookup", "domain_name", "resource_group", "period_start"),
     )
@@ -319,9 +320,9 @@ class ProjectUsageBucketRow(LifecycleTimestampsMixin, Base):  # type: ignore[mis
     __table_args__ = (
         sa.UniqueConstraint(
             "project_id",
-            "resource_group",
+            "resource_group_id",
             "period_start",
-            name="uq_project_usage_bucket",
+            name="uq_project_usage_bucket_rg_id",
         ),
         sa.Index("ix_project_usage_bucket_lookup", "project_id", "resource_group", "period_start"),
     )
@@ -425,9 +426,9 @@ class UserUsageBucketRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
         sa.UniqueConstraint(
             "user_uuid",
             "project_id",
-            "resource_group",
+            "resource_group_id",
             "period_start",
-            name="uq_user_usage_bucket",
+            name="uq_user_usage_bucket_rg_id",
         ),
         sa.Index(
             "ix_user_usage_bucket_lookup",

--- a/src/ai/backend/manager/repositories/fair_share/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/fair_share/db_source/db_source.py
@@ -97,9 +97,13 @@ class FairShareDBSource:
         """Create a new domain fair share record."""
         async with self._db.begin_session_read_committed() as db_sess:
             result = await execute_creator(db_sess, creator)
-            sg_row = await self._fetch_scaling_group_row(db_sess, result.row.resource_group)
+            sg_row = await self._fetch_scaling_group_row_by_id(
+                db_sess, result.row.resource_group_id
+            )
             fair_share_spec = sg_row.fair_share_spec or FairShareScalingGroupSpec()
-            available_slots = await self._fetch_available_slots(db_sess, result.row.resource_group)
+            available_slots = await self._fetch_available_slots(
+                db_sess, result.row.resource_group_id
+            )
             return result.row.to_data(
                 default_weight=fair_share_spec.default_weight,
                 available_slots=available_slots,
@@ -114,10 +118,10 @@ class FairShareDBSource:
             result = await execute_upserter(
                 db_sess,
                 upserter,
-                index_elements=["resource_group", "domain_name"],
+                index_elements=["resource_group_id", "domain_name"],
             )
             fair_share_spec, available_slots = await self._try_fetch_scaling_group_context(
-                db_sess, result.row.resource_group
+                db_sess, result.row.resource_group_id
             )
             return result.row.to_data(
                 default_weight=fair_share_spec.default_weight,
@@ -126,7 +130,7 @@ class FairShareDBSource:
 
     async def get_domain_fair_share(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         domain_name: str,
     ) -> DomainFairShareData:
         """Get domain fair share data.
@@ -149,16 +153,16 @@ class FairShareDBSource:
 
             # Step 2: Query fair share record
             fs_query = sa.select(DomainFairShareRow).where(
-                DomainFairShareRow.resource_group == resource_group,
+                DomainFairShareRow.resource_group_id == resource_group_id,
                 DomainFairShareRow.domain_name == domain_name,
             )
             fs_result = await db_sess.execute(fs_query)
             fs_row = fs_result.scalar_one_or_none()
 
             # Step 3: Fetch scaling group row and available slots
-            sg_row = await self._fetch_scaling_group_row(db_sess, resource_group)
+            sg_row = await self._fetch_scaling_group_row_by_id(db_sess, resource_group_id)
             fair_share_spec = sg_row.fair_share_spec or FairShareScalingGroupSpec()
-            available_slots = await self._fetch_available_slots(db_sess, resource_group)
+            available_slots = await self._fetch_available_slots(db_sess, resource_group_id)
 
             # Step 4: Return existing record (with merged resource weights)
             if fs_row is not None:
@@ -170,7 +174,12 @@ class FairShareDBSource:
             # Step 5: Create default from scaling group spec
             now = datetime.now(UTC)
             return self._create_default_domain_fair_share(
-                resource_group, domain_name, fair_share_spec, available_slots, now
+                sg_row.name,
+                sg_row.id,
+                domain_name,
+                fair_share_spec,
+                available_slots,
+                now,
             )
 
     async def search_domain_fair_shares(
@@ -185,16 +194,18 @@ class FairShareDBSource:
             result = await execute_batch_querier(db_sess, query, querier)
 
             # Collect unique resource groups and fetch their specs and capacities
-            resource_groups = {row.DomainFairShareRow.resource_group for row in result.rows}
-            resource_groups_list = list(resource_groups)
-            specs = await self._fetch_fair_share_specs_batch(db_sess, resource_groups_list)
-            capacities = await self._fetch_cluster_capacities_batch(db_sess, resource_groups_list)
+            resource_group_ids = {row.DomainFairShareRow.resource_group_id for row in result.rows}
+            resource_group_ids_list = list(resource_group_ids)
+            specs = await self._fetch_fair_share_specs_batch(db_sess, resource_group_ids_list)
+            capacities = await self._fetch_cluster_capacities_batch(
+                db_sess, resource_group_ids_list
+            )
 
             # Convert rows to data with appropriate default_weight and available_slots
             items = [
                 row.DomainFairShareRow.to_data(
-                    specs[row.DomainFairShareRow.resource_group].default_weight,
-                    capacities[row.DomainFairShareRow.resource_group],
+                    specs[row.DomainFairShareRow.resource_group_id].default_weight,
+                    capacities[row.DomainFairShareRow.resource_group_id],
                 )
                 for row in result.rows
             ]
@@ -224,6 +235,7 @@ class FairShareDBSource:
             DomainFairShareEntitySearchResult with domain entities and their complete fair share details.
         """
         async with self._db.begin_readonly_session_read_committed() as db_sess:
+            sg_row = await self._fetch_scaling_group_row_by_id(db_sess, scope.resource_group_id)
             # Build LEFT JOIN query: all domains LEFT JOIN fair_share (filtered by resource_group)
             query = (
                 sa.select(
@@ -235,7 +247,7 @@ class FairShareDBSource:
                     DomainFairShareRow,
                     sa.and_(
                         DomainRow.name == DomainFairShareRow.domain_name,
-                        DomainFairShareRow.resource_group == scope.resource_group,
+                        DomainFairShareRow.resource_group_id == scope.resource_group_id,
                     ),
                 )
             )
@@ -243,13 +255,14 @@ class FairShareDBSource:
             result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
 
             # Fetch scaling group spec AND available_slots for default generation
-            spec = await self._fetch_fair_share_spec(db_sess, scope.resource_group)
-            available_slots = await self._fetch_available_slots(db_sess, scope.resource_group)
+            spec = await self._fetch_fair_share_spec(db_sess, scope.resource_group_id)
+            available_slots = await self._fetch_available_slots(db_sess, scope.resource_group_id)
             now = datetime.now(UTC)
 
             items = [
                 self._build_domain_data(
-                    resource_group=scope.resource_group,
+                    resource_group=sg_row.name,
+                    resource_group_id=scope.resource_group_id,
                     domain_name=row.domain_name,
                     fair_share_row=row.DomainFairShareRow,
                     spec=spec,
@@ -269,6 +282,7 @@ class FairShareDBSource:
     def _build_domain_data(
         self,
         resource_group: str,
+        resource_group_id: ResourceGroupID,
         domain_name: str,
         fair_share_row: DomainFairShareRow | None,
         spec: FairShareScalingGroupSpec,
@@ -288,7 +302,7 @@ class FairShareDBSource:
             )
         # No record: create default
         return self._create_default_domain_fair_share(
-            resource_group, domain_name, spec, available_slots, now
+            resource_group, resource_group_id, domain_name, spec, available_slots, now
         )
 
     # ==================== Project Fair Share ====================
@@ -300,9 +314,13 @@ class FairShareDBSource:
         """Create a new project fair share record."""
         async with self._db.begin_session_read_committed() as db_sess:
             result = await execute_creator(db_sess, creator)
-            sg_row = await self._fetch_scaling_group_row(db_sess, result.row.resource_group)
+            sg_row = await self._fetch_scaling_group_row_by_id(
+                db_sess, result.row.resource_group_id
+            )
             fair_share_spec = sg_row.fair_share_spec or FairShareScalingGroupSpec()
-            available_slots = await self._fetch_available_slots(db_sess, result.row.resource_group)
+            available_slots = await self._fetch_available_slots(
+                db_sess, result.row.resource_group_id
+            )
             return result.row.to_data(
                 default_weight=fair_share_spec.default_weight,
                 available_slots=available_slots,
@@ -317,10 +335,10 @@ class FairShareDBSource:
             result = await execute_upserter(
                 db_sess,
                 upserter,
-                index_elements=["resource_group", "project_id"],
+                index_elements=["resource_group_id", "project_id"],
             )
             fair_share_spec, available_slots = await self._try_fetch_scaling_group_context(
-                db_sess, result.row.resource_group
+                db_sess, result.row.resource_group_id
             )
             return result.row.to_data(
                 default_weight=fair_share_spec.default_weight,
@@ -329,7 +347,7 @@ class FairShareDBSource:
 
     async def get_project_fair_share(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         project_id: uuid.UUID,
     ) -> ProjectFairShareData:
         """Get project fair share data.
@@ -354,16 +372,16 @@ class FairShareDBSource:
 
             # Step 2: Query fair share record
             fs_query = sa.select(ProjectFairShareRow).where(
-                ProjectFairShareRow.resource_group == resource_group,
+                ProjectFairShareRow.resource_group_id == resource_group_id,
                 ProjectFairShareRow.project_id == project_id,
             )
             fs_result = await db_sess.execute(fs_query)
             fs_row = fs_result.scalar_one_or_none()
 
             # Step 3: Fetch scaling group row and available slots
-            sg_row = await self._fetch_scaling_group_row(db_sess, resource_group)
+            sg_row = await self._fetch_scaling_group_row_by_id(db_sess, resource_group_id)
             fair_share_spec = sg_row.fair_share_spec or FairShareScalingGroupSpec()
-            available_slots = await self._fetch_available_slots(db_sess, resource_group)
+            available_slots = await self._fetch_available_slots(db_sess, resource_group_id)
 
             # Step 4: Return existing record (with merged resource weights)
             if fs_row is not None:
@@ -375,7 +393,13 @@ class FairShareDBSource:
             # Step 5: Create default from scaling group spec
             now = datetime.now(UTC)
             return self._create_default_project_fair_share(
-                resource_group, project_id, domain_name, fair_share_spec, available_slots, now
+                sg_row.name,
+                resource_group_id,
+                project_id,
+                domain_name,
+                fair_share_spec,
+                available_slots,
+                now,
             )
 
     async def search_project_fair_shares(
@@ -390,16 +414,18 @@ class FairShareDBSource:
             result = await execute_batch_querier(db_sess, query, querier)
 
             # Collect unique resource groups and fetch their specs and capacities
-            resource_groups = {row.ProjectFairShareRow.resource_group for row in result.rows}
-            resource_groups_list = list(resource_groups)
-            specs = await self._fetch_fair_share_specs_batch(db_sess, resource_groups_list)
-            capacities = await self._fetch_cluster_capacities_batch(db_sess, resource_groups_list)
+            resource_group_ids = {row.ProjectFairShareRow.resource_group_id for row in result.rows}
+            resource_group_ids_list = list(resource_group_ids)
+            specs = await self._fetch_fair_share_specs_batch(db_sess, resource_group_ids_list)
+            capacities = await self._fetch_cluster_capacities_batch(
+                db_sess, resource_group_ids_list
+            )
 
             # Convert rows to data with appropriate default_weight and available_slots
             items = [
                 row.ProjectFairShareRow.to_data(
-                    specs[row.ProjectFairShareRow.resource_group].default_weight,
-                    capacities[row.ProjectFairShareRow.resource_group],
+                    specs[row.ProjectFairShareRow.resource_group_id].default_weight,
+                    capacities[row.ProjectFairShareRow.resource_group_id],
                 )
                 for row in result.rows
             ]
@@ -442,7 +468,7 @@ class FairShareDBSource:
                     ProjectFairShareRow,
                     sa.and_(
                         GroupRow.id == ProjectFairShareRow.project_id,
-                        ProjectFairShareRow.resource_group == scope.resource_group,
+                        ProjectFairShareRow.resource_group_id == scope.resource_group_id,
                     ),
                 )
             )
@@ -450,13 +476,15 @@ class FairShareDBSource:
             result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
 
             # Fetch scaling group spec AND available_slots for default generation
-            spec = await self._fetch_fair_share_spec(db_sess, scope.resource_group)
-            available_slots = await self._fetch_available_slots(db_sess, scope.resource_group)
+            spec = await self._fetch_fair_share_spec(db_sess, scope.resource_group_id)
+            available_slots = await self._fetch_available_slots(db_sess, scope.resource_group_id)
             now = datetime.now(UTC)
+            sg_row = await self._fetch_scaling_group_row_by_id(db_sess, scope.resource_group_id)
 
             items = [
                 self._build_project_data(
-                    resource_group=scope.resource_group,
+                    resource_group=sg_row.name,
+                    resource_group_id=scope.resource_group_id,
                     project_id=row.project_id,
                     domain_name=row.domain_name,
                     fair_share_row=row.ProjectFairShareRow,
@@ -477,6 +505,7 @@ class FairShareDBSource:
     def _build_project_data(
         self,
         resource_group: str,
+        resource_group_id: ResourceGroupID,
         project_id: uuid.UUID,
         domain_name: str,
         fair_share_row: ProjectFairShareRow | None,
@@ -497,7 +526,7 @@ class FairShareDBSource:
             )
         # No record: create default
         return self._create_default_project_fair_share(
-            resource_group, project_id, domain_name, spec, available_slots, now
+            resource_group, resource_group_id, project_id, domain_name, spec, available_slots, now
         )
 
     # ==================== User Fair Share ====================
@@ -509,9 +538,13 @@ class FairShareDBSource:
         """Create a new user fair share record."""
         async with self._db.begin_session_read_committed() as db_sess:
             result = await execute_creator(db_sess, creator)
-            sg_row = await self._fetch_scaling_group_row(db_sess, result.row.resource_group)
+            sg_row = await self._fetch_scaling_group_row_by_id(
+                db_sess, result.row.resource_group_id
+            )
             fair_share_spec = sg_row.fair_share_spec or FairShareScalingGroupSpec()
-            available_slots = await self._fetch_available_slots(db_sess, result.row.resource_group)
+            available_slots = await self._fetch_available_slots(
+                db_sess, result.row.resource_group_id
+            )
             return result.row.to_data(
                 default_weight=fair_share_spec.default_weight,
                 available_slots=available_slots,
@@ -526,10 +559,10 @@ class FairShareDBSource:
             result = await execute_upserter(
                 db_sess,
                 upserter,
-                index_elements=["resource_group", "user_uuid", "project_id"],
+                index_elements=["resource_group_id", "user_uuid", "project_id"],
             )
             fair_share_spec, available_slots = await self._try_fetch_scaling_group_context(
-                db_sess, result.row.resource_group
+                db_sess, result.row.resource_group_id
             )
             return result.row.to_data(
                 default_weight=fair_share_spec.default_weight,
@@ -554,7 +587,7 @@ class FairShareDBSource:
             return await execute_bulk_upserter(
                 db_sess,
                 bulk_upserter,
-                index_elements=["resource_group", "domain_name"],
+                index_elements=["resource_group_id", "domain_name"],
             )
 
     async def bulk_upsert_project_fair_share(
@@ -573,7 +606,7 @@ class FairShareDBSource:
             return await execute_bulk_upserter(
                 db_sess,
                 bulk_upserter,
-                index_elements=["resource_group", "project_id"],
+                index_elements=["resource_group_id", "project_id"],
             )
 
     async def bulk_upsert_user_fair_share(
@@ -592,12 +625,12 @@ class FairShareDBSource:
             return await execute_bulk_upserter(
                 db_sess,
                 bulk_upserter,
-                index_elements=["resource_group", "user_uuid", "project_id"],
+                index_elements=["resource_group_id", "user_uuid", "project_id"],
             )
 
     async def get_user_fair_share(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         project_id: uuid.UUID,
         user_uuid: uuid.UUID,
     ) -> UserFairShareData:
@@ -631,7 +664,7 @@ class FairShareDBSource:
 
             # Step 2: Query fair share record
             fs_query = sa.select(UserFairShareRow).where(
-                UserFairShareRow.resource_group == resource_group,
+                UserFairShareRow.resource_group_id == resource_group_id,
                 UserFairShareRow.user_uuid == user_uuid,
                 UserFairShareRow.project_id == project_id,
             )
@@ -639,9 +672,9 @@ class FairShareDBSource:
             fs_row = fs_result.scalar_one_or_none()
 
             # Step 3: Fetch scaling group row and available slots
-            sg_row = await self._fetch_scaling_group_row(db_sess, resource_group)
+            sg_row = await self._fetch_scaling_group_row_by_id(db_sess, resource_group_id)
             fair_share_spec = sg_row.fair_share_spec or FairShareScalingGroupSpec()
-            available_slots = await self._fetch_available_slots(db_sess, resource_group)
+            available_slots = await self._fetch_available_slots(db_sess, resource_group_id)
 
             # Step 4: Return existing record (with merged resource weights)
             if fs_row is not None:
@@ -653,7 +686,8 @@ class FairShareDBSource:
             # Step 5: Create default from scaling group spec
             now = datetime.now(UTC)
             return self._create_default_user_fair_share(
-                resource_group,
+                sg_row.name,
+                resource_group_id,
                 user_uuid,
                 project_id,
                 domain_name,
@@ -717,9 +751,9 @@ class FairShareDBSource:
 
     async def get_scaling_group_fair_share_spec(
         self,
-        scaling_group: str,
+        resource_group_id: ResourceGroupID,
     ) -> FairShareScalingGroupSpec:
-        """Get fair share spec for scaling group.
+        """Get fair share spec for a resource group.
 
         Returns:
             FairShareScalingGroupSpec with defaults if not configured.
@@ -728,7 +762,7 @@ class FairShareDBSource:
             ScalingGroupNotFound: If scaling group doesn't exist.
         """
         async with self._db.begin_readonly_session_read_committed() as db_sess:
-            return await self._fetch_fair_share_spec(db_sess, scaling_group)
+            return await self._fetch_fair_share_spec(db_sess, resource_group_id)
 
     async def search_user_fair_shares(
         self,
@@ -742,16 +776,18 @@ class FairShareDBSource:
             result = await execute_batch_querier(db_sess, query, querier)
 
             # Collect unique resource groups and fetch their specs and capacities
-            resource_groups = {row.UserFairShareRow.resource_group for row in result.rows}
-            resource_groups_list = list(resource_groups)
-            specs = await self._fetch_fair_share_specs_batch(db_sess, resource_groups_list)
-            capacities = await self._fetch_cluster_capacities_batch(db_sess, resource_groups_list)
+            resource_group_ids = {row.UserFairShareRow.resource_group_id for row in result.rows}
+            resource_group_ids_list = list(resource_group_ids)
+            specs = await self._fetch_fair_share_specs_batch(db_sess, resource_group_ids_list)
+            capacities = await self._fetch_cluster_capacities_batch(
+                db_sess, resource_group_ids_list
+            )
 
             # Convert rows to data with appropriate default_weight and available_slots
             items = [
                 row.UserFairShareRow.to_data(
-                    specs[row.UserFairShareRow.resource_group].default_weight,
-                    capacities[row.UserFairShareRow.resource_group],
+                    specs[row.UserFairShareRow.resource_group_id].default_weight,
+                    capacities[row.UserFairShareRow.resource_group_id],
                 )
                 for row in result.rows
             ]
@@ -800,7 +836,7 @@ class FairShareDBSource:
                     sa.and_(
                         AssocGroupUserRow.user_id == UserFairShareRow.user_uuid,
                         AssocGroupUserRow.group_id == UserFairShareRow.project_id,
-                        UserFairShareRow.resource_group == scope.resource_group,
+                        UserFairShareRow.resource_group_id == scope.resource_group_id,
                     ),
                 )
             )
@@ -808,13 +844,15 @@ class FairShareDBSource:
             result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
 
             # Fetch scaling group spec AND available_slots for default generation
-            spec = await self._fetch_fair_share_spec(db_sess, scope.resource_group)
-            available_slots = await self._fetch_available_slots(db_sess, scope.resource_group)
+            sg_row = await self._fetch_scaling_group_row_by_id(db_sess, scope.resource_group_id)
+            spec = await self._fetch_fair_share_spec(db_sess, scope.resource_group_id)
+            available_slots = await self._fetch_available_slots(db_sess, scope.resource_group_id)
             now = datetime.now(UTC)
 
             items = [
                 self._build_user_data(
-                    resource_group=scope.resource_group,
+                    resource_group=sg_row.name,
+                    resource_group_id=scope.resource_group_id,
                     user_uuid=row.user_uuid,
                     project_id=row.project_id,
                     domain_name=row.domain_name,
@@ -836,6 +874,7 @@ class FairShareDBSource:
     def _build_user_data(
         self,
         resource_group: str,
+        resource_group_id: ResourceGroupID,
         user_uuid: uuid.UUID,
         project_id: uuid.UUID,
         domain_name: str,
@@ -857,18 +896,25 @@ class FairShareDBSource:
             )
         # No record: create default
         return self._create_default_user_fair_share(
-            resource_group, user_uuid, project_id, domain_name, spec, available_slots, now
+            resource_group,
+            resource_group_id,
+            user_uuid,
+            project_id,
+            domain_name,
+            spec,
+            available_slots,
+            now,
         )
 
     async def get_user_scheduling_ranks_batch(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         project_user_ids: Sequence[ProjectUserIds],
     ) -> dict[uuid.UUID, int]:
         """Get scheduling ranks for multiple users across projects.
 
         Args:
-            resource_group: The resource group (scaling group) name.
+            resource_group_id: The resource group (scaling group) id.
             project_user_ids: Sequence of ProjectUserIds containing project and user IDs.
 
         Returns:
@@ -897,7 +943,7 @@ class FairShareDBSource:
                 UserFairShareRow.scheduling_rank,
             ).where(
                 sa.and_(
-                    UserFairShareRow.resource_group == resource_group,
+                    UserFairShareRow.resource_group_id == resource_group_id,
                     UserFairShareRow.scheduling_rank.is_not(None),
                     sa.or_(*conditions),
                 )
@@ -922,7 +968,7 @@ class FairShareDBSource:
         factors and ranks in a single transaction.
 
         Args:
-            resource_group: The resource group being updated
+            resource_group_id: The resource group ID being updated
             calculation_result: Calculated factors and ranks from FairShareFactorCalculator
             lookback_start: Start of lookback period used in calculation
             lookback_end: End of lookback period used in calculation
@@ -950,7 +996,7 @@ class FairShareDBSource:
                     last_calculated_at=now,
                 )
                 upsert_stmt = insert_stmt.on_conflict_do_update(
-                    index_elements=["resource_group", "domain_name"],
+                    index_elements=["resource_group_id", "domain_name"],
                     set_={
                         "resource_group_id": insert_stmt.excluded.resource_group_id,
                         "fair_share_factor": insert_stmt.excluded.fair_share_factor,
@@ -978,7 +1024,7 @@ class FairShareDBSource:
                     last_calculated_at=now,
                 )
                 upsert_stmt = insert_stmt.on_conflict_do_update(
-                    index_elements=["resource_group", "project_id"],
+                    index_elements=["resource_group_id", "project_id"],
                     set_={
                         "resource_group_id": insert_stmt.excluded.resource_group_id,
                         "domain_name": insert_stmt.excluded.domain_name,
@@ -1010,7 +1056,7 @@ class FairShareDBSource:
                     scheduling_rank=scheduling_rank,
                 )
                 upsert_stmt = insert_stmt.on_conflict_do_update(
-                    index_elements=["resource_group", "user_uuid", "project_id"],
+                    index_elements=["resource_group_id", "user_uuid", "project_id"],
                     set_={
                         "resource_group_id": insert_stmt.excluded.resource_group_id,
                         "domain_name": insert_stmt.excluded.domain_name,
@@ -1029,7 +1075,7 @@ class FairShareDBSource:
 
     async def get_user_fair_share_factors_batch(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         project_user_ids: Sequence[ProjectUserIds],
     ) -> dict[uuid.UUID, UserFairShareFactors]:
         """Get combined fair share factors for multiple users with 3-way JOIN.
@@ -1038,7 +1084,7 @@ class FairShareDBSource:
         by joining the three fair share tables.
 
         Args:
-            resource_group: The resource group (scaling group) name.
+            resource_group_id: The resource group ID.
             project_user_ids: Sequence of ProjectUserIds containing project and user IDs.
 
         Returns:
@@ -1076,20 +1122,20 @@ class FairShareDBSource:
                 .join(
                     ProjectFairShareRow,
                     sa.and_(
-                        ProjectFairShareRow.resource_group == UserFairShareRow.resource_group,
+                        ProjectFairShareRow.resource_group_id == UserFairShareRow.resource_group_id,
                         ProjectFairShareRow.project_id == UserFairShareRow.project_id,
                     ),
                 )
                 .join(
                     DomainFairShareRow,
                     sa.and_(
-                        DomainFairShareRow.resource_group == UserFairShareRow.resource_group,
+                        DomainFairShareRow.resource_group_id == UserFairShareRow.resource_group_id,
                         DomainFairShareRow.domain_name == UserFairShareRow.domain_name,
                     ),
                 )
                 .where(
                     sa.and_(
-                        UserFairShareRow.resource_group == resource_group,
+                        UserFairShareRow.resource_group_id == resource_group_id,
                         sa.or_(*conditions),
                     )
                 )
@@ -1110,7 +1156,7 @@ class FairShareDBSource:
 
     async def get_fair_share_calculation_context(
         self,
-        scaling_group: str,
+        resource_group_id: ResourceGroupID,
         today: date,
     ) -> FairShareCalculationContext:
         """Get all data needed for fair share factor calculation in a single session.
@@ -1121,7 +1167,7 @@ class FairShareDBSource:
         The Calculator is responsible for applying time decay to raw usage buckets.
 
         Args:
-            scaling_group: The scaling group name
+            resource_group_id: The resource group ID
             today: Current date for decay calculation
 
         Returns:
@@ -1132,26 +1178,26 @@ class FairShareDBSource:
         """
         async with self._db.begin_readonly_session_read_committed() as db_sess:
             # 1. Fetch scaling group spec
-            spec = await self._fetch_fair_share_spec(db_sess, scaling_group)
+            spec = await self._fetch_fair_share_spec(db_sess, resource_group_id)
 
             # Calculate lookback range
             lookback_start = today - timedelta(days=spec.lookback_days)
             lookback_end = today
 
             # 2. Fetch cluster capacity (sum of ALIVE schedulable agents' available_slots)
-            cluster_capacity = await self._fetch_cluster_capacity(db_sess, scaling_group)
+            cluster_capacity = await self._fetch_cluster_capacity(db_sess, resource_group_id)
 
             # 3. Fetch fair shares with resource weights merged
             fair_shares = await self._fetch_fair_shares(
                 db_sess,
-                scaling_group,
+                resource_group_id,
                 spec.default_weight,
                 cluster_capacity,
             )
 
             # 4. Fetch raw usage buckets (no decay applied)
             raw_usage_buckets = await self._fetch_raw_usage_buckets(
-                db_sess, scaling_group, lookback_start, lookback_end
+                db_sess, resource_group_id, lookback_start, lookback_end
             )
 
             # 5. Collect project_ids from raw usage buckets and fetch domain names
@@ -1196,56 +1242,70 @@ class FairShareDBSource:
     async def _fetch_fair_share_spec(
         self,
         db_sess: SASession,
-        scaling_group: str,
+        resource_group_id: ResourceGroupID,
     ) -> FairShareScalingGroupSpec:
-        """Fetch fair share spec from scaling group."""
+        """Fetch a resource group's fair share spec by ID."""
         result = await db_sess.execute(
             sa.select(
-                ScalingGroupRow.name,
+                ScalingGroupRow.id,
                 ScalingGroupRow.fair_share_spec,
-            ).where(ScalingGroupRow.name == scaling_group)
+            ).where(ScalingGroupRow.id == resource_group_id)
         )
         row = result.one_or_none()
         if row is None:
-            raise ScalingGroupNotFound(scaling_group)
+            raise ScalingGroupNotFound(str(resource_group_id))
 
         if row.fair_share_spec is not None:
             return cast(FairShareScalingGroupSpec, row.fair_share_spec)
 
         return FairShareScalingGroupSpec()
 
-    async def _fetch_scaling_group_row(
+    async def _fetch_scaling_group_row_by_id(
         self,
         db_sess: SASession,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
     ) -> ScalingGroupRow:
-        """Fetch scaling group row.
+        """Fetch a scaling group row by ID.
 
         Raises:
             ScalingGroupNotFound: If scaling group does not exist
         """
         result = await db_sess.execute(
-            sa.select(ScalingGroupRow).where(ScalingGroupRow.name == resource_group)
+            sa.select(ScalingGroupRow).where(ScalingGroupRow.id == resource_group_id)
         )
         row = result.scalar_one_or_none()
         if row is None:
-            raise ScalingGroupNotFound(resource_group)
+            raise ScalingGroupNotFound(str(resource_group_id))
+        return row
+
+    async def _fetch_scaling_group_row_by_name(
+        self,
+        db_sess: SASession,
+        resource_group_name: str,
+    ) -> ScalingGroupRow:
+        """Fetch a scaling group row by name.
+
+        Raises:
+            ScalingGroupNotFound: If scaling group does not exist
+        """
+        result = await db_sess.execute(
+            sa.select(ScalingGroupRow).where(ScalingGroupRow.name == resource_group_name)
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            raise ScalingGroupNotFound(resource_group_name)
         return row
 
     async def _try_fetch_scaling_group_context(
         self,
         db_sess: SASession,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
     ) -> tuple[FairShareScalingGroupSpec, list[SlotQuantity]]:
-        """Fetch scaling group context for response building, with graceful fallback.
-
-        Returns defaults when scaling group doesn't exist.
-        Used by upsert methods where the scaling group may not exist.
-        """
+        """Fetch resource group context, falling back to response defaults."""
         try:
-            sg_row = await self._fetch_scaling_group_row(db_sess, resource_group)
+            sg_row = await self._fetch_scaling_group_row_by_id(db_sess, resource_group_id)
             fair_share_spec = sg_row.fair_share_spec or FairShareScalingGroupSpec()
-            available_slots = await self._fetch_available_slots(db_sess, resource_group)
+            available_slots = await self._fetch_available_slots(db_sess, sg_row.id)
         except ScalingGroupNotFound:
             fair_share_spec = FairShareScalingGroupSpec()
             available_slots = []
@@ -1254,7 +1314,7 @@ class FairShareDBSource:
     async def _fetch_available_slots(
         self,
         db_sess: SASession,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
     ) -> list[SlotQuantity]:
         """Fetch total available slots from all ALIVE schedulable agents.
 
@@ -1263,7 +1323,7 @@ class FairShareDBSource:
 
         Args:
             db_sess: Database session
-            resource_group: Scaling group name
+            resource_group_id: Resource group ID
 
         Returns:
             Sum of capacity from all ALIVE schedulable agents, rank-ordered
@@ -1278,7 +1338,7 @@ class FairShareDBSource:
             )
             .select_from(j)
             .where(
-                AgentRow.scaling_group == resource_group,
+                AgentRow.resource_group_id == resource_group_id,
                 AgentRow.status == AgentStatus.ALIVE,
                 AgentRow.schedulable.is_(True),
             )
@@ -1325,6 +1385,7 @@ class FairShareDBSource:
     def _create_default_domain_fair_share(
         self,
         resource_group: str,
+        resource_group_id: ResourceGroupID,
         domain_name: str,
         scaling_group_spec: FairShareScalingGroupSpec,
         available_slots: list[SlotQuantity],
@@ -1341,6 +1402,7 @@ class FairShareDBSource:
         """
         return DomainFairShareData(
             resource_group=resource_group,
+            resource_group_id=resource_group_id,
             domain_name=domain_name,
             data=self._create_default_fair_share_data(scaling_group_spec, available_slots, now),
         )
@@ -1348,6 +1410,7 @@ class FairShareDBSource:
     def _create_default_project_fair_share(
         self,
         resource_group: str,
+        resource_group_id: ResourceGroupID,
         project_id: uuid.UUID,
         domain_name: str,
         scaling_group_spec: FairShareScalingGroupSpec,
@@ -1366,6 +1429,7 @@ class FairShareDBSource:
         """
         return ProjectFairShareData(
             resource_group=resource_group,
+            resource_group_id=resource_group_id,
             project_id=project_id,
             domain_name=domain_name,
             data=self._create_default_fair_share_data(scaling_group_spec, available_slots, now),
@@ -1374,6 +1438,7 @@ class FairShareDBSource:
     def _create_default_user_fair_share(
         self,
         resource_group: str,
+        resource_group_id: ResourceGroupID,
         user_uuid: uuid.UUID,
         project_id: uuid.UUID,
         domain_name: str,
@@ -1394,6 +1459,7 @@ class FairShareDBSource:
         """
         return UserFairShareData(
             resource_group=resource_group,
+            resource_group_id=resource_group_id,
             user_uuid=user_uuid,
             project_id=project_id,
             domain_name=domain_name,
@@ -1404,45 +1470,45 @@ class FairShareDBSource:
     async def _fetch_fair_share_specs_batch(
         self,
         db_sess: SASession,
-        scaling_groups: Sequence[str],
-    ) -> dict[str, FairShareScalingGroupSpec]:
-        """Fetch fair share specs for multiple scaling groups.
+        resource_group_ids: Sequence[ResourceGroupID],
+    ) -> dict[ResourceGroupID, FairShareScalingGroupSpec]:
+        """Fetch fair share specs for multiple resource groups.
 
-        Returns a mapping from scaling group name to its fair share spec.
-        If a scaling group has no spec configured, returns default spec.
+        Returns a mapping from resource group ID to its fair share spec.
+        If a resource group has no spec configured, returns the default spec.
         """
-        if not scaling_groups:
+        if not resource_group_ids:
             return {}
 
         result = await db_sess.execute(
             sa.select(
-                ScalingGroupRow.name,
+                ScalingGroupRow.id,
                 ScalingGroupRow.fair_share_spec,
-            ).where(ScalingGroupRow.name.in_(scaling_groups))
+            ).where(ScalingGroupRow.id.in_(resource_group_ids))
         )
 
-        specs: dict[str, FairShareScalingGroupSpec] = {}
+        specs: dict[ResourceGroupID, FairShareScalingGroupSpec] = {}
         for row in result:
             if row.fair_share_spec is not None:
-                specs[row.name] = row.fair_share_spec
+                specs[row.id] = row.fair_share_spec
             else:
-                specs[row.name] = FairShareScalingGroupSpec()
+                specs[row.id] = FairShareScalingGroupSpec()
 
         return specs
 
     async def _fetch_cluster_capacity(
         self,
         db_sess: SASession,
-        scaling_group: str,
+        resource_group_id: ResourceGroupID,
     ) -> list[SlotQuantity]:
-        """Fetch total capacity from ALIVE schedulable agents in scaling group.
+        """Fetch total capacity from ALIVE schedulable agents in a resource group.
 
         Uses normalized agent_resources table to sum capacity per slot,
         ordered by resource_slot_types.rank.
 
         Args:
             db_sess: Database session
-            scaling_group: The scaling group name
+            resource_group_id: The resource group ID
 
         Returns:
             Sum of capacity from all ALIVE schedulable agents, rank-ordered
@@ -1458,7 +1524,7 @@ class FairShareDBSource:
             .select_from(j)
             .where(
                 sa.and_(
-                    AgentRow.scaling_group == scaling_group,
+                    AgentRow.resource_group_id == resource_group_id,
                     AgentRow.status == AgentStatus.ALIVE,
                     AgentRow.schedulable == sa.true(),
                 )
@@ -1472,21 +1538,21 @@ class FairShareDBSource:
     async def _fetch_cluster_capacities_batch(
         self,
         db_sess: SASession,
-        scaling_groups: Sequence[str],
-    ) -> dict[str, list[SlotQuantity]]:
-        """Fetch total capacity for multiple scaling groups.
+        resource_group_ids: Sequence[ResourceGroupID],
+    ) -> dict[ResourceGroupID, list[SlotQuantity]]:
+        """Fetch total capacity for multiple resource groups.
 
-        Uses normalized agent_resources table to sum capacity per slot per scaling group,
+        Uses normalized agent_resources table to sum capacity per slot per resource group,
         ordered by resource_slot_types.rank.
 
         Args:
             db_sess: Database session
-            scaling_groups: List of scaling group names
+            resource_group_ids: Resource group IDs
 
         Returns:
-            Mapping from scaling group name to its cluster capacity (sum of capacity)
+            Mapping from resource group ID to its cluster capacity
         """
-        if not scaling_groups:
+        if not resource_group_ids:
             return {}
 
         j = sa.join(AgentResourceRow, AgentRow, AgentResourceRow.agent_id == AgentRow.id).join(
@@ -1494,40 +1560,48 @@ class FairShareDBSource:
         )
         query = (
             sa.select(
-                AgentRow.scaling_group,
+                AgentRow.resource_group_id,
                 AgentResourceRow.slot_name,
                 sa.func.sum(AgentResourceRow.capacity).label("total_capacity"),
             )
             .select_from(j)
             .where(
                 sa.and_(
-                    AgentRow.scaling_group.in_(scaling_groups),
+                    AgentRow.resource_group_id.in_(resource_group_ids),
                     AgentRow.status == AgentStatus.ALIVE,
                     AgentRow.schedulable == sa.true(),
                 )
             )
-            .group_by(AgentRow.scaling_group, AgentResourceRow.slot_name, ResourceSlotTypeRow.rank)
-            .order_by(AgentRow.scaling_group, ResourceSlotTypeRow.rank)
+            .group_by(
+                AgentRow.resource_group_id,
+                AgentResourceRow.slot_name,
+                ResourceSlotTypeRow.rank,
+            )
+            .order_by(AgentRow.resource_group_id, ResourceSlotTypeRow.rank)
         )
         result = await db_sess.execute(query)
 
-        capacities: dict[str, list[SlotQuantity]] = {sg: [] for sg in scaling_groups}
+        capacities: dict[ResourceGroupID, list[SlotQuantity]] = {
+            resource_group_id: [] for resource_group_id in resource_group_ids
+        }
         for row in result:
-            capacities[row.scaling_group].append(SlotQuantity(row.slot_name, row.total_capacity))
+            capacities[row.resource_group_id].append(
+                SlotQuantity(row.slot_name, row.total_capacity)
+            )
 
         return capacities
 
     async def _fetch_fair_shares(
         self,
         db_sess: SASession,
-        scaling_group: str,
+        resource_group_id: ResourceGroupID,
         default_weight: Decimal,
         available_slots: list[SlotQuantity],
     ) -> FairSharesByLevel:
         """Fetch all fair share records for a resource group with merged resource weights."""
         # Get domain fair shares
         domain_query = sa.select(DomainFairShareRow).where(
-            DomainFairShareRow.resource_group == scaling_group
+            DomainFairShareRow.resource_group_id == resource_group_id
         )
         domain_result = await db_sess.execute(domain_query)
         domain_fair_shares = {
@@ -1537,7 +1611,7 @@ class FairShareDBSource:
 
         # Get project fair shares
         project_query = sa.select(ProjectFairShareRow).where(
-            ProjectFairShareRow.resource_group == scaling_group
+            ProjectFairShareRow.resource_group_id == resource_group_id
         )
         project_result = await db_sess.execute(project_query)
         project_fair_shares = {
@@ -1547,7 +1621,7 @@ class FairShareDBSource:
 
         # Get user fair shares
         user_query = sa.select(UserFairShareRow).where(
-            UserFairShareRow.resource_group == scaling_group
+            UserFairShareRow.resource_group_id == resource_group_id
         )
         user_result = await db_sess.execute(user_query)
         user_fair_shares = {
@@ -1566,7 +1640,7 @@ class FairShareDBSource:
     async def _fetch_raw_usage_buckets(
         self,
         db_sess: SASession,
-        scaling_group: str,
+        resource_group_id: ResourceGroupID,
         lookback_start: date,
         lookback_end: date,
     ) -> RawUsageBucketsByLevel:
@@ -1596,7 +1670,7 @@ class FairShareDBSource:
             )
             .where(
                 sa.and_(
-                    UserUsageBucketRow.resource_group == scaling_group,
+                    UserUsageBucketRow.resource_group_id == resource_group_id,
                     UserUsageBucketRow.period_start >= lookback_start,
                     UserUsageBucketRow.period_start <= lookback_end,
                     ube.c.bucket_type == "user",
@@ -1623,7 +1697,7 @@ class FairShareDBSource:
             )
             .where(
                 sa.and_(
-                    ProjectUsageBucketRow.resource_group == scaling_group,
+                    ProjectUsageBucketRow.resource_group_id == resource_group_id,
                     ProjectUsageBucketRow.period_start >= lookback_start,
                     ProjectUsageBucketRow.period_start <= lookback_end,
                     ube.c.bucket_type == "project",
@@ -1650,7 +1724,7 @@ class FairShareDBSource:
             )
             .where(
                 sa.and_(
-                    DomainUsageBucketRow.resource_group == scaling_group,
+                    DomainUsageBucketRow.resource_group_id == resource_group_id,
                     DomainUsageBucketRow.period_start >= lookback_start,
                     DomainUsageBucketRow.period_start <= lookback_end,
                     ube.c.bucket_type == "domain",

--- a/src/ai/backend/manager/repositories/fair_share/repository.py
+++ b/src/ai/backend/manager/repositories/fair_share/repository.py
@@ -105,17 +105,17 @@ class FairShareRepository:
     @fair_share_repository_resilience.apply()
     async def get_domain_fair_share(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         domain_name: str,
     ) -> DomainFairShareData:
-        """Get a domain fair share record by scaling group and domain name.
+        """Get a domain fair share record by scaling group id and domain name.
 
         Returns default values if the domain exists but has no fair share record.
 
         Raises:
             DomainNotFound: If the domain does not exist.
         """
-        return await self._db_source.get_domain_fair_share(resource_group, domain_name)
+        return await self._db_source.get_domain_fair_share(resource_group_id, domain_name)
 
     @fair_share_repository_resilience.apply()
     async def search_domain_fair_shares(
@@ -165,17 +165,17 @@ class FairShareRepository:
     @fair_share_repository_resilience.apply()
     async def get_project_fair_share(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         project_id: uuid.UUID,
     ) -> ProjectFairShareData:
-        """Get a project fair share record by scaling group and project ID.
+        """Get a project fair share record by scaling group id and project ID.
 
         Returns default values if the project exists but has no fair share record.
 
         Raises:
             ProjectNotFound: If the project does not exist.
         """
-        return await self._db_source.get_project_fair_share(resource_group, project_id)
+        return await self._db_source.get_project_fair_share(resource_group_id, project_id)
 
     @fair_share_repository_resilience.apply()
     async def search_project_fair_shares(
@@ -251,18 +251,18 @@ class FairShareRepository:
     @fair_share_repository_resilience.apply()
     async def get_user_fair_share(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         project_id: uuid.UUID,
         user_uuid: uuid.UUID,
     ) -> UserFairShareData:
-        """Get a user fair share record by scaling group, project ID, and user UUID.
+        """Get a user fair share record by scaling group id, project ID, and user UUID.
 
         Returns default values if the user exists in the project but has no fair share record.
 
         Raises:
             UserNotFound: If the user does not exist in the project.
         """
-        return await self._db_source.get_user_fair_share(resource_group, project_id, user_uuid)
+        return await self._db_source.get_user_fair_share(resource_group_id, project_id, user_uuid)
 
     @fair_share_repository_resilience.apply()
     async def search_user_fair_shares(
@@ -334,9 +334,9 @@ class FairShareRepository:
     @fair_share_repository_resilience.apply()
     async def get_scaling_group_fair_share_spec(
         self,
-        scaling_group: str,
+        resource_group_id: ResourceGroupID,
     ) -> FairShareScalingGroupSpec:
-        """Get fair share spec for scaling group.
+        """Get fair share spec for a resource group.
 
         Returns:
             FairShareScalingGroupSpec with defaults if not configured.
@@ -344,18 +344,18 @@ class FairShareRepository:
         Raises:
             ScalingGroupNotFound: If scaling group doesn't exist.
         """
-        return await self._db_source.get_scaling_group_fair_share_spec(scaling_group)
+        return await self._db_source.get_scaling_group_fair_share_spec(resource_group_id)
 
     @fair_share_repository_resilience.apply()
     async def get_user_scheduling_ranks_batch(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         project_user_ids: Sequence[ProjectUserIds],
     ) -> dict[uuid.UUID, int]:
         """Get scheduling ranks for multiple users across projects.
 
         Args:
-            resource_group: The resource group (scaling group) name.
+            resource_group_id: The resource group (scaling group) id.
             project_user_ids: Sequence of ProjectUserIds containing project and user IDs.
 
         Returns:
@@ -363,7 +363,7 @@ class FairShareRepository:
             Users not found in the database or with NULL rank are omitted.
         """
         return await self._db_source.get_user_scheduling_ranks_batch(
-            resource_group, project_user_ids
+            resource_group_id, project_user_ids
         )
 
     # ==================== Bulk Factor Updates ====================
@@ -383,7 +383,7 @@ class FairShareRepository:
         factors in a single transaction.
 
         Args:
-            resource_group: The resource group being updated
+            resource_group_id: The resource group ID
             calculation_result: Calculated factors from FairShareFactorCalculator
             lookback_start: Start of lookback period used in calculation
             lookback_end: End of lookback period used in calculation
@@ -401,7 +401,7 @@ class FairShareRepository:
     @fair_share_repository_resilience.apply()
     async def get_user_fair_share_factors_batch(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         project_user_ids: Sequence[ProjectUserIds],
     ) -> dict[uuid.UUID, UserFairShareFactors]:
         """Get combined fair share factors for multiple users with 3-way JOIN.
@@ -411,7 +411,7 @@ class FairShareRepository:
         sequencing in FairShareSequencer.
 
         Args:
-            resource_group: The resource group (scaling group) name.
+            resource_group_id: The resource group ID.
             project_user_ids: Sequence of ProjectUserIds containing project and user IDs.
 
         Returns:
@@ -419,13 +419,13 @@ class FairShareRepository:
             Users not found in any of the fair share tables are omitted.
         """
         return await self._db_source.get_user_fair_share_factors_batch(
-            resource_group, project_user_ids
+            resource_group_id, project_user_ids
         )
 
     @fair_share_repository_resilience.apply()
     async def get_fair_share_calculation_context(
         self,
-        scaling_group: str,
+        resource_group_id: ResourceGroupID,
         today: date,
     ) -> FairShareCalculationContext:
         """Get all data needed for fair share factor calculation.
@@ -434,7 +434,7 @@ class FairShareRepository:
         in one database session for consistency and efficiency.
 
         Args:
-            scaling_group: The scaling group name
+            resource_group_id: The resource group ID
             today: Current date for decay calculation
 
         Returns:
@@ -443,4 +443,4 @@ class FairShareRepository:
         Raises:
             ScalingGroupNotFound: If the scaling group doesn't exist
         """
-        return await self._db_source.get_fair_share_calculation_context(scaling_group, today)
+        return await self._db_source.get_fair_share_calculation_context(resource_group_id, today)

--- a/src/ai/backend/manager/repositories/fair_share/types.py
+++ b/src/ai/backend/manager/repositories/fair_share/types.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import override
+from typing import Any, override
 
 import sqlalchemy as sa
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.manager.data.fair_share import (
     DomainFairShareData,
     ProjectFairShareData,
@@ -47,11 +48,12 @@ __all__ = (
 class DomainFairShareSearchScope(SearchScope):
     """Required scope for domain fair share entity search.
 
-    Used for Field-level queries where resource_group is determined by parent context.
+    Used for field-level queries where the resource group is determined by
+    parent context.
     """
 
-    resource_group: str
-    """Required. The scaling group to search within."""
+    resource_group_id: ResourceGroupID
+    """Required. The scaling group id to search within."""
 
     @override
     def to_condition(self) -> QueryCondition:
@@ -68,13 +70,13 @@ class DomainFairShareSearchScope(SearchScope):
 
     @property
     @override
-    def existence_checks(self) -> Sequence[ExistenceCheck[str]]:
+    def existence_checks(self) -> Sequence[ExistenceCheck[ResourceGroupID]]:
         """Return existence checks for scope validation."""
         return [
             ExistenceCheck(
-                column=ScalingGroupRow.name,
-                value=self.resource_group,
-                error=ScalingGroupNotFound(self.resource_group),
+                column=ScalingGroupRow.id,
+                value=self.resource_group_id,
+                error=ScalingGroupNotFound(str(self.resource_group_id)),
             ),
         ]
 
@@ -83,14 +85,15 @@ class DomainFairShareSearchScope(SearchScope):
 class ProjectFairShareSearchScope(SearchScope):
     """Required scope for project fair share entity search.
 
-    Used for Field-level queries where resource_group and domain are determined by parent context.
+    Used for field-level queries where the resource group and domain are
+    determined by parent context.
     """
-
-    resource_group: str
-    """Required. The scaling group to search within."""
 
     domain_name: str
     """Required. The domain to search within."""
+
+    resource_group_id: ResourceGroupID
+    """Required. The scaling group id to search within."""
 
     @override
     def to_condition(self) -> QueryCondition:
@@ -108,13 +111,13 @@ class ProjectFairShareSearchScope(SearchScope):
 
     @property
     @override
-    def existence_checks(self) -> Sequence[ExistenceCheck[str]]:
+    def existence_checks(self) -> Sequence[ExistenceCheck[Any]]:
         """Return existence checks for scope validation."""
         return [
             ExistenceCheck(
-                column=ScalingGroupRow.name,
-                value=self.resource_group,
-                error=ScalingGroupNotFound(self.resource_group),
+                column=ScalingGroupRow.id,
+                value=self.resource_group_id,
+                error=ScalingGroupNotFound(str(self.resource_group_id)),
             ),
             ExistenceCheck(
                 column=DomainRow.name,
@@ -128,17 +131,18 @@ class ProjectFairShareSearchScope(SearchScope):
 class UserFairShareSearchScope(SearchScope):
     """Required scope for user fair share entity search.
 
-    Used for Field-level queries where resource_group, domain, and project are determined by parent context.
+    Used for field-level queries where the resource group, domain, and project
+    are determined by parent context.
     """
-
-    resource_group: str
-    """Required. The scaling group to search within."""
 
     domain_name: str
     """Required. The domain to search within."""
 
     project_id: uuid.UUID
     """Required. The project to search within."""
+
+    resource_group_id: ResourceGroupID
+    """Required. The scaling group id to search within."""
 
     @override
     def to_condition(self) -> QueryCondition:
@@ -162,13 +166,15 @@ class UserFairShareSearchScope(SearchScope):
     @override
     def existence_checks(
         self,
-    ) -> Sequence[ExistenceCheck[str] | ExistenceCheck[uuid.UUID]]:
+    ) -> Sequence[
+        ExistenceCheck[str] | ExistenceCheck[uuid.UUID] | ExistenceCheck[ResourceGroupID]
+    ]:
         """Return existence checks for scope validation."""
         return [
             ExistenceCheck(
-                column=ScalingGroupRow.name,
-                value=self.resource_group,
-                error=ScalingGroupNotFound(self.resource_group),
+                column=ScalingGroupRow.id,
+                value=self.resource_group_id,
+                error=ScalingGroupNotFound(str(self.resource_group_id)),
             ),
             ExistenceCheck(
                 column=DomainRow.name,

--- a/src/ai/backend/manager/repositories/fair_share/upserters.py
+++ b/src/ai/backend/manager/repositories/fair_share/upserters.py
@@ -23,7 +23,7 @@ from ai.backend.manager.types import OptionalState, TriState
 class DomainFairShareUpserterSpec(UpserterSpec[DomainFairShareRow]):
     """Upserter spec for DomainFairShareRow.
 
-    Unique constraint: (resource_group, domain_name)
+    Unique constraint: (resource_group_id, domain_name)
 
     - Identity fields are required (for unique constraint)
     - Spec fields use Row defaults on INSERT if NOP
@@ -127,7 +127,7 @@ class DomainFairShareBulkWeightUpserterSpec(UpserterSpec[DomainFairShareRow]):
 class ProjectFairShareUpserterSpec(UpserterSpec[ProjectFairShareRow]):
     """Upserter spec for ProjectFairShareRow.
 
-    Unique constraint: (resource_group, project_id)
+    Unique constraint: (resource_group_id, project_id)
 
     - Identity fields are required (for unique constraint)
     - Spec fields use Row defaults on INSERT if NOP
@@ -235,7 +235,7 @@ class ProjectFairShareBulkWeightUpserterSpec(UpserterSpec[ProjectFairShareRow]):
 class UserFairShareUpserterSpec(UpserterSpec[UserFairShareRow]):
     """Upserter spec for UserFairShareRow.
 
-    Unique constraint: (resource_group, user_uuid, project_id)
+    Unique constraint: (resource_group_id, user_uuid, project_id)
 
     - Identity fields are required (for unique constraint)
     - Spec fields use Row defaults on INSERT if NOP

--- a/src/ai/backend/manager/repositories/resource_usage_history/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/resource_usage_history/db_source/db_source.py
@@ -13,6 +13,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.engine import CursorResult
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import ResourceSlot
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.models.kernel import KernelRow
@@ -253,7 +254,7 @@ class ResourceUsageHistoryDBSource:
             result = await execute_upserter(
                 db_sess,
                 upserter,
-                index_elements=["domain_name", "resource_group", "period_start"],
+                index_elements=["domain_name", "resource_group_id", "period_start"],
             )
             return DomainUsageBucketData.from_row(result.row)
 
@@ -298,7 +299,7 @@ class ResourceUsageHistoryDBSource:
             result = await execute_upserter(
                 db_sess,
                 upserter,
-                index_elements=["project_id", "resource_group", "period_start"],
+                index_elements=["project_id", "resource_group_id", "period_start"],
             )
             return ProjectUsageBucketData.from_row(result.row)
 
@@ -343,7 +344,7 @@ class ResourceUsageHistoryDBSource:
             result = await execute_upserter(
                 db_sess,
                 upserter,
-                index_elements=["user_uuid", "project_id", "resource_group", "period_start"],
+                index_elements=["user_uuid", "project_id", "resource_group_id", "period_start"],
             )
             return UserUsageBucketData.from_row(result.row)
 
@@ -370,7 +371,7 @@ class ResourceUsageHistoryDBSource:
 
     async def get_aggregated_usage_by_user(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         lookback_start: date,
         lookback_end: date,
     ) -> Mapping[tuple[uuid.UUID, uuid.UUID], ResourceSlot]:
@@ -381,13 +382,13 @@ class ResourceUsageHistoryDBSource:
         """
         async with self._db.begin_readonly_session_read_committed() as db_sess:
             return await self._fetch_aggregated_usage_by_user(
-                db_sess, resource_group, lookback_start, lookback_end
+                db_sess, resource_group_id, lookback_start, lookback_end
             )
 
     async def _fetch_aggregated_usage_by_user(
         self,
         db_sess: SASession,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         lookback_start: date,
         lookback_end: date,
     ) -> Mapping[tuple[uuid.UUID, uuid.UUID], ResourceSlot]:
@@ -409,7 +410,7 @@ class ResourceUsageHistoryDBSource:
             )
             .where(
                 sa.and_(
-                    UserUsageBucketRow.resource_group == resource_group,
+                    UserUsageBucketRow.resource_group_id == resource_group_id,
                     UserUsageBucketRow.period_start >= lookback_start,
                     UserUsageBucketRow.period_start <= lookback_end,
                     ube.c.bucket_type == "user",
@@ -434,7 +435,7 @@ class ResourceUsageHistoryDBSource:
 
     async def get_aggregated_usage_by_project(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         lookback_start: date,
         lookback_end: date,
     ) -> Mapping[uuid.UUID, ResourceSlot]:
@@ -459,7 +460,7 @@ class ResourceUsageHistoryDBSource:
                 )
                 .where(
                     sa.and_(
-                        ProjectUsageBucketRow.resource_group == resource_group,
+                        ProjectUsageBucketRow.resource_group_id == resource_group_id,
                         ProjectUsageBucketRow.period_start >= lookback_start,
                         ProjectUsageBucketRow.period_start <= lookback_end,
                         ube.c.bucket_type == "project",
@@ -482,7 +483,7 @@ class ResourceUsageHistoryDBSource:
 
     async def get_aggregated_usage_by_domain(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         lookback_start: date,
         lookback_end: date,
     ) -> Mapping[str, ResourceSlot]:
@@ -507,7 +508,7 @@ class ResourceUsageHistoryDBSource:
                 )
                 .where(
                     sa.and_(
-                        DomainUsageBucketRow.resource_group == resource_group,
+                        DomainUsageBucketRow.resource_group_id == resource_group_id,
                         DomainUsageBucketRow.period_start >= lookback_start,
                         DomainUsageBucketRow.period_start <= lookback_end,
                         ube.c.bucket_type == "domain",
@@ -585,7 +586,7 @@ class ResourceUsageHistoryDBSource:
         existing = await self._fetch_existing_user_buckets(db_sess, keys_list)
 
         for key, bucket_delta in deltas.items():
-            lookup_key = (key.user_uuid, key.project_id, key.resource_group, key.period_date)
+            lookup_key = (key.user_uuid, key.project_id, key.resource_group_id, key.period_date)
             existing_usage = existing.get(lookup_key, ResourceSlot())
             # JSONB stores resource-seconds (amount * seconds) for legacy compatibility
             resource_seconds = self._calculate_resource_seconds(
@@ -608,12 +609,13 @@ class ResourceUsageHistoryDBSource:
                     resource_usage=new_usage,
                 )
                 .on_conflict_do_update(
-                    index_elements=["user_uuid", "project_id", "resource_group", "period_start"],
-                    set_={
-                        "resource_group_id": key.resource_group_id,
-                        "resource_usage": new_usage,
-                        "updated_at": sa.func.now(),
-                    },
+                    index_elements=[
+                        "user_uuid",
+                        "project_id",
+                        "resource_group_id",
+                        "period_start",
+                    ],
+                    set_={"resource_usage": new_usage, "updated_at": sa.func.now()},
                 )
                 .returning(UserUsageBucketRow.__table__.c.id)
             )
@@ -632,7 +634,7 @@ class ResourceUsageHistoryDBSource:
         self,
         db_sess: SASession,
         keys: list[UserUsageBucketKey],
-    ) -> dict[tuple[uuid.UUID, uuid.UUID, str, date], ResourceSlot]:
+    ) -> dict[tuple[uuid.UUID, uuid.UUID, ResourceGroupID, date], ResourceSlot]:
         """Fetch existing user buckets for the given keys."""
         if not keys:
             return {}
@@ -642,7 +644,7 @@ class ResourceUsageHistoryDBSource:
             sa.and_(
                 UserUsageBucketRow.user_uuid == key.user_uuid,
                 UserUsageBucketRow.project_id == key.project_id,
-                UserUsageBucketRow.resource_group == key.resource_group,
+                UserUsageBucketRow.resource_group_id == key.resource_group_id,
                 UserUsageBucketRow.period_start == key.period_date,
             )
             for key in keys
@@ -651,7 +653,7 @@ class ResourceUsageHistoryDBSource:
         query = sa.select(
             UserUsageBucketRow.user_uuid,
             UserUsageBucketRow.project_id,
-            UserUsageBucketRow.resource_group,
+            UserUsageBucketRow.resource_group_id,
             UserUsageBucketRow.period_start,
             UserUsageBucketRow.resource_usage,
         ).where(sa.or_(*conditions))
@@ -661,7 +663,7 @@ class ResourceUsageHistoryDBSource:
             (
                 row.user_uuid,
                 row.project_id,
-                row.resource_group,
+                row.resource_group_id,
                 row.period_start,
             ): row.resource_usage
             for row in result.all()
@@ -682,7 +684,7 @@ class ResourceUsageHistoryDBSource:
         existing = await self._fetch_existing_project_buckets(db_sess, keys_list)
 
         for key, bucket_delta in deltas.items():
-            lookup_key = (key.project_id, key.resource_group, key.period_date)
+            lookup_key = (key.project_id, key.resource_group_id, key.period_date)
             existing_usage = existing.get(lookup_key, ResourceSlot())
             resource_seconds = self._calculate_resource_seconds(
                 bucket_delta.slots, bucket_delta.duration_seconds
@@ -703,12 +705,8 @@ class ResourceUsageHistoryDBSource:
                     resource_usage=new_usage,
                 )
                 .on_conflict_do_update(
-                    index_elements=["project_id", "resource_group", "period_start"],
-                    set_={
-                        "resource_group_id": key.resource_group_id,
-                        "resource_usage": new_usage,
-                        "updated_at": sa.func.now(),
-                    },
+                    index_elements=["project_id", "resource_group_id", "period_start"],
+                    set_={"resource_usage": new_usage, "updated_at": sa.func.now()},
                 )
                 .returning(ProjectUsageBucketRow.__table__.c.id)
             )
@@ -727,7 +725,7 @@ class ResourceUsageHistoryDBSource:
         self,
         db_sess: SASession,
         keys: list[ProjectUsageBucketKey],
-    ) -> dict[tuple[uuid.UUID, str, date], ResourceSlot]:
+    ) -> dict[tuple[uuid.UUID, ResourceGroupID, date], ResourceSlot]:
         """Fetch existing project buckets for the given keys."""
         if not keys:
             return {}
@@ -735,7 +733,7 @@ class ResourceUsageHistoryDBSource:
         conditions = [
             sa.and_(
                 ProjectUsageBucketRow.project_id == key.project_id,
-                ProjectUsageBucketRow.resource_group == key.resource_group,
+                ProjectUsageBucketRow.resource_group_id == key.resource_group_id,
                 ProjectUsageBucketRow.period_start == key.period_date,
             )
             for key in keys
@@ -743,14 +741,14 @@ class ResourceUsageHistoryDBSource:
 
         query = sa.select(
             ProjectUsageBucketRow.project_id,
-            ProjectUsageBucketRow.resource_group,
+            ProjectUsageBucketRow.resource_group_id,
             ProjectUsageBucketRow.period_start,
             ProjectUsageBucketRow.resource_usage,
         ).where(sa.or_(*conditions))
 
         result = await db_sess.execute(query)
         return {
-            (row.project_id, row.resource_group, row.period_start): row.resource_usage
+            (row.project_id, row.resource_group_id, row.period_start): row.resource_usage
             for row in result.all()
         }
 
@@ -769,7 +767,7 @@ class ResourceUsageHistoryDBSource:
         existing = await self._fetch_existing_domain_buckets(db_sess, keys_list)
 
         for key, bucket_delta in deltas.items():
-            lookup_key = (key.domain_name, key.resource_group, key.period_date)
+            lookup_key = (key.domain_name, key.resource_group_id, key.period_date)
             existing_usage = existing.get(lookup_key, ResourceSlot())
             resource_seconds = self._calculate_resource_seconds(
                 bucket_delta.slots, bucket_delta.duration_seconds
@@ -789,12 +787,8 @@ class ResourceUsageHistoryDBSource:
                     resource_usage=new_usage,
                 )
                 .on_conflict_do_update(
-                    index_elements=["domain_name", "resource_group", "period_start"],
-                    set_={
-                        "resource_group_id": key.resource_group_id,
-                        "resource_usage": new_usage,
-                        "updated_at": sa.func.now(),
-                    },
+                    index_elements=["domain_name", "resource_group_id", "period_start"],
+                    set_={"resource_usage": new_usage, "updated_at": sa.func.now()},
                 )
                 .returning(DomainUsageBucketRow.__table__.c.id)
             )
@@ -813,7 +807,7 @@ class ResourceUsageHistoryDBSource:
         self,
         db_sess: SASession,
         keys: list[DomainUsageBucketKey],
-    ) -> dict[tuple[str, str, date], ResourceSlot]:
+    ) -> dict[tuple[str, ResourceGroupID, date], ResourceSlot]:
         """Fetch existing domain buckets for the given keys."""
         if not keys:
             return {}
@@ -821,7 +815,7 @@ class ResourceUsageHistoryDBSource:
         conditions = [
             sa.and_(
                 DomainUsageBucketRow.domain_name == key.domain_name,
-                DomainUsageBucketRow.resource_group == key.resource_group,
+                DomainUsageBucketRow.resource_group_id == key.resource_group_id,
                 DomainUsageBucketRow.period_start == key.period_date,
             )
             for key in keys
@@ -829,14 +823,14 @@ class ResourceUsageHistoryDBSource:
 
         query = sa.select(
             DomainUsageBucketRow.domain_name,
-            DomainUsageBucketRow.resource_group,
+            DomainUsageBucketRow.resource_group_id,
             DomainUsageBucketRow.period_start,
             DomainUsageBucketRow.resource_usage,
         ).where(sa.or_(*conditions))
 
         result = await db_sess.execute(query)
         return {
-            (row.domain_name, row.resource_group, row.period_start): row.resource_usage
+            (row.domain_name, row.resource_group_id, row.period_start): row.resource_usage
             for row in result.all()
         }
 
@@ -887,7 +881,7 @@ class ResourceUsageHistoryDBSource:
 
     async def update_bucket_entry_capacities(
         self,
-        scaling_group: str,
+        resource_group_id: ResourceGroupID,
         capacity_by_slot: Mapping[str, Decimal],
     ) -> None:
         """Update capacity column on usage_bucket_entries for a scaling group.
@@ -896,7 +890,7 @@ class ResourceUsageHistoryDBSource:
         Updates all entries whose parent bucket belongs to the given scaling group.
 
         Args:
-            scaling_group: Scaling group name to filter buckets
+            resource_group_id: Resource group ID used to filter buckets
             capacity_by_slot: Mapping of slot_name to capacity value
         """
         if not capacity_by_slot:
@@ -916,7 +910,7 @@ class ResourceUsageHistoryDBSource:
                     # Subquery: bucket_ids in this scaling group
                     bucket_ids_subq = (
                         sa.select(parent_table.c.id)
-                        .where(parent_table.c.resource_group == scaling_group)
+                        .where(parent_table.c.resource_group_id == resource_group_id)
                         .scalar_subquery()
                     )
                     stmt = (

--- a/src/ai/backend/manager/repositories/resource_usage_history/repository.py
+++ b/src/ai/backend/manager/repositories/resource_usage_history/repository.py
@@ -8,6 +8,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience import (
     MetricArgs,
@@ -249,7 +250,7 @@ class ResourceUsageHistoryRepository:
     @resource_usage_history_repository_resilience.apply()
     async def get_aggregated_usage_by_user(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         lookback_start: date,
         lookback_end: date,
     ) -> Mapping[tuple[uuid.UUID, uuid.UUID], ResourceSlot]:
@@ -260,13 +261,13 @@ class ResourceUsageHistoryRepository:
         calculation service.
         """
         return await self._db_source.get_aggregated_usage_by_user(
-            resource_group, lookback_start, lookback_end
+            resource_group_id, lookback_start, lookback_end
         )
 
     @resource_usage_history_repository_resilience.apply()
     async def get_aggregated_usage_by_project(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         lookback_start: date,
         lookback_end: date,
     ) -> Mapping[uuid.UUID, ResourceSlot]:
@@ -276,13 +277,13 @@ class ResourceUsageHistoryRepository:
         lookback period for each project.
         """
         return await self._db_source.get_aggregated_usage_by_project(
-            resource_group, lookback_start, lookback_end
+            resource_group_id, lookback_start, lookback_end
         )
 
     @resource_usage_history_repository_resilience.apply()
     async def get_aggregated_usage_by_domain(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         lookback_start: date,
         lookback_end: date,
     ) -> Mapping[str, ResourceSlot]:
@@ -292,7 +293,7 @@ class ResourceUsageHistoryRepository:
         lookback period for each domain.
         """
         return await self._db_source.get_aggregated_usage_by_domain(
-            resource_group, lookback_start, lookback_end
+            resource_group_id, lookback_start, lookback_end
         )
 
     # ==================== Bucket Delta Updates ====================
@@ -320,11 +321,11 @@ class ResourceUsageHistoryRepository:
     @resource_usage_history_repository_resilience.apply()
     async def update_bucket_entry_capacities(
         self,
-        scaling_group: str,
+        resource_group_id: ResourceGroupID,
         capacity_by_slot: Mapping[str, Decimal],
     ) -> None:
         """Update capacity on usage_bucket_entries for a scaling group.
 
         Called after cluster capacity is fetched during fair share calculation.
         """
-        await self._db_source.update_bucket_entry_capacities(scaling_group, capacity_by_slot)
+        await self._db_source.update_bucket_entry_capacities(resource_group_id, capacity_by_slot)

--- a/src/ai/backend/manager/repositories/resource_usage_history/types.py
+++ b/src/ai/backend/manager/repositories/resource_usage_history/types.py
@@ -10,6 +10,7 @@ from typing import Any, override
 
 import sqlalchemy as sa
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.errors.resource import DomainNotFound, ProjectNotFound, ScalingGroupNotFound
 from ai.backend.manager.errors.user import UserNotFound
@@ -38,6 +39,7 @@ class KernelUsageRecordData:
     project_id: uuid.UUID
     domain_name: str
     resource_group: str
+    resource_group_id: ResourceGroupID
     period_start: datetime
     period_end: datetime
     resource_usage: ResourceSlot
@@ -53,6 +55,7 @@ class KernelUsageRecordData:
             project_id=row.project_id,
             domain_name=row.domain_name,
             resource_group=row.resource_group,
+            resource_group_id=row.resource_group_id,
             period_start=row.period_start,
             period_end=row.period_end,
             resource_usage=row.resource_usage,
@@ -66,6 +69,7 @@ class DomainUsageBucketData:
     id: uuid.UUID
     domain_name: str
     resource_group: str
+    resource_group_id: ResourceGroupID
     period_start: date
     period_end: date
     decay_unit_days: int
@@ -81,6 +85,7 @@ class DomainUsageBucketData:
             id=row.id,
             domain_name=row.domain_name,
             resource_group=row.resource_group,
+            resource_group_id=row.resource_group_id,
             period_start=row.period_start,
             period_end=row.period_end,
             decay_unit_days=row.decay_unit_days,
@@ -99,6 +104,7 @@ class ProjectUsageBucketData:
     project_id: uuid.UUID
     domain_name: str
     resource_group: str
+    resource_group_id: ResourceGroupID
     period_start: date
     period_end: date
     decay_unit_days: int
@@ -115,6 +121,7 @@ class ProjectUsageBucketData:
             project_id=row.project_id,
             domain_name=row.domain_name,
             resource_group=row.resource_group,
+            resource_group_id=row.resource_group_id,
             period_start=row.period_start,
             period_end=row.period_end,
             decay_unit_days=row.decay_unit_days,
@@ -134,6 +141,7 @@ class UserUsageBucketData:
     project_id: uuid.UUID
     domain_name: str
     resource_group: str
+    resource_group_id: ResourceGroupID
     period_start: date
     period_end: date
     decay_unit_days: int
@@ -151,6 +159,7 @@ class UserUsageBucketData:
             project_id=row.project_id,
             domain_name=row.domain_name,
             resource_group=row.resource_group,
+            resource_group_id=row.resource_group_id,
             period_start=row.period_start,
             period_end=row.period_end,
             decay_unit_days=row.decay_unit_days,

--- a/src/ai/backend/manager/repositories/resource_usage_history/upserters.py
+++ b/src/ai/backend/manager/repositories/resource_usage_history/upserters.py
@@ -21,7 +21,7 @@ from ai.backend.manager.repositories.base import UpserterSpec
 class DomainUsageBucketUpserterSpec(UpserterSpec[DomainUsageBucketRow]):
     """Upserter spec for DomainUsageBucketRow.
 
-    Unique constraint: (domain_name, resource_group, period_start)
+    Unique constraint: (domain_name, resource_group_id, period_start)
     """
 
     domain_name: str
@@ -68,7 +68,7 @@ class DomainUsageBucketUpserterSpec(UpserterSpec[DomainUsageBucketRow]):
 class ProjectUsageBucketUpserterSpec(UpserterSpec[ProjectUsageBucketRow]):
     """Upserter spec for ProjectUsageBucketRow.
 
-    Unique constraint: (project_id, resource_group, period_start)
+    Unique constraint: (project_id, resource_group_id, period_start)
     """
 
     project_id: uuid.UUID
@@ -117,7 +117,7 @@ class ProjectUsageBucketUpserterSpec(UpserterSpec[ProjectUsageBucketRow]):
 class UserUsageBucketUpserterSpec(UpserterSpec[UserUsageBucketRow]):
     """Upserter spec for UserUsageBucketRow.
 
-    Unique constraint: (user_uuid, project_id, resource_group, period_start)
+    Unique constraint: (user_uuid, project_id, resource_group_id, period_start)
     """
 
     user_uuid: uuid.UUID

--- a/src/ai/backend/manager/services/fair_share/actions.py
+++ b/src/ai/backend/manager/services/fair_share/actions.py
@@ -41,7 +41,7 @@ class DomainFairShareAction(BaseAction):
 class GetDomainFairShareAction(DomainFairShareAction):
     """Action to get a domain fair share record."""
 
-    resource_group: str
+    resource_group_id: ResourceGroupID
     domain_name: str
 
     @override
@@ -51,7 +51,7 @@ class GetDomainFairShareAction(DomainFairShareAction):
 
     @override
     def entity_id(self) -> str | None:
-        return f"{self.resource_group}:{self.domain_name}"
+        return f"{self.resource_group_id}:{self.domain_name}"
 
 
 @dataclass
@@ -113,7 +113,7 @@ class SearchRGDomainFairSharesAction(DomainFairShareAction):
 
     @override
     def entity_id(self) -> str | None:
-        return self.scope.resource_group
+        return str(self.scope.resource_group_id)
 
 
 @dataclass
@@ -145,7 +145,7 @@ class ProjectFairShareAction(BaseAction):
 class GetProjectFairShareAction(ProjectFairShareAction):
     """Action to get a project fair share record."""
 
-    resource_group: str
+    resource_group_id: ResourceGroupID
     project_id: uuid.UUID
 
     @override
@@ -155,7 +155,7 @@ class GetProjectFairShareAction(ProjectFairShareAction):
 
     @override
     def entity_id(self) -> str | None:
-        return f"{self.resource_group}:{self.project_id}"
+        return f"{self.resource_group_id}:{self.project_id}"
 
 
 @dataclass
@@ -217,7 +217,7 @@ class SearchRGProjectFairSharesAction(ProjectFairShareAction):
 
     @override
     def entity_id(self) -> str | None:
-        return self.scope.resource_group
+        return str(self.scope.resource_group_id)
 
 
 @dataclass
@@ -249,7 +249,7 @@ class UserFairShareAction(BaseAction):
 class GetUserFairShareAction(UserFairShareAction):
     """Action to get a user fair share record."""
 
-    resource_group: str
+    resource_group_id: ResourceGroupID
     project_id: uuid.UUID
     user_uuid: uuid.UUID
 
@@ -260,7 +260,7 @@ class GetUserFairShareAction(UserFairShareAction):
 
     @override
     def entity_id(self) -> str | None:
-        return f"{self.resource_group}:{self.project_id}:{self.user_uuid}"
+        return f"{self.resource_group_id}:{self.project_id}:{self.user_uuid}"
 
 
 @dataclass
@@ -322,7 +322,7 @@ class SearchRGUserFairSharesAction(UserFairShareAction):
 
     @override
     def entity_id(self) -> str | None:
-        return self.scope.resource_group
+        return str(self.scope.resource_group_id)
 
 
 @dataclass
@@ -356,7 +356,7 @@ class UpsertDomainFairShareWeightAction(DomainFairShareAction):
 
     @override
     def entity_id(self) -> str | None:
-        return f"{self.resource_group}:{self.domain_name}"
+        return f"{self.resource_group_id}:{self.domain_name}"
 
 
 @dataclass
@@ -387,7 +387,7 @@ class UpsertProjectFairShareWeightAction(ProjectFairShareAction):
 
     @override
     def entity_id(self) -> str | None:
-        return f"{self.resource_group}:{self.project_id}"
+        return f"{self.resource_group_id}:{self.project_id}"
 
 
 @dataclass
@@ -419,7 +419,7 @@ class UpsertUserFairShareWeightAction(UserFairShareAction):
 
     @override
     def entity_id(self) -> str | None:
-        return f"{self.resource_group}:{self.project_id}:{self.user_uuid}"
+        return f"{self.resource_group_id}:{self.project_id}:{self.user_uuid}"
 
 
 @dataclass
@@ -459,7 +459,7 @@ class BulkUpsertDomainFairShareWeightAction(DomainFairShareAction):
 
     @override
     def entity_id(self) -> str | None:
-        return f"{self.resource_group}:[{len(self.inputs)} domains]"
+        return f"{self.resource_group_id}:[{len(self.inputs)} domains]"
 
 
 @dataclass
@@ -497,7 +497,7 @@ class BulkUpsertProjectFairShareWeightAction(ProjectFairShareAction):
 
     @override
     def entity_id(self) -> str | None:
-        return f"{self.resource_group}:[{len(self.inputs)} projects]"
+        return f"{self.resource_group_id}:[{len(self.inputs)} projects]"
 
 
 @dataclass
@@ -536,7 +536,7 @@ class BulkUpsertUserFairShareWeightAction(UserFairShareAction):
 
     @override
     def entity_id(self) -> str | None:
-        return f"{self.resource_group}:[{len(self.inputs)} users]"
+        return f"{self.resource_group_id}:[{len(self.inputs)} users]"
 
 
 @dataclass

--- a/src/ai/backend/manager/services/fair_share/service.py
+++ b/src/ai/backend/manager/services/fair_share/service.py
@@ -93,7 +93,7 @@ class FairShareService:
         Repository handles default value creation internally.
         """
         result = await self._repository.get_domain_fair_share(
-            resource_group=action.resource_group,
+            resource_group_id=action.resource_group_id,
             domain_name=action.domain_name,
         )
         return GetDomainFairShareActionResult(data=result)
@@ -140,7 +140,7 @@ class FairShareService:
         Repository handles default value creation internally.
         """
         result = await self._repository.get_project_fair_share(
-            resource_group=action.resource_group,
+            resource_group_id=action.resource_group_id,
             project_id=action.project_id,
         )
         return GetProjectFairShareActionResult(data=result)
@@ -187,7 +187,7 @@ class FairShareService:
         Repository handles default value creation internally.
         """
         result = await self._repository.get_user_fair_share(
-            resource_group=action.resource_group,
+            resource_group_id=action.resource_group_id,
             project_id=action.project_id,
             user_uuid=action.user_uuid,
         )

--- a/src/ai/backend/manager/sokovan/scheduler/fair_share/aggregator.py
+++ b/src/ai/backend/manager/sokovan/scheduler/fair_share/aggregator.py
@@ -94,7 +94,8 @@ class FairShareAggregator:
 
         Args:
             kernels: Kernels to process
-            scaling_group: The scaling group name
+            resource_group_id: The resource group ID
+            resource_group: The resource group name retained for compatibility
             now: Current time from DB
 
         Returns:
@@ -297,7 +298,8 @@ class FairShareAggregator:
 
         Args:
             kernel: Kernel to process
-            scaling_group: The scaling group
+            resource_group_id: The resource group ID
+            resource_group: The resource group name retained for compatibility
             now: Current time from DB
 
         Returns:
@@ -388,7 +390,8 @@ class FairShareAggregator:
 
         Args:
             kernel: Kernel info
-            scaling_group: The scaling group
+            resource_group_id: The resource group ID
+            resource_group: The resource group name retained for compatibility
             start_time: Start of observation period
             end_time: End of observation period
 

--- a/src/ai/backend/manager/sokovan/scheduler/handlers/observer/fair_share.py
+++ b/src/ai/backend/manager/sokovan/scheduler/handlers/observer/fair_share.py
@@ -138,12 +138,13 @@ class FairShareObserver(KernelObserver):
             return ObservationResult(observed_count=0)
 
         now = await self._scheduler_repository.get_db_now()
-        # Fair share records and factor queries are keyed by name.
+        # Keep the legacy name alongside the ID while name-based writes remain supported.
         resource_group_name = await self._scheduler_repository.get_resource_group_name_by_id(
             resource_group_id
         )
 
         # ===== Phase 1: Record usage =====
+        # TODO: Remove resource_group name from spec once DB schema is updated
         preparation_result = self._aggregator.prepare_kernel_usage_records(
             kernels, resource_group_id, resource_group_name, now
         )
@@ -206,16 +207,16 @@ class FairShareObserver(KernelObserver):
         4. WRITE: update factors + ranks together
 
         Args:
-            scaling_group: The scaling group being processed
+            resource_group_id: The resource group ID being processed
             today: Current date for decay calculation
         """
         try:
-            log.debug("[FairShareObserver] Phase 2: calculating factors for {}", scaling_group)
+            log.debug("[FairShareObserver] Phase 2: calculating factors for {}", resource_group_id)
 
             # ===== Single batched DB read =====
             # Get all data needed for calculation in one database session
             context = await self._fair_share_repository.get_fair_share_calculation_context(
-                scaling_group, today
+                resource_group_id, today
             )
 
             log.debug(
@@ -229,7 +230,7 @@ class FairShareObserver(KernelObserver):
             if context.cluster_capacity:
                 capacity_by_slot = {sq.slot_name: sq.quantity for sq in context.cluster_capacity}
                 await self._resource_usage_repository.update_bucket_entry_capacities(
-                    scaling_group,
+                    resource_group_id,
                     capacity_by_slot,
                 )
 
@@ -274,7 +275,7 @@ class FairShareObserver(KernelObserver):
         except Exception as e:
             log.warning(
                 "Failed to calculate fair share factors and ranks for {}: {}",
-                scaling_group,
+                resource_group_id,
                 e,
             )
             # Don't fail the observation for calculation errors

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/provisioner.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/provisioner.py
@@ -222,7 +222,9 @@ class SessionProvisioner:
                 sequencer.name, success_detail=sequencer.success_message()
             ),
         ):
-            sequenced_workloads = await sequencer.sequence(sg_info.name, system_snapshot, workloads)
+            sequenced_workloads = await sequencer.sequence(
+                resource_group_id, system_snapshot, workloads
+            )
 
         # Build mutable agents with occupancy data from snapshot
         agent_occupancy = (

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/sequencers/drf.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/sequencers/drf.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 from decimal import Decimal
 from typing import override
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import AccessKey, ResourceSlot
 from ai.backend.manager.data.sokovan import SessionWorkload, SystemSnapshot
 
@@ -33,14 +34,14 @@ class DRFSequencer(WorkloadSequencer):
     @override
     async def sequence(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         system_snapshot: SystemSnapshot,
         workloads: Sequence[SessionWorkload],
     ) -> Sequence[SessionWorkload]:
         """
         Sequence the workloads based on Dominant Resource Fairness.
 
-        :param resource_group: The resource group (scaling group) name.
+        :param resource_group_id: The resource group ID.
         :param system_snapshot: The current system snapshot containing resource state.
         :param workloads: A sequence of SessionWorkload objects to sequence.
         :return: A sequence of SessionWorkload objects sequenced by DRF.

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/sequencers/fair_share.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/sequencers/fair_share.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, override
 from uuid import UUID
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.manager.data.fair_share import ProjectUserIds, UserFairShareFactors
 from ai.backend.manager.data.sokovan import SessionWorkload, SystemSnapshot
 
@@ -55,7 +56,7 @@ class FairShareSequencer(WorkloadSequencer):
     @override
     async def sequence(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         system_snapshot: SystemSnapshot,
         workloads: Sequence[SessionWorkload],
     ) -> Sequence[SessionWorkload]:
@@ -65,7 +66,7 @@ class FairShareSequencer(WorkloadSequencer):
         Workloads are sorted by (domain_factor, project_factor, user_factor) in descending order.
         Higher factor = higher priority (users with lower historical usage get scheduled first).
 
-        :param resource_group: The resource group (scaling group) name.
+        :param resource_group_id: The resource group ID.
         :param system_snapshot: The current system snapshot containing resource state.
         :param workloads: A sequence of SessionWorkload objects to sequence.
         :return: A sequence of SessionWorkload objects ordered by fair share factors.
@@ -74,7 +75,7 @@ class FairShareSequencer(WorkloadSequencer):
             return []
 
         # Load fair share factors from repository using 3-way JOIN
-        user_factors = await self._load_factors(resource_group, workloads)
+        user_factors = await self._load_factors(resource_group_id, workloads)
 
         # Sort by factors in descending order (higher factor = higher priority)
         # If a user doesn't have recorded factors, use default (lowest priority)
@@ -85,7 +86,7 @@ class FairShareSequencer(WorkloadSequencer):
 
     async def _load_factors(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         workloads: Sequence[SessionWorkload],
     ) -> dict[UUID, UserFairShareFactors]:
         """Load fair share factors from the repository for the given workloads."""
@@ -102,7 +103,7 @@ class FairShareSequencer(WorkloadSequencer):
 
         # Fetch factors from repository using 3-way JOIN
         return await self._repository.get_user_fair_share_factors_batch(
-            resource_group, project_user_ids
+            resource_group_id, project_user_ids
         )
 
     def _get_sort_key(

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/sequencers/fifo.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/sequencers/fifo.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 from typing import override
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.manager.data.sokovan import SessionWorkload, SystemSnapshot
 
 from .sequencer import WorkloadSequencer
@@ -30,14 +31,14 @@ class FIFOSequencer(WorkloadSequencer):
     @override
     async def sequence(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         system_snapshot: SystemSnapshot,
         workloads: Sequence[SessionWorkload],
     ) -> Sequence[SessionWorkload]:
         """
         Sequence the workloads in FIFO order.
 
-        :param resource_group: The resource group (scaling group) name.
+        :param resource_group_id: The resource group ID.
         :param system_snapshot: The current system snapshot containing resource state.
         :param workloads: A sequence of SessionWorkload objects to sequence.
         :return: A sequence of SessionWorkload objects in FIFO order.

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/sequencers/lifo.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/sequencers/lifo.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 from typing import override
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.manager.data.sokovan import SessionWorkload, SystemSnapshot
 
 from .sequencer import WorkloadSequencer
@@ -30,14 +31,14 @@ class LIFOSequencer(WorkloadSequencer):
     @override
     async def sequence(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         system_snapshot: SystemSnapshot,
         workloads: Sequence[SessionWorkload],
     ) -> Sequence[SessionWorkload]:
         """
         Sequence the workloads in LIFO order.
 
-        :param resource_group: The resource group (scaling group) name.
+        :param resource_group_id: The resource group ID.
         :param system_snapshot: The current system snapshot containing resource state.
         :param workloads: A sequence of SessionWorkload objects to sequence.
         :return: A sequence of SessionWorkload objects in LIFO order.

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/sequencers/sequencer.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/sequencers/sequencer.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Sequence
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.manager.data.sokovan import SessionWorkload, SystemSnapshot
 
 
@@ -24,14 +25,14 @@ class WorkloadSequencer(ABC):
     @abstractmethod
     async def sequence(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         system_snapshot: SystemSnapshot,
         workloads: Sequence[SessionWorkload],
     ) -> Sequence[SessionWorkload]:
         """
         Sequence the workloads based on the system snapshot.
 
-        :param resource_group: The resource group (scaling group) name.
+        :param resource_group_id: The resource group ID.
         :param system_snapshot: The current system snapshot containing resource state.
         :param workloads: A sequence of SessionWorkload objects to order.
         :return: A sequence of SessionWorkload objects ordered by the sequencer's logic.
@@ -60,14 +61,14 @@ class SchedulingSequencer:
 
     async def sequence(
         self,
-        resource_group: str,
+        resource_group_id: ResourceGroupID,
         system_snapshot: SystemSnapshot,
         workloads: Sequence[SessionWorkload],
     ) -> Sequence[SessionWorkload]:
         """
         Sequence the workloads based on their priority using the configured workload sequencer.
 
-        :param resource_group: The resource group (scaling group) name.
+        :param resource_group_id: The resource group ID.
         :param system_snapshot: The current system snapshot containing resource state.
         :param workloads: A sequence of SessionWorkload objects to order.
         :return: A sequence of SessionWorkload objects ordered by priority and the sequencer's logic.
@@ -79,7 +80,7 @@ class SchedulingSequencer:
         result: list[SessionWorkload] = []
         for priority in sorted(priority_workloads.keys(), reverse=True):
             sequenced = await self._workload_sequencer.sequence(
-                resource_group, system_snapshot, priority_workloads[priority]
+                resource_group_id, system_snapshot, priority_workloads[priority]
             )
             result.extend(sequenced)
         return result

--- a/tests/unit/manager/api/fair_share/test_rg_handler.py
+++ b/tests/unit/manager/api/fair_share/test_rg_handler.py
@@ -14,6 +14,7 @@ from uuid import UUID
 
 import pytest
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import ResourceSlot, SlotQuantity
 from ai.backend.manager.data.fair_share import (
     DomainFairShareData,
@@ -32,11 +33,14 @@ from ai.backend.manager.services.fair_share.actions import (
     GetUserFairShareAction,
 )
 
+RESOURCE_GROUP_ID = ResourceGroupID(UUID("880e8400-e29b-41d4-a716-446655440003"))
+
 
 def create_domain_fair_share_data() -> DomainFairShareData:
     """Create domain fair share data for testing."""
     return DomainFairShareData(
         resource_group="default",
+        resource_group_id=RESOURCE_GROUP_ID,
         domain_name="test-domain",
         data=FairShareData(
             spec=FairShareSpec(
@@ -67,6 +71,7 @@ def create_project_fair_share_data() -> ProjectFairShareData:
     """Create project fair share data for testing."""
     return ProjectFairShareData(
         resource_group="default",
+        resource_group_id=RESOURCE_GROUP_ID,
         project_id=UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
         domain_name="test-domain",
         data=FairShareData(
@@ -98,6 +103,7 @@ def create_user_fair_share_data() -> UserFairShareData:
     """Create user fair share data for testing."""
     return UserFairShareData(
         resource_group="default",
+        resource_group_id=RESOURCE_GROUP_ID,
         user_uuid=UUID("11111111-2222-3333-4444-555555555555"),
         project_id=UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
         domain_name="test-domain",
@@ -150,7 +156,7 @@ class TestRGGetDomainFairShare:
 
         await processors.fair_share.get_domain_fair_share.wait_for_complete(
             GetDomainFairShareAction(
-                resource_group="default",
+                resource_group_id=RESOURCE_GROUP_ID,
                 domain_name="test-domain",
             )
         )
@@ -160,7 +166,7 @@ class TestRGGetDomainFairShare:
         call_args = processors.fair_share.get_domain_fair_share.wait_for_complete.call_args
         action = call_args[0][0]
         assert isinstance(action, GetDomainFairShareAction)
-        assert action.resource_group == "default"
+        assert action.resource_group_id == RESOURCE_GROUP_ID
         assert action.domain_name == "test-domain"
 
     async def test_returns_data_when_found(
@@ -171,7 +177,7 @@ class TestRGGetDomainFairShare:
         processors = mock_processors_with_domain_exists
         action_result = await processors.fair_share.get_domain_fair_share.wait_for_complete(
             GetDomainFairShareAction(
-                resource_group="default",
+                resource_group_id=RESOURCE_GROUP_ID,
                 domain_name="test-domain",
             )
         )
@@ -199,7 +205,7 @@ class TestRGGetDomainFairShare:
         with pytest.raises(DomainNotFound):
             await processors.fair_share.get_domain_fair_share.wait_for_complete(
                 GetDomainFairShareAction(
-                    resource_group="default",
+                    resource_group_id=RESOURCE_GROUP_ID,
                     domain_name="nonexistent-domain",
                 )
             )
@@ -229,7 +235,7 @@ class TestRGGetProjectFairShare:
 
         await processors.fair_share.get_project_fair_share.wait_for_complete(
             GetProjectFairShareAction(
-                resource_group="default",
+                resource_group_id=RESOURCE_GROUP_ID,
                 project_id=project_id,
             )
         )
@@ -237,7 +243,7 @@ class TestRGGetProjectFairShare:
         call_args = processors.fair_share.get_project_fair_share.wait_for_complete.call_args
         action = call_args[0][0]
         assert isinstance(action, GetProjectFairShareAction)
-        assert action.resource_group == "default"
+        assert action.resource_group_id == RESOURCE_GROUP_ID
         assert action.project_id == project_id
 
     async def test_returns_data_when_found(
@@ -248,7 +254,7 @@ class TestRGGetProjectFairShare:
         processors = mock_processors_with_project_exists
         action_result = await processors.fair_share.get_project_fair_share.wait_for_complete(
             GetProjectFairShareAction(
-                resource_group="default",
+                resource_group_id=RESOURCE_GROUP_ID,
                 project_id=UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
             )
         )
@@ -275,7 +281,7 @@ class TestRGGetProjectFairShare:
         with pytest.raises(ProjectNotFound):
             await processors.fair_share.get_project_fair_share.wait_for_complete(
                 GetProjectFairShareAction(
-                    resource_group="default",
+                    resource_group_id=RESOURCE_GROUP_ID,
                     project_id=UUID("11111111-2222-3333-4444-555555555555"),
                 )
             )
@@ -306,7 +312,7 @@ class TestRGGetUserFairShare:
 
         await processors.fair_share.get_user_fair_share.wait_for_complete(
             GetUserFairShareAction(
-                resource_group="default",
+                resource_group_id=RESOURCE_GROUP_ID,
                 project_id=project_id,
                 user_uuid=user_uuid,
             )
@@ -315,7 +321,7 @@ class TestRGGetUserFairShare:
         call_args = processors.fair_share.get_user_fair_share.wait_for_complete.call_args
         action = call_args[0][0]
         assert isinstance(action, GetUserFairShareAction)
-        assert action.resource_group == "default"
+        assert action.resource_group_id == RESOURCE_GROUP_ID
         assert action.project_id == project_id
         assert action.user_uuid == user_uuid
 
@@ -327,7 +333,7 @@ class TestRGGetUserFairShare:
         processors = mock_processors_with_user_exists
         action_result = await processors.fair_share.get_user_fair_share.wait_for_complete(
             GetUserFairShareAction(
-                resource_group="default",
+                resource_group_id=RESOURCE_GROUP_ID,
                 project_id=UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
                 user_uuid=UUID("11111111-2222-3333-4444-555555555555"),
             )
@@ -355,7 +361,7 @@ class TestRGGetUserFairShare:
         with pytest.raises(UserNotFound):
             await processors.fair_share.get_user_fair_share.wait_for_complete(
                 GetUserFairShareAction(
-                    resource_group="default",
+                    resource_group_id=RESOURCE_GROUP_ID,
                     project_id=UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
                     user_uuid=UUID("11111111-2222-3333-4444-555555555555"),
                 )

--- a/tests/unit/manager/api/gql/fair_share/test_domain_fair_share_queries.py
+++ b/tests/unit/manager/api/gql/fair_share/test_domain_fair_share_queries.py
@@ -16,6 +16,7 @@ from ai.backend.common.dto.manager.v2.fair_share.response import (
     GetDomainFairSharePayload,
     SearchDomainFairSharesPayload,
 )
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import ResourceSlot, SlotQuantity
 from ai.backend.manager.api.adapters.fair_share.adapter import FairShareAdapter
 from ai.backend.manager.api.gql.fair_share.resolver import domain as domain_resolver
@@ -68,6 +69,7 @@ def sample_domain_fair_share_data() -> DomainFairShareData:
     today = now.date()
     return DomainFairShareData(
         resource_group="default",
+        resource_group_id=ResourceGroupID(UUID("880e8400-e29b-41d4-a716-446655440003")),
         domain_name="test-domain",
         data=FairShareData(
             spec=FairShareSpec(

--- a/tests/unit/manager/api/gql/fair_share/test_rg_domain_resolver.py
+++ b/tests/unit/manager/api/gql/fair_share/test_rg_domain_resolver.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import UTC, date, datetime
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
 
 import pytest
 
@@ -12,6 +13,7 @@ from ai.backend.common.dto.manager.v2.fair_share.response import (
     GetDomainFairSharePayload,
     SearchDomainFairSharesPayload,
 )
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import ResourceSlot, SlotQuantity
 from ai.backend.manager.api.adapters.fair_share.adapter import FairShareAdapter
 from ai.backend.manager.api.gql.fair_share.resolver import domain as domain_resolver
@@ -37,6 +39,7 @@ class TestRGDomainFairShare:
         """Domain fair share data for existing record."""
         return DomainFairShareData(
             resource_group="default",
+            resource_group_id=ResourceGroupID(UUID("880e8400-e29b-41d4-a716-446655440003")),
             domain_name="test-domain",
             data=FairShareData(
                 spec=FairShareSpec(

--- a/tests/unit/manager/api/gql/fair_share/test_rg_project_resolver.py
+++ b/tests/unit/manager/api/gql/fair_share/test_rg_project_resolver.py
@@ -13,6 +13,7 @@ from ai.backend.common.dto.manager.v2.fair_share.response import (
     GetProjectFairSharePayload,
     SearchProjectFairSharesPayload,
 )
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import ResourceSlot, SlotQuantity
 from ai.backend.manager.api.adapters.fair_share.adapter import FairShareAdapter
 from ai.backend.manager.api.gql.fair_share.resolver import project as project_resolver
@@ -43,6 +44,7 @@ class TestRGProjectFairShare:
         """Project fair share data for existing record."""
         return ProjectFairShareData(
             resource_group="default",
+            resource_group_id=ResourceGroupID(UUID("880e8400-e29b-41d4-a716-446655440003")),
             project_id=project_id,
             domain_name="test-domain",
             data=FairShareData(

--- a/tests/unit/manager/api/gql/fair_share/test_rg_user_resolver.py
+++ b/tests/unit/manager/api/gql/fair_share/test_rg_user_resolver.py
@@ -13,6 +13,7 @@ from ai.backend.common.dto.manager.v2.fair_share.response import (
     GetUserFairSharePayload,
     SearchUserFairSharesPayload,
 )
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import ResourceSlot, SlotQuantity
 from ai.backend.manager.api.adapters.fair_share.adapter import FairShareAdapter
 from ai.backend.manager.api.gql.fair_share.resolver import user as user_resolver
@@ -44,10 +45,18 @@ class TestRGUserFairShare:
         return UUID("11111111-2222-3333-4444-555555555555")
 
     @pytest.fixture
-    def user_fair_share_data(self, project_id: UUID, user_uuid: UUID) -> UserFairShareData:
+    def resource_group_id(self) -> ResourceGroupID:
+        """Test resource group ID."""
+        return ResourceGroupID(UUID("880e8400-e29b-41d4-a716-446655440003"))
+
+    @pytest.fixture
+    def user_fair_share_data(
+        self, project_id: UUID, user_uuid: UUID, resource_group_id: ResourceGroupID
+    ) -> UserFairShareData:
         """User fair share data for existing record."""
         return UserFairShareData(
             resource_group="default",
+            resource_group_id=resource_group_id,
             user_uuid=user_uuid,
             project_id=project_id,
             domain_name="test-domain",

--- a/tests/unit/manager/models/fair_share/test_row.py
+++ b/tests/unit/manager/models/fair_share/test_row.py
@@ -56,7 +56,7 @@ class TestDomainFairShareRow:
         scaling_group: str,
         resource_group_id: ResourceGroupID,
     ) -> None:
-        """Duplicate (scaling_group, domain_name) should raise IntegrityError."""
+        """Duplicate (resource_group_id, domain_name) should raise IntegrityError."""
         duplicate = DomainFairShareRow(
             domain_name=domain_name,
             resource_group=scaling_group,
@@ -126,7 +126,7 @@ class TestProjectFairShareRow:
         scaling_group: str,
         resource_group_id: ResourceGroupID,
     ) -> None:
-        """Duplicate (scaling_group, project_id) should raise IntegrityError."""
+        """Duplicate (resource_group_id, project_id) should raise IntegrityError."""
         duplicate = ProjectFairShareRow(
             project_id=project_id,
             domain_name=domain_name,
@@ -172,7 +172,7 @@ class TestUserFairShareRow:
         scaling_group: str,
         resource_group_id: ResourceGroupID,
     ) -> None:
-        """Duplicate (scaling_group, user_uuid, project_id) should raise IntegrityError."""
+        """Duplicate (resource_group_id, user_uuid, project_id) should raise IntegrityError."""
         duplicate = UserFairShareRow(
             user_uuid=user_uuid,
             project_id=project_id,

--- a/tests/unit/manager/models/resource_usage_history/test_row.py
+++ b/tests/unit/manager/models/resource_usage_history/test_row.py
@@ -27,11 +27,13 @@ class TestDomainUsageBucketRow:
         self,
         database_with_usage_tables: ExtendedAsyncSAEngine,
         domain_usage_bucket_id: uuid.UUID,
+        resource_group_id: ResourceGroupID,
     ) -> None:
         """Verify default values are set correctly."""
         async with database_with_usage_tables.begin_readonly_session() as db_sess:
             row = await db_sess.get(DomainUsageBucketRow, domain_usage_bucket_id)
             assert row is not None
+            assert row.resource_group_id == resource_group_id
             assert row.period_start == date(2024, 1, 1)
             assert row.decay_unit_days == 1
             assert row.resource_usage == ResourceSlot()
@@ -58,7 +60,7 @@ class TestDomainUsageBucketRow:
         scaling_group: str,
         resource_group_id: ResourceGroupID,
     ) -> None:
-        """Duplicate (domain_name, scaling_group, period_start) should raise IntegrityError."""
+        """Duplicate (domain_name, resource_group_id, period_start) should raise IntegrityError."""
         duplicate = DomainUsageBucketRow(
             domain_name=domain_name,
             resource_group=scaling_group,
@@ -83,12 +85,14 @@ class TestProjectUsageBucketRow:
         database_with_usage_tables: ExtendedAsyncSAEngine,
         project_usage_bucket_id: uuid.UUID,
         project_id: uuid.UUID,
+        resource_group_id: ResourceGroupID,
     ) -> None:
         """Verify project usage bucket is created with correct project_id."""
         async with database_with_usage_tables.begin_readonly_session() as db_sess:
             row = await db_sess.get(ProjectUsageBucketRow, project_usage_bucket_id)
             assert row is not None
             assert row.project_id == project_id
+            assert row.resource_group_id == resource_group_id
             assert row.period_start == date(2024, 1, 1)
 
     async def test_unique_constraint_violation(
@@ -100,7 +104,7 @@ class TestProjectUsageBucketRow:
         scaling_group: str,
         resource_group_id: ResourceGroupID,
     ) -> None:
-        """Duplicate (project_id, scaling_group, period_start) should raise IntegrityError."""
+        """Duplicate (project_id, resource_group_id, period_start) should raise IntegrityError."""
         duplicate = ProjectUsageBucketRow(
             project_id=project_id,
             domain_name=domain_name,
@@ -127,6 +131,7 @@ class TestUserUsageBucketRow:
         user_usage_bucket_id: uuid.UUID,
         user_uuid: uuid.UUID,
         project_id: uuid.UUID,
+        resource_group_id: ResourceGroupID,
     ) -> None:
         """Verify user usage bucket is created with correct user_uuid and project_id."""
         async with database_with_usage_tables.begin_readonly_session() as db_sess:
@@ -134,6 +139,7 @@ class TestUserUsageBucketRow:
             assert row is not None
             assert row.user_uuid == user_uuid
             assert row.project_id == project_id
+            assert row.resource_group_id == resource_group_id
             assert row.period_start == date(2024, 1, 1)
 
     async def test_unique_constraint_violation(
@@ -146,7 +152,7 @@ class TestUserUsageBucketRow:
         scaling_group: str,
         resource_group_id: ResourceGroupID,
     ) -> None:
-        """Duplicate (user_uuid, project_id, scaling_group, period_start) should raise IntegrityError."""
+        """Duplicate (user_uuid, project_id, resource_group_id, period_start) should raise IntegrityError."""
         duplicate = UserUsageBucketRow(
             user_uuid=user_uuid,
             project_id=project_id,
@@ -172,6 +178,7 @@ class TestKernelUsageRecordRow:
         self,
         database_with_usage_tables: ExtendedAsyncSAEngine,
         kernel_usage_record_id: tuple[uuid.UUID, uuid.UUID, uuid.UUID],
+        resource_group_id: ResourceGroupID,
     ) -> None:
         """Verify kernel usage record is created with correct IDs."""
         record_id, kernel_id, session_id = kernel_usage_record_id
@@ -180,6 +187,7 @@ class TestKernelUsageRecordRow:
             assert row is not None
             assert row.kernel_id == kernel_id
             assert row.session_id == session_id
+            assert row.resource_group_id == resource_group_id
             assert row.resource_usage == ResourceSlot()
 
     async def test_create_with_resource_usage(

--- a/tests/unit/manager/repositories/fair_share/test_bulk_upsert_fair_share.py
+++ b/tests/unit/manager/repositories/fair_share/test_bulk_upsert_fair_share.py
@@ -196,7 +196,7 @@ class TestBulkUpsertDomainFairShare:
             for name, weight in existing_weights.items():
                 row = DomainFairShareRow(
                     resource_group=sg_name,
-                    resource_group_id=ResourceGroupID(uuid.uuid4()),
+                    resource_group_id=rg_id,
                     domain_name=name,
                     weight=weight,
                 )
@@ -543,7 +543,7 @@ class TestBulkUpsertProjectFairShare:
             for pid, weight in existing_weights.items():
                 row = ProjectFairShareRow(
                     resource_group=sg_name,
-                    resource_group_id=ResourceGroupID(uuid.uuid4()),
+                    resource_group_id=rg_id,
                     project_id=pid,
                     domain_name=domain_name,
                     weight=weight,
@@ -856,7 +856,7 @@ class TestBulkUpsertUserFairShare:
             for uid, weight in existing_weights.items():
                 row = UserFairShareRow(
                     resource_group=sg_name,
-                    resource_group_id=ResourceGroupID(uuid.uuid4()),
+                    resource_group_id=rg_id,
                     user_uuid=uid,
                     project_id=project_id,
                     domain_name=domain_name,

--- a/tests/unit/manager/repositories/fair_share/test_entity_based_search.py
+++ b/tests/unit/manager/repositories/fair_share/test_entity_based_search.py
@@ -73,7 +73,8 @@ from ai.backend.manager.repositories.fair_share.types import (
 )
 from ai.backend.testutils.db import with_tables
 
-RESOURCE_GROUP_ID = ResourceGroupID(uuid.UUID("00000000-0000-0000-0000-000000000001"))
+RESOURCE_GROUP_ID = ResourceGroupID(uuid.uuid4())
+EMPTY_RESOURCE_GROUP_ID = ResourceGroupID(uuid.uuid4())
 
 
 class TestSearchDomainFairSharesEntityBased:
@@ -119,6 +120,7 @@ class TestSearchDomainFairSharesEntityBased:
         async with db_with_cleanup.begin_session() as db_sess:
             db_sess.add(
                 ScalingGroupRow(
+                    id=RESOURCE_GROUP_ID,
                     name=sg_name,
                     description="Test scaling group",
                     is_active=True,
@@ -209,6 +211,7 @@ class TestSearchDomainFairSharesEntityBased:
         async with db_with_cleanup.begin_session() as db_sess:
             db_sess.add(
                 ScalingGroupRow(
+                    id=EMPTY_RESOURCE_GROUP_ID,
                     name=sg_name,
                     description="Scaling group without domains",
                     is_active=True,
@@ -225,6 +228,7 @@ class TestSearchDomainFairSharesEntityBased:
     @dataclass
     class TwoScalingGroupsFixture:
         rg1: str
+        rg1_id: ResourceGroupID
         rg2: str
         domain_in_rg1: str
         domain_in_rg2: str
@@ -241,9 +245,11 @@ class TestSearchDomainFairSharesEntityBased:
         domain2 = f"domain2-{uuid.uuid4().hex[:8]}"
 
         async with db_with_cleanup.begin_session() as db_sess:
-            for sg_name in [rg1, rg2]:
+            resource_group_ids = [ResourceGroupID(uuid.uuid4()), ResourceGroupID(uuid.uuid4())]
+            for resource_group_id, sg_name in zip(resource_group_ids, [rg1, rg2], strict=True):
                 db_sess.add(
                     ScalingGroupRow(
+                        id=resource_group_id,
                         name=sg_name,
                         description=f"Test {sg_name}",
                         is_active=True,
@@ -271,7 +277,11 @@ class TestSearchDomainFairSharesEntityBased:
             await db_sess.commit()
 
         return self.TwoScalingGroupsFixture(
-            rg1=rg1, rg2=rg2, domain_in_rg1=domain1, domain_in_rg2=domain2
+            rg1=rg1,
+            rg1_id=resource_group_ids[0],
+            rg2=rg2,
+            domain_in_rg1=domain1,
+            domain_in_rg2=domain2,
         )
 
     @pytest.fixture
@@ -320,7 +330,7 @@ class TestSearchDomainFairSharesEntityBased:
         fair_share_repository: FairShareRepository,
     ) -> None:
         """Non-existent resource_group in scope should raise ScalingGroupNotFound."""
-        scope = DomainFairShareSearchScope(resource_group="nonexistent-rg")
+        scope = DomainFairShareSearchScope(resource_group_id=ResourceGroupID(uuid.uuid4()))
         querier = BatchQuerier(
             pagination=OffsetPagination(limit=100, offset=0),
             conditions=[],
@@ -338,7 +348,7 @@ class TestSearchDomainFairSharesEntityBased:
         scaling_group_without_domains: str,
     ) -> None:
         """Valid resource_group with no domains should return empty result (not error)."""
-        scope = DomainFairShareSearchScope(resource_group=scaling_group_without_domains)
+        scope = DomainFairShareSearchScope(resource_group_id=EMPTY_RESOURCE_GROUP_ID)
         querier = BatchQuerier(
             pagination=OffsetPagination(limit=100, offset=0),
             conditions=[],
@@ -359,7 +369,7 @@ class TestSearchDomainFairSharesEntityBased:
         domain_with_record: str,
     ) -> None:
         """Domain with fair share record should have complete details with use_default=False."""
-        scope = DomainFairShareSearchScope(resource_group=scaling_group)
+        scope = DomainFairShareSearchScope(resource_group_id=RESOURCE_GROUP_ID)
         querier = BatchQuerier(
             pagination=OffsetPagination(limit=100, offset=0),
             conditions=[],
@@ -385,7 +395,7 @@ class TestSearchDomainFairSharesEntityBased:
         domain_without_record: str,
     ) -> None:
         """Domain without fair share record should have default values with use_default=True."""
-        scope = DomainFairShareSearchScope(resource_group=scaling_group)
+        scope = DomainFairShareSearchScope(resource_group_id=RESOURCE_GROUP_ID)
         querier = BatchQuerier(
             pagination=OffsetPagination(limit=100, offset=0),
             conditions=[],
@@ -412,7 +422,7 @@ class TestSearchDomainFairSharesEntityBased:
         domain_without_record: str,
     ) -> None:
         """Search should return both domains with complete data (record vs default)."""
-        scope = DomainFairShareSearchScope(resource_group=scaling_group)
+        scope = DomainFairShareSearchScope(resource_group_id=RESOURCE_GROUP_ID)
         querier = BatchQuerier(
             pagination=OffsetPagination(limit=100, offset=0),
             conditions=[],
@@ -448,7 +458,7 @@ class TestSearchDomainFairSharesEntityBased:
         Both domains appear in results; fair share data is from the queried RG.
         """
         fixture = two_scaling_groups_with_domains
-        scope = DomainFairShareSearchScope(resource_group=fixture.rg1)
+        scope = DomainFairShareSearchScope(resource_group_id=fixture.rg1_id)
         querier = BatchQuerier(
             pagination=OffsetPagination(limit=100, offset=0),
             conditions=[],
@@ -473,7 +483,7 @@ class TestSearchDomainFairSharesEntityBased:
         five_domains_two_with_records: list[str],
     ) -> None:
         """Pagination total_count should include entities without records."""
-        scope = DomainFairShareSearchScope(resource_group=scaling_group)
+        scope = DomainFairShareSearchScope(resource_group_id=RESOURCE_GROUP_ID)
         querier = BatchQuerier(
             pagination=OffsetPagination(limit=2, offset=0),
             conditions=[],
@@ -500,7 +510,7 @@ class TestSearchDomainFairSharesEntityBased:
         which is NULL for entities without records, causing SQL to exclude them.
         RG conditions reference ScalingGroupForDomainRow.domain (INNER JOIN'd), which is never NULL.
         """
-        scope = DomainFairShareSearchScope(resource_group=scaling_group)
+        scope = DomainFairShareSearchScope(resource_group_id=RESOURCE_GROUP_ID)
         querier = BatchQuerier(
             pagination=OffsetPagination(limit=100, offset=0),
             conditions=[
@@ -526,7 +536,7 @@ class TestSearchDomainFairSharesEntityBased:
         domain_without_record: str,
     ) -> None:
         """RG-context filter should return both domains (with and without records)."""
-        scope = DomainFairShareSearchScope(resource_group=scaling_group)
+        scope = DomainFairShareSearchScope(resource_group_id=RESOURCE_GROUP_ID)
 
         # Filter for domain_without_record only
         querier_without = BatchQuerier(
@@ -591,7 +601,7 @@ class TestSearchDomainFairSharesEntityBased:
         domain_not_in_rg: str,
     ) -> None:
         """BA-4682: Domain not in any RG should appear in search results with defaults."""
-        scope = DomainFairShareSearchScope(resource_group=scaling_group)
+        scope = DomainFairShareSearchScope(resource_group_id=RESOURCE_GROUP_ID)
         querier = BatchQuerier(
             pagination=OffsetPagination(limit=100, offset=0),
             conditions=[],
@@ -653,6 +663,7 @@ class TestSearchProjectFairSharesEntityBased:
         async with db_with_cleanup.begin_session() as db_sess:
             db_sess.add(
                 ScalingGroupRow(
+                    id=RESOURCE_GROUP_ID,
                     name=sg_name,
                     description="Test scaling group",
                     is_active=True,
@@ -790,7 +801,7 @@ class TestSearchProjectFairSharesEntityBased:
     ) -> None:
         """Non-existent resource_group in scope should raise ScalingGroupNotFound."""
         scope = ProjectFairShareSearchScope(
-            resource_group="nonexistent-rg",
+            resource_group_id=ResourceGroupID(uuid.uuid4()),
             domain_name=domain_name,
         )
         querier = BatchQuerier(
@@ -813,7 +824,7 @@ class TestSearchProjectFairSharesEntityBased:
     ) -> None:
         """Project with fair share record should have details populated."""
         scope = ProjectFairShareSearchScope(
-            resource_group=scaling_group,
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name=domain_name,
         )
         querier = BatchQuerier(
@@ -838,7 +849,7 @@ class TestSearchProjectFairSharesEntityBased:
     ) -> None:
         """Project without fair share record should have default values with use_default=True."""
         scope = ProjectFairShareSearchScope(
-            resource_group=scaling_group,
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name=domain_name,
         )
         querier = BatchQuerier(
@@ -869,7 +880,7 @@ class TestSearchProjectFairSharesEntityBased:
     ) -> None:
         """Search should return both projects with and without records."""
         scope = ProjectFairShareSearchScope(
-            resource_group=scaling_group,
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name=domain_name,
         )
         querier = BatchQuerier(
@@ -907,7 +918,7 @@ class TestSearchProjectFairSharesEntityBased:
         ScalingGroupForProjectRow.group (INNER JOIN'd), which is never NULL.
         """
         scope = ProjectFairShareSearchScope(
-            resource_group=scaling_group,
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name=domain_name,
         )
         querier = BatchQuerier(
@@ -971,7 +982,7 @@ class TestSearchProjectFairSharesEntityBased:
     ) -> None:
         """BA-4682: Project not in any RG should appear in search results with defaults."""
         scope = ProjectFairShareSearchScope(
-            resource_group=scaling_group,
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name=domain_name,
         )
         querier = BatchQuerier(
@@ -1035,6 +1046,7 @@ class TestSearchUserFairSharesEntityBased:
         async with db_with_cleanup.begin_session() as db_sess:
             db_sess.add(
                 ScalingGroupRow(
+                    id=RESOURCE_GROUP_ID,
                     name=sg_name,
                     description="Test scaling group",
                     is_active=True,
@@ -1230,7 +1242,7 @@ class TestSearchUserFairSharesEntityBased:
         """Non-existent resource_group in scope should raise ScalingGroupNotFound."""
 
         scope = UserFairShareSearchScope(
-            resource_group="nonexistent-rg",
+            resource_group_id=ResourceGroupID(uuid.uuid4()),
             domain_name=domain_name,
             project_id=project_id,
         )
@@ -1256,7 +1268,7 @@ class TestSearchUserFairSharesEntityBased:
         """User with fair share record should have details populated."""
 
         scope = UserFairShareSearchScope(
-            resource_group=scaling_group,
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name=domain_name,
             project_id=project_id,
         )
@@ -1285,7 +1297,7 @@ class TestSearchUserFairSharesEntityBased:
         """User without fair share record should have default values with use_default=True."""
 
         scope = UserFairShareSearchScope(
-            resource_group=scaling_group,
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name=domain_name,
             project_id=project_id,
         )
@@ -1320,7 +1332,7 @@ class TestSearchUserFairSharesEntityBased:
         """Search should return both users with and without records."""
 
         scope = UserFairShareSearchScope(
-            resource_group=scaling_group,
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name=domain_name,
             project_id=project_id,
         )
@@ -1360,7 +1372,7 @@ class TestSearchUserFairSharesEntityBased:
         AssocGroupUserRow.user_id (INNER JOIN'd), which is never NULL.
         """
         scope = UserFairShareSearchScope(
-            resource_group=scaling_group,
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name=domain_name,
             project_id=project_id,
         )

--- a/tests/unit/manager/repositories/fair_share/test_fair_share_repository.py
+++ b/tests/unit/manager/repositories/fair_share/test_fair_share_repository.py
@@ -66,7 +66,7 @@ from ai.backend.manager.repositories.fair_share import (
 from ai.backend.manager.types import OptionalState, TriState
 from ai.backend.testutils.db import with_tables
 
-RESOURCE_GROUP_ID = ResourceGroupID(uuid.UUID("00000000-0000-0000-0000-000000000001"))
+RESOURCE_GROUP_ID = ResourceGroupID(uuid.uuid4())
 
 
 class TestFairShareRepository:
@@ -121,6 +121,7 @@ class TestFairShareRepository:
 
         async with db_with_cleanup.begin_session() as db_sess:
             sg = ScalingGroupRow(
+                id=RESOURCE_GROUP_ID,
                 name=sg_name,
                 description="Test scaling group for fair share",
                 is_active=True,
@@ -338,13 +339,11 @@ class TestFairShareRepository:
         )
         await fair_share_repository.upsert_domain_fair_share(upserter1)
 
-        replacement_resource_group_id = ResourceGroupID(uuid.uuid4())
-
-        # Second upsert - should update calculated fields and synchronize the resource group ID
+        # Second upsert - should update calculated fields
         upserter2 = Upserter(
             spec=DomainFairShareUpserterSpec(
                 resource_group=test_scaling_group,
-                resource_group_id=replacement_resource_group_id,
+                resource_group_id=RESOURCE_GROUP_ID,
                 domain_name=test_domain_name,
                 fair_share_factor=OptionalState.update(Decimal("0.75")),
                 normalized_usage=OptionalState.update(Decimal("0.5")),
@@ -364,7 +363,7 @@ class TestFairShareRepository:
                     DomainFairShareRow.domain_name == test_domain_name,
                 )
             )
-        assert stored_resource_group_id == replacement_resource_group_id
+        assert stored_resource_group_id == RESOURCE_GROUP_ID
 
     async def test_get_domain_fair_share(
         self,
@@ -386,7 +385,7 @@ class TestFairShareRepository:
 
         # Get
         result = await fair_share_repository.get_domain_fair_share(
-            resource_group=test_scaling_group,
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name=test_domain_name,
         )
 
@@ -401,7 +400,7 @@ class TestFairShareRepository:
         """Test getting non-existent domain fair share raises DomainNotFound"""
         with pytest.raises(DomainNotFound):
             await fair_share_repository.get_domain_fair_share(
-                resource_group="non-existent-sg",
+                resource_group_id=ResourceGroupID(uuid.uuid4()),
                 domain_name="non-existent-domain",
             )
 
@@ -522,7 +521,7 @@ class TestFairShareRepository:
         await fair_share_repository.create_project_fair_share(creator)
 
         result = await fair_share_repository.get_project_fair_share(
-            resource_group=test_scaling_group,
+            resource_group_id=RESOURCE_GROUP_ID,
             project_id=test_project_id,
         )
 
@@ -605,7 +604,7 @@ class TestFairShareRepository:
         await fair_share_repository.create_user_fair_share(creator)
 
         result = await fair_share_repository.get_user_fair_share(
-            resource_group=test_scaling_group,
+            resource_group_id=RESOURCE_GROUP_ID,
             project_id=test_project_id,
             user_uuid=test_user_uuid,
         )
@@ -626,6 +625,7 @@ class TestFairShareRepository:
         regardless of resource group membership.
         """
         non_existent_sg = f"non-existent-sg-{uuid.uuid4().hex[:8]}"
+        non_existent_sg_id = ResourceGroupID(uuid.uuid4())
         domain_name = f"test-domain-{uuid.uuid4().hex[:8]}"
 
         # Create domain row (required for the fair share row's domain_name column)
@@ -644,7 +644,7 @@ class TestFairShareRepository:
         upserter = Upserter(
             spec=DomainFairShareUpserterSpec(
                 resource_group=non_existent_sg,
-                resource_group_id=RESOURCE_GROUP_ID,
+                resource_group_id=non_existent_sg_id,
                 domain_name=domain_name,
                 weight=TriState.update(Decimal("2.5")),
                 fair_share_factor=OptionalState.update(Decimal("1.0")),
@@ -654,6 +654,7 @@ class TestFairShareRepository:
         result = await fair_share_repository.upsert_domain_fair_share(upserter)
 
         assert result.resource_group == non_existent_sg
+        assert result.resource_group_id == non_existent_sg_id
         assert result.domain_name == domain_name
         assert result.data.spec.weight == Decimal("2.5")
 
@@ -668,6 +669,7 @@ class TestFairShareRepository:
         Regression test for BA-4683.
         """
         non_existent_sg = f"non-existent-sg-{uuid.uuid4().hex[:8]}"
+        non_existent_sg_id = ResourceGroupID(uuid.uuid4())
         project_id = uuid.uuid4()
 
         # Create project resource policy and project
@@ -695,7 +697,7 @@ class TestFairShareRepository:
         upserter = Upserter(
             spec=ProjectFairShareUpserterSpec(
                 resource_group=non_existent_sg,
-                resource_group_id=RESOURCE_GROUP_ID,
+                resource_group_id=non_existent_sg_id,
                 project_id=project_id,
                 domain_name=test_domain_name,
                 weight=TriState.update(Decimal("3.0")),
@@ -706,6 +708,7 @@ class TestFairShareRepository:
         result = await fair_share_repository.upsert_project_fair_share(upserter)
 
         assert result.resource_group == non_existent_sg
+        assert result.resource_group_id == non_existent_sg_id
         assert result.project_id == project_id
         assert result.data.spec.weight == Decimal("3.0")
 
@@ -722,11 +725,12 @@ class TestFairShareRepository:
         Regression test for BA-4683.
         """
         non_existent_sg = f"non-existent-sg-{uuid.uuid4().hex[:8]}"
+        non_existent_sg_id = ResourceGroupID(uuid.uuid4())
 
         upserter = Upserter(
             spec=UserFairShareUpserterSpec(
                 resource_group=non_existent_sg,
-                resource_group_id=RESOURCE_GROUP_ID,
+                resource_group_id=non_existent_sg_id,
                 user_uuid=test_user_uuid,
                 project_id=test_project_id,
                 domain_name=test_domain_name,
@@ -738,6 +742,7 @@ class TestFairShareRepository:
         result = await fair_share_repository.upsert_user_fair_share(upserter)
 
         assert result.resource_group == non_existent_sg
+        assert result.resource_group_id == non_existent_sg_id
         assert result.user_uuid == test_user_uuid
         assert result.project_id == test_project_id
         assert result.data.spec.weight == Decimal("1.8")
@@ -806,7 +811,7 @@ class TestFairShareRepository:
     ) -> None:
         """BA-4682: Domain not in any RG should return default fair share, not raise."""
         result = await fair_share_repository.get_domain_fair_share(
-            resource_group=test_scaling_group,
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name=domain_not_in_rg,
         )
 
@@ -822,7 +827,7 @@ class TestFairShareRepository:
     ) -> None:
         """BA-4682: Project not in any RG should return default fair share, not raise."""
         result = await fair_share_repository.get_project_fair_share(
-            resource_group=test_scaling_group,
+            resource_group_id=RESOURCE_GROUP_ID,
             project_id=project_not_in_rg,
         )
 

--- a/tests/unit/manager/repositories/resource_usage_history/test_resource_usage_history_repository.py
+++ b/tests/unit/manager/repositories/resource_usage_history/test_resource_usage_history_repository.py
@@ -130,6 +130,19 @@ class TestResourceUsageHistoryRepository:
         return sg_name
 
     @pytest.fixture
+    async def test_resource_group_id(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_scaling_group: str,
+    ) -> ResourceGroupID:
+        """Return the ID of the test scaling group."""
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            result = await db_sess.execute(
+                sa.select(ScalingGroupRow.id).where(ScalingGroupRow.name == test_scaling_group)
+            )
+            return result.scalar_one()
+
+    @pytest.fixture
     async def test_domain_name(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
@@ -242,6 +255,7 @@ class TestResourceUsageHistoryRepository:
         self,
         resource_usage_history_repository: ResourceUsageHistoryRepository,
         test_scaling_group: str,
+        test_resource_group_id: ResourceGroupID,
         test_domain_name: str,
         test_project_id: uuid.UUID,
         test_user_uuid: uuid.UUID,
@@ -259,7 +273,7 @@ class TestResourceUsageHistoryRepository:
                 project_id=test_project_id,
                 domain_name=test_domain_name,
                 resource_group=test_scaling_group,
-                resource_group_id=RESOURCE_GROUP_ID,
+                resource_group_id=test_resource_group_id,
                 period_start=now - timedelta(minutes=5),
                 period_end=now,
                 resource_usage=ResourceSlot({"cpu": Decimal("300"), "mem": Decimal("1073741824")}),
@@ -272,12 +286,14 @@ class TestResourceUsageHistoryRepository:
         assert result.session_id == session_id
         assert result.user_uuid == test_user_uuid
         assert result.project_id == test_project_id
+        assert result.resource_group_id == test_resource_group_id
         assert result.resource_usage["cpu"] == Decimal("300")
 
     async def test_bulk_create_kernel_usage_records(
         self,
         resource_usage_history_repository: ResourceUsageHistoryRepository,
         test_scaling_group: str,
+        test_resource_group_id: ResourceGroupID,
         test_domain_name: str,
         test_project_id: uuid.UUID,
         test_user_uuid: uuid.UUID,
@@ -300,7 +316,7 @@ class TestResourceUsageHistoryRepository:
                     project_id=test_project_id,
                     domain_name=test_domain_name,
                     resource_group=test_scaling_group,
-                    resource_group_id=RESOURCE_GROUP_ID,
+                    resource_group_id=test_resource_group_id,
                     period_start=period_start,
                     period_end=period_end,
                     resource_usage=ResourceSlot({"cpu": Decimal("300")}),
@@ -321,6 +337,7 @@ class TestResourceUsageHistoryRepository:
         self,
         resource_usage_history_repository: ResourceUsageHistoryRepository,
         test_scaling_group: str,
+        test_resource_group_id: ResourceGroupID,
         test_domain_name: str,
         test_project_id: uuid.UUID,
         test_user_uuid: uuid.UUID,
@@ -343,7 +360,7 @@ class TestResourceUsageHistoryRepository:
                     project_id=test_project_id,
                     domain_name=test_domain_name,
                     resource_group=test_scaling_group,
-                    resource_group_id=RESOURCE_GROUP_ID,
+                    resource_group_id=test_resource_group_id,
                     period_start=period_start,
                     period_end=period_end,
                     resource_usage=ResourceSlot({"cpu": Decimal("300")}),
@@ -372,6 +389,7 @@ class TestResourceUsageHistoryRepository:
         self,
         resource_usage_history_repository: ResourceUsageHistoryRepository,
         test_scaling_group: str,
+        test_resource_group_id: ResourceGroupID,
         test_domain_name: str,
     ) -> None:
         """Test creating domain usage bucket"""
@@ -381,7 +399,7 @@ class TestResourceUsageHistoryRepository:
             spec=DomainUsageBucketCreatorSpec(
                 domain_name=test_domain_name,
                 resource_group=test_scaling_group,
-                resource_group_id=RESOURCE_GROUP_ID,
+                resource_group_id=test_resource_group_id,
                 period_start=today,
                 period_end=today + timedelta(days=1),
                 decay_unit_days=1,
@@ -400,6 +418,7 @@ class TestResourceUsageHistoryRepository:
 
         assert result.domain_name == test_domain_name
         assert result.resource_group == test_scaling_group
+        assert result.resource_group_id == test_resource_group_id
         assert result.period_start == today
         assert result.resource_usage["cpu"] == Decimal("86400")
 
@@ -407,6 +426,7 @@ class TestResourceUsageHistoryRepository:
         self,
         resource_usage_history_repository: ResourceUsageHistoryRepository,
         test_scaling_group: str,
+        test_resource_group_id: ResourceGroupID,
         test_domain_name: str,
     ) -> None:
         """Test upsert domain usage bucket - insert case"""
@@ -416,7 +436,7 @@ class TestResourceUsageHistoryRepository:
             spec=DomainUsageBucketUpserterSpec(
                 domain_name=test_domain_name,
                 resource_group=test_scaling_group,
-                resource_group_id=RESOURCE_GROUP_ID,
+                resource_group_id=test_resource_group_id,
                 period_start=today,
                 period_end=today + timedelta(days=1),
                 decay_unit_days=1,
@@ -435,6 +455,7 @@ class TestResourceUsageHistoryRepository:
         db_with_cleanup: ExtendedAsyncSAEngine,
         resource_usage_history_repository: ResourceUsageHistoryRepository,
         test_scaling_group: str,
+        test_resource_group_id: ResourceGroupID,
         test_domain_name: str,
     ) -> None:
         """Test upsert domain usage bucket - update case"""
@@ -445,7 +466,7 @@ class TestResourceUsageHistoryRepository:
             spec=DomainUsageBucketUpserterSpec(
                 domain_name=test_domain_name,
                 resource_group=test_scaling_group,
-                resource_group_id=RESOURCE_GROUP_ID,
+                resource_group_id=test_resource_group_id,
                 period_start=today,
                 period_end=today + timedelta(days=1),
                 decay_unit_days=1,
@@ -455,14 +476,12 @@ class TestResourceUsageHistoryRepository:
         )
         await resource_usage_history_repository.upsert_domain_usage_bucket(upserter1)
 
-        replacement_resource_group_id = ResourceGroupID(uuid.uuid4())
-
         # Second upsert (update)
         upserter2 = Upserter(
             spec=DomainUsageBucketUpserterSpec(
                 domain_name=test_domain_name,
                 resource_group=test_scaling_group,
-                resource_group_id=replacement_resource_group_id,
+                resource_group_id=test_resource_group_id,
                 period_start=today,
                 period_end=today + timedelta(days=1),
                 decay_unit_days=1,
@@ -481,12 +500,13 @@ class TestResourceUsageHistoryRepository:
                     DomainUsageBucketRow.period_start == today,
                 )
             )
-        assert stored_resource_group_id == replacement_resource_group_id
+        assert stored_resource_group_id == test_resource_group_id
 
     async def test_search_domain_usage_buckets(
         self,
         resource_usage_history_repository: ResourceUsageHistoryRepository,
         test_scaling_group: str,
+        test_resource_group_id: ResourceGroupID,
         test_domain_name: str,
     ) -> None:
         """Test searching domain usage buckets with BatchQuerier"""
@@ -499,7 +519,7 @@ class TestResourceUsageHistoryRepository:
                 spec=DomainUsageBucketCreatorSpec(
                     domain_name=test_domain_name,
                     resource_group=test_scaling_group,
-                    resource_group_id=RESOURCE_GROUP_ID,
+                    resource_group_id=test_resource_group_id,
                     period_start=bucket_date,
                     period_end=bucket_date + timedelta(days=1),
                     decay_unit_days=1,
@@ -531,6 +551,7 @@ class TestResourceUsageHistoryRepository:
         self,
         resource_usage_history_repository: ResourceUsageHistoryRepository,
         test_scaling_group: str,
+        test_resource_group_id: ResourceGroupID,
         test_domain_name: str,
         test_project_id: uuid.UUID,
         test_user_uuid: uuid.UUID,
@@ -544,7 +565,7 @@ class TestResourceUsageHistoryRepository:
                 project_id=test_project_id,
                 domain_name=test_domain_name,
                 resource_group=test_scaling_group,
-                resource_group_id=RESOURCE_GROUP_ID,
+                resource_group_id=test_resource_group_id,
                 period_start=today,
                 period_end=today + timedelta(days=1),
                 decay_unit_days=1,
@@ -557,12 +578,14 @@ class TestResourceUsageHistoryRepository:
 
         assert result.user_uuid == test_user_uuid
         assert result.project_id == test_project_id
+        assert result.resource_group_id == test_resource_group_id
         assert result.resource_usage["cpu"] == Decimal("3600")
 
     async def test_upsert_user_usage_bucket(
         self,
         resource_usage_history_repository: ResourceUsageHistoryRepository,
         test_scaling_group: str,
+        test_resource_group_id: ResourceGroupID,
         test_domain_name: str,
         test_project_id: uuid.UUID,
         test_user_uuid: uuid.UUID,
@@ -576,7 +599,7 @@ class TestResourceUsageHistoryRepository:
                 project_id=test_project_id,
                 domain_name=test_domain_name,
                 resource_group=test_scaling_group,
-                resource_group_id=RESOURCE_GROUP_ID,
+                resource_group_id=test_resource_group_id,
                 period_start=today,
                 period_end=today + timedelta(days=1),
                 decay_unit_days=1,
@@ -596,6 +619,7 @@ class TestResourceUsageHistoryRepository:
         self,
         resource_usage_history_repository: ResourceUsageHistoryRepository,
         test_scaling_group: str,
+        test_resource_group_id: ResourceGroupID,
         test_domain_name: str,
         test_project_id: uuid.UUID,
     ) -> None:
@@ -607,7 +631,7 @@ class TestResourceUsageHistoryRepository:
                 project_id=test_project_id,
                 domain_name=test_domain_name,
                 resource_group=test_scaling_group,
-                resource_group_id=RESOURCE_GROUP_ID,
+                resource_group_id=test_resource_group_id,
                 period_start=today,
                 period_end=today + timedelta(days=1),
                 decay_unit_days=1,
@@ -619,6 +643,7 @@ class TestResourceUsageHistoryRepository:
         result = await resource_usage_history_repository.create_project_usage_bucket(creator)
 
         assert result.project_id == test_project_id
+        assert result.resource_group_id == test_resource_group_id
         assert result.resource_usage["cpu"] == Decimal("3600")
 
     # ==================== Aggregation Tests ====================
@@ -628,6 +653,7 @@ class TestResourceUsageHistoryRepository:
         resource_usage_history_repository: ResourceUsageHistoryRepository,
         db_with_cleanup: ExtendedAsyncSAEngine,
         test_scaling_group: str,
+        test_resource_group_id: ResourceGroupID,
         test_domain_name: str,
         test_project_id: uuid.UUID,
         test_user_uuid: uuid.UUID,
@@ -644,7 +670,7 @@ class TestResourceUsageHistoryRepository:
                     project_id=test_project_id,
                     domain_name=test_domain_name,
                     resource_group=test_scaling_group,
-                    resource_group_id=RESOURCE_GROUP_ID,
+                    resource_group_id=test_resource_group_id,
                     period_start=bucket_date,
                     period_end=bucket_date + timedelta(days=1),
                     decay_unit_days=1,
@@ -670,7 +696,7 @@ class TestResourceUsageHistoryRepository:
         lookback_start = today - timedelta(days=7)
         lookback_end = today
         results = await resource_usage_history_repository.get_aggregated_usage_by_user(
-            resource_group=test_scaling_group,
+            resource_group_id=test_resource_group_id,
             lookback_start=lookback_start,
             lookback_end=lookback_end,
         )
@@ -682,7 +708,7 @@ class TestResourceUsageHistoryRepository:
     async def test_get_aggregated_usage_by_user_empty(
         self,
         resource_usage_history_repository: ResourceUsageHistoryRepository,
-        test_scaling_group: str,
+        test_resource_group_id: ResourceGroupID,
     ) -> None:
         """Test getting aggregated usage with no data returns empty dict"""
         today = datetime.now(tz=UTC).date()
@@ -690,7 +716,7 @@ class TestResourceUsageHistoryRepository:
         lookback_end = today
 
         results = await resource_usage_history_repository.get_aggregated_usage_by_user(
-            resource_group=test_scaling_group,
+            resource_group_id=test_resource_group_id,
             lookback_start=lookback_start,
             lookback_end=lookback_end,
         )
@@ -702,6 +728,7 @@ class TestResourceUsageHistoryRepository:
         resource_usage_history_repository: ResourceUsageHistoryRepository,
         db_with_cleanup: ExtendedAsyncSAEngine,
         test_scaling_group: str,
+        test_resource_group_id: ResourceGroupID,
         test_domain_name: str,
         test_project_id: uuid.UUID,
     ) -> None:
@@ -716,7 +743,7 @@ class TestResourceUsageHistoryRepository:
                     project_id=test_project_id,
                     domain_name=test_domain_name,
                     resource_group=test_scaling_group,
-                    resource_group_id=RESOURCE_GROUP_ID,
+                    resource_group_id=test_resource_group_id,
                     period_start=bucket_date,
                     period_end=bucket_date + timedelta(days=1),
                     decay_unit_days=1,
@@ -742,7 +769,7 @@ class TestResourceUsageHistoryRepository:
         lookback_start = today - timedelta(days=7)
         lookback_end = today
         results = await resource_usage_history_repository.get_aggregated_usage_by_project(
-            resource_group=test_scaling_group,
+            resource_group_id=test_resource_group_id,
             lookback_start=lookback_start,
             lookback_end=lookback_end,
         )
@@ -755,6 +782,7 @@ class TestResourceUsageHistoryRepository:
         resource_usage_history_repository: ResourceUsageHistoryRepository,
         db_with_cleanup: ExtendedAsyncSAEngine,
         test_scaling_group: str,
+        test_resource_group_id: ResourceGroupID,
         test_domain_name: str,
     ) -> None:
         """Test getting aggregated usage by domain"""
@@ -767,7 +795,7 @@ class TestResourceUsageHistoryRepository:
                 spec=DomainUsageBucketCreatorSpec(
                     domain_name=test_domain_name,
                     resource_group=test_scaling_group,
-                    resource_group_id=RESOURCE_GROUP_ID,
+                    resource_group_id=test_resource_group_id,
                     period_start=bucket_date,
                     period_end=bucket_date + timedelta(days=1),
                     decay_unit_days=1,
@@ -793,7 +821,7 @@ class TestResourceUsageHistoryRepository:
         lookback_start = today - timedelta(days=7)
         lookback_end = today
         results = await resource_usage_history_repository.get_aggregated_usage_by_domain(
-            resource_group=test_scaling_group,
+            resource_group_id=test_resource_group_id,
             lookback_start=lookback_start,
             lookback_end=lookback_end,
         )

--- a/tests/unit/manager/repositories/resource_usage_history/test_usage_bucket_entries.py
+++ b/tests/unit/manager/repositories/resource_usage_history/test_usage_bucket_entries.py
@@ -127,6 +127,7 @@ class TestUsageBucketEntries:
         raw_slots = ResourceSlot({"cpu": Decimal("2"), "mem": Decimal("4096000")})
         duration = 300  # 5-minute slice
         period = date(2024, 1, 15)
+        resource_group_id = ResourceGroupID(uuid.uuid4())
 
         result = UsageBucketAggregationResult(
             user_usage_deltas={},
@@ -135,7 +136,7 @@ class TestUsageBucketEntries:
                 DomainUsageBucketKey(
                     domain_name=test_domain_name,
                     resource_group="default",
-                    resource_group_id=RESOURCE_GROUP_ID,
+                    resource_group_id=resource_group_id,
                     period_date=period,
                 ): BucketDelta(slots=raw_slots, duration_seconds=duration),
             },
@@ -174,10 +175,11 @@ class TestUsageBucketEntries:
     ) -> None:
         """Verify that multiple increments accumulate amount and duration."""
         period = date(2024, 1, 15)
+        resource_group_id = ResourceGroupID(uuid.uuid4())
         key = DomainUsageBucketKey(
             domain_name=test_domain_name,
             resource_group="default",
-            resource_group_id=RESOURCE_GROUP_ID,
+            resource_group_id=resource_group_id,
             period_date=period,
         )
 
@@ -195,18 +197,11 @@ class TestUsageBucketEntries:
         await db_source.increment_usage_buckets(result1)
 
         # Second increment: 3 CPUs for 300 seconds
-        replacement_resource_group_id = ResourceGroupID(uuid.uuid4())
-        replacement_key = DomainUsageBucketKey(
-            domain_name=test_domain_name,
-            resource_group="default",
-            resource_group_id=replacement_resource_group_id,
-            period_date=period,
-        )
         result2 = UsageBucketAggregationResult(
             user_usage_deltas={},
             project_usage_deltas={},
             domain_usage_deltas={
-                replacement_key: BucketDelta(
+                key: BucketDelta(
                     slots=ResourceSlot({"cpu": Decimal("3")}),
                     duration_seconds=300,
                 ),
@@ -240,7 +235,7 @@ class TestUsageBucketEntries:
                     DomainUsageBucketRow.period_start == period,
                 )
             )
-            assert stored_resource_group_id == replacement_resource_group_id
+            assert stored_resource_group_id == resource_group_id
 
     async def test_increment_user_buckets_creates_entries(
         self,
@@ -254,6 +249,7 @@ class TestUsageBucketEntries:
         raw_slots = ResourceSlot({"cpu": Decimal("3"), "cuda.device": Decimal("2")})
         duration = 300  # 5-minute slice
         period = date(2024, 1, 15)
+        resource_group_id = ResourceGroupID(uuid.uuid4())
 
         result = UsageBucketAggregationResult(
             user_usage_deltas={
@@ -262,7 +258,7 @@ class TestUsageBucketEntries:
                     project_id=project_id,
                     domain_name=test_domain_name,
                     resource_group="default",
-                    resource_group_id=RESOURCE_GROUP_ID,
+                    resource_group_id=resource_group_id,
                     period_date=period,
                 ): BucketDelta(slots=raw_slots, duration_seconds=duration),
             },
@@ -301,6 +297,7 @@ class TestUsageBucketEntries:
         """Verify that aggregation queries read from normalized entries."""
         period1 = date(2024, 1, 15)
         period2 = date(2024, 1, 16)
+        resource_group_id = ResourceGroupID(uuid.uuid4())
 
         # Insert two domain buckets with entries (raw amount, not resource-seconds)
         result = UsageBucketAggregationResult(
@@ -310,7 +307,7 @@ class TestUsageBucketEntries:
                 DomainUsageBucketKey(
                     domain_name=test_domain_name,
                     resource_group="default",
-                    resource_group_id=RESOURCE_GROUP_ID,
+                    resource_group_id=resource_group_id,
                     period_date=period1,
                 ): BucketDelta(
                     slots=ResourceSlot({"cpu": Decimal("2")}),
@@ -319,7 +316,7 @@ class TestUsageBucketEntries:
                 DomainUsageBucketKey(
                     domain_name=test_domain_name,
                     resource_group="default",
-                    resource_group_id=RESOURCE_GROUP_ID,
+                    resource_group_id=resource_group_id,
                     period_date=period2,
                 ): BucketDelta(
                     slots=ResourceSlot({"cpu": Decimal("3")}),
@@ -331,7 +328,7 @@ class TestUsageBucketEntries:
 
         # Query aggregated usage — SUM(amount) across buckets
         aggregated = await db_source.get_aggregated_usage_by_domain(
-            resource_group="default",
+            resource_group_id=resource_group_id,
             lookback_start=date(2024, 1, 14),
             lookback_end=date(2024, 1, 17),
         )

--- a/tests/unit/manager/services/fair_share/test_fair_share_service.py
+++ b/tests/unit/manager/services/fair_share/test_fair_share_service.py
@@ -81,14 +81,14 @@ class TestGetDomainFairShare:
         mock_repository.get_domain_fair_share = AsyncMock(return_value=expected_data)
 
         action = GetDomainFairShareAction(
-            resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name="test-domain",
         )
 
         result = await service.get_domain_fair_share(action)
 
         mock_repository.get_domain_fair_share.assert_called_once_with(
-            resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name="test-domain",
         )
         assert result.data == expected_data
@@ -104,6 +104,7 @@ class TestGetDomainFairShare:
         # Repository now creates and returns complete default data internally
         default_data = DomainFairShareData(
             resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name="test-domain",
             data=FairShareData(
                 spec=FairShareSpec(
@@ -131,7 +132,7 @@ class TestGetDomainFairShare:
         mock_repository.get_domain_fair_share = AsyncMock(return_value=default_data)
 
         action = GetDomainFairShareAction(
-            resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name="test-domain",
         )
 
@@ -154,7 +155,7 @@ class TestGetDomainFairShare:
         )
 
         action = GetDomainFairShareAction(
-            resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name="nonexistent-domain",
         )
 
@@ -180,6 +181,7 @@ class TestGetDomainFairShare:
 
         default_data = DomainFairShareData(
             resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name="test-domain",
             data=FairShareData(
                 spec=FairShareSpec(
@@ -207,7 +209,7 @@ class TestGetDomainFairShare:
         mock_repository.get_domain_fair_share = AsyncMock(return_value=default_data)
 
         action = GetDomainFairShareAction(
-            resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name="test-domain",
         )
 
@@ -298,14 +300,14 @@ class TestGetProjectFairShare:
         mock_repository.get_project_fair_share = AsyncMock(return_value=expected_data)
 
         action = GetProjectFairShareAction(
-            resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             project_id=project_id,
         )
 
         result = await service.get_project_fair_share(action)
 
         mock_repository.get_project_fair_share.assert_called_once_with(
-            resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             project_id=project_id,
         )
         assert result.data == expected_data
@@ -322,6 +324,7 @@ class TestGetProjectFairShare:
         # Repository now creates and returns complete default data internally
         default_data = ProjectFairShareData(
             resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             project_id=project_id,
             domain_name="test-domain",
             data=FairShareData(
@@ -350,7 +353,7 @@ class TestGetProjectFairShare:
         mock_repository.get_project_fair_share = AsyncMock(return_value=default_data)
 
         action = GetProjectFairShareAction(
-            resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             project_id=project_id,
         )
 
@@ -375,7 +378,7 @@ class TestGetProjectFairShare:
         )
 
         action = GetProjectFairShareAction(
-            resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             project_id=project_id,
         )
 
@@ -402,6 +405,7 @@ class TestGetProjectFairShare:
 
         default_data = ProjectFairShareData(
             resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             project_id=project_id,
             domain_name="test-domain",
             data=FairShareData(
@@ -430,7 +434,7 @@ class TestGetProjectFairShare:
         mock_repository.get_project_fair_share = AsyncMock(return_value=default_data)
 
         action = GetProjectFairShareAction(
-            resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             project_id=project_id,
         )
 
@@ -522,7 +526,7 @@ class TestGetUserFairShare:
         mock_repository.get_user_fair_share = AsyncMock(return_value=expected_data)
 
         action = GetUserFairShareAction(
-            resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             project_id=project_id,
             user_uuid=user_uuid,
         )
@@ -530,7 +534,7 @@ class TestGetUserFairShare:
         result = await service.get_user_fair_share(action)
 
         mock_repository.get_user_fair_share.assert_called_once_with(
-            resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             project_id=project_id,
             user_uuid=user_uuid,
         )
@@ -549,6 +553,7 @@ class TestGetUserFairShare:
         # Repository now creates and returns complete default data internally
         default_data = UserFairShareData(
             resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             user_uuid=user_uuid,
             project_id=project_id,
             domain_name="test-domain",
@@ -579,7 +584,7 @@ class TestGetUserFairShare:
         mock_repository.get_user_fair_share = AsyncMock(return_value=default_data)
 
         action = GetUserFairShareAction(
-            resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             project_id=project_id,
             user_uuid=user_uuid,
         )
@@ -607,7 +612,7 @@ class TestGetUserFairShare:
         )
 
         action = GetUserFairShareAction(
-            resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             project_id=project_id,
             user_uuid=user_uuid,
         )
@@ -636,6 +641,7 @@ class TestGetUserFairShare:
 
         default_data = UserFairShareData(
             resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             user_uuid=user_uuid,
             project_id=project_id,
             domain_name="test-domain",
@@ -666,7 +672,7 @@ class TestGetUserFairShare:
         mock_repository.get_user_fair_share = AsyncMock(return_value=default_data)
 
         action = GetUserFairShareAction(
-            resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             project_id=project_id,
             user_uuid=user_uuid,
         )
@@ -757,6 +763,7 @@ class TestSearchDomainFairShareEntities:
         # Mock domain with record
         domain_with_record = DomainFairShareData(
             resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name="domain-with-record",
             data=FairShareData(
                 spec=FairShareSpec(
@@ -775,6 +782,7 @@ class TestSearchDomainFairShareEntities:
         # Mock default domain (without record in DB, created by Repository)
         domain_without_record = DomainFairShareData(
             resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name="domain-without-record",
             data=FairShareData(
                 spec=FairShareSpec(
@@ -800,7 +808,7 @@ class TestSearchDomainFairShareEntities:
 
         mock_repository.search_rg_domain_fair_shares = AsyncMock(return_value=entity_result)
 
-        scope = DomainFairShareSearchScope(resource_group="default")
+        scope = DomainFairShareSearchScope(resource_group_id=RESOURCE_GROUP_ID)
         querier = BatchQuerier(
             pagination=OffsetPagination(offset=0, limit=100),
             conditions=[],
@@ -827,6 +835,7 @@ class TestSearchDomainFairShareEntities:
         # Repository creates default with weight set to default_weight
         default_domain = DomainFairShareData(
             resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name="domain-without-record",
             data=FairShareData(
                 spec=FairShareSpec(
@@ -851,7 +860,7 @@ class TestSearchDomainFairShareEntities:
 
         mock_repository.search_rg_domain_fair_shares = AsyncMock(return_value=entity_result)
 
-        scope = DomainFairShareSearchScope(resource_group="default")
+        scope = DomainFairShareSearchScope(resource_group_id=RESOURCE_GROUP_ID)
         querier = BatchQuerier(
             pagination=OffsetPagination(offset=0, limit=100),
             conditions=[],
@@ -882,6 +891,7 @@ class TestSearchDomainFairShareEntities:
 
         default_domain = DomainFairShareData(
             resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name="domain-without-record",
             data=FairShareData(
                 spec=FairShareSpec(
@@ -906,7 +916,7 @@ class TestSearchDomainFairShareEntities:
 
         mock_repository.search_rg_domain_fair_shares = AsyncMock(return_value=entity_result)
 
-        scope = DomainFairShareSearchScope(resource_group="default")
+        scope = DomainFairShareSearchScope(resource_group_id=RESOURCE_GROUP_ID)
         querier = BatchQuerier(
             pagination=OffsetPagination(offset=0, limit=100),
             conditions=[],
@@ -941,6 +951,7 @@ class TestSearchProjectFairShareEntities:
         # Mock project with record
         project_with_record = ProjectFairShareData(
             resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             project_id=project_id_with_record,
             domain_name="test-domain",
             data=FairShareData(
@@ -960,6 +971,7 @@ class TestSearchProjectFairShareEntities:
         # Mock default project
         project_without_record = ProjectFairShareData(
             resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             project_id=project_id_without_record,
             domain_name="test-domain",
             data=FairShareData(
@@ -986,7 +998,9 @@ class TestSearchProjectFairShareEntities:
 
         mock_repository.search_rg_project_fair_shares = AsyncMock(return_value=entity_result)
 
-        scope = ProjectFairShareSearchScope(resource_group="default", domain_name="test-domain")
+        scope = ProjectFairShareSearchScope(
+            domain_name="test-domain", resource_group_id=RESOURCE_GROUP_ID
+        )
         querier = BatchQuerier(
             pagination=OffsetPagination(offset=0, limit=100),
             conditions=[],
@@ -1016,6 +1030,7 @@ class TestSearchUserFairShareEntities:
         # Mock user with record
         user_with_record = UserFairShareData(
             resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             user_uuid=user_uuid_with_record,
             project_id=project_id,
             domain_name="test-domain",
@@ -1037,6 +1052,7 @@ class TestSearchUserFairShareEntities:
         # Mock default user
         user_without_record = UserFairShareData(
             resource_group="default",
+            resource_group_id=RESOURCE_GROUP_ID,
             user_uuid=user_uuid_without_record,
             project_id=project_id,
             domain_name="test-domain",
@@ -1066,9 +1082,9 @@ class TestSearchUserFairShareEntities:
         mock_repository.search_rg_user_fair_shares = AsyncMock(return_value=entity_result)
 
         scope = UserFairShareSearchScope(
-            resource_group="default",
             domain_name="test-domain",
             project_id=project_id,
+            resource_group_id=RESOURCE_GROUP_ID,
         )
         querier = BatchQuerier(
             pagination=OffsetPagination(offset=0, limit=100),
@@ -1100,6 +1116,7 @@ class TestUpsertFairShareWeightWithoutResourceGroup:
         today = now.date()
         expected_data = DomainFairShareData(
             resource_group="non-existent-sg",
+            resource_group_id=RESOURCE_GROUP_ID,
             domain_name="test-domain",
             data=FairShareData(
                 spec=FairShareSpec(
@@ -1147,6 +1164,7 @@ class TestUpsertFairShareWeightWithoutResourceGroup:
         today = now.date()
         expected_data = ProjectFairShareData(
             resource_group="non-existent-sg",
+            resource_group_id=RESOURCE_GROUP_ID,
             project_id=project_id,
             domain_name="test-domain",
             data=FairShareData(
@@ -1197,6 +1215,7 @@ class TestUpsertFairShareWeightWithoutResourceGroup:
         today = now.date()
         expected_data = UserFairShareData(
             resource_group="non-existent-sg",
+            resource_group_id=RESOURCE_GROUP_ID,
             user_uuid=user_uuid,
             project_id=project_id,
             domain_name="test-domain",

--- a/tests/unit/manager/sokovan/scheduler/fair_share/test_calculator.py
+++ b/tests/unit/manager/sokovan/scheduler/fair_share/test_calculator.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 
 import pytest
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import ResourceSlot, SlotQuantity
 from ai.backend.manager.data.fair_share import (
     DomainFairShareData,
@@ -530,6 +531,7 @@ class TestCalculateFactors:
                 domain={
                     domain_name: DomainFairShareData(
                         resource_group="default",
+                        resource_group_id=ResourceGroupID(uuid4()),
                         domain_name=domain_name,
                         data=FairShareData(
                             spec=make_fair_share_spec(weight=Decimal("1.0")),
@@ -542,6 +544,7 @@ class TestCalculateFactors:
                 project={
                     project_id: ProjectFairShareData(
                         resource_group="default",
+                        resource_group_id=ResourceGroupID(uuid4()),
                         project_id=project_id,
                         domain_name=domain_name,
                         data=FairShareData(
@@ -555,6 +558,7 @@ class TestCalculateFactors:
                 user={
                     user_key: UserFairShareData(
                         resource_group="default",
+                        resource_group_id=ResourceGroupID(uuid4()),
                         user_uuid=user_uuid,
                         project_id=project_id,
                         domain_name=domain_name,
@@ -667,6 +671,7 @@ class TestCalculateFactors:
                 domain={
                     domain_name: DomainFairShareData(
                         resource_group="default",
+                        resource_group_id=ResourceGroupID(uuid4()),
                         domain_name=domain_name,
                         data=FairShareData(
                             spec=make_fair_share_spec(weight=Decimal("0.5")),
@@ -697,6 +702,7 @@ class TestCalculateFactors:
                 domain={
                     domain_name: DomainFairShareData(
                         resource_group="default",
+                        resource_group_id=ResourceGroupID(uuid4()),
                         domain_name=domain_name,
                         data=FairShareData(
                             spec=make_fair_share_spec(weight=Decimal("2.0")),
@@ -930,6 +936,7 @@ class TestIntegrationScenarios:
                 domain={
                     domain_a: DomainFairShareData(
                         resource_group="default",
+                        resource_group_id=ResourceGroupID(uuid4()),
                         domain_name=domain_a,
                         data=FairShareData(
                             spec=make_fair_share_spec(),
@@ -940,6 +947,7 @@ class TestIntegrationScenarios:
                     ),
                     domain_b: DomainFairShareData(
                         resource_group="default",
+                        resource_group_id=ResourceGroupID(uuid4()),
                         domain_name=domain_b,
                         data=FairShareData(
                             spec=make_fair_share_spec(),
@@ -952,6 +960,7 @@ class TestIntegrationScenarios:
                 project={
                     project_a: ProjectFairShareData(
                         resource_group="default",
+                        resource_group_id=ResourceGroupID(uuid4()),
                         project_id=project_a,
                         domain_name=domain_a,
                         data=FairShareData(
@@ -963,6 +972,7 @@ class TestIntegrationScenarios:
                     ),
                     project_b: ProjectFairShareData(
                         resource_group="default",
+                        resource_group_id=ResourceGroupID(uuid4()),
                         project_id=project_b,
                         domain_name=domain_b,
                         data=FairShareData(
@@ -976,6 +986,7 @@ class TestIntegrationScenarios:
                 user={
                     user_a: UserFairShareData(
                         resource_group="default",
+                        resource_group_id=ResourceGroupID(uuid4()),
                         user_uuid=user_a.user_uuid,
                         project_id=project_a,
                         domain_name=domain_a,
@@ -989,6 +1000,7 @@ class TestIntegrationScenarios:
                     ),
                     user_b: UserFairShareData(
                         resource_group="default",
+                        resource_group_id=ResourceGroupID(uuid4()),
                         user_uuid=user_b.user_uuid,
                         project_id=project_b,
                         domain_name=domain_b,
@@ -1064,6 +1076,7 @@ class TestDomainNameResolution:
                 project={
                     project_id: ProjectFairShareData(
                         resource_group="default",
+                        resource_group_id=ResourceGroupID(uuid4()),
                         project_id=project_id,
                         domain_name=domain_name,
                         data=FairShareData(
@@ -1189,6 +1202,7 @@ class TestDomainNameResolution:
                 project={
                     project_id: ProjectFairShareData(
                         resource_group="default",
+                        resource_group_id=ResourceGroupID(uuid4()),
                         project_id=project_id,
                         domain_name="",
                         data=FairShareData(

--- a/tests/unit/manager/sokovan/scheduler/provisioner/sequencers/test_drf.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/sequencers/test_drf.py
@@ -20,8 +20,8 @@ from ai.backend.manager.sokovan.scheduler.provisioner.sequencers.drf import DRFS
 
 class TestDRFSequencer:
     @pytest.fixture
-    def scaling_group(self) -> str:
-        return "default"
+    def resource_group_id(self) -> ResourceGroupID:
+        return ResourceGroupID(uuid.uuid4())
 
     @pytest.fixture
     def sequencer(self) -> DRFSequencer:
@@ -116,13 +116,19 @@ class TestDRFSequencer:
         assert sequencer.name == "DRFSequencer"
 
     async def test_empty_workload(
-        self, scaling_group: str, sequencer: DRFSequencer, empty_system_snapshot: SystemSnapshot
+        self,
+        resource_group_id: ResourceGroupID,
+        sequencer: DRFSequencer,
+        empty_system_snapshot: SystemSnapshot,
     ) -> None:
-        result = await sequencer.sequence(scaling_group, empty_system_snapshot, [])
+        result = await sequencer.sequence(resource_group_id, empty_system_snapshot, [])
         assert result == []
 
     async def test_single_user_workloads(
-        self, scaling_group: str, sequencer: DRFSequencer, empty_system_snapshot: SystemSnapshot
+        self,
+        resource_group_id: ResourceGroupID,
+        sequencer: DRFSequencer,
+        empty_system_snapshot: SystemSnapshot,
     ) -> None:
         workloads = [
             SessionWorkload(
@@ -149,7 +155,7 @@ class TestDRFSequencer:
             ),
         ]
 
-        result = await sequencer.sequence(scaling_group, empty_system_snapshot, workloads)
+        result = await sequencer.sequence(resource_group_id, empty_system_snapshot, workloads)
 
         # With no existing allocations, order should be preserved
         assert len(result) == 2
@@ -158,7 +164,7 @@ class TestDRFSequencer:
 
     async def test_multiple_users_different_dominant_shares(
         self,
-        scaling_group: str,
+        resource_group_id: ResourceGroupID,
         sequencer: DRFSequencer,
         system_snapshot_with_allocations: SystemSnapshot,
     ) -> None:
@@ -199,7 +205,7 @@ class TestDRFSequencer:
         ]
 
         result = await sequencer.sequence(
-            scaling_group, system_snapshot_with_allocations, workloads
+            resource_group_id, system_snapshot_with_allocations, workloads
         )
 
         # Should be ordered by dominant share (ascending): user3 (5%), user1 (20%), user2 (30%)
@@ -209,7 +215,10 @@ class TestDRFSequencer:
         assert result[2].access_key == AccessKey("user2")
 
     async def test_multiple_users_same_dominant_share(
-        self, scaling_group: str, sequencer: DRFSequencer, empty_system_snapshot: SystemSnapshot
+        self,
+        resource_group_id: ResourceGroupID,
+        sequencer: DRFSequencer,
+        empty_system_snapshot: SystemSnapshot,
     ) -> None:
         # All users have no existing allocations (0% dominant share)
         workloads = [
@@ -248,7 +257,7 @@ class TestDRFSequencer:
             ),
         ]
 
-        result = await sequencer.sequence(scaling_group, empty_system_snapshot, workloads)
+        result = await sequencer.sequence(resource_group_id, empty_system_snapshot, workloads)
 
         # With same dominant share, order should be preserved
         assert len(result) == 3
@@ -258,7 +267,7 @@ class TestDRFSequencer:
 
     async def test_new_user_gets_priority(
         self,
-        scaling_group: str,
+        resource_group_id: ResourceGroupID,
         sequencer: DRFSequencer,
         system_snapshot_with_allocations: SystemSnapshot,
     ) -> None:
@@ -288,7 +297,7 @@ class TestDRFSequencer:
         ]
 
         result = await sequencer.sequence(
-            scaling_group, system_snapshot_with_allocations, workloads
+            resource_group_id, system_snapshot_with_allocations, workloads
         )
 
         # New user with 0% dominant share should get priority
@@ -297,7 +306,7 @@ class TestDRFSequencer:
         assert result[1].access_key == AccessKey("user2")
 
     async def test_dominant_share_calculation_with_zero_capacity(
-        self, scaling_group: str, sequencer: DRFSequencer
+        self, resource_group_id: ResourceGroupID, sequencer: DRFSequencer
     ) -> None:
         # Test edge case where some resource has zero capacity
         system_snapshot = SystemSnapshot(
@@ -354,5 +363,5 @@ class TestDRFSequencer:
         ]
 
         # Should not crash when dividing by zero capacity
-        result = await sequencer.sequence(scaling_group, system_snapshot, workloads)
+        result = await sequencer.sequence(resource_group_id, system_snapshot, workloads)
         assert len(result) == 1

--- a/tests/unit/manager/sokovan/scheduler/provisioner/sequencers/test_fair_share.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/sequencers/test_fair_share.py
@@ -1,0 +1,44 @@
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.types import AccessKey, ResourceSlot, SessionId
+from ai.backend.manager.data.fair_share import ProjectUserIds
+from ai.backend.manager.data.sokovan import SessionWorkload, SystemSnapshot
+from ai.backend.manager.repositories.fair_share import FairShareRepository
+from ai.backend.manager.sokovan.scheduler.provisioner.sequencers.fair_share import (
+    FairShareSequencer,
+)
+
+
+async def test_loads_factors_by_resource_group_id() -> None:
+    resource_group_id = ResourceGroupID(uuid.uuid4())
+    project_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    workload = SessionWorkload(
+        session_id=SessionId(uuid.uuid4()),
+        access_key=AccessKey("user"),
+        requested_slots=ResourceSlot(cpu=Decimal("1")),
+        user_uuid=user_id,
+        group_id=project_id,
+        domain_name="default",
+        scaling_group="default",
+        resource_group_id=resource_group_id,
+        priority=0,
+    )
+    repository = MagicMock(spec=FairShareRepository)
+    repository.get_user_fair_share_factors_batch = AsyncMock(return_value={})
+    sequencer = FairShareSequencer(repository)
+
+    result = await sequencer.sequence(
+        resource_group_id,
+        MagicMock(spec=SystemSnapshot),
+        [workload],
+    )
+
+    assert result == [workload]
+    repository.get_user_fair_share_factors_batch.assert_awaited_once_with(
+        resource_group_id,
+        [ProjectUserIds(project_id=project_id, user_ids=frozenset({user_id}))],
+    )

--- a/tests/unit/manager/sokovan/scheduler/provisioner/sequencers/test_fifo.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/sequencers/test_fifo.py
@@ -20,8 +20,8 @@ from ai.backend.manager.sokovan.scheduler.provisioner.sequencers.fifo import FIF
 
 class TestFIFOSequencer:
     @pytest.fixture
-    def scaling_group(self) -> str:
-        return "default"
+    def resource_group_id(self) -> ResourceGroupID:
+        return ResourceGroupID(uuid.uuid4())
 
     @pytest.fixture
     def sequencer(self) -> FIFOSequencer:
@@ -61,13 +61,19 @@ class TestFIFOSequencer:
         assert sequencer.name == "FIFOSequencer"
 
     async def test_empty_workload(
-        self, scaling_group: str, sequencer: FIFOSequencer, system_snapshot: SystemSnapshot
+        self,
+        resource_group_id: ResourceGroupID,
+        sequencer: FIFOSequencer,
+        system_snapshot: SystemSnapshot,
     ) -> None:
-        result = await sequencer.sequence(scaling_group, system_snapshot, [])
+        result = await sequencer.sequence(resource_group_id, system_snapshot, [])
         assert result == []
 
     async def test_preserves_order(
-        self, scaling_group: str, sequencer: FIFOSequencer, system_snapshot: SystemSnapshot
+        self,
+        resource_group_id: ResourceGroupID,
+        sequencer: FIFOSequencer,
+        system_snapshot: SystemSnapshot,
     ) -> None:
         workloads = [
             SessionWorkload(
@@ -105,7 +111,7 @@ class TestFIFOSequencer:
             ),
         ]
 
-        result = await sequencer.sequence(scaling_group, system_snapshot, workloads)
+        result = await sequencer.sequence(resource_group_id, system_snapshot, workloads)
 
         # FIFO should preserve the original order
         assert len(result) == 3
@@ -114,7 +120,7 @@ class TestFIFOSequencer:
         assert result[2] == workloads[2]
 
     async def test_ignores_system_snapshot(
-        self, scaling_group: str, sequencer: FIFOSequencer
+        self, resource_group_id: ResourceGroupID, sequencer: FIFOSequencer
     ) -> None:
         # FIFO should work the same regardless of system state
         snapshot_with_allocations = SystemSnapshot(
@@ -187,7 +193,7 @@ class TestFIFOSequencer:
             ),
         ]
 
-        result = await sequencer.sequence(scaling_group, snapshot_with_allocations, workloads)
+        result = await sequencer.sequence(resource_group_id, snapshot_with_allocations, workloads)
 
         # Should still preserve original order despite different allocations
         assert len(result) == 2

--- a/tests/unit/manager/sokovan/scheduler/provisioner/sequencers/test_lifo.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/sequencers/test_lifo.py
@@ -20,8 +20,8 @@ from ai.backend.manager.sokovan.scheduler.provisioner.sequencers.lifo import LIF
 
 class TestLIFOSequencer:
     @pytest.fixture
-    def scaling_group(self) -> str:
-        return "default"
+    def resource_group_id(self) -> ResourceGroupID:
+        return ResourceGroupID(uuid.uuid4())
 
     @pytest.fixture
     def sequencer(self) -> LIFOSequencer:
@@ -61,13 +61,19 @@ class TestLIFOSequencer:
         assert sequencer.name == "LIFOSequencer"
 
     async def test_empty_workload(
-        self, scaling_group: str, sequencer: LIFOSequencer, system_snapshot: SystemSnapshot
+        self,
+        resource_group_id: ResourceGroupID,
+        sequencer: LIFOSequencer,
+        system_snapshot: SystemSnapshot,
     ) -> None:
-        result = await sequencer.sequence(scaling_group, system_snapshot, [])
+        result = await sequencer.sequence(resource_group_id, system_snapshot, [])
         assert result == []
 
     async def test_reverses_order(
-        self, scaling_group: str, sequencer: LIFOSequencer, system_snapshot: SystemSnapshot
+        self,
+        resource_group_id: ResourceGroupID,
+        sequencer: LIFOSequencer,
+        system_snapshot: SystemSnapshot,
     ) -> None:
         workloads = [
             SessionWorkload(
@@ -105,7 +111,7 @@ class TestLIFOSequencer:
             ),
         ]
 
-        result = await sequencer.sequence(scaling_group, system_snapshot, workloads)
+        result = await sequencer.sequence(resource_group_id, system_snapshot, workloads)
 
         # LIFO should reverse the order
         assert len(result) == 3
@@ -114,7 +120,10 @@ class TestLIFOSequencer:
         assert result[2] == workloads[0]  # First becomes last
 
     async def test_single_workload(
-        self, scaling_group: str, sequencer: LIFOSequencer, system_snapshot: SystemSnapshot
+        self,
+        resource_group_id: ResourceGroupID,
+        sequencer: LIFOSequencer,
+        system_snapshot: SystemSnapshot,
     ) -> None:
         workloads = [
             SessionWorkload(
@@ -130,14 +139,14 @@ class TestLIFOSequencer:
             ),
         ]
 
-        result = await sequencer.sequence(scaling_group, system_snapshot, workloads)
+        result = await sequencer.sequence(resource_group_id, system_snapshot, workloads)
 
         # Single item should remain the same
         assert len(result) == 1
         assert result[0] == workloads[0]
 
     async def test_ignores_system_snapshot(
-        self, scaling_group: str, sequencer: LIFOSequencer
+        self, resource_group_id: ResourceGroupID, sequencer: LIFOSequencer
     ) -> None:
         # LIFO should work the same regardless of system state
         snapshot_with_allocations = SystemSnapshot(
@@ -221,7 +230,7 @@ class TestLIFOSequencer:
             ),
         ]
 
-        result = await sequencer.sequence(scaling_group, snapshot_with_allocations, workloads)
+        result = await sequencer.sequence(resource_group_id, snapshot_with_allocations, workloads)
 
         # Should still reverse order despite different allocations
         assert len(result) == 3

--- a/tests/unit/manager/sokovan/scheduler/provisioner/sequencers/test_sequencer.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/sequencers/test_sequencer.py
@@ -36,8 +36,8 @@ def make_workload(access_key: str, priority: int) -> SessionWorkload:
 
 class TestSchedulingSequencer:
     @pytest.fixture
-    def scaling_group(self) -> str:
-        return "default"
+    def resource_group_id(self) -> ResourceGroupID:
+        return ResourceGroupID(uuid.uuid4())
 
     @pytest.fixture
     def sequencer(self) -> SchedulingSequencer:
@@ -75,16 +75,16 @@ class TestSchedulingSequencer:
 
     async def test_empty_workloads(
         self,
-        scaling_group: str,
+        resource_group_id: ResourceGroupID,
         sequencer: SchedulingSequencer,
         system_snapshot: SystemSnapshot,
     ) -> None:
-        result = await sequencer.sequence(scaling_group, system_snapshot, [])
+        result = await sequencer.sequence(resource_group_id, system_snapshot, [])
         assert result == []
 
     async def test_keeps_all_workloads_across_priorities(
         self,
-        scaling_group: str,
+        resource_group_id: ResourceGroupID,
         sequencer: SchedulingSequencer,
         system_snapshot: SystemSnapshot,
     ) -> None:
@@ -94,13 +94,13 @@ class TestSchedulingSequencer:
             make_workload("low", priority=0),
         ]
 
-        result = await sequencer.sequence(scaling_group, system_snapshot, workloads)
+        result = await sequencer.sequence(resource_group_id, system_snapshot, workloads)
 
         assert {w.access_key for w in result} == {AccessKey(k) for k in ("high", "mid", "low")}
 
     async def test_orders_by_descending_priority(
         self,
-        scaling_group: str,
+        resource_group_id: ResourceGroupID,
         sequencer: SchedulingSequencer,
         system_snapshot: SystemSnapshot,
     ) -> None:
@@ -110,13 +110,13 @@ class TestSchedulingSequencer:
             make_workload("mid", priority=5),
         ]
 
-        result = await sequencer.sequence(scaling_group, system_snapshot, workloads)
+        result = await sequencer.sequence(resource_group_id, system_snapshot, workloads)
 
         assert [w.access_key for w in result] == [AccessKey(k) for k in ("high", "mid", "low")]
 
     async def test_preserves_order_within_same_priority(
         self,
-        scaling_group: str,
+        resource_group_id: ResourceGroupID,
         sequencer: SchedulingSequencer,
         system_snapshot: SystemSnapshot,
     ) -> None:
@@ -127,7 +127,7 @@ class TestSchedulingSequencer:
             make_workload("low-second", priority=0),
         ]
 
-        result = await sequencer.sequence(scaling_group, system_snapshot, workloads)
+        result = await sequencer.sequence(resource_group_id, system_snapshot, workloads)
 
         assert [w.access_key for w in result] == [
             AccessKey(k) for k in ("high-first", "high-second", "low-first", "low-second")


### PR DESCRIPTION
## Summary
- Keep resource group names in the existing REST and GraphQL contracts while resolving them to stable IDs at API boundaries.
- Use `ResourceGroupID` throughout fair-share services, repositories, usage aggregation, sequencers, and agent-capacity queries.
- Change fair-share and usage-bucket uniqueness to resource group IDs and add an Alembic migration for the constraints and supporting index.

## Test plan
- [x] `pants fmt ::`
- [x] `pants fix ::`
- [x] `pants lint --changed-since=origin/main`
- [x] Pre-push MyPy checks for 89 affected source files
- [x] Pre-push affected unit and repository tests
- [x] Alembic upgrade, downgrade, re-upgrade, and schema diff check

Resolves BA-6780

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12818.org.readthedocs.build/en/12818/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12818.org.readthedocs.build/ko/12818/

<!-- readthedocs-preview sorna-ko end -->