### PR TITLE
ci(BA-6967): run full CI suite on release PRs detected by PR title prefix

### DIFF
--- a/.github/actions/detect-release-pr/action.yml
+++ b/.github/actions/detect-release-pr/action.yml
@@ -1,0 +1,23 @@
+name: detect-release-pr
+description: Detect a release PR from the pr-title-prefix result. Exposes the result as both the 'release' output and the IS_RELEASE_PR environment variable for subsequent steps.
+outputs:
+  release:
+    description: "'true' if the PR title has the 'release' prefix"
+    value: ${{ steps.decide.outputs.release }}
+runs:
+  using: composite
+  steps:
+    - id: title
+      uses: ./.github/actions/pr-title-prefix
+    - id: decide
+      shell: bash
+      env:
+        PREFIX: ${{ steps.title.outputs.prefix }}
+      run: |
+        if [ "$PREFIX" == "release" ]; then
+          RELEASE=true
+        else
+          RELEASE=false
+        fi
+        echo "release=$RELEASE" >> "$GITHUB_OUTPUT"
+        echo "IS_RELEASE_PR=$RELEASE" >> "$GITHUB_ENV"

--- a/.github/actions/pr-title-prefix/action.yml
+++ b/.github/actions/pr-title-prefix/action.yml
@@ -1,0 +1,16 @@
+name: pr-title-prefix
+description: Extract the conventional commit prefix (scope stripped) from the PR title
+outputs:
+  prefix:
+    description: The PR title prefix with any scope stripped (empty for non-PR events)
+    value: ${{ steps.parse.outputs.prefix }}
+runs:
+  using: composite
+  steps:
+    - id: parse
+      shell: bash
+      env:
+        TITLE: ${{ github.event.pull_request.title }}
+      run: |
+        PREFIX=$(echo "$TITLE" | tr ':' '\n' | head -n 1 | sed -E 's/\([^)]+\)$//')
+        echo "prefix=$PREFIX" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/check-version-change.yml
+++ b/.github/workflows/check-version-change.yml
@@ -1,0 +1,31 @@
+name: check-version-change
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-version-change:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the revision
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+      - name: Detect release PR
+        uses: ./.github/actions/detect-release-pr
+      - uses: dorny/paths-filter@v3
+        if: env.IS_RELEASE_PR != 'true'
+        id: filter
+        with:
+          filters: |
+            version:
+              - 'VERSION'
+      - name: Fail if VERSION is changed in a non-release PR
+        if: env.IS_RELEASE_PR != 'true' && steps.filter.outputs.version == 'true'
+        run: |
+          echo "The VERSION file is modified, but the PR title does not have the 'release' prefix."
+          echo "If this is a release PR, retitle it with the 'release:' prefix and then push a new commit"
+          echo "(or close and reopen the PR) to re-trigger CI with the full test suite."
+          echo "Otherwise, revert the VERSION file change."
+          exit 1

--- a/.github/workflows/check-version-change.yml
+++ b/.github/workflows/check-version-change.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   check-version-change:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,14 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      release: ${{ steps.release.outputs.release }}
     steps:
     - uses: actions/checkout@v6
       with:
         lfs: false
+    - name: Detect release PR
+      id: release
+      uses: ./.github/actions/detect-release-pr
     - uses: dorny/paths-filter@v3
       id: filter
       with:
@@ -64,6 +68,7 @@ jobs:
         needs.detect-changes.result != 'success'
         || needs.detect-changes.outputs.code == 'true'
         || startsWith(github.ref, 'refs/tags/')
+        || needs.detect-changes.outputs.release == 'true'
       )
     runs-on: ubuntu-latest
     steps:
@@ -130,8 +135,10 @@ jobs:
         fi
         echo "BASE_REF=$BASE_REF" >> $GITHUB_ENV
     - name: Check BUILD files
+      env:
+        IS_RELEASE_PR: ${{ needs.detect-changes.outputs.release }}
       run: |
