### PR TITLE
feat(BA-6886): register APP_CONFIG_FRAGMENT as an RBAC resource type

### DIFF
--- a/changes/12856.feature.md
+++ b/changes/12856.feature.md
@@ -1,0 +1,1 @@
+Register `APP_CONFIG_FRAGMENT` as an RBAC resource type and backfill its write permissions onto existing write-capable roles, so app config fragment writes can be authorized by RBAC (BEP-1052).

--- a/src/ai/backend/common/data/permission/types.py
+++ b/src/ai/backend/common/data/permission/types.py
@@ -269,6 +269,7 @@ class EntityType(enum.StrEnum):
             cls.SESSION,
             cls.ARTIFACT,
             cls.ARTIFACT_REGISTRY,
+            cls.APP_CONFIG_FRAGMENT,
             cls.NOTIFICATION_CHANNEL,
             cls.NOTIFICATION_RULE,
             cls.MODEL_DEPLOYMENT,

--- a/src/ai/backend/manager/models/alembic/versions/b3d9f7a2c184_add_app_config_fragment_permissions_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/b3d9f7a2c184_add_app_config_fragment_permissions_to_rbac.py
@@ -34,21 +34,38 @@ depends_on = None
 
 def upgrade() -> None:
     # Backfill only ``user``/``domain`` scopes (``public`` is superadmin-only, no role) and only
