### PR TITLE
feat(BA-6825): make manager DB authoritative for an agent's resource group

### DIFF
--- a/changes/12898.enhance.md
+++ b/changes/12898.enhance.md
@@ -1,0 +1,1 @@
+Keep the manager DB authoritative for an agent's resource group so heartbeats no longer overwrite it; a newly registered agent resolves its configured resource group or falls back to the default one.

--- a/src/ai/backend/manager/data/agent/types.py
+++ b/src/ai/backend/manager/data/agent/types.py
@@ -52,7 +52,6 @@ class AgentStatus(enum.Enum):
 class AgentDataForHeartbeatUpdate:
     status: AgentStatus
     status_changed: datetime | None
-    scaling_group: str
     available_slots: ResourceSlot
     addr: str
     public_host: str | None
@@ -124,7 +123,6 @@ class AgentHeartbeatUpsert:
             "id": self.metadata.id,
             "status": AgentStatus.ALIVE,
             "region": self.metadata.region,
-            "scaling_group": self.metadata.scaling_group,
             "available_slots": self.resource_info.available_slots,
             "addr": self.network_info.addr,
             "public_host": self.network_info.public_host,
@@ -144,7 +142,6 @@ class AgentHeartbeatUpsert:
             "id": self.metadata.id,
             "status": AgentStatus.ALIVE,
             "region": self.metadata.region,
-            "scaling_group": self.metadata.scaling_group,
             "available_slots": self.resource_info.available_slots,
             "addr": self.network_info.addr,
             "public_host": self.network_info.public_host,
@@ -203,7 +200,6 @@ class UpsertResult:
         was_revived = existing_data.status in (AgentStatus.LOST, AgentStatus.TERMINATED)
         need_resource_slot_update = (
             existing_data.available_slots != upsert_data.resource_info.available_slots
-            or existing_data.scaling_group != upsert_data.metadata.scaling_group
             or existing_data.addr != upsert_data.network_info.addr
             or existing_data.public_host != upsert_data.network_info.public_host
             or existing_data.public_key != upsert_data.network_info.public_key

--- a/src/ai/backend/manager/errors/resource.py
+++ b/src/ai/backend/manager/errors/resource.py
@@ -82,6 +82,22 @@ class ScalingGroupNotFound(ObjectNotFound):
         )
 
 
+class UnresolvableResourceGroup(BackendAIError, web.HTTPBadRequest):
+    error_type = "https://api.backend.ai/probs/unresolvable-resource-group"
+    error_title = (
+        "The agent's resource group could not be resolved "
+        "and no default resource group is configured."
+    )
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.SCALING_GROUP,
+            operation=ErrorOperation.ACCESS,
+            error_detail=ErrorDetail.NOT_FOUND,
+        )
+
+
 class ScalingGroupSessionTypeNotAllowed(BackendAIError, web.HTTPUnprocessableEntity):
     error_type = "https://api.backend.ai/probs/scaling-group-session-type-not-allowed"
     error_title = "Scaling group does not allow this session type."

