### PR TITLE
feat(BA-6868): RBAC-gate AppConfig fragment single writes at the processors

### DIFF
--- a/changes/12801.feature.md
+++ b/changes/12801.feature.md
@@ -1,0 +1,1 @@
+Authorize AppConfig fragment writes by RBAC (BEP-1052): create/update/purge are gated by the writer's permission at the fragment's `user`/`domain` scope (bound on create, unbound on purge), while `public` fragments are global-scoped and superadmin-only.

--- a/changes/12825.feature.md
+++ b/changes/12825.feature.md
@@ -1,0 +1,1 @@
+Add reusable RBAC scoped-write primitives: `RBACWriteOps.create_scoped` / `purge_scoped` (write/clear an entity's scope association in the same transaction), global-scoped entity support in the entity creator/unbinder, and `BulkScopeActionRBACValidator` for per-scope bulk authorization.

--- a/changes/12826.feature.md
+++ b/changes/12826.feature.md
@@ -1,0 +1,1 @@
+Bind `user` / `domain` AppConfig fragments to their RBAC scope on create and unbind on purge (`public` stays global-scoped, no association), registering `APP_CONFIG_FRAGMENT` as an RBAC scope; a migration backfills its permissions onto existing roles so fragment writes can be authorized by RBAC (BEP-1052).

--- a/changes/12827.feature.md
+++ b/changes/12827.feature.md
@@ -1,0 +1,1 @@
+Authorize AppConfig fragment `create` / `update` / `purge` by RBAC at the fragment's scope — a user writes their own `user`-scope fragment, a domain admin their domain's, a superadmin any; `public` fragments are superadmin-only (BEP-1052). Enforced only when RBAC enforcement is enabled.

--- a/src/ai/backend/common/data/app_config/types.py
+++ b/src/ai/backend/common/data/app_config/types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import enum
 
-from ai.backend.common.data.permission.types import ScopeType
+from ai.backend.common.data.permission.types import RBACElementType, ScopeType
 
 __all__ = ("AppConfigScopeType",)
 
@@ -33,6 +33,21 @@ class AppConfigScopeType(enum.StrEnum):
                 return ScopeType.DOMAIN
             case AppConfigScopeType.USER:
                 return ScopeType.USER
+
+    def to_rbac_element_type(self) -> RBACElementType | None:
+        """The RBAC scope element a fragment at this scope belongs to.
+
+        ``public`` maps to the global scope, which has no RBAC scope element — a public
+        fragment is *global-scoped* (no scope association; superadmin-only writes), so it
+        returns ``None``.
+        """
+        match self:
+            case AppConfigScopeType.PUBLIC:
+                return None
+            case AppConfigScopeType.DOMAIN:
+                return RBACElementType.DOMAIN
+            case AppConfigScopeType.USER:
+                return RBACElementType.USER
 
     def to_rbac_scope_id(self, scope_id: str) -> str:
         """The RBAC scope id for a write at this fragment scope.

--- a/src/ai/backend/common/data/permission/types.py
+++ b/src/ai/backend/common/data/permission/types.py
@@ -270,6 +270,7 @@ class EntityType(enum.StrEnum):
             cls.ARTIFACT,
             cls.ARTIFACT_REGISTRY,
             cls.APP_CONFIG,
+            cls.APP_CONFIG_FRAGMENT,
             cls.NOTIFICATION_CHANNEL,
             cls.NOTIFICATION_RULE,
             cls.MODEL_DEPLOYMENT,
@@ -358,6 +359,7 @@ class ScopeType(enum.StrEnum):
     ROLE = "role"
     ROLE_ASSIGNMENT = "role:assignment"
     NOTIFICATION_CHANNEL = "notification_channel"
+    APP_CONFIG_FRAGMENT = "app_config_fragment"
     KEYPAIR = "keypair"
     KEYPAIR_RESOURCE_POLICY = "keypair_resource_policy"
 

--- a/src/ai/backend/manager/actions/validators/rbac/__init__.py
+++ b/src/ai/backend/manager/actions/validators/rbac/__init__.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
+from ai.backend.manager.actions.validators.rbac.bulk_scope import BulkScopeActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.legacy import (
     LegacyScopeActionRBACValidator,
     LegacySingleEntityActionRBACValidator,
@@ -16,6 +17,9 @@ class RBACValidators:
     scope: ScopeActionRBACValidator
     single_entity: SingleEntityActionRBACValidator
     bulk: BulkActionRBACValidator
+    # Optional so the many test fixtures that build RBACValidators without it keep working;
+    # production (the composer) always sets it.
+    bulk_scope: BulkScopeActionRBACValidator | None = None
 
 
 @dataclass

--- a/src/ai/backend/manager/actions/validators/rbac/bulk_scope.py
+++ b/src/ai/backend/manager/actions/validators/rbac/bulk_scope.py
@@ -1,0 +1,93 @@
+from typing import Any, override
+
+from ai.backend.common.contexts.user import current_user
+from ai.backend.common.exception import UnreachableError
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.action.bulk import BaseBulkAction
+from ai.backend.manager.actions.validator.bulk import (
+    BulkActionValidator,
+    BulkValidationResult,
+    DeniedEntity,
+)
+from ai.backend.manager.config.provider import ManagerConfigProvider
+from ai.backend.manager.data.permission.role import (
+    BulkPermissionCheckInput,
+    PermissionResolutionKey,
+)
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.repositories.permission_controller.repository import (
+    PermissionControllerRepository,
+)
+
+_DENY_REASON = "permission_denied"
+
+
+class BulkScopeActionRBACValidator(BulkActionValidator):
+    """Bulk analog of ``ScopeActionRBACValidator``: authorize a bulk action at each of its
+    scope targets by the caller's permission on the action's *own* entity type.
+
+    ``BulkActionRBACValidator`` checks each target as the entity itself (subject =
+    ``ref.element_type``), which fits bulk actions whose targets are entities. Here the
+    targets are *scopes*, so the checked subject is ``action.entity_type()`` — e.g. "create
+    APP_CONFIG_FRAGMENT in scope X", not "act on the USER / DOMAIN scope itself". A global
+    target (no scope grants its resource op) is denied, so only a superadmin passes.
+    """
+
+    _repository: PermissionControllerRepository
+    _config_provider: ManagerConfigProvider
+
+    def __init__(
+        self,
+        repository: PermissionControllerRepository,
+        config_provider: ManagerConfigProvider,
+    ) -> None:
+        self._repository = repository
+        self._config_provider = config_provider
+
+    @classmethod
+    @override
+    def name(cls) -> str:
+        return "rbac_scope"
+
+    @override
+    async def validate(
+        self, action: BaseBulkAction[Any], meta: BaseActionTriggerMeta
+    ) -> BulkValidationResult:
+        element_refs = [t.to_rbac_element_ref() for t in action.targets()]
+        if not self._config_provider.config.manager.rbac.enforcement_enabled:
+            return BulkValidationResult(allowed_entities=element_refs, denied_entities=[])
+
+        user = current_user()
+        if user is None:
+            raise UnreachableError("User context is not available")
+        if user.is_superadmin:
+            return BulkValidationResult(allowed_entities=element_refs, denied_entities=[])
+
+        subject_entity_type = action.entity_type().to_element()
+        keys = [
+            PermissionResolutionKey(
+                user_id=user.user_id,
+                element_type=ref.element_type,
+                entity_id=ref.element_id,
+                subject_entity_type=subject_entity_type,
+            )
+            for ref in element_refs
+        ]
+        permission_map = await self._repository.check_bulk_permission_with_scope_chain(
+            BulkPermissionCheckInput(
+                keys=keys,
+                operation=action.operation_type().to_permission_operation(),
+            )
+        )
+
+        allowed_entities: list[RBACElementRef] = []
+        denied_entities: list[DeniedEntity] = []
+        for ref, key in zip(element_refs, keys, strict=True):
+            if permission_map.get(key, False):
+                allowed_entities.append(ref)
+            else:
+                denied_entities.append(DeniedEntity(entity_ref=ref, deny_reason=_DENY_REASON))
+        return BulkValidationResult(
+            allowed_entities=allowed_entities,
+            denied_entities=denied_entities,
+        )

--- a/src/ai/backend/manager/dependencies/processing/composer.py
+++ b/src/ai/backend/manager/dependencies/processing/composer.py
@@ -31,6 +31,7 @@ from ai.backend.manager.actions.monitors.reporter import ReporterMonitor
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import LegacyRBACValidators, RBACValidators
 from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
+from ai.backend.manager.actions.validators.rbac.bulk_scope import BulkScopeActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.legacy import (
     LegacyScopeActionRBACValidator,
     LegacySingleEntityActionRBACValidator,
@@ -269,6 +270,9 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
                 permission_controller_repository, config_provider
             ),
             bulk=BulkActionRBACValidator(permission_controller_repository, config_provider),
+            bulk_scope=BulkScopeActionRBACValidator(
+                permission_controller_repository, config_provider
+            ),
         )
         legacy_rbac_validators = LegacyRBACValidators(
             scope=LegacyScopeActionRBACValidator(permission_controller_repository),

--- a/src/ai/backend/manager/models/alembic/versions/b3d9f7a2c184_add_app_config_fragment_permissions_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/b3d9f7a2c184_add_app_config_fragment_permissions_to_rbac.py
@@ -1,0 +1,93 @@
+"""add_app_config_fragment_permissions_to_rbac
+
+Backfill ``APP_CONFIG_FRAGMENT`` permissions onto existing write-capable RBAC roles (a
+user's own ``user``-scope role and ``domain`` admins) so they can exercise fragment writes
+once RBAC enforcement is enabled (BEP-1052). New roles receive these permissions at role
+creation; this migration only covers roles that predate the new entity type.
+
+Only ``permissions`` rows are backfilled. The RBAC scope *associations*
+(``association_scopes_entities``, which bind a fragment to its owning scope) are NOT
+migrated: they are per-fragment and written at fragment-creation time, and this feature is
+still unreleased, so no fragments — and therefore no associations — exist yet.
+
+Revision ID: b3d9f7a2c184
+Revises: a3c1d8e5b294
+Create Date: 2026-07-14 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.rbac_models.migration.enums import (
+    EntityType,
+    OperationType,
+)
+
+# revision identifiers, used by Alembic.
+revision = "b3d9f7a2c184"
+down_revision = "a3c1d8e5b294"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+MEMBER_ROLE_SUFFIX = "member"
+APP_CONFIG_FRAGMENT_ENTITY_TYPE = EntityType.APP_CONFIG_FRAGMENT.value
+
+
+def upgrade() -> None:
+    db_conn = op.get_bind()
+    _add_app_config_fragment_permissions(db_conn)
+
+
+def downgrade() -> None:
+    db_conn = op.get_bind()
+    db_conn.execute(
+        sa.text("DELETE FROM permissions WHERE entity_type = :entity_type"),
+        {"entity_type": APP_CONFIG_FRAGMENT_ENTITY_TYPE},
+    )
+
+
+def _add_app_config_fragment_permissions(db_conn: sa.engine.Connection) -> None:
+    """Backfill APP_CONFIG_FRAGMENT write permissions onto existing write-capable roles.
+
+    A fragment lives only at ``user`` or ``domain`` scope (``public`` is global →
+    superadmin-only, no role), so only those scopes are touched — a permission at any
+    other scope (``project`` etc.) could never match a real fragment. Reads go through the
+    allow list, not RBAC, so only the write path needs backfilling: grant the full
+    operation set to the write-capable roles, i.e. a user's own ``user``-scope role and
+    ``domain`` admins. Member roles are excluded (they do not write fragments).
+    """
+    owner_ops = [op_type.value for op_type in OperationType.owner_operations()]
+
+    insert_query = sa.text("""
+        WITH role_scopes AS (
+            SELECT DISTINCT
+                p.role_id,
+                r.name AS role_name,
+                p.scope_type,
+                p.scope_id
+            FROM permissions p
+            JOIN roles r ON p.role_id = r.id
+            WHERE p.scope_type IN ('user', 'domain')
+        )
+        INSERT INTO permissions (role_id, scope_type, scope_id, entity_type, operation)
+        SELECT
+            rs.role_id,
+            rs.scope_type,
+            rs.scope_id,
+            :entity_type AS entity_type,
+            unnest(CAST(:owner_ops AS text[])) AS operation
+        FROM role_scopes rs
+        WHERE NOT (rs.role_name LIKE :member_pattern)
+        ON CONFLICT (role_id, scope_type, scope_id, entity_type, operation) DO NOTHING
+    """)
+
+    db_conn.execute(
+        insert_query,
+        {
+            "owner_ops": owner_ops,
+            "member_pattern": f"%{MEMBER_ROLE_SUFFIX}",
+            "entity_type": APP_CONFIG_FRAGMENT_ENTITY_TYPE,
+        },
+    )

--- a/src/ai/backend/manager/models/rbac_models/migration/enums.py
+++ b/src/ai/backend/manager/models/rbac_models/migration/enums.py
@@ -115,6 +115,7 @@ class EntityType(enum.StrEnum):
     ARTIFACT = "artifact"
     ARTIFACT_REGISTRY = "artifact_registry"
     APP_CONFIG = "app_config"
+    APP_CONFIG_FRAGMENT = "app_config_fragment"
     NOTIFICATION_CHANNEL = "notification_channel"
     NOTIFICATION_RULE = "notification_rule"
     MODEL_DEPLOYMENT = "model_deployment"
@@ -142,6 +143,7 @@ class EntityType(enum.StrEnum):
             cls.ARTIFACT,
             cls.ARTIFACT_REGISTRY,
             cls.APP_CONFIG,
+            cls.APP_CONFIG_FRAGMENT,
             cls.NOTIFICATION_CHANNEL,
             cls.NOTIFICATION_RULE,
             cls.MODEL_DEPLOYMENT,

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
 from ai.backend.common.metrics.metric import DomainType, LayerType
@@ -18,6 +19,7 @@ from ai.backend.manager.data.app_config_fragment.types import (
     AppConfigFragmentData,
     AppConfigFragmentSearchResult,
 )
+from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.errors.app_config import (
     AppConfigFragmentNotFound,
 )
@@ -25,19 +27,26 @@ from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowLi
 from ai.backend.manager.models.app_config_fragment.conditions import AppConfigFragmentConditions
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
 from ai.backend.manager.models.scopes import SearchScope
+from ai.backend.manager.repositories.app_config_fragment.creators import (
+    AppConfigFragmentCreatorSpec,
+)
+from ai.backend.manager.repositories.app_config_fragment.purgers import (
+    AppConfigFragmentPurgerSpec,
+)
 from ai.backend.manager.repositories.app_config_fragment.types import (
     AppConfigScopeArguments,
 )
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
     BulkCreator,
-    Creator,
     NoPagination,
     Purger,
     Querier,
     Updater,
 )
-from ai.backend.manager.repositories.ops import DBOpsProvider
+from ai.backend.manager.repositories.base.rbac.entity_creator import RBACEntityCreator
+from ai.backend.manager.repositories.base.rbac.entity_purger import RBACEntityPurger
+from ai.backend.manager.repositories.ops.rbac.provider import RBACOpsProvider
 
 __all__ = ("AppConfigFragmentDBSource",)
 
@@ -64,23 +73,29 @@ app_config_fragment_db_source_resilience = Resilience(
 class AppConfigFragmentDBSource:
     """Database source for app config fragment operations."""
 
-    _ops: DBOpsProvider
+    _rbac_ops_provider: RBACOpsProvider
 
-    def __init__(self, ops_provider: DBOpsProvider) -> None:
-        self._ops = ops_provider
+    def __init__(self, rbac_ops_provider: RBACOpsProvider) -> None:
+        self._rbac_ops_provider = rbac_ops_provider
 
     @app_config_fragment_db_source_resilience.apply()
-    async def create(self, creator: Creator[AppConfigFragmentRow]) -> AppConfigFragmentData:
-        # The FK to the allow-list is the gate: inserting a fragment with no
-        # allow-list row for its ``(config_name, scope_type)`` raises
-        # ``AppConfigFragmentWriteNotAllowed`` (see the spec's integrity checks).
-        async with self._ops.write_ops() as w:
-            created = await w.create(creator)
+    async def create(self, spec: AppConfigFragmentCreatorSpec) -> AppConfigFragmentData:
+        scope_element = spec.scope_type.to_rbac_element_type()
+        scope_ref = (
+            RBACElementRef(scope_element, spec.scope_id) if scope_element is not None else None
+        )
+        rbac_creator = RBACEntityCreator(
+            spec=spec,
+            element_type=RBACElementType.APP_CONFIG_FRAGMENT,
+            scope_ref=scope_ref,
+        )
+        async with self._rbac_ops_provider.write_ops() as w:
+            created = await w.create_scoped(rbac_creator)
             return created.row.to_data()
 
     @app_config_fragment_db_source_resilience.apply()
     async def get_by_id(self, fragment_id: AppConfigFragmentID) -> AppConfigFragmentData:
-        async with self._ops.read_ops() as r:
+        async with self._rbac_ops_provider.read_ops() as r:
             result = await r.query(Querier(row_class=AppConfigFragmentRow, pk_value=fragment_id))
             if result is None:
                 raise AppConfigFragmentNotFound(f"App config fragment {fragment_id} not found")
@@ -88,22 +103,27 @@ class AppConfigFragmentDBSource:
 
     @app_config_fragment_db_source_resilience.apply()
     async def update(self, updater: Updater[AppConfigFragmentRow]) -> AppConfigFragmentData:
-        # No write-gate here: the FK to the allow-list guarantees a fragment row exists
-        # only while its ``(config_name, scope_type)`` entry does, so an existing
-        # fragment is always writable at its own scope.
-        async with self._ops.write_ops() as w:
+        async with self._rbac_ops_provider.write_ops() as w:
             result = await w.update(updater)
             if result is None:
                 raise AppConfigFragmentNotFound(f"App config fragment {updater.pk_value} not found")
             return result.row.to_data()
 
     @app_config_fragment_db_source_resilience.apply()
-    async def purge(self, purger: Purger[AppConfigFragmentRow]) -> AppConfigFragmentData:
-        # No write-gate here — see ``update``.
-        async with self._ops.write_ops() as w:
-            result = await w.purge(purger)
+    async def purge(self, purger_spec: AppConfigFragmentPurgerSpec) -> AppConfigFragmentData:
+        # Purge is an RBAC unbind: the fragment row, its scope associations, and any
+        # permissions granted at its own scope are deleted together (entity-as-scope).
+        rbac_purger = RBACEntityPurger(
+            row_class=AppConfigFragmentRow,
+            pk_value=purger_spec.fragment_id,
+            spec=purger_spec,
+        )
+        async with self._rbac_ops_provider.write_ops() as w:
+            result = await w.purge_scoped(rbac_purger)
             if result is None:
-                raise AppConfigFragmentNotFound(f"App config fragment {purger.pk_value} not found")
+                raise AppConfigFragmentNotFound(
+                    f"App config fragment {purger_spec.fragment_id} not found"
+                )
             return result.row.to_data()
 
     @app_config_fragment_db_source_resilience.apply()
@@ -112,7 +132,7 @@ class AppConfigFragmentDBSource:
         bulk_creator: BulkCreator[AppConfigFragmentRow],
     ) -> AppConfigFragmentBulkResult:
         """Create many fragments with per-item partial success."""
-        async with self._ops.write_ops() as w:
+        async with self._rbac_ops_provider.write_ops() as w:
             result = await w.bulk_create_partial(bulk_creator)
             return AppConfigFragmentBulkResult(
                 succeeded=[row.to_data() for row in result.successes],
@@ -128,7 +148,7 @@ class AppConfigFragmentDBSource:
         updaters: Sequence[Updater[AppConfigFragmentRow]],
     ) -> AppConfigFragmentBulkResult:
         """Update many fragments with per-item partial success."""
-        async with self._ops.write_ops() as w:
+        async with self._rbac_ops_provider.write_ops() as w:
             result = await w.bulk_update_partial(updaters)
             succeeded = [row.to_data() for row in result.successes]
             succeeded_ids = {data.id for data in succeeded}
@@ -152,7 +172,7 @@ class AppConfigFragmentDBSource:
         purgers: Sequence[Purger[AppConfigFragmentRow]],
     ) -> AppConfigFragmentBulkResult:
         """Purge many fragments with per-item partial success."""
