### PR TITLE
feat(BA-6824): add scaling_groups.is_default with partial unique index

### DIFF
--- a/changes/12885.feature.md
+++ b/changes/12885.feature.md
@@ -1,0 +1,1 @@
+Add an `is_default` column to scaling groups with a partial unique index so that at most one resource group can be the default at a time.

--- a/fixtures/manager/example-users.json
+++ b/fixtures/manager/example-users.json
@@ -57,6 +57,7 @@
             "name": "default",
             "description": "The default agent scaling group",
             "is_active": true,
+            "is_default": true,
             "driver": "static",
             "driver_opts": {},
             "scheduler": "fifo",

--- a/src/ai/backend/manager/models/alembic/versions/b3f1a9c2d7e4_add_is_default_to_scaling_group.py
+++ b/src/ai/backend/manager/models/alembic/versions/b3f1a9c2d7e4_add_is_default_to_scaling_group.py
@@ -1,0 +1,36 @@
+"""add is_default to scaling_group
+
+Revision ID: b3f1a9c2d7e4
+Revises: aa27f1d5cd35
+Create Date: 2026-07-15 10:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b3f1a9c2d7e4"
+down_revision = "aa27f1d5cd35"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # is_default marks the single default scaling group. The partial unique index
+    # guarantees at most one row has is_default = true (a minimum of one is NOT
+    # guaranteed). Both statements use IF NOT EXISTS so the migration is idempotent
+    # and safe to re-apply (including on backport).
+    op.execute(
+        "ALTER TABLE scaling_groups "
+        "ADD COLUMN IF NOT EXISTS is_default boolean NOT NULL DEFAULT false"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_scaling_groups_is_default "
+        "ON scaling_groups (is_default) WHERE is_default"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS uq_scaling_groups_is_default")
+    op.execute("ALTER TABLE scaling_groups DROP COLUMN IF EXISTS is_default")

--- a/src/ai/backend/manager/models/scaling_group/row.py
+++ b/src/ai/backend/manager/models/scaling_group/row.py
@@ -28,7 +28,7 @@ from sqlalchemy.orm import (
     relationship,
     selectinload,
 )
-from sqlalchemy.sql.expression import true
+from sqlalchemy.sql.expression import false, true
 
 from ai.backend.common.identifier.project import ProjectID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
@@ -277,6 +277,15 @@ def _get_resource_preset_join_condition() -> Any:
 
 class ScalingGroupRow(Base):  # type: ignore[misc]
     __tablename__ = "scaling_groups"
+    __table_args__ = (
+        # Partial unique index: at most one row may have is_default = true.
+        sa.Index(
+            "uq_scaling_groups_is_default",
+            "is_default",
+            unique=True,
+            postgresql_where=sa.text("is_default"),
+        ),
+    )
     name: Mapped[str] = mapped_column("name", sa.String(length=64), primary_key=True)
     id: Mapped[ResourceGroupID] = mapped_column(
         "id",
@@ -291,6 +300,13 @@ class ScalingGroupRow(Base):  # type: ignore[misc]
     )
     is_public: Mapped[bool] = mapped_column(
         "is_public", sa.Boolean, index=True, default=True, server_default=true(), nullable=False
+    )
+    # At most one scaling group may be the default at a time. This is enforced by
+    # the partial unique index in ``__table_args__`` (a minimum of one is NOT
+    # guaranteed). To switch the default, clear the previous default before
+    # setting the new one within the same transaction.
+    is_default: Mapped[bool] = mapped_column(
+        "is_default", sa.Boolean, default=False, server_default=false(), nullable=False
     )
     created_at: Mapped[datetime | None] = mapped_column(
         "created_at", sa.DateTime(timezone=True), server_default=sa.func.now()


### PR DESCRIPTION
## Summary
- Add an `is_default` boolean column to `scaling_groups`, guarded by a partial unique index (`WHERE is_default`) so at most one group can be default at a time (a minimum of one is NOT guaranteed).
- Alembic migration is idempotent, including on backport (`ADD COLUMN IF NOT EXISTS`, `CREATE UNIQUE INDEX IF NOT EXISTS`).
- Fixtures mark the single `default` scaling group as default, so exactly one group is default after fixtures load.

Scope note: this story is schema-only. The atomic set-default operation (clear previous default within the same transaction) is enforced structurally by the partial unique index; exposing it via repository/service/API is left to follow-up work.

## Test plan
- [x] `pants test tests/unit/manager/repositories/scaling_group/::`
- [x] Migration `upgrade -> downgrade -> upgrade` is idempotent against a live DB

Resolves BA-6824