### PR TITLE
fix(BA-6922): pluralize the app config allow-list REST v2 prefix

### DIFF
--- a/changes/13034.breaking.md
+++ b/changes/13034.breaking.md
@@ -1,0 +1,1 @@
+Rename the app config allow-list REST v2 prefix from `/v2/app-config-allow-list` to `/v2/app-config-allow-lists`, matching every other v2 entity collection. The bundled SDK is updated with it; callers hitting the raw path must use the new one.

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -39942,11 +39942,11 @@
         "description": "Purge a fragment by id (auth required, RBAC-gated).\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
-    "/v2/app-config-allow-list/": {
+    "/v2/app-config-allow-lists/": {
       "post": {
-        "operationId": "v2/app-config-allow-list.admin_create",
+        "operationId": "v2/app-config-allow-lists.admin_create",
         "tags": [
-          "v2/app-config-allow-list"
+          "v2/app-config-allow-lists"
         ],
         "responses": {
           "200": {
@@ -39971,11 +39971,11 @@
         "description": "Register a new app config allow-list entry (superadmin only).\n\n**Preconditions:**\n* Superadmin privilege required.\n"
       }
     },
-    "/v2/app-config-allow-list/search": {
+    "/v2/app-config-allow-lists/search": {
       "post": {
-        "operationId": "v2/app-config-allow-list.admin_search",
+        "operationId": "v2/app-config-allow-lists.admin_search",
         "tags": [
-          "v2/app-config-allow-list"
+          "v2/app-config-allow-lists"
         ],
         "responses": {
           "200": {
@@ -40000,11 +40000,11 @@
         "description": "Search app config allow-list entries with pagination (superadmin only).\n\n**Preconditions:**\n* Superadmin privilege required.\n"
       }
     },
-    "/v2/app-config-allow-list/{app_config_allow_list_id}": {
+    "/v2/app-config-allow-lists/{app_config_allow_list_id}": {
       "get": {
-        "operationId": "v2/app-config-allow-list.admin_get",
+        "operationId": "v2/app-config-allow-lists.admin_get",
         "tags": [
-          "v2/app-config-allow-list"
+          "v2/app-config-allow-lists"
         ],
         "responses": {
           "200": {
@@ -40029,9 +40029,9 @@
         "description": "Get an app config allow-list entry by id (superadmin only).\n\n**Preconditions:**\n* Superadmin privilege required.\n"
       },
       "patch": {
-        "operationId": "v2/app-config-allow-list.admin_update",
+        "operationId": "v2/app-config-allow-lists.admin_update",
         "tags": [
-          "v2/app-config-allow-list"
+          "v2/app-config-allow-lists"
         ],
         "responses": {
           "200": {
@@ -40065,9 +40065,9 @@
         "description": "Update an app config allow-list entry's rank by id (superadmin only).\n\n**Preconditions:**\n* Superadmin privilege required.\n"
       },
       "delete": {
-        "operationId": "v2/app-config-allow-list.admin_purge",
+        "operationId": "v2/app-config-allow-lists.admin_purge",
         "tags": [
-          "v2/app-config-allow-list"
+          "v2/app-config-allow-lists"
         ],
         "responses": {
           "200": {

--- a/src/ai/backend/client/v2/domains_v2/app_config_allow_list.py
+++ b/src/ai/backend/client/v2/domains_v2/app_config_allow_list.py
@@ -19,7 +19,7 @@ from ai.backend.common.dto.manager.v2.app_config_allow_list.response import (
     UpdateAppConfigAllowListPayload,
 )
 
-_PATH: Final = "/v2/app-config-allow-list"
+_PATH: Final = "/v2/app-config-allow-lists"
 
 
 class V2AppConfigAllowListClient(BaseDomainClient):

--- a/src/ai/backend/manager/api/rest/v2/app_config_allow_list/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_allow_list/registry.py
@@ -19,6 +19,10 @@ def register_v2_app_config_allow_list_routes(
 ) -> RouteRegistry:
     """Register all REST v2 app config allow-list routes (superadmin only).
 
+    The allow-list is an admin-only entity — every route is ``superadmin_required`` — so
+    it carries no scoped search counterpart to ``/search``. A non-admin never queries the
+    allow-list directly; it is read through the app config resolve path.
+
     Layout:
         POST   /                            register an allow-list entry
         POST   /search                      paginated search
@@ -26,7 +30,7 @@ def register_v2_app_config_allow_list_routes(
         PATCH  /{app_config_allow_list_id}  update (rank) by id
         DELETE /{app_config_allow_list_id}  purge by id
     """
-    registry = RouteRegistry.create("app-config-allow-list", route_deps.cors_options)
+    registry = RouteRegistry.create("app-config-allow-lists", route_deps.cors_options)
 
     registry.add("POST", "/", handler.admin_create, middlewares=[superadmin_required])
     registry.add("POST", "/search", handler.admin_search, middlewares=[superadmin_required])

--- a/src/ai/backend/manager/api/rest/v2/app_config_definition/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_definition/registry.py
@@ -19,6 +19,10 @@ def register_v2_app_config_definition_routes(
 ) -> RouteRegistry:
     """Register all REST v2 app config definition routes (superadmin only).
 
+    A config definition is an admin-only entity — every route is ``superadmin_required`` —
+    so it carries no scoped search counterpart to ``/search``. A non-admin never queries
+    definitions directly; they are read through the app config resolve path.
+
     Layout:
         POST   /                              register a config definition
         POST   /search                        paginated search

--- a/tests/unit/client_v2/test_app_config_allow_list.py
+++ b/tests/unit/client_v2/test_app_config_allow_list.py
@@ -72,7 +72,7 @@ class TestAdminCreate:
 
         call_args = mock_session.request.call_args
         assert call_args[0][0] == "POST"
-        assert str(call_args[0][1]).endswith("/v2/app-config-allow-list/")
+        assert str(call_args[0][1]).endswith("/v2/app-config-allow-lists/")
         assert isinstance(result, CreateAppConfigAllowListPayload)
         assert result.app_config_allow_list.config_name == "theme"
         assert result.app_config_allow_list.scope_type == AppConfigScopeType.DOMAIN
@@ -98,7 +98,7 @@ class TestAdminSearch:
 
         call_args = mock_session.request.call_args
         assert call_args[0][0] == "POST"
-        assert "/v2/app-config-allow-list/search" in str(call_args[0][1])
+        assert "/v2/app-config-allow-lists/search" in str(call_args[0][1])
         assert isinstance(result, SearchAppConfigAllowListPayload)
         assert [item.config_name for item in result.items] == ["menu"]
         assert result.total_count == 1
@@ -117,7 +117,7 @@ class TestAdminGet:
 
         call_args = mock_session.request.call_args
         assert call_args[0][0] == "GET"
-        assert str(call_args[0][1]).endswith(f"/v2/app-config-allow-list/{entry_id}")
+        assert str(call_args[0][1]).endswith(f"/v2/app-config-allow-lists/{entry_id}")
         assert isinstance(result, AppConfigAllowListNode)
         assert result.config_name == "preferences"
 
@@ -140,7 +140,7 @@ class TestAdminUpdate:
 
         call_args = mock_session.request.call_args
         assert call_args[0][0] == "PATCH"
-        assert str(call_args[0][1]).endswith(f"/v2/app-config-allow-list/{entry_id}")
+        assert str(call_args[0][1]).endswith(f"/v2/app-config-allow-lists/{entry_id}")
         assert isinstance(result, UpdateAppConfigAllowListPayload)
         assert result.app_config_allow_list.rank == 250
 
@@ -158,6 +158,6 @@ class TestAdminPurge:
 
         call_args = mock_session.request.call_args
         assert call_args[0][0] == "DELETE"
-        assert str(call_args[0][1]).endswith(f"/v2/app-config-allow-list/{entry_id}")
+        assert str(call_args[0][1]).endswith(f"/v2/app-config-allow-lists/{entry_id}")
         assert isinstance(result, PurgeAppConfigAllowListPayload)
         assert result.id == entry_id


### PR DESCRIPTION
Related: #12929 (BA-6922)

## Summary

Two REST v2 convention gaps in the app config family, found while reviewing the fragment search surface.

**1. `app-config-allow-list` was the only singular entity prefix.** Every other v2 entity collection is plural:

| | prefix |
|---|---|
| before | `/v2/app-config-allow-list` |
| after | `/v2/app-config-allow-lists` |
| siblings | `app-config-definitions`, `app-config-fragments`, `resource-policies`, `model-cards`, `runtime-variants`, … |

Renamed across the route registry, the SDK `_PATH`, its tests, and `openapi.json`. **The CLI command name stays singular** (`bai admin app-config-allow-list`) — every v2 admin group is singular there (`resource-policy`, `model-card`, `app-config-definition`), so the CLI was already right.

**2. The missing scoped search on allow-list and definition is now stated, not implied.** `api/rest/v2/AGENTS.md` says a search always comes in two variants — a superadmin `/search` and a scoped one — and both registries only have the first. That is correct here: both are admin-only entities (every route is `superadmin_required`) and a non-admin reads them through the app config resolve path rather than querying them. The registry docstrings now say so, so the omission does not read as an oversight to the next person checking the convention.

## Breaking change

`/v2/app-config-allow-list/*` → `/v2/app-config-allow-lists/*`. The bundled SDK is updated in the same commit, so `bai` and the Python client keep working; any caller hitting the raw path needs the new one.

## Not in this PR

`POST /v2/app-config-fragments/scoped-search` does not match either documented form — the current `/{entity}/{scope_type}/{scope_id}/search` or the forward `/{entity}/scoped/search` (cf. `scheduling-history`'s `/kernels/scoped/search`). That route is added by #13020 and does not exist on `main`, so it cannot be fixed from a `main`-based branch; it is corrected on that PR instead.

## Test plan

- [x] Formatter, linter, visibility and mypy clean over the touched manager, client and test packages
- [x] `openapi.json` regenerated with `./backend.ai mgr api dump-openapi`; the delta is exactly the three allow-list paths
- [x] Verified no other reference to the singular path remains (`errors/app_config.py` keeps `probs/app-config-allow-list-not-found`, which is an error-type URN, not a route)
- [ ] CI verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)