-        if [ "$GITHUB_EVENT_NAME" == "push" ] && [[ "$GITHUB_REF" == refs/tags/* ]]; then
+        if [[ "$GITHUB_REF" == refs/tags/* || "$IS_RELEASE_PR" == "true" ]]; then
           pants tailor --check update-build-files --check '::'
         else
           pants tailor --check update-build-files --check --changed-since=$BASE_REF
@@ -162,6 +169,7 @@ jobs:
         needs.detect-changes.result != 'success'
         || needs.detect-changes.outputs.code == 'true'
         || startsWith(github.ref, 'refs/tags/')
+        || needs.detect-changes.outputs.release == 'true'
       )
     runs-on: ubuntu-latest
     steps:
@@ -270,27 +278,38 @@ jobs:
         filters: |
           models:
             - 'src/ai/backend/manager/models/**'
+    - name: Detect release PR
+      uses: ./.github/actions/detect-release-pr
+    - name: Decide whether to run the migration check
+      env:
+        MODELS_CHANGED: ${{ steps.filter.outputs.models }}
+      run: |
+        if [[ "$MODELS_CHANGED" == "true" || "$GITHUB_REF" == refs/tags/* || "$IS_RELEASE_PR" == "true" ]]; then
+          echo "RUN_ALEMBIC_CHECK=true" >> "$GITHUB_ENV"
+        else
+          echo "RUN_ALEMBIC_CHECK=false" >> "$GITHUB_ENV"
+        fi
     - name: Skip if no model changes
-      if: steps.filter.outputs.models != 'true' && !startsWith(github.ref, 'refs/tags/')
+      if: env.RUN_ALEMBIC_CHECK != 'true'
       run: |
         echo "No alembic-related changes detected, skipping."
         exit 0
     - name: Parse versions from config
-      if: steps.filter.outputs.models == 'true' || startsWith(github.ref, 'refs/tags/')
+      if: env.RUN_ALEMBIC_CHECK == 'true'
       run: |
         PYTHON_VERSION=$(grep -m 1 -oP '(?<=CPython==)([^"]+)' pants.toml)
         echo "PANTS_CONFIG_FILES=pants.ci.toml" >> $GITHUB_ENV
         echo "PROJECT_PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_ENV
     - name: Set up Python as Runtime
-      if: steps.filter.outputs.models == 'true' || startsWith(github.ref, 'refs/tags/')
+      if: env.RUN_ALEMBIC_CHECK == 'true'
       uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PROJECT_PYTHON_VERSION }}
     - name: Check for multiple heads
-      if: steps.filter.outputs.models == 'true' || startsWith(github.ref, 'refs/tags/')
+      if: env.RUN_ALEMBIC_CHECK == 'true'
       run: python scripts/check-multiple-alembic-heads.py
     - name: Set up remote cache backend (if applicable)
-      if: (steps.filter.outputs.models == 'true' || startsWith(github.ref, 'refs/tags/')) && env.REMOTE_CACHE_BACKEND_ENDPOINT != ''
+      if: env.RUN_ALEMBIC_CHECK == 'true' && env.REMOTE_CACHE_BACKEND_ENDPOINT != ''
       run: |
         echo "PANTS_REMOTE_STORE_ADDRESS=${REMOTE_CACHE_BACKEND_ENDPOINT}" >> $GITHUB_ENV
         echo "PANTS_REMOTE_CACHE_READ=true" >> $GITHUB_ENV
@@ -299,7 +318,7 @@ jobs:
       env:
         REMOTE_CACHE_BACKEND_ENDPOINT: ${{ secrets.PANTS_REMOTE_CACHE_ENDPOINT_ARC }}
     - name: Bootstrap Pants
-      if: steps.filter.outputs.models == 'true' || startsWith(github.ref, 'refs/tags/')
+      if: env.RUN_ALEMBIC_CHECK == 'true'
       uses: pantsbuild/actions/init-pants@v11
       with:
         gha-cache-key: v1
@@ -310,26 +329,26 @@ jobs:
         # export jobs (build-scies/wheels/supergraph) already disable it.
         cache-lmdb-store: 'false'
     - name: Prepare DB
-      if: steps.filter.outputs.models == 'true' || startsWith(github.ref, 'refs/tags/')
+      if: env.RUN_ALEMBIC_CHECK == 'true'
       run: docker compose -f docker-compose.halfstack-main.yml up -d backendai-half-db --wait
     - name: Pants export
-      if: steps.filter.outputs.models == 'true' || startsWith(github.ref, 'refs/tags/')
+      if: env.RUN_ALEMBIC_CHECK == 'true'
       run: pants export --resolve=python-default
     - name: Prepare the alembic configuration file
-      if: steps.filter.outputs.models == 'true' || startsWith(github.ref, 'refs/tags/')
+      if: env.RUN_ALEMBIC_CHECK == 'true'
       run: cp configs/manager/halfstack.alembic.ini alembic.ini
     - name: Prepare database schema
-      if: steps.filter.outputs.models == 'true' || startsWith(github.ref, 'refs/tags/')
+      if: env.RUN_ALEMBIC_CHECK == 'true'
       run: ./backend.ai mgr schema oneshot
     - name: Try creating alembic migration
-      if: steps.filter.outputs.models == 'true' || startsWith(github.ref, 'refs/tags/')
+      if: env.RUN_ALEMBIC_CHECK == 'true'
       id: create-revision
       run: |
         output=$(./py -m alembic revision --autogenerate)
         revision_file=$(echo "$output" | grep -oP '(?<=Generating ).*\.py')
         echo "REVISION_FILE=$revision_file" >> $GITHUB_OUTPUT
     - name: Verify that revision is empty
-      if: steps.filter.outputs.models == 'true' || startsWith(github.ref, 'refs/tags/')
+      if: env.RUN_ALEMBIC_CHECK == 'true'
       run: python scripts/check-alembic-revision.py ${{ steps.create-revision.outputs.REVISION_FILE }}
 
 
@@ -343,8 +362,9 @@ jobs:
         needs.detect-changes.result != 'success'
         || needs.detect-changes.outputs.code == 'true'
         || startsWith(github.ref, 'refs/tags/')
+        || needs.detect-changes.outputs.release == 'true'
       )
-    runs-on: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
+    runs-on: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || needs.detect-changes.outputs.release == 'true') && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -389,8 +409,10 @@ jobs:
         cache-lmdb-store: 'true'
     - name: Test
       timeout-minutes: 60
+      env:
+        IS_RELEASE_PR: ${{ needs.detect-changes.outputs.release }}
       run: |
-        if [ "$GITHUB_EVENT_NAME" == "push" ] && [[ "$GITHUB_REF" == refs/tags/* ]]; then
+        if [[ "$GITHUB_REF" == refs/tags/* || "$IS_RELEASE_PR" == "true" ]]; then
           pants test --shard='${{ matrix.shard }}' \
             tests/unit/:: -- -v
         else
@@ -422,8 +444,9 @@ jobs:
         needs.detect-changes.result != 'success'
         || needs.detect-changes.outputs.code == 'true'
         || startsWith(github.ref, 'refs/tags/')
+        || needs.detect-changes.outputs.release == 'true'
       )
-    runs-on: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
+    runs-on: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || needs.detect-changes.outputs.release == 'true') && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -468,12 +491,14 @@ jobs:
         cache-lmdb-store: 'true'
     - name: Test
       timeout-minutes: 60
+      env:
+        IS_RELEASE_PR: ${{ needs.detect-changes.outputs.release }}
       run: |
         # configure redis sentinel cluster hostnames for testing
         grep -q "127.0.0.1 node01" /etc/hosts || echo "127.0.0.1 node01" | sudo tee -a /etc/hosts
         grep -q "127.0.0.1 node02" /etc/hosts || echo "127.0.0.1 node02" | sudo tee -a /etc/hosts
         grep -q "127.0.0.1 node03" /etc/hosts || echo "127.0.0.1 node03" | sudo tee -a /etc/hosts
-        if [ "$GITHUB_EVENT_NAME" == "push" ] && [[ "$GITHUB_REF" == refs/tags/* ]]; then
+        if [[ "$GITHUB_REF" == refs/tags/* || "$IS_RELEASE_PR" == "true" ]]; then
           pants test --shard='${{ matrix.shard }}' \
             tests/component/:: -- -v
         else
@@ -505,8 +530,9 @@ jobs:
         needs.detect-changes.result != 'success'
         || needs.detect-changes.outputs.code == 'true'
         || startsWith(github.ref, 'refs/tags/')
+        || needs.detect-changes.outputs.release == 'true'
       )
-    runs-on: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
+    runs-on: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || needs.detect-changes.outputs.release == 'true') && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -551,13 +577,15 @@ jobs:
         cache-lmdb-store: 'true'
     - name: Test
       timeout-minutes: 60
+      env:
+        IS_RELEASE_PR: ${{ needs.detect-changes.outputs.release }}
       run: |
         # configure redis sentinel cluster hostnames for testing
         grep -q "127.0.0.1 node01" /etc/hosts || echo "127.0.0.1 node01" | sudo tee -a /etc/hosts
         grep -q "127.0.0.1 node02" /etc/hosts || echo "127.0.0.1 node02" | sudo tee -a /etc/hosts
         grep -q "127.0.0.1 node03" /etc/hosts || echo "127.0.0.1 node03" | sudo tee -a /etc/hosts
         # Release: run full integration suite; PR/push: only directly changed integration tests
-        if [ "$GITHUB_EVENT_NAME" == "push" ] && [[ "$GITHUB_REF" == refs/tags/* ]]; then
+        if [[ "$GITHUB_REF" == refs/tags/* || "$IS_RELEASE_PR" == "true" ]]; then
           pants test --shard='${{ matrix.shard }}' \
             tests/integration/:: -- -v
         else

--- a/.github/workflows/pr-prefix.yml
+++ b/.github/workflows/pr-prefix.yml
@@ -8,11 +8,18 @@ jobs:
   check-pr-prefix:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out the revision
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+      - name: Extract PR title prefix
+        id: title
+        uses: ./.github/actions/pr-title-prefix
       - name: Check PR title prefix
         env:
-          TITLE: ${{ github.event.pull_request.title }}
+          PREFIX: ${{ steps.title.outputs.prefix }}
         run: |
-          if echo "$TITLE" | tr ':' '\n' | head -n 1 | grep -qE '^(feat|fix|docs?|refactor|ci|chore|release|test|deps)(\([^)]+\))?$';
+          if echo "$PREFIX" | grep -qE '^(feat|fix|docs?|refactor|ci|chore|release|test|deps)$';
           then
             echo "PR title is valid."
           else

--- a/.github/workflows/pr-prefix.yml
+++ b/.github/workflows/pr-prefix.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   check-pr-prefix:
     runs-on: ubuntu-latest

--- a/changes/13036.misc.md
+++ b/changes/13036.misc.md
@@ -1,0 +1,1 @@
+Run the full CI test suite on release PRs (detected by the `release:` PR title prefix) so that release-blocking failures surface before the tag-push release CI, and warn when the `VERSION` file is modified in a non-release PR


### PR DESCRIPTION
## Summary
- Detect release PRs by the PR title prefix (the same convention `check-pr-title-prefix` enforces) and run the full CI suite on them — full `tailor` check, full unit/component/integration test suites, and the full alembic migration check — on 8-core runners, so release-blocking failures surface before the tag-push CI instead of forcing a redo of the release PR.
- Extract PR title parsing into a `pr-title-prefix` composite action (single source of parsing) with a `detect-release-pr` composite action layered on top; `pr-prefix.yml` validation is rewired onto the same action with equivalent behavior.
- Add a non-required `check-version-change` workflow that fails when the `VERSION` file is modified in a PR whose title lacks the `release` prefix, guiding the author to retitle and re-trigger CI.

Resolves BA-6967

🤖 Generated with [Claude Code](https://claude.com/claude-code)