### PR TITLE
ci: pass quote-capable outputs to the backport workflow shell via env vars

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -136,13 +136,14 @@ jobs:
       - name: Save result to file
         if: ${{ steps.commit.outputs.pr_number }}
         env:
-          # The result JSON embeds the commit message and author, which may
+          # Per-target backport entries (commit, target branch, commit
+          # message, author, ...). The embedded commit message and author may
           # contain quotes -- inline ${{ }} interpolation into the shell
           # breaks on them (e.g. an apostrophe in the PR title).
-          MILESTONES_RESULT: ${{ steps.milestones.outputs.result }}
+          BACKPORT_TARGETS_JSON: ${{ steps.milestones.outputs.result }}
         run: |
           mkdir -p /tmp/backport-results
-          printf '%s' "$MILESTONES_RESULT" > /tmp/backport-results/${{ matrix.commits }}.json
+          printf '%s' "$BACKPORT_TARGETS_JSON" > /tmp/backport-results/${{ matrix.commits }}.json
       - name: Upload result artifact
         if: ${{ steps.commit.outputs.pr_number }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -75,6 +75,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           COMMIT_MESSAGE: ${{ steps.commit.outputs.commit_message }}
+          COMMIT_AUTHOR: ${{ steps.commit.outputs.author }}
+          COMMIT_AUTHOR_EMAIL: ${{ steps.commit.outputs.author_email }}
+          COMMIT_LABELS: ${{ steps.commit.outputs.labels }}
         run: |
           target_milestone=$(gh pr view ${{ steps.commit.outputs.pr_number }} --json milestone --jq .milestone.title)
 
@@ -114,9 +117,9 @@ jobs:
                 --arg message "$COMMIT_MESSAGE" \
                 --arg pr "${{ steps.commit.outputs.pr_number }}" \
                 --arg release "${{ steps.commit.outputs.latest_release }}" \
-                --arg author "${{ steps.commit.outputs.author }}" \
-                --arg email "${{ steps.commit.outputs.author_email }}" \
-                --arg labels "${{ steps.commit.outputs.labels }}" \
+                --arg author "$COMMIT_AUTHOR" \
+                --arg email "$COMMIT_AUTHOR_EMAIL" \
+                --arg labels "$COMMIT_LABELS" \
                 '. += [{
                   commit: $commit,
                   target_branch: $branch,
@@ -132,9 +135,14 @@ jobs:
           echo "result=$result" >> $GITHUB_OUTPUT
       - name: Save result to file
         if: ${{ steps.commit.outputs.pr_number }}
+        env:
+          # The result JSON embeds the commit message and author, which may
+          # contain quotes -- inline ${{ }} interpolation into the shell
+          # breaks on them (e.g. an apostrophe in the PR title).
+          MILESTONES_RESULT: ${{ steps.milestones.outputs.result }}
         run: |
           mkdir -p /tmp/backport-results
-          echo '${{ steps.milestones.outputs.result }}' > /tmp/backport-results/${{ matrix.commits }}.json
+          printf '%s' "$MILESTONES_RESULT" > /tmp/backport-results/${{ matrix.commits }}.json
       - name: Upload result artifact
         if: ${{ steps.commit.outputs.pr_number }}
         uses: actions/upload-artifact@v4
@@ -185,9 +193,11 @@ jobs:
       - name: Cherry-pick
         env:
           COMMIT_MESSAGE: ${{ matrix.commit_message }}
+          COMMIT_AUTHOR: ${{ matrix.author }}
+          COMMIT_AUTHOR_EMAIL: ${{ matrix.author_email }}
         run: |
-          git config user.name "${{ matrix.author }}"
-          git config user.email "${{ matrix.author_email }}"
+          git config user.name "$COMMIT_AUTHOR"
+          git config user.email "$COMMIT_AUTHOR_EMAIL"
           target_commit="${{ matrix.commit }}"
           git fetch origin main "$target_commit"
           git cherry-pick --strategy=recursive --strategy-option=theirs "$target_commit"

--- a/changes/13021.fix.md
+++ b/changes/13021.fix.md
@@ -1,0 +1,1 @@
+Fix the backport workflow silently dropping backports for commits whose message contains a quote character: the milestones result JSON (and author/label values) are now passed to the shell via environment variables instead of inline template interpolation.


### PR DESCRIPTION
## Summary

The backport workflow's "Save result to file" step interpolated the milestones result JSON **inline into a single-quoted bash string**:

```yaml
run: |
  echo '${{ steps.milestones.outputs.result }}' > /tmp/backport-results/....json
```

Any commit message containing an apostrophe terminates the quote early and the step dies with `syntax error near unexpected token '('` — first triggered by #12985 (title contains `aiohttp's`), which lost its automatic 26.4 backport.

## Why only now

The vulnerable payload only includes the commit message when a target branch was resolved **at run time**. Auditing all apostrophe-titled commits on main: #12898/#12638/#12278 had no milestone, and #11983's milestone was set 52 seconds *after* merge — so the payload stayed empty and the step passed. #12985 was the first apostrophe-titled PR with its milestone set before merge (per our new milestone discipline), which finally lit the latent bug. (Side finding: #11983 silently missed its 26.4 backport this way.)

## History

Third instance of this defect class here: `8bac28817` (hotfix: shell var-expansion), then #7405 moved the commit message into an `env:` var for the jq arguments — but left this step and the author/labels interpolations behind.

## Changes

Following the same env-var pattern (#7405 / GitHub's workflow-injection guidance):
- `Save result to file`: result JSON via `MILESTONES_RESULT` env + `printf '%s'` (no shell parsing of the payload)
- `Get target branches`: author / author-email / labels jq args via env vars
- `Cherry-pick`: `git config user.name/email` via env vars

## Verification

- Reproduced the exact failing payload against both patterns: old → identical `syntax error near unexpected token '('`; new → file round-trips, JSON parses, apostrophe intact
- YAML validates

After merge: re-dispatch the backport workflow for `b166f88b3` (#12985) — and optionally `f30e32437` (#11983, the silently-missed backport).

🤖 Generated with [Claude Code](https://claude.com/claude-code)