### PR TITLE
feat(BA-6583): Implement session lifetime checker

### DIFF
--- a/changes/12821.feature.md
+++ b/changes/12821.feature.md
@@ -1,0 +1,1 @@
+Add a reconciler-based session lifetime checker.

--- a/proposals/BEP-1054-reconciler-based-idle-checker.md
+++ b/proposals/BEP-1054-reconciler-based-idle-checker.md
@@ -32,7 +32,7 @@ This proposal re-homes idle checking onto a sokovan reconciler stage and promote
 ### Non-Goals
 
 - The concrete judgment rules of each checker (timeout math, threshold comparison, metric names) are implementation concerns and are out of scope.
-- Backfilling legacy keypair `idle_timeout` / `max_session_lifetime` into checker specs is left as an open question.
+- Backfilling or falling back to legacy keypair resource-policy idle settings is out of scope. Reconciler-based idle checkers use only their own specs.
 
 ## Current Design
 
@@ -170,7 +170,7 @@ The idle stage lives on the **generic reconciler** — one fetch per tick, not p
 
 **Per resource group, the Source:**
 
-1. reads the idle-eligible running sessions in the group;
+1. reads the idle-eligible running sessions with a recorded start time in the group;
 2. collects the distinct scopes those sessions belong to — the resource group, their projects, their domains;
 3. loads only the enabled `idle_checker_bindings` (with their checker specs) attached to those scopes;
 4. composes each session's effective checker set from the bindings on its own scopes.
@@ -218,11 +218,13 @@ The Source does not branch centrally on checker type to read Valkey or Prometheu
 
 | `checker_type` | Terminates when… | Runtime signal |
 |---|---|---|
-| `session_lifetime` | a session has run longer than its maximum lifetime | none (session creation time) |
+| `session_lifetime` | a started session has run longer than its maximum lifetime; zero disables the definition | none (session start time) |
 | `network_timeout` | an interactive session has had no access and no active connections beyond a timeout | last-access / active-connection signals |
 | `utilization` | a session's resource utilization stays below thresholds across a window, after a grace period | windowed utilization metrics |
 
-The exact judgment rules for each checker are an implementation concern and are intentionally not specified here. A single scope can bind multiple checkers of the same `checker_type`
+The exact judgment rules for each checker are an implementation concern and are intentionally not specified here. A single scope can bind multiple checkers of the same `checker_type`.
+
+Checker specs are the sole configuration source for reconciler-based idle decisions. The Source and checker implementations do not read `keypair_resource_policies.idle_timeout` or `keypair_resource_policies.max_session_lifetime`, and those legacy values are neither fallback values nor implicit defaults. Whether a checker applies is controlled only by its scope bindings; its threshold or lifetime is controlled only by its spec.
 
 ### Utilization via Prometheus
 
@@ -263,7 +265,6 @@ flowchart TB
 
 ## Open Questions
 
-- Should the legacy keypair `idle_timeout` / `max_session_lifetime` values be backfilled into checker specs, or only honored as a fallback during rollout?
 - Should utilization `and` / `or` threshold semantics match the legacy behavior or be redefined?
 
 ## References

--- a/src/ai/backend/common/data/idle_checker/types.py
+++ b/src/ai/backend/common/data/idle_checker/types.py
@@ -17,10 +17,16 @@ class CheckerType(enum.StrEnum):
 
 
 class SessionLifetimeSpec(BackendAISchema):
-    """Config for ``CheckerType.SESSION_LIFETIME``.
+    """Config for ``CheckerType.SESSION_LIFETIME``."""
 
-    Concrete fields (e.g. max lifetime) land with the checker-logic stories.
-    """
+    max_lifetime_seconds: int = Field(
+        ge=0,
+        description=(
+            "Maximum time in seconds that a session may remain running. "
+            "Zero disables this checker definition. This is the sole lifetime limit "
+            "used by the reconciler idle checker."
+        ),
+    )
 
 
 class NetworkTimeoutSpec(BackendAISchema):

--- a/src/ai/backend/manager/models/session/conditions.py
+++ b/src/ai/backend/manager/models/session/conditions.py
@@ -46,7 +46,7 @@ class SessionConditions:
         return inner
 
     @staticmethod
-    def started() -> QueryCondition:
+    def by_started_at() -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return SessionRow.starts_at.isnot(None)
 

--- a/src/ai/backend/manager/models/session/conditions.py
+++ b/src/ai/backend/manager/models/session/conditions.py
@@ -46,6 +46,13 @@ class SessionConditions:
         return inner
 
     @staticmethod
+    def started() -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return SessionRow.starts_at.isnot(None)
+
+        return inner
+
+    @staticmethod
     def by_idle_check_candidates(
         candidates: Collection[tuple[ScopeId, Collection[SessionTypes]]],
     ) -> QueryCondition:

--- a/src/ai/backend/manager/repositories/idle_checker/repository.py
+++ b/src/ai/backend/manager/repositories/idle_checker/repository.py
@@ -59,6 +59,7 @@ class IdleCheckerRepository:
             pagination=NoPagination(),
             conditions=[
                 SessionConditions.by_statuses(session_statuses),
+                SessionConditions.started(),
                 SessionConditions.by_idle_check_candidates(idle_check_candidates),
             ],
         )

