### PR TITLE
feat(BA-6917): add expiry-sweep source fetching expired idle-check deadlines

### DIFF
--- a/changes/12925.feature.md
+++ b/changes/12925.feature.md
@@ -1,0 +1,1 @@
+Add the expiry-sweep source that fetches expired session idle-check deadlines for the reconciler-based idle checker (BEP-1054)

--- a/src/ai/backend/manager/models/idle_checker/conditions.py
+++ b/src/ai/backend/manager/models/idle_checker/conditions.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 
 from ai.backend.manager.models.clauses import QueryCondition
 
-from .row import IdleCheckerBindingRow
+from .row import IdleCheckerBindingRow, SessionIdleCheckRow
 
 
 class IdleCheckerBindingConditions:
@@ -12,5 +12,17 @@ class IdleCheckerBindingConditions:
     def enabled() -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return IdleCheckerBindingRow.enabled == sa.true()
+
+        return inner
+
+
+class SessionIdleCheckConditions:
+    @staticmethod
+    def expired() -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return sa.and_(
+                SessionIdleCheckRow.expire_at.isnot(None),
+                SessionIdleCheckRow.expire_at <= sa.func.now(),
+            )
 
         return inner

--- a/src/ai/backend/manager/models/idle_checker/conditions.py
+++ b/src/ai/backend/manager/models/idle_checker/conditions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime
+
 import sqlalchemy as sa
 
 from ai.backend.manager.models.clauses import QueryCondition
@@ -18,11 +20,11 @@ class IdleCheckerBindingConditions:
 
 class SessionIdleCheckConditions:
     @staticmethod
-    def expired() -> QueryCondition:
+    def expired(now: datetime) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return sa.and_(
                 SessionIdleCheckRow.expire_at.isnot(None),
-                SessionIdleCheckRow.expire_at <= sa.func.now(),
+                SessionIdleCheckRow.expire_at <= now,
             )
 
         return inner

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from datetime import datetime
 from typing import cast
 
 import sqlalchemy as sa
@@ -22,7 +23,6 @@ from ai.backend.manager.models.session.row import SessionRow
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.idle_checker.types import (
     BoundCheckerData,
-    ExpiredIdleCheckBatchData,
     ExpiredIdleCheckData,
     IdleCheckerDefinitionData,
     IdleCheckSessionData,
@@ -35,6 +35,10 @@ class IdleCheckerDBSource:
 
     def __init__(self, ops_provider: DBOpsProvider) -> None:
         self._ops = ops_provider
+
+    async def current_time(self) -> datetime:
+        async with self._ops.read_ops() as r:
+            return await r.current_time()
 
     async def fetch_bound_checkers(
         self,
@@ -110,13 +114,11 @@ class IdleCheckerDBSource:
     async def fetch_expired_idle_checks(
         self,
         querier: BatchQuerier,
-    ) -> ExpiredIdleCheckBatchData:
+    ) -> Sequence[ExpiredIdleCheckData]:
         check_query = sa.select(SessionIdleCheckRow).join(
             SessionRow, SessionIdleCheckRow.session_id == SessionRow.id
         )
         async with self._ops.read_ops() as r:
-            # Same transaction as the fetch, so now >= every returned expire_at.
-            now = await r.current_time()
             result_rows = (await r.batch_query_in_global(check_query, querier)).rows
         checks: list[ExpiredIdleCheckData] = []
         for row in result_rows:
@@ -133,4 +135,4 @@ class IdleCheckerDBSource:
                     last_message=check_row.last_message,
                 )
             )
-        return ExpiredIdleCheckBatchData(checks=tuple(checks), now=now)
+        return tuple(checks)

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -13,11 +13,17 @@ from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.data.idle_checker.types import IdleCheckSession
 from ai.backend.manager.data.permission.id import ScopeId
