### PR TITLE
feat(BA-6874): wire compute-schedule into the API handler

### DIFF
--- a/changes/12841.feature.md
+++ b/changes/12841.feature.md
@@ -1,0 +1,1 @@
+Add the `computeSchedule` (dry-run) GraphQL query that probes, without provisioning, whether each kernel of a would-be session fits a resource group's nodes and returns per-kernel remediation hints.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -3046,6 +3046,11 @@ type ComputeSchedulePayload
   Per-kernel compute-schedule outcomes, correlated to the request by list index.
   """
   results: [ComputeScheduleKernelResult!]!
+
+  """
+  Reason the resource group as a whole cannot admit the session (e.g. it has no agents). Null when per-kernel results apply.
+  """
+  resourceGroupReason: String
 }
 
 type ComputeSession implements Item
@@ -19284,6 +19289,11 @@ type UnschedulableReasonHint
 
   """Architectures that actually exist among the scheduling targets."""
   availableArchs: [String!]
+
+  """
+  The requested image could not be found. When True, adjusting resource slots cannot make the kernel schedulable.
+  """
+  imageNotFound: Boolean!
 }
 
 type UnsetQuotaScope

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -3046,11 +3046,6 @@ type ComputeSchedulePayload
   Per-kernel compute-schedule outcomes, correlated to the request by list index.
   """
   results: [ComputeScheduleKernelResult!]!
-
-  """
-  Reason the resource group as a whole cannot admit the session (e.g. it has no agents). Null when per-kernel results apply.
-  """
-  resourceGroupReason: String
 }
 
 type ComputeSession implements Item