-        async with self._ops.write_ops() as w:
+        async with self._rbac_ops_provider.write_ops() as w:
             result = await w.bulk_purge_partial(list(purgers))
             succeeded = [row.to_data() for row in result.successes]
             succeeded_ids = {data.id for data in succeeded}
@@ -173,7 +193,7 @@ class AppConfigFragmentDBSource:
     @app_config_fragment_db_source_resilience.apply()
     async def admin_search(self, querier: BatchQuerier) -> AppConfigFragmentSearchResult:
         """Superadmin/internal path: query across all fragments with no scope filter."""
-        async with self._ops.read_ops() as r:
+        async with self._rbac_ops_provider.read_ops() as r:
             result = await r.batch_query_in_global(sa.select(AppConfigFragmentRow), querier)
             return AppConfigFragmentSearchResult(
                 items=[row.AppConfigFragmentRow.to_data() for row in result.rows],
@@ -189,7 +209,7 @@ class AppConfigFragmentDBSource:
         scopes: Sequence[SearchScope],
     ) -> AppConfigFragmentSearchResult:
         """Scoped path: query fragments restricted to ``scopes`` (combined with OR)."""
-        async with self._ops.read_ops() as r:
+        async with self._rbac_ops_provider.read_ops() as r:
             result = await r.batch_query_with_scopes(
                 sa.select(AppConfigFragmentRow), querier, scopes
             )
