### PR TITLE
feat(BA-6852): record Agent kernel transitions into scheduling history

### DIFF
--- a/changes/13033.feature.md
+++ b/changes/13033.feature.md
@@ -1,0 +1,1 @@
+Record Agent-reported kernel status transitions into the kernel scheduling history and apply them idempotently, so the kernel scheduling-history APIs return the actual lifecycle instead of an empty list

--- a/src/ai/backend/common/events/event_types/kernel/anycast.py
+++ b/src/ai/backend/common/events/event_types/kernel/anycast.py
@@ -9,7 +9,7 @@ from ai.backend.common.events.types import AbstractAnycastEvent, EventDomain
 from ai.backend.common.events.user_event.user_event import UserEvent
 from ai.backend.common.types import KernelId, SessionId
 
-from .types import KernelLifecycleEventReason
+from .types import KernelLifecycleEventReason, KernelTransitionResult
 
 
 @dataclass
@@ -165,6 +165,58 @@ class KernelTerminatedAnycastEvent(KernelTerminationEvent):
     @override
     def event_name(cls) -> str:
         return "kernel_terminated"
+
+
+@dataclass
+class KernelStatusTransitionAnycastEvent(BaseKernelEvent):
+    """Unified kernel status transition report from the Agent (BEP-1061).
+
+    Carries only the transition and its processing result — no phase/step
+    payload. ``from_status``/``to_status`` are sokovan ``KernelStatus`` values;
+    ``from_status`` lets the Manager reject a duplicate/stale transition
+    idempotently.
+    """
+
+    from_status: str
+    to_status: str
+    reason: str = ""
+    result: KernelTransitionResult = KernelTransitionResult.SUCCESS
+    error_code: str | None = None
+    message: str = ""
+
+    @override
+    def serialize(self) -> tuple[Any, ...]:
+        return (
+            str(self.kernel_id),
+            self.from_status,
+            self.to_status,
+            self.reason,
+            str(self.result),
+            self.error_code,
+            self.message,
+        )
+
+    @classmethod
+    @override
+    def deserialize(cls, value: tuple[Any, ...]) -> Self:
+        return cls(
+            kernel_id=KernelId(uuid.UUID(value[0])),
+            from_status=value[1],
+            to_status=value[2],
+            reason=value[3],
+            result=KernelTransitionResult(value[4]),
+            error_code=value[5],
+            message=value[6],
+        )
+
+    @override
+    def user_event(self) -> UserEvent | None:
+        return None
+
+    @classmethod
+    @override
+    def event_name(cls) -> str:
+        return "kernel_status_transition"
 
 
 @dataclass

--- a/src/ai/backend/common/events/event_types/kernel/types.py
+++ b/src/ai/backend/common/events/event_types/kernel/types.py
@@ -2,6 +2,17 @@ import enum
 from typing import Self
 
 
+class KernelTransitionResult(enum.StrEnum):
+    """Agent processing result carried by the unified kernel transition event.
+
+    The Agent reports only success/failure; classifying a failure into
+    retry/timeout/give-up is sokovan's decision (BEP-1061).
+    """
+
+    SUCCESS = "SUCCESS"
+    FAILED = "FAILED"
+
+
 class KernelLifecycleEventReason(enum.StrEnum):
     AGENT_TERMINATION = "agent-termination"
     ALREADY_TERMINATED = "already-terminated"

--- a/src/ai/backend/manager/data/kernel/types.py
+++ b/src/ai/backend/manager/data/kernel/types.py
@@ -328,6 +328,32 @@ class KernelSchedulingPhase(StrEnum):
     TERMINATING = "TERMINATING"
     TERMINATED = "TERMINATED"
 
+    @classmethod
+    def from_kernel_status(cls, status: KernelStatus) -> KernelSchedulingPhase | None:
+        """Map a sokovan status onto the recordable phase set, None if outside it.
+
+        Entry transitions start from a status outside this set (e.g. SCHEDULED),
+        which is recorded as an empty ``from_status``.
+        """
+        try:
+            return cls(status.name)
+        except ValueError:
+            return None
+
+    def agent_stage(self) -> str:
+        """The Agent execution stage that reports transitions into this phase (BEP-1061)."""
+        match self:
+            case (
+                KernelSchedulingPhase.PREPARING
+                | KernelSchedulingPhase.PULLING
+                | KernelSchedulingPhase.PREPARED
+            ):
+                return "prepare"
+            case KernelSchedulingPhase.CREATING | KernelSchedulingPhase.RUNNING:
+                return "create"
+            case KernelSchedulingPhase.TERMINATING | KernelSchedulingPhase.TERMINATED:
+                return "terminate"
+
 
 @dataclass
 class KernelSchedulingHistoryData:

--- a/src/ai/backend/manager/event_dispatcher/dispatch.py
+++ b/src/ai/backend/manager/event_dispatcher/dispatch.py
@@ -50,6 +50,7 @@ from ai.backend.common.events.event_types.kernel.anycast import (
     KernelPreparingAnycastEvent,
     KernelPullingAnycastEvent,
     KernelStartedAnycastEvent,
+    KernelStatusTransitionAnycastEvent,
     KernelTerminatedAnycastEvent,
     KernelTerminatingAnycastEvent,
 )