--- a/src/ai/backend/manager/repositories/idle_checker/repository.py
+++ b/src/ai/backend/manager/repositories/idle_checker/repository.py
@@ -59,7 +59,7 @@ class IdleCheckerRepository:
             pagination=NoPagination(),
             conditions=[
                 SessionConditions.by_statuses(session_statuses),
-                SessionConditions.started(),
+                SessionConditions.by_started_at(),
                 SessionConditions.by_idle_check_candidates(idle_check_candidates),
             ],
         )

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/base.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import datetime
 
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId
@@ -37,6 +38,8 @@ class IdleChecker(ABC):
     async def judge(
         self,
         assignments: Sequence[CheckerAssignment],
+        *,
+        current_time: datetime,
     ) -> Sequence[IdleJudgment]:
         """Evaluate every assignment of this type in one batched call.
 

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/base.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/base.py
@@ -14,6 +14,13 @@ from ai.backend.manager.repositories.idle_checker.types import IdleCheckerDefini
 
 
 @dataclass(frozen=True)
+class IdleCheckerContext:
+    """Shared execution context for every checker in one reconcile tick."""
+
+    current_time: datetime
+
+
+@dataclass(frozen=True)
 class CheckerAssignment:
     """One checker definition and the sessions it must judge this tick."""
 
@@ -39,7 +46,7 @@ class IdleChecker(ABC):
         self,
         assignments: Sequence[CheckerAssignment],
         *,
-        current_time: datetime,
+        context: IdleCheckerContext,
     ) -> Sequence[IdleJudgment]:
         """Evaluate every assignment of this type in one batched call.
 

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from datetime import datetime
 from decimal import Decimal
 from typing import override
 
@@ -10,6 +9,7 @@ from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
     IdleChecker,
+    IdleCheckerContext,
     IdleJudgment,
 )
 
@@ -24,7 +24,7 @@ class SessionLifetimeChecker(IdleChecker):
         self,
         assignments: Sequence[CheckerAssignment],
         *,
-        current_time: datetime,
+        context: IdleCheckerContext,
     ) -> Sequence[IdleJudgment]:
         judgments: list[IdleJudgment] = []
         for assignment in assignments:
