### PR TITLE
fix(appproxy): make circuit locks self-cleaning to prevent unbounded growth

### DIFF
--- a/src/ai/backend/appproxy/coordinator/types.py
+++ b/src/ai/backend/appproxy/coordinator/types.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import itertools
 import logging
+import weakref
 from collections import defaultdict
 from collections.abc import AsyncIterator, Callable, Sequence
 from contextlib import AbstractAsyncContextManager, AsyncExitStack
@@ -105,19 +106,19 @@ class CircuitManager:
     event_producer: EventProducer
     traefik_etcd: TraefikEtcd | None
     local_config: ServerConfig
-    _circuit_locks: dict[UUID, asyncio.Lock] = field(default_factory=dict)
-
-    def _get_lock(self, circuit_id: UUID) -> asyncio.Lock:
-        if circuit_id not in self._circuit_locks:
-            self._circuit_locks[circuit_id] = asyncio.Lock()
-        return self._circuit_locks[circuit_id]
-
-    def _release_circuit_lock(self, circuit_id: UUID) -> None:
-        self._circuit_locks.pop(circuit_id, None)
+    # Weak values: an entry vanishes with its last user, so no explicit release.
+    _circuit_locks: weakref.WeakValueDictionary[UUID, asyncio.Lock] = field(
+        default_factory=weakref.WeakValueDictionary
+    )
 
     @actxmgr
     async def circuit_lock(self, circuit_id: UUID) -> AsyncIterator[None]:
-        async with self._get_lock(circuit_id):
+        # No await between lookup and store — callers converge on one lock.
+        lock = self._circuit_locks.get(circuit_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._circuit_locks[circuit_id] = lock
+        async with lock:
             yield
 
     async def initialize_circuits(self, circuits: Sequence[Circuit]) -> None:
@@ -264,8 +265,6 @@ class CircuitManager:
                         await self.unload_legacy_circuit(circuit)
             except Exception:
                 log.exception("Failed to unload circuit {}", circuit.id)
-            finally:
-                self._release_circuit_lock(circuit.id)
 
     async def unload_traefik_circuit(self, circuit: Circuit) -> None:
         log.debug("unload_traefik_circuit(): start")

--- a/tests/unit/appproxy/coordinator/test_circuit_locking.py
+++ b/tests/unit/appproxy/coordinator/test_circuit_locking.py
@@ -1,66 +1,16 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
 
 from ai.backend.appproxy.coordinator.models import Circuit
 from ai.backend.appproxy.coordinator.types import CircuitManager, CircuitRouteUpdateItem
-
-
-class _ReadonlySessionContext:
-    def __init__(self, order: list[str]) -> None:
-        self._order = order
-
-    async def __aenter__(self) -> object:
-        self._order.append("db_enter")
-        return object()
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc: BaseException | None,
-        tb: Any,
-    ) -> None:
-        self._order.append("db_exit")
-
-
-class _FakeDB:
-    def __init__(self, order: list[str]) -> None:
-        self._order = order
-
-    def begin_readonly_session(self) -> _ReadonlySessionContext:
-        return _ReadonlySessionContext(self._order)
-
-
-class _FakeCircuitManager:
-    def __init__(self, order: list[str]) -> None:
-        self._order = order
-
-    @asynccontextmanager
-    async def circuit_lock(self, _circuit_id: UUID) -> AsyncIterator[None]:
-        self._order.append("lock_enter")
-        try:
-            yield
-        finally:
-            self._order.append("lock_exit")
-
-    def release_circuit_lock(self, _circuit_id: UUID) -> None:
-        self._order.append("release_lock")
-
-    async def _update_circuit_routes_unlocked(
-        self,
-        _circuit: object,
-        _old_routes: list[object],
-    ) -> None:
-        self._order.append("update")
 
 
 @dataclass
@@ -187,27 +137,44 @@ class TestCircuitManagerLocking:
         # Lock entry is cleaned up after unload
         assert circuit.id not in circuit_manager._circuit_locks
 
-    @pytest.fixture
-    def patch_unload(
-        self,
-        circuit_manager: CircuitManager,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        monkeypatch.setattr(circuit_manager, "unload_traefik_circuit", AsyncMock(return_value=None))
-
-    async def test_unload_removes_circuit_lock(
+    async def test_circuit_lock_entry_lives_only_while_used(
         self,
         circuit_manager: CircuitManager,
         circuit: Circuit,
-        patch_unload: None,
     ) -> None:
-        # Populate the lock entry
         async with circuit_manager.circuit_lock(circuit.id):
-            pass
-        assert circuit.id in circuit_manager._circuit_locks
+            assert circuit.id in circuit_manager._circuit_locks
+        assert circuit.id not in circuit_manager._circuit_locks
 
-        # Act
-        await circuit_manager.unload_circuits([circuit])
+    async def test_waiters_keep_lock_entry_alive(
+        self,
+        circuit_manager: CircuitManager,
+        circuit: Circuit,
+    ) -> None:
+        entered = asyncio.Event()
+        release = asyncio.Event()
 
-        # Assert - lock entry should be cleaned up
+        async def _holder() -> None:
+            async with circuit_manager.circuit_lock(circuit.id):
+                entered.set()
+                await release.wait()
+
+        async def _waiter() -> None:
+            async with circuit_manager.circuit_lock(circuit.id):
+                pass
+
+        holder_task = asyncio.create_task(_holder())
+        await entered.wait()
+        held_lock = circuit_manager._circuit_locks.get(circuit.id)
+        assert held_lock is not None
+
+        waiter_task = asyncio.create_task(_waiter())
+        await asyncio.sleep(0)
+
+        assert circuit_manager._circuit_locks.get(circuit.id) is held_lock
+
+        release.set()
+        await asyncio.gather(holder_task, waiter_task)
+        # Drop the test's own strong ref so the entry can be collected.
+        del held_lock
         assert circuit.id not in circuit_manager._circuit_locks


### PR DESCRIPTION
## Summary
- Replace `CircuitManager._circuit_locks` (plain dict) with a `weakref.WeakValueDictionary` so a per-circuit lock entry lives exactly as long as some coroutine holds or waits on it, then vanishes with its last user
- Fixes unbounded memory growth in Traefik mode: the 30s reconcile loop registers a lock entry for every live circuit, but entries were only removed by `unload_circuits()` in the same process — HA setups (reconcile consumed by instance A, unload run by instance B) and missed-unload circuits leaked entries forever
- Also fixes a mutual-exclusion race: the old explicit pop could orphan a lock that still had waiters, letting a subsequent caller create a second lock for the same circuit and enter the critical section concurrently

## Test plan
- [x] `pants test tests/unit/appproxy/coordinator::` — all pass
- [x] New tests: lock entry self-cleans after its last user; pending waiters keep the entry alive and concurrent callers converge on the same lock object
- [x] mypy / ruff clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)