### PR TITLE
refactor(BA-6880): decouple the session-spec preparer chain from ownership scope

### DIFF
--- a/changes/12849.enhance.md
+++ b/changes/12849.enhance.md
@@ -1,0 +1,1 @@
+Decouple the session-spec preparer chain from ownership scope by introducing a scope-free `SessionResourceSpec`, so scheduling that only resolves resources (e.g. a dry-run probe) no longer requires a domain/project/resource-group scope it never uses.

--- a/src/ai/backend/manager/data/session/draft.py
+++ b/src/ai/backend/manager/data/session/draft.py
@@ -207,6 +207,25 @@ class SessionClassificationDraft(_DraftBaseModel):
     tag: str | None = None
 
 
+class SessionResourceSpecDraft(_DraftBaseModel):
+    """Scope-free draft consumed by the preparer chain.
+
+    Mirrors :class:`~ai.backend.manager.data.session.spec.SessionResourceSpec`
+    (the finalized counterpart) and holds everything the preparer
+    resolves. Ownership scope is carried separately by the caller (see
+    :meth:`SessionSpecDraft.to_resource_draft`), so no rule needs it.
+    """
+
+    identity: SessionIdentityDraft = Field(default_factory=SessionIdentityDraft)
+    classification: SessionClassificationDraft = Field(default_factory=SessionClassificationDraft)
+    network: SessionNetworkDraft = Field(default_factory=SessionNetworkDraft)
+    callback_url: yarl.URL | None = None
+    dependencies: tuple[SessionID, ...] = ()
+    options: SessionOptionsDraft = Field(default_factory=SessionOptionsDraft)
+    kernel_specs: tuple[KernelSpecDraft, ...] = ()
+    internal_data_extras: InternalDataExtras = Field(default_factory=InternalDataExtras)
+
+
 class SessionSpecDraft(_DraftBaseModel):
     """Top-level draft mirroring ``SessionSpec``.
 
@@ -226,3 +245,20 @@ class SessionSpecDraft(_DraftBaseModel):
     options: SessionOptionsDraft = Field(default_factory=SessionOptionsDraft)
     kernel_specs: tuple[KernelSpecDraft, ...] = ()
     internal_data_extras: InternalDataExtras = Field(default_factory=InternalDataExtras)
+
+    def to_resource_draft(self) -> SessionResourceSpecDraft:
+        """Project onto the scope-free draft the preparer chain operates on.
+
+        Scope is dropped here — it is pass-through input the preparer
+        never touches; the caller re-attaches it after finalize.
+        """
+        return SessionResourceSpecDraft(
+            identity=self.identity,
+            classification=self.classification,
+            network=self.network,
+            callback_url=self.callback_url,
+            dependencies=self.dependencies,
+            options=self.options,
+            kernel_specs=self.kernel_specs,
+            internal_data_extras=self.internal_data_extras,
+        )

--- a/src/ai/backend/manager/data/session/draft.py
+++ b/src/ai/backend/manager/data/session/draft.py
@@ -223,32 +223,9 @@ class SessionResourceSpecDraft(_DraftBaseModel):
 class SessionSpecDraft(_DraftBaseModel):
     """Top-level draft mirroring ``SessionSpec``.
 
-    ``internal_data_extras`` carries request-envelope fields (sudo
-    toggle, model-definition overlay) that feed
-    :class:`KernelSpec.internal_data`. DB-sourced pieces like dotfiles
-    are merged in by the preparer chain against its context — they
-    never flow through the draft.
+    Composed of a scope-free :class:`SessionResourceSpecDraft` (consumed by
+    the preparer chain) plus a :class:`SessionScopeDraft`.
     """
 
-    identity: SessionIdentityDraft = Field(default_factory=SessionIdentityDraft)
+    resource_spec: SessionResourceSpecDraft = Field(default_factory=SessionResourceSpecDraft)
     scope: SessionScopeDraft = Field(default_factory=SessionScopeDraft)
-    classification: SessionClassificationDraft = Field(default_factory=SessionClassificationDraft)
-    network: SessionNetworkDraft = Field(default_factory=SessionNetworkDraft)
-    callback_url: yarl.URL | None = None
-    dependencies: tuple[SessionID, ...] = ()
-    options: SessionOptionsDraft = Field(default_factory=SessionOptionsDraft)
-    kernel_specs: tuple[KernelSpecDraft, ...] = ()
-    internal_data_extras: InternalDataExtras = Field(default_factory=InternalDataExtras)
-
-    def to_resource_draft(self) -> SessionResourceSpecDraft:
-        """Project onto the scope-free draft the preparer chain operates on."""
-        return SessionResourceSpecDraft(
-            identity=self.identity,
-            classification=self.classification,
-            network=self.network,
-            callback_url=self.callback_url,
-            dependencies=self.dependencies,
-            options=self.options,
-            kernel_specs=self.kernel_specs,
-            internal_data_extras=self.internal_data_extras,
-        )

--- a/src/ai/backend/manager/data/session/draft.py
+++ b/src/ai/backend/manager/data/session/draft.py
@@ -208,13 +208,7 @@ class SessionClassificationDraft(_DraftBaseModel):
 
 
 class SessionResourceSpecDraft(_DraftBaseModel):
-    """Scope-free draft consumed by the preparer chain.
-
-    Mirrors :class:`~ai.backend.manager.data.session.spec.SessionResourceSpec`
-    (the finalized counterpart) and holds everything the preparer
-    resolves. Ownership scope is carried separately by the caller (see
-    :meth:`SessionSpecDraft.to_resource_draft`), so no rule needs it.
-    """
+    """Scope-free draft consumed by the preparer chain."""
 
     identity: SessionIdentityDraft = Field(default_factory=SessionIdentityDraft)
     classification: SessionClassificationDraft = Field(default_factory=SessionClassificationDraft)
@@ -247,11 +241,7 @@ class SessionSpecDraft(_DraftBaseModel):
     internal_data_extras: InternalDataExtras = Field(default_factory=InternalDataExtras)
 
     def to_resource_draft(self) -> SessionResourceSpecDraft:
-        """Project onto the scope-free draft the preparer chain operates on.
-
-        Scope is dropped here — it is pass-through input the preparer
-        never touches; the caller re-attaches it after finalize.
-        """
+        """Project onto the scope-free draft the preparer chain operates on."""
         return SessionResourceSpecDraft(
             identity=self.identity,
             classification=self.classification,

--- a/src/ai/backend/manager/data/session/spec.py
+++ b/src/ai/backend/manager/data/session/spec.py
@@ -177,10 +177,3 @@ class SessionSpec(_SpecBaseModel):
 
     resource_spec: SessionResourceSpec
     scope: SessionScope
-
-    @classmethod
-    def from_resource_spec(
-        cls, scope: SessionScope, resource_spec: SessionResourceSpec
-    ) -> SessionSpec:
-        """Attach an ownership ``scope`` to a prepared, scope-free spec."""
-        return cls(resource_spec=resource_spec, scope=scope)

--- a/src/ai/backend/manager/data/session/spec.py
+++ b/src/ai/backend/manager/data/session/spec.py
@@ -44,6 +44,16 @@ from ai.backend.manager.data.session.options import (
 from ai.backend.manager.errors.kernel import IncompleteSessionSpec
 
 
+def _format_loc(loc: tuple[object, ...]) -> str:
+    parts: list[str] = []
+    for item in loc:
+        if isinstance(item, int):
+            parts.append(f"[{item}]")
+        else:
+            parts.append(f".{item}" if parts else str(item))
+    return "".join(parts)
+
+
 class _SpecBaseModel(BackendAISchema):
     """Base for resolved session-spec sub-models.
 
@@ -130,8 +140,42 @@ class KernelSpec(_SpecBaseModel):
     vfolder_mounts: tuple[VFolderMount, ...] = ()
 
 
+class SessionResourceSpec(_SpecBaseModel):
+    """Scope-free resolved spec — the output of the preparer chain.
+
+    Carries everything the draft-based preparer actually resolves
+    (identity, network, options, kernel specs, ...) but **not** the
+    ownership scope (domain / project / resource group): the preparer
+    never touches scope, so it is pass-through input that callers attach
+    afterward. The node-fitting dry-run consumes this type directly,
+    while the enqueue path wraps it with a scope via
+    :meth:`SessionSpec.from_resource_spec` before persisting.
+    """
+
+    identity: SessionIdentity
+    classification: SessionClassification
+    network: SessionNetwork
+    callback_url: yarl.URL | None = None
+    dependencies: tuple[SessionID, ...] = ()
+    options: SessionOptions
+    kernel_specs: tuple[KernelSpec, ...]
+    internal_data_extras: InternalDataExtras = Field(default_factory=InternalDataExtras)
+
+    @override
+    @classmethod
+    def build_validation_error(cls, info: SchemaValidationFailureInfo) -> BackendAIError:
+        missing_paths = [_format_loc(tuple(err["loc"])) for err in info.errors]
+        return IncompleteSessionSpec(
+            extra_msg="SessionResourceSpec fields not resolved: " + ", ".join(missing_paths),
+            extra_data={"missing": missing_paths},
+        )
+
+
 class SessionSpec(_SpecBaseModel):
     """Full spec to create one ``SessionRow`` and its owned kernels.
+
+    Composed from a scope-free :class:`SessionResourceSpec` plus a
+    resolved :class:`SessionScope` via :meth:`from_resource_spec`.
 
     Vfolder mounts live on :attr:`KernelSpec.vfolder_mounts` —
     per-kernel at the spec level. The ``SessionRow.vfolder_mounts``
@@ -149,21 +193,28 @@ class SessionSpec(_SpecBaseModel):
     kernel_specs: tuple[KernelSpec, ...]
     internal_data_extras: InternalDataExtras = Field(default_factory=InternalDataExtras)
 
+    @classmethod
+    def from_resource_spec(
+        cls, scope: SessionScope, resource_spec: SessionResourceSpec
+    ) -> SessionSpec:
+        """Attach an ownership ``scope`` to a prepared, scope-free spec."""
+        return cls(
+            identity=resource_spec.identity,
+            scope=scope,
+            classification=resource_spec.classification,
+            network=resource_spec.network,
+            callback_url=resource_spec.callback_url,
+            dependencies=resource_spec.dependencies,
+            options=resource_spec.options,
+            kernel_specs=resource_spec.kernel_specs,
+            internal_data_extras=resource_spec.internal_data_extras,
+        )
+
     @override
     @classmethod
     def build_validation_error(cls, info: SchemaValidationFailureInfo) -> BackendAIError:
-        missing_paths = [cls._format_loc(tuple(err["loc"])) for err in info.errors]
+        missing_paths = [_format_loc(tuple(err["loc"])) for err in info.errors]
         return IncompleteSessionSpec(
             extra_msg="SessionSpec fields not resolved: " + ", ".join(missing_paths),
             extra_data={"missing": missing_paths},
         )
-
-    @staticmethod
-    def _format_loc(loc: tuple[object, ...]) -> str:
-        parts: list[str] = []
-        for item in loc:
-            if isinstance(item, int):
-                parts.append(f"[{item}]")
-            else:
-                parts.append(f".{item}" if parts else str(item))
-        return "".join(parts)

--- a/src/ai/backend/manager/data/session/spec.py
+++ b/src/ai/backend/manager/data/session/spec.py
@@ -175,38 +175,12 @@ class SessionSpec(_SpecBaseModel):
     from the main kernel's resolved mount list at enqueue time.
     """
 
-    identity: SessionIdentity
+    resource_spec: SessionResourceSpec
     scope: SessionScope
-    classification: SessionClassification
-    network: SessionNetwork
-    callback_url: yarl.URL | None = None
-    dependencies: tuple[SessionID, ...] = ()
-    options: SessionOptions
-    kernel_specs: tuple[KernelSpec, ...]
-    internal_data_extras: InternalDataExtras = Field(default_factory=InternalDataExtras)
 
     @classmethod
     def from_resource_spec(
         cls, scope: SessionScope, resource_spec: SessionResourceSpec
     ) -> SessionSpec:
         """Attach an ownership ``scope`` to a prepared, scope-free spec."""
-        return cls(
-            identity=resource_spec.identity,
-            scope=scope,
-            classification=resource_spec.classification,
-            network=resource_spec.network,
-            callback_url=resource_spec.callback_url,
-            dependencies=resource_spec.dependencies,
-            options=resource_spec.options,
-            kernel_specs=resource_spec.kernel_specs,
-            internal_data_extras=resource_spec.internal_data_extras,
-        )
-
-    @override
-    @classmethod
-    def build_validation_error(cls, info: SchemaValidationFailureInfo) -> BackendAIError:
-        missing_paths = [_format_loc(tuple(err["loc"])) for err in info.errors]
-        return IncompleteSessionSpec(
-            extra_msg="SessionSpec fields not resolved: " + ", ".join(missing_paths),
-            extra_data={"missing": missing_paths},
-        )
+        return cls(resource_spec=resource_spec, scope=scope)

--- a/src/ai/backend/manager/data/session/spec.py
+++ b/src/ai/backend/manager/data/session/spec.py
@@ -144,12 +144,7 @@ class SessionResourceSpec(_SpecBaseModel):
     """Scope-free resolved spec — the output of the preparer chain.
 
     Carries everything the draft-based preparer actually resolves
-    (identity, network, options, kernel specs, ...) but **not** the
-    ownership scope (domain / project / resource group): the preparer
-    never touches scope, so it is pass-through input that callers attach
-    afterward. The node-fitting dry-run consumes this type directly,
-    while the enqueue path wraps it with a scope via
-    :meth:`SessionSpec.from_resource_spec` before persisting.
+    (identity, network, options, kernel specs, ...).
     """
 
     identity: SessionIdentity
