### PR TITLE
feat(BA-6909): add session_idle_checks table storing per-checker idle deadlines

### DIFF
--- a/changes/12918.feature.md
+++ b/changes/12918.feature.md
@@ -1,0 +1,1 @@
+Add the session_idle_checks table storing per-checker idle deadlines for the reconciler-based idle checker (BEP-1054)

--- a/src/ai/backend/manager/models/alembic/versions/5c92586bff94_create_session_idle_checks.py
+++ b/src/ai/backend/manager/models/alembic/versions/5c92586bff94_create_session_idle_checks.py
@@ -1,0 +1,70 @@
+"""create session_idle_checks
+
+Store each session's projected cleanup time and latest judgment per applied
+idle checker (BEP-1054).
+
+Revision ID: 5c92586bff94
+Revises: b3f1a9c2d7e4
+Create Date: 2026-07-16
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.base import GUID
+
+# revision identifiers, used by Alembic.
+revision = "5c92586bff94"
+down_revision = "b3f1a9c2d7e4"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "session_idle_checks",
+        sa.Column("session_id", GUID, nullable=False),
+        sa.Column("idle_checker_id", GUID, nullable=False),
+        sa.Column("expire_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_status", sa.String(length=64), nullable=False),
+        sa.Column("last_message", sa.Text(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["session_id"],
+            ["sessions.id"],
+            name="fk_session_idle_checks_session_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["idle_checker_id"],
+            ["idle_checkers.id"],
+            name="fk_session_idle_checks_idle_checker_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "session_id",
+            "idle_checker_id",
+            name="pk_session_idle_checks",
+        ),
+    )
+    op.create_index(
+        "ix_session_idle_checks_expire_at_not_null",
+        "session_idle_checks",
+        ["expire_at"],
+        postgresql_where=sa.text("expire_at IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_session_idle_checks_expire_at_not_null",
+        table_name="session_idle_checks",
+    )
+    op.drop_table("session_idle_checks")

--- a/src/ai/backend/manager/models/idle_checker/__init__.py
+++ b/src/ai/backend/manager/models/idle_checker/__init__.py
@@ -1,3 +1,3 @@
-from .row import IdleCheckerBindingRow, IdleCheckerRow
+from .row import IdleCheckerBindingRow, IdleCheckerRow, SessionIdleCheckRow
 
-__all__ = ("IdleCheckerRow", "IdleCheckerBindingRow")
+__all__ = ("IdleCheckerRow", "IdleCheckerBindingRow", "SessionIdleCheckRow")

--- a/src/ai/backend/manager/models/idle_checker/row.py
+++ b/src/ai/backend/manager/models/idle_checker/row.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.data.idle_checker.types import CheckerType, IdleCheckerSpec
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
-from ai.backend.common.types import SessionTypes
+from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.models.base import GUID, Base, PydanticColumn, StrEnumType
 
 
@@ -75,6 +75,51 @@ class IdleCheckerBindingRow(Base):  # type: ignore[misc]
     created_at: Mapped[datetime] = mapped_column(
         "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
     )
+    updated_at: Mapped[datetime] = mapped_column(
+        "updated_at",
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+    )
+
+
+class SessionIdleCheckRow(Base):  # type: ignore[misc]
+    __tablename__ = "session_idle_checks"
+    __table_args__ = (
+        sa.ForeignKeyConstraint(
+            ["session_id"],
+            ["sessions.id"],
+            name="fk_session_idle_checks_session_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["idle_checker_id"],
+            ["idle_checkers.id"],
+            name="fk_session_idle_checks_idle_checker_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "session_id",
+            "idle_checker_id",
+            name="pk_session_idle_checks",
+        ),
+        sa.Index(
+            "ix_session_idle_checks_expire_at_not_null",
+            "expire_at",
+            postgresql_where=sa.text("expire_at IS NOT NULL"),
+        ),
+    )
+
+    session_id: Mapped[SessionId] = mapped_column("session_id", GUID(SessionId), nullable=False)
+    idle_checker_id: Mapped[IdleCheckerID] = mapped_column(
+        "idle_checker_id", GUID(IdleCheckerID), nullable=False
+    )
+    expire_at: Mapped[datetime | None] = mapped_column(
+        "expire_at", sa.DateTime(timezone=True), nullable=True
+    )
+    last_status: Mapped[str] = mapped_column("last_status", sa.String(length=64), nullable=False)
+    last_message: Mapped[str] = mapped_column("last_message", sa.Text, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         "updated_at",
         sa.DateTime(timezone=True),

--- a/tests/unit/manager/repositories/idle_checker/test_row.py
+++ b/tests/unit/manager/repositories/idle_checker/test_row.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import pytest
+import sqlalchemy as sa
+
+from ai.backend.common.data.idle_checker.types import (
+    CheckerType,
+    IdleCheckerSpec,
+    SessionLifetimeSpec,
+)
+from ai.backend.common.identifier.domain import DomainID
+from ai.backend.common.identifier.idle_checker import IdleCheckerID
+from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.types import (
+    ClusterMode,
+    ResourceSlot,
+    SessionId,
+    SessionResult,
+    SessionTypes,
+)
+from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.group import GroupRow
+from ai.backend.manager.models.idle_checker.row import IdleCheckerRow, SessionIdleCheckRow
+from ai.backend.manager.models.resource_policy import ProjectResourcePolicyRow
+from ai.backend.manager.models.scaling_group import ScalingGroupRow
+from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.testutils.db import with_tables
+
+
+@dataclass(frozen=True)
+class SessionIdleCheckFixture:
+    session_id: SessionId
+    checker_id: IdleCheckerID
+
+
+class TestSessionIdleCheckRow:
+    @pytest.fixture
+    async def database(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                ProjectResourcePolicyRow,
+                DomainRow,
+                GroupRow,
+                ScalingGroupRow,
+                SessionRow,
+                IdleCheckerRow,
+                SessionIdleCheckRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    async def persisted_idle_check(
+        self,
+        database: ExtendedAsyncSAEngine,
+    ) -> SessionIdleCheckFixture:
+        domain_id = DomainID(uuid.uuid4())
+        project_id = uuid.uuid4()
+        resource_group_id = ResourceGroupID(uuid.uuid4())
+        session_id = SessionId(uuid.uuid4())
+        checker_id = IdleCheckerID(uuid.uuid4())
+        created_at = datetime(2026, 1, 1, tzinfo=UTC)
+        async with database.begin_session() as db_sess:
+            db_sess.add(
+                ProjectResourcePolicyRow(
+                    name="session-idle-check-policy",
+                    max_vfolder_count=10,
+                    max_quota_scope_size=1024,
+                    max_network_count=10,
+                )
+            )
+            db_sess.add(
+                DomainRow(
+                    id=domain_id,
+                    name="session-idle-check-domain",
+                    description=None,
+                    is_active=True,
+                )
+            )
+            db_sess.add(
+                GroupRow(
+                    id=project_id,
+                    name="session-idle-check-project",
+                    description=None,
+                    is_active=True,
+                    domain_name="session-idle-check-domain",
+                    resource_policy="session-idle-check-policy",
+                )
+            )
+            db_sess.add(
+                ScalingGroupRow(
+                    id=resource_group_id,
+                    name="session-idle-check-resource-group",
+                    description=None,
+                    is_active=True,
+                    is_public=True,
+                    driver="static",
+                    driver_opts={},
+                    scheduler="fifo",
+                    use_host_network=False,
+                )
+            )
+            db_sess.add(
+                SessionRow(
+                    id=session_id,
+                    creation_id=str(session_id)[:32],
+                    name=f"session-{session_id}",
+                    session_type=SessionTypes.INTERACTIVE,
+                    cluster_mode=ClusterMode.SINGLE_NODE,
+                    cluster_size=1,
+                    domain_name="session-idle-check-domain",
+                    domain_id=domain_id,
+                    resource_group_id=resource_group_id,
+                    group_id=project_id,
+                    user_uuid=uuid.uuid4(),
+                    access_key=None,
+                    tag=None,
+                    status=SessionStatus.RUNNING,
+                    status_info=None,
+                    status_data=None,
+                    status_history={},
+                    result=SessionResult.UNDEFINED,
+                    created_at=created_at,
+                    terminated_at=None,
+                    starts_at=created_at,
+                    startup_command=None,
+                    callback_url=None,
+                    occupying_slots=ResourceSlot({"cpu": "1"}),
+                    requested_slots=ResourceSlot({"cpu": "1"}),
+                    vfolder_mounts=[],
+                    environ=None,
+                    bootstrap_script=None,
+                    use_host_network=False,
+                    scaling_group_name="session-idle-check-resource-group",
+                )
+            )
+            db_sess.add(
+                IdleCheckerRow(
+                    id=checker_id,
+                    name=f"checker-{checker_id}",
+                    description=None,
+                    checker_type=CheckerType.SESSION_LIFETIME,
+                    target_session_types=[SessionTypes.INTERACTIVE],
+                    spec=IdleCheckerSpec(
+                        type=CheckerType.SESSION_LIFETIME,
+                        session_lifetime=SessionLifetimeSpec(max_lifetime_seconds=3600),
+                    ),
+                )
+            )
+            await db_sess.flush()
+            db_sess.add(
+                SessionIdleCheckRow(
+                    session_id=session_id,
+                    idle_checker_id=checker_id,
+                    expire_at=None,
+                    last_status="grace_period",
+                    last_message="Waiting for the grace period to end.",
+                )
+            )
+        return SessionIdleCheckFixture(session_id=session_id, checker_id=checker_id)
+
+    async def test_persists_null_expire_at_and_updated_at(
+        self,
+        database: ExtendedAsyncSAEngine,
+        persisted_idle_check: SessionIdleCheckFixture,
+    ) -> None:
+        async with database.begin_readonly_session() as db_sess:
+            row = await db_sess.get(
+                SessionIdleCheckRow,
+                (persisted_idle_check.session_id, persisted_idle_check.checker_id),
+            )
+
+        assert row is not None
+        assert row.expire_at is None
+        assert row.last_status == "grace_period"
+        assert row.updated_at is not None
+
+    async def test_rejects_duplicate_session_checker_pair(
+        self,
+        database: ExtendedAsyncSAEngine,
+        persisted_idle_check: SessionIdleCheckFixture,
+    ) -> None:
+        with pytest.raises(sa.exc.IntegrityError):
+            async with database.begin_session() as db_sess:
+                db_sess.add(
+                    SessionIdleCheckRow(
+                        session_id=persisted_idle_check.session_id,
+                        idle_checker_id=persisted_idle_check.checker_id,
+                        expire_at=datetime(2026, 1, 2, tzinfo=UTC),
+                        last_status="active",
+                        last_message="The session is active.",
+                    )
+                )
+
+    async def test_deleting_session_cascades_idle_check(
+        self,
+        database: ExtendedAsyncSAEngine,
+        persisted_idle_check: SessionIdleCheckFixture,
+    ) -> None:
+        async with database.begin_session() as db_sess:
+            await db_sess.execute(
+                sa.delete(SessionRow).where(SessionRow.id == persisted_idle_check.session_id)
+            )
+
+        async with database.begin_readonly_session() as db_sess:
+            row = await db_sess.get(
+                SessionIdleCheckRow,
+                (persisted_idle_check.session_id, persisted_idle_check.checker_id),
+            )
+
+        assert row is None
+
+    async def test_deleting_checker_cascades_idle_check(
+        self,
+        database: ExtendedAsyncSAEngine,
+        persisted_idle_check: SessionIdleCheckFixture,
+    ) -> None:
+        async with database.begin_session() as db_sess:
+            await db_sess.execute(
+                sa.delete(IdleCheckerRow).where(
+                    IdleCheckerRow.id == persisted_idle_check.checker_id
+                )
+            )
+
+        async with database.begin_readonly_session() as db_sess:
+            row = await db_sess.get(
+                SessionIdleCheckRow,
+                (persisted_idle_check.session_id, persisted_idle_check.checker_id),
+            )
+
+        assert row is None


### PR DESCRIPTION
## Summary
- Add the `session_idle_checks` table (BEP-1054): one row per (session, applied idle checker) holding the projected cleanup time (`expire_at`), latest judgment status/message, and update timestamp
- `expire_at` gets a partial index (`WHERE expire_at IS NOT NULL`) tailored to the expiry-sweep stage's `expire_at <= now` scan; FKs to `sessions` and `idle_checkers` cascade on delete
- Add `SessionIdleCheckRow` ORM model and the corresponding alembic migration

## Test plan
- [x] `tests/unit/manager/repositories/idle_checker/test_row.py` — persists NULL `expire_at` with server-default `updated_at`, rejects duplicate (session, checker) pairs, cascades on session/checker deletion (real DB via `with_tables`)
- [x] `pants lint/check/test` on the changed files (pre-push hook)

Resolves BA-6909

🤖 Generated with [Claude Code](https://claude.com/claude-code)