### PR TITLE
feat(BA-6954): require session idle check expiration

### DIFF
--- a/changes/13023.feature.md
+++ b/changes/13023.feature.md
@@ -1,0 +1,1 @@
+Require every session idle check to have an expiration deadline.

--- a/src/ai/backend/manager/models/alembic/versions/ea422739665b_make_session_idle_check_expire_at_non_nullable.py
+++ b/src/ai/backend/manager/models/alembic/versions/ea422739665b_make_session_idle_check_expire_at_non_nullable.py
@@ -1,0 +1,40 @@
+"""make session idle check expire_at non-nullable
+
+Revision ID: ea422739665b
+Revises: a0a28251f296
+Create Date: 2026-07-22 15:16:51.824682
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "ea422739665b"
+down_revision = "a0a28251f296"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+_TABLE = "session_idle_checks"
+
+
+def upgrade() -> None:
+    # A missing deadline carries no valid judgment under the new contract. Deleting
+    # the row avoids manufacturing a deadline that could terminate the session.
+    op.execute(sa.text("DELETE FROM session_idle_checks WHERE expire_at IS NULL"))
+    op.alter_column(
+        _TABLE,
+        "expire_at",
+        existing_type=sa.DateTime(timezone=True),
+        nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        _TABLE,
+        "expire_at",
+        existing_type=sa.DateTime(timezone=True),
+        nullable=True,
+    )

--- a/src/ai/backend/manager/models/idle_checker/conditions.py
+++ b/src/ai/backend/manager/models/idle_checker/conditions.py
@@ -22,9 +22,6 @@ class SessionIdleCheckConditions:
     @staticmethod
     def expired(now: datetime) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return sa.and_(
-                SessionIdleCheckRow.expire_at.isnot(None),
-                SessionIdleCheckRow.expire_at <= now,
-            )
+            return SessionIdleCheckRow.expire_at <= now
 
         return inner

--- a/src/ai/backend/manager/models/idle_checker/row.py
+++ b/src/ai/backend/manager/models/idle_checker/row.py
@@ -96,8 +96,8 @@ class SessionIdleCheckRow(UpdatedAtMixin, Base):  # type: ignore[misc]
     idle_checker_id: Mapped[IdleCheckerID] = mapped_column(
         "idle_checker_id", GUID(IdleCheckerID), nullable=False
     )
-    expire_at: Mapped[datetime | None] = mapped_column(
-        "expire_at", sa.DateTime(timezone=True), nullable=True
+    expire_at: Mapped[datetime] = mapped_column(
+        "expire_at", sa.DateTime(timezone=True), nullable=False
     )
     last_status: Mapped[str] = mapped_column("last_status", sa.String(length=64), nullable=False)
     last_message: Mapped[str] = mapped_column("last_message", sa.Text, nullable=False)

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -130,9 +130,6 @@ class IdleCheckerDBSource:
         checks: list[ExpiredIdleCheckData] = []
         for row in result_rows:
             check_row: SessionIdleCheckRow = row.SessionIdleCheckRow
-            if check_row.expire_at is None:
-                # Unreachable under the expired() condition; guards the type.
-                continue
             checks.append(
                 ExpiredIdleCheckData(
                     session_id=check_row.session_id,

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -961,31 +961,6 @@ class TestFetchExpiredIdleChecks:
         )
 
     @pytest.fixture
-    async def session_without_deadline(
-        self,
-        database: ExtendedAsyncSAEngine,
-    ) -> SessionId:
-        scope = _expired_check_scope_fixture("no-deadline")
-        session_id = SessionId(uuid.uuid4())
-        checker_id = IdleCheckerID(uuid.uuid4())
-        async with database.begin_session() as db_sess:
-            for scope_row in _expired_check_scope_rows(scope):
-                db_sess.add(scope_row)
-            db_sess.add(_expired_check_session_row(scope, session_id, SessionStatus.RUNNING))
-            db_sess.add(_expired_check_checker_row(checker_id))
-            await db_sess.flush()
-            db_sess.add(
-                SessionIdleCheckRow(
-                    session_id=session_id,
-                    idle_checker_id=checker_id,
-                    expire_at=None,
-                    last_status="grace_period",
-                    last_message="Waiting for the grace period to end.",
-                )
-            )
-        return session_id
-
-    @pytest.fixture
     async def session_with_future_deadline(
         self,
         database: ExtendedAsyncSAEngine,
@@ -1053,17 +1028,6 @@ class TestFetchExpiredIdleChecks:
         assert check.expire_at == expired_check_session.first_expire_at
         assert check.last_status == "expired"
         assert check.last_message == "Judged expired."
-
-    async def test_excludes_checks_without_deadline(
-        self,
-        repository: IdleCheckerRepository,
-        session_without_deadline: SessionId,
-    ) -> None:
-        batch = await repository.fetch_expired_idle_checks([SessionStatus.RUNNING])
-        check_session_ids = {check.session_id for check in batch.checks}
-
-        assert batch.checks == ()
-        assert session_without_deadline not in check_session_ids
 
     async def test_excludes_checks_with_future_deadline(
         self,

--- a/tests/unit/manager/repositories/idle_checker/test_row.py
+++ b/tests/unit/manager/repositories/idle_checker/test_row.py
@@ -71,6 +71,7 @@ class TestSessionIdleCheckRow:
         session_id = SessionId(uuid.uuid4())
         checker_id = IdleCheckerID(uuid.uuid4())
         created_at = datetime(2026, 1, 1, tzinfo=UTC)
+        expire_at = datetime(2026, 1, 2, tzinfo=UTC)
         async with database.begin_session() as db_sess:
             db_sess.add(
                 ProjectResourcePolicyRow(
@@ -163,14 +164,14 @@ class TestSessionIdleCheckRow:
                 SessionIdleCheckRow(
                     session_id=session_id,
                     idle_checker_id=checker_id,
-                    expire_at=None,
-                    last_status="grace_period",
-                    last_message="Waiting for the grace period to end.",
+                    expire_at=expire_at,
+                    last_status="active",
+                    last_message="The session is active.",
                 )
             )
         return SessionIdleCheckFixture(session_id=session_id, checker_id=checker_id)
 
-    async def test_persists_null_expire_at_and_updated_at(
+    async def test_persists_expire_at_and_updated_at(
         self,
         database: ExtendedAsyncSAEngine,
         persisted_idle_check: SessionIdleCheckFixture,
@@ -182,8 +183,8 @@ class TestSessionIdleCheckRow:
             )
 
         assert row is not None
-        assert row.expire_at is None
-        assert row.last_status == "grace_period"
+        assert row.expire_at == datetime(2026, 1, 2, tzinfo=UTC)
+        assert row.last_status == "active"
         assert row.updated_at is not None
 
     async def test_rejects_duplicate_session_checker_pair(


### PR DESCRIPTION
## Summary

- Make `session_idle_checks.expire_at` non-nullable in both the manager schema and ORM model.
- Remove legacy rows without a deadline during migration instead of manufacturing a deadline that could terminate a session.
- Simplify expired-check queries and tests around the required deadline contract.

## Test plan

- [x] `pants fmt ::`
- [x] `pants fix ::`
- [x] `pants lint --changed-since=origin/main`
- [x] Pre-push MyPy and changed tests
- [x] Alembic offline SQL generation and single-head validation

Resolves BA-6954