-from ai.backend.manager.models.idle_checker.row import IdleCheckerBindingRow, IdleCheckerRow
+from ai.backend.manager.models.idle_checker.row import (
+    IdleCheckerBindingRow,
+    IdleCheckerRow,
+    SessionIdleCheckRow,
+)
 from ai.backend.manager.models.session.row import SessionRow
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.idle_checker.types import (
     BoundCheckerData,
+    ExpiredIdleCheckBatchData,
+    ExpiredIdleCheckData,
     IdleCheckerDefinitionData,
     IdleCheckSessionData,
 )
@@ -100,3 +106,31 @@ class IdleCheckerDBSource:
             )
             for row in session_rows
         )
+
+    async def fetch_expired_idle_checks(
+        self,
+        querier: BatchQuerier,
+    ) -> ExpiredIdleCheckBatchData:
+        check_query = sa.select(SessionIdleCheckRow).join(
+            SessionRow, SessionIdleCheckRow.session_id == SessionRow.id
+        )
+        async with self._ops.read_ops() as r:
+            # Same transaction as the fetch, so now >= every returned expire_at.
+            now = await r.current_time()
+            result_rows = (await r.batch_query_in_global(check_query, querier)).rows
+        checks: list[ExpiredIdleCheckData] = []
+        for row in result_rows:
+            check_row: SessionIdleCheckRow = row.SessionIdleCheckRow
+            if check_row.expire_at is None:
+                # Unreachable under the expired() condition; guards the type.
+                continue
+            checks.append(
+                ExpiredIdleCheckData(
+                    session_id=check_row.session_id,
+                    checker_id=check_row.idle_checker_id,
+                    expire_at=check_row.expire_at,
+                    last_status=check_row.last_status,
+                    last_message=check_row.last_message,
+                )
+            )
+        return ExpiredIdleCheckBatchData(checks=tuple(checks), now=now)

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from datetime import datetime
+from collections.abc import Collection, Sequence
 from typing import cast
 
 import sqlalchemy as sa
@@ -14,15 +13,19 @@ from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.data.idle_checker.types import IdleCheckSession
 from ai.backend.manager.data.permission.id import ScopeId
+from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.models.idle_checker.conditions import SessionIdleCheckConditions
 from ai.backend.manager.models.idle_checker.row import (
     IdleCheckerBindingRow,
     IdleCheckerRow,
     SessionIdleCheckRow,
 )
+from ai.backend.manager.models.session.conditions import SessionConditions
 from ai.backend.manager.models.session.row import SessionRow
-from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.repositories.base import BatchQuerier, NoPagination
 from ai.backend.manager.repositories.idle_checker.types import (
     BoundCheckerData,
+    ExpiredIdleCheckBatchData,
     ExpiredIdleCheckData,
     IdleCheckerDefinitionData,
     IdleCheckSessionData,
@@ -35,10 +38,6 @@ class IdleCheckerDBSource:
 
     def __init__(self, ops_provider: DBOpsProvider) -> None:
         self._ops = ops_provider
-
-    async def current_time(self) -> datetime:
-        async with self._ops.read_ops() as r:
-            return await r.current_time()
 
     async def fetch_bound_checkers(
         self,
@@ -113,12 +112,20 @@ class IdleCheckerDBSource:
 
     async def fetch_expired_idle_checks(
         self,
-        querier: BatchQuerier,
-    ) -> Sequence[ExpiredIdleCheckData]:
+        session_statuses: Collection[SessionStatus],
+    ) -> ExpiredIdleCheckBatchData:
         check_query = sa.select(SessionIdleCheckRow).join(
             SessionRow, SessionIdleCheckRow.session_id == SessionRow.id
         )
         async with self._ops.read_ops() as r:
+            now = await r.current_time()
+            querier = BatchQuerier(
+                pagination=NoPagination(),
+                conditions=[
+                    SessionIdleCheckConditions.expired(now),
+                    SessionConditions.by_statuses(session_statuses),
+                ],
+            )
             result_rows = (await r.batch_query_in_global(check_query, querier)).rows
         checks: list[ExpiredIdleCheckData] = []
         for row in result_rows:
@@ -135,4 +142,4 @@ class IdleCheckerDBSource:
                     last_message=check_row.last_message,
                 )
             )