@@ -237,6 +257,6 @@ class AppConfigFragmentDBSource:
                 AppConfigAllowListRow.scope_type == AppConfigFragmentRow.scope_type,
             ),
         )
-        async with self._ops.read_ops() as r:
+        async with self._rbac_ops_provider.read_ops() as r:
             result = await r.batch_query_in_global(selector, querier)
             return [row.AppConfigFragmentRow.to_data() for row in result.rows]

--- a/src/ai/backend/manager/repositories/app_config_fragment/purgers.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/purgers.py
@@ -1,0 +1,26 @@
+"""Purger specs for app config fragment repository."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.repositories.base.rbac.entity_purger import RBACEntityPurgerSpec
+
+
+@dataclass
+class AppConfigFragmentPurgerSpec(RBACEntityPurgerSpec):
+    """RBAC purge info for one fragment: identifies it so its scope association is cleared."""
+
+    fragment_id: AppConfigFragmentID
+
+    @override
+    def element_type(self) -> RBACElementType:
+        return RBACElementType.APP_CONFIG_FRAGMENT
+
+    @override
+    def entity_ref(self) -> RBACElementRef:
+        return RBACElementRef(RBACElementType.APP_CONFIG_FRAGMENT, str(self.fragment_id))

--- a/src/ai/backend/manager/repositories/app_config_fragment/repositories.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repositories.py
@@ -4,6 +4,7 @@ from typing import Self
 from ai.backend.manager.repositories.app_config_fragment.repository import (
     AppConfigFragmentRepository,
 )
+from ai.backend.manager.repositories.ops.rbac.provider import RBACOpsProvider
 from ai.backend.manager.repositories.types import RepositoryArgs
 
 
@@ -13,6 +14,7 @@ class AppConfigFragmentRepositories:
 
     @classmethod
     def create(cls, args: RepositoryArgs) -> Self:
+        # Fragment writes bind to an RBAC scope (see db_source), so use the RBAC ops provider.
         return cls(
-            repository=AppConfigFragmentRepository(args.ops_provider),
+            repository=AppConfigFragmentRepository(RBACOpsProvider(args.db)),
         )

--- a/src/ai/backend/manager/repositories/app_config_fragment/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repository.py
@@ -15,8 +15,14 @@ from ai.backend.manager.data.app_config_fragment.types import (
 )
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
 from ai.backend.manager.models.scopes import SearchScope
+from ai.backend.manager.repositories.app_config_fragment.creators import (
+    AppConfigFragmentCreatorSpec,
+)
 from ai.backend.manager.repositories.app_config_fragment.db_source import (
     AppConfigFragmentDBSource,
+)
+from ai.backend.manager.repositories.app_config_fragment.purgers import (
+    AppConfigFragmentPurgerSpec,
 )
 from ai.backend.manager.repositories.app_config_fragment.types import (
     AppConfigScopeArguments,
@@ -24,11 +30,10 @@ from ai.backend.manager.repositories.app_config_fragment.types import (
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
     BulkCreator,
-    Creator,
     Purger,
     Updater,
 )
-from ai.backend.manager.repositories.ops import DBOpsProvider
+from ai.backend.manager.repositories.ops.rbac.provider import RBACOpsProvider
 
 __all__ = ("AppConfigFragmentRepository",)
 
@@ -57,12 +62,12 @@ class AppConfigFragmentRepository:
 
     _db_source: AppConfigFragmentDBSource
 
-    def __init__(self, ops_provider: DBOpsProvider) -> None:
+    def __init__(self, ops_provider: RBACOpsProvider) -> None:
         self._db_source = AppConfigFragmentDBSource(ops_provider)
 
     @app_config_fragment_repository_resilience.apply()
-    async def create(self, creator: Creator[AppConfigFragmentRow]) -> AppConfigFragmentData:
-        return await self._db_source.create(creator)
+    async def create(self, spec: AppConfigFragmentCreatorSpec) -> AppConfigFragmentData:
+        return await self._db_source.create(spec)
 
     @app_config_fragment_repository_resilience.apply()
     async def get_by_id(self, fragment_id: AppConfigFragmentID) -> AppConfigFragmentData:
@@ -73,8 +78,8 @@ class AppConfigFragmentRepository:
         return await self._db_source.update(updater)
 
     @app_config_fragment_repository_resilience.apply()
-    async def purge(self, purger: Purger[AppConfigFragmentRow]) -> AppConfigFragmentData:
-        return await self._db_source.purge(purger)
+    async def purge(self, purger_spec: AppConfigFragmentPurgerSpec) -> AppConfigFragmentData:
+        return await self._db_source.purge(purger_spec)
 
     @app_config_fragment_repository_resilience.apply()
     async def admin_search(self, querier: BatchQuerier) -> AppConfigFragmentSearchResult:

--- a/src/ai/backend/manager/repositories/base/rbac/entity_creator.py
+++ b/src/ai/backend/manager/repositories/base/rbac/entity_creator.py
@@ -37,19 +37,21 @@ class RBACEntityCreator[TRow: Base]:
     """Creator for a single entity with scope associations for RBAC.
 
     Creates an entity row and associates it with one or more permission scopes.
-    The primary scope is required; additional scopes are optional.
 
     Attributes:
         spec: CreatorSpec implementation defining the row to create.
         element_type: The RBAC element type for this entity.
         scope_ref: Primary scope reference (scope_type + scope_id) for this entity.