@@ -173,9 +168,6 @@ class SessionResourceSpec(_SpecBaseModel):
 
 class SessionSpec(_SpecBaseModel):
     """Full spec to create one ``SessionRow`` and its owned kernels.
-
-    Composed from a scope-free :class:`SessionResourceSpec` plus a
-    resolved :class:`SessionScope` via :meth:`from_resource_spec`.
 
     Vfolder mounts live on :attr:`KernelSpec.vfolder_mounts` —
     per-kernel at the spec level. The ``SessionRow.vfolder_mounts``

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -116,6 +116,7 @@ from ai.backend.manager.data.session.draft import (
     SessionIdentityDraft,
     SessionNetworkDraft,
     SessionOptionsDraft,
+    SessionResourceSpecDraft,
     SessionScopeDraft,
     SessionSpecDraft,
 )
@@ -1142,12 +1143,35 @@ class AgentRegistry:
             )
 
         draft = SessionSpecDraft(
-            identity=SessionIdentityDraft(
-                session_id=SessionID(uuid.uuid4()),
-                creation_id=session_creation_id,
-                session_name=session_name,
-                access_key=access_key,
-                user_uuid=user_scope.user_uuid,
+            resource_spec=SessionResourceSpecDraft(
+                identity=SessionIdentityDraft(
+                    session_id=SessionID(uuid.uuid4()),
+                    creation_id=session_creation_id,
+                    session_name=session_name,
+                    access_key=access_key,
+                    user_uuid=user_scope.user_uuid,
+                ),
+                classification=SessionClassificationDraft(
+                    session_type=session_type,
+                    tag=session_tag,
+                ),
+                network=SessionNetworkDraft(network_id=network_id),
+                callback_url=callback_url,
+                dependencies=dependencies,
+                options=SessionOptionsDraft(
+                    priority=priority,
+                    is_preemptible=is_preemptible,
+                    cluster_mode=cluster_mode,
+                    cluster_size=cluster_size,
+                    scheduling_target=SchedulingTargetDraft(
+                        designated_agents=tuple(AgentId(a) for a in (agent_list or ())),
+                    ),
+                    kernel_groups=tuple(groups_by_role.values()),
+                    handler_options=None,
+                ),
+                internal_data_extras=InternalDataExtras(
+                    sudo_session_enabled=sudo_session_enabled,
+                ),
             ),
             scope=SessionScopeDraft(
                 domain_id=domain_id,
@@ -1155,27 +1179,6 @@ class AgentRegistry:
                 project_id=ProjectID(user_scope.group_id),
                 resource_group_id=resource_group_id,
                 resource_group_name=resource_group_name,
-            ),
-            classification=SessionClassificationDraft(
-                session_type=session_type,
-                tag=session_tag,
-            ),
-            network=SessionNetworkDraft(network_id=network_id),
-            callback_url=callback_url,
-            dependencies=dependencies,
-            options=SessionOptionsDraft(
-                priority=priority,
-                is_preemptible=is_preemptible,
-                cluster_mode=cluster_mode,
-                cluster_size=cluster_size,
-                scheduling_target=SchedulingTargetDraft(
-                    designated_agents=tuple(AgentId(a) for a in (agent_list or ())),
-                ),
-                kernel_groups=tuple(groups_by_role.values()),
-                handler_options=None,
-            ),
-            internal_data_extras=InternalDataExtras(
-                sudo_session_enabled=sudo_session_enabled,
             ),
         )
 

--- a/src/ai/backend/manager/repositories/scheduler/creators.py
+++ b/src/ai/backend/manager/repositories/scheduler/creators.py
@@ -75,12 +75,12 @@ class KernelRowFromSpec(CreatorSpec[KernelRow]):
         )
 
         return KernelRow(
-            session_id=self.spec.identity.session_id,
-            session_creation_id=self.spec.identity.creation_id,
-            session_name=self.spec.identity.session_name,
-            session_type=self.spec.classification.session_type,
-            cluster_mode=self.spec.options.cluster_mode.value,
-            cluster_size=self.spec.options.cluster_size,
+            session_id=self.spec.resource_spec.identity.session_id,
+            session_creation_id=self.spec.resource_spec.identity.creation_id,
+            session_name=self.spec.resource_spec.identity.session_name,
+            session_type=self.spec.resource_spec.classification.session_type,
+            cluster_mode=self.spec.resource_spec.options.cluster_mode.value,
+            cluster_size=self.spec.resource_spec.options.cluster_size,
             cluster_role=self.kernel_spec.cluster_role,
             cluster_idx=self.kernel_spec.cluster_idx,
             local_rank=self.kernel_spec.local_rank,
@@ -89,13 +89,13 @@ class KernelRowFromSpec(CreatorSpec[KernelRow]):
             resource_group_id=self.spec.scope.resource_group_id,
             domain_name=str(self.spec.scope.domain_name),
             group_id=self.spec.scope.project_id,
-            user_uuid=self.spec.identity.user_uuid,
-            access_key=self.spec.identity.access_key,
+            user_uuid=self.spec.resource_spec.identity.user_uuid,
+            access_key=self.spec.resource_spec.identity.access_key,
             image=(image_info.canonical if image_info is not None else None),
             image_id=(image_info.id if image_info is not None else None),
             architecture=(image_info.architecture if image_info is not None else None),
             registry=(image_info.registry if image_info is not None else None),
-            tag=self.spec.classification.tag,
+            tag=self.spec.resource_spec.classification.tag,
             starts_at=execution.starts_at,
             status=KernelStatus.PENDING,
             status_history={
@@ -109,11 +109,11 @@ class KernelRowFromSpec(CreatorSpec[KernelRow]):
             bootstrap_script=execution.bootstrap_script,
             startup_command=execution.startup_command,
             internal_data=dict(self.kernel_spec.internal_data),
-            callback_url=self.spec.callback_url,
+            callback_url=self.spec.resource_spec.callback_url,
             mounts=[mount.name for mount in resolved_mounts],
             vfolder_mounts=resolved_mounts,
             preopen_ports=list(self.kernel_spec.preopen_ports),
-            use_host_network=self.spec.network.use_host_network,
+            use_host_network=self.spec.resource_spec.network.use_host_network,
             uid=self.kernel_spec.uid,
             main_gid=self.kernel_spec.main_gid,
             gids=list(self.kernel_spec.supplementary_gids),
@@ -147,7 +147,7 @@ class SessionRowFromSpec(CreatorSpec[SessionRow]):
     @override
     def build_row(self) -> SessionRow:
         spec = self.spec
-        kernel_specs = spec.kernel_specs
+        kernel_specs = spec.resource_spec.kernel_specs
         main_kernel = kernel_specs[0] if kernel_specs else None
 
         session_images: list[str] = []
@@ -177,30 +177,30 @@ class SessionRowFromSpec(CreatorSpec[SessionRow]):
         session_startup = main_kernel.execution_spec.startup_command if main_kernel else None
 
         designated_agent_ids = [
-            str(agent) for agent in spec.options.scheduling_target.designated_agents
+            str(agent) for agent in spec.resource_spec.options.scheduling_target.designated_agents
         ] or None
 
         cluster_mode_value = (
-            spec.options.cluster_mode.value
-            if isinstance(spec.options.cluster_mode, ClusterMode)
-            else str(spec.options.cluster_mode)
+            spec.resource_spec.options.cluster_mode.value
+            if isinstance(spec.resource_spec.options.cluster_mode, ClusterMode)
+            else str(spec.resource_spec.options.cluster_mode)
         )
 
         return SessionRow(
-            id=spec.identity.session_id,
-            creation_id=spec.identity.creation_id,
-            name=spec.identity.session_name,
-            access_key=spec.identity.access_key,
-            user_uuid=spec.identity.user_uuid,
+            id=spec.resource_spec.identity.session_id,
+            creation_id=spec.resource_spec.identity.creation_id,
+            name=spec.resource_spec.identity.session_name,
+            access_key=spec.resource_spec.identity.access_key,
+            user_uuid=spec.resource_spec.identity.user_uuid,
             group_id=spec.scope.project_id,
             domain_id=spec.scope.domain_id,
             domain_name=str(spec.scope.domain_name),
             resource_group_id=spec.scope.resource_group_id,
             scaling_group_name=str(spec.scope.resource_group_name),
-            session_type=spec.classification.session_type,
+            session_type=spec.resource_spec.classification.session_type,
             cluster_mode=cluster_mode_value,
-            cluster_size=spec.options.cluster_size,
-            priority=spec.options.priority,
+            cluster_size=spec.resource_spec.options.cluster_size,
+            priority=spec.resource_spec.options.priority,
             status=SessionStatus.PENDING,
             status_history={
                 SessionStatus.PENDING.name: self.enqueue_time.isoformat(),
@@ -209,17 +209,17 @@ class SessionRowFromSpec(CreatorSpec[SessionRow]):
             occupying_slots=ResourceSlot(),
             vfolder_mounts=main_mounts,
             environ=session_environ,
-            tag=spec.classification.tag,
+            tag=spec.resource_spec.classification.tag,
             starts_at=session_starts_at,
             batch_timeout=session_batch_timeout,
-            callback_url=spec.callback_url,
+            callback_url=spec.resource_spec.callback_url,
             images=session_images,
             image_ids=session_image_ids,
-            network_type=spec.network.network_type,
-            network_id=spec.network.network_id,
+            network_type=spec.resource_spec.network.network_type,
+            network_id=spec.resource_spec.network.network_id,
             designated_agent_ids=designated_agent_ids,
             bootstrap_script=session_bootstrap,
-            use_host_network=spec.network.use_host_network,
+            use_host_network=spec.resource_spec.network.use_host_network,
             timeout=None,
             startup_command=session_startup,
         )

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -1378,7 +1378,7 @@ class ScheduleDBSource:
         async with self._begin_session_read_committed() as db_sess:
             image_ids = {
                 kernel.execution_spec.resource_input.image_id
-                for kernel in spec.kernel_specs
+                for kernel in spec.resource_spec.kernel_specs
                 if kernel.execution_spec.resource_input.image_id is not None
             }
             image_metadata: dict[ImageID, ImageInfo] = {}
@@ -1400,7 +1400,7 @@ class ScheduleDBSource:
                     for row in rows
                 }
 
-            for kernel in spec.kernel_specs:
+            for kernel in spec.resource_spec.kernel_specs:
                 image_id = kernel.execution_spec.resource_input.image_id
                 if image_id is not None and image_id not in image_metadata:
                     raise ImageNotFound(
@@ -1410,7 +1410,7 @@ class ScheduleDBSource:
 
             # Validate dependencies — each dependency session must exist.
             matched_dependency_ids: list[SessionId] = []
-            for dependency_id in spec.dependencies:
+            for dependency_id in spec.resource_spec.dependencies:
                 result = await db_sess.execute(
                     sa.select(SessionRow.id).where(SessionRow.id == dependency_id)
                 )
@@ -1437,7 +1437,7 @@ class ScheduleDBSource:
                     ),
                     enqueue_time=enqueue_time,
                 )
-                for kernel in spec.kernel_specs
+                for kernel in spec.resource_spec.kernel_specs
             ]
 
             rbac_creator = RBACEntityCreator(
@@ -1445,7 +1445,7 @@ class ScheduleDBSource:
                 element_type=RBACElementType.SESSION,
                 scope_ref=RBACElementRef(
                     element_type=RBACElementType.USER,
-                    element_id=str(spec.identity.user_uuid),
+                    element_id=str(spec.resource_spec.identity.user_uuid),
                 ),
                 additional_scope_refs=[
                     RBACElementRef(
@@ -1461,7 +1461,7 @@ class ScheduleDBSource:
                 element_type=RBACElementType.KERNEL,
                 scope_ref=RBACElementRef(
                     element_type=RBACElementType.SESSION,
-                    element_id=str(spec.identity.session_id),
+                    element_id=str(spec.resource_spec.identity.session_id),
                 ),
             )
             kernel_result = await execute_rbac_bulk_entity_creator(db_sess, kernel_rbac_creator)
@@ -1484,7 +1484,7 @@ class ScheduleDBSource:
             if matched_dependency_ids:
                 dependency_rows = [
                     SessionDependencyRow(
-                        session_id=spec.identity.session_id,
+                        session_id=spec.resource_spec.identity.session_id,
                         depends_on=depend_id,
                     )
                     for depend_id in matched_dependency_ids
@@ -1492,7 +1492,7 @@ class ScheduleDBSource:
                 db_sess.add_all(dependency_rows)
 
             history_spec = SessionSchedulingHistoryCreatorSpec(
-                session_id=SessionId(spec.identity.session_id),
+                session_id=SessionId(spec.resource_spec.identity.session_id),
                 phase="enqueue",
                 result=SchedulingResult.SUCCESS,
                 message="enqueue success",
@@ -1503,7 +1503,7 @@ class ScheduleDBSource:
 
             await db_sess.commit()
 
-        return SessionId(spec.identity.session_id)
+        return SessionId(spec.resource_spec.identity.session_id)
 
     async def fetch_session_spec_contexts(
         self,
@@ -1521,12 +1521,12 @@ class ScheduleDBSource:
         ``scheduling_controller`` subtree.
         """
         resource_group_id = draft.scope.resource_group_id
-        access_key = draft.identity.access_key
-        user_uuid = draft.identity.user_uuid
+        access_key = draft.resource_spec.identity.access_key
+        user_uuid = draft.resource_spec.identity.user_uuid
         domain_name = str(draft.scope.domain_name) if draft.scope.domain_name else None
         project_id = draft.scope.project_id
 
-        kernel_specs = tuple(draft.options.kernel_groups or ())
+        kernel_specs = tuple(draft.resource_spec.options.kernel_groups or ())
 
         async with self._begin_readonly_session_read_committed() as db_sess:
             network_info: ScalingGroupNetworkInfo | None = None
