### PR TITLE
fix(BA-6896): stop RBAC backfill downgrades from deleting live permissions

### DIFF
--- a/changes/12881.fix.md
+++ b/changes/12881.fix.md
@@ -1,0 +1,1 @@
+Stop RBAC backfill migrations from deleting operator-managed permission rows on downgrade

--- a/src/ai/backend/manager/models/alembic/versions/013a6676866c_migrate_notification_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/013a6676866c_migrate_notification_data_to_rbac.py
@@ -182,54 +182,6 @@ def _associate_notification_rules_to_scopes(db_conn: Connection) -> None:
         db_conn.execute(insert_query)
 
 
-def _remove_entity_from_scopes(db_conn: Connection, entity_type: EntityType) -> None:
-    """Remove all entity-scope associations for a given entity type."""
-    entity_type_value = entity_type.value
-
-    while True:
-        # Query records to delete
-        query = sa.text("""
-            SELECT id FROM association_scopes_entities
-            WHERE entity_type = :entity_type
-            LIMIT :limit
-        """)
-        rows = db_conn.execute(query, {"entity_type": entity_type_value, "limit": BATCH_SIZE}).all()
-        if not rows:
-            break
-
-        # Delete the queried records
-        ids = ", ".join(f"'{row.id}'" for row in rows)
-        delete_query = sa.text(f"""
-            DELETE FROM association_scopes_entities
-            WHERE id IN ({ids})
-        """)
-        db_conn.execute(delete_query)
-
-
-def _remove_entity_type_permissions(db_conn: Connection, entity_type: EntityType) -> None:
-    """Remove all entity type permissions for a given entity type."""
-    entity_type_value = entity_type.value
-
-    while True:
-        # Query permission IDs to delete
-        query = sa.text("""
-            SELECT id FROM permissions
-            WHERE entity_type = :entity_type
-            LIMIT :limit
-        """)
-        rows = db_conn.execute(query, {"entity_type": entity_type_value, "limit": BATCH_SIZE}).all()
-        if not rows:
-            break
-
-        # Delete the queried permissions
-        ids = ", ".join(f"'{row.id}'" for row in rows)
-        delete_query = sa.text(f"""
-            DELETE FROM permissions
-            WHERE id IN ({ids})
-        """)
-        db_conn.execute(delete_query)
-
-
 def upgrade() -> None:
     conn = op.get_bind()
     _migrate_new_entity_type(conn)
@@ -238,8 +190,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-    _remove_entity_from_scopes(conn, EntityType.NOTIFICATION_CHANNEL)
-    _remove_entity_from_scopes(conn, EntityType.NOTIFICATION_RULE)
-    _remove_entity_type_permissions(conn, EntityType.NOTIFICATION_CHANNEL)
-    _remove_entity_type_permissions(conn, EntityType.NOTIFICATION_RULE)
+    # Forward-only: the seeded rows are indistinguishable from ones granted
+    # afterwards, so deleting by entity_type would erase operator-managed grants.
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/091d0274c2e3_migrate_agent_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/091d0274c2e3_migrate_agent_data_to_rbac.py
@@ -197,45 +197,6 @@ def _associate_agent_to_project_scope(db_conn: Connection) -> None:
             db_conn.execute(insert_query, values_list)
 
 
-def _remove_agent_edges(db_conn: Connection) -> None:
-    """Remove all AGENT AUTO edges from association_scopes_entities."""
-    while True:
-        delete_query = sa.text("""
-            DELETE FROM association_scopes_entities
-            WHERE id IN (
-                SELECT id FROM association_scopes_entities
-                WHERE entity_type = :entity_type
-                  AND relation_type = :relation_type
-                LIMIT :limit
-            )
-        """)
-        result = db_conn.execute(
-            delete_query,
-            {"entity_type": ENTITY_TYPE_AGENT, "relation_type": "auto", "limit": BATCH_SIZE},
-        )
-        if result.rowcount == 0:
-            break
-
-
-def _remove_agent_permissions(db_conn: Connection) -> None:
-    """Remove all AGENT entity-type permissions."""
-    while True:
-        delete_query = sa.text("""
-            DELETE FROM permissions
-            WHERE id IN (
-                SELECT id FROM permissions
-                WHERE entity_type = :entity_type
-                LIMIT :limit
-            )
-        """)
-        result = db_conn.execute(
-            delete_query,
-            {"entity_type": ENTITY_TYPE_AGENT, "limit": BATCH_SIZE},
-        )
-        if result.rowcount == 0:
-            break
-
-
 def upgrade() -> None:
     conn = op.get_bind()
     _add_entity_type_permissions(conn)
