### PR TITLE
refactor(BA-6898): move last-access marker upkeep to the event dispatcher

### DIFF
--- a/changes/12888.enhance.md
+++ b/changes/12888.enhance.md
@@ -1,0 +1,1 @@
+Maintain session last-access markers in the event dispatcher and stream service unconditionally, decoupling them from the legacy `idle.enabled`-gated network timeout checker

--- a/src/ai/backend/common/clients/valkey_client/valkey_live/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_live/client.py
@@ -56,6 +56,8 @@ _SESSION_LAST_RESPONSE_SUFFIX: Final[str] = "last_response_time"
 _AGENT_LAST_SEEN_HASH: Final[str] = "agent.last_seen"
 # Matches the legacy marker retention (1 day); safety net over the TERMINATED-event deletion.
 _SESSION_LAST_ACCESS_EXPIRATION: Final[int] = 86400
+# Sentinel meaning the session has ongoing activity; the idle checker skips judgment for it.
+_SESSION_ACTIVE_SENTINEL: Final[str] = "0"
 
 
 class ValkeyLiveClient:
@@ -214,7 +216,7 @@ class ValkeyLiveClient:
         """
         await self.store_live_data(
             self._session_last_access_key(session_id),
-            "0",
+            _SESSION_ACTIVE_SENTINEL,
             ex=_SESSION_LAST_ACCESS_EXPIRATION,
             xx=True,
         )

--- a/src/ai/backend/common/clients/valkey_client/valkey_live/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_live/client.py
@@ -54,6 +54,8 @@ _DEFAULT_EXPIRATION = 3600  # 1 hour default expiration
 _SESSION_REQUESTS_SUFFIX: Final[str] = "requests"
 _SESSION_LAST_RESPONSE_SUFFIX: Final[str] = "last_response_time"
 _AGENT_LAST_SEEN_HASH: Final[str] = "agent.last_seen"
+# Matches the legacy marker retention (1 day); safety net over the TERMINATED-event deletion.
+_SESSION_LAST_ACCESS_EXPIRATION: Final[int] = 86400
 
 
 class ValkeyLiveClient:
@@ -191,6 +193,35 @@ class ValkeyLiveClient:
         """Delete live data keys."""
         async with self._client.client() as conn:
             return await conn.delete([key])
+
+    def _session_last_access_key(self, session_id: str) -> str:
+        return f"session.{session_id}.last_access"
+
+    async def update_session_last_access(self, session_id: str) -> None:
+        """Refresh the session's last network access marker with the server time."""
+        timestamp = await self.get_server_time()
+        await self.store_live_data(
+            self._session_last_access_key(session_id),
+            f"{timestamp:.06f}",
+            ex=_SESSION_LAST_ACCESS_EXPIRATION,
+        )
+
+    async def mark_session_active(self, session_id: str) -> None:
+        """Write the "0" sentinel meaning the session has ongoing activity (never idle).
+
+        Only updates an existing marker (XX) so that markers of already-terminated
+        sessions are not resurrected.
+        """
+        await self.store_live_data(
+            self._session_last_access_key(session_id),
+            "0",
+            ex=_SESSION_LAST_ACCESS_EXPIRATION,
+            xx=True,
+        )
+
+    async def delete_session_last_access(self, session_id: str) -> None:
+        """Remove the session's last network access marker."""
+        await self.delete_live_data(self._session_last_access_key(session_id))
 
     @valkey_live_resilience.apply()
     async def incr_live_data(

--- a/src/ai/backend/common/clients/valkey_client/valkey_live/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_live/client.py
@@ -30,7 +30,7 @@ from ai.backend.common.resilience import (
     RetryArgs,
     RetryPolicy,
 )
-from ai.backend.common.types import ValkeyTarget
+from ai.backend.common.types import SessionId, ValkeyTarget
 from ai.backend.logging.utils import BraceStyleAdapter
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
@@ -194,10 +194,10 @@ class ValkeyLiveClient:
         async with self._client.client() as conn:
             return await conn.delete([key])
 
-    def _session_last_access_key(self, session_id: str) -> str:
+    def _session_last_access_key(self, session_id: SessionId) -> str:
         return f"session.{session_id}.last_access"
 
-    async def update_session_last_access(self, session_id: str) -> None:
+    async def update_session_last_access(self, session_id: SessionId) -> None:
         """Refresh the session's last network access marker with the server time."""
         timestamp = await self.get_server_time()
         await self.store_live_data(
@@ -206,7 +206,7 @@ class ValkeyLiveClient:
             ex=_SESSION_LAST_ACCESS_EXPIRATION,
         )
 
-    async def mark_session_active(self, session_id: str) -> None:
+    async def mark_session_active(self, session_id: SessionId) -> None:
         """Write the "0" sentinel meaning the session has ongoing activity (never idle).
 
         Only updates an existing marker (XX) so that markers of already-terminated
@@ -219,7 +219,7 @@ class ValkeyLiveClient:
             xx=True,
         )
 
-    async def delete_session_last_access(self, session_id: str) -> None:
+    async def delete_session_last_access(self, session_id: SessionId) -> None:
         """Remove the session's last network access marker."""
         await self.delete_live_data(self._session_last_access_key(session_id))
 

--- a/src/ai/backend/manager/dependencies/processing/composer.py
+++ b/src/ai/backend/manager/dependencies/processing/composer.py
@@ -293,6 +293,7 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
         dispatchers = Dispatchers(
             DispatcherArgs(
                 valkey_container_log=setup_input.valkey_container_log,
+                valkey_live=setup_input.valkey_live,
                 valkey_stat=setup_input.valkey_stat,
                 valkey_stream=setup_input.valkey_stream,
                 schedule_coordinator=setup_input.schedule_coordinator,

--- a/src/ai/backend/manager/event_dispatcher/dispatch.py
+++ b/src/ai/backend/manager/event_dispatcher/dispatch.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from ai.backend.common.clients.valkey_client.valkey_container_log.client import (
     ValkeyContainerLogClient,
 )
+from ai.backend.common.clients.valkey_client.valkey_live.client import ValkeyLiveClient
 from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
 from ai.backend.common.clients.valkey_client.valkey_stream.client import ValkeyStreamClient
 from ai.backend.common.etcd import AsyncEtcd
@@ -148,6 +149,7 @@ from .reporters import EventLogger
 @dataclass
 class DispatcherArgs:
     valkey_container_log: ValkeyContainerLogClient
+    valkey_live: ValkeyLiveClient
     valkey_stat: ValkeyStatClient
     valkey_stream: ValkeyStreamClient
     schedule_coordinator: ScheduleCoordinator
@@ -221,8 +223,8 @@ class Dispatchers:
             args.agent_registry,
             args.db,
             args.event_dispatcher_plugin_ctx,
-            args.idle_checker_host,
             args.scheduling_controller,
+            args.valkey_live,
         )
         self._vfolder_event_handler = VFolderEventHandler(args.db)
         self._idle_check_event_handler = IdleCheckEventHandler(args.idle_checker_host)
@@ -536,19 +538,19 @@ class Dispatchers:
         evd.consume(
             ExecutionFinishedAnycastEvent,
             None,
-            self._session_event_handler.handle_execution_finished,
+            self._session_event_handler.handle_execution_ended,
             name="session_execution.finished",
         )
         evd.consume(
             ExecutionTimeoutAnycastEvent,
             None,
-            self._session_event_handler.handle_execution_timeout,
+            self._session_event_handler.handle_execution_ended,
             name="session_execution.timeout",
         )
         evd.consume(
             ExecutionCancelledAnycastEvent,
             None,
-            self._session_event_handler.handle_execution_cancelled,
+            self._session_event_handler.handle_execution_ended,
             name="session_execution.cancelled",
         )
 

--- a/src/ai/backend/manager/event_dispatcher/handlers/session.py
+++ b/src/ai/backend/manager/event_dispatcher/handlers/session.py
@@ -95,7 +95,7 @@ class SessionEventHandler:
         published by the manager.
         """
         log.info("handle_session_started: ev:{} s:{}", event.event_name(), event.session_id)
-        await self._valkey_live.update_session_last_access(str(event.session_id))
+        await self._valkey_live.update_session_last_access(event.session_id)
         await self._handle_started_or_cancelled(None, source, event)
         await self._event_dispatcher_plugin_ctx.handle_event(context, source, event)
 
@@ -130,7 +130,7 @@ class SessionEventHandler:
         source: AgentId,
         event: SessionTerminatedAnycastEvent,
     ) -> None:
-        await self._valkey_live.delete_session_last_access(str(event.session_id))
+        await self._valkey_live.delete_session_last_access(event.session_id)
         await self._registry.clean_session(event.session_id)
         await self.invoke_session_callback(None, source, event)
 
@@ -153,7 +153,7 @@ class SessionEventHandler:
         _source: AgentId,
         event: ExecutionStartedAnycastEvent,
     ) -> None:
-        await self._valkey_live.mark_session_active(str(event.session_id))
+        await self._valkey_live.mark_session_active(event.session_id)
 
     async def handle_execution_ended(
         self,
@@ -165,7 +165,7 @@ class SessionEventHandler:
             | ExecutionCancelledAnycastEvent
         ),
     ) -> None:
-        await self._valkey_live.update_session_last_access(str(event.session_id))
+        await self._valkey_live.update_session_last_access(event.session_id)
 
     async def handle_batch_result(
         self,

--- a/src/ai/backend/manager/event_dispatcher/handlers/session.py
+++ b/src/ai/backend/manager/event_dispatcher/handlers/session.py
@@ -9,6 +9,7 @@ import sqlalchemy as sa
 import yarl
 from sqlalchemy.exc import NoResultFound
 
+from ai.backend.common.clients.valkey_client.valkey_live.client import ValkeyLiveClient
 from ai.backend.common.events.event_types.session.anycast import (
     DoTerminateSessionEvent,
     ExecutionCancelledAnycastEvent,
@@ -33,9 +34,7 @@ from ai.backend.common.types import (
     SessionTypes,
 )
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.errors.kernel import SessionNotFound
-from ai.backend.manager.idle import IdleCheckerHost
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.routing import RouteHealthStatus, RouteStatus, RoutingRow
 from ai.backend.manager.models.session import KernelLoadingStrategy, SessionRow
@@ -53,22 +52,22 @@ class SessionEventHandler:
     _registry: AgentRegistry
     _db: ExtendedAsyncSAEngine
     _event_dispatcher_plugin_ctx: EventDispatcherPluginContext
-    _idle_checker_host: IdleCheckerHost
     _scheduling_controller: SchedulingController
+    _valkey_live: ValkeyLiveClient
 
     def __init__(
         self,
         registry: AgentRegistry,
         db: ExtendedAsyncSAEngine,
         event_dispatcher_plugin_ctx: EventDispatcherPluginContext,
-        idle_checker_host: IdleCheckerHost,
         scheduling_controller: SchedulingController,
+        valkey_live: ValkeyLiveClient,
     ) -> None:
         self._registry = registry
         self._db = db
         self._event_dispatcher_plugin_ctx = event_dispatcher_plugin_ctx
-        self._idle_checker_host = idle_checker_host
         self._scheduling_controller = scheduling_controller
+        self._valkey_live = valkey_live
 
     async def _handle_started_or_cancelled(
         self,
@@ -96,10 +95,8 @@ class SessionEventHandler:
         published by the manager.
         """
         log.info("handle_session_started: ev:{} s:{}", event.event_name(), event.session_id)
+        await self._valkey_live.update_session_last_access(str(event.session_id))
         await self._handle_started_or_cancelled(None, source, event)
-        await self._idle_checker_host.dispatch_session_status_event(
-            event.session_id, SessionStatus.RUNNING
-        )
         await self._event_dispatcher_plugin_ctx.handle_event(context, source, event)
 
     async def handle_session_cancelled(
@@ -133,6 +130,7 @@ class SessionEventHandler:
         source: AgentId,
         event: SessionTerminatedAnycastEvent,
     ) -> None:
+        await self._valkey_live.delete_session_last_access(str(event.session_id))
         await self._registry.clean_session(event.session_id)
         await self.invoke_session_callback(None, source, event)
 
@@ -148,6 +146,26 @@ class SessionEventHandler:
             reason=reason.value,
             forced=False,
         )
+
+    async def handle_execution_started(
+        self,
+        _context: None,
+        _source: AgentId,
+        event: ExecutionStartedAnycastEvent,
+    ) -> None:
+        await self._valkey_live.mark_session_active(str(event.session_id))
+
+    async def handle_execution_ended(
+        self,
+        _context: None,
+        _source: AgentId,
+        event: (
+            ExecutionFinishedAnycastEvent
+            | ExecutionTimeoutAnycastEvent
+            | ExecutionCancelledAnycastEvent
+        ),
+    ) -> None:
+        await self._valkey_live.update_session_last_access(str(event.session_id))
 
     async def handle_batch_result(
         self,
@@ -297,46 +315,6 @@ class SessionEventHandler:
 
         self._registry.webhook_ptask_group.create_task(
             _make_session_callback(data, callback_url),
-        )
-
-    async def handle_execution_started(
-        self,
-        _context: None,
-        _source: AgentId,
-        event: ExecutionStartedAnycastEvent,
-    ) -> None:
-        await self._idle_checker_host.dispatch_session_execution_status_event(
-            event.session_id, event.execution_status()
-        )
-
-    async def handle_execution_finished(
-        self,
-        _context: None,
-        _source: AgentId,
-        event: ExecutionFinishedAnycastEvent,
-    ) -> None:
-        await self._idle_checker_host.dispatch_session_execution_status_event(
-            event.session_id, event.execution_status()
-        )
-
-    async def handle_execution_timeout(
-        self,
-        _context: None,
-        _source: AgentId,
-        event: ExecutionTimeoutAnycastEvent,
-    ) -> None:
-        await self._idle_checker_host.dispatch_session_execution_status_event(
-            event.session_id, event.execution_status()
-        )
-
-    async def handle_execution_cancelled(
-        self,
-        _context: None,
-        _source: AgentId,
-        event: ExecutionCancelledAnycastEvent,
-    ) -> None:
-        await self._idle_checker_host.dispatch_session_execution_status_event(
-            event.session_id, event.execution_status()
         )
 
 

--- a/src/ai/backend/manager/idle.py
+++ b/src/ai/backend/manager/idle.py
@@ -62,13 +62,11 @@ from ai.backend.common.types import (
     BackendAISchema,
     BinarySize,
     ResourceSlot,
-    SessionExecutionStatus,
     SessionTypes,
 )
 from ai.backend.common.utils import nmget
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.config.provider import ManagerConfigProvider
-from ai.backend.manager.data.session.types import SessionStatus
 
 from .defs import DEFAULT_ROLE, LockID
 from .errors.kernel import IdlePolicyNotFound
@@ -165,11 +163,6 @@ class UtilizationResourceReport(UserDict[str, UtilizationExtraInfo]):
         return {k: v.avg_util >= v.threshold for k, v in self.data.items()}
 
 
-class AppStreamingStatus(enum.Enum):
-    NO_ACTIVE_CONNECTIONS = 0
-    HAS_ACTIVE_CONNECTIONS = 1
-
-
 class ThresholdOperator(enum.StrEnum):
     AND = "and"
     OR = "or"
@@ -199,7 +192,6 @@ class IdleCheckerHost:
         valkey_stat: ValkeyStatClient,
     ) -> None:
         self._checkers: list[BaseIdleChecker] = []
-        self._event_dispatch_checkers: list[AbstractEventDispatcherIdleChecker] = []
         self._frozen = False
         self._db = db
         self._config_provider = config_provider
@@ -217,13 +209,6 @@ class IdleCheckerHost:
             )
         self._checkers.append(checker)
 
