### PR TITLE
test(BA-6862): seed association_scopes_entities in check_presets tests (#12813)

### DIFF
--- a/changes/12813.test.md
+++ b/changes/12813.test.md
@@ -1,0 +1,1 @@
+Seed `association_scopes_entities` in resource preset `check_presets` repository tests to match project membership resolution.

--- a/tests/unit/manager/repositories/resource_preset/test_check_presets.py
+++ b/tests/unit/manager/repositories/resource_preset/test_check_presets.py
@@ -146,7 +146,6 @@ class TestCheckPresetsOccupiedSlots:
                 sgroups_for_domains,  # association table
                 sgroups_for_keypairs,  # association table
                 sgroups_for_groups,  # association table
-                AssociationScopesEntitiesRow,  # RBAC project membership
             ],
         ):
             # Seed default resource slot types (FK target for normalized tables)
@@ -298,16 +297,6 @@ class TestCheckPresetsOccupiedSlots:
             await db_sess.flush()
 
             # RBAC project membership (queried by check_presets)
-            db_sess.add(
-                AssociationScopesEntitiesRow(
-                    scope_type=ScopeType.PROJECT,
-                    scope_id=str(group_id),
-                    entity_type=EntityType.USER,
-                    entity_id=str(test_user_uuid),
-                )
-            )
-            # Record project membership in the RBAC association table, which
-            # check_presets now uses to resolve the user's group.
             db_sess.add(
                 AssociationScopesEntitiesRow(
                     scope_type=ScopeType.PROJECT,
@@ -1239,7 +1228,6 @@ class TestCheckPresetsZeroValues:
                 sgroups_for_domains,  # association table
                 sgroups_for_keypairs,  # association table
                 sgroups_for_groups,  # association table
-                AssociationScopesEntitiesRow,  # RBAC project membership
             ],
         ):
             # Seed default resource slot types (FK target for normalized tables)
@@ -1423,16 +1411,6 @@ class TestCheckPresetsZeroValues:
             await db_sess.flush()
 
             # RBAC project membership (queried by check_presets)
-            db_sess.add(
-                AssociationScopesEntitiesRow(
-                    scope_type=ScopeType.PROJECT,
-                    scope_id=str(group_id),
-                    entity_type=EntityType.USER,
-                    entity_id=str(test_user_uuid),
-                )
-            )
-            # Record project membership in the RBAC association table, which
-            # check_presets now uses to resolve the user's group.
             db_sess.add(
                 AssociationScopesEntitiesRow(
                     scope_type=ScopeType.PROJECT,

--- a/tests/unit/manager/repositories/resource_preset/test_check_presets.py
+++ b/tests/unit/manager/repositories/resource_preset/test_check_presets.py
@@ -47,7 +47,7 @@ from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
 from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
-from ai.backend.manager.models.group import GroupRow, association_groups_users
+from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
@@ -146,7 +146,7 @@ class TestCheckPresetsOccupiedSlots:
                 sgroups_for_domains,  # association table
                 sgroups_for_keypairs,  # association table
                 sgroups_for_groups,  # association table
-                association_groups_users,  # association table
+                AssociationScopesEntitiesRow,  # RBAC project membership
             ],
         ):
             # Seed default resource slot types (FK target for normalized tables)
@@ -297,11 +297,13 @@ class TestCheckPresetsOccupiedSlots:
             db_sess.add(group)
             await db_sess.flush()
 
-            # Add user to group
-            await db_sess.execute(
-                sa.insert(association_groups_users).values(
-                    user_id=test_user_uuid,
-                    group_id=group_id,
+            # RBAC project membership (queried by check_presets)
+            db_sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=str(group_id),
+                    entity_type=EntityType.USER,
+                    entity_id=str(test_user_uuid),
                 )
             )
             # Record project membership in the RBAC association table, which
@@ -1237,7 +1239,7 @@ class TestCheckPresetsZeroValues:
                 sgroups_for_domains,  # association table
                 sgroups_for_keypairs,  # association table
                 sgroups_for_groups,  # association table
-                association_groups_users,  # association table
+                AssociationScopesEntitiesRow,  # RBAC project membership
             ],
         ):
             # Seed default resource slot types (FK target for normalized tables)
@@ -1420,11 +1422,13 @@ class TestCheckPresetsZeroValues:
             db_sess.add(group)
             await db_sess.flush()
 
-            # Add user to group
-            await db_sess.execute(
-                sa.insert(association_groups_users).values(
-                    user_id=test_user_uuid,
-                    group_id=group_id,
+            # RBAC project membership (queried by check_presets)
+            db_sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=str(group_id),
+                    entity_type=EntityType.USER,
+                    entity_id=str(test_user_uuid),
                 )
             )
             # Record project membership in the RBAC association table, which


### PR DESCRIPTION
This is an auto-generated backport PR of #12813 to the 26.4 release.