### PR TITLE
feat(BA-6893): add kernel scheduling-history SDK v2 client and CLI commands

### DIFF
--- a/.claude/skills/bai-cli/SKILL.md
+++ b/.claude/skills/bai-cli/SKILL.md
@@ -55,7 +55,7 @@ Check options with `--help`.
 - **service-catalog**: user(empty group) · admin(search)
 - **runtime-variant**: user(get, search) · admin(get, search, create, update, delete, bulk-delete)
 - **runtime-variant-preset**: user(get, search) · admin(get, search, create, update, delete)
-- **scheduling-history**: sub session / deployment / route — each (search, search-scoped)
+- **scheduling-history**: sub session / kernel / deployment / route — each (search, search-scoped)
 - **scheduling-handler**: admin(list)
 
 ### Storage

--- a/changes/12866.feature.md
+++ b/changes/12866.feature.md
@@ -1,0 +1,1 @@
+Add kernel scheduling-history queries to REST v2, the SDK, and the CLI (`bai scheduling-history kernel search / search-scoped`).

--- a/src/ai/backend/client/cli/v2/scheduling_history/commands.py
+++ b/src/ai/backend/client/cli/v2/scheduling_history/commands.py
@@ -1,6 +1,6 @@
 """CLI commands for scheduling history management.
 
-Commands are organized into sub-groups: ``session``, ``deployment``,
+Commands are organized into sub-groups: ``session``, ``kernel``, ``deployment``,
 and ``route``.
 """
 
@@ -9,6 +9,7 @@ from __future__ import annotations
 import click
 
 from .deployment import deployment
+from .kernel import kernel
 from .route import route
 from .session import session
 
@@ -20,5 +21,6 @@ def scheduling_history() -> None:
 
 # Register sub-groups
 scheduling_history.add_command(session)
+scheduling_history.add_command(kernel)
 scheduling_history.add_command(deployment)
 scheduling_history.add_command(route)

