### PR TITLE
feat(BA-6916): let an RBAC creator carry no scope, and add scoped partial bulk ops

### DIFF
--- a/changes/12914.feature.md
+++ b/changes/12914.feature.md
@@ -1,0 +1,1 @@
+Let an RBAC entity creator carry no scope (`scope_ref=None`) so a GLOBAL entity outside the RBAC scope hierarchy is created with no scope association, and add `bulk_create_scoped_partial` / `bulk_purge_scoped_partial` for scoped bulk writes that need per-item partial success (BEP-1052).

--- a/src/ai/backend/manager/repositories/base/rbac/entity_creator.py
+++ b/src/ai/backend/manager/repositories/base/rbac/entity_creator.py
@@ -17,7 +17,7 @@ from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
 )
-from ai.backend.manager.repositories.base.creator import CreatorSpec
+from ai.backend.manager.repositories.base.creator import BulkCreatorError, CreatorSpec
 from ai.backend.manager.repositories.base.integrity import (
     match_integrity_error,
     parse_integrity_error,
@@ -36,22 +36,33 @@ TRow = TypeVar("TRow", bound=Base)
 class RBACEntityCreator[TRow: Base]:
     """Creator for a single entity with scope associations for RBAC.
 
-    Creates an entity row and associates it with one or more permission scopes.
-    The primary scope is required; additional scopes are optional.
+    Creates an entity row and associates it with the permission scopes it belongs to.
+    A ``scope_ref`` of ``None`` marks the entity as GLOBAL — outside the RBAC scope
+    hierarchy — so it binds to no scope at all and its create is a plain insert.
 
     Attributes:
         spec: CreatorSpec implementation defining the row to create.
         element_type: The RBAC element type for this entity.
-        scope_ref: Primary scope reference (scope_type + scope_id) for this entity.
+        scope_ref: Primary scope reference (scope_type + scope_id) for this entity, or
+            ``None`` for a GLOBAL entity. A GLOBAL entity has no scope to associate, so
+            ``additional_scope_refs`` and ``relation_type`` do not apply to it and are
+            ignored.
         additional_scope_refs: Additional scope references for multi-scope entities.
+            Only meaningful alongside a ``scope_ref``.
         relation_type: The relation type for the scope-entity association. Defaults to AUTO.
     """
 
     spec: CreatorSpec[TRow]
     element_type: RBACElementType
-    scope_ref: RBACElementRef
+    scope_ref: RBACElementRef | None
     additional_scope_refs: Sequence[RBACElementRef] = field(default_factory=list)
     relation_type: RelationType = RelationType.AUTO
+
+    def all_scope_refs(self) -> list[RBACElementRef]:
+        """Every scope this entity binds to; empty for a GLOBAL entity (``scope_ref=None``)."""
+        if self.scope_ref is None:
+            return []
+        return [self.scope_ref, *self.additional_scope_refs]
 
 
 @dataclass
@@ -74,7 +85,9 @@ async def execute_rbac_entity_creator[TRow: Base](
     4. Insert AssociationScopesEntitiesRow (scope -> entity mapping)
 
     The AssociationScopesEntitiesRow maps the entity to its owning scope,
-    enabling scope-based entity discovery and permission inheritance.
+    enabling scope-based entity discovery and permission inheritance. A creator that
+    binds to no scope (see :attr:`RBACEntityCreator.scope_ref`) skips step 4, making
+    this a plain insert.
 
     Args:
         db_sess: Async SQLAlchemy session (must be writable).
@@ -106,7 +119,6 @@ async def execute_rbac_entity_creator[TRow: Base](
     instance_state = inspect(row)
     pk_value = instance_state.identity[0]
     entity_type = creator.element_type.to_entity_type()
-    all_scope_refs = [creator.scope_ref, *creator.additional_scope_refs]
     associations = [
         AssociationScopesEntitiesRow(
             scope_type=scope_ref.element_type.to_scope_type(),
@@ -115,11 +127,23 @@ async def execute_rbac_entity_creator[TRow: Base](
             entity_id=str(pk_value),
             relation_type=creator.relation_type,
         )
-        for scope_ref in all_scope_refs
+        for scope_ref in creator.all_scope_refs()
     ]
     await bulk_insert_on_conflict_do_nothing(db_sess, associations)
 
     return RBACEntityCreatorResult(row=row)
+
+
+@dataclass
+class RBACBulkEntityCreatorResultWithFailures[TRow: Base]:
+    """Result of a scoped bulk create that isolates each entity.
+
+    Mirrors :class:`BulkCreatorResultWithFailures`. ``errors`` index into the sequence of
+    creators handed to the executor, not into any list the caller may have derived it from.
+    """
+
+    successes: list[TRow]
+    errors: list[BulkCreatorError[TRow]]
 
 
 # =============================================================================
@@ -259,8 +283,7 @@ async def execute_rbac_entity_creators[TRow: Base](
     for creator, row in zip(creators, rows, strict=True):
         pk_value = inspect(row).identity[0]
         entity_type = creator.element_type.to_entity_type()
-        all_scope_refs = [creator.scope_ref, *creator.additional_scope_refs]
-        for scope_ref in all_scope_refs:
+        for scope_ref in creator.all_scope_refs():
             associations.append(
                 AssociationScopesEntitiesRow(
                     scope_type=scope_ref.element_type.to_scope_type(),

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -36,10 +36,24 @@ from ai.backend.manager.repositories.base import (
     Purger,
     PurgerResult,
 )
+from ai.backend.manager.repositories.base.creator import BulkCreatorError
+from ai.backend.manager.repositories.base.integrity import parse_integrity_error
+from ai.backend.manager.repositories.base.purger import (
+    BulkPurgerError,
+    BulkPurgerResultWithFailures,
+)
 from ai.backend.manager.repositories.base.rbac.entity_creator import (
     RBACBulkEntityCreatorResult,
+    RBACBulkEntityCreatorResultWithFailures,
     RBACEntityCreator,
+    RBACEntityCreatorResult,
+    execute_rbac_entity_creator,
     execute_rbac_entity_creators,
+)
+from ai.backend.manager.repositories.base.rbac.entity_purger import (
+    RBACEntityPurger,
+    RBACEntityPurgerResult,
+    execute_rbac_entity_purger,
 )
 from ai.backend.manager.repositories.ops.base.provider import DBOpsProvider, WriteOps
 from ai.backend.manager.repositories.permission_controller.role_manager import RoleManager
@@ -148,12 +162,77 @@ class RBACWriteOps(WriteOps):
         )
         await self._sess.execute(stmt)
 
+    async def create_scoped[TRow: Base](
+        self,
+        creator: RBACEntityCreator[TRow],
+    ) -> RBACEntityCreatorResult[TRow]:
+        """Insert one row with its RBAC scope association (the creator carries its scope)."""
+        return await execute_rbac_entity_creator(self._sess, creator)
+
     async def bulk_create_scoped[TRow: Base](
         self,
         creators: Sequence[RBACEntityCreator[TRow]],
     ) -> RBACBulkEntityCreatorResult[TRow]:
         """Insert rows with their RBAC scope associations (each creator carries its scope)."""
         return await execute_rbac_entity_creators(self._sess, creators)
+
+    async def bulk_create_scoped_partial[TRow: Base](
+        self,
+        creators: Sequence[RBACEntityCreator[TRow]],
+    ) -> RBACBulkEntityCreatorResultWithFailures[TRow]:
+        """Insert rows with their scope associations, isolating each row for partial success.
+
+        The scoped counterpart of :meth:`bulk_create_partial`: a row and its association share
+        one savepoint, so a rejected row rolls back both and leaves the rest created.
+        :meth:`bulk_create_scoped` flushes the batch at once instead and is all-or-nothing.
+        """
+        successes: list[TRow] = []
+        errors: list[BulkCreatorError[TRow]] = []
+        for index, creator in enumerate(creators):
+            async with self.savepoint():
+                try:
+                    result = await execute_rbac_entity_creator(self._sess, creator)
+                    successes.append(result.row)
+                except sa.exc.IntegrityError as e:
+                    errors.append(
+                        BulkCreatorError(
+                            spec=creator.spec, exception=parse_integrity_error(e), index=index
+                        )
+                    )
+                except Exception as e:
+                    # execute_rbac_entity_creator maps the integrity errors its spec declares
+                    # onto domain errors; whatever arrives here fails just this row.
+                    errors.append(BulkCreatorError(spec=creator.spec, exception=e, index=index))
+        return RBACBulkEntityCreatorResultWithFailures(successes=successes, errors=errors)
+
+    async def purge_scoped[TRow: Base](
+        self,
+        purger: RBACEntityPurger[TRow],
+    ) -> RBACEntityPurgerResult[TRow] | None:
+        """Delete one row and its RBAC entries; ``None`` if the row is already gone."""
+        return await execute_rbac_entity_purger(self._sess, purger)
+
+    async def bulk_purge_scoped_partial[TRow: Base](
+        self,
+        purgers: Sequence[RBACEntityPurger[TRow]],
+    ) -> BulkPurgerResultWithFailures[TRow]:
+        """Delete rows with their RBAC entries, isolating each row for partial success.
+
+        The scoped counterpart of :meth:`bulk_purge_partial`: a row and its RBAC entries share
+        one savepoint, so a failed row rolls back both and leaves the rest deleted. A purger
+        targeting a row that is already gone is skipped — no success, no error.
+        """
+        successes: list[TRow] = []
+        errors: list[BulkPurgerError[TRow]] = []
+        for index, purger in enumerate(purgers):
+            async with self.savepoint():
+                try:
+                    result = await execute_rbac_entity_purger(self._sess, purger)
+                    if result is not None:
+                        successes.append(result.row)
+                except Exception as e:
+                    errors.append(BulkPurgerError(purger=purger, exception=e, index=index))
+        return BulkPurgerResultWithFailures(successes=successes, errors=errors)
 
     async def add_users_to_scope(
         self,

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -189,20 +189,23 @@ class RBACWriteOps(WriteOps):
         successes: list[TRow] = []
         errors: list[BulkCreatorError[TRow]] = []
         for index, creator in enumerate(creators):
-            async with self.savepoint():
-                try:
+            # The handlers stay outside the savepoint: a failure has to reach the context
+            # manager for it to roll back. Catching inside would leave it releasing a
+            # savepoint the failed statement already aborted, which kills the whole batch.
+            try:
+                async with self.savepoint():
                     result = await execute_rbac_entity_creator(self._sess, creator)
-                    successes.append(result.row)
-                except sa.exc.IntegrityError as e:
-                    errors.append(
-                        BulkCreatorError(
-                            spec=creator.spec, exception=parse_integrity_error(e), index=index
-                        )
+                successes.append(result.row)
+            except sa.exc.IntegrityError as e:
+                errors.append(
+                    BulkCreatorError(
+                        spec=creator.spec, exception=parse_integrity_error(e), index=index
                     )
-                except Exception as e:
-                    # execute_rbac_entity_creator maps the integrity errors its spec declares
-                    # onto domain errors; whatever arrives here fails just this row.
-                    errors.append(BulkCreatorError(spec=creator.spec, exception=e, index=index))
+                )
+            except Exception as e:
+                # execute_rbac_entity_creator maps the integrity errors its spec declares
+                # onto domain errors; whatever arrives here fails just this row.
+                errors.append(BulkCreatorError(spec=creator.spec, exception=e, index=index))
         return RBACBulkEntityCreatorResultWithFailures(successes=successes, errors=errors)
 
     async def purge_scoped[TRow: Base](
@@ -225,13 +228,14 @@ class RBACWriteOps(WriteOps):
         successes: list[TRow] = []
         errors: list[BulkPurgerError[TRow]] = []
         for index, purger in enumerate(purgers):
-            async with self.savepoint():
-                try:
+            # The handler stays outside the savepoint — see bulk_create_scoped_partial.
+            try:
+                async with self.savepoint():
                     result = await execute_rbac_entity_purger(self._sess, purger)
-                    if result is not None:
-                        successes.append(result.row)
-                except Exception as e:
-                    errors.append(BulkPurgerError(purger=purger, exception=e, index=index))
+                if result is not None:
+                    successes.append(result.row)
+            except Exception as e:
+                errors.append(BulkPurgerError(purger=purger, exception=e, index=index))
         return BulkPurgerResultWithFailures(successes=successes, errors=errors)
 
     async def add_users_to_scope(

--- a/tests/unit/manager/repositories/base/rbac/test_entity_creator.py
+++ b/tests/unit/manager/repositories/base/rbac/test_entity_creator.py
@@ -523,6 +523,37 @@ class TestRBACEntityCreatorBasic:
             assert assoc_row.scope_type == ScopeType.PROJECT
             assert assoc_row.scope_id == project_scope_id
 
+    async def test_create_entity_without_scope_inserts_row_only(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        create_tables: None,
+        user_scope_id: str,
+    ) -> None:
+        """A GLOBAL entity (``scope_ref=None``) is inserted with no association at all.
+
+        ``additional_scope_refs`` does not apply to it and is ignored, so a stray one must not
+        resurrect an association.
+        """
+        creator = RBACEntityCreator(
+            spec=SimpleCreatorSpec(
+                name="global-entity",
+                scope_type=ScopeType.USER,
+                scope_id=user_scope_id,
+            ),
+            element_type=RBACElementType.VFOLDER,
+            scope_ref=None,
+            additional_scope_refs=[RBACElementRef(RBACElementType.USER, user_scope_id)],
+        )
+        async with database_connection.begin_session() as db_sess:
+            result = await execute_rbac_entity_creator(db_sess, creator)
+
+            assert result.row.name == "global-entity"
+            assert result.row.id is not None
+            assoc_count = await db_sess.scalar(
+                sa.select(sa.func.count()).select_from(AssociationScopesEntitiesRow)
+            )
+            assert assoc_count == 0
+
     async def test_create_multiple_entities_sequentially(
         self,
         database_connection: ExtendedAsyncSAEngine,

--- a/tests/unit/manager/repositories/ops/rbac/test_provider.py
+++ b/tests/unit/manager/repositories/ops/rbac/test_provider.py
@@ -1,7 +1,13 @@
-"""Integration tests for RBAC ops scope creation with a real database.
+"""Integration tests for the RBAC ops provider (RBACWriteOps) with a real database.
 
-Verify that ``create_scope`` / ``bulk_create_scopes`` materialize both the virtual
-scope node and the scope-as-entity membership in the scope's own virtual scope.
+These verify observable outcomes — which rows and which scope associations survive an
+operation — rather than internal call wiring. Two surfaces are covered:
+
+- ``create_scope`` / ``bulk_create_scopes`` materialize both the virtual scope node and
+  the scope-as-entity membership in the scope's own virtual scope.
+- ``bulk_create_scoped_partial`` / ``bulk_purge_scoped_partial`` isolate each item so a
+  rejected one leaves the rest of the batch intact. The unscoped counterparts
+  (``bulk_create_partial`` / ``bulk_purge_partial``) are covered by the base ops tests.
 """
 
 from __future__ import annotations
@@ -16,7 +22,15 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
-from ai.backend.common.entity.types import EntityType, ScopeRef, ScopeType
+from ai.backend.common.data.permission.types import EntityType, RBACElementType
+from ai.backend.common.entity.types import (
+    EntityType as VirtualScopeEntityType,
+)
+from ai.backend.common.entity.types import (
+    ScopeRef,
+    ScopeType,
+)
+from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.base import GUID, Base
 from ai.backend.manager.models.domain import DomainRow
@@ -38,6 +52,11 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.repositories.base import Creator, CreatorSpec
+from ai.backend.manager.repositories.base.rbac.entity_creator import RBACEntityCreator
+from ai.backend.manager.repositories.base.rbac.entity_purger import (
+    RBACEntityPurger,
+    RBACEntityPurgerSpec,
+)
 from ai.backend.manager.repositories.ops.rbac.provider import RBACOpsProvider, ScopeCreation
 from ai.backend.testutils.db import with_tables
 
@@ -60,11 +79,13 @@ _ORM_CLUSTER = (
 )
 
 _TEST_SCOPE_TYPE = ScopeType("test-scope")
-_TEST_ENTITY_TYPE = EntityType("test-scope")
+_TEST_ENTITY_TYPE = VirtualScopeEntityType("test-scope")
+
+_USER_SCOPE_ID = str(uuid.uuid4())
 
 
 # =============================================================================
-# Test Row Model (synthetic owner scope entity)
+# Test Row Models
 # =============================================================================
 
 
@@ -95,6 +116,36 @@ def make_scope_creation(scope_id: UUID, name: str) -> ScopeCreation[OpsRBACScope
     )
 
 
+class RBACOpsTestRow(Base):  # type: ignore[misc]
+    __tablename__ = "test_rbac_ops_entity"
+    __table_args__ = {"extend_existing": True}
+
+    id: Mapped[int] = mapped_column(sa.Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(sa.String(64), nullable=False, unique=True)
+
+
+@dataclass
+class RBACOpsCreatorSpec(CreatorSpec[RBACOpsTestRow]):
+    name: str
+
+    @override
+    def build_row(self) -> RBACOpsTestRow:
+        return RBACOpsTestRow(name=self.name)
+
+
+@dataclass
+class RBACOpsPurgerSpec(RBACEntityPurgerSpec):
+    entity_id: str
+
+    @override
+    def element_type(self) -> RBACElementType:
+        return RBACElementType.VFOLDER
+
+    @override
+    def entity_ref(self) -> RBACElementRef:
+        return RBACElementRef(RBACElementType.VFOLDER, self.entity_id)
+
+
 # =============================================================================
 # Tables & Fixtures
 # =============================================================================
@@ -111,6 +162,17 @@ async def scope_tables(
     database_connection: ExtendedAsyncSAEngine,
 ) -> AsyncGenerator[None, None]:
     async with with_tables(database_connection, _SCOPE_TABLES):  # type: ignore[arg-type]
+        yield
+
+
+@pytest.fixture
+async def rbac_ops_tables(
+    database_connection: ExtendedAsyncSAEngine,
+) -> AsyncGenerator[None, None]:
+    async with with_tables(
+        database_connection,
+        [RBACOpsTestRow, AssociationScopesEntitiesRow, RoleRow, PermissionRow],
+    ):
         yield
 
 
@@ -224,3 +286,154 @@ class TestScopeCreationVirtualScope:
             assert membership.entity_id in scope_ids
             assert membership.virtual_scope_id == vs_by_scope[membership.entity_id].id
             assert membership.permission_cap is None
+
+
+async def _scope_ids_of(database: ExtendedAsyncSAEngine, entity_id: str) -> list[str]:
+    async with database.begin_readonly_session() as db_sess:
+        rows = await db_sess.scalars(
+            sa.select(AssociationScopesEntitiesRow).where(
+                AssociationScopesEntitiesRow.entity_type == EntityType.VFOLDER,
+                AssociationScopesEntitiesRow.entity_id == entity_id,
+            )
+        )
+        return [row.scope_id for row in rows]
+
+
+class TestBulkCreateScopedPartial:
+    async def test_all_created_with_their_associations(
+        self,
+        provider: RBACOpsProvider,
+        database_connection: ExtendedAsyncSAEngine,
+        rbac_ops_tables: None,
+    ) -> None:
+        """A scoped item binds to its scope; an unscoped one is inserted with no association."""
+        async with provider.write_ops() as w:
+            result = await w.bulk_create_scoped_partial([
+                RBACEntityCreator(
+                    spec=RBACOpsCreatorSpec(name="scoped"),
+                    element_type=RBACElementType.VFOLDER,
+                    scope_ref=RBACElementRef(RBACElementType.USER, _USER_SCOPE_ID),
+                ),
+                RBACEntityCreator(
+                    spec=RBACOpsCreatorSpec(name="global"),
+                    element_type=RBACElementType.VFOLDER,
+                    scope_ref=None,
+                ),
+            ])
+            assert [row.name for row in result.successes] == ["scoped", "global"]
+            assert result.errors == []
+            ids = {row.name: str(row.id) for row in result.successes}
+
+        assert await _scope_ids_of(database_connection, ids["scoped"]) == [_USER_SCOPE_ID]
+        assert await _scope_ids_of(database_connection, ids["global"]) == []
+
+    async def test_rejected_item_leaves_the_rest_created(
+        self,
+        provider: RBACOpsProvider,
+        database_connection: ExtendedAsyncSAEngine,
+        rbac_ops_tables: None,
+    ) -> None:
+        """A row and its association share one savepoint, so a rejected row rolls back both."""
+        async with provider.write_ops() as w:
+            await w.bulk_create_scoped_partial([
+                RBACEntityCreator(
+                    spec=RBACOpsCreatorSpec(name="taken"),
+                    element_type=RBACElementType.VFOLDER,
+                    scope_ref=RBACElementRef(RBACElementType.USER, _USER_SCOPE_ID),
+                )
+            ])
+
+        async with provider.write_ops() as w:
+            result = await w.bulk_create_scoped_partial([
+                RBACEntityCreator(  # unique violation -> rejected
+                    spec=RBACOpsCreatorSpec(name="taken"),
+                    element_type=RBACElementType.VFOLDER,
+                    scope_ref=RBACElementRef(RBACElementType.USER, _USER_SCOPE_ID),
+                ),
+                RBACEntityCreator(
+                    spec=RBACOpsCreatorSpec(name="fresh"),
+                    element_type=RBACElementType.VFOLDER,
+                    scope_ref=RBACElementRef(RBACElementType.USER, _USER_SCOPE_ID),
+                ),
+            ])
+            assert [row.name for row in result.successes] == ["fresh"]
+            assert [e.index for e in result.errors] == [0]
+            fresh_id = str(result.successes[0].id)
+
+        # the surviving row kept its association, and the rejected one left none behind
+        assert await _scope_ids_of(database_connection, fresh_id) == [_USER_SCOPE_ID]
+        async with database_connection.begin_readonly_session() as db_sess:
+            names = await db_sess.scalars(sa.select(RBACOpsTestRow.name))
+            assert sorted(names) == ["fresh", "taken"]
+            assoc_count = await db_sess.scalar(
+                sa.select(sa.func.count()).select_from(AssociationScopesEntitiesRow)
+            )
+            assert assoc_count == 2  # one per surviving row, none orphaned by the rejection
+
+
+class TestBulkPurgeScopedPartial:
+    async def test_purges_rows_and_their_associations(
+        self,
+        provider: RBACOpsProvider,
+        database_connection: ExtendedAsyncSAEngine,
+        rbac_ops_tables: None,
+    ) -> None:
+        """Deleting a row takes its scope association with it, leaving nothing orphaned."""
+        async with provider.write_ops() as w:
+            created = await w.bulk_create_scoped_partial([
+                RBACEntityCreator(
+                    spec=RBACOpsCreatorSpec(name="doomed"),
+                    element_type=RBACElementType.VFOLDER,
+                    scope_ref=RBACElementRef(RBACElementType.USER, _USER_SCOPE_ID),
+                )
+            ])
+            entity_id = str(created.successes[0].id)
+            pk_value = created.successes[0].id
+        assert await _scope_ids_of(database_connection, entity_id) == [_USER_SCOPE_ID]
+
+        async with provider.write_ops() as w:
+            result = await w.bulk_purge_scoped_partial([
+                RBACEntityPurger(
+                    row_class=RBACOpsTestRow,
+                    pk_value=pk_value,
+                    spec=RBACOpsPurgerSpec(entity_id=entity_id),
+                )
+            ])
+            assert [row.name for row in result.successes] == ["doomed"]
+            assert result.errors == []
+
+        assert await _scope_ids_of(database_connection, entity_id) == []
+        async with database_connection.begin_readonly_session() as db_sess:
+            remaining = await db_sess.scalar(sa.select(sa.func.count()).select_from(RBACOpsTestRow))
+            assert remaining == 0
+
+    async def test_missing_row_is_skipped_not_reported(
+        self,
+        provider: RBACOpsProvider,
+        database_connection: ExtendedAsyncSAEngine,
+        rbac_ops_tables: None,
+    ) -> None:
+        """A purger for an already-gone row yields no success and no error, like the unscoped op."""
+        async with provider.write_ops() as w:
+            created = await w.bulk_create_scoped_partial([
+                RBACEntityCreator(
+                    spec=RBACOpsCreatorSpec(name="kept"),
+                    element_type=RBACElementType.VFOLDER,
+                    scope_ref=RBACElementRef(RBACElementType.USER, _USER_SCOPE_ID),
+                )
+            ])
+            kept_id = created.successes[0].id
+
+        async with provider.write_ops() as w:
+            result = await w.bulk_purge_scoped_partial([
+                RBACEntityPurger(
+                    row_class=RBACOpsTestRow,
+                    pk_value=9_999_999,  # never existed
+                    spec=RBACOpsPurgerSpec(entity_id="9999999"),
+                )
+            ])
+            assert result.successes == []
+            assert result.errors == []
+
+        # the untouched row and its association are still there
+        assert await _scope_ids_of(database_connection, str(kept_id)) == [_USER_SCOPE_ID]

--- a/tests/unit/manager/repositories/ops/rbac/test_provider.py
+++ b/tests/unit/manager/repositories/ops/rbac/test_provider.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncGenerator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import override
 from uuid import UUID
 
@@ -22,7 +22,7 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
-from ai.backend.common.data.permission.types import EntityType, RBACElementType
+from ai.backend.common.data.permission.types import EntityType, RBACElementType, RelationType
 from ai.backend.common.entity.types import (
     EntityType as VirtualScopeEntityType,
 )
@@ -82,6 +82,7 @@ _TEST_SCOPE_TYPE = ScopeType("test-scope")
 _TEST_ENTITY_TYPE = VirtualScopeEntityType("test-scope")
 
 _USER_SCOPE_ID = str(uuid.uuid4())
+_USER_SCOPE_REF = RBACElementRef(RBACElementType.USER, _USER_SCOPE_ID)
 
 
 # =============================================================================
@@ -124,6 +125,18 @@ class RBACOpsTestRow(Base):  # type: ignore[misc]
     name: Mapped[str] = mapped_column(sa.String(64), nullable=False, unique=True)
 
 
+class RBACOpsBlockerRow(Base):  # type: ignore[misc]
+    """Referencing row whose RESTRICT foreign key makes its target's delete fail."""
+
+    __tablename__ = "test_rbac_ops_blocker"
+    __table_args__ = {"extend_existing": True}
+
+    id: Mapped[int] = mapped_column(sa.Integer, primary_key=True, autoincrement=True)
+    target_id: Mapped[int] = mapped_column(
+        sa.ForeignKey("test_rbac_ops_entity.id", ondelete="RESTRICT"), nullable=False
+    )
+
+
 @dataclass
 class RBACOpsCreatorSpec(CreatorSpec[RBACOpsTestRow]):
     name: str
@@ -144,6 +157,14 @@ class RBACOpsPurgerSpec(RBACEntityPurgerSpec):
     @override
     def entity_ref(self) -> RBACElementRef:
         return RBACElementRef(RBACElementType.VFOLDER, self.entity_id)
+
+
+@dataclass(frozen=True)
+class _ScopedRow:
+    """A scope-bound row a test purges, or collides with, detached from its session."""
+
+    name: str
+    id: int
 
 
 # =============================================================================
@@ -171,7 +192,7 @@ async def rbac_ops_tables(
 ) -> AsyncGenerator[None, None]:
     async with with_tables(
         database_connection,
-        [RBACOpsTestRow, AssociationScopesEntitiesRow, RoleRow, PermissionRow],
+        [RBACOpsTestRow, RBACOpsBlockerRow, AssociationScopesEntitiesRow, RoleRow, PermissionRow],
     ):
         yield
 
@@ -288,87 +309,133 @@ class TestScopeCreationVirtualScope:
             assert membership.permission_cap is None
 
 
-async def _scope_ids_of(database: ExtendedAsyncSAEngine, entity_id: str) -> list[str]:
-    async with database.begin_readonly_session() as db_sess:
-        rows = await db_sess.scalars(
-            sa.select(AssociationScopesEntitiesRow).where(
-                AssociationScopesEntitiesRow.entity_type == EntityType.VFOLDER,
-                AssociationScopesEntitiesRow.entity_id == entity_id,
+@pytest.fixture
+async def scoped_rows(
+    database_connection: ExtendedAsyncSAEngine,
+    rbac_ops_tables: None,
+) -> list[_ScopedRow]:
+    """Two committed rows bound to ``_USER_SCOPE_REF``, each with its scope association.
+
+    Inserted directly rather than through the scoped ops, so a broken op under test fails
+    the assertion instead of the arrange step.
+    """
+    async with database_connection.begin_session() as db_sess:
+        rows = [RBACOpsTestRow(name=name) for name in ("first", "second")]
+        db_sess.add_all(rows)
+        await db_sess.flush()
+        db_sess.add_all([
+            AssociationScopesEntitiesRow(
+                scope_type=_USER_SCOPE_REF.element_type.to_scope_type(),
+                scope_id=_USER_SCOPE_ID,
+                entity_type=EntityType.VFOLDER,
+                entity_id=str(row.id),
+                relation_type=RelationType.AUTO,
             )
-        )
-        return [row.scope_id for row in rows]
+            for row in rows
+        ])
+        return [_ScopedRow(name=row.name, id=row.id) for row in rows]
+
+
+@pytest.fixture
+async def blocking_reference(
+    database_connection: ExtendedAsyncSAEngine,
+    scoped_rows: list[_ScopedRow],
+) -> None:
+    """A RESTRICT reference onto the first scoped row, making its delete fail."""
+    async with database_connection.begin_session() as db_sess:
+        db_sess.add(RBACOpsBlockerRow(target_id=scoped_rows[0].id))
+
+
+@dataclass(frozen=True)
+class _ScopedCreateCase:
+    """A creator to run through a scoped create, and the associations it should leave."""
+
+    name: str
+    scope_ref: RBACElementRef | None
+    expected_scope_ids: list[str] = field(default_factory=list)
 
 
 class TestBulkCreateScopedPartial:
-    async def test_all_created_with_their_associations(
+    @pytest.mark.parametrize(
+        "case",
+        [
+            _ScopedCreateCase(
+                name="scoped",
+                scope_ref=_USER_SCOPE_REF,
+                expected_scope_ids=[_USER_SCOPE_ID],
+            ),
+            _ScopedCreateCase(name="global", scope_ref=None),
+        ],
+        ids=lambda case: case.name,
+    )
+    async def test_row_binds_to_the_scope_its_creator_carries(
         self,
+        case: _ScopedCreateCase,
         provider: RBACOpsProvider,
         database_connection: ExtendedAsyncSAEngine,
         rbac_ops_tables: None,
     ) -> None:
-        """A scoped item binds to its scope; an unscoped one is inserted with no association."""
+        """A scoped creator binds its row to its scope; a scope-less one associates nothing."""
         async with provider.write_ops() as w:
             result = await w.bulk_create_scoped_partial([
                 RBACEntityCreator(
-                    spec=RBACOpsCreatorSpec(name="scoped"),
+                    spec=RBACOpsCreatorSpec(name=case.name),
                     element_type=RBACElementType.VFOLDER,
-                    scope_ref=RBACElementRef(RBACElementType.USER, _USER_SCOPE_ID),
-                ),
-                RBACEntityCreator(
-                    spec=RBACOpsCreatorSpec(name="global"),
-                    element_type=RBACElementType.VFOLDER,
-                    scope_ref=None,
-                ),
+                    scope_ref=case.scope_ref,
+                )
             ])
-            assert [row.name for row in result.successes] == ["scoped", "global"]
+            assert [row.name for row in result.successes] == [case.name]
             assert result.errors == []
-            ids = {row.name: str(row.id) for row in result.successes}
+            entity_id = str(result.successes[0].id)
 
-        assert await _scope_ids_of(database_connection, ids["scoped"]) == [_USER_SCOPE_ID]
-        assert await _scope_ids_of(database_connection, ids["global"]) == []
+        async with database_connection.begin_readonly_session() as db_sess:
+            scope_ids = await db_sess.scalars(
+                sa.select(AssociationScopesEntitiesRow.scope_id).where(
+                    AssociationScopesEntitiesRow.entity_type == EntityType.VFOLDER,
+                    AssociationScopesEntitiesRow.entity_id == entity_id,
+                )
+            )
+            assert list(scope_ids) == case.expected_scope_ids
 
     async def test_rejected_item_leaves_the_rest_created(
         self,
         provider: RBACOpsProvider,
         database_connection: ExtendedAsyncSAEngine,
-        rbac_ops_tables: None,
+        scoped_rows: list[_ScopedRow],
     ) -> None:
         """A row and its association share one savepoint, so a rejected row rolls back both."""
         async with provider.write_ops() as w:
-            await w.bulk_create_scoped_partial([
-                RBACEntityCreator(
-                    spec=RBACOpsCreatorSpec(name="taken"),
-                    element_type=RBACElementType.VFOLDER,
-                    scope_ref=RBACElementRef(RBACElementType.USER, _USER_SCOPE_ID),
-                )
-            ])
-
-        async with provider.write_ops() as w:
             result = await w.bulk_create_scoped_partial([
-                RBACEntityCreator(  # unique violation -> rejected
-                    spec=RBACOpsCreatorSpec(name="taken"),
+                RBACEntityCreator(  # unique violation on `name` -> rejected
+                    spec=RBACOpsCreatorSpec(name=scoped_rows[0].name),
                     element_type=RBACElementType.VFOLDER,
-                    scope_ref=RBACElementRef(RBACElementType.USER, _USER_SCOPE_ID),
+                    scope_ref=_USER_SCOPE_REF,
                 ),
                 RBACEntityCreator(
                     spec=RBACOpsCreatorSpec(name="fresh"),
                     element_type=RBACElementType.VFOLDER,
-                    scope_ref=RBACElementRef(RBACElementType.USER, _USER_SCOPE_ID),
+                    scope_ref=_USER_SCOPE_REF,
                 ),
             ])
             assert [row.name for row in result.successes] == ["fresh"]
             assert [e.index for e in result.errors] == [0]
             fresh_id = str(result.successes[0].id)
 
-        # the surviving row kept its association, and the rejected one left none behind
-        assert await _scope_ids_of(database_connection, fresh_id) == [_USER_SCOPE_ID]
         async with database_connection.begin_readonly_session() as db_sess:
             names = await db_sess.scalars(sa.select(RBACOpsTestRow.name))
-            assert sorted(names) == ["fresh", "taken"]
+            assert sorted(names) == ["first", "fresh", "second"]
+            # the surviving row kept its association, and the rejected one left none behind
+            fresh_scope_ids = await db_sess.scalars(
+                sa.select(AssociationScopesEntitiesRow.scope_id).where(
+                    AssociationScopesEntitiesRow.entity_type == EntityType.VFOLDER,
+                    AssociationScopesEntitiesRow.entity_id == fresh_id,
+                )
+            )
+            assert list(fresh_scope_ids) == [_USER_SCOPE_ID]
             assoc_count = await db_sess.scalar(
                 sa.select(sa.func.count()).select_from(AssociationScopesEntitiesRow)
             )
-            assert assoc_count == 2  # one per surviving row, none orphaned by the rejection
+            assert assoc_count == 3  # one per surviving row, none orphaned by the rejection
 
 
 class TestBulkPurgeScopedPartial:
@@ -376,54 +443,39 @@ class TestBulkPurgeScopedPartial:
         self,
         provider: RBACOpsProvider,
         database_connection: ExtendedAsyncSAEngine,
-        rbac_ops_tables: None,
+        scoped_rows: list[_ScopedRow],
     ) -> None:
         """Deleting a row takes its scope association with it, leaving nothing orphaned."""
-        async with provider.write_ops() as w:
-            created = await w.bulk_create_scoped_partial([
-                RBACEntityCreator(
-                    spec=RBACOpsCreatorSpec(name="doomed"),
-                    element_type=RBACElementType.VFOLDER,
-                    scope_ref=RBACElementRef(RBACElementType.USER, _USER_SCOPE_ID),
-                )
-            ])
-            entity_id = str(created.successes[0].id)
-            pk_value = created.successes[0].id
-        assert await _scope_ids_of(database_connection, entity_id) == [_USER_SCOPE_ID]
-
+        doomed, kept = scoped_rows
         async with provider.write_ops() as w:
             result = await w.bulk_purge_scoped_partial([
                 RBACEntityPurger(
                     row_class=RBACOpsTestRow,
-                    pk_value=pk_value,
-                    spec=RBACOpsPurgerSpec(entity_id=entity_id),
+                    pk_value=doomed.id,
+                    spec=RBACOpsPurgerSpec(entity_id=str(doomed.id)),
                 )
             ])
-            assert [row.name for row in result.successes] == ["doomed"]
+            assert [row.name for row in result.successes] == [doomed.name]
             assert result.errors == []
 
-        assert await _scope_ids_of(database_connection, entity_id) == []
         async with database_connection.begin_readonly_session() as db_sess:
-            remaining = await db_sess.scalar(sa.select(sa.func.count()).select_from(RBACOpsTestRow))
-            assert remaining == 0
+            names = await db_sess.scalars(sa.select(RBACOpsTestRow.name))
+            assert list(names) == [kept.name]
+            doomed_scope_ids = await db_sess.scalars(
+                sa.select(AssociationScopesEntitiesRow.scope_id).where(
+                    AssociationScopesEntitiesRow.entity_type == EntityType.VFOLDER,
+                    AssociationScopesEntitiesRow.entity_id == str(doomed.id),
+                )
+            )
+            assert list(doomed_scope_ids) == []
 
     async def test_missing_row_is_skipped_not_reported(
         self,
         provider: RBACOpsProvider,
         database_connection: ExtendedAsyncSAEngine,
-        rbac_ops_tables: None,
+        scoped_rows: list[_ScopedRow],
     ) -> None:
         """A purger for an already-gone row yields no success and no error, like the unscoped op."""
-        async with provider.write_ops() as w:
-            created = await w.bulk_create_scoped_partial([
-                RBACEntityCreator(
-                    spec=RBACOpsCreatorSpec(name="kept"),
-                    element_type=RBACElementType.VFOLDER,
-                    scope_ref=RBACElementRef(RBACElementType.USER, _USER_SCOPE_ID),
-                )
-            ])
-            kept_id = created.successes[0].id
-
         async with provider.write_ops() as w:
             result = await w.bulk_purge_scoped_partial([
                 RBACEntityPurger(
@@ -435,5 +487,49 @@ class TestBulkPurgeScopedPartial:
             assert result.successes == []
             assert result.errors == []
 
-        # the untouched row and its association are still there
-        assert await _scope_ids_of(database_connection, str(kept_id)) == [_USER_SCOPE_ID]
+        # the untouched rows and their associations are still there
+        async with database_connection.begin_readonly_session() as db_sess:
+            names = await db_sess.scalars(sa.select(RBACOpsTestRow.name))
+            assert sorted(names) == [row.name for row in scoped_rows]
+            assoc_count = await db_sess.scalar(
+                sa.select(sa.func.count()).select_from(AssociationScopesEntitiesRow)
+            )
+            assert assoc_count == len(scoped_rows)
+
+    async def test_failed_row_leaves_the_rest_purged(
+        self,
+        provider: RBACOpsProvider,
+        database_connection: ExtendedAsyncSAEngine,
+        scoped_rows: list[_ScopedRow],
+        blocking_reference: None,
+    ) -> None:
+        """A row whose delete violates a constraint fails alone: its RBAC cleanup rolls back
+        with it, and the batch carries on rather than dying on the aborted savepoint."""
+        blocked, free = scoped_rows
+        async with provider.write_ops() as w:
+            result = await w.bulk_purge_scoped_partial([
+                RBACEntityPurger(  # RESTRICT foreign key -> delete rejected
+                    row_class=RBACOpsTestRow,
+                    pk_value=blocked.id,
+                    spec=RBACOpsPurgerSpec(entity_id=str(blocked.id)),
+                ),
+                RBACEntityPurger(
+                    row_class=RBACOpsTestRow,
+                    pk_value=free.id,
+                    spec=RBACOpsPurgerSpec(entity_id=str(free.id)),
+                ),
+            ])
+            assert [row.name for row in result.successes] == [free.name]
+            assert [e.index for e in result.errors] == [0]
+
+        async with database_connection.begin_readonly_session() as db_sess:
+            names = await db_sess.scalars(sa.select(RBACOpsTestRow.name))
+            assert list(names) == [blocked.name]
+            # the failed row kept the association its rolled-back cleanup had deleted
+            blocked_scope_ids = await db_sess.scalars(
+                sa.select(AssociationScopesEntitiesRow.scope_id).where(
+                    AssociationScopesEntitiesRow.entity_type == EntityType.VFOLDER,
+                    AssociationScopesEntitiesRow.entity_id == str(blocked.id),
+                )
+            )
+            assert list(blocked_scope_ids) == [_USER_SCOPE_ID]


### PR DESCRIPTION
Extracted from #12826 so the RBAC infrastructure lands on its own, ahead of the AppConfig fragment work that consumes it. No caller changes here — the type widening and the two new ops leave existing behavior untouched.

## Why

`RBACEntityCreator.scope_ref` was required, so an entity that belongs to **no** RBAC scope could not be expressed. Callers had to branch and route such an entity to a plain `create` instead, splitting one write path into two.

Separately, the scoped bulk ops were all-or-nothing, so a caller needing per-item partial success on scoped writes had no op to reach for.

## What

**`RBACEntityCreator.scope_ref` is nullable.** `None` marks a GLOBAL entity — outside the RBAC scope hierarchy — so it binds to no scope and its create is a plain insert. Such an entity has no scope to associate, so `additional_scope_refs` and `relation_type` do not apply to it and are ignored.

**Two new ops on `RBACWriteOps`**, mirroring the unscoped partial ones:

| op | isolation | on rejection |
|---|---|---|
| `bulk_create_scoped` (existing) | one flush for the batch | all-or-nothing |
| `bulk_create_scoped_partial` (new) | one savepoint per row + its association | that row only; rest are created |
| `bulk_purge_scoped_partial` (new) | one savepoint per row + its RBAC entries | that row only; rest are deleted |

## Compatibility

Widening `scope_ref` to `RBACElementRef | None` leaves every existing caller valid — `pants check` passes over all 41 direct dependents. The new ops have no callers yet on `main`.

## Tests

`test_create_entity_without_scope_inserts_row_only` pins the new contract: a creator with `scope_ref=None` inserts the row and **zero** associations, and a stray `additional_scope_refs` does not resurrect one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)