### PR TITLE
feat(BA-6903): add scope action runner, processor, and validator

### DIFF
--- a/changes/12909.feature.md
+++ b/changes/12909.feature.md
@@ -1,0 +1,1 @@
+Add an independent scope action runner (processor, validator, and monitor abstraction) bound to the self-contained scope base action.

--- a/src/ai/backend/manager/actions/scope/__init__.py
+++ b/src/ai/backend/manager/actions/scope/__init__.py
@@ -1,5 +1,19 @@
 from .base import (
     BaseScopeAction,
 )
+from .monitor import ScopeActionMonitor
+from .processor import ScopeActionProcessor
+from .result import (
+    ScopeActionProcessResult,
+    ScopeActionResultMeta,
+)
+from .validator import ScopeActionValidator
 
-__all__ = ("BaseScopeAction",)
+__all__ = (
+    "BaseScopeAction",
+    "ScopeActionMonitor",
+    "ScopeActionProcessor",
+    "ScopeActionProcessResult",
+    "ScopeActionResultMeta",
+    "ScopeActionValidator",
+)

--- a/src/ai/backend/manager/actions/scope/monitor/__init__.py
+++ b/src/ai/backend/manager/actions/scope/monitor/__init__.py
@@ -1,0 +1,3 @@
+from .base import ScopeActionMonitor
+
+__all__ = ("ScopeActionMonitor",)

--- a/src/ai/backend/manager/actions/scope/monitor/base.py
+++ b/src/ai/backend/manager/actions/scope/monitor/base.py
@@ -1,0 +1,22 @@
+from abc import ABC
+
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.scope.base import BaseScopeAction
+from ai.backend.manager.actions.scope.result import ScopeActionProcessResult
+
+__all__ = ("ScopeActionMonitor",)
+
+
+class ScopeActionMonitor(ABC):
+    """Observes the lifecycle of a scope action.
+
+    Bound to the self-contained :class:`BaseScopeAction` (pure ABC). ``prepare``
+    runs before the action function; ``done`` runs after it completes (or fails), with
+    the outcome carried in :class:`ScopeActionProcessResult`.
+    """
+
+    async def prepare(self, action: BaseScopeAction, meta: BaseActionTriggerMeta) -> None:
+        raise NotImplementedError("Subclasses must implement the prepare method")
+
+    async def done(self, action: BaseScopeAction, result: ScopeActionProcessResult) -> None:
+        raise NotImplementedError("Subclasses must implement the done method")

--- a/src/ai/backend/manager/actions/scope/processor.py
+++ b/src/ai/backend/manager/actions/scope/processor.py
@@ -1,0 +1,105 @@
+import logging
+import uuid
+from collections.abc import Awaitable, Callable, Sequence
+from datetime import UTC, datetime
+
+from ai.backend.common.exception import BackendAIError, ErrorCode
+from ai.backend.logging.utils import BraceStyleAdapter
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.scope.base import BaseScopeAction
+from ai.backend.manager.actions.scope.monitor import ScopeActionMonitor
+from ai.backend.manager.actions.scope.result import (
+    ScopeActionProcessResult,
+    ScopeActionResultMeta,
+)
+from ai.backend.manager.actions.scope.validator import ScopeActionValidator
+from ai.backend.manager.actions.types import OperationStatus
+
+__all__ = ("ScopeActionProcessor",)
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class ScopeActionProcessor[TAction: BaseScopeAction, TResult]:
+    """Validate, run monitors around, then execute a scope action.
+
+    Each registered validator runs first. The action function then executes within a
+    monitor lifecycle: every monitor's ``prepare`` is called before, and ``done`` after
+    (on success or failure), with status / timing / error captured into a
+    :class:`ScopeActionProcessResult`. This path depends only on the pure-ABC
+    :class:`BaseScopeAction`, never on the legacy ``BaseAction`` framework.
+    """
+
+    _func: Callable[[TAction], Awaitable[TResult]]
+    _monitors: Sequence[ScopeActionMonitor]
+    _validators: Sequence[ScopeActionValidator]
+
+    def __init__(
+        self,
+        func: Callable[[TAction], Awaitable[TResult]],
+        monitors: Sequence[ScopeActionMonitor] | None = None,
+        validators: Sequence[ScopeActionValidator] | None = None,
+    ) -> None:
+        self._func = func
+        self._monitors = monitors or []
+        self._validators = validators or []
+
+    async def _prepare_monitors(self, action: TAction, trigger_meta: BaseActionTriggerMeta) -> None:
+        for monitor in self._monitors:
+            try:
+                await monitor.prepare(action, trigger_meta)
+            except Exception as e:
+                log.warning("Error in monitor prepare method: {}", e)
+
+    async def _finalize_monitors(self, action: TAction, meta: ScopeActionResultMeta) -> None:
+        process_result = ScopeActionProcessResult(meta=meta)
+        for monitor in reversed(self._monitors):
+            try:
+                await monitor.done(action, process_result)
+            except Exception as e:
+                log.warning("Error in monitor done method: {}", e)
+
+    async def run(self, action: TAction) -> TResult:
+        started_at = datetime.now(UTC)
+        action_id = uuid.uuid4()
+        trigger_meta = BaseActionTriggerMeta(action_id=action_id, started_at=started_at)
+
+        for validator in self._validators:
+            await validator.validate(action, trigger_meta)
+
+        status = OperationStatus.UNKNOWN
+        description = "unknown"
+        error_code: ErrorCode | None = None
+
+        await self._prepare_monitors(action, trigger_meta)
+        try:
+            result = await self._func(action)
+        except BackendAIError as e:
+            log.exception("Action processing error: {}", e)
+            status = OperationStatus.ERROR
+            description = str(e)
+            error_code = e.error_code()
+            raise
+        except BaseException as e:
+            log.exception("Unexpected error during action processing: {}", e)
+            status = OperationStatus.ERROR
+            description = str(e)
+            error_code = ErrorCode.default()
+            raise
+        else:
+            status = OperationStatus.SUCCESS
+            description = "Success"
+            return result
+        finally:
+            ended_at = datetime.now(UTC)
+            meta = ScopeActionResultMeta(
+                action_id=action_id,
+                scope_targets=action.scope_targets(),
+                status=status,
+                description=description,
+                started_at=started_at,
+                ended_at=ended_at,
+                duration=ended_at - started_at,
+                error_code=error_code,
+            )
+            await self._finalize_monitors(action, meta)

