### PR TITLE
fix: stop storing JSON null in runtime_variants.default_model_definition

### DIFF
--- a/changes/13009.fix.md
+++ b/changes/13009.fix.md
@@ -1,0 +1,1 @@
+Fix runtime variant creation storing a JSON `null` model definition that made created variants unreadable via the v2 API, and backfill existing rows

--- a/src/ai/backend/manager/models/alembic/versions/a0a28251f296_backfill_jsonb_null_default_model_.py
+++ b/src/ai/backend/manager/models/alembic/versions/a0a28251f296_backfill_jsonb_null_default_model_.py
@@ -1,0 +1,41 @@
+"""backfill jsonb null default_model_definition in runtime_variants
+
+Runtime variants created through the create API stored a JSON ``null`` in
+``runtime_variants.default_model_definition``: the creator never set the
+attribute and SQLAlchemy's JSON type serializes Python ``None`` as JSON
+``null`` rather than SQL ``NULL``, so it slipped past the NOT NULL
+constraint. Such rows load back as ``None`` and fail the node conversion,
+which requires a model definition value. The creator now seeds an empty
+draft (``{}``); this migration backfills the already-materialized JSON
+``null`` rows with the same empty draft. ``{}`` (not ``{"models": null}``)
+keeps every field truly unset, consistent with the exclude_unset write path
+established by revision 2ec0aa5a19cf.
+
+Revision ID: a0a28251f296
+Revises: e5b71c94d2a8
+Create Date: 2026-07-22 09:17:13.529025
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a0a28251f296"
+down_revision = "e5b71c94d2a8"
+branch_labels = None
+depends_on = None
+# Part of: NEXT_RELEASE_VERSION
+
+
+def upgrade() -> None:
+    op.execute(
+        "UPDATE runtime_variants"
+        " SET default_model_definition = '{}'::jsonb"
+        " WHERE default_model_definition = 'null'::jsonb"
+    )
+
+
+def downgrade() -> None:
+    # The JSON null values carried no information (never-set attribute
+    # artifacts), so there is nothing to restore.
+    pass

--- a/src/ai/backend/manager/repositories/runtime_variant/creators.py
+++ b/src/ai/backend/manager/repositories/runtime_variant/creators.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
+from ai.backend.common.config import ModelDefinitionDraft
 from ai.backend.manager.errors.repository import UniqueConstraintViolationError
 from ai.backend.manager.errors.resource import RuntimeVariantConflict
 from ai.backend.manager.models.runtime_variant.row import RuntimeVariantRow
@@ -31,4 +32,5 @@ class RuntimeVariantCreatorSpec(CreatorSpec[RuntimeVariantRow]):
         row = RuntimeVariantRow()
         row.name = self.name
         row.description = self.description
+        row.default_model_definition = ModelDefinitionDraft()
         return row

--- a/tests/component/scheduling_history/conftest.py
+++ b/tests/component/scheduling_history/conftest.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
 from ai.backend.manager.actions.validators import ActionValidators
+from ai.backend.manager.actions.validators.rbac import RBACValidators
 from ai.backend.manager.api.rest.routing import RouteRegistry
 
 # Statically imported so that Pants includes these modules in the test PEX.
@@ -30,7 +31,11 @@ def scheduling_history_processors(
     repo = SchedulingHistoryRepository(database_engine)
     service = SchedulingHistoryService(repo)
     return SchedulingHistoryProcessors(
-        service=service, action_monitors=[], validators=MagicMock(spec=ActionValidators)
+        service=service,
+        action_monitors=[],
+        validators=ActionValidators(
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- Runtime variants created through the create API stored a JSON `null` in the NOT NULL `default_model_definition` column: the creator never set the attribute, and SQLAlchemy's JSON type serializes Python `None` as JSON `null` (not SQL `NULL`), slipping past the constraint. Such rows load back as `None` and fail the v2 node conversion with a 400 once the field became required in `RuntimeVariantNode` (#12970). The creator now seeds an empty `ModelDefinitionDraft` (stored as `{}`, consistent with the exclude_unset write path from #12872), and a new data migration (`a0a28251f296`) backfills already-materialized JSON `null` rows.
- Fix the scheduling_history component conftest: `MagicMock(spec=ActionValidators)` rejects the `rbac` attribute (a dataclass field without a default is not a class attribute), which broke all 12 tests at fixture setup once `SchedulingHistoryProcessors` started wiring `validators.rbac.scope` (#12869). Construct a real `ActionValidators` with mocked `RBACValidators` instead, following the existing artifact_revision conftest pattern.

## Test plan
- [x] `tests/component/runtime_variant/test_runtime_variant_crud.py` — previously 6/7 failing, now passes
- [x] `tests/component/scheduling_history/test_scheduling_history.py` — previously 12/12 setup errors, now passes
- [x] `tests/unit/manager/api/adapters/test_runtime_variant_adapter.py` passes
- [x] Migration verified on a local DB: inserted a `'null'::jsonb` row, `alembic upgrade head` converts it to `{}` while leaving seeded variants untouched; `downgrade -1` / re-`upgrade` round-trip OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)