@@ -1661,11 +1661,11 @@ class ScheduleDBSource:
         request list resolves to a single ``VFolderMount`` tuple that every
         replica sharing the role copies verbatim.
         """
-        user_uuid = draft.identity.user_uuid
+        user_uuid = draft.resource_spec.identity.user_uuid
         domain_name = str(draft.scope.domain_name) if draft.scope.domain_name else None
         project_id = draft.scope.project_id
-        access_key = draft.identity.access_key
-        kernel_specs = tuple(draft.options.kernel_groups or ())
+        access_key = draft.resource_spec.identity.access_key
+        kernel_specs = tuple(draft.resource_spec.options.kernel_groups or ())
 
         vfolder_mounts_by_role: dict[str, tuple[VFolderMount, ...]] = {}
         if domain_name is None or user_uuid is None:

--- a/src/ai/backend/manager/services/model_serving/services/model_serving.py
+++ b/src/ai/backend/manager/services/model_serving/services/model_serving.py
@@ -76,6 +76,7 @@ from ai.backend.manager.data.session.draft import (
     SessionIdentityDraft,
     SessionNetworkDraft,
     SessionOptionsDraft,
+    SessionResourceSpecDraft,
     SessionScopeDraft,
     SessionSpecDraft,
 )
@@ -475,12 +476,33 @@ class ModelServingService:
             )
 
         draft = SessionSpecDraft(
-            identity=SessionIdentityDraft(
-                session_id=SessionID(uuid.uuid4()),
-                creation_id=session_creation_id,
-                session_name=session_name,
-                access_key=AccessKey(service_prepare_ctx.owner_access_key),
-                user_uuid=created_user.uuid,
+            resource_spec=SessionResourceSpecDraft(
+                identity=SessionIdentityDraft(
+                    session_id=SessionID(uuid.uuid4()),
+                    creation_id=session_creation_id,
+                    session_name=session_name,
+                    access_key=AccessKey(service_prepare_ctx.owner_access_key),
+                    user_uuid=created_user.uuid,
+                ),
+                classification=SessionClassificationDraft(
+                    session_type=SessionTypes.INFERENCE,
+                    tag=action.tag,
+                ),
+                network=SessionNetworkDraft(),
+                callback_url=callback_url,
+                options=SessionOptionsDraft(
+                    priority=SESSION_PRIORITY_DEFAULT,
+                    is_preemptible=False,
+                    cluster_mode=action.cluster_mode,
+                    cluster_size=action.cluster_size,
+                    scheduling_target=SchedulingTargetDraft(),
+                    kernel_groups=kernel_groups,
+                    handler_options=None,
+                ),
+                internal_data_extras=InternalDataExtras(
+                    sudo_session_enabled=sudo_session_enabled,
+                    model_definition_path=service_prepare_ctx.model_definition_path,
+                ),
             ),
             scope=SessionScopeDraft(
                 domain_id=domain_id,
@@ -488,25 +510,6 @@ class ModelServingService:
                 project_id=ProjectID(service_prepare_ctx.group_id),
                 resource_group_id=resource_group_id,
                 resource_group_name=resource_group_name,
-            ),
-            classification=SessionClassificationDraft(
-                session_type=SessionTypes.INFERENCE,
-                tag=action.tag,
-            ),
-            network=SessionNetworkDraft(),
-            callback_url=callback_url,
-            options=SessionOptionsDraft(
-                priority=SESSION_PRIORITY_DEFAULT,
-                is_preemptible=False,
-                cluster_mode=action.cluster_mode,
-                cluster_size=action.cluster_size,
-                scheduling_target=SchedulingTargetDraft(),
-                kernel_groups=kernel_groups,
-                handler_options=None,
-            ),
-            internal_data_extras=InternalDataExtras(
-                sudo_session_enabled=sudo_session_enabled,
-                model_definition_path=service_prepare_ctx.model_definition_path,
             ),
         )
 

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -60,6 +60,7 @@ from ai.backend.manager.data.session.draft import (
     SessionIdentityDraft,
     SessionNetworkDraft,
     SessionOptionsDraft,
+    SessionResourceSpecDraft,
     SessionScopeDraft,
     SessionSpecDraft,
 )
@@ -339,22 +340,24 @@ class SessionService:
         )
 
         draft = SessionSpecDraft(
-            identity=SessionIdentityDraft(
-                session_id=SessionID(uuid.uuid4()),
-                creation_id=uuid.uuid4().hex,
-                session_name="compute-schedule",
-                access_key=action.access_key,
-                user_uuid=action.user_uuid,
+            resource_spec=SessionResourceSpecDraft(
+                identity=SessionIdentityDraft(
+                    session_id=SessionID(uuid.uuid4()),
+                    creation_id=uuid.uuid4().hex,
+                    session_name="compute-schedule",
+                    access_key=action.access_key,
+                    user_uuid=action.user_uuid,
+                ),
+                classification=SessionClassificationDraft(session_type=SessionTypes.INTERACTIVE),
+                options=SessionOptionsDraft(
+                    cluster_mode=action.cluster_mode,
+                    cluster_size=len(action.kernels),
+                    kernel_groups=kernel_groups,
+                ),
             ),
             scope=SessionScopeDraft(
                 resource_group_id=action.resource_group_id,
                 resource_group_name=resource_group_name,
-            ),
-            classification=SessionClassificationDraft(session_type=SessionTypes.INTERACTIVE),
-            options=SessionOptionsDraft(
-                cluster_mode=action.cluster_mode,
-                cluster_size=len(action.kernels),
-                kernel_groups=kernel_groups,
             ),
         )
 
@@ -1689,12 +1692,43 @@ class SessionService:
         )
 
         draft = SessionSpecDraft(
-            identity=SessionIdentityDraft(
-                session_id=SessionID(uuid.uuid4()),
-                creation_id=secrets.token_urlsafe(16),
-                session_name=action.session_name,
-                access_key=access_key,
-                user_uuid=user_id,
+            resource_spec=SessionResourceSpecDraft(
+                identity=SessionIdentityDraft(
+                    session_id=SessionID(uuid.uuid4()),
+                    creation_id=secrets.token_urlsafe(16),
+                    session_name=action.session_name,
+                    access_key=access_key,
+                    user_uuid=user_id,
+                ),
+                classification=SessionClassificationDraft(
+                    session_type=action.session_type,
+                    tag=action.tag,
+                ),
+                network=SessionNetworkDraft(
+                    network_id=(
+                        str(action.scheduling.attach_network)
+                        if action.scheduling.attach_network is not None
+                        else None
+                    ),
+                ),
+                callback_url=callback_url,
+                dependencies=dependencies,
+                options=SessionOptionsDraft(
+                    priority=action.scheduling.priority or SESSION_PRIORITY_DEFAULT,
+                    is_preemptible=action.scheduling.is_preemptible,
+                    cluster_mode=action.resource.cluster_mode,
+                    cluster_size=action.resource.cluster_size,
+                    scheduling_target=SchedulingTargetDraft(
+                        designated_agents=tuple(
+                            AgentId(a) for a in (action.scheduling.agent_list or ())
+                        ),
+                    ),
+                    kernel_groups=kernel_groups,
+                    handler_options=None,
+                ),
+                internal_data_extras=InternalDataExtras(
+                    sudo_session_enabled=False,
+                ),
             ),
             scope=SessionScopeDraft(
                 domain_id=domain_id,
@@ -1702,35 +1736,6 @@ class SessionService:
                 project_id=ProjectID(action.group_id),
                 resource_group_id=resource_group_id,
                 resource_group_name=resource_group_name,
-            ),
-            classification=SessionClassificationDraft(
-                session_type=action.session_type,
-                tag=action.tag,
-            ),
-            network=SessionNetworkDraft(
-                network_id=(
-                    str(action.scheduling.attach_network)
-                    if action.scheduling.attach_network is not None
-                    else None
-                ),
-            ),
-            callback_url=callback_url,
-            dependencies=dependencies,
-            options=SessionOptionsDraft(
-                priority=action.scheduling.priority or SESSION_PRIORITY_DEFAULT,
-                is_preemptible=action.scheduling.is_preemptible,
-                cluster_mode=action.resource.cluster_mode,
-                cluster_size=action.resource.cluster_size,
-                scheduling_target=SchedulingTargetDraft(
-                    designated_agents=tuple(
-                        AgentId(a) for a in (action.scheduling.agent_list or ())
-                    ),
-                ),
-                kernel_groups=kernel_groups,
-                handler_options=None,
-            ),
-            internal_data_extras=InternalDataExtras(
-                sudo_session_enabled=False,
             ),
         )
 

--- a/src/ai/backend/manager/sokovan/deployment/deployment_draft_builder.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_draft_builder.py
@@ -37,6 +37,7 @@ from ai.backend.manager.data.session.draft import (
     SessionIdentityDraft,
     SessionNetworkDraft,
     SessionOptionsDraft,
+    SessionResourceSpecDraft,
     SessionScopeDraft,
     SessionSpecDraft,
 )
@@ -97,12 +98,34 @@ class DeploymentSessionDraftBuilder:
         )
 
         return SessionSpecDraft(
-            identity=SessionIdentityDraft(
-                session_id=SessionID(uuid4()),
-                creation_id=secrets.token_urlsafe(16),
-                session_name=f"{deployment_info.metadata.name}-{route_id!s}",
-                access_key=context.session_owner.access_key,
-                user_uuid=context.session_owner.uuid,
+            resource_spec=SessionResourceSpecDraft(
+                identity=SessionIdentityDraft(
+                    session_id=SessionID(uuid4()),
+                    creation_id=secrets.token_urlsafe(16),
+                    session_name=f"{deployment_info.metadata.name}-{route_id!s}",
+                    access_key=context.session_owner.access_key,
+                    user_uuid=context.session_owner.uuid,
+                ),
+                classification=SessionClassificationDraft(
+                    session_type=SessionTypes.INFERENCE,
+                    tag=deployment_info.metadata.tag,
+                ),
+                network=SessionNetworkDraft(),
+                callback_url=target_revision.execution.callback_url,
+                options=SessionOptionsDraft(
+                    priority=SESSION_PRIORITY_DEFAULT,
+                    is_preemptible=False,
+                    cluster_mode=target_revision.cluster_config.mode,
+                    cluster_size=target_revision.cluster_config.size,
+                    scheduling_target=SchedulingTargetDraft(),
+                    kernel_groups=kernel_groups,
+                    handler_options=None,
+                ),
+                internal_data_extras=InternalDataExtras(
+                    sudo_session_enabled=context.session_owner.sudo_session_enabled,
+                    model_definition_path=target_revision.model_mount_config.definition_path,
+                    model_definition=model_definition_payload,
+                ),
             ),
             scope=SessionScopeDraft(
                 domain_id=context.domain_id,
@@ -110,26 +133,6 @@ class DeploymentSessionDraftBuilder:
                 project_id=ProjectID(context.group_id),
                 resource_group_id=context.resource_group_id,
                 resource_group_name=ResourceGroupName(deployment_info.metadata.resource_group),
-            ),
-            classification=SessionClassificationDraft(
-                session_type=SessionTypes.INFERENCE,
-                tag=deployment_info.metadata.tag,
-            ),
-            network=SessionNetworkDraft(),
-            callback_url=target_revision.execution.callback_url,
-            options=SessionOptionsDraft(
-                priority=SESSION_PRIORITY_DEFAULT,
-                is_preemptible=False,
-                cluster_mode=target_revision.cluster_config.mode,
-                cluster_size=target_revision.cluster_config.size,
-                scheduling_target=SchedulingTargetDraft(),
-                kernel_groups=kernel_groups,
-                handler_options=None,
-            ),
-            internal_data_extras=InternalDataExtras(
-                sudo_session_enabled=context.session_owner.sudo_session_enabled,
-                model_definition_path=target_revision.model_mount_config.definition_path,
-                model_definition=model_definition_payload,
             ),
         )
 

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/provisioner.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/provisioner.py
@@ -438,7 +438,7 @@ class SessionProvisioner:
         session_metadata = SessionMetadata(
             session_id=session_workload.session_id,
             session_type=session_workload.session_type,
-            scaling_group=session_workload.scaling_group,
+            resource_group_id=session_workload.resource_group_id,
             cluster_mode=session_workload.cluster_mode,
         )
 

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/exceptions.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/exceptions.py
@@ -77,11 +77,11 @@ class NoAgentsInResourceGroupError(AgentSelectionError):
     error_type = "https://api.backend.ai/probs/no-agents-in-resource-group"
     error_title = "Unavailable : Resource group has no candidate agents."
 
-    _resource_group: ResourceGroupID
+    _resource_group_id: ResourceGroupID
 
-    def __init__(self, resource_group: ResourceGroupID) -> None:
-        self._resource_group = resource_group
-        super().__init__(f"No agents available in resource group '{resource_group}'")
+    def __init__(self, resource_group_id: ResourceGroupID) -> None:
+        self._resource_group_id = resource_group_id
+        super().__init__(f"No agents available in resource group '{resource_group_id}'")
 
     @override
     def error_code(self) -> ErrorCode:

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/exceptions.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/exceptions.py
@@ -16,6 +16,7 @@ from ai.backend.common.exception import (
     ErrorDomain,
     ErrorOperation,
 )
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import AgentId, ResourceSlot
 from ai.backend.manager.data.sokovan import SchedulingPredicate
 from ai.backend.manager.sokovan.scheduler.exceptions import SchedulingError
@@ -76,9 +77,9 @@ class NoAgentsInResourceGroupError(AgentSelectionError):
     error_type = "https://api.backend.ai/probs/no-agents-in-resource-group"
     error_title = "Unavailable : Resource group has no candidate agents."
 
-    _resource_group: str
+    _resource_group: ResourceGroupID
 
-    def __init__(self, resource_group: str) -> None:
+    def __init__(self, resource_group: ResourceGroupID) -> None:
         self._resource_group = resource_group
         super().__init__(f"No agents available in resource group '{resource_group}'")
 

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/selector.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/selector.py
@@ -13,6 +13,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from uuid import UUID
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import (
     AgentId,
     BinarySize,
@@ -70,8 +71,8 @@ class SessionMetadata:
     session_id: SessionId
     # Type of the session (e.g., INTERACTIVE, BATCH, INFERENCE)
     session_type: SessionTypes
-    # Scaling group the session belongs to
-    scaling_group: str
+    # Resource group the session belongs to
+    resource_group_id: ResourceGroupID
     # Cluster mode (e.g., SINGLE, MULTI)
     cluster_mode: ClusterMode
 
@@ -281,7 +282,7 @@ class AgentSelector:
             # Empty list for sessions with no kernels
             return []
         if not agents:
-            raise NoAgentsInResourceGroupError(criteria.session_metadata.scaling_group)
+            raise NoAgentsInResourceGroupError(criteria.session_metadata.resource_group_id)
 
         # Track agent state changes as diffs using AgentStateTracker
         state_trackers = [AgentStateTracker(original_agent=agent) for agent in agents]

--- a/src/ai/backend/manager/sokovan/scheduling_controller/preparers/assign_container_user_mapping_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/preparers/assign_container_user_mapping_rule.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import override
 
-from ai.backend.manager.data.session.draft import SessionSpecDraft
+from ai.backend.manager.data.session.draft import SessionResourceSpecDraft
 from ai.backend.manager.sokovan.scheduling_controller.preparers.draft_rule import (
     SessionSpecDraftRule,
     SessionSpecPreparationContext,
@@ -36,9 +36,9 @@ class AssignContainerUserMappingRule(SessionSpecDraftRule):
     @override
     async def prepare(
         self,
-        draft: SessionSpecDraft,
+        draft: SessionResourceSpecDraft,
         context: SessionSpecPreparationContext,
-    ) -> SessionSpecDraft:
+    ) -> SessionResourceSpecDraft:
         info = context.container_user_info
         if info is None:
             return draft

--- a/src/ai/backend/manager/sokovan/scheduling_controller/preparers/assign_network_config_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/preparers/assign_network_config_rule.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 from typing import override
 
-from ai.backend.manager.data.session.draft import SessionSpecDraft
+from ai.backend.manager.data.session.draft import SessionResourceSpecDraft
 from ai.backend.manager.models.network import NetworkType
 from ai.backend.manager.sokovan.scheduling_controller.preparers.draft_rule import (
     SessionSpecDraftRule,
@@ -42,9 +42,9 @@ class AssignNetworkConfigRule(SessionSpecDraftRule):
     @override
     async def prepare(
         self,
-        draft: SessionSpecDraft,
+        draft: SessionResourceSpecDraft,
         context: SessionSpecPreparationContext,
-    ) -> SessionSpecDraft:
+    ) -> SessionResourceSpecDraft:
         net = draft.network
         if net.network_type is not None:
             return draft

--- a/src/ai/backend/manager/sokovan/scheduling_controller/preparers/assign_user_identity_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/preparers/assign_user_identity_rule.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from typing import override
 
 from ai.backend.common.contexts.user import current_user
-from ai.backend.manager.data.session.draft import SessionSpecDraft
+from ai.backend.manager.data.session.draft import SessionResourceSpecDraft
 from ai.backend.manager.sokovan.scheduling_controller.preparers.draft_rule import (
     SessionSpecDraftRule,
     SessionSpecPreparationContext,
@@ -33,9 +33,9 @@ class AssignUserIdentityRule(SessionSpecDraftRule):
     @override
     async def prepare(
         self,
-        draft: SessionSpecDraft,
-        _context: SessionSpecPreparationContext,
-    ) -> SessionSpecDraft:
+        draft: SessionResourceSpecDraft,
+        context: SessionSpecPreparationContext,
+    ) -> SessionResourceSpecDraft:
         if draft.identity.user_uuid is not None:
             return draft
         user = current_user()

--- a/src/ai/backend/manager/sokovan/scheduling_controller/preparers/build_internal_data_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/preparers/build_internal_data_rule.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 from typing import Any, override
 
-from ai.backend.manager.data.session.draft import SessionSpecDraft
+from ai.backend.manager.data.session.draft import SessionResourceSpecDraft
 from ai.backend.manager.sokovan.scheduling_controller.preparers.draft_rule import (
     SessionSpecDraftRule,
     SessionSpecPreparationContext,
@@ -46,9 +46,9 @@ class BuildInternalDataRule(SessionSpecDraftRule):
     @override
     async def prepare(
         self,
-        draft: SessionSpecDraft,
+        draft: SessionResourceSpecDraft,
         context: SessionSpecPreparationContext,
-    ) -> SessionSpecDraft:
+    ) -> SessionResourceSpecDraft:
         extras = draft.internal_data_extras
         overlay: dict[str, Any] = context.dotfile_data.to_internal_data()
         if extras.model_definition_path is not None:

--- a/src/ai/backend/manager/sokovan/scheduling_controller/preparers/compute_kernel_resources_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/preparers/compute_kernel_resources_rule.py
@@ -30,7 +30,7 @@ from ai.backend.common.types import BinarySize, ResourceSlotEntry
 from ai.backend.manager.data.session.creation import ImageInfo
 from ai.backend.manager.data.session.draft import (
     KernelExecutionSpecDraft,
-    SessionSpecDraft,
+    SessionResourceSpecDraft,
 )
 from ai.backend.manager.data.session.options import ResourceOpts
 from ai.backend.manager.defs import DEFAULT_SHARED_MEMORY_SIZE, INTRINSIC_SLOTS
@@ -56,9 +56,9 @@ class ComputeKernelResourcesRule(SessionSpecDraftRule):
     @override
     async def prepare(
         self,
-        draft: SessionSpecDraft,
+        draft: SessionResourceSpecDraft,
         context: SessionSpecPreparationContext,
-    ) -> SessionSpecDraft:
+    ) -> SessionResourceSpecDraft:
         if draft.options.kernel_groups is None:
             return draft
 

--- a/src/ai/backend/manager/sokovan/scheduling_controller/preparers/draft_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/preparers/draft_rule.py
@@ -28,7 +28,7 @@ from ai.backend.manager.data.session.creation import (
     ImageInfo,
     ScalingGroupNetworkInfo,
 )
-from ai.backend.manager.data.session.draft import SessionSpecDraft
+from ai.backend.manager.data.session.draft import SessionResourceSpecDraft
 from ai.backend.manager.data.session.options import DefaultSessionOptions
 
 
@@ -76,8 +76,8 @@ class SessionSpecDraftRule(ABC):
     @abstractmethod
     async def prepare(
         self,
-        draft: SessionSpecDraft,
+        draft: SessionResourceSpecDraft,
         context: SessionSpecPreparationContext,
-    ) -> SessionSpecDraft:
+    ) -> SessionResourceSpecDraft:
         """Return a new draft with this rule's fields resolved."""
         raise NotImplementedError