@@ -244,6 +205,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-    _remove_agent_edges(conn)
-    _remove_agent_permissions(conn)
+    # Forward-only: the seeded rows are indistinguishable from ones granted
+    # afterwards, so deleting by entity_type would erase operator-managed grants.
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/0e0723286a7a_migrate_image_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/0e0723286a7a_migrate_image_data_to_rbac.py
@@ -148,50 +148,6 @@ def _associate_image_to_scope(db_conn: Connection) -> None:
             db_conn.execute(insert_query, values_list)
 
 
-def _remove_image_edges(db_conn: Connection) -> None:
-    """Remove all IMAGE AUTO edges from association_scopes_entities."""
-    entity_type = EntityType.IMAGE.value
-    relation_type = "auto"
-
-    while True:
-        delete_query = sa.text("""
-            DELETE FROM association_scopes_entities
-            WHERE id IN (
-                SELECT id FROM association_scopes_entities
-                WHERE entity_type = :entity_type
-                  AND relation_type = :relation_type
-                LIMIT :limit
-            )
-        """)
-        result = db_conn.execute(
-            delete_query,
-            {"entity_type": entity_type, "relation_type": relation_type, "limit": BATCH_SIZE},
-        )
-        if result.rowcount == 0:
-            break
-
-
-def _remove_image_permissions(db_conn: Connection) -> None:
-    """Remove all IMAGE entity-type permissions."""
-    entity_type = EntityType.IMAGE.value
-
-    while True:
-        delete_query = sa.text("""
-            DELETE FROM permissions
-            WHERE id IN (
-                SELECT id FROM permissions
-                WHERE entity_type = :entity_type
-                LIMIT :limit
-            )
-        """)
-        result = db_conn.execute(
-            delete_query,
-            {"entity_type": entity_type, "limit": BATCH_SIZE},
-        )
-        if result.rowcount == 0:
-            break
-
-
 def upgrade() -> None:
     conn = op.get_bind()
     _add_entity_type_permissions(conn)
@@ -199,6 +155,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-    _remove_image_edges(conn)
-    _remove_image_permissions(conn)
+    # Forward-only: the seeded rows are indistinguishable from ones granted
+    # afterwards, so deleting by entity_type would erase operator-managed grants.
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/21159a293dfb_migrate_keypair_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/21159a293dfb_migrate_keypair_data_to_rbac.py
@@ -137,45 +137,6 @@ def _associate_keypair_to_scope(db_conn: Connection) -> None:
             db_conn.execute(insert_query, values_list)
 
 
-def _remove_keypair_edges(db_conn: Connection) -> None:
-    """Remove all KEYPAIR AUTO edges from association_scopes_entities."""
-    while True:
-        delete_query = sa.text("""
-            DELETE FROM association_scopes_entities
-            WHERE id IN (
-                SELECT id FROM association_scopes_entities
-                WHERE entity_type = :entity_type
-                  AND relation_type = :relation_type
-                LIMIT :limit
-            )
-        """)
-        result = db_conn.execute(
-            delete_query,
-            {"entity_type": ENTITY_TYPE_KEYPAIR, "relation_type": "auto", "limit": BATCH_SIZE},
-        )
-        if result.rowcount == 0:
-            break
-
-
-def _remove_keypair_permissions(db_conn: Connection) -> None:
-    """Remove all KEYPAIR entity-type permissions."""
-    while True:
-        delete_query = sa.text("""
-            DELETE FROM permissions
-            WHERE id IN (
-                SELECT id FROM permissions
-                WHERE entity_type = :entity_type
-                LIMIT :limit
-            )
-        """)
-        result = db_conn.execute(
-            delete_query,
-            {"entity_type": ENTITY_TYPE_KEYPAIR, "limit": BATCH_SIZE},
-        )
-        if result.rowcount == 0:
-            break
-
-
 def upgrade() -> None:
     conn = op.get_bind()
     _add_entity_type_permissions(conn)
@@ -183,6 +144,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-    _remove_keypair_edges(conn)
-    _remove_keypair_permissions(conn)
+    # Forward-only: the seeded rows are indistinguishable from ones granted
+    # afterwards, so deleting by entity_type would erase operator-managed grants.
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/2185ae0dd371_migrate_vfolder_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/2185ae0dd371_migrate_vfolder_data_to_rbac.py
@@ -291,76 +291,6 @@ def _add_object_permissions_for_vfolder_invitations(db_conn: Connection) -> None
             db_conn.execute(insert_query)
 
 
