### PR TITLE
feat(BA-6930): add sessions retention purger with ordered kernel/session delete

### DIFF
--- a/changes/12955.feature.md
+++ b/changes/12955.feature.md
@@ -1,0 +1,1 @@
+Add DB record retention cleanup for the sessions category with ordered kernel-then-session deletion.

--- a/src/ai/backend/manager/repositories/retention/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/retention/db_source/db_source.py
@@ -13,30 +13,36 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
+import sqlalchemy as sa
 from sqlalchemy.sql.elements import ColumnElement
 
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.data.auth.login_session_types import LoginSessionStatus
+from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.retention.types import RetentionCategory, RetentionPurgeResult
 from ai.backend.manager.data.role_invitation.types import RoleInvitationState
+from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.data.vfolder.types import VFolderInvitationState
 from ai.backend.manager.errors.retention import RetentionCategoryNotSupportedError
 from ai.backend.manager.models.audit_log.row import AuditLogRow
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.error_logs import ErrorLogRow
 from ai.backend.manager.models.event_log.row import EventLogRow
+from ai.backend.manager.models.kernel.row import KernelRow
 from ai.backend.manager.models.login_session.row import LoginHistoryRow, LoginSessionRow
 from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.replica_group_history.row import ReplicaGroupHistoryRow
 from ai.backend.manager.models.resource_usage_history.row import KernelUsageRecordRow
 from ai.backend.manager.models.role_invitation.row import RoleInvitationRow
+from ai.backend.manager.models.routing.row import RoutingRow
 from ai.backend.manager.models.scheduling_history.row import (
     DeploymentHistoryRow,
     KernelSchedulingHistoryRow,
     RouteHistoryRow,
     SessionSchedulingHistoryRow,
 )
+from ai.backend.manager.models.session.row import SessionRow
 from ai.backend.manager.models.vfolder.row import VFolderInvitationRow
 from ai.backend.manager.repositories.base import BatchPurger, BatchPurgerSpec
 from ai.backend.manager.repositories.ops import DBOpsProvider
@@ -86,9 +92,26 @@ class RetentionDBSource:
         """Build the fixed ``category -> tables`` catalog once (column refs are
         constant; only the threshold is applied per sweep).
 
-        Categories with a bespoke ordered delete (sessions, deployments,
-        usage_buckets) are implemented separately and intentionally absent.
+        ``deployments`` and ``usage_buckets`` keep a bespoke ordered delete and
+        are intentionally absent until wired.
         """
+        # sessions: kernels are listed before sessions so the ordered per-table
+        # drain removes kernels first (kernels.session_id is a plain FK). A
+        # session is skipped this sweep while any kernel still references it or a
+        # RESTRICT-guarded routing points at it, then purged once the blocker
+        # ages out -- expressed as correlated NOT EXISTS guards below.
+        session_has_kernel = (
+            sa.select(sa.literal(1))
+            .where(KernelRow.session_id == SessionRow.id)
+            .correlate(SessionRow)
+            .exists()
+        )
+        session_has_routing = (
+            sa.select(sa.literal(1))
+            .where(RoutingRow.session == SessionRow.id)
+            .correlate(SessionRow)
+            .exists()
+        )
         return {
             RetentionCategory.LOGS: (
                 _BoundaryTable(EventLogRow, EventLogRow.created_at),
@@ -138,6 +161,22 @@ class RetentionDBSource:
             ),
             RetentionCategory.USAGE_RECORDS: (
                 _BoundaryTable(KernelUsageRecordRow, KernelUsageRecordRow.period_end),
+            ),
+            RetentionCategory.SESSIONS: (
+                _BoundaryTable(
+                    KernelRow,
+                    KernelRow.terminated_at,
+                    (KernelRow.status.in_(KernelStatus.terminal_statuses()),),
+                ),
+                _BoundaryTable(
+                    SessionRow,
+                    SessionRow.terminated_at,
+                    (
+                        SessionRow.status.in_(SessionStatus.terminal_statuses()),
+                        ~session_has_kernel,
+                        ~session_has_routing,
+                    ),
+                ),
             ),
         }
 

