### PR TITLE
feat(BA-6828): remove update_scaling_group RPC and rewire ModifyAgent

### DIFF
--- a/changes/12992.feature.md
+++ b/changes/12992.feature.md
@@ -1,1 +1,1 @@
-Remove the manager-to-agent `update_scaling_group` RPC push; `ModifyAgent` now updates the manager DB as the source of truth and immediately terminates sessions conflicting with the agent's new resource group
+Remove the manager-to-agent `update_scaling_group` RPC push

--- a/changes/12992.feature.md
+++ b/changes/12992.feature.md
@@ -1,0 +1,1 @@
+Remove the manager-to-agent `update_scaling_group` RPC push; `ModifyAgent` now updates the manager DB as the source of truth and immediately terminates sessions conflicting with the agent's new resource group

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1566,9 +1566,6 @@ class AbstractAgent[
         # existing containers still hold ports from the old range.
         self.port_pool.release_many(host_ports)
 
-    def update_scaling_group(self, scaling_group: str) -> None:
-        self.local_config.update(agent_update={"scaling_group": scaling_group})
-
     async def _clean_kernel_registry_loop(self) -> None:
         # TODO: After reducing `kernel_registry` dependencies and roles, this kind of tasks should be deprecated
         cleanup_tasks: set[asyncio.Task[None]] = set()

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -4,7 +4,6 @@ import asyncio
 import functools
 import logging
 import os
-import shutil
 import signal
 import ssl
 import sys
@@ -38,7 +37,6 @@ import aiohttp_cors
 import aiomonitor
 import aiotools
 import click
-import tomlkit
 from aiohttp import web
 from aiohttp.typedefs import Handler
 from aiotools import aclosing
@@ -49,10 +47,8 @@ from etcd_client import WatchEventType
 from setproctitle import setproctitle
 from zmq.auth.certs import load_certificate
 
-from ai.backend.agent.agent import AbstractAgent
 from ai.backend.agent.errors import (
     AgentInitializationError,
-    InvalidAgentConfigError,
     ResourceError,
 )
 from ai.backend.agent.health.docker import DockerHealthChecker
@@ -624,47 +620,6 @@ class AgentRPCServer(aobject):
     @collect_error
     async def update_status(self, status: str, agent_id: AgentId) -> None:
         await self.runtime.update_status(status, agent_id)
-
-    @rpc_function
-    @collect_error
-    async def update_scaling_group(
-        self, scaling_group: str, agent_id: AgentId | None = None
-    ) -> None:
-        cfg_src_path = config.find_config_file("agent")
-        with cfg_src_path.open() as f:
-            data = tomlkit.load(f)
-        agent = self.runtime.get_agent(agent_id)
-        if "agents" in data:
-            self._update_scaling_group_override(data, scaling_group, agent)
-        else:
-            self._update_scaling_group_default(data, scaling_group)
-        shutil.copy(cfg_src_path, f"{cfg_src_path}.bak")
-        with cfg_src_path.open("w") as f:
-            tomlkit.dump(data, f)
-
-        agent.update_scaling_group(scaling_group)
-        log.info("rpc::update_scaling_group()")
-
-    def _update_scaling_group_default(
-        self,
-        config_data: tomlkit.TOMLDocument,
-        scaling_group: str,
-    ) -> None:
-        config_data["agent"]["scaling-group"] = scaling_group  # type: ignore[index]
-
-    def _update_scaling_group_override(
-        self,
-        config_data: tomlkit.TOMLDocument,
-        scaling_group: str,
-        agent: AbstractAgent[Any, Any],
-    ) -> None:
-        if "agents" not in config_data:
-            raise InvalidAgentConfigError("Missing 'agents' section in configuration data.")
-
-        for agent_config in config_data["agents"]:  # type: ignore[union-attr]
-            if agent_config["agent"]["id"] == str(agent.id):  # type: ignore[index]
-                agent_config["agent"]["scaling-group"] = scaling_group  # type: ignore[index]
-                break
 
     @rpc_function
     @collect_error

--- a/src/ai/backend/common/clients/agent/client.py
+++ b/src/ai/backend/common/clients/agent/client.py
@@ -473,12 +473,6 @@ class AgentClient(BackendAIClient):
             await self._peer.call.push_image(image_ref, registry, agent_id=self.agent_id),
         )
 
-    # Scaling group management
-    @agent_client_resilience.apply()
-    async def update_scaling_group(self, scaling_group: str) -> None:
-        """Update scaling group on the agent."""
-        await self._peer.call.update_scaling_group(scaling_group, self.agent_id)
-
     # Local configuration management
     @agent_client_resilience.apply()
     async def get_local_config(self) -> Mapping[str, str]:

--- a/src/ai/backend/manager/api/gql_legacy/agent.py
+++ b/src/ai/backend/manager/api/gql_legacy/agent.py
@@ -927,14 +927,14 @@ class ModifyAgent(graphene.Mutation):  # type: ignore[misc]
                 )
             if resource_group_id is None:
                 return cls(False, f"no such scaling group: {scaling_group}")
-            # The v1 mutation always terminates the sessions conflicting with the
-            # new group; drain first to keep them.
+            # The v1 mutation refuses to move an agent that still has sessions
+            # under the old group; drain them first.
             await graph_ctx.processors.agent.update_resource_group.wait_for_complete(
                 UpdateAgentResourceGroupAction(
                     agent_id=AgentId(id),
                     resource_group_id=ResourceGroupID(resource_group_id),
                     policy=ConflictingSessionCleanupPolicy.TERMINATE,
-                    force=True,
+                    force=False,
                 )
             )
             if not data:

--- a/src/ai/backend/manager/api/gql_legacy/agent.py
+++ b/src/ai/backend/manager/api/gql_legacy/agent.py
@@ -18,6 +18,7 @@ from graphene.types.datetime import DateTime as GQLDateTime
 from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
 
 from ai.backend.common.identifier.project import ProjectID
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import (
     AccessKey,
     AgentId,
@@ -49,6 +50,10 @@ from ai.backend.manager.models.resource_slot import AgentResourceRow
 from ai.backend.manager.models.scaling_group import ScalingGroupRow
 from ai.backend.manager.models.user import UserRole, users
 from ai.backend.manager.repositories.agent.query import QueryConditions, QueryOrders
+from ai.backend.manager.services.agent.actions.update_resource_group import (
+    UpdateAgentResourceGroupAction,
+)
+from ai.backend.manager.services.agent.types import ConflictingSessionCleanupPolicy
 
 from .base import (
     FilterExprArg,
@@ -914,8 +919,7 @@ class ModifyAgent(graphene.Mutation):  # type: ignore[misc]
         data: dict[str, Any] = {}
         set_if_set(props, data, "schedulable")
         set_if_set(props, data, "scaling_group")
-        # TODO: Need to skip the following RPC call if the agent is not alive, or timeout.
-        scaling_group = data.get("scaling_group")
+        scaling_group = data.pop("scaling_group", None)
         if scaling_group is not None:
             async with graph_ctx.db.begin_readonly_read_committed() as conn:
                 resource_group_id = await conn.scalar(
@@ -923,8 +927,18 @@ class ModifyAgent(graphene.Mutation):  # type: ignore[misc]
                 )
             if resource_group_id is None:
                 return cls(False, f"no such scaling group: {scaling_group}")
-            data["resource_group_id"] = resource_group_id
-            await graph_ctx.registry.update_scaling_group(AgentId(id), scaling_group)
+            # The v1 mutation always terminates the sessions conflicting with the
+            # new group; drain first to keep them.
+            await graph_ctx.processors.agent.update_resource_group.wait_for_complete(
+                UpdateAgentResourceGroupAction(
+                    agent_id=AgentId(id),
+                    resource_group_id=ResourceGroupID(resource_group_id),
+                    policy=ConflictingSessionCleanupPolicy.TERMINATE,
+                    force=True,
+                )
+            )
+            if not data:
+                return cls(True, "success")
 
         update_query = sa.update(agents).values(data).where(agents.c.id == id)
         return await simple_db_mutate(cls, graph_ctx, update_query)

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1401,11 +1401,6 @@ class AgentRegistry:
 
         return await execute_with_retry(_query)
 
-    async def update_scaling_group(self, agent_id: AgentId, scaling_group: str) -> None:
-        verified_agent_id = await self.get_instance(agent_id)
-        async with self._agent_client_pool.acquire(verified_agent_id) as client:
-            await client.update_scaling_group(scaling_group)
-
     async def recalc_resource_usage(self, do_fullscan: bool = False) -> None:
         async def _recalc() -> Mapping[AccessKey, ConcurrencyUsed]:
             access_key_to_concurrency_used: dict[AccessKey, ConcurrencyUsed] = {}

--- a/tests/unit/agent/test_agent.py
+++ b/tests/unit/agent/test_agent.py
@@ -5,15 +5,11 @@ Tests for agent configuration and RPC server functionality.
 from __future__ import annotations
 
 import os
-from collections.abc import Callable
-from pathlib import Path
-from typing import Any, cast
-from unittest.mock import AsyncMock, Mock, patch
+from typing import Any
+from unittest.mock import AsyncMock, Mock
 
 import pytest
-import tomlkit
 
-from ai.backend.agent.agent import AbstractAgent
 from ai.backend.agent.config.unified import (
     AgentConfig,
     AgentUnifiedConfig,
@@ -21,12 +17,10 @@ from ai.backend.agent.config.unified import (
     ResourceConfig,
     ScratchType,
 )
-from ai.backend.agent.dummy.agent import DummyAgent
 from ai.backend.agent.server import AgentRPCServer
 from ai.backend.agent.types import AgentBackend
 from ai.backend.common.configs.etcd import EtcdConfig
 from ai.backend.common.typed_validators import HostPortPair
-from ai.backend.common.types import AgentId
 
 
 @pytest.fixture
@@ -68,35 +62,6 @@ async def agent_rpc_server(
     return ars
 
 
-@pytest.fixture
-def mock_agent_factory() -> Callable[[str, str], Mock]:
-    """Factory fixture to create mock agent instances with specified agent_id."""
-
-    def _create_agent(agent_id: str, scaling_group: str = "default") -> Mock:
-        mock_agent = Mock(spec=DummyAgent)
-        mock_agent.id = AgentId(agent_id)
-        mock_agent.local_config = AgentUnifiedConfig(
-            agent=AgentConfig(backend=AgentBackend.DUMMY, scaling_group=scaling_group, id=agent_id),  # type: ignore[call-arg]
-            container=ContainerConfig(scratch_type=ScratchType.HOSTDIR),  # type: ignore[call-arg]
-            resource=ResourceConfig(),  # type: ignore[call-arg]
-            etcd=EtcdConfig(
-                namespace="test",
-                addr=HostPortPair(host="127.0.0.1", port=2379),
-                user=None,
-                password=None,
-            ),
-        )
-
-        # Use the real update_scaling_group method - capture agent in closure properly
-        def update_sg(sg: str) -> None:
-            AbstractAgent.update_scaling_group(mock_agent, sg)
-
-        mock_agent.update_scaling_group = update_sg
-        return mock_agent
-
-    return _create_agent
-
-
 class TestAgentConfigReading:
     """Tests for reading agent configuration from etcd."""
 
@@ -129,141 +94,3 @@ class TestAgentConfigReading:
 
         assert agent_rpc_server.local_config.container.kernel_gid.real == expected_gid
         assert agent_rpc_server.local_config.container.kernel_uid.real == expected_uid
-
-
-class TestScalingGroupUpdates:
-    """Tests for updating scaling group configuration."""
-
-    def test_update_scaling_group_changes_config(self) -> None:
-        """Test that update_scaling_group modifies the in-memory config."""
-        mock_agent = Mock(spec=DummyAgent)
-        mock_agent.local_config = AgentUnifiedConfig(
-            agent=AgentConfig(backend=AgentBackend.DUMMY, scaling_group="default"),  # type: ignore[call-arg]
-            container=ContainerConfig(scratch_type=ScratchType.HOSTDIR),  # type: ignore[call-arg]
-            resource=ResourceConfig(),  # type: ignore[call-arg]
-            etcd=EtcdConfig(
-                namespace="test",
-                addr=HostPortPair(host="127.0.0.1", port=2379),
-                user=None,
-                password=None,
-            ),
-        )
-
-        AbstractAgent.update_scaling_group(mock_agent, "gpu")
-
-        assert mock_agent.local_config.agent.scaling_group == "gpu"
-
-    async def test_update_scaling_group_persists_single_agent(
-        self, tmp_path: Path, mock_agent_factory: Callable[[str, str], Mock]
-    ) -> None:
-        """Test that scaling group updates persist to config file in single-agent mode."""
-        config_file = tmp_path / "agent.toml"
-        config_file.write_text(
-            """[agent]
-backend = "dummy"
-scaling-group = "default"
-id = "test-agent"
-
-[container]
-scratch-type = "hostdir"
-
-[resource]
-
-[etcd]
-namespace = "test"
-addr = { host = "127.0.0.1", port = 2379 }
-"""
-        )
-
-        # Create server with runtime
-        server = object.__new__(AgentRPCServer)
-        runtime = Mock()
-        runtime._default_agent_id = AgentId("test-agent")
-
-        def get_agent_impl(agent_id: AgentId | None = None) -> Mock:
-            if agent_id is None:
-                agent_id = runtime._default_agent_id
-            return cast(Mock, runtime.agents[agent_id])
-
-        runtime.get_agent = get_agent_impl
-
-        mock_agent = mock_agent_factory("test-agent", "default")
-        runtime.agents = {AgentId("test-agent"): mock_agent}
-        server.runtime = runtime
-
-        with patch("ai.backend.common.config.find_config_file", return_value=config_file):
-            await server.update_scaling_group.__wrapped__.__wrapped__(server, "gpu", None)  # type: ignore[attr-defined]
-
-        # Verify file was updated
-        with open(config_file) as f:
-            updated_config = tomlkit.load(f)
-
-        assert updated_config["agent"]["scaling-group"] == "gpu"  # type: ignore[index]
-        assert mock_agent.local_config.agent.scaling_group == "gpu"
-
-    async def test_update_scaling_group_persists_multi_agent(
-        self, tmp_path: Path, mock_agent_factory: Callable[[str, str], Mock]
-    ) -> None:
-        """Test that scaling group updates persist correctly in multi-agent mode."""
-        config_file = tmp_path / "agent.toml"
-        config_file.write_text(
-            """[agent]
-backend = "dummy"
-scaling-group = "default"
-
-[container]
-scratch-type = "hostdir"
-
-[resource]
-
-[etcd]
-namespace = "test"
-addr = { host = "127.0.0.1", port = 2379 }
-
-[[agents]]
-[agents.agent]
-id = "agent-1"
-scaling-group = "default"
-
-[[agents]]
-[agents.agent]
-id = "agent-2"
-scaling-group = "default"
-"""
-        )
-
-        # Create server with runtime
-        server = object.__new__(AgentRPCServer)
-        runtime = Mock()
-        runtime._default_agent_id = AgentId("agent-1")
-
-        def get_agent_impl(agent_id: AgentId | None = None) -> Mock:
-            if agent_id is None:
-                agent_id = runtime._default_agent_id
-            return cast(Mock, runtime.agents[agent_id])
-
-        runtime.get_agent = get_agent_impl
-
-        mock_agent1 = mock_agent_factory("agent-1", "default")
-        mock_agent2 = mock_agent_factory("agent-2", "default")
-
-        runtime.agents = {
-            AgentId("agent-1"): mock_agent1,
-            AgentId("agent-2"): mock_agent2,
-        }
-        server.runtime = runtime
-
-        with patch("ai.backend.common.config.find_config_file", return_value=config_file):
-            await server.update_scaling_group.__wrapped__.__wrapped__(  # type: ignore[attr-defined]
-                server, "gpu", AgentId("agent-2")
-            )
-
-        # Verify file was updated
-        with open(config_file) as f:
-            updated_config = tomlkit.load(f)
-
-        # Only agent-2's scaling group should be updated
-        assert updated_config["agents"][1]["agent"]["scaling-group"] == "gpu"  # type: ignore[index]
-        assert updated_config["agents"][0]["agent"]["scaling-group"] == "default"  # type: ignore[index]
-        assert mock_agent2.local_config.agent.scaling_group == "gpu"
-        assert mock_agent1.local_config.agent.scaling_group == "default"


### PR DESCRIPTION
## Summary
- Remove the manager→agent `update_scaling_group` RPC push: the `AgentRegistry` method, the agent client method, and the agent-side RPC handler including the `agent.toml` rewrite (+`.bak`) and in-memory config update. The RPC existed only to keep the next heartbeat from reverting a group change, which is obsolete now that the manager DB is the source of truth for an agent's resource group.
- Rewire the v1 `ModifyAgent` mutation to the conflicting-session cleanup service (`UpdateAgentResourceGroupAction`) with `policy=TERMINATE` and `force=False`, so the mutation fails with `AgentHasConflictingSessions` when the agent still has sessions under the old group — the admin drains them first.
- Drop the unit tests covering the removed `agent.toml` rewrite / in-memory update behavior.

## Test plan
- [ ] `pants test --changed-since=origin/main` passes in CI
- [ ] Live-server verification (agent group change via `ModifyAgent`, conflicting-session gating) is covered by BA-6831

Resolves BA-6828

🤖 Generated with [Claude Code](https://claude.com/claude-code)