@@ -43,7 +43,7 @@ class SessionLifetimeChecker(IdleChecker):
                 if session.starts_at is None:
                     continue
                 running_seconds = Decimal(
-                    str((current_time - session.starts_at).total_seconds())
+                    str((context.current_time - session.starts_at).total_seconds())
                 ).normalize()
                 judgments.append(
                     IdleJudgment(

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Sequence
 from datetime import datetime
 from decimal import Decimal
 from typing import override
 
-from ai.backend.manager.errors.common import InternalServerError
+from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
     IdleChecker,
     IdleJudgment,
 )
+
+log = BraceStyleAdapter(logging.getLogger(__name__))
 
 
 class SessionLifetimeChecker(IdleChecker):
@@ -27,9 +30,12 @@ class SessionLifetimeChecker(IdleChecker):
         for assignment in assignments:
             lifetime_spec = assignment.definition.spec.session_lifetime
             if lifetime_spec is None:
-                raise InternalServerError(
-                    f"Session lifetime checker(id: {assignment.definition.checker_id}) received an empty spec."
+                log.error(
+                    "Session lifetime checker {} has mismatched spec type: {}",
+                    assignment.definition.checker_id,
+                    assignment.definition.spec.type,
                 )
+                continue
             if lifetime_spec.max_lifetime_seconds == 0:
                 continue
             max_lifetime_seconds = Decimal(lifetime_spec.max_lifetime_seconds)

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime
+from decimal import Decimal
+from typing import override
+
+from ai.backend.manager.errors.common import InternalServerError
+from ai.backend.manager.sokovan.idle_check.checkers.base import (
+    CheckerAssignment,
+    IdleChecker,
+    IdleJudgment,
+)
+
+
+class SessionLifetimeChecker(IdleChecker):
+    """Judge sessions solely against each checker definition's lifetime setting."""
+
+    @override
+    async def judge(
+        self,
+        assignments: Sequence[CheckerAssignment],
+        *,
+        current_time: datetime,
+    ) -> Sequence[IdleJudgment]:
+        judgments: list[IdleJudgment] = []
+        for assignment in assignments:
+            lifetime_spec = assignment.definition.spec.session_lifetime
+            if lifetime_spec is None:
+                raise InternalServerError(
+                    f"Session lifetime checker(id: {assignment.definition.checker_id}) received an empty spec."
+                )
+            if lifetime_spec.max_lifetime_seconds == 0:
+                continue
+            max_lifetime_seconds = Decimal(lifetime_spec.max_lifetime_seconds)
+            for session in assignment.sessions:
+                if session.starts_at is None:
+                    continue
+                running_seconds = Decimal(
+                    str((current_time - session.starts_at).total_seconds())
+                ).normalize()
+                judgments.append(
+                    IdleJudgment(
+                        checker_id=assignment.definition.checker_id,
+                        session_id=session.session_id,
+                        is_idle=running_seconds >= max_lifetime_seconds,
+                        message=(
+                            "Session lifetime exceeded: "
+                            f"max_lifetime_seconds={max_lifetime_seconds:f}, "
+                            f"running_seconds={running_seconds:f}"
+                        ),
+                    )
+                )
+        return judgments

--- a/src/ai/backend/manager/sokovan/idle_check/handlers/reconcile.py
+++ b/src/ai/backend/manager/sokovan/idle_check/handlers/reconcile.py
@@ -41,7 +41,10 @@ class IdleCheckReconcileHandler(ReconcilerHandler[IdleCheckReconcileInfo, IdleCh
             checker = self._checkers.get(checker_type)
             if checker is None:
                 continue
-            judgments = await checker.judge(assignments)
+            judgments = await checker.judge(
+                assignments,
+                current_time=reconcile_info.current_time,
+            )
             for judgment in judgments:
                 if not judgment.is_idle:
                     continue

--- a/src/ai/backend/manager/sokovan/idle_check/handlers/reconcile.py
+++ b/src/ai/backend/manager/sokovan/idle_check/handlers/reconcile.py
@@ -15,6 +15,7 @@ from ai.backend.manager.repositories.idle_checker.types import (
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
     IdleChecker,
+    IdleCheckerContext,
 )
 from ai.backend.manager.sokovan.idle_check.types import (
     IdleCheckReconcileInfo,
@@ -36,6 +37,7 @@ class IdleCheckReconcileHandler(ReconcilerHandler[IdleCheckReconcileInfo, IdleCh
     @override
     async def execute(self, reconcile_info: IdleCheckReconcileInfo) -> IdleCheckResult:
         assignments_by_type = self._assignments_by_type(reconcile_info.batch)
+        context = IdleCheckerContext(current_time=reconcile_info.current_time)
         reasons_by_session: defaultdict[SessionId, list[IdleReason]] = defaultdict(list)
         for checker_type, assignments in assignments_by_type.items():
             checker = self._checkers.get(checker_type)
@@ -43,7 +45,7 @@ class IdleCheckReconcileHandler(ReconcilerHandler[IdleCheckReconcileInfo, IdleCh
                 continue
             judgments = await checker.judge(
                 assignments,
-                current_time=reconcile_info.current_time,
+                context=context,
             )
             for judgment in judgments:
                 if not judgment.is_idle:

--- a/src/ai/backend/manager/sokovan/stages/idle_check.py
+++ b/src/ai/backend/manager/sokovan/stages/idle_check.py
@@ -14,6 +14,9 @@ from ai.backend.manager.defs import LockID
 from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
 from ai.backend.manager.sokovan.idle_check.applier import IdleCheckApplier
 from ai.backend.manager.sokovan.idle_check.checkers.base import IdleChecker
+from ai.backend.manager.sokovan.idle_check.checkers.session_lifetime import (
+    SessionLifetimeChecker,
+)
 from ai.backend.manager.sokovan.idle_check.handlers.reconcile import IdleCheckReconcileHandler
 from ai.backend.manager.sokovan.idle_check.source import IdleCheckSource
 from ai.backend.manager.sokovan.idle_check.types import (
@@ -48,7 +51,9 @@ def build_idle_check_stage(
         lock_id=LockID.LOCKID_IDLE_CHECK_RECONCILE,
         transitions=transitions,
     )
-    checkers: Mapping[CheckerType, IdleChecker] = {}
+    checkers: Mapping[CheckerType, IdleChecker] = {
+        CheckerType.SESSION_LIFETIME: SessionLifetimeChecker(),
+    }
     stage = ReconcilerStage(
         handler=IdleCheckReconcileHandler(checkers),
         source=IdleCheckSource(idle_checker_repository),

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -53,6 +53,7 @@ class SeededIdleCheckData:
     project_session_id: SessionId
     domain_session_id: SessionId
     inference_session_id: SessionId
+    unstarted_session_id: SessionId
     resource_group_checker_id: IdleCheckerID
     project_checker_id: IdleCheckerID
     domain_checker_id: IdleCheckerID
@@ -278,7 +279,7 @@ class TestFetchIdleCheckBatch:
                     target_session_types=[SessionTypes.INTERACTIVE, SessionTypes.BATCH],
                     spec=IdleCheckerSpec(
                         type=CheckerType.SESSION_LIFETIME,
-                        session_lifetime=SessionLifetimeSpec(),
+                        session_lifetime=SessionLifetimeSpec(max_lifetime_seconds=3600),
                     ),
                 )
             )
@@ -326,10 +327,12 @@ class TestFetchIdleCheckBatch:
         project_session_id = SessionId(uuid.uuid4())
         domain_session_id = SessionId(uuid.uuid4())
         inference_session_id = SessionId(uuid.uuid4())
+        unstarted_session_id = SessionId(uuid.uuid4())
         session_specs = (
             (
                 resource_group_scope,
                 resource_group_session_id,
+                datetime(2026, 1, 1, tzinfo=UTC),
                 datetime(2026, 1, 1, tzinfo=UTC),
                 SessionTypes.INTERACTIVE,
             ),
@@ -337,11 +340,13 @@ class TestFetchIdleCheckBatch:
                 project_scope,
                 project_session_id,
                 datetime(2026, 1, 2, tzinfo=UTC),
+                datetime(2026, 1, 2, tzinfo=UTC),
                 SessionTypes.INTERACTIVE,
             ),
             (
                 domain_scope,
                 domain_session_id,
+                datetime(2026, 1, 3, tzinfo=UTC),
                 datetime(2026, 1, 3, tzinfo=UTC),
                 SessionTypes.INTERACTIVE,
             ),
@@ -349,7 +354,15 @@ class TestFetchIdleCheckBatch:
                 resource_group_scope,
                 inference_session_id,
                 datetime(2026, 1, 4, tzinfo=UTC),
+                datetime(2026, 1, 4, tzinfo=UTC),
                 SessionTypes.INFERENCE,
+            ),
+            (
+                domain_scope,
+                unstarted_session_id,
+                datetime(2026, 1, 5, tzinfo=UTC),
+                None,
+                SessionTypes.INTERACTIVE,
             ),
         )
         resource_group_checker_id = IdleCheckerID(uuid.uuid4())
@@ -361,7 +374,7 @@ class TestFetchIdleCheckBatch:
                 CheckerType.SESSION_LIFETIME,
                 IdleCheckerSpec(
                     type=CheckerType.SESSION_LIFETIME,
-                    session_lifetime=SessionLifetimeSpec(),
+                    session_lifetime=SessionLifetimeSpec(max_lifetime_seconds=3600),
                 ),
                 ScopeType.RESOURCE_GROUP,
                 resource_group_scope.scaling_group_id,
@@ -428,7 +441,7 @@ class TestFetchIdleCheckBatch:
                         use_host_network=False,
                     )
                 )
-            for scope, session_id, created_at, session_type in session_specs:
+            for scope, session_id, created_at, starts_at, session_type in session_specs:
                 db_sess.add(
                     SessionRow(
                         id=session_id,
@@ -451,7 +464,7 @@ class TestFetchIdleCheckBatch:
                         result=SessionResult.UNDEFINED,
                         created_at=created_at,
                         terminated_at=None,
-                        starts_at=created_at,
+                        starts_at=starts_at,
                         startup_command=None,
                         callback_url=None,
                         occupying_slots=ResourceSlot({"cpu": "1"}),
@@ -490,6 +503,7 @@ class TestFetchIdleCheckBatch:
             project_session_id=project_session_id,
             domain_session_id=domain_session_id,
             inference_session_id=inference_session_id,
+            unstarted_session_id=unstarted_session_id,
             resource_group_checker_id=resource_group_checker_id,
             project_checker_id=project_checker_id,
             domain_checker_id=domain_checker_id,
@@ -586,14 +600,24 @@ class TestFetchIdleCheckBatch:
         seeded_idle_check_data: SeededIdleCheckData,
     ) -> None:
         batch = await repository.fetch_idle_check_batch([SessionStatus.RUNNING])
-        targets_by_session_id = {target.session.session_id: target for target in batch.targets}
+        target_session_ids = {target.session.session_id for target in batch.targets}
 
-        assert set(targets_by_session_id) == {
-            seeded_idle_check_data.resource_group_session_id,
-            seeded_idle_check_data.project_session_id,
-            seeded_idle_check_data.domain_session_id,
-        }
-        assert seeded_idle_check_data.inference_session_id not in targets_by_session_id
+        assert seeded_idle_check_data.inference_session_id not in target_session_ids
+
+    @pytest.mark.parametrize(
+        "seeded_idle_check_data",
+        [("resource-group", "project", "domain")],
+        indirect=True,
+    )
+    async def test_excludes_sessions_without_starts_at(
+        self,
+        repository: IdleCheckerRepository,
+        seeded_idle_check_data: SeededIdleCheckData,
+    ) -> None:
+        batch = await repository.fetch_idle_check_batch([SessionStatus.RUNNING])
+        target_session_ids = {target.session.session_id for target in batch.targets}
+
+        assert seeded_idle_check_data.unstarted_session_id not in target_session_ids
 
     @pytest.fixture
     async def per_type_checker_data(
@@ -704,7 +728,7 @@ class TestFetchIdleCheckBatch:
                         target_session_types=list(target_types),
                         spec=IdleCheckerSpec(
                             type=CheckerType.SESSION_LIFETIME,
-                            session_lifetime=SessionLifetimeSpec(),
+                            session_lifetime=SessionLifetimeSpec(max_lifetime_seconds=3600),
                         ),
                     )
                 )

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -602,6 +602,11 @@ class TestFetchIdleCheckBatch:
         batch = await repository.fetch_idle_check_batch([SessionStatus.RUNNING])
         target_session_ids = {target.session.session_id for target in batch.targets}
 
+        assert target_session_ids == {
+            seeded_idle_check_data.resource_group_session_id,
+            seeded_idle_check_data.project_session_id,
+            seeded_idle_check_data.domain_session_id,
+        }
         assert seeded_idle_check_data.inference_session_id not in target_session_ids
 
     @pytest.mark.parametrize(
@@ -617,6 +622,11 @@ class TestFetchIdleCheckBatch:
         batch = await repository.fetch_idle_check_batch([SessionStatus.RUNNING])
         target_session_ids = {target.session.session_id for target in batch.targets}
 
+        assert target_session_ids == {
+            seeded_idle_check_data.resource_group_session_id,
+            seeded_idle_check_data.project_session_id,
+            seeded_idle_check_data.domain_session_id,
+        }
         assert seeded_idle_check_data.unstarted_session_id not in target_session_ids
 
     @pytest.fixture

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -53,7 +53,7 @@ class SeededIdleCheckData:
     project_session_id: SessionId
     domain_session_id: SessionId
     inference_session_id: SessionId
-    unstarted_session_id: SessionId
+    not_started_session_id: SessionId
     resource_group_checker_id: IdleCheckerID
     project_checker_id: IdleCheckerID
     domain_checker_id: IdleCheckerID
@@ -327,7 +327,7 @@ class TestFetchIdleCheckBatch:
         project_session_id = SessionId(uuid.uuid4())
         domain_session_id = SessionId(uuid.uuid4())
         inference_session_id = SessionId(uuid.uuid4())
-        unstarted_session_id = SessionId(uuid.uuid4())
+        not_started_session_id = SessionId(uuid.uuid4())
         session_specs = (
             (
                 resource_group_scope,
@@ -359,7 +359,7 @@ class TestFetchIdleCheckBatch:
             ),
             (
                 domain_scope,
-                unstarted_session_id,
+                not_started_session_id,
                 datetime(2026, 1, 5, tzinfo=UTC),
                 None,
                 SessionTypes.INTERACTIVE,
@@ -503,7 +503,7 @@ class TestFetchIdleCheckBatch:
             project_session_id=project_session_id,
             domain_session_id=domain_session_id,
             inference_session_id=inference_session_id,
-            unstarted_session_id=unstarted_session_id,
+            not_started_session_id=not_started_session_id,
             resource_group_checker_id=resource_group_checker_id,
             project_checker_id=project_checker_id,
             domain_checker_id=domain_checker_id,
@@ -627,7 +627,7 @@ class TestFetchIdleCheckBatch:
             seeded_idle_check_data.project_session_id,
             seeded_idle_check_data.domain_session_id,
         }
-        assert seeded_idle_check_data.unstarted_session_id not in target_session_ids
+        assert seeded_idle_check_data.not_started_session_id not in target_session_ids
 
     @pytest.fixture
     async def per_type_checker_data(

--- a/tests/unit/manager/sokovan/idle_check/test_handler.py
+++ b/tests/unit/manager/sokovan/idle_check/test_handler.py
@@ -29,6 +29,7 @@ from ai.backend.manager.repositories.idle_checker.types import (
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
     IdleChecker,
+    IdleCheckerContext,
     IdleJudgment,
 )
 from ai.backend.manager.sokovan.idle_check.handlers.reconcile import IdleCheckReconcileHandler
@@ -56,14 +57,14 @@ class FakeChecker(IdleChecker):
 
     idle_session_ids: set[SessionId]
     judge_calls: list[list[tuple[IdleCheckerID, list[SessionId]]]]
-    judge_current_times: list[datetime]
+    judge_contexts: list[IdleCheckerContext]
     should_fail: bool
     _message: str
 
     def __init__(self, message: str = "idle") -> None:
         self.idle_session_ids = set()
         self.judge_calls = []
-        self.judge_current_times = []
+        self.judge_contexts = []
         self.should_fail = False
         self._message = message
 
@@ -72,9 +73,9 @@ class FakeChecker(IdleChecker):
         self,
         assignments: Sequence[CheckerAssignment],
         *,
-        current_time: datetime,
+        context: IdleCheckerContext,
     ) -> Sequence[IdleJudgment]:
-        self.judge_current_times.append(current_time)
+        self.judge_contexts.append(context)
         call_record: list[tuple[IdleCheckerID, list[SessionId]]] = []
         for assignment in assignments:
             session_ids = [session.session_id for session in assignment.sessions]
@@ -196,8 +197,9 @@ class TestIdleCheckReconcileHandler:
         assert network_checker.judge_calls == [
             [(network_bound.checker.checker_id, [second_session_id])],
         ]
-        assert lifetime_checker.judge_current_times == [_NOW]
-        assert network_checker.judge_current_times == [_NOW]
+        expected_context = IdleCheckerContext(current_time=_NOW)
+        assert lifetime_checker.judge_contexts == [expected_context]
+        assert network_checker.judge_contexts == [expected_context]
 
     async def test_deduplicates_cross_scope_assignments(
         self,

--- a/tests/unit/manager/sokovan/idle_check/test_handler.py
+++ b/tests/unit/manager/sokovan/idle_check/test_handler.py
@@ -42,7 +42,8 @@ _NOW = datetime(2026, 1, 2, tzinfo=UTC)
 
 _SPECS: Final[dict[CheckerType, IdleCheckerSpec]] = {
     CheckerType.SESSION_LIFETIME: IdleCheckerSpec(
-        type=CheckerType.SESSION_LIFETIME, session_lifetime=SessionLifetimeSpec()
+        type=CheckerType.SESSION_LIFETIME,
+        session_lifetime=SessionLifetimeSpec(max_lifetime_seconds=3600),
     ),
     CheckerType.NETWORK_TIMEOUT: IdleCheckerSpec(
         type=CheckerType.NETWORK_TIMEOUT, network=NetworkTimeoutSpec()
@@ -55,12 +56,14 @@ class FakeChecker(IdleChecker):
 
     idle_session_ids: set[SessionId]
     judge_calls: list[list[tuple[IdleCheckerID, list[SessionId]]]]
+    judge_current_times: list[datetime]
     should_fail: bool
     _message: str
 
     def __init__(self, message: str = "idle") -> None:
         self.idle_session_ids = set()
         self.judge_calls = []
+        self.judge_current_times = []
         self.should_fail = False
         self._message = message
 
@@ -68,7 +71,10 @@ class FakeChecker(IdleChecker):
     async def judge(
         self,
         assignments: Sequence[CheckerAssignment],
+        *,
+        current_time: datetime,
     ) -> Sequence[IdleJudgment]:
+        self.judge_current_times.append(current_time)
         call_record: list[tuple[IdleCheckerID, list[SessionId]]] = []
         for assignment in assignments:
             session_ids = [session.session_id for session in assignment.sessions]
@@ -145,7 +151,9 @@ class TestIdleCheckReconcileHandler:
 
     @pytest.fixture()
     def handler(
-        self, lifetime_checker: FakeChecker, network_checker: FakeChecker
+        self,
+        lifetime_checker: FakeChecker,
+        network_checker: FakeChecker,
     ) -> IdleCheckReconcileHandler:
         return IdleCheckReconcileHandler({
             CheckerType.SESSION_LIFETIME: lifetime_checker,
@@ -188,6 +196,8 @@ class TestIdleCheckReconcileHandler:
         assert network_checker.judge_calls == [
             [(network_bound.checker.checker_id, [second_session_id])],
         ]
+        assert lifetime_checker.judge_current_times == [_NOW]
+        assert network_checker.judge_current_times == [_NOW]
 
     async def test_deduplicates_cross_scope_assignments(
         self,

--- a/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
+++ b/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, datetime, timedelta
+from typing import Protocol
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from ai.backend.common.data.idle_checker.types import (
+    CheckerType,
+    IdleCheckerSpec,
+    NetworkTimeoutSpec,
+    SessionLifetimeSpec,
+)
+from ai.backend.common.identifier.idle_checker import IdleCheckerID
+from ai.backend.common.types import SessionId, SessionTypes
+from ai.backend.manager.data.idle_checker.types import IdleCheckSession
+from ai.backend.manager.errors.common import InternalServerError
+from ai.backend.manager.repositories.idle_checker.types import IdleCheckerDefinitionData
+from ai.backend.manager.sokovan.idle_check.checkers.base import CheckerAssignment
+from ai.backend.manager.sokovan.idle_check.checkers.session_lifetime import (
+    SessionLifetimeChecker,
+)
+
+_BASE_TIME = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+class SessionFactory(Protocol):
+    def __call__(
+        self,
+        *,
+        starts_at: datetime | None = _BASE_TIME,
+        created_at: datetime = _BASE_TIME,
+    ) -> IdleCheckSession: ...
+
+
+class AssignmentFactory(Protocol):
+    def __call__(
+        self,
+        *,
+        max_lifetime_seconds: int,
+        sessions: Sequence[IdleCheckSession],
+    ) -> CheckerAssignment: ...
+
+
+class TestSessionLifetimeSpec:
+    def test_accepts_zero_as_disabled_lifetime(self) -> None:
+        spec = SessionLifetimeSpec(max_lifetime_seconds=0)
+
+        assert spec.max_lifetime_seconds == 0
+
+    def test_rejects_negative_lifetime(self) -> None:
+        with pytest.raises(ValidationError):
+            SessionLifetimeSpec(max_lifetime_seconds=-1)
+
+
+class TestSessionLifetimeChecker:
+    @pytest.fixture()
+    def checker(self) -> SessionLifetimeChecker:
+        return SessionLifetimeChecker()
+
+    @pytest.fixture()
+    def session_factory(self) -> SessionFactory:
+        def create_session(
+            *,
+            starts_at: datetime | None = _BASE_TIME,
+            created_at: datetime = _BASE_TIME,
+        ) -> IdleCheckSession:
+            return IdleCheckSession(
+                session_id=SessionId(uuid4()),
+                created_at=created_at,
+                starts_at=starts_at,
+            )
+
+        return create_session
+
+    @pytest.fixture()
+    def assignment_factory(self) -> AssignmentFactory:
+        def create_assignment(
+            *,
+            max_lifetime_seconds: int,
+            sessions: Sequence[IdleCheckSession],
+        ) -> CheckerAssignment:
+            return CheckerAssignment(
+                definition=IdleCheckerDefinitionData(
+                    checker_id=IdleCheckerID(uuid4()),
+                    checker_type=CheckerType.SESSION_LIFETIME,
+                    target_session_types=frozenset({SessionTypes.INTERACTIVE}),
+                    spec=IdleCheckerSpec(
+                        type=CheckerType.SESSION_LIFETIME,
+                        session_lifetime=SessionLifetimeSpec(
+                            max_lifetime_seconds=max_lifetime_seconds
+                        ),
+                    ),
+                ),
+                sessions=sessions,
+            )
+
+        return create_assignment
+
+    async def test_session_before_deadline_is_active(
+        self,
+        checker: SessionLifetimeChecker,
+        session_factory: SessionFactory,
+        assignment_factory: AssignmentFactory,
+    ) -> None:
+        session = session_factory()
+        assignment = assignment_factory(max_lifetime_seconds=30, sessions=(session,))
+
+        judgments = await checker.judge(
+            (assignment,), current_time=_BASE_TIME + timedelta(seconds=29)
+        )
+
+        assert len(judgments) == 1
+        assert judgments[0].session_id == session.session_id
+        assert judgments[0].is_idle is False
+
+    async def test_session_at_deadline_is_idle(
+        self,
+        checker: SessionLifetimeChecker,
+        session_factory: SessionFactory,
+        assignment_factory: AssignmentFactory,
+    ) -> None:
+        session = session_factory()
+        assignment = assignment_factory(max_lifetime_seconds=30, sessions=(session,))
+
+        judgments = await checker.judge(
+            (assignment,), current_time=_BASE_TIME + timedelta(seconds=30)
+        )
+
+        assert len(judgments) == 1
+        assert judgments[0].session_id == session.session_id
+        assert judgments[0].is_idle is True
+        assert judgments[0].message == (
+            "Session lifetime exceeded: max_lifetime_seconds=30, running_seconds=30"
+        )
+
+    async def test_session_after_deadline_is_idle(
+        self,
+        checker: SessionLifetimeChecker,
+        session_factory: SessionFactory,
+        assignment_factory: AssignmentFactory,
+    ) -> None:
+        session = session_factory()
+        assignment = assignment_factory(max_lifetime_seconds=30, sessions=(session,))
+
+        judgments = await checker.judge(
+            (assignment,), current_time=_BASE_TIME + timedelta(seconds=31.2)
+        )
+
+        assert judgments[0].is_idle is True
+        assert judgments[0].message == (
+            "Session lifetime exceeded: max_lifetime_seconds=30, running_seconds=31.2"
+        )
+
+    async def test_disabled_lifetime_skips_assignment(
+        self,
+        checker: SessionLifetimeChecker,
+        session_factory: SessionFactory,
+        assignment_factory: AssignmentFactory,
+    ) -> None:
+        assignment = assignment_factory(
+            max_lifetime_seconds=0,
+            sessions=(session_factory(),),
+        )
+
+        judgments = await checker.judge((assignment,), current_time=_BASE_TIME + timedelta(days=1))
+
+        assert judgments == []
+
+    async def test_excludes_session_when_starts_at_is_missing(
+        self,
+        checker: SessionLifetimeChecker,
+        session_factory: SessionFactory,
+        assignment_factory: AssignmentFactory,
+    ) -> None:
+        session = session_factory(
+            starts_at=None,
+            created_at=_BASE_TIME - timedelta(seconds=30),
+        )
+        assignment = assignment_factory(max_lifetime_seconds=30, sessions=(session,))
+
+        judgments = await checker.judge((assignment,), current_time=_BASE_TIME)
+
+        assert judgments == []
+
+    async def test_evaluates_multiple_definitions_independently(
+        self,
+        checker: SessionLifetimeChecker,
+        session_factory: SessionFactory,
+        assignment_factory: AssignmentFactory,
+    ) -> None:
+        session = session_factory()
+        short_lifetime = assignment_factory(max_lifetime_seconds=10, sessions=(session,))
+        long_lifetime = assignment_factory(max_lifetime_seconds=30, sessions=(session,))
+
+        judgments = await checker.judge(
+            (short_lifetime, long_lifetime),
+            current_time=_BASE_TIME + timedelta(seconds=20),
+        )
+
+        assert [judgment.checker_id for judgment in judgments] == [
+            short_lifetime.definition.checker_id,
+            long_lifetime.definition.checker_id,
+        ]
+        assert [judgment.is_idle for judgment in judgments] == [True, False]
+
+    async def test_evaluates_every_session_in_assignment(
+        self,
+        checker: SessionLifetimeChecker,
+        session_factory: SessionFactory,
+        assignment_factory: AssignmentFactory,
+    ) -> None:
+        expired_session = session_factory(starts_at=_BASE_TIME - timedelta(seconds=30))
+        active_session = session_factory(starts_at=_BASE_TIME - timedelta(seconds=10))
+        assignment = assignment_factory(
+            max_lifetime_seconds=20,
+            sessions=(expired_session, active_session),
+        )
+
+        judgments = await checker.judge((assignment,), current_time=_BASE_TIME)
+
+        assert [judgment.session_id for judgment in judgments] == [
+            expired_session.session_id,
+            active_session.session_id,
+        ]
+        assert [judgment.is_idle for judgment in judgments] == [True, False]
+
+    async def test_rejects_assignment_with_mismatched_spec(
+        self,
+        checker: SessionLifetimeChecker,
+        session_factory: SessionFactory,
+    ) -> None:
+        assignment = CheckerAssignment(
+            definition=IdleCheckerDefinitionData(
+                checker_id=IdleCheckerID(uuid4()),
+                checker_type=CheckerType.SESSION_LIFETIME,
+                target_session_types=frozenset({SessionTypes.INTERACTIVE}),
+                spec=IdleCheckerSpec(
+                    type=CheckerType.NETWORK_TIMEOUT,
+                    network=NetworkTimeoutSpec(),
+                ),
+            ),
+            sessions=(session_factory(),),
+        )
+
+        with pytest.raises(InternalServerError):
+            await checker.judge((assignment,), current_time=_BASE_TIME)

--- a/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
+++ b/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
@@ -17,7 +17,6 @@ from ai.backend.common.data.idle_checker.types import (
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.data.idle_checker.types import IdleCheckSession
-from ai.backend.manager.errors.common import InternalServerError
 from ai.backend.manager.repositories.idle_checker.types import IdleCheckerDefinitionData
 from ai.backend.manager.sokovan.idle_check.checkers.base import CheckerAssignment
 from ai.backend.manager.sokovan.idle_check.checkers.session_lifetime import (
@@ -228,12 +227,13 @@ class TestSessionLifetimeChecker:
         ]
         assert [judgment.is_idle for judgment in judgments] == [True, False]
 
-    async def test_rejects_assignment_with_mismatched_spec(
+    async def test_skips_mismatched_spec_and_evaluates_remaining_assignments(
         self,
         checker: SessionLifetimeChecker,
         session_factory: SessionFactory,
+        assignment_factory: AssignmentFactory,
     ) -> None:
-        assignment = CheckerAssignment(
+        mismatched_assignment = CheckerAssignment(
             definition=IdleCheckerDefinitionData(
                 checker_id=IdleCheckerID(uuid4()),
                 checker_type=CheckerType.SESSION_LIFETIME,
@@ -245,6 +245,16 @@ class TestSessionLifetimeChecker:
             ),
             sessions=(session_factory(),),
         )
+        valid_assignment = assignment_factory(
+            max_lifetime_seconds=30,
+            sessions=(session_factory(),),
+        )
 
-        with pytest.raises(InternalServerError):
-            await checker.judge((assignment,), current_time=_BASE_TIME)
+        judgments = await checker.judge(
+            (mismatched_assignment, valid_assignment),
+            current_time=_BASE_TIME + timedelta(seconds=30),
+        )
+
+        assert [judgment.checker_id for judgment in judgments] == [
+            valid_assignment.definition.checker_id
+        ]

--- a/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
+++ b/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
@@ -18,7 +18,10 @@ from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.data.idle_checker.types import IdleCheckSession
 from ai.backend.manager.repositories.idle_checker.types import IdleCheckerDefinitionData
-from ai.backend.manager.sokovan.idle_check.checkers.base import CheckerAssignment
+from ai.backend.manager.sokovan.idle_check.checkers.base import (
+    CheckerAssignment,
+    IdleCheckerContext,
+)
 from ai.backend.manager.sokovan.idle_check.checkers.session_lifetime import (
     SessionLifetimeChecker,
 )
@@ -109,7 +112,10 @@ class TestSessionLifetimeChecker:
         assignment = assignment_factory(max_lifetime_seconds=30, sessions=(session,))
 
         judgments = await checker.judge(
-            (assignment,), current_time=_BASE_TIME + timedelta(seconds=29)
+            (assignment,),
+            context=IdleCheckerContext(
+                current_time=_BASE_TIME + timedelta(seconds=29),
+            ),
         )
 
         assert len(judgments) == 1
@@ -126,7 +132,10 @@ class TestSessionLifetimeChecker:
         assignment = assignment_factory(max_lifetime_seconds=30, sessions=(session,))
 
         judgments = await checker.judge(
-            (assignment,), current_time=_BASE_TIME + timedelta(seconds=30)
+            (assignment,),
+            context=IdleCheckerContext(
+                current_time=_BASE_TIME + timedelta(seconds=30),
+            ),
         )
 
         assert len(judgments) == 1
@@ -146,7 +155,10 @@ class TestSessionLifetimeChecker:
         assignment = assignment_factory(max_lifetime_seconds=30, sessions=(session,))
 
         judgments = await checker.judge(
-            (assignment,), current_time=_BASE_TIME + timedelta(seconds=31.2)
+            (assignment,),
+            context=IdleCheckerContext(
+                current_time=_BASE_TIME + timedelta(seconds=31.2),
+            ),
         )
 
         assert judgments[0].is_idle is True
@@ -165,7 +177,10 @@ class TestSessionLifetimeChecker:
             sessions=(session_factory(),),
         )
 
-        judgments = await checker.judge((assignment,), current_time=_BASE_TIME + timedelta(days=1))
+        judgments = await checker.judge(
+            (assignment,),
+            context=IdleCheckerContext(current_time=_BASE_TIME + timedelta(days=1)),
+        )
 
         assert judgments == []
 
@@ -181,7 +196,9 @@ class TestSessionLifetimeChecker:
         )
         assignment = assignment_factory(max_lifetime_seconds=30, sessions=(session,))
 
-        judgments = await checker.judge((assignment,), current_time=_BASE_TIME)
+        judgments = await checker.judge(
+            (assignment,), context=IdleCheckerContext(current_time=_BASE_TIME)
+        )
 
         assert judgments == []
 
@@ -197,7 +214,9 @@ class TestSessionLifetimeChecker:
 
         judgments = await checker.judge(
             (short_lifetime, long_lifetime),
-            current_time=_BASE_TIME + timedelta(seconds=20),
+            context=IdleCheckerContext(
+                current_time=_BASE_TIME + timedelta(seconds=20),
+            ),
         )
 
         assert [judgment.checker_id for judgment in judgments] == [
@@ -219,7 +238,9 @@ class TestSessionLifetimeChecker:
             sessions=(expired_session, active_session),
         )
 
-        judgments = await checker.judge((assignment,), current_time=_BASE_TIME)
+        judgments = await checker.judge(
+            (assignment,), context=IdleCheckerContext(current_time=_BASE_TIME)
+        )
 
         assert [judgment.session_id for judgment in judgments] == [
             expired_session.session_id,
@@ -252,7 +273,9 @@ class TestSessionLifetimeChecker:
 
         judgments = await checker.judge(
             (mismatched_assignment, valid_assignment),
-            current_time=_BASE_TIME + timedelta(seconds=30),
+            context=IdleCheckerContext(
+                current_time=_BASE_TIME + timedelta(seconds=30),
+            ),
         )
 
         assert [judgment.checker_id for judgment in judgments] == [

--- a/tests/unit/manager/sokovan/idle_check/test_stage.py
+++ b/tests/unit/manager/sokovan/idle_check/test_stage.py
@@ -1,13 +1,101 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
 
+import pytest
+from pytest_mock import MockerFixture
+
+from ai.backend.common.data.idle_checker.types import (
+    CheckerType,
+    IdleCheckerSpec,
+    SessionLifetimeSpec,
+)
+from ai.backend.common.data.permission.types import ScopeType
+from ai.backend.common.identifier.idle_checker import IdleCheckerID
+from ai.backend.common.types import SessionId, SessionTypes
+from ai.backend.manager.data.idle_checker.types import IdleCheckSession
+from ai.backend.manager.data.permission.id import ScopeId
 from ai.backend.manager.defs import LockID
+from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
+from ai.backend.manager.repositories.idle_checker.types import (
+    BoundCheckerData,
+    IdleCheckBatchData,
+    IdleCheckerDefinitionData,
+    IdleCheckTargetData,
+)
+from ai.backend.manager.sokovan.idle_check.checkers.session_lifetime import (
+    SessionLifetimeChecker,
+)
+from ai.backend.manager.sokovan.reconciler.base import ReconcilerStageRegistration
 from ai.backend.manager.sokovan.stages.factory import build_reconciler_coordinator
 from ai.backend.manager.sokovan.stages.idle_check import build_idle_check_stage
 
 
+@dataclass(frozen=True)
+class SessionLifetimeStageSetup:
+    registration: ReconcilerStageRegistration
+    checker: AsyncMock
+
+
 class TestBuildIdleCheckStage:
+    @pytest.fixture()
+    def idle_check_batch(self) -> IdleCheckBatchData:
+        checker_id = IdleCheckerID(uuid4())
+        session = IdleCheckSession(
+            session_id=SessionId(uuid4()),
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            starts_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        definition = IdleCheckerDefinitionData(
+            checker_id=checker_id,
+            checker_type=CheckerType.SESSION_LIFETIME,
+            target_session_types=frozenset({SessionTypes.INTERACTIVE}),
+            spec=IdleCheckerSpec(
+                type=CheckerType.SESSION_LIFETIME,
+                session_lifetime=SessionLifetimeSpec(max_lifetime_seconds=3600),
+            ),
+        )
+        return IdleCheckBatchData(
+            targets=(
+                IdleCheckTargetData(
+                    session=session,
+                    checkers=(
+                        BoundCheckerData(
+                            scope=ScopeId(ScopeType.DOMAIN, str(uuid4())),
+                            binding_created_at=datetime(2026, 1, 1, tzinfo=UTC),
+                            checker=definition,
+                        ),
+                    ),
+                ),
+            )
+        )
+
+    @pytest.fixture()
+    def idle_checker_repository(self, idle_check_batch: IdleCheckBatchData) -> AsyncMock:
+        repository = AsyncMock(spec=IdleCheckerRepository)
+        repository.fetch_idle_check_batch.return_value = idle_check_batch
+        return repository
+
+    @pytest.fixture()
+    def session_lifetime_stage(
+        self,
+        mocker: MockerFixture,
+        idle_checker_repository: AsyncMock,
+    ) -> SessionLifetimeStageSetup:
+        checker = AsyncMock(spec=SessionLifetimeChecker)
+        checker.judge.return_value = ()
+        mocker.patch(
+            "ai.backend.manager.sokovan.stages.idle_check.SessionLifetimeChecker",
+            return_value=checker,
+        )
+        return SessionLifetimeStageSetup(
+            registration=build_idle_check_stage(idle_checker_repository),
+            checker=checker,
+        )
+
     def test_registration_metadata(self) -> None:
         registration = build_idle_check_stage(MagicMock())
         assert registration.reconcile_type == "idle_check"
@@ -15,6 +103,13 @@ class TestBuildIdleCheckStage:
         assert registration.task_spec.reconcile_type == "idle_check"
         assert registration.task_spec.short_interval == 10.0
         assert registration.task_spec.long_interval == 60.0
+
+    async def test_runs_session_lifetime_checker(
+        self, session_lifetime_stage: SessionLifetimeStageSetup
+    ) -> None:
+        await session_lifetime_stage.registration.stage.run()
+
+        session_lifetime_stage.checker.judge.assert_awaited_once()
 
 
 class TestFactoryRegistration:


### PR DESCRIPTION
## Summary
- Add a reconciler-based session lifetime checker driven only by checker specifications.
- Skip disabled checker definitions and running sessions without a recorded start time.
- Register the checker in the idle-check stage and cover deadline, multi-definition, and repository filtering behavior.

## Test plan
- [x] `pants fmt ::`
- [x] `pants fix ::`
- [x] `pants lint --changed-since=origin/main`
- [x] Push-hook MyPy checks for changed targets
- [x] Push-hook tests for changed targets

Resolves BA-6583