--- a/src/ai/backend/manager/sokovan/scheduling_controller/preparers/expand_kernel_groups_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/preparers/expand_kernel_groups_rule.py
@@ -24,7 +24,7 @@ from typing import override
 
 from ai.backend.manager.data.session.draft import (
     KernelSpecDraft,
-    SessionSpecDraft,
+    SessionResourceSpecDraft,
 )
 from ai.backend.manager.sokovan.scheduling_controller.preparers.draft_rule import (
     SessionSpecDraftRule,
@@ -47,9 +47,9 @@ class ExpandKernelGroupsRule(SessionSpecDraftRule):
     @override
     async def prepare(
         self,
-        draft: SessionSpecDraft,
+        draft: SessionResourceSpecDraft,
         context: SessionSpecPreparationContext,
-    ) -> SessionSpecDraft:
+    ) -> SessionResourceSpecDraft:
         groups = draft.options.kernel_groups
         if groups is None:
             return draft

--- a/src/ai/backend/manager/sokovan/scheduling_controller/preparers/inject_session_environ_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/preparers/inject_session_environ_rule.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import override
 
-from ai.backend.manager.data.session.draft import SessionSpecDraft
+from ai.backend.manager.data.session.draft import SessionResourceSpecDraft
 from ai.backend.manager.sokovan.scheduling_controller.preparers.draft_rule import (
     SessionSpecDraftRule,
     SessionSpecPreparationContext,
@@ -36,9 +36,9 @@ class InjectSessionEnvironRule(SessionSpecDraftRule):
     @override
     async def prepare(
         self,
-        draft: SessionSpecDraft,
+        draft: SessionResourceSpecDraft,
         context: SessionSpecPreparationContext,
-    ) -> SessionSpecDraft:
+    ) -> SessionResourceSpecDraft:
         if not draft.internal_data_extras.sudo_session_enabled:
             return draft
 

--- a/src/ai/backend/manager/sokovan/scheduling_controller/preparers/merge_resource_group_defaults_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/preparers/merge_resource_group_defaults_rule.py
@@ -32,7 +32,7 @@ from typing import override
 
 from ai.backend.manager.data.session.draft import (
     KernelExecutionSpecDraft,
-    SessionSpecDraft,
+    SessionResourceSpecDraft,
 )
 from ai.backend.manager.data.session.options import KernelExecutionSpec
 from ai.backend.manager.sokovan.scheduling_controller.preparers.draft_rule import (
@@ -51,9 +51,9 @@ class MergeResourceGroupDefaultsRule(SessionSpecDraftRule):
     @override
     async def prepare(
         self,
-        draft: SessionSpecDraft,
+        draft: SessionResourceSpecDraft,
         context: SessionSpecPreparationContext,
-    ) -> SessionSpecDraft:
+    ) -> SessionResourceSpecDraft:
         rg = context.resource_group_defaults
 
         # Option-level fill.

--- a/src/ai/backend/manager/sokovan/scheduling_controller/preparers/resolve_vfolder_mounts_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/preparers/resolve_vfolder_mounts_rule.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from typing import override
 
-from ai.backend.manager.data.session.draft import SessionSpecDraft
+from ai.backend.manager.data.session.draft import SessionResourceSpecDraft
 from ai.backend.manager.sokovan.scheduling_controller.preparers.draft_rule import (
     SessionSpecDraftRule,
     SessionSpecPreparationContext,
@@ -40,9 +40,9 @@ class ResolveVFolderMountsRule(SessionSpecDraftRule):
     @override
     async def prepare(
         self,
-        draft: SessionSpecDraft,
+        draft: SessionResourceSpecDraft,
         context: SessionSpecPreparationContext,
-    ) -> SessionSpecDraft:
+    ) -> SessionResourceSpecDraft:
         resolved = context.vfolder_mounts_by_role
         if not resolved or not draft.kernel_specs:
             return draft

--- a/src/ai/backend/manager/sokovan/scheduling_controller/preparers/session_spec_preparer.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/preparers/session_spec_preparer.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
-from ai.backend.manager.data.session.draft import SessionSpecDraft
-from ai.backend.manager.data.session.spec import SessionSpec
+from ai.backend.manager.data.session.draft import SessionResourceSpecDraft
+from ai.backend.manager.data.session.spec import SessionResourceSpec
 from ai.backend.manager.sokovan.scheduling_controller.preparers.draft_rule import (
     SessionSpecDraftRule,
     SessionSpecPreparationContext,
@@ -43,15 +43,15 @@ class SessionSpecPreparer:
 
     async def prepare(
         self,
-        initial_draft: SessionSpecDraft,
+        initial_draft: SessionResourceSpecDraft,
         context: SessionSpecPreparationContext,
-    ) -> SessionSpec:
+    ) -> SessionResourceSpec:
         """Run every rule in declaration order and finalize."""
         draft = initial_draft
         for rule in self._rules:
             draft = await rule.prepare(draft, context)
         return self._finalize(draft)
 
-    def _finalize(self, draft: SessionSpecDraft) -> SessionSpec:
-        """Project a fully-prepared draft into a frozen ``SessionSpec``."""
-        return SessionSpec.model_validate(draft.model_dump(exclude_none=True))
+    def _finalize(self, draft: SessionResourceSpecDraft) -> SessionResourceSpec:
+        """Project a fully-prepared draft into a frozen ``SessionResourceSpec``."""
+        return SessionResourceSpec.model_validate(draft.model_dump(exclude_none=True))

--- a/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
@@ -13,6 +13,7 @@ from ai.backend.common.events.event_types.session.broadcast import SchedulingBro
 from ai.backend.common.events.types import AbstractBroadcastEvent
 from ai.backend.common.exception import InvalidAPIParameters
 from ai.backend.common.identifier.image import ImageID
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.plugin.hook import ALL_COMPLETED, PASSED, HookPluginContext
 from ai.backend.common.types import KernelId, ResourceSlot, ResourceSlotEntry, SessionId
 from ai.backend.logging.utils import BraceStyleAdapter
@@ -24,7 +25,11 @@ from ai.backend.manager.data.session.compute_schedule import (
     UnschedulableReasonHint,
 )
 from ai.backend.manager.data.session.draft import SessionSpecDraft