--- a/tests/unit/manager/repositories/retention/test_retention_repository.py
+++ b/tests/unit/manager/repositories/retention/test_retention_repository.py
@@ -16,40 +16,62 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 
 import pytest
 import sqlalchemy as sa
 
 from ai.backend.common.events.types import EventDomain
+from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.actions.types import OperationStatus
+from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.error_log.types import ErrorLogSeverity
+from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.permission.status import RoleStatus
-from ai.backend.manager.data.retention.types import RetentionCategory
+from ai.backend.manager.data.retention.types import RetentionCategory, RetentionPurgeResult
 from ai.backend.manager.errors.retention import RetentionCategoryNotSupportedError
+from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.audit_log.row import AuditLogRow
 from ai.backend.manager.models.base import Base
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.endpoint import EndpointLifecycle, EndpointRow
 from ai.backend.manager.models.error_logs import ErrorLogRow
 from ai.backend.manager.models.event_log.row import EventLogRow
+from ai.backend.manager.models.group import GroupRow, ProjectType
+from ai.backend.manager.models.hasher.types import PasswordInfo
+from ai.backend.manager.models.image import ImageRow
+from ai.backend.manager.models.kernel.row import KernelRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.models.replica_group import ReplicaGroupRow
 from ai.backend.manager.models.replica_group_history.row import ReplicaGroupHistoryRow
 from ai.backend.manager.models.resource_policy import (
     KeyPairResourcePolicyRow,
+    ProjectResourcePolicyRow,
     UserResourcePolicyRow,
 )
 from ai.backend.manager.models.resource_usage_history.row import KernelUsageRecordRow
+from ai.backend.manager.models.routing.row import RouteStatus, RoutingRow
+from ai.backend.manager.models.scaling_group import ScalingGroupOpts, ScalingGroupRow
 from ai.backend.manager.models.scheduling_history.row import (
     DeploymentHistoryRow,
     KernelSchedulingHistoryRow,
     RouteHistoryRow,
     SessionSchedulingHistoryRow,
 )
-from ai.backend.manager.models.user import UserRow
+from ai.backend.manager.models.session import (
+    SessionDependencyRow,
+    SessionRow,
+    SessionStatus,
+    SessionTypes,
+)
+from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.vfolder.row import VFolderRow
 from ai.backend.manager.repositories.base import BatchPurger
 from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.manager.repositories.retention.purgers import TimestampBoundaryPurgerSpec
@@ -60,6 +82,26 @@ _NOW = datetime(2026, 1, 1, tzinfo=UTC)
 _THRESHOLD = _NOW - timedelta(days=30)
 _OLD = _NOW - timedelta(days=400)  # older than threshold -> eligible for purge
 _NEW = _NOW - timedelta(days=1)  # newer than threshold -> preserved
+
+
+@dataclass
+class _Scope:
+    """Shared parent rows a session/kernel/routing all hang off of."""
+
+    domain_name: str = "retention-domain"
+    domain_id: DomainID = field(default_factory=lambda: DomainID(uuid.uuid4()))
+    group_id: uuid.UUID = field(default_factory=uuid.uuid4)
+    user_uuid: uuid.UUID = field(default_factory=uuid.uuid4)
+    sgroup_name: str = "retention-sgroup"
+    sgroup_id: ResourceGroupID = field(default_factory=lambda: ResourceGroupID(uuid.uuid4()))
+    policy_name: str = "retention-project-policy"
+    user_policy_name: str = "retention-user-policy"
+
+
+async def db_purge(engine: ExtendedAsyncSAEngine, threshold: datetime) -> RetentionPurgeResult:
+    """Run the public sessions-category purge against a real engine."""
+    repo = RetentionRepository(DBOpsProvider(engine))
+    return await repo.purge_older_than(RetentionCategory.SESSIONS, threshold, batch_size=100)
 
 
 async def _insert(engine: ExtendedAsyncSAEngine, rows: list[Base]) -> None:
