### PR TITLE
fix(BA-6897): make pre-constraint RBAC backfill upgrades skip existing rows

### DIFF
--- a/changes/12883.fix.md
+++ b/changes/12883.fix.md
@@ -1,0 +1,1 @@
+Make RBAC backfill migrations skip already-present rows so re-running them inserts no duplicates

--- a/src/ai/backend/manager/models/alembic/versions/013a6676866c_migrate_notification_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/013a6676866c_migrate_notification_data_to_rbac.py
@@ -112,10 +112,20 @@ def _migrate_new_entity_type(db_conn: Connection) -> None:
                 f"('{input.permission_group_id}', '{input.entity_type}', '{input.operation}')"
                 for input in inputs
             )
+            # `permissions` has no unique constraint on these columns at this
+            # revision, so ON CONFLICT has nothing to match on -- skip existing
+            # rows explicitly to keep re-runs idempotent.
             query = sa.text(f"""
                 INSERT INTO permissions (permission_group_id, entity_type, operation)
-                VALUES {values}
-                ON CONFLICT DO NOTHING
+                SELECT DISTINCT v.permission_group_id::uuid, v.entity_type, v.operation
+                FROM (VALUES {values}) AS v(permission_group_id, entity_type, operation)
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM permissions p
+                    WHERE p.permission_group_id = v.permission_group_id::uuid
+                      AND p.entity_type = v.entity_type
+                      AND p.operation = v.operation
+                )
             """)
             db_conn.execute(query)
 

--- a/src/ai/backend/manager/models/alembic/versions/2185ae0dd371_migrate_vfolder_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/2185ae0dd371_migrate_vfolder_data_to_rbac.py
@@ -105,10 +105,20 @@ def _migrate_new_entity_type(db_conn: Connection) -> None:
                 f"('{perm_id}', '{entity_type}', '{operation}')"
                 for perm_id, entity_type, operation in inputs
             )
+            # `permissions` has no unique constraint on these columns at this
+            # revision, so ON CONFLICT has nothing to match on -- skip existing
+            # rows explicitly to keep re-runs idempotent.
             query = sa.text(f"""
                 INSERT INTO permissions (permission_group_id, entity_type, operation)
-                VALUES {values}
-                ON CONFLICT DO NOTHING
+                SELECT DISTINCT v.permission_group_id::uuid, v.entity_type, v.operation
+                FROM (VALUES {values}) AS v(permission_group_id, entity_type, operation)
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM permissions p
+                    WHERE p.permission_group_id = v.permission_group_id::uuid
+                      AND p.entity_type = v.entity_type
+                      AND p.operation = v.operation
+                )
             """)
             db_conn.execute(query)
 
@@ -224,10 +234,20 @@ def _add_permission_groups_for_vfolder_invitations(db_conn: Connection) -> None:
 
         if values_list:
             values = ", ".join(values_list)
+            # `permission_groups` has no unique constraint on these columns at
+            # this revision, so ON CONFLICT has nothing to match on -- skip
+            # existing rows explicitly to keep re-runs idempotent.
             insert_query = sa.text(f"""
                 INSERT INTO permission_groups (role_id, scope_type, scope_id)
-                VALUES {values}
-                ON CONFLICT DO NOTHING
+                SELECT DISTINCT v.role_id::uuid, v.scope_type, v.scope_id
+                FROM (VALUES {values}) AS v(role_id, scope_type, scope_id)
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM permission_groups pg
+                    WHERE pg.role_id = v.role_id::uuid
+                      AND pg.scope_type = v.scope_type
+                      AND pg.scope_id = v.scope_id
+                )
             """)
             db_conn.execute(insert_query)
 
@@ -283,10 +303,21 @@ def _add_object_permissions_for_vfolder_invitations(db_conn: Connection) -> None
 
         if values_list:
             values = ", ".join(values_list)