-def _remove_entity_from_scopes(db_conn: Connection) -> None:
-    """Remove all vfolder-scope associations."""
-    entity_type = EntityType.VFOLDER.value
-
-    while True:
-        # Query records to delete
-        query = sa.text("""
-            SELECT id FROM association_scopes_entities
-            WHERE entity_type = :entity_type
-            LIMIT :limit
-        """)
-        rows = db_conn.execute(query, {"entity_type": entity_type, "limit": BATCH_SIZE}).all()
-        if not rows:
-            break
-
-        # Delete the queried records
-        ids = ", ".join(f"'{row.id}'" for row in rows)
-        delete_query = sa.text(f"""
-            DELETE FROM association_scopes_entities
-            WHERE id IN ({ids})
-        """)
-        db_conn.execute(delete_query)
-
-
-def _remove_entity_type_permissions(db_conn: Connection) -> None:
-    """Remove all VFOLDER entity type permissions."""
-    entity_type = EntityType.VFOLDER.value
-
-    while True:
-        # Query permission IDs to delete
-        query = sa.text("""
-            SELECT id FROM permissions
-            WHERE entity_type = :entity_type
-            LIMIT :limit
-        """)
-        rows = db_conn.execute(query, {"entity_type": entity_type, "limit": BATCH_SIZE}).all()
-        if not rows:
-            break
-
-        # Delete the queried permissions
-        ids = ", ".join(f"'{row.id}'" for row in rows)
-        delete_query = sa.text(f"""
-            DELETE FROM permissions
-            WHERE id IN ({ids})
-        """)
-        db_conn.execute(delete_query)
-
-
-def _remove_object_permissions(db_conn: Connection) -> None:
-    """Remove all VFOLDER object permissions."""
-    entity_type = EntityType.VFOLDER.value
-
-    while True:
-        query = sa.text("""
-            SELECT id FROM object_permissions
-            WHERE entity_type = :entity_type
-            LIMIT :limit
-        """)
-        rows = db_conn.execute(query, {"entity_type": entity_type, "limit": BATCH_SIZE}).all()
-        if not rows:
-            break
-
-        ids = ", ".join(f"'{row.id}'" for row in rows)
-        delete_query = sa.text(f"""
-            DELETE FROM object_permissions
-            WHERE id IN ({ids})
-        """)
-        db_conn.execute(delete_query)
-
-
 def upgrade() -> None:
     conn = op.get_bind()
     _migrate_new_entity_type(conn)
@@ -370,7 +300,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-    _remove_object_permissions(conn)
-    _remove_entity_from_scopes(conn)
-    _remove_entity_type_permissions(conn)
+    # Forward-only: the seeded rows are indistinguishable from ones granted
+    # afterwards, so deleting by entity_type would erase operator-managed grants.
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/2e42a745f939_migrate_container_registry_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/2e42a745f939_migrate_container_registry_data_to_rbac.py
@@ -198,49 +198,6 @@ def _associate_global_container_registries_to_scope(db_conn: Connection) -> None
             db_conn.execute(insert_query, values_list)
 
 
-def _remove_container_registry_edges(db_conn: Connection) -> None:
-    """Remove all CONTAINER_REGISTRY AUTO edges from association_scopes_entities."""
-    while True:
-        delete_query = sa.text("""
-            DELETE FROM association_scopes_entities
-            WHERE id IN (
-                SELECT id FROM association_scopes_entities
-                WHERE entity_type = :entity_type
-                  AND relation_type = :relation_type
-                LIMIT :limit
-            )
-        """)
-        result = db_conn.execute(
-            delete_query,
-            {
-                "entity_type": ENTITY_TYPE_CONTAINER_REGISTRY,
-                "relation_type": "auto",
-                "limit": BATCH_SIZE,
-            },
-        )
-        if result.rowcount == 0:
-            break
-
-
-def _remove_container_registry_permissions(db_conn: Connection) -> None:
-    """Remove all CONTAINER_REGISTRY entity-type permissions."""
-    while True:
-        delete_query = sa.text("""
-            DELETE FROM permissions
-            WHERE id IN (
-                SELECT id FROM permissions
-                WHERE entity_type = :entity_type
-                LIMIT :limit
-            )
-        """)
-        result = db_conn.execute(
-            delete_query,
-            {"entity_type": ENTITY_TYPE_CONTAINER_REGISTRY, "limit": BATCH_SIZE},
-        )
-        if result.rowcount == 0:
-            break
-
-
 def upgrade() -> None:
     conn = op.get_bind()
     _add_entity_type_permissions(conn)
@@ -249,6 +206,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-    _remove_container_registry_edges(conn)
-    _remove_container_registry_permissions(conn)
+    # Forward-only: the seeded rows are indistinguishable from ones granted
+    # afterwards, so deleting by entity_type would erase operator-managed grants.
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/30c8308738ee_migrate_session_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/30c8308738ee_migrate_session_data_to_rbac.py
@@ -184,46 +184,6 @@ def _associate_sessions_to_scopes(db_conn: Connection) -> None:
                 db_conn.execute(insert_query, values)
 
 