@@ -335,10 +377,298 @@ class TestTerminalStateFilter:
             return [tuple(r) for r in result.all()]
 
 
+class TestSessionsRetention:
+    """sessions: ordered kernels->sessions delete, guarded by remaining-kernel
+    and live-routing NOT EXISTS so a sweep never trips the plain/RESTRICT FKs."""
+
+    @pytest.fixture
+    async def db(
+        self, database_connection: ExtendedAsyncSAEngine
+    ) -> AsyncIterator[ExtendedAsyncSAEngine]:
+        async with with_tables(
+            database_connection,
+            [
+                DomainRow,
+                ProjectResourcePolicyRow,
+                UserResourcePolicyRow,
+                KeyPairResourcePolicyRow,
+                ScalingGroupRow,
+                UserRow,
+                KeyPairRow,
+                GroupRow,
+                SessionRow,
+                AgentRow,
+                ContainerRegistryRow,
+                ImageRow,
+                KernelRow,
+                VFolderRow,
+                EndpointRow,
+                ReplicaGroupRow,
+                RoutingRow,
+                SessionDependencyRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    async def scope(self, db: ExtendedAsyncSAEngine) -> _Scope:
+        scope = _Scope()
+        async with db.begin_session() as sess:
+            sess.add(
+                ProjectResourcePolicyRow(
+                    name=scope.policy_name,
+                    max_vfolder_count=0,
+                    max_quota_scope_size=-1,
+                    max_network_count=0,
+                )
+            )
+            sess.add(
+                UserResourcePolicyRow(
+                    name=scope.user_policy_name,
+                    max_vfolder_count=0,
+                    max_quota_scope_size=-1,
+                    max_session_count_per_model_session=10,
+                    max_customized_image_count=10,
+                )
+            )
+            sess.add(
+                DomainRow(
+                    id=scope.domain_id,
+                    name=scope.domain_name,
+                    description=None,
+                    is_active=True,
+                )
+            )
+            sess.add(
+                ScalingGroupRow(
+                    name=scope.sgroup_name,
+                    id=scope.sgroup_id,
+                    driver="static",
+                    driver_opts={},
+                    scheduler="fifo",
+                    scheduler_opts=ScalingGroupOpts(),
+                )
+            )
+            sess.add(
+                UserRow(
+                    uuid=scope.user_uuid,
+                    username="retention-user",
+                    email="retention@example.com",
+                    password=PasswordInfo(
+                        password="pw",
+                        algorithm=PasswordHashAlgorithm.PBKDF2_SHA256,
+                        rounds=100_000,
+                        salt_size=32,
+                    ),
+                    need_password_change=False,
+                    full_name="Retention User",
+                    description="",
+                    status=UserStatus.ACTIVE,
+                    status_info="",
+                    domain_name=scope.domain_name,
+                    role=UserRole.USER,
+                    resource_policy=scope.user_policy_name,
+                )
+            )
+            sess.add(
+                GroupRow(
+                    id=scope.group_id,
+                    name="retention-group",
+                    description=None,
+                    is_active=True,
+                    domain_name=scope.domain_name,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts={},
+                    dotfiles=b"\x90",
+                    resource_policy=scope.policy_name,
+                    type=ProjectType.GENERAL,
+                )
+            )
+        return scope
+
+    async def _add_session(
+        self,
+        db: ExtendedAsyncSAEngine,
+        scope: _Scope,
+        *,
+        status: SessionStatus,
+        terminated_at: datetime | None,
+    ) -> uuid.UUID:
+        session_id = uuid.uuid4()
+        async with db.begin_session() as sess:
+            sess.add(
+                SessionRow(
+                    id=session_id,
+                    name=f"session-{session_id}",
+                    session_type=SessionTypes.INTERACTIVE,
+                    cluster_mode="single-node",
+                    cluster_size=1,
+                    domain_name=scope.domain_name,
+                    domain_id=scope.domain_id,
+                    group_id=scope.group_id,
+                    scaling_group_name=scope.sgroup_name,
+                    resource_group_id=scope.sgroup_id,
+                    user_uuid=scope.user_uuid,
+                    occupying_slots=ResourceSlot({}),
+                    requested_slots=ResourceSlot({}),
+                    status=status,
+                    status_info="",
+                    target_sgroup_names=[],
+                    vfolder_mounts=[],
+                    environ={},
+                    terminated_at=terminated_at,
+                )
+            )
+        return session_id
+
+    async def _add_kernel(
+        self,
+        db: ExtendedAsyncSAEngine,
+        scope: _Scope,
+        session_id: uuid.UUID,
+        *,
+        status: KernelStatus,
+        terminated_at: datetime | None,
+    ) -> None:
+        async with db.begin_session() as sess:
+            sess.add(
+                KernelRow(
+                    session_id=session_id,
+                    domain_name=scope.domain_name,
+                    group_id=scope.group_id,
+                    user_uuid=scope.user_uuid,
+                    scaling_group=scope.sgroup_name,
+                    resource_group_id=scope.sgroup_id,
+                    occupied_slots=ResourceSlot({}),
+                    requested_slots=ResourceSlot({}),
+                    occupied_shares={},
+                    vfolder_mounts=[],
+                    status=status,
+                    repl_in_port=0,
+                    repl_out_port=0,
+                    stdin_port=0,
+                    stdout_port=0,
+                    terminated_at=terminated_at,
+                )
+            )
+
+    async def _add_routing_for(
+        self, db: ExtendedAsyncSAEngine, scope: _Scope, session_id: uuid.UUID
+    ) -> None:
+        async with db.begin_session() as sess:
+            endpoint_id = uuid.uuid4()
+            sess.add(
+                EndpointRow(
+                    id=endpoint_id,
+                    name=f"endpoint-{endpoint_id}",
+                    created_user=scope.user_uuid,
+                    session_owner=scope.user_uuid,
+                    domain=scope.domain_name,
+                    project=scope.group_id,
+                    resource_group=scope.sgroup_name,
+                    lifecycle_stage=EndpointLifecycle.DESTROYED,
+                    replicas=0,
+                )
+            )
+            await sess.flush()
+            sess.add(
+                RoutingRow(
+                    id=uuid.uuid4(),
+                    endpoint=endpoint_id,
+                    session=session_id,
+                    session_owner=scope.user_uuid,
+                    domain=scope.domain_name,
+                    project=scope.group_id,
+                    status=RouteStatus.RUNNING,
+                    traffic_ratio=1.0,
+                    revision=uuid.uuid4(),
+                )
+            )
+
+    async def test_deletes_old_session_after_its_kernels(
+        self, db: ExtendedAsyncSAEngine, scope: _Scope
+    ) -> None:
+        session_id = await self._add_session(
+            db, scope, status=SessionStatus.TERMINATED, terminated_at=_OLD
+        )
+        await self._add_kernel(
+            db, scope, session_id, status=KernelStatus.TERMINATED, terminated_at=_OLD
+        )
+        await self._add_kernel(
+            db, scope, session_id, status=KernelStatus.CANCELLED, terminated_at=_OLD
+        )
+
+        result = await db_purge(db, _THRESHOLD)
+
+        assert result.deleted_count == 3  # 2 kernels + 1 session
+        assert await _count(db, KernelRow) == 0
+        assert await _count(db, SessionRow) == 0
+
+    async def test_live_routing_skips_session_without_error(
+        self, db: ExtendedAsyncSAEngine, scope: _Scope
+    ) -> None:
+        session_id = await self._add_session(
+            db, scope, status=SessionStatus.TERMINATED, terminated_at=_OLD
+        )
+        await self._add_routing_for(db, scope, session_id)
+
+        result = await db_purge(db, _THRESHOLD)
+
+        assert result.deleted_count == 0
+        assert await _count(db, SessionRow) == 1  # RESTRICT-referenced session preserved
+
+    async def test_recent_kernel_defers_its_session(
+        self, db: ExtendedAsyncSAEngine, scope: _Scope
+    ) -> None:
+        session_id = await self._add_session(
+            db, scope, status=SessionStatus.TERMINATED, terminated_at=_OLD
+        )
+        # Kernel terminated inside the boundary: it survives, so its session is
+        # held back this sweep instead of failing the plain FK.
+        await self._add_kernel(
+            db, scope, session_id, status=KernelStatus.TERMINATED, terminated_at=_NEW
+        )
+
+        result = await db_purge(db, _THRESHOLD)
+
+        assert result.deleted_count == 0
+        assert await _count(db, KernelRow) == 1
+        assert await _count(db, SessionRow) == 1
+
+    async def test_preserves_recent_and_nonterminal_sessions(
+        self, db: ExtendedAsyncSAEngine, scope: _Scope
+    ) -> None:
+        await self._add_session(db, scope, status=SessionStatus.TERMINATED, terminated_at=_NEW)
+        await self._add_session(db, scope, status=SessionStatus.RUNNING, terminated_at=None)
+
+        result = await db_purge(db, _THRESHOLD)
+
+        assert result.deleted_count == 0
+        assert await _count(db, SessionRow) == 2
+
+    async def test_cascades_session_dependencies(
+        self, db: ExtendedAsyncSAEngine, scope: _Scope
+    ) -> None:
+        dependant = await self._add_session(
+            db, scope, status=SessionStatus.TERMINATED, terminated_at=_OLD
+        )
+        dependency = await self._add_session(
+            db, scope, status=SessionStatus.TERMINATED, terminated_at=_OLD
+        )
+        async with db.begin_session() as sess:
+            sess.add(SessionDependencyRow(session_id=dependant, depends_on=dependency))
+
+        result = await db_purge(db, _THRESHOLD)
+
+        assert result.deleted_count == 2
+        assert await _count(db, SessionRow) == 0
+        assert await _count(db, SessionDependencyRow) == 0  # cascaded with the sessions
+
+
 class TestUnsupportedCategory:
     async def test_ordered_delete_categories_are_rejected(self, repo: RetentionRepository) -> None:
+        # sessions is wired here (BA-6930); deployments/usage_buckets stay unwired.
         for category in (
-            RetentionCategory.SESSIONS,
             RetentionCategory.DEPLOYMENTS,
             RetentionCategory.USAGE_BUCKETS,
         ):


### PR DESCRIPTION
## Summary
- Wire the `sessions` retention category into the repository catalog as an ordered two-table entry (`kernels` before `sessions`), reusing the existing `_BoundaryTable` / `TimestampBoundaryPurgerSpec` pattern rather than a bespoke code path.
- Guard the session delete with correlated `NOT EXISTS` on remaining kernels (plain FK) and on referencing routings (`routings.session` `ON DELETE RESTRICT`), so a blocked session is skipped this sweep and purged once the blocker ages out — the sweep never errors.
- Filter terminal rows via `KernelStatus.terminal_statuses()` / `SessionStatus.terminal_statuses()`; `session_dependencies` and vfolder attachments are removed by DB cascade. Redis cleanup is out of scope (CLI, BA-6935).

## Test plan
- [ ] `pants test tests/unit/manager/repositories/retention/test_retention_repository.py::TestSessionsRetention` (real-DB `with_tables`): ordered delete, live-routing skip, recent-kernel defer, recent/non-terminal preserved, session_dependencies cascade

Resolves BA-6930