### PR TITLE
feat(BA-6904): add bulk action runner, processor, and validator

### DIFF
--- a/changes/12913.feature.md
+++ b/changes/12913.feature.md
@@ -1,0 +1,1 @@
+Add an independent bulk action runner (processor, validator, and monitor abstraction) bound to the self-contained bulk base action.

--- a/src/ai/backend/manager/actions/bulk/__init__.py
+++ b/src/ai/backend/manager/actions/bulk/__init__.py
@@ -1,5 +1,19 @@
 from .base import (
     BaseBulkAction,
 )
+from .monitor import BulkActionMonitor
+from .processor import BulkActionProcessor
+from .result import (
+    BulkActionProcessResult,
+    BulkActionResultMeta,
+)
+from .validator import BulkActionValidator
 
-__all__ = ("BaseBulkAction",)
+__all__ = (
+    "BaseBulkAction",
+    "BulkActionMonitor",
+    "BulkActionProcessor",
+    "BulkActionProcessResult",
+    "BulkActionResultMeta",
+    "BulkActionValidator",
+)

--- a/src/ai/backend/manager/actions/bulk/monitor/__init__.py
+++ b/src/ai/backend/manager/actions/bulk/monitor/__init__.py
@@ -1,0 +1,3 @@
+from .base import BulkActionMonitor
+
+__all__ = ("BulkActionMonitor",)

--- a/src/ai/backend/manager/actions/bulk/monitor/base.py
+++ b/src/ai/backend/manager/actions/bulk/monitor/base.py
@@ -1,0 +1,22 @@
+from abc import ABC
+
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.bulk.base import BaseBulkAction
+from ai.backend.manager.actions.bulk.result import BulkActionProcessResult
+
+__all__ = ("BulkActionMonitor",)
+
+
+class BulkActionMonitor(ABC):
+    """Observes the lifecycle of a bulk action.
+
+    Bound to the self-contained :class:`BaseBulkAction` (pure ABC). ``prepare``
+    runs before the action function; ``done`` runs after it completes (or fails), with
+    the outcome carried in :class:`BulkActionProcessResult`.
+    """
+
+    async def prepare(self, action: BaseBulkAction, meta: BaseActionTriggerMeta) -> None:
+        raise NotImplementedError("Subclasses must implement the prepare method")
+
+    async def done(self, action: BaseBulkAction, result: BulkActionProcessResult) -> None:
+        raise NotImplementedError("Subclasses must implement the done method")

--- a/src/ai/backend/manager/actions/bulk/processor.py
+++ b/src/ai/backend/manager/actions/bulk/processor.py
@@ -1,0 +1,105 @@
+import logging
+import uuid
+from collections.abc import Awaitable, Callable, Sequence
+from datetime import UTC, datetime
+
+from ai.backend.common.exception import BackendAIError, ErrorCode
+from ai.backend.logging.utils import BraceStyleAdapter
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.bulk.base import BaseBulkAction
+from ai.backend.manager.actions.bulk.monitor import BulkActionMonitor
+from ai.backend.manager.actions.bulk.result import (
+    BulkActionProcessResult,
+    BulkActionResultMeta,
+)
+from ai.backend.manager.actions.bulk.validator import BulkActionValidator
+from ai.backend.manager.actions.types import OperationStatus
+
+__all__ = ("BulkActionProcessor",)
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class BulkActionProcessor[TAction: BaseBulkAction, TResult]:
+    """Validate, run monitors around, then execute a bulk action.
+
+    Each registered validator runs first. The action function then executes within a
+    monitor lifecycle: every monitor's ``prepare`` is called before, and ``done`` after
+    (on success or failure), with status / timing / error captured into a
+    :class:`BulkActionProcessResult`. This path depends only on the pure-ABC
+    :class:`BaseBulkAction`, never on the legacy ``BaseAction`` framework.
+    """
+
+    _func: Callable[[TAction], Awaitable[TResult]]
+    _monitors: Sequence[BulkActionMonitor]
+    _validators: Sequence[BulkActionValidator]
+
+    def __init__(
+        self,
+        func: Callable[[TAction], Awaitable[TResult]],
+        monitors: Sequence[BulkActionMonitor] | None = None,
+        validators: Sequence[BulkActionValidator] | None = None,
+    ) -> None:
+        self._func = func
+        self._monitors = monitors or []
+        self._validators = validators or []
+
+    async def _prepare_monitors(self, action: TAction, trigger_meta: BaseActionTriggerMeta) -> None:
+        for monitor in self._monitors:
+            try:
+                await monitor.prepare(action, trigger_meta)
+            except Exception as e:
+                log.warning("Error in monitor prepare method: {}", e)
+
+    async def _finalize_monitors(self, action: TAction, meta: BulkActionResultMeta) -> None:
+        process_result = BulkActionProcessResult(meta=meta)
+        for monitor in reversed(self._monitors):
+            try:
+                await monitor.done(action, process_result)
+            except Exception as e:
+                log.warning("Error in monitor done method: {}", e)
+
+    async def run(self, action: TAction) -> TResult:
+        started_at = datetime.now(UTC)
+        action_id = uuid.uuid4()
+        trigger_meta = BaseActionTriggerMeta(action_id=action_id, started_at=started_at)
+
+        for validator in self._validators:
+            await validator.validate(action, trigger_meta)
+
+        status = OperationStatus.UNKNOWN
+        description = "unknown"
+        error_code: ErrorCode | None = None
+
+        await self._prepare_monitors(action, trigger_meta)
+        try:
+            result = await self._func(action)
+        except BackendAIError as e:
+            log.exception("Action processing error: {}", e)
+            status = OperationStatus.ERROR
+            description = str(e)
+            error_code = e.error_code()
+            raise
+        except BaseException as e:
+            log.exception("Unexpected error during action processing: {}", e)
+            status = OperationStatus.ERROR
+            description = str(e)
+            error_code = ErrorCode.default()
+            raise
+        else:
+            status = OperationStatus.SUCCESS
+            description = "Success"
+            return result
+        finally:
+            ended_at = datetime.now(UTC)
+            meta = BulkActionResultMeta(
+                action_id=action_id,
+                entity_ids=action.entity_ids(),
+                status=status,
+                description=description,
+                started_at=started_at,
+                ended_at=ended_at,
+                duration=ended_at - started_at,
+                error_code=error_code,
+            )
+            await self._finalize_monitors(action, meta)