-    def add_event_dispatch_checker(self, checker: AbstractEventDispatcherIdleChecker) -> None:
-        if self._frozen:
-            raise RuntimeError(
-                "Cannot add a new event dispatch idle checker after the idle checker host is frozen."
-            )
-        self._event_dispatch_checkers.append(checker)
-
     async def start(self) -> None:
         self._frozen = True
         raw_config = self._config_provider.config.idle.checkers
@@ -232,10 +217,6 @@ class IdleCheckerHost:
         )
         for checker in self._checkers:
             await checker.populate_config(raw_config.get(checker.name) or {})
-        for event_dispatcher_checker in self._event_dispatch_checkers:
-            await event_dispatcher_checker.populate_config(
-                raw_config.get(event_dispatcher_checker.name()) or {}
-            )
         self.timer = GlobalTimer(
             self._lock_factory(LockID.LOCKID_IDLE_CHECK_TIMER, self.check_interval),
             self._event_producer,
@@ -251,30 +232,6 @@ class IdleCheckerHost:
         await self.timer.leave()
         await self._valkey_stat.close()
         await self._valkey_live.close()
-
-    async def update_app_streaming_status(
-        self,
-        session_id: SessionId,
-        status: AppStreamingStatus,
-    ) -> None:
-        for checker in self._checkers:
-            await checker.update_app_streaming_status(session_id, status)
-
-    async def dispatch_session_status_event(
-        self,
-        session_id: SessionId,
-        status: SessionStatus,
-    ) -> None:
-        for checker in self._event_dispatch_checkers:
-            await checker.watch_session_status(session_id, status)
-
-    async def dispatch_session_execution_status_event(
-        self,
-        session_id: SessionId,
-        status: SessionExecutionStatus,
-    ) -> None:
-        for checker in self._event_dispatch_checkers:
-            await checker.watch_session_execution(session_id, status)
 
     async def do_idle_check(self) -> None:
         log.debug("do_idle_check(): triggered")
@@ -424,13 +381,6 @@ class AbstractIdleCheckReporter(ABC):
     @abstractmethod
     async def populate_config(self, config: Mapping[str, Any]) -> None:
         raise NotImplementedError
-
-    async def update_app_streaming_status(
-        self,
-        session_id: SessionId,
-        status: AppStreamingStatus,
-    ) -> None:
-        pass
 
     @classmethod
     def get_report_key(cls, session_id: SessionId) -> str:
@@ -586,134 +536,12 @@ class BaseIdleChecker(AbstractIdleChecker, AbstractIdleCheckReporter):
         )
 
 
