### PR TITLE
fix(BA-6922): use the scoped search route shape the convention documents

### DIFF
--- a/changes/13035.fix.md
+++ b/changes/13035.fix.md
@@ -1,0 +1,1 @@
+Use `POST /v2/app-config-fragments/scoped/search` for the scoped fragment search, matching the documented scoped-search route shape instead of `/scoped-search`.

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -40281,7 +40281,7 @@
         "description": "Search fragments across all scopes with pagination (superadmin only).\n\n**Preconditions:**\n* Superadmin privilege required.\n"
       }
     },
-    "/v2/app-config-fragments/scoped-search": {
+    "/v2/app-config-fragments/scoped/search": {
       "post": {
         "operationId": "v2/app-config-fragments.scoped_search",
         "tags": [

--- a/src/ai/backend/manager/api/rest/v2/app_config_fragment/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_fragment/registry.py
@@ -22,14 +22,14 @@ def register_v2_app_config_fragment_routes(
     Writes and single-fragment reads are open to any authenticated user and gated by RBAC
     at the processor (a user acts on their own user-scope, a domain admin on their domain's,
     a superadmin on any; public is superadmin-only). Only the system-wide ``/search`` is
-    superadmin-only — non-admins list their visible fragments via ``/scoped-search``.
+    superadmin-only — non-admins list their visible fragments via ``/scoped/search``.
 
     Layout:
         POST   /                  create a fragment              (auth, RBAC)
         POST   /bulk-update       update many by id              (auth, RBAC)
         POST   /bulk-delete       purge many by id               (auth, RBAC)
         POST   /search            system-wide paginated search   (superadmin)
-        POST   /scoped-search     principal-visible search       (auth)
+        POST   /scoped/search     principal-visible search       (auth)
         GET    /{fragment_id}     get by id                      (auth, RBAC)
         PATCH  /{fragment_id}     update config by id            (auth, RBAC)
         DELETE /{fragment_id}     purge by id                    (auth, RBAC)
@@ -40,7 +40,7 @@ def register_v2_app_config_fragment_routes(
     registry.add("POST", "/bulk-update", handler.bulk_update, middlewares=[auth_required])
     registry.add("POST", "/bulk-delete", handler.bulk_purge, middlewares=[auth_required])
     registry.add("POST", "/search", handler.admin_search, middlewares=[superadmin_required])
-    registry.add("POST", "/scoped-search", handler.scoped_search, middlewares=[auth_required])
+    registry.add("POST", "/scoped/search", handler.scoped_search, middlewares=[auth_required])
     registry.add("GET", "/{fragment_id}", handler.get, middlewares=[auth_required])
     registry.add("PATCH", "/{fragment_id}", handler.update, middlewares=[auth_required])
     registry.add("DELETE", "/{fragment_id}", handler.purge, middlewares=[auth_required])


### PR DESCRIPTION
## 📚 Stacked PRs

- #13020 — `BA-6922` feat: AppConfig fragment search REST v2 API (admin + scoped)
- this PR — `BA-6922` fix: use the scoped search route shape the convention documents  ← you are here

Merge in order, bottom-up. Each PR is based on the one above it, so its diff shows only its own layer.

Related: #12929 (BA-6922)

## Summary

`POST /v2/app-config-fragments/scoped-search` matches neither documented route shape:

| | shape |
|---|---|
| `api/rest/v2/AGENTS.md`, current | `POST /v2/{entity}/{scope_type}/{scope_id}/search` |
| `api/rest/v2/AGENTS.md`, forward direction | `POST /v2/{entity}/scoped/search` |
| before | `POST /v2/app-config-fragments/scoped-search` |
| after | `POST /v2/app-config-fragments/scoped/search` |

`scheduling-history` already ships the forward form as `POST /v2/scheduling-history/kernels/scoped/search`, so this follows it rather than inventing a third spelling.

The route is introduced by #13020 and does not exist on `main`, so this is based on that branch.

## Test plan

- [x] `openapi.json` regenerated with `./backend.ai mgr api dump-openapi`; the delta is the single path string
- [ ] CI verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)