-def _remove_session_permissions(db_conn: Connection) -> None:
-    """Remove all SESSION entity-type permissions."""
-    while True:
-        # Delete permissions in batches using a parameterized subquery
-        delete_query = sa.text("""
-            DELETE FROM permissions
-            WHERE id IN (
-                SELECT id FROM permissions
-                WHERE entity_type = :entity_type
-                LIMIT :limit
-            )
-        """)
-        result = db_conn.execute(
-            delete_query,
-            {"entity_type": SESSION_ENTITY_TYPE, "limit": BATCH_SIZE},
-        )
-        if result.rowcount == 0:
-            break
-
-
-def _remove_session_edges(db_conn: Connection) -> None:
-    """Remove all SESSION AUTO edges from association_scopes_entities."""
-    while True:
-        # Delete associations in batches using a parameterized subquery
-        delete_query = sa.text("""
-            DELETE FROM association_scopes_entities
-            WHERE id IN (
-                SELECT id FROM association_scopes_entities
-                WHERE entity_type = :entity_type
-                LIMIT :limit
-            )
-        """)
-        result = db_conn.execute(
-            delete_query,
-            {"entity_type": SESSION_ENTITY_TYPE, "limit": BATCH_SIZE},
-        )
-        if result.rowcount == 0:
-            break
-
-
 def upgrade() -> None:
     conn = op.get_bind()
     _add_entity_type_permissions(conn)
@@ -231,6 +191,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-    _remove_session_edges(conn)
-    _remove_session_permissions(conn)
+    # Forward-only: the seeded rows are indistinguishable from ones granted
+    # afterwards, so deleting by entity_type would erase operator-managed grants.
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/3b6297b1bd75_add_admin_page_read_permissions.py
+++ b/src/ai/backend/manager/models/alembic/versions/3b6297b1bd75_add_admin_page_read_permissions.py
@@ -48,32 +48,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-
-    # Remove READ permission for project_admin_page only from project admin roles
-    # that match the same pattern and scope_type used in upgrade().
-    conn.execute(
-        sa.text("""
-        DELETE FROM permissions p
-        USING roles r
-        WHERE p.role_id = r.id
-          AND r.name LIKE 'role\\_project\\_%\\_admin'
-          AND p.scope_type = 'project'
-          AND p.entity_type = 'project_admin_page'
-          AND p.operation = 'read'
-    """)
-    )
-
-    # Remove READ permission for domain_admin_page only from domain admin roles
-    # that match the same pattern and scope_type used in upgrade().
-    conn.execute(
-        sa.text("""
-        DELETE FROM permissions p
-        USING roles r
-        WHERE p.role_id = r.id
-          AND r.name LIKE 'role\\_domain\\_%\\_admin'
-          AND p.scope_type = 'domain'
-          AND p.entity_type = 'domain_admin_page'
-          AND p.operation = 'read'
-    """)
-    )
+    # Forward-only: the seeded rows are indistinguishable from ones granted
+    # afterwards, so deleting by entity_type would erase operator-managed grants.
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/67f5338ff571_migrate_artifact_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/67f5338ff571_migrate_artifact_data_to_rbac.py
@@ -134,54 +134,6 @@ def _associate_entity_to_scopes(db_conn: Connection) -> None:
         db_conn.execute(insert_query)
 
 
-def _remove_entity_from_scopes(db_conn: Connection) -> None:
-    """Remove all artifact-scope associations."""
-    entity_type = EntityType.ARTIFACT.value
-
-    while True:
-        # Query records to delete
-        query = sa.text("""
-            SELECT id FROM association_scopes_entities
-            WHERE entity_type = :entity_type
-            LIMIT :limit
-        """)
-        rows = db_conn.execute(query, {"entity_type": entity_type, "limit": BATCH_SIZE}).all()
-        if not rows:
-            break
-
-        # Delete the queried records
-        ids = ", ".join(f"'{row.id}'" for row in rows)
-        delete_query = sa.text(f"""
-            DELETE FROM association_scopes_entities
-            WHERE id IN ({ids})
-        """)
-        db_conn.execute(delete_query)
-
-
-def _remove_entity_type_permissions(db_conn: Connection) -> None:
-    """Remove all ARTIFACT entity type permissions."""
-    entity_type = EntityType.ARTIFACT.value
-
-    while True:
-        # Query permission IDs to delete
-        query = sa.text("""
-            SELECT id FROM permissions
-            WHERE entity_type = :entity_type
-            LIMIT :limit
-        """)
-        rows = db_conn.execute(query, {"entity_type": entity_type, "limit": BATCH_SIZE}).all()
-        if not rows:
-            break
-
-        # Delete the queried permissions
-        ids = ", ".join(f"'{row.id}'" for row in rows)
-        delete_query = sa.text(f"""
-            DELETE FROM permissions
-            WHERE id IN ({ids})
-        """)
-        db_conn.execute(delete_query)
-
-
 def upgrade() -> None:
     conn = op.get_bind()
     _migrate_new_entity_type(conn)
