### PR TITLE
fix(BA-6899): stop app_configs downgrade from creating its enum twice (#12887)

### DIFF
--- a/changes/12887.fix.md
+++ b/changes/12887.fix.md
@@ -1,0 +1,1 @@
+Fix the legacy app_configs downgrade failing with a duplicate enum type error

--- a/src/ai/backend/manager/models/alembic/versions/84d5c6daf8cc_drop_legacy_app_configs_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/84d5c6daf8cc_drop_legacy_app_configs_table.py
@@ -36,7 +36,6 @@ def downgrade() -> None:
     # Recreate the predecessor table to allow `alembic downgrade` to
     # complete cleanly. Existing-row restoration is not attempted.
     app_config_scope_type = sa.Enum("DOMAIN", "PROJECT", "USER", name="app_config_scope_type")
-    app_config_scope_type.create(op.get_bind(), checkfirst=True)
     op.create_table(
         "app_configs",
         IDColumn(),


### PR DESCRIPTION
This is an auto-generated backport PR of #12887 to the 26.4 release.