### PR TITLE
feat(BA-6928): add retention_policies table and timestamp mixins

### DIFF
--- a/.claude/skills/db-migrate/SKILL.md
+++ b/.claude/skills/db-migrate/SKILL.md
@@ -36,7 +36,7 @@ Check the schema version and apply or roll back Alembic migrations for Backend.A
 |-------|---------|--------|
 | up-to-date | current == head | none |
 | behind | current behind head | upgrade (below) |
-| diverged | multiple heads | fix `down_revision` per `alembic/AGENTS.md` (no merge migrations) |
+| diverged | multiple heads | reconcile per `alembic/AGENTS.md`: repoint your own migration's `down_revision`, or add an empty merge migration when main itself has 2+ heads |
 | no revision | current empty (fresh DB) | upgrade for initial setup |
 
 ## Apply
@@ -57,7 +57,7 @@ Re-check status afterwards. **Downgrade may remove data or features — verify a
 
 | Symptom | Cause | Action |
 |---------|-------|--------|
-| Multiple heads detected | diverged migrations | fix `down_revision` per `alembic/AGENTS.md` (no merge migrations), then retry |
+| Multiple heads detected | diverged migrations | reconcile per `alembic/AGENTS.md` (repoint your own `down_revision`, or add an empty merge migration if main has 2+ heads), then retry |
 | Cannot locate revision 'X' | bad revision id / wrong config | `./py -m alembic -c <config> history`; check typo & component |
 | Foreign key constraint violation | existing data blocks the change | review the migration's data-migration logic; fix data integrity; often needs manual intervention |
 | Cannot connect (connection refused :5432) | PostgreSQL down / misconfig | `docker ps \| grep postgres`; see `/halfstack` |
@@ -73,7 +73,7 @@ Re-check status afterwards. **Downgrade may remove data or features — verify a
 
 - **After pulling code:** `git pull` → check status → upgrade → start services (`/local-dev`) → verify.
 - **After authoring a migration** (see `alembic/AGENTS.md`): review file → test upgrade → test downgrade (`--direction=downgrade --target=-1`) → re-upgrade → commit.
