### PR TITLE
fix(BA-6944): align active app connection tracker identifiers

### DIFF
--- a/changes/12973.fix.md
+++ b/changes/12973.fix.md
@@ -1,0 +1,1 @@
+Fix active app connection tracking to consistently distinguish session and kernel identifiers.

--- a/src/ai/backend/common/clients/valkey_client/valkey_live/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_live/client.py
@@ -30,7 +30,7 @@ from ai.backend.common.resilience import (
     RetryArgs,
     RetryPolicy,
 )
-from ai.backend.common.types import SessionId, ValkeyTarget
+from ai.backend.common.types import KernelId, SessionId, ValkeyTarget
 from ai.backend.logging.utils import BraceStyleAdapter
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
@@ -273,7 +273,7 @@ class ValkeyLiveClient:
         return seconds + (microseconds / 10**6)
 
     @valkey_live_resilience.apply()
-    async def count_active_connections(self, session_id: str) -> int:
+    async def count_active_connections(self, session_id: SessionId) -> int:
         """Count active connections for a session."""
         async with self._client.client() as conn:
             return await conn.zcount(
@@ -314,7 +314,8 @@ class ValkeyLiveClient:
     @valkey_live_resilience.apply()
     async def update_connection_tracker(
         self,
-        session_id: str,
+        session_id: SessionId,
+        kernel_id: KernelId,
         service: str,
         stream_id: str,
     ) -> None:
@@ -322,12 +323,13 @@ class ValkeyLiveClient:
         Update connection tracker with current timestamp.
 
         :param session_id: The session ID to track connections for.
+        :param kernel_id: The kernel ID hosting the connection.
         :param service: The service name.
         :param stream_id: The stream ID.
         """
         current_time = await self.get_server_time()
         connection_id = self._active_app_connection_value(
-            kernel_id=session_id,
+            kernel_id=kernel_id,
             service=service,
             stream_id=stream_id,
         )
@@ -336,33 +338,10 @@ class ValkeyLiveClient:
             await conn.zadd(tracker_key, {connection_id: current_time})
 
     @valkey_live_resilience.apply()
-    async def update_app_connection_tracker(
-        self,
-        kernel_id: str,
-        service: str,
-        stream_id: str,
-    ) -> None:
-        """
-        Update app connection tracker for a specific kernel, service, and stream.
-
-        :param kernel_id: The kernel ID.
-        :param service: The service name.
-        :param stream_id: The stream ID.
-        """
-        tracker_key = self._active_app_connection_key(kernel_id)  # TODO: Check if this is correct
-        tracker_val = self._active_app_connection_value(
-            kernel_id=kernel_id,
-            service=service,
-            stream_id=stream_id,
-        )
-        current_time = await self.get_server_time()
-        async with self._client.client() as conn:
-            await conn.zadd(tracker_key, {tracker_val: current_time})
-
-    @valkey_live_resilience.apply()
     async def remove_connection_tracker(
         self,
-        session_id: str,
+        session_id: SessionId,
+        kernel_id: KernelId,
         service: str,
         stream_id: str,
     ) -> int:
@@ -370,13 +349,14 @@ class ValkeyLiveClient:
         Remove connection from tracker.
 
         :param session_id: The session ID to remove connection from.
+        :param kernel_id: The kernel ID hosting the connection.
         :param service: The service name.
         :param stream_id: The stream ID.
         :return: Number of connections removed.
         """
         tracker_key = self._active_app_connection_key(session_id)
         connection_id = self._active_app_connection_value(
-            kernel_id=session_id,
+            kernel_id=kernel_id,
             service=service,
             stream_id=stream_id,
         )
@@ -386,7 +366,7 @@ class ValkeyLiveClient:
     @valkey_live_resilience.apply()
     async def remove_stale_connections(
         self,
-        session_id: str,
+        session_id: SessionId,
         max_timestamp: float,
     ) -> int:
         """
@@ -586,7 +566,7 @@ class ValkeyLiveClient:
         async with self._client.client() as conn:
             return await conn.delete([key])
 
-    def _active_app_connection_key(self, session_id: str) -> str:
+    def _active_app_connection_key(self, session_id: SessionId) -> str:
         """
         Generate the key for tracking active app connections for a session.
         :param session_id: The session ID.
@@ -596,7 +576,7 @@ class ValkeyLiveClient:
 
     def _active_app_connection_value(
         self,
-        kernel_id: str,
+        kernel_id: KernelId,
         service: str,
         stream_id: str,
     ) -> str:

--- a/src/ai/backend/manager/api/rest/stream/handler.py
+++ b/src/ai/backend/manager/api/rest/stream/handler.py
@@ -94,7 +94,7 @@ class PrivateContext:
     zctx: zmq.asyncio.Context
     conn_tracker_lock: asyncio.Lock
     conn_tracker_gc_task: asyncio.Task[Any]
-    active_session_ids: defaultdict[KernelId, int]
+    active_connection_counts: defaultdict[SessionId, int]
 
 
 class StreamHandler:
@@ -151,7 +151,7 @@ class StreamHandler:
             GetStreamingSessionAction(session_name=session_name, user_uuid=user_id),
         )
         log.info("STREAM_PTY(s:{0})", session_name)
-        stream_key = KernelId(uuid.UUID(result.kernel_id))
+        stream_key = result.kernel_id
         kernel_host: str
         if result.kernel_host is None:
             hostname = urlparse(result.agent_addr).hostname
@@ -347,7 +347,7 @@ class StreamHandler:
         session_result = await self._stream.get_streaming_session.wait_for_complete(
             GetStreamingSessionAction(session_name=session_name, user_uuid=user_id),
         )
-        stream_key = KernelId(uuid.UUID(session_result.kernel_id))
+        stream_key = session_result.kernel_id
 
         ws = web.WebSocketResponse(max_msg_size=config.manager.max_wsmsg_size)
         await ws.prepare(request)
@@ -464,8 +464,8 @@ class StreamHandler:
         session_result = await self._stream.get_streaming_session.wait_for_complete(
             GetStreamingSessionAction(session_name=session_name, user_uuid=user_id),
         )
-        kernel_id = KernelId(uuid.UUID(session_result.kernel_id))
-        session_id = SessionId(uuid.UUID(session_result.session_id))
+        kernel_id = session_result.kernel_id
+        session_id = session_result.session_id
         stream_key = kernel_id
         stream_id = uuid.uuid4().hex
         app_ctx.stream_proxy_handlers[stream_key].add(myself)
@@ -519,16 +519,16 @@ class StreamHandler:
         else:
             raise InvalidAPIParameters(f"Unsupported service protocol: {sport['protocol']}")
 
-        conn_tracker_key = f"session.{kernel_id}.active_app_connections"
+        connection_tracker_throttle_key = (session_id, kernel_id, service, stream_id)
         update_connection_tracker = self._stream.create_connection_refresh_callback(
-            kernel_id, service, stream_id
+            session_id, kernel_id, service, stream_id
         )
 
         async def refresh_cb(_kernel_id_str: str, _data: bytes) -> None:
             await asyncio.shield(
                 rpc_ptask_group.create_task(
                     call_non_bursty(
-                        conn_tracker_key,
+                        connection_tracker_throttle_key,
                         update_connection_tracker,
                         max_bursts=128,
                         max_idle=5000,
@@ -542,7 +542,7 @@ class StreamHandler:
 
         async def add_conn_track() -> None:
             async with app_ctx.conn_tracker_lock:
-                app_ctx.active_session_ids[kernel_id] += 1
+                app_ctx.active_connection_counts[session_id] += 1
                 await self._stream.track_connection.wait_for_complete(
                     TrackConnectionAction(
                         kernel_id=kernel_id,
@@ -554,9 +554,9 @@ class StreamHandler:
 
         async def clear_conn_track() -> None:
             async with app_ctx.conn_tracker_lock:
-                app_ctx.active_session_ids[kernel_id] -= 1
-                if app_ctx.active_session_ids[kernel_id] <= 0:
-                    del app_ctx.active_session_ids[kernel_id]
+                app_ctx.active_connection_counts[session_id] -= 1
+                if app_ctx.active_connection_counts[session_id] <= 0:
+                    del app_ctx.active_connection_counts[session_id]
                 await self._stream.untrack_connection.wait_for_complete(
                     UntrackConnectionAction(
                         kernel_id=kernel_id,
@@ -677,11 +677,11 @@ async def stream_conn_tracker_gc(
 ) -> None:
     try:
         while True:
-            active_ids = list(app_ctx.active_session_ids.keys())
-            if active_ids:
+            active_session_ids = list(app_ctx.active_connection_counts.keys())
+            if active_session_ids:
                 try:
                     await stream_processors.gc_stale_connections.wait_for_complete(
-                        GCStaleConnectionsAction(active_session_ids=active_ids),
+                        GCStaleConnectionsAction(active_session_ids=active_session_ids),
                     )
                 except Exception:
                     log.warning("stream_conn_tracker_gc(): error during GC, retrying...")
@@ -708,7 +708,7 @@ async def stream_app_ctx(
     app_ctx.stream_stdin_socks = defaultdict(weakref.WeakSet)
     app_ctx.zctx = zmq.asyncio.Context()
     app_ctx.conn_tracker_lock = asyncio.Lock()
-    app_ctx.active_session_ids = defaultdict(int)
+    app_ctx.active_connection_counts = defaultdict(int)
     app_ctx.conn_tracker_gc_task = asyncio.create_task(
         stream_conn_tracker_gc(
             app_ctx,

--- a/src/ai/backend/manager/services/stream/actions/gc_stale_connections.py
+++ b/src/ai/backend/manager/services/stream/actions/gc_stale_connections.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.types import KernelId
+from ai.backend.common.types import SessionId
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.services.stream.actions.base import StreamAction
@@ -11,7 +11,7 @@ from ai.backend.manager.services.stream.actions.base import StreamAction
 
 @dataclass(frozen=True)
 class GCStaleConnectionsAction(StreamAction):
-    active_session_ids: list[KernelId]
+    active_session_ids: list[SessionId]
 
     @override
     def entity_id(self) -> str | None:
@@ -25,7 +25,7 @@ class GCStaleConnectionsAction(StreamAction):
 
 @dataclass(frozen=True)
 class GCStaleConnectionsActionResult(BaseActionResult):
-    removed_sessions: list[str]
+    inactive_session_ids: list[SessionId]
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/stream/actions/get_streaming_session.py
+++ b/src/ai/backend/manager/services/stream/actions/get_streaming_session.py
@@ -4,6 +4,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, override
 
+from ai.backend.common.types import KernelId, SessionId
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.services.stream.actions.base import StreamAction
@@ -26,8 +27,8 @@ class GetStreamingSessionAction(StreamAction):
 
 @dataclass(frozen=True)
 class GetStreamingSessionActionResult(BaseActionResult):
-    session_id: str
-    kernel_id: str
+    session_id: SessionId
+    kernel_id: KernelId
     kernel_host: str | None
     agent_addr: str | None
     repl_in_port: int
@@ -36,4 +37,4 @@ class GetStreamingSessionActionResult(BaseActionResult):
 
     @override
     def entity_id(self) -> str | None:
-        return self.session_id
+        return str(self.session_id)

--- a/src/ai/backend/manager/services/stream/actions/track_connection.py
+++ b/src/ai/backend/manager/services/stream/actions/track_connection.py
@@ -28,8 +28,8 @@ class TrackConnectionAction(StreamAction):
 
 @dataclass(frozen=True)
 class TrackConnectionActionResult(BaseActionResult):
-    kernel_id: str
+    kernel_id: KernelId
 
     @override
     def entity_id(self) -> str | None:
-        return self.kernel_id
+        return str(self.kernel_id)

--- a/src/ai/backend/manager/services/stream/actions/untrack_connection.py
+++ b/src/ai/backend/manager/services/stream/actions/untrack_connection.py
@@ -28,9 +28,9 @@ class UntrackConnectionAction(StreamAction):
 
 @dataclass(frozen=True)
 class UntrackConnectionActionResult(BaseActionResult):
-    kernel_id: str
+    kernel_id: KernelId
     remaining_count: int
 
     @override
     def entity_id(self) -> str | None:
-        return self.kernel_id
+        return str(self.kernel_id)

--- a/src/ai/backend/manager/services/stream/processors.py
+++ b/src/ai/backend/manager/services/stream/processors.py
@@ -1,7 +1,7 @@
 from collections.abc import Awaitable, Callable
 from typing import override
 
-from ai.backend.common.types import KernelId
+from ai.backend.common.types import KernelId, SessionId
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
@@ -71,11 +71,14 @@ class StreamProcessors(AbstractProcessorPackage):
 
     def create_connection_refresh_callback(
         self,
+        session_id: SessionId,
         kernel_id: KernelId,
         service: str,
         stream_id: str,
     ) -> Callable[..., Awaitable[None]]:
-        return self._service.create_connection_refresh_callback(kernel_id, service, stream_id)
+        return self._service.create_connection_refresh_callback(
+            session_id, kernel_id, service, stream_id
+        )
 
     @override
     def supported_actions(self) -> list[ActionSpec]:

--- a/src/ai/backend/manager/services/stream/service.py
+++ b/src/ai/backend/manager/services/stream/service.py
@@ -76,8 +76,8 @@ class StreamService:
         )
         kernel = session.main_kernel
         return GetStreamingSessionActionResult(
-            session_id=str(session.id),
-            kernel_id=str(kernel.id),
+            session_id=session.id,
+            kernel_id=kernel.id,
             kernel_host=kernel.kernel_host,
             agent_addr=kernel.agent_addr,
             repl_in_port=kernel.repl_in_port,
@@ -133,35 +133,36 @@ class StreamService:
 
     def create_connection_refresh_callback(
         self,
+        session_id: SessionId,
         kernel_id: KernelId,
         service: str,
         stream_id: str,
     ) -> Callable[..., Awaitable[None]]:
         async def update_connection_tracker() -> None:
-            await self._valkey_live.update_app_connection_tracker(
-                str(kernel_id), service, stream_id
+            await self._valkey_live.update_connection_tracker(
+                session_id, kernel_id, service, stream_id
             )
 
         return update_connection_tracker
 
     async def track_connection(self, action: TrackConnectionAction) -> TrackConnectionActionResult:
         await self._valkey_live.update_connection_tracker(
-            str(action.kernel_id), action.service, action.stream_id
+            action.session_id, action.kernel_id, action.service, action.stream_id
         )
         await self._valkey_live.mark_session_active(action.session_id)
-        return TrackConnectionActionResult(kernel_id=str(action.kernel_id))
+        return TrackConnectionActionResult(kernel_id=action.kernel_id)
 
     async def untrack_connection(
         self, action: UntrackConnectionAction
     ) -> UntrackConnectionActionResult:
         await self._valkey_live.remove_connection_tracker(
-            str(action.kernel_id), action.service, action.stream_id
+            action.session_id, action.kernel_id, action.service, action.stream_id
         )
-        remaining_count = await self._valkey_live.count_active_connections(str(action.kernel_id))
+        remaining_count = await self._valkey_live.count_active_connections(action.session_id)
         if remaining_count == 0:
             await self._valkey_live.update_session_last_access(action.session_id)
         return UntrackConnectionActionResult(
-            kernel_id=str(action.kernel_id),
+            kernel_id=action.kernel_id,
             remaining_count=remaining_count,
         )
 
@@ -172,14 +173,14 @@ class StreamService:
             await self._etcd.get("config/idle/app-streaming-packet-timeout") or "5m",
         )
         now = await self._valkey_live.get_server_time()
-        removed_sessions: list[str] = []
+        inactive_session_ids: list[SessionId] = []
         for session_id in action.active_session_ids:
-            prev_remaining = await self._valkey_live.count_active_connections(str(session_id))
+            prev_remaining = await self._valkey_live.count_active_connections(session_id)
             removed_count = await self._valkey_live.remove_stale_connections(
-                str(session_id),
+                session_id,
                 now - no_packet_timeout.total_seconds(),
             )
-            remaining = await self._valkey_live.count_active_connections(str(session_id))
+            remaining = await self._valkey_live.count_active_connections(session_id)
             log.debug(
                 "conn_tracker: gc {} removed/remaining = {}/{}",
                 session_id,
@@ -187,6 +188,6 @@ class StreamService:
                 remaining,
             )
             if prev_remaining > 0 and remaining == 0:
-                await self._valkey_live.update_session_last_access(SessionId(session_id))
-                removed_sessions.append(str(session_id))
-        return GCStaleConnectionsActionResult(removed_sessions=removed_sessions)
+                await self._valkey_live.update_session_last_access(session_id)
+                inactive_session_ids.append(session_id)
+        return GCStaleConnectionsActionResult(inactive_session_ids=inactive_session_ids)

--- a/tests/unit/common/clients/valkey_client/test_valkey_live_client.py
+++ b/tests/unit/common/clients/valkey_client/test_valkey_live_client.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 import pytest
 
 from ai.backend.common.clients.valkey_client.valkey_live.client import ValkeyLiveClient
-from ai.backend.common.types import SessionId
+from ai.backend.common.types import KernelId, SessionId
 
 
 async def test_valkey_live_hset_operations(test_valkey_live: ValkeyLiveClient) -> None:
@@ -102,6 +102,56 @@ class TestSessionLastAccessMarker:
         await test_valkey_live.delete_session_last_access(session_id)
 
         assert await test_valkey_live.get_live_data(marker_key) is None
+
+
+class TestActiveAppConnections:
+    @pytest.fixture()
+    def session_id(self) -> SessionId:
+        return SessionId(uuid4())
+
+    @pytest.fixture()
+    def kernel_id(self) -> KernelId:
+        return KernelId(uuid4())
+
+    @pytest.fixture()
+    def other_kernel_id(self) -> KernelId:
+        return KernelId(uuid4())
+
+    async def test_tracker_uses_session_key_and_kernel_member(
+        self,
+        test_valkey_live: ValkeyLiveClient,
+        session_id: SessionId,
+        kernel_id: KernelId,
+        other_kernel_id: KernelId,
+    ) -> None:
+        await test_valkey_live.update_connection_tracker(
+            session_id,
+            kernel_id,
+            "jupyter",
+            "stream-001",
+        )
+
+        assert await test_valkey_live.count_active_connections(session_id) == 1
+
+        unrelated_removed_count = await test_valkey_live.remove_connection_tracker(
+            session_id,
+            other_kernel_id,
+            "jupyter",
+            "stream-001",
+        )
+
+        assert unrelated_removed_count == 0
+        assert await test_valkey_live.count_active_connections(session_id) == 1
+
+        removed_count = await test_valkey_live.remove_connection_tracker(
+            session_id,
+            kernel_id,
+            "jupyter",
+            "stream-001",
+        )
+
+        assert removed_count == 1
+        assert await test_valkey_live.count_active_connections(session_id) == 0
 
 
 async def test_valkey_live_client_lifecycle(test_valkey_live: ValkeyLiveClient) -> None:

--- a/tests/unit/manager/services/stream/test_stream_service.py
+++ b/tests/unit/manager/services/stream/test_stream_service.py
@@ -110,8 +110,8 @@ class TestGetStreamingSession(TestStreamService):
         result = await stream_service.get_streaming_session(action)
 
         assert isinstance(result, GetStreamingSessionActionResult)
-        assert result.session_id == str(FAKE_SESSION_ID)
-        assert result.kernel_id == str(FAKE_KERNEL_ID)
+        assert result.session_id == FAKE_SESSION_ID
+        assert result.kernel_id == FAKE_KERNEL_ID
         assert result.kernel_host == "10.0.0.1"
         assert result.agent_addr == "agent1:6001"
         assert result.repl_in_port == 2000
@@ -280,9 +280,9 @@ class TestTrackConnection(TestStreamService):
         result = await stream_service.track_connection(action)
 
         assert isinstance(result, TrackConnectionActionResult)
-        assert result.kernel_id == str(FAKE_KERNEL_ID)
+        assert result.kernel_id == FAKE_KERNEL_ID
         mock_valkey_live.update_connection_tracker.assert_awaited_once_with(
-            str(FAKE_KERNEL_ID), "jupyter", "stream-001"
+            FAKE_SESSION_ID, FAKE_KERNEL_ID, "jupyter", "stream-001"
         )
         mock_valkey_live.mark_session_active.assert_awaited_once_with(FAKE_SESSION_ID)
 
@@ -324,8 +324,9 @@ class TestUntrackConnection(TestStreamService):
         assert isinstance(result, UntrackConnectionActionResult)
         assert result.remaining_count == 0
         mock_valkey_live.remove_connection_tracker.assert_awaited_once_with(
-            str(FAKE_KERNEL_ID), "jupyter", "stream-001"
+            FAKE_SESSION_ID, FAKE_KERNEL_ID, "jupyter", "stream-001"
         )
+        mock_valkey_live.count_active_connections.assert_awaited_once_with(FAKE_SESSION_ID)
         mock_valkey_live.update_session_last_access.assert_awaited_once_with(FAKE_SESSION_ID)
 
     async def test_remaining_connections_does_not_refresh_marker(
@@ -344,6 +345,7 @@ class TestUntrackConnection(TestStreamService):
         result = await stream_service.untrack_connection(action)
 
         assert result.remaining_count == 3
+        mock_valkey_live.count_active_connections.assert_awaited_once_with(FAKE_SESSION_ID)
         mock_valkey_live.update_session_last_access.assert_not_awaited()
 
 
@@ -356,18 +358,16 @@ class TestGCStaleConnections(TestStreamService):
     ) -> None:
         mock_etcd.get.return_value = "10m"
         mock_valkey_live.get_server_time.return_value = 1000.0
-        sid = str(FAKE_SESSION_ID)
-
         # prev_remaining=2, removed_count=2, remaining=0 → session goes idle
         mock_valkey_live.count_active_connections.side_effect = [2, 0]
         mock_valkey_live.remove_stale_connections.return_value = 2
 
-        action = GCStaleConnectionsAction(active_session_ids=[KernelId(FAKE_SESSION_ID)])
+        action = GCStaleConnectionsAction(active_session_ids=[FAKE_SESSION_ID])
 
         result = await stream_service.gc_stale_connections(action)
 
         assert isinstance(result, GCStaleConnectionsActionResult)
-        assert sid in result.removed_sessions
+        assert result.inactive_session_ids == [FAKE_SESSION_ID]
         mock_valkey_live.update_session_last_access.assert_awaited_once_with(FAKE_SESSION_ID)
 
     async def test_empty_session_ids_returns_empty(
@@ -383,7 +383,7 @@ class TestGCStaleConnections(TestStreamService):
 
         result = await stream_service.gc_stale_connections(action)
 
-        assert result.removed_sessions == []
+        assert result.inactive_session_ids == []
 
     async def test_etcd_none_uses_default_timeout(
         self,
@@ -398,7 +398,7 @@ class TestGCStaleConnections(TestStreamService):
 
         result = await stream_service.gc_stale_connections(action)
 
-        assert result.removed_sessions == []
+        assert result.inactive_session_ids == []
         mock_etcd.get.assert_awaited_once_with("config/idle/app-streaming-packet-timeout")
 
     async def test_active_to_idle_included_in_removed(
@@ -410,8 +410,8 @@ class TestGCStaleConnections(TestStreamService):
         mock_etcd.get.return_value = "5m"
         mock_valkey_live.get_server_time.return_value = 2000.0
 
-        sid1 = KernelId(uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001"))
-        sid2 = KernelId(uuid.UUID("aaaaaaaa-0000-0000-0000-000000000002"))
+        sid1 = SessionId(uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001"))
+        sid2 = SessionId(uuid.UUID("aaaaaaaa-0000-0000-0000-000000000002"))
 
         # sid1: prev=3, remaining=0 → goes idle
         # sid2: prev=5, remaining=2 → stays active
@@ -422,5 +422,5 @@ class TestGCStaleConnections(TestStreamService):
 
         result = await stream_service.gc_stale_connections(action)
 
-        assert str(sid1) in result.removed_sessions
-        assert str(sid2) not in result.removed_sessions
+        assert sid1 in result.inactive_session_ids
+        assert sid2 not in result.inactive_session_ids


### PR DESCRIPTION
## Summary
- Store active app connection ZSETs under session IDs while retaining kernel IDs in connection members.
- Propagate typed SessionId and KernelId values through stream actions, services, refresh callbacks, cleanup, and GC.
- Add regression coverage for distinct session/kernel IDs and per-connection tracking behavior.

## Test plan
- [x] `pants test tests/unit/common/clients/valkey_client/test_valkey_live_client.py`
- [x] `pants test tests/unit/manager/services/stream/test_stream_service.py`
- [x] `pants test tests/unit/manager/test_idle_checker.py`
- [x] `pants test tests/component/stream/test_stream_websocket.py tests/component/streaming/test_streaming.py`
- [x] `pants lint --changed-since=origin/main`

Resolves #12972 (BA-6944)