+            ``None`` marks a *global-scoped* entity — one living outside the RBAC scope
+            hierarchy (e.g. a public app-config fragment) — which carries no scope
+            association (only a superadmin reaches it, bypassing scope resolution).
         additional_scope_refs: Additional scope references for multi-scope entities.
         relation_type: The relation type for the scope-entity association. Defaults to AUTO.
     """
 
     spec: CreatorSpec[TRow]
     element_type: RBACElementType
-    scope_ref: RBACElementRef
+    scope_ref: RBACElementRef | None
     additional_scope_refs: Sequence[RBACElementRef] = field(default_factory=list)
     relation_type: RelationType = RelationType.AUTO
 
@@ -106,7 +108,10 @@ async def execute_rbac_entity_creator[TRow: Base](
     instance_state = inspect(row)
     pk_value = instance_state.identity[0]
     entity_type = creator.element_type.to_entity_type()
-    all_scope_refs = [creator.scope_ref, *creator.additional_scope_refs]
+    # A None primary scope marks a global-scoped entity: no association row.
+    all_scope_refs = [
+        ref for ref in (creator.scope_ref, *creator.additional_scope_refs) if ref is not None
+    ]
     associations = [
         AssociationScopesEntitiesRow(
             scope_type=scope_ref.element_type.to_scope_type(),
@@ -117,7 +122,8 @@ async def execute_rbac_entity_creator[TRow: Base](
         )
         for scope_ref in all_scope_refs
     ]
-    await bulk_insert_on_conflict_do_nothing(db_sess, associations)
+    if associations:
+        await bulk_insert_on_conflict_do_nothing(db_sess, associations)
 
     return RBACEntityCreatorResult(row=row)
 
@@ -255,11 +261,14 @@ async def execute_rbac_entity_creators[TRow: Base](
         match_integrity_error(parsed, checks)
 
     # 3. Collect all associations from each creator's scope refs
+    # (a None primary scope marks a global-scoped entity: no association row)
     associations: list[AssociationScopesEntitiesRow] = []
     for creator, row in zip(creators, rows, strict=True):
         pk_value = inspect(row).identity[0]
         entity_type = creator.element_type.to_entity_type()
-        all_scope_refs = [creator.scope_ref, *creator.additional_scope_refs]
+        all_scope_refs = [
+            ref for ref in (creator.scope_ref, *creator.additional_scope_refs) if ref is not None
+        ]
         for scope_ref in all_scope_refs:
             associations.append(
                 AssociationScopesEntitiesRow(
@@ -270,6 +279,7 @@ async def execute_rbac_entity_creators[TRow: Base](
                     relation_type=creator.relation_type,
                 ),
             )
-    await bulk_insert_on_conflict_do_nothing(db_sess, associations)
+    if associations:
+        await bulk_insert_on_conflict_do_nothing(db_sess, associations)
 
     return RBACBulkEntityCreatorResult(rows=rows)

--- a/src/ai/backend/manager/repositories/base/rbac/scope_unbinder.py
+++ b/src/ai/backend/manager/repositories/base/rbac/scope_unbinder.py
@@ -53,8 +53,12 @@ class RBACScopeEntityUnbinder[TRow: Base](ABC):
 
     @property
     @abstractmethod
-    def scope_ref(self) -> RBACElementRef:
-        """RBAC element ref for the scope to unbind entities from."""
+    def scope_ref(self) -> RBACElementRef | None:
+        """RBAC element ref for the scope to unbind entities from.
+
+        ``None`` marks global-scoped entities (outside the RBAC scope hierarchy):
+        only the business rows are deleted — there is no scope association to remove.
+        """
         raise NotImplementedError
 
     @property
@@ -110,6 +114,12 @@ async def execute_rbac_scope_entity_unbinder[TRow: Base](
         db_sess, BatchPurger(spec=unbinder.build_purger_spec())
     )
     scope_ref = unbinder.scope_ref
+    if scope_ref is None:
+        # Global-scoped entities carry no scope association — nothing more to delete.
+        return RBACUnbinderResult(
+            deleted_count=purge_result.deleted_count,
+            association_rows=[],
+        )
     where_clauses = [
         AssociationScopesEntitiesRow.entity_type == unbinder.entity_type.to_entity_type(),
         AssociationScopesEntitiesRow.scope_type == scope_ref.element_type.to_scope_type(),

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -39,7 +39,14 @@ from ai.backend.manager.repositories.base import (
 from ai.backend.manager.repositories.base.rbac.entity_creator import (
     RBACBulkEntityCreatorResult,
     RBACEntityCreator,
+    RBACEntityCreatorResult,
+    execute_rbac_entity_creator,
     execute_rbac_entity_creators,
+)
+from ai.backend.manager.repositories.base.rbac.entity_purger import (
+    RBACEntityPurger,
+    RBACEntityPurgerResult,
+    execute_rbac_entity_purger,
 )
 from ai.backend.manager.repositories.ops.base.provider import DBOpsProvider, WriteOps
 from ai.backend.manager.repositories.permission_controller.role_manager import RoleManager
@@ -124,12 +131,31 @@ class RBACWriteOps(WriteOps):
         )
         await self._sess.execute(stmt)
 
+    async def create_scoped[TRow: Base](
+        self,
+        creator: RBACEntityCreator[TRow],
+    ) -> RBACEntityCreatorResult[TRow]:
+        """Insert one row with its RBAC scope association (the creator carries its scope)."""
+        return await execute_rbac_entity_creator(self._sess, creator)
+
     async def bulk_create_scoped[TRow: Base](
         self,
         creators: Sequence[RBACEntityCreator[TRow]],
     ) -> RBACBulkEntityCreatorResult[TRow]:
         """Insert rows with their RBAC scope associations (each creator carries its scope)."""
         return await execute_rbac_entity_creators(self._sess, creators)
+
+    async def purge_scoped[TRow: Base](
+        self,
+        purger: RBACEntityPurger[TRow],
+    ) -> RBACEntityPurgerResult[TRow] | None:
+        """Delete one row and its RBAC entries (the counterpart of :meth:`create_scoped`).
+
+        The association table has no FK to the entity tables, so a scope-bound row's
+        association is cleared in the same transaction. Returns ``None`` when the row is
+        already gone, so a concurrent purge reports not-found.
+        """
+        return await execute_rbac_entity_purger(self._sess, purger)
 
     async def add_users_to_scope(
         self,

--- a/src/ai/backend/manager/repositories/repositories.py
+++ b/src/ai/backend/manager/repositories/repositories.py
@@ -8,6 +8,9 @@ from ai.backend.manager.repositories.app_config_allow_list.repositories import (
 from ai.backend.manager.repositories.app_config_definition.repositories import (
     AppConfigDefinitionRepositories,
 )
+from ai.backend.manager.repositories.app_config_fragment.repositories import (
+    AppConfigFragmentRepositories,
+)
 from ai.backend.manager.repositories.artifact.repositories import ArtifactRepositories
 from ai.backend.manager.repositories.artifact_registry.repositories import (
     ArtifactRegistryRepositories,
@@ -94,6 +97,7 @@ class Repositories:
     agent: AgentRepositories
     app_config_allow_list: AppConfigAllowListRepositories
     app_config_definition: AppConfigDefinitionRepositories
+    app_config_fragment: AppConfigFragmentRepositories
     auth: AuthRepositories
     container_registry: ContainerRegistryRepositories
     deployment: DeploymentRepositories
@@ -148,6 +152,7 @@ class Repositories:
         agent_repositories = AgentRepositories.create(args)
         app_config_allow_list_repositories = AppConfigAllowListRepositories.create(args)
         app_config_definition_repositories = AppConfigDefinitionRepositories.create(args)
+        app_config_fragment_repositories = AppConfigFragmentRepositories.create(args)
         auth_repositories = AuthRepositories.create(args)
         container_registry_repositories = ContainerRegistryRepositories.create(args)
         deployment_repositories = DeploymentRepositories.create(args)
@@ -203,6 +208,7 @@ class Repositories:
             agent=agent_repositories,
             app_config_allow_list=app_config_allow_list_repositories,
             app_config_definition=app_config_definition_repositories,
+            app_config_fragment=app_config_fragment_repositories,
             auth=auth_repositories,
             container_registry=container_registry_repositories,
             deployment=deployment_repositories,

--- a/src/ai/backend/manager/services/app_config_fragment/actions/base.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/base.py
@@ -53,9 +53,8 @@ class AppConfigFragmentSingleEntityActionResult(BaseSingleEntityActionResult):
 class AppConfigFragmentBulkTarget(ActionTarget):
     """One existing fragment touched by a bulk update / purge, exposed for per-entity RBAC.
 
-    Bulk create has no targets — the fragments do not exist yet, so its action returns an
-    empty sequence. The target lets a future ``BulkActionValidator`` iterate the batch;
-    richer per-item data stays on the action's ``bulk_*`` payload.
+    Bulk create targets scopes instead (the fragments do not exist yet) — see
+    ``AppConfigFragmentScopeTarget`` in ``bulk_create``.
     """
 
     fragment_id: AppConfigFragmentID
@@ -68,12 +67,11 @@ class AppConfigFragmentBulkTarget(ActionTarget):
 
 
 class AppConfigFragmentBulkAction(BaseBulkAction[AppConfigFragmentBulkTarget]):
-    """Base for bulk app config fragment mutations (bulk create / update / purge).
+    """Base for bulk app config fragment mutations over existing fragments (update / purge).
 
     Bulk operations span many fragments (potentially across scopes), so there is no single
     entity id to report. Each concrete action exposes its per-item targets via ``targets()``
-    so a ``BulkActionValidator`` can authorize the batch per entity. No validator is wired
-    yet — authorization currently lives in the repository's allow-list write-gate.
+    so the bulk RBAC validator can authorize the batch per fragment.
     """
 
     @override

