### PR TITLE
fix: reserve /home/work to prevent duplicate container mount points

### DIFF
--- a/changes/12969.fix.md
+++ b/changes/12969.fix.md
@@ -1,0 +1,1 @@
+Reject vfolder mount aliases set to exactly `/home/work`, which collided with the intrinsic scratch mount and made container creation fail with "Duplicate mount point"

--- a/src/ai/backend/common/defs/__init__.py
+++ b/src/ai/backend/common/defs/__init__.py
@@ -34,6 +34,10 @@ RESERVED_VFOLDERS = [
     ".jupyter",
     ".tmux.conf",
     ".ssh",
+    # The agent always bind-mounts the scratch directory at /home/work,
+    # so mounting a vfolder exactly there makes dockerd reject the container
+    # with "Duplicate mount point: /home/work".
+    "/home/work",
     "/bin",
     "/boot",
     "/dev",

--- a/src/ai/backend/manager/defs.py
+++ b/src/ai/backend/manager/defs.py
@@ -3,7 +3,6 @@ Common definitions/constants used throughout the manager.
 """
 
 import enum
-import re
 from typing import Final
 
 from ai.backend.common.arch import CURRENT_ARCH
@@ -42,38 +41,7 @@ DEFAULT_ROLE: Final = "main"
 
 PASSWORD_PLACEHOLDER: Final = "*****"
 
-_RESERVED_VFOLDER_PATTERNS = [r"^\.[a-z0-9]+rc$", r"^\.[a-z0-9]+_profile$"]
 RESERVED_DOTFILES = [".terminfo", ".jupyter", ".ssh", ".ssh/authorized_keys", ".local", ".config"]
-RESERVED_VFOLDERS = [
-    ".terminfo",
-    ".jupyter",
-    ".tmux.conf",
-    ".ssh",
-    # The agent always bind-mounts the scratch directory at /home/work,
-    # so mounting a vfolder exactly there makes dockerd reject the container
-    # with "Duplicate mount point: /home/work".
-    "/home/work",
-    "/bin",
-    "/boot",
-    "/dev",
-    "/etc",
-    "/lib",
-    "/lib64",
-    "/media",
-    "/mnt",
-    "/opt",
-    "/proc",
-    "/root",
-    "/run",
-    "/sbin",
-    "/srv",
-    "/sys",
-    "/tmp",
-    "/usr",
-    "/var",
-    "/home",
-]
-RESERVED_VFOLDER_PATTERNS = [re.compile(x) for x in _RESERVED_VFOLDER_PATTERNS]
 
 # Mapping between vfolder names and their in-container paths.
 VFOLDER_DSTPATHS_MAP = {

--- a/src/ai/backend/manager/defs.py
+++ b/src/ai/backend/manager/defs.py
@@ -49,6 +49,10 @@ RESERVED_VFOLDERS = [
     ".jupyter",
     ".tmux.conf",
     ".ssh",
+    # The agent always bind-mounts the scratch directory at /home/work,
+    # so mounting a vfolder exactly there makes dockerd reject the container
+    # with "Duplicate mount point: /home/work".
+    "/home/work",
     "/bin",
     "/boot",
     "/dev",

--- a/src/ai/backend/manager/models/vfolder/row.py
+++ b/src/ai/backend/manager/models/vfolder/row.py
@@ -24,7 +24,11 @@ from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 from sqlalchemy.orm import Mapped, foreign, load_only, mapped_column, relationship, selectinload
 
-from ai.backend.common.defs import MODEL_VFOLDER_LENGTH_LIMIT
+from ai.backend.common.defs import (
+    MODEL_VFOLDER_LENGTH_LIMIT,
+    RESERVED_VFOLDER_PATTERNS,
+    RESERVED_VFOLDERS,
+)
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import (
     QuotaScopeID,
@@ -53,11 +57,7 @@ from ai.backend.manager.data.vfolder.types import (
     VFolderOwnershipType,
 )
 from ai.backend.manager.data.vfolder.types import VFolderMountPermission as VFolderPermission
-from ai.backend.manager.defs import (
-    RESERVED_VFOLDER_PATTERNS,
-    RESERVED_VFOLDERS,
-    is_noop_host,
-)
+from ai.backend.manager.defs import is_noop_host
 from ai.backend.manager.errors.api import InvalidAPIParameters
 from ai.backend.manager.errors.common import ObjectNotFound
 from ai.backend.manager.errors.storage import (

--- a/tests/unit/manager/api/test_utils.py
+++ b/tests/unit/manager/api/test_utils.py
@@ -63,6 +63,9 @@ def test_vfolder_name_validator() -> None:
     assert verify_vfolder_name("/home/work/boot")
     assert verify_vfolder_name("/home/work/root")
     assert verify_vfolder_name("home/work")
+    # Mounting exactly at /home/work collides with the agent's intrinsic
+    # scratch mount and makes dockerd reject container creation.
+    assert not verify_vfolder_name("/home/work")
 
 
 def test_dotfile_name_validator() -> None:


### PR DESCRIPTION
## Summary
- Setting a vfolder mount alias to exactly `/home/work` passes every alias validation path (`registry.create_session`, sokovan `validate_session_spec`, and `MountNameValidationRule`): the checks only strip the `/home/work/` prefix (with trailing slash), and `RESERVED_VFOLDERS` contains `/home` but not `/home/work`.
- The agent always bind-mounts the scratch directory at `/home/work` (`agent/docker/agent.py`), so such a session passes scheduling and then fails at container creation on the agent with `DockerError(400, "Duplicate mount point: /home/work")` — observed in production on 26.4.3.
- Add `/home/work` to `RESERVED_VFOLDERS` so every validation path rejects the alias up front with `InvalidAPIParameters`.
- `RESERVED_VFOLDERS`/`RESERVED_VFOLDER_PATTERNS` were duplicated between `ai.backend.common.defs` (used by sokovan) and `ai.backend.manager.defs` (used by `verify_vfolder_name`); consolidated onto `common.defs` as the single source of truth and removed the manager copy.

## Test plan
- [x] `pants fmt/fix/lint --changed-since=origin/main` all pass
- [x] Extended `test_vfolder_name_validator` unit test: `verify_vfolder_name("/home/work")` must be rejected while `/home/work/<name>` aliases and a folder literally named `home/work` stay allowed (CI)
- [ ] Manual: create a session with `mount_map` alias `/home/work` → expect `InvalidAPIParameters` at session creation instead of `failed-to-create` at the agent
