### PR TITLE
feat(BA-6950): integrate idle check expiry sweep stage

### DIFF
--- a/changes/12988.feature.md
+++ b/changes/12988.feature.md
@@ -1,0 +1,1 @@
+Register the idle-check expiry sweep stage with the reconciler.

--- a/src/ai/backend/manager/defs.py
+++ b/src/ai/backend/manager/defs.py
@@ -130,6 +130,7 @@ class LockID(enum.IntEnum):
         238  # For replica-group steady-state autoscale reconcile
     )
     LOCKID_IDLE_CHECK_RECONCILE = 239  # For idle-check reconcile
+    LOCKID_IDLE_CHECK_SWEEP_RECONCILE = 240  # For idle-check expiry sweep reconcile
 
 
 SERVICE_MAX_RETRIES = 5  # FIXME: make configurable

--- a/src/ai/backend/manager/dependencies/orchestration/sokovan.py
+++ b/src/ai/backend/manager/dependencies/orchestration/sokovan.py
@@ -198,6 +198,7 @@ class SokovanOrchestratorDependency(
         reconciler_coordinator, reconciler_task_specs = build_reconciler_coordinator(
             replica_group_repository=setup_input.replica_group_repository,
             idle_checker_repository=setup_input.idle_checker_repository,
+            scheduling_controller=setup_input.scheduling_controller,
             valkey_schedule=setup_input.valkey_schedule,
             lock_factory=setup_input.distributed_lock_factory,
             config_provider=setup_input.config_provider,

--- a/src/ai/backend/manager/sokovan/stages/factory.py
+++ b/src/ai/backend/manager/sokovan/stages/factory.py
@@ -9,11 +9,13 @@ from ai.backend.manager.repositories.replica_group.repository import ReplicaGrou
 from ai.backend.manager.sokovan.reconciler.base import ReconcilerStageRunner, ReconcilerTaskSpec
 from ai.backend.manager.sokovan.reconciler.coordinator import ReconcilerCoordinator
 from ai.backend.manager.sokovan.reconciler.flag import ValkeyReconcilerFlag
+from ai.backend.manager.sokovan.scheduling_controller import SchedulingController
 from ai.backend.manager.sokovan.stages.group_autoscale import build_group_autoscale_stage
 from ai.backend.manager.sokovan.stages.group_draining import build_group_draining_stage
 from ai.backend.manager.sokovan.stages.group_rolling import build_group_rolling_stage
 from ai.backend.manager.sokovan.stages.group_scaling import build_group_scaling_stage
 from ai.backend.manager.sokovan.stages.idle_check import build_idle_check_stage
+from ai.backend.manager.sokovan.stages.idle_check_sweep import build_idle_check_sweep_stage
 from ai.backend.manager.types import DistributedLockFactory
 
 
@@ -21,6 +23,7 @@ def build_reconciler_coordinator(
     *,
     replica_group_repository: ReplicaGroupRepository,
     idle_checker_repository: IdleCheckerRepository,
+    scheduling_controller: SchedulingController,
     valkey_schedule: ValkeyScheduleClient,
     lock_factory: DistributedLockFactory,
     config_provider: ManagerConfigProvider,
@@ -31,6 +34,7 @@ def build_reconciler_coordinator(
         build_group_draining_stage(replica_group_repository),
         build_group_autoscale_stage(replica_group_repository),
         build_idle_check_stage(idle_checker_repository),
+        build_idle_check_sweep_stage(idle_checker_repository, scheduling_controller),
     ]
     stages: dict[str, ReconcilerStageRunner] = {}
     task_specs: list[ReconcilerTaskSpec] = []

--- a/src/ai/backend/manager/sokovan/stages/idle_check_sweep.py
+++ b/src/ai/backend/manager/sokovan/stages/idle_check_sweep.py
@@ -55,7 +55,7 @@ def build_idle_check_sweep_stage(
         reconcile_type=reconcile_type,
         if_needed_event_factory=DoReconcileProcessIfNeededEvent,
         process_event_factory=DoReconcileProcessEvent,
-        long_interval=10.0,
+        long_interval=30.0,
     )
     return ReconcilerStageRegistration(
         reconcile_type=reconcile_type,

--- a/src/ai/backend/manager/sokovan/stages/idle_check_sweep.py
+++ b/src/ai/backend/manager/sokovan/stages/idle_check_sweep.py
@@ -1,0 +1,64 @@
+"""Idle-check expiry sweep reconcile stage."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ai.backend.common.events.event_types.schedule.anycast import (
+    DoReconcileProcessEvent,
+    DoReconcileProcessIfNeededEvent,
+)
+from ai.backend.manager.data.session.types import SchedulingResult, SessionStatus
+from ai.backend.manager.defs import LockID
+from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
+from ai.backend.manager.sokovan.idle_check.handlers.sweep import IdleCheckSweepHandler
+from ai.backend.manager.sokovan.idle_check.sweep.applier import IdleCheckSweepApplier
+from ai.backend.manager.sokovan.idle_check.sweep.source import IdleCheckSweepSource
+from ai.backend.manager.sokovan.idle_check.types import (
+    IdleCheckCategory,
+    IdleCheckKind,
+    IdleCheckTargetStatuses,
+)
+from ai.backend.manager.sokovan.reconciler.base import (
+    ReconcilerStage,
+    ReconcilerStageMetadata,
+    ReconcilerStageRegistration,
+    ReconcilerTaskSpec,
+)
+from ai.backend.manager.sokovan.scheduling_controller import SchedulingController
+
+
+def build_idle_check_sweep_stage(
+    idle_checker_repository: IdleCheckerRepository,
+    scheduling_controller: SchedulingController,
+) -> ReconcilerStageRegistration:
+    reconcile_type = "idle_check_sweep"
+    transitions: Mapping[SchedulingResult, SessionStatus] = {}
+    metadata = ReconcilerStageMetadata(
+        category=IdleCheckCategory.IDLE,
+        kind=IdleCheckKind.SESSION,
+        target_statuses=IdleCheckTargetStatuses(
+            session_statuses=frozenset({SessionStatus.RUNNING}),
+        ),
+        name="idle_check_sweep_reconcile",
+        phase="idle_check_sweep",
+        lock_id=LockID.LOCKID_IDLE_CHECK_SWEEP_RECONCILE,
+        transitions=transitions,
+    )
+    stage = ReconcilerStage(
+        handler=IdleCheckSweepHandler(scheduling_controller),
+        source=IdleCheckSweepSource(idle_checker_repository),
+        applier=IdleCheckSweepApplier(),
+        metadata=metadata,
+    )
+    task_spec = ReconcilerTaskSpec(
+        reconcile_type=reconcile_type,
+        if_needed_event_factory=DoReconcileProcessIfNeededEvent,
+        process_event_factory=DoReconcileProcessEvent,
+        long_interval=10.0,
+    )
+    return ReconcilerStageRegistration(
+        reconcile_type=reconcile_type,
+        stage=stage,
+        task_spec=task_spec,
+    )

--- a/tests/unit/manager/sokovan/idle_check/test_stage.py
+++ b/tests/unit/manager/sokovan/idle_check/test_stage.py
@@ -159,7 +159,7 @@ class TestBuildIdleCheckSweepStage:
         assert registration.stage.lock_id == LockID.LOCKID_IDLE_CHECK_SWEEP_RECONCILE
         assert registration.task_spec.reconcile_type == "idle_check_sweep"
         assert registration.task_spec.short_interval is None
-        assert registration.task_spec.long_interval == 10.0
+        assert registration.task_spec.long_interval == 30.0
 
     async def test_runs_expiry_sweep(self, sweep_stage: IdleCheckSweepStageSetup) -> None:
         await sweep_stage.registration.stage.run()

--- a/tests/unit/manager/sokovan/idle_check/test_stage.py
+++ b/tests/unit/manager/sokovan/idle_check/test_stage.py
@@ -14,14 +14,18 @@ from ai.backend.common.data.idle_checker.types import (
     SessionLifetimeSpec,
 )
 from ai.backend.common.data.permission.types import ScopeType
+from ai.backend.common.events.event_types.kernel.types import KernelLifecycleEventReason
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.data.idle_checker.types import IdleCheckSession
 from ai.backend.manager.data.permission.id import ScopeId
+from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.defs import LockID
 from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
 from ai.backend.manager.repositories.idle_checker.types import (
     BoundCheckerData,
+    ExpiredIdleCheckBatchData,
+    ExpiredIdleCheckData,
     IdleCheckBatchData,
     IdleCheckerDefinitionData,
     IdleCheckTargetData,
@@ -30,14 +34,24 @@ from ai.backend.manager.sokovan.idle_check.checkers.session_lifetime import (
     SessionLifetimeChecker,
 )
 from ai.backend.manager.sokovan.reconciler.base import ReconcilerStageRegistration
+from ai.backend.manager.sokovan.scheduling_controller import SchedulingController
 from ai.backend.manager.sokovan.stages.factory import build_reconciler_coordinator
 from ai.backend.manager.sokovan.stages.idle_check import build_idle_check_stage
+from ai.backend.manager.sokovan.stages.idle_check_sweep import build_idle_check_sweep_stage
 
 
 @dataclass(frozen=True)
 class SessionLifetimeStageSetup:
     registration: ReconcilerStageRegistration
     checker: AsyncMock
+
+
+@dataclass(frozen=True)
+class IdleCheckSweepStageSetup:
+    registration: ReconcilerStageRegistration
+    repository: AsyncMock
+    scheduling_controller: AsyncMock
+    session_id: SessionId
 
 
 class TestBuildIdleCheckStage:
@@ -112,13 +126,64 @@ class TestBuildIdleCheckStage:
         session_lifetime_stage.checker.judge.assert_awaited_once()
 
 
+class TestBuildIdleCheckSweepStage:
+    @pytest.fixture()
+    def sweep_stage(self) -> IdleCheckSweepStageSetup:
+        now = datetime(2026, 1, 1, tzinfo=UTC)
+        session_id = SessionId(uuid4())
+        repository = AsyncMock(spec=IdleCheckerRepository)
+        repository.fetch_expired_idle_checks.return_value = ExpiredIdleCheckBatchData(
+            checks=(
+                ExpiredIdleCheckData(
+                    session_id=session_id,
+                    checker_id=IdleCheckerID(uuid4()),
+                    expire_at=now,
+                    last_status="expired",
+                    last_message="maximum lifetime exceeded",
+                ),
+            ),
+            now=now,
+        )
+        scheduling_controller = AsyncMock(spec=SchedulingController)
+        return IdleCheckSweepStageSetup(
+            registration=build_idle_check_sweep_stage(repository, scheduling_controller),
+            repository=repository,
+            scheduling_controller=scheduling_controller,
+            session_id=session_id,
+        )
+
+    def test_registration_metadata(self) -> None:
+        registration = build_idle_check_sweep_stage(MagicMock(), MagicMock())
+
+        assert registration.reconcile_type == "idle_check_sweep"
+        assert registration.stage.lock_id == LockID.LOCKID_IDLE_CHECK_SWEEP_RECONCILE
+        assert registration.task_spec.reconcile_type == "idle_check_sweep"
+        assert registration.task_spec.short_interval is None
+        assert registration.task_spec.long_interval == 10.0
+
+    async def test_runs_expiry_sweep(self, sweep_stage: IdleCheckSweepStageSetup) -> None:
+        await sweep_stage.registration.stage.run()
+
+        sweep_stage.repository.fetch_expired_idle_checks.assert_awaited_once_with(
+            frozenset({SessionStatus.RUNNING})
+        )
+        sweep_stage.scheduling_controller.mark_sessions_for_termination.assert_awaited_once_with(
+            [sweep_stage.session_id],
+            reason=KernelLifecycleEventReason.IDLE_TIMEOUT.value,
+            message="idle check timeout",
+        )
+
+
 class TestFactoryRegistration:
-    def test_idle_check_is_registered(self) -> None:
+    def test_idle_check_stages_are_registered(self) -> None:
         _, task_specs = build_reconciler_coordinator(
             replica_group_repository=MagicMock(),
             idle_checker_repository=MagicMock(),
+            scheduling_controller=MagicMock(),
             valkey_schedule=MagicMock(),
             lock_factory=MagicMock(),
             config_provider=MagicMock(),
         )
-        assert "idle_check" in {task_spec.reconcile_type for task_spec in task_specs}
+        assert {"idle_check", "idle_check_sweep"}.issubset({
+            task_spec.reconcile_type for task_spec in task_specs
+        })


### PR DESCRIPTION
## Summary

- Register the idle-check expiry sweep with the Sokovan reconciler.
- Terminate running sessions whose idle-check deadlines have expired.
- Add a dedicated distributed lock and verify stage execution and registration.

## Test plan

- [x] Run Pants formatting and lint checks.
- [x] Run changed-scope type checks and unit tests via the push hook.

Resolves BA-6950