-    # the write path (reads use the allow list, not RBAC); member roles (suffix ``member``) do not
-    # write fragments and are excluded. ``permission`` is the NOT NULL bitmask from c6648c039bd4:
-    # bits are inlined as literals so this migration stays frozen against later Permission enum
-    # changes, and grant operations have no bit (0).
+    # the write path (reads use the allow list, not RBAC). ``permission`` is the NOT NULL bitmask
+    # from c6648c039bd4: bits are inlined as literals so this migration stays frozen against later
+    # Permission enum changes, and grant operations have no bit (0).
+    #
+    # Sibling backfills (f1a2b3c4d5e6, 30c8308738ee, ...) select owner roles negatively, via
+    # ``NOT (role_name LIKE '%member')``. That is unsafe here: role names carry no enforced
+    # convention (``CreateRoleInput.name`` is a free string and the caller picks the scope), so a
+    # custom read-only ``domain``-scoped role matches and would receive fragment ``hard-delete``
+    # and ``grant:all`` over the whole domain. Select admins positively instead — by the
+    # capability each domain admin role provably holds rather than by the shape of its name:
+    #
+    # * ``domain`` — the role must hold ``domain_admin_page`` at that same domain. Every domain
+    #   admin role holds it under both naming schemes by the time this runs: 3b6297b1bd75 covers
+    #   ``role_domain_%_admin``, f2b9a4c7e103/a3c1d8e5b294 cover ``domain-%-admin``, and all three
+    #   are ancestors of this revision. ``domain_admin_page`` is absent from the frozen enum, so
+    #   it is inlined as a literal, as those three migrations do.
+    # * ``user`` — kept broad. A user-scope grant only ever reaches that user's own scope, and
+    #   writing an own-scope fragment is deliberately not admin-only (see
+    #   ``AppConfigScopeType.to_rbac_scope_type``).
+    #
+    # ``role_superadmin`` holds domain-scoped rows but no ``domain_admin_page``, so it drops out.
+    # That is correct and matches 3b6297b1bd75: superadmin authority comes from the
+    # ``user.is_superadmin`` short-circuit in the RBAC validators, never from these rows.
     db_conn = op.get_bind()
     db_conn.execute(
         sa.text("""
             WITH role_scopes AS (
                 SELECT DISTINCT
                     p.role_id,
-                    r.name AS role_name,
                     p.scope_type,
                     p.scope_id
                 FROM permissions p
-                JOIN roles r ON p.role_id = r.id
                 WHERE p.scope_type IN ('user', 'domain')
             ),
             role_operations AS (
@@ -58,7 +75,15 @@ def upgrade() -> None:
                     rs.scope_id,
                     unnest(CAST(:owner_ops AS text[])) AS operation
                 FROM role_scopes rs
-                WHERE NOT (rs.role_name LIKE '%member')
+                WHERE rs.scope_type = 'user'
+                   OR EXISTS (
+                        SELECT 1
+                        FROM permissions admin_page
+                        WHERE admin_page.role_id = rs.role_id
+                          AND admin_page.entity_type = 'domain_admin_page'
+                          AND admin_page.scope_type = rs.scope_type
+                          AND admin_page.scope_id = rs.scope_id
+                   )
             )
             INSERT INTO permissions (
                 role_id, scope_type, scope_id, entity_type, operation, permission
@@ -88,8 +113,11 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    db_conn = op.get_bind()
-    db_conn.execute(
-        sa.text("DELETE FROM permissions WHERE entity_type = :entity_type"),
-        {"entity_type": EntityType.APP_CONFIG_FRAGMENT.value},
-    )
+    # No-op, following f2b9a4c7e103. Deleting by ``entity_type`` cannot distinguish the rows
+    # this backfill inserted from the ones granted natively at role creation: current code
+    # already writes APP_CONFIG_FRAGMENT permissions for every new role, because the entity
+    # type is part of ``_resource_types()``. A blanket DELETE would therefore strip permissions
+    # that roles created since this revision legitimately hold, and re-running ``upgrade`` would
+    # not restore them for roles the backfill does not select. Leaving the rows in place is
+    # safe — every row this migration writes is one role creation would have granted anyway.
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/b3d9f7a2c184_add_app_config_fragment_permissions_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/b3d9f7a2c184_add_app_config_fragment_permissions_to_rbac.py
@@ -33,30 +33,17 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Backfill only ``user``/``domain`` scopes (``public`` is superadmin-only, no role) and only
-    # the write path (reads use the allow list, not RBAC). ``permission`` is the NOT NULL bitmask
-    # from c6648c039bd4: bits are inlined as literals so this migration stays frozen against later
-    # Permission enum changes, and grant operations have no bit (0).
+    # Only ``user``/``domain`` scopes (``public`` is superadmin-only, no role) and only the write
+    # path (reads use the allow list, not RBAC). Permission bits and ``domain_admin_page`` are
+    # inlined as literals to stay frozen against later enum changes; grants have no bit (0).
     #
-    # Sibling backfills (f1a2b3c4d5e6, 30c8308738ee, ...) select owner roles negatively, via
-    # ``NOT (role_name LIKE '%member')``. That is unsafe here: role names carry no enforced
-    # convention (``CreateRoleInput.name`` is a free string and the caller picks the scope), so a
-    # custom read-only ``domain``-scoped role matches and would receive fragment ``hard-delete``
-    # and ``grant:all`` over the whole domain. Select admins positively instead — by the
-    # capability each domain admin role provably holds rather than by the shape of its name:
-    #
-    # * ``domain`` — the role must hold ``domain_admin_page`` at that same domain. Every domain
-    #   admin role holds it under both naming schemes by the time this runs: 3b6297b1bd75 covers
-    #   ``role_domain_%_admin``, f2b9a4c7e103/a3c1d8e5b294 cover ``domain-%-admin``, and all three
-    #   are ancestors of this revision. ``domain_admin_page`` is absent from the frozen enum, so
-    #   it is inlined as a literal, as those three migrations do.
-    # * ``user`` — kept broad. A user-scope grant only ever reaches that user's own scope, and
-    #   writing an own-scope fragment is deliberately not admin-only (see
-    #   ``AppConfigScopeType.to_rbac_scope_type``).
-    #
-    # ``role_superadmin`` holds domain-scoped rows but no ``domain_admin_page``, so it drops out.
-    # That is correct and matches 3b6297b1bd75: superadmin authority comes from the
-    # ``user.is_superadmin`` short-circuit in the RBAC validators, never from these rows.
+    # Domain admins are selected positively, by the ``domain_admin_page`` capability at the same
+    # scope, not by the ``NOT (role_name LIKE '%member')`` filter sibling backfills use: role names
+    # carry no enforced convention, so that filter would hand a custom read-only domain role
+    # fragment ``hard-delete`` and ``grant:all``. ``user`` scope needs no such check — a user-scope
+    # grant only ever reaches that user's own scope. ``role_superadmin`` holds no
+    # ``domain_admin_page`` and drops out; its authority comes from the ``user.is_superadmin``
+    # short-circuit in the RBAC validators, not these rows.
     db_conn = op.get_bind()
     db_conn.execute(
         sa.text("""

--- a/src/ai/backend/manager/models/alembic/versions/b3d9f7a2c184_add_app_config_fragment_permissions_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/b3d9f7a2c184_add_app_config_fragment_permissions_to_rbac.py
@@ -1,0 +1,95 @@
+"""add_app_config_fragment_permissions_to_rbac
+
+Backfill ``APP_CONFIG_FRAGMENT`` permissions onto existing write-capable RBAC roles (a
+user's own ``user``-scope role and ``domain`` admins) so they can exercise fragment writes
+once RBAC enforcement is enabled (BEP-1052). New roles receive these permissions at role
+creation; this migration only covers roles that predate the new entity type.
+
+Only ``permissions`` rows are backfilled. The RBAC scope *associations*
+(``association_scopes_entities``, which bind a fragment to its owning scope) are NOT
+migrated: they are per-fragment and written at fragment-creation time, and this feature is
+still unreleased, so no fragments — and therefore no associations — exist yet.
+
+Revision ID: b3d9f7a2c184
+Revises: c4e1a9b73f52
+Create Date: 2026-07-14 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.rbac_models.migration.enums import (
+    EntityType,
+    OperationType,
+)
+
+# revision identifiers, used by Alembic.
+revision = "b3d9f7a2c184"
+down_revision = "c4e1a9b73f52"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Backfill only ``user``/``domain`` scopes (``public`` is superadmin-only, no role) and only
+    # the write path (reads use the allow list, not RBAC); member roles (suffix ``member``) do not
+    # write fragments and are excluded. ``permission`` is the NOT NULL bitmask from c6648c039bd4:
+    # bits are inlined as literals so this migration stays frozen against later Permission enum
+    # changes, and grant operations have no bit (0).
+    db_conn = op.get_bind()
+    db_conn.execute(
+        sa.text("""
+            WITH role_scopes AS (
+                SELECT DISTINCT
+                    p.role_id,
+                    r.name AS role_name,
+                    p.scope_type,
+                    p.scope_id
+                FROM permissions p
+                JOIN roles r ON p.role_id = r.id
+                WHERE p.scope_type IN ('user', 'domain')
+            ),
+            role_operations AS (
+                SELECT
+                    rs.role_id,
+                    rs.scope_type,
+                    rs.scope_id,
+                    unnest(CAST(:owner_ops AS text[])) AS operation
+                FROM role_scopes rs
+                WHERE NOT (rs.role_name LIKE '%member')
+            )
+            INSERT INTO permissions (
+                role_id, scope_type, scope_id, entity_type, operation, permission
+            )
+            SELECT
+                ro.role_id,
+                ro.scope_type,
+                ro.scope_id,
+                :entity_type AS entity_type,
+                ro.operation,
+                CASE ro.operation
+                    WHEN 'read' THEN 1
+                    WHEN 'update' THEN 2
+                    WHEN 'create' THEN 4
+                    WHEN 'soft-delete' THEN 8
+                    WHEN 'hard-delete' THEN 16
+                    ELSE 0
+                END AS permission
+            FROM role_operations ro
+            ON CONFLICT (role_id, scope_type, scope_id, entity_type, operation) DO NOTHING
+        """),
+        {
+            "owner_ops": [op_type.value for op_type in OperationType.owner_operations()],
+            "entity_type": EntityType.APP_CONFIG_FRAGMENT.value,
+        },
+    )
+
+
+def downgrade() -> None:
+    db_conn = op.get_bind()
+    db_conn.execute(
+        sa.text("DELETE FROM permissions WHERE entity_type = :entity_type"),
+        {"entity_type": EntityType.APP_CONFIG_FRAGMENT.value},
+    )

--- a/src/ai/backend/manager/models/alembic/versions/b3d9f7a2c184_add_app_config_fragment_permissions_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/b3d9f7a2c184_add_app_config_fragment_permissions_to_rbac.py
@@ -1,14 +1,9 @@
 """add_app_config_fragment_permissions_to_rbac
 
-Backfill ``APP_CONFIG_FRAGMENT`` permissions onto existing write-capable RBAC roles (a
-user's own ``user``-scope role and ``domain`` admins) so they can exercise fragment writes
-once RBAC enforcement is enabled (BEP-1052). New roles receive these permissions at role
-creation; this migration only covers roles that predate the new entity type.
-
-Only ``permissions`` rows are backfilled. The RBAC scope *associations*
-(``association_scopes_entities``, which bind a fragment to its owning scope) are NOT
-migrated: they are per-fragment and written at fragment-creation time, and this feature is
-still unreleased, so no fragments — and therefore no associations — exist yet.
+Backfill ``APP_CONFIG_FRAGMENT`` permissions onto write-capable roles that predate the
+entity type (BEP-1052); new roles receive them at role creation. Only ``permissions`` rows
+are backfilled — the scope associations are written per-fragment at fragment-creation time,
+and no fragments exist yet.
 
 Revision ID: b3d9f7a2c184
 Revises: c4e1a9b73f52
@@ -18,6 +13,7 @@ Create Date: 2026-07-14 00:00:00.000000
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.engine import Connection
 
 from ai.backend.manager.models.rbac_models.migration.enums import (
     EntityType,
@@ -31,80 +27,93 @@ down_revision = "c4e1a9b73f52"
 branch_labels = None
 depends_on = None
 
+DOMAIN_ADMIN_PAGE_ENTITY_TYPE = "domain_admin_page"
+PROJECT_ADMIN_PAGE_ENTITY_TYPE = "project_admin_page"
+APP_CONFIG_FRAGMENT_ENTITY_TYPE = EntityType.APP_CONFIG_FRAGMENT.value
+
 
 def upgrade() -> None:
-    # Only ``user``/``domain`` scopes (``public`` is superadmin-only, no role) and only the write
-    # path (reads use the allow list, not RBAC). Permission bits and ``domain_admin_page`` are
-    # inlined as literals to stay frozen against later enum changes; grants have no bit (0).
-    #
-    # Domain admins are selected positively, by the ``domain_admin_page`` capability at the same
-    # scope, not by the ``NOT (role_name LIKE '%member')`` filter sibling backfills use: role names
-    # carry no enforced convention, so that filter would hand a custom read-only domain role
-    # fragment ``hard-delete`` and ``grant:all``. ``user`` scope needs no such check — a user-scope
-    # grant only ever reaches that user's own scope. ``role_superadmin`` holds no
-    # ``domain_admin_page`` and drops out; its authority comes from the ``user.is_superadmin``
-    # short-circuit in the RBAC validators, not these rows.
     db_conn = op.get_bind()
-    db_conn.execute(
-        sa.text("""
-            WITH role_scopes AS (
-                SELECT DISTINCT
-                    p.role_id,
-                    p.scope_type,
-                    p.scope_id
-                FROM permissions p
-                WHERE p.scope_type IN ('user', 'domain')
-            ),
-            role_operations AS (
-                SELECT
-                    rs.role_id,
-                    rs.scope_type,
-                    rs.scope_id,
-                    unnest(CAST(:owner_ops AS text[])) AS operation
-                FROM role_scopes rs
-                WHERE rs.scope_type = 'user'
-                   OR EXISTS (
-                        SELECT 1
-                        FROM permissions admin_page
-                        WHERE admin_page.role_id = rs.role_id
-                          AND admin_page.entity_type = 'domain_admin_page'
-                          AND admin_page.scope_type = rs.scope_type
-                          AND admin_page.scope_id = rs.scope_id
-                   )
-            )
-            INSERT INTO permissions (
-                role_id, scope_type, scope_id, entity_type, operation, permission
-            )
-            SELECT
-                ro.role_id,
-                ro.scope_type,
-                ro.scope_id,
-                :entity_type AS entity_type,
-                ro.operation,
-                CASE ro.operation
-                    WHEN 'read' THEN 1
-                    WHEN 'update' THEN 2
-                    WHEN 'create' THEN 4
-                    WHEN 'soft-delete' THEN 8
-                    WHEN 'hard-delete' THEN 16
-                    ELSE 0
-                END AS permission
-            FROM role_operations ro
-            ON CONFLICT (role_id, scope_type, scope_id, entity_type, operation) DO NOTHING
-        """),
-        {
-            "owner_ops": [op_type.value for op_type in OperationType.owner_operations()],
-            "entity_type": EntityType.APP_CONFIG_FRAGMENT.value,
-        },
-    )
+    _add_entity_type_permissions(db_conn)
 
 
 def downgrade() -> None:
-    # No-op, following f2b9a4c7e103. Deleting by ``entity_type`` cannot distinguish the rows
-    # this backfill inserted from the ones granted natively at role creation: current code
-    # already writes APP_CONFIG_FRAGMENT permissions for every new role, because the entity
-    # type is part of ``_resource_types()``. A blanket DELETE would therefore strip permissions
-    # that roles created since this revision legitimately hold, and re-running ``upgrade`` would
-    # not restore them for roles the backfill does not select. Leaving the rows in place is
-    # safe — every row this migration writes is one role creation would have granted anyway.
+    # No-op, following f2b9a4c7e103: current code grants APP_CONFIG_FRAGMENT permissions to
+    # every new role, so a DELETE by entity_type cannot tell this backfill's rows from those
+    # and would strip permissions newer roles legitimately hold. Every row written here is one
+    # role creation would have granted anyway, so leaving them in place is safe.
     pass
+
+
+def _add_entity_type_permissions(db_conn: Connection) -> None:
+    """Backfill APP_CONFIG_FRAGMENT owner permissions onto write-capable roles.
+
+    - user scope → every role
+    - domain/project scope → roles holding `domain_admin_page` / `project_admin_page`
+    - members (read-only, served by the allow list), `public`, and `role_superadmin` are skipped
+
+    Admins are matched by `*_admin_page` capability, not a `role_name LIKE '%member'` filter, since
+    role names carry no enforced convention.
+    """
+    owner_ops = [op_type.value for op_type in OperationType.owner_operations()]
+
+    # Bit values mirror ai.backend.common.data.permission.types.Permission (IntFlag), inlined as
+    # literals to stay frozen against later enum changes — as in c6648c039bd4. Grant operations
+    # (grant:*) have no dedicated bit and map to 0 (NONE).
+    insert_query = sa.text("""
+        WITH role_scopes AS (
+            SELECT DISTINCT
+                p.role_id,
+                p.scope_type,
+                p.scope_id
+            FROM permissions p
+            WHERE p.scope_type IN ('user', 'domain', 'project')
+        ),
+        role_operations AS (
+            SELECT
+                rs.role_id,
+                rs.scope_type,
+                rs.scope_id,
+                unnest(CAST(:owner_ops AS text[])) AS operation
+            FROM role_scopes rs
+            WHERE rs.scope_type = 'user'
+               OR EXISTS (
+                    SELECT 1
+                    FROM permissions admin_page
+                    WHERE admin_page.role_id = rs.role_id
+                      AND admin_page.entity_type = CASE rs.scope_type
+                          WHEN 'domain' THEN :domain_admin_page_entity_type
+                          WHEN 'project' THEN :project_admin_page_entity_type
+                      END
+                      AND admin_page.scope_type = rs.scope_type
+                      AND admin_page.scope_id = rs.scope_id
+               )
+        )
+        INSERT INTO permissions (role_id, scope_type, scope_id, entity_type, operation, permission)
+        SELECT
+            role_id,
+            scope_type,
+            scope_id,
+            :entity_type AS entity_type,
+            operation,
+            CASE operation
+                WHEN 'read' THEN 1
+                WHEN 'update' THEN 2
+                WHEN 'create' THEN 4
+                WHEN 'soft-delete' THEN 8
+                WHEN 'hard-delete' THEN 16
+                ELSE 0
+            END AS permission
+        FROM role_operations
+        ON CONFLICT (role_id, scope_type, scope_id, entity_type, operation) DO NOTHING
+    """)
+
+    db_conn.execute(
+        insert_query,
+        {
+            "owner_ops": owner_ops,
+            "domain_admin_page_entity_type": DOMAIN_ADMIN_PAGE_ENTITY_TYPE,
+            "project_admin_page_entity_type": PROJECT_ADMIN_PAGE_ENTITY_TYPE,
+            "entity_type": APP_CONFIG_FRAGMENT_ENTITY_TYPE,
+        },
+    )

--- a/src/ai/backend/manager/models/rbac_models/migration/enums.py
+++ b/src/ai/backend/manager/models/rbac_models/migration/enums.py
@@ -115,6 +115,7 @@ class EntityType(enum.StrEnum):
     ARTIFACT = "artifact"
     ARTIFACT_REGISTRY = "artifact_registry"
     APP_CONFIG = "app_config"
+    APP_CONFIG_FRAGMENT = "app_config_fragment"
     NOTIFICATION_CHANNEL = "notification_channel"
     NOTIFICATION_RULE = "notification_rule"
     MODEL_DEPLOYMENT = "model_deployment"
@@ -141,7 +142,7 @@ class EntityType(enum.StrEnum):
             cls.SESSION,
             cls.ARTIFACT,
             cls.ARTIFACT_REGISTRY,
-            cls.APP_CONFIG,
+            cls.APP_CONFIG_FRAGMENT,
             cls.NOTIFICATION_CHANNEL,
             cls.NOTIFICATION_RULE,
             cls.MODEL_DEPLOYMENT,

--- a/tests/unit/manager/actions/test_action_types.py
+++ b/tests/unit/manager/actions/test_action_types.py
@@ -58,7 +58,7 @@ class TestEntityType:
         scope_types = EntityType._scope_types()
         assert scope_types == {EntityType.USER, EntityType.PROJECT, EntityType.DOMAIN}
 
-    def test_resource_types_returns_original_nine(self) -> None:
+    def test_resource_types_returns_expected_set(self) -> None:
         resource_types = EntityType._resource_types()
         expected = {
             EntityType.VFOLDER,
@@ -66,13 +66,14 @@ class TestEntityType:
             EntityType.SESSION,
             EntityType.ARTIFACT,
             EntityType.ARTIFACT_REGISTRY,
+            EntityType.APP_CONFIG_FRAGMENT,
             EntityType.NOTIFICATION_CHANNEL,
             EntityType.NOTIFICATION_RULE,
             EntityType.MODEL_DEPLOYMENT,
             EntityType.MODEL_CARD,
         }
         assert resource_types == expected
-        assert len(resource_types) == 9
+        assert len(resource_types) == 10
 
     def test_scope_and_resource_types_no_overlap(self) -> None:
         scope_types = EntityType._scope_types()

--- a/tests/unit/manager/rbac/test_permission_types.py
+++ b/tests/unit/manager/rbac/test_permission_types.py
@@ -118,7 +118,7 @@ class TestEntityType:
         assert member_accessible == expected
 
     def test_rbac_entity_types_are_categorized(self) -> None:
-        """Test that RBAC scope and resource types have no overlap and cover the original 12 types."""
+        """Test that RBAC scope and resource types have no overlap and cover all 13 types."""
         scope_types = EntityType._scope_types()
         resource_types = EntityType._resource_types()
 
@@ -129,13 +129,14 @@ class TestEntityType:
         # Verify scope types are exactly 3
         assert scope_types == {EntityType.USER, EntityType.PROJECT, EntityType.DOMAIN}
 
-        # Verify resource types are exactly 9
+        # Verify resource types are exactly 10
         assert resource_types == {
             EntityType.VFOLDER,
             EntityType.IMAGE,
             EntityType.SESSION,
             EntityType.ARTIFACT,
             EntityType.ARTIFACT_REGISTRY,
+            EntityType.APP_CONFIG_FRAGMENT,
             EntityType.NOTIFICATION_CHANNEL,
             EntityType.NOTIFICATION_RULE,
             EntityType.MODEL_DEPLOYMENT,


### PR DESCRIPTION
## Summary
Register `APP_CONFIG_FRAGMENT` as an RBAC resource type and backfill its write permissions onto existing write-capable roles, so later PRs in the stack can authorize fragment writes through RBAC (BEP-1052).

Split out of #12826 as its base: the entity-type registration and the permission backfill are independent of the per-fragment scope binding, and land together because a backfilled permission is meaningless unless the type is a resource type.

## Changes
- `EntityType._resource_types()` — add `APP_CONFIG_FRAGMENT`, so **new** roles receive its permissions at role creation (10 → 11 types)
- `rbac_models/migration/enums.py` — same registration for the migration-local enum
- `b3d9f7a2c184` — backfill the permissions onto roles that **predate** the entity type

## What the migration backfills
Only `permissions` rows, and only where a fragment can actually live:

| | |
|---|---|
| Scopes touched | `user` and `domain` only — a fragment lives at no other scope. `public` maps to `ScopeType.GLOBAL` and is granted to **nobody**: superadmin reaches it through the `is_superadmin` short-circuit in the RBAC validators, which needs no rows |
| Roles targeted | a user's own `user`-scope role, and `domain` admins **selected by capability** — the role must hold `domain_admin_page` at that same domain (see below) |
| Operations | the full owner operation set; `permission` carries the matching bitmask (`c6648c039bd4` shape), grant operations store 0 |
| Not migrated | the scope **associations** (`association_scopes_entities`) — they are per-fragment and written at fragment-creation time (#12826). The feature is unreleased, so no fragments and no associations exist yet |

`ON CONFLICT DO NOTHING`, so re-running grants nothing twice. `downgrade` is a no-op, following `f2b9a4c7e103`: a `DELETE` by `entity_type` cannot tell backfilled rows from the ones role creation now grants natively, so it would strip permissions that roles created since this revision legitimately hold.

## Selecting admins by capability, not by name
The sibling backfills (`f1a2b3c4d5e6`, `30c8308738ee`, …) select owner roles **negatively**, via `NOT (role_name LIKE '%member')`. That is unsafe: role names carry no enforced convention — `CreateRoleInput.name` is a free string and the caller picks the scope — so any domain-scoped role not named `%member` matches. The `domain-viewer` preset in `test_create_preset_roles.py` (read-only: `VFOLDER:READ`, `SESSION:READ`) is exactly that shape and would have received `hard-delete` and `grant:all` on fragments across the whole domain.

Those grant rows are not inert: the live check matches on `permissions.operation` (`db_source.py`), and the bitmask is the half that is currently unread.

So this migration selects admins positively instead:

```sql
WHERE rs.scope_type = 'user'
   OR EXISTS (SELECT 1 FROM permissions admin_page
              WHERE admin_page.role_id     = rs.role_id
                AND admin_page.entity_type = 'domain_admin_page'
                AND admin_page.scope_type  = rs.scope_type
                AND admin_page.scope_id    = rs.scope_id)
```

- **`domain`** — every domain admin role holds `domain_admin_page` at its own domain by the time this runs, under **both** naming schemes: `3b6297b1bd75` covers `role_domain_%_admin`, `f2b9a4c7e103`/`a3c1d8e5b294` cover `domain-%-admin`, and all three are ancestors of this revision. So no name matching is needed and the `roles` join drops out entirely. Matching `scope_id` too keeps an admin of domain A from being granted on domain B.
- **`user`** — kept broad. A user-scope grant only ever reaches that user's own scope, and writing an own-scope fragment is deliberately **not** admin-only (see `AppConfigScopeType.to_rbac_scope_type`).
- **`role_superadmin`** holds domain-scoped rows but no `domain_admin_page`, so it drops out. That is correct and matches `3b6297b1bd75`: superadmin authority comes from the `is_superadmin` short-circuit, never from these rows.

Verified against a local DB (per `models/alembic/AGENTS.md`, data migrations must be checked against a real DB):

| domain-scope role | outcome |
|---|---|
| `domain-testdom-admin` (runtime naming) | full ops ✅ |
| `role_domain_default_admin` (legacy naming) | full ops ✅ |
| `domain-auditors-readonly` (read-only custom, the escalation) | **nothing** ✅ |
| `role_domain_default_member` | nothing ✅ |
| `role_superadmin` | nothing ✅ |

## Backport
Not needed for 26.4 — the feature does not exist there:

| | `main` | `26.4` |
|---|---|---|
| `app_config_fragment` paths | 36 | **0** |
| `create_app_config_fragments_table` migration | present | **absent** |
| `EntityType.APP_CONFIG_FRAGMENT` | present | **absent** |

26.4's `84d5c6daf8cc` says it directly: the replacement tables "are introduced in a follow-up migration on top of this one". Backporting would fail to import `EntityType.APP_CONFIG_FRAGMENT`, and would grant permissions on a table that does not exist.

Jira: https://lablup.atlassian.net/browse/BA-6886

🤖 Generated with [Claude Code](https://claude.com/claude-code)
