### PR TITLE
feat(BA-6942): expose runtime variant model defaults

### DIFF
--- a/changes/12970.feature.md
+++ b/changes/12970.feature.md
@@ -1,0 +1,1 @@
+Expose runtime variant model defaults through REST and GraphQL APIs.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -17715,6 +17715,16 @@ type RuntimeVariant implements Node
   """
   description: String
 
+  """
+  Added in 26.8.0. Whether legacy model configuration files in the model vfolder participate in revision resolution.
+  """
+  readsVfolderConfigFiles: Boolean!
+
+  """
+  Added in 26.8.0. Model definition defaults stored for this runtime variant.
+  """
+  defaultModelDefinition: RuntimeVariantModelDefinition!
+
   """Timestamp when this runtime variant was registered."""
   createdAt: DateTime!
 
@@ -17768,6 +17778,85 @@ type RuntimeVariantInfo
 {
   name: String
   human_readable_name: String
+}
+
+"""
+Added in 26.8.0. Default model configuration stored for a runtime variant.
+"""
+type RuntimeVariantModelConfig
+  @join__type(graph: STRAWBERRY)
+{
+  """Default model name."""
+  name: String
+
+  """Default model path."""
+  modelPath: String
+
+  """Default model service configuration."""
+  service: RuntimeVariantModelServiceConfig
+
+  """Default model metadata."""
+  metadata: ModelMetadata
+}
+
+"""
+Added in 26.8.0. Model definition defaults stored for a runtime variant.
+"""
+type RuntimeVariantModelDefinition
+  @join__type(graph: STRAWBERRY)
+{
+  """Default model configurations supplied by the runtime variant."""
+  models: [RuntimeVariantModelConfig!]
+}
+
+"""
+Added in 26.8.0. Default health-check settings stored for a runtime variant.
+"""
+type RuntimeVariantModelHealthCheck
+  @join__type(graph: STRAWBERRY)
+{
+  """Whether health checks are enabled."""
+  enable: Boolean
+
+  """Health-check interval in seconds."""
+  interval: Float
+
+  """Health-check endpoint path."""
+  path: String
+
+  """Maximum number of retries."""
+  maxRetries: Int
+
+  """Maximum time to wait for a health check."""
+  maxWaitTime: Float
+
+  """Expected healthy HTTP status code."""
+  expectedStatusCode: Int
+
+  """Initial health-check grace period in seconds."""
+  initialDelay: Float
+}
+
+"""
+Added in 26.8.0. Default model service configuration stored for a runtime variant.
+"""
+type RuntimeVariantModelServiceConfig
+  @join__type(graph: STRAWBERRY)
+{
+  """Actions to run before starting the model service."""
+  preStartActions: [PreStartAction!]
+
+  """Command that starts the model service."""
+  command: String
+
+  """Shell used to run the command."""
+  shell: String
+
+  """Model service port."""
+  port: Int
+
+  """Default model service health-check settings."""
+  healthCheck: RuntimeVariantModelHealthCheck
 }
 
 """Added in 26.4.2. Order specification."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -12318,6 +12318,16 @@ type RuntimeVariant implements Node {
   """
   description: String
 
+  """
+  Added in 26.8.0. Whether legacy model configuration files in the model vfolder participate in revision resolution.
+  """
+  readsVfolderConfigFiles: Boolean!
+
+  """
+  Added in 26.8.0. Model definition defaults stored for this runtime variant.
+  """
+  defaultModelDefinition: RuntimeVariantModelDefinition!
+
   """Timestamp when this runtime variant was registered."""
   createdAt: DateTime!
 
@@ -12357,6 +12367,77 @@ input RuntimeVariantFilter {
 
   """Added in 26.7.0. Negate the given sub-filters."""
   NOT: [RuntimeVariantFilter!] = null
+}
+
+"""
+Added in 26.8.0. Default model configuration stored for a runtime variant.
+"""
+type RuntimeVariantModelConfig {
+  """Default model name."""
+  name: String
+
+  """Default model path."""
+  modelPath: String
+
+  """Default model service configuration."""
+  service: RuntimeVariantModelServiceConfig
+
+  """Default model metadata."""
+  metadata: ModelMetadata
+}
+
+"""
+Added in 26.8.0. Model definition defaults stored for a runtime variant.
+"""
+type RuntimeVariantModelDefinition {
+  """Default model configurations supplied by the runtime variant."""
+  models: [RuntimeVariantModelConfig!]
+}
+
+"""
+Added in 26.8.0. Default health-check settings stored for a runtime variant.
+"""
+type RuntimeVariantModelHealthCheck {
+  """Whether health checks are enabled."""
+  enable: Boolean
+
+  """Health-check interval in seconds."""
+  interval: Float
+
+  """Health-check endpoint path."""
+  path: String
+
+  """Maximum number of retries."""
+  maxRetries: Int
+
+  """Maximum time to wait for a health check."""
+  maxWaitTime: Float
+
+  """Expected healthy HTTP status code."""
+  expectedStatusCode: Int
+
+  """Initial health-check grace period in seconds."""
+  initialDelay: Float
+}
+
+"""
+Added in 26.8.0. Default model service configuration stored for a runtime variant.
+"""
+type RuntimeVariantModelServiceConfig {
+  """Actions to run before starting the model service."""
+  preStartActions: [PreStartAction!]
+
+  """Command that starts the model service."""
+  command: String
+
+  """Shell used to run the command."""
+  shell: String
+
+  """Model service port."""
+  port: Int
+
+  """Default model service health-check settings."""
+  healthCheck: RuntimeVariantModelHealthCheck
 }
 
 """Added in 26.4.2. Order specification."""

--- a/src/ai/backend/common/dto/manager/v2/runtime_variant/response.py
+++ b/src/ai/backend/common/dto/manager/v2/runtime_variant/response.py
@@ -3,15 +3,77 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import Field
+from pydantic import AliasChoices, Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.dto.manager.v2.deployment.types import (
+    ModelMetadataInfoDTO,
+    PreStartActionInfoDTO,
+)
+
+
+class RuntimeVariantModelHealthCheckInfo(BaseResponseModel):
+    enable: bool | None = Field(default=None, description="Whether health checks are enabled.")
+    interval: float | None = Field(default=None, description="Health-check interval in seconds.")
+    path: str | None = Field(default=None, description="Health-check endpoint path.")
+    max_retries: int | None = Field(default=None, description="Maximum number of retries.")
+    max_wait_time: float | None = Field(
+        default=None, description="Maximum time to wait for a health check."
+    )
+    expected_status_code: int | None = Field(
+        default=None, description="Expected healthy HTTP status code."
+    )
+    initial_delay: float | None = Field(
+        default=None, description="Initial health-check grace period in seconds."
+    )
+
+
+class RuntimeVariantModelServiceConfigInfo(BaseResponseModel):
+    pre_start_actions: list[PreStartActionInfoDTO] | None = Field(
+        default=None, description="Actions to run before starting the model service."
+    )
+    command: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("command", "start_command"),
+        description="Command that starts the model service.",
+    )
+    shell: str | None = Field(default=None, description="Shell used to run the command.")
+    port: int | None = Field(default=None, description="Model service port.")
+    health_check: RuntimeVariantModelHealthCheckInfo | None = Field(
+        default=None, description="Default model service health-check settings."
+    )
+
+
+class RuntimeVariantModelConfigInfo(BaseResponseModel):
+    name: str | None = Field(default=None, description="Default model name.")
+    model_path: str | None = Field(default=None, description="Default model path.")
+    service: RuntimeVariantModelServiceConfigInfo | None = Field(
+        default=None, description="Default model service configuration."
+    )
+    metadata: ModelMetadataInfoDTO | None = Field(
+        default=None, description="Default model metadata."
+    )
+
+
+class RuntimeVariantModelDefinitionInfo(BaseResponseModel):
+    models: list[RuntimeVariantModelConfigInfo] | None = Field(
+        default=None, description="Default model configurations supplied by the runtime variant."
+    )
 
 
 class RuntimeVariantNode(BaseResponseModel):
     id: UUID = Field(description="ID of the runtime variant.")
     name: str = Field(description="Unique name of the runtime variant.")
     description: str | None = Field(default=None, description="Description.")
+    reads_vfolder_config_files: bool = Field(
+        description=(
+            "Whether legacy model configuration files in the model vfolder participate in "
+            "revision resolution."
+        )
+    )
+    default_model_definition: RuntimeVariantModelDefinitionInfo = Field(
+        description="Model definition defaults stored for the runtime variant."
+    )
     created_at: datetime = Field(description="Creation timestamp.")
     updated_at: datetime | None = Field(default=None, description="Last update timestamp.")
 

--- a/src/ai/backend/manager/api/adapters/runtime_variant/adapter.py
+++ b/src/ai/backend/manager/api/adapters/runtime_variant/adapter.py
@@ -16,6 +16,7 @@ from ai.backend.common.dto.manager.v2.runtime_variant.response import (
     CreateRuntimeVariantPayload,
     DeleteRuntimeVariantPayload,
     DeleteRuntimeVariantsPayload,
+    RuntimeVariantModelDefinitionInfo,
     RuntimeVariantNode,
     SearchRuntimeVariantsPayload,
     UpdateRuntimeVariantPayload,
@@ -231,6 +232,11 @@ class RuntimeVariantAdapter(BaseAdapter):
             id=data.id,
             name=data.name,
             description=data.description,
+            reads_vfolder_config_files=data.reads_vfolder_config_files,
+            default_model_definition=RuntimeVariantModelDefinitionInfo.model_validate(
+                data.default_model_definition,
+                from_attributes=True,
+            ),
             created_at=data.created_at,
             updated_at=data.updated_at,
         )

--- a/src/ai/backend/manager/api/gql/runtime_variant/types.py
+++ b/src/ai/backend/manager/api/gql/runtime_variant/types.py
@@ -33,11 +33,24 @@ from ai.backend.common.dto.manager.v2.runtime_variant.response import (
     DeleteRuntimeVariantsPayload as DeleteRuntimeVariantsPayloadDTO,
 )
 from ai.backend.common.dto.manager.v2.runtime_variant.response import (
+    RuntimeVariantModelConfigInfo as RuntimeVariantModelConfigInfoDTO,
+)
+from ai.backend.common.dto.manager.v2.runtime_variant.response import (
+    RuntimeVariantModelDefinitionInfo as RuntimeVariantModelDefinitionInfoDTO,
+)
+from ai.backend.common.dto.manager.v2.runtime_variant.response import (
+    RuntimeVariantModelHealthCheckInfo as RuntimeVariantModelHealthCheckInfoDTO,
+)
+from ai.backend.common.dto.manager.v2.runtime_variant.response import (
+    RuntimeVariantModelServiceConfigInfo as RuntimeVariantModelServiceConfigInfoDTO,
+)
+from ai.backend.common.dto.manager.v2.runtime_variant.response import (
     RuntimeVariantNode as RuntimeVariantNodeDTO,
 )
 from ai.backend.common.dto.manager.v2.runtime_variant.response import (
     UpdateRuntimeVariantPayload as UpdateRuntimeVariantPayloadDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import StringFilter as StringFilterGQL
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -50,6 +63,10 @@ from ai.backend.manager.api.gql.decorators import (
     gql_pydantic_input,
     gql_pydantic_type,
 )
+from ai.backend.manager.api.gql.deployment.types.revision import (
+    ModelMetadataGQL,
+    PreStartActionGQL,
+)
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
 
 
@@ -60,6 +77,79 @@ from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, Pydant
 class RuntimeVariantOrderFieldGQL(StrEnum):
     NAME = "name"
     CREATED_AT = "created_at"
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Default health-check settings stored for a runtime variant.",
+    ),
+    model=RuntimeVariantModelHealthCheckInfoDTO,
+    name="RuntimeVariantModelHealthCheck",
+)
+class RuntimeVariantModelHealthCheckGQL(PydanticOutputMixin[RuntimeVariantModelHealthCheckInfoDTO]):
+    enable: bool | None = gql_field(description="Whether health checks are enabled.")
+    interval: float | None = gql_field(description="Health-check interval in seconds.")
+    path: str | None = gql_field(description="Health-check endpoint path.")
+    max_retries: int | None = gql_field(description="Maximum number of retries.")
+    max_wait_time: float | None = gql_field(description="Maximum time to wait for a health check.")
+    expected_status_code: int | None = gql_field(description="Expected healthy HTTP status code.")
+    initial_delay: float | None = gql_field(
+        description="Initial health-check grace period in seconds."
+    )
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Default model service configuration stored for a runtime variant.",
+    ),
+    model=RuntimeVariantModelServiceConfigInfoDTO,
+    name="RuntimeVariantModelServiceConfig",
+)
+class RuntimeVariantModelServiceConfigGQL(
+    PydanticOutputMixin[RuntimeVariantModelServiceConfigInfoDTO]
+):
+    pre_start_actions: list[PreStartActionGQL] | None = gql_field(
+        description="Actions to run before starting the model service."
+    )
+    command: str | None = gql_field(description="Command that starts the model service.")
+    shell: str | None = gql_field(description="Shell used to run the command.")
+    port: int | None = gql_field(description="Model service port.")
+    health_check: RuntimeVariantModelHealthCheckGQL | None = gql_field(
+        description="Default model service health-check settings."
+    )
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Default model configuration stored for a runtime variant.",
+    ),
+    model=RuntimeVariantModelConfigInfoDTO,
+    name="RuntimeVariantModelConfig",
+)
+class RuntimeVariantModelConfigGQL(PydanticOutputMixin[RuntimeVariantModelConfigInfoDTO]):
+    name: str | None = gql_field(description="Default model name.")
+    model_path: str | None = gql_field(description="Default model path.")
+    service: RuntimeVariantModelServiceConfigGQL | None = gql_field(
+        description="Default model service configuration."
+    )
+    metadata: ModelMetadataGQL | None = gql_field(description="Default model metadata.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Model definition defaults stored for a runtime variant.",
+    ),
+    model=RuntimeVariantModelDefinitionInfoDTO,
+    name="RuntimeVariantModelDefinition",
+)
+class RuntimeVariantModelDefinitionGQL(PydanticOutputMixin[RuntimeVariantModelDefinitionInfoDTO]):
+    models: list[RuntimeVariantModelConfigGQL] | None = gql_field(
+        description="Default model configurations supplied by the runtime variant."
+    )
 
 
 @gql_node_type(
@@ -76,6 +166,21 @@ class RuntimeVariantGQL(PydanticNodeMixin[RuntimeVariantNodeDTO]):
     )
     description: str | None = gql_field(
         description="Human-readable description explaining the runtime engine and its typical use cases."
+    )
+    reads_vfolder_config_files: bool = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Whether legacy model configuration files in the model vfolder participate in "
+                "revision resolution."
+            ),
+        )
+    )
+    default_model_definition: RuntimeVariantModelDefinitionGQL = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Model definition defaults stored for this runtime variant.",
+        )
     )
     created_at: datetime = gql_field(
         description="Timestamp when this runtime variant was registered."

--- a/tests/unit/manager/api/adapters/test_runtime_variant_adapter.py
+++ b/tests/unit/manager/api/adapters/test_runtime_variant_adapter.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from ai.backend.common.config import ModelDefinitionDraft
+from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
+from ai.backend.manager.api.adapters.runtime_variant.adapter import RuntimeVariantAdapter
+from ai.backend.manager.data.runtime_variant.types import RuntimeVariantData
+
+
+class TestRuntimeVariantDataToNode:
+    def test_maps_start_command_to_command(self) -> None:
+        data = RuntimeVariantData(
+            id=RuntimeVariantID(uuid4()),
+            name="vllm",
+            description=None,
+            reads_vfolder_config_files=False,
+            default_model_definition=ModelDefinitionDraft.model_validate({
+                "models": [
+                    {
+                        "service": {
+                            "start_command": "vllm serve '{model_path}'",
+                        },
+                    }
+                ]
+            }),
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            updated_at=None,
+        )
+
+        node = RuntimeVariantAdapter._data_to_node(data)
+
+        assert node.default_model_definition.models is not None
+        service = node.default_model_definition.models[0].service
+        assert service is not None
+        assert service.command == "vllm serve '{model_path}'"


### PR DESCRIPTION
## Summary

- Expose `reads_vfolder_config_files` and stored `default_model_definition` through Runtime Variant REST and GraphQL APIs.
- Present the deprecated internal `start_command` field as `command` in API responses.
- Add generated GraphQL schema references and focused command-mapping coverage.

## Test plan

- [x] Run formatting and lint checks.
- [x] Run MyPy checks for changed targets.
- [x] Run Runtime Variant adapter and GraphQL unit tests.
- [x] Verify REST and GraphQL responses against the local server.

Resolves BA-6942

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--12970.org.readthedocs.build/en/12970/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--12970.org.readthedocs.build/ko/12970/

<!-- readthedocs-preview sorna-ko end -->