### PR TITLE
fix(manager): drop APP_CONFIG from migration enum resource types

### DIFF
--- a/changes/12935.fix.md
+++ b/changes/12935.fix.md
@@ -1,0 +1,1 @@
+Drop the stale `APP_CONFIG` entry from the RBAC migration enum's resource types so it matches the original enum.

--- a/src/ai/backend/manager/models/rbac_models/migration/enums.py
+++ b/src/ai/backend/manager/models/rbac_models/migration/enums.py
@@ -141,7 +141,6 @@ class EntityType(enum.StrEnum):
             cls.SESSION,
             cls.ARTIFACT,
             cls.ARTIFACT_REGISTRY,
-            cls.APP_CONFIG,
             cls.NOTIFICATION_CHANNEL,
             cls.NOTIFICATION_RULE,
             cls.MODEL_DEPLOYMENT,


### PR DESCRIPTION
## Summary
- BA-6873 (#12839) removed `cls.APP_CONFIG` from `EntityType._resource_types()` in the original common enum but missed the migration copy in `manager/models/rbac_models/migration/enums.py`.
- The stale copy broke the enum-sync tests (`_resource_types` plus the three `*_accessible_entity_types_*` sets all derive from it).
- Mirror the removal so the migration copy matches the original again.

## Test plan
- [x] `pants test tests/unit/manager/rbac/test_migration_enums.py` — all 16 pass