+            # `object_permissions` has no unique constraint on these columns at
+            # this revision, so ON CONFLICT has nothing to match on -- skip
+            # existing rows explicitly to keep re-runs idempotent.
             insert_query = sa.text(f"""
                 INSERT INTO object_permissions (role_id, entity_type, entity_id, operation)
-                VALUES {values}
-                ON CONFLICT DO NOTHING
+                SELECT DISTINCT v.role_id::uuid, v.entity_type, v.entity_id, v.operation
+                FROM (VALUES {values}) AS v(role_id, entity_type, entity_id, operation)
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM object_permissions o
+                    WHERE o.role_id = v.role_id::uuid
+                      AND o.entity_type = v.entity_type
+                      AND o.entity_id = v.entity_id
+                      AND o.operation = v.operation
+                )
             """)
             db_conn.execute(insert_query)
 

--- a/src/ai/backend/manager/models/alembic/versions/67f5338ff571_migrate_artifact_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/67f5338ff571_migrate_artifact_data_to_rbac.py
@@ -94,10 +94,20 @@ def _migrate_new_entity_type(db_conn: Connection) -> None:
                 f"('{perm_id}', '{entity_type}', '{operation}')"
                 for perm_id, entity_type, operation in inputs
             )
+            # `permissions` has no unique constraint on these columns at this
+            # revision, so ON CONFLICT has nothing to match on -- skip existing
+            # rows explicitly to keep re-runs idempotent.
             query = sa.text(f"""
                 INSERT INTO permissions (permission_group_id, entity_type, operation)
-                VALUES {values}
-                ON CONFLICT DO NOTHING
+                SELECT DISTINCT v.permission_group_id::uuid, v.entity_type, v.operation
+                FROM (VALUES {values}) AS v(permission_group_id, entity_type, operation)
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM permissions p
+                    WHERE p.permission_group_id = v.permission_group_id::uuid
+                      AND p.entity_type = v.entity_type
+                      AND p.operation = v.operation
+                )
             """)
             db_conn.execute(query)
 

--- a/src/ai/backend/manager/models/alembic/versions/6d850788c7c8_migrate_artifact_registry_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/6d850788c7c8_migrate_artifact_registry_data_to_rbac.py
@@ -94,10 +94,20 @@ def _migrate_new_entity_type(db_conn: Connection) -> None:
                 f"('{perm_id}', '{entity_type}', '{operation}')"
                 for perm_id, entity_type, operation in inputs
             )
+            # `permissions` has no unique constraint on these columns at this
+            # revision, so ON CONFLICT has nothing to match on -- skip existing
+            # rows explicitly to keep re-runs idempotent.
             query = sa.text(f"""
                 INSERT INTO permissions (permission_group_id, entity_type, operation)
-                VALUES {values}
-                ON CONFLICT DO NOTHING
+                SELECT DISTINCT v.permission_group_id::uuid, v.entity_type, v.operation
+                FROM (VALUES {values}) AS v(permission_group_id, entity_type, operation)
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM permissions p
+                    WHERE p.permission_group_id = v.permission_group_id::uuid
+                      AND p.entity_type = v.entity_type
+                      AND p.operation = v.operation
+                )
             """)
             db_conn.execute(query)
 

--- a/src/ai/backend/manager/models/alembic/versions/a5e87ed3b6d4_migrate_app_config_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/a5e87ed3b6d4_migrate_app_config_data_to_rbac.py
@@ -103,10 +103,20 @@ def _migrate_new_entity_type(db_conn: Connection) -> None:
                 f"('{input.permission_group_id}', '{input.entity_type}', '{input.operation}')"
                 for input in inputs
             )
+            # `permissions` has no unique constraint on these columns at this
+            # revision, so ON CONFLICT has nothing to match on -- skip existing
+            # rows explicitly to keep re-runs idempotent.
             query = sa.text(f"""
                 INSERT INTO permissions (permission_group_id, entity_type, operation)
-                VALUES {values}
-                ON CONFLICT DO NOTHING
+                SELECT DISTINCT v.permission_group_id::uuid, v.entity_type, v.operation
+                FROM (VALUES {values}) AS v(permission_group_id, entity_type, operation)
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM permissions p
+                    WHERE p.permission_group_id = v.permission_group_id::uuid
+                      AND p.entity_type = v.entity_type
+                      AND p.operation = v.operation
+                )
             """)
             db_conn.execute(query)
 

--- a/src/ai/backend/manager/models/alembic/versions/d0a3c0716970_migrate_model_deployment_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/d0a3c0716970_migrate_model_deployment_data_to_rbac.py
@@ -106,10 +106,20 @@ def _migrate_new_entity_type(db_conn: Connection) -> None:
                 f"('{input.permission_group_id}', '{input.entity_type}', '{input.operation}')"
                 for input in inputs
             )
