### PR TITLE
fix(BA-6915): drop the column default before retyping sessions.result

### DIFF
--- a/changes/12912.fix.md
+++ b/changes/12912.fix.md
@@ -1,0 +1,1 @@
+Fix the session result enum downgrade aborting when the column default cannot be cast to the recreated type

--- a/src/ai/backend/manager/models/alembic/versions/0b1efbb2db84_fix_sessionresult_enum_type_coexistence.py
+++ b/src/ai/backend/manager/models/alembic/versions/0b1efbb2db84_fix_sessionresult_enum_type_coexistence.py
@@ -41,6 +41,23 @@ def _is_expected_divergence(exc: BaseException) -> bool:
     return _sqlstate_of(exc) in _EXPECTED_DIVERGENCE_SQLSTATES
 
 
+def _retype_result_column(conn: sa.engine.Connection, table: str, target_type: str) -> None:
+    """Change ``<table>.result`` to ``target_type``, carrying its default across.
+
+    PostgreSQL cannot cast an existing column default between two unrelated enum
+    types, so ALTER COLUMN ... TYPE fails outright while a default is attached.
+    Drop it, retype, then put it back -- the same order dec0deba5893 uses.
+    """
+    conn.exec_driver_sql(f"ALTER TABLE {table} ALTER COLUMN result DROP DEFAULT")
+    conn.exec_driver_sql(
+        f"ALTER TABLE {table} ALTER COLUMN result"
+        f" TYPE {target_type} USING result::text::{target_type}"
+    )
+    conn.exec_driver_sql(
+        f"ALTER TABLE {table} ALTER COLUMN result SET DEFAULT 'UNDEFINED'::{target_type}"
+    )
+
+
 def upgrade() -> None:
     conn = op.get_bind()
 
@@ -62,10 +79,7 @@ def upgrade() -> None:
                 #   - "sessionresults" was created by b6b884fbae1f (2022, sessions.result)
                 #   - ffcf0ed13a26 skipped rename because both existed
                 # Fix: alter sessions.result to use the singular type, then drop plural.
-                conn.exec_driver_sql(
-                    "ALTER TABLE sessions ALTER COLUMN result"
-                    " TYPE sessionresult USING result::text::sessionresult"
-                )
+                _retype_result_column(conn, "sessions", "sessionresult")
                 conn.exec_driver_sql("DROP TYPE sessionresults")
             elif has_plural and not has_singular:
                 # Only plural exists (ffcf0ed13a26 was never applied, or was skipped).
@@ -102,10 +116,7 @@ def downgrade() -> None:
                 conn.exec_driver_sql(
                     "CREATE TYPE sessionresults AS ENUM ('UNDEFINED', 'SUCCESS', 'FAILURE')"
                 )
-                conn.exec_driver_sql(
-                    "ALTER TABLE sessions ALTER COLUMN result"
-                    " TYPE sessionresults USING result::text::sessionresults"
-                )
+                _retype_result_column(conn, "sessions", "sessionresults")
     except sa.exc.DBAPIError as e:
         if not _is_expected_divergence(e):
             raise


### PR DESCRIPTION
## 📚 Stacked PRs

- #12910 — `BA-6914` fix: migrations that drop a foreign key by a name the DB may not use
- #12907 — `BA-6913` fix: indexes that only exist on migrated databases
- #12912 — `BA-6915` fix: drop the column default before retyping sessions.result  ← you are here

Merge in order, top-down. Each PR is based on the one above it, so its diff shows only its own layer. The order is fixed by the alembic chain: #12907's migration takes #12910's parent as its `down_revision`.

## Problem

`0b1efbb2db84`'s downgrade recreates the plural `sessionresults` type and then:

```sql
ALTER TABLE sessions ALTER COLUMN result TYPE sessionresults USING result::text::sessionresults
```

`sessions.result` carries a default. PostgreSQL cannot cast an existing default across two unrelated enum types, so this aborts before touching a row:

```
DatatypeMismatchError: default for column "result" cannot be cast automatically to type sessionresults
```

The migration guards its DDL with a `try/except` over a list of expected-divergence SQLSTATEs — but `42804` isn't on it, so the error is reraised and **the whole downgrade chain stops here**.

## The correct order already exists in this repo

`dec0deba5893` does the same conversion and succeeds, because it handles the default:

```python
_drop_column_default(conn, table, column)
_alter_column_to_sessionresult(conn, table, column)
_set_column_default_undefined_sessionresult(conn, table, column)
```

`0b1efbb2db84` just omits it. This PR gives it the same order, on both the downgrade and the mirror-image `ALTER` in `upgrade()`.

## Reproduction

On a DB built at head by `mgr schema oneshot`, downgraded with **no skipped revisions**:

1. 150 downgrade steps run cleanly.
2. `dec0deba5893`'s downgrade recreates the singular `sessionresult` and converts `sessions.result` to it.
3. Crossing `0b1efbb2db84`, the `has_singular and not has_plural` branch fires and aborts.

Confirmed by hand that `DROP DEFAULT` → `ALTER COLUMN TYPE` → `SET DEFAULT` completes, leaving `result` as `sessionresults` with default `'UNDEFINED'::sessionresults`.

## Verification

With this fix on top of #12881, #12883, #12887, #12907, #12910, a single straight `alembic downgrade` from head to `d86417a6bf7b` — below the deepest RBAC backfill — now completes:

```
exit=0   steps run: 175   (no skipped revisions)
current: d86417a6bf7b
```

That path previously stopped after 28 steps. Each fix moved it further: 28 → 84 → 150 → **175, target reached**.

Found while surveying the downgrade chain for #12881.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