--- a/src/ai/backend/manager/actions/scope/result.py
+++ b/src/ai/backend/manager/actions/scope/result.py
@@ -1,0 +1,37 @@
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from ai.backend.common.entity.types import ScopeRef
+from ai.backend.common.exception import ErrorCode
+from ai.backend.manager.actions.types import OperationStatus
+
+__all__ = (
+    "ScopeActionResultMeta",
+    "ScopeActionProcessResult",
+)
+
+
+@dataclass
+class ScopeActionResultMeta:
+    """Outcome metadata for a scope action run.
+
+    Self-contained for the pure-ABC scope line; carries the ``scope_targets`` the
+    action ran against because :class:`BaseScopeAction` operates on a sequence of
+    scopes rather than a single identified entity.
+    """
+
+    action_id: uuid.UUID
+    scope_targets: Sequence[ScopeRef]
+    status: OperationStatus
+    description: str
+    started_at: datetime
+    ended_at: datetime
+    duration: timedelta
+    error_code: ErrorCode | None
+
+
+@dataclass
+class ScopeActionProcessResult:
+    meta: ScopeActionResultMeta

--- a/src/ai/backend/manager/actions/scope/validator/__init__.py
+++ b/src/ai/backend/manager/actions/scope/validator/__init__.py
@@ -1,0 +1,3 @@
+from .base import ScopeActionValidator
+
+__all__ = ("ScopeActionValidator",)

--- a/src/ai/backend/manager/actions/scope/validator/base.py
+++ b/src/ai/backend/manager/actions/scope/validator/base.py
@@ -1,0 +1,18 @@
+from abc import ABC, abstractmethod
+
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.scope.base import BaseScopeAction
+
+__all__ = ("ScopeActionValidator",)
+
+
+class ScopeActionValidator(ABC):
+    """Validates a scope action before execution.
+
+    Bound to the self-contained :class:`BaseScopeAction` (pure ABC), so this
+    contract stays independent of the legacy ``BaseAction`` hierarchy.
+    """
+
+    @abstractmethod
+    async def validate(self, action: BaseScopeAction, meta: BaseActionTriggerMeta) -> None:
+        raise NotImplementedError("Subclasses must implement the validate method")


### PR DESCRIPTION
## Summary
- Add the isolated **scope action runner** line, mirroring the existing single-entity line.
- `ScopeActionProcessor` validates, wraps execution in a monitor lifecycle, then runs the action — bound only to the pure-ABC `BaseScopeAction`, independent of the legacy `BaseAction` framework.
- `ScopeActionResultMeta` carries `scope_targets: Sequence[ScopeRef]` (scope actions target a sequence of scopes, not a single entity id).
- Adds `ScopeActionValidator` and the `ScopeActionMonitor` ABC (a structural dependency of the processor's monitor lifecycle, same as the single-entity line).

## Test plan
- [x] `pants check` / `pants test` pass in CI

Resolves BA-6903