### PR TITLE
chore(manager): enforce repositories/services layer deps in BUILD

### DIFF
--- a/changes/12932.misc.md
+++ b/changes/12932.misc.md
@@ -1,0 +1,1 @@
+Enforce the manager layer dependency order (repositories must not import services/api, services must not import api) at build time via Pants visibility rules.

--- a/src/ai/backend/manager/BUILD
+++ b/src/ai/backend/manager/BUILD
@@ -85,6 +85,31 @@ __dependencies_rules__(
         "//stubs/**",
         "!*",
     ),
+    # repositories: may depend on models/data/dto; must not depend on services or api.
+    (
+        "/repositories/**",
+        "!/services/**",
+        "!/api/**",
+        "/**",
+        "//src/ai/backend/common/**",
+        "//src/ai/backend/cli/**",
+        "//src/ai/backend/logging/**",
+        "//reqs#*",
+        "//stubs/**",
+        "!*",
+    ),
+    # services: must not depend on api.
+    (
+        "/services/**",
+        "!/api/**",
+        "/**",
+        "//src/ai/backend/common/**",
+        "//src/ai/backend/cli/**",
+        "//src/ai/backend/logging/**",
+        "//reqs#*",
+        "//stubs/**",
+        "!*",
+    ),
     # default: every other file in the component.
     (
         "*",

--- a/src/ai/backend/manager/BUILD
+++ b/src/ai/backend/manager/BUILD
@@ -85,7 +85,7 @@ __dependencies_rules__(
         "//stubs/**",
         "!*",
     ),
-    # repositories: may depend on models/data/dto; must not depend on services or api.
+    # repositories: must not depend on services or api.
     (
         "/repositories/**",
         "!/services/**",


### PR DESCRIPTION
## Summary
- Extend the manager `__dependencies_rules__` to cover the `repositories/` and `services/` layers, alongside the existing `data`/`views`/`models` rules.
- `repositories/**` may depend on `models`/`data`/`dto` but not `services` or `api`; `services/**` must not depend on `api`.
- Makes the documented layer order (`api → services → repositories → models`) enforced at build time via Pants visibility instead of by review.

## Test plan
- [x] `pants lint --changed-since=origin/main` passes (`visibility` check succeeds)