--- a/src/ai/backend/manager/services/app_config_fragment/actions/create.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/create.py
@@ -44,7 +44,14 @@ class CreateAppConfigFragmentAction(AppConfigFragmentScopeAction):
 
     @override
     def target_element(self) -> RBACElementRef:
-        return RBACElementRef(RBACElementType.APP_CONFIG_FRAGMENT, "")
+        # The scope this create acts on, so RBAC checks the writer's permission there:
+        # a user/domain fragment targets its USER/DOMAIN scope. A public fragment is
+        # global-scoped (no RBAC scope element) and is superadmin-only — its target has
+        # no scope to resolve, so a non-superadmin write fails the scope-chain check.
+        element = self.creator_spec.scope_type.to_rbac_element_type()
+        if element is None:
+            return RBACElementRef(RBACElementType.APP_CONFIG_FRAGMENT, "")
+        return RBACElementRef(element, self.creator_spec.scope_id)
 
 
 @dataclass

--- a/src/ai/backend/manager/services/app_config_fragment/actions/purge.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/purge.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
 from ai.backend.manager.data.permission.types import RBACElementRef
-from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
-from ai.backend.manager.repositories.base import Purger
+from ai.backend.manager.repositories.app_config_fragment.purgers import (
+    AppConfigFragmentPurgerSpec,
+)
 from ai.backend.manager.services.app_config_fragment.actions.base import (
     AppConfigFragmentSingleEntityAction,
     AppConfigFragmentSingleEntityActionResult,
@@ -25,7 +25,7 @@ class PurgeAppConfigFragmentAction(AppConfigFragmentSingleEntityAction):
     entry itself cascades to its fragments without going through this action.
     """
 
-    purger: Purger[AppConfigFragmentRow]
+    purger_spec: AppConfigFragmentPurgerSpec
 
     @override
     @classmethod
@@ -34,11 +34,11 @@ class PurgeAppConfigFragmentAction(AppConfigFragmentSingleEntityAction):
 
     @override
     def target_entity_id(self) -> str:
-        return str(self.purger.pk_value)
+        return str(self.purger_spec.fragment_id)
 
     @override
     def target_element(self) -> RBACElementRef:
-        return RBACElementRef(RBACElementType.APP_CONFIG_FRAGMENT, str(self.purger.pk_value))
+        return self.purger_spec.entity_ref()
 
 
 @dataclass

--- a/src/ai/backend/manager/services/app_config_fragment/processors.py
+++ b/src/ai/backend/manager/services/app_config_fragment/processors.py
@@ -7,6 +7,7 @@ from ai.backend.manager.actions.processor.bulk import BulkActionProcessor
 from ai.backend.manager.actions.processor.scope import ScopeActionProcessor
 from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
 from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
+from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.app_config_fragment.actions.admin_search import (
     AdminSearchAppConfigFragmentAction,
     AdminSearchAppConfigFragmentActionResult,
@@ -77,16 +78,36 @@ class AppConfigFragmentProcessors(AbstractProcessorPackage):
         self,
         service: AppConfigFragmentService,
         action_monitors: list[ActionMonitor],
+        validators: ActionValidators,
     ) -> None:
-        self.create = ScopeActionProcessor(service.create, action_monitors)
+        self.create = ScopeActionProcessor(
+            service.create, action_monitors, validators=[validators.rbac.scope]
+        )
         self.get = SingleEntityActionProcessor(service.get, action_monitors)
         self.admin_search = ScopeActionProcessor(service.admin_search, action_monitors)
-        self.scoped_search = BulkActionProcessor(service.scoped_search, monitors=action_monitors)
-        self.update = SingleEntityActionProcessor(service.update, action_monitors)
-        self.purge = SingleEntityActionProcessor(service.purge, action_monitors)
-        self.bulk_create = BulkActionProcessor(service.bulk_create, monitors=action_monitors)
-        self.bulk_update = BulkActionProcessor(service.bulk_update, monitors=action_monitors)
-        self.bulk_purge = BulkActionProcessor(service.bulk_purge, monitors=action_monitors)
+        self.scoped_search = BulkActionProcessor(
+            service.scoped_search, monitors=action_monitors, validators=[validators.rbac.bulk]
+        )
+        self.update = SingleEntityActionProcessor(
+            service.update, action_monitors, validators=[validators.rbac.single_entity]
+        )
+        self.purge = SingleEntityActionProcessor(
+            service.purge, action_monitors, validators=[validators.rbac.single_entity]
+        )
+        # bulk_create writes into scopes (not existing entities), so it uses the bulk-scope
+        # validator (subject = the fragment entity type) rather than the entity-target one.
+        bulk_scope = validators.rbac.bulk_scope
+        self.bulk_create = BulkActionProcessor(
+            service.bulk_create,
+            monitors=action_monitors,
+            validators=[bulk_scope] if bulk_scope is not None else None,
+        )
+        self.bulk_update = BulkActionProcessor(
+            service.bulk_update, monitors=action_monitors, validators=[validators.rbac.bulk]
+        )
+        self.bulk_purge = BulkActionProcessor(
+            service.bulk_purge, monitors=action_monitors, validators=[validators.rbac.bulk]
+        )
 
     @override
     def supported_actions(self) -> list[ActionSpec]:

--- a/src/ai/backend/manager/services/app_config_fragment/service.py
+++ b/src/ai/backend/manager/services/app_config_fragment/service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from ai.backend.manager.repositories.app_config_fragment.repository import (
     AppConfigFragmentRepository,
 )
-from ai.backend.manager.repositories.base import BulkCreator, Creator
+from ai.backend.manager.repositories.base import BulkCreator
 from ai.backend.manager.services.app_config_fragment.actions.admin_search import (
     AdminSearchAppConfigFragmentAction,
     AdminSearchAppConfigFragmentActionResult,
@@ -62,7 +62,7 @@ class AppConfigFragmentService:
     async def create(
         self, action: CreateAppConfigFragmentAction
     ) -> CreateAppConfigFragmentActionResult:
-        data = await self._repository.create(Creator(spec=action.creator_spec))
+        data = await self._repository.create(action.creator_spec)
         return CreateAppConfigFragmentActionResult(fragment=data)
 
     async def get(self, action: GetAppConfigFragmentAction) -> GetAppConfigFragmentActionResult:
@@ -103,7 +103,7 @@ class AppConfigFragmentService:
     async def purge(
         self, action: PurgeAppConfigFragmentAction
     ) -> PurgeAppConfigFragmentActionResult:
-        data = await self._repository.purge(action.purger)
+        data = await self._repository.purge(action.purger_spec)
         return PurgeAppConfigFragmentActionResult(fragment=data)
 
     async def bulk_create(

--- a/src/ai/backend/manager/services/factory.py
+++ b/src/ai/backend/manager/services/factory.py
@@ -18,6 +18,12 @@ from ai.backend.manager.services.app_config_definition.processors import (
 from ai.backend.manager.services.app_config_definition.service import (
     AppConfigDefinitionService,
 )
+from ai.backend.manager.services.app_config_fragment.processors import (
+    AppConfigFragmentProcessors,
+)
+from ai.backend.manager.services.app_config_fragment.service import (
+    AppConfigFragmentService,
+)
 from ai.backend.manager.services.artifact.processors import ArtifactProcessors
 from ai.backend.manager.services.artifact.service import ArtifactService
 from ai.backend.manager.services.artifact_registry.processors import ArtifactRegistryProcessors
@@ -344,6 +350,9 @@ def create_services(args: ServiceArgs) -> Services:
         app_config_definition=AppConfigDefinitionService(
             repository=repositories.app_config_definition.repository,
         ),
+        app_config_fragment=AppConfigFragmentService(
+            repository=repositories.app_config_fragment.repository,
+        ),
         login_client_type=LoginClientTypeService(
             repository=repositories.auth.login_client_type,
         ),
@@ -510,6 +519,9 @@ def create_processors(
         auth=AuthProcessors(services.auth, action_monitors, validators),
         app_config_definition=AppConfigDefinitionProcessors(
             services.app_config_definition, action_monitors
+        ),
+        app_config_fragment=AppConfigFragmentProcessors(
+            services.app_config_fragment, action_monitors, validators
         ),
         login_client_type=LoginClientTypeProcessors(services.login_client_type, action_monitors),
         login_client_type_admin=LoginClientTypeAdminProcessors(

--- a/src/ai/backend/manager/services/processors.py
+++ b/src/ai/backend/manager/services/processors.py
@@ -57,6 +57,12 @@ if TYPE_CHECKING:
     from ai.backend.manager.services.app_config_definition.service import (
         AppConfigDefinitionService,
     )
+    from ai.backend.manager.services.app_config_fragment.processors import (
+        AppConfigFragmentProcessors,
+    )
+    from ai.backend.manager.services.app_config_fragment.service import (
+        AppConfigFragmentService,
+    )
     from ai.backend.manager.services.artifact.processors import (
         ArtifactProcessors,
     )
@@ -377,6 +383,7 @@ class Services:
     agent: AgentService
     app_config_allow_list: AppConfigAllowListService
     app_config_definition: AppConfigDefinitionService
+    app_config_fragment: AppConfigFragmentService
     domain: DomainService
     dotfile: DotfileService
     error_log: ErrorLogService
@@ -444,6 +451,7 @@ class Processors(AbstractProcessorPackage):
     agent: AgentProcessors
     app_config_allow_list: AppConfigAllowListProcessors
     app_config_definition: AppConfigDefinitionProcessors
+    app_config_fragment: AppConfigFragmentProcessors
     domain: DomainProcessors
     dotfile: DotfileProcessors
     error_log: ErrorLogProcessors
@@ -504,6 +512,7 @@ class Processors(AbstractProcessorPackage):
             *self.agent.supported_actions(),
             *self.app_config_allow_list.supported_actions(),
             *self.app_config_definition.supported_actions(),
+            *self.app_config_fragment.supported_actions(),
             *self.domain.supported_actions(),
             *self.dotfile.supported_actions(),
             *self.error_log.supported_actions(),

--- a/tests/unit/manager/actions/test_action_types.py
+++ b/tests/unit/manager/actions/test_action_types.py
@@ -58,7 +58,7 @@ class TestEntityType:
         scope_types = EntityType._scope_types()
         assert scope_types == {EntityType.USER, EntityType.PROJECT, EntityType.DOMAIN}
 
-    def test_resource_types_returns_original_nine(self) -> None:
+    def test_resource_types_returns_expected_set(self) -> None:
         resource_types = EntityType._resource_types()
         expected = {
             EntityType.VFOLDER,
@@ -67,13 +67,14 @@ class TestEntityType:
             EntityType.ARTIFACT,
             EntityType.ARTIFACT_REGISTRY,
             EntityType.APP_CONFIG,
+            EntityType.APP_CONFIG_FRAGMENT,
             EntityType.NOTIFICATION_CHANNEL,
             EntityType.NOTIFICATION_RULE,
             EntityType.MODEL_DEPLOYMENT,
             EntityType.MODEL_CARD,
         }
         assert resource_types == expected
-        assert len(resource_types) == 10
+        assert len(resource_types) == 11
 
     def test_scope_and_resource_types_no_overlap(self) -> None:
         scope_types = EntityType._scope_types()

--- a/tests/unit/manager/actions/validators/test_app_config_fragment_create_authorization.py
+++ b/tests/unit/manager/actions/validators/test_app_config_fragment_create_authorization.py
@@ -1,0 +1,266 @@
+"""RBAC authorization tests for creating an app config fragment (BEP-1052).
+
+Drives the real ``ScopeActionRBACValidator`` (the validator wired to the fragment
+``create`` processor) against a real ``PermissionControllerRepository`` and the actual
+``CreateAppConfigFragmentAction``. This verifies the end-to-end contract the wiring
+promises:
+
+- a user may create a fragment in their **own** user scope,
+- creating in **another** user's scope is denied,
+- creating a **public** (global-scoped) fragment is superadmin-only.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from ai.backend.common.contexts.user import with_user
+from ai.backend.common.data.app_config.types import AppConfigScopeType
+from ai.backend.common.data.permission.types import (
+    EntityType,
+    OperationType,
+    Permission,
+    ScopeType,
+)
+from ai.backend.common.data.user.types import UserData, UserRole
+from ai.backend.common.identifier.user import UserID
+from ai.backend.manager.actions.action.base import BaseActionTriggerMeta
+from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
+from ai.backend.manager.data.user.types import UserStatus
+from ai.backend.manager.errors.permission import NotEnoughPermission
+
+# ORM cluster: configure_mappers() resolves string relationships against the registry
+# when this isolated test registers rows; these keep the referenced mappers live.
+from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.image import ImageRow
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.rbac_models import UserRoleRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.rbac_models.permission.object_permission import ObjectPermissionRow
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
+from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.scaling_group import ScalingGroupForDomainRow
+from ai.backend.manager.models.user import UserRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.app_config_fragment.creators import (
+    AppConfigFragmentCreatorSpec,
+)
+from ai.backend.manager.repositories.permission_controller.repository import (
+    PermissionControllerRepository,
+)
+from ai.backend.manager.services.app_config_fragment.actions.create import (
+    CreateAppConfigFragmentAction,
+)
+from ai.backend.testutils.db import with_tables
+
+_ORM_CLUSTER = (
+    AgentRow,
+    ImageRow,
+    ScalingGroupForDomainRow,
+)
+
+_DOMAIN = "default"
+
+
+def _user_data(user_id: UserID, *, is_superadmin: bool) -> UserData:
+    return UserData(
+        user_id=user_id,
+        is_authorized=True,
+        is_admin=is_superadmin,
+        is_superadmin=is_superadmin,
+        role=UserRole.SUPERADMIN if is_superadmin else UserRole.USER,
+        domain_name=_DOMAIN,
+    )
+
+
+async def _seed_user_with_role(
+    db: ExtendedAsyncSAEngine,
+    *,
+    user_id: UserID,
+    role_id: uuid.UUID,
+) -> None:
+    suffix = user_id.hex[:8]
+    policy_name = f"policy-{suffix}"
+    async with db.begin_session() as db_sess:
+        db_sess.add(
+            UserResourcePolicyRow(
+                name=policy_name,
+                max_vfolder_count=0,
+                max_quota_scope_size=-1,
+                max_session_count_per_model_session=0,
+                max_customized_image_count=0,
+            )
+        )
+        db_sess.add(
+            UserRow(
+                uuid=user_id,
+                email=f"user-{suffix}@test.com",
+                resource_policy=policy_name,
+                status=UserStatus.ACTIVE,
+                need_password_change=False,
+                sudo_session_enabled=False,
+            )
+        )
+        await db_sess.flush()
+        db_sess.add(RoleRow(id=role_id, name=f"role-{suffix}", description="fragment authz test"))
+        await db_sess.flush()
+        db_sess.add(UserRoleRow(user_id=user_id, role_id=role_id))
+        await db_sess.flush()
+
+
+async def _grant_fragment_create(
+    db: ExtendedAsyncSAEngine,
+    *,
+    role_id: uuid.UUID,
+    scope_id: str,
+) -> None:
+    async with db.begin_session() as db_sess:
+        db_sess.add(
+            PermissionRow(
+                role_id=role_id,
+                scope_type=ScopeType.USER,
+                scope_id=scope_id,
+                entity_type=EntityType.APP_CONFIG_FRAGMENT,
+                operation=OperationType.CREATE,
+                permission=Permission.from_operation(OperationType.CREATE),
+            )
+        )
+        await db_sess.flush()
+
+
+@pytest.fixture
+def trigger_meta() -> BaseActionTriggerMeta:
+    return BaseActionTriggerMeta(action_id=uuid.uuid4(), started_at=datetime.now(UTC))
+
+
+@pytest.fixture
+async def db_with_rbac_tables(
+    database_connection: ExtendedAsyncSAEngine,
+) -> AsyncIterator[ExtendedAsyncSAEngine]:
+    async with with_tables(
+        database_connection,
+        [
+            DomainRow,
+            UserResourcePolicyRow,
+            KeyPairResourcePolicyRow,
+            RoleRow,
+            UserRoleRow,
+            UserRow,
+            KeyPairRow,
+            PermissionRow,
+            ObjectPermissionRow,
+            AssociationScopesEntitiesRow,
+        ],
+    ):
+        yield database_connection
+
+
+@pytest.fixture
+def repository(db_with_rbac_tables: ExtendedAsyncSAEngine) -> PermissionControllerRepository:
+    return PermissionControllerRepository(db_with_rbac_tables)
+
+
+@pytest.fixture
+def scope_validator(repository: PermissionControllerRepository) -> ScopeActionRBACValidator:
+    # MagicMock config_provider → enforcement_enabled is truthy, so the check runs.
+    return ScopeActionRBACValidator(repository, MagicMock())
+
+
+@pytest.fixture
+async def owner_user(db_with_rbac_tables: ExtendedAsyncSAEngine) -> UserData:
+    """A non-superadmin granted APP_CONFIG_FRAGMENT:CREATE on their own user scope."""
+    user_id = UserID(uuid.uuid4())
+    role_id = uuid.uuid4()
+    await _seed_user_with_role(db_with_rbac_tables, user_id=user_id, role_id=role_id)
+    await _grant_fragment_create(db_with_rbac_tables, role_id=role_id, scope_id=str(user_id))
+    return _user_data(user_id, is_superadmin=False)
+
+
+class TestScopeAuthorization:
+    """user / domain fragment writes are authorized by the scope-chain RBAC check."""
+
+    async def test_own_user_scope_is_allowed(
+        self,
+        scope_validator: ScopeActionRBACValidator,
+        trigger_meta: BaseActionTriggerMeta,
+        owner_user: UserData,
+    ) -> None:
+        action = CreateAppConfigFragmentAction(
+            creator_spec=AppConfigFragmentCreatorSpec(
+                config_name="cfg",
+                scope_type=AppConfigScopeType.USER,
+                scope_id=str(owner_user.user_id),
+                config={},
+            )
+        )
+        with with_user(owner_user):
+            await scope_validator.validate(action, trigger_meta)
+
+    async def test_another_user_scope_is_denied(
+        self,
+        scope_validator: ScopeActionRBACValidator,
+        trigger_meta: BaseActionTriggerMeta,
+        owner_user: UserData,
+    ) -> None:
+        other_user_id = UserID(uuid.uuid4())
+        action = CreateAppConfigFragmentAction(
+            creator_spec=AppConfigFragmentCreatorSpec(
+                config_name="cfg",
+                scope_type=AppConfigScopeType.USER,
+                scope_id=str(other_user_id),
+                config={},
+            )
+        )
+        with with_user(owner_user):
+            with pytest.raises(NotEnoughPermission):
+                await scope_validator.validate(action, trigger_meta)
+
+
+class TestPublicScopeAuthorization:
+    """A public fragment is global-scoped: no role grants the write, so the scope-chain
+    check denies everyone and only a superadmin bypasses it."""
+
+    async def test_non_superadmin_is_denied(
+        self,
+        scope_validator: ScopeActionRBACValidator,
+        trigger_meta: BaseActionTriggerMeta,
+    ) -> None:
+        action = CreateAppConfigFragmentAction(
+            creator_spec=AppConfigFragmentCreatorSpec(
+                config_name="cfg",
+                scope_type=AppConfigScopeType.PUBLIC,
+                scope_id="",
+                config={},
+            )
+        )
+        with with_user(_user_data(UserID(uuid.uuid4()), is_superadmin=False)):
+            with pytest.raises(NotEnoughPermission):
+                await scope_validator.validate(action, trigger_meta)
+
+    async def test_superadmin_is_allowed(
+        self,
+        scope_validator: ScopeActionRBACValidator,
+        trigger_meta: BaseActionTriggerMeta,
+    ) -> None:
+        action = CreateAppConfigFragmentAction(
+            creator_spec=AppConfigFragmentCreatorSpec(
+                config_name="cfg",
+                scope_type=AppConfigScopeType.PUBLIC,
+                scope_id="",
+                config={},
+            )
+        )
+        with with_user(_user_data(UserID(uuid.uuid4()), is_superadmin=True)):
+            await scope_validator.validate(action, trigger_meta)

--- a/tests/unit/manager/rbac/test_permission_types.py
+++ b/tests/unit/manager/rbac/test_permission_types.py
@@ -129,7 +129,7 @@ class TestEntityType:
         # Verify scope types are exactly 3
         assert scope_types == {EntityType.USER, EntityType.PROJECT, EntityType.DOMAIN}
 
-        # Verify resource types are exactly 10
+        # Verify resource types are exactly 11
         assert resource_types == {
             EntityType.VFOLDER,
             EntityType.IMAGE,
@@ -137,6 +137,7 @@ class TestEntityType:
             EntityType.ARTIFACT,
             EntityType.ARTIFACT_REGISTRY,
             EntityType.APP_CONFIG,
+            EntityType.APP_CONFIG_FRAGMENT,
             EntityType.NOTIFICATION_CHANNEL,
             EntityType.NOTIFICATION_RULE,
             EntityType.MODEL_DEPLOYMENT,

--- a/tests/unit/manager/repositories/app_config_fragment/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_repository.py
@@ -6,8 +6,10 @@ import uuid
 from collections.abc import AsyncGenerator
 
 import pytest
+import sqlalchemy as sa
 
 from ai.backend.common.data.app_config.types import AppConfigScopeType
+from ai.backend.common.data.permission.types import EntityType, ScopeType
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.user import UserID
@@ -23,9 +25,17 @@ from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowLi
 from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
 from ai.backend.manager.models.app_config_fragment.conditions import AppConfigFragmentConditions
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
+from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.app_config_fragment.creators import (
     AppConfigFragmentCreatorSpec,
+)
+from ai.backend.manager.repositories.app_config_fragment.purgers import (
+    AppConfigFragmentPurgerSpec,
 )
 from ai.backend.manager.repositories.app_config_fragment.repository import (
     AppConfigFragmentRepository,
@@ -41,12 +51,11 @@ from ai.backend.manager.repositories.app_config_fragment.updaters import (
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
     BulkCreator,
-    Creator,
     OffsetPagination,
     Purger,
     Updater,
 )
-from ai.backend.manager.repositories.ops import DBOpsProvider
+from ai.backend.manager.repositories.ops.rbac.provider import RBACOpsProvider
 from ai.backend.manager.types import OptionalState
 from ai.backend.testutils.db import with_tables
 
@@ -62,16 +71,26 @@ async def database(
     database_connection: ExtendedAsyncSAEngine,
 ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
     # FK order: app_config_definitions (parent) before the allow-list and fragments (children).
+    # AssociationScopesEntitiesRow holds the RBAC scope↔fragment binding written on create;
+    # RoleRow + PermissionRow back the entity-as-scope purge, which clears any permissions
+    # granted at the fragment's own scope when it is purged.
     async with with_tables(
         database_connection,
-        [AppConfigDefinitionRow, AppConfigAllowListRow, AppConfigFragmentRow],
+        [
+            AppConfigDefinitionRow,
+            AppConfigAllowListRow,
+            AppConfigFragmentRow,
+            AssociationScopesEntitiesRow,
+            RoleRow,
+            PermissionRow,
+        ],
     ):
         yield database_connection
 
 
 @pytest.fixture
 def repository(database: ExtendedAsyncSAEngine) -> AppConfigFragmentRepository:
-    return AppConfigFragmentRepository(DBOpsProvider(database))
+    return AppConfigFragmentRepository(RBACOpsProvider(database))
 
 
 def _allow_list_row(config_name: str, scope_type: AppConfigScopeType) -> AppConfigAllowListRow:
@@ -190,14 +209,12 @@ class TestCreateAndGet:
         self, repository: AppConfigFragmentRepository, theme_registered: None
     ) -> None:
         created = await repository.create(
-            Creator(
-                spec=AppConfigFragmentCreatorSpec(
-                    config_name="theme",
-                    scope_type=AppConfigScopeType.PUBLIC,
-                    scope_id="public",
-                    config={"theme": "dark"},
-                )
-            ),
+            AppConfigFragmentCreatorSpec(
+                config_name="theme",
+                scope_type=AppConfigScopeType.PUBLIC,
+                scope_id="public",
+                config={"theme": "dark"},
+            )
         )
         fetched = await repository.get_by_id(created.id)
         assert fetched.id == created.id
@@ -214,14 +231,12 @@ class TestCreateAndGet:
     ) -> None:
         with pytest.raises(AppConfigFragmentWriteNotAllowed):
             await repository.create(
-                Creator(
-                    spec=AppConfigFragmentCreatorSpec(
-                        config_name="theme",
-                        scope_type=AppConfigScopeType.PUBLIC,
-                        scope_id="public",
-                        config={"theme": "dark"},
-                    )
-                ),
+                AppConfigFragmentCreatorSpec(
+                    config_name="theme",
+                    scope_type=AppConfigScopeType.PUBLIC,
+                    scope_id="public",
+                    config={"theme": "dark"},
+                )
             )
 
     async def test_unique_constraint_violation(
@@ -231,14 +246,12 @@ class TestCreateAndGet:
     ) -> None:
         with pytest.raises(UniqueConstraintViolationError):
             await repository.create(
-                Creator(
-                    spec=AppConfigFragmentCreatorSpec(
-                        config_name=domain_scoped_fragment.config_name,
-                        scope_type=domain_scoped_fragment.scope_type,
-                        scope_id=domain_scoped_fragment.scope_id,
-                        config={"k": "v"},
-                    )
-                ),
+                AppConfigFragmentCreatorSpec(
+                    config_name=domain_scoped_fragment.config_name,
+                    scope_type=domain_scoped_fragment.scope_type,
+                    scope_id=domain_scoped_fragment.scope_id,
+                    config={"k": "v"},
+                )
             )
 
 
@@ -275,7 +288,7 @@ class TestPurge:
         domain_scoped_fragment: AppConfigFragmentData,
     ) -> None:
         purged = await repository.purge(
-            Purger(row_class=AppConfigFragmentRow, pk_value=domain_scoped_fragment.id),
+            AppConfigFragmentPurgerSpec(fragment_id=domain_scoped_fragment.id),
         )
         assert purged.id == domain_scoped_fragment.id
         with pytest.raises(AppConfigFragmentNotFound):
@@ -285,7 +298,7 @@ class TestPurge:
         missing_id = AppConfigFragmentID(uuid.uuid4())
         with pytest.raises(AppConfigFragmentNotFound):
             await repository.purge(
-                Purger(row_class=AppConfigFragmentRow, pk_value=missing_id),
+                AppConfigFragmentPurgerSpec(fragment_id=missing_id),
             )
 
 
@@ -704,3 +717,66 @@ class TestApplicableFragments:
             AppConfigScopeArguments(domain_id=DomainID(_DOMAIN_UUID), user_id=UserID(_USER_UUID)),
         )
         assert applicable == []