-class AbstractEventDispatcherIdleChecker(ABC):
-    @classmethod
-    @abstractmethod
-    def name(cls) -> str:
-        raise NotImplementedError
-
-    @abstractmethod
-    async def populate_config(self, raw_config: Mapping[str, Any]) -> None:
-        raise NotImplementedError
-
-    @abstractmethod
-    async def watch_session_status(
-        self,
-        session_id: SessionId,
-        status: SessionStatus,
-    ) -> None:
-        """
-        Check the session status and update the idle checker's state accordingly.
-        This method is called when the session status changes.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    async def watch_session_execution(
-        self,
-        session_id: SessionId,
-        status: SessionExecutionStatus,
-    ) -> None:
-        """
-        Check the session status and update the idle checker's state accordingly.
-        This method is called when the session status changes.
-        """
-        raise NotImplementedError
-
-
 NETWORK_IDLE_CHECKER_NAME = "network_timeout"
 SESSION_LIFETIME_CHECKER_NAME = "session_lifetime"
 UTILIZATION_CHECKER_NAME = "utilization"
 
 
-@dataclass
-class EventDispatcherIdleCheckerInitArgs:
-    redis_live: ValkeyLiveClient
-    idle_timeout: timedelta | None = None
-
-
 DEFAULT_NETWORK_CHECKER_IDLE_TIMEOUT: Final[timedelta] = timedelta(minutes=10)
-
-
-class NetworkTimeoutEventDispatcherIdleChecker(AbstractEventDispatcherIdleChecker):
-    _redis_live: ValkeyLiveClient
-    _idle_timeout: timedelta
-
-    _config_iv = t.Dict(
-        {
-            t.Key("threshold", default=None): t.Null | tx.TimeDuration(),
-        },
-    ).allow_extra("*")
-
-    def __init__(
-        self,
-        args: EventDispatcherIdleCheckerInitArgs,
-    ) -> None:
-        self._redis_live = args.redis_live
-        self._idle_timeout = args.idle_timeout or DEFAULT_NETWORK_CHECKER_IDLE_TIMEOUT
-
-    @override
-    @classmethod
-    def name(cls) -> str:
-        return NETWORK_IDLE_CHECKER_NAME
-
-    @override
-    async def populate_config(self, raw_config: Mapping[str, Any]) -> None:
-        config = self._config_iv.check(raw_config)
-        self._idle_timeout = config["threshold"] or DEFAULT_NETWORK_CHECKER_IDLE_TIMEOUT
-
-    @override
-    async def watch_session_status(
-        self,
-        session_id: SessionId,
-        status: SessionStatus,
-    ) -> None:
-        match status:
-            case SessionStatus.RUNNING:
-                await self._update_timeout(session_id)
-
-    @override
-    async def watch_session_execution(
-        self,
-        session_id: SessionId,
-        status: SessionExecutionStatus,
-    ) -> None:
-        match status:
-            case SessionExecutionStatus.STARTED:
-                await self._disable_timeout(session_id)
-            case (
-                SessionExecutionStatus.FINISHED
-                | SessionExecutionStatus.TIMEOUT
-                | SessionExecutionStatus.CANCELED
-            ):
-                await self._update_timeout(session_id)
-
-    async def update_app_streaming_status(
-        self,
-        session_id: SessionId,
-        status: AppStreamingStatus,
-    ) -> None:
-        if status == AppStreamingStatus.HAS_ACTIVE_CONNECTIONS:
-            await self._disable_timeout(session_id)
-        elif status == AppStreamingStatus.NO_ACTIVE_CONNECTIONS:
-            await self._update_timeout(session_id)
-
-    async def _disable_timeout(self, session_id: SessionId) -> None:
-        log.debug("NetworkTimeoutIdleChecker._disable_timeout({})", session_id)
-        await self._redis_live.store_live_data(
-            f"session.{session_id}.last_access",
-            "0",
-            xx=True,
-        )
-
-    async def _update_timeout(self, session_id: SessionId) -> None:
-        log.debug("NetworkTimeoutIdleChecker._update_timeout({})", session_id)
-        timestamp = await self._redis_live.get_server_time()
-        await self._redis_live.store_live_data(
-            f"session.{session_id}.last_access",
-            f"{timestamp:.06f}",
-            ex=max(86400, int(self._idle_timeout.total_seconds() * 2)),
-        )
 
 
 class NetworkTimeoutIdleChecker(BaseIdleChecker):
@@ -1303,8 +1131,6 @@ checker_registry: Mapping[str, type[BaseIdleChecker]] = {
     UtilizationIdleChecker.name: UtilizationIdleChecker,
 }
 
-event_dispatcher_idle_checkers = (NetworkTimeoutEventDispatcherIdleChecker,)
-
 
 async def init_idle_checkers(
     db: SAEngine,
@@ -1353,11 +1179,4 @@ async def init_idle_checkers(
         log.info("Initializing idle checker: {}", checker_name)
         checker_instance = checker_cls(checker_init_args)
         checker_host.add_checker(checker_instance)
-    event_dispatcher_checker_args = EventDispatcherIdleCheckerInitArgs(
-        checker_host._valkey_live,
-    )
-    for event_dispatcher_checker_cls in event_dispatcher_idle_checkers:
-        if event_dispatcher_checker_cls.name() in enabled_checker_names:
-            event_dispatcher_checker = event_dispatcher_checker_cls(event_dispatcher_checker_args)
-            checker_host.add_event_dispatch_checker(event_dispatcher_checker)
     return checker_host

--- a/src/ai/backend/manager/services/factory.py
+++ b/src/ai/backend/manager/services/factory.py
@@ -424,7 +424,6 @@ def create_services(args: ServiceArgs) -> Services:
             repository=repositories.stream.repository,
             registry=args.agent_registry,
             valkey_live=args.valkey_live,
-            idle_checker_host=args.idle_checker_host,
             etcd=args.etcd,
         ),
         events=EventsService(

--- a/src/ai/backend/manager/services/stream/service.py
+++ b/src/ai/backend/manager/services/stream/service.py
@@ -8,11 +8,10 @@ from typing import Final
 from ai.backend.common import validators as tx
 from ai.backend.common.clients.valkey_client.valkey_live.client import ValkeyLiveClient
 from ai.backend.common.etcd import AsyncEtcd
-from ai.backend.common.types import AgentId, KernelId, SessionId
+from ai.backend.common.types import AgentId, KernelId
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.errors.api import NotImplementedAPI
 from ai.backend.manager.errors.resource import AgentNotAllocated
-from ai.backend.manager.idle import AppStreamingStatus, IdleCheckerHost
 from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.repositories.stream.repository import StreamRepository
 from ai.backend.manager.services.stream.actions.execute_in_stream import (
@@ -55,7 +54,6 @@ class StreamService:
     _repository: StreamRepository
     _registry: AgentRegistry
     _valkey_live: ValkeyLiveClient
-    _idle_checker_host: IdleCheckerHost
     _etcd: AsyncEtcd
 
     def __init__(
@@ -63,13 +61,11 @@ class StreamService:
         repository: StreamRepository,
         registry: AgentRegistry,
         valkey_live: ValkeyLiveClient,
-        idle_checker_host: IdleCheckerHost,
         etcd: AsyncEtcd,
     ) -> None:
         self._repository = repository
         self._registry = registry
         self._valkey_live = valkey_live
-        self._idle_checker_host = idle_checker_host
         self._etcd = etcd
 
     async def get_streaming_session(
@@ -152,10 +148,7 @@ class StreamService:
         await self._valkey_live.update_connection_tracker(
             str(action.kernel_id), action.service, action.stream_id
         )
-        await self._idle_checker_host.update_app_streaming_status(
-            action.session_id,
-            AppStreamingStatus.HAS_ACTIVE_CONNECTIONS,
-        )
+        await self._valkey_live.mark_session_active(str(action.session_id))
         return TrackConnectionActionResult(kernel_id=str(action.kernel_id))
 
     async def untrack_connection(
@@ -166,10 +159,7 @@ class StreamService:
         )
         remaining_count = await self._valkey_live.count_active_connections(str(action.kernel_id))
         if remaining_count == 0:
-            await self._idle_checker_host.update_app_streaming_status(
-                action.session_id,
-                AppStreamingStatus.NO_ACTIVE_CONNECTIONS,
-            )
+            await self._valkey_live.update_session_last_access(str(action.session_id))
         return UntrackConnectionActionResult(
             kernel_id=str(action.kernel_id),
             remaining_count=remaining_count,
@@ -197,9 +187,6 @@ class StreamService:
                 remaining,
             )
             if prev_remaining > 0 and remaining == 0:
-                await self._idle_checker_host.update_app_streaming_status(
-                    SessionId(session_id),
-                    AppStreamingStatus.NO_ACTIVE_CONNECTIONS,
-                )
+                await self._valkey_live.update_session_last_access(str(session_id))
                 removed_sessions.append(str(session_id))
         return GCStaleConnectionsActionResult(removed_sessions=removed_sessions)

--- a/src/ai/backend/manager/services/stream/service.py
+++ b/src/ai/backend/manager/services/stream/service.py
@@ -8,7 +8,7 @@ from typing import Final
 from ai.backend.common import validators as tx
 from ai.backend.common.clients.valkey_client.valkey_live.client import ValkeyLiveClient
 from ai.backend.common.etcd import AsyncEtcd
-from ai.backend.common.types import AgentId, KernelId
+from ai.backend.common.types import AgentId, KernelId, SessionId
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.errors.api import NotImplementedAPI
 from ai.backend.manager.errors.resource import AgentNotAllocated
@@ -148,7 +148,7 @@ class StreamService:
         await self._valkey_live.update_connection_tracker(
             str(action.kernel_id), action.service, action.stream_id
         )
-        await self._valkey_live.mark_session_active(str(action.session_id))
+        await self._valkey_live.mark_session_active(action.session_id)
         return TrackConnectionActionResult(kernel_id=str(action.kernel_id))
 
     async def untrack_connection(
@@ -159,7 +159,7 @@ class StreamService:
         )
         remaining_count = await self._valkey_live.count_active_connections(str(action.kernel_id))
         if remaining_count == 0:
-            await self._valkey_live.update_session_last_access(str(action.session_id))
+            await self._valkey_live.update_session_last_access(action.session_id)
         return UntrackConnectionActionResult(
             kernel_id=str(action.kernel_id),
             remaining_count=remaining_count,
@@ -187,6 +187,6 @@ class StreamService:
                 remaining,
             )
             if prev_remaining > 0 and remaining == 0:
-                await self._valkey_live.update_session_last_access(str(session_id))
+                await self._valkey_live.update_session_last_access(SessionId(session_id))
                 removed_sessions.append(str(session_id))
         return GCStaleConnectionsActionResult(removed_sessions=removed_sessions)

--- a/tests/component/stream/conftest.py
+++ b/tests/component/stream/conftest.py
@@ -73,7 +73,6 @@ def stream_processors(
         repository=repo,
         registry=AsyncMock(),
         valkey_live=valkey_clients.live,
-        idle_checker_host=AsyncMock(),
         etcd=async_etcd,
     )
     return StreamProcessors(service=service, action_monitors=[])

--- a/tests/component/streaming/conftest.py
+++ b/tests/component/streaming/conftest.py
@@ -70,7 +70,6 @@ def stream_processors(
         repository=repo,
         registry=AsyncMock(),
         valkey_live=valkey_clients.live,
-        idle_checker_host=AsyncMock(),
         etcd=async_etcd,
     )
     return StreamProcessors(service=service, action_monitors=[])

--- a/tests/unit/common/clients/valkey_client/test_valkey_live_client.py
+++ b/tests/unit/common/clients/valkey_client/test_valkey_live_client.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import pytest
 
 from ai.backend.common.clients.valkey_client.valkey_live.client import ValkeyLiveClient
+from ai.backend.common.types import SessionId
 
 
 async def test_valkey_live_hset_operations(test_valkey_live: ValkeyLiveClient) -> None:
@@ -49,17 +50,17 @@ async def test_valkey_live_multiple_data_operations(test_valkey_live: ValkeyLive
 
 class TestSessionLastAccessMarker:
     @pytest.fixture()
-    def session_id(self) -> str:
-        return str(uuid4())
+    def session_id(self) -> SessionId:
+        return SessionId(uuid4())
 
     @pytest.fixture()
-    def marker_key(self, session_id: str) -> str:
+    def marker_key(self, session_id: SessionId) -> str:
         return f"session.{session_id}.last_access"
 
     async def test_update_writes_server_timestamp(
         self,
         test_valkey_live: ValkeyLiveClient,
-        session_id: str,
+        session_id: SessionId,
         marker_key: str,
     ) -> None:
         await test_valkey_live.update_session_last_access(session_id)
@@ -71,7 +72,7 @@ class TestSessionLastAccessMarker:
     async def test_mark_active_requires_existing_marker(
         self,
         test_valkey_live: ValkeyLiveClient,
-        session_id: str,
+        session_id: SessionId,
         marker_key: str,
     ) -> None:
         await test_valkey_live.mark_session_active(session_id)
@@ -81,7 +82,7 @@ class TestSessionLastAccessMarker:
     async def test_mark_active_overwrites_existing_marker(
         self,
         test_valkey_live: ValkeyLiveClient,
-        session_id: str,
+        session_id: SessionId,
         marker_key: str,
     ) -> None:
         await test_valkey_live.update_session_last_access(session_id)
@@ -93,7 +94,7 @@ class TestSessionLastAccessMarker:
     async def test_delete_removes_marker(
         self,
         test_valkey_live: ValkeyLiveClient,
-        session_id: str,
+        session_id: SessionId,
         marker_key: str,
     ) -> None:
         await test_valkey_live.update_session_last_access(session_id)

--- a/tests/unit/common/clients/valkey_client/test_valkey_live_client.py
+++ b/tests/unit/common/clients/valkey_client/test_valkey_live_client.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import random
+from uuid import uuid4
+
+import pytest
 
 from ai.backend.common.clients.valkey_client.valkey_live.client import ValkeyLiveClient
 
@@ -42,6 +45,62 @@ async def test_valkey_live_multiple_data_operations(test_valkey_live: ValkeyLive
     results = await test_valkey_live.get_multiple_live_data(keys)
     assert len(results) == 3
     assert all(result is not None for result in results)
+
+
+class TestSessionLastAccessMarker:
+    @pytest.fixture()
+    def session_id(self) -> str:
+        return str(uuid4())
+
+    @pytest.fixture()
+    def marker_key(self, session_id: str) -> str:
+        return f"session.{session_id}.last_access"
+
+    async def test_update_writes_server_timestamp(
+        self,
+        test_valkey_live: ValkeyLiveClient,
+        session_id: str,
+        marker_key: str,
+    ) -> None:
+        await test_valkey_live.update_session_last_access(session_id)
+
+        raw_marker = await test_valkey_live.get_live_data(marker_key)
+        assert raw_marker is not None
+        assert float(raw_marker) > 0
+
+    async def test_mark_active_requires_existing_marker(
+        self,
+        test_valkey_live: ValkeyLiveClient,
+        session_id: str,
+        marker_key: str,
+    ) -> None:
+        await test_valkey_live.mark_session_active(session_id)
+
+        assert await test_valkey_live.get_live_data(marker_key) is None
+
+    async def test_mark_active_overwrites_existing_marker(
+        self,
+        test_valkey_live: ValkeyLiveClient,
+        session_id: str,
+        marker_key: str,
+    ) -> None:
+        await test_valkey_live.update_session_last_access(session_id)
+
+        await test_valkey_live.mark_session_active(session_id)
+
+        assert await test_valkey_live.get_live_data(marker_key) == b"0"
+
+    async def test_delete_removes_marker(
+        self,
+        test_valkey_live: ValkeyLiveClient,
+        session_id: str,
+        marker_key: str,
+    ) -> None:
+        await test_valkey_live.update_session_last_access(session_id)
+
+        await test_valkey_live.delete_session_last_access(session_id)
+
+        assert await test_valkey_live.get_live_data(marker_key) is None
 
 
 async def test_valkey_live_client_lifecycle(test_valkey_live: ValkeyLiveClient) -> None:

--- a/tests/unit/manager/event_dispatcher/handlers/test_session.py
+++ b/tests/unit/manager/event_dispatcher/handlers/test_session.py
@@ -257,7 +257,7 @@ class TestSessionActivityMarkers:
 
         await handler.handle_session_started(None, AgentId("i-test"), event)
 
-        mock_valkey_live.update_session_last_access.assert_awaited_once_with(str(session_id))
+        mock_valkey_live.update_session_last_access.assert_awaited_once_with(session_id)
 
     async def test_session_terminated_deletes_marker(self, session_id: SessionId) -> None:
         handler, _mock_registry, mock_valkey_live = _make_handler(_make_mock_db(AsyncMock()))
@@ -266,7 +266,7 @@ class TestSessionActivityMarkers:
         with patch.object(handler, "invoke_session_callback", new=AsyncMock()):
             await handler.handle_session_terminated(None, AgentId("i-test"), event)
 
-        mock_valkey_live.delete_session_last_access.assert_awaited_once_with(str(session_id))
+        mock_valkey_live.delete_session_last_access.assert_awaited_once_with(session_id)
 
     async def test_execution_started_marks_session_active(self, session_id: SessionId) -> None:
         handler, _mock_registry, mock_valkey_live = _make_handler(_make_mock_db(AsyncMock()))
@@ -274,7 +274,7 @@ class TestSessionActivityMarkers:
 
         await handler.handle_execution_started(None, AgentId("i-test"), event)
 
-        mock_valkey_live.mark_session_active.assert_awaited_once_with(str(session_id))
+        mock_valkey_live.mark_session_active.assert_awaited_once_with(session_id)
 
     @pytest.mark.parametrize(
         "event_cls",
@@ -298,4 +298,4 @@ class TestSessionActivityMarkers:
 
         await handler.handle_execution_ended(None, AgentId("i-test"), event)
 
-        mock_valkey_live.update_session_last_access.assert_awaited_once_with(str(session_id))
+        mock_valkey_live.update_session_last_access.assert_awaited_once_with(session_id)

--- a/tests/unit/manager/event_dispatcher/handlers/test_session.py
+++ b/tests/unit/manager/event_dispatcher/handlers/test_session.py
@@ -12,6 +12,11 @@ import pytest
 import yarl
 
 from ai.backend.common.events.event_types.session.anycast import (
+    ExecutionCancelledAnycastEvent,
+    ExecutionFinishedAnycastEvent,
+    ExecutionStartedAnycastEvent,
+    ExecutionTimeoutAnycastEvent,
+    SessionStartedAnycastEvent,
     SessionTerminatedAnycastEvent,
 )
 from ai.backend.common.types import (
@@ -63,25 +68,28 @@ def _make_mock_session_row(
     return row
 
 
-def _make_handler(mock_db: MagicMock) -> tuple[SessionEventHandler, MagicMock]:
+def _make_handler(mock_db: MagicMock) -> tuple[SessionEventHandler, MagicMock, AsyncMock]:
     """Create a SessionEventHandler with mocked dependencies.
 
