### PR TITLE
fix(install): run the app-proxy schema migration through the coordinator CLI

### DIFF
--- a/changes/12875.fix.md
+++ b/changes/12875.fix.md
@@ -1,0 +1,1 @@
+Fix PACKAGE-mode TUI installs leaving the app-proxy database without any tables (the schema migration silently failed with `ModuleNotFoundError`); the migration now runs through the coordinator CLI's `schema oneshot`, and a failing migration aborts the install.

--- a/src/ai/backend/install/context.py
+++ b/src/ai/backend/install/context.py
@@ -10,7 +10,6 @@ import random
 import re
 import secrets
 import shutil
-import sys
 import tempfile
 import uuid
 from abc import ABCMeta, abstractmethod
@@ -383,6 +382,27 @@ class Context(metaclass=ABCMeta):
         if exit_code != 0:
             raise RuntimeError(
                 f"Manager CLI command failed (exit {exit_code}): {' '.join(cmdargs)}"
+            )
+
+    async def run_appproxy_coordinator_cli(self, cmdargs: Sequence[str]) -> None:
+        if self.install_info.type == InstallType.SOURCE:
+            # Develop mode: use ./backend.ai from current directory
+            cmd_str = " ".join(cmdargs)
+            exit_code = await self.run_shell(f"./backend.ai app-proxy-coordinator {cmd_str}")
+
+        elif self.install_info.type == InstallType.PACKAGE:
+            # Package mode: use backendai-appproxy-coordinator from base_path
+            executable = Path(self.install_info.base_path) / "backendai-appproxy-coordinator"
+            exit_code = await self.run_exec(
+                [str(executable), "app-proxy-coordinator", *cmdargs],
+                cwd=self.install_info.base_path,
+            )
+        else:
+            raise RuntimeError(f"Unsupported install type: {self.install_info.type}")
+
+        if exit_code != 0:
+            raise RuntimeError(
+                f"App-proxy coordinator CLI command failed (exit {exit_code}): {' '.join(cmdargs)}"
             )
 
     @actxmgr
@@ -1174,12 +1194,12 @@ class Context(metaclass=ABCMeta):
         await app_conn.execute("GRANT ALL ON SCHEMA public TO appproxy;")
         await app_conn.close()
 
-        # 4. Run Alembic migration for app-proxy
+        # 4. Run the schema migration for app-proxy. The alembic scripts live
+        # inside the ai.backend.appproxy package (script_location is a package
+        # resource path), so this must run through the coordinator CLI -- the
+        # installer's own interpreter cannot import them in PACKAGE mode.
         alembic_ini = self.copy_config("alembic-appproxy.ini")
-        await self.run_exec(
-            [sys.executable, "-m", "alembic", "-c", str(alembic_ini), "upgrade", "head"],
-            cwd=self.install_info.base_path,
-        )
+        await self.run_appproxy_coordinator_cli(["schema", "oneshot", "-f", str(alembic_ini)])
         # NOTE: The "default" scaling_group's wsproxy_addr/token are set by
         # configure_appproxy_fixture(), which runs after load_fixtures() seeds
         # the row. Do not update scaling_groups here -- the row does not exist


### PR DESCRIPTION
## Summary

Follow-up to #12872, found by running a full PACKAGE-mode install end-to-end: the app-proxy database ended up with **no tables at all**, so the coordinator 500s on every query (`relation "workers" does not exist`) and workers cannot register.

## Root cause

`install_appproxy_db()` ran the migration as `sys.executable -m alembic -c alembic-appproxy.ini upgrade head`. That ini's `script_location` is a package resource path (`ai.backend.appproxy.coordinator.models:alembic`), so the migration can only run in an interpreter that can import the appproxy package — which the installer's own interpreter cannot in PACKAGE mode:

```
ModuleNotFoundError: No module named 'ai.backend.appproxy'
```

The failure was silently swallowed because `run_exec`'s exit code was not checked (same failure class that #12872 fixed for `run_manager_cli`).

## Changes

- Add `run_appproxy_coordinator_cli()` (mirroring `run_manager_cli`): `./backend.ai app-proxy-coordinator …` in SOURCE mode, the installed `backendai-appproxy-coordinator` binary in PACKAGE mode; raises on non-zero exit.
- Replace the raw alembic invocation with `schema oneshot -f alembic-appproxy.ini` through that helper — the same flow the manager already uses (`mgr schema oneshot`).

## Verification

Full E2E on a fresh PACKAGE install (halfstack + all six services):

- `schema oneshot` via the installed coordinator binary creates the appproxy tables (`workers`, `circuits`, `endpoints`, `tokens`, …)
- coordinator starts clean; worker registers (`workers.status = ALIVE`)
- scaling_group points at the coordinator with the correct api_secret (#12872 change confirmed live: the "Updating manager scaling_groups…" step runs after fixture load)
- manager/webserver/agent/storage all up; admin web login OK; compute session created and executed to completion (`exit code = 0`)
- `pants fmt/lint/check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)