@@ -19286,14 +19281,6 @@ type UnschedulableReasonHint
 {
   """Subtract these slots to fit the best-fitting node."""
   requiredReduction: [ResourceSlotEntry!]
-
-  """Architectures that actually exist among the scheduling targets."""
-  availableArchs: [String!]
-
-  """
-  The requested image could not be found. When True, adjusting resource slots cannot make the kernel schedulable.
-  """
-  imageNotFound: Boolean!
 }
 
 type UnsetQuotaScope

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -2184,11 +2184,6 @@ type ComputeSchedulePayload {
   Per-kernel compute-schedule outcomes, correlated to the request by list index.
   """
   results: [ComputeScheduleKernelResult!]!
-
-  """
-  Reason the resource group as a whole cannot admit the session (e.g. it has no agents). Null when per-kernel results apply.
-  """
-  resourceGroupReason: String
 }
 
 extend type ComputeSessionNode implements Node @key(fields: "id") {
@@ -13488,14 +13483,6 @@ Added in 26.8.0. What the caller could change so an unschedulable kernel would f
 type UnschedulableReasonHint {
   """Subtract these slots to fit the best-fitting node."""
   requiredReduction: [ResourceSlotEntry!]
-
-  """Architectures that actually exist among the scheduling targets."""
-  availableArchs: [String!]
-
-  """
-  The requested image could not be found. When True, adjusting resource slots cannot make the kernel schedulable.
-  """
-  imageNotFound: Boolean!
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -2184,6 +2184,11 @@ type ComputeSchedulePayload {
   Per-kernel compute-schedule outcomes, correlated to the request by list index.
   """
   results: [ComputeScheduleKernelResult!]!
+
+  """
+  Reason the resource group as a whole cannot admit the session (e.g. it has no agents). Null when per-kernel results apply.
+  """
+  resourceGroupReason: String
 }
 
 extend type ComputeSessionNode implements Node @key(fields: "id") {
@@ -13486,6 +13491,11 @@ type UnschedulableReasonHint {
 
   """Architectures that actually exist among the scheduling targets."""
   availableArchs: [String!]
+
+  """
+  The requested image could not be found. When True, adjusting resource slots cannot make the kernel schedulable.
+  """
+  imageNotFound: Boolean!
 }
 
 """

--- a/src/ai/backend/common/dto/manager/v2/scheduler/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/scheduler/__init__.py
@@ -9,7 +9,6 @@ from ai.backend.common.dto.manager.v2.scheduler.request import (
 from ai.backend.common.dto.manager.v2.scheduler.response import (
     ComputeScheduleKernelResultInfo,
     ComputeSchedulePayload,
-    ResourceGroupUnschedulableReasonDTO,
     SchedulingBroadcastEventPayloadNode,
     SchedulingStatusDTO,
     UnschedulableReasonHintInfo,
@@ -20,7 +19,6 @@ __all__ = (
     "ComputeScheduleKernelResourceInput",
     "ComputeScheduleKernelResultInfo",
     "ComputeSchedulePayload",
-    "ResourceGroupUnschedulableReasonDTO",
     "SchedulingBroadcastEventPayloadNode",
     "SchedulingStatusDTO",
     "UnschedulableReasonHintInfo",

--- a/src/ai/backend/common/dto/manager/v2/scheduler/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/scheduler/__init__.py
@@ -9,6 +9,7 @@ from ai.backend.common.dto.manager.v2.scheduler.request import (
 from ai.backend.common.dto.manager.v2.scheduler.response import (
     ComputeScheduleKernelResultInfo,
     ComputeSchedulePayload,
+    ResourceGroupUnschedulableReasonDTO,
     SchedulingBroadcastEventPayloadNode,
     SchedulingStatusDTO,
     UnschedulableReasonHintInfo,
@@ -19,6 +20,7 @@ __all__ = (
     "ComputeScheduleKernelResourceInput",
     "ComputeScheduleKernelResultInfo",
     "ComputeSchedulePayload",
+    "ResourceGroupUnschedulableReasonDTO",
     "SchedulingBroadcastEventPayloadNode",
     "SchedulingStatusDTO",
     "UnschedulableReasonHintInfo",

--- a/src/ai/backend/common/dto/manager/v2/scheduler/response.py
+++ b/src/ai/backend/common/dto/manager/v2/scheduler/response.py
@@ -14,9 +14,17 @@ from ai.backend.common.dto.manager.v2.common import ResourceSlotEntryInfo
 __all__ = (
     "ComputeScheduleKernelResultInfo",
     "ComputeSchedulePayload",
+    "ResourceGroupUnschedulableReasonDTO",
     "SchedulingBroadcastEventPayloadNode",
     "UnschedulableReasonHintInfo",
 )
+
+
+class ResourceGroupUnschedulableReasonDTO(StrEnum):
+    """Reason the resource group as a whole cannot admit the session."""
+
+    RESOURCE_GROUP_NOT_FOUND = "RESOURCE_GROUP_NOT_FOUND"
+    NO_SCHEDULABLE_AGENTS = "NO_SCHEDULABLE_AGENTS"
 
 
 class SchedulingStatusDTO(StrEnum):
@@ -80,7 +88,7 @@ class ComputeScheduleKernelResultInfo(BaseResponseModel):
     requested_slots: list[ResourceSlotEntryInfo] = Field(
         description="Resource slots resolved for this kernel after applying defaults.",
     )
-    requested_architecture: str = Field(
+    requested_architecture: str | None = Field(
         description="Architecture resolved for this kernel.",
     )
     success: bool = Field(
@@ -98,7 +106,7 @@ class ComputeSchedulePayload(BaseResponseModel):
     results: list[ComputeScheduleKernelResultInfo] = Field(
         description="Per-kernel compute-schedule outcomes, correlated to the request by list index.",
     )
-    resource_group_reason: str | None = Field(
+    resource_group_reason: ResourceGroupUnschedulableReasonDTO | None = Field(
         default=None,
         description=(
             "Reason the resource group as a whole cannot admit the session "

--- a/src/ai/backend/common/dto/manager/v2/scheduler/response.py
+++ b/src/ai/backend/common/dto/manager/v2/scheduler/response.py
@@ -60,6 +60,13 @@ class UnschedulableReasonHintInfo(BaseResponseModel):
         default=None,
         description="Architectures that actually exist among the scheduling targets.",
     )
+    image_not_found: bool = Field(
+        default=False,
+        description=(
+            "The requested image could not be found. When True, adjusting resource "
+            "slots cannot make the kernel schedulable."
+        ),
+    )
 
 
 class ComputeScheduleKernelResultInfo(BaseResponseModel):
@@ -90,4 +97,11 @@ class ComputeSchedulePayload(BaseResponseModel):
 
     results: list[ComputeScheduleKernelResultInfo] = Field(
         description="Per-kernel compute-schedule outcomes, correlated to the request by list index.",
+    )
+    resource_group_reason: str | None = Field(
+        default=None,
+        description=(
+            "Reason the resource group as a whole cannot admit the session "
+            "(e.g. it has no agents). Null when per-kernel results apply."
+        ),
     )

--- a/src/ai/backend/common/dto/manager/v2/scheduler/response.py
+++ b/src/ai/backend/common/dto/manager/v2/scheduler/response.py
@@ -14,17 +14,9 @@ from ai.backend.common.dto.manager.v2.common import ResourceSlotEntryInfo
 __all__ = (
     "ComputeScheduleKernelResultInfo",
     "ComputeSchedulePayload",
-    "ResourceGroupUnschedulableReasonDTO",
     "SchedulingBroadcastEventPayloadNode",
     "UnschedulableReasonHintInfo",
 )
-
-
-class ResourceGroupUnschedulableReasonDTO(StrEnum):
-    """Reason the resource group as a whole cannot admit the session."""
-
-    RESOURCE_GROUP_NOT_FOUND = "RESOURCE_GROUP_NOT_FOUND"
-    NO_SCHEDULABLE_AGENTS = "NO_SCHEDULABLE_AGENTS"
 
 
 class SchedulingStatusDTO(StrEnum):
@@ -64,17 +56,6 @@ class UnschedulableReasonHintInfo(BaseResponseModel):
         default=None,
         description="Subtract these slots to fit the best-fitting node.",
     )
-    available_archs: list[str] | None = Field(
-        default=None,
-        description="Architectures that actually exist among the scheduling targets.",
-    )
-    image_not_found: bool = Field(
-        default=False,
-        description=(
-            "The requested image could not be found. When True, adjusting resource "
-            "slots cannot make the kernel schedulable."
-        ),
-    )
 
 
 class ComputeScheduleKernelResultInfo(BaseResponseModel):
@@ -88,7 +69,7 @@ class ComputeScheduleKernelResultInfo(BaseResponseModel):
     requested_slots: list[ResourceSlotEntryInfo] = Field(
         description="Resource slots resolved for this kernel after applying defaults.",
     )
-    requested_architecture: str | None = Field(
+    requested_architecture: str = Field(
         description="Architecture resolved for this kernel.",
     )
     success: bool = Field(
@@ -105,11 +86,4 @@ class ComputeSchedulePayload(BaseResponseModel):
 
     results: list[ComputeScheduleKernelResultInfo] = Field(
         description="Per-kernel compute-schedule outcomes, correlated to the request by list index.",
-    )
-    resource_group_reason: ResourceGroupUnschedulableReasonDTO | None = Field(
-        default=None,
-        description=(
-            "Reason the resource group as a whole cannot admit the session "
-            "(e.g. it has no agents). Null when per-kernel results apply."
-        ),
     )

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -40,6 +40,12 @@ from ai.backend.common.dto.manager.v2.resource_slot.types import (
     ResourceOptsEntryInfoDTO,
     ResourceOptsInfoDTO,
 )
+from ai.backend.common.dto.manager.v2.scheduler.request import ComputeScheduleInput
+from ai.backend.common.dto.manager.v2.scheduler.response import (
+    ComputeScheduleKernelResultInfo,
+    ComputeSchedulePayload,
+    UnschedulableReasonHintInfo,
+)
 from ai.backend.common.dto.manager.v2.session.request import (
     AdminSearchSessionsInput,
     EnqueueSessionInput,
@@ -78,10 +84,13 @@ from ai.backend.common.types import (
     SessionId,
     SessionTypes,
 )
+from ai.backend.common.types import ResourceSlotEntry as DataResourceSlotEntry
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.kernel.types import KernelInfo, KernelStatus, KernelStatusInMatchSpec
 from ai.backend.manager.data.resource_slot.types import ResourceAllocationAggregate
+from ai.backend.manager.data.session.compute_schedule import ComputeScheduleKernelResult
+from ai.backend.manager.data.session.draft import KernelResourceInput
 from ai.backend.manager.data.session.types import SessionData, SessionStatus
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.models.kernel.conditions import KernelConditions
@@ -124,6 +133,9 @@ from ai.backend.manager.services.session.actions.batch_get_kernel_resource_alloc
 )
 from ai.backend.manager.services.session.actions.batch_get_session_resource_allocation import (
     BatchGetSessionResourceAllocationAction,
+)
+from ai.backend.manager.services.session.actions.compute_schedule import (
+    ComputeScheduleAction,
 )
 from ai.backend.manager.services.session.actions.enqueue_session import (
     EnqueueSessionAction,
@@ -315,6 +327,88 @@ class SessionAdapter(BaseAdapter):
         result = await self._processors.session.enqueue_session.wait_for_complete(action)
         return EnqueueSessionPayload(
             session=self._session_data_to_node(result.session_data),
+        )
+
+    # -------------------------------------------------------------------------
+    # Compute schedule
+    # -------------------------------------------------------------------------
+
+    async def compute_schedule(self, input: ComputeScheduleInput) -> ComputeSchedulePayload:
+        """Probe whether each kernel of a would-be session fits the target
+        resource group's nodes, without provisioning.
+
+        A self-service query: the requesting user is resolved from the request
+        context and passed as ``user_uuid``. The service resolves that user's
+        main access key from it, so the adapter supplies no access key.
+        """
+        cluster_mode = (
+            ClusterMode.MULTI_NODE
+            if input.cluster_mode == ClusterModeEnum.MULTI_NODE
+            else ClusterMode.SINGLE_NODE
+        )
+        kernels = [
+            KernelResourceInput(
+                image_id=kernel.image_id,
+                resources=tuple(
+                    DataResourceSlotEntry(
+                        resource_type=entry.resource_type,
+                        quantity=entry.quantity,
+                    )
+                    for entry in kernel.resources
+                ),
+            )
+            for kernel in input.kernels
+        ]
+        action = ComputeScheduleAction(
+            kernels=kernels,
+            cluster_mode=cluster_mode,
+            resource_group_id=input.resource_group_id,
+            user_uuid=self._require_user_id(),
+        )
+        result = await self._processors.session.compute_schedule.wait_for_complete(action)
+        return ComputeSchedulePayload(
+            results=[
+                self._compute_schedule_kernel_result_to_info(kernel_result)
+                for kernel_result in result.result.kernel_results
+            ],
+            resource_group_reason=result.result.resource_group_reason,
+        )
+
+    @staticmethod
+    def _compute_schedule_kernel_result_to_info(
+        result: ComputeScheduleKernelResult,
+    ) -> ComputeScheduleKernelResultInfo:
+        """Map the internal per-kernel fitting outcome onto its response DTO."""
+        reason_hint: UnschedulableReasonHintInfo | None = None
+        hint = result.reason_hint
+        if hint is not None:
+            required_reduction = (
+                [
+                    ResourceSlotEntryInfo(
+                        resource_type=entry.resource_type,
+                        quantity=Decimal(entry.quantity),
+                    )
+                    for entry in hint.required_reduction
+                ]
+                if hint.required_reduction is not None
+                else None
+            )
+            reason_hint = UnschedulableReasonHintInfo(
+                required_reduction=required_reduction,
+                available_archs=hint.available_archs,
+                image_not_found=hint.image_not_found,
+            )
+        return ComputeScheduleKernelResultInfo(
+            requested_slots=[
+                ResourceSlotEntryInfo(
+                    resource_type=entry.resource_type,
+                    quantity=Decimal(entry.quantity),
+                )
+                for entry in result.requested_slots
+            ],
+            requested_architecture=result.requested_architecture or "",
+            success=result.success,
+            reason_hint=reason_hint,
         )
 
     # -------------------------------------------------------------------------

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -44,7 +44,6 @@ from ai.backend.common.dto.manager.v2.scheduler.request import ComputeScheduleIn
 from ai.backend.common.dto.manager.v2.scheduler.response import (
     ComputeScheduleKernelResultInfo,
     ComputeSchedulePayload,
-    ResourceGroupUnschedulableReasonDTO,
     UnschedulableReasonHintInfo,
 )
 from ai.backend.common.dto.manager.v2.session.request import (
@@ -367,17 +366,11 @@ class SessionAdapter(BaseAdapter):
             user_uuid=self._require_user_id(),
         )
         result = await self._processors.session.compute_schedule.wait_for_complete(action)
-        resource_group_reason = result.result.resource_group_reason
         return ComputeSchedulePayload(
             results=[
                 self._compute_schedule_kernel_result_to_info(kernel_result)
                 for kernel_result in result.result.kernel_results
             ],
-            resource_group_reason=(
-                ResourceGroupUnschedulableReasonDTO(resource_group_reason.value)
-                if resource_group_reason is not None
-                else None
-            ),
         )
 
     @staticmethod
@@ -401,8 +394,6 @@ class SessionAdapter(BaseAdapter):
             )
             reason_hint = UnschedulableReasonHintInfo(
                 required_reduction=required_reduction,
-                available_archs=hint.available_archs,
-                image_not_found=hint.image_not_found,
             )
         return ComputeScheduleKernelResultInfo(
             requested_slots=[

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -44,6 +44,7 @@ from ai.backend.common.dto.manager.v2.scheduler.request import ComputeScheduleIn
 from ai.backend.common.dto.manager.v2.scheduler.response import (
     ComputeScheduleKernelResultInfo,
     ComputeSchedulePayload,
+    ResourceGroupUnschedulableReasonDTO,
     UnschedulableReasonHintInfo,
 )
 from ai.backend.common.dto.manager.v2.session.request import (
@@ -366,12 +367,17 @@ class SessionAdapter(BaseAdapter):
             user_uuid=self._require_user_id(),
         )
         result = await self._processors.session.compute_schedule.wait_for_complete(action)
+        resource_group_reason = result.result.resource_group_reason
         return ComputeSchedulePayload(
             results=[
                 self._compute_schedule_kernel_result_to_info(kernel_result)
                 for kernel_result in result.result.kernel_results
             ],
-            resource_group_reason=result.result.resource_group_reason,
+            resource_group_reason=(
+                ResourceGroupUnschedulableReasonDTO(resource_group_reason.value)
+                if resource_group_reason is not None
+                else None
+            ),
         )
 
     @staticmethod
@@ -406,7 +412,7 @@ class SessionAdapter(BaseAdapter):
                 )
                 for entry in result.requested_slots
             ],
-            requested_architecture=result.requested_architecture or "",
+            requested_architecture=result.requested_architecture,
             success=result.success,
             reason_hint=reason_hint,
         )

--- a/src/ai/backend/manager/api/gql/scheduler.py
+++ b/src/ai/backend/manager/api/gql/scheduler.py
@@ -30,6 +30,7 @@ from ai.backend.manager.api.gql.common_types import (
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
+    gql_added_field,
     gql_enum,
     gql_field,
     gql_pydantic_input,
@@ -39,7 +40,6 @@ from ai.backend.manager.api.gql.decorators import (
 )
 from ai.backend.manager.api.gql.session.types import SessionClusterModeGQL
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
-from ai.backend.manager.errors.common import ServiceUnavailable
 from ai.backend.manager.errors.kernel import InvalidSessionId
 
 from .session_federation import Session
@@ -200,6 +200,15 @@ class ComputeScheduleInputGQL(PydanticInputMixin[ComputeScheduleInput]):
 class UnschedulableReasonHintGQL:
     required_reduction: list[ResourceSlotEntryGQL] | None
     available_archs: list[str] | None
+    image_not_found: bool = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "The requested image could not be found. When true, adjusting resource "
+                "slots cannot make the kernel schedulable."
+            ),
+        )
+    )
 
 
 @gql_pydantic_type(
@@ -230,6 +239,15 @@ class ComputeScheduleKernelResultGQL:
 )
 class ComputeSchedulePayloadGQL:
     results: list[ComputeScheduleKernelResultGQL]
+    resource_group_reason: str | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Reason the resource group as a whole cannot admit the session "
+                "(e.g. it has no agents). Null when per-kernel results apply."
+            ),
+        )
+    )
 
 
 @gql_root_field(
@@ -247,5 +265,6 @@ async def compute_schedule(
     input: ComputeScheduleInputGQL,
     info: Info[StrawberryGQLContext],
 ) -> ComputeSchedulePayloadGQL | None:
-    # Schema-only surface: the adapter wiring lands in a follow-up.
-    raise ServiceUnavailable("Compute schedule is not yet available.")
+    payload = await info.context.adapters.session.compute_schedule(input.to_pydantic())
+    result: ComputeSchedulePayloadGQL = ComputeSchedulePayloadGQL.from_pydantic(payload)  # type: ignore[attr-defined]
+    return result

--- a/src/ai/backend/manager/api/gql/scheduler.py
+++ b/src/ai/backend/manager/api/gql/scheduler.py
@@ -30,7 +30,6 @@ from ai.backend.manager.api.gql.common_types import (
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
-    gql_added_field,
     gql_enum,
     gql_field,
     gql_pydantic_input,
@@ -199,16 +198,6 @@ class ComputeScheduleInputGQL(PydanticInputMixin[ComputeScheduleInput]):
 )
 class UnschedulableReasonHintGQL:
     required_reduction: list[ResourceSlotEntryGQL] | None
-    available_archs: list[str] | None
-    image_not_found: bool = gql_added_field(
-        BackendAIGQLMeta(
-            added_version=NEXT_RELEASE_VERSION,
-            description=(
-                "The requested image could not be found. When true, adjusting resource "
-                "slots cannot make the kernel schedulable."
-            ),
-        )
-    )
 
 
 @gql_pydantic_type(
@@ -229,19 +218,6 @@ class ComputeScheduleKernelResultGQL:
     reason_hint: UnschedulableReasonHintGQL | None
 
 
-@gql_enum(
-    BackendAIGQLMeta(
-        added_version=NEXT_RELEASE_VERSION,
-        description="Reason the resource group as a whole cannot admit the session.",
-    )
-)
-class ResourceGroupUnschedulableReason(StrEnum):
-    """Reason the resource group as a whole cannot admit the session."""
-
-    RESOURCE_GROUP_NOT_FOUND = "RESOURCE_GROUP_NOT_FOUND"
-    NO_SCHEDULABLE_AGENTS = "NO_SCHEDULABLE_AGENTS"
-
-
 @gql_pydantic_type(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
@@ -252,15 +228,6 @@ class ResourceGroupUnschedulableReason(StrEnum):
 )
 class ComputeSchedulePayloadGQL:
     results: list[ComputeScheduleKernelResultGQL]
-    resource_group_reason: ResourceGroupUnschedulableReason | None = gql_added_field(
-        BackendAIGQLMeta(
-            added_version=NEXT_RELEASE_VERSION,
-            description=(
-                "Reason the resource group as a whole cannot admit the session "
-                "(e.g. it has no agents). Null when per-kernel results apply."
-            ),
-        )
-    )
 
 
 @gql_root_field(

--- a/src/ai/backend/manager/api/gql/scheduler.py
+++ b/src/ai/backend/manager/api/gql/scheduler.py
@@ -229,6 +229,19 @@ class ComputeScheduleKernelResultGQL:
     reason_hint: UnschedulableReasonHintGQL | None
 
 
+@gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Reason the resource group as a whole cannot admit the session.",
+    )
+)
+class ResourceGroupUnschedulableReason(StrEnum):
+    """Reason the resource group as a whole cannot admit the session."""
+
+    RESOURCE_GROUP_NOT_FOUND = "RESOURCE_GROUP_NOT_FOUND"
+    NO_SCHEDULABLE_AGENTS = "NO_SCHEDULABLE_AGENTS"
+
+
 @gql_pydantic_type(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
@@ -239,7 +252,7 @@ class ComputeScheduleKernelResultGQL:
 )
 class ComputeSchedulePayloadGQL:
     results: list[ComputeScheduleKernelResultGQL]
-    resource_group_reason: str | None = gql_added_field(
+    resource_group_reason: ResourceGroupUnschedulableReason | None = gql_added_field(
         BackendAIGQLMeta(
             added_version=NEXT_RELEASE_VERSION,
             description=(

--- a/src/ai/backend/manager/data/session/compute_schedule.py
+++ b/src/ai/backend/manager/data/session/compute_schedule.py
@@ -1,8 +1,20 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
 
 from ai.backend.common.types import ResourceSlotEntry
+
+
+class ResourceGroupUnschedulableReason(StrEnum):
+    """Reason the resource group as a whole cannot admit the session.
+
+    Set only when no per-kernel result applies (the check could not even reach
+    per-kernel node fitting).
+    """
+
+    RESOURCE_GROUP_NOT_FOUND = "RESOURCE_GROUP_NOT_FOUND"
+    NO_SCHEDULABLE_AGENTS = "NO_SCHEDULABLE_AGENTS"
 
 
 @dataclass(frozen=True)
@@ -46,4 +58,4 @@ class ComputeScheduleKernelResult:
 @dataclass(frozen=True)
 class ComputeScheduleResult:
     kernel_results: list[ComputeScheduleKernelResult]
-    resource_group_reason: str | None = None
+    resource_group_reason: ResourceGroupUnschedulableReason | None = None

--- a/src/ai/backend/manager/data/session/compute_schedule.py
+++ b/src/ai/backend/manager/data/session/compute_schedule.py
@@ -1,20 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import StrEnum
 
 from ai.backend.common.types import ResourceSlotEntry
-
-
-class ResourceGroupUnschedulableReason(StrEnum):
-    """Reason the resource group as a whole cannot admit the session.
-
-    Set only when no per-kernel result applies (the check could not even reach
-    per-kernel node fitting).
-    """
-
-    RESOURCE_GROUP_NOT_FOUND = "RESOURCE_GROUP_NOT_FOUND"
-    NO_SCHEDULABLE_AGENTS = "NO_SCHEDULABLE_AGENTS"
 
 
 @dataclass(frozen=True)
@@ -25,15 +13,9 @@ class UnschedulableReasonHint:
     ``RemediationHint``.
 
     - ``required_reduction`` — subtract these slots to fit the best-fitting node.
-    - ``required_container_reduction`` — free this many containers.
-    - ``available_archs`` — architectures that actually exist.
-    - ``image_not_found`` — True if the requested image was not found.
     """
 
     required_reduction: tuple[ResourceSlotEntry, ...] | None = None
-    required_container_reduction: int | None = None
-    available_archs: list[str] | None = None
-    image_not_found: bool = False
 
 
 @dataclass(frozen=True)
@@ -50,7 +32,7 @@ class ComputeScheduleKernelResult:
     """
 
     requested_slots: tuple[ResourceSlotEntry, ...]
-    requested_architecture: str | None
+    requested_architecture: str
     success: bool
     reason_hint: UnschedulableReasonHint | None = None
 
@@ -58,4 +40,3 @@ class ComputeScheduleKernelResult:
 @dataclass(frozen=True)
 class ComputeScheduleResult:
     kernel_results: list[ComputeScheduleKernelResult]
-    resource_group_reason: ResourceGroupUnschedulableReason | None = None

--- a/src/ai/backend/manager/services/session/actions/compute_schedule.py
+++ b/src/ai/backend/manager/services/session/actions/compute_schedule.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 from ai.backend.common.data.permission.types import EntityType
 from ai.backend.common.identifier.resource_group import ResourceGroupID
-from ai.backend.common.types import AccessKey, ClusterMode
+from ai.backend.common.types import ClusterMode
 from ai.backend.manager.actions.action import BaseAction, BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.compute_schedule import (
@@ -25,16 +25,12 @@ class ComputeScheduleAction(BaseAction):
 
     Each kernel is an unresolved ``KernelResourceInput``; the result list
     corresponds positionally, so callers match results to kernels by index.
-
-    ``user_uuid`` and ``access_key`` identify the requesting user and are
-    resolved by the caller.
     """
 
     kernels: list[KernelResourceInput]
     cluster_mode: ClusterMode
     resource_group_id: ResourceGroupID
     user_uuid: UUID
-    access_key: AccessKey
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -326,9 +326,10 @@ class SessionService:
         kernel, unique role for positional correlation) and delegate the
         node-fitting decision to the scheduling controller.
         """
-        resource_group_name = await self._scheduler_repository.get_resource_group_name_by_id(
-            action.resource_group_id
-        )
+        user = await self._user_repository.get_user_by_uuid(action.user_uuid)
+        if user.main_access_key is None:
+            raise InternalServerError(f"User {action.user_uuid} has no main access key configured")
+        access_key = AccessKey(user.main_access_key)
 
         kernel_groups = tuple(
             KernelGroupDraft(
@@ -338,30 +339,25 @@ class SessionService:
             )
             for idx, kernel in enumerate(action.kernels)
         )
-
-        draft = SessionSpecDraft(
-            resource_spec=SessionResourceSpecDraft(
-                identity=SessionIdentityDraft(
-                    session_id=SessionID(uuid.uuid4()),
-                    creation_id=uuid.uuid4().hex,
-                    session_name="compute-schedule",
-                    access_key=action.access_key,
-                    user_uuid=action.user_uuid,
-                ),
-                classification=SessionClassificationDraft(session_type=SessionTypes.INTERACTIVE),
-                options=SessionOptionsDraft(
-                    cluster_mode=action.cluster_mode,
-                    cluster_size=len(action.kernels),
-                    kernel_groups=kernel_groups,
-                ),
+        resource_spec = SessionResourceSpecDraft(
+            identity=SessionIdentityDraft(
+                session_id=SessionID(uuid.uuid4()),
+                creation_id=uuid.uuid4().hex,
+                session_name="compute-schedule",
+                access_key=access_key,
+                user_uuid=action.user_uuid,
             ),
-            scope=SessionScopeDraft(
-                resource_group_id=action.resource_group_id,
-                resource_group_name=resource_group_name,
+            classification=SessionClassificationDraft(session_type=SessionTypes.INTERACTIVE),
+            options=SessionOptionsDraft(
+                cluster_mode=action.cluster_mode,
+                cluster_size=len(action.kernels),
+                kernel_groups=kernel_groups,
             ),
         )
 
-        result = await self._scheduling_controller.compute_schedule(draft)
+        result = await self._scheduling_controller.compute_schedule(
+            action.resource_group_id, resource_spec
+        )
         return ComputeScheduleActionResult(result=result)
 
     async def resolve_session_name(

--- a/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
@@ -22,6 +22,7 @@ from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.session.compute_schedule import (
     ComputeScheduleKernelResult,
     ComputeScheduleResult,
+    ResourceGroupUnschedulableReason,
     UnschedulableReasonHint,
 )
 from ai.backend.manager.data.session.draft import (
@@ -392,7 +393,7 @@ class SchedulingController:
             for kernel_id, data in kernel_data.items()
             if data.resource_spec is not None
         }
-        resource_group_reason: str | None = None
+        resource_group_reason: ResourceGroupUnschedulableReason | None = None
 
         if kernel_requirements:
             criteria = AgentSelectionCriteria(
@@ -415,7 +416,7 @@ class SchedulingController:
             try:
                 scheduling_data = await self._repository.get_scheduling_data(resource_group_id)
             except ScalingGroupNotFound:
-                resource_group_reason = "Resource group does not exist"
+                resource_group_reason = ResourceGroupUnschedulableReason.RESOURCE_GROUP_NOT_FOUND
                 return ComputeScheduleResult(
                     [
                         ComputeScheduleKernelResult(
@@ -443,7 +444,7 @@ class SchedulingController:
                     mutable_agents, criteria, config, None
                 )
             except NoAgentsInResourceGroupError:
-                resource_group_reason = "No schedulable agents exist in the resource group"
+                resource_group_reason = ResourceGroupUnschedulableReason.NO_SCHEDULABLE_AGENTS
                 for result in kernel_data.values():
                     result.success = False
             except BatchAgentSelectionFailedError as e:

--- a/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
@@ -24,7 +24,11 @@ from ai.backend.manager.data.session.compute_schedule import (
     ComputeScheduleResult,
     UnschedulableReasonHint,
 )
-from ai.backend.manager.data.session.draft import SessionSpecDraft
+from ai.backend.manager.data.session.draft import (
+    SessionResourceSpecDraft,
+    SessionScopeDraft,
+    SessionSpecDraft,
+)
 from ai.backend.manager.data.session.spec import (
     SessionResourceSpec,
     SessionScope,
@@ -476,7 +480,8 @@ class SchedulingController:
 
     async def compute_schedule(
         self,
-        draft: SessionSpecDraft,
+        resource_group_id: ResourceGroupID,
+        draft: SessionResourceSpecDraft,
     ) -> ComputeScheduleResult:
         """Compute whether each kernel of a would-be session fits the target
         resource group's nodes, without provisioning.