+
+
+class TestRBACScopeAssociation:
+    """Create binds a ``user`` / ``domain`` fragment to its RBAC scope so the RBAC validator can
+    resolve ownership on a later update/purge; ``public`` (GLOBAL, no RBAC scope) gets none."""
+
+    @staticmethod
+    async def _scope_bindings(
+        database: ExtendedAsyncSAEngine, entity_id: str
+    ) -> list[AssociationScopesEntitiesRow]:
+        async with database.begin_readonly_session() as db_sess:
+            rows = await db_sess.scalars(
+                sa.select(AssociationScopesEntitiesRow).where(
+                    AssociationScopesEntitiesRow.entity_type == EntityType.APP_CONFIG_FRAGMENT,
+                    AssociationScopesEntitiesRow.entity_id == entity_id,
+                )
+            )
+            return list(rows)
+
+    @staticmethod
+    async def _create(
+        repository: AppConfigFragmentRepository, scope_type: AppConfigScopeType, scope_id: str
+    ) -> AppConfigFragmentData:
+        return await repository.create(
+            AppConfigFragmentCreatorSpec(
+                config_name="theme",
+                scope_type=scope_type,
+                scope_id=scope_id,
+                config={"k": "v"},
+            )
+        )
+
+    async def test_user_scope_create_binds_to_user_scope(
+        self,
+        repository: AppConfigFragmentRepository,
+        database: ExtendedAsyncSAEngine,
+        theme_registered: None,
+    ) -> None:
+        created = await self._create(repository, AppConfigScopeType.USER, _USER_ID)
+        bindings = await self._scope_bindings(database, str(created.id))
+        assert len(bindings) == 1
+        assert bindings[0].scope_type is ScopeType.USER
+        assert bindings[0].scope_id == _USER_ID
+
+    async def test_public_scope_create_binds_nothing(
+        self,
+        repository: AppConfigFragmentRepository,
+        database: ExtendedAsyncSAEngine,
+        theme_registered: None,
+    ) -> None:
+        created = await self._create(repository, AppConfigScopeType.PUBLIC, "public")
+        assert await self._scope_bindings(database, str(created.id)) == []
+
+    async def test_purge_removes_the_scope_binding(
+        self,
+        repository: AppConfigFragmentRepository,
+        database: ExtendedAsyncSAEngine,
+        theme_registered: None,
+    ) -> None:
+        created = await self._create(repository, AppConfigScopeType.USER, _USER_ID)
+        assert len(await self._scope_bindings(database, str(created.id))) == 1
+        await repository.purge(AppConfigFragmentPurgerSpec(fragment_id=created.id))
+        assert await self._scope_bindings(database, str(created.id)) == []

