### PR TITLE
feat(BA-6934): add retention policy SDK v2 + CLI v2

### DIFF
--- a/.claude/skills/bai-cli/entity-reference.md
+++ b/.claude/skills/bai-cli/entity-reference.md
@@ -60,6 +60,7 @@ Syntax: `./bai [admin|my] {entity} [{sub-entity}] {command} [options]`
 - **resource-policy**: admin(search, get, create, update, delete) | my(search)
 - **resource-slot**: sub: slot-type(search), agent-resource(search), allocation(search)
 - **resource-usage**: sub: domain(search), project(search), user(search)
+- **retention-policy**: admin(search, get, create, update, delete, purge)
 
 ## Monitoring & Audit
 

--- a/changes/12956.feature.md
+++ b/changes/12956.feature.md
@@ -1,0 +1,1 @@
+Add retention policy client SDK v2 and admin CLI v2 (`bai admin retention-policy`).

--- a/src/ai/backend/client/cli/v2/admin/__init__.py
+++ b/src/ai/backend/client/cli/v2/admin/__init__.py
@@ -230,3 +230,12 @@ def invitation() -> None:
 )
 def role_preset() -> None:
     """Admin role preset commands."""
+
+
+@admin.group(
+    cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.admin.retention_policy:retention_policy",
+    name="retention-policy",
+)
+def retention_policy() -> None:
+    """Admin retention policy commands."""

--- a/src/ai/backend/client/cli/v2/admin/retention_policy.py
+++ b/src/ai/backend/client/cli/v2/admin/retention_policy.py
@@ -1,0 +1,227 @@
+"""Admin CLI commands for retention policy management (superadmin only)."""
+
+from __future__ import annotations
+
+import uuid
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    parse_order_options,
+    print_result,
+    run_async,
+)
+from ai.backend.common.data.retention.types import RetentionCategory
+
+_CATEGORY_CHOICE = click.Choice([c.value for c in RetentionCategory])
+
+
+@click.group(name="retention-policy")
+def retention_policy() -> None:
+    """Admin retention policy commands (superadmin required)."""
+
+
+@retention_policy.command()
+@click.option("--limit", type=int, default=None, help="Maximum items to return.")
+@click.option("--offset", type=int, default=None, help="Number of items to skip.")
+@click.option(
+    "--category",
+    type=_CATEGORY_CHOICE,
+    default=None,
+    help="Filter by retention category.",
+)
+@click.option(
+    "--enabled/--disabled",
+    "enabled",
+    default=None,
+    help="Filter by enabled flag.",
+)
+@click.option(
+    "--order-by",
+    multiple=True,
+    help="Order by field:direction (e.g., category:asc, created_at:desc).",
+)
+def search(
+    limit: int | None,
+    offset: int | None,
+    category: str | None,
+    enabled: bool | None,
+    order_by: tuple[str, ...],
+) -> None:
+    """Search retention policies (superadmin only)."""
+    from ai.backend.common.dto.manager.v2.retention_policy.request import (
+        RetentionPolicyFilter,
+        RetentionPolicyOrder,
+        SearchRetentionPoliciesInput,
+    )
+    from ai.backend.common.dto.manager.v2.retention_policy.types import (
+        RetentionPolicyOrderField,
+    )
+
+    filter_dto: RetentionPolicyFilter | None = None
+    if category is not None or enabled is not None:
+        filter_dto = RetentionPolicyFilter(
+            category=RetentionCategory(category) if category is not None else None,
+            enabled=enabled,
+        )
+
+    orders = (
+        parse_order_options(order_by, RetentionPolicyOrderField, RetentionPolicyOrder)
+        if order_by
+        else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.retention_policy.search(
+                SearchRetentionPoliciesInput(
+                    filter=filter_dto,
+                    order=orders,
+                    limit=limit,
+                    offset=offset,
+                ),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
+@retention_policy.command()
+@click.argument("policy_id", type=click.UUID)
+def get(policy_id: uuid.UUID) -> None:
+    """Get a retention policy by ID (superadmin only)."""
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.retention_policy.get(policy_id)
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
+@retention_policy.command()
+@click.option("--category", type=_CATEGORY_CHOICE, required=True, help="Retention category.")
+@click.option(
+    "--retention-period-days",
+    type=click.IntRange(min=1),
+    required=True,
+    help="Retention period in days; records older than now - period are purged.",
+)
+@click.option(
+    "--enabled/--disabled",
+    "enabled",
+    default=True,
+    help="Whether this policy is active (default: enabled).",
+)
+def create(category: str, retention_period_days: int, enabled: bool) -> None:
+    """Create a retention policy (superadmin only)."""
+    from ai.backend.common.dto.manager.v2.retention_policy.request import (
+        CreateRetentionPolicyInput,
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.retention_policy.create(
+                CreateRetentionPolicyInput(
+                    category=RetentionCategory(category),
+                    retention_period_days=retention_period_days,
+                    enabled=enabled,
+                ),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
+@retention_policy.command()
+@click.argument("policy_id", type=click.UUID)
+@click.option(
+    "--category",
+    type=_CATEGORY_CHOICE,
+    default=None,
+    help="New category; omit to leave unchanged.",
+)
+@click.option(
+    "--retention-period-days",
+    type=click.IntRange(min=1),
+    default=None,
+    help="New retention period in days; omit to leave unchanged.",
+)
+@click.option(
+    "--enabled/--disabled",
+    "enabled",
+    default=None,
+    help="Toggle enabled; omit to leave unchanged.",
+)
+def update(
+    policy_id: uuid.UUID,
+    category: str | None,
+    retention_period_days: int | None,
+    enabled: bool | None,
+) -> None:
+    """Update a retention policy by ID (superadmin only)."""
+    from ai.backend.common.dto.manager.v2.retention_policy.request import (
+        UpdateRetentionPolicyInput,
+    )
+    from ai.backend.common.identifier.retention_policy import RetentionPolicyID
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.retention_policy.update(
+                policy_id,
+                UpdateRetentionPolicyInput(
+                    id=RetentionPolicyID(policy_id),
+                    category=RetentionCategory(category) if category is not None else None,
+                    retention_period_days=retention_period_days,
+                    enabled=enabled,
+                ),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
+@retention_policy.command()
+@click.argument("policy_id", type=click.UUID)
+def delete(policy_id: uuid.UUID) -> None:
+    """Delete a retention policy by ID (superadmin only)."""
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.retention_policy.delete(policy_id)
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
+@retention_policy.command()
+@click.argument("policy_id", type=click.UUID)
+def purge(policy_id: uuid.UUID) -> None:
+    """Purge (permanently remove) a retention policy by ID (superadmin only)."""
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.retention_policy.purge(policy_id)
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)

--- a/src/ai/backend/client/v2/domains_v2/retention_policy.py
+++ b/src/ai/backend/client/v2/domains_v2/retention_policy.py
@@ -1,0 +1,73 @@
+"""V2 SDK client for the retention policy domain (superadmin only)."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from ai.backend.client.v2.base_domain import BaseDomainClient
+from ai.backend.common.dto.manager.v2.retention_policy.request import (
+    CreateRetentionPolicyInput,
+    SearchRetentionPoliciesInput,
+    UpdateRetentionPolicyInput,
+)
+from ai.backend.common.dto.manager.v2.retention_policy.response import (
+    CreateRetentionPolicyPayload,
+    DeleteRetentionPolicyPayload,
+    PurgeRetentionPolicyPayload,
+    RetentionPolicyNode,
+    SearchRetentionPoliciesPayload,
+    UpdateRetentionPolicyPayload,
+)
+
+_PATH = "/v2/retention-policies"
+
+
+class V2RetentionPolicyClient(BaseDomainClient):
+    """SDK client for retention policy operations."""
+
+    async def search(self, request: SearchRetentionPoliciesInput) -> SearchRetentionPoliciesPayload:
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/search",
+            request=request,
+            response_model=SearchRetentionPoliciesPayload,
+        )
+
+    async def get(self, policy_id: UUID) -> RetentionPolicyNode:
+        return await self._client.typed_request(
+            "GET",
+            f"{_PATH}/{policy_id}",
+            response_model=RetentionPolicyNode,
+        )
+
+    async def create(self, request: CreateRetentionPolicyInput) -> CreateRetentionPolicyPayload:
+        return await self._client.typed_request(
+            "POST",
+            _PATH,
+            request=request,
+            response_model=CreateRetentionPolicyPayload,
+        )
+
+    async def update(
+        self, policy_id: UUID, request: UpdateRetentionPolicyInput
+    ) -> UpdateRetentionPolicyPayload:
+        return await self._client.typed_request(
+            "PATCH",
+            f"{_PATH}/{policy_id}",
+            request=request,
+            response_model=UpdateRetentionPolicyPayload,
+        )
+
+    async def delete(self, policy_id: UUID) -> DeleteRetentionPolicyPayload:
+        return await self._client.typed_request(
+            "DELETE",
+            f"{_PATH}/{policy_id}",
+            response_model=DeleteRetentionPolicyPayload,
+        )
+
+    async def purge(self, policy_id: UUID) -> PurgeRetentionPolicyPayload:
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/{policy_id}/purge",
+            response_model=PurgeRetentionPolicyPayload,
+        )

--- a/src/ai/backend/client/v2/v2_registry.py
+++ b/src/ai/backend/client/v2/v2_registry.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
     from .domains_v2.resource_preset import V2ResourcePresetClient
     from .domains_v2.resource_slot import V2ResourceSlotClient
     from .domains_v2.resource_usage import V2ResourceUsageClient
+    from .domains_v2.retention_policy import V2RetentionPolicyClient
     from .domains_v2.role_invitation import V2RoleInvitationClient
     from .domains_v2.role_preset import V2RolePresetClient
     from .domains_v2.runtime_variant import V2RuntimeVariantClient
@@ -308,6 +309,12 @@ class V2ClientRegistry:
         from .domains_v2.resource_usage import V2ResourceUsageClient
 
         return V2ResourceUsageClient(self._client)
+
+    @cached_property
+    def retention_policy(self) -> V2RetentionPolicyClient:
+        from .domains_v2.retention_policy import V2RetentionPolicyClient
+
+        return V2RetentionPolicyClient(self._client)
 
     @cached_property
     def scheduling_handler(self) -> V2SchedulingHandlerClient:


### PR DESCRIPTION
## Summary
- Add `V2RetentionPolicyClient` (SDK v2) consuming the existing super-admin `retention_policies` REST v2 API, with the standard 6 operations (search/get/create/update/delete/purge) and typed request/response DTOs.
- Add the `bai admin retention-policy` CLI v2 group wiring those operations; category is validated against the fixed 8-value catalog and 403s surface cleanly for non-super-admins.
- Register the client in `V2ClientRegistry` and the group in the admin CLI; add the entity to the `bai-cli` skill reference.

## Test plan
- [ ] `bai admin retention-policy search` lists the 8 categories (period/enabled/last_swept_at)
- [ ] `bai admin retention-policy update <id> --retention-period-days N --enabled/--disabled` reflects the change
- [ ] Non-super-admin invocation surfaces a 403

Resolves BA-6934