@@ -485,10 +490,10 @@ class SchedulingController:
         the real agent selector against a live snapshot of the group's agents.
         Results correspond positionally to ``draft.resource_spec.options.kernel_groups``.
         """
-        rg_id = draft.scope.resource_group_id
-        if rg_id is None:
-            raise InvalidAPIParameters("resource_group_id is required for compute-schedule")
-        fetched = await self._repository.fetch_session_spec_contexts(draft)
+        # SessionScopeDraft is used only to fetch dotfile data and container user info.
+        fetched = await self._repository.fetch_session_spec_contexts(
+            SessionSpecDraft(scope=SessionScopeDraft(), resource_spec=draft)
+        )
         prep_ctx = SessionSpecPreparationContext(
             resource_group_defaults=fetched.resource_group_defaults,
             resource_group_network=fetched.resource_group_network,
@@ -500,9 +505,11 @@ class SchedulingController:
             # storage-RPC resolution by leaving the per-role mount map empty.
             vfolder_mounts_by_role={},
         )
-        resource_spec = await self._spec_preparer.prepare(draft.resource_spec, prep_ctx)
+        resource_spec = await self._spec_preparer.prepare(draft, prep_ctx)
         compute_schedule_kernel_data = self._prepare_kernel_data(resource_spec, fetched)
-        return await self._compute_schedule(resource_spec, rg_id, compute_schedule_kernel_data)
+        return await self._compute_schedule(
+            resource_spec, resource_group_id, compute_schedule_kernel_data
+        )
 
     async def mark_scheduling_needed(self, schedule_types: Sequence[ScheduleType]) -> None:
         """