--- a/src/ai/backend/client/cli/v2/scheduling_history/kernel.py
+++ b/src/ai/backend/client/cli/v2/scheduling_history/kernel.py
@@ -1,0 +1,250 @@
+"""CLI commands for kernel scheduling history."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    parse_order_options,
+    print_result,
+)
+
+if TYPE_CHECKING:
+    from ai.backend.common.dto.manager.v2.scheduling_history.request import KernelHistoryFilter
+
+# Shared result choices for scheduling history filters
+_RESULT_CHOICES = click.Choice(
+    ["SUCCESS", "FAILURE", "STALE", "NEED_RETRY", "EXPIRED", "GIVE_UP", "SKIPPED"],
+    case_sensitive=False,
+)
+
+
+def _build_kernel_history_filter(
+    *,
+    phase: str | None,
+    from_status: tuple[str, ...],
+    to_status: tuple[str, ...],
+    result: str | None,
+    error_code: str | None,
+    message: str | None,
+    kernel_id: str | None = None,
+    session_id: str | None = None,
+) -> KernelHistoryFilter | None:
+    """Build a KernelHistoryFilter from explicit CLI options.
+
+    ``kernel_id`` and ``session_id`` are omitted by callers whose scope already
+    narrows by that id. Returns None if no filter options were provided.
+    """
+    from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
+    from ai.backend.common.dto.manager.v2.scheduling_history.request import (
+        KernelHistoryFilter,
+        SchedulingResultFilter,
+    )
+    from ai.backend.common.dto.manager.v2.scheduling_history.types import SchedulingResultType
+
+    has_any = any(
+        opt is not None for opt in (kernel_id, session_id, phase, result, error_code, message)
+    )
+    if not has_any and not from_status and not to_status:
+        return None
+
+    return KernelHistoryFilter(
+        kernel_id=UUIDFilter(equals=UUID(kernel_id)) if kernel_id is not None else None,
+        session_id=UUIDFilter(equals=UUID(session_id)) if session_id is not None else None,
+        phase=StringFilter(contains=phase) if phase is not None else None,
+        from_status=list(from_status) if from_status else None,
+        to_status=list(to_status) if to_status else None,
+        result=(
+            SchedulingResultFilter(equals=SchedulingResultType(result))
+            if result is not None
+            else None
+        ),
+        error_code=StringFilter(contains=error_code) if error_code is not None else None,
+        message=StringFilter(contains=message) if message is not None else None,
+    )
+
+
+@click.group()
+def kernel() -> None:
+    """Kernel scheduling history commands."""
+
+
+@kernel.command()
+@click.option("--limit", type=int, default=None, help="Maximum items to return.")
+@click.option("--offset", type=int, default=None, help="Number of items to skip.")
+@click.option("--kernel-id", type=str, default=None, help="Filter by kernel ID (UUID).")
+@click.option("--session-id", type=str, default=None, help="Filter by session ID (UUID).")
+@click.option("--phase", type=str, default=None, help="Filter by scheduling phase (contains).")
+@click.option(
+    "--from-status",
+    type=str,
+    multiple=True,
+    help="Filter by from_status values (repeatable).",
+)
+@click.option(
+    "--to-status",
+    type=str,
+    multiple=True,
+    help="Filter by to_status values (repeatable).",
+)
+@click.option("--result", type=_RESULT_CHOICES, default=None, help="Filter by scheduling result.")
+@click.option("--error-code", type=str, default=None, help="Filter by error code (contains).")
+@click.option("--message", type=str, default=None, help="Filter by message (contains).")
+@click.option(
+    "--order-by",
+    multiple=True,
+    help=(
+        "Order by field:direction (e.g., created_at:desc). Fields: created_at, "
+        "updated_at, phase, from_status, to_status, result, attempts."
+    ),
+)
+def search(
+    limit: int | None,
+    offset: int | None,
+    kernel_id: str | None,
+    session_id: str | None,
+    phase: str | None,
+    from_status: tuple[str, ...],
+    to_status: tuple[str, ...],
+    result: str | None,
+    error_code: str | None,
+    message: str | None,
+    order_by: tuple[str, ...],
+) -> None:
+    """Search kernel scheduling histories (superadmin only)."""
+    from ai.backend.common.dto.manager.v2.scheduling_history.request import (
+        AdminSearchKernelHistoriesInput,
+        KernelHistoryOrder,
+    )
+    from ai.backend.common.dto.manager.v2.scheduling_history.types import KernelHistoryOrderField
+
+    history_filter = _build_kernel_history_filter(
+        kernel_id=kernel_id,
+        session_id=session_id,
+        phase=phase,
+        from_status=from_status,
+        to_status=to_status,
+        result=result,
+        error_code=error_code,
+        message=message,
+    )
+
+    orders = (
+        parse_order_options(order_by, KernelHistoryOrderField, KernelHistoryOrder)
+        if order_by
+        else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result_data = await registry.scheduling_history.search_kernel_history(
+                AdminSearchKernelHistoriesInput(
+                    filter=history_filter,
+                    order=orders,
+                    limit=limit,
+                    offset=offset,
+                ),
+            )
+            print_result(result_data)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@kernel.command(name="search-scoped")
+@click.argument("kernel_id", type=str)
+@click.option("--limit", type=int, default=None, help="Maximum items to return.")
+@click.option("--offset", type=int, default=None, help="Number of items to skip.")
+@click.option("--session-id", type=str, default=None, help="Filter by session ID (UUID).")
+@click.option("--phase", type=str, default=None, help="Filter by scheduling phase (contains).")
+@click.option(
+    "--from-status",
+    type=str,
+    multiple=True,
+    help="Filter by from_status values (repeatable).",
+)
+@click.option(
+    "--to-status",
+    type=str,
+    multiple=True,
+    help="Filter by to_status values (repeatable).",
+)
+@click.option("--result", type=_RESULT_CHOICES, default=None, help="Filter by scheduling result.")
+@click.option("--error-code", type=str, default=None, help="Filter by error code (contains).")
+@click.option("--message", type=str, default=None, help="Filter by message (contains).")
+@click.option(
+    "--order-by",
+    multiple=True,
+    help=(
+        "Order by field:direction (e.g., created_at:desc). Fields: created_at, "
+        "updated_at, phase, from_status, to_status, result, attempts."
+    ),
+)
+def search_scoped(
+    kernel_id: str,
+    session_id: str | None,
+    limit: int | None,
+    offset: int | None,
+    phase: str | None,
+    from_status: tuple[str, ...],
+    to_status: tuple[str, ...],
+    result: str | None,
+    error_code: str | None,
+    message: str | None,
+    order_by: tuple[str, ...],
+) -> None:
+    """Search kernel scheduling history scoped to KERNEL_ID."""
+    from ai.backend.common.dto.manager.v2.rbac.types import UUIDScope
+    from ai.backend.common.dto.manager.v2.scheduling_history.request import (
+        KernelHistoryOrder,
+        ScopedSearchKernelHistoriesInput,
+    )
+    from ai.backend.common.dto.manager.v2.scheduling_history.types import (
+        KernelHistoryOrderField,
+        KernelHistoryScopeDTO,
+    )
+
+    scope = KernelHistoryScopeDTO(kernel=[UUIDScope(value=UUID(kernel_id))])
+
+    # The scope already narrows by kernel ID, so it is not repeated in the filter.
+    history_filter = _build_kernel_history_filter(
+        session_id=session_id,
+        phase=phase,
+        from_status=from_status,
+        to_status=to_status,
+        result=result,
+        error_code=error_code,
+        message=message,
+    )
+
+    orders = (
+        parse_order_options(order_by, KernelHistoryOrderField, KernelHistoryOrder)
+        if order_by
+        else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result_data = await registry.scheduling_history.kernel_scoped_search(
+                ScopedSearchKernelHistoriesInput(
+                    scope=scope,
+                    filter=history_filter,
+                    order=orders,
+                    limit=limit,
+                    offset=offset,
+                ),
+            )
+            print_result(result_data)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())

--- a/src/ai/backend/client/v2/domains_v2/scheduling_history.py
+++ b/src/ai/backend/client/v2/domains_v2/scheduling_history.py
@@ -7,13 +7,16 @@ from uuid import UUID
 from ai.backend.client.v2.base_domain import BaseDomainClient
 from ai.backend.common.dto.manager.v2.scheduling_history.request import (
     AdminSearchDeploymentHistoriesInput,
+    AdminSearchKernelHistoriesInput,
     AdminSearchRouteHistoriesInput,
     AdminSearchSessionHistoriesInput,
+    ScopedSearchKernelHistoriesInput,
 )
 from ai.backend.common.dto.manager.v2.scheduling_history.response import (
     AdminSearchDeploymentHistoriesPayload,
     AdminSearchRouteHistoriesPayload,
     AdminSearchSessionHistoriesPayload,
+    SearchKernelHistoriesPayload,
 )
 
 _PATH = "/v2/scheduling-history"
@@ -44,6 +47,30 @@ class V2SchedulingHistoryClient(BaseDomainClient):
             f"{_PATH}/sessions/{session_id}/search",
             request=request,
             response_model=AdminSearchSessionHistoriesPayload,
+        )
+
+    # ========== Kernel History ==========
+
+    async def search_kernel_history(
+        self, request: AdminSearchKernelHistoriesInput
+    ) -> SearchKernelHistoriesPayload:
+        """Search kernel scheduling histories with admin scope."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/kernels/admin/search",
+            request=request,
+            response_model=SearchKernelHistoriesPayload,
+        )
+
+    async def kernel_scoped_search(
+        self, request: ScopedSearchKernelHistoriesInput
+    ) -> SearchKernelHistoriesPayload:
+        """Search kernel scheduling histories within a session and/or kernel scope."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/kernels/scoped/search",
+            request=request,
+            response_model=SearchKernelHistoriesPayload,
         )
 
     # ========== Deployment History ==========


### PR DESCRIPTION
## 📚 Stacked PRs

- #12857 — `BA-6887` fix: kernel history conditions reference the real status columns ✅
- #12867 — `BA-6889` models: kernel query conditions and orders ✅
- #12868 — `BA-6890` repository: kernel search scope and scoped search ✅
- #12869 — `BA-6891` DTO + service: kernel v2 DTOs and search actions ✅
- #12870 — `BA-6892` adapter + REST v2: kernel endpoints ✅
- #12989 — `BA-6883` GraphQL v2: kernel history roots ✅
- #13003 — `BA-6957` fix: authorize kernel scoped history via the owning session ✅
- #12866 — `BA-6893` SDK + CLI: kernel commands  ← you are here
- #12997 — `BA-6953` component tests: kernel REST v2 endpoints

Every PR below this one is merged, so this PR now branches straight off `main` and its diff is client-only.

## Summary

SDK v2 methods and CLI commands over the two REST routes from #12870, completing the surface BA-6889..BA-6892 built up.

| Command | SDK method | Route |
|---|---|---|
| `bai scheduling-history kernel search` | `search_kernel_history(request)` | `POST /v2/scheduling-history/kernels/admin/search` |
| `bai scheduling-history kernel search-scoped KERNEL_ID` | `kernel_scoped_search(request)` | `POST /v2/scheduling-history/kernels/scoped/search` |

- Both commands sit in the user-facing `cli/v2/scheduling_history/` group as a `kernel` sub-group, matching the existing `session` / `deployment` / `route` sub-groups of this entity. The system-wide `search` is still gated server-side by `superadmin_required`, so a regular user calling it gets a 403.
- Method naming follows the sibling sub-entities in the same SDK client (`search_{entity}_history` / `{entity}_scoped_search`), and the scope travels in the request body (`ScopedSearchKernelHistoriesInput.scope`) rather than as a path parameter.
- `search-scoped` takes the kernel id as a **positional argument**, like every other scoped search in the CLI, and wraps it into `KernelHistoryScopeDTO(kernel=[UUIDScope(...)])` — the list-shaped scope introduced by #13071 (BA-6989). `--session-id` on this command is an ordinary filter, not a second scope axis, because the server accepts exactly one scope item.
- The scoped search is authorized through the owning session (#13003): whoever may read the session may read its kernels' scheduling history.
- This is the only PR in the stack with user-visible behaviour, so it carries the single news fragment. The layers below it are internal; a changelog entry on any of them would describe a change users never experience.

**Not covered:** #13071 also lets the scope name a *session* (`scope.session`), returning the history of every kernel that session owns. The CLI does not expose that axis — the positional argument is the kernel id. If it is wanted, it belongs in a follow-up as its own command rather than as an optional positional.

## How to test

Common options for both commands: `--limit` / `--offset`, `--phase` (contains), `--from-status` / `--to-status` (repeatable), `--result SUCCESS|FAILURE|STALE|NEED_RETRY|EXPIRED|GIVE_UP|SKIPPED`, `--error-code` / `--message` (contains), `--order-by created_at:desc` (also `updated_at`, repeatable), `--session-id`. `search` additionally takes `--kernel-id`; on `search-scoped` the kernel id is the positional scope instead.

```bash
# Find a kernel id (admin)
bai admin session kernel search --limit 5

# 1. Owner reads their kernel's history → 200
bai scheduling-history kernel search-scoped <KERNEL_ID>

# 2. Filters and ordering
bai scheduling-history kernel search-scoped <KERNEL_ID> --result FAILURE
bai scheduling-history kernel search-scoped <KERNEL_ID> --order-by created_at:asc

# 3. System-wide search with filters (superadmin)
bai scheduling-history kernel search --session-id <SESSION_ID>

# 4. Permission gate: the system-wide search as a regular user → 403
bai scheduling-history kernel search --limit 1

# 5. Missing kernel → 404
bai scheduling-history kernel search-scoped 00000000-0000-0000-0000-000000000001
```

Note: `kernel_scheduling_history` has no writer yet (BA-6852), so an empty list is the expected live response. To see populated responses, insert rows directly; `from_status` / `to_status` must be valid `KernelSchedulingPhase` values (`PREPARING|PULLING|PREPARED|CREATING|RUNNING|TERMINATING|TERMINATED`) or serialization fails. Test accounts live in `fixtures/manager/example-keypairs.json`.

## Test plan

Verified end to end against a live manager rebased onto current `main` (which includes #13071), with a seeded history row:

- [x] `search` → 200; row fields (`kernel_id`, `session_id`, `phase`, `from_status`/`to_status`, `result`, `attempts`, timestamps) deserialize
- [x] `search-scoped KERNEL_ID` → 200, returns only that kernel's rows
- [x] `search-scoped KERNEL_ID --session-id` → matching session returns the row, non-matching returns none
- [x] Filters (`--phase`, `--result`, `--from-status`, `--to-status`, `--message`, `--kernel-id`, `--session-id`) and `--order-by created_at:desc`
- [x] `--limit 1 --offset 1` → `has_previous_page: true`
- [x] `search-scoped` with no positional → `Missing argument 'KERNEL_ID'`
- [x] Missing kernel → 404 `kernel_read_not-found`
- [x] Regular user calling `search` → 403; the same user's `search-scoped` on their own kernel → 200
- [x] `pants fmt` / `fix` / `lint` / `check` clean
- [ ] Responses containing scheduler-written history rows — blocked on BA-6852 as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
