### PR TITLE
fix(BA-6874): fetch resource-group agents regardless of pending sessions

### DIFF
--- a/changes/12879.fix.md
+++ b/changes/12879.fix.md
@@ -1,0 +1,1 @@
+Fix the compute-schedule dry-run reporting no schedulable agents for a resource group that has agents but no pending sessions.

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -282,19 +282,19 @@ class ScheduleDBSource:
             # 1. Get scaling group
             scaling_group_meta = await self._fetch_scaling_group(db_sess, resource_group_id)
 
-            # 2. Get pending sessions
+            # 2. Get agents
+            agents = await self._fetch_agents(db_sess, scaling_group_meta.id)
+
+            # 3. Get pending sessions
             pending_sessions = await self._fetch_pending_sessions(db_sess, scaling_group_meta.id)
             if not pending_sessions.sessions:
                 return SchedulingData(
                     scaling_group=scaling_group_meta,
                     pending_sessions=pending_sessions,
-                    agents=[],
+                    agents=agents,
                     snapshot_data=None,
                     spec=spec,
                 )
-
-            # 3. Get agents
-            agents = await self._fetch_agents(db_sess, scaling_group_meta.id)
 
             # 4. Get snapshot data
             snapshot_data = await self._fetch_snapshot_data(

--- a/src/ai/backend/manager/repositories/scheduler/repository.py
+++ b/src/ai/backend/manager/repositories/scheduler/repository.py
@@ -109,12 +109,9 @@ class SchedulerRepository:
         self._config_provider = config_provider
 
     @scheduler_repository_resilience.apply()
-    async def get_scheduling_data(
-        self, resource_group_id: ResourceGroupID
-    ) -> SchedulingData | None:
+    async def get_scheduling_data(self, resource_group_id: ResourceGroupID) -> SchedulingData:
         """
         Get scheduling data from database.
-        Returns None if no pending sessions exist.
         Raises ScalingGroupNotFound if scaling group doesn't exist.
         """
         known_slot_types = await self._get_known_slot_types()
@@ -124,11 +121,7 @@ class SchedulerRepository:
             max_container_count=max_container_count,
         )
 
-        scheduling_data = await self._db_source.get_scheduling_data(resource_group_id, spec)
-        if not scheduling_data.pending_sessions.sessions:
-            return None
-
-        return scheduling_data
+        return await self._db_source.get_scheduling_data(resource_group_id, spec)
 
     @scheduler_repository_resilience.apply()
     async def allocate_sessions(self, allocation_batch: AllocationBatch) -> list[SessionId]:

--- a/src/ai/backend/manager/sokovan/scheduler/handlers/lifecycle/schedule_sessions.py
+++ b/src/ai/backend/manager/sokovan/scheduler/handlers/lifecycle/schedule_sessions.py
@@ -120,7 +120,7 @@ class ScheduleSessionsLifecycleHandler(SessionLifecycleHandler):
 
         # Fetch scheduling data required by Provisioner
         scheduling_data = await self._repository.get_scheduling_data(resource_group_id)
-        if scheduling_data is None:
+        if not scheduling_data.pending_sessions.sessions:
             log.debug(
                 "No scheduling data for scaling group {}. Skipping all sessions.",
                 resource_group_id,

--- a/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
@@ -32,6 +32,7 @@ from ai.backend.manager.data.session.spec import (
 )
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.errors.common import InternalServerError, RejectedByHook
+from ai.backend.manager.errors.resource import ScalingGroupNotFound
 from ai.backend.manager.metrics.scheduler import (
     SchedulerOperationMetricObserver,
     SchedulerPhaseMetricObserver,
@@ -407,8 +408,9 @@ class SchedulingController:
             )
             # The selector mutates the agents list on full success; feed clones so
             # the live snapshot is never altered.
-            scheduling_data = await self._repository.get_scheduling_data(resource_group_id)
-            if scheduling_data is None:
+            try:
+                scheduling_data = await self._repository.get_scheduling_data(resource_group_id)
+            except ScalingGroupNotFound:
                 resource_group_reason = "Resource group does not exist"
                 return ComputeScheduleResult(
                     [

--- a/tests/unit/manager/sokovan/scheduler/handlers/test_lifecycle_handlers.py
+++ b/tests/unit/manager/sokovan/scheduler/handlers/test_lifecycle_handlers.py
@@ -281,14 +281,16 @@ class TestScheduleSessionsLifecycleHandler:
         mock_repository: AsyncMock,
         pending_sessions_multiple: list[SessionWithKernels],
     ) -> None:
-        """SC-SS-005: No scheduling data available skips all sessions.
+        """SC-SS-005: No pending sessions in scheduling data skips all sessions.
 
-        Given: Repository returns None for scheduling data
+        Given: Repository returns scheduling data with no pending sessions
         When: Handler is invoked
         Then: All sessions marked as skipped with appropriate reason
         """
         # Arrange
-        mock_repository.get_scheduling_data.return_value = None
+        mock_scheduling_data = MagicMock()
+        mock_scheduling_data.pending_sessions.sessions = []
+        mock_repository.get_scheduling_data.return_value = mock_scheduling_data
 
         # Act
         result = await handler.execute(ResourceGroupID(uuid.uuid4()), pending_sessions_multiple)


### PR DESCRIPTION
## Summary
- `get_scheduling_data` short-circuited with an empty agent list (and a `None` return) when a resource group had no pending sessions. The compute-schedule dry-run always runs with zero pending sessions, so it never saw the group's agents and always reported "No schedulable agents exist in the resource group".
- `db_source`: fetch agents before the no-pending-sessions early return, so the returned `SchedulingData` always carries the group's agents.
- `repository`: return `SchedulingData` unconditionally (raising `ScalingGroupNotFound` when the group is missing) instead of returning `None` on no pending sessions; callers (scheduler lifecycle handler, compute-schedule controller) are adapted to the new contract.

## Test plan
- [x] compute-schedule dry-run against a resource group with a live, schedulable agent and no pending sessions returns `success: true`
- [x] over-large request returns `success: false` with a `requiredReduction` hint
- [x] unknown image returns `imageNotFound: true`; architecture mismatch returns `availableArchs`

Resolves BA-6874

🤖 Generated with [Claude Code](https://claude.com/claude-code)