-        return tuple(checks)
+        return ExpiredIdleCheckBatchData(checks=tuple(checks), now=now)

--- a/src/ai/backend/manager/repositories/idle_checker/repository.py
+++ b/src/ai/backend/manager/repositories/idle_checker/repository.py
@@ -93,11 +93,13 @@ class IdleCheckerRepository:
     async def fetch_expired_idle_checks(
         self, session_statuses: Collection[SessionStatus]
     ) -> ExpiredIdleCheckBatchData:
+        now = await self._db_source.current_time()
         querier = BatchQuerier(
             pagination=NoPagination(),
             conditions=[
-                SessionIdleCheckConditions.expired(),
+                SessionIdleCheckConditions.expired(now),
                 SessionConditions.by_statuses(session_statuses),
             ],
         )
-        return await self._db_source.fetch_expired_idle_checks(querier)
+        checks = await self._db_source.fetch_expired_idle_checks(querier)
+        return ExpiredIdleCheckBatchData(checks=checks, now=now)

--- a/src/ai/backend/manager/repositories/idle_checker/repository.py
+++ b/src/ai/backend/manager/repositories/idle_checker/repository.py
@@ -6,12 +6,16 @@ from collections.abc import Collection
 from ai.backend.common.types import SessionTypes
 from ai.backend.manager.data.permission.id import ScopeId
 from ai.backend.manager.data.session.types import SessionStatus
-from ai.backend.manager.models.idle_checker.conditions import IdleCheckerBindingConditions
+from ai.backend.manager.models.idle_checker.conditions import (
+    IdleCheckerBindingConditions,
+    SessionIdleCheckConditions,
+)
 from ai.backend.manager.models.session.conditions import SessionConditions
 from ai.backend.manager.repositories.base import BatchQuerier, NoPagination
 from ai.backend.manager.repositories.idle_checker.db_source.db_source import IdleCheckerDBSource
 from ai.backend.manager.repositories.idle_checker.types import (
     BoundCheckerData,
+    ExpiredIdleCheckBatchData,
     IdleCheckBatchData,
     IdleCheckTargetData,
 )
@@ -85,3 +89,15 @@ class IdleCheckerRepository:
             )
 
         return IdleCheckBatchData(targets=tuple(targets))
+
+    async def fetch_expired_idle_checks(
+        self, session_statuses: Collection[SessionStatus]
+    ) -> ExpiredIdleCheckBatchData:
+        querier = BatchQuerier(
+            pagination=NoPagination(),
+            conditions=[
+                SessionIdleCheckConditions.expired(),
+                SessionConditions.by_statuses(session_statuses),
+            ],
+        )
+        return await self._db_source.fetch_expired_idle_checks(querier)

--- a/src/ai/backend/manager/repositories/idle_checker/repository.py
+++ b/src/ai/backend/manager/repositories/idle_checker/repository.py
@@ -6,10 +6,7 @@ from collections.abc import Collection
 from ai.backend.common.types import SessionTypes
 from ai.backend.manager.data.permission.id import ScopeId
 from ai.backend.manager.data.session.types import SessionStatus
-from ai.backend.manager.models.idle_checker.conditions import (
-    IdleCheckerBindingConditions,
-    SessionIdleCheckConditions,
-)
+from ai.backend.manager.models.idle_checker.conditions import IdleCheckerBindingConditions
 from ai.backend.manager.models.session.conditions import SessionConditions
 from ai.backend.manager.repositories.base import BatchQuerier, NoPagination
 from ai.backend.manager.repositories.idle_checker.db_source.db_source import IdleCheckerDBSource
@@ -93,13 +90,4 @@ class IdleCheckerRepository:
     async def fetch_expired_idle_checks(
         self, session_statuses: Collection[SessionStatus]
     ) -> ExpiredIdleCheckBatchData:
-        now = await self._db_source.current_time()
-        querier = BatchQuerier(
-            pagination=NoPagination(),
-            conditions=[
-                SessionIdleCheckConditions.expired(now),
-                SessionConditions.by_statuses(session_statuses),
-            ],
-        )
-        checks = await self._db_source.fetch_expired_idle_checks(querier)
-        return ExpiredIdleCheckBatchData(checks=checks, now=now)
+        return await self._db_source.fetch_expired_idle_checks(session_statuses)

--- a/src/ai/backend/manager/repositories/idle_checker/types.py
+++ b/src/ai/backend/manager/repositories/idle_checker/types.py
@@ -8,7 +8,7 @@ from datetime import datetime
 
 from ai.backend.common.data.idle_checker.types import CheckerType, IdleCheckerSpec
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
-from ai.backend.common.types import SessionTypes
+from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.data.idle_checker.types import IdleCheckSession
 from ai.backend.manager.data.permission.id import ScopeId
 
@@ -57,3 +57,26 @@ class IdleCheckBatchData:
     """Handler-oriented idle-check input for one reconciler tick."""
 
     targets: Sequence[IdleCheckTargetData]
+
+
+@dataclass(frozen=True)
+class ExpiredIdleCheckData:
+    """One stored judgment whose deadline has passed, kept per checker as its own reason."""
+
+    session_id: SessionId
+    checker_id: IdleCheckerID
+    expire_at: datetime
+    last_status: str
+    last_message: str
+
+
+@dataclass(frozen=True)
+class ExpiredIdleCheckBatchData:
+    """Sweep input for one reconciler tick.
+
+    ``now`` is the DB time read in the same transaction as the fetch, so every
+    returned check satisfies ``expire_at <= now``.
+    """
+
+    checks: Sequence[ExpiredIdleCheckData]
+    now: datetime

--- a/src/ai/backend/manager/repositories/idle_checker/types.py
+++ b/src/ai/backend/manager/repositories/idle_checker/types.py
@@ -72,8 +72,8 @@ class ExpiredIdleCheckData:
 
 @dataclass(frozen=True)
 class ExpiredIdleCheckBatchData:
-    """Expired idle checks selected by the repository query.
-    `now` is the DB transaction timestamp used by the reconciler.
+    """Idle checks expired as of the DB timestamp.
+    `now` is the same timestamp passed to the reconciler.
     """
 
     checks: Sequence[ExpiredIdleCheckData]

--- a/src/ai/backend/manager/repositories/idle_checker/types.py
+++ b/src/ai/backend/manager/repositories/idle_checker/types.py
@@ -72,10 +72,8 @@ class ExpiredIdleCheckData:
 
 @dataclass(frozen=True)
 class ExpiredIdleCheckBatchData:
-    """Sweep input for one reconciler tick.
-
-    ``now`` is the DB time read in the same transaction as the fetch, so every
-    returned check satisfies ``expire_at <= now``.
+    """Expired idle checks selected by the repository query.
+    `now` is the DB transaction timestamp used by the reconciler.
     """
 
     checks: Sequence[ExpiredIdleCheckData]

--- a/src/ai/backend/manager/sokovan/idle_check/sweep/source.py
+++ b/src/ai/backend/manager/sokovan/idle_check/sweep/source.py
@@ -1,0 +1,31 @@
+"""Source of the expiry-sweep stage: stored judgments whose deadline has passed."""
+
+from __future__ import annotations
+
+from typing import override
+
+from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
+from ai.backend.manager.sokovan.idle_check.sweep.types import IdleCheckSweepReconcileInfo
+from ai.backend.manager.sokovan.idle_check.types import (
+    IdleCheckCategory,
+    IdleCheckTargetStatuses,
+)
+from ai.backend.manager.sokovan.reconciler.base import ReconcilerSource
+
+
+class IdleCheckSweepSource(
+    ReconcilerSource[IdleCheckSweepReconcileInfo, IdleCheckCategory, IdleCheckTargetStatuses]
+):
+    _repository: IdleCheckerRepository
+
+    def __init__(self, repository: IdleCheckerRepository) -> None:
+        self._repository = repository
+
+    @override
+    async def fetch_reconcile_info(
+        self,
+        category: IdleCheckCategory,
+        target_statuses: IdleCheckTargetStatuses,
+    ) -> IdleCheckSweepReconcileInfo:
+        batch = await self._repository.fetch_expired_idle_checks(target_statuses.session_statuses)
+        return IdleCheckSweepReconcileInfo(batch=batch)

