### PR TITLE
fix(BA-6970): take the allow-list entry id from the path on update

### DIFF
--- a/changes/13027.fix.md
+++ b/changes/13027.fix.md
@@ -1,0 +1,1 @@
+Take the app-config allow-list entry id from the request path on update instead of the request body, so a mismatched body id can no longer be silently discarded.

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -1090,14 +1090,8 @@
         "type": "object"
       },
       "UpdateAppConfigAllowListInput": {
-        "description": "Input for updating an app config allow-list entry.\n\nOnly ``rank`` is updatable — the identity pair (``config_name``, ``scope_type``)\nis immutable (purge and recreate to change it).",
+        "description": "Input for updating an app config allow-list entry.\n\nOnly ``rank`` is updatable — the identity pair (``config_name``, ``scope_type``)\nis immutable (purge and recreate to change it). The target entry is identified by the\nrequest path, not this body.",
         "properties": {
-          "id": {
-            "description": "App config allow-list entry id to update.",
-            "format": "uuid",
-            "title": "Id",
-            "type": "string"
-          },
           "rank": {
             "anyOf": [
               {
@@ -1112,9 +1106,6 @@
             "title": "Rank"
           }
         },
-        "required": [
-          "id"
-        ],
         "title": "UpdateAppConfigAllowListInput",
         "type": "object"
       },

--- a/src/ai/backend/client/cli/v2/admin/app_config_allow_list.py
+++ b/src/ai/backend/client/cli/v2/admin/app_config_allow_list.py
@@ -175,7 +175,7 @@ def update(app_config_allow_list_id: uuid.UUID, rank: int) -> None:
         try:
             result = await registry.app_config_allow_list.admin_update(
                 app_config_allow_list_id,
-                UpdateAppConfigAllowListInput(id=app_config_allow_list_id, rank=rank),
+                UpdateAppConfigAllowListInput(rank=rank),
             )
             print_result(result)
         finally:

--- a/src/ai/backend/common/dto/manager/v2/app_config_allow_list/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_allow_list/request.py
@@ -50,10 +50,10 @@ class UpdateAppConfigAllowListInput(BaseRequestModel):
     """Input for updating an app config allow-list entry.
 
     Only ``rank`` is updatable — the identity pair (``config_name``, ``scope_type``)
-    is immutable (purge and recreate to change it).
+    is immutable (purge and recreate to change it). The target entry is identified by the
+    request path, not this body.
     """
 
-    id: UUID = Field(description="App config allow-list entry id to update.")
     rank: int | None = Field(
         default=None,
         description=(

--- a/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
@@ -155,7 +155,7 @@ class AppConfigAllowListAdapter(BaseAdapter):
         )
 
     async def admin_update(
-        self, input: UpdateAppConfigAllowListInput
+        self, entry_id: AppConfigAllowListID, input: UpdateAppConfigAllowListInput
     ) -> UpdateAppConfigAllowListPayload:
         updater = Updater(
             spec=AppConfigAllowListUpdaterSpec(
@@ -165,7 +165,7 @@ class AppConfigAllowListAdapter(BaseAdapter):
                     else OptionalState.nop()
                 ),
             ),
-            pk_value=AppConfigAllowListID(input.id),
+            pk_value=entry_id,
         )
         action_result = await self._processors.app_config_allow_list.update.wait_for_complete(
             UpdateAppConfigAllowListAction(updater=updater)

--- a/src/ai/backend/manager/api/gql/app_config_allow_list/resolver.py
+++ b/src/ai/backend/manager/api/gql/app_config_allow_list/resolver.py
@@ -131,7 +131,9 @@ async def admin_update_app_config_allow_list(
     input: UpdateAppConfigAllowListInputGQL,
 ) -> UpdateAppConfigAllowListPayloadGQL | None:
     check_admin_only()
-    payload = await info.context.adapters.app_config_allow_list.admin_update(input.to_pydantic())
+    payload = await info.context.adapters.app_config_allow_list.admin_update(
+        AppConfigAllowListID(input.id), input.to_pydantic()
+    )
     return UpdateAppConfigAllowListPayloadGQL.from_pydantic(payload)
 
 

--- a/src/ai/backend/manager/api/rest/v2/app_config_allow_list/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_allow_list/handler.py
@@ -63,8 +63,9 @@ class V2AppConfigAllowListHandler:
         body: BodyParam[UpdateAppConfigAllowListInput],
     ) -> APIResponse:
         """Update an app config allow-list entry's rank by id (superadmin only)."""
-        merged = body.parsed.model_copy(update={"id": path.parsed.app_config_allow_list_id})
-        result = await self._adapter.admin_update(merged)
+        result = await self._adapter.admin_update(
+            AppConfigAllowListID(path.parsed.app_config_allow_list_id), body.parsed
+        )
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
     async def admin_purge(

--- a/tests/unit/client_v2/test_app_config_allow_list.py
+++ b/tests/unit/client_v2/test_app_config_allow_list.py
@@ -135,7 +135,7 @@ class TestAdminUpdate:
 
         result = await client.admin_update(
             entry_id,
-            UpdateAppConfigAllowListInput(id=entry_id, rank=250),
+            UpdateAppConfigAllowListInput(rank=250),
         )
 
         call_args = mock_session.request.call_args


### PR DESCRIPTION
Resolves #13026 (BA-6970)

## Summary

`PATCH /v2/app-config-allow-list/{id}` carried the entry id in **both** the path and the request body. The handler merged the path id into the body via `model_copy(update={"id": ...})`, so:

- a mismatched body `id` was silently overwritten — the client's value was ignored without error,
- `model_copy` bypassed Pydantic v2 re-validation,
- OpenAPI advertised `id` as a required body field the handler always discards.

This drops `id` from `UpdateAppConfigAllowListInput` and passes the path id to the adapter directly — the `id` / `data` split the `/api-guide` skill prescribes for update (`update_user(id, data)`, id identifies the item, data holds the changes; id does not belong in the body DTO). `app_config_fragment` already follows this (BA-6921).

## Changes

- **DTO** (`app_config_allow_list/request.py`): remove `id` from `UpdateAppConfigAllowListInput` (`rank` only).
- **Adapter**: `admin_update(entry_id, input)` — id as a separate argument.
- **Handler**: pass `path.parsed.app_config_allow_list_id` directly; no `model_copy`.
- **CLI**: stop putting `id` in the body; it already travels in the URL.
- **OpenAPI** regenerated — the update body now lists `rank` only.

## Scope

app_config domain only. The same A-pattern (path id merged into a body that also declares id) still exists on `model_card`, `runtime_variant`, `runtime_variant_preset`, `deployment_revision_preset`, and `retention_policy` — out of scope here, tracked under the same convention.

## Test plan

- [x] `pants lint` / `pants check` clean
- [x] OpenAPI regenerated; `UpdateAppConfigAllowListInput` body = `['rank']`
- [ ] Live-server check: `PATCH` with a body id different from the path id updates the path entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13027.org.readthedocs.build/en/13027/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13027.org.readthedocs.build/ko/13027/

<!-- readthedocs-preview sorna-ko end -->