-from ai.backend.manager.data.session.spec import SessionSpec
+from ai.backend.manager.data.session.spec import (
+    SessionResourceSpec,
+    SessionScope,
+    SessionSpec,
+)
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.errors.common import InternalServerError, RejectedByHook
 from ai.backend.manager.metrics.scheduler import (
@@ -278,7 +283,9 @@ class SchedulingController:
         with self._metric_observer.measure_phase(
             "scheduling_controller", rg_id, "spec_preparation"
         ):
-            spec = await self._spec_preparer.prepare(draft, prep_ctx)
+            resource_spec = await self._spec_preparer.prepare(draft.to_resource_draft(), prep_ctx)
+            scope = SessionScope.model_validate(draft.scope.model_dump(exclude_none=True))
+            spec = SessionSpec.from_resource_spec(scope, resource_spec)
 
         hook_result = await self._hook_plugin_ctx.dispatch(
             "PRE_ENQUEUE_SESSION",
@@ -328,7 +335,7 @@ class SchedulingController:
         return session_id
 
     def _prepare_kernel_data(
-        self, spec: SessionSpec, fetched: SessionSpecContextFetch
+        self, spec: SessionResourceSpec, fetched: SessionSpecContextFetch
     ) -> dict[KernelId, _KernelComputeScheduleData]:
         prepared_data: dict[KernelId, _KernelComputeScheduleData] = {}
         for kernel_spec in spec.kernel_specs:
@@ -367,7 +374,8 @@ class SchedulingController:
 
     async def _compute_schedule(
         self,
-        spec: SessionSpec,
+        spec: SessionResourceSpec,
+        resource_group_id: ResourceGroupID,
         kernel_data: dict[KernelId, _KernelComputeScheduleData],
     ) -> ComputeScheduleResult:
         kernel_requirements: dict[UUID, KernelResourceSpec] = {
@@ -382,7 +390,7 @@ class SchedulingController:
                 session_metadata=SessionMetadata(
                     session_id=SessionId(UUID(str(spec.identity.session_id))),
                     session_type=spec.classification.session_type,
-                    scaling_group=str(spec.scope.resource_group_name),
+                    resource_group_id=resource_group_id,
                     cluster_mode=spec.options.cluster_mode,
                 ),
                 kernel_requirements=kernel_requirements,
@@ -395,9 +403,7 @@ class SchedulingController:
             )
             # The selector mutates the agents list on full success; feed clones so
             # the live snapshot is never altered.
-            scheduling_data = await self._repository.get_scheduling_data(
-                spec.scope.resource_group_id
-            )
+            scheduling_data = await self._repository.get_scheduling_data(resource_group_id)
             if scheduling_data is None:
                 resource_group_reason = "Resource group does not exist"
                 return ComputeScheduleResult(
@@ -488,9 +494,9 @@ class SchedulingController:
             # storage-RPC resolution by leaving the per-role mount map empty.
             vfolder_mounts_by_role={},
         )
-        spec = await self._spec_preparer.prepare(draft, prep_ctx)
-        compute_schedule_kernel_data = self._prepare_kernel_data(spec, fetched)
-        return await self._compute_schedule(spec, compute_schedule_kernel_data)
+        resource_spec = await self._spec_preparer.prepare(draft.to_resource_draft(), prep_ctx)
+        compute_schedule_kernel_data = self._prepare_kernel_data(resource_spec, fetched)
+        return await self._compute_schedule(resource_spec, rg_id, compute_schedule_kernel_data)
 
     async def mark_scheduling_needed(self, schedule_types: Sequence[ScheduleType]) -> None:
         """

--- a/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
@@ -285,7 +285,7 @@ class SchedulingController:
         ):
             resource_spec = await self._spec_preparer.prepare(draft.resource_spec, prep_ctx)
             scope = SessionScope.model_validate(draft.scope.model_dump(exclude_none=True))
-            spec = SessionSpec.from_resource_spec(scope, resource_spec)
+            spec = SessionSpec(resource_spec=resource_spec, scope=scope)
 
         hook_result = await self._hook_plugin_ctx.dispatch(
             "PRE_ENQUEUE_SESSION",

--- a/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
@@ -199,7 +199,7 @@ class SchedulingController:
             return
         domain_name = str(draft.scope.domain_name) if draft.scope.domain_name else None
         project_id = draft.scope.project_id
-        access_key = draft.identity.access_key
+        access_key = draft.resource_spec.identity.access_key
         if access_key is None or domain_name is None or project_id is None:
             raise InternalServerError(
                 "Unreachable: resource_group_id supplied without identity context",
@@ -221,7 +221,7 @@ class SchedulingController:
 
         Only input is the :class:`SessionSpecDraft` — request-envelope
         extras (sudo, model-definition overlay) ride on
-        ``draft.internal_data_extras``. Validation-adjacent DB reads (image
+        ``draft.resource_spec.internal_data_extras``. Validation-adjacent DB reads (image
         metadata, keypair policy, resource-group network, container uid/gid,
         dotfiles, active session count) flow through
         :meth:`SchedulerRepository.fetch_session_spec_contexts`; vfolder mounts
@@ -283,16 +283,16 @@ class SchedulingController:
         with self._metric_observer.measure_phase(
             "scheduling_controller", rg_id, "spec_preparation"
         ):
-            resource_spec = await self._spec_preparer.prepare(draft.to_resource_draft(), prep_ctx)
+            resource_spec = await self._spec_preparer.prepare(draft.resource_spec, prep_ctx)
             scope = SessionScope.model_validate(draft.scope.model_dump(exclude_none=True))
             spec = SessionSpec.from_resource_spec(scope, resource_spec)
 
         hook_result = await self._hook_plugin_ctx.dispatch(
             "PRE_ENQUEUE_SESSION",
             (
-                spec.identity.session_id,
-                spec.identity.session_name,
-                spec.identity.access_key,
+                spec.resource_spec.identity.session_id,
+                spec.resource_spec.identity.session_name,
+                spec.resource_spec.identity.access_key,
             ),
             return_when=ALL_COMPLETED,
         )
@@ -307,14 +307,14 @@ class SchedulingController:
 
         log.info(
             "Session {} ({}) enqueued successfully via draft path",
-            spec.identity.session_name,
+            spec.resource_spec.identity.session_name,
             session_id,
         )
 
         await self._event_producer.broadcast_events_batch([
             SchedulingBroadcastEvent(
                 session_id=session_id,
-                creation_id=spec.identity.creation_id,
+                creation_id=spec.resource_spec.identity.creation_id,
                 status_transition=str(SessionStatus.PENDING),
                 reason="Session enqueued",
             )
@@ -330,7 +330,11 @@ class SchedulingController:
             )
         await self._hook_plugin_ctx.notify(
             "POST_ENQUEUE_SESSION",
-            (session_id, spec.identity.session_name, spec.identity.access_key),
+            (
+                session_id,
+                spec.resource_spec.identity.session_name,
+                spec.resource_spec.identity.access_key,
+            ),
         )
         return session_id
 
@@ -477,7 +481,7 @@ class SchedulingController:
 
         Reuses the enqueue prep chain (vfolder resolution skipped), then drives
         the real agent selector against a live snapshot of the group's agents.
-        Results correspond positionally to ``draft.options.kernel_groups``.
+        Results correspond positionally to ``draft.resource_spec.options.kernel_groups``.
         """
         rg_id = draft.scope.resource_group_id
         if rg_id is None:
@@ -494,7 +498,7 @@ class SchedulingController:
             # storage-RPC resolution by leaving the per-role mount map empty.
             vfolder_mounts_by_role={},
         )
-        resource_spec = await self._spec_preparer.prepare(draft.to_resource_draft(), prep_ctx)
+        resource_spec = await self._spec_preparer.prepare(draft.resource_spec, prep_ctx)
         compute_schedule_kernel_data = self._prepare_kernel_data(resource_spec, fetched)
         return await self._compute_schedule(resource_spec, rg_id, compute_schedule_kernel_data)
 

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/container_limit_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/container_limit_rule.py
@@ -31,7 +31,7 @@ class ContainerLimitRule(SessionSpecValidatorRule):
         limit = policy.max_containers_per_session
         if limit <= 0:
             return
-        count = len(spec.kernel_specs)
+        count = len(spec.resource_spec.kernel_specs)
         if count > limit:
             raise QuotaExceeded(
                 extra_msg=(

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/dotfile_vfolder_conflict_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/dotfile_vfolder_conflict_rule.py
@@ -37,7 +37,7 @@ class DotfileVFolderConflictRule(SessionSpecValidatorRule):
         if not dotfiles:
             return
         kernel_paths: set[PurePosixPath] = set()
-        for kernel in spec.kernel_specs:
+        for kernel in spec.resource_spec.kernel_specs:
             for mount in kernel.vfolder_mounts:
                 kernel_paths.add(mount.kernel_path)
         if not kernel_paths:

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/image_slot_type_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/image_slot_type_rule.py
@@ -50,7 +50,7 @@ class ImageSlotTypeRule(SessionSpecValidatorRule):
                 ),
             )
         errors: list[str] = []
-        for idx, kernel in enumerate(spec.kernel_specs):
+        for idx, kernel in enumerate(spec.resource_spec.kernel_specs):
             image_info = context.image_infos.get(kernel.execution_spec.resource_input.image_id)
             if image_info is None:
                 continue

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/inference_model_folder_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/inference_model_folder_rule.py
@@ -33,9 +33,9 @@ class InferenceModelFolderRule(SessionSpecValidatorRule):
         spec: SessionSpec,
         _context: SessionSpecValidationContext,
     ) -> None:
-        if spec.classification.session_type != SessionTypes.INFERENCE:
+        if spec.resource_spec.classification.session_type != SessionTypes.INFERENCE:
             return
-        for kernel in spec.kernel_specs:
+        for kernel in spec.resource_spec.kernel_specs:
             for mount in kernel.vfolder_mounts:
                 if mount.usage_mode == VFolderUsageMode.MODEL:
                     return

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/mount_name_validation_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/mount_name_validation_rule.py
@@ -32,7 +32,7 @@ class MountNameValidationRule(SessionSpecValidatorRule):
         spec: SessionSpec,
         _context: SessionSpecValidationContext,
     ) -> None:
-        for kernel_idx, kernel in enumerate(spec.kernel_specs):
+        for kernel_idx, kernel in enumerate(spec.resource_spec.kernel_specs):
             seen_paths: set[str] = set()
             for mount_idx, mount in enumerate(kernel.vfolder_mounts):
                 path = str(mount.kernel_path)

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/requested_slot_type_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/requested_slot_type_rule.py
@@ -49,7 +49,7 @@ class RequestedSlotTypeRule(SessionSpecValidatorRule):
                 ),
             )
         errors: list[str] = []
