### PR TITLE
feat(BA-6931): add deployments and usage_buckets retention purgers

### DIFF
--- a/changes/12958.feature.md
+++ b/changes/12958.feature.md
@@ -1,0 +1,1 @@
+Add dedicated retention cleanup for deployments and usage_buckets, purging destroyed endpoints (with their revisions, terminal routings and replica groups, and expired tokens) and expired usage buckets.

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -102,6 +102,12 @@ class RouteStatus(enum.Enum):
     def inactive_route_statuses(cls) -> set[RouteStatus]:
         return {RouteStatus.TERMINATING, RouteStatus.TERMINATED, RouteStatus.FAILED_TO_START}
 
+    @classmethod
+    @lru_cache(maxsize=1)
+    def terminal_statuses(cls) -> set[RouteStatus]:
+        """Routes that will not transition further (TERMINATING is still in-flight)."""
+        return {RouteStatus.TERMINATED, RouteStatus.FAILED_TO_START}
+
     def is_active(self) -> bool:
         return self in self.active_route_statuses()
 
@@ -193,6 +199,12 @@ class ReplicaGroupLifecycle(enum.StrEnum):
     FAILED = "failed"
     DRAINING = "draining"
     DRAINED = "drained"
+
+    @classmethod
+    @lru_cache(maxsize=1)
+    def terminal_statuses(cls) -> set[ReplicaGroupLifecycle]:
+        """Replica-group lifecycles that will not transition further."""
+        return {cls.DRAINED, cls.FAILED}
 
 
 class ReplicaGroupScalingStatus(enum.StrEnum):

--- a/src/ai/backend/manager/data/role_invitation/types.py
+++ b/src/ai/backend/manager/data/role_invitation/types.py
@@ -4,6 +4,7 @@ import enum
 import uuid
 from dataclasses import dataclass
 from datetime import datetime
+from functools import lru_cache
 
 
 class RoleInvitationState(enum.StrEnum):
@@ -11,6 +12,16 @@ class RoleInvitationState(enum.StrEnum):
     ACCEPTED = "accepted"
     REJECTED = "rejected"
     CANCELED = "canceled"
+
+    @classmethod
+    @lru_cache(maxsize=1)
+    def declined_states(cls) -> frozenset[RoleInvitationState]:
+        """Terminal states that did not grant a role (rejected / canceled).
+
+        ACCEPTED is excluded: acceptance writes a durable ``user_roles`` row, but
+        the invitation record is kept rather than purged as history.
+        """
+        return frozenset((cls.REJECTED, cls.CANCELED))
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/data/vfolder/types.py
+++ b/src/ai/backend/manager/data/vfolder/types.py
@@ -4,6 +4,7 @@ import enum
 import uuid
 from dataclasses import dataclass
 from datetime import datetime
+from functools import lru_cache
 from typing import Any, override
 
 from ai.backend.common.data.user.types import UserRole
@@ -89,6 +90,16 @@ class VFolderInvitationState(enum.StrEnum):
     CANCELED = "canceled"  # canceled by inviter
     ACCEPTED = "accepted"
     REJECTED = "rejected"  # rejected by invitee
+
+    @classmethod
+    @lru_cache(maxsize=1)
+    def declined_states(cls) -> frozenset[VFolderInvitationState]:
+        """Terminal states that did not grant access (rejected / canceled).
+
+        ACCEPTED is excluded: acceptance writes a durable ``vfolder_permissions``
+        row, but the invitation record is kept rather than purged as history.
+        """
+        return frozenset((cls.REJECTED, cls.CANCELED))
 
 
 class VFolderOperationStatus(enum.StrEnum):

--- a/src/ai/backend/manager/errors/retention.py
+++ b/src/ai/backend/manager/errors/retention.py
@@ -19,11 +19,11 @@ from .common import ObjectNotFound
 
 
 class RetentionCategoryNotSupportedError(RepositoryError):
-    """Raised when a retention category has no code-side cleanup wired yet.
+    """Raised when a retention category has no code-side cleanup wired.
 
-    The ordered-delete categories (``sessions``, ``deployments``,
-    ``usage_buckets``) are implemented separately; requesting one here fails
-    loudly instead of silently deleting nothing.
+    A defensive guard: every :class:`RetentionCategory` is mapped in the
+    repository catalog, so an unmapped category fails loudly instead of
+    silently deleting nothing.
     """
 
     error_type = "https://api.backend.ai/probs/retention-category-not-supported"

--- a/src/ai/backend/manager/repositories/retention/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/retention/db_source/db_source.py
@@ -1,24 +1,25 @@
 """Database source for retention cleanup.
 
