### PR TITLE
fix(BA-6952): repair retention sweep under default seed

### DIFF
--- a/changes/12995.fix.md
+++ b/changes/12995.fix.md
@@ -1,0 +1,1 @@
+Fix DB record retention sweep never running under the default policy seed, and repair `clear-history` and `schema oneshot` for the retention tables.

--- a/src/ai/backend/manager/cli/__main__.py
+++ b/src/ai/backend/manager/cli/__main__.py
@@ -270,6 +270,7 @@ def clear_history(cli_ctx: CLIContext, retention: str, vacuum_full: bool) -> Non
     from more_itertools import chunked
 
     from ai.backend.common.validators import TimeDuration
+    from ai.backend.manager.models.base import ensure_all_tables_registered
     from ai.backend.manager.models.kernel import kernels
     from ai.backend.manager.repositories.db.engine import connect_database, vacuum_db
     from ai.backend.manager.repositories.ops import DBOpsProvider
@@ -324,6 +325,9 @@ def clear_history(cli_ctx: CLIContext, retention: str, vacuum_full: bool) -> Non
 
     async def _force_retention_sweep() -> None:
         log.info("Triggering an immediate DB record retention sweep...")
+        # This standalone CLI process has not imported the full model tree, so
+        # register every table before the sweep issues its first ORM query.
+        ensure_all_tables_registered()
         async with (
             connect_database(bootstrap_config.db) as db,
             config_provider_ctx(cli_ctx) as config_provider,

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -94,6 +94,13 @@ def ensure_all_tables_registered() -> None:
         if module_info.name in _SKIP_SUBPACKAGES:
             continue
         importlib.import_module(f"ai.backend.manager.models.{module_info.name}")
+        # A domain package may keep its __init__ empty (no Row re-export) and
+        # declare its table only in ``row.py``; import it so create_all sees it.
+        if module_info.ispkg:
+            try:
+                importlib.import_module(f"ai.backend.manager.models.{module_info.name}.row")
+            except ModuleNotFoundError:
+                pass
 
 
 pgsql_connect_opts = {

--- a/src/ai/backend/manager/repositories/base/purger.py
+++ b/src/ai/backend/manager/repositories/base/purger.py
@@ -333,9 +333,12 @@ async def execute_batch_purger[TRow: Base](
         purger = BatchPurger(spec=OldSessionBatchPurgerSpec(cutoff_date))
         result = await execute_batch_purger(db_sess, purger)
     """
-    # Extract table and PK columns from the subquery
+    # Resolve the target table from the mapped entity rather than the query's
+    # FROM clause: an entity with an eager (``lazy="joined"``) relationship
+    # compiles to an _ORMJoin whose primary_key is a ColumnSet, not a Table.
     base_subquery = purger.spec.build_subquery()
-    table = cast(sa.Table, base_subquery.froms[0])
+    entity = base_subquery.column_descriptions[0]["entity"]
+    table = sa.inspect(entity).local_table
     pk_columns = list(table.primary_key.columns)
 
     total_deleted = 0

--- a/src/ai/backend/manager/repositories/retention/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/retention/db_source/db_source.py
@@ -288,14 +288,15 @@ class RetentionDBSource:
         return specs
 
     async def sweep(self) -> list[RetentionPurgeResult]:
-        """Purge every enabled category once, within a single transaction.
+        """Purge every enabled category once, each isolated by a savepoint.
 
         Reads ``batch_size`` / ``per_tick_budget`` from config at call time (so a
-        config change takes effect on the next tick). The whole sweep runs in one
-        ``write_ops`` session, so reading DB ``now``, loading policies, draining
-        each category, and stamping ``last_swept_at`` all share one snapshot and
-        commit atomically at the end — a crash mid-tick rolls the entire tick
-        back, leaving no delete-without-stamp drift.
+        config change takes effect on the next tick). The tick runs in one
+        ``write_ops`` session sharing a single ``now`` snapshot, but each category
+        drains and stamps ``last_swept_at`` inside its own savepoint: a category
+        keeps the delete-and-stamp together (no delete-without-stamp drift) while a
+        failing category rolls back only its own savepoint and is skipped, so one
+        broken category no longer aborts the whole tick.
 
         Policies are visited least-recently-swept first. A category with no wired
         cleanup raises :class:`RetentionCategoryNotSupportedError`; the loop
@@ -328,8 +329,18 @@ class RetentionDBSource:
                         policy.category.value,
                     )
                     continue
-                deleted = await self._drain_specs(w, specs, batch_size)
-                await w.update(Updater(spec=LastSweptAtUpdaterSpec(now), pk_value=policy.id))
+                try:
+                    async with w.savepoint() as sp:
+                        deleted = await self._drain_specs(sp, specs, batch_size)
+                        await sp.update(
+                            Updater(spec=LastSweptAtUpdaterSpec(now), pk_value=policy.id)
+                        )
+                except Exception:
+                    log.exception(
+                        "retention sweep failed for category {}; isolated and skipped",
+                        policy.category.value,
+                    )
+                    continue
                 results.append(
                     RetentionPurgeResult(category=policy.category, deleted_count=deleted)
                 )

--- a/tests/unit/manager/repositories/base/test_purger.py
+++ b/tests/unit/manager/repositories/base/test_purger.py
@@ -10,7 +10,7 @@ from uuid import UUID
 import pytest
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ai.backend.manager.errors.repository import (
     ForeignKeyViolationError,
@@ -1214,3 +1214,98 @@ class TestBulkPurgerPartial:
             assert result.errors[0].purger.pk_value == 2
             assert result.errors[1].index == 3  # parent-4
             assert result.errors[1].purger.pk_value == 4
+
+
+# =============================================================================
+# Eager-join entity regression (BA-6952)
+# =============================================================================
+
+
+class EagerJoinPurgerParentRow(Base):  # type: ignore[misc]
+    """Parent referenced by an eagerly-joined child relationship."""
+
+    __tablename__ = "test_eager_join_purger_parent"
+    __table_args__ = {"extend_existing": True}
+
+    id: Mapped[int] = mapped_column(sa.Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(sa.String(50), nullable=False)
+
+
+class EagerJoinPurgerChildRow(Base):  # type: ignore[misc]
+    """Child whose ``select()`` compiles its FROM to an _ORMJoin via ``lazy="joined"``.
+
+    Regression guard for BA-6952: ``execute_batch_purger`` used to read the target
+    table from the query's FROM clause, which is an _ORMJoin (whose ``primary_key``
+    is a ColumnSet without ``.columns``) for an eagerly-joined entity, raising
+    ``AttributeError`` and aborting the retention sweep.
+    """
+
+    __tablename__ = "test_eager_join_purger_child"
+    __table_args__ = {"extend_existing": True}
+
+    id: Mapped[int] = mapped_column(sa.Integer, primary_key=True)
+    parent_id: Mapped[int] = mapped_column(
+        sa.Integer,
+        sa.ForeignKey("test_eager_join_purger_parent.id"),
+        nullable=False,
+    )
+    status: Mapped[str] = mapped_column(sa.String(20), nullable=False, default="pending")
+    parent: Mapped[EagerJoinPurgerParentRow] = relationship(lazy="joined")
+
+
+class TestBatchPurgerEagerJoin:
+    """Batch purge over an entity with an eager (``lazy="joined"``) relationship."""
+
+    @pytest.fixture
+    async def seeded_child(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[type[EagerJoinPurgerChildRow], None]:
+        """Create parent+child tables and seed 3 inactive + 2 active children."""
+        async with database_connection.begin() as conn:
+            await conn.run_sync(
+                lambda c: EagerJoinPurgerParentRow.__table__.create(c, checkfirst=True)
+            )
+            await conn.run_sync(
+                lambda c: EagerJoinPurgerChildRow.__table__.create(c, checkfirst=True)
+            )
+        async with database_connection.begin_session() as db_sess:
+            db_sess.add(EagerJoinPurgerParentRow(id=1, name="parent-1"))
+            await db_sess.flush()
+            for i in range(1, 6):
+                db_sess.add(
+                    EagerJoinPurgerChildRow(
+                        id=i,
+                        parent_id=1,
+                        status="inactive" if i <= 3 else "active",
+                    )
+                )
+
+        yield EagerJoinPurgerChildRow
+
+        async with database_connection.begin() as conn:
+            await conn.run_sync(
+                lambda c: EagerJoinPurgerChildRow.__table__.drop(c, checkfirst=True)
+            )
+            await conn.run_sync(
+                lambda c: EagerJoinPurgerParentRow.__table__.drop(c, checkfirst=True)
+            )
+
+    async def test_purge_resolves_table_from_mapped_entity(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        seeded_child: type[EagerJoinPurgerChildRow],
+    ) -> None:
+        """An eagerly-joined entity purges by its own table without raising."""
+        async with database_connection.begin_session() as db_sess:
+            spec = SimpleBatchPurgerSpec(
+                row_class=seeded_child,
+                conditions=[seeded_child.status == "inactive"],
+            )
+            result = await execute_batch_purger(db_sess, BatchPurger(spec=spec))
+
+            assert isinstance(result, BatchPurgerResult)
+            assert result.deleted_count == 3
+
+            remaining = await db_sess.execute(sa.select(sa.func.count()).select_from(seeded_child))
+            assert remaining.scalar() == 2

--- a/tests/unit/manager/repositories/retention/test_retention_repository.py
+++ b/tests/unit/manager/repositories/retention/test_retention_repository.py
@@ -1376,3 +1376,69 @@ class TestCatalogCompleteness:
         # RetentionCategory must resolve to a purger spec set.
         catalog = RetentionDBSource._catalog(_THRESHOLD)
         assert set(catalog) == set(RetentionCategory)
+
+
+class TestSweepCategoryIsolation:
+    """A failing category is rolled back in isolation; healthy categories persist."""
+
+    @pytest.fixture
+    async def db(
+        self, database_connection: ExtendedAsyncSAEngine
+    ) -> AsyncIterator[ExtendedAsyncSAEngine]:
+        async with with_tables(
+            database_connection,
+            [
+                DomainRow,
+                UserResourcePolicyRow,
+                KeyPairResourcePolicyRow,
+                UserRow,
+                KeyPairRow,
+                EventLogRow,
+                AuditLogRow,
+                ErrorLogRow,
+                KernelUsageRecordRow,
+                RetentionPolicyRow,
+            ],
+        ):
+            yield database_connection
+
+    async def test_failing_category_does_not_abort_others(
+        self, db: ExtendedAsyncSAEngine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # logs (never swept) is drained first and succeeds; usage_records (swept
+        # recently) is drained second and is forced to fail. Its savepoint rolls
+        # back without touching the already-drained logs work.
+        original_drain = RetentionDBSource._drain_specs
+
+        async def _flaky_drain(
+            self: RetentionDBSource,
+            w: object,
+            specs: object,
+            batch_size: int,
+        ) -> int:
+            if any(spec.row_class is KernelUsageRecordRow for spec in specs):  # type: ignore[attr-defined]
+                raise RuntimeError("injected category failure")
+            return await original_drain(self, w, specs, batch_size)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(RetentionDBSource, "_drain_specs", _flaky_drain)
+
+        await _insert(
+            db,
+            [
+                EventLogRow(event_name="old", event_domain=EventDomain.SESSION, created_at=_OLD),
+                _usage_record(period_end=_OLD),
+                _policy_row(RetentionCategory.LOGS),
+                _policy_row(RetentionCategory.USAGE_RECORDS, last_swept_at=_NEW),
+            ],
+        )
+
+        results = await _make_db_source(db).sweep()
+
+        # Only the healthy category is reported; the sweep does not raise.
+        assert [r.category for r in results] == [RetentionCategory.LOGS]
+        # Healthy category committed even though a later category failed.
+        assert await _count(db, EventLogRow) == 0
+        assert await _swept_at(db, RetentionCategory.LOGS) is not None
+        # Failing category rolled back to its savepoint: row kept, not stamped.
+        assert await _count(db, KernelUsageRecordRow) == 1
+        assert await _swept_at(db, RetentionCategory.USAGE_RECORDS) == _NEW


### PR DESCRIPTION
## Summary
BEP-1063 DB record retention never ran under the shipped default seed (all 8 categories enabled). This fixes three code-path defects and hardens the sweep:

- **purger** (`repositories/base/purger.py`): `execute_batch_purger` resolved the target table from `build_subquery().froms[0]`, which is an `_ORMJoin` (its `primary_key` is a `ColumnSet` without `.columns`) for an eagerly-joined entity like `DeploymentRevisionRow` → `AttributeError`. Since a sweep tick is atomic, this one broken category aborted the whole tick, so nothing was ever purged under the default seed. Now the table is resolved from the mapped entity.
- **sweep** (`repositories/retention/db_source/db_source.py`): each category now drains + stamps inside its own savepoint, so a single failing category rolls back only itself instead of aborting the tick; healthy categories keep delete-and-stamp atomic.
- **clear-history** (`cli/__main__.py`): the standalone CLI crashed with `InvalidRequestError` (mapper not configured) on the forced sweep's first ORM query. It now calls `ensure_all_tables_registered()` first, so the sweep and VACUUM run.
- **models** (`models/base.py`): `ensure_all_tables_registered()` now also imports each subpackage's `row` module, so `mgr schema oneshot` creates tables whose `__init__.py` is empty (e.g. `retention_policies`).

## Test plan
- [x] New regression tests: batch purge over an eagerly-joined entity; per-category failure isolation in the sweep
- [x] `pants fmt/fix/lint/check` clean; retention + purger + ops + leader unit tests pass
- [x] Regression sweep of shared-code blast radius: all `tests/unit/manager/repositories` + `models` unit tests, and `component` tests for every batch-purger caller (domain/user/group/vfolder/scaling_group/deployment_revision_preset/rbac), plus `tests/unit/cli` lazy-import
- [x] Live local stack: default seed (8 enabled incl. deployments) sweeps correctly; `mgr clear-history` completes (Redis → sweep → VACUUM); `mgr schema oneshot` creates `retention_policies` on a fresh DB

Resolves BA-6952