-- **Merge conflicts:** if status shows diverged heads, fix `down_revision` per `alembic/AGENTS.md` (never create merge migrations) before applying.
+- **Merge conflicts:** if status shows diverged heads, reconcile per `alembic/AGENTS.md` (repoint your own migration's `down_revision`, or add an empty merge migration when main itself has 2+ heads) before applying.
 
 ## Related skills
 

--- a/changes/12951.feature.md
+++ b/changes/12951.feature.md
@@ -1,0 +1,1 @@
+Add a `retention_policies` table and `RetentionCategory` catalog as the storage foundation for DB record retention management.

--- a/src/ai/backend/manager/data/retention/types.py
+++ b/src/ai/backend/manager/data/retention/types.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import enum
+
+
+class RetentionCategory(enum.StrEnum):
+    """
+    Identifier linking a ``retention_policies`` row to its code-side cleanup
+    procedure. A pure identifier carrying no table references.
+    """
+
+    LOGS = "logs"
+    LOGIN = "login"
+    RECONCILE_HISTORY = "reconcile_history"
+    ROLES_INVITATIONS = "roles_invitations"
+    DEPLOYMENTS = "deployments"
+    SESSIONS = "sessions"
+    USAGE_RECORDS = "usage_records"
+    USAGE_BUCKETS = "usage_buckets"

--- a/src/ai/backend/manager/models/alembic/AGENTS.md
+++ b/src/ai/backend/manager/models/alembic/AGENTS.md
@@ -12,6 +12,15 @@
 - **Do NOT edit the revision of a released migration** — do not modify the `revision`/`down_revision` of an
   already-released migration. Editing `down_revision` is allowed only when inserting a backport into the main chain before merge.
 
+## Diverged heads
+
+- **Your migration diverged from main** (main has a single head; your `down_revision` points to an older revision):
+  repoint your **own unmerged** migration's `down_revision` to the current head. No merge migration.
+- **main itself has two or more heads** (independent migrations merged without reconciling): add an **empty merge
+  migration** whose `down_revision` is the tuple of the heads (`down_revision = ("<head_a>", "<head_b>")`, with
+  `upgrade`/`downgrade` = `pass`), then chain new migrations on top of it. Do NOT edit the diverged migrations'
+  `down_revision` to linearize them — they may already be released.
+
 ## Forward direction (under consideration)
 
 - Avoid adding alembic migrations in a backport where possible. If you must, place the corresponding version on the backport

--- a/src/ai/backend/manager/models/alembic/versions/4a39641d0fc2_create_retention_policies_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/4a39641d0fc2_create_retention_policies_table.py
@@ -1,0 +1,73 @@
+"""create retention_policies table
+
+Introduce the policy storage for DB record retention management (BEP-1063).
+``retention_policies`` holds one row per ``RetentionCategory`` — the
+admin-tunable ``retention_period`` + ``enabled`` knobs, plus a read-only
+``last_swept_at`` observability field. The migration seeds one row per catalog
+category with conservative defaults.
+
+Revision ID: 4a39641d0fc2
+Revises: d004f760adc7
+Create Date: 2026-07-19
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.base import GUID
+
+# revision identifiers, used by Alembic.
+revision = "4a39641d0fc2"
+down_revision = "d004f760adc7"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+# (category, retention_period) — see BEP-1063 §3(a) default seed.
+SEED_DATA = [
+    ("logs", "1 year"),
+    ("login", "1 year"),
+    ("reconcile_history", "1 year"),
+    ("roles_invitations", "1 year"),
+    ("deployments", "1 year"),
+    ("sessions", "1 year"),
+    ("usage_records", "90 days"),
+    ("usage_buckets", "2 years"),
+]
+
+
+def upgrade() -> None:
+    op.create_table(
+        "retention_policies",
+        sa.Column("id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")),
+        sa.Column("category", sa.String(length=64), nullable=False),
+        sa.Column("retention_period", sa.Interval(), nullable=False),
+        sa.Column("enabled", sa.Boolean(), server_default=sa.true(), nullable=False),
+        sa.Column("last_swept_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("category", name="uq_retention_policies_category"),
+    )
+    for category, period in SEED_DATA:
+        op.execute(
+            sa.text(
+                "INSERT INTO retention_policies (category, retention_period)"
+                " VALUES (:category, CAST(:period AS interval))"
+                " ON CONFLICT (category) DO NOTHING"
+            ).bindparams(category=category, period=period)
+        )
+
+
+def downgrade() -> None:
+    op.drop_table("retention_policies")

--- a/src/ai/backend/manager/models/alembic/versions/d004f760adc7_merge_7a97_and_b3d9.py
+++ b/src/ai/backend/manager/models/alembic/versions/d004f760adc7_merge_7a97_and_b3d9.py
@@ -1,0 +1,27 @@
+"""merge 7a97 and b3d9
+
+Reconcile the two heads left on main by independent migrations
+``7a9720934f55`` (usage-bucket resource group ids) and ``b3d9f7a2c184``
+(APP_CONFIG_FRAGMENT RBAC permissions), which branched from a shared parent
+without reconciling. Empty merge — no schema change.
+
+Revision ID: d004f760adc7
+Revises: 7a9720934f55, b3d9f7a2c184
+Create Date: 2026-07-19
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "d004f760adc7"
+down_revision = ("7a9720934f55", "b3d9f7a2c184")
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/src/ai/backend/manager/models/app_config_allow_list/row.py
+++ b/src/ai/backend/manager/models/app_config_allow_list/row.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime
-
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -11,11 +9,12 @@ from ai.backend.manager.data.app_config_allow_list.types import (
     AppConfigAllowListData,
 )
 from ai.backend.manager.models.base import GUID, Base, StrEnumType
+from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
 
 __all__ = ("AppConfigAllowListRow",)
 
 
-class AppConfigAllowListRow(Base):  # type: ignore[misc]
+class AppConfigAllowListRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     """Permission to write config fragments for one config name at one scope type.
 
     A config fragment may be created only when a matching row exists here.
@@ -55,19 +54,6 @@ class AppConfigAllowListRow(Base):  # type: ignore[misc]
     rank: Mapped[int] = mapped_column(
         "rank",
         sa.Integer,
-        nullable=False,
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at",
-        sa.DateTime(timezone=True),
-        server_default=sa.func.now(),
-        nullable=False,
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
         nullable=False,
     )
 

--- a/src/ai/backend/manager/models/app_config_definition/row.py
+++ b/src/ai/backend/manager/models/app_config_definition/row.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
-from datetime import datetime
-
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.identifier.app_config_definition import AppConfigDefinitionID
 from ai.backend.manager.data.app_config_definition.types import AppConfigDefinitionData
 from ai.backend.manager.models.base import GUID, Base
+from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
 
 __all__ = ("AppConfigDefinitionRow",)
 
 
-class AppConfigDefinitionRow(Base):  # type: ignore[misc]
+class AppConfigDefinitionRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     """One registered ``config_name`` (admin-managed).
 
     Purging a row cascades to its allow-list entries (``ON DELETE CASCADE``) and,
@@ -29,19 +28,6 @@ class AppConfigDefinitionRow(Base):  # type: ignore[misc]
     )
     config_name: Mapped[str] = mapped_column(
         "config_name", sa.String(length=128), nullable=False, unique=True
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at",
-        sa.DateTime(timezone=True),
-        server_default=sa.func.now(),
-        nullable=False,
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
-        nullable=False,
     )
 
     def to_data(self) -> AppConfigDefinitionData:

--- a/src/ai/backend/manager/models/app_config_fragment/row.py
+++ b/src/ai/backend/manager/models/app_config_fragment/row.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Any
 
 import sqlalchemy as sa
@@ -13,11 +12,12 @@ from ai.backend.manager.data.app_config_fragment.types import (
     AppConfigFragmentData,
 )
 from ai.backend.manager.models.base import GUID, Base, StrEnumType
+from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
 
 __all__ = ("AppConfigFragmentRow",)
 
 
-class AppConfigFragmentRow(Base):  # type: ignore[misc]
+class AppConfigFragmentRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     """One scoped app config fragment — a single JSON document at ``(config_name, scope_type, scope_id)``.
 
     A fragment's merge priority is its allow-list entry's ``rank`` — the fragment
@@ -64,19 +64,6 @@ class AppConfigFragmentRow(Base):  # type: ignore[misc]
     config: Mapped[dict[str, Any]] = mapped_column(
         "config",
         JSONB,
-        nullable=False,
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at",
-        sa.DateTime(timezone=True),
-        server_default=sa.func.now(),
-        nullable=False,
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
         nullable=False,
     )
 

--- a/src/ai/backend/manager/models/deployment_policy/row.py
+++ b/src/ai/backend/manager/models/deployment_policy/row.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import uuid
-from datetime import datetime
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
@@ -20,6 +19,7 @@ from ai.backend.manager.models.base import (
     Base,
     StrEnumType,
 )
+from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
 
 if TYPE_CHECKING:
     from ai.backend.manager.models.endpoint import EndpointRow
@@ -29,7 +29,7 @@ __all__ = ("DeploymentPolicyRow",)
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
-class DeploymentPolicyRow(Base):  # type: ignore[misc]
+class DeploymentPolicyRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     """
     Represents a deployment policy for a deployment.
 