-Holds the ``category -> tables`` catalog (kept inside the repository, never a
-module global) and drains each table with chunk-based delete-and-advance via
-the shared ``batch_purge``.
+The single caller-facing operation is :meth:`sweep`: it reads every enabled
+policy and drains records past each category's age boundary, stamping
+``last_swept_at`` — all in one transaction. Categories map to purger specs via
+one :meth:`_catalog`, and each spec drains via the shared ``batch_purge``.
 """
 
 from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
 import sqlalchemy as sa
-from sqlalchemy.sql.elements import ColumnElement
 
+from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.auth.login_session_types import LoginSessionStatus
+from ai.backend.manager.data.deployment.types import ReplicaGroupLifecycle, RouteStatus
 from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.retention.types import (
@@ -31,14 +32,22 @@ from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.data.vfolder.types import VFolderInvitationState
 from ai.backend.manager.errors.retention import RetentionCategoryNotSupportedError
 from ai.backend.manager.models.audit_log.row import AuditLogRow
-from ai.backend.manager.models.base import Base
+from ai.backend.manager.models.deployment_revision.row import DeploymentRevisionRow
+from ai.backend.manager.models.endpoint.row import EndpointRow, EndpointTokenRow
 from ai.backend.manager.models.error_logs import ErrorLogRow
 from ai.backend.manager.models.event_log.row import EventLogRow
 from ai.backend.manager.models.kernel.row import KernelRow
 from ai.backend.manager.models.login_session.row import LoginHistoryRow, LoginSessionRow
 from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.models.replica_group.row import ReplicaGroupRow
 from ai.backend.manager.models.replica_group_history.row import ReplicaGroupHistoryRow
-from ai.backend.manager.models.resource_usage_history.row import KernelUsageRecordRow
+from ai.backend.manager.models.resource_usage_history.row import (
+    DomainUsageBucketRow,
+    KernelUsageRecordRow,
+    ProjectUsageBucketRow,
+    UsageBucketEntryRow,
+    UserUsageBucketRow,
+)
 from ai.backend.manager.models.retention.row import RetentionPolicyRow
 from ai.backend.manager.models.role_invitation.row import RoleInvitationRow
 from ai.backend.manager.models.routing.row import RoutingRow
@@ -52,50 +61,26 @@ from ai.backend.manager.models.session.row import SessionRow
 from ai.backend.manager.models.vfolder.row import VFolderInvitationRow
 from ai.backend.manager.repositories.base import (
     BatchPurger,
-    BatchPurgerSpec,
     BatchQuerier,
     NoPagination,
     Updater,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider, ReadOps, WriteOps
-from ai.backend.manager.repositories.retention.purgers import TimestampBoundaryPurgerSpec
+from ai.backend.manager.repositories.retention.purgers import RetentionPurgerSpec
 from ai.backend.manager.repositories.retention.updaters import LastSweptAtUpdaterSpec
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
-# Invitation states that are terminal (no further update expected), so their
-# proxy timestamp is a safe grace boundary. Only PENDING is non-terminal.
-_TERMINAL_ROLE_INVITATION_STATES = (
-    RoleInvitationState.ACCEPTED,
-    RoleInvitationState.REJECTED,
-    RoleInvitationState.CANCELED,
-)
-_TERMINAL_VFOLDER_INVITATION_STATES = (
-    VFolderInvitationState.ACCEPTED,
-    VFolderInvitationState.REJECTED,
-    VFolderInvitationState.CANCELED,
-)
-
-
-@dataclass(frozen=True)
-class _BoundaryTable:
-    """One table's fixed cleanup definition; only ``threshold`` varies per sweep.
-
-    The boundary column is chosen by table nature: append-only logs use
-    ``created_at``, in-place-merged history uses ``updated_at``, and lifecycle
-    records use their terminal timestamp plus a terminal-status
-    ``extra_conditions`` filter.
-    """
-
-    row_class: type[Base]
-    boundary: Any
-    extra_conditions: Sequence[ColumnElement[bool]] = field(default_factory=tuple)
+# usage_bucket_entries.bucket_type discriminators: the three bucket kinds share
+# one FK-less entries table, so each parent purge matches its own entries.
+_DOMAIN_BUCKET_TYPE = "domain"
+_PROJECT_BUCKET_TYPE = "project"
+_USER_BUCKET_TYPE = "user"
 
 
 class RetentionDBSource:
     _ops: DBOpsProvider
     _config_provider: ManagerConfigProvider
-    _catalog: Mapping[RetentionCategory, Sequence[_BoundaryTable]]
 
     def __init__(
         self,
@@ -104,21 +89,22 @@ class RetentionDBSource:
     ) -> None:
         self._ops = ops_provider
         self._config_provider = config_provider
-        self._catalog = self._build_catalog()
 
     @staticmethod
-    def _build_catalog() -> Mapping[RetentionCategory, Sequence[_BoundaryTable]]:
-        """Build the fixed ``category -> tables`` catalog once (column refs are
-        constant; only the threshold is applied per sweep).
+    def _catalog(
+        threshold: datetime,
+    ) -> Mapping[RetentionCategory, Sequence[RetentionPurgerSpec[Any]]]:
+        """Build the ``category -> specs`` catalog with ``threshold`` bound.
 
-        ``deployments`` and ``usage_buckets`` keep a bespoke ordered delete and
-        are intentionally absent until wired.
+        The ordered-delete categories (``sessions``, ``deployments``,
+        ``usage_buckets``) list their specs child-before-parent so the drain
+        removes FK-less or plain-FK children first. FK-CASCADE children are left
+        to the DB unless they also need their own boundary sweep (terminal
+        routings / replica_groups outliving a still-running endpoint).
         """
-        # sessions: kernels are listed before sessions so the ordered per-table
-        # drain removes kernels first (kernels.session_id is a plain FK). A
-        # session is skipped this sweep while any kernel still references it or a
+        # A session is held back while any kernel still references it or a
         # RESTRICT-guarded routing points at it, then purged once the blocker
