### PR TITLE
feat(BA-6949): seed retention_policies as disabled by default (opt-in)

### DIFF
--- a/changes/12996.enhance.md
+++ b/changes/12996.enhance.md
@@ -1,0 +1,1 @@
+Make DB record retention opt-in by seeding all retention policy categories as disabled by default.

--- a/fixtures/manager/example-retention-policies.json
+++ b/fixtures/manager/example-retention-policies.json
@@ -1,0 +1,52 @@
+{
+  "retention_policies": [
+    {
+      "id": "b1e5f4a0-0001-4c10-8a01-000000000001",
+      "category": "logs",
+      "retention_period": {"days": 365},
+      "enabled": false
+    },
+    {
+      "id": "b1e5f4a0-0002-4c10-8a01-000000000002",
+      "category": "login",
+      "retention_period": {"days": 365},
+      "enabled": false
+    },
+    {
+      "id": "b1e5f4a0-0003-4c10-8a01-000000000003",
+      "category": "reconcile_history",
+      "retention_period": {"days": 365},
+      "enabled": false
+    },
+    {
+      "id": "b1e5f4a0-0004-4c10-8a01-000000000004",
+      "category": "roles_invitations",
+      "retention_period": {"days": 365},
+      "enabled": false
+    },
+    {
+      "id": "b1e5f4a0-0005-4c10-8a01-000000000005",
+      "category": "deployments",
+      "retention_period": {"days": 365},
+      "enabled": false
+    },
+    {
+      "id": "b1e5f4a0-0006-4c10-8a01-000000000006",
+      "category": "sessions",
+      "retention_period": {"days": 365},
+      "enabled": false
+    },
+    {
+      "id": "b1e5f4a0-0007-4c10-8a01-000000000007",
+      "category": "usage_records",
+      "retention_period": {"days": 90},
+      "enabled": false
+    },
+    {
+      "id": "b1e5f4a0-0008-4c10-8a01-000000000008",
+      "category": "usage_buckets",
+      "retention_period": {"days": 730},
+      "enabled": false
+    }
+  ]
+}

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -1295,6 +1295,7 @@ configure_backendai() {
   ./backend.ai mgr fixture populate fixtures/manager/example-roles.json
   ./backend.ai mgr fixture populate fixtures/manager/example-prometheus-query-preset-categories.json
   ./backend.ai mgr fixture populate fixtures/manager/example-prometheus-query-presets.json
+  ./backend.ai mgr fixture populate fixtures/manager/example-retention-policies.json
 
   # Populate artifact registries only when the storage halfstack profile is
   # active; the example registry points at the local MinIO and depends on

--- a/src/ai/backend/install/context.py
+++ b/src/ai/backend/install/context.py
@@ -653,6 +653,10 @@ class Context(metaclass=ABCMeta):
             "ai.backend.install.fixtures", "example-prometheus-query-presets.json"
         ) as path:
             await self.run_manager_cli(["mgr", "fixture", "populate", str(path)])
+        with self.resource_path(
+            "ai.backend.install.fixtures", "example-retention-policies.json"
+        ) as path:
+            await self.run_manager_cli(["mgr", "fixture", "populate", str(path)])
 
     async def check_prerequisites(self) -> None:
         self.os_info = await detect_os()

--- a/src/ai/backend/install/fixtures/example-retention-policies.json
+++ b/src/ai/backend/install/fixtures/example-retention-policies.json
@@ -1,0 +1,52 @@
+{
+  "retention_policies": [
+    {
+      "id": "b1e5f4a0-0001-4c10-8a01-000000000001",
+      "category": "logs",
+      "retention_period": {"days": 365},
+      "enabled": false
+    },
+    {
+      "id": "b1e5f4a0-0002-4c10-8a01-000000000002",
+      "category": "login",
+      "retention_period": {"days": 365},
+      "enabled": false
+    },
+    {
+      "id": "b1e5f4a0-0003-4c10-8a01-000000000003",
+      "category": "reconcile_history",
+      "retention_period": {"days": 365},
+      "enabled": false
+    },
+    {
+      "id": "b1e5f4a0-0004-4c10-8a01-000000000004",
+      "category": "roles_invitations",
+      "retention_period": {"days": 365},
+      "enabled": false
+    },
+    {
+      "id": "b1e5f4a0-0005-4c10-8a01-000000000005",
+      "category": "deployments",
+      "retention_period": {"days": 365},
+      "enabled": false
+    },
+    {
+      "id": "b1e5f4a0-0006-4c10-8a01-000000000006",
+      "category": "sessions",
+      "retention_period": {"days": 365},
+      "enabled": false
+    },
+    {
+      "id": "b1e5f4a0-0007-4c10-8a01-000000000007",
+      "category": "usage_records",
+      "retention_period": {"days": 90},
+      "enabled": false
+    },
+    {
+      "id": "b1e5f4a0-0008-4c10-8a01-000000000008",
+      "category": "usage_buckets",
+      "retention_period": {"days": 730},
+      "enabled": false
+    }
+  ]
+}

