### PR TITLE
feat(BA-6905): add single-entity action monitors

### DIFF
--- a/changes/12921.feature.md
+++ b/changes/12921.feature.md
@@ -1,0 +1,1 @@
+Add single-entity action monitors (audit-log, Prometheus, reporter) bound to the self-contained single-entity action line.

--- a/src/ai/backend/manager/actions/single_entity/__init__.py
+++ b/src/ai/backend/manager/actions/single_entity/__init__.py
@@ -1,7 +1,12 @@
 from .base import (
     BaseSingleEntityAction,
 )
-from .monitor import SingleEntityActionMonitor
+from .monitor import (
+    SingleEntityActionMonitor,
+    SingleEntityAuditLogMonitor,
+    SingleEntityPrometheusMonitor,
+    SingleEntityReporterMonitor,
+)
 from .processor import SingleEntityActionProcessor
 from .result import (
     SingleEntityActionProcessResult,
@@ -16,4 +21,7 @@ __all__ = (
     "SingleEntityActionProcessResult",
     "SingleEntityActionResultMeta",
     "SingleEntityActionValidator",
+    "SingleEntityAuditLogMonitor",
+    "SingleEntityPrometheusMonitor",
+    "SingleEntityReporterMonitor",
 )

--- a/src/ai/backend/manager/actions/single_entity/base.py
+++ b/src/ai/backend/manager/actions/single_entity/base.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.entity.types import EntityType
 from ai.backend.common.identifier.entity import EntityID
+from ai.backend.manager.actions.types import ActionOperationType
 
 
 class BaseSingleEntityAction(ABC):
@@ -24,3 +25,14 @@ class BaseSingleEntityAction(ABC):
     def required_permission(cls) -> Permission:
         """Return the permission required to perform this action."""
         raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def operation_type(cls) -> ActionOperationType:
+        """Return the operation that this action performs on the entity."""
+        raise NotImplementedError
+
+    @classmethod
+    def action_type(cls) -> str:
+        """Return the action-type identifier, ``"<entity_type>:<operation_type>"``."""
+        return f"{cls.entity_type()}:{cls.operation_type()}"

--- a/src/ai/backend/manager/actions/single_entity/monitor/__init__.py
+++ b/src/ai/backend/manager/actions/single_entity/monitor/__init__.py
@@ -1,3 +1,11 @@
+from .audit_log import SingleEntityAuditLogMonitor
 from .base import SingleEntityActionMonitor
+from .prometheus import SingleEntityPrometheusMonitor
+from .reporter import SingleEntityReporterMonitor
 
-__all__ = ("SingleEntityActionMonitor",)
+__all__ = (
+    "SingleEntityActionMonitor",
+    "SingleEntityAuditLogMonitor",
+    "SingleEntityPrometheusMonitor",
+    "SingleEntityReporterMonitor",
+)

--- a/src/ai/backend/manager/actions/single_entity/monitor/audit_log.py
+++ b/src/ai/backend/manager/actions/single_entity/monitor/audit_log.py
@@ -1,0 +1,52 @@
+from typing import override
+
+from ai.backend.common.contexts.request_id import current_request_id
+from ai.backend.common.contexts.user import current_user, triggered_user
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.single_entity.base import BaseSingleEntityAction
+from ai.backend.manager.actions.single_entity.monitor.base import SingleEntityActionMonitor
+from ai.backend.manager.actions.single_entity.result import SingleEntityActionProcessResult
+from ai.backend.manager.actions.types import BLANK_ID
+from ai.backend.manager.repositories.audit_log import AuditLogCreatorSpec, AuditLogRepository
+from ai.backend.manager.repositories.base import Creator
+
+__all__ = ("SingleEntityAuditLogMonitor",)
+
+
+class SingleEntityAuditLogMonitor(SingleEntityActionMonitor):
+    _repository: AuditLogRepository
+
+    def __init__(self, repository: AuditLogRepository) -> None:
+        self._repository = repository
+
+    async def _generate_log(
+        self, action: BaseSingleEntityAction, result: SingleEntityActionProcessResult
+    ) -> None:
+        trigger = triggered_user()
+        acting = current_user()
+        creator = Creator(
+            spec=AuditLogCreatorSpec(
+                action_id=result.meta.action_id,
+                entity_type=action.entity_type(),
+                operation=action.operation_type(),
+                created_at=result.meta.started_at,
+                description=result.meta.description,
+                status=result.meta.status,
+                entity_id=str(result.meta.entity_id),
+                request_id=current_request_id() or BLANK_ID,
+                triggered_by=str(trigger.user_id) if trigger else None,
+                acted_as=acting.user_id if acting else None,
+                duration=result.meta.duration,
+            )
+        )
+        await self._repository.create(creator)
+
+    @override
+    async def prepare(self, action: BaseSingleEntityAction, meta: BaseActionTriggerMeta) -> None:
+        pass
+
+    @override
+    async def done(
+        self, action: BaseSingleEntityAction, result: SingleEntityActionProcessResult
+    ) -> None:
+        await self._generate_log(action, result)

--- a/src/ai/backend/manager/actions/single_entity/monitor/prometheus.py
+++ b/src/ai/backend/manager/actions/single_entity/monitor/prometheus.py
@@ -1,0 +1,33 @@
+from typing import cast, override
+
+from ai.backend.common.data.permission.types import EntityType
+from ai.backend.common.metrics.metric import ActionMetricObserver
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.single_entity.base import BaseSingleEntityAction
+from ai.backend.manager.actions.single_entity.monitor.base import SingleEntityActionMonitor
+from ai.backend.manager.actions.single_entity.result import SingleEntityActionProcessResult
+
+__all__ = ("SingleEntityPrometheusMonitor",)
+
+
+class SingleEntityPrometheusMonitor(SingleEntityActionMonitor):
+    _observer: ActionMetricObserver
+
+    def __init__(self) -> None:
+        self._observer = ActionMetricObserver.instance()
+
+    @override
+    async def prepare(self, action: BaseSingleEntityAction, meta: BaseActionTriggerMeta) -> None:
+        return
+
+    @override
+    async def done(
+        self, action: BaseSingleEntityAction, result: SingleEntityActionProcessResult
+    ) -> None:
+        self._observer.observe_action(
+            entity_type=cast(EntityType, action.entity_type()),
+            operation_type=action.operation_type(),
+            status=result.meta.status,
+            duration=result.meta.duration.total_seconds(),
+            error_code=result.meta.error_code,
+        )

--- a/src/ai/backend/manager/actions/single_entity/monitor/reporter.py
+++ b/src/ai/backend/manager/actions/single_entity/monitor/reporter.py
@@ -1,0 +1,60 @@
+from typing import cast, override
+
+from ai.backend.common.contexts.request_id import current_request_id
+from ai.backend.common.contexts.user import current_user, triggered_user
+from ai.backend.common.data.permission.types import EntityType
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.single_entity.base import BaseSingleEntityAction
+from ai.backend.manager.actions.single_entity.monitor.base import SingleEntityActionMonitor
+from ai.backend.manager.actions.single_entity.result import SingleEntityActionProcessResult
+from ai.backend.manager.reporters.base import FinishedActionMessage, StartedActionMessage
+from ai.backend.manager.reporters.hub import ReporterHub
+
+__all__ = ("SingleEntityReporterMonitor",)
+
+
+class SingleEntityReporterMonitor(SingleEntityActionMonitor):
+    _reporter_hub: ReporterHub
+
+    def __init__(self, reporter_hub: ReporterHub) -> None:
+        self._reporter_hub = reporter_hub
+
+    @override
+    async def prepare(self, action: BaseSingleEntityAction, meta: BaseActionTriggerMeta) -> None:
+        trigger = triggered_user()
+        acting = current_user()
+        message = StartedActionMessage(
+            action_id=meta.action_id,
+            action_type=action.action_type(),
+            entity_id=action.entity_id(),
+            entity_type=cast(EntityType, action.entity_type()),
+            request_id=current_request_id(),
+            triggered_by=str(trigger.user_id) if trigger else None,
+            acted_as=acting.user_id if acting else None,
+            operation_type=action.operation_type(),
+            created_at=meta.started_at,
+        )
+        await self._reporter_hub.report_started(message)
+
+    @override
+    async def done(
+        self, action: BaseSingleEntityAction, result: SingleEntityActionProcessResult
+    ) -> None:
+        trigger = triggered_user()
+        acting = current_user()
+        message = FinishedActionMessage(
+            action_id=result.meta.action_id,
+            action_type=action.action_type(),
+            entity_id=result.meta.entity_id,
+            entity_type=cast(EntityType, action.entity_type()),
+            request_id=current_request_id(),
+            triggered_by=str(trigger.user_id) if trigger else None,
+            acted_as=acting.user_id if acting else None,
+            operation_type=action.operation_type(),
+            status=result.meta.status,
+            description=result.meta.description,
+            created_at=result.meta.started_at,
+            ended_at=result.meta.ended_at,
+            duration=result.meta.duration,
+        )
+        await self._reporter_hub.report_finished(message)


### PR DESCRIPTION
## Summary
- Add concrete `SingleEntityAuditLogMonitor`, `SingleEntityPrometheusMonitor`, and `SingleEntityReporterMonitor` bound to the self-contained single-entity action line.
- Extend `BaseSingleEntityAction` with `operation_type()` (abstract) and `action_type()` to supply the contract the monitors require.
- Export the concrete monitors from the `single_entity` and `single_entity/monitor` packages.

## Test plan
- [ ] Verify each monitor's `prepare`/`done` against a single-entity action run (audit-log row written, metric observed, reporter Started/Finished emitted).

Resolves BA-6905

🤖 Generated with [Claude Code](https://claude.com/claude-code)