--- a/src/ai/backend/manager/actions/bulk/result.py
+++ b/src/ai/backend/manager/actions/bulk/result.py
@@ -1,0 +1,37 @@
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from ai.backend.common.exception import ErrorCode
+from ai.backend.common.identifier.entity import EntityID
+from ai.backend.manager.actions.types import OperationStatus
+
+__all__ = (
+    "BulkActionResultMeta",
+    "BulkActionProcessResult",
+)
+
+
+@dataclass
+class BulkActionResultMeta:
+    """Outcome metadata for a bulk action run.
+
+    Self-contained for the pure-ABC bulk line; carries the ``entity_ids`` the action
+    ran against because :class:`BaseBulkAction` operates on an explicit set of
+    entities rather than a single identified entity.
+    """
+
+    action_id: uuid.UUID
+    entity_ids: Sequence[EntityID]
+    status: OperationStatus
+    description: str
+    started_at: datetime
+    ended_at: datetime
+    duration: timedelta
+    error_code: ErrorCode | None
+
+
+@dataclass
+class BulkActionProcessResult:
+    meta: BulkActionResultMeta

--- a/src/ai/backend/manager/actions/bulk/validator/__init__.py
+++ b/src/ai/backend/manager/actions/bulk/validator/__init__.py
@@ -1,0 +1,3 @@
+from .base import BulkActionValidator
+
+__all__ = ("BulkActionValidator",)

--- a/src/ai/backend/manager/actions/bulk/validator/base.py
+++ b/src/ai/backend/manager/actions/bulk/validator/base.py
@@ -1,0 +1,18 @@
+from abc import ABC, abstractmethod
+
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.bulk.base import BaseBulkAction
+
+__all__ = ("BulkActionValidator",)
+
+
+class BulkActionValidator(ABC):
+    """Validates a bulk action before execution.
+
+    Bound to the self-contained :class:`BaseBulkAction` (pure ABC), so this
+    contract stays independent of the legacy ``BaseAction`` hierarchy.
+    """
+
+    @abstractmethod
+    async def validate(self, action: BaseBulkAction, meta: BaseActionTriggerMeta) -> None:
+        raise NotImplementedError("Subclasses must implement the validate method")


### PR DESCRIPTION
## Summary
- Add the isolated **bulk action runner** line, mirroring the existing single-entity line.
- `BulkActionProcessor` validates, wraps execution in a monitor lifecycle, then runs the action — bound only to the pure-ABC `BaseBulkAction`, independent of the legacy `BaseAction` framework.
- `BulkActionResultMeta` carries `entity_ids: Sequence[EntityID]` (bulk actions operate on an explicit set of entities).
- Adds `BulkActionValidator` and the `BulkActionMonitor` ABC (a structural dependency of the processor's monitor lifecycle, same as the single-entity line).

## Test plan
- [x] `pants check` / `pants test` pass in CI

Resolves BA-6904