### PR TITLE
fix(install): point PACKAGE scaling_group at the app-proxy coordinator

### DIFF
--- a/changes/12872.fix.md
+++ b/changes/12872.fix.md
@@ -1,0 +1,1 @@
+Fix PACKAGE-mode TUI installs leaving the default scaling group pointed at the placeholder wsproxy address (`:5050`) instead of the app-proxy coordinator, and make failing manager CLI steps abort the install instead of being silently ignored.

--- a/src/ai/backend/install/context.py
+++ b/src/ai/backend/install/context.py
@@ -368,14 +368,21 @@ class Context(metaclass=ABCMeta):
         if self.install_info.type == InstallType.SOURCE:
             # Develop mode: use ./backend.ai from current directory
             cmd_str = " ".join(cmdargs)
-            await self.run_shell(f"./backend.ai {cmd_str}")
+            exit_code = await self.run_shell(f"./backend.ai {cmd_str}")
 
         elif self.install_info.type == InstallType.PACKAGE:
             # Package mode: use backendai-manager from base_path
             executable = Path(self.install_info.base_path) / "backendai-manager"
-            await self.run_exec(
+            exit_code = await self.run_exec(
                 [str(executable), *cmdargs],
                 cwd=self.install_info.base_path,
+            )
+        else:
+            raise RuntimeError(f"Unsupported install type: {self.install_info.type}")
+
+        if exit_code != 0:
+            raise RuntimeError(
+                f"Manager CLI command failed (exit {exit_code}): {' '.join(cmdargs)}"
             )
 
     @actxmgr
@@ -1124,7 +1131,6 @@ class Context(metaclass=ABCMeta):
 
     async def install_appproxy_db(self) -> None:
         halfstack = self.install_info.halfstack_config
-        service = self.install_info.service_config
 
         self.log_header("Setting up databases... (app-proxy)")
 
@@ -1174,27 +1180,10 @@ class Context(metaclass=ABCMeta):
             [sys.executable, "-m", "alembic", "-c", str(alembic_ini), "upgrade", "head"],
             cwd=self.install_info.base_path,
         )
-
-        # 5. Update scaling_groups in core DB
-        # TODO: Still using wsproxy_* columns for backward compatibility (same with install-dev.sh logic)
-        core_conn = await asyncpg.connect(
-            host=halfstack.postgres_addr.face.host,
-            port=halfstack.postgres_addr.face.port,
-            user=halfstack.postgres_user,
-            password=halfstack.postgres_password,
-            database="backend",
-        )
-        await core_conn.execute(
-            """
-            UPDATE scaling_groups
-            SET wsproxy_api_token = $1,
-                wsproxy_addr = $2
-            WHERE name = 'default'
-            """,
-            service.appproxy_api_secret,
-            f"http://{service.appproxy_coordinator_addr.face.host}:{service.appproxy_coordinator_addr.face.port}",
-        )
-        await core_conn.close()
+        # NOTE: The "default" scaling_group's wsproxy_addr/token are set by
+        # configure_appproxy_fixture(), which runs after load_fixtures() seeds
+        # the row. Do not update scaling_groups here -- the row does not exist
+        # yet at this point in the install flow.
 
     async def configure_appproxy(self) -> None:
         halfstack = self.install_info.halfstack_config
@@ -2271,6 +2260,10 @@ class PackageContext(Context):
         await self.configure_client()
         self.log_header("Loading fixtures...")
         await self.load_fixtures()
+        # load_fixtures() seeds the "default" scaling_group with placeholder
+        # wsproxy_addr/token from the example fixture, so this must run *after*
+        # it to overwrite them with the real coordinator address and secret.
+        await self.configure_appproxy_fixture()
         self.log_header("Preparing vfolder volumes...")
         await self.prepare_local_vfolder_host()
         # TODO: install as systemd services?


### PR DESCRIPTION
## Summary

In **PACKAGE-mode** TUI installs, the `default` scaling_group's `wsproxy_addr`/`wsproxy_api_token` were left at the placeholder values from the example fixture (`http://127.0.0.1:5050`), so the manager could never reach the app-proxy coordinator (`:10200`). Model-service routing and app proxying are broken on a fresh PACKAGE install.

## Root cause — an ordering bug

`install_appproxy_db()` issues `UPDATE scaling_groups ... WHERE name='default'`, but it runs **before** `load_fixtures()` creates that row. The UPDATE matches 0 rows and the fixture placeholder survives. DEV mode looked fine only because it *additionally* runs `configure_appproxy_fixture()` **after** `load_fixtures()`, which upserts the correct values.

| step | DEV | PACKAGE (before) |
|---|---|---|
| `install_appproxy_db()` UPDATE | before fixtures → 0 rows | before fixtures → 0 rows |
| `load_fixtures()` seeds `:5050` | ✓ | ✓ (last) |
| `configure_appproxy_fixture()` re-point | ✓ | **missing** |

## Changes

- **Call `configure_appproxy_fixture()` in `PackageContext` after `load_fixtures()`**, mirroring `DevContext`. It upserts (`__mode: update`) the real coordinator address + `api_secret` regardless of ordering.
- **Drop the dead `scaling_groups` UPDATE from `install_appproxy_db()`** — it always ran before the row existed (both modes) and is redundant with `configure_appproxy_fixture()`. The app-proxy DB/role/migration setup (steps 1–4) is untouched.
- **Make `run_manager_cli()` raise on a non-zero exit code** so a failing manager CLI step (`schema oneshot`, `fixture populate`, …) aborts the install instead of being silently swallowed — this class of failure is what masked the bug.

## Verification

Reproduced on a local PACKAGE install (`docker` halfstack, DB `127.0.0.1:8100`):

```
# before
default | http://127.0.0.1:5050  | v625xZLOgbMHhl0s49VuqQ
# after running the added configure_appproxy_fixture() step
default | http://127.0.0.1:10200 | 73b3110c...  (= coordinator api_secret)
```

`pants fmt / lint / check` pass on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)