### PR TITLE
doc: require an audience qualifier segment in REST v2 URLs

### DIFF
--- a/changes/12990.doc.md
+++ b/changes/12990.doc.md
@@ -1,0 +1,1 @@
+Require an audience qualifier segment (`admin` / `scoped` / `my`) in REST v2 URLs, and define the URL shape for sub-apps that group several entities.

--- a/src/ai/backend/client/cli/v2/AGENTS.md
+++ b/src/ai/backend/client/cli/v2/AGENTS.md
@@ -19,10 +19,10 @@
 - `get` by ID (any authenticated user) → `{entity}/commands.py`
 - scoped search → take the scope as a required argument in `{entity}/commands.py`
 
-**scoped search CLI pattern** (under consideration — may change to follow the SDK `scoped_search` direction):
-- Currently: the command name reflects the scope — `./bai session project-search {project_id}`.
+**scoped search CLI pattern:**
+- Command name `search-scoped`, mapped to SDK `scoped_search()` and REST `POST /v2/{entity}/scoped/search`.
 - The scope ID is a required positional argument, not an option flag.
-- Mapped to REST `POST /v2/{entity}/{scope_type}/{scope_id}/search`.
+- **Legacy:** a command named after the scope — `./bai session project-search {project_id}` — do not add new ones.
 
 **Place self-service operations (server `my_` prefix) in `my/{entity}.py`.**
 

--- a/src/ai/backend/client/v2/AGENTS.md
+++ b/src/ai/backend/client/v2/AGENTS.md
@@ -12,15 +12,14 @@ Each client class inherits from `BaseDomainClient` and uses `self._client.typed_
 ## Naming conventions
 
 - admin methods: `admin_search()`, `admin_create()`, `admin_update()`, `admin_delete()`, `admin_purge()`
-- scoped search methods: currently `{scope}_search()` — e.g. `project_search(project_id, request)`, `domain_search(domain_name, request)`.
-  **Forward direction (under consideration):** unify to `scoped_search(request)` following the server `scopedFoosV2` convention, and take the scope
-  as a field of the request DTO. (The URL pattern and CLI surface must be decided together.)
+- scoped search methods: `scoped_search(request)`, taking the scope as a field of the request DTO.
+  **Legacy:** `{scope}_search()` — e.g. `project_search(project_id, request)` — do not add new ones.
 - self-service methods: `my_search()`, `my_issue()` — mapped to `/v2/{entity}/my/{operation}`
 - user-facing methods: `get()`, `enqueue()`
 
 **scoped search URL pattern:**
-- The SDK method calls `POST /v2/{entity}/{scope_type}/{scope_id}/search`.
-- e.g. `f"{_PATH}/projects/{project_id}/search"` (not `f"{_PATH}/search-by-project/{id}"`)
+- The SDK method calls `POST /v2/{entity}/scoped/search`, e.g. `f"{_PATH}/scoped/search"`.
+- **Legacy:** `POST /v2/{entity}/{scope_type}/{scope_id}/search` — do not add new ones.
 - Do NOT use the `search-by-{scope}` URL pattern.
 
 ## typed_request pattern

--- a/src/ai/backend/manager/api/AGENTS.md
+++ b/src/ai/backend/manager/api/AGENTS.md
@@ -19,8 +19,8 @@
 ## Naming & scope
 
 - superadmin only: `admin_` prefix + call `_check_superadmin(request)` on the first line.
-- scoped: currently a `{scope}_` prefix (e.g. `domain_search_users`). **Forward direction (under consideration):** unify to `scoped_` and
-  receive the scope as a request field (see scoped search REST URL below).
+- scoped: `scoped_` prefix, receiving the scope as a request field (see scoped search REST URL below).
+  **Legacy:** a `{scope}_` prefix (e.g. `domain_search_users`) — do not add new ones.
 - self-service: `my_` prefix (e.g. `my_keypairs`). The Adapter resolves the user internally.
   - REST URL: `/v2/{entity}/my/{operation}` — the entity comes first, `my` is the scope qualifier.
 
@@ -28,12 +28,14 @@
 - `admin_search_*`: superadmin only, no scope — system-wide query.
 - scoped search: non-admin, scope argument required — query within that scope.
 - There is no "unscoped system-wide query" for non-admins.
+- The audience (`admin` / `scoped` / `my`) is always a REST path segment before the operation
+  name — see `api/rest/v2/AGENTS.md` for the full URL grammar.
 
-**scoped search REST URL** (under consideration):
-- Current: `/v2/{entity}/{scope_type}/{scope_id}/search` — express the scope as a nested resource path (not `search-by-{scope}`).
-  Example: `/v2/sessions/projects/{project_id}/search`.
-- **Forward direction:** Use a fixed path of the form `/v2/{entity}/scoped/search` and receive the scope as a request body field
-  (not a path param). Consistent with SDK `scoped_search` and GQL `scopedFoosV2`.
+**scoped search REST URL:**
+- Fixed path `/v2/{entity}/scoped/search`, with the scope as a request body field (not a path param).
+  Consistent with SDK `scoped_search` and GQL `scopedFoosV2`.
+- **Legacy:** the scope as a nested resource path, `/v2/{entity}/{scope_type}/{scope_id}/search`
+  (e.g. `/v2/sessions/projects/{project_id}/search`) — do not add new ones.
 
 **create / update / get / delete / purge — criteria for splitting out `admin_`:**
 - admin-only entities (Domain, ContainerRegistry, etc.): a single `admin_` endpoint.

--- a/src/ai/backend/manager/api/rest/v2/AGENTS.md
+++ b/src/ai/backend/manager/api/rest/v2/AGENTS.md
@@ -20,7 +20,6 @@ REST v2 Handler → Adapter (api/adapters/) → Processor → Service → Reposi
 - Each handler is injected with an **individual adapter** (not the Adapters registry): call `self._adapter.method()` —
   no `self._adapters.domain.method()`.
 - The Adapter is shared with the GQL layer — do not create a REST-only adapter.
-- `admin_`-prefixed adapter methods → `superadmin_required` middleware, non-admin → `auth_required`.
 
 ## DTO
 
@@ -30,25 +29,33 @@ REST v2 Handler → Adapter (api/adapters/) → Processor → Service → Reposi
 
 ## Naming & scope
 
-- superadmin only: `admin_` prefix + `superadmin_required` middleware.
-- scoped: currently a `{scope}_` prefix. **Forward direction (under consideration):** unify to `scoped_` and receive the scope as a request field (see below).
-- self-service: `/v2/{entity}/my/` — the entity comes first, `my` is the scope qualifier.
+Method names carry the audience as a prefix: `admin_`, `scoped_`, `my_`.
+**Legacy:** scoped endpoints named after the scope (`project_search`) — do not add new ones.
 
-**search — always two variants:**
-- `POST /v2/{entity}/search`: superadmin only, no scope — system-wide query.
-- scoped search (non-admin): scope required — query within that scope.
-- There is no "unscoped system-wide query" for non-admins.
+**URL grammar:** `/v2/{entity}/{audience}/{operation}`
 
-**scoped search URL** (under consideration):
-- Current: `POST /v2/{entity}/{scope_type}/{scope_id}/search` — express the scope as a nested resource path (not `search-by-{scope}`).
-  Example: `/v2/sessions/projects/{project_id}/search`. (More examples: `CONTEXTS.md`)
-- **Forward direction:** fixed path `/v2/{entity}/scoped/search` + scope as a request body field (not a path param).
+| Segment | Rule |
+|---|---|
+| `{entity}` | The resource. For a sub-app covering several entities, the `{domain}/{entity}` pair — `/v2/scheduling-history/kernels/…`. `{entity}` below means the whole pair. |
+| `{audience}` | Exactly one of `admin` / `scoped` / `my`, matching the method prefix. Never omitted. |
+
+**the three audiences:**
+
+| Audience | Who | Scope | Middleware |
+|---|---|---|---|
+| `admin` | superadmin only | none — system-wide | `superadmin_required` |
+| `scoped` | non-admin | required | `auth_required` |
+| `my` | the caller | the adapter resolves the user via `current_user()` | `auth_required` |
+
+- search always has both `admin` and `scoped` variants — there is no "unscoped system-wide query" for non-admins.
+- e.g. `POST /v2/{entity}/admin/search`, `POST /v2/{entity}/scoped/search`, `POST /v2/keypairs/my/issue`.
+
+**how the scope reaches a `scoped` endpoint:**
+- The scope is a **request body field**, so the path stays the fixed `/v2/{entity}/scoped/search`.
   Consistent with SDK `scoped_search` and GQL `scopedFoosV2`.
-- All scoped search routes use the `auth_required` middleware.
-
-**self-service (`my`):**
-- `POST /v2/{entity}/my/{operation}` (e.g. `/v2/keypairs/my/search`). The adapter resolves the user via `current_user()`.
-  `auth_required` middleware.
+- **Legacy:** a nested resource path, `POST /v2/{entity}/{scope_type}/{scope_id}/search`
+  (e.g. `/v2/sessions/projects/{project_id}/search`). Most existing routes still look like this —
+  do not add new ones. (Examples: `CONTEXTS.md`)
 
 **create / update / get / delete / purge — criteria for splitting out `admin_`:**
 - admin-only entities: a single `admin_`.


### PR DESCRIPTION
## Summary

The scoped-search shape sat as "under consideration" across four `AGENTS.md` files, so neither direction was safe to follow when adding a new endpoint. Settle it, and fill two gaps the wording left open.

- **Scoped search is settled.** The scope travels as a request body field and the path is the fixed `/v2/{entity}/scoped/search`; methods take the `scoped_` prefix. The nested `{scope_type}/{scope_id}` path and `{scope}_`-named methods are marked **legacy** — kept in the docs, since most existing code still looks like that, but flagged as "do not add new ones".
- **The audience is now a required path segment.** `admin` / `scoped` / `my` are already method prefixes, and `scoped` / `my` already appeared in URLs, but the admin variant was written as a bare `POST /v2/{entity}/search`, leaving the audience unreadable from the path. It is now `/v2/{entity}/admin/search`.
- **Multi-entity domains have a defined shape.** `POST /v2/{entity}/search` assumed one entity per sub-app and had no reading for `scheduling-history`, which holds session, kernel, deployment, and route histories. Pinned as `/v2/{domain}/{entity}/{qualifier}/{operation}`, with the qualifier attached to the entity.

Applied across `manager/api/AGENTS.md`, `manager/api/rest/v2/AGENTS.md`, `client/v2/AGENTS.md`, and `client/cli/v2/AGENTS.md` — the same decision was recorded as pending in each, and `client/v2/AGENTS.md` explicitly asked for the URL pattern and CLI surface to be decided together. The full URL grammar lives only in `rest/v2/AGENTS.md`; the parent references it.

Docs only. #12989 and #12866 follow the settled shape.

## Test plan

- [x] URL grammar stated once, in `api/rest/v2/AGENTS.md`; the parent `api/AGENTS.md` links rather than repeats
- [x] Legacy shapes documented as legacy instead of deleted, so existing code stays readable
- [ ] Existing bare-`/search` routes are left alone — migrating them is a breaking change and needs its own decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)