@@ -189,6 +141,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-    _remove_entity_from_scopes(conn)
-    _remove_entity_type_permissions(conn)
+    # Forward-only: the seeded rows are indistinguishable from ones granted
+    # afterwards, so deleting by entity_type would erase operator-managed grants.
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/6d850788c7c8_migrate_artifact_registry_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/6d850788c7c8_migrate_artifact_registry_data_to_rbac.py
@@ -134,54 +134,6 @@ def _associate_entity_to_scopes(db_conn: Connection) -> None:
         db_conn.execute(insert_query)
 
 
-def _remove_entity_from_scopes(db_conn: Connection) -> None:
-    """Remove all artifact_registry-scope associations."""
-    entity_type = EntityType.ARTIFACT_REGISTRY.value
-
-    while True:
-        # Query records to delete
-        query = sa.text("""
-            SELECT id FROM association_scopes_entities
-            WHERE entity_type = :entity_type
-            LIMIT :limit
-        """)
-        rows = db_conn.execute(query, {"entity_type": entity_type, "limit": BATCH_SIZE}).all()
-        if not rows:
-            break
-
-        # Delete the queried records
-        ids = ", ".join(f"'{row.id}'" for row in rows)
-        delete_query = sa.text(f"""
-            DELETE FROM association_scopes_entities
-            WHERE id IN ({ids})
-        """)
-        db_conn.execute(delete_query)
-
-
-def _remove_entity_type_permissions(db_conn: Connection) -> None:
-    """Remove all ARTIFACT_REGISTRY entity type permissions."""
-    entity_type = EntityType.ARTIFACT_REGISTRY.value
-
-    while True:
-        # Query permission IDs to delete
-        query = sa.text("""
-            SELECT id FROM permissions
-            WHERE entity_type = :entity_type
-            LIMIT :limit
-        """)
-        rows = db_conn.execute(query, {"entity_type": entity_type, "limit": BATCH_SIZE}).all()
-        if not rows:
-            break
-
-        # Delete the queried permissions
-        ids = ", ".join(f"'{row.id}'" for row in rows)
-        delete_query = sa.text(f"""
-            DELETE FROM permissions
-            WHERE id IN ({ids})
-        """)
-        db_conn.execute(delete_query)
-
-
 def upgrade() -> None:
     conn = op.get_bind()
     _migrate_new_entity_type(conn)
@@ -189,6 +141,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-    _remove_entity_from_scopes(conn)
-    _remove_entity_type_permissions(conn)
+    # Forward-only: the seeded rows are indistinguishable from ones granted
+    # afterwards, so deleting by entity_type would erase operator-managed grants.
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/7h4m7ygnaao1_remigrate_vfolder_invitation_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/7h4m7ygnaao1_remigrate_vfolder_invitation_data_to_rbac.py
@@ -136,121 +136,6 @@ def _insert_entity_as_scope_permissions_for_invitations(db_conn: Connection) -> 
                 )
 
 