--- a/tests/unit/manager/services/app_config_fragment/test_create_action.py
+++ b/tests/unit/manager/services/app_config_fragment/test_create_action.py
@@ -1,0 +1,57 @@
+"""Unit tests for CreateAppConfigFragmentAction's RBAC target resolution.
+
+``target_element()`` decides the scope the RBAC scope validator authorizes a fragment
+create against (BEP-1052): a user/domain fragment targets its USER/DOMAIN scope, while a
+public fragment is global-scoped (no RBAC scope element) and thus superadmin-only.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ai.backend.common.data.app_config.types import AppConfigScopeType
+from ai.backend.common.data.permission.types import RBACElementType, ScopeType
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.repositories.app_config_fragment.creators import (
+    AppConfigFragmentCreatorSpec,
+)
+from ai.backend.manager.services.app_config_fragment.actions.create import (
+    CreateAppConfigFragmentAction,
+)
+
+
+def _action(scope_type: AppConfigScopeType, scope_id: str) -> CreateAppConfigFragmentAction:
+    spec: AppConfigFragmentCreatorSpec = AppConfigFragmentCreatorSpec(
+        config_name="cfg",
+        scope_type=scope_type,
+        scope_id=scope_id,
+        config={},
+    )
+    return CreateAppConfigFragmentAction(creator_spec=spec)
+
+
+class TestCreateTargetElement:
+    def test_user_scope_targets_the_user_scope(self) -> None:
+        action = _action(AppConfigScopeType.USER, "user-1")
+        assert action.target_element() == RBACElementRef(RBACElementType.USER, "user-1")
+        assert action.scope_type() == ScopeType.USER
+
+    def test_domain_scope_targets_the_domain_scope(self) -> None:
+        action = _action(AppConfigScopeType.DOMAIN, "default")
+        assert action.target_element() == RBACElementRef(RBACElementType.DOMAIN, "default")
+        assert action.scope_type() == ScopeType.DOMAIN
+
+    def test_public_scope_has_no_scope_element(self) -> None:
+        # A public fragment is global-scoped: its target carries the fragment element type
+        # with an empty id, so the scope-chain check finds no scope and denies any
+        # non-superadmin writer (public writes are superadmin-only).
+        action = _action(AppConfigScopeType.PUBLIC, "")
+        assert action.target_element() == RBACElementRef(RBACElementType.APP_CONFIG_FRAGMENT, "")
+        assert action.scope_type() == ScopeType.GLOBAL
+
+    def test_target_element_uses_the_spec_scope_id(self) -> None:
+        # Cross-user create: the target scope is the *supplied* user id, so RBAC checks the
+        # writer's permission on that other user's scope (which they lack) — not their own.
+        other: Any = "victim-user"
+        action = _action(AppConfigScopeType.USER, other)
+        assert action.target_element() == RBACElementRef(RBACElementType.USER, other)

--- a/tests/unit/manager/services/app_config_fragment/test_service.py
+++ b/tests/unit/manager/services/app_config_fragment/test_service.py
@@ -24,6 +24,9 @@ from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentR
 from ai.backend.manager.repositories.app_config_fragment.creators import (
     AppConfigFragmentCreatorSpec,
 )
+from ai.backend.manager.repositories.app_config_fragment.purgers import (
+    AppConfigFragmentPurgerSpec,
+)
 from ai.backend.manager.repositories.app_config_fragment.repository import (
     AppConfigFragmentRepository,
 )
@@ -33,7 +36,6 @@ from ai.backend.manager.repositories.app_config_fragment.updaters import (
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
     BulkCreator,
-    Creator,
     OffsetPagination,
     Purger,
     Updater,
@@ -120,7 +122,7 @@ class TestAppConfigFragmentService:
         result = await service.create(CreateAppConfigFragmentAction(creator_spec=spec))
 
         assert result.fragment == fragment
-        mock_repository.create.assert_called_once_with(Creator(spec=spec))
+        mock_repository.create.assert_called_once_with(spec)
 
     # --- get / search ---
 
@@ -222,12 +224,12 @@ class TestAppConfigFragmentService:
     ) -> None:
         fragment = _fragment()
         mock_repository.purge = AsyncMock(return_value=fragment)
-        purger = Purger(row_class=AppConfigFragmentRow, pk_value=fragment.id)
+        purger_spec = AppConfigFragmentPurgerSpec(fragment_id=fragment.id)
 
-        result = await service.purge(PurgeAppConfigFragmentAction(purger=purger))
+        result = await service.purge(PurgeAppConfigFragmentAction(purger_spec=purger_spec))
 
         assert result.fragment == fragment
-        mock_repository.purge.assert_called_once_with(purger)
+        mock_repository.purge.assert_called_once_with(purger_spec)
 
     # --- bulk ---
 


### PR DESCRIPTION
## Summary
Attach the RBAC validators to the fragment write processors so `create` / `update` / `purge` are authorized at the fragment scope, and register the service/processors in the DI containers. A user may write their own `user`-scope fragment; a cross-user write is denied; `public` fragments are superadmin-only. Enforced only when RBAC enforcement is enabled.

Bulk-write authorization (bulk scope targets + bulk-scope validator wiring) ships with the API PR (#12759).

## 📚 Stacked PRs

Part of the AppConfigFragment / AppConfig stack under BEP-1052 (epic BA-5781). **Merge in order** (#12801 was split into #12825 / #12826 / #12827):

1. ✅ #12306 — `feat(BA-6552)`: app_config_fragments DB model and Alembic migration
2. ✅ #12307 — `feat(BA-6553)`: repository layer
3. ✅ #12403 — `refactor(BA-6619)`: consolidate AppConfigScopeType into common.data
4. ✅ #12405 — `refactor(BA-6620)`: ExistsQuerier + AppConfigAllowList.exists
5. ✅ #12358 — `feat(BA-6554)`: AppConfigFragment service layer
6. ✅ #12516 — `feat(BA-6702)`: move fragment rank to the allow list with scope defaults
7. ✅ #12517 — `feat(BA-6701)`: expose allow-list rank on the v2 API surface
8. ✅ #12518 — `feat(BA-6704)`: cascade app config subtree deletion from the definition
9. ✅ #12426 — `feat(BA-6626)`: app_config_fragment bulk repository layer
10. ✅ #12401 — `feat(BA-6618)`: app_config_fragment bulk CRUD service layer
11. ✅ #12706 — `feat(BA-6810)`: AppConfigFragment visible-fragments query (repository layer)
12. ❌ ~~#12825~~ — `feat(BA-6867)`: RBAC scoped-ops primitives (closed — folded into #12826)
13. #12826 — `feat(BA-6859)`: bind fragments to their RBAC scope on write (repository layer)
14. 👉 **#12827 — `feat(BA-6868)`: RBAC-gate fragment single writes at the processors** ← you are here
15. #12359 — `feat(BA-6555)`: AppConfig merge engine + resolve service (service layer)
16. #12377 — `feat(BA-6556)`: AppConfig REST v2 API
17. #12759 — `feat(BA-6860)`: fragment write API routes + bulk write authz

Jira: https://lablup.atlassian.net/browse/BA-6868

🤖 Generated with [Claude Code](https://claude.com/claude-code)

