### PR TITLE
feat(BA-6923): add ensure_scope op and self/hierarchy scope bindings on creation

### DIFF
--- a/changes/12934.feature.md
+++ b/changes/12934.feature.md
@@ -1,0 +1,1 @@
+Add ensure-virtual-scope RBAC ops that bind a scope to its own (and optionally its parent's) virtual scope, so ownership resolves through the single virtual-scope path.

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -285,18 +285,18 @@ class RBACWriteOps(WriteOps):
     async def create_scope[TRow: Base](
         self,
         creation: ScopeCreation[TRow],
-        parent: ScopeRef | None = None,
+        bound_scope: ScopeRef | None = None,
     ) -> CreatorResult[TRow]:
         """Create the real scope entity via ``creation.creator`` and its virtual scope node.
 
-        ``creation.scope.scope_id`` must match the id the created row carries. When ``parent``
-        is given, the parent scope is bound to this scope's virtual scope so it can reach this
-        scope's entities.
+        ``creation.scope.scope_id`` must match the id the created row carries. When
+        ``bound_scope`` is given, it is bound to this scope's virtual scope so it can reach
+        this scope's entities.
         """
         result = await self.create(creation.creator)
         await self._insert_virtual_scopes([creation.scope])
-        if parent is not None:
-            await self.bind_scope(parent, creation.scope, permission_cap=None)
+        if bound_scope is not None:
+            await self.bind_scope(bound_scope, creation.scope, permission_cap=None)
         return result
 
     async def bulk_create_scopes[TRow: Base](
@@ -430,14 +430,14 @@ class RBACWriteOps(WriteOps):
     async def ensure_scope(
         self,
         scope: ScopeRef,
-        parent: ScopeRef | None = None,
+        bound_scope: ScopeRef | None = None,
     ) -> None:
-        """Ensure the virtual scope node for an already-created ``scope``. When ``parent`` is
-        given, the parent scope is bound to this scope's virtual scope. Idempotent.
+        """Ensure the virtual scope node for an already-created ``scope``. When ``bound_scope``
+        is given, it is bound to this scope's virtual scope. Idempotent.
         """
         await self._insert_virtual_scopes([scope])
-        if parent is not None:
-            await self.bind_scope(parent, scope, permission_cap=None)
+        if bound_scope is not None:
+            await self.bind_scope(bound_scope, scope, permission_cap=None)
 
 
 class RBACOpsProvider(DBOpsProvider):

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -116,40 +116,52 @@ class RBACWriteOps(WriteOps):
         return virtual_scope_id
 
     async def _insert_virtual_scopes(self, scopes: Sequence[ScopeRef]) -> None:
-        """Create the virtual scope nodes for ``scopes`` and register each scope
-        as an entity member of its own virtual scope (idempotent).
-
-        Access to the scope object itself then resolves as an ordinary entity through the
-        single-path permission resolution. ``permission_cap`` is NULL (ownership, no ceiling).
-        """
+        """Create each scope's virtual scope node with its self entity-membership and self
+        scope_binding (permission_cap NULL). Idempotent: an existing scope is a no-op."""
         if not scopes:
             return
         values = [{"scope_type": s.scope_type, "scope_id": s.scope_id} for s in scopes]
-        stmt = (
+        insert_stmt = (
             pg_insert(VirtualScopeRow)
             .values(values)
             .on_conflict_do_nothing(index_elements=["scope_type", "scope_id"])
+            .returning(
+                VirtualScopeRow.id,
+                VirtualScopeRow.scope_type,
+                VirtualScopeRow.scope_id,
+            )
         )
-        await self._sess.execute(stmt)
-        membership_source = sa.select(
-            VirtualScopeRow.id,
-            VirtualScopeRow.scope_type,
-            VirtualScopeRow.scope_id,
-            sa.null(),
-        ).where(
-            sa.tuple_(VirtualScopeRow.scope_type, VirtualScopeRow.scope_id).in_([
-                (s.scope_type, s.scope_id) for s in scopes
-            ])
-        )
+        inserted = (await self._sess.execute(insert_stmt)).all()
+        if not inserted:
+            return
         membership_stmt = (
             pg_insert(EntityMembershipRow)
-            .from_select(
-                ["virtual_scope_id", "entity_type", "entity_id", "permission_cap"],
-                membership_source,
-            )
+            .values([
+                {
+                    "virtual_scope_id": row.id,
+                    "entity_type": row.scope_type,
+                    "entity_id": row.scope_id,
+                    "permission_cap": None,
+                }
+                for row in inserted
+            ])
             .on_conflict_do_nothing()
         )
         await self._sess.execute(membership_stmt)
+        binding_stmt = (
+            pg_insert(ScopeBindingRow)
+            .values([
+                {
+                    "virtual_scope_id": row.id,
+                    "scope_type": row.scope_type,
+                    "scope_id": row.scope_id,
+                    "permission_cap": None,
+                }
+                for row in inserted
+            ])
+            .on_conflict_do_nothing()
+        )
+        await self._sess.execute(binding_stmt)
 
     async def _delete_virtual_scopes(self, scopes: Sequence[ScopeRef]) -> None:
         """Delete the virtual scope nodes for ``scopes`` (FK CASCADE removes their edges)."""
@@ -273,14 +285,18 @@ class RBACWriteOps(WriteOps):
     async def create_scope[TRow: Base](
         self,
         creation: ScopeCreation[TRow],
+        parent: ScopeRef | None = None,
     ) -> CreatorResult[TRow]:
         """Create the real scope entity via ``creation.creator`` and its virtual scope node.
 
-        The virtual scope insert is idempotent (get-or-create). ``creation.scope.scope_id``
-        must match the id the created row carries.
+        ``creation.scope.scope_id`` must match the id the created row carries. When ``parent``
+        is given, the parent scope is bound to this scope's virtual scope so it can reach this
+        scope's entities.
         """
         result = await self.create(creation.creator)
         await self._insert_virtual_scopes([creation.scope])
+        if parent is not None:
+            await self.bind_scope(parent, creation.scope, permission_cap=None)
         return result
 
     async def bulk_create_scopes[TRow: Base](
@@ -408,6 +424,20 @@ class RBACWriteOps(WriteOps):
             ]),
         )
         await self._sess.execute(stmt)
+
+    # -- Virtual scope: ensure compatibility for externally-created rows ----------
+
+    async def ensure_scope(
+        self,
+        scope: ScopeRef,
+        parent: ScopeRef | None = None,
+    ) -> None:
+        """Ensure the virtual scope node for an already-created ``scope``. When ``parent`` is
+        given, the parent scope is bound to this scope's virtual scope. Idempotent.
+        """
+        await self._insert_virtual_scopes([scope])
+        if parent is not None:
+            await self.bind_scope(parent, scope, permission_cap=None)
 
 
 class RBACOpsProvider(DBOpsProvider):

--- a/tests/unit/manager/repositories/ops/rbac/test_provider.py
+++ b/tests/unit/manager/repositories/ops/rbac/test_provider.py
@@ -1,15 +1,4 @@
-"""Integration tests for the RBAC ops provider (RBACWriteOps) with a real database.
-
-These verify observable outcomes — which rows and which scope associations survive an
-operation — rather than internal call wiring. Two surfaces are covered:
-
-- ``create_scope`` / ``bulk_create_scopes`` / ``ensure_scope`` materialize the virtual
-  scope node, the scope-as-entity membership, and the self scope_binding in the scope's own
-  virtual scope; a ``parent`` additionally binds the parent scope to that virtual scope.
-- ``bulk_create_scoped_partial`` / ``bulk_purge_scoped_partial`` isolate each item so a
-  rejected one leaves the rest of the batch intact. The unscoped counterparts
-  (``bulk_create_partial`` / ``bulk_purge_partial``) are covered by the base ops tests.
-"""
+"""Integration tests for the RBAC ops provider (RBACWriteOps) with a real database."""
 
 from __future__ import annotations
 
@@ -82,7 +71,7 @@ _ORM_CLUSTER = (
 
 _TEST_SCOPE_TYPE = ScopeType("test-scope")
 _TEST_ENTITY_TYPE = VirtualScopeEntityType("test-scope")
-_TEST_PARENT_SCOPE_TYPE = ScopeType("test-parent-scope")
+_TEST_BOUND_SCOPE_TYPE = ScopeType("test-bound-scope")
 
 _USER_SCOPE_ID = str(uuid.uuid4())
 _USER_SCOPE_REF = RBACElementRef(RBACElementType.USER, _USER_SCOPE_ID)
@@ -245,7 +234,7 @@ def bulk_scopes() -> BulkScopeContext:
 
 class TestScopeCreationVirtualScope:
     """create_scope / bulk_create_scopes materialize the VS node, self-membership, and
-    self scope_binding (plus a parent hierarchy binding when a parent is given)."""
+    self scope_binding (plus a bound-scope binding when a bound_scope is given)."""
 
     async def test_create_scope_adds_virtual_scope_membership_and_self_binding(
         self,
@@ -295,20 +284,20 @@ class TestScopeCreationVirtualScope:
         assert binding.scope_id == scope_id
         assert binding.permission_cap is None
 
-    async def test_create_scope_with_parent_binds_parent_to_its_virtual_scope(
+    async def test_create_scope_with_bound_scope_binds_it_to_its_virtual_scope(
         self,
         database_connection: ExtendedAsyncSAEngine,
         provider: RBACOpsProvider,
         scope_tables: None,
         single_scope: SingleScopeContext,
     ) -> None:
-        """create_scope(parent=...) binds the parent scope to the new scope's VS on top of
-        the self binding, so the parent reaches this scope's entities in one hop."""
+        """create_scope(bound_scope=...) binds that scope to the new scope's VS on top of
+        the self binding, so it reaches this scope's entities in one hop."""
         scope_id = single_scope.scope_id
-        parent = ScopeRef(scope_type=_TEST_PARENT_SCOPE_TYPE, scope_id=uuid.uuid4())
+        bound_scope = ScopeRef(scope_type=_TEST_BOUND_SCOPE_TYPE, scope_id=uuid.uuid4())
 
         async with provider.write_ops() as w:
-            await w.create_scope(single_scope.creation, parent=parent)
+            await w.create_scope(single_scope.creation, bound_scope=bound_scope)
 
         async with database_connection.begin_session_read_committed() as sess:
             vs = (
@@ -328,7 +317,7 @@ class TestScopeCreationVirtualScope:
 
         assert {(b.scope_type, b.scope_id) for b in binding_rows} == {
             (_TEST_SCOPE_TYPE, scope_id),  # self binding
-            (_TEST_PARENT_SCOPE_TYPE, parent.scope_id),  # hierarchy binding
+            (_TEST_BOUND_SCOPE_TYPE, bound_scope.scope_id),  # bound-scope binding
         }
 
     async def test_bulk_create_scopes_adds_vs_membership_and_self_binding_per_scope(
@@ -435,20 +424,20 @@ class TestEnsureScope:
         assert membership_count == 1
         assert binding_count == 1
 
-    async def test_ensure_scope_with_parent_adds_hierarchy_binding(
+    async def test_ensure_scope_with_bound_scope_adds_binding(
         self,
         database_connection: ExtendedAsyncSAEngine,
         provider: RBACOpsProvider,
         scope_tables: None,
     ) -> None:
-        """ensure_scope(scope, parent) binds both the scope itself and its parent to the
-        scope's VS."""
+        """ensure_scope(scope, bound_scope) binds both the scope itself and the bound scope
+        to the scope's VS."""
         scope_id = uuid.uuid4()
         scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=scope_id)
-        parent = ScopeRef(scope_type=_TEST_PARENT_SCOPE_TYPE, scope_id=uuid.uuid4())
+        bound_scope = ScopeRef(scope_type=_TEST_BOUND_SCOPE_TYPE, scope_id=uuid.uuid4())
 
         async with provider.write_ops() as w:
-            await w.ensure_scope(scope, parent=parent)
+            await w.ensure_scope(scope, bound_scope=bound_scope)
 
         async with database_connection.begin_session_read_committed() as sess:
             vs = (
@@ -468,7 +457,7 @@ class TestEnsureScope:
 
         assert {(b.scope_type, b.scope_id) for b in binding_rows} == {
             (_TEST_SCOPE_TYPE, scope_id),  # self binding
-            (_TEST_PARENT_SCOPE_TYPE, parent.scope_id),  # hierarchy binding
+            (_TEST_BOUND_SCOPE_TYPE, bound_scope.scope_id),  # bound-scope binding
         }
 
 

--- a/tests/unit/manager/repositories/ops/rbac/test_provider.py
+++ b/tests/unit/manager/repositories/ops/rbac/test_provider.py
@@ -3,8 +3,9 @@
 These verify observable outcomes — which rows and which scope associations survive an
 operation — rather than internal call wiring. Two surfaces are covered:
 
-- ``create_scope`` / ``bulk_create_scopes`` materialize both the virtual scope node and
-  the scope-as-entity membership in the scope's own virtual scope.
+- ``create_scope`` / ``bulk_create_scopes`` / ``ensure_scope`` materialize the virtual
+  scope node, the scope-as-entity membership, and the self scope_binding in the scope's own
+  virtual scope; a ``parent`` additionally binds the parent scope to that virtual scope.
 - ``bulk_create_scoped_partial`` / ``bulk_purge_scoped_partial`` isolate each item so a
   rejected one leaves the rest of the batch intact. The unscoped counterparts
   (``bulk_create_partial`` / ``bulk_purge_partial``) are covered by the base ops tests.
@@ -50,6 +51,7 @@ from ai.backend.manager.models.scaling_group import ScalingGroupForDomainRow
 from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.repositories.base import Creator, CreatorSpec
 from ai.backend.manager.repositories.base.rbac.entity_creator import RBACEntityCreator
@@ -80,6 +82,7 @@ _ORM_CLUSTER = (
 
 _TEST_SCOPE_TYPE = ScopeType("test-scope")
 _TEST_ENTITY_TYPE = VirtualScopeEntityType("test-scope")
+_TEST_PARENT_SCOPE_TYPE = ScopeType("test-parent-scope")
 
 _USER_SCOPE_ID = str(uuid.uuid4())
 _USER_SCOPE_REF = RBACElementRef(RBACElementType.USER, _USER_SCOPE_ID)
@@ -175,6 +178,7 @@ _SCOPE_TABLES = [
     OpsRBACScopeRow,
     VirtualScopeRow,
     EntityMembershipRow,
+    ScopeBindingRow,
 ]
 
 
@@ -240,16 +244,18 @@ def bulk_scopes() -> BulkScopeContext:
 
 
 class TestScopeCreationVirtualScope:
-    """create_scope / bulk_create_scopes materialize the VS node and self-membership."""
+    """create_scope / bulk_create_scopes materialize the VS node, self-membership, and
+    self scope_binding (plus a parent hierarchy binding when a parent is given)."""
 
-    async def test_create_scope_adds_virtual_scope_and_self_membership(
+    async def test_create_scope_adds_virtual_scope_membership_and_self_binding(
         self,
         database_connection: ExtendedAsyncSAEngine,
         provider: RBACOpsProvider,
         scope_tables: None,
         single_scope: SingleScopeContext,
     ) -> None:
-        """create_scope creates the VS node and registers the scope in its own VS."""
+        """create_scope creates the VS node, registers the scope in its own VS, and binds
+        the scope to its own VS."""
         scope_id = single_scope.scope_id
 
         async with provider.write_ops() as w:
@@ -268,6 +274,7 @@ class TestScopeCreationVirtualScope:
                 .all()
             )
             membership_rows = (await sess.execute(sa.select(EntityMembershipRow))).scalars().all()
+            binding_rows = (await sess.execute(sa.select(ScopeBindingRow))).scalars().all()
 
         assert len(vs_rows) == 1
         vs = vs_rows[0]
@@ -281,14 +288,58 @@ class TestScopeCreationVirtualScope:
         assert membership.entity_id == scope_id
         assert membership.permission_cap is None
 
-    async def test_bulk_create_scopes_adds_vs_and_self_membership_per_scope(
+        assert len(binding_rows) == 1
+        binding = binding_rows[0]
+        assert binding.virtual_scope_id == vs.id
+        assert binding.scope_type == _TEST_SCOPE_TYPE
+        assert binding.scope_id == scope_id
+        assert binding.permission_cap is None
+
+    async def test_create_scope_with_parent_binds_parent_to_its_virtual_scope(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        provider: RBACOpsProvider,
+        scope_tables: None,
+        single_scope: SingleScopeContext,
+    ) -> None:
+        """create_scope(parent=...) binds the parent scope to the new scope's VS on top of
+        the self binding, so the parent reaches this scope's entities in one hop."""
+        scope_id = single_scope.scope_id
+        parent = ScopeRef(scope_type=_TEST_PARENT_SCOPE_TYPE, scope_id=uuid.uuid4())
+
+        async with provider.write_ops() as w:
+            await w.create_scope(single_scope.creation, parent=parent)
+
+        async with database_connection.begin_session_read_committed() as sess:
+            vs = (
+                await sess.execute(
+                    sa.select(VirtualScopeRow).where(VirtualScopeRow.scope_id == scope_id)
+                )
+            ).scalar_one()
+            binding_rows = (
+                (
+                    await sess.execute(
+                        sa.select(ScopeBindingRow).where(ScopeBindingRow.virtual_scope_id == vs.id)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        assert {(b.scope_type, b.scope_id) for b in binding_rows} == {
+            (_TEST_SCOPE_TYPE, scope_id),  # self binding
+            (_TEST_PARENT_SCOPE_TYPE, parent.scope_id),  # hierarchy binding
+        }
+
+    async def test_bulk_create_scopes_adds_vs_membership_and_self_binding_per_scope(
         self,
         database_connection: ExtendedAsyncSAEngine,
         provider: RBACOpsProvider,
         scope_tables: None,
         bulk_scopes: BulkScopeContext,
     ) -> None:
-        """bulk_create_scopes creates one VS node and one self-membership per scope."""
+        """bulk_create_scopes creates one VS node, self-membership, and self binding per
+        scope."""
         scope_ids = bulk_scopes.scope_ids
 
         async with provider.write_ops() as w:
@@ -297,6 +348,7 @@ class TestScopeCreationVirtualScope:
         async with database_connection.begin_session_read_committed() as sess:
             vs_rows = (await sess.execute(sa.select(VirtualScopeRow))).scalars().all()
             membership_rows = (await sess.execute(sa.select(EntityMembershipRow))).scalars().all()
+            binding_rows = (await sess.execute(sa.select(ScopeBindingRow))).scalars().all()
 
         assert {vs.scope_id for vs in vs_rows} == set(scope_ids)
         vs_by_scope = {vs.scope_id: vs for vs in vs_rows}
@@ -307,6 +359,117 @@ class TestScopeCreationVirtualScope:
             assert membership.entity_id in scope_ids
             assert membership.virtual_scope_id == vs_by_scope[membership.entity_id].id
             assert membership.permission_cap is None
+
+        assert len(binding_rows) == 3
+        for binding in binding_rows:
+            assert binding.scope_type == _TEST_SCOPE_TYPE
+            assert binding.scope_id in scope_ids
+            assert binding.virtual_scope_id == vs_by_scope[binding.scope_id].id
+            assert binding.permission_cap is None
+
+
+class TestEnsureScope:
+    """ensure_scope backfills the VS node, self-membership, and self binding for an
+    already-created scope, without creating the real scope row."""
+
+    async def test_ensure_scope_adds_vs_membership_and_self_binding_without_real_row(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        provider: RBACOpsProvider,
+        scope_tables: None,
+    ) -> None:
+        """ensure_scope creates the VS node, self-membership, and self binding, and leaves
+        no real scope row behind."""
+        scope_id = uuid.uuid4()
+        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=scope_id)
+
+        async with provider.write_ops() as w:
+            await w.ensure_scope(scope)
+
+        async with database_connection.begin_session_read_committed() as sess:
+            vs_rows = (await sess.execute(sa.select(VirtualScopeRow))).scalars().all()
+            membership_rows = (await sess.execute(sa.select(EntityMembershipRow))).scalars().all()
+            binding_rows = (await sess.execute(sa.select(ScopeBindingRow))).scalars().all()
+            real_row_count = await sess.scalar(
+                sa.select(sa.func.count()).select_from(OpsRBACScopeRow)
+            )
+
+        assert len(vs_rows) == 1
+        vs = vs_rows[0]
+        assert vs.scope_id == scope_id
+
+        assert len(membership_rows) == 1
+        assert membership_rows[0].virtual_scope_id == vs.id
+        assert membership_rows[0].entity_id == scope_id
+
+        assert len(binding_rows) == 1
+        assert binding_rows[0].virtual_scope_id == vs.id
+        assert binding_rows[0].scope_id == scope_id
+        assert binding_rows[0].permission_cap is None
+
+        assert real_row_count == 0
+
+    async def test_ensure_scope_is_idempotent(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        provider: RBACOpsProvider,
+        scope_tables: None,
+    ) -> None:
+        """Calling ensure_scope twice leaves exactly one VS node, membership, and binding."""
+        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=uuid.uuid4())
+
+        async with provider.write_ops() as w:
+            await w.ensure_scope(scope)
+            await w.ensure_scope(scope)
+
+        async with database_connection.begin_session_read_committed() as sess:
+            vs_count = await sess.scalar(sa.select(sa.func.count()).select_from(VirtualScopeRow))
+            membership_count = await sess.scalar(
+                sa.select(sa.func.count()).select_from(EntityMembershipRow)
+            )
+            binding_count = await sess.scalar(
+                sa.select(sa.func.count()).select_from(ScopeBindingRow)
+            )
+
+        assert vs_count == 1
+        assert membership_count == 1
+        assert binding_count == 1
+
+    async def test_ensure_scope_with_parent_adds_hierarchy_binding(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        provider: RBACOpsProvider,
+        scope_tables: None,
+    ) -> None:
+        """ensure_scope(scope, parent) binds both the scope itself and its parent to the
+        scope's VS."""
+        scope_id = uuid.uuid4()
+        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=scope_id)
+        parent = ScopeRef(scope_type=_TEST_PARENT_SCOPE_TYPE, scope_id=uuid.uuid4())
+
+        async with provider.write_ops() as w:
+            await w.ensure_scope(scope, parent=parent)
+
+        async with database_connection.begin_session_read_committed() as sess:
+            vs = (
+                await sess.execute(
+                    sa.select(VirtualScopeRow).where(VirtualScopeRow.scope_id == scope_id)
+                )
+            ).scalar_one()
+            binding_rows = (
+                (
+                    await sess.execute(
+                        sa.select(ScopeBindingRow).where(ScopeBindingRow.virtual_scope_id == vs.id)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        assert {(b.scope_type, b.scope_id) for b in binding_rows} == {
+            (_TEST_SCOPE_TYPE, scope_id),  # self binding
+            (_TEST_PARENT_SCOPE_TYPE, parent.scope_id),  # hierarchy binding
+        }
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Add ensure-virtual-scope RBAC ops that backfill VS structures next to the legacy write path, so an entity can adopt virtual-scope resolution on its own without an all-at-once cutover.
- `_insert_virtual_scopes` now also writes each scope's self `scope_binding`, so an owner resolves its own entities through the single virtual-scope path.
- `create_scope` / `ensure_scope` take an optional `bound_scope` that binds additional scopes to this scope's virtual scope (hierarchy binding). `ensure_scope` backfills the VS node without creating the real scope row.

## Test plan
- [x] `create_scope` materializes the VS node, self entity-membership, and self scope_binding
- [x] `ensure_scope` backfills VS structures without creating the real row, and is idempotent
- [x] `ensure_scope(scope, parent)` adds the hierarchy binding

Resolves BA-6923