--- a/src/ai/backend/manager/models/alembic/versions/b3e8f1a24c76_seed_retention_policies_disabled.py
+++ b/src/ai/backend/manager/models/alembic/versions/b3e8f1a24c76_seed_retention_policies_disabled.py
@@ -1,0 +1,52 @@
+"""seed retention_policies disabled by default
+
+Make DB record retention opt-in (BEP-1063 follow-up). The initial table
+migration ``4a39641d0fc2`` seeded eight category rows without an explicit
+``enabled`` value, so they inherited the column default ``true`` and retention
+swept automatically. Flip the column default to ``false`` and disable the seeded
+rows so nothing is purged until a super-admin turns a category on.
+
+Revision ID: b3e8f1a24c76
+Revises: 577c7a215934
+Create Date: 2026-07-21
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b3e8f1a24c76"
+down_revision = "577c7a215934"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+SEED_CATEGORIES = [
+    "logs",
+    "login",
+    "reconcile_history",
+    "roles_invitations",
+    "deployments",
+    "sessions",
+    "usage_records",
+    "usage_buckets",
+]
+
+
+def upgrade() -> None:
+    op.alter_column("retention_policies", "enabled", server_default=sa.false())
+    op.execute(
+        sa.text(
+            "UPDATE retention_policies SET enabled = false WHERE category = ANY(:categories)"
+        ).bindparams(categories=SEED_CATEGORIES)
+    )
+
+
+def downgrade() -> None:
+    op.alter_column("retention_policies", "enabled", server_default=sa.true())
+    op.execute(
+        sa.text(
+            "UPDATE retention_policies SET enabled = true WHERE category = ANY(:categories)"
+        ).bindparams(categories=SEED_CATEGORIES)
+    )

--- a/src/ai/backend/manager/models/alembic/versions/b3e8f1a24c76_seed_retention_policies_disabled.py
+++ b/src/ai/backend/manager/models/alembic/versions/b3e8f1a24c76_seed_retention_policies_disabled.py
@@ -7,7 +7,7 @@ swept automatically. Flip the column default to ``false`` and disable the seeded
 rows so nothing is purged until a super-admin turns a category on.
 
 Revision ID: b3e8f1a24c76
-Revises: 577c7a215934
+Revises: ea422739665b
 Create Date: 2026-07-21
 
 """
@@ -17,7 +17,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "b3e8f1a24c76"
-down_revision = "577c7a215934"
+down_revision = "ea422739665b"
 # Part of: NEXT_RELEASE_VERSION
 branch_labels = None
 depends_on = None
@@ -44,9 +44,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # The ``enabled`` flag is operator-managed policy state; do not flip rows
+    # back to enabled here — only restore the previous column default.
     op.alter_column("retention_policies", "enabled", server_default=sa.true())
-    op.execute(
-        sa.text(
-            "UPDATE retention_policies SET enabled = true WHERE category = ANY(:categories)"
-        ).bindparams(categories=SEED_CATEGORIES)
-    )

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -12,6 +12,7 @@ from collections.abc import (
     Sequence,
 )
 from dataclasses import dataclass
+from datetime import timedelta
 from decimal import Decimal
 from typing import (
     TYPE_CHECKING,
@@ -1079,6 +1080,19 @@ async def populate_fixture(
                                 del row[col.name]
                             else:
                                 row[col.name] = None
+                if isinstance(col.type, sa.Interval):
+                    # asyncpg encodes intervals only from datetime.timedelta.
+                    # Accept a kwargs dict (e.g. {"days": 365}) or a number of
+                    # seconds in the fixture JSON.
+                    for row in rows:
+                        if col.name in row and row[col.name] is not None:
+                            value = row[col.name]
+                            if isinstance(value, timedelta):
+                                continue
+                            if isinstance(value, Mapping):
+                                row[col.name] = timedelta(**value)
+                            else:
+                                row[col.name] = timedelta(seconds=value)
                 if isinstance(col.type, EnumType):
                     for row in rows:
                         if col.name in row:

--- a/src/ai/backend/manager/models/retention/row.py
+++ b/src/ai/backend/manager/models/retention/row.py
@@ -28,7 +28,7 @@ class RetentionPolicyRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
         "retention_period", sa.Interval, nullable=False
     )
     enabled: Mapped[bool] = mapped_column(
-        "enabled", sa.Boolean, nullable=False, server_default=sa.true()
+        "enabled", sa.Boolean, nullable=False, server_default=sa.false()
     )
     last_swept_at: Mapped[datetime | None] = mapped_column(
         "last_swept_at", sa.DateTime(timezone=True), nullable=True

--- a/tests/unit/manager/models/test_retention_policy_row.py
+++ b/tests/unit/manager/models/test_retention_policy_row.py
@@ -59,7 +59,8 @@ class TestRetentionPolicyRow:
             ).scalar_one()
         assert row.category is RetentionCategory.USAGE_RECORDS
         assert row.retention_period == timedelta(days=90)
-        assert row.enabled is True
+        # Retention is opt-in: rows default to disabled (server_default=false).
+        assert row.enabled is False
         assert row.last_swept_at is None
         # created_at / updated_at come from LifecycleTimestampsMixin (server_default).
         assert row.created_at is not None

--- a/tests/unit/manager/models/test_retention_policy_row.py
+++ b/tests/unit/manager/models/test_retention_policy_row.py
@@ -8,6 +8,7 @@ import sqlalchemy as sa
 from sqlalchemy.exc import IntegrityError
 
 from ai.backend.manager.data.retention.types import RetentionCategory
+from ai.backend.manager.models.base import populate_fixture
 from ai.backend.manager.models.retention.row import RetentionPolicyRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.testutils.db import with_tables
@@ -65,6 +66,57 @@ class TestRetentionPolicyRow:
         # created_at / updated_at come from LifecycleTimestampsMixin (server_default).
         assert row.created_at is not None
         assert row.updated_at is not None
+
+    async def test_populate_fixture_converts_interval_kwargs_dict(
+        self, db: ExtendedAsyncSAEngine
+    ) -> None:
+        fixture_data: dict[str, list[dict[str, object]]] = {
+            "retention_policies": [
+                {
+                    "category": "usage_records",
+                    "retention_period": {"days": 90},
+                    "enabled": False,
+                }
+            ],
+        }
+
+        await populate_fixture(db, fixture_data)
+
+        async with db.begin_readonly_session() as sess:
+            row = (
+                await sess.execute(
+                    sa.select(RetentionPolicyRow).where(
+                        RetentionPolicyRow.category == RetentionCategory.USAGE_RECORDS
+                    )
+                )
+            ).scalar_one()
+        assert row.retention_period == timedelta(days=90)
+        assert row.enabled is False
+
+    async def test_populate_fixture_converts_interval_seconds_number(
+        self, db: ExtendedAsyncSAEngine
+    ) -> None:
+        fixture_data: dict[str, list[dict[str, object]]] = {
+            "retention_policies": [
+                {
+                    "category": "logs",
+                    "retention_period": 3600,
+                    "enabled": False,
+                }
+            ],
+        }
+
+        await populate_fixture(db, fixture_data)
+
+        async with db.begin_readonly_session() as sess:
+            row = (
+                await sess.execute(
+                    sa.select(RetentionPolicyRow).where(
+                        RetentionPolicyRow.category == RetentionCategory.LOGS
+                    )
+                )
+            ).scalar_one()
+        assert row.retention_period == timedelta(seconds=3600)
 
     async def test_duplicate_category_violates_unique(self, db: ExtendedAsyncSAEngine) -> None:
         async with db.begin_session() as sess:


### PR DESCRIPTION
## Summary
- Retention swept automatically because the initial migration (`4a39641d0fc2`) seeded eight category rows without an explicit `enabled`, inheriting the column default `true`. This makes DB record retention **opt-in**.
- Follow-up migration `b3e8f1a24c76` flips the `enabled` server_default to `false` and disables the eight seeded rows; the row model's `server_default` is changed to match. Nothing is purged until a super-admin turns a category on.
- Adds `fixtures/manager/example-retention-policies.json` (8 categories, `enabled=false`, default periods) and wires it into `install-dev.sh`. Teaches `populate_fixture` to convert `sa.Interval` fixture values to `timedelta` (asyncpg encodes intervals only from `timedelta`).

## Test plan
- [x] `pants fmt/fix/lint/check` pass
- [x] `pants test` — retention row/repository/sweep + fixture loader tests pass
- [x] Migration upgrade/downgrade verified against local DB (seeded rows→false, new rows inherit false default, downgrade reverses only seeded categories)
- [x] Fixture loads end-to-end via real `populate_fixture` (8 rows, `enabled=false`, correct periods)

Resolves BA-6949