+            # `permissions` has no unique constraint on these columns at this
+            # revision, so ON CONFLICT has nothing to match on -- skip existing
+            # rows explicitly to keep re-runs idempotent.
             query = sa.text(f"""
                 INSERT INTO permissions (permission_group_id, entity_type, operation)
-                VALUES {values}
-                ON CONFLICT DO NOTHING
+                SELECT DISTINCT v.permission_group_id::uuid, v.entity_type, v.operation
+                FROM (VALUES {values}) AS v(permission_group_id, entity_type, operation)
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM permissions p
+                    WHERE p.permission_group_id = v.permission_group_id::uuid
+                      AND p.entity_type = v.entity_type
+                      AND p.operation = v.operation
+                )
             """)
             db_conn.execute(query)
 


### PR DESCRIPTION
## 📚 Stacked PRs

- #12881 — `BA-6896` fix: RBAC backfill downgrades no longer delete live permissions
- #12883 — `BA-6897` fix: pre-constraint RBAC backfill upgrades skip existing rows  ← you are here

Merge in order, bottom-up. Each PR is based on the one above it, so its diff shows only its own layer.

## Problem

Six RBAC backfill migrations insert with a bare `ON CONFLICT DO NOTHING`, but **the clause can never fire**.

At their point in the chain, `permissions` (created in `9adcd6f48ba1`) carries only:

```python
sa.PrimaryKeyConstraint("id", name=op.f("pk_permissions")),
```

`id` defaults to `uuid_generate_v4()`, so the sole conflict target is a freshly generated UUID. There is no unique constraint on `(permission_group_id, entity_type, operation)` — `ix_id_permission_group_id` is `unique=False`. The same holds for `permission_groups` and `object_permissions` in the vfolder migration.

`3f5c20f7bb07` only adds the `permissions` unique constraint much later in the chain, and it deletes duplicates before creating it — evidence that duplicates were reachable all along.

This was masked while the downgrades deleted the rows first. With #12881 making them forward-only, a downgrade/upgrade cycle accumulates duplicates until the chain reaches `3f5c20f7bb07` / `7369d1eb7d4a`, which dedupe before creating the constraints.

## Verified by running the real migration code

These six target the pre-redesign schema (`permission_group_id`), which no longer exists at head, so they cannot be driven through alembic on a head DB. Instead the tables were recreated exactly as defined at that revision and **each migration module's own `_migrate_new_entity_type()` was invoked three times** against a real Postgres connection — the real code path, not a transcription of it.

Row counts after each run:

| migration | `main` run 1 → 2 → 3 | this PR run 1 → 2 → 3 |
|---|---|---|
| artifact | 11 → 22 → 33 **DUPLICATES** | 11 → 11 → 11 idempotent |
| artifact_registry | 11 → 22 → 33 **DUPLICATES** | 11 → 11 → 11 idempotent |
| app_config | 11 → 22 → 33 **DUPLICATES** | 11 → 11 → 11 idempotent |
| model_deployment | 11 → 22 → 33 **DUPLICATES** | 11 → 11 → 11 idempotent |
| notification | 22 → 44 → 66 **DUPLICATES** | 22 → 22 → 22 idempotent |
| vfolder | 11 → 22 → 33 **DUPLICATES** | 11 → 11 → 11 idempotent |

## Scope

- **Changed (6):** artifact, artifact_registry, app_config, model_deployment, notification, vfolder (vfolder also guards `permission_groups` + `object_permissions`).
- **Unchanged (9):** session, agent, image, keypair, container_registry, resource_group, vfolder_invitation, model_card, admin_page — their constraint already exists, so their `ON CONFLICT` genuinely fires (a bare `ON CONFLICT DO NOTHING` catches any unique violation).
- **`association_scopes_entities` left alone:** it carries `uq_scope_id_entity_id` at these revisions (`82f4d3dea750` recreates it after `430b1631804d` drops it), so its bare `ON CONFLICT` works.

`DISTINCT` collapses repeats within a single batch. Editing released `upgrade()` bodies is safe here: a DB already past these revisions never re-runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