--- a/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
@@ -22,7 +22,6 @@ from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.session.compute_schedule import (
     ComputeScheduleKernelResult,
     ComputeScheduleResult,
-    ResourceGroupUnschedulableReason,
     UnschedulableReasonHint,
 )
 from ai.backend.manager.data.session.draft import (
@@ -37,7 +36,7 @@ from ai.backend.manager.data.session.spec import (
 )
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.errors.common import InternalServerError, RejectedByHook
-from ai.backend.manager.errors.resource import ScalingGroupNotFound
+from ai.backend.manager.errors.image import ImageNotFound
 from ai.backend.manager.metrics.scheduler import (
     SchedulerOperationMetricObserver,
     SchedulerPhaseMetricObserver,
@@ -50,7 +49,6 @@ from ai.backend.manager.repositories.scheduler import (
 from ai.backend.manager.repositories.scheduler.types.session_creation import SessionSpecContextFetch
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.exceptions import (
     BatchAgentSelectionFailedError,
-    NoAgentsInResourceGroupError,
 )
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.selector import (
     AgentSelectionConfig,
@@ -121,7 +119,7 @@ class _KernelComputeScheduleResourceSpec:
 
 @dataclass
 class _KernelComputeScheduleData:
-    resource_spec: _KernelComputeScheduleResourceSpec | None
+    resource_spec: _KernelComputeScheduleResourceSpec
 
     requested_slots: tuple[ResourceSlotEntry, ...]
     reason_hint: UnschedulableReasonHint | None
@@ -357,13 +355,7 @@ class SchedulingController:
                 else None
             )
             if image_info is None:
-                prepared_data[kernel_id] = _KernelComputeScheduleData(
-                    resource_spec=None,
-                    requested_slots=tuple(resource_input.resources),
-                    reason_hint=UnschedulableReasonHint(image_not_found=True),
-                    success=False,
-                )
-                continue
+                raise ImageNotFound(f"Image '{resource_input.image_id}' not found")
             prepared_data[kernel_id] = _KernelComputeScheduleData(
                 resource_spec=_KernelComputeScheduleResourceSpec(
                     image=_Image(
@@ -389,11 +381,8 @@ class SchedulingController:
         kernel_data: dict[KernelId, _KernelComputeScheduleData],
     ) -> ComputeScheduleResult:
         kernel_requirements: dict[UUID, KernelResourceSpec] = {
-            kernel_id: data.resource_spec.spec
-            for kernel_id, data in kernel_data.items()
-            if data.resource_spec is not None
+            kernel_id: data.resource_spec.spec for kernel_id, data in kernel_data.items()
         }
-        resource_group_reason: ResourceGroupUnschedulableReason | None = None
 
         if kernel_requirements:
             criteria = AgentSelectionCriteria(
@@ -411,42 +400,25 @@ class SchedulingController:
                 max_container_count=None,
                 enforce_spreading_endpoint_replica=False,
             )
-            # The selector mutates the agents list on full success; feed clones so
-            # the live snapshot is never altered.
-            try:
-                scheduling_data = await self._repository.get_scheduling_data(resource_group_id)
-            except ScalingGroupNotFound:
-                resource_group_reason = ResourceGroupUnschedulableReason.RESOURCE_GROUP_NOT_FOUND
-                return ComputeScheduleResult(
-                    [
-                        ComputeScheduleKernelResult(
-                            requested_slots=data.requested_slots,
-                            requested_architecture=data.resource_spec.image.architecture
-                            if data.resource_spec is not None
-                            else None,
-                            success=False,
-                            reason_hint=data.reason_hint,
-                        )
-                        for data in kernel_data.values()
-                    ],
-                    resource_group_reason=resource_group_reason,
-                )
+            # An unknown resource group (ScalingGroupNotFound) is a request error,
+            # not a per-kernel fitting outcome, so let it propagate to the caller.
+            scheduling_data = await self._repository.get_scheduling_data(resource_group_id)
             agent_occupancy = (
                 scheduling_data.snapshot_data.resource_occupancy.by_agent
                 if scheduling_data.snapshot_data
                 else {}
             )
+            # The selector mutates the agents list on full success; feed clones so
+            # the live snapshot is never altered.
             mutable_agents = [
                 agent.to_agent_info(agent_occupancy) for agent in scheduling_data.agents
             ]
+            # A resource group with no candidate agents (NoAgentsInResourceGroupError)
+            # is likewise a whole-request error, so it propagates too.
             try:
                 await self._agent_selector.select_agents_for_batch_requirements(
                     mutable_agents, criteria, config, None
                 )
-            except NoAgentsInResourceGroupError:
-                resource_group_reason = ResourceGroupUnschedulableReason.NO_SCHEDULABLE_AGENTS
-                for result in kernel_data.values():
-                    result.success = False
             except BatchAgentSelectionFailedError as e:
                 for err in e.errors:
                     hint = err.build_remediation_hint()
@@ -456,7 +428,6 @@ class SchedulingController:
                             if hint.required_reduction is not None
                             else None
                         ),
-                        available_archs=hint.available_archs,
                     )
                     for kernel_id in err.resource_requirement.kernel_ids:
                         failed_draft = kernel_data.get(kernel_id)
@@ -467,17 +438,13 @@ class SchedulingController:
         kernel_result = [
             ComputeScheduleKernelResult(
                 requested_slots=kernel_data.requested_slots,
-                requested_architecture=kernel_data.resource_spec.image.architecture
-                if kernel_data.resource_spec is not None
-                else None,
+                requested_architecture=kernel_data.resource_spec.image.architecture,
                 success=kernel_data.success,
                 reason_hint=kernel_data.reason_hint,
             )
             for kernel_data in kernel_data.values()
         ]
-        return ComputeScheduleResult(
-            kernel_results=kernel_result, resource_group_reason=resource_group_reason
-        )
+        return ComputeScheduleResult(kernel_results=kernel_result)
 
     async def compute_schedule(
         self,


### PR DESCRIPTION
## Summary
- Wire the compute-schedule (dry-run) GraphQL resolver through the session adapter to the service, so callers can invoke the query end-to-end (resolver → adapter → service → scheduling controller). Previously the resolver was a schema-only stub raising `ServiceUnavailable`.
- Resolve the caller's main access key server-side (in the service, from `user_uuid` via the user repository) instead of passing a hardcoded value from the adapter.
- Extend the response payload to carry the full remediation breadth the internal data type already exposes: `UnschedulableReasonHint.required_container_reduction` / `image_not_found` and `ComputeSchedulePayload.resource_group_reason` (new GraphQL fields use `gql_added_field`).

## Known limitation (draft)
The end-to-end path is not yet functional at runtime: the `compute_schedule` service builds a `SessionSpecDraft` whose `scope.domain_id` / `domain_name` / `project_id` are unset, so the shared `SessionSpec` finalize validation (`session_spec_preparer._finalize`) rejects every request with `IncompleteSessionSpec` before node-fitting runs. These scope fields are consumed only by the enqueue persistence path (`scheduler/creators.py`) and are dead weight for the DB-mutation-free dry-run. Resolving this (populate scope from the user vs. relax the validation for this path) is deferred and tracked separately; this PR lands the wiring + payload surface.

## Test plan
- [x] `pants fmt / fix / lint / check` pass
- [x] GraphQL schema builds; new payload fields (`requiredContainerReduction`, `imageNotFound`, `resourceGroupReason`) exposed in SDL
- [x] Live GQL query reaches resolver → adapter → service → controller (verified request flow; blocked at the scope validation described above)
- [x] End-to-end success for admin and non-admin (blocked on the scope limitation above)

Resolves BA-6874

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12841.org.readthedocs.build/en/12841/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12841.org.readthedocs.build/ko/12841/

<!-- readthedocs-preview sorna-ko end -->