### PR TITLE
feat(BA-6962): add REST v2 endpoint for scheduler compute-schedule (dry-run)

### DIFF
--- a/changes/13014.feature.md
+++ b/changes/13014.feature.md
@@ -1,0 +1,1 @@
+Add `POST /v2/sessions/compute-schedule` REST endpoint to probe session schedulability against a resource group without provisioning

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -26508,6 +26508,65 @@
         "title": "EnqueueSessionInput",
         "type": "object"
       },
+      "ComputeScheduleKernelResourceInput": {
+        "description": "Per-kernel resource inputs for a compute-schedule request.\n\nMirrors the scheduler's ``KernelResourceInput``: the requested resource\nslots plus an optional image whose architecture and resource-group\ndefaults are resolved downstream. Results are correlated to kernels by\nlist index, so no identifier is carried here.",
+        "properties": {
+          "image_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Image to schedule this kernel against. May be null when a resource-group default supplies the image downstream.",
+            "title": "Image Id"
+          },
+          "resources": {
+            "description": "Requested resource slots (cpu, mem, accelerators) for this kernel.",
+            "items": {
+              "$ref": "#/components/schemas/ResourceSlotEntryInput"
+            },
+            "title": "Resources",
+            "type": "array"
+          }
+        },
+        "title": "ComputeScheduleKernelResourceInput",
+        "type": "object"
+      },
+      "ComputeScheduleInput": {
+        "description": "Compute a session's scheduling against a resource group without provisioning.\n\n``cluster_mode`` decides whether kernel slots are summed onto a single\nnode (SINGLE_NODE) or placed individually (MULTI_NODE).",
+        "properties": {
+          "kernels": {
+            "description": "Per-kernel resource requests to test against the resource group.",
+            "items": {
+              "$ref": "#/components/schemas/ComputeScheduleKernelResourceInput"
+            },
+            "title": "Kernels",
+            "type": "array"
+          },
+          "cluster_mode": {
+            "$ref": "#/components/schemas/ClusterModeEnum",
+            "description": "Cluster networking mode governing how kernel slots are placed."
+          },
+          "resource_group_id": {
+            "description": "Target resource group to compute the scheduling against.",
+            "format": "uuid",
+            "title": "Resource Group Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kernels",
+          "cluster_mode",
+          "resource_group_id"
+        ],
+        "title": "ComputeScheduleInput",
+        "type": "object"
+      },
       "SessionFilter": {
         "description": "Filter criteria for session listing.",
         "properties": {
@@ -48492,6 +48551,35 @@
         },
         "parameters": [],
         "description": "Enqueue a new compute session.\n\n**Preconditions:**\n* User privilege required.\n"
+      }
+    },
+    "/v2/sessions/compute-schedule": {
+      "post": {
+        "operationId": "v2/sessions.compute_schedule",
+        "tags": [
+          "v2/sessions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ComputeScheduleInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Compute whether a would-be session fits a resource group, without provisioning.\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
     "/v2/sessions/search": {

--- a/src/ai/backend/manager/api/rest/v2/session/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/session/handler.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Final
 
 from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam, QueryParam
 from ai.backend.common.dto.manager.v2.kernel.request import AdminSearchKernelsInput
+from ai.backend.common.dto.manager.v2.scheduler.request import ComputeScheduleInput
 from ai.backend.common.dto.manager.v2.session.request import (
     AdminSearchSessionsInput,
     EnqueueSessionInput,
@@ -57,6 +58,14 @@ class V2SessionHandler:
             group_id=body.parsed.project_id,
         )
         return APIResponse.build(status_code=HTTPStatus.CREATED, response_model=result)
+
+    async def compute_schedule(
+        self,
+        body: BodyParam[ComputeScheduleInput],
+    ) -> APIResponse:
+        """Compute whether a would-be session fits a resource group, without provisioning."""
+        result = await self._adapter.compute_schedule(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
     async def admin_search_sessions(
         self,

--- a/src/ai/backend/manager/api/rest/v2/session/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/session/registry.py
@@ -28,6 +28,12 @@ def register_v2_session_routes(
     )
     registry.add(
         "POST",
+        "/compute-schedule",
+        handler.compute_schedule,
+        middlewares=[auth_required],
+    )
+    registry.add(
+        "POST",
         "/search",
         handler.admin_search_sessions,
         middlewares=[superadmin_required],


### PR DESCRIPTION
## Summary
- Add `POST /v2/sessions/compute-schedule` REST v2 route exposing the existing `SessionAdapter.compute_schedule` (shared with the GQL `compute_schedule` query).
- Self-service endpoint with `auth_required`; the adapter resolves the requesting user from the request context, and per-kernel admission results include max-aggregated `required_reduction` hints for kernels that do not fit.

## Test plan
- [x] `pants fmt` / `fix` / `lint` / `check` pass locally
- [x] Live server: admin request (cpu=1, mem=1GiB) returns `success: true` with resolved architecture
- [x] Live server: oversized request (cpu=512, mem=100TiB) returns `success: false` with `reason_hint.required_reduction`
- [x] Live server: non-admin user (user@lablup.com) request succeeds
- [x] Missing `image_id` without a resource-group default is rejected with `incomplete-session-spec` (400)

Resolves BA-6962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13014.org.readthedocs.build/en/13014/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13014.org.readthedocs.build/ko/13014/

<!-- readthedocs-preview sorna-ko end -->