--- a/src/ai/backend/manager/sokovan/idle_check/sweep/types.py
+++ b/src/ai/backend/manager/sokovan/idle_check/sweep/types.py
@@ -1,0 +1,26 @@
+"""Info types for the expiry-sweep reconcile stage."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import override
+from uuid import UUID
+
+from ai.backend.manager.repositories.idle_checker.types import ExpiredIdleCheckBatchData
+from ai.backend.manager.sokovan.reconciler.base import BaseReconcilerInfo
+
+
+@dataclass
+class IdleCheckSweepReconcileInfo(BaseReconcilerInfo):
+    batch: ExpiredIdleCheckBatchData
+
+    @override
+    def entity_ids(self) -> Sequence[UUID]:
+        # A session with multiple expired checks is transitioned at most once.
+        return list(dict.fromkeys(check.session_id for check in self.batch.checks))
+
+    @override
+    def now(self) -> datetime:
+        return self.batch.now

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -28,7 +28,11 @@ from ai.backend.common.types import (
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
-from ai.backend.manager.models.idle_checker.row import IdleCheckerBindingRow, IdleCheckerRow
+from ai.backend.manager.models.idle_checker.row import (
+    IdleCheckerBindingRow,
+    IdleCheckerRow,
+    SessionIdleCheckRow,
+)
 from ai.backend.manager.models.resource_policy import ProjectResourcePolicyRow
 from ai.backend.manager.models.scaling_group import ScalingGroupRow
 from ai.backend.manager.models.session import SessionRow
@@ -65,6 +69,116 @@ class PerTypeCheckerData:
     batch_session_id: SessionId
     interactive_checker_id: IdleCheckerID
     batch_checker_id: IdleCheckerID
+
+
+@dataclass(frozen=True)
+class ExpiredCheckSessionData:
+    session_id: SessionId
+    first_checker_id: IdleCheckerID
+    second_checker_id: IdleCheckerID
+    first_expire_at: datetime
+    second_expire_at: datetime
+
+
+def _expired_check_scope_rows(
+    scope: ScopeFixture,
+) -> tuple[ProjectResourcePolicyRow, DomainRow, GroupRow, ScalingGroupRow]:
+    return (
+        ProjectResourcePolicyRow(
+            name=f"{scope.domain_name}-policy",
+            max_vfolder_count=10,
+            max_quota_scope_size=1024,
+            max_network_count=10,
+        ),
+        DomainRow(
+            id=scope.domain_id,
+            name=scope.domain_name,
+            description=None,
+            is_active=True,
+        ),
+        GroupRow(
+            id=scope.project_id,
+            name=f"{scope.domain_name}-project",
+            description=None,
+            is_active=True,
+            domain_name=scope.domain_name,
+            resource_policy=f"{scope.domain_name}-policy",
+        ),
+        ScalingGroupRow(
+            id=scope.scaling_group_id,
+            name=scope.scaling_group_name,
+            description=None,
+            is_active=True,
+            is_public=True,
+            driver="static",
+            driver_opts={},
+            scheduler="fifo",
+            use_host_network=False,
+        ),
+    )
+
+
+def _expired_check_session_row(
+    scope: ScopeFixture,
+    session_id: SessionId,
+    status: SessionStatus,
+) -> SessionRow:
+    return SessionRow(
+        id=session_id,
+        creation_id=str(session_id)[:32],
+        name=f"session-{session_id}",
+        session_type=SessionTypes.INTERACTIVE,
+        cluster_mode=ClusterMode.SINGLE_NODE,
+        cluster_size=1,
+        domain_name=scope.domain_name,
+        domain_id=scope.domain_id,
+        resource_group_id=scope.scaling_group_id,
+        group_id=scope.project_id,
+        user_uuid=uuid.uuid4(),
+        access_key=None,
+        tag=None,
+        status=status,
+        status_info=None,
+        status_data=None,
+        status_history={},
+        result=SessionResult.UNDEFINED,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        terminated_at=None,
+        starts_at=datetime(2026, 1, 1, tzinfo=UTC),
+        startup_command=None,
+        callback_url=None,
+        occupying_slots=ResourceSlot({"cpu": "1"}),
+        requested_slots=ResourceSlot({"cpu": "1"}),
+        vfolder_mounts=[],
+        environ=None,
+        bootstrap_script=None,
+        use_host_network=False,
+        scaling_group_name=scope.scaling_group_name,
+    )
+
+
+def _expired_check_checker_row(checker_id: IdleCheckerID) -> IdleCheckerRow:
+    return IdleCheckerRow(
+        id=checker_id,
+        name=f"checker-{checker_id}",
+        description=None,
+        checker_type=CheckerType.SESSION_LIFETIME,
+        target_session_types=[SessionTypes.INTERACTIVE],
+        spec=IdleCheckerSpec(
+            type=CheckerType.SESSION_LIFETIME,
+            session_lifetime=SessionLifetimeSpec(max_lifetime_seconds=3600),
+        ),
+    )
+
+
+def _expired_check_scope_fixture(prefix: str) -> ScopeFixture:
+    return ScopeFixture(
+        domain_name=f"{prefix}-domain",
+        domain_id=DomainID(uuid.uuid4()),
+        project_id=uuid.uuid4(),
+        scaling_group_name=f"{prefix}-sgroup",
+        scaling_group_id=ResourceGroupID(uuid.uuid4()),
+    )
 
 
 class TestFetchIdleCheckBatch:
@@ -776,3 +890,212 @@ class TestFetchIdleCheckBatch:
         batch_target = targets_by_session_id[per_type_checker_data.batch_session_id]
         batch_checker_ids = [bound.checker.checker_id for bound in batch_target.checkers]
         assert batch_checker_ids == [per_type_checker_data.batch_checker_id]
+
+
+class TestFetchExpiredIdleChecks:
+    @pytest.fixture
+    async def database(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                ProjectResourcePolicyRow,
+                DomainRow,
+                GroupRow,
+                ScalingGroupRow,
+                SessionRow,
+                IdleCheckerRow,
+                SessionIdleCheckRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    def repository(self, database: ExtendedAsyncSAEngine) -> IdleCheckerRepository:
+        return IdleCheckerRepository(DBOpsProvider(database))
+
+    @pytest.fixture
+    async def expired_check_session(
+        self,
+        database: ExtendedAsyncSAEngine,
+    ) -> ExpiredCheckSessionData:
+        scope = _expired_check_scope_fixture("expired-check")
+        session_id = SessionId(uuid.uuid4())
+        first_checker_id = IdleCheckerID(uuid.uuid4())
+        second_checker_id = IdleCheckerID(uuid.uuid4())
+        first_expire_at = datetime(2026, 1, 1, tzinfo=UTC)
+        second_expire_at = datetime(2026, 2, 1, tzinfo=UTC)
+        async with database.begin_session() as db_sess:
+            for scope_row in _expired_check_scope_rows(scope):
+                db_sess.add(scope_row)
+            db_sess.add(_expired_check_session_row(scope, session_id, SessionStatus.RUNNING))
+            db_sess.add(_expired_check_checker_row(first_checker_id))
+            db_sess.add(_expired_check_checker_row(second_checker_id))
+            await db_sess.flush()
+            db_sess.add(
+                SessionIdleCheckRow(
+                    session_id=session_id,
+                    idle_checker_id=first_checker_id,
+                    expire_at=first_expire_at,
+                    last_status="expired",
+                    last_message="Judged expired.",
+                )
+            )
+            db_sess.add(
+                SessionIdleCheckRow(
+                    session_id=session_id,
+                    idle_checker_id=second_checker_id,
+                    expire_at=second_expire_at,
+                    last_status="expired",
+                    last_message="Judged expired.",
+                )
+            )
+        return ExpiredCheckSessionData(
+            session_id=session_id,
+            first_checker_id=first_checker_id,
+            second_checker_id=second_checker_id,
+            first_expire_at=first_expire_at,
+            second_expire_at=second_expire_at,
+        )
+
+    @pytest.fixture
+    async def session_without_deadline(
+        self,
+        database: ExtendedAsyncSAEngine,
+    ) -> SessionId:
+        scope = _expired_check_scope_fixture("no-deadline")
+        session_id = SessionId(uuid.uuid4())
+        checker_id = IdleCheckerID(uuid.uuid4())
+        async with database.begin_session() as db_sess:
+            for scope_row in _expired_check_scope_rows(scope):
+                db_sess.add(scope_row)
+            db_sess.add(_expired_check_session_row(scope, session_id, SessionStatus.RUNNING))
+            db_sess.add(_expired_check_checker_row(checker_id))
+            await db_sess.flush()
+            db_sess.add(
+                SessionIdleCheckRow(
+                    session_id=session_id,
+                    idle_checker_id=checker_id,
+                    expire_at=None,
+                    last_status="grace_period",
+                    last_message="Waiting for the grace period to end.",
+                )
+            )
+        return session_id
+
+    @pytest.fixture
+    async def session_with_future_deadline(
+        self,
+        database: ExtendedAsyncSAEngine,
+    ) -> SessionId:
+        scope = _expired_check_scope_fixture("future-deadline")
+        session_id = SessionId(uuid.uuid4())
+        checker_id = IdleCheckerID(uuid.uuid4())
+        async with database.begin_session() as db_sess:
+            for scope_row in _expired_check_scope_rows(scope):
+                db_sess.add(scope_row)
+            db_sess.add(_expired_check_session_row(scope, session_id, SessionStatus.RUNNING))
+            db_sess.add(_expired_check_checker_row(checker_id))
+            await db_sess.flush()
+            db_sess.add(
+                SessionIdleCheckRow(
+                    session_id=session_id,
+                    idle_checker_id=checker_id,
+                    expire_at=datetime(2100, 1, 1, tzinfo=UTC),
+                    last_status="active",
+                    last_message="The session is active.",
+                )
+            )
+        return session_id
+
+    @pytest.fixture
+    async def terminated_session_with_expired_check(
+        self,
+        database: ExtendedAsyncSAEngine,
+    ) -> SessionId:
+        scope = _expired_check_scope_fixture("terminated")
+        session_id = SessionId(uuid.uuid4())
+        checker_id = IdleCheckerID(uuid.uuid4())
+        async with database.begin_session() as db_sess:
+            for scope_row in _expired_check_scope_rows(scope):
+                db_sess.add(scope_row)
+            db_sess.add(_expired_check_session_row(scope, session_id, SessionStatus.TERMINATED))
+            db_sess.add(_expired_check_checker_row(checker_id))
+            await db_sess.flush()
+            db_sess.add(
+                SessionIdleCheckRow(
+                    session_id=session_id,
+                    idle_checker_id=checker_id,
+                    expire_at=datetime(2026, 1, 1, tzinfo=UTC),
+                    last_status="expired",
+                    last_message="Judged expired.",
+                )
+            )
+        return session_id
+
+    async def test_returns_each_expired_check_of_running_session(
+        self,
+        repository: IdleCheckerRepository,
+        expired_check_session: ExpiredCheckSessionData,
+    ) -> None:
+        batch = await repository.fetch_expired_idle_checks([SessionStatus.RUNNING])
+        checks_by_key = {(check.session_id, check.checker_id): check for check in batch.checks}
+
+        assert set(checks_by_key) == {
+            (expired_check_session.session_id, expired_check_session.first_checker_id),
+            (expired_check_session.session_id, expired_check_session.second_checker_id),
+        }
+        check = checks_by_key[
+            (expired_check_session.session_id, expired_check_session.first_checker_id)
+        ]
+        assert check.expire_at == expired_check_session.first_expire_at
+        assert check.last_status == "expired"
+        assert check.last_message == "Judged expired."
+
+    async def test_excludes_checks_without_deadline(
+        self,
+        repository: IdleCheckerRepository,
+        session_without_deadline: SessionId,
+    ) -> None:
+        batch = await repository.fetch_expired_idle_checks([SessionStatus.RUNNING])
+        check_session_ids = {check.session_id for check in batch.checks}
+
+        assert batch.checks == ()
+        assert session_without_deadline not in check_session_ids
+
+    async def test_excludes_checks_with_future_deadline(
+        self,
+        repository: IdleCheckerRepository,
+        session_with_future_deadline: SessionId,
+    ) -> None:
+        batch = await repository.fetch_expired_idle_checks([SessionStatus.RUNNING])
+        check_session_ids = {check.session_id for check in batch.checks}
+
+        assert batch.checks == ()
+        assert session_with_future_deadline not in check_session_ids
+
+    async def test_excludes_sessions_not_in_target_statuses(
+        self,
+        repository: IdleCheckerRepository,
+        terminated_session_with_expired_check: SessionId,
+    ) -> None:
+        batch = await repository.fetch_expired_idle_checks([SessionStatus.RUNNING])
+        check_session_ids = {check.session_id for check in batch.checks}
+
+        assert batch.checks == ()
+        assert terminated_session_with_expired_check not in check_session_ids
+
+    async def test_now_is_db_sourced_and_covers_every_deadline(
+        self,
+        repository: IdleCheckerRepository,
+        expired_check_session: ExpiredCheckSessionData,
+    ) -> None:
+        batch = await repository.fetch_expired_idle_checks([SessionStatus.RUNNING])
+        check_session_ids = {check.session_id for check in batch.checks}
+
+        assert batch.now.tzinfo is not None
+        assert check_session_ids == {expired_check_session.session_id}
+        for check in batch.checks:
+            assert check.expire_at <= batch.now


### PR DESCRIPTION
## Summary
- Implement the Source path of the BEP-1054 expiry-sweep stage: read `session_idle_checks` rows whose deadline has passed (`expire_at IS NOT NULL AND expire_at <= now()`, matching the partial index) joined to sessions in the target statuses
- `IdleCheckerRepository.fetch_expired_idle_checks` / `IdleCheckerDBSource.fetch_expired_idle_checks` return `ExpiredIdleCheckBatchData` — per-checker expired checks (kept as separate reasons per session) plus a DB-sourced `now` read in the same transaction
- Add `IdleCheckSweepSource` + `IdleCheckSweepReconcileInfo` under `sokovan/idle_check/sweep/` implementing the `ReconcilerSource` contract (`entity_ids()` deduplicates sessions, `now()` is the DB time); Handler/Applier and stage registration follow in a later PR

## Test plan
- [x] `tests/unit/manager/repositories/idle_checker/test_repository.py::TestFetchExpiredIdleChecks` — per-kind seeded fixtures (real DB via `with_tables`): returns each expired check of a running session with stored judgment fields, excludes NULL/future deadlines and non-target-status sessions, `now` covers every returned deadline
- [x] `pants lint/check/test` on the changed files (pre-push hook)

Resolves BA-6917

🤖 Generated with [Claude Code](https://claude.com/claude-code)