### PR TITLE
fix(BA-6955): grant kernel scheduling-history read alongside session read

### DIFF
--- a/changes/13000.fix.md
+++ b/changes/13000.fix.md
@@ -1,0 +1,1 @@
+Grant kernel scheduling-history read permission alongside session read — natively for newly created scope roles and via backfill for existing ones — so the owner of a kernel can query its scheduling history

--- a/src/ai/backend/manager/data/domain/types.py
+++ b/src/ai/backend/manager/data/domain/types.py
@@ -55,6 +55,7 @@ class DomainData:
             for entity in EntityType.admin_accessible_entity_types_in_domain()
         }
         operations[RBACElementType.DOMAIN_ADMIN_PAGE] = {OperationType.READ}
+        operations[RBACElementType.KERNEL_HISTORY] = {OperationType.READ}
         return operations
 
 

--- a/src/ai/backend/manager/data/group/types.py
+++ b/src/ai/backend/manager/data/group/types.py
@@ -72,6 +72,7 @@ class GroupData:
             for entity in EntityType.admin_accessible_entity_types_in_project()
         }
         operations[RBACElementType.PROJECT_ADMIN_PAGE] = {OperationType.READ}
+        operations[RBACElementType.KERNEL_HISTORY] = {OperationType.READ}
         return operations
 
 
@@ -99,10 +100,12 @@ class ProjectMemberRoleSpec:
         return f"project-{str(self.project_id)[:8]}-member"
 
     def entity_operations(self) -> Mapping[RBACElementType, Iterable[OperationType]]:
-        return {
+        operations: dict[RBACElementType, Iterable[OperationType]] = {
             entity.to_element(): OperationType.member_operations()
             for entity in EntityType.member_accessible_entity_types_in_project()
         }
+        operations[RBACElementType.KERNEL_HISTORY] = {OperationType.READ}
+        return operations
 
 
 @dataclass

--- a/src/ai/backend/manager/data/user/types.py
+++ b/src/ai/backend/manager/data/user/types.py
@@ -110,6 +110,7 @@ class UserData:
             entity.to_element(): OperationType.owner_operations()
             for entity in EntityType.owner_accessible_entity_types_in_user()
         }
+        resource_entity_permissions[RBACElementType.KERNEL_HISTORY] = {OperationType.READ}
         user_permissions = OperationType.owner_operations() - {OperationType.CREATE}
         return {RBACElementType.USER: user_permissions, **resource_entity_permissions}
 

--- a/src/ai/backend/manager/models/alembic/versions/a1c4e7b93f22_add_kernel_history_read_permissions.py
+++ b/src/ai/backend/manager/models/alembic/versions/a1c4e7b93f22_add_kernel_history_read_permissions.py
@@ -1,4 +1,4 @@
-"""add kernel history read permissions to roles that can read kernels
+"""add kernel history read permissions to roles that can read sessions
 
 Revision ID: a1c4e7b93f22
 Revises: 3f9a1c7b2e04
@@ -12,39 +12,43 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "a1c4e7b93f22"
 down_revision = "3f9a1c7b2e04"
+# Part of: NEXT_RELEASE_VERSION
 branch_labels = None
 depends_on = None
 
 _ENTITY_TYPE = "kernel:history"
 
+# A kernel is reachable through its owning session, and nothing grants the bare
+# `kernel` entity, so session READ is what carries kernel history access.
+_SOURCE_ENTITY_TYPE = "session"
+
 
 def upgrade() -> None:
     conn = op.get_bind()
 
