### PR TITLE
refactor(BA-6901): type single/bulk/scope base action ids as EntityID

### DIFF
--- a/changes/12897.misc.md
+++ b/changes/12897.misc.md
@@ -1,0 +1,1 @@
+Type the single-entity, bulk, and scope base action identifiers as `EntityID`.

--- a/src/ai/backend/manager/actions/bulk/base.py
+++ b/src/ai/backend/manager/actions/bulk/base.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.entity.types import EntityType
+from ai.backend.common.identifier.entity import EntityID
 
 
 class BaseBulkAction(ABC):
@@ -10,12 +11,12 @@ class BaseBulkAction(ABC):
 
     @classmethod
     @abstractmethod
-    def entity_type(self) -> EntityType:
+    def entity_type(cls) -> EntityType:
         """Return the type of entity that this action applies to."""
         raise NotImplementedError
 
     @abstractmethod
-    def entity_ids(self) -> Sequence[str]:
+    def entity_ids(self) -> Sequence[EntityID]:
         """Return the IDs of the entities that this action applies to."""
         raise NotImplementedError
 

--- a/src/ai/backend/manager/actions/scope/base.py
+++ b/src/ai/backend/manager/actions/scope/base.py
@@ -2,21 +2,20 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 
 from ai.backend.common.data.permission.types import Permission
-from ai.backend.common.entity.types import EntityType
-from ai.backend.manager.actions.types import Scope
+from ai.backend.common.entity.types import EntityType, ScopeRef
 
 
 class BaseScopeAction(ABC):
     """Base for actions that target entities by scope rather than by identity."""
 
     @abstractmethod
-    def scope_targets(self) -> Sequence[Scope]:
+    def scope_targets(self) -> Sequence[ScopeRef]:
         """Return the Sequence of scopes that this action applies to."""
         raise NotImplementedError
 
     @classmethod
     @abstractmethod
-    def entity_type(self) -> EntityType:
+    def entity_type(cls) -> EntityType:
         """Return the type of entity that this action applies to."""
         raise NotImplementedError
 

--- a/src/ai/backend/manager/actions/single_entity/base.py
+++ b/src/ai/backend/manager/actions/single_entity/base.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.entity.types import EntityType
+from ai.backend.common.identifier.entity import EntityID
 
 
 class BaseSingleEntityAction(ABC):
@@ -9,12 +10,12 @@ class BaseSingleEntityAction(ABC):
 
     @classmethod
     @abstractmethod
-    def entity_type(self) -> EntityType:
+    def entity_type(cls) -> EntityType:
         """Return the type of entity that this action applies to."""
         raise NotImplementedError
 
     @abstractmethod
-    def entity_id(self) -> str:
+    def entity_id(self) -> EntityID:
         """Return the ID of the entity that this action applies to."""
         raise NotImplementedError
 

--- a/src/ai/backend/manager/actions/single_entity/result.py
+++ b/src/ai/backend/manager/actions/single_entity/result.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 from ai.backend.common.exception import ErrorCode
+from ai.backend.common.identifier.entity import EntityID
 from ai.backend.manager.actions.types import OperationStatus
 
 __all__ = (
@@ -20,7 +21,7 @@ class SingleEntityActionResultMeta:
     """
 
     action_id: uuid.UUID
-    entity_id: str
+    entity_id: EntityID
     status: OperationStatus
     description: str
     started_at: datetime


### PR DESCRIPTION
## Summary
- Type `entity_id()` (single-entity) and `entity_ids()` (bulk) and `SingleEntityActionResultMeta.entity_id` with `common.identifier.entity.EntityID` instead of `str`.
- Correct the `@classmethod` first-parameter name from `self` to `cls` on `entity_type()` across the single-entity, bulk, and scope base actions.
- `BaseScopeAction.scope_targets()` already returns a sequence of scopes (now typed as `ScopeRef`).

## Test plan
- [x] `pants lint` / `pants check` pass in CI
- [x] No existing consumers break (the self-contained base packages have no external subclasses yet)

Resolves BA-6901