### PR TITLE
fix(BA-6899): stop app_configs downgrade from creating its enum twice

### DIFF
--- a/changes/12887.fix.md
+++ b/changes/12887.fix.md
@@ -1,0 +1,1 @@
+Fix the legacy app_configs downgrade failing with a duplicate enum type error

--- a/src/ai/backend/manager/models/alembic/versions/84d5c6daf8cc_drop_legacy_app_configs_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/84d5c6daf8cc_drop_legacy_app_configs_table.py
@@ -36,7 +36,6 @@ def downgrade() -> None:
     # Recreate the predecessor table to allow `alembic downgrade` to
     # complete cleanly. Existing-row restoration is not attempted.
     app_config_scope_type = sa.Enum("DOMAIN", "PROJECT", "USER", name="app_config_scope_type")
-    app_config_scope_type.create(op.get_bind(), checkfirst=True)
     op.create_table(
         "app_configs",
         IDColumn(),


### PR DESCRIPTION
## Problem

`84d5c6daf8cc`'s `downgrade()` **fails every time, on every database**. Any downgrade that has to cross this revision is blocked.

It creates `app_config_scope_type` twice within itself:

```python
app_config_scope_type = sa.Enum("DOMAIN", "PROJECT", "USER", name="app_config_scope_type")
app_config_scope_type.create(op.get_bind(), checkfirst=True)   # 1. creates it
op.create_table(
    "app_configs",
    ...
    sa.Column("scope_type", app_config_scope_type, ...),       # 2. emits CREATE TYPE again
```

`upgrade()` drops the type, so at this point it is absent and step 1 creates it. Step 2 then re-emits `CREATE TYPE` for the same enum with no existence check:

```
asyncpg.exceptions.DuplicateObjectError: type "app_config_scope_type" already exists
[SQL: CREATE TYPE app_config_scope_type AS ENUM ('DOMAIN', 'PROJECT', 'USER')]
```

This is **not** environment-specific and **not** an artifact of the one-shot bootstrap. On a clean DB built at head, with the enum confirmed absent (`ABSENT at head`) and no model declaring it, stamping `84d5c6daf8cc` and running only its downgrade reproduces the failure deterministically.

## Fix

Delete the explicit `create()` and let `create_table()` create the type once. `upgrade()` already does `DROP TYPE IF EXISTS`, so the pair round-trips.

## Verification

Run against a real DB built at head, before and after:

| step | before | after |
|---|---|---|
| `downgrade 84d5c6daf8cc -> f3a8c1d05e64` | **DuplicateObjectError** | exit 0 — `app_configs` restored, enum present, `scope_type` is `USER-DEFINED/app_config_scope_type` |
| `upgrade` back to `84d5c6daf8cc` | — | exit 0 — table and enum dropped again |
| `downgrade` a second time | — | exit 0 |

Found while verifying the downgrade chain for #12881.

🤖 Generated with [Claude Code](https://claude.com/claude-code)