-        for idx, kernel in enumerate(spec.kernel_specs):
+        for idx, kernel in enumerate(spec.resource_spec.kernel_specs):
             unknown = sorted({
                 entry.resource_type
                 for entry in kernel.execution_spec.resource_input.resources

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/required_resource_slot_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/required_resource_slot_rule.py
@@ -37,7 +37,7 @@ class RequiredResourceSlotRule(SessionSpecValidatorRule):
         if not required:
             return
 
-        for idx, kernel in enumerate(spec.kernel_specs):
+        for idx, kernel in enumerate(spec.resource_spec.kernel_specs):
             requested = {
                 entry.resource_type: parse_quantity(entry.quantity)
                 for entry in kernel.execution_spec.resource_input.resources

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/resource_limit_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/resource_limit_rule.py
@@ -46,7 +46,7 @@ class ResourceLimitRule(SessionSpecValidatorRule):
         spec: SessionSpec,
         context: SessionSpecValidationContext,
     ) -> None:
-        for idx, kernel in enumerate(spec.kernel_specs):
+        for idx, kernel in enumerate(spec.resource_spec.kernel_specs):
             image_info = context.image_infos.get(kernel.execution_spec.resource_input.image_id)
             if image_info is None:
                 continue

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/service_port_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/service_port_rule.py
@@ -28,7 +28,7 @@ class ServicePortRule(SessionSpecValidatorRule):
         spec: SessionSpec,
         context: SessionSpecValidationContext,
     ) -> None:
-        for idx, kernel in enumerate(spec.kernel_specs):
+        for idx, kernel in enumerate(spec.resource_spec.kernel_specs):
             preopen = set(kernel.preopen_ports)
             if not preopen:
                 continue

--- a/tests/unit/manager/repositories/scheduler/test_automount_vfolder_resolution.py
+++ b/tests/unit/manager/repositories/scheduler/test_automount_vfolder_resolution.py
@@ -41,6 +41,7 @@ from ai.backend.manager.data.session.draft import (
     KernelGroupDraft,
     SessionIdentityDraft,
     SessionOptionsDraft,
+    SessionResourceSpecDraft,
     SessionScopeDraft,
     SessionSpecDraft,
 )
@@ -315,18 +316,20 @@ class TestAutoMountVFolderResolution:
         # A session with a single kernel group and NO explicit mounts —
         # exactly the case the regression dropped auto-mounts for.
         draft = SessionSpecDraft(
-            identity=SessionIdentityDraft(
-                creation_id="automount-regression",
-                session_name="automount-regression",
-                user_uuid=test_user,
+            resource_spec=SessionResourceSpecDraft(
+                identity=SessionIdentityDraft(
+                    creation_id="automount-regression",
+                    session_name="automount-regression",
+                    user_uuid=test_user,
+                ),
+                options=SessionOptionsDraft(
+                    kernel_groups=(KernelGroupDraft(role="main", replica_count=1),),
+                ),
             ),
             scope=SessionScopeDraft(
                 domain_name=DomainName(test_domain_name),
                 project_id=ProjectID(test_group),
                 resource_group_name=None,
-            ),
-            options=SessionOptionsDraft(
-                kernel_groups=(KernelGroupDraft(role="main", replica_count=1),),
             ),
         )
 

--- a/tests/unit/manager/services/session/test_session_service.py
+++ b/tests/unit/manager/services/session/test_session_service.py
@@ -1918,7 +1918,7 @@ class TestEnqueueSession:
         await configured_session_service.enqueue_session(enqueue_action_without_rg)
 
         draft = mock_scheduling_controller.enqueue_session_from_draft.await_args.args[0]
-        assert draft.options.handler_options is None
+        assert draft.resource_spec.options.handler_options is None
 
     async def test_leaves_resource_opts_unset_when_shmem_omitted(
         self,
@@ -1932,8 +1932,11 @@ class TestEnqueueSession:
         await configured_session_service.enqueue_session(enqueue_action_without_rg)
 
         draft = mock_scheduling_controller.enqueue_session_from_draft.await_args.args[0]
-        assert draft.options.kernel_groups is not None
-        assert draft.options.kernel_groups[0].execution_spec.resource_input.resource_opts is None
+        assert draft.resource_spec.options.kernel_groups is not None
+        assert (
+            draft.resource_spec.options.kernel_groups[0].execution_spec.resource_input.resource_opts
+            is None
+        )
 
     async def test_keeps_resource_opts_when_shmem_supplied(
         self,
@@ -1962,7 +1965,9 @@ class TestEnqueueSession:
         await configured_session_service.enqueue_session(action)
 
         draft = mock_scheduling_controller.enqueue_session_from_draft.await_args.args[0]
-        assert draft.options.kernel_groups is not None
-        resource_opts = draft.options.kernel_groups[0].execution_spec.resource_input.resource_opts
+        assert draft.resource_spec.options.kernel_groups is not None
+        resource_opts = draft.resource_spec.options.kernel_groups[
+            0
+        ].execution_spec.resource_input.resource_opts
         assert resource_opts is not None
         assert resource_opts.shmem == BinarySize.from_str("256m")

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_agent_selection_with_resources.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_agent_selection_with_resources.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 import pytest
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import AgentId, ClusterMode, ResourceSlot, SessionId, SessionTypes
 from ai.backend.manager.data.sokovan import AgentInfo
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.concentrated import (
@@ -39,7 +40,7 @@ class TestAgentSelectionWithResources:
         session_metadata = SessionMetadata(
             session_id=SessionId(uuid.uuid4()),
             session_type=SessionTypes.INTERACTIVE,
-            scaling_group="default",
+            resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
             cluster_mode=ClusterMode.SINGLE_NODE,
         )
 
@@ -104,7 +105,7 @@ class TestAgentSelectionWithResources:
         session_metadata = SessionMetadata(
             session_id=SessionId(uuid.uuid4()),
             session_type=SessionTypes.BATCH,
-            scaling_group="default",
+            resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
             cluster_mode=ClusterMode.MULTI_NODE,
         )
 
@@ -164,7 +165,7 @@ class TestAgentSelectionWithResources:
         session_metadata = SessionMetadata(
             session_id=SessionId(uuid.uuid4()),
             session_type=SessionTypes.INTERACTIVE,
-            scaling_group="default",
+            resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
             cluster_mode=ClusterMode.SINGLE_NODE,
         )
 
@@ -224,7 +225,7 @@ class TestAgentSelectionWithResources:
         session_metadata = SessionMetadata(
             session_id=SessionId(uuid.uuid4()),
             session_type=SessionTypes.BATCH,
-            scaling_group="default",
+            resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
             cluster_mode=ClusterMode.SINGLE_NODE,
         )
 
@@ -269,7 +270,7 @@ class TestAgentSelectionWithResources:
         session_metadata = SessionMetadata(
             session_id=SessionId(uuid.uuid4()),
             session_type=SessionTypes.INTERACTIVE,
-            scaling_group="default",
+            resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
             cluster_mode=ClusterMode.SINGLE_NODE,
         )
 

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_concentrated_selector.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_concentrated_selector.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 import pytest
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import (
     AgentId,
     ClusterMode,
@@ -43,7 +44,7 @@ class TestConcentratedAgentSelector:
             session_metadata=SessionMetadata(
                 session_id=SessionId(uuid.uuid4()),
                 session_type=SessionTypes.INTERACTIVE,
-                scaling_group="default",
+                resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
                 cluster_mode=ClusterMode.SINGLE_NODE,
             ),
             kernel_requirements={},
@@ -155,7 +156,7 @@ class TestConcentratedAgentSelector:
             session_metadata=SessionMetadata(
                 session_id=SessionId(uuid.uuid4()),
                 session_type=SessionTypes.INFERENCE,
-                scaling_group="default",
+                resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
                 cluster_mode=ClusterMode.SINGLE_NODE,
             ),
             kernel_requirements={},

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_dispersed_selector.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_dispersed_selector.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 import pytest
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import (
     AgentId,
     ClusterMode,
@@ -46,7 +47,7 @@ class TestDispersedAgentSelector:
             session_metadata=SessionMetadata(
                 session_id=SessionId(uuid.uuid4()),
                 session_type=SessionTypes.INTERACTIVE,
-                scaling_group="default",
+                resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
                 cluster_mode=ClusterMode.SINGLE_NODE,
             ),
             kernel_requirements={},

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_failed_agent_filtering.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_failed_agent_filtering.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 import pytest
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import AgentId, ClusterMode, ResourceSlot, SessionId, SessionTypes
 from ai.backend.manager.data.sokovan import AgentInfo
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.concentrated import (
@@ -52,7 +53,7 @@ def _make_criteria_with_failed_agents(
         session_metadata=SessionMetadata(
             session_id=SessionId(uuid.uuid4()),
             session_type=SessionTypes.INTERACTIVE,
-            scaling_group="default",
+            resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
             cluster_mode=ClusterMode.SINGLE_NODE,
         ),
         kernel_requirements={

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_failure_message_format.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_failure_message_format.py
@@ -14,6 +14,7 @@ from uuid import UUID
 
 import pytest
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import (
     AgentId,
     ClusterMode,
@@ -114,7 +115,7 @@ class TestNoAvailableAgentErrorAggregationFormat:
             session_metadata=SessionMetadata(
                 session_id=SessionId(uuid.uuid4()),
                 session_type=SessionTypes.INTERACTIVE,
-                scaling_group="default",
+                resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
                 cluster_mode=ClusterMode.SINGLE_NODE,
             ),
             kernel_requirements={
@@ -238,7 +239,7 @@ class TestDesignatedAgentFailureFormat:
             session_metadata=SessionMetadata(
                 session_id=SessionId(uuid.uuid4()),
                 session_type=SessionTypes.INTERACTIVE,
-                scaling_group="default",
+                resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
                 cluster_mode=ClusterMode.SINGLE_NODE,
             ),
             kernel_requirements={
@@ -433,7 +434,7 @@ class TestGoldenNoAvailableAgentError:
             session_metadata=SessionMetadata(
                 session_id=SessionId(uuid.uuid4()),
                 session_type=SessionTypes.INTERACTIVE,
-                scaling_group="default",
+                resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
                 cluster_mode=ClusterMode.SINGLE_NODE,
             ),
             kernel_requirements={
@@ -514,7 +515,7 @@ class TestGoldenNoDesignatedAgentCompatible:
             session_metadata=SessionMetadata(
                 session_id=SessionId(uuid.uuid4()),
                 session_type=SessionTypes.INTERACTIVE,
-                scaling_group="default",
+                resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
                 cluster_mode=ClusterMode.SINGLE_NODE,
             ),
             kernel_requirements={
@@ -629,5 +630,8 @@ class TestGoldenNoAvailableAgentDirectConstruction:
 
 class TestGoldenNoAgentsInResourceGroupError:
     def test_full_message(self) -> None:
-        err = NoAgentsInResourceGroupError("default")
-        assert err.extra_msg == "No agents available in resource group 'default'"
+        err = NoAgentsInResourceGroupError(ResourceGroupID(uuid.UUID(int=0)))
+        assert (
+            err.extra_msg
+            == "No agents available in resource group '00000000-0000-0000-0000-000000000000'"
+        )

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_legacy_selector.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_legacy_selector.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 import pytest
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import (
     AgentId,
     ClusterMode,
@@ -47,7 +48,7 @@ class TestLegacyAgentSelector:
             session_metadata=SessionMetadata(
                 session_id=SessionId(uuid.uuid4()),
                 session_type=SessionTypes.INTERACTIVE,
-                scaling_group="default",
+                resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
                 cluster_mode=ClusterMode.SINGLE_NODE,
             ),
             kernel_requirements={},

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_remediation_hint.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_remediation_hint.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import uuid
 from decimal import Decimal
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import AgentId, KernelId, ResourceSlot
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.exceptions import (
     ContainerLimitExceededError,
@@ -80,7 +81,9 @@ class TestNoCompatibleAgentSuggestion:
 
 class TestNoAgentsInResourceGroupSuggestion:
     def test_empty_suggestion(self) -> None:
-        suggestion = NoAgentsInResourceGroupError("default").build_remediation_hint()
+        suggestion = NoAgentsInResourceGroupError(
+            ResourceGroupID(uuid.UUID(int=0))
+        ).build_remediation_hint()
         assert suggestion.available_archs is None
         assert suggestion.available_agent_ids is None
         assert suggestion.required_reduction is None

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_resource_requirements.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_resource_requirements.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 
 import pytest
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import ClusterMode, ResourceSlot, SessionId, SessionTypes
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.selector import (
     AgentSelectionCriteria,
@@ -22,7 +23,7 @@ class TestResourceRequirements:
         session_metadata = SessionMetadata(
             session_id=SessionId(uuid.uuid4()),
             session_type=SessionTypes.INTERACTIVE,
-            scaling_group="default",
+            resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
             cluster_mode=ClusterMode.SINGLE_NODE,
         )
 
@@ -75,7 +76,7 @@ class TestResourceRequirements:
         session_metadata = SessionMetadata(
             session_id=SessionId(uuid.uuid4()),
             session_type=SessionTypes.BATCH,
-            scaling_group="default",
+            resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
             cluster_mode=ClusterMode.SINGLE_NODE,
         )
 
@@ -113,7 +114,7 @@ class TestResourceRequirements:
         session_metadata = SessionMetadata(
             session_id=SessionId(uuid.uuid4()),
             session_type=SessionTypes.INTERACTIVE,
-            scaling_group="default",
+            resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
             cluster_mode=ClusterMode.MULTI_NODE,
         )
 
@@ -169,7 +170,7 @@ class TestResourceRequirements:
         session_metadata = SessionMetadata(
             session_id=SessionId(uuid.uuid4()),
             session_type=SessionTypes.INFERENCE,
-            scaling_group="default",
+            resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
             cluster_mode=ClusterMode.SINGLE_NODE,
         )
 
@@ -187,7 +188,7 @@ class TestResourceRequirements:
         session_metadata = SessionMetadata(
             session_id=SessionId(uuid.uuid4()),
             session_type=SessionTypes.BATCH,
-            scaling_group="gpu-group",
+            resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
             cluster_mode=ClusterMode.SINGLE_NODE,
         )
 

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_roundrobin_selector.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_roundrobin_selector.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 import pytest
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import (
     AgentId,
     ClusterMode,
@@ -38,7 +39,7 @@ class TestRoundRobinAgentSelector:
             session_metadata=SessionMetadata(
                 session_id=SessionId(uuid.uuid4()),
                 session_type=SessionTypes.INTERACTIVE,
-                scaling_group="default",
+                resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
                 cluster_mode=ClusterMode.SINGLE_NODE,
             ),
             kernel_requirements={},

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_selector_edge_cases.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_selector_edge_cases.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 import pytest
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import (
     AgentId,
     ClusterMode,
@@ -45,7 +46,7 @@ class TestSelectorEdgeCases:
             session_metadata=SessionMetadata(
                 session_id=SessionId(uuid.uuid4()),
                 session_type=SessionTypes.INTERACTIVE,
-                scaling_group="default",
+                resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
                 cluster_mode=ClusterMode.SINGLE_NODE,
             ),
             kernel_requirements={},

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_selector_integration.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_selector_integration.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 import pytest
 
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import (
     AgentId,
     ClusterMode,
@@ -45,7 +46,7 @@ class TestSelectorIntegration:
             session_metadata=SessionMetadata(
                 session_id=SessionId(uuid.uuid4()),
                 session_type=SessionTypes.INTERACTIVE,
-                scaling_group="default",
+                resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
                 cluster_mode=ClusterMode.SINGLE_NODE,
             ),
             kernel_requirements={},
@@ -210,7 +211,7 @@ class TestSelectorIntegration:
             session_metadata=SessionMetadata(
                 session_id=SessionId(uuid.uuid4()),
                 session_type=SessionTypes.INFERENCE,
-                scaling_group="default",
+                resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
                 cluster_mode=ClusterMode.SINGLE_NODE,
             ),
             kernel_requirements={},

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_assign_container_user_mapping_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_assign_container_user_mapping_rule.py
@@ -9,7 +9,7 @@ from ai.backend.manager.data.session.creation import (
 )
 from ai.backend.manager.data.session.draft import (
     KernelSpecDraft,
-    SessionSpecDraft,
+    SessionResourceSpecDraft,
 )
 from ai.backend.manager.data.session.options import DefaultSessionOptions
 from ai.backend.manager.sokovan.scheduling_controller.preparers.assign_container_user_mapping_rule import (
@@ -38,14 +38,14 @@ class TestAssignContainerUserMappingRule:
     async def test_noop_when_context_info_absent(
         self, rule: AssignContainerUserMappingRule
     ) -> None:
-        draft = SessionSpecDraft(kernel_specs=(KernelSpecDraft(cluster_role="main"),))
+        draft = SessionResourceSpecDraft(kernel_specs=(KernelSpecDraft(cluster_role="main"),))
         result = await rule.prepare(draft, _context(None))
         assert result is draft
 
     async def test_fills_unset_fields_from_context(
         self, rule: AssignContainerUserMappingRule
     ) -> None:
-        draft = SessionSpecDraft(
+        draft = SessionResourceSpecDraft(
             kernel_specs=(
                 KernelSpecDraft(cluster_role="main"),
                 KernelSpecDraft(cluster_role="worker"),
@@ -60,7 +60,7 @@ class TestAssignContainerUserMappingRule:
             assert kernel.supplementary_gids == (200, 300)
 
     async def test_preserves_caller_set_values(self, rule: AssignContainerUserMappingRule) -> None:
-        draft = SessionSpecDraft(
+        draft = SessionResourceSpecDraft(
             kernel_specs=(
                 KernelSpecDraft(
                     cluster_role="main",
@@ -80,7 +80,7 @@ class TestAssignContainerUserMappingRule:
 
     async def test_fills_partial_draft(self, rule: AssignContainerUserMappingRule) -> None:
         """A kernel with only ``uid`` set still picks up ``main_gid`` from the context."""
-        draft = SessionSpecDraft(
+        draft = SessionResourceSpecDraft(
             kernel_specs=(KernelSpecDraft(cluster_role="main", uid=2000),),
         )
         info = ContainerUserInfo(uid=1000, main_gid=100, supplementary_gids=[])

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_assign_network_config_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_assign_network_config_rule.py
@@ -19,7 +19,7 @@ from ai.backend.manager.data.session.creation import (
 )
 from ai.backend.manager.data.session.draft import (
     SessionNetworkDraft,
-    SessionSpecDraft,
+    SessionResourceSpecDraft,
 )
 from ai.backend.manager.data.session.options import DefaultSessionOptions
 from ai.backend.manager.models.network import NetworkType
@@ -50,7 +50,7 @@ def _context(
 class TestAssignNetworkConfigRule:
     async def test_persistent_when_network_id_set(self, rule: AssignNetworkConfigRule) -> None:
         """A caller-supplied ``network_id`` resolves to PERSISTENT."""
-        draft = SessionSpecDraft(
+        draft = SessionResourceSpecDraft(
             network=SessionNetworkDraft(network_id="net-123"),
         )
         result = await rule.prepare(draft, _context(use_host_network=True))
@@ -63,7 +63,7 @@ class TestAssignNetworkConfigRule:
         self, rule: AssignNetworkConfigRule
     ) -> None:
         """An empty network + RG host_network flag selects HOST."""
-        draft = SessionSpecDraft()
+        draft = SessionResourceSpecDraft()
         result = await rule.prepare(draft, _context(use_host_network=True))
         assert result.network.network_type == NetworkType.HOST
         assert result.network.use_host_network is True
@@ -71,7 +71,7 @@ class TestAssignNetworkConfigRule:
 
     async def test_volatile_default(self, rule: AssignNetworkConfigRule) -> None:
         """No network id and no host flag falls back to VOLATILE."""
-        draft = SessionSpecDraft()
+        draft = SessionResourceSpecDraft()
         result = await rule.prepare(draft, _context(use_host_network=False))
         assert result.network.network_type == NetworkType.VOLATILE
         assert result.network.use_host_network is False
@@ -81,7 +81,7 @@ class TestAssignNetworkConfigRule:
         self, rule: AssignNetworkConfigRule
     ) -> None:
         """An already-set ``network_type`` short-circuits the rule."""
-        draft = SessionSpecDraft(
+        draft = SessionResourceSpecDraft(
             network=SessionNetworkDraft(
                 network_type=NetworkType.VOLATILE,
                 network_id="leftover-id",  # intentionally inconsistent
@@ -96,6 +96,6 @@ class TestAssignNetworkConfigRule:
         self, rule: AssignNetworkConfigRule
     ) -> None:
         """No scaling-group info in the context still yields VOLATILE."""
-        draft = SessionSpecDraft()
+        draft = SessionResourceSpecDraft()
         result = await rule.prepare(draft, _context(scaling_group=False))
         assert result.network.network_type == NetworkType.VOLATILE

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_assign_user_identity_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_assign_user_identity_rule.py
@@ -10,7 +10,7 @@ from ai.backend.common.contexts.user import with_user
 from ai.backend.common.data.user.types import UserData, UserRole
 from ai.backend.manager.data.session.draft import (
     SessionIdentityDraft,
-    SessionSpecDraft,
+    SessionResourceSpecDraft,
 )
 from ai.backend.manager.data.session.options import DefaultSessionOptions
 from ai.backend.manager.sokovan.scheduling_controller.preparers.assign_user_identity_rule import (
@@ -52,7 +52,7 @@ class TestAssignUserIdentityRule:
     ) -> None:
         creator = uuid.uuid4()
         with with_user(_user(creator)):
-            result = await rule.prepare(SessionSpecDraft(), context)
+            result = await rule.prepare(SessionResourceSpecDraft(), context)
         assert result.identity.user_uuid == creator
 
     async def test_preserves_caller_user_uuid(
@@ -62,7 +62,7 @@ class TestAssignUserIdentityRule:
     ) -> None:
         """Defensive: if the draft already has user_uuid, the rule is a no-op."""
         prefilled = uuid.uuid4()
-        draft = SessionSpecDraft(
+        draft = SessionResourceSpecDraft(
             identity=SessionIdentityDraft(user_uuid=prefilled),
         )
         with with_user(_user(uuid.uuid4())):
@@ -75,5 +75,5 @@ class TestAssignUserIdentityRule:
         context: SessionSpecPreparationContext,
     ) -> None:
         # No with_user block — ambient ctx is empty.
-        result = await rule.prepare(SessionSpecDraft(), context)
+        result = await rule.prepare(SessionResourceSpecDraft(), context)
         assert result.identity.user_uuid is None

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_build_internal_data_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_build_internal_data_rule.py
@@ -24,7 +24,7 @@ from ai.backend.manager.data.dotfile.types import (
 )
 from ai.backend.manager.data.session.draft import (
     KernelSpecDraft,
-    SessionSpecDraft,
+    SessionResourceSpecDraft,
 )
 from ai.backend.manager.data.session.options import (
     DefaultSessionOptions,
@@ -55,8 +55,8 @@ def _draft(
     sudo_session_enabled: bool = False,
     model_definition_path: str | None = None,
     model_definition: Mapping[str, Any] | None = None,
-) -> SessionSpecDraft:
-    return SessionSpecDraft(
+) -> SessionResourceSpecDraft:
+    return SessionResourceSpecDraft(
         kernel_specs=kernels,
         internal_data_extras=InternalDataExtras(
             sudo_session_enabled=sudo_session_enabled,

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_compute_kernel_resources_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_compute_kernel_resources_rule.py
@@ -25,7 +25,7 @@ from ai.backend.manager.data.session.draft import (
     KernelGroupDraft,
     KernelResourceInput,
     SessionOptionsDraft,
-    SessionSpecDraft,
+    SessionResourceSpecDraft,
 )
 from ai.backend.manager.data.session.options import DefaultSessionOptions, ResourceOpts
 from ai.backend.manager.sokovan.scheduling_controller.preparers.compute_kernel_resources_rule import (
@@ -70,8 +70,8 @@ def _context(
     )
 
 
-def _draft(group: KernelGroupDraft) -> SessionSpecDraft:
-    return SessionSpecDraft(options=SessionOptionsDraft(kernel_groups=(group,)))
+def _draft(group: KernelGroupDraft) -> SessionResourceSpecDraft:
+    return SessionResourceSpecDraft(options=SessionOptionsDraft(kernel_groups=(group,)))
 
 
 class TestComputeKernelResourcesRule:
@@ -244,6 +244,6 @@ class TestComputeKernelResourcesRule:
 
     async def test_noop_when_kernel_groups_unset(self, rule: ComputeKernelResourcesRule) -> None:
         """With no ``kernel_groups``, the draft is returned unchanged."""
-        draft = SessionSpecDraft()
+        draft = SessionResourceSpecDraft()
         result = await rule.prepare(draft, _context({}))
         assert result is draft

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_expand_kernel_groups_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_expand_kernel_groups_rule.py
@@ -20,7 +20,7 @@ from ai.backend.manager.data.session.draft import (
     KernelGroupDraft,
     KernelResourceInput,
     SessionOptionsDraft,
-    SessionSpecDraft,
+    SessionResourceSpecDraft,
 )
 from ai.backend.manager.data.session.options import DefaultSessionOptions
 from ai.backend.manager.sokovan.scheduling_controller.preparers.draft_rule import (
@@ -62,8 +62,8 @@ def _make_group(
     )
 
 
-def _draft_with_groups(groups: tuple[KernelGroupDraft, ...]) -> SessionSpecDraft:
-    return SessionSpecDraft(options=SessionOptionsDraft(kernel_groups=groups))
+def _draft_with_groups(groups: tuple[KernelGroupDraft, ...]) -> SessionResourceSpecDraft:
+    return SessionResourceSpecDraft(options=SessionOptionsDraft(kernel_groups=groups))
 
 
 class TestExpandKernelGroupsRule:
@@ -73,7 +73,7 @@ class TestExpandKernelGroupsRule:
         context: SessionSpecPreparationContext,
     ) -> None:
         """With no kernel_groups on the draft, kernel_specs stays empty."""
-        draft = SessionSpecDraft()
+        draft = SessionResourceSpecDraft()
         result = await rule.prepare(draft, context)
         assert result.kernel_specs == ()
 

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_inject_session_environ_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_inject_session_environ_rule.py
@@ -7,7 +7,7 @@ import pytest
 from ai.backend.manager.data.session.draft import (
     KernelExecutionSpecDraft,
     KernelSpecDraft,
-    SessionSpecDraft,
+    SessionResourceSpecDraft,
 )
 from ai.backend.manager.data.session.options import (
     DefaultSessionOptions,
@@ -32,8 +32,10 @@ def _context() -> SessionSpecPreparationContext:
     )
 
 
-def _draft_with_sudo(*, sudo: bool, kernel_specs: tuple[KernelSpecDraft, ...]) -> SessionSpecDraft:
-    return SessionSpecDraft(
+def _draft_with_sudo(
+    *, sudo: bool, kernel_specs: tuple[KernelSpecDraft, ...]
+) -> SessionResourceSpecDraft:
+    return SessionResourceSpecDraft(
         kernel_specs=kernel_specs,
         internal_data_extras=InternalDataExtras(sudo_session_enabled=sudo),
     )

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_merge_resource_group_defaults_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_merge_resource_group_defaults_rule.py
@@ -26,7 +26,7 @@ from ai.backend.manager.data.session.draft import (
     KernelResourceInput,
     SchedulingTargetDraft,
     SessionOptionsDraft,
-    SessionSpecDraft,
+    SessionResourceSpecDraft,
 )
 from ai.backend.manager.data.session.options import (
     AgentSelectionPolicy,
@@ -92,7 +92,7 @@ class TestMergeResourceGroupDefaultsRule:
         rg_defaults: DefaultSessionOptions,
     ) -> None:
         """Unset option-level fields absorb every RG default."""
-        result = await rule.prepare(SessionSpecDraft(), _context(rg_defaults))
+        result = await rule.prepare(SessionResourceSpecDraft(), _context(rg_defaults))
         opts = result.options
         assert opts.priority == 42
         assert opts.is_preemptible is False
@@ -109,7 +109,7 @@ class TestMergeResourceGroupDefaultsRule:
         rg_defaults: DefaultSessionOptions,
     ) -> None:
         """Caller-set option-level fields survive the overlay."""
-        draft = SessionSpecDraft(
+        draft = SessionResourceSpecDraft(
             options=SessionOptionsDraft(
                 priority=99,
                 cluster_mode=ClusterMode.SINGLE_NODE,
@@ -133,7 +133,7 @@ class TestMergeResourceGroupDefaultsRule:
         rg_image_id: ImageID,
     ) -> None:
         """A group without an execution_spec inherits every RG baseline field."""
-        draft = SessionSpecDraft(
+        draft = SessionResourceSpecDraft(
             options=SessionOptionsDraft(
                 kernel_groups=(KernelGroupDraft(role="main", replica_count=1),),
             ),
@@ -159,7 +159,7 @@ class TestMergeResourceGroupDefaultsRule:
     ) -> None:
         """Caller-set execution_spec fields win over the RG baseline."""
         caller_image = ImageID(uuid.uuid4())
-        draft = SessionSpecDraft(
+        draft = SessionResourceSpecDraft(
             options=SessionOptionsDraft(
                 kernel_groups=(
                     KernelGroupDraft(
@@ -192,7 +192,7 @@ class TestMergeResourceGroupDefaultsRule:
     ) -> None:
         """With no RG default_kernel_execution_spec, only option-level fill happens."""
         rg = DefaultSessionOptions(priority=7)
-        draft = SessionSpecDraft(
+        draft = SessionResourceSpecDraft(
             options=SessionOptionsDraft(
                 kernel_groups=(KernelGroupDraft(role="main", replica_count=1),),
             ),

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_resolve_vfolder_mounts_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_resolve_vfolder_mounts_rule.py
@@ -11,7 +11,7 @@ from ai.backend.common.types import (
     VFolderMount,
     VFolderUsageMode,
 )
-from ai.backend.manager.data.session.draft import KernelSpecDraft, SessionSpecDraft
+from ai.backend.manager.data.session.draft import KernelSpecDraft, SessionResourceSpecDraft
 from ai.backend.manager.data.session.options import DefaultSessionOptions
 from ai.backend.manager.sokovan.scheduling_controller.preparers.draft_rule import (
     SessionSpecPreparationContext,
@@ -45,7 +45,7 @@ def _context(
 class TestResolveVFolderMountsRule:
     async def test_noop_when_context_empty(self) -> None:
         rule = ResolveVFolderMountsRule()
-        draft = SessionSpecDraft(kernel_specs=(KernelSpecDraft(cluster_role="main"),))
+        draft = SessionResourceSpecDraft(kernel_specs=(KernelSpecDraft(cluster_role="main"),))
         result = await rule.prepare(draft, _context())
         assert result is draft
         assert result.kernel_specs[0].vfolder_mounts == ()
@@ -53,7 +53,7 @@ class TestResolveVFolderMountsRule:
     async def test_stamps_per_role_mounts_onto_matching_kernels(self) -> None:
         rule = ResolveVFolderMountsRule()
         mount = _mount("data")
-        draft = SessionSpecDraft(
+        draft = SessionResourceSpecDraft(
             kernel_specs=(
                 KernelSpecDraft(cluster_role="main"),
                 KernelSpecDraft(cluster_role="worker"),

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_session_spec_preparer.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_session_spec_preparer.py
@@ -22,10 +22,7 @@ from typing import override
 
 import pytest
 
-from ai.backend.common.identifier.domain import DomainID, DomainName
 from ai.backend.common.identifier.image import ImageID
-from ai.backend.common.identifier.project import ProjectID
-from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
 from ai.backend.common.identifier.session import SessionID
 from ai.backend.common.types import AccessKey, ClusterMode, ResourceSlotEntry, SessionTypes
 from ai.backend.manager.data.session.draft import (
@@ -37,8 +34,7 @@ from ai.backend.manager.data.session.draft import (
     SessionIdentityDraft,
     SessionNetworkDraft,
     SessionOptionsDraft,
-    SessionScopeDraft,
-    SessionSpecDraft,
+    SessionResourceSpecDraft,
 )
 from ai.backend.manager.data.session.options import (
     DefaultSessionOptions,
@@ -65,7 +61,7 @@ class _TransformRule(SessionSpecDraftRule):
         self,
         tag: str,
         log: list[str],
-        transform: Callable[[SessionSpecDraft], SessionSpecDraft],
+        transform: Callable[[SessionResourceSpecDraft], SessionResourceSpecDraft],
     ) -> None:
         self._tag = tag
         self._log = log
@@ -78,9 +74,9 @@ class _TransformRule(SessionSpecDraftRule):
     @override
     async def prepare(
         self,
-        draft: SessionSpecDraft,
+        draft: SessionResourceSpecDraft,
         context: SessionSpecPreparationContext,
-    ) -> SessionSpecDraft:
+    ) -> SessionResourceSpecDraft:
         self._log.append(self._tag)
         return self._transform(draft)
 
@@ -112,22 +108,17 @@ def minimal_kernel_group(image_id: ImageID) -> KernelGroupDraft:
 
 
 @pytest.fixture
-def complete_draft(image_id: ImageID, minimal_kernel_group: KernelGroupDraft) -> SessionSpecDraft:
+def complete_draft(
+    image_id: ImageID, minimal_kernel_group: KernelGroupDraft
+) -> SessionResourceSpecDraft:
     """A finalize-ready draft for tests that only care about the happy path."""
-    return SessionSpecDraft(
+    return SessionResourceSpecDraft(
         identity=SessionIdentityDraft(
             session_id=SessionID(uuid.uuid4()),
             creation_id="test-creation-id",
             session_name="test-session",
             access_key=AccessKey("AKIAIOSFODNN7EXAMPLE"),
             user_uuid=uuid.uuid4(),
-        ),
-        scope=SessionScopeDraft(
-            domain_id=DomainID(uuid.uuid4()),
-            domain_name=DomainName("default"),
-            project_id=ProjectID(uuid.uuid4()),
-            resource_group_id=ResourceGroupID(uuid.uuid4()),
-            resource_group_name=ResourceGroupName("default"),
         ),
         classification=SessionClassificationDraft(
             session_type=SessionTypes.INTERACTIVE,
@@ -166,7 +157,7 @@ class TestRuleChain:
     async def test_empty_rule_chain_just_finalizes(
         self,
         context: SessionSpecPreparationContext,
-        complete_draft: SessionSpecDraft,
+        complete_draft: SessionResourceSpecDraft,
     ) -> None:
         """With no rules, the input draft must already be finalize-ready."""
         preparer = SessionSpecPreparer([])
@@ -176,7 +167,7 @@ class TestRuleChain:
     async def test_runs_rules_in_declaration_order(
         self,
         context: SessionSpecPreparationContext,
-        complete_draft: SessionSpecDraft,
+        complete_draft: SessionResourceSpecDraft,
     ) -> None:
         """Rules execute in the order they are passed to the constructor."""
         log: list[str] = []
@@ -195,12 +186,12 @@ class TestRuleChain:
         """Each rule sees the draft emitted by the previous rule."""
         log: list[str] = []
 
-        def set_priority(d: SessionSpecDraft) -> SessionSpecDraft:
+        def set_priority(d: SessionResourceSpecDraft) -> SessionResourceSpecDraft:
             return d.model_copy(update={"options": d.options.model_copy(update={"priority": 7})})
 
         captured: dict[str, int | None] = {}
 
-        def capture_priority(d: SessionSpecDraft) -> SessionSpecDraft:
+        def capture_priority(d: SessionResourceSpecDraft) -> SessionResourceSpecDraft:
             captured["priority"] = d.options.priority
             return d
 
@@ -211,7 +202,7 @@ class TestRuleChain:
         with pytest.raises(IncompleteSessionSpec):
             # Draft stays incomplete (identity / scope / etc. still
             # unset), but the rule chain runs to completion first.
-            await preparer.prepare(SessionSpecDraft(), context)
+            await preparer.prepare(SessionResourceSpecDraft(), context)
 
         assert captured["priority"] == 7
         assert log == ["set", "capture"]
@@ -219,7 +210,7 @@ class TestRuleChain:
     async def test_end_to_end_with_real_rule(
         self,
         context: SessionSpecPreparationContext,
-        complete_draft: SessionSpecDraft,
+        complete_draft: SessionResourceSpecDraft,
     ) -> None:
         """``MergeResourceGroupDefaultsRule`` wired through the runner fills
         unset options and produces a valid ``SessionSpec``."""
@@ -246,7 +237,7 @@ class TestFinalization:
     ) -> None:
         """An empty draft surfaces every required-spec field as a missing path."""
         with pytest.raises(IncompleteSessionSpec) as exc_info:
-            await preparer.prepare(SessionSpecDraft(), context)
+            await preparer.prepare(SessionResourceSpecDraft(), context)
         extra_data = exc_info.value.extra_data
         assert extra_data is not None
         missing: list[str] = extra_data["missing"]
@@ -256,9 +247,6 @@ class TestFinalization:
         assert "identity.session_name" in missing
         assert "identity.access_key" in missing
         assert "identity.user_uuid" in missing
-        assert "scope.domain_name" in missing
-        assert "scope.project_id" in missing
-        assert "scope.resource_group_name" in missing
         assert "classification.session_type" in missing
         assert "network.network_type" in missing
         assert "options.priority" in missing
@@ -272,15 +260,13 @@ class TestFinalization:
         self,
         preparer: SessionSpecPreparer,
         context: SessionSpecPreparationContext,
-        complete_draft: SessionSpecDraft,
+        complete_draft: SessionResourceSpecDraft,
     ) -> None:
         """A fully populated draft projects cleanly into a SessionSpec."""
         spec = await preparer.prepare(complete_draft, context)
 
         assert spec.identity.session_name == "test-session"
         assert spec.identity.access_key == AccessKey("AKIAIOSFODNN7EXAMPLE")
-        assert spec.scope.domain_name == DomainName("default")
-        assert spec.scope.resource_group_name == ResourceGroupName("default")
         assert spec.classification.session_type == SessionTypes.INTERACTIVE
         assert spec.options.priority == 10
         assert spec.options.cluster_mode == ClusterMode.SINGLE_NODE
@@ -296,7 +282,7 @@ class TestFinalization:
         self,
         preparer: SessionSpecPreparer,
         context: SessionSpecPreparationContext,
-        complete_draft: SessionSpecDraft,
+        complete_draft: SessionResourceSpecDraft,
     ) -> None:
         """Optional spec fields not set on the draft land as None on the spec."""
         spec = await preparer.prepare(complete_draft, context)
@@ -313,7 +299,7 @@ class TestFinalization:
         context: SessionSpecPreparationContext,
     ) -> None:
         """Only genuinely unset fields surface; set fields stay off the list."""
-        draft = SessionSpecDraft(
+        draft = SessionResourceSpecDraft(
             identity=SessionIdentityDraft(
                 session_id=SessionID(uuid.uuid4()),
                 # session_name intentionally unset
@@ -333,7 +319,7 @@ class TestFinalization:
         self,
         preparer: SessionSpecPreparer,
         context: SessionSpecPreparationContext,
-        complete_draft: SessionSpecDraft,
+        complete_draft: SessionResourceSpecDraft,
         image_id: ImageID,
     ) -> None:
         """Missing fields inside a ``kernel_specs`` entry report with index."""
@@ -361,7 +347,7 @@ class TestFinalization:
         self,
         preparer: SessionSpecPreparer,
         context: SessionSpecPreparationContext,
-        complete_draft: SessionSpecDraft,
+        complete_draft: SessionResourceSpecDraft,
     ) -> None:
         """Missing fields inside an ``execution_spec`` sub-draft report the full path."""
         broken_kernel = KernelSpecDraft(

--- a/tests/unit/manager/sokovan/scheduling_controller/test_enqueue_session_from_draft.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/test_enqueue_session_from_draft.py
@@ -69,6 +69,7 @@ from ai.backend.manager.data.session.draft import (
     SessionIdentityDraft,
     SessionNetworkDraft,
     SessionOptionsDraft,
+    SessionResourceSpecDraft,
     SessionScopeDraft,
     SessionSpecDraft,
 )
@@ -98,12 +99,6 @@ def image_id() -> ImageID:
 def draft(image_id: ImageID) -> SessionSpecDraft:
     """A minimal but valid draft that satisfies every preparer rule."""
     return SessionSpecDraft(
-        identity=SessionIdentityDraft(
-            session_id=SessionID(uuid.uuid4()),
-            creation_id="ci-1",
-            session_name="module-test-session",
-            access_key=AccessKey("AKIAIOSFODNN7EXAMPLE"),
-        ),
         scope=SessionScopeDraft(
             domain_id=DomainID(uuid.uuid4()),
             domain_name=DomainName("default"),
@@ -111,43 +106,55 @@ def draft(image_id: ImageID) -> SessionSpecDraft:
             resource_group_id=ResourceGroupID(uuid.uuid4()),
             resource_group_name=ResourceGroupName("default"),
         ),
-        classification=SessionClassificationDraft(session_type=SessionTypes.INTERACTIVE),
-        network=SessionNetworkDraft(),
-        options=SessionOptionsDraft(
-            priority=10,
-            is_preemptible=True,
-            cluster_mode=ClusterMode.SINGLE_NODE,
-            cluster_size=1,
-            scheduling_target=SchedulingTargetDraft(),
-            kernel_groups=(
-                KernelGroupDraft(
-                    role="main",
-                    replica_count=1,
-                    execution_spec=KernelExecutionSpecDraft(
-                        resource_input=KernelResourceInput(
-                            image_id=image_id,
-                            resources=(
-                                ResourceSlotEntry(resource_type="cpu", quantity=str(Decimal(2))),
-                                ResourceSlotEntry(
-                                    resource_type="mem",
-                                    quantity=str(Decimal(2 * 1024 * 1024 * 1024)),
+        resource_spec=SessionResourceSpecDraft(
+            identity=SessionIdentityDraft(
+                session_id=SessionID(uuid.uuid4()),
+                creation_id="ci-1",
+                session_name="module-test-session",
+                access_key=AccessKey("AKIAIOSFODNN7EXAMPLE"),
+            ),
+            classification=SessionClassificationDraft(session_type=SessionTypes.INTERACTIVE),
+            network=SessionNetworkDraft(),
+            options=SessionOptionsDraft(
+                priority=10,
+                is_preemptible=True,
+                cluster_mode=ClusterMode.SINGLE_NODE,
+                cluster_size=1,
+                scheduling_target=SchedulingTargetDraft(),
+                kernel_groups=(
+                    KernelGroupDraft(
+                        role="main",
+                        replica_count=1,
+                        execution_spec=KernelExecutionSpecDraft(
+                            resource_input=KernelResourceInput(
+                                image_id=image_id,
+                                resources=(
+                                    ResourceSlotEntry(
+                                        resource_type="cpu", quantity=str(Decimal(2))
+                                    ),
+                                    ResourceSlotEntry(
+                                        resource_type="mem",
+                                        quantity=str(Decimal(2 * 1024 * 1024 * 1024)),
+                                    ),
                                 ),
+                                resource_opts=ResourceOpts(),
                             ),
-                            resource_opts=ResourceOpts(),
-                        ),
-                        mounts=(
-                            MountInfoEntry(
-                                vfolder_id=VFolderUUID(
-                                    VFolderID(quota_scope_id=None, folder_id=uuid.uuid4()).folder_id
+                            mounts=(
+                                MountInfoEntry(
+                                    vfolder_id=VFolderUUID(
+                                        VFolderID(
+                                            quota_scope_id=None, folder_id=uuid.uuid4()
+                                        ).folder_id
+                                    ),
+                                    mount_destination="/home/work/data",
+                                    mount_perm=MountPermission.READ_WRITE,
                                 ),
-                                mount_destination="/home/work/data",
-                                mount_perm=MountPermission.READ_WRITE,
                             ),
                         ),
                     ),
                 ),
+                handler_options=SessionHandlerOptions(),
             ),
-            handler_options=SessionHandlerOptions(),
         ),
     )
 
@@ -310,11 +317,17 @@ class TestEnqueueSessionFromDraft:
         repository.enqueue_session_from_spec.assert_awaited_once()
         enqueued_spec = repository.enqueue_session_from_spec.await_args.args[0]
         assert isinstance(enqueued_spec, SessionSpec)
-        assert enqueued_spec.identity.session_id == draft.identity.session_id
-        assert enqueued_spec.identity.session_name == draft.identity.session_name
-        assert enqueued_spec.options.cluster_size == 1
-        assert len(enqueued_spec.kernel_specs) == 1
-        kernel = enqueued_spec.kernel_specs[0]
+        assert (
+            enqueued_spec.resource_spec.identity.session_id
+            == draft.resource_spec.identity.session_id
+        )
+        assert (
+            enqueued_spec.resource_spec.identity.session_name
+            == draft.resource_spec.identity.session_name
+        )
+        assert enqueued_spec.resource_spec.options.cluster_size == 1
+        assert len(enqueued_spec.resource_spec.kernel_specs) == 1
+        kernel = enqueued_spec.resource_spec.kernel_specs[0]
         assert kernel.cluster_role == "main"
         assert kernel.execution_spec.resource_input.image_id == image_id
         # vfolder mounts flowed through context → resolved on the kernel spec
@@ -377,7 +390,7 @@ class TestEnqueueSessionFromDraft:
             await controller.enqueue_session_from_draft(draft)
 
         enqueued_spec = repository.enqueue_session_from_spec.await_args.args[0]
-        assert enqueued_spec.network.network_type == NetworkType.VOLATILE
+        assert enqueued_spec.resource_spec.network.network_type == NetworkType.VOLATILE
 
 
 class TestResourceGroupAccessibility:
@@ -423,5 +436,5 @@ class TestResourceGroupAccessibility:
         repository.query_accessible_resource_group_ids.assert_awaited_once()
         assert (
             repository.query_accessible_resource_group_ids.await_args.kwargs["access_key"]
-            == draft.identity.access_key
+            == draft.resource_spec.identity.access_key
         )

--- a/tests/unit/manager/sokovan/scheduling_controller/validators/test_session_spec_rules.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/validators/test_session_spec_rules.py
@@ -46,6 +46,7 @@ from ai.backend.manager.data.session.spec import (
     SessionClassification,
     SessionIdentity,
     SessionNetwork,
+    SessionResourceSpec,
     SessionScope,
     SessionSpec,
 )
@@ -143,12 +144,26 @@ def _spec(
         kernel.model_copy(update={"vfolder_mounts": vfolder_mounts}) for kernel in kernel_specs
     )
     return SessionSpec(
-        identity=SessionIdentity(
-            session_id=SessionID(uuid.uuid4()),
-            creation_id="c-1",
-            session_name="s",
-            access_key=AccessKey("AK"),
-            user_uuid=uuid.uuid4(),
+        resource_spec=SessionResourceSpec(
+            identity=SessionIdentity(
+                session_id=SessionID(uuid.uuid4()),
+                creation_id="c-1",
+                session_name="s",
+                access_key=AccessKey("AK"),
+                user_uuid=uuid.uuid4(),
+            ),
+            classification=SessionClassification(session_type=session_type),
+            network=SessionNetwork(network_type=NetworkType.VOLATILE),
+            options=SessionOptions(
+                priority=10,
+                is_preemptible=True,
+                cluster_mode=ClusterMode.SINGLE_NODE,
+                cluster_size=len(kernel_specs),
+                scheduling_target=SchedulingTarget(),
+                kernel_groups=[],
+                handler_options=SessionHandlerOptions(),
+            ),
+            kernel_specs=decorated_kernel_specs,
         ),
         scope=SessionScope(
             domain_id=DomainID(uuid.uuid4()),
@@ -157,18 +172,6 @@ def _spec(
             resource_group_id=ResourceGroupID(uuid.uuid4()),
             resource_group_name=ResourceGroupName("default"),
         ),
-        classification=SessionClassification(session_type=session_type),
-        network=SessionNetwork(network_type=NetworkType.VOLATILE),
-        options=SessionOptions(
-            priority=10,
-            is_preemptible=True,
-            cluster_mode=ClusterMode.SINGLE_NODE,
-            cluster_size=len(kernel_specs),
-            scheduling_target=SchedulingTarget(),
-            kernel_groups=[],
-            handler_options=SessionHandlerOptions(),
-        ),
-        kernel_specs=decorated_kernel_specs,
     )
 
 


### PR DESCRIPTION
## Summary
- Introduce `SessionResourceSpec` / `SessionResourceSpecDraft` (`SessionSpec` / `SessionSpecDraft` minus scope) as the scope-free type the preparer chain and all 9 rules operate on and finalize into. No preparer rule ever reads or writes ownership scope, yet the finalized `SessionSpec` required it — forcing every caller to supply a complete `domain`/`project`/`resource-group` scope even when irrelevant.
- `SessionSpec` is now composed from a `SessionResourceSpec` + a resolved `SessionScope` via `SessionSpec.from_resource_spec()`. The enqueue path attaches scope after finalize (via `SessionSpecDraft.to_resource_draft()` → prepare → compose), preserving its behavior and scope validation.
- The compute-schedule (dry-run) path consumes `SessionResourceSpec` directly and passes the resource group id explicitly, so it no longer fails finalize purely because `domain`/`project` are unset.
- Replace `SessionMetadata.scaling_group` (name) with `resource_group_id: ResourceGroupID`, and make `NoAgentsInResourceGroupError` carry a `ResourceGroupID`.

## Test plan
- [x] `pants fmt / fix / lint / check` pass (source + tests)
- [x] `pants test` on the affected sokovan suites passes (enforced by the pre-push hook)
- [x] Preparer-rule, preparer-finalize, and selector message-format unit tests updated for the scope-free type and `resource_group_id`

Resolves BA-6880