-def _revert_ref_edges_to_auto(db_conn: Connection) -> None:
-    """
-    Revert REF edges back to AUTO (restore old migration's state).
-
-    Only edges derived from vfolder invitations are reverted:
-    - entity_type = VFOLDER
-    - scope_type = 'user'
-    - (scope_id, entity_id) pairs present in vfolder_permissions (user_id, vfolder_id)
-
-    This is a batched operation to handle large datasets.
-    """
-    entity_type = EntityType.VFOLDER.value
-    last_id = uuid.UUID(int=0)
-
-    while True:
-        # Query invitation-derived REF edges in batches using keyset pagination
-        query = sa.text("""
-            SELECT ase.id
-            FROM association_scopes_entities AS ase
-            JOIN vfolder_permissions AS vp
-              ON ase.scope_type = 'user'
-             AND ase.entity_type = :entity_type
-             AND ase.scope_id = vp."user"::text
-             AND ase.entity_id = vp.vfolder::text
-            WHERE ase.relation_type = 'ref'
-              AND ase.id > :last_id
-            ORDER BY ase.id
-            LIMIT :limit
-        """)
-        rows = db_conn.execute(
-            query,
-            {"entity_type": entity_type, "last_id": last_id, "limit": BATCH_SIZE},
-        ).all()
-        if not rows:
-            break
-        last_id = rows[-1].id
-
-        # Update the queried records using parameterized query
-        for row in rows:
-            update_query = sa.text("""
-                UPDATE association_scopes_entities
-                SET relation_type = 'auto'
-                WHERE id = :id
-            """)
-            db_conn.execute(update_query, {"id": str(row.id)})
-
-
-def _remove_entity_as_scope_permissions(db_conn: Connection) -> None:
-    """
-    Remove entity-as-scope permissions for VFolder invitations.
-
-    This removes only those permissions that were introduced by this migration,
-    i.e., permissions derived from vfolder invitation records in vfolder_permissions
-    using the same mount-permission-to-operation mapping as in the upgrade step.
-
-    Batched operation to handle large datasets.
-    """
-    entity_type = EntityType.VFOLDER.value
-    last_id = uuid.UUID(int=0)
-
-    while True:
-        # Fetch a batch of vfolder invitation records from vfolder_permissions
-        vfolder_query = sa.text("""
-            SELECT
-                vp.id,
-                ur.role_id,
-                vp.vfolder::text AS vfolder_id,
-                vp.permission AS mount_permission
-            FROM vfolder_permissions vp
-            JOIN user_roles ur ON vp."user" = ur.user_id
-            WHERE vp.id > :last_id
-            ORDER BY vp.id
-            LIMIT :limit
-        """)
-        vfolder_rows = db_conn.execute(
-            vfolder_query,
-            {"last_id": last_id, "limit": BATCH_SIZE},
-        ).all()
-
-        if not vfolder_rows:
-            break
-
-        for row in vfolder_rows:
-            try:
-                # Map mount_permission to one or more RBAC operations,
-                # mirroring the logic used during upgrade
-                mount_perm = VFolderPermission(row.mount_permission)
-                operations = vfolder_mount_permission_to_operation[mount_perm]
-            except (ValueError, KeyError):
-                # Skip invalid permissions
-                continue
-
-            for operation in operations:
-                delete_query = sa.text("""
-                    DELETE FROM permissions
-                    WHERE role_id = :role_id
-                      AND scope_type = 'vfolder'
-                      AND scope_id = :scope_id
-                      AND entity_type = :entity_type
-                      AND operation = :operation
-                """)
-                db_conn.execute(
-                    delete_query,
-                    {
-                        "role_id": str(row.role_id),
-                        "scope_id": row.vfolder_id,
-                        "entity_type": entity_type,
-                        "operation": operation.value,
-                    },
-                )
-
-        # Advance pagination cursor using the highest processed vfolder_permissions.id
-        last_id = vfolder_rows[-1].id
-
-
 def upgrade() -> None:
     conn = op.get_bind()
     _upsert_ref_edges_for_invitations(conn)
@@ -258,6 +143,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-    _remove_entity_as_scope_permissions(conn)
-    _revert_ref_edges_to_auto(conn)
+    # Forward-only: the seeded rows are indistinguishable from ones granted
+    # afterwards, so reverting them would erase operator-managed grants.
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/82e817b74ae4_migrate_resource_group_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/82e817b74ae4_migrate_resource_group_data_to_rbac.py
@@ -197,49 +197,6 @@ def _associate_resource_group_to_project_scope(db_conn: Connection) -> None:
             db_conn.execute(insert_query, values_list)
 
 
-def _remove_resource_group_edges(db_conn: Connection) -> None:
-    """Remove all RESOURCE_GROUP AUTO edges from association_scopes_entities."""
-    while True:
-        delete_query = sa.text("""
-            DELETE FROM association_scopes_entities
-            WHERE id IN (
-                SELECT id FROM association_scopes_entities
-                WHERE entity_type = :entity_type
-                  AND relation_type = :relation_type
-                LIMIT :limit
-            )
-        """)
-        result = db_conn.execute(
-            delete_query,
-            {
-                "entity_type": ENTITY_TYPE_RESOURCE_GROUP,
-                "relation_type": "auto",
-                "limit": BATCH_SIZE,
-            },
-        )
-        if result.rowcount == 0:
-            break
-
-
-def _remove_resource_group_permissions(db_conn: Connection) -> None:
-    """Remove all RESOURCE_GROUP entity-type permissions."""
-    while True:
-        delete_query = sa.text("""
-            DELETE FROM permissions
-            WHERE id IN (
-                SELECT id FROM permissions
-                WHERE entity_type = :entity_type
-                LIMIT :limit
-            )
-        """)
-        result = db_conn.execute(
-            delete_query,
-            {"entity_type": ENTITY_TYPE_RESOURCE_GROUP, "limit": BATCH_SIZE},
-        )
-        if result.rowcount == 0:
-            break
-
-
 def upgrade() -> None:
     conn = op.get_bind()
     _add_entity_type_permissions(conn)