--- a/src/ai/backend/manager/models/agent/row.py
+++ b/src/ai/backend/manager/models/agent/row.py
@@ -169,7 +169,6 @@ class AgentRow(Base):  # type: ignore[misc]
         return AgentDataForHeartbeatUpdate(
             status=self.status,
             status_changed=self.status_changed,
-            scaling_group=self.scaling_group,
             available_slots=self.available_slots,
             addr=self.addr,
             public_host=self.public_host,

--- a/src/ai/backend/manager/repositories/agent/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/agent/db_source/db_source.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 
@@ -6,7 +8,6 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import selectinload
 
 from ai.backend.common.exception import AgentNotFound
-from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import AgentId, ImageID
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.data.agent.types import (
@@ -18,7 +19,7 @@ from ai.backend.manager.data.agent.types import (
     UpsertResult,
 )
 from ai.backend.manager.data.image.types import ImageDataWithDetails, ImageIdentifier
-from ai.backend.manager.errors.resource import ScalingGroupNotFound
+from ai.backend.manager.errors.resource import UnresolvableResourceGroup
 from ai.backend.manager.models.agent import ADMIN_PERMISSIONS as ADMIN_AGENT_PERMISSIONS
 from ai.backend.manager.models.agent import AgentRow, agents
 from ai.backend.manager.models.image import ImageRow
@@ -92,23 +93,8 @@ class AgentDBSource:
                 raise AgentNotFound(f"Agent with id {agent_id} not found")
             return agent_row.to_data()
 
-    async def _resolve_scaling_group_id(
-        self, session: "AsyncSession", scaling_group_name: str
-    ) -> ResourceGroupID:
-        scaling_group_id = await session.scalar(
-            sa.select(ScalingGroupRow.id).where(ScalingGroupRow.name == scaling_group_name)
-        )
-        if scaling_group_id is None:
-            log.error("Scaling group named [{}] does not exist.", scaling_group_name)
-            raise ScalingGroupNotFound(scaling_group_name)
-        return ResourceGroupID(scaling_group_id)
-
     async def upsert_agent_with_state(self, upsert_data: AgentHeartbeatUpsert) -> UpsertResult:
         async with self._db.begin_session_read_committed() as session:
-            resource_group_id = await self._resolve_scaling_group_id(
-                session, upsert_data.metadata.scaling_group
-            )
-
             query = (
                 sa.select(AgentRow).where(AgentRow.id == upsert_data.metadata.id).with_for_update()
             )
@@ -116,21 +102,59 @@ class AgentDBSource:
             agent_data = row.to_heartbeat_update_data() if row is not None else None
             upsert_result = UpsertResult.from_state_comparison(agent_data, upsert_data)
 
-            stmt = pg_insert(agents).values({
-                **upsert_data.insert_fields,
-                "resource_group_id": resource_group_id,
-            })
-            final_query = stmt.on_conflict_do_update(
-                index_elements=["id"],
-                set_={
-                    **upsert_data.update_fields,
-                    "resource_group_id": resource_group_id,
-                },
-            )
-
-            await session.execute(final_query)
+            if row is None:
+                await self._insert_new_agent(session, upsert_data)
+            else:
+                await session.execute(
+                    sa.update(agents)
+                    .where(agents.c.id == upsert_data.metadata.id)
+                    .values(upsert_data.update_fields)
+                )
 
             return upsert_result
+
+    async def _insert_new_agent(
+        self, session: AsyncSession, upsert_data: AgentHeartbeatUpsert
+    ) -> None:
+        resource_group_name = upsert_data.metadata.scaling_group
+        group_select = (
+            sa.select(
+                *[
+                    sa.literal(value, type_=agents.c[key].type).label(key)
+                    for key, value in upsert_data.insert_fields.items()
+                ],
+                ScalingGroupRow.name.label("scaling_group"),
+                ScalingGroupRow.id.label("resource_group_id"),
+            )
+            .select_from(ScalingGroupRow)
+            .where(
+                sa.or_(
+                    ScalingGroupRow.name == resource_group_name,
+                    ScalingGroupRow.is_default,
+                )
+            )
+            .order_by(sa.case((ScalingGroupRow.name == resource_group_name, 0), else_=1))
+            .limit(1)
+        )
+        stmt = (
+            pg_insert(agents)
+            .from_select(
+                [*upsert_data.insert_fields.keys(), "scaling_group", "resource_group_id"],
+                group_select,
+            )
+            # Guard a rare race where a concurrent registration inserted first
+            .on_conflict_do_update(
+                index_elements=["id"],
+                set_={**upsert_data.update_fields},
+            )
+            .returning(agents.c.id)
+        )
+        affected = (await session.execute(stmt)).scalar_one_or_none()
+        if affected is None:
+            raise UnresolvableResourceGroup(
+                f"Scaling group '{resource_group_name}' not found "
+                "and no default scaling group is set."
+            )
 
     async def update_agent_status_exit(self, updater: Updater[AgentRow]) -> None:
         async with self._db.begin_session() as session:

--- a/tests/unit/manager/repositories/agent/test_repository.py
+++ b/tests/unit/manager/repositories/agent/test_repository.py
@@ -41,7 +41,7 @@ from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.agent.types import AgentHeartbeatUpsert, AgentStatus
 from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.session.types import SessionStatus
-from ai.backend.manager.errors.resource import ScalingGroupNotFound
+from ai.backend.manager.errors.resource import UnresolvableResourceGroup
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
@@ -423,14 +423,16 @@ class TestAgentRepositoryDB:
         agent = await agent_repository.get_by_id(lost_agent.agent_id)
         assert agent.status == AgentStatus.ALIVE
 
-    async def test_sync_agent_heartbeat_scaling_group_change_updates_resource_group_id(
+    async def test_sync_agent_heartbeat_scaling_group_change_is_ignored(
         self,
         agent_repository: AgentRepository,
         alive_agent: AgentFixtureData,
+        scaling_group: ScalingGroupFixtureData,
         sample_agent_info: AgentInfo,
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> None:
-        """A heartbeat reporting a different scaling group updates both name and id columns"""
+        """The DB is authoritative: a heartbeat reporting a different scaling group must not
+        change the agent's group columns."""
         new_sgroup_name = str(uuid4())
         new_sgroup_id = ResourceGroupID(uuid4())
         async with db_with_cleanup.begin_session() as db_sess:
@@ -465,14 +467,15 @@ class TestAgentRepositoryDB:
                     )
                 )
             ).one()
-        assert row.scaling_group == new_sgroup_name
-        assert row.resource_group_id == new_sgroup_id
+        assert row.scaling_group == scaling_group.name
+        assert row.resource_group_id == scaling_group.id
 
-    async def test_sync_agent_heartbeat_scaling_group_not_found(
+    async def test_sync_agent_heartbeat_unresolvable_group_no_default(
         self,
         agent_repository: AgentRepository,
     ) -> None:
-        """Test sync_agent_heartbeat raises ScalingGroupNotFound for non-existent scaling group"""
+        """A new agent whose reported group does not exist and with no default group configured
+        fails registration with UnresolvableResourceGroup."""
         agent_id = AgentId("agent-no-sgroup")
         agent_info_with_nonexistent_sg = AgentInfo(
             ip="192.168.1.100",
@@ -501,7 +504,7 @@ class TestAgentRepositoryDB:
             heartbeat_received=datetime.now(tzutc()),
         )
 
-        with pytest.raises(ScalingGroupNotFound):
+        with pytest.raises(UnresolvableResourceGroup):
             await agent_repository.sync_agent_heartbeat(agent_id, upsert_data)
 
     async def test_sync_agent_heartbeat_with_new_resource_slots(
@@ -522,6 +525,323 @@ class TestAgentRepositoryDB:
 
         assert result.need_resource_slot_update is True
         mock_config_provider.legacy_etcd_config_loader.update_resource_slots.assert_called_once()
+
+    # ==================== upsert_agent_with_state tests ====================
+
+    @pytest.fixture
+    def agent_db_source(self, db_with_cleanup: ExtendedAsyncSAEngine) -> AgentDBSource:
+        """AgentDBSource backed by the real test database."""
+        return AgentDBSource(db_with_cleanup)
+
+    @pytest.fixture
+    async def default_scaling_group(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ScalingGroupFixtureData, None]:
+        """Create a scaling group marked as the default (is_default=True)."""
+        name = str(uuid4())
+        scaling_group_id = ResourceGroupID(uuid4())
+        async with db_with_cleanup.begin_session() as db_sess:
+            db_sess.add(
+                ScalingGroupRow(
+                    id=scaling_group_id,
+                    name=name,
+                    description="Default scaling group",
+                    is_active=True,
+                    is_public=True,
+                    is_default=True,
+                    driver="static",
+                    driver_opts={},
+                    scheduler="fifo",
+                    scheduler_opts=ScalingGroupOpts(),
+                    use_host_network=False,
+                )
+            )
+        yield ScalingGroupFixtureData(name=name, id=scaling_group_id)
+
+    async def test_upsert_new_agent_inserts_with_resolved_group(
+        self,
+        agent_db_source: AgentDBSource,
+        scaling_group: ScalingGroupFixtureData,
+        sample_agent_info: AgentInfo,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> None:
+        """A new agent (no existing row) is inserted with the resolved resource group."""
+        agent_id = AgentId("upsert-new-resolvable")
+        upsert_data = AgentHeartbeatUpsert.from_agent_info(
+            agent_id=agent_id,
+            agent_info=sample_agent_info,
+            heartbeat_received=datetime.now(tzutc()),
+        )
+
+        result = await agent_db_source.upsert_agent_with_state(upsert_data)
+
+        assert result.was_revived is False
+        assert result.need_resource_slot_update is True
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            row = (
+                await db_sess.execute(
+                    sa.select(
+                        AgentRow.status, AgentRow.scaling_group, AgentRow.resource_group_id
+                    ).where(AgentRow.id == agent_id)
+                )
+            ).one()
+        assert row.status == AgentStatus.ALIVE
+        assert row.scaling_group == scaling_group.name
+        assert row.resource_group_id == scaling_group.id
+
+    async def test_upsert_new_agent_prefers_named_group_over_default(
+        self,
+        agent_db_source: AgentDBSource,
+        scaling_group: ScalingGroupFixtureData,
+        default_scaling_group: ScalingGroupFixtureData,
+        sample_agent_info: AgentInfo,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> None:
+        """With a default group present, a resolvable reported name still wins over the default."""
+        agent_id = AgentId("upsert-new-named-over-default")
+        # sample_agent_info reports scaling_group.name, which exists and is not the default.
+        upsert_data = AgentHeartbeatUpsert.from_agent_info(
+            agent_id=agent_id,
+            agent_info=sample_agent_info,
+            heartbeat_received=datetime.now(tzutc()),
+        )
+
+        await agent_db_source.upsert_agent_with_state(upsert_data)
+
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            row = (
+                await db_sess.execute(
+                    sa.select(AgentRow.scaling_group, AgentRow.resource_group_id).where(
+                        AgentRow.id == agent_id
+                    )
+                )
+            ).one()
+        assert row.scaling_group == scaling_group.name
+        assert row.resource_group_id == scaling_group.id
+        assert row.resource_group_id != default_scaling_group.id
+
+    async def test_upsert_new_agent_unresolvable_name_falls_back_to_default(
+        self,
+        agent_db_source: AgentDBSource,
+        default_scaling_group: ScalingGroupFixtureData,
+        sample_agent_info: AgentInfo,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> None:
+        """A new agent reporting an unknown group is registered into the default group."""
+        agent_id = AgentId("upsert-new-fallback")
+        info = sample_agent_info.model_copy(update={"scaling_group": f"ghost-{uuid4()}"})
+        upsert_data = AgentHeartbeatUpsert.from_agent_info(
+            agent_id=agent_id,
+            agent_info=info,
+            heartbeat_received=datetime.now(tzutc()),
+        )
+
+        await agent_db_source.upsert_agent_with_state(upsert_data)
+
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            row = (
+                await db_sess.execute(
+                    sa.select(AgentRow.scaling_group, AgentRow.resource_group_id).where(
+                        AgentRow.id == agent_id
+                    )
+                )
+            ).one()
+        assert row.scaling_group == default_scaling_group.name
+        assert row.resource_group_id == default_scaling_group.id
+
+    async def test_upsert_new_agent_empty_name_uses_default(
+        self,
+        agent_db_source: AgentDBSource,
+        default_scaling_group: ScalingGroupFixtureData,
+        sample_agent_info: AgentInfo,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> None:
+        """A new agent reporting no group name (empty) is registered into the default group."""
+        agent_id = AgentId("upsert-new-empty")
+        info = sample_agent_info.model_copy(update={"scaling_group": ""})
+        upsert_data = AgentHeartbeatUpsert.from_agent_info(
+            agent_id=agent_id,
+            agent_info=info,
+            heartbeat_received=datetime.now(tzutc()),
+        )
+
+        await agent_db_source.upsert_agent_with_state(upsert_data)
+
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            resource_group_id = await db_sess.scalar(
+                sa.select(AgentRow.resource_group_id).where(AgentRow.id == agent_id)
+            )
+        assert resource_group_id == default_scaling_group.id
+
+    async def test_upsert_new_agent_unresolvable_name_no_default_raises(
+        self,
+        agent_db_source: AgentDBSource,
+        scaling_group: ScalingGroupFixtureData,
+        sample_agent_info: AgentInfo,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> None:
+        """Registration fails when the reported group is unknown and no default group exists."""
+        agent_id = AgentId("upsert-new-noresolve")
+        info = sample_agent_info.model_copy(update={"scaling_group": f"ghost-{uuid4()}"})
+        upsert_data = AgentHeartbeatUpsert.from_agent_info(
+            agent_id=agent_id,
+            agent_info=info,
+            heartbeat_received=datetime.now(tzutc()),
+        )
+
+        with pytest.raises(UnresolvableResourceGroup):
+            await agent_db_source.upsert_agent_with_state(upsert_data)
+
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            exists = await db_sess.scalar(sa.select(AgentRow.id).where(AgentRow.id == agent_id))
+        assert exists is None
+
+    async def test_upsert_existing_agent_keeps_group_on_different_report(
+        self,
+        agent_db_source: AgentDBSource,
+        alive_agent: AgentFixtureData,
+        scaling_group: ScalingGroupFixtureData,
+        sample_agent_info: AgentInfo,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> None:
+        """An existing agent reporting a different (resolvable) group keeps its DB group."""
+        other_name = str(uuid4())
+        other_id = ResourceGroupID(uuid4())
+        async with db_with_cleanup.begin_session() as db_sess:
+            db_sess.add(
+                ScalingGroupRow(
+                    id=other_id,
+                    name=other_name,
+                    description="Another scaling group",
+                    is_active=True,
+                    is_public=True,
+                    driver="static",
+                    driver_opts={},
+                    scheduler="fifo",
+                    scheduler_opts=ScalingGroupOpts(),
+                    use_host_network=False,
+                )
+            )
+        info = sample_agent_info.model_copy(update={"scaling_group": other_name})
+        upsert_data = AgentHeartbeatUpsert.from_agent_info(
+            agent_id=alive_agent.agent_id,
+            agent_info=info,
+            heartbeat_received=datetime.now(tzutc()),
+        )
+
+        result = await agent_db_source.upsert_agent_with_state(upsert_data)
+
+        assert result.was_revived is False
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            row = (
+                await db_sess.execute(
+                    sa.select(AgentRow.scaling_group, AgentRow.resource_group_id).where(
+                        AgentRow.id == alive_agent.agent_id
+                    )
+                )
+            ).one()
+        assert row.scaling_group == scaling_group.name
+        assert row.resource_group_id == scaling_group.id
+
+    async def test_upsert_revived_agent_keeps_group(
+        self,
+        agent_db_source: AgentDBSource,
+        lost_agent: AgentFixtureData,
+        scaling_group: ScalingGroupFixtureData,
+        sample_agent_info: AgentInfo,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> None:
+        """A redeploy hits the UPDATE path: the lost agent is revived and its group is unchanged."""
+        upsert_data = AgentHeartbeatUpsert.from_agent_info(
+            agent_id=lost_agent.agent_id,
+            agent_info=sample_agent_info,
+            heartbeat_received=datetime.now(tzutc()),
+        )
+
+        result = await agent_db_source.upsert_agent_with_state(upsert_data)
+
+        assert result.was_revived is True
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            row = (
+                await db_sess.execute(
+                    sa.select(
+                        AgentRow.status, AgentRow.scaling_group, AgentRow.resource_group_id
+                    ).where(AgentRow.id == lost_agent.agent_id)
+                )
+            ).one()
+        assert row.status == AgentStatus.ALIVE
+        assert row.scaling_group == scaling_group.name
+        assert row.resource_group_id == scaling_group.id
+
+    async def test_upsert_existing_agent_unresolvable_report_keeps_group(
+        self,
+        agent_db_source: AgentDBSource,
+        alive_agent: AgentFixtureData,
+        scaling_group: ScalingGroupFixtureData,
+        default_scaling_group: ScalingGroupFixtureData,
+        sample_agent_info: AgentInfo,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> None:
+        """An existing agent reporting an unknown group is not moved to the default group."""
+        info = sample_agent_info.model_copy(update={"scaling_group": f"ghost-{uuid4()}"})
+        upsert_data = AgentHeartbeatUpsert.from_agent_info(
+            agent_id=alive_agent.agent_id,
+            agent_info=info,
+            heartbeat_received=datetime.now(tzutc()),
+        )
+
+        await agent_db_source.upsert_agent_with_state(upsert_data)
+
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            row = (
+                await db_sess.execute(
+                    sa.select(AgentRow.scaling_group, AgentRow.resource_group_id).where(
+                        AgentRow.id == alive_agent.agent_id
+                    )
+                )
+            ).one()
+        assert row.scaling_group == scaling_group.name
+        assert row.resource_group_id == scaling_group.id
+
+    async def test_upsert_existing_agent_unresolvable_report_no_default_still_updates(
+        self,
+        agent_db_source: AgentDBSource,
+        alive_agent: AgentFixtureData,
+        scaling_group: ScalingGroupFixtureData,
+        sample_agent_info: AgentInfo,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> None:
+        """An existing agent reporting an unknown group with no default group must not fail its
+        heartbeat: status/resources still update and the group is left unchanged."""
+        new_addr = "tcp://10.0.0.9:6001"
+        info = sample_agent_info.model_copy(
+            update={"scaling_group": f"ghost-{uuid4()}", "addr": new_addr}
+        )
+        upsert_data = AgentHeartbeatUpsert.from_agent_info(
+            agent_id=alive_agent.agent_id,
+            agent_info=info,
+            heartbeat_received=datetime.now(tzutc()),
+        )
+
+        result = await agent_db_source.upsert_agent_with_state(upsert_data)
+
+        assert result.was_revived is False
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            row = (
+                await db_sess.execute(
+                    sa.select(
+                        AgentRow.status,
+                        AgentRow.addr,
+                        AgentRow.scaling_group,
+                        AgentRow.resource_group_id,
+                    ).where(AgentRow.id == alive_agent.agent_id)
+                )
+            ).one()
+        assert row.status == AgentStatus.ALIVE
+        assert row.addr == new_addr  # the heartbeat update actually ran
+        assert row.scaling_group == scaling_group.name  # group unchanged
+        assert row.resource_group_id == scaling_group.id
 
 
 class TestAgentRepositoryCache:


### PR DESCRIPTION
## Summary
- The manager DB is now authoritative for an agent's resource group: a heartbeat only updates the agent's status/resources and never overwrites its `scaling_group` / `resource_group_id`.
- The resource group is seeded only on first-registration INSERT, resolved from the reported name inside a single `INSERT ... SELECT scaling_groups`, falling back to the `is_default` group. Registration fails with `UnresolvableResourceGroup` (400) when neither the reported name nor a default group exists.
- An already-registered agent (redeploy / UPDATE path) can never be moved by a stale config, and its heartbeat still succeeds even if the reported group is unknown.
- Removed the resource-group comparison from `from_state_comparison` (a group change no longer occurs via heartbeat, so it must not trigger a resource-slot resync).

## Test plan
- [x] `pants test tests/unit/manager/repositories/agent/test_repository.py::TestAgentRepositoryDB`
- [x] New agent: resolvable name inserts into that group; named group wins over an existing default
- [x] New agent: unknown/empty name falls back to the default group; no name+no default raises `UnresolvableResourceGroup` (no row created)
- [x] Existing agent: reporting a different/unknown group leaves the DB group unchanged; heartbeat still updates status/resources
- [x] Redeploy (LOST row) revives without moving the group

Resolves BA-6825