### PR TITLE
fix(BA-6957): authorize kernel scoped scheduling-history via the owning session

### DIFF
--- a/changes/13003.fix.md
+++ b/changes/13003.fix.md
@@ -1,0 +1,1 @@
+Authorize the kernel-scoped scheduling-history search through `session` read so the owner of a kernel can query its scheduling history instead of receiving a permission error

--- a/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
@@ -79,6 +79,9 @@ from ai.backend.manager.repositories.scheduling_history.types import (
     RouteHistorySearchScope,
     SessionSchedulingHistorySearchScope,
 )
+from ai.backend.manager.services.scheduling_history.actions.resolve_kernel_session import (
+    ResolveKernelSessionAction,
+)
 from ai.backend.manager.services.scheduling_history.actions.search_deployment_history import (
     SearchDeploymentHistoryAction,
 )
@@ -447,9 +450,18 @@ class SchedulingHistoryAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
+        # The owning session is the authorization subject; resolve it before
+        # dispatching so the RBAC check targets the session directly.
+        resolve_result = (
+            await self._processors.scheduling_history.resolve_kernel_session.wait_for_complete(
+                ResolveKernelSessionAction(kernel_id=KernelId(input.scope.kernel_id))
+            )
+        )
         action_result = await self._processors.scheduling_history.search_kernel_scoped_history.wait_for_complete(
             SearchKernelScopedHistoryAction(
-                kernel_id=KernelId(input.scope.kernel_id), querier=querier
+                kernel_id=KernelId(input.scope.kernel_id),
+                session_id=resolve_result.session_id,
+                querier=querier,
             )
         )
         return SearchKernelHistoriesPayload(

--- a/src/ai/backend/manager/models/alembic/versions/a1c4e7b93f22_add_kernel_history_read_permissions.py
+++ b/src/ai/backend/manager/models/alembic/versions/a1c4e7b93f22_add_kernel_history_read_permissions.py
@@ -1,13 +1,21 @@
 """add kernel history read permissions to roles that can read kernels
 
+Intentionally a no-op. As shipped, this migration was inert: it mirrored READ
+grants from a ``kernel`` entity that nothing creates — kernel-entity permission
+records are deliberately kept empty — so its SELECT matched zero rows, which
+also masked its INSERT omitting the NOT NULL ``permissions.permission`` column.
+The body has been emptied to make the no-op explicit; the revision is kept only
+because it has already been applied.
+
+Kernel scheduling history is authorized through ``session`` READ via the RBAC
+scope chain (kernel -> session -> user/project) instead, so no ``kernel:history``
+grant is wanted. See ``SearchKernelScopedHistoryAction``.
+
 Revision ID: a1c4e7b93f22
 Revises: 3f9a1c7b2e04
 Create Date: 2026-07-20 00:00:00.000000
 
 """
-
-import sqlalchemy as sa
-from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "a1c4e7b93f22"
@@ -15,36 +23,10 @@ down_revision = "3f9a1c7b2e04"
 branch_labels = None
 depends_on = None
 
-_ENTITY_TYPE = "kernel:history"
-
 
 def upgrade() -> None:
-    conn = op.get_bind()
-
-    # Reading a kernel carries reading its scheduling history, so mirror every
-    # existing kernel READ grant onto the history entity within the same scope.
-    # ON CONFLICT DO NOTHING keeps this idempotent for release-branch backports.
-    conn.execute(
-        sa.text("""
-            INSERT INTO permissions (role_id, scope_type, scope_id, entity_type, operation)
-            SELECT DISTINCT p.role_id, p.scope_type, p.scope_id, :entity_type, 'read'
-            FROM permissions p
-            WHERE p.entity_type = 'kernel'
-              AND p.operation = 'read'
-            ON CONFLICT DO NOTHING
-        """),
-        {"entity_type": _ENTITY_TYPE},
-    )
+    pass
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-
-    conn.execute(
-        sa.text("""
-            DELETE FROM permissions
-            WHERE entity_type = :entity_type
-              AND operation = 'read'
-        """),
-        {"entity_type": _ENTITY_TYPE},
-    )
+    pass

--- a/src/ai/backend/manager/repositories/scheduling_history/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduling_history/db_source/db_source.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
 
+from ai.backend.common.types import KernelId, SessionId
 from ai.backend.manager.data.deployment.types import (
     DeploymentHistoryListResult,
     RouteHistoryListResult,
@@ -16,6 +17,8 @@ from ai.backend.manager.data.kernel.types import (
 from ai.backend.manager.data.session.types import (
     SessionSchedulingHistoryListResult,
 )
+from ai.backend.manager.errors.kernel import KernelNotFound
+from ai.backend.manager.models.kernel.row import KernelRow
 from ai.backend.manager.models.scheduling_history import (
     DeploymentHistoryRow,
     KernelSchedulingHistoryRow,
@@ -121,6 +124,19 @@ class SchedulingHistoryDBSource:
             )
 
     # ========== Kernel History (Scoped) ==========
+
+    async def resolve_session_id(self, kernel_id: KernelId) -> SessionId:
+        """Return the id of the session owning ``kernel_id``.
+
+        Raises ``KernelNotFound`` when no such kernel exists.
+        """
+        async with self._db.begin_readonly_session() as db_sess:
+            session_id = await db_sess.scalar(
+                sa.select(KernelRow.session_id).where(KernelRow.id == kernel_id)
+            )
+            if session_id is None:
+                raise KernelNotFound(str(kernel_id))
+            return SessionId(session_id)
 
     async def search_kernel_scoped_history(
         self,

--- a/src/ai/backend/manager/repositories/scheduling_history/repository.py
+++ b/src/ai/backend/manager/repositories/scheduling_history/repository.py
@@ -11,6 +11,7 @@ from ai.backend.common.resilience import (
     RetryPolicy,
 )
 from ai.backend.common.resilience.policies.retry import BackoffStrategy
+from ai.backend.common.types import KernelId, SessionId
 from ai.backend.manager.data.deployment.types import (
     DeploymentHistoryListResult,
     RouteHistoryListResult,
@@ -93,6 +94,14 @@ class SchedulingHistoryRepository:
         return await self._db_source.search_kernel_history(querier)
 
     # ========== Kernel History (Scoped) ==========
+
+    @scheduling_history_repository_resilience.apply()
+    async def resolve_session_id(self, kernel_id: KernelId) -> SessionId:
+        """Return the id of the session owning ``kernel_id``.
+
+        Raises ``KernelNotFound`` when no such kernel exists.
+        """
+        return await self._db_source.resolve_session_id(kernel_id)
 
     @scheduling_history_repository_resilience.apply()
     async def search_kernel_scoped_history(

--- a/src/ai/backend/manager/services/scheduling_history/actions/__init__.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/__init__.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 from .base import SchedulingHistoryAction
+from .resolve_kernel_session import (
+    ResolveKernelSessionAction,
+    ResolveKernelSessionActionResult,
+)
 from .search_deployment_history import (
     SearchDeploymentHistoryAction,
     SearchDeploymentHistoryActionResult,
@@ -35,6 +39,8 @@ from .search_session_scoped_history import (
 )
 
 __all__ = (
+    "ResolveKernelSessionAction",
+    "ResolveKernelSessionActionResult",
     "SchedulingHistoryAction",
     # Admin actions
     "SearchSessionHistoryAction",

--- a/src/ai/backend/manager/services/scheduling_history/actions/resolve_kernel_session.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/resolve_kernel_session.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import EntityType
+from ai.backend.common.types import KernelId, SessionId
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+
+from .base import SchedulingHistoryAction
+
+
+@dataclass
+class ResolveKernelSessionAction(SchedulingHistoryAction):
+    """Resolve the session owning a kernel.
+
+    Pre-step for kernel-scoped queries: the owning session is the authorization
+    subject, so the caller resolves it first and passes it to the scoped action.
+    """
+
+    kernel_id: KernelId
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.KERNEL
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+    @override
+    def entity_id(self) -> str | None:
+        return str(self.kernel_id)
+
+
+@dataclass
+class ResolveKernelSessionActionResult(BaseActionResult):
+    """Result of resolving the session owning a kernel."""
+
+    session_id: SessionId
+
+    @override
+    def entity_id(self) -> str | None:
+        return str(self.session_id)

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.permission.types import EntityType, RBACElementType, ScopeType
-from ai.backend.common.types import KernelId
+from ai.backend.common.types import KernelId, SessionId
 from ai.backend.manager.actions.action.scope import BaseScopeAction, BaseScopeActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.kernel.types import KernelSchedulingHistoryData
@@ -16,19 +16,21 @@ from ai.backend.manager.repositories.base import BatchQuerier
 class SearchKernelScopedHistoryAction(BaseScopeAction):
     """Action to search the scheduling history of one kernel.
 
-    The history is the entity being read and the kernel is the scope containing it,
-    mirroring the other scoped searches (a role assignment within a role, a vfolder
-    within a user). Authorization therefore needs a ``kernel:history`` read
-    permission on the role preset; without one, only super admins pass.
+    The owning session is the authorization subject, scope, and target: kernel
+    permission records are intentionally kept empty, so whoever may read the
+    session may read its kernels' scheduling history. The caller resolves
+    ``kernel_id -> session_id`` first (``ResolveKernelSessionAction``) and
+    passes both in; ``kernel_id`` bounds the repository query.
     """
 
     kernel_id: KernelId
+    session_id: SessionId
     querier: BatchQuerier
 
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EntityType.KERNEL_HISTORY
+        return EntityType.SESSION
 
     @override
     @classmethod
@@ -37,17 +39,17 @@ class SearchKernelScopedHistoryAction(BaseScopeAction):
 
     @override
     def scope_type(self) -> ScopeType:
-        return ScopeType.KERNEL
+        return ScopeType.SESSION
 
     @override
     def scope_id(self) -> str:
-        return str(self.kernel_id)
+        return str(self.session_id)
 
     @override
     def target_element(self) -> RBACElementRef:
         return RBACElementRef(
-            element_type=RBACElementType.KERNEL,
-            element_id=str(self.kernel_id),
+            element_type=RBACElementType.SESSION,
+            element_id=str(self.session_id),
         )
 
 
@@ -60,11 +62,12 @@ class SearchKernelScopedHistoryActionResult(BaseScopeActionResult):
     has_next_page: bool
     has_previous_page: bool
     kernel_id: KernelId
+    session_id: SessionId
 
     @override
     def scope_type(self) -> ScopeType:
-        return ScopeType.KERNEL
+        return ScopeType.SESSION
 
     @override
     def scope_id(self) -> str:
-        return str(self.kernel_id)
+        return str(self.session_id)

--- a/src/ai/backend/manager/services/scheduling_history/processors.py
+++ b/src/ai/backend/manager/services/scheduling_history/processors.py
@@ -10,6 +10,8 @@ from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpe
 from ai.backend.manager.actions.validators import ActionValidators
 
 from .actions import (
+    ResolveKernelSessionAction,
+    ResolveKernelSessionActionResult,
     SearchDeploymentHistoryAction,
     SearchDeploymentHistoryActionResult,
     SearchDeploymentScopedHistoryAction,
@@ -49,6 +51,9 @@ class SchedulingHistoryProcessors(AbstractProcessorPackage):
     search_session_scoped_history: ActionProcessor[
         SearchSessionScopedHistoryAction, SearchSessionScopedHistoryActionResult
     ]
+    resolve_kernel_session: ActionProcessor[
+        ResolveKernelSessionAction, ResolveKernelSessionActionResult
+    ]
     search_kernel_scoped_history: ScopeActionProcessor[
         SearchKernelScopedHistoryAction, SearchKernelScopedHistoryActionResult
     ]
@@ -81,6 +86,9 @@ class SchedulingHistoryProcessors(AbstractProcessorPackage):
         self.search_session_scoped_history = ActionProcessor(
             service.search_session_scoped_history, action_monitors
         )
+        self.resolve_kernel_session = ActionProcessor(
+            service.resolve_kernel_session, action_monitors
+        )
         self.search_kernel_scoped_history = ScopeActionProcessor(
             service.search_kernel_scoped_history,
             monitors=action_monitors,
@@ -103,6 +111,7 @@ class SchedulingHistoryProcessors(AbstractProcessorPackage):
             SearchRouteHistoryAction.spec(),
             # Scoped actions (added in 26.2.0)
             SearchSessionScopedHistoryAction.spec(),
+            ResolveKernelSessionAction.spec(),
             SearchKernelScopedHistoryAction.spec(),
             SearchDeploymentScopedHistoryAction.spec(),
             SearchRouteScopedHistoryAction.spec(),

--- a/src/ai/backend/manager/services/scheduling_history/service.py
+++ b/src/ai/backend/manager/services/scheduling_history/service.py
@@ -5,6 +5,10 @@ from ai.backend.manager.repositories.scheduling_history.types import (
     KernelSchedulingHistorySearchScope,
 )
 
+from .actions.resolve_kernel_session import (
+    ResolveKernelSessionAction,
+    ResolveKernelSessionActionResult,
+)
 from .actions.search_deployment_history import (
     SearchDeploymentHistoryAction,
     SearchDeploymentHistoryActionResult,
@@ -132,6 +136,14 @@ class SchedulingHistoryService:
             has_previous_page=result.has_previous_page,
         )
 
+    async def resolve_kernel_session(
+        self,
+        action: ResolveKernelSessionAction,
+    ) -> ResolveKernelSessionActionResult:
+        """Resolves the session owning a kernel; raises KernelNotFound if absent."""
+        session_id = await self._repository.resolve_session_id(action.kernel_id)
+        return ResolveKernelSessionActionResult(session_id=session_id)
+
     async def search_kernel_scoped_history(
         self,
         action: SearchKernelScopedHistoryAction,
@@ -148,6 +160,7 @@ class SchedulingHistoryService:
             has_next_page=result.has_next_page,
             has_previous_page=result.has_previous_page,
             kernel_id=action.kernel_id,
+            session_id=action.session_id,
         )
 
     async def search_deployment_scoped_history(

--- a/tests/unit/manager/services/scheduling_history/test_scheduling_history_service.py
+++ b/tests/unit/manager/services/scheduling_history/test_scheduling_history_service.py
@@ -44,6 +44,9 @@ from ai.backend.manager.repositories.scheduling_history.types import (
     RouteHistorySearchScope,
     SessionSchedulingHistorySearchScope,
 )
+from ai.backend.manager.services.scheduling_history.actions.resolve_kernel_session import (
+    ResolveKernelSessionAction,
+)
 from ai.backend.manager.services.scheduling_history.actions.search_deployment_history import (
     SearchDeploymentHistoryAction,
 )
@@ -359,8 +362,25 @@ class TestSearchKernelHistoryAction:
         mock_repository.search_kernel_history.assert_awaited_once_with(querier=querier)
 
 
+class TestResolveKernelSessionAction:
+    async def test_resolves_the_owning_session(
+        self,
+        service: SchedulingHistoryService,
+        mock_repository: MagicMock,
+    ) -> None:
+        kernel_id = KernelId(uuid4())
+        session_id = SessionId(uuid4())
+        mock_repository.resolve_session_id.return_value = session_id
+
+        action = ResolveKernelSessionAction(kernel_id=kernel_id)
+        result = await service.resolve_kernel_session(action)
+
+        assert result.session_id == session_id
+        mock_repository.resolve_session_id.assert_awaited_once_with(kernel_id)
+
+
 class TestSearchKernelScopedHistoryAction:
-    async def test_scopes_to_the_kernel_and_exposes_its_rbac_element(
+    async def test_scopes_to_the_owning_session_and_narrows_to_the_kernel(
         self,
         service: SchedulingHistoryService,
         mock_repository: MagicMock,
@@ -376,16 +396,23 @@ class TestSearchKernelScopedHistoryAction:
             )
         )
         kernel_id = KernelId(uuid4())
+        session_id = SessionId(uuid4())
 
-        action = SearchKernelScopedHistoryAction(kernel_id=kernel_id, querier=querier)
+        action = SearchKernelScopedHistoryAction(
+            kernel_id=kernel_id, session_id=session_id, querier=querier
+        )
         result = await service.search_kernel_scoped_history(action)
 
         assert result.items == [history_item]
+        # Authorized via session read: kernel permission records are intentionally
+        # empty, so the owning session is the subject, scope, and target of the
+        # RBAC check; kernel_id bounds the repository query.
         assert action.target_element() == RBACElementRef(
-            element_type=RBACElementType.KERNEL, element_id=str(kernel_id)
+            element_type=RBACElementType.SESSION, element_id=str(session_id)
         )
-        assert action.scope_type() is ScopeType.KERNEL
-        assert action.entity_type() is EntityType.KERNEL_HISTORY
+        assert action.scope_type() is ScopeType.SESSION
+        assert action.scope_id() == str(session_id)
+        assert action.entity_type() is EntityType.SESSION
         mock_repository.search_kernel_scoped_history.assert_awaited_once_with(
             querier=querier,
             scope=KernelSchedulingHistorySearchScope(kernel_id=kernel_id),


### PR DESCRIPTION
Resolves BA-6957

## Summary

`POST /v2/scheduling-history/kernels/scoped/search` (and the `scopedKernelSchedulingHistories` GQL query) is registered with `auth_required` and documented as running *under a non-admin scope*, but rejected every non-superadmin caller — including the owner of the kernel.

`SearchKernelScopedHistoryAction` declared `EntityType.KERNEL_HISTORY`, and no permission record for kernel entities exists anywhere — **which is intended**: the design owner confirmed kernel-entity permission records are deliberately kept empty. An action gated on them can therefore never pass for a regular user.

Kernel reads are authorized through the owning session, so the session becomes the subject, scope, and target of the RBAC check:

- The adapter (shared by REST v2 and GQL) resolves `kernel_id → session_id` up front through a new `ResolveKernelSessionAction` (repository lookup; `KernelNotFound` on a missing kernel) and dispatches the scoped search with both ids.
- `SearchKernelScopedHistoryAction` takes `kernel_id` and `session_id`: the session drives `entity_type` / `scope_type` / `target_element`, while `kernel_id` bounds the repository search scope (`KernelSchedulingHistorySearchScope`). Whoever may read the session may read its kernels' scheduling history — no permission rows needed, so users created later are covered too.
- A missing kernel now uniformly raises `KernelNotFound` at the resolve step, where it previously surfaced as 403 for regular users and 404 for admins.

Also empties migration `a1c4e7b93f22` into an explicit no-op (`pass` bodies). As shipped it was inert: it mirrored grants from a `kernel` entity that never exists, so its `SELECT` matched nothing — which also masked an `INSERT` omitting the `NOT NULL` `permission` column. The revision is kept only because it has already been applied.

## Test plan

Verified on a live stack with **zero** `kernel:history` permission records (the intended state), against real kernels created through the scheduler:

- [x] Owner's scoped query → **200**
- [x] Control: with `EntityType.KERNEL_HISTORY` the same call → **403** `lacks permission read on kernel:history`
- [x] Kernel narrowing with seeded rows: a kernel's scoped query excludes rows of **sibling kernels in the same session** as well as rows from other sessions; admin unscoped returns all rows
- [x] Another same-domain user → 200, matching `session` read semantics — kernel history is exactly as visible as its owning session
- [x] Missing kernel → `KernelNotFound` for both regular users and admins
- [x] Superadmin unaffected: scoped and unscoped both 200; regular user calling the admin-only unscoped search still → 403
- [x] Unit tests updated: resolve action + scoped action (SESSION subject/scope/target; kernel-bounded repository scope)
- [ ] Responses containing actual scheduler-written history rows — `kernel_scheduling_history` has no writer yet (BA-6852); unrelated to authorization

## Notes

- Sibling scoped-history endpoints (session, deployment, route) are all `superadmin_required`, so they bypass RBAC via the validator's superadmin early-return — the kernel one is the first non-admin history endpoint, which is why this went unnoticed.
- The SDK/CLI surface for these endpoints lands separately in #12866; this PR carries only the authorization change so either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