@@ -248,6 +205,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-    _remove_resource_group_edges(conn)
-    _remove_resource_group_permissions(conn)
+    # Forward-only: the seeded rows are indistinguishable from ones granted
+    # afterwards, so deleting by entity_type would erase operator-managed grants.
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/a5e87ed3b6d4_migrate_app_config_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/a5e87ed3b6d4_migrate_app_config_data_to_rbac.py
@@ -141,54 +141,6 @@ def _associate_entity_to_scopes(db_conn: Connection) -> None:
         db_conn.execute(insert_query)
 
 
-def _remove_entity_from_scopes(db_conn: Connection) -> None:
-    """Remove all app_config-scope associations."""
-    entity_type = EntityType.APP_CONFIG.value
-
-    while True:
-        # Query records to delete
-        query = sa.text("""
-            SELECT id FROM association_scopes_entities
-            WHERE entity_type = :entity_type
-            LIMIT :limit
-        """)
-        rows = db_conn.execute(query, {"entity_type": entity_type, "limit": BATCH_SIZE}).all()
-        if not rows:
-            break
-
-        # Delete the queried records
-        ids = ", ".join(f"'{row.id}'" for row in rows)
-        delete_query = sa.text(f"""
-            DELETE FROM association_scopes_entities
-            WHERE id IN ({ids})
-        """)
-        db_conn.execute(delete_query)
-
-
-def _remove_entity_type_permissions(db_conn: Connection) -> None:
-    """Remove all APP_CONFIG entity type permissions."""
-    entity_type = EntityType.APP_CONFIG.value
-
-    while True:
-        # Query permission IDs to delete
-        query = sa.text("""
-            SELECT id FROM permissions
-            WHERE entity_type = :entity_type
-            LIMIT :limit
-        """)
-        rows = db_conn.execute(query, {"entity_type": entity_type, "limit": BATCH_SIZE}).all()
-        if not rows:
-            break
-
-        # Delete the queried permissions
-        ids = ", ".join(f"'{row.id}'" for row in rows)
-        delete_query = sa.text(f"""
-            DELETE FROM permissions
-            WHERE id IN ({ids})
-        """)
-        db_conn.execute(delete_query)
-
-
 def upgrade() -> None:
     conn = op.get_bind()
     _migrate_new_entity_type(conn)
@@ -196,6 +148,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-    _remove_entity_from_scopes(conn)
-    _remove_entity_type_permissions(conn)
+    # Forward-only: the seeded rows are indistinguishable from ones granted
+    # afterwards, so deleting by entity_type would erase operator-managed grants.
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/d0a3c0716970_migrate_model_deployment_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/d0a3c0716970_migrate_model_deployment_data_to_rbac.py
@@ -146,54 +146,6 @@ def _associate_model_deployments_to_scopes(db_conn: Connection) -> None:
         db_conn.execute(insert_query)
 
 
-def _remove_entity_from_scopes(db_conn: Connection, entity_type: EntityType) -> None:
-    """Remove all entity-scope associations for a given entity type."""
-    entity_type_value = entity_type.value
-
-    while True:
-        # Query records to delete
-        query = sa.text("""
-            SELECT id FROM association_scopes_entities
-            WHERE entity_type = :entity_type
-            LIMIT :limit
-        """)
-        rows = db_conn.execute(query, {"entity_type": entity_type_value, "limit": BATCH_SIZE}).all()
-        if not rows:
-            break
-
-        # Delete the queried records
-        ids = ", ".join(f"'{row.id}'" for row in rows)
-        delete_query = sa.text(f"""
-            DELETE FROM association_scopes_entities
-            WHERE id IN ({ids})
-        """)
-        db_conn.execute(delete_query)
-
-
-def _remove_entity_type_permissions(db_conn: Connection, entity_type: EntityType) -> None:
-    """Remove all entity type permissions for a given entity type."""
-    entity_type_value = entity_type.value
-
-    while True:
-        # Query permission IDs to delete
-        query = sa.text("""
-            SELECT id FROM permissions
-            WHERE entity_type = :entity_type
-            LIMIT :limit
-        """)
-        rows = db_conn.execute(query, {"entity_type": entity_type_value, "limit": BATCH_SIZE}).all()
-        if not rows:
-            break
-
-        # Delete the queried permissions
-        ids = ", ".join(f"'{row.id}'" for row in rows)
-        delete_query = sa.text(f"""
-            DELETE FROM permissions
-            WHERE id IN ({ids})
-        """)
-        db_conn.execute(delete_query)
-
-
 def upgrade() -> None:
     conn = op.get_bind()
     _migrate_new_entity_type(conn)