@@ -68,21 +68,6 @@ class DeploymentPolicyRow(Base):  # type: ignore[misc]
         pgsql.JSONB(),
         nullable=False,
         server_default="{}",
-    )
-
-    # Timestamps
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at",
-        sa.DateTime(timezone=True),
-        server_default=sa.func.now(),
-        nullable=False,
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
-        nullable=False,
     )
 
     endpoint_row: Mapped[EndpointRow | None] = relationship(

--- a/src/ai/backend/manager/models/deployment_revision/row.py
+++ b/src/ai/backend/manager/models/deployment_revision/row.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 import sqlalchemy as sa
@@ -41,6 +40,7 @@ from ai.backend.manager.models.base import (
     StrEnumType,
     URLColumn,
 )
+from ai.backend.manager.models.mixins.timestamp import CreatedAtMixin
 from ai.backend.manager.models.runtime_variant_preset.types import RuntimeVariantPresetValueEntry
 
 if TYPE_CHECKING:
@@ -79,7 +79,7 @@ def _get_routings_join_condition() -> sa.sql.elements.ColumnElement[Any]:
     return DeploymentRevisionRow.id == foreign(RoutingRow.revision)
 
 
-class DeploymentRevisionRow(Base):  # type: ignore[misc]
+class DeploymentRevisionRow(CreatedAtMixin, Base):  # type: ignore[misc]
     """
     Represents a deployment revision (K8s ReplicaSet equivalent).
 
@@ -239,14 +239,6 @@ class DeploymentRevisionRow(Base):  # type: ignore[misc]
         GUID(DeploymentPresetID),
         sa.ForeignKey("deployment_revision_presets.id", ondelete="SET NULL"),
         nullable=True,
-    )
-
-    # Metadata
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at",
-        sa.DateTime(timezone=True),
-        server_default=sa.func.now(),
-        nullable=False,
     )
 
     # Normalized resource slot rows

--- a/src/ai/backend/manager/models/domain/row.py
+++ b/src/ai/backend/manager/models/domain/row.py
@@ -33,6 +33,7 @@ from ai.backend.manager.models.base import (
     SlugType,
     VFolderHostPermissionColumn,
 )
+from ai.backend.manager.models.mixins.timestamp import CreatedAtMixin
 from ai.backend.manager.models.rbac import (
     AbstractPermissionContext,
     AbstractPermissionContextBuilder,
@@ -90,7 +91,7 @@ def _get_network_join_condition() -> sa.ColumnElement[bool]:
     return DomainRow.name == foreign(NetworkRow.domain_name)
 
 
-class DomainRow(Base):  # type: ignore[misc]
+class DomainRow(CreatedAtMixin, Base):  # type: ignore[misc]
     __tablename__ = "domains"
 
     name: Mapped[str] = mapped_column(
@@ -105,9 +106,6 @@ class DomainRow(Base):  # type: ignore[misc]
     )
     description: Mapped[str | None] = mapped_column("description", sa.String(length=512))
     is_active: Mapped[bool] = mapped_column("is_active", sa.Boolean, default=True, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
-    )
     modified_at: Mapped[datetime] = mapped_column(
         "modified_at",
         sa.DateTime(timezone=True),

--- a/src/ai/backend/manager/models/fair_share/row.py
+++ b/src/ai/backend/manager/models/fair_share/row.py
@@ -32,6 +32,7 @@ from ai.backend.manager.models.base import (
     Base,
     ResourceSlotColumn,
 )
+from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
 
 if TYPE_CHECKING:
     from ai.backend.manager.models.domain import DomainRow
@@ -95,7 +96,7 @@ def _get_domain_fair_share_domain_join_condition() -> sa.ColumnElement[bool]:
     return DomainFairShareRow.domain_name == foreign(DomainRow.name)
 
 
-class DomainFairShareRow(Base):  # type: ignore[misc]
+class DomainFairShareRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     """Per-domain Fair Share state.
 
     Stores weight (configured value) and calculated values together for current state.
@@ -225,20 +226,6 @@ class DomainFairShareRow(Base):  # type: ignore[misc]
         "Example: 1 means daily aggregation, 7 means weekly aggregation.",
     )
 
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
-    )
-
     domain: Mapped[DomainRow | None] = relationship(
         "DomainRow",
         primaryjoin=_get_domain_fair_share_domain_join_condition,
@@ -324,7 +311,7 @@ def _get_project_fair_share_domain_join_condition() -> sa.ColumnElement[bool]:
     return ProjectFairShareRow.domain_name == foreign(DomainRow.name)
 
 
-class ProjectFairShareRow(Base):  # type: ignore[misc]
+class ProjectFairShareRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     """Per-project Fair Share state.
 
     One row per (resource_group, project_id) combination.
@@ -439,20 +426,6 @@ class ProjectFairShareRow(Base):  # type: ignore[misc]
         comment="Aggregation period for usage buckets in days.",
     )
 
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
-    )
-
     project: Mapped[GroupRow | None] = relationship(
         "GroupRow",
         primaryjoin=_get_project_fair_share_project_join_condition,
@@ -552,7 +525,7 @@ def _get_user_fair_share_domain_join_condition() -> sa.ColumnElement[bool]:
     return UserFairShareRow.domain_name == foreign(DomainRow.name)
 
 
-class UserFairShareRow(Base):  # type: ignore[misc]
+class UserFairShareRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     """Per-user Fair Share state.
 
     Since a User can belong to multiple Projects, distinguished by
@@ -677,20 +650,6 @@ class UserFairShareRow(Base):  # type: ignore[misc]
         nullable=False,
         default=DEFAULT_DECAY_UNIT_DAYS,
         comment="Aggregation period for usage buckets in days.",
-    )
-
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
     )
 
     user: Mapped[UserRow | None] = relationship(

--- a/src/ai/backend/manager/models/idle_checker/row.py
+++ b/src/ai/backend/manager/models/idle_checker/row.py
@@ -10,9 +10,10 @@ from ai.backend.common.data.idle_checker.types import CheckerType, IdleCheckerSp
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.models.base import GUID, Base, PydanticColumn, StrEnumType
+from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin, UpdatedAtMixin
 
 
-class IdleCheckerRow(Base):  # type: ignore[misc]
+class IdleCheckerRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     __tablename__ = "idle_checkers"
 
     id: Mapped[IdleCheckerID] = mapped_column(
@@ -31,19 +32,9 @@ class IdleCheckerRow(Base):  # type: ignore[misc]
     spec: Mapped[IdleCheckerSpec] = mapped_column(
         "spec", PydanticColumn(IdleCheckerSpec), nullable=False
     )
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
-    )
 
 
-class IdleCheckerBindingRow(Base):  # type: ignore[misc]
+class IdleCheckerBindingRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     __tablename__ = "idle_checker_bindings"
     __table_args__ = (
         sa.ForeignKeyConstraint(
@@ -72,19 +63,9 @@ class IdleCheckerBindingRow(Base):  # type: ignore[misc]
     enabled: Mapped[bool] = mapped_column(
         "enabled", sa.Boolean, nullable=False, server_default=sa.true()
     )
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
-    )
 
 
-class SessionIdleCheckRow(Base):  # type: ignore[misc]
+class SessionIdleCheckRow(UpdatedAtMixin, Base):  # type: ignore[misc]
     __tablename__ = "session_idle_checks"
     __table_args__ = (
         sa.ForeignKeyConstraint(
@@ -120,10 +101,3 @@ class SessionIdleCheckRow(Base):  # type: ignore[misc]
     )
     last_status: Mapped[str] = mapped_column("last_status", sa.String(length=64), nullable=False)
     last_message: Mapped[str] = mapped_column("last_message", sa.Text, nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
-    )

--- a/src/ai/backend/manager/models/login_client_type/row.py
+++ b/src/ai/backend/manager/models/login_client_type/row.py
@@ -8,6 +8,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.manager.models.base import GUID, Base
+from ai.backend.manager.models.mixins.timestamp import CreatedAtMixin
 
 if TYPE_CHECKING:
     from ai.backend.manager.data.login_client_type.types import LoginClientTypeData
@@ -15,7 +16,7 @@ if TYPE_CHECKING:
 __all__ = ("LoginClientTypeRow",)
 
 
-class LoginClientTypeRow(Base):  # type: ignore[misc]
+class LoginClientTypeRow(CreatedAtMixin, Base):  # type: ignore[misc]
     __tablename__ = "login_client_types"
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -23,12 +24,6 @@ class LoginClientTypeRow(Base):  # type: ignore[misc]
     )
     name: Mapped[str] = mapped_column("name", sa.String(length=64), nullable=False, unique=True)
     description: Mapped[str | None] = mapped_column("description", sa.Text, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at",
-        sa.DateTime(timezone=True),
-        server_default=sa.func.now(),
-        nullable=False,
-    )
     modified_at: Mapped[datetime] = mapped_column(
         "modified_at",
         sa.DateTime(timezone=True),

--- a/src/ai/backend/manager/models/login_session/row.py
+++ b/src/ai/backend/manager/models/login_session/row.py
@@ -16,6 +16,7 @@ from ai.backend.manager.models.base import (
     Base,
     StrEnumType,
 )
+from ai.backend.manager.models.mixins.timestamp import CreatedAtMixin
 
 if TYPE_CHECKING:
     from ai.backend.manager.data.auth.login_session_types import LoginHistoryData, LoginSessionData
@@ -23,7 +24,7 @@ if TYPE_CHECKING:
 __all__ = ("LoginSessionRow", "LoginHistoryRow")
 
 
-class LoginSessionRow(Base):  # type: ignore[misc]
+class LoginSessionRow(CreatedAtMixin, Base):  # type: ignore[misc]
     __tablename__ = "login_sessions"
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -54,12 +55,6 @@ class LoginSessionRow(Base):  # type: ignore[misc]
         default=LoginSessionStatus.ACTIVE,
         server_default=LoginSessionStatus.ACTIVE.value,
         index=True,
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at",
-        sa.DateTime(timezone=True),
-        server_default=sa.func.now(),
-        nullable=False,
     )
     last_accessed_at: Mapped[datetime | None] = mapped_column(
         "last_accessed_at", sa.DateTime(timezone=True), nullable=True

--- a/src/ai/backend/manager/models/mixins/timestamp.py
+++ b/src/ai/backend/manager/models/mixins/timestamp.py
@@ -1,0 +1,39 @@
+"""Shared mixins for record audit timestamps.
+
+``CreatedAtMixin`` / ``UpdatedAtMixin`` each provide a single column so a table
+can adopt exactly the ones it needs; ``LifecycleTimestampsMixin`` composes both
+for the common create-and-update case. ``sort_order`` keeps the timestamps last
+and ordered created -> updated regardless of the MRO.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+
+class CreatedAtMixin:
+    created_at: Mapped[datetime] = mapped_column(
+        "created_at",
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+        sort_order=9998,
+    )
+
+
+class UpdatedAtMixin:
+    updated_at: Mapped[datetime] = mapped_column(
+        "updated_at",
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+        sort_order=9999,
+    )
+
+
+class LifecycleTimestampsMixin(CreatedAtMixin, UpdatedAtMixin):
+    pass

--- a/src/ai/backend/manager/models/prometheus_query_preset/row.py
+++ b/src/ai/backend/manager/models/prometheus_query_preset/row.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
 
 import sqlalchemy as sa
 from pydantic import ConfigDict
@@ -14,6 +13,7 @@ from ai.backend.manager.models.base import (
     Base,
     PydanticColumn,
 )
+from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
 
 __all__ = ("PrometheusQueryPresetRow",)
 
@@ -25,7 +25,7 @@ class PresetOptions(BackendAISchema):
     model_config = ConfigDict(frozen=True)
 
 
-class PrometheusQueryPresetRow(Base):  # type: ignore[misc]
+class PrometheusQueryPresetRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     __tablename__ = "prometheus_query_presets"
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -52,19 +52,6 @@ class PrometheusQueryPresetRow(Base):  # type: ignore[misc]
         PydanticColumn(PresetOptions),
         nullable=False,
         server_default=sa.text('\'{"filter_labels":[],"group_labels":[]}\'::jsonb'),
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
     )
 
     def to_data(self) -> PrometheusQueryPresetData:

--- a/src/ai/backend/manager/models/prometheus_query_preset_category/row.py
+++ b/src/ai/backend/manager/models/prometheus_query_preset_category/row.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
 
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
@@ -10,11 +9,12 @@ from ai.backend.manager.data.prometheus_query_preset_category import (
     PrometheusQueryPresetCategoryData,
 )
 from ai.backend.manager.models.base import GUID, Base
+from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
 
 __all__ = ("PrometheusQueryPresetCategoryRow",)
 
 
-class PrometheusQueryPresetCategoryRow(Base):  # type: ignore[misc]
+class PrometheusQueryPresetCategoryRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     __tablename__ = "prometheus_query_preset_categories"
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -22,19 +22,6 @@ class PrometheusQueryPresetCategoryRow(Base):  # type: ignore[misc]
     )
     name: Mapped[str] = mapped_column("name", sa.String(length=128), nullable=False, unique=True)
     description: Mapped[str | None] = mapped_column("description", sa.Text, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at",
-        sa.DateTime(timezone=True),
-        server_default=sa.func.now(),
-        nullable=False,
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
-        nullable=False,
-    )
 
     def to_data(self) -> PrometheusQueryPresetCategoryData:
         return PrometheusQueryPresetCategoryData(

--- a/src/ai/backend/manager/models/rbac_models/entity_field.py
+++ b/src/ai/backend/manager/models/rbac_models/entity_field.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
 
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
@@ -10,9 +9,10 @@ from ai.backend.manager.models.base import (
     GUID,
     Base,
 )
+from ai.backend.manager.models.mixins.timestamp import CreatedAtMixin
 
 
-class EntityFieldRow(Base):  # type: ignore[misc]
+class EntityFieldRow(CreatedAtMixin, Base):  # type: ignore[misc]
     """Deprecated: No longer actively used. The field-scoped entity concept
     (RBACFieldCreator/RBACFieldPurger) was removed by BEP-1048.
     Kept only for the existing database table; will be dropped in a future migration.
@@ -54,10 +54,4 @@ class EntityFieldRow(Base):  # type: ignore[misc]
         "field_id",
         sa.String(64),
         nullable=False,
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
     )

--- a/src/ai/backend/manager/models/rbac_models/permission/permission.py
+++ b/src/ai/backend/manager/models/rbac_models/permission/permission.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
 from typing import Self
 
 import sqlalchemy as sa
@@ -20,9 +19,10 @@ from ai.backend.manager.models.base import (
     IntFlagType,
     StrEnumType,
 )
+from ai.backend.manager.models.mixins.timestamp import CreatedAtMixin
 
 
-class PermissionRow(Base):  # type: ignore[misc]
+class PermissionRow(CreatedAtMixin, Base):  # type: ignore[misc]
     __tablename__ = "permissions"
     __table_args__ = (
         sa.Index("ix_permissions_role_scope", "role_id", "scope_type", "scope_id"),
@@ -64,9 +64,6 @@ class PermissionRow(Base):  # type: ignore[misc]
     )
     permission: Mapped[Permission] = mapped_column(
         "permission", IntFlagType(Permission), nullable=False
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
     )
 
     @classmethod

--- a/src/ai/backend/manager/models/rbac_models/role.py
+++ b/src/ai/backend/manager/models/rbac_models/role.py
@@ -27,6 +27,7 @@ from ai.backend.manager.models.base import (
     Base,
     StrEnumType,
 )
+from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
 
 if TYPE_CHECKING:
     from .permission.object_permission import ObjectPermissionRow
@@ -45,7 +46,7 @@ def _get_object_permission_rows_join_condition() -> sa.ColumnElement[bool]:
     return RoleRow.id == foreign(ObjectPermissionRow.role_id)
 
 
-class RoleRow(Base):  # type: ignore[misc]
+class RoleRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     __tablename__ = "roles"
     __table_args__ = (sa.Index("ix_id_status", "id", "status"),)
 
@@ -74,16 +75,6 @@ class RoleRow(Base):  # type: ignore[misc]
         nullable=False,
         default=False,
         server_default=sa.false(),
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
-        nullable=False,
     )
     deleted_at: Mapped[datetime | None] = mapped_column(
         "deleted_at", sa.DateTime(timezone=True), nullable=True

--- a/src/ai/backend/manager/models/rbac_models/role_permission_preset/row.py
+++ b/src/ai/backend/manager/models/rbac_models/role_permission_preset/row.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime
-
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -17,9 +15,10 @@ from ai.backend.manager.models.base import (
     Base,
     StrEnumType,
 )
+from ai.backend.manager.models.mixins.timestamp import CreatedAtMixin
 
 
-class RolePermissionPresetRow(Base):  # type: ignore[misc]
+class RolePermissionPresetRow(CreatedAtMixin, Base):  # type: ignore[misc]
     __tablename__ = "role_permission_presets"
     __table_args__ = (
         sa.UniqueConstraint(
@@ -47,9 +46,6 @@ class RolePermissionPresetRow(Base):  # type: ignore[misc]
     )
     operation: Mapped[OperationType] = mapped_column(
         "operation", StrEnumType(OperationType, length=32), nullable=False
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
     )
 
     def to_data(self) -> RolePermissionPresetData:

--- a/src/ai/backend/manager/models/rbac_models/role_preset/row.py
+++ b/src/ai/backend/manager/models/rbac_models/role_preset/row.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime
-
 import sqlalchemy as sa
 from sqlalchemy.orm import (
     Mapped,
@@ -16,9 +14,10 @@ from ai.backend.manager.models.base import (
     Base,
     StrEnumType,
 )
+from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
 
 
-class RolePresetRow(Base):  # type: ignore[misc]
+class RolePresetRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     __tablename__ = "role_presets"
     __table_args__ = (
         sa.Index(
@@ -43,16 +42,6 @@ class RolePresetRow(Base):  # type: ignore[misc]
     # the Update API never mutates this column directly.
     deleted: Mapped[bool] = mapped_column(
         "deleted", sa.Boolean, nullable=False, server_default=sa.false()
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
-        nullable=False,
     )
 
     def to_data(self) -> RolePresetData:

--- a/src/ai/backend/manager/models/replica_group/row.py
+++ b/src/ai/backend/manager/models/replica_group/row.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 import sqlalchemy as sa
@@ -17,6 +16,7 @@ from ai.backend.manager.data.deployment.types import (
     ReplicaGroupScalingStatus,
 )
 from ai.backend.manager.models.base import GUID, Base, PydanticColumn, StrEnumType
+from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
 from ai.backend.manager.views.replica_group import (
     ReplicaGroupDeploySchedulingView,
     ReplicaGroupScalingSchedulingView,
@@ -56,7 +56,7 @@ def _get_target_revision_join_condition() -> sa.sql.elements.ColumnElement[Any]:
     return foreign(ReplicaGroupRow.target_revision_id) == DeploymentRevisionRow.id
 
 
-class ReplicaGroupRow(Base):  # type: ignore[misc]
+class ReplicaGroupRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     """
     A group of replicas (routes) within a single deployment.
 
@@ -137,20 +137,6 @@ class ReplicaGroupRow(Base):  # type: ignore[misc]
     rollout: Mapped[ReplicaGroupRolloutSpec] = mapped_column(
         "rollout",
         PydanticColumn(ReplicaGroupRolloutSpec),
-        nullable=False,
-    )
-
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at",
-        sa.DateTime(timezone=True),
-        server_default=sa.func.now(),
-        nullable=False,
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
         nullable=False,
     )
 

--- a/src/ai/backend/manager/models/resource_slot/row.py
+++ b/src/ai/backend/manager/models/resource_slot/row.py
@@ -20,6 +20,7 @@ from ai.backend.manager.models.base import (
     Base,
     PydanticColumn,
 )
+from ai.backend.manager.models.mixins.timestamp import CreatedAtMixin, LifecycleTimestampsMixin
 from ai.backend.manager.models.resource_slot.types import NumberFormat
 
 __all__ = (
@@ -32,7 +33,7 @@ __all__ = (
 )
 
 
-class ResourceSlotTypeRow(Base):  # type: ignore[misc]
+class ResourceSlotTypeRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     """Registry of known resource slot types with display metadata.
 
     Primary key is slot_name (e.g., 'cpu', 'mem', 'cuda.device').
@@ -94,22 +95,9 @@ class ResourceSlotTypeRow(Base):  # type: ignore[misc]
     rank: Mapped[int] = mapped_column(
         "rank", sa.Integer, nullable=False, server_default=sa.text("0")
     )
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
-    )
 
 
-class AgentResourceRow(Base):  # type: ignore[misc]
+class AgentResourceRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     """Per-agent, per-slot resource capacity and usage.
 
     Composite primary key: (agent_id, slot_name).
@@ -127,19 +115,6 @@ class AgentResourceRow(Base):  # type: ignore[misc]
     )
     used: Mapped[Decimal] = mapped_column(
         "used", sa.Numeric(precision=24, scale=6), nullable=False, server_default=sa.text("0")
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
     )
 
     slot_type_row: Mapped[ResourceSlotTypeRow] = relationship(
@@ -170,7 +145,7 @@ class AgentResourceRow(Base):  # type: ignore[misc]
     )
 
 
-class ResourceAllocationRow(Base):  # type: ignore[misc]
+class ResourceAllocationRow(CreatedAtMixin, Base):  # type: ignore[misc]
     """Per-kernel, per-slot resource allocation.
 
     Composite primary key: (kernel_id, slot_name).
@@ -185,12 +160,6 @@ class ResourceAllocationRow(Base):  # type: ignore[misc]
     )
     used: Mapped[Decimal | None] = mapped_column(
         "used", sa.Numeric(precision=24, scale=6), nullable=True
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
     )
     used_at: Mapped[datetime | None] = mapped_column(
         "used_at",

--- a/src/ai/backend/manager/models/resource_usage_history/row.py
+++ b/src/ai/backend/manager/models/resource_usage_history/row.py
@@ -31,6 +31,7 @@ from ai.backend.manager.models.base import (
     Base,
     ResourceSlotColumn,
 )
+from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
 
 if TYPE_CHECKING:
     from ai.backend.manager.models.domain import DomainRow
@@ -174,7 +175,7 @@ def _get_domain_usage_bucket_domain_join_condition() -> sa.ColumnElement[bool]:
     return DomainUsageBucketRow.domain_name == foreign(DomainRow.name)
 
 
-class DomainUsageBucketRow(Base):  # type: ignore[misc]
+class DomainUsageBucketRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     """Per-domain period-based resource usage aggregation.
 
     Cache summing all Project/User usage within the domain.
@@ -220,21 +221,6 @@ class DomainUsageBucketRow(Base):  # type: ignore[misc]
         "Sum of agent.available_slots for calculating usage ratio.",
     )
 
-    # Metadata
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
-    )
-
     # Relationships
     domain: Mapped[DomainRow | None] = relationship(
         "DomainRow",
@@ -267,7 +253,7 @@ def _get_project_usage_bucket_domain_join_condition() -> sa.ColumnElement[bool]:
     return ProjectUsageBucketRow.domain_name == foreign(DomainRow.name)
 
 
-class ProjectUsageBucketRow(Base):  # type: ignore[misc]
+class ProjectUsageBucketRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     """Per-project period-based resource usage aggregation.
 
     Cache summing all User usage within the project.
@@ -312,21 +298,6 @@ class ProjectUsageBucketRow(Base):  # type: ignore[misc]
         default=ResourceSlot,
         comment="Scaling group capacity at bucket period. "
         "Sum of agent.available_slots for calculating usage ratio.",
-    )
-
-    # Metadata
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
     )
 
     # Relationships
@@ -374,7 +345,7 @@ def _get_user_usage_bucket_domain_join_condition() -> sa.ColumnElement[bool]:
     return UserUsageBucketRow.domain_name == foreign(DomainRow.name)
 
 
-class UserUsageBucketRow(Base):  # type: ignore[misc]
+class UserUsageBucketRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     """Per-user period-based resource usage aggregation (computation cache).
 
     Cache aggregating raw data from kernel_usage_records per decay_unit period.
@@ -425,21 +396,6 @@ class UserUsageBucketRow(Base):  # type: ignore[misc]
         default=ResourceSlot,
         comment="Scaling group capacity at bucket period. "
         "Sum of agent.available_slots for calculating usage ratio.",
-    )
-
-    # Metadata
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
     )
 
     # Relationships

--- a/src/ai/backend/manager/models/retention/row.py
+++ b/src/ai/backend/manager/models/retention/row.py
@@ -8,9 +8,10 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.manager.data.retention.types import RetentionCategory
 from ai.backend.manager.models.base import GUID, Base, StrEnumType
+from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
 
 
-class RetentionPolicyRow(Base):  # type: ignore[misc]
+class RetentionPolicyRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     __tablename__ = "retention_policies"
     __table_args__ = (sa.UniqueConstraint("category", name="uq_retention_policies_category"),)
 
@@ -28,14 +29,4 @@ class RetentionPolicyRow(Base):  # type: ignore[misc]
     )
     last_swept_at: Mapped[datetime | None] = mapped_column(
         "last_swept_at", sa.DateTime(timezone=True), nullable=True
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        "updated_at",
-        sa.DateTime(timezone=True),
-        nullable=False,
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
     )

--- a/src/ai/backend/manager/models/retention/row.py
+++ b/src/ai/backend/manager/models/retention/row.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ai.backend.manager.data.retention.types import RetentionCategory
+from ai.backend.manager.models.base import GUID, Base, StrEnumType
+
+
+class RetentionPolicyRow(Base):  # type: ignore[misc]
+    __tablename__ = "retention_policies"
+    __table_args__ = (sa.UniqueConstraint("category", name="uq_retention_policies_category"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
+    )
+    category: Mapped[RetentionCategory] = mapped_column(
+        "category", StrEnumType(RetentionCategory), nullable=False
+    )
+    retention_period: Mapped[timedelta] = mapped_column(
+        "retention_period", sa.Interval, nullable=False
+    )
+    enabled: Mapped[bool] = mapped_column(
+        "enabled", sa.Boolean, nullable=False, server_default=sa.true()
+    )
+    last_swept_at: Mapped[datetime | None] = mapped_column(
+        "last_swept_at", sa.DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        "updated_at",
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+    )

--- a/src/ai/backend/manager/models/virtual_scope/entity_membership.py
+++ b/src/ai/backend/manager/models/virtual_scope/entity_membership.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime
-
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -15,9 +13,10 @@ from ai.backend.manager.models.base import (
     Base,
     IntFlagType,
 )
+from ai.backend.manager.models.mixins.timestamp import CreatedAtMixin
 
 
-class EntityMembershipRow(Base):  # type: ignore[misc]
+class EntityMembershipRow(CreatedAtMixin, Base):  # type: ignore[misc]
     __tablename__ = "entity_memberships"
     __table_args__ = (
         sa.Index(
@@ -40,9 +39,6 @@ class EntityMembershipRow(Base):  # type: ignore[misc]
     entity_id: Mapped[EntityID] = mapped_column("entity_id", GUID(), primary_key=True)
     permission_cap: Mapped[Permission | None] = mapped_column(
         "permission_cap", IntFlagType(Permission), nullable=True
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
     )
 
     def to_data(self) -> EntityMembershipData:

--- a/src/ai/backend/manager/models/virtual_scope/scope_binding.py
+++ b/src/ai/backend/manager/models/virtual_scope/scope_binding.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime
-
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -15,9 +13,10 @@ from ai.backend.manager.models.base import (
     Base,
     IntFlagType,
 )
+from ai.backend.manager.models.mixins.timestamp import CreatedAtMixin
 
 
-class ScopeBindingRow(Base):  # type: ignore[misc]
+class ScopeBindingRow(CreatedAtMixin, Base):  # type: ignore[misc]
     __tablename__ = "scope_bindings"
     __table_args__ = (
         sa.Index("ix_scope_bindings_scope", "scope_type", "scope_id"),
@@ -40,9 +39,6 @@ class ScopeBindingRow(Base):  # type: ignore[misc]
     scope_id: Mapped[ScopeID] = mapped_column("scope_id", GUID(), primary_key=True)
     permission_cap: Mapped[Permission | None] = mapped_column(
         "permission_cap", IntFlagType(Permission), nullable=True
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
     )
 
     def to_data(self) -> ScopeBindingData:

--- a/src/ai/backend/manager/models/virtual_scope/virtual_scope.py
+++ b/src/ai/backend/manager/models/virtual_scope/virtual_scope.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime
-
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -13,9 +11,10 @@ from ai.backend.manager.models.base import (
     GUID,
     Base,
 )
+from ai.backend.manager.models.mixins.timestamp import CreatedAtMixin
 
 
-class VirtualScopeRow(Base):  # type: ignore[misc]
+class VirtualScopeRow(CreatedAtMixin, Base):  # type: ignore[misc]
     __tablename__ = "virtual_scopes"
     __table_args__ = (
         sa.UniqueConstraint("scope_type", "scope_id", name="uq_virtual_scopes_scope"),
@@ -32,9 +31,6 @@ class VirtualScopeRow(Base):  # type: ignore[misc]
         "scope_type", sa.String(length=32), nullable=False
     )
     scope_id: Mapped[ScopeID] = mapped_column("scope_id", GUID(), nullable=False)
-    created_at: Mapped[datetime] = mapped_column(
-        "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
-    )
 
     def to_data(self) -> VirtualScopeData:
         return VirtualScopeData(

--- a/tests/unit/manager/models/test_retention_policy_row.py
+++ b/tests/unit/manager/models/test_retention_policy_row.py
@@ -61,6 +61,9 @@ class TestRetentionPolicyRow:
         assert row.retention_period == timedelta(days=90)
         assert row.enabled is True
         assert row.last_swept_at is None
+        # created_at / updated_at come from LifecycleTimestampsMixin (server_default).
+        assert row.created_at is not None
+        assert row.updated_at is not None
 
     async def test_duplicate_category_violates_unique(self, db: ExtendedAsyncSAEngine) -> None:
         async with db.begin_session() as sess:

--- a/tests/unit/manager/models/test_retention_policy_row.py
+++ b/tests/unit/manager/models/test_retention_policy_row.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import timedelta
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+
+from ai.backend.manager.data.retention.types import RetentionCategory
+from ai.backend.manager.models.retention.row import RetentionPolicyRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.testutils.db import with_tables
+
+
+class TestRetentionCategory:
+    def test_has_the_eight_catalog_categories(self) -> None:
+        assert {c.value for c in RetentionCategory} == {
+            "logs",
+            "login",
+            "reconcile_history",
+            "roles_invitations",
+            "deployments",
+            "sessions",
+            "usage_records",
+            "usage_buckets",
+        }
+
+    def test_unknown_category_string_is_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            RetentionCategory("unknown_category")
+
+
+class TestRetentionPolicyRow:
+    @pytest.fixture
+    async def db(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncIterator[ExtendedAsyncSAEngine]:
+        async with with_tables(database_connection, [RetentionPolicyRow]):
+            yield database_connection
+
+    async def test_insert_and_read_back(self, db: ExtendedAsyncSAEngine) -> None:
+        async with db.begin_session() as sess:
+            sess.add(
+                RetentionPolicyRow(
+                    category=RetentionCategory.USAGE_RECORDS,
+                    retention_period=timedelta(days=90),
+                )
+            )
+
+        async with db.begin_readonly_session() as sess:
+            row = (
+                await sess.execute(
+                    sa.select(RetentionPolicyRow).where(
+                        RetentionPolicyRow.category == RetentionCategory.USAGE_RECORDS
+                    )
+                )
+            ).scalar_one()
+        assert row.category is RetentionCategory.USAGE_RECORDS
+        assert row.retention_period == timedelta(days=90)
+        assert row.enabled is True
+        assert row.last_swept_at is None
+
+    async def test_duplicate_category_violates_unique(self, db: ExtendedAsyncSAEngine) -> None:
+        async with db.begin_session() as sess:
+            sess.add(
+                RetentionPolicyRow(
+                    category=RetentionCategory.LOGS,
+                    retention_period=timedelta(days=365),
+                )
+            )
+
+        with pytest.raises(IntegrityError):
+            async with db.begin_session() as sess:
+                sess.add(
+                    RetentionPolicyRow(
+                        category=RetentionCategory.LOGS,
+                        retention_period=timedelta(days=365),
+                    )
+                )


### PR DESCRIPTION
## Summary
- Add `retention_policies` table + `RetentionCategory` enum (8 categories) + seed migration per BEP-1063 §3(a) — `usage_records`=90d, `usage_buckets`=2yr, remaining=1yr. main carried two diverged alembic heads, so an empty merge migration reconciles them before this table chains on top.
- Extract `created_at`/`updated_at` into reusable timestamp mixins (`CreatedAtMixin`, `UpdatedAtMixin`, `LifecycleTimestampsMixin`) and adopt them in `RetentionPolicyRow` plus 31 existing rows whose columns exactly match the mixin form (no schema change). Rows with nullable/indexed/client-default timestamps were left for a follow-up.
- Correct the diverged-head guidance in `alembic/AGENTS.md` and the `/db-migrate` skill: a main-side 2+ head divergence is reconciled with an empty merge migration, not a `down_revision` edit.

## Test plan
- [ ] migration up creates `retention_policies` and seeds the 8 categories with correct defaults
- [ ] duplicate `category` insert violates the unique constraint; unknown category string rejected by the enum
- [ ] migration down drops the table
- [ ] existing rows unchanged after mixin adoption (transitive DB test suite passes)

Resolves BA-6928