### PR TITLE
fix(BA-6887): reference the real from_status/to_status columns in kernel history conditions

### DIFF
--- a/changes/12857.fix.md
+++ b/changes/12857.fix.md
@@ -1,0 +1,1 @@
+Point the kernel scheduling-history query conditions at the `from_status` / `to_status` columns the table actually defines, instead of the pre-rename `from_phase` / `to_phase` names.

--- a/changes/12857.fix.md
+++ b/changes/12857.fix.md
@@ -1,1 +1,1 @@
-Point the kernel scheduling-history query conditions at the `from_status` / `to_status` columns the table actually defines, instead of the pre-rename `from_phase` / `to_phase` names.
+Point the kernel scheduling-history query conditions at the `from_status` / `to_status` columns the table actually defines, instead of the pre-rename `from_phase` / `to_phase` names, and add the missing `phase` string filters to match the session, deployment, and route history conditions.

--- a/src/ai/backend/manager/models/scheduling_history/conditions.py
+++ b/src/ai/backend/manager/models/scheduling_history/conditions.py
@@ -422,22 +422,16 @@ class KernelSchedulingHistoryConditions:
         return inner
 
     @staticmethod
-    def by_from_phase(phase: KernelSchedulingPhase) -> QueryCondition:
+    def by_from_status(phase: KernelSchedulingPhase) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return cast(
-                sa.sql.expression.ColumnElement[bool],
-                KernelSchedulingHistoryRow.from_phase == str(phase),
-            )
+            return KernelSchedulingHistoryRow.from_status == str(phase)
 
         return inner
 
     @staticmethod
-    def by_to_phase(phase: KernelSchedulingPhase) -> QueryCondition:
+    def by_to_status(phase: KernelSchedulingPhase) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return cast(
-                sa.sql.expression.ColumnElement[bool],
-                KernelSchedulingHistoryRow.to_phase == str(phase),
-            )
+            return KernelSchedulingHistoryRow.to_status == str(phase)
 
         return inner
 

--- a/src/ai/backend/manager/models/scheduling_history/conditions.py
+++ b/src/ai/backend/manager/models/scheduling_history/conditions.py
@@ -421,6 +421,64 @@ class KernelSchedulingHistoryConditions:
 
         return inner
 
+    # String filter conditions for phase
+    @staticmethod
+    def by_phase_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            col = cast(sa.ColumnElement[str], KernelSchedulingHistoryRow.phase)
+            if spec.case_insensitive:
+                col = sa.func.lower(col)
+                pattern = f"%{spec.value.lower()}%"
+            else:
+                pattern = f"%{spec.value}%"
+            expr = col.like(pattern)
+            return ~expr if spec.negated else expr
+
+        return inner
+
+    @staticmethod
+    def by_phase_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            col = cast(sa.ColumnElement[str], KernelSchedulingHistoryRow.phase)
+            if spec.case_insensitive:
+                col = sa.func.lower(col)
+                val = spec.value.lower()
+            else:
+                val = spec.value
+            if spec.negated:
+                return col != val
+            return col == val
+
+        return inner
+
+    @staticmethod
+    def by_phase_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            col = cast(sa.ColumnElement[str], KernelSchedulingHistoryRow.phase)
+            if spec.case_insensitive:
+                col = sa.func.lower(col)
+                pattern = f"{spec.value.lower()}%"
+            else:
+                pattern = f"{spec.value}%"
+            expr = col.like(pattern)
+            return ~expr if spec.negated else expr
+
+        return inner
+
+    @staticmethod
+    def by_phase_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            col = cast(sa.ColumnElement[str], KernelSchedulingHistoryRow.phase)
+            if spec.case_insensitive:
+                col = sa.func.lower(col)
+                pattern = f"%{spec.value.lower()}"
+            else:
+                pattern = f"%{spec.value}"
+            expr = col.like(pattern)
+            return ~expr if spec.negated else expr
+
+        return inner
+
     @staticmethod
     def by_from_status(phase: KernelSchedulingPhase) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
@@ -441,6 +499,8 @@ class KernelSchedulingHistoryConditions:
             return KernelSchedulingHistoryRow.error_code == error_code
 
         return inner
+
+    by_phase_in = staticmethod(make_string_in_factory(KernelSchedulingHistoryRow.phase))
 
     @staticmethod
     def by_cursor_forward(cursor_id: str) -> QueryCondition:

--- a/tests/unit/manager/models/scheduling_history/BUILD
+++ b/tests/unit/manager/models/scheduling_history/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/tests/unit/manager/models/scheduling_history/test_conditions.py
+++ b/tests/unit/manager/models/scheduling_history/test_conditions.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from ai.backend.common.data.filter_specs import StringInMatchSpec, StringMatchSpec
+from ai.backend.manager.data.kernel.types import KernelSchedulingPhase
+from ai.backend.manager.models.clauses import QueryCondition
+from ai.backend.manager.models.scheduling_history.conditions import (
+    KernelSchedulingHistoryConditions,
+)
+
+
+@dataclass(frozen=True)
+class _ConditionCase:
+    label: str
+    condition: QueryCondition
+    expected_sql: str
+
+
+class TestKernelSchedulingHistoryConditions:
+    @pytest.mark.parametrize(
+        "case",
+        [
+            _ConditionCase(
+                label="by_from_status",
+                condition=KernelSchedulingHistoryConditions.by_from_status(
+                    KernelSchedulingPhase.PULLING
+                ),
+                expected_sql="kernel_scheduling_history.from_status = 'PULLING'",
+            ),
+            _ConditionCase(
+                label="by_to_status",
+                condition=KernelSchedulingHistoryConditions.by_to_status(
+                    KernelSchedulingPhase.RUNNING
+                ),
+                expected_sql="kernel_scheduling_history.to_status = 'RUNNING'",
+            ),
+            _ConditionCase(
+                label="by_phase_contains",
+                condition=KernelSchedulingHistoryConditions.by_phase_contains(
+                    StringMatchSpec(value="PULLING", case_insensitive=False, negated=False)
+                ),
+                expected_sql="kernel_scheduling_history.phase LIKE '%PULLING%'",
+            ),
+            _ConditionCase(
+                label="by_phase_contains-negated",
+                condition=KernelSchedulingHistoryConditions.by_phase_contains(
+                    StringMatchSpec(value="PULLING", case_insensitive=False, negated=True)
+                ),
+                expected_sql="kernel_scheduling_history.phase NOT LIKE '%PULLING%'",
+            ),
+            _ConditionCase(
+                label="by_phase_contains-case_insensitive",
+                condition=KernelSchedulingHistoryConditions.by_phase_contains(
+                    StringMatchSpec(value="PULLING", case_insensitive=True, negated=False)
+                ),
+                expected_sql="lower(kernel_scheduling_history.phase) LIKE '%pulling%'",
+            ),
+            _ConditionCase(
+                label="by_phase_contains-case_insensitive-negated",
+                condition=KernelSchedulingHistoryConditions.by_phase_contains(
+                    StringMatchSpec(value="PULLING", case_insensitive=True, negated=True)
+                ),
+                expected_sql="lower(kernel_scheduling_history.phase) NOT LIKE '%pulling%'",
+            ),
+            _ConditionCase(
+                label="by_phase_equals",
+                condition=KernelSchedulingHistoryConditions.by_phase_equals(
+                    StringMatchSpec(value="PULLING", case_insensitive=False, negated=False)
+                ),
+                expected_sql="kernel_scheduling_history.phase = 'PULLING'",
+            ),
+            _ConditionCase(
+                label="by_phase_equals-negated",
+                condition=KernelSchedulingHistoryConditions.by_phase_equals(
+                    StringMatchSpec(value="PULLING", case_insensitive=False, negated=True)
+                ),
+                expected_sql="kernel_scheduling_history.phase != 'PULLING'",
+            ),
+            _ConditionCase(
+                label="by_phase_equals-case_insensitive",
+                condition=KernelSchedulingHistoryConditions.by_phase_equals(
+                    StringMatchSpec(value="PULLING", case_insensitive=True, negated=False)
+                ),
+                expected_sql="lower(kernel_scheduling_history.phase) = 'pulling'",
+            ),
+            _ConditionCase(
+                label="by_phase_equals-case_insensitive-negated",
+                condition=KernelSchedulingHistoryConditions.by_phase_equals(
+                    StringMatchSpec(value="PULLING", case_insensitive=True, negated=True)
+                ),
+                expected_sql="lower(kernel_scheduling_history.phase) != 'pulling'",
+            ),
+            _ConditionCase(
+                label="by_phase_starts_with",
+                condition=KernelSchedulingHistoryConditions.by_phase_starts_with(
+                    StringMatchSpec(value="PULLING", case_insensitive=False, negated=False)
+                ),
+                expected_sql="kernel_scheduling_history.phase LIKE 'PULLING%'",
+            ),
+            _ConditionCase(
+                label="by_phase_starts_with-negated",
+                condition=KernelSchedulingHistoryConditions.by_phase_starts_with(
+                    StringMatchSpec(value="PULLING", case_insensitive=False, negated=True)
+                ),
+                expected_sql="kernel_scheduling_history.phase NOT LIKE 'PULLING%'",
+            ),
+            _ConditionCase(
+                label="by_phase_starts_with-case_insensitive",
+                condition=KernelSchedulingHistoryConditions.by_phase_starts_with(
+                    StringMatchSpec(value="PULLING", case_insensitive=True, negated=False)
+                ),
+                expected_sql="lower(kernel_scheduling_history.phase) LIKE 'pulling%'",
+            ),
+            _ConditionCase(
+                label="by_phase_starts_with-case_insensitive-negated",
+                condition=KernelSchedulingHistoryConditions.by_phase_starts_with(
+                    StringMatchSpec(value="PULLING", case_insensitive=True, negated=True)
+                ),
+                expected_sql="lower(kernel_scheduling_history.phase) NOT LIKE 'pulling%'",
+            ),
+            _ConditionCase(
+                label="by_phase_ends_with",
+                condition=KernelSchedulingHistoryConditions.by_phase_ends_with(
+                    StringMatchSpec(value="PULLING", case_insensitive=False, negated=False)
+                ),
+                expected_sql="kernel_scheduling_history.phase LIKE '%PULLING'",
+            ),
+            _ConditionCase(
+                label="by_phase_ends_with-negated",
+                condition=KernelSchedulingHistoryConditions.by_phase_ends_with(
+                    StringMatchSpec(value="PULLING", case_insensitive=False, negated=True)
+                ),
+                expected_sql="kernel_scheduling_history.phase NOT LIKE '%PULLING'",
+            ),
+            _ConditionCase(
+                label="by_phase_ends_with-case_insensitive",
+                condition=KernelSchedulingHistoryConditions.by_phase_ends_with(
+                    StringMatchSpec(value="PULLING", case_insensitive=True, negated=False)
+                ),
+                expected_sql="lower(kernel_scheduling_history.phase) LIKE '%pulling'",
+            ),
+            _ConditionCase(
+                label="by_phase_ends_with-case_insensitive-negated",
+                condition=KernelSchedulingHistoryConditions.by_phase_ends_with(
+                    StringMatchSpec(value="PULLING", case_insensitive=True, negated=True)
+                ),
+                expected_sql="lower(kernel_scheduling_history.phase) NOT LIKE '%pulling'",
+            ),
+            _ConditionCase(
+                label="by_phase_in",
+                condition=KernelSchedulingHistoryConditions.by_phase_in(
+                    StringInMatchSpec(
+                        values=["PULLING", "CREATING"], case_insensitive=False, negated=False
+                    )
+                ),
+                expected_sql="kernel_scheduling_history.phase IN ('PULLING', 'CREATING')",
+            ),
+            _ConditionCase(
+                label="by_phase_in-negated",
+                condition=KernelSchedulingHistoryConditions.by_phase_in(
+                    StringInMatchSpec(
+                        values=["PULLING", "CREATING"], case_insensitive=False, negated=True
+                    )
+                ),
+                expected_sql="(kernel_scheduling_history.phase NOT IN ('PULLING', 'CREATING'))",
+            ),
+            _ConditionCase(
+                label="by_phase_in-case_insensitive",
+                condition=KernelSchedulingHistoryConditions.by_phase_in(
+                    StringInMatchSpec(
+                        values=["PULLING", "CREATING"], case_insensitive=True, negated=False
+                    )
+                ),
+                expected_sql="lower(kernel_scheduling_history.phase) IN ('pulling', 'creating')",
+            ),
+            _ConditionCase(
+                label="by_phase_in-case_insensitive-negated",
+                condition=KernelSchedulingHistoryConditions.by_phase_in(
+                    StringInMatchSpec(
+                        values=["PULLING", "CREATING"], case_insensitive=True, negated=True
+                    )
+                ),
+                expected_sql=(
+                    "(lower(kernel_scheduling_history.phase) NOT IN ('pulling', 'creating'))"
+                ),
+            ),
+        ],
+        ids=lambda case: case.label,
+    )
+    def test_condition_compiles_to_expected_sql(self, case: _ConditionCase) -> None:
+        sql = str(case.condition().compile(compile_kwargs={"literal_binds": True}))
+
+        assert sql == case.expected_sql