@@ -349,6 +350,12 @@ class Dispatchers:
         )
 
         evd = event_dispatcher.with_reporters([EventLogger(self._db)])
+        evd.consume(
+            KernelStatusTransitionAnycastEvent,
+            None,
+            self._kernel_event_handler.handle_kernel_status_transition,
+            name="api.session.ktransit",
+        )
         evd.consume(
             KernelPreparingAnycastEvent,
             None,

--- a/src/ai/backend/manager/event_dispatcher/handlers/kernel.py
+++ b/src/ai/backend/manager/event_dispatcher/handlers/kernel.py
@@ -15,6 +15,7 @@ from ai.backend.common.events.event_types.kernel.anycast import (
     KernelPreparingAnycastEvent,
     KernelPullingAnycastEvent,
     KernelStartedAnycastEvent,
+    KernelStatusTransitionAnycastEvent,
     KernelTerminatedAnycastEvent,
     KernelTerminatingAnycastEvent,
 )
@@ -102,6 +103,23 @@ class KernelEventHandler:
             pass
         finally:
             log_buffer.close()
+
+    async def handle_kernel_status_transition(
+        self,
+        _context: None,
+        _source: AgentId,
+        event: KernelStatusTransitionAnycastEvent,
+    ) -> None:
+        log.info(
+            "handle_kernel_status_transition: ev:{} k:{} {} -> {} ({})",
+            event.event_name(),
+            event.kernel_id,
+            event.from_status,
+            event.to_status,
+            event.result,
+        )
+
+        await self._schedule_coordinator.handle_kernel_status_transition(event)
 
     async def handle_kernel_preparing(
         self,

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -53,7 +53,11 @@ from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.data.agent.types import AgentStatus
 from ai.backend.manager.data.dotfile.types import DotfileBundle, DotfileEntry, SSHKeypair
 from ai.backend.manager.data.image.types import ImageIdentifier
-from ai.backend.manager.data.kernel.types import KernelListResult, KernelStatus
+from ai.backend.manager.data.kernel.types import (
+    KernelListResult,
+    KernelSchedulingPhase,
+    KernelStatus,
+)
 from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.data.resource.types import SlotTypePolicy
 from ai.backend.manager.data.session.creation import (
@@ -108,7 +112,10 @@ from ai.backend.manager.models.resource_slot import (
     ResourceSlotTypeRow,
 )
 from ai.backend.manager.models.scaling_group import ScalingGroupRow, query_allowed_sgroups
-from ai.backend.manager.models.scheduling_history.row import SessionSchedulingHistoryRow
+from ai.backend.manager.models.scheduling_history.row import (
+    KernelSchedulingHistoryRow,
+    SessionSchedulingHistoryRow,
+)
 from ai.backend.manager.models.session import (
     PRIVATE_SESSION_TYPES,
     SessionDependencyRow,
@@ -167,6 +174,7 @@ from ai.backend.manager.repositories.scheduler.types.session_creation import (
 )
 from ai.backend.manager.repositories.scheduler.types.snapshot import ResourcePolicies, SnapshotData
 from ai.backend.manager.repositories.scheduling_history import (
+    KernelSchedulingHistoryCreatorSpec,
     SessionSchedulingHistoryCreatorSpec,
 )
 from ai.backend.manager.repositories.vfolder.mount import prepare_vfolder_mounts
@@ -2512,6 +2520,120 @@ class ScheduleDBSource:
             # Free allocations and release the kernel's reserved/used hold.
             await self._free_allocations_and_release(db_sess, [kernel_id], now)
         return True
+
+    async def update_kernel_status_transition(
+        self,
+        kernel_id: KernelId,
+        from_status: KernelStatus,
+        to_status: KernelStatus,
+        reason: str,
+        result: SchedulingResult,
+        error_code: str | None,
+        message: str,
+    ) -> bool:
+        """Apply an Agent-reported kernel transition and record it into history.
+
+        ``from -> to`` is applied atomically (UPDATE WHERE status = from), so a
+        duplicate/stale transition matches nothing and is rejected idempotently.
+        On a failure report the status is left untouched and only history is
+        recorded, still gated on the current status matching ``from_status``.
+        Both the apply and the history record happen in one transaction.
+        """
+        to_phase = KernelSchedulingPhase.from_kernel_status(to_status)
+        if to_phase is None:
+            # Not an Agent-reportable phase; the coordinator validates upstream.
+            return False
+
+        async with self._begin_session_read_committed() as db_sess:
+            now = await self._get_db_now_in_session(db_sess)
+            if result == SchedulingResult.SUCCESS:
+                values: dict[str, Any] = {
+                    "status": to_status,
+                    "status_info": reason,
+                    "status_changed": now,
+                    "status_history": sql_json_merge(
+                        KernelRow.__table__.c.status_history,
+                        (),
+                        {to_status.name: now.isoformat()},
+                    ),
+                }
+                if to_status == KernelStatus.TERMINATED:
+                    values["terminated_at"] = now
+                stmt = (
+                    sa.update(KernelRow)
+                    .where(
+                        sa.and_(
+                            KernelRow.id == kernel_id,
+                            KernelRow.status == from_status,
+                        )
+                    )
+                    .values(**values)
+                    .returning(KernelRow.session_id)
+                )
+                row = (await db_sess.execute(stmt)).first()
+                if row is None:
+                    return False
+                session_id = SessionId(row[0])
+                if to_status == KernelStatus.TERMINATED:
+                    await self._free_allocations_and_release(db_sess, [kernel_id], now)
+            else:
+                sel = sa.select(KernelRow.session_id).where(
+                    sa.and_(
+                        KernelRow.id == kernel_id,
+                        KernelRow.status == from_status,
+                    )
+                )
+                row = (await db_sess.execute(sel)).first()
+                if row is None:
+                    return False
+                session_id = SessionId(row[0])
+
+            history_spec = KernelSchedulingHistoryCreatorSpec(
+                kernel_id=kernel_id,
+                session_id=session_id,
+                phase=to_phase.agent_stage(),
+                result=result,
+                message=message,
+                from_status=KernelSchedulingPhase.from_kernel_status(from_status),
+                to_status=to_phase,
+                error_code=error_code,
+            )
+            await self._record_kernel_transition_history(db_sess, history_spec)
+        return True
+
+    async def _record_kernel_transition_history(
+        self,
+        db_sess: SASession,
+        spec: KernelSchedulingHistoryCreatorSpec,
+    ) -> None:
+        """Record a kernel history row, merging with the last identical one.
+
+        Mirrors the session history merge logic: a redelivered transition
+        (at-least-once transport, sweep re-emission) increments ``attempts``
+        instead of duplicating the row.
+        """
+        new_row = spec.build_row()
+        last_row = (
+            (
+                await db_sess.execute(
+                    sa.select(KernelSchedulingHistoryRow)
+                    .where(KernelSchedulingHistoryRow.kernel_id == spec.kernel_id)
+                    .order_by(KernelSchedulingHistoryRow.created_at.desc())
+                    .limit(1)
+                )
+            )
+            .scalars()
+            .first()
+        )
+        if last_row is not None and last_row.should_merge_with(new_row):
+            await db_sess.execute(
+                sa.update(KernelSchedulingHistoryRow)
+                .where(KernelSchedulingHistoryRow.id == last_row.id)
+                .values(attempts=KernelSchedulingHistoryRow.attempts + 1)
+            )
+        else:
+            db_sess.add(new_row)
+            await db_sess.flush()
 
     async def reset_kernels_to_pending_for_sessions(
         self, session_ids: list[SessionId], reason: str

--- a/src/ai/backend/manager/repositories/scheduler/repository.py
+++ b/src/ai/backend/manager/repositories/scheduler/repository.py
@@ -27,6 +27,7 @@ from ai.backend.common.resource.types import TotalResourceData
 from ai.backend.common.types import (
     AccessKey,
     AgentId,
+    KernelId,
     SessionId,
     SlotName,
     SlotTypes,
@@ -36,7 +37,7 @@ from ai.backend.common.types import (
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.kernel.types import KernelListResult, KernelStatus
-from ai.backend.manager.data.session.types import SessionInfo, SessionStatus
+from ai.backend.manager.data.session.types import SchedulingResult, SessionInfo, SessionStatus
 from ai.backend.manager.data.sokovan import (
     AllocationBatch,
     KernelCreationInfo,
@@ -455,6 +456,22 @@ class SchedulerRepository:
     async def update_kernel_status_cancelled(self, kernel_id: UUID, reason: str) -> bool:
         """Update kernel status to CANCELLED."""
         return await self._db_source.update_kernel_status_cancelled(kernel_id, reason)
+
+    @scheduler_repository_resilience.apply()
+    async def update_kernel_status_transition(
+        self,
+        kernel_id: KernelId,
+        from_status: KernelStatus,
+        to_status: KernelStatus,
+        reason: str,
+        result: SchedulingResult,
+        error_code: str | None,
+        message: str,
+    ) -> bool:
+        """Apply an Agent-reported kernel transition and record it into history."""
+        return await self._db_source.update_kernel_status_transition(
+            kernel_id, from_status, to_status, reason, result, error_code, message
+        )
 
     @scheduler_repository_resilience.apply()
     async def update_kernel_status_terminated(

--- a/src/ai/backend/manager/sokovan/scheduler/coordinator.py
+++ b/src/ai/backend/manager/sokovan/scheduler/coordinator.py
@@ -15,8 +15,10 @@ from ai.backend.common.events.event_types.kernel.anycast import (
     KernelPreparingAnycastEvent,
     KernelPullingAnycastEvent,
     KernelStartedAnycastEvent,
+    KernelStatusTransitionAnycastEvent,
     KernelTerminatedAnycastEvent,
 )
+from ai.backend.common.events.event_types.kernel.types import KernelTransitionResult
 from ai.backend.common.events.event_types.schedule.anycast import (
     DoSokovanProcessIfNeededEvent,
     DoSokovanProcessScheduleEvent,
@@ -30,7 +32,7 @@ from ai.backend.common.leader.tasks import EventTaskSpec
 from ai.backend.common.types import AccessKey, AgentId, SessionId
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.config.provider import ManagerConfigProvider
-from ai.backend.manager.data.kernel.types import KernelStatus
+from ai.backend.manager.data.kernel.types import KernelSchedulingPhase, KernelStatus
 from ai.backend.manager.data.session.types import (
     SchedulingResult,
     SessionStatus,
@@ -155,6 +157,20 @@ class FailureClassificationResult:
 
     need_retry: list[SessionTransitionInfo]
     """Sessions that can be retried - should transition to need_retry status."""
+
+
+# Follow-up scheduling requested after an applied Agent kernel transition,
+# matching the granular event handlers below.
+_FOLLOWUP_SCHEDULES_BY_KERNEL_STATUS: Mapping[KernelStatus, list[ScheduleType]] = {
+    KernelStatus.PREPARING: [ScheduleType.CHECK_PRECONDITION],
+    KernelStatus.PULLING: [ScheduleType.CHECK_PULLING_PROGRESS],
+    KernelStatus.PREPARED: [ScheduleType.CHECK_PULLING_PROGRESS],
+    KernelStatus.RUNNING: [ScheduleType.CHECK_CREATING_PROGRESS],
+    KernelStatus.TERMINATED: [
+        ScheduleType.DETECT_KERNEL_TERMINATION,
+        ScheduleType.CHECK_TERMINATING_PROGRESS,
+    ],
+}
 
 
 class ScheduleCoordinator:
@@ -1568,6 +1584,54 @@ class ScheduleCoordinator:
         return await self.process_schedule(schedule_type)
 
     # Kernel event handling methods using the coordinator's kernel state engine
+
+    async def handle_kernel_status_transition(
+        self, event: KernelStatusTransitionAnycastEvent
+    ) -> bool:
+        """Handle the unified Agent kernel transition event (BEP-1061).
+
+        Records the transition into kernel scheduling history and applies
+        ``from -> to`` through the kernel state engine; a duplicate/stale
+        transition is rejected idempotently by the ``from_status`` pin.
+        """
+        try:
+            from_status = KernelStatus(event.from_status)
+            to_status = KernelStatus(event.to_status)
+        except ValueError:
+            log.warning(
+                "Ignoring kernel transition with unknown status: k:{} {} -> {}",
+                event.kernel_id,
+                event.from_status,
+                event.to_status,
+            )
+            return False
+        if KernelSchedulingPhase.from_kernel_status(to_status) is None:
+            log.warning(
+                "Ignoring kernel transition to a non-agent-reportable status: k:{} -> {}",
+                event.kernel_id,
+                to_status,
+            )
+            return False
+
+        scheduling_result = (
+            SchedulingResult.SUCCESS
+            if event.result == KernelTransitionResult.SUCCESS
+            else SchedulingResult.FAILURE
+        )
+        applied = await self._kernel_state_engine.apply_kernel_status_transition(
+            event.kernel_id,
+            from_status,
+            to_status,
+            event.reason,
+            scheduling_result,
+            event.error_code,
+            event.message,
+        )
+        if applied and scheduling_result == SchedulingResult.SUCCESS:
+            schedule_types = _FOLLOWUP_SCHEDULES_BY_KERNEL_STATUS.get(to_status)
+            if schedule_types:
+                await self._scheduling_controller.mark_scheduling_needed(schedule_types)
+        return applied
 
     async def handle_kernel_pulling(self, event: KernelPullingAnycastEvent) -> bool:
         """Handle kernel pulling event through the kernel state engine."""

--- a/src/ai/backend/manager/sokovan/scheduler/kernel/state_engine.py
+++ b/src/ai/backend/manager/sokovan/scheduler/kernel/state_engine.py
@@ -10,6 +10,8 @@ from uuid import UUID
 
 from ai.backend.common.types import AgentId, KernelId, SessionId
 from ai.backend.logging.utils import BraceStyleAdapter
+from ai.backend.manager.data.kernel.types import KernelStatus
+from ai.backend.manager.data.session.types import SchedulingResult
 from ai.backend.manager.data.sokovan import KernelCreationInfo
 from ai.backend.manager.repositories.scheduler import SchedulerRepository
 
@@ -37,6 +39,35 @@ class KernelStateEngine:
         :param repository: SchedulerRepository for database operations
         """
         self._repository = repository
+
+    async def apply_kernel_status_transition(
+        self,
+        kernel_id: KernelId,
+        from_status: KernelStatus,
+        to_status: KernelStatus,
+        reason: str,
+        result: SchedulingResult,
+        error_code: str | None,
+        message: str,
+    ) -> bool:
+        """Apply an Agent-reported ``from -> to`` transition and record history.
+
+        The repository pins the current status to ``from_status``, so a
+        duplicate/stale transition is rejected idempotently. A failure report
+        records history without touching the status.
+
+        :return: True if the transition was applied (or the failure recorded)
+        """
+        log.debug(
+            "Applying kernel {} transition {} -> {} ({})",
+            kernel_id,
+            from_status,
+            to_status,
+            result,
+        )
+        return await self._repository.update_kernel_status_transition(
+            kernel_id, from_status, to_status, reason, result, error_code, message
+        )
 
     async def mark_kernel_pulling(
         self,

--- a/tests/unit/manager/repositories/scheduler/conftest.py
+++ b/tests/unit/manager/repositories/scheduler/conftest.py
@@ -64,7 +64,10 @@ from ai.backend.manager.models.resource_policy import (
 from ai.backend.manager.models.resource_slot import AgentResourceRow, ResourceAllocationRow
 from ai.backend.manager.models.resource_slot.row import ResourceSlotTypeRow
 from ai.backend.manager.models.scaling_group import ScalingGroupOpts, ScalingGroupRow
-from ai.backend.manager.models.scheduling_history.row import SessionSchedulingHistoryRow
+from ai.backend.manager.models.scheduling_history.row import (
+    KernelSchedulingHistoryRow,
+    SessionSchedulingHistoryRow,
+)
 from ai.backend.manager.models.session import SessionDependencyRow, SessionRow
 from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
@@ -94,6 +97,7 @@ _SCHEDULER_ROWS: list[type] = [
     AgentResourceRow,
     SessionDependencyRow,
     SessionSchedulingHistoryRow,
+    KernelSchedulingHistoryRow,
 ]
 
 _AGENT_ADDR = "127.0.0.1:6001"

--- a/tests/unit/manager/repositories/scheduler/test_kernel_status_transition.py
+++ b/tests/unit/manager/repositories/scheduler/test_kernel_status_transition.py
@@ -1,0 +1,282 @@
+"""Tests for ScheduleDBSource.update_kernel_status_transition (BEP-1061 3e).
+
+Applying an Agent-reported ``from -> to`` kernel transition atomically and
+recording it into ``kernel_scheduling_history`` in the same transaction.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+from dateutil.tz import tzutc
+from sqlalchemy import select
+
+from ai.backend.common.identifier.domain import DomainID
+from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.types import (
+    AccessKey,
+    ClusterMode,
+    KernelId,
+    ResourceSlot,
+    SessionId,
+    SessionResult,
+    SessionTypes,
+)
+from ai.backend.manager.data.kernel.types import KernelStatus
+from ai.backend.manager.data.session.types import SchedulingResult, SessionStatus
+from ai.backend.manager.models.kernel.row import KernelRow
+from ai.backend.manager.models.scheduling_history.row import KernelSchedulingHistoryRow
+from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.scheduler.db_source.db_source import ScheduleDBSource
+
+
+@pytest.fixture
+async def pulling_kernel(
+    db_with_cleanup: ExtendedAsyncSAEngine,
+    test_domain_name: str,
+    test_domain_id: DomainID,
+    test_scaling_group_name: str,
+    test_scaling_group_id: ResourceGroupID,
+    test_group_id: uuid.UUID,
+    test_user_uuid: uuid.UUID,
+    test_access_key: AccessKey,
+) -> AsyncGenerator[tuple[SessionId, KernelId], None]:
+    """A session with one kernel in PULLING status, inserted directly."""
+    session_id = SessionId(uuid.uuid4())
+    kernel_id = KernelId(uuid.uuid4())
+    async with db_with_cleanup.begin_session() as db_sess:
+        db_sess.add(
+            SessionRow(
+                id=session_id,
+                name=f"test-session-{uuid.uuid4().hex[:8]}",
+                session_type=SessionTypes.INTERACTIVE,
+                domain_name=test_domain_name,
+                domain_id=test_domain_id,
+                group_id=test_group_id,
+                scaling_group_name=test_scaling_group_name,
+                resource_group_id=test_scaling_group_id,
+                status=SessionStatus.PREPARING,
+                status_info="test",
+                cluster_mode=ClusterMode.SINGLE_NODE,
+                requested_slots=ResourceSlot({"cpu": Decimal("1")}),
+                created_at=datetime.now(tzutc()),
+                images=["python:3.13"],
+                vfolder_mounts=[],
+                environ={},
+                result=SessionResult.UNDEFINED,
+            )
+        )
+        await db_sess.flush()
+        db_sess.add(
+            KernelRow(
+                id=kernel_id,
+                session_id=session_id,
+                agent=None,
+                agent_addr=None,
+                scaling_group=test_scaling_group_name,
+                resource_group_id=test_scaling_group_id,
+                cluster_idx=0,
+                cluster_role="main",
+                cluster_hostname=f"kernel-{uuid.uuid4().hex[:8]}",
+                image="python:3.13",
+                architecture="x86_64",
+                registry="docker.io",
+                container_id=None,
+                status=KernelStatus.PULLING,
+                status_changed=datetime.now(tzutc()),
+                occupied_slots=ResourceSlot(),
+                requested_slots=ResourceSlot({"cpu": Decimal("1")}),
+                domain_name=test_domain_name,
+                group_id=test_group_id,
+                user_uuid=test_user_uuid,
+                access_key=test_access_key,
+                mounts=[],
+                environ={},
+                vfolder_mounts=[],
+                preopen_ports=[],
+                repl_in_port=2001,
+                repl_out_port=2002,
+                stdin_port=2003,
+                stdout_port=2004,
+            )
+        )
+        await db_sess.flush()
+    yield session_id, kernel_id
+
+
+async def _kernel_state(
+    db: ExtendedAsyncSAEngine, kernel_id: KernelId
+) -> tuple[KernelStatus, list[KernelSchedulingHistoryRow]]:
+    """Fetch the kernel's current status and its ordered history rows in one session."""
+    async with db.begin_readonly_session() as db_sess:
+        status = await db_sess.scalar(select(KernelRow.status).where(KernelRow.id == kernel_id))
+        result = await db_sess.execute(
+            select(KernelSchedulingHistoryRow)
+            .where(KernelSchedulingHistoryRow.kernel_id == kernel_id)
+            .order_by(KernelSchedulingHistoryRow.created_at)
+        )
+        return status, list(result.scalars().all())
+
+
+class TestUpdateKernelStatusTransition:
+    async def test_applies_transition_and_records_history(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        pulling_kernel: tuple[SessionId, KernelId],
+    ) -> None:
+        session_id, kernel_id = pulling_kernel
+        db_source = ScheduleDBSource(db_with_cleanup)
+
+        applied = await db_source.update_kernel_status_transition(
+            kernel_id,
+            KernelStatus.PULLING,
+            KernelStatus.PREPARED,
+            "image-pulled",
+            SchedulingResult.SUCCESS,
+            None,
+            "prepare done",
+        )
+
+        assert applied is True
+        status, rows = await _kernel_state(db_with_cleanup, kernel_id)
+        assert status == KernelStatus.PREPARED
+        assert len(rows) == 1
+        assert rows[0].session_id == session_id
+        assert rows[0].phase == "prepare"
+        assert rows[0].from_status == "PULLING"
+        assert rows[0].to_status == "PREPARED"
+        assert rows[0].result == str(SchedulingResult.SUCCESS)
+        assert rows[0].attempts == 1
+
+    async def test_stale_transition_rejected_without_history(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        pulling_kernel: tuple[SessionId, KernelId],
+    ) -> None:
+        _, kernel_id = pulling_kernel
+        db_source = ScheduleDBSource(db_with_cleanup)
+
+        applied = await db_source.update_kernel_status_transition(
+            kernel_id,
+            KernelStatus.CREATING,  # does not match the current PULLING status
+            KernelStatus.RUNNING,
+            "stale",
+            SchedulingResult.SUCCESS,
+            None,
+            "stale transition",
+        )
+
+        assert applied is False
+        status, rows = await _kernel_state(db_with_cleanup, kernel_id)
+        assert status == KernelStatus.PULLING
+        assert rows == []
+
+    async def test_redelivered_applied_transition_rejected(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        pulling_kernel: tuple[SessionId, KernelId],
+    ) -> None:
+        _, kernel_id = pulling_kernel
+        db_source = ScheduleDBSource(db_with_cleanup)
+
+        first = await db_source.update_kernel_status_transition(
+            kernel_id,
+            KernelStatus.PULLING,
+            KernelStatus.PREPARED,
+            "image-pulled",
+            SchedulingResult.SUCCESS,
+            None,
+            "prepare done",
+        )
+        redelivered = await db_source.update_kernel_status_transition(
+            kernel_id,
+            KernelStatus.PULLING,
+            KernelStatus.PREPARED,
+            "image-pulled",
+            SchedulingResult.SUCCESS,
+            None,
+            "prepare done",
+        )
+
+        assert first is True
+        assert redelivered is False
+        _, rows = await _kernel_state(db_with_cleanup, kernel_id)
+        assert len(rows) == 1
+        assert rows[0].attempts == 1
+
+    async def test_failed_report_records_without_status_change(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        pulling_kernel: tuple[SessionId, KernelId],
+    ) -> None:
+        session_id, kernel_id = pulling_kernel
+        db_source = ScheduleDBSource(db_with_cleanup)
+
+        recorded = await db_source.update_kernel_status_transition(
+            kernel_id,
+            KernelStatus.PULLING,
+            KernelStatus.PREPARED,
+            "image-pull-failed",
+            SchedulingResult.FAILURE,
+            "PULL_TIMEOUT",
+            "registry timeout",
+        )
+
+        assert recorded is True
+        status, rows = await _kernel_state(db_with_cleanup, kernel_id)
+        assert status == KernelStatus.PULLING
+        assert len(rows) == 1
+        assert rows[0].session_id == session_id
+        assert rows[0].result == str(SchedulingResult.FAILURE)
+        assert rows[0].error_code == "PULL_TIMEOUT"
+
+    async def test_repeated_failed_report_merges_attempts(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        pulling_kernel: tuple[SessionId, KernelId],
+    ) -> None:
+        _, kernel_id = pulling_kernel
+        db_source = ScheduleDBSource(db_with_cleanup)
+
+        for _ in range(2):
+            await db_source.update_kernel_status_transition(
+                kernel_id,
+                KernelStatus.PULLING,
+                KernelStatus.PREPARED,
+                "image-pull-failed",
+                SchedulingResult.FAILURE,
+                "PULL_TIMEOUT",
+                "registry timeout",
+            )
+
+        _, rows = await _kernel_state(db_with_cleanup, kernel_id)
+        assert len(rows) == 1
+        assert rows[0].attempts == 2
+
+    async def test_non_reportable_target_status_ignored(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        pulling_kernel: tuple[SessionId, KernelId],
+    ) -> None:
+        _, kernel_id = pulling_kernel
+        db_source = ScheduleDBSource(db_with_cleanup)
+
+        applied = await db_source.update_kernel_status_transition(
+            kernel_id,
+            KernelStatus.PULLING,
+            KernelStatus.CANCELLED,  # not an Agent-reportable phase
+            "cancelled",
+            SchedulingResult.SUCCESS,
+            None,
+            "cancel is sokovan's concern",
+        )
+
+        assert applied is False
+        status, rows = await _kernel_state(db_with_cleanup, kernel_id)
+        assert status == KernelStatus.PULLING
+        assert rows == []

--- a/tests/unit/manager/sokovan/scheduler/test_coordinator.py
+++ b/tests/unit/manager/sokovan/scheduler/test_coordinator.py
@@ -12,6 +12,7 @@ Test Scenarios:
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -20,6 +21,10 @@ from uuid import uuid4
 import pytest
 from dateutil.tz import tzutc
 
+from ai.backend.common.events.event_types.kernel.anycast import (
+    KernelStatusTransitionAnycastEvent,
+)
+from ai.backend.common.events.event_types.kernel.types import KernelTransitionResult
 from ai.backend.common.types import AccessKey, KernelId, SessionId
 from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.session.options import HandlerOptions
@@ -43,6 +48,7 @@ from ai.backend.manager.sokovan.scheduler.results import (
     SessionExecutionResult,
     SessionTransitionInfo,
 )
+from ai.backend.manager.sokovan.scheduler.types import ScheduleType
 
 # =============================================================================
 # Test Fixtures
@@ -1224,3 +1230,177 @@ class TestScheduleCoordinatorPromotionRecordOrdering:
         (finalize,) = records[session_id].phases
         assert finalize.name == "finalize_start"
         assert [step.name for step in finalize.steps] == ["trigger_batch_execution"]
+
+
+# =============================================================================
+# TestHandleKernelStatusTransition (BEP-1061 unified transition event)
+# =============================================================================
+
+
+class TestHandleKernelStatusTransition:
+    """Tests for the unified Agent kernel transition handler."""
+
+    @pytest.fixture
+    def mock_coordinator(self) -> MagicMock:
+        coordinator = MagicMock(spec=ScheduleCoordinator)
+        coordinator._kernel_state_engine = AsyncMock()
+        coordinator._kernel_state_engine.apply_kernel_status_transition.return_value = True
+        coordinator._scheduling_controller = AsyncMock()
+        return coordinator
+
+    @dataclass(frozen=True)
+    class _AppliedCase:
+        from_status: KernelStatus
+        to_status: KernelStatus
+        # Expected mark_scheduling_needed awaits; empty means no follow-up mark.
+        expected_marks: list[list[ScheduleType]] = field(default_factory=list)
+
+    @pytest.mark.parametrize(
+        "case",
+        [
+            # Full domain of Agent-reportable target phases (BEP-1061 handler table).
+            _AppliedCase(
+                from_status=KernelStatus.SCHEDULED,
+                to_status=KernelStatus.PREPARING,
+                expected_marks=[[ScheduleType.CHECK_PRECONDITION]],
+            ),
+            _AppliedCase(
+                from_status=KernelStatus.PREPARING,
+                to_status=KernelStatus.PULLING,
+                expected_marks=[[ScheduleType.CHECK_PULLING_PROGRESS]],
+            ),
+            _AppliedCase(
+                from_status=KernelStatus.PULLING,
+                to_status=KernelStatus.PREPARED,
+                expected_marks=[[ScheduleType.CHECK_PULLING_PROGRESS]],
+            ),
+            _AppliedCase(
+                from_status=KernelStatus.PREPARED,
+                to_status=KernelStatus.CREATING,
+            ),
+            _AppliedCase(
+                from_status=KernelStatus.CREATING,
+                to_status=KernelStatus.RUNNING,
+                expected_marks=[[ScheduleType.CHECK_CREATING_PROGRESS]],
+            ),
+            _AppliedCase(
+                from_status=KernelStatus.RUNNING,
+                to_status=KernelStatus.TERMINATING,
+            ),
+            _AppliedCase(
+                from_status=KernelStatus.TERMINATING,
+                to_status=KernelStatus.TERMINATED,
+                expected_marks=[
+                    [
+                        ScheduleType.DETECT_KERNEL_TERMINATION,
+                        ScheduleType.CHECK_TERMINATING_PROGRESS,
+                    ]
+                ],
+            ),
+        ],
+        ids=lambda case: f"{case.from_status.name}-to-{case.to_status.name}",
+    )
+    async def test_applied_transition_marks_followup_schedules(
+        self,
+        mock_coordinator: MagicMock,
+        case: _AppliedCase,
+    ) -> None:
+        event = KernelStatusTransitionAnycastEvent(
+            kernel_id=KernelId(uuid4()),
+            from_status=case.from_status.value,
+            to_status=case.to_status.value,
+            reason="test",
+        )
+
+        applied = await ScheduleCoordinator.handle_kernel_status_transition(mock_coordinator, event)
+
+        assert applied is True
+        engine_call = mock_coordinator._kernel_state_engine.apply_kernel_status_transition
+        engine_call.assert_awaited_once_with(
+            event.kernel_id,
+            case.from_status,
+            case.to_status,
+            "test",
+            SchedulingResult.SUCCESS,
+            None,
+            "",
+        )
+        mark = mock_coordinator._scheduling_controller.mark_scheduling_needed
+        assert [c.args[0] for c in mark.await_args_list] == case.expected_marks
+
+    async def test_failed_report_records_without_followup(
+        self,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        event = KernelStatusTransitionAnycastEvent(
+            kernel_id=KernelId(uuid4()),
+            from_status=KernelStatus.PULLING.value,
+            to_status=KernelStatus.PREPARED.value,
+            reason="pull-failed",
+            result=KernelTransitionResult.FAILED,
+            error_code="PULL_TIMEOUT",
+            message="registry timeout",
+        )
+
+        applied = await ScheduleCoordinator.handle_kernel_status_transition(mock_coordinator, event)
+
+        assert applied is True
+        engine_call = mock_coordinator._kernel_state_engine.apply_kernel_status_transition
+        engine_call.assert_awaited_once_with(
+            event.kernel_id,
+            KernelStatus.PULLING,
+            KernelStatus.PREPARED,
+            "pull-failed",
+            SchedulingResult.FAILURE,
+            "PULL_TIMEOUT",
+            "registry timeout",
+        )
+        mock_coordinator._scheduling_controller.mark_scheduling_needed.assert_not_awaited()
+
+    async def test_stale_transition_marks_nothing(
+        self,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        mock_coordinator._kernel_state_engine.apply_kernel_status_transition.return_value = False
+        event = KernelStatusTransitionAnycastEvent(
+            kernel_id=KernelId(uuid4()),
+            from_status=KernelStatus.PULLING.value,
+            to_status=KernelStatus.PREPARED.value,
+        )
+
+        applied = await ScheduleCoordinator.handle_kernel_status_transition(mock_coordinator, event)
+
+        assert applied is False
+        mock_coordinator._scheduling_controller.mark_scheduling_needed.assert_not_awaited()
+
+    @dataclass(frozen=True)
+    class _IgnoredCase:
+        from_status: str
+        to_status: str
+
+    @pytest.mark.parametrize(
+        "case",
+        [
+            _IgnoredCase(from_status="PULLING", to_status="NOT_A_STATUS"),
+            _IgnoredCase(from_status="NOT_A_STATUS", to_status="PREPARED"),
+            # Statuses outside the Agent-reportable phase set.
+            _IgnoredCase(from_status="PENDING", to_status="SCHEDULED"),
+            _IgnoredCase(from_status="RUNNING", to_status="CANCELLED"),
+        ],
+        ids=lambda case: f"{case.from_status}-to-{case.to_status}",
+    )
+    async def test_invalid_transition_ignored(
+        self,
+        mock_coordinator: MagicMock,
+        case: _IgnoredCase,
+    ) -> None:
+        event = KernelStatusTransitionAnycastEvent(
+            kernel_id=KernelId(uuid4()),
+            from_status=case.from_status,
+            to_status=case.to_status,
+        )
+
+        applied = await ScheduleCoordinator.handle_kernel_status_transition(mock_coordinator, event)
+
+        assert applied is False
+        mock_coordinator._kernel_state_engine.apply_kernel_status_transition.assert_not_awaited()


### PR DESCRIPTION
Resolves #12785 (BA-6852)

## Summary

Nothing wrote `kernel_scheduling_history` until now — `KernelSchedulingHistoryCreatorSpec` had no caller — so the kernel scheduling-history APIs (#12870/#12989/#12866) always returned empty lists. This implements the Manager-side recording/apply contract of BEP-1061 §3e, plus the unified event type from §3d that it consumes.

| Piece | Change |
|---|---|
| Event (§3d) | `KernelStatusTransitionAnycastEvent(kernel_id, from_status, to_status, reason, result, error_code, message)` — no phase/step payload; `from`/`to` are sokovan `KernelStatus` values |
| Apply (§3e-2) | Atomic `UPDATE … WHERE status = from` in the scheduler repository, so a duplicate/stale transition matches nothing and is rejected idempotently; a `FAILED` report leaves the status untouched |
| Record (§3e-1) | History row written in the **same transaction**, mapping the transition onto `phase`/`from_status`/`to_status`/`result`/`error_code`/`message`; a redelivered identical record merges by incrementing `attempts` (at-least-once transport / sweep re-emission) |
| Follow-up | Applied transitions request the same `ScheduleType` marks as the granular handlers (e.g. `CHECK_PULLING_PROGRESS` after `PULLING`) |
| Guard | Targets outside the Agent-reportable phase set (`PREPARING…TERMINATED`) are ignored — CANCELLED/reschedule stays with sokovan session scheduling, per the BEP |

`phase` derives from the Agent execution stage owning the target status (`prepare` / `create` / `terminate`, per the BEP handler table). `TERMINATED` transitions also free resource allocations, mirroring the existing terminated path.

## Boundary

The Agent-side egress that emits this event is **BA-6851** (not started); until it lands, the granular anycast events remain the live path and this handler consumes only what is published to the unified event. Migrating granular consumers is **BA-6853**.

Note: BA-6852 is assigned to @HyeockJinKim — this PR was made on jopemachine's direction to unblock the kernel history feature line; happy to hand over or adjust to your planned shape.

## Test plan

- [x] Unit — coordinator handler (13 cases): full domain of the 7 Agent-reportable target phases with their follow-up schedule marks, `FAILED` report without follow-up, stale rejection, unknown/non-reportable statuses ignored
- [x] Repository (real DB, 6 cases): apply+record atomically; stale `from` rejected without history; redelivered applied transition rejected; `FAILED` records without status change; repeated `FAILED` merges to one row with `attempts=2`; non-reportable target ignored
- [x] **Live end-to-end**: published the event onto the Redis `events` stream against a running manager — status applied (`PULLING → PREPARED`), history row recorded and visible to the kernel owner through `scopedKernelSchedulingHistories`, redelivered copy rejected (no duplicate), repeated failure reports merged (`attempts=2`)
- [x] `ruff check` / `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)