@@ -201,6 +153,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-    _remove_entity_from_scopes(conn, EntityType.MODEL_DEPLOYMENT)
-    _remove_entity_type_permissions(conn, EntityType.MODEL_DEPLOYMENT)
+    # Forward-only: the seeded rows are indistinguishable from ones granted
+    # afterwards, so deleting by entity_type would erase operator-managed grants.
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/f1a2b3c4d5e6_add_model_card_permissions_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/f1a2b3c4d5e6_add_model_card_permissions_to_rbac.py
@@ -30,11 +30,9 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    db_conn = op.get_bind()
-    db_conn.execute(
-        sa.text("DELETE FROM permissions WHERE entity_type = :entity_type"),
-        {"entity_type": MODEL_CARD_ENTITY_TYPE},
-    )
+    # Forward-only: the seeded rows are indistinguishable from ones granted
+    # afterwards, so deleting by entity_type would erase operator-managed grants.
+    pass
 
 
 def _add_model_card_permissions(db_conn: sa.engine.Connection) -> None:


### PR DESCRIPTION
## 📚 Stacked PRs

- #12881 — `BA-6896` fix: RBAC backfill downgrades no longer delete live permissions  ← you are here
- #12883 — `BA-6897` fix: pre-constraint RBAC backfill upgrades skip existing rows

Merge in order, bottom-up. Each PR is based on the one above it, so its diff shows only its own layer.

## Problem

15 RBAC backfill migrations seed `permissions` / `association_scopes_entities` / `object_permissions` for a new entity type, and their `downgrade()` removes those rows with a blanket `DELETE ... WHERE entity_type = %s`.

Once the runtime starts using an entity type, operators grant and revoke permissions and attach entities to scopes of their own. Those rows are indistinguishable from the seeded ones, so a downgrade also erases real operator-managed grants — including the object permissions backing live vfolder invitations. The loss is unrecoverable: a later `upgrade` only re-creates the seed, not the operator's grants.

## Verified against a real database

Not a static reading — reproduced with real alembic on a Postgres DB built at head via `mgr schema oneshot`. For each migration: seed a permission row on an operator-owned role (indistinguishable from a seeded one), `stamp <rev>`, then `downgrade <parent>` so **only that migration's downgrade runs**, then check whether the operator's row survived.

| migration | entity_type | `main` (before) | this PR (after) |
|---|---|---|---|
| 30c8308738ee | session | **DESTROYED** | survived |
| 091d0274c2e3 | agent | **DESTROYED** | survived |
| 0e0723286a7a | image | **DESTROYED** | survived |
| 21159a293dfb | keypair | **DESTROYED** | survived |
| 2e42a745f939 | container_registry | **DESTROYED** | survived |
| 82e817b74ae4 | resource_group | **DESTROYED** | survived |
| 67f5338ff571 | artifact | **DESTROYED** | survived |
| 6d850788c7c8 | artifact_registry | **DESTROYED** | survived |
| a5e87ed3b6d4 | app_config | **DESTROYED** | survived |
| 013a6676866c | notification_channel | **DESTROYED** | survived |
| d0a3c0716970 | model_deployment | **DESTROYED** | survived |
| 2185ae0dd371 | vfolder | **DESTROYED** | survived |
| f1a2b3c4d5e6 | model_card | **DESTROYED** | survived |
| 3b6297b1bd75 | project_admin_page | **DESTROYED** ¹ | survived |

¹ `3b6297b1bd75` deletes only from roles matching `role_project_%_admin`, so it needs a role matching that pattern to bite; with one, it destroys the row like the rest.

## Solution

Make these `downgrade()`s no-ops with a short comment, and drop the now-dead delete/revert helpers.

This is not a new convention — it matches the forward-only precedent already set by sibling backfill migrations (`6e5a7a62a687`, `3632aad9d5d9`, `f2b9a4c7e103`, `5a4e677aea42`, `e3fb172166dc`), which are no-ops for exactly this reason.

## Out of scope

Schema-reverting migrations (constraints, columns, tables) keep their existing `downgrade()` — dropping a column the upgrade added is a real, safe revert. Only data backfills are changed here.

`7h4m7ygnaao1` also reverted `ref` edges back to `auto` on downgrade; that flips rows the operator may own too, so the whole downgrade is now a no-op.

## End-to-end verification

Added once the downgrade chain was repaired (#12887, #12907, #12910, #12912 fixed six walls that made this impossible before). A single straight `alembic downgrade` from head to `d86417a6bf7b` — **175 revisions, no skipped steps** — run on a seeded database. Operator-managed permission rows counted by `entity_type`, since `role_id` does not exist in the schema at that depth:

| chain | exit | operator rows |
|---|---|---|
| with this PR | 0 | **10 → 10 — all survived** |
| this PR reverted | 0 | **10 → 4** — session, vfolder, agent, image, container_registry, model_card destroyed |

The four survivors are the pre-redesign entity types, whose downgrades never matched these rows in the first place.

## Follow-up

Making these downgrades no-ops exposes a latent idempotency bug in six of them — fixed in the stacked PR #12883, which should land together with this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