### PR DESCRIPTION
## 📚 Stacked PRs

- #12857 — `BA-6887` fix: kernel history conditions reference the real status columns  ← you are here
- #12867 — `BA-6889` models: kernel query conditions and orders
- #12868 — `BA-6890` repository: kernel search scope and scoped search
- #12869 — `BA-6891` DTO + service: kernel v2 DTOs and search actions
- #12870 — `BA-6892` adapter + REST v2: kernel endpoints
- #12866 — `BA-6893` SDK + CLI: kernel commands

Merge in order, bottom-up. Each PR is based on the one above it, so its diff shows only its own layer.

## Problem

`KernelSchedulingHistoryConditions.by_from_phase` / `by_to_phase` referenced `KernelSchedulingHistoryRow.from_phase` and `.to_phase`. Those columns exist, but under different names — the `kernel_scheduling_history` table defines **`from_status`** and **`to_status`**. Both factories return a lazily-evaluated closure, so either would have raised `AttributeError` the moment its condition was actually evaluated.

## How the names drifted

An incomplete rename, spread over three changes:

| Commit | What happened |
|---|---|
| `1a2316bb2` (BA-3061) | Created `kernel_scheduling_history` with **`from_phase` / `to_phase`** columns. |
| `dd85bdbe2` (BA-3062) | Renamed them to **`from_status` / `to_status`**, by editing that not-yet-released migration in place. The query conditions added in the same change kept the **old** names. |
| `34af67f18` (BA-5127) | Moved the conditions from `repositories/scheduling_history/options.py` into `models/scheduling_history/conditions.py` — the stale reference came along. |

Two things kept it hidden:

- **No callers.** Both factories are dead code today, so the closure was never evaluated.
- **`cast()` hid it from the type checker.** The bad attribute access sat inside a `cast(...)`, so the lookups were never flagged.

## Fix

- Point the conditions at the real `from_status` / `to_status` columns.
- Rename to `by_from_status` / `by_to_status`, matching both the column names and the equivalent `SessionSchedulingHistoryConditions.by_from_status` / `by_to_status`. Safe to rename outright: there are no callers.
- Drop the now-unnecessary `cast()`, which was only masking the error.

## Scope of impact

**No user-visible behavior changes.** Nothing calls these factories, so the fault was unreachable — this clears a latent fault rather than a live one. Found while implementing the kernel scheduling-history read stack (BA-6882), which is the first code to call them; split out because it stands on its own and is not scoped to that story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)