### PR TITLE
docs(alembic): align README head-reconciliation rule with guardrails

### DIFF
--- a/changes/12983.doc.md
+++ b/changes/12983.doc.md
@@ -1,0 +1,1 @@
+Clarify the alembic README head-reconciliation rule: repoint your own unmerged migration, but add an empty merge migration when main itself has multiple released heads.

--- a/src/ai/backend/manager/models/alembic/README.md
+++ b/src/ai/backend/manager/models/alembic/README.md
@@ -26,9 +26,12 @@ The same strategy applies to all components:
    an existing migration that has already been released. Editing `down_revision` is
    allowed only when inserting a backport migration into the main branch chain before
    the change is merged (see Step 2 below).
-4. **Linear chain** -- The migration chain must always remain linear (single head).
-   Never create merge migrations. If multiple heads appear after inserting a backport,
-   fix the `down_revision` pointers instead.
+4. **Single head** -- The migration chain must resolve to a single head. Keep it linear
+   by fixing `down_revision` pointers when *your own unmerged* migration diverged; use an
+   empty merge migration only when *main itself* already has two or more released heads.
+   When merging released heads, do **not** edit the existing migrations'
+   `revision`/`down_revision` pointers — they may already be released.
+   Generate the empty merge migration with `./py -m alembic merge heads`.
 
 ### Backport Procedure
 


### PR DESCRIPTION
## Summary
- The alembic README Principle 4 said "never create merge migrations", contradicting the alembic guardrails (`CLAUDE.md`): when **main itself** already has two or more released heads, the correct fix is an **empty merge migration**, not editing released migrations' `down_revision`.
- Rewrote Principle 4 to distinguish the two cases (repoint your own *unmerged* migration vs. merge already-released heads), reiterate that released migrations' `revision`/`down_revision` must not be edited, and note `./py -m alembic merge heads` for generating the merge migration.

## Test plan
- [x] Docs-only change; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)