### PR TITLE
feat(BA-6867): add generic RBAC scoped-ops primitives

### DIFF
--- a/changes/12825.feature.md
+++ b/changes/12825.feature.md
@@ -1,0 +1,1 @@
+Add reusable RBAC scoped-write primitives: `RBACWriteOps.create_scoped` / `purge_scoped` (write/clear an entity's scope association in the same transaction), global-scoped entity support in the entity creator/unbinder, and `BulkScopeActionRBACValidator` for per-scope bulk authorization.

--- a/src/ai/backend/manager/actions/validators/rbac/__init__.py
+++ b/src/ai/backend/manager/actions/validators/rbac/__init__.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
+from ai.backend.manager.actions.validators.rbac.bulk_scope import BulkScopeActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.legacy import (
     LegacyScopeActionRBACValidator,
     LegacySingleEntityActionRBACValidator,
@@ -16,6 +17,9 @@ class RBACValidators:
     scope: ScopeActionRBACValidator
     single_entity: SingleEntityActionRBACValidator
     bulk: BulkActionRBACValidator
+    # Optional so the many test fixtures that build RBACValidators without it keep working;
+    # production (the composer) always sets it.
+    bulk_scope: BulkScopeActionRBACValidator | None = None
 
 
 @dataclass

--- a/src/ai/backend/manager/actions/validators/rbac/bulk_scope.py
+++ b/src/ai/backend/manager/actions/validators/rbac/bulk_scope.py
@@ -1,0 +1,93 @@
+from typing import Any, override
+
+from ai.backend.common.contexts.user import current_user
+from ai.backend.common.exception import UnreachableError
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.action.bulk import BaseBulkAction
+from ai.backend.manager.actions.validator.bulk import (
+    BulkActionValidator,
+    BulkValidationResult,
+    DeniedEntity,
+)
+from ai.backend.manager.config.provider import ManagerConfigProvider
+from ai.backend.manager.data.permission.role import (
+    BulkPermissionCheckInput,
+    PermissionResolutionKey,
+)
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.repositories.permission_controller.repository import (
+    PermissionControllerRepository,
+)
+
+_DENY_REASON = "permission_denied"
+
+
+class BulkScopeActionRBACValidator(BulkActionValidator):
+    """Bulk analog of ``ScopeActionRBACValidator``: authorize a bulk action at each of its
+    scope targets by the caller's permission on the action's *own* entity type.
+
+    ``BulkActionRBACValidator`` checks each target as the entity itself (subject =
+    ``ref.element_type``), which fits bulk actions whose targets are entities. Here the
+    targets are *scopes*, so the checked subject is ``action.entity_type()`` — e.g. "create
+    APP_CONFIG_FRAGMENT in scope X", not "act on the USER / DOMAIN scope itself". A global
+    target (no scope grants its resource op) is denied, so only a superadmin passes.
+    """
+
+    _repository: PermissionControllerRepository
+    _config_provider: ManagerConfigProvider
+
+    def __init__(
+        self,
+        repository: PermissionControllerRepository,
+        config_provider: ManagerConfigProvider,
+    ) -> None:
+        self._repository = repository
+        self._config_provider = config_provider
+
+    @classmethod
+    @override
+    def name(cls) -> str:
+        return "rbac_scope"
+
+    @override
+    async def validate(
+        self, action: BaseBulkAction[Any], meta: BaseActionTriggerMeta
+    ) -> BulkValidationResult:
+        element_refs = [t.to_rbac_element_ref() for t in action.targets()]
+        if not self._config_provider.config.manager.rbac.enforcement_enabled:
+            return BulkValidationResult(allowed_entities=element_refs, denied_entities=[])
+
+        user = current_user()
+        if user is None:
+            raise UnreachableError("User context is not available")
+        if user.is_superadmin:
+            return BulkValidationResult(allowed_entities=element_refs, denied_entities=[])
+
+        subject_entity_type = action.entity_type().to_element()
+        keys = [
+            PermissionResolutionKey(
+                user_id=user.user_id,
+                element_type=ref.element_type,
+                entity_id=ref.element_id,
+                subject_entity_type=subject_entity_type,
+            )
+            for ref in element_refs
+        ]
+        permission_map = await self._repository.check_bulk_permission_with_scope_chain(
+            BulkPermissionCheckInput(
+                keys=keys,
+                operation=action.operation_type().to_permission_operation(),
+            )
+        )
+
+        allowed_entities: list[RBACElementRef] = []
+        denied_entities: list[DeniedEntity] = []
+        for ref, key in zip(element_refs, keys, strict=True):
+            if permission_map.get(key, False):
+                allowed_entities.append(ref)
+            else:
+                denied_entities.append(DeniedEntity(entity_ref=ref, deny_reason=_DENY_REASON))
+        return BulkValidationResult(
+            allowed_entities=allowed_entities,
+            denied_entities=denied_entities,
+        )

--- a/src/ai/backend/manager/repositories/base/rbac/entity_creator.py
+++ b/src/ai/backend/manager/repositories/base/rbac/entity_creator.py
@@ -37,19 +37,21 @@ class RBACEntityCreator[TRow: Base]:
     """Creator for a single entity with scope associations for RBAC.
 
     Creates an entity row and associates it with one or more permission scopes.
-    The primary scope is required; additional scopes are optional.
 
     Attributes:
         spec: CreatorSpec implementation defining the row to create.
         element_type: The RBAC element type for this entity.
         scope_ref: Primary scope reference (scope_type + scope_id) for this entity.
+            ``None`` marks a *global-scoped* entity — one living outside the RBAC scope
+            hierarchy (e.g. a public app-config fragment) — which carries no scope
+            association (only a superadmin reaches it, bypassing scope resolution).
         additional_scope_refs: Additional scope references for multi-scope entities.
         relation_type: The relation type for the scope-entity association. Defaults to AUTO.
     """
 
     spec: CreatorSpec[TRow]
     element_type: RBACElementType
-    scope_ref: RBACElementRef
+    scope_ref: RBACElementRef | None
     additional_scope_refs: Sequence[RBACElementRef] = field(default_factory=list)
     relation_type: RelationType = RelationType.AUTO
 
@@ -106,7 +108,10 @@ async def execute_rbac_entity_creator[TRow: Base](
     instance_state = inspect(row)
     pk_value = instance_state.identity[0]
     entity_type = creator.element_type.to_entity_type()
-    all_scope_refs = [creator.scope_ref, *creator.additional_scope_refs]
+    # A None primary scope marks a global-scoped entity: no association row.
+    all_scope_refs = [
+        ref for ref in (creator.scope_ref, *creator.additional_scope_refs) if ref is not None
+    ]
     associations = [
         AssociationScopesEntitiesRow(
             scope_type=scope_ref.element_type.to_scope_type(),
@@ -117,7 +122,8 @@ async def execute_rbac_entity_creator[TRow: Base](
         )
         for scope_ref in all_scope_refs
     ]
-    await bulk_insert_on_conflict_do_nothing(db_sess, associations)
+    if associations:
+        await bulk_insert_on_conflict_do_nothing(db_sess, associations)
 
     return RBACEntityCreatorResult(row=row)
 
@@ -255,11 +261,14 @@ async def execute_rbac_entity_creators[TRow: Base](
         match_integrity_error(parsed, checks)
 
     # 3. Collect all associations from each creator's scope refs
+    # (a None primary scope marks a global-scoped entity: no association row)
     associations: list[AssociationScopesEntitiesRow] = []
     for creator, row in zip(creators, rows, strict=True):
         pk_value = inspect(row).identity[0]
         entity_type = creator.element_type.to_entity_type()
-        all_scope_refs = [creator.scope_ref, *creator.additional_scope_refs]
+        all_scope_refs = [
+            ref for ref in (creator.scope_ref, *creator.additional_scope_refs) if ref is not None
+        ]
         for scope_ref in all_scope_refs:
             associations.append(
                 AssociationScopesEntitiesRow(
@@ -270,6 +279,7 @@ async def execute_rbac_entity_creators[TRow: Base](
                     relation_type=creator.relation_type,
                 ),
             )
-    await bulk_insert_on_conflict_do_nothing(db_sess, associations)
+    if associations:
+        await bulk_insert_on_conflict_do_nothing(db_sess, associations)
 
     return RBACBulkEntityCreatorResult(rows=rows)

--- a/src/ai/backend/manager/repositories/base/rbac/scope_unbinder.py
+++ b/src/ai/backend/manager/repositories/base/rbac/scope_unbinder.py
@@ -53,8 +53,12 @@ class RBACScopeEntityUnbinder[TRow: Base](ABC):
 
     @property
     @abstractmethod
-    def scope_ref(self) -> RBACElementRef:
-        """RBAC element ref for the scope to unbind entities from."""
+    def scope_ref(self) -> RBACElementRef | None:
+        """RBAC element ref for the scope to unbind entities from.
+
+        ``None`` marks global-scoped entities (outside the RBAC scope hierarchy):
+        only the business rows are deleted — there is no scope association to remove.
+        """
         raise NotImplementedError
 
     @property
@@ -110,6 +114,12 @@ async def execute_rbac_scope_entity_unbinder[TRow: Base](
         db_sess, BatchPurger(spec=unbinder.build_purger_spec())
     )
     scope_ref = unbinder.scope_ref
+    if scope_ref is None:
+        # Global-scoped entities carry no scope association — nothing more to delete.
+        return RBACUnbinderResult(
+            deleted_count=purge_result.deleted_count,
+            association_rows=[],
+        )
     where_clauses = [
         AssociationScopesEntitiesRow.entity_type == unbinder.entity_type.to_entity_type(),
         AssociationScopesEntitiesRow.scope_type == scope_ref.element_type.to_scope_type(),

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -39,7 +39,14 @@ from ai.backend.manager.repositories.base import (
 from ai.backend.manager.repositories.base.rbac.entity_creator import (
     RBACBulkEntityCreatorResult,
     RBACEntityCreator,
+    RBACEntityCreatorResult,
+    execute_rbac_entity_creator,
     execute_rbac_entity_creators,
+)
+from ai.backend.manager.repositories.base.rbac.entity_purger import (
+    RBACEntityPurger,
+    RBACEntityPurgerResult,
+    execute_rbac_entity_purger,
 )
 from ai.backend.manager.repositories.ops.base.provider import DBOpsProvider, WriteOps
 from ai.backend.manager.repositories.permission_controller.role_manager import RoleManager
@@ -124,12 +131,31 @@ class RBACWriteOps(WriteOps):
         )
         await self._sess.execute(stmt)
 
+    async def create_scoped[TRow: Base](
+        self,
+        creator: RBACEntityCreator[TRow],
+    ) -> RBACEntityCreatorResult[TRow]:
+        """Insert one row with its RBAC scope association (the creator carries its scope)."""
+        return await execute_rbac_entity_creator(self._sess, creator)
+
     async def bulk_create_scoped[TRow: Base](
         self,
         creators: Sequence[RBACEntityCreator[TRow]],
     ) -> RBACBulkEntityCreatorResult[TRow]:
         """Insert rows with their RBAC scope associations (each creator carries its scope)."""
         return await execute_rbac_entity_creators(self._sess, creators)
+
+    async def purge_scoped[TRow: Base](
+        self,
+        purger: RBACEntityPurger[TRow],
+    ) -> RBACEntityPurgerResult[TRow] | None:
+        """Delete one row and its RBAC entries (the counterpart of :meth:`create_scoped`).
+
+        The association table has no FK to the entity tables, so a scope-bound row's
+        association is cleared in the same transaction. Returns ``None`` when the row is
+        already gone, so a concurrent purge reports not-found.
+        """
+        return await execute_rbac_entity_purger(self._sess, purger)
 
     async def add_users_to_scope(
         self,


### PR DESCRIPTION
## Summary
Foundational, entity-agnostic RBAC write primitives extracted from the AppConfig fragment work so any entity can reuse them.

- `RBACWriteOps.create_scoped` / `purge_scoped` — single scoped create/purge that writes/clears the entity's scope association in the same transaction.
- `entity_creator` — a `None` primary `scope_ref` marks a global-scoped entity (no association).
- `scope_unbinder` — `scope_ref` is `Optional` to support global-scoped entities.
- `BulkScopeActionRBACValidator` — per-scope RBAC validation for bulk scope actions.

## 📚 Stacked PRs

Part of the AppConfigFragment / AppConfig stack under BEP-1052 (epic BA-5781). **Merge in order** (#12801 was split into #12825 / #12826 / #12827):

1. ✅ #12306 — `feat(BA-6552)`: app_config_fragments DB model and Alembic migration
2. ✅ #12307 — `feat(BA-6553)`: repository layer
3. ✅ #12403 — `refactor(BA-6619)`: consolidate AppConfigScopeType into common.data
4. ✅ #12405 — `refactor(BA-6620)`: ExistsQuerier + AppConfigAllowList.exists
5. ✅ #12358 — `feat(BA-6554)`: AppConfigFragment service layer
6. ✅ #12516 — `feat(BA-6702)`: move fragment rank to the allow list with scope defaults
7. ✅ #12517 — `feat(BA-6701)`: expose allow-list rank on the v2 API surface
8. ✅ #12518 — `feat(BA-6704)`: cascade app config subtree deletion from the definition
9. ✅ #12426 — `feat(BA-6626)`: app_config_fragment bulk repository layer
10. ✅ #12401 — `feat(BA-6618)`: app_config_fragment bulk CRUD service layer
11. #12706 — `feat(BA-6810)`: AppConfigFragment visible-fragments query (repository layer)
12. 👉 **#12825 — `feat(BA-6867)`: RBAC scoped-ops primitives** ← you are here
13. #12826 — `feat(BA-6859)`: bind fragments to their RBAC scope on write (repository layer)
14. #12827 — `feat(BA-6868)`: RBAC-gate fragment single writes at the processors
15. #12359 — `feat(BA-6555)`: AppConfig merge engine + resolve service (service layer)
16. #12377 — `feat(BA-6556)`: AppConfig REST v2 API
17. #12759 — `feat(BA-6860)`: fragment write API routes + bulk write authz

Jira: https://lablup.atlassian.net/browse/BA-6867

🤖 Generated with [Claude Code](https://claude.com/claude-code)