-    Returns the handler and the mock registry so callers can inspect create_task calls.
+    Returns the handler with the mock registry and mock valkey-live client so
+    callers can inspect create_task and last-access marker calls.
     """
     mock_registry = MagicMock()
     mock_registry.webhook_ptask_group = MagicMock()
+    mock_registry.clean_session = AsyncMock()
     mock_event_dispatcher_plugin_ctx = MagicMock()
-    mock_idle_checker_host = MagicMock()
+    mock_event_dispatcher_plugin_ctx.handle_event = AsyncMock()
     mock_scheduling_controller = MagicMock()
     mock_scheduling_controller.mark_sessions_for_termination = AsyncMock()
+    mock_valkey_live = AsyncMock()
     handler = SessionEventHandler(
         registry=mock_registry,
         db=mock_db,
         event_dispatcher_plugin_ctx=mock_event_dispatcher_plugin_ctx,
-        idle_checker_host=mock_idle_checker_host,
         scheduling_controller=mock_scheduling_controller,
+        valkey_live=mock_valkey_live,
     )
-    return handler, mock_registry
+    return handler, mock_registry, mock_valkey_live
 
 
 async def _invoke_and_capture(
@@ -91,7 +99,7 @@ async def _invoke_and_capture(
     """Run invoke_session_callback and return the captured webhook payload data."""
     mock_db_session = AsyncMock()
     mock_db = _make_mock_db(mock_db_session)
-    handler, mock_registry = _make_handler(mock_db)
+    handler, mock_registry, _mock_valkey_live = _make_handler(mock_db)
 
     captured_data: dict[str, Any] = {}
 
@@ -219,7 +227,7 @@ class TestInvokeSessionCallbackPayload:
 
         mock_db_session = AsyncMock()
         mock_db = _make_mock_db(mock_db_session)
-        handler, mock_registry = _make_handler(mock_db)
+        handler, mock_registry, _mock_valkey_live = _make_handler(mock_db)
 
         with (
             patch(
@@ -234,3 +242,60 @@ class TestInvokeSessionCallbackPayload:
             await handler.invoke_session_callback(None, AgentId("i-test"), event)
 
         mock_callback.assert_not_called()
+
+
+class TestSessionActivityMarkers:
+    """Tests for the session last-access marker upkeep on session/execution events."""
+
+    @pytest.fixture
+    def session_id(self) -> SessionId:
+        return SessionId(uuid.uuid4())
+
+    async def test_session_started_initializes_marker(self, session_id: SessionId) -> None:
+        handler, _mock_registry, mock_valkey_live = _make_handler(_make_mock_db(AsyncMock()))
+        event = SessionStartedAnycastEvent(session_id, "creation-id")
+
+        await handler.handle_session_started(None, AgentId("i-test"), event)
+
+        mock_valkey_live.update_session_last_access.assert_awaited_once_with(str(session_id))
+
+    async def test_session_terminated_deletes_marker(self, session_id: SessionId) -> None:
+        handler, _mock_registry, mock_valkey_live = _make_handler(_make_mock_db(AsyncMock()))
+        event = SessionTerminatedAnycastEvent(session_id, "user-requested")
+
+        with patch.object(handler, "invoke_session_callback", new=AsyncMock()):
+            await handler.handle_session_terminated(None, AgentId("i-test"), event)
+
+        mock_valkey_live.delete_session_last_access.assert_awaited_once_with(str(session_id))
+
+    async def test_execution_started_marks_session_active(self, session_id: SessionId) -> None:
+        handler, _mock_registry, mock_valkey_live = _make_handler(_make_mock_db(AsyncMock()))
+        event = ExecutionStartedAnycastEvent(session_id)
+
+        await handler.handle_execution_started(None, AgentId("i-test"), event)
+
+        mock_valkey_live.mark_session_active.assert_awaited_once_with(str(session_id))
+
+    @pytest.mark.parametrize(
+        "event_cls",
+        [
+            ExecutionFinishedAnycastEvent,
+            ExecutionTimeoutAnycastEvent,
+            ExecutionCancelledAnycastEvent,
+        ],
+    )
+    async def test_execution_ended_refreshes_marker(
+        self,
+        session_id: SessionId,
+        event_cls: type[
+            ExecutionFinishedAnycastEvent
+            | ExecutionTimeoutAnycastEvent
+            | ExecutionCancelledAnycastEvent
+        ],
+    ) -> None:
+        handler, _mock_registry, mock_valkey_live = _make_handler(_make_mock_db(AsyncMock()))
+        event = event_cls(session_id)
+
+        await handler.handle_execution_ended(None, AgentId("i-test"), event)
+
+        mock_valkey_live.update_session_last_access.assert_awaited_once_with(str(session_id))

--- a/tests/unit/manager/services/stream/test_stream_service.py
+++ b/tests/unit/manager/services/stream/test_stream_service.py
@@ -9,7 +9,6 @@ from ai.backend.common.clients.valkey_client.valkey_live.client import ValkeyLiv
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.types import KernelId, SessionId
 from ai.backend.manager.errors.kernel import SessionNotFound
-from ai.backend.manager.idle import AppStreamingStatus, IdleCheckerHost
 from ai.backend.manager.models.session.row import SessionRow
 from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.repositories.stream.repository import StreamRepository
@@ -62,10 +61,6 @@ class TestStreamService:
         return AsyncMock(spec=ValkeyLiveClient)
 
     @pytest.fixture
-    def mock_idle_checker_host(self) -> AsyncMock:
-        return AsyncMock(spec=IdleCheckerHost)
-
-    @pytest.fixture
     def mock_etcd(self) -> AsyncMock:
         return AsyncMock(spec=AsyncEtcd)
 
@@ -75,14 +70,12 @@ class TestStreamService:
         mock_repository: AsyncMock,
         mock_registry: AsyncMock,
         mock_valkey_live: AsyncMock,
-        mock_idle_checker_host: AsyncMock,
         mock_etcd: AsyncMock,
     ) -> StreamService:
         return StreamService(
             repository=mock_repository,
             registry=mock_registry,
             valkey_live=mock_valkey_live,
-            idle_checker_host=mock_idle_checker_host,
             etcd=mock_etcd,
         )
 
@@ -272,11 +265,10 @@ class TestStartServiceInStream(TestStreamService):
 
 
 class TestTrackConnection(TestStreamService):
-    async def test_track_updates_valkey_and_idle_checker(
+    async def test_track_updates_tracker_and_marker(
         self,
         stream_service: StreamService,
         mock_valkey_live: AsyncMock,
-        mock_idle_checker_host: AsyncMock,
     ) -> None:
         action = TrackConnectionAction(
             kernel_id=FAKE_KERNEL_ID,
@@ -292,16 +284,12 @@ class TestTrackConnection(TestStreamService):
         mock_valkey_live.update_connection_tracker.assert_awaited_once_with(
             str(FAKE_KERNEL_ID), "jupyter", "stream-001"
         )
-        mock_idle_checker_host.update_app_streaming_status.assert_awaited_once_with(
-            FAKE_SESSION_ID,
-            AppStreamingStatus.HAS_ACTIVE_CONNECTIONS,
-        )
+        mock_valkey_live.mark_session_active.assert_awaited_once_with(str(FAKE_SESSION_ID))
 
     async def test_re_registration_calls_same_methods(
         self,
         stream_service: StreamService,
         mock_valkey_live: AsyncMock,
-        mock_idle_checker_host: AsyncMock,
     ) -> None:
         action = TrackConnectionAction(
             kernel_id=FAKE_KERNEL_ID,
@@ -314,15 +302,14 @@ class TestTrackConnection(TestStreamService):
         await stream_service.track_connection(action)
 
         assert mock_valkey_live.update_connection_tracker.await_count == 2
-        assert mock_idle_checker_host.update_app_streaming_status.await_count == 2
+        assert mock_valkey_live.mark_session_active.await_count == 2
 
 
 class TestUntrackConnection(TestStreamService):
-    async def test_last_connection_triggers_no_active(
+    async def test_last_connection_refreshes_last_access_marker(
         self,
         stream_service: StreamService,
         mock_valkey_live: AsyncMock,
-        mock_idle_checker_host: AsyncMock,
     ) -> None:
         mock_valkey_live.count_active_connections.return_value = 0
         action = UntrackConnectionAction(
@@ -339,16 +326,12 @@ class TestUntrackConnection(TestStreamService):
         mock_valkey_live.remove_connection_tracker.assert_awaited_once_with(
             str(FAKE_KERNEL_ID), "jupyter", "stream-001"
         )
-        mock_idle_checker_host.update_app_streaming_status.assert_awaited_once_with(
-            FAKE_SESSION_ID,
-            AppStreamingStatus.NO_ACTIVE_CONNECTIONS,
-        )
+        mock_valkey_live.update_session_last_access.assert_awaited_once_with(str(FAKE_SESSION_ID))
 
-    async def test_remaining_connections_does_not_trigger_no_active(
+    async def test_remaining_connections_does_not_refresh_marker(
         self,
         stream_service: StreamService,
         mock_valkey_live: AsyncMock,
-        mock_idle_checker_host: AsyncMock,
     ) -> None:
         mock_valkey_live.count_active_connections.return_value = 3
         action = UntrackConnectionAction(
@@ -361,7 +344,7 @@ class TestUntrackConnection(TestStreamService):
         result = await stream_service.untrack_connection(action)
 
         assert result.remaining_count == 3
-        mock_idle_checker_host.update_app_streaming_status.assert_not_awaited()
+        mock_valkey_live.update_session_last_access.assert_not_awaited()
 
 
 class TestGCStaleConnections(TestStreamService):
@@ -369,7 +352,6 @@ class TestGCStaleConnections(TestStreamService):
         self,
         stream_service: StreamService,
         mock_valkey_live: AsyncMock,
-        mock_idle_checker_host: AsyncMock,
         mock_etcd: AsyncMock,
     ) -> None:
         mock_etcd.get.return_value = "10m"
@@ -386,10 +368,7 @@ class TestGCStaleConnections(TestStreamService):
 
         assert isinstance(result, GCStaleConnectionsActionResult)
         assert sid in result.removed_sessions
-        mock_idle_checker_host.update_app_streaming_status.assert_awaited_once_with(
-            SessionId(uuid.UUID(sid)),
-            AppStreamingStatus.NO_ACTIVE_CONNECTIONS,
-        )
+        mock_valkey_live.update_session_last_access.assert_awaited_once_with(sid)
 
     async def test_empty_session_ids_returns_empty(
         self,
@@ -426,7 +405,6 @@ class TestGCStaleConnections(TestStreamService):
         self,
         stream_service: StreamService,
         mock_valkey_live: AsyncMock,
-        mock_idle_checker_host: AsyncMock,
         mock_etcd: AsyncMock,
     ) -> None:
         mock_etcd.get.return_value = "5m"

--- a/tests/unit/manager/services/stream/test_stream_service.py
+++ b/tests/unit/manager/services/stream/test_stream_service.py
@@ -284,7 +284,7 @@ class TestTrackConnection(TestStreamService):
         mock_valkey_live.update_connection_tracker.assert_awaited_once_with(
             str(FAKE_KERNEL_ID), "jupyter", "stream-001"
         )
-        mock_valkey_live.mark_session_active.assert_awaited_once_with(str(FAKE_SESSION_ID))
+        mock_valkey_live.mark_session_active.assert_awaited_once_with(FAKE_SESSION_ID)
 
     async def test_re_registration_calls_same_methods(
         self,
@@ -326,7 +326,7 @@ class TestUntrackConnection(TestStreamService):
         mock_valkey_live.remove_connection_tracker.assert_awaited_once_with(
             str(FAKE_KERNEL_ID), "jupyter", "stream-001"
         )
-        mock_valkey_live.update_session_last_access.assert_awaited_once_with(str(FAKE_SESSION_ID))
+        mock_valkey_live.update_session_last_access.assert_awaited_once_with(FAKE_SESSION_ID)
 
     async def test_remaining_connections_does_not_refresh_marker(
         self,
@@ -368,7 +368,7 @@ class TestGCStaleConnections(TestStreamService):
 
         assert isinstance(result, GCStaleConnectionsActionResult)
         assert sid in result.removed_sessions
-        mock_valkey_live.update_session_last_access.assert_awaited_once_with(sid)
+        mock_valkey_live.update_session_last_access.assert_awaited_once_with(FAKE_SESSION_ID)
 
     async def test_empty_session_ids_returns_empty(
         self,


### PR DESCRIPTION
## Summary
- Maintain the `session.<id>.last_access` markers unconditionally in the event dispatcher: `SessionEventHandler` initializes the marker on session RUNNING, writes the `"0"` activity sentinel on execution start, refreshes the timestamp on execution end, and deletes the marker on TERMINATED.
- The stream service writes the markers directly on connection track/untrack/GC via its own `valkey_live` client, so marker upkeep no longer depends on the `idle.enabled` legacy config.
- Remove the event-handling plumbing from the legacy idle checker: `NetworkTimeoutEventDispatcherIdleChecker`, `AbstractEventDispatcherIdleChecker`, the host dispatch/`update_app_streaming_status` chain (the app-streaming path had no live caller), and the `AppStreamingStatus` enum.
- Add semantic marker methods to `ValkeyLiveClient` (`update_session_last_access`, `mark_session_active` with XX to avoid resurrecting terminated sessions' markers, `delete_session_last_access`) with a 1-day TTL matching the legacy retention.

## Test plan
- [x] `pants test` on stream service, session event handler, and valkey-live client suites (marker upkeep behaviors, XX semantics against real Valkey)
- [x] `pants lint/check --changed-dependents=direct` (pre-push hook)
- [ ] CI green

Related: BA-6894 (#12878) — the reconciler network timeout checker reads these markers.

Resolves BA-6898

🤖 Generated with [Claude Code](https://claude.com/claude-code)