-        # ages out -- expressed as correlated NOT EXISTS guards below.
+        # ages out -- expressed as correlated NOT EXISTS guards.
         session_has_kernel = (
             sa.select(sa.literal(1))
             .where(KernelRow.session_id == SessionRow.id)
@@ -133,27 +119,35 @@ class RetentionDBSource:
         )
         return {
             RetentionCategory.LOGS: (
-                _BoundaryTable(EventLogRow, EventLogRow.created_at),
-                _BoundaryTable(AuditLogRow, AuditLogRow.created_at),
-                # error_logs purges purely on the boundary — is_read/is_cleared
-                # flags are intentionally ignored (all rows past boundary go).
-                _BoundaryTable(ErrorLogRow, ErrorLogRow.created_at),
+                RetentionPurgerSpec(EventLogRow, EventLogRow.created_at, threshold),
+                RetentionPurgerSpec(AuditLogRow, AuditLogRow.created_at, threshold),
+                # error_logs purges purely on the boundary; is_read/is_cleared are ignored.
+                RetentionPurgerSpec(ErrorLogRow, ErrorLogRow.created_at, threshold),
             ),
-            # updated_at (not created_at): attempts++ merges touch updated_at,
-            # so a recently-retried row keeps an old created_at but survives.
+            # updated_at (not created_at): a retry merge touches updated_at, so a
+            # recently-retried row keeps an old created_at but survives.
             RetentionCategory.RECONCILE_HISTORY: (
-                _BoundaryTable(SessionSchedulingHistoryRow, SessionSchedulingHistoryRow.updated_at),
-                _BoundaryTable(KernelSchedulingHistoryRow, KernelSchedulingHistoryRow.updated_at),
-                _BoundaryTable(DeploymentHistoryRow, DeploymentHistoryRow.updated_at),
-                _BoundaryTable(RouteHistoryRow, RouteHistoryRow.updated_at),
-                _BoundaryTable(ReplicaGroupHistoryRow, ReplicaGroupHistoryRow.updated_at),
+                RetentionPurgerSpec(
+                    SessionSchedulingHistoryRow, SessionSchedulingHistoryRow.updated_at, threshold
+                ),
+                RetentionPurgerSpec(
+                    KernelSchedulingHistoryRow, KernelSchedulingHistoryRow.updated_at, threshold
+                ),
+                RetentionPurgerSpec(
+                    DeploymentHistoryRow, DeploymentHistoryRow.updated_at, threshold
+                ),
+                RetentionPurgerSpec(RouteHistoryRow, RouteHistoryRow.updated_at, threshold),
+                RetentionPurgerSpec(
+                    ReplicaGroupHistoryRow, ReplicaGroupHistoryRow.updated_at, threshold
+                ),
             ),
             RetentionCategory.LOGIN: (
-                _BoundaryTable(LoginHistoryRow, LoginHistoryRow.created_at),
-                _BoundaryTable(
+                RetentionPurgerSpec(LoginHistoryRow, LoginHistoryRow.created_at, threshold),
+                RetentionPurgerSpec(
                     LoginSessionRow,
                     LoginSessionRow.invalidated_at,
-                    (
+                    threshold,
+                    conditions=(
                         LoginSessionRow.status.in_((
                             LoginSessionStatus.INVALIDATED,
                             LoginSessionStatus.REVOKED,
@@ -162,40 +156,121 @@ class RetentionDBSource:
                 ),
             ),
             RetentionCategory.ROLES_INVITATIONS: (
-                _BoundaryTable(
+                RetentionPurgerSpec(
                     RoleRow,
                     RoleRow.deleted_at,
-                    (RoleRow.status == RoleStatus.DELETED,),
+                    threshold,
+                    conditions=(RoleRow.status == RoleStatus.DELETED,),
                 ),
-                _BoundaryTable(
+                RetentionPurgerSpec(
                     RoleInvitationRow,
                     RoleInvitationRow.updated_at,
-                    (RoleInvitationRow.state.in_(_TERMINAL_ROLE_INVITATION_STATES),),
+                    threshold,
+                    conditions=(
+                        RoleInvitationRow.state.in_(RoleInvitationState.declined_states()),
+                    ),
                 ),
-                _BoundaryTable(
+                RetentionPurgerSpec(
                     VFolderInvitationRow,
                     VFolderInvitationRow.modified_at,
-                    (VFolderInvitationRow.state.in_(_TERMINAL_VFOLDER_INVITATION_STATES),),
+                    threshold,
+                    conditions=(
+                        VFolderInvitationRow.state.in_(VFolderInvitationState.declined_states()),
+                    ),
                 ),
             ),
             RetentionCategory.USAGE_RECORDS: (
-                _BoundaryTable(KernelUsageRecordRow, KernelUsageRecordRow.period_end),
+                RetentionPurgerSpec(
+                    KernelUsageRecordRow, KernelUsageRecordRow.period_end, threshold
+                ),
             ),
             RetentionCategory.SESSIONS: (
-                _BoundaryTable(
+                RetentionPurgerSpec(
                     KernelRow,
                     KernelRow.terminated_at,
-                    (KernelRow.status.in_(KernelStatus.terminal_statuses()),),
+                    threshold,
+                    conditions=(KernelRow.status.in_(KernelStatus.terminal_statuses()),),
                 ),
-                _BoundaryTable(
+                RetentionPurgerSpec(
                     SessionRow,
                     SessionRow.terminated_at,
-                    (
+                    threshold,
+                    conditions=(
                         SessionRow.status.in_(SessionStatus.terminal_statuses()),
                         ~session_has_kernel,
                         ~session_has_routing,
                     ),
                 ),
+            ),
+            # deployment_revisions carry no ON DELETE to endpoints, so they are
+            # drained first by endpoint id; policies / auto_scaling_rules cascade.
+            # Terminal routings / replica_groups outlive a still-live endpoint, so
+            # they get their own boundary sweep; endpoint_tokens expire on theirs.
+            RetentionCategory.DEPLOYMENTS: (
+                RetentionPurgerSpec(
+                    DeploymentRevisionRow,
+                    EndpointRow.destroyed_at,
+                    threshold,
+                    match_column=DeploymentRevisionRow.endpoint,
+                    source_key=EndpointRow.id,
+                    source_conditions=(EndpointRow.lifecycle_stage == EndpointLifecycle.DESTROYED,),
+                ),
+                RetentionPurgerSpec(
+                    RoutingRow,
+                    RoutingRow.updated_at,
+                    threshold,
+                    conditions=(RoutingRow.status.in_(RouteStatus.terminal_statuses()),),
+                ),
+                RetentionPurgerSpec(
+                    ReplicaGroupRow,
+                    ReplicaGroupRow.updated_at,
+                    threshold,
+                    conditions=(
+                        ReplicaGroupRow.lifecycle.in_(ReplicaGroupLifecycle.terminal_statuses()),
+                    ),
+                ),
+                RetentionPurgerSpec(
+                    EndpointRow,
+                    EndpointRow.destroyed_at,
+                    threshold,
+                    conditions=(EndpointRow.lifecycle_stage == EndpointLifecycle.DESTROYED,),
+                ),
+                RetentionPurgerSpec(EndpointTokenRow, EndpointTokenRow.expires_at, threshold),
+            ),
+            # Each bucket kind is purged on its own period_end, with its FK-less
+            # usage_bucket_entries (keyed by bucket_id + bucket_type) drained first.
+            RetentionCategory.USAGE_BUCKETS: (
+                RetentionPurgerSpec(
+                    UsageBucketEntryRow,
+                    DomainUsageBucketRow.period_end,
+                    threshold,
+                    conditions=(UsageBucketEntryRow.bucket_type == _DOMAIN_BUCKET_TYPE,),
+                    match_column=UsageBucketEntryRow.bucket_id,
+                    source_key=DomainUsageBucketRow.id,
+                ),
+                RetentionPurgerSpec(
+                    DomainUsageBucketRow, DomainUsageBucketRow.period_end, threshold
+                ),
+                RetentionPurgerSpec(
+                    UsageBucketEntryRow,
+                    ProjectUsageBucketRow.period_end,
+                    threshold,
+                    conditions=(UsageBucketEntryRow.bucket_type == _PROJECT_BUCKET_TYPE,),
+                    match_column=UsageBucketEntryRow.bucket_id,
+                    source_key=ProjectUsageBucketRow.id,
+                ),
+                RetentionPurgerSpec(
+                    ProjectUsageBucketRow, ProjectUsageBucketRow.period_end, threshold
+                ),
+                RetentionPurgerSpec(
+                    UsageBucketEntryRow,
+                    UserUsageBucketRow.period_end,
+                    threshold,
+                    conditions=(UsageBucketEntryRow.bucket_type == _USER_BUCKET_TYPE,),
+                    match_column=UsageBucketEntryRow.bucket_id,
+                    source_key=UserUsageBucketRow.id,
+                ),
+                RetentionPurgerSpec(UserUsageBucketRow, UserUsageBucketRow.period_end, threshold),
             ),
         }
 
@@ -203,20 +278,14 @@ class RetentionDBSource:
         self,
         category: RetentionCategory,
         threshold: datetime,
-    ) -> list[BatchPurgerSpec[Any]]:
-        """Look up the category's tables and bind ``threshold`` into each spec."""
-        tables = self._catalog.get(category)
-        if tables is None:
+    ) -> Sequence[RetentionPurgerSpec[Any]]:
+        """Look up the category's specs (each already bound to ``threshold``)."""
+        specs = self._catalog(threshold).get(category)
+        if specs is None:
             raise RetentionCategoryNotSupportedError(
-                f"Retention category '{category.value}' has no simple/grouped "
-                "cleanup wired in this repository."
+                f"Retention category '{category.value}' has no cleanup wired in this repository."
             )
-        return [
-            TimestampBoundaryPurgerSpec(
-                t.row_class, t.boundary, threshold, extra_conditions=t.extra_conditions
-            )
-            for t in tables
-        ]
+        return specs
 
     async def sweep(self) -> list[RetentionPurgeResult]:
         """Purge every enabled category once, within a single transaction.
@@ -228,13 +297,12 @@ class RetentionDBSource:
         commit atomically at the end — a crash mid-tick rolls the entire tick
         back, leaving no delete-without-stamp drift.
 
-        Policies are visited least-recently-swept first. A category whose cleanup
-        is not wired yet (``deployments`` / ``usage_buckets``) raises
-        :class:`RetentionCategoryNotSupportedError`; the loop isolates that (a
-        pure lookup, so the transaction stays valid) and skips it without a stamp
-        so it is retried once wired. When ``per_tick_budget`` is set, once the
-        tick's cumulative deletions reach it the remaining categories are deferred
-        to the next tick.
+        Policies are visited least-recently-swept first. A category with no wired
+        cleanup raises :class:`RetentionCategoryNotSupportedError`; the loop
+        isolates that (a pure lookup, so the transaction stays valid) and skips it
+        without a stamp so it is retried once wired. When ``per_tick_budget`` is
+        set, once the tick's cumulative deletions reach it the remaining
+        categories are deferred to the next tick.
         """
         retention_config = self._config_provider.config.retention
         batch_size = retention_config.batch_size
@@ -294,7 +362,7 @@ class RetentionDBSource:
     async def _drain_specs(
         self,
         w: WriteOps,
-        specs: list[BatchPurgerSpec[Any]],
+        specs: Sequence[RetentionPurgerSpec[Any]],
         batch_size: int,
     ) -> int:
         """Drain each spec's rows on ``w`` in ``batch_size`` chunks; total deleted.

--- a/src/ai/backend/manager/repositories/retention/purgers.py
+++ b/src/ai/backend/manager/repositories/retention/purgers.py
@@ -1,12 +1,9 @@
-"""Batch-purge specs for retention cleanup.
+"""Batch-purge spec for retention cleanup.
 
-A single :class:`TimestampBoundaryPurgerSpec` covers every retention target:
-common-column groups (``logs`` on ``created_at``, ``reconcile_history`` on
-``updated_at``) reuse one instance per table, simple categories reuse it
-directly, and lifecycle categories add a terminal-state filter through
-``extra_conditions``. Keeping the boundary logic in one spec is the shared
-"mixin" the design calls for — the ``category -> specs`` mapping lives in the
-DB source, not here.
+One spec expresses every target: rows of a table older than ``threshold`` on a
+boundary timestamp. When ``match_column`` is set the boundary lives on a parent
+table and the rows are matched through their foreign key -- this covers the
+FK-less children of the ordered-delete categories.
 """
 
 from __future__ import annotations
@@ -17,32 +14,42 @@ from datetime import datetime
 from typing import Any, override
 
 import sqlalchemy as sa
-from sqlalchemy.sql.elements import ColumnElement
 
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.repositories.base.purger import BatchPurgerSpec
 
 
 @dataclass
-class TimestampBoundaryPurgerSpec[TRow: Base](BatchPurgerSpec[TRow]):
-    """Selects rows older than ``threshold`` on a single boundary timestamp.
+class RetentionPurgerSpec[TRow: Base](BatchPurgerSpec[TRow]):
+    """Selects rows older than ``threshold`` on ``boundary``.
 
-    Rows whose ``boundary`` column is NULL are never selected, so a lifecycle
-    record still lacking its terminal timestamp is preserved. ``extra_conditions``
-    appends terminal-status / lifecycle filters (e.g. ``status == DELETED``).
+    A NULL boundary is never selected, so a lifecycle record still lacking its
+    terminal timestamp is preserved. ``conditions`` narrows the target rows
+    (terminal-status / discriminator filters). When ``match_column`` is set the
+    boundary belongs to a parent table: rows are kept whose ``match_column`` is
+    among ``source_key`` values past the boundary (with ``source_conditions``),
+    letting an FK-less child be drained by its parent.
     """
 
+    # Any-typed columns: targets span declaratively- and imperatively-mapped
+    # attributes and nullable lifecycle columns.
     row_class: type[TRow]
-    # A mapped timestamp column expression. Any-typed because targets range over
-    # declaratively-mapped attributes and imperatively-mapped ones (error_logs),
-    # and over both non-null and nullable lifecycle columns.
     boundary: Any
     threshold: datetime
-    extra_conditions: Sequence[ColumnElement[bool]] = field(default_factory=tuple)
+    conditions: Sequence[Any] = field(default_factory=tuple)
+    match_column: Any = None
+    source_key: Any = None
+    source_conditions: Sequence[Any] = field(default_factory=tuple)
 
     @override
     def build_subquery(self) -> sa.sql.Select[tuple[TRow]]:
-        stmt = sa.select(self.row_class).where(self.boundary < self.threshold)
-        for condition in self.extra_conditions:
+        if self.match_column is None:
+            stmt = sa.select(self.row_class).where(self.boundary < self.threshold)
+        else:
+            source = sa.select(self.source_key).where(self.boundary < self.threshold)
+            for condition in self.source_conditions:
+                source = source.where(condition)
+            stmt = sa.select(self.row_class).where(self.match_column.in_(source))
+        for condition in self.conditions:
             stmt = stmt.where(condition)
         return stmt

--- a/tests/unit/manager/repositories/retention/test_retention_repository.py
+++ b/tests/unit/manager/repositories/retention/test_retention_repository.py
@@ -4,14 +4,14 @@ Everything runs through the public ``sweep()`` entry point (there is no other
 caller-facing operation). Per category with self-contained tables, a seeded
 policy drives the sweep and we assert rows past the age boundary are purged
 while newer / non-terminal / recently-touched rows are preserved, deletion
-advances across batches, unwired categories are skipped, and the per-tick budget
-defers the rest.
+advances across batches, and the per-tick budget defers the rest.
 
 ``sessions`` exercises the ordered kernels->sessions delete with the
 remaining-kernel / live-routing NOT EXISTS guards. The terminal-state filter is
-validated on the FK-free ``roles`` table via its ``TimestampBoundaryPurgerSpec``
-directly; ``login`` and the invitation tables share that exact spec, so they are
-not duplicated here.
+validated on the FK-free ``roles`` table via ``RetentionPurgerSpec`` directly;
+``login`` and the invitation tables share that exact spec, so they are not
+duplicated here. deployments' specs are likewise exercised directly (its
+deployment_revisions FK chain makes a full sweep disproportionate).
 
 sweep() derives its threshold from DB ``now``, so fixtures use timestamps
 relative to the real current time; every category is seeded with a 30-day policy
@@ -23,18 +23,23 @@ from __future__ import annotations
 import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
 from unittest.mock import MagicMock
 
 import pytest
 import sqlalchemy as sa
 
+from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.events.types import EventDomain
+from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.schema.deployment import IntOrPercent, ReplicaGroupRolloutSpec
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.actions.types import OperationStatus
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
+from ai.backend.manager.data.deployment.types import ReplicaGroupLifecycle
 from ai.backend.manager.data.error_log.types import ErrorLogSeverity
 from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.permission.status import RoleStatus
@@ -43,8 +48,9 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.audit_log.row import AuditLogRow
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
+from ai.backend.manager.models.deployment_policy.row import DeploymentPolicyRow
 from ai.backend.manager.models.domain import DomainRow
-from ai.backend.manager.models.endpoint import EndpointLifecycle, EndpointRow
+from ai.backend.manager.models.endpoint import EndpointLifecycle, EndpointRow, EndpointTokenRow
 from ai.backend.manager.models.error_logs import ErrorLogRow
 from ai.backend.manager.models.event_log.row import EventLogRow
 from ai.backend.manager.models.group import GroupRow, ProjectType
@@ -60,7 +66,13 @@ from ai.backend.manager.models.resource_policy import (
     ProjectResourcePolicyRow,
     UserResourcePolicyRow,
 )
-from ai.backend.manager.models.resource_usage_history.row import KernelUsageRecordRow
+from ai.backend.manager.models.resource_usage_history.row import (
+    DomainUsageBucketRow,
+    KernelUsageRecordRow,
+    ProjectUsageBucketRow,
+    UsageBucketEntryRow,
+    UserUsageBucketRow,
+)
 from ai.backend.manager.models.retention.row import RetentionPolicyRow
 from ai.backend.manager.models.routing.row import RouteStatus, RoutingRow
 from ai.backend.manager.models.scaling_group import ScalingGroupOpts, ScalingGroupRow
@@ -82,13 +94,15 @@ from ai.backend.manager.models.vfolder.row import VFolderRow
 from ai.backend.manager.repositories.base import BatchPurger
 from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.manager.repositories.retention.db_source.db_source import RetentionDBSource
-from ai.backend.manager.repositories.retention.purgers import TimestampBoundaryPurgerSpec
+from ai.backend.manager.repositories.retention.purgers import RetentionPurgerSpec
 from ai.backend.testutils.db import with_tables
 
 _NOW = datetime.now(UTC)
 _THRESHOLD = _NOW - timedelta(days=30)
 _OLD = _NOW - timedelta(days=400)  # older than threshold -> eligible for purge
 _NEW = _NOW - timedelta(days=1)  # newer than threshold -> preserved
+_OLD_DATE = _OLD.date()  # date-typed boundary for usage_buckets (period_end is Date)
+_NEW_DATE = _NEW.date()
 _RETENTION_DAYS = 30
 
 
@@ -403,11 +417,11 @@ class TestTerminalStateFilter:
                 RoleRow(name="active", status=RoleStatus.ACTIVE),
             ],
         )
-        spec = TimestampBoundaryPurgerSpec(
+        spec = RetentionPurgerSpec(
             RoleRow,
             RoleRow.deleted_at,
             _THRESHOLD,
-            extra_conditions=(RoleRow.status == RoleStatus.DELETED,),
+            conditions=(RoleRow.status == RoleStatus.DELETED,),
         )
 
         async with DBOpsProvider(db).write_ops() as w:
@@ -714,8 +728,7 @@ class TestSessionsRetention:
 
 class TestSweep:
     """sweep() orchestration across policies: policy-driven purge + last_swept_at
-    stamp, unwired categories skipped without aborting the tick, per-tick budget
-    defers the rest, disabled policies excluded."""
+    stamp, per-tick budget defers the rest, disabled policies excluded."""
 
     @pytest.fixture
     async def db(
@@ -738,7 +751,7 @@ class TestSweep:
         ):
             yield database_connection
 
-    async def test_purges_wired_stamps_swept_and_skips_unwired(
+    async def test_purges_enabled_categories_and_stamps_swept(
         self, db: ExtendedAsyncSAEngine, db_source: RetentionDBSource
     ) -> None:
         await _insert(
@@ -746,20 +759,22 @@ class TestSweep:
             [
                 EventLogRow(event_name="old", event_domain=EventDomain.SESSION, created_at=_OLD),
                 EventLogRow(event_name="recent", event_domain=EventDomain.SESSION, created_at=_NEW),
+                _usage_record(period_end=_OLD),
                 _policy_row(RetentionCategory.LOGS),
-                # Seeded enabled but not wired yet -> must be skipped, not abort the tick.
-                _policy_row(RetentionCategory.DEPLOYMENTS),
+                _policy_row(RetentionCategory.USAGE_RECORDS),
             ],
         )
 
         results = await db_source.sweep()
 
-        assert [r.category for r in results] == [RetentionCategory.LOGS]
-        assert results[0].deleted_count == 1  # only the old EventLog row
-        assert await _count(db, EventLogRow) == 1
+        assert {r.category for r in results} == {
+            RetentionCategory.LOGS,
+            RetentionCategory.USAGE_RECORDS,
+        }
+        assert await _count(db, EventLogRow) == 1  # old purged, recent kept
+        assert await _count(db, KernelUsageRecordRow) == 0
         assert await _swept_at(db, RetentionCategory.LOGS) is not None
-        # Skipped category keeps its NULL stamp so it retries once wired.
-        assert await _swept_at(db, RetentionCategory.DEPLOYMENTS) is None
+        assert await _swept_at(db, RetentionCategory.USAGE_RECORDS) is not None
 
     async def test_per_tick_budget_defers_remaining_categories(
         self, db: ExtendedAsyncSAEngine
@@ -800,3 +815,564 @@ class TestSweep:
 
         assert results == []
         assert await _count(db, EventLogRow) == 1  # disabled -> row preserved
+
+
+class TestDeploymentsRetention:
+    """deployments: DESTROYED endpoints past destroyed_at drive the purge; CASCADE
+    children (deployment_policies) follow at the DB; endpoint_tokens clear on
+    their own expiry. Specs are exercised directly to avoid the
+    deployment_revisions image/vfolder/runtime FK chain; the FK-less-child form
+    is checked against endpoint_tokens standing in for deployment_revisions."""
+
+    @pytest.fixture
+    async def db(
+        self, database_connection: ExtendedAsyncSAEngine
+    ) -> AsyncIterator[ExtendedAsyncSAEngine]:
+        async with with_tables(
+            database_connection,
+            [
+                DomainRow,
+                ProjectResourcePolicyRow,
+                ScalingGroupRow,
+                GroupRow,
+                EndpointRow,
+                DeploymentPolicyRow,
+                EndpointTokenRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    async def scope(self, db: ExtendedAsyncSAEngine) -> _Scope:
+        scope = _Scope()
+        async with db.begin_session() as sess:
+            sess.add(
+                ProjectResourcePolicyRow(
+                    name=scope.policy_name,
+                    max_vfolder_count=0,
+                    max_quota_scope_size=-1,
+                    max_network_count=0,
+                )
+            )
+            sess.add(
+                DomainRow(
+                    id=scope.domain_id, name=scope.domain_name, description=None, is_active=True
+                )
+            )
+            sess.add(
+                ScalingGroupRow(
+                    name=scope.sgroup_name,
+                    id=scope.sgroup_id,
+                    driver="static",
+                    driver_opts={},
+                    scheduler="fifo",
+                    scheduler_opts=ScalingGroupOpts(),
+                )
+            )
+            sess.add(
+                GroupRow(
+                    id=scope.group_id,
+                    name="retention-group",
+                    description=None,
+                    is_active=True,
+                    domain_name=scope.domain_name,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts={},
+                    dotfiles=b"\x90",
+                    resource_policy=scope.policy_name,
+                    type=ProjectType.GENERAL,
+                )
+            )
+        return scope
+
+    async def _add_endpoint(
+        self,
+        db: ExtendedAsyncSAEngine,
+        scope: _Scope,
+        *,
+        lifecycle: EndpointLifecycle,
+        destroyed_at: datetime | None,
+    ) -> DeploymentID:
+        endpoint_id = DeploymentID(uuid.uuid4())
+        async with db.begin_session() as sess:
+            sess.add(
+                EndpointRow(
+                    id=endpoint_id,
+                    name=f"endpoint-{endpoint_id}",
+                    created_user=scope.user_uuid,
+                    session_owner=scope.user_uuid,
+                    domain=scope.domain_name,
+                    project=scope.group_id,
+                    resource_group=scope.sgroup_name,
+                    lifecycle_stage=lifecycle,
+                    replicas=0,
+                    destroyed_at=destroyed_at,
+                )
+            )
+        return endpoint_id
+
+    async def _add_deployment_policy(
+        self, db: ExtendedAsyncSAEngine, endpoint_id: DeploymentID
+    ) -> None:
+        async with db.begin_session() as sess:
+            sess.add(DeploymentPolicyRow(endpoint=endpoint_id, strategy=DeploymentStrategy.ROLLING))
+
+    async def _add_token(
+        self,
+        db: ExtendedAsyncSAEngine,
+        scope: _Scope,
+        *,
+        endpoint_id: DeploymentID,
+        expires_at: datetime | None,
+    ) -> None:
+        async with db.begin_session() as sess:
+            sess.add(
+                EndpointTokenRow(
+                    id=uuid.uuid4(),
+                    token=f"tok-{uuid.uuid4()}",
+                    endpoint=endpoint_id,
+                    session_owner=scope.user_uuid,
+                    domain=scope.domain_name,
+                    project=scope.group_id,
+                    expires_at=expires_at,
+                )
+            )
+
+    async def _purge_endpoints(self, db: ExtendedAsyncSAEngine) -> int:
+        spec = RetentionPurgerSpec(
+            EndpointRow,
+            EndpointRow.destroyed_at,
+            _THRESHOLD,
+            conditions=(EndpointRow.lifecycle_stage == EndpointLifecycle.DESTROYED,),
+        )
+        async with DBOpsProvider(db).write_ops() as w:
+            result = await w.batch_purge(BatchPurger(spec=spec, batch_size=100))
+        return result.deleted_count
+
+    async def test_destroyed_endpoint_past_boundary_cascades_children(
+        self, db: ExtendedAsyncSAEngine, scope: _Scope
+    ) -> None:
+        endpoint_id = await self._add_endpoint(
+            db, scope, lifecycle=EndpointLifecycle.DESTROYED, destroyed_at=_OLD
+        )
+        await self._add_deployment_policy(db, endpoint_id)
+
+        deleted = await self._purge_endpoints(db)
+
+        assert deleted == 1  # the endpoint; its policy cascades at the DB level
+        assert await _count(db, EndpointRow) == 0
+        assert await _count(db, DeploymentPolicyRow) == 0
+
+    async def test_preserves_living_and_recent_endpoints(
+        self, db: ExtendedAsyncSAEngine, scope: _Scope
+    ) -> None:
+        await self._add_endpoint(db, scope, lifecycle=EndpointLifecycle.READY, destroyed_at=None)
+        await self._add_endpoint(
+            db, scope, lifecycle=EndpointLifecycle.DESTROYED, destroyed_at=_NEW
+        )
+
+        deleted = await self._purge_endpoints(db)
+
+        assert deleted == 0
+        assert await _count(db, EndpointRow) == 2
+
+    async def test_endpoint_tokens_purged_by_expiry(
+        self, db: ExtendedAsyncSAEngine, scope: _Scope
+    ) -> None:
+        # endpoint id is irrelevant to expiry-based purge; use throwaway ids.
+        await self._add_token(db, scope, endpoint_id=DeploymentID(uuid.uuid4()), expires_at=_OLD)
+        await self._add_token(db, scope, endpoint_id=DeploymentID(uuid.uuid4()), expires_at=_NEW)
+        # A never-expiring token (NULL expires_at) is preserved.
+        await self._add_token(db, scope, endpoint_id=DeploymentID(uuid.uuid4()), expires_at=None)
+
+        spec = RetentionPurgerSpec(EndpointTokenRow, EndpointTokenRow.expires_at, _THRESHOLD)
+        async with DBOpsProvider(db).write_ops() as w:
+            result = await w.batch_purge(BatchPurger(spec=spec, batch_size=100))
+
+        assert result.deleted_count == 1
+        assert await _count(db, EndpointTokenRow) == 2
+
+    async def test_fk_less_child_deleted_by_destroyed_endpoint(
+        self, db: ExtendedAsyncSAEngine, scope: _Scope
+    ) -> None:
+        # endpoint_tokens stand in for deployment_revisions: an FK-less child
+        # keyed by endpoint id, deleted when its parent endpoint is DESTROYED and
+        # past the boundary.
+        destroyed_id = await self._add_endpoint(
+            db, scope, lifecycle=EndpointLifecycle.DESTROYED, destroyed_at=_OLD
+        )
+        living_id = await self._add_endpoint(
+            db, scope, lifecycle=EndpointLifecycle.READY, destroyed_at=None
+        )
+        await self._add_token(db, scope, endpoint_id=destroyed_id, expires_at=_NEW)
+        await self._add_token(db, scope, endpoint_id=living_id, expires_at=_NEW)
+
+        spec = RetentionPurgerSpec(
+            EndpointTokenRow,
+            EndpointRow.destroyed_at,
+            _THRESHOLD,
+            match_column=EndpointTokenRow.endpoint,
+            source_key=EndpointRow.id,
+            source_conditions=(EndpointRow.lifecycle_stage == EndpointLifecycle.DESTROYED,),
+        )
+        async with DBOpsProvider(db).write_ops() as w:
+            result = await w.batch_purge(BatchPurger(spec=spec, batch_size=100))
+
+        assert result.deleted_count == 1  # only the destroyed endpoint's child
+        assert await _count(db, EndpointTokenRow) == 1  # the living endpoint's survives
+
+
+class TestDeploymentsTerminalChildCleanup:
+    """deployments also clears terminal routings and replica_groups on their own
+    updated_at boundary. Endpoint cascade only reaches children of a purged
+    endpoint, so a route/group retired under a still-live endpoint must be swept
+    independently."""
+
+    @pytest.fixture
+    async def db(
+        self, database_connection: ExtendedAsyncSAEngine
+    ) -> AsyncIterator[ExtendedAsyncSAEngine]:
+        async with with_tables(
+            database_connection,
+            [
+                DomainRow,
+                ProjectResourcePolicyRow,
+                UserResourcePolicyRow,
+                KeyPairResourcePolicyRow,
+                ScalingGroupRow,
+                UserRow,
+                KeyPairRow,
+                GroupRow,
+                SessionRow,
+                EndpointRow,
+                ReplicaGroupRow,
+                RoutingRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    async def scope(self, db: ExtendedAsyncSAEngine) -> _Scope:
+        scope = _Scope()
+        async with db.begin_session() as sess:
+            sess.add(
+                ProjectResourcePolicyRow(
+                    name=scope.policy_name,
+                    max_vfolder_count=0,
+                    max_quota_scope_size=-1,
+                    max_network_count=0,
+                )
+            )
+            sess.add(
+                UserResourcePolicyRow(
+                    name=scope.user_policy_name,
+                    max_vfolder_count=0,
+                    max_quota_scope_size=-1,
+                    max_session_count_per_model_session=10,
+                    max_customized_image_count=10,
+                )
+            )
+            sess.add(
+                DomainRow(
+                    id=scope.domain_id, name=scope.domain_name, description=None, is_active=True
+                )
+            )
+            sess.add(
+                ScalingGroupRow(
+                    name=scope.sgroup_name,
+                    id=scope.sgroup_id,
+                    driver="static",
+                    driver_opts={},
+                    scheduler="fifo",
+                    scheduler_opts=ScalingGroupOpts(),
+                )
+            )
+            sess.add(
+                UserRow(
+                    uuid=scope.user_uuid,
+                    username="retention-user",
+                    email="retention@example.com",
+                    password=PasswordInfo(
+                        password="pw",
+                        algorithm=PasswordHashAlgorithm.PBKDF2_SHA256,
+                        rounds=100_000,
+                        salt_size=32,
+                    ),
+                    need_password_change=False,
+                    full_name="Retention User",
+                    description="",
+                    status=UserStatus.ACTIVE,
+                    status_info="",
+                    domain_name=scope.domain_name,
+                    role=UserRole.USER,
+                    resource_policy=scope.user_policy_name,
+                )
+            )
+            sess.add(
+                GroupRow(
+                    id=scope.group_id,
+                    name="retention-group",
+                    description=None,
+                    is_active=True,
+                    domain_name=scope.domain_name,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts={},
+                    dotfiles=b"\x90",
+                    resource_policy=scope.policy_name,
+                    type=ProjectType.GENERAL,
+                )
+            )
+        return scope
+
+    async def _add_live_endpoint(self, db: ExtendedAsyncSAEngine, scope: _Scope) -> DeploymentID:
+        endpoint_id = DeploymentID(uuid.uuid4())
+        async with db.begin_session() as sess:
+            sess.add(
+                EndpointRow(
+                    id=endpoint_id,
+                    name=f"endpoint-{endpoint_id}",
+                    created_user=scope.user_uuid,
+                    session_owner=scope.user_uuid,
+                    domain=scope.domain_name,
+                    project=scope.group_id,
+                    resource_group=scope.sgroup_name,
+                    lifecycle_stage=EndpointLifecycle.READY,
+                    replicas=0,
+                )
+            )
+        return endpoint_id
+
+    async def _add_routing(
+        self,
+        db: ExtendedAsyncSAEngine,
+        scope: _Scope,
+        endpoint_id: DeploymentID,
+        *,
+        status: RouteStatus,
+        updated_at: datetime,
+    ) -> None:
+        async with db.begin_session() as sess:
+            sess.add(
+                RoutingRow(
+                    id=uuid.uuid4(),
+                    endpoint=endpoint_id,
+                    session=None,
+                    session_owner=scope.user_uuid,
+                    domain=scope.domain_name,
+                    project=scope.group_id,
+                    status=status,
+                    traffic_ratio=1.0,
+                    revision=uuid.uuid4(),
+                    updated_at=updated_at,
+                )
+            )
+
+    async def _add_replica_group(
+        self,
+        db: ExtendedAsyncSAEngine,
+        endpoint_id: DeploymentID,
+        *,
+        lifecycle: ReplicaGroupLifecycle,
+        updated_at: datetime,
+    ) -> None:
+        async with db.begin_session() as sess:
+            sess.add(
+                ReplicaGroupRow(
+                    id=uuid.uuid4(),
+                    deployment_id=endpoint_id,
+                    lifecycle=lifecycle,
+                    rollout=ReplicaGroupRolloutSpec(
+                        max_surge=IntOrPercent(count=1),
+                        max_unavailable=IntOrPercent(count=0),
+                    ),
+                    updated_at=updated_at,
+                )
+            )
+
+    async def test_terminal_routings_purged_under_live_endpoint(
+        self, db: ExtendedAsyncSAEngine, scope: _Scope
+    ) -> None:
+        endpoint_id = await self._add_live_endpoint(db, scope)
+        await self._add_routing(
+            db, scope, endpoint_id, status=RouteStatus.TERMINATED, updated_at=_OLD
+        )
+        await self._add_routing(
+            db, scope, endpoint_id, status=RouteStatus.FAILED_TO_START, updated_at=_OLD
+        )
+        # Running route -> not terminal, preserved.
+        await self._add_routing(db, scope, endpoint_id, status=RouteStatus.RUNNING, updated_at=_OLD)
+        # Terminal but inside the boundary -> held back this sweep.
+        await self._add_routing(
+            db, scope, endpoint_id, status=RouteStatus.TERMINATED, updated_at=_NEW
+        )
+
+        spec = RetentionPurgerSpec(
+            RoutingRow,
+            RoutingRow.updated_at,
+            _THRESHOLD,
+            conditions=(RoutingRow.status.in_(RouteStatus.terminal_statuses()),),
+        )
+        async with DBOpsProvider(db).write_ops() as w:
+            result = await w.batch_purge(BatchPurger(spec=spec, batch_size=100))
+
+        assert result.deleted_count == 2  # terminated + failed-to-start, both old
+        assert await _count(db, RoutingRow) == 2  # running + recently-terminated
+        assert await _count(db, EndpointRow) == 1  # the live endpoint is untouched
+
+    async def test_terminal_replica_groups_purged_under_live_endpoint(
+        self, db: ExtendedAsyncSAEngine, scope: _Scope
+    ) -> None:
+        endpoint_id = await self._add_live_endpoint(db, scope)
+        await self._add_replica_group(
+            db, endpoint_id, lifecycle=ReplicaGroupLifecycle.DRAINED, updated_at=_OLD
+        )
+        await self._add_replica_group(
+            db, endpoint_id, lifecycle=ReplicaGroupLifecycle.FAILED, updated_at=_OLD
+        )
+        # Active group -> not terminal, preserved.
+        await self._add_replica_group(
+            db, endpoint_id, lifecycle=ReplicaGroupLifecycle.STABLE, updated_at=_OLD
+        )
+        # Drained but inside the boundary -> held back this sweep.
+        await self._add_replica_group(
+            db, endpoint_id, lifecycle=ReplicaGroupLifecycle.DRAINED, updated_at=_NEW
+        )
+
+        spec = RetentionPurgerSpec(
+            ReplicaGroupRow,
+            ReplicaGroupRow.updated_at,
+            _THRESHOLD,
+            conditions=(ReplicaGroupRow.lifecycle.in_(ReplicaGroupLifecycle.terminal_statuses()),),
+        )
+        async with DBOpsProvider(db).write_ops() as w:
+            result = await w.batch_purge(BatchPurger(spec=spec, batch_size=100))
+
+        assert result.deleted_count == 2  # drained + failed, both old
+        assert await _count(db, ReplicaGroupRow) == 2  # stable + recently-drained
+        assert await _count(db, EndpointRow) == 1  # the live endpoint is untouched
+
+
+class TestUsageBucketsRetention:
+    """usage_buckets: each bucket kind purged on its own period_end, with its
+    FK-less usage_bucket_entries (keyed by bucket_id + bucket_type) drained first
+    so no orphan entry remains. FK-free, so it runs end-to-end through sweep()."""
+
+    @pytest.fixture
+    async def db(
+        self, database_connection: ExtendedAsyncSAEngine
+    ) -> AsyncIterator[ExtendedAsyncSAEngine]:
+        async with with_tables(
+            database_connection,
+            [
+                DomainUsageBucketRow,
+                ProjectUsageBucketRow,
+                UserUsageBucketRow,
+                UsageBucketEntryRow,
+                RetentionPolicyRow,
+            ],
+        ):
+            yield database_connection
+
+    async def _add_domain_bucket(self, db: ExtendedAsyncSAEngine, *, period_end: date) -> uuid.UUID:
+        bucket_id = uuid.uuid4()
+        async with db.begin_session() as sess:
+            sess.add(
+                DomainUsageBucketRow(
+                    id=bucket_id,
+                    domain_name="d",
+                    resource_group="rg",
+                    resource_group_id=ResourceGroupID(uuid.uuid4()),
+                    period_start=period_end - timedelta(days=1),
+                    period_end=period_end,
+                )
+            )
+        return bucket_id
+
+    async def _add_project_bucket(
+        self, db: ExtendedAsyncSAEngine, *, period_end: date
+    ) -> uuid.UUID:
+        bucket_id = uuid.uuid4()
+        async with db.begin_session() as sess:
+            sess.add(
+                ProjectUsageBucketRow(
+                    id=bucket_id,
+                    project_id=uuid.uuid4(),
+                    domain_name="d",
+                    resource_group="rg",
+                    resource_group_id=ResourceGroupID(uuid.uuid4()),
+                    period_start=period_end - timedelta(days=1),
+                    period_end=period_end,
+                )
+            )
+        return bucket_id
+
+    async def _add_user_bucket(self, db: ExtendedAsyncSAEngine, *, period_end: date) -> uuid.UUID:
+        bucket_id = uuid.uuid4()
+        async with db.begin_session() as sess:
+            sess.add(
+                UserUsageBucketRow(
+                    id=bucket_id,
+                    user_uuid=uuid.uuid4(),
+                    project_id=uuid.uuid4(),
+                    domain_name="d",
+                    resource_group="rg",
+                    resource_group_id=ResourceGroupID(uuid.uuid4()),
+                    period_start=period_end - timedelta(days=1),
+                    period_end=period_end,
+                )
+            )
+        return bucket_id
+
+    async def _add_entry(
+        self, db: ExtendedAsyncSAEngine, *, bucket_id: uuid.UUID, bucket_type: str, slot: str
+    ) -> None:
+        async with db.begin_session() as sess:
+            sess.add(
+                UsageBucketEntryRow(
+                    bucket_id=bucket_id,
+                    bucket_type=bucket_type,
+                    slot_name=slot,
+                    amount=Decimal("1"),
+                    duration_seconds=1,
+                    capacity=Decimal("1"),
+                )
+            )
+
+    async def test_old_buckets_and_their_entries_purged_no_orphan(
+        self, db: ExtendedAsyncSAEngine
+    ) -> None:
+        old_bucket = await self._add_domain_bucket(db, period_end=_OLD_DATE)
+        await self._add_entry(db, bucket_id=old_bucket, bucket_type="domain", slot="cpu")
+        await self._add_entry(db, bucket_id=old_bucket, bucket_type="domain", slot="mem")
+        new_bucket = await self._add_domain_bucket(db, period_end=_NEW_DATE)
+        await self._add_entry(db, bucket_id=new_bucket, bucket_type="domain", slot="cpu")
+
+        result = await _sweep_category(db, RetentionCategory.USAGE_BUCKETS)
+
+        assert result.deleted_count == 3  # 2 entries + 1 bucket
+        assert await _count(db, DomainUsageBucketRow) == 1
+        assert await _count(db, UsageBucketEntryRow) == 1  # only the live bucket's entry
+
+    async def test_all_three_bucket_kinds_purged(self, db: ExtendedAsyncSAEngine) -> None:
+        domain_bucket = await self._add_domain_bucket(db, period_end=_OLD_DATE)
+        await self._add_entry(db, bucket_id=domain_bucket, bucket_type="domain", slot="cpu")
+        project_bucket = await self._add_project_bucket(db, period_end=_OLD_DATE)
+        await self._add_entry(db, bucket_id=project_bucket, bucket_type="project", slot="cpu")
+        user_bucket = await self._add_user_bucket(db, period_end=_OLD_DATE)
+        await self._add_entry(db, bucket_id=user_bucket, bucket_type="user", slot="cpu")
+
+        result = await _sweep_category(db, RetentionCategory.USAGE_BUCKETS)
+
+        assert result.deleted_count == 6  # 3 buckets + 3 entries
+        assert await _count(db, DomainUsageBucketRow) == 0
+        assert await _count(db, ProjectUsageBucketRow) == 0
+        assert await _count(db, UserUsageBucketRow) == 0
+        assert await _count(db, UsageBucketEntryRow) == 0
+
+
+class TestCatalogCompleteness:
+    def test_every_category_is_wired(self) -> None:
+        # The sweep iterates enabled policies of any category, so every
+        # RetentionCategory must resolve to a purger spec set.
+        catalog = RetentionDBSource._catalog(_THRESHOLD)
+        assert set(catalog) == set(RetentionCategory)


### PR DESCRIPTION
## Summary
- Wire the two ordered-delete retention categories into the shared catalog: **deployments** (DESTROYED endpoints past `destroyed_at`; FK-less `deployment_revisions` drained by endpoint id first; `deployment_policies`/`endpoint_auto_scaling_rules` cascade; terminal `routings`/`replica_groups` swept on their own `updated_at` boundary so routes/groups retired under a still-live endpoint don't linger; `endpoint_tokens` by expiry) and **usage_buckets** (each bucket kind on `period_end` with its FK-less `usage_bucket_entries` drained first).
- Generalize the purger into a single `RetentionPurgerSpec` (local boundary, or foreign-key boundary for FK-less children) built by one `_catalog(threshold)`, removing the descriptor/`build_spec` layer and the two prior spec classes.
- Move terminal-status definitions onto their enums (`RouteStatus`/`ReplicaGroupLifecycle.terminal_statuses()`, `RoleInvitationState`/`VFolderInvitationState.declined_states()`). Invitation retention purges only declined (rejected/canceled) rows and **keeps ACCEPTED** — acceptance writes a durable `user_roles`/`vfolder_permissions` record, so the invitation is history, but it is retained conservatively.

## Test plan
- [x] `pants fmt/fix/lint` pass on the changeset
- [x] `pants check` (mypy) clean across changed files
- [x] `pants test tests/unit/manager/repositories/retention/` — deployments (endpoint boundary + lifecycle filter, cascade, endpoint_tokens expiry, FK-less child), terminal routings/replica_groups under a live endpoint, usage_buckets ordered entries→buckets (no orphans, all three kinds), catalog completeness

Resolves BA-6931

🤖 Generated with [Claude Code](https://claude.com/claude-code)