-    # Reading a kernel carries reading its scheduling history, so mirror every
-    # existing kernel READ grant onto the history entity within the same scope.
+    # Mirror every session READ grant onto the history entity within the same
+    # scope, carrying the source permission bits (the column is NOT NULL).
     # ON CONFLICT DO NOTHING keeps this idempotent for release-branch backports.
     conn.execute(
         sa.text("""
-            INSERT INTO permissions (role_id, scope_type, scope_id, entity_type, operation)
-            SELECT DISTINCT p.role_id, p.scope_type, p.scope_id, :entity_type, 'read'
+            INSERT INTO permissions (
+                role_id, scope_type, scope_id, entity_type, operation, permission
+            )
+            SELECT DISTINCT p.role_id, p.scope_type, p.scope_id,
+                   :entity_type, 'read', p.permission
             FROM permissions p
-            WHERE p.entity_type = 'kernel'
+            WHERE p.entity_type = :source_entity_type
               AND p.operation = 'read'
             ON CONFLICT DO NOTHING
         """),
-        {"entity_type": _ENTITY_TYPE},
+        {"entity_type": _ENTITY_TYPE, "source_entity_type": _SOURCE_ENTITY_TYPE},
     )
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-
-    conn.execute(
-        sa.text("""
-            DELETE FROM permissions
-            WHERE entity_type = :entity_type
-              AND operation = 'read'
-        """),
-        {"entity_type": _ENTITY_TYPE},
-    )
+    # No-op: kernel:history READ is part of each scope role's intended permission
+    # set (granted natively at role creation for roles created after the fix).
+    # A mirror-based DELETE cannot distinguish rows inserted by this backfill
+    # from those granted at creation, so it would strip permissions the roles
+    # legitimately hold. Leaving the backfilled rows in place is safe.
+    pass

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
@@ -18,8 +18,9 @@ class SearchKernelScopedHistoryAction(BaseScopeAction):
 
     The history is the entity being read and the kernel is the scope containing it,
     mirroring the other scoped searches (a role assignment within a role, a vfolder
-    within a user). Authorization therefore needs a ``kernel:history`` read
-    permission on the role preset; without one, only super admins pass.
+    within a user). Authorization needs a ``kernel:history`` read grant at a scope
+    covering the kernel; scope roles receive it alongside ``session`` read, since
+    kernels are reached through their owning session.
     """
 
     kernel_id: KernelId

--- a/tests/unit/manager/data/domain/test_types.py
+++ b/tests/unit/manager/data/domain/test_types.py
@@ -34,6 +34,12 @@ class TestDomainDataEntityOperations:
         assert RBACElementType.DOMAIN_ADMIN_PAGE in operations
         assert set(operations[RBACElementType.DOMAIN_ADMIN_PAGE]) == {OperationType.READ}
 
+    def test_includes_kernel_history_read(self) -> None:
+        operations = _make_domain_data().entity_operations()
+
+        assert RBACElementType.KERNEL_HISTORY in operations
+        assert set(operations[RBACElementType.KERNEL_HISTORY]) == {OperationType.READ}
+
     def test_admin_resource_entries_unchanged(self) -> None:
         operations = _make_domain_data().entity_operations()
 

--- a/tests/unit/manager/data/group/test_types.py
+++ b/tests/unit/manager/data/group/test_types.py
@@ -4,7 +4,7 @@ import uuid
 
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
-from ai.backend.manager.data.group.types import GroupData, ProjectType
+from ai.backend.manager.data.group.types import GroupData, ProjectMemberRoleSpec, ProjectType
 from ai.backend.manager.data.permission.types import OperationType
 
 
@@ -34,9 +34,28 @@ class TestGroupDataEntityOperations:
         assert RBACElementType.PROJECT_ADMIN_PAGE in operations
         assert set(operations[RBACElementType.PROJECT_ADMIN_PAGE]) == {OperationType.READ}
 
+    def test_includes_kernel_history_read(self) -> None:
+        operations = _make_group_data().entity_operations()
+
+        assert RBACElementType.KERNEL_HISTORY in operations
+        assert set(operations[RBACElementType.KERNEL_HISTORY]) == {OperationType.READ}
+
     def test_admin_resource_entries_unchanged(self) -> None:
         operations = _make_group_data().entity_operations()
 
         # Sanity check: existing admin entries still receive full admin operations.
         assert set(operations[RBACElementType.VFOLDER]) == OperationType.admin_operations()
         assert set(operations[RBACElementType.USER]) == OperationType.admin_operations()
+
+
+class TestProjectMemberRoleSpecEntityOperations:
+    def test_includes_kernel_history_read(self) -> None:
+        operations = ProjectMemberRoleSpec(project_id=uuid.uuid4()).entity_operations()
+
+        assert RBACElementType.KERNEL_HISTORY in operations
+        assert set(operations[RBACElementType.KERNEL_HISTORY]) == {OperationType.READ}
+
+    def test_member_resource_entries_unchanged(self) -> None:
+        operations = ProjectMemberRoleSpec(project_id=uuid.uuid4()).entity_operations()
+
+        assert set(operations[RBACElementType.SESSION]) == OperationType.member_operations()

--- a/tests/unit/manager/data/user/BUILD
+++ b/tests/unit/manager/data/user/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/data/user/test_types.py
+++ b/tests/unit/manager/data/user/test_types.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.manager.data.permission.types import OperationType
+from ai.backend.manager.data.user.types import UserData
+
+
+@pytest.fixture
+def user_data() -> UserData:
+    user_id = uuid.uuid4()
+    return UserData(
+        id=user_id,
+        uuid=user_id,
+        username="test-user",
+        email="test-user@example.com",
+        need_password_change=False,
+        full_name=None,
+        description=None,
+        is_active=True,
+        status="active",
+        status_info=None,
+        created_at=None,
+        modified_at=None,
+        domain_name="default",
+        role=None,
+        resource_policy="default",
+        allowed_client_ip=None,
+        totp_activated=False,
+        totp_activated_at=None,
+        sudo_session_enabled=False,
+        main_access_key=None,
+        container_uid=None,
+        container_main_gid=None,
+        container_gids=None,
+        integration_name=None,
+    )
+
+
+class TestUserDataEntityOperations:
+    def test_includes_kernel_history_read(self, user_data: UserData) -> None:
+        operations = user_data.entity_operations()
+
+        assert RBACElementType.KERNEL_HISTORY in operations
+        assert set(operations[RBACElementType.KERNEL_HISTORY]) == {OperationType.READ}
+
+    def test_owner_resource_entries_unchanged(self, user_data: UserData) -> None:
+        operations = user_data.entity_operations()
+
+        assert set(operations[RBACElementType.SESSION]) == OperationType.owner_operations()
+        assert set(operations[RBACElementType.USER]) == (
+            OperationType.owner_operations() - {OperationType.CREATE}
+        )


### PR DESCRIPTION
Resolves #12999 (BA-6955)

## Summary

`POST /v2/scheduling-history/kernels/scoped/search` (and the `scopedKernelSchedulingHistories` GQL query) is registered with `auth_required` and its action declares `kernel:history` as the entity being read, yet every non-superadmin caller — including the owner of the kernel — was rejected, because **nothing ever granted `kernel:history` read**:

- Migration `a1c4e7b93f22` mirrored grants from `entity_type = 'kernel'`, which nothing creates (kernels are reached through their owning session), so its `SELECT` matched zero rows. The empty result also masked the `INSERT` omitting the `NOT NULL` `permission` column.
- Runtime scope-role creation never included `kernel:history` either, so even a corrected backfill would have left users created afterwards without access.

Per the scope-chain model in `proposals/BEP-1048/permission-check-scope-chain-examples.md` §2, the subject of the check is the entity being read, with grants expected at ancestor scopes — so the fix supplies the grants rather than changing the action's entity type:

| Half | Change | Precedent |
|---|---|---|
| Existing roles | Rewrite the (unreleased) migration to mirror `session` READ grants, carrying the source `permission` bits | `21159a293dfb` and the other migrate-to-rbac backfills |
| New roles | Grant `kernel:history` READ natively in the user owner, project admin, project member, and domain admin scope roles | `*_admin_page` entries in the same `entity_operations()` methods |
| Downgrade | Documented no-op — a mirror-based DELETE cannot tell backfilled rows from natively granted ones | `f2b9a4c7e103` |

Reading a session is what carries kernel visibility (`search_kernel.py` authorizes via `session`), so kernel scheduling history follows the same boundary: it is exactly as visible as the session it belongs to, including domain-scoped `session` read grants.

## Test plan

Verified on a live stack (kernel `f53384a7…` owned by `user@lablup.com`):

- [x] Runtime half: a freshly created user's owner role receives `kernel:history read (permission=1)` natively, with no migration involved
- [x] Backfill half: the upgrade SQL inserted 16 mirrored rows; re-running inserted 0 (idempotent, `ON CONFLICT DO NOTHING`)
- [x] Owner passes the scoped query end-to-end (GQL v2, same adapter → action → RBAC path as REST)
- [x] Negative control: deleting the `kernel:history` rows makes the same owner query fail with `NotEnoughPermission`; restoring them makes it pass — the check is enforced by exactly these rows
- [x] Unit tests added for the four `entity_operations()` changes (`tests/unit/manager/data/{user,group,domain}/test_types.py`)
- [ ] Responses containing actual history rows — kernel scheduling-history rows are never written in this environment (session history recorded 4 rows for the same session while kernel history stayed empty); unrelated to authorization, tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)