### PR TITLE
refactor(BA-6910): return idle check judgments from handler

### DIFF
--- a/changes/12991.enhance.md
+++ b/changes/12991.enhance.md
@@ -1,0 +1,1 @@
+Refine idle check reconciler judgment output for persistence.

--- a/changes/12991.enhance.md
+++ b/changes/12991.enhance.md
@@ -1,1 +1,1 @@
-Refine idle check reconciler judgment output for persistence.
+Return per-checker idle judgments with deadlines and lifecycle phases from the idle-check reconciler.

--- a/src/ai/backend/manager/data/idle_checker/types.py
+++ b/src/ai/backend/manager/data/idle_checker/types.py
@@ -7,13 +7,6 @@ from enum import StrEnum
 from ai.backend.common.types import SessionId
 
 
-class IdleCheckPhase(StrEnum):
-    NOT_CHECKED = "not_checked"
-    ACTIVE = "active"
-    IDLE = "idle"
-    IDLE_EXPIRED = "idle_expired"
-
-
 class IdleJudgmentStatus(StrEnum):
     ACTIVE = "active"
     IDLE = "idle"

--- a/src/ai/backend/manager/data/idle_checker/types.py
+++ b/src/ai/backend/manager/data/idle_checker/types.py
@@ -14,6 +14,11 @@ class IdleCheckPhase(StrEnum):
     IDLE_EXPIRED = "idle_expired"
 
 
+class IdleJudgmentStatus(StrEnum):
+    ACTIVE = "active"
+    IDLE = "idle"
+
+
 @dataclass(frozen=True)
 class IdleCheckSession:
     """Session fields needed to evaluate idle checkers."""

--- a/src/ai/backend/manager/data/idle_checker/types.py
+++ b/src/ai/backend/manager/data/idle_checker/types.py
@@ -2,14 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from enum import StrEnum
 
 from ai.backend.common.types import SessionId
-
-
-class IdleJudgmentStatus(StrEnum):
-    ACTIVE = "active"
-    IDLE = "idle"
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/data/idle_checker/types.py
+++ b/src/ai/backend/manager/data/idle_checker/types.py
@@ -8,8 +8,9 @@ from ai.backend.common.types import SessionId
 
 
 class IdleCheckPhase(StrEnum):
+    NOT_CHECKED = "not_checked"
     ACTIVE = "active"
-    IDLE_GRACE_PERIOD = "idle_grace_period"
+    IDLE = "idle"
     IDLE_EXPIRED = "idle_expired"
 
 

--- a/src/ai/backend/manager/data/idle_checker/types.py
+++ b/src/ai/backend/manager/data/idle_checker/types.py
@@ -2,8 +2,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from enum import StrEnum
 
 from ai.backend.common.types import SessionId
+
+
+class IdleCheckPhase(StrEnum):
+    ACTIVE = "active"
+    IDLE_GRACE_PERIOD = "idle_grace_period"
+    IDLE_EXPIRED = "idle_expired"
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/base.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/base.py
@@ -6,11 +6,10 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
-from enum import StrEnum
 
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId
-from ai.backend.manager.data.idle_checker.types import IdleCheckSession
+from ai.backend.manager.data.idle_checker.types import IdleCheckPhase, IdleCheckSession
 from ai.backend.manager.repositories.idle_checker.types import IdleCheckerDefinitionData
 
 
@@ -29,20 +28,14 @@ class CheckerAssignment:
     sessions: Sequence[IdleCheckSession]
 
 
-class IdleJudgmentStatus(StrEnum):
-    IDLE = "idle"
-    BUSY = "busy"
-
-
 @dataclass(frozen=True)
 class IdleJudgment:
     """One session's judgment from one checker definition."""
 
     checker_id: IdleCheckerID
     session_id: SessionId
-    is_idle: bool
-    expire_at: datetime | None
-    status: IdleJudgmentStatus
+    expire_at: datetime
+    status: IdleCheckPhase
     message: str
 
 

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/base.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/base.py
@@ -7,9 +7,10 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 
+from ai.backend.common.data.idle_checker.types import IdleCheckPhase
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId
-from ai.backend.manager.data.idle_checker.types import IdleCheckSession, IdleJudgmentStatus
+from ai.backend.manager.data.idle_checker.types import IdleCheckSession
 from ai.backend.manager.repositories.idle_checker.types import IdleCheckerDefinitionData
 
 
@@ -35,7 +36,7 @@ class IdleJudgment:
     checker_id: IdleCheckerID
     session_id: SessionId
     expire_at: datetime
-    status: IdleJudgmentStatus
+    status: IdleCheckPhase
     message: str
 
 

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/base.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/base.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId
-from ai.backend.manager.data.idle_checker.types import IdleCheckPhase, IdleCheckSession
+from ai.backend.manager.data.idle_checker.types import IdleCheckSession, IdleJudgmentStatus
 from ai.backend.manager.repositories.idle_checker.types import IdleCheckerDefinitionData
 
 
@@ -35,7 +35,7 @@ class IdleJudgment:
     checker_id: IdleCheckerID
     session_id: SessionId
     expire_at: datetime
-    status: IdleCheckPhase
+    status: IdleJudgmentStatus
     message: str
 
 

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/base.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/base.py
@@ -29,8 +29,9 @@ class CheckerAssignment:
     sessions: Sequence[IdleCheckSession]
 
 
-class IdleCheckerStatus(StrEnum):
-    """Marker base for checker-specific judgment statuses."""
+class IdleJudgmentStatus(StrEnum):
+    IDLE = "idle"
+    BUSY = "busy"
 
 
 @dataclass(frozen=True)
@@ -41,7 +42,7 @@ class IdleJudgment:
     session_id: SessionId
     is_idle: bool
     expire_at: datetime | None
-    status: IdleCheckerStatus
+    status: IdleJudgmentStatus
     message: str
 
 

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/base.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/base.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
+from enum import StrEnum
 
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId
@@ -28,6 +29,11 @@ class CheckerAssignment:
     sessions: Sequence[IdleCheckSession]
 
 
+class IdleJudgmentStatus(StrEnum):
+    IDLE = "idle"
+    BUSY = "busy"
+
+
 @dataclass(frozen=True)
 class IdleJudgment:
     """One session's judgment from one checker definition."""
@@ -35,6 +41,8 @@ class IdleJudgment:
     checker_id: IdleCheckerID
     session_id: SessionId
     is_idle: bool
+    expire_at: datetime | None
+    status: IdleJudgmentStatus
     message: str
 
 

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/base.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/base.py
@@ -29,9 +29,8 @@ class CheckerAssignment:
     sessions: Sequence[IdleCheckSession]
 
 
-class IdleJudgmentStatus(StrEnum):
-    IDLE = "idle"
-    BUSY = "busy"
+class IdleCheckerStatus(StrEnum):
+    """Marker base for checker-specific judgment statuses."""
 
 
 @dataclass(frozen=True)
@@ -42,7 +41,7 @@ class IdleJudgment:
     session_id: SessionId
     is_idle: bool
     expire_at: datetime | None
-    status: IdleJudgmentStatus
+    status: IdleCheckerStatus
     message: str
 
 

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
@@ -11,11 +11,16 @@ from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
     IdleChecker,
     IdleCheckerContext,
+    IdleCheckerStatus,
     IdleJudgment,
-    IdleJudgmentStatus,
 )
 
 log = BraceStyleAdapter(logging.getLogger(__name__))
+
+
+class SessionLifetimeStatus(IdleCheckerStatus):
+    WITHIN_LIMIT = "within_limit"
+    EXCEEDED = "exceeded"
 
 
 class SessionLifetimeChecker(IdleChecker):
@@ -60,7 +65,11 @@ class SessionLifetimeChecker(IdleChecker):
                         session_id=session.session_id,
                         is_idle=is_idle,
                         expire_at=expires_at,
-                        status=IdleJudgmentStatus.IDLE if is_idle else IdleJudgmentStatus.BUSY,
+                        status=(
+                            SessionLifetimeStatus.EXCEEDED
+                            if is_idle
+                            else SessionLifetimeStatus.WITHIN_LIMIT
+                        ),
                         message=(
                             "Session lifetime check: "
                             f"max_lifetime_seconds={max_lifetime_seconds:f}, "

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
+from datetime import timedelta
 from decimal import Decimal
 from typing import override
 
@@ -11,6 +12,7 @@ from ai.backend.manager.sokovan.idle_check.checkers.base import (
     IdleChecker,
     IdleCheckerContext,
     IdleJudgment,
+    IdleJudgmentStatus,
 )
 
 log = BraceStyleAdapter(logging.getLogger(__name__))
@@ -45,13 +47,22 @@ class SessionLifetimeChecker(IdleChecker):
                 running_seconds = Decimal(
                     str((context.current_time - session.starts_at).total_seconds())
                 ).normalize()
+                is_idle = running_seconds >= max_lifetime_seconds
+                if is_idle:
+                    expires_at = session.starts_at + timedelta(
+                        seconds=lifetime_spec.max_lifetime_seconds
+                    )
+                else:
+                    expires_at = None
                 judgments.append(
                     IdleJudgment(
                         checker_id=assignment.definition.checker_id,
                         session_id=session.session_id,
-                        is_idle=running_seconds >= max_lifetime_seconds,
+                        is_idle=is_idle,
+                        expire_at=expires_at,
+                        status=IdleJudgmentStatus.IDLE if is_idle else IdleJudgmentStatus.BUSY,
                         message=(
-                            "Session lifetime exceeded: "
+                            "Session lifetime check: "
                             f"max_lifetime_seconds={max_lifetime_seconds:f}, "
                             f"running_seconds={running_seconds:f}"
                         ),

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
@@ -6,8 +6,8 @@ from datetime import timedelta
 from decimal import Decimal
 from typing import override
 
+from ai.backend.common.data.idle_checker.types import IdleCheckPhase
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.manager.data.idle_checker.types import IdleJudgmentStatus
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
     IdleChecker,
@@ -55,7 +55,7 @@ class SessionLifetimeChecker(IdleChecker):
                         checker_id=assignment.definition.checker_id,
                         session_id=session.session_id,
                         expire_at=expires_at,
-                        status=IdleJudgmentStatus.IDLE,
+                        status=IdleCheckPhase.IDLE,
                         message=(
                             "Session lifetime check: "
                             f"max_lifetime_seconds={max_lifetime_seconds:f}, "

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
@@ -56,11 +56,7 @@ class SessionLifetimeChecker(IdleChecker):
                         checker_id=assignment.definition.checker_id,
                         session_id=session.session_id,
                         expire_at=expires_at,
-                        status=(
-                            IdleCheckPhase.IDLE_EXPIRED
-                            if is_expired
-                            else IdleCheckPhase.IDLE_GRACE_PERIOD
-                        ),
+                        status=(IdleCheckPhase.IDLE_EXPIRED if is_expired else IdleCheckPhase.IDLE),
                         message=(
                             "Session lifetime check: "
                             f"max_lifetime_seconds={max_lifetime_seconds:f}, "

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
@@ -11,16 +11,11 @@ from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
     IdleChecker,
     IdleCheckerContext,
-    IdleCheckerStatus,
     IdleJudgment,
+    IdleJudgmentStatus,
 )
 
 log = BraceStyleAdapter(logging.getLogger(__name__))
-
-
-class SessionLifetimeStatus(IdleCheckerStatus):
-    WITHIN_LIMIT = "within_limit"
-    EXCEEDED = "exceeded"
 
 
 class SessionLifetimeChecker(IdleChecker):
@@ -65,11 +60,7 @@ class SessionLifetimeChecker(IdleChecker):
                         session_id=session.session_id,
                         is_idle=is_idle,
                         expire_at=expires_at,
-                        status=(
-                            SessionLifetimeStatus.EXCEEDED
-                            if is_idle
-                            else SessionLifetimeStatus.WITHIN_LIMIT
-                        ),
+                        status=IdleJudgmentStatus.IDLE if is_idle else IdleJudgmentStatus.BUSY,
                         message=(
                             "Session lifetime check: "
                             f"max_lifetime_seconds={max_lifetime_seconds:f}, "

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 from typing import override
 
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.manager.data.idle_checker.types import IdleCheckPhase
+from ai.backend.manager.data.idle_checker.types import IdleJudgmentStatus
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
     IdleChecker,
@@ -47,7 +47,6 @@ class SessionLifetimeChecker(IdleChecker):
                 running_seconds = Decimal(
                     str((context.current_time - session.starts_at).total_seconds())
                 ).normalize()
-                is_expired = running_seconds >= max_lifetime_seconds
                 expires_at = session.starts_at + timedelta(
                     seconds=lifetime_spec.max_lifetime_seconds
                 )
@@ -56,7 +55,7 @@ class SessionLifetimeChecker(IdleChecker):
                         checker_id=assignment.definition.checker_id,
                         session_id=session.session_id,
                         expire_at=expires_at,
-                        status=(IdleCheckPhase.IDLE_EXPIRED if is_expired else IdleCheckPhase.IDLE),
+                        status=IdleJudgmentStatus.IDLE,
                         message=(
                             "Session lifetime check: "
                             f"max_lifetime_seconds={max_lifetime_seconds:f}, "

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
@@ -7,12 +7,12 @@ from decimal import Decimal
 from typing import override
 
 from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.data.idle_checker.types import IdleCheckPhase
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
     IdleChecker,
     IdleCheckerContext,
     IdleJudgment,
-    IdleJudgmentStatus,
 )
 
 log = BraceStyleAdapter(logging.getLogger(__name__))
@@ -47,20 +47,20 @@ class SessionLifetimeChecker(IdleChecker):
                 running_seconds = Decimal(
                     str((context.current_time - session.starts_at).total_seconds())
                 ).normalize()
-                is_idle = running_seconds >= max_lifetime_seconds
-                if is_idle:
-                    expires_at = session.starts_at + timedelta(
-                        seconds=lifetime_spec.max_lifetime_seconds
-                    )
-                else:
-                    expires_at = None
+                is_expired = running_seconds >= max_lifetime_seconds
+                expires_at = session.starts_at + timedelta(
+                    seconds=lifetime_spec.max_lifetime_seconds
+                )
                 judgments.append(
                     IdleJudgment(
                         checker_id=assignment.definition.checker_id,
                         session_id=session.session_id,
-                        is_idle=is_idle,
                         expire_at=expires_at,
-                        status=IdleJudgmentStatus.IDLE if is_idle else IdleJudgmentStatus.BUSY,
+                        status=(
+                            IdleCheckPhase.IDLE_EXPIRED
+                            if is_expired
+                            else IdleCheckPhase.IDLE_GRACE_PERIOD
+                        ),
                         message=(
                             "Session lifetime check: "
                             f"max_lifetime_seconds={max_lifetime_seconds:f}, "

--- a/src/ai/backend/manager/sokovan/idle_check/handlers/reconcile.py
+++ b/src/ai/backend/manager/sokovan/idle_check/handlers/reconcile.py
@@ -16,18 +16,14 @@ from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
     IdleChecker,
     IdleCheckerContext,
+    IdleJudgment,
 )
-from ai.backend.manager.sokovan.idle_check.types import (
-    IdleCheckReconcileInfo,
-    IdleCheckReport,
-    IdleCheckResult,
-    IdleReason,
-)
+from ai.backend.manager.sokovan.idle_check.types import IdleCheckReconcileInfo, IdleCheckResult
 from ai.backend.manager.sokovan.reconciler.base import ReconcilerHandler
 
 
 class IdleCheckReconcileHandler(ReconcilerHandler[IdleCheckReconcileInfo, IdleCheckResult]):
-    """Drive checker-axis judgments and merge idle reasons into session reports."""
+    """Drive checker-axis judgments for persistence by the applier."""
 
     _checkers: Mapping[CheckerType, IdleChecker]
 
@@ -38,7 +34,7 @@ class IdleCheckReconcileHandler(ReconcilerHandler[IdleCheckReconcileInfo, IdleCh
     async def execute(self, reconcile_info: IdleCheckReconcileInfo) -> IdleCheckResult:
         assignments_by_type = self._assignments_by_type(reconcile_info.batch)
         context = IdleCheckerContext(current_time=reconcile_info.current_time)
-        reasons_by_session: defaultdict[SessionId, list[IdleReason]] = defaultdict(list)
+        all_judgments: list[IdleJudgment] = []
         for checker_type, assignments in assignments_by_type.items():
             checker = self._checkers.get(checker_type)
             if checker is None:
@@ -47,16 +43,8 @@ class IdleCheckReconcileHandler(ReconcilerHandler[IdleCheckReconcileInfo, IdleCh
                 assignments,
                 context=context,
             )
-            for judgment in judgments:
-                if not judgment.is_idle:
-                    continue
-                reasons_by_session[judgment.session_id].append(
-                    IdleReason(checker_id=judgment.checker_id, message=judgment.message)
-                )
-        reports: list[IdleCheckReport] = []
-        for session_id, reasons in reasons_by_session.items():
-            reports.append(IdleCheckReport(session_id=session_id, reasons=reasons))
-        return IdleCheckResult(reports=reports)
+            all_judgments.extend(judgments)
+        return IdleCheckResult(judgments=all_judgments)
 
     def _assignments_by_type(
         self, batch: IdleCheckBatchData

--- a/src/ai/backend/manager/sokovan/idle_check/types.py
+++ b/src/ai/backend/manager/sokovan/idle_check/types.py
@@ -8,7 +8,6 @@ from datetime import datetime
 from typing import override
 from uuid import UUID
 
-from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId
 from ai.backend.manager.data.reconciler.types import (
     BaseReconcilerCategory,
@@ -18,6 +17,7 @@ from ai.backend.manager.data.reconciler.types import (
 from ai.backend.manager.data.session.options import HandlerPolicyResolver
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.repositories.idle_checker.types import IdleCheckBatchData
+from ai.backend.manager.sokovan.idle_check.checkers.base import IdleJudgment
 from ai.backend.manager.sokovan.reconciler.base import (
     BaseReconcilerInfo,
     BaseReconcilerKind,
@@ -79,29 +79,13 @@ class IdleCheckDecision(ReconcilerDecision):
         return self.handler_policy
 
 
-@dataclass(frozen=True)
-class IdleReason:
-    """One checker's grounds for judging a session idle."""
-
-    checker_id: IdleCheckerID
-    message: str
-
-
-@dataclass(frozen=True)
-class IdleCheckReport:
-    """One session judged idle and every checker's reason for it."""
-
-    session_id: SessionId
-    reasons: Sequence[IdleReason]
-
-
 @dataclass
 class IdleCheckResult(BaseReconcilerResult):
-    reports: list[IdleCheckReport] = field(default_factory=list)
+    judgments: list[IdleJudgment] = field(default_factory=list)
 
     @override
     def processed_count(self) -> int:
-        return len(self.reports)
+        return len(self.judgments)
 
     @override
     def failed_count(self) -> int:
@@ -109,5 +93,4 @@ class IdleCheckResult(BaseReconcilerResult):
 
     @override
     def decisions(self) -> Sequence[ReconcilerDecision]:
-        # Idle output is a termination list, not per-entity retryable outcomes.
         return ()

--- a/tests/unit/manager/sokovan/idle_check/test_handler.py
+++ b/tests/unit/manager/sokovan/idle_check/test_handler.py
@@ -15,7 +15,7 @@ from ai.backend.common.data.idle_checker.types import (
 )
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
-from ai.backend.manager.data.idle_checker.types import IdleCheckSession
+from ai.backend.manager.data.idle_checker.types import IdleCheckSession, IdleJudgmentStatus
 from ai.backend.manager.errors.common import InternalServerError
 from ai.backend.manager.repositories.idle_checker.types import (
     IdleCheckAssignmentData,
@@ -29,11 +29,7 @@ from ai.backend.manager.sokovan.idle_check.checkers.base import (
     IdleJudgment,
 )
 from ai.backend.manager.sokovan.idle_check.handlers.reconcile import IdleCheckReconcileHandler
-from ai.backend.manager.sokovan.idle_check.types import (
-    IdleCheckReconcileInfo,
-    IdleCheckReport,
-    IdleReason,
-)
+from ai.backend.manager.sokovan.idle_check.types import IdleCheckReconcileInfo
 
 _NOW = datetime(2026, 1, 2, tzinfo=UTC)
 
@@ -84,7 +80,12 @@ class FakeChecker(IdleChecker):
             IdleJudgment(
                 checker_id=assignment.definition.checker_id,
                 session_id=session.session_id,
-                is_idle=session.session_id in self.idle_session_ids,
+                expire_at=_NOW,
+                status=(
+                    IdleJudgmentStatus.IDLE
+                    if session.session_id in self.idle_session_ids
+                    else IdleJudgmentStatus.ACTIVE
+                ),
                 message=self._message,
             )
             for assignment in assignments
@@ -193,7 +194,7 @@ class TestIdleCheckReconcileHandler:
         assert lifetime_checker.judge_contexts == [expected_context]
         assert network_checker.judge_contexts == [expected_context]
 
-    async def test_merges_idle_reasons(
+    async def test_returns_all_judgments(
         self,
         handler: IdleCheckReconcileHandler,
         first_session_id: SessionId,
@@ -218,37 +219,39 @@ class TestIdleCheckReconcileHandler:
 
         result = await handler.execute(reconcile_info)
 
-        assert result.reports == [
-            IdleCheckReport(
+        assert result.judgments == [
+            IdleJudgment(
+                checker_id=lifetime_definition.checker_id,
                 session_id=first_session_id,
-                reasons=[
-                    IdleReason(
-                        checker_id=lifetime_definition.checker_id,
-                        message="max lifetime exceeded",
-                    ),
-                    IdleReason(
-                        checker_id=network_definition.checker_id,
-                        message="no network activity",
-                    ),
-                ],
+                expire_at=_NOW,
+                status=IdleJudgmentStatus.IDLE,
+                message="max lifetime exceeded",
             ),
-            IdleCheckReport(
+            IdleJudgment(
+                checker_id=lifetime_definition.checker_id,
                 session_id=second_session_id,
-                reasons=[
-                    IdleReason(
-                        checker_id=lifetime_definition.checker_id,
-                        message="max lifetime exceeded",
-                    )
-                ],
+                expire_at=_NOW,
+                status=IdleJudgmentStatus.IDLE,
+                message="max lifetime exceeded",
+            ),
+            IdleJudgment(
+                checker_id=network_definition.checker_id,
+                session_id=first_session_id,
+                expire_at=_NOW,
+                status=IdleJudgmentStatus.IDLE,
+                message="no network activity",
             ),
         ]
+        assert result.processed_count() == 3
 
-    async def test_active_session_has_no_report(
+    async def test_returns_non_idle_judgments(
         self,
         handler: IdleCheckReconcileHandler,
         first_session_id: SessionId,
         lifetime_definition: IdleCheckerDefinitionData,
         network_definition: IdleCheckerDefinitionData,
+        lifetime_checker: FakeChecker,
+        network_checker: FakeChecker,
     ) -> None:
         reconcile_info = IdleCheckReconcileInfo(
             batch=IdleCheckBatchData(
@@ -262,7 +265,14 @@ class TestIdleCheckReconcileHandler:
 
         result = await handler.execute(reconcile_info)
 
-        assert result.reports == []
+        assert len(result.judgments) == 2
+        assert all(judgment.status is IdleJudgmentStatus.ACTIVE for judgment in result.judgments)
+        assert all(judgment.expire_at == _NOW for judgment in result.judgments)
+        expected_call = [(lifetime_definition.checker_id, [first_session_id])]
+        assert lifetime_checker.judge_calls == [expected_call]
+        assert network_checker.judge_calls == [
+            [(network_definition.checker_id, [first_session_id])]
+        ]
 
     async def test_skips_unimplemented_checker_types(
         self,
@@ -285,14 +295,5 @@ class TestIdleCheckReconcileHandler:
 
         result = await handler.execute(reconcile_info)
 
-        assert result.reports == [
-            IdleCheckReport(
-                session_id=first_session_id,
-                reasons=[
-                    IdleReason(
-                        checker_id=lifetime_definition.checker_id,
-                        message="max lifetime exceeded",
-                    )
-                ],
-            )
-        ]
+        assert len(result.judgments) == 1
+        assert result.judgments[0].checker_id == lifetime_definition.checker_id

--- a/tests/unit/manager/sokovan/idle_check/test_handler.py
+++ b/tests/unit/manager/sokovan/idle_check/test_handler.py
@@ -10,12 +10,13 @@ import pytest
 from ai.backend.common.data.idle_checker.types import (
     CheckerType,
     IdleCheckerSpec,
+    IdleCheckPhase,
     NetworkTimeoutSpec,
     SessionLifetimeSpec,
 )
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
-from ai.backend.manager.data.idle_checker.types import IdleCheckSession, IdleJudgmentStatus
+from ai.backend.manager.data.idle_checker.types import IdleCheckSession
 from ai.backend.manager.errors.common import InternalServerError
 from ai.backend.manager.repositories.idle_checker.types import (
     IdleCheckAssignmentData,
@@ -82,9 +83,9 @@ class FakeChecker(IdleChecker):
                 session_id=session.session_id,
                 expire_at=_NOW,
                 status=(
-                    IdleJudgmentStatus.IDLE
+                    IdleCheckPhase.IDLE
                     if session.session_id in self.idle_session_ids
-                    else IdleJudgmentStatus.ACTIVE
+                    else IdleCheckPhase.ACTIVE
                 ),
                 message=self._message,
             )
@@ -224,21 +225,21 @@ class TestIdleCheckReconcileHandler:
                 checker_id=lifetime_definition.checker_id,
                 session_id=first_session_id,
                 expire_at=_NOW,
-                status=IdleJudgmentStatus.IDLE,
+                status=IdleCheckPhase.IDLE,
                 message="max lifetime exceeded",
             ),
             IdleJudgment(
                 checker_id=lifetime_definition.checker_id,
                 session_id=second_session_id,
                 expire_at=_NOW,
-                status=IdleJudgmentStatus.IDLE,
+                status=IdleCheckPhase.IDLE,
                 message="max lifetime exceeded",
             ),
             IdleJudgment(
                 checker_id=network_definition.checker_id,
                 session_id=first_session_id,
                 expire_at=_NOW,
-                status=IdleJudgmentStatus.IDLE,
+                status=IdleCheckPhase.IDLE,
                 message="no network activity",
             ),
         ]
@@ -266,7 +267,7 @@ class TestIdleCheckReconcileHandler:
         result = await handler.execute(reconcile_info)
 
         assert len(result.judgments) == 2
-        assert all(judgment.status is IdleJudgmentStatus.ACTIVE for judgment in result.judgments)
+        assert all(judgment.status is IdleCheckPhase.ACTIVE for judgment in result.judgments)
         assert all(judgment.expire_at == _NOW for judgment in result.judgments)
         expected_call = [(lifetime_definition.checker_id, [first_session_id])]
         assert lifetime_checker.judge_calls == [expected_call]

--- a/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
+++ b/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
@@ -21,10 +21,10 @@ from ai.backend.manager.repositories.idle_checker.types import IdleCheckerDefini
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
     IdleCheckerContext,
-    IdleJudgmentStatus,
 )
 from ai.backend.manager.sokovan.idle_check.checkers.session_lifetime import (
     SessionLifetimeChecker,
+    SessionLifetimeStatus,
 )
 
 _BASE_TIME = datetime(2026, 1, 1, tzinfo=UTC)
@@ -123,7 +123,7 @@ class TestSessionLifetimeChecker:
         assert judgments[0].session_id == session.session_id
         assert judgments[0].is_idle is False
         assert judgments[0].expire_at is None
-        assert judgments[0].status is IdleJudgmentStatus.BUSY
+        assert judgments[0].status is SessionLifetimeStatus.WITHIN_LIMIT
         assert judgments[0].message == (
             "Session lifetime check: max_lifetime_seconds=30, running_seconds=29"
         )
@@ -148,7 +148,7 @@ class TestSessionLifetimeChecker:
         assert judgments[0].session_id == session.session_id
         assert judgments[0].is_idle is True
         assert judgments[0].expire_at == _BASE_TIME + timedelta(seconds=30)
-        assert judgments[0].status is IdleJudgmentStatus.IDLE
+        assert judgments[0].status is SessionLifetimeStatus.EXCEEDED
         assert judgments[0].message == (
             "Session lifetime check: max_lifetime_seconds=30, running_seconds=30"
         )
@@ -171,7 +171,7 @@ class TestSessionLifetimeChecker:
 
         assert judgments[0].is_idle is True
         assert judgments[0].expire_at == _BASE_TIME + timedelta(seconds=30)
-        assert judgments[0].status is IdleJudgmentStatus.IDLE
+        assert judgments[0].status is SessionLifetimeStatus.EXCEEDED
         assert judgments[0].message == (
             "Session lifetime check: max_lifetime_seconds=30, running_seconds=31.2"
         )

--- a/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
+++ b/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
@@ -11,12 +11,13 @@ from pydantic import ValidationError
 from ai.backend.common.data.idle_checker.types import (
     CheckerType,
     IdleCheckerSpec,
+    IdleCheckPhase,
     NetworkTimeoutSpec,
     SessionLifetimeSpec,
 )
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
-from ai.backend.manager.data.idle_checker.types import IdleCheckSession, IdleJudgmentStatus
+from ai.backend.manager.data.idle_checker.types import IdleCheckSession
 from ai.backend.manager.repositories.idle_checker.types import IdleCheckerDefinitionData
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
@@ -121,7 +122,7 @@ class TestSessionLifetimeChecker:
         assert len(judgments) == 1
         assert judgments[0].session_id == session.session_id
         assert judgments[0].expire_at == _BASE_TIME + timedelta(seconds=30)
-        assert judgments[0].status is IdleJudgmentStatus.IDLE
+        assert judgments[0].status is IdleCheckPhase.IDLE
         assert judgments[0].message == (
             "Session lifetime check: max_lifetime_seconds=30, running_seconds=29"
         )
@@ -145,7 +146,7 @@ class TestSessionLifetimeChecker:
         assert len(judgments) == 1
         assert judgments[0].session_id == session.session_id
         assert judgments[0].expire_at == _BASE_TIME + timedelta(seconds=30)
-        assert judgments[0].status is IdleJudgmentStatus.IDLE
+        assert judgments[0].status is IdleCheckPhase.IDLE
         assert judgments[0].message == (
             "Session lifetime check: max_lifetime_seconds=30, running_seconds=30"
         )
@@ -167,7 +168,7 @@ class TestSessionLifetimeChecker:
         )
 
         assert judgments[0].expire_at == _BASE_TIME + timedelta(seconds=30)
-        assert judgments[0].status is IdleJudgmentStatus.IDLE
+        assert judgments[0].status is IdleCheckPhase.IDLE
         assert judgments[0].message == (
             "Session lifetime check: max_lifetime_seconds=30, running_seconds=31.2"
         )
@@ -230,8 +231,8 @@ class TestSessionLifetimeChecker:
             long_lifetime.definition.checker_id,
         ]
         assert [judgment.status for judgment in judgments] == [
-            IdleJudgmentStatus.IDLE,
-            IdleJudgmentStatus.IDLE,
+            IdleCheckPhase.IDLE,
+            IdleCheckPhase.IDLE,
         ]
 
     async def test_evaluates_every_session_in_assignment(
@@ -256,8 +257,8 @@ class TestSessionLifetimeChecker:
             active_session.session_id,
         ]
         assert [judgment.status for judgment in judgments] == [
-            IdleJudgmentStatus.IDLE,
-            IdleJudgmentStatus.IDLE,
+            IdleCheckPhase.IDLE,
+            IdleCheckPhase.IDLE,
         ]
 
     async def test_skips_mismatched_spec_and_evaluates_remaining_assignments(

--- a/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
+++ b/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
@@ -21,10 +21,10 @@ from ai.backend.manager.repositories.idle_checker.types import IdleCheckerDefini
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
     IdleCheckerContext,
+    IdleJudgmentStatus,
 )
 from ai.backend.manager.sokovan.idle_check.checkers.session_lifetime import (
     SessionLifetimeChecker,
-    SessionLifetimeStatus,
 )
 
 _BASE_TIME = datetime(2026, 1, 1, tzinfo=UTC)
@@ -123,7 +123,7 @@ class TestSessionLifetimeChecker:
         assert judgments[0].session_id == session.session_id
         assert judgments[0].is_idle is False
         assert judgments[0].expire_at is None
-        assert judgments[0].status is SessionLifetimeStatus.WITHIN_LIMIT
+        assert judgments[0].status is IdleJudgmentStatus.BUSY
         assert judgments[0].message == (
             "Session lifetime check: max_lifetime_seconds=30, running_seconds=29"
         )
@@ -148,7 +148,7 @@ class TestSessionLifetimeChecker:
         assert judgments[0].session_id == session.session_id
         assert judgments[0].is_idle is True
         assert judgments[0].expire_at == _BASE_TIME + timedelta(seconds=30)
-        assert judgments[0].status is SessionLifetimeStatus.EXCEEDED
+        assert judgments[0].status is IdleJudgmentStatus.IDLE
         assert judgments[0].message == (
             "Session lifetime check: max_lifetime_seconds=30, running_seconds=30"
         )
@@ -171,7 +171,7 @@ class TestSessionLifetimeChecker:
 
         assert judgments[0].is_idle is True
         assert judgments[0].expire_at == _BASE_TIME + timedelta(seconds=30)
-        assert judgments[0].status is SessionLifetimeStatus.EXCEEDED
+        assert judgments[0].status is IdleJudgmentStatus.IDLE
         assert judgments[0].message == (
             "Session lifetime check: max_lifetime_seconds=30, running_seconds=31.2"
         )

--- a/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
+++ b/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
@@ -102,7 +102,7 @@ class TestSessionLifetimeChecker:
 
         return create_assignment
 
-    async def test_session_before_deadline_is_in_grace_period(
+    async def test_session_before_deadline_is_idle(
         self,
         checker: SessionLifetimeChecker,
         session_factory: SessionFactory,
@@ -121,7 +121,7 @@ class TestSessionLifetimeChecker:
         assert len(judgments) == 1
         assert judgments[0].session_id == session.session_id
         assert judgments[0].expire_at == _BASE_TIME + timedelta(seconds=30)
-        assert judgments[0].status is IdleCheckPhase.IDLE_GRACE_PERIOD
+        assert judgments[0].status is IdleCheckPhase.IDLE
         assert judgments[0].message == (
             "Session lifetime check: max_lifetime_seconds=30, running_seconds=29"
         )
@@ -231,7 +231,7 @@ class TestSessionLifetimeChecker:
         ]
         assert [judgment.status for judgment in judgments] == [
             IdleCheckPhase.IDLE_EXPIRED,
-            IdleCheckPhase.IDLE_GRACE_PERIOD,
+            IdleCheckPhase.IDLE,
         ]
 
     async def test_evaluates_every_session_in_assignment(
@@ -257,7 +257,7 @@ class TestSessionLifetimeChecker:
         ]
         assert [judgment.status for judgment in judgments] == [
             IdleCheckPhase.IDLE_EXPIRED,
-            IdleCheckPhase.IDLE_GRACE_PERIOD,
+            IdleCheckPhase.IDLE,
         ]
 
     async def test_skips_mismatched_spec_and_evaluates_remaining_assignments(

--- a/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
+++ b/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
@@ -16,12 +16,11 @@ from ai.backend.common.data.idle_checker.types import (
 )
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
-from ai.backend.manager.data.idle_checker.types import IdleCheckSession
+from ai.backend.manager.data.idle_checker.types import IdleCheckPhase, IdleCheckSession
 from ai.backend.manager.repositories.idle_checker.types import IdleCheckerDefinitionData
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
     IdleCheckerContext,
-    IdleJudgmentStatus,
 )
 from ai.backend.manager.sokovan.idle_check.checkers.session_lifetime import (
     SessionLifetimeChecker,
@@ -103,7 +102,7 @@ class TestSessionLifetimeChecker:
 
         return create_assignment
 
-    async def test_session_before_deadline_is_active(
+    async def test_session_before_deadline_is_in_grace_period(
         self,
         checker: SessionLifetimeChecker,
         session_factory: SessionFactory,
@@ -121,9 +120,8 @@ class TestSessionLifetimeChecker:
 
         assert len(judgments) == 1
         assert judgments[0].session_id == session.session_id
-        assert judgments[0].is_idle is False
-        assert judgments[0].expire_at is None
-        assert judgments[0].status is IdleJudgmentStatus.BUSY
+        assert judgments[0].expire_at == _BASE_TIME + timedelta(seconds=30)
+        assert judgments[0].status is IdleCheckPhase.IDLE_GRACE_PERIOD
         assert judgments[0].message == (
             "Session lifetime check: max_lifetime_seconds=30, running_seconds=29"
         )
@@ -146,9 +144,8 @@ class TestSessionLifetimeChecker:
 
         assert len(judgments) == 1
         assert judgments[0].session_id == session.session_id
-        assert judgments[0].is_idle is True
         assert judgments[0].expire_at == _BASE_TIME + timedelta(seconds=30)
-        assert judgments[0].status is IdleJudgmentStatus.IDLE
+        assert judgments[0].status is IdleCheckPhase.IDLE_EXPIRED
         assert judgments[0].message == (
             "Session lifetime check: max_lifetime_seconds=30, running_seconds=30"
         )
@@ -169,9 +166,8 @@ class TestSessionLifetimeChecker:
             ),
         )
 
-        assert judgments[0].is_idle is True
         assert judgments[0].expire_at == _BASE_TIME + timedelta(seconds=30)
-        assert judgments[0].status is IdleJudgmentStatus.IDLE
+        assert judgments[0].status is IdleCheckPhase.IDLE_EXPIRED
         assert judgments[0].message == (
             "Session lifetime check: max_lifetime_seconds=30, running_seconds=31.2"
         )
@@ -233,7 +229,10 @@ class TestSessionLifetimeChecker:
             short_lifetime.definition.checker_id,
             long_lifetime.definition.checker_id,
         ]
-        assert [judgment.is_idle for judgment in judgments] == [True, False]
+        assert [judgment.status for judgment in judgments] == [
+            IdleCheckPhase.IDLE_EXPIRED,
+            IdleCheckPhase.IDLE_GRACE_PERIOD,
+        ]
 
     async def test_evaluates_every_session_in_assignment(
         self,
@@ -256,7 +255,10 @@ class TestSessionLifetimeChecker:
             expired_session.session_id,
             active_session.session_id,
         ]
-        assert [judgment.is_idle for judgment in judgments] == [True, False]
+        assert [judgment.status for judgment in judgments] == [
+            IdleCheckPhase.IDLE_EXPIRED,
+            IdleCheckPhase.IDLE_GRACE_PERIOD,
+        ]
 
     async def test_skips_mismatched_spec_and_evaluates_remaining_assignments(
         self,

--- a/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
+++ b/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
@@ -21,6 +21,7 @@ from ai.backend.manager.repositories.idle_checker.types import IdleCheckerDefini
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
     IdleCheckerContext,
+    IdleJudgmentStatus,
 )
 from ai.backend.manager.sokovan.idle_check.checkers.session_lifetime import (
     SessionLifetimeChecker,
@@ -121,6 +122,11 @@ class TestSessionLifetimeChecker:
         assert len(judgments) == 1
         assert judgments[0].session_id == session.session_id
         assert judgments[0].is_idle is False
+        assert judgments[0].expire_at is None
+        assert judgments[0].status is IdleJudgmentStatus.BUSY
+        assert judgments[0].message == (
+            "Session lifetime check: max_lifetime_seconds=30, running_seconds=29"
+        )
 
     async def test_session_at_deadline_is_idle(
         self,
@@ -141,8 +147,10 @@ class TestSessionLifetimeChecker:
         assert len(judgments) == 1
         assert judgments[0].session_id == session.session_id
         assert judgments[0].is_idle is True
+        assert judgments[0].expire_at == _BASE_TIME + timedelta(seconds=30)
+        assert judgments[0].status is IdleJudgmentStatus.IDLE
         assert judgments[0].message == (
-            "Session lifetime exceeded: max_lifetime_seconds=30, running_seconds=30"
+            "Session lifetime check: max_lifetime_seconds=30, running_seconds=30"
         )
 
     async def test_session_after_deadline_is_idle(
@@ -162,8 +170,10 @@ class TestSessionLifetimeChecker:
         )
 
         assert judgments[0].is_idle is True
+        assert judgments[0].expire_at == _BASE_TIME + timedelta(seconds=30)
+        assert judgments[0].status is IdleJudgmentStatus.IDLE
         assert judgments[0].message == (
-            "Session lifetime exceeded: max_lifetime_seconds=30, running_seconds=31.2"
+            "Session lifetime check: max_lifetime_seconds=30, running_seconds=31.2"
         )
 
     async def test_disabled_lifetime_skips_assignment(

--- a/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
+++ b/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
@@ -16,7 +16,7 @@ from ai.backend.common.data.idle_checker.types import (
 )
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
-from ai.backend.manager.data.idle_checker.types import IdleCheckPhase, IdleCheckSession
+from ai.backend.manager.data.idle_checker.types import IdleCheckSession, IdleJudgmentStatus
 from ai.backend.manager.repositories.idle_checker.types import IdleCheckerDefinitionData
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
@@ -121,12 +121,12 @@ class TestSessionLifetimeChecker:
         assert len(judgments) == 1
         assert judgments[0].session_id == session.session_id
         assert judgments[0].expire_at == _BASE_TIME + timedelta(seconds=30)
-        assert judgments[0].status is IdleCheckPhase.IDLE
+        assert judgments[0].status is IdleJudgmentStatus.IDLE
         assert judgments[0].message == (
             "Session lifetime check: max_lifetime_seconds=30, running_seconds=29"
         )
 
-    async def test_session_at_deadline_is_idle(
+    async def test_session_at_deadline_is_idle_until_applied(
         self,
         checker: SessionLifetimeChecker,
         session_factory: SessionFactory,
@@ -145,12 +145,12 @@ class TestSessionLifetimeChecker:
         assert len(judgments) == 1
         assert judgments[0].session_id == session.session_id
         assert judgments[0].expire_at == _BASE_TIME + timedelta(seconds=30)
-        assert judgments[0].status is IdleCheckPhase.IDLE_EXPIRED
+        assert judgments[0].status is IdleJudgmentStatus.IDLE
         assert judgments[0].message == (
             "Session lifetime check: max_lifetime_seconds=30, running_seconds=30"
         )
 
-    async def test_session_after_deadline_is_idle(
+    async def test_session_after_deadline_is_idle_until_applied(
         self,
         checker: SessionLifetimeChecker,
         session_factory: SessionFactory,
@@ -167,7 +167,7 @@ class TestSessionLifetimeChecker:
         )
 
         assert judgments[0].expire_at == _BASE_TIME + timedelta(seconds=30)
-        assert judgments[0].status is IdleCheckPhase.IDLE_EXPIRED
+        assert judgments[0].status is IdleJudgmentStatus.IDLE
         assert judgments[0].message == (
             "Session lifetime check: max_lifetime_seconds=30, running_seconds=31.2"
         )
@@ -230,8 +230,8 @@ class TestSessionLifetimeChecker:
             long_lifetime.definition.checker_id,
         ]
         assert [judgment.status for judgment in judgments] == [
-            IdleCheckPhase.IDLE_EXPIRED,
-            IdleCheckPhase.IDLE,
+            IdleJudgmentStatus.IDLE,
+            IdleJudgmentStatus.IDLE,
         ]
 
     async def test_evaluates_every_session_in_assignment(
@@ -256,8 +256,8 @@ class TestSessionLifetimeChecker:
             active_session.session_id,
         ]
         assert [judgment.status for judgment in judgments] == [
-            IdleCheckPhase.IDLE_EXPIRED,
-            IdleCheckPhase.IDLE,
+            IdleJudgmentStatus.IDLE,
+            IdleJudgmentStatus.IDLE,
         ]
 
     async def test_skips_mismatched_spec_and_evaluates_remaining_assignments(


### PR DESCRIPTION
## Summary

- Consume the flat session-checker assignments produced by the judgment Source and batch them by checker type.
- Return per-checker judgments with `expire_at`, `IdleCheckPhase`, and a diagnostic message instead of aggregating session-level termination reports.
- Have the session-lifetime checker return the configured deadline as an `IDLE` judgment for the Applier to persist.

## Dependency

- Stacked on #13042 (`feat/BA-6973`) for the judgment Source input contract.

## Test plan

- [x] Formatting and lint checks
- [x] MyPy checks for affected idle-check packages
- [x] Handler and session-lifetime checker unit tests
- [x] Source and stage integration unit tests

Resolves BA-6910