### PR TITLE
feat(BA-6971): add idle check assignment sync source

### DIFF
--- a/changes/13038.feature.md
+++ b/changes/13038.feature.md
@@ -1,1 +1,1 @@
-Add idle-check assignment synchronization source and lifecycle phases.
+Add idle-check assignment synchronization source.

--- a/changes/13038.feature.md
+++ b/changes/13038.feature.md
@@ -1,0 +1,1 @@
+Add idle-check assignment synchronization source and lifecycle phases.

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -32,8 +32,8 @@ from ai.backend.manager.repositories.idle_checker.types import (
     IdleCheckAssignmentData,
     IdleCheckBatchData,
     IdleCheckerDefinitionData,
+    SessionIdleCheckAssignmentData,
     SessionIdleCheckPair,
-    SessionIdleCheckPairBatchData,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider
 
@@ -121,10 +121,10 @@ class IdleCheckerDBSource:
             )
         return ExpiredIdleCheckBatchData(checks=tuple(checks), now=now)
 
-    async def fetch_desired_session_idle_check_pairs(
+    async def fetch_session_idle_check_assignments(
         self,
         session_statuses: Collection[SessionStatus],
-    ) -> list[SessionIdleCheckPair]:
+    ) -> SessionIdleCheckAssignmentData:
         scope_matches = sa.or_(
             sa.and_(
                 IdleCheckerBindingRow.scope_type == ScopeType.RESOURCE_GROUP.value,
@@ -139,7 +139,7 @@ class IdleCheckerDBSource:
                 IdleCheckerBindingRow.scope_id == SessionRow.domain_id,
             ),
         )
-        query = (
+        desired_query = (
             sa.select(
                 SessionRow.id,
                 IdleCheckerBindingRow.idle_checker_id,
@@ -160,22 +160,7 @@ class IdleCheckerDBSource:
             )
             .distinct()
         )
-        querier = BatchQuerier(pagination=NoPagination())
-        async with self._ops.read_ops() as r:
-            rows = (await r.batch_query_in_global(query, querier)).rows
-        return [
-            SessionIdleCheckPair(
-                session_id=SessionId(row.id),
-                checker_id=cast(IdleCheckerID, row.idle_checker_id),
-            )
-            for row in rows
-        ]
-
-    async def fetch_current_session_idle_checks(
-        self,
-        session_statuses: Collection[SessionStatus],
-    ) -> SessionIdleCheckPairBatchData:
-        query = (
+        current_query = (
             sa.select(
                 SessionIdleCheckRow.session_id,
                 SessionIdleCheckRow.idle_checker_id,
@@ -186,14 +171,22 @@ class IdleCheckerDBSource:
         querier = BatchQuerier(pagination=NoPagination())
         async with self._ops.read_ops() as r:
             now = await r.current_time()
-            rows = (await r.batch_query_in_global(query, querier)).rows
-        return SessionIdleCheckPairBatchData(
-            pairs=tuple(
+            desired_rows = (await r.batch_query_in_global(desired_query, querier)).rows
+            current_rows = (await r.batch_query_in_global(current_query, querier)).rows
+        return SessionIdleCheckAssignmentData(
+            desired_pairs=tuple(
+                SessionIdleCheckPair(
+                    session_id=SessionId(row.id),
+                    checker_id=cast(IdleCheckerID, row.idle_checker_id),
+                )
+                for row in desired_rows
+            ),
+            current_pairs=tuple(
                 SessionIdleCheckPair(
                     session_id=SessionId(row.session_id),
                     checker_id=cast(IdleCheckerID, row.idle_checker_id),
                 )
-                for row in rows
+                for row in current_rows
             ),
             now=now,
         )

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -12,12 +12,14 @@ from ai.backend.common.data.idle_checker.types import (
     IdleCheckerSpec,
     IdleCheckPhase,
 )
+from ai.backend.common.data.permission.types import ScopeType
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.data.idle_checker.types import IdleCheckSession
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.models.idle_checker.conditions import SessionIdleCheckConditions
 from ai.backend.manager.models.idle_checker.row import (
+    IdleCheckerBindingRow,
     IdleCheckerRow,
     SessionIdleCheckRow,
 )
@@ -30,6 +32,8 @@ from ai.backend.manager.repositories.idle_checker.types import (
     IdleCheckAssignmentData,
     IdleCheckBatchData,
     IdleCheckerDefinitionData,
+    SessionIdleCheckPair,
+    SessionIdleCheckPairBatchData,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider
 
@@ -116,3 +120,73 @@ class IdleCheckerDBSource:
                 )
             )
         return ExpiredIdleCheckBatchData(checks=tuple(checks), now=now)
+
+    async def fetch_desired_session_idle_check_pairs(
+        self,
+        session_statuses: Collection[SessionStatus],
+    ) -> list[SessionIdleCheckPair]:
+        scope_matches = sa.or_(
+            sa.and_(
+                IdleCheckerBindingRow.scope_type == ScopeType.RESOURCE_GROUP.value,
+                IdleCheckerBindingRow.scope_id == SessionRow.resource_group_id,
+            ),
+            sa.and_(
+                IdleCheckerBindingRow.scope_type == ScopeType.PROJECT.value,
+                IdleCheckerBindingRow.scope_id == SessionRow.group_id,
+            ),
+            sa.and_(
+                IdleCheckerBindingRow.scope_type == ScopeType.DOMAIN.value,
+                IdleCheckerBindingRow.scope_id == SessionRow.domain_id,
+            ),
+        )
+        query = (
+            sa.select(
+                SessionRow.id,
+                IdleCheckerBindingRow.idle_checker_id,
+            )
+            .select_from(SessionRow)
+            .join(IdleCheckerBindingRow, scope_matches)
+            .join(
+                IdleCheckerRow,
+                sa.and_(
+                    IdleCheckerRow.id == IdleCheckerBindingRow.idle_checker_id,
+                    SessionRow.session_type == sa.any_(IdleCheckerRow.target_session_types),
+                ),
+            )
+            .where(
+                SessionRow.status.in_(session_statuses),
+                SessionRow.starts_at.is_not(None),
+                IdleCheckerBindingRow.enabled == sa.true(),
+            )
+            .distinct()
+        )
+        querier = BatchQuerier(pagination=NoPagination())
+        async with self._ops.read_ops() as r:
+            rows = (await r.batch_query_in_global(query, querier)).rows
+        return [
+            SessionIdleCheckPair(
+                session_id=SessionId(row.id),
+                checker_id=cast(IdleCheckerID, row.idle_checker_id),
+            )
+            for row in rows
+        ]
+
+    async def fetch_current_session_idle_checks(self) -> SessionIdleCheckPairBatchData:
+        query = sa.select(
+            SessionIdleCheckRow.session_id,
+            SessionIdleCheckRow.idle_checker_id,
+        )
+        querier = BatchQuerier(pagination=NoPagination())
+        async with self._ops.read_ops() as r:
+            now = await r.current_time()
+            rows = (await r.batch_query_in_global(query, querier)).rows
+        return SessionIdleCheckPairBatchData(
+            pairs=tuple(
+                SessionIdleCheckPair(
+                    session_id=SessionId(row.session_id),
+                    checker_id=cast(IdleCheckerID, row.idle_checker_id),
+                )
+                for row in rows
+            ),
+            now=now,
+        )

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -171,10 +171,17 @@ class IdleCheckerDBSource:
             for row in rows
         ]
 
-    async def fetch_current_session_idle_checks(self) -> SessionIdleCheckPairBatchData:
-        query = sa.select(
-            SessionIdleCheckRow.session_id,
-            SessionIdleCheckRow.idle_checker_id,
+    async def fetch_current_session_idle_checks(
+        self,
+        session_statuses: Collection[SessionStatus],
+    ) -> SessionIdleCheckPairBatchData:
+        query = (
+            sa.select(
+                SessionIdleCheckRow.session_id,
+                SessionIdleCheckRow.idle_checker_id,
+            )
+            .join(SessionRow, SessionIdleCheckRow.session_id == SessionRow.id)
+            .where(SessionRow.status.in_(session_statuses))
         )
         querier = BatchQuerier(pagination=NoPagination())
         async with self._ops.read_ops() as r:

--- a/src/ai/backend/manager/repositories/idle_checker/repository.py
+++ b/src/ai/backend/manager/repositories/idle_checker/repository.py
@@ -7,6 +7,8 @@ from ai.backend.manager.repositories.idle_checker.db_source.db_source import Idl
 from ai.backend.manager.repositories.idle_checker.types import (
     ExpiredIdleCheckBatchData,
     IdleCheckBatchData,
+    SessionIdleCheckPair,
+    SessionIdleCheckPairBatchData,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider
 
@@ -25,6 +27,15 @@ class IdleCheckerRepository:
         self, session_statuses: Collection[SessionStatus]
     ) -> IdleCheckBatchData:
         return await self._db_source.fetch_judgment_batch(session_statuses)
+
+    async def fetch_desired_session_idle_check_pairs(
+        self,
+        session_statuses: Collection[SessionStatus],
+    ) -> list[SessionIdleCheckPair]:
+        return await self._db_source.fetch_desired_session_idle_check_pairs(session_statuses)
+
+    async def fetch_current_session_idle_checks(self) -> SessionIdleCheckPairBatchData:
+        return await self._db_source.fetch_current_session_idle_checks()
 
     async def fetch_expired_idle_checks(
         self, session_statuses: Collection[SessionStatus]

--- a/src/ai/backend/manager/repositories/idle_checker/repository.py
+++ b/src/ai/backend/manager/repositories/idle_checker/repository.py
@@ -34,8 +34,11 @@ class IdleCheckerRepository:
     ) -> list[SessionIdleCheckPair]:
         return await self._db_source.fetch_desired_session_idle_check_pairs(session_statuses)
 
-    async def fetch_current_session_idle_checks(self) -> SessionIdleCheckPairBatchData:
-        return await self._db_source.fetch_current_session_idle_checks()
+    async def fetch_current_session_idle_checks(
+        self,
+        session_statuses: Collection[SessionStatus],
+    ) -> SessionIdleCheckPairBatchData:
+        return await self._db_source.fetch_current_session_idle_checks(session_statuses)
 
     async def fetch_expired_idle_checks(
         self, session_statuses: Collection[SessionStatus]

--- a/src/ai/backend/manager/repositories/idle_checker/repository.py
+++ b/src/ai/backend/manager/repositories/idle_checker/repository.py
@@ -7,8 +7,7 @@ from ai.backend.manager.repositories.idle_checker.db_source.db_source import Idl
 from ai.backend.manager.repositories.idle_checker.types import (
     ExpiredIdleCheckBatchData,
     IdleCheckBatchData,
-    SessionIdleCheckPair,
-    SessionIdleCheckPairBatchData,
+    SessionIdleCheckAssignmentData,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider
 
@@ -28,17 +27,11 @@ class IdleCheckerRepository:
     ) -> IdleCheckBatchData:
         return await self._db_source.fetch_judgment_batch(session_statuses)
 
-    async def fetch_desired_session_idle_check_pairs(
+    async def fetch_session_idle_check_assignments(
         self,
         session_statuses: Collection[SessionStatus],
-    ) -> list[SessionIdleCheckPair]:
-        return await self._db_source.fetch_desired_session_idle_check_pairs(session_statuses)
-
-    async def fetch_current_session_idle_checks(
-        self,
-        session_statuses: Collection[SessionStatus],
-    ) -> SessionIdleCheckPairBatchData:
-        return await self._db_source.fetch_current_session_idle_checks(session_statuses)
+    ) -> SessionIdleCheckAssignmentData:
+        return await self._db_source.fetch_session_idle_check_assignments(session_statuses)
 
     async def fetch_expired_idle_checks(
         self, session_statuses: Collection[SessionStatus]

--- a/src/ai/backend/manager/repositories/idle_checker/types.py
+++ b/src/ai/backend/manager/repositories/idle_checker/types.py
@@ -45,7 +45,9 @@ class SessionIdleCheckPair:
 
 @dataclass(frozen=True)
 class SessionIdleCheckAssignmentData:
+    # Pairs that should exist, derived from enabled checker scope bindings.
     desired_pairs: Sequence[SessionIdleCheckPair]
+    # Existing pairs for sessions in the target statuses, excluding terminal sessions.
     current_pairs: Sequence[SessionIdleCheckPair]
     now: datetime
 

--- a/src/ai/backend/manager/repositories/idle_checker/types.py
+++ b/src/ai/backend/manager/repositories/idle_checker/types.py
@@ -44,8 +44,9 @@ class SessionIdleCheckPair:
 
 
 @dataclass(frozen=True)
-class SessionIdleCheckPairBatchData:
-    pairs: Sequence[SessionIdleCheckPair]
+class SessionIdleCheckAssignmentData:
+    desired_pairs: Sequence[SessionIdleCheckPair]
+    current_pairs: Sequence[SessionIdleCheckPair]
     now: datetime
 
 

--- a/src/ai/backend/manager/repositories/idle_checker/types.py
+++ b/src/ai/backend/manager/repositories/idle_checker/types.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 
-from ai.backend.common.data.idle_checker.types import CheckerType, IdleCheckerSpec
+from ai.backend.common.data.idle_checker.types import CheckerType, IdleCheckerSpec, IdleCheckPhase
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.data.idle_checker.types import IdleCheckSession
@@ -38,13 +38,25 @@ class IdleCheckBatchData:
 
 
 @dataclass(frozen=True)
+class SessionIdleCheckPair:
+    session_id: SessionId
+    checker_id: IdleCheckerID
+
+
+@dataclass(frozen=True)
+class SessionIdleCheckPairBatchData:
+    pairs: Sequence[SessionIdleCheckPair]
+    now: datetime
+
+
+@dataclass(frozen=True)
 class ExpiredIdleCheckData:
     """One stored judgment whose deadline has passed, kept per checker as its own reason."""
 
     session_id: SessionId
     checker_id: IdleCheckerID
     expire_at: datetime
-    last_status: str
+    last_status: IdleCheckPhase
     last_message: str
 
 

--- a/src/ai/backend/manager/sokovan/idle_check/assignment_sync/source.py
+++ b/src/ai/backend/manager/sokovan/idle_check/assignment_sync/source.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import override
+
+from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
+from ai.backend.manager.sokovan.idle_check.assignment_sync.types import (
+    IdleCheckAssignmentSyncReconcileInfo,
+)
+from ai.backend.manager.sokovan.idle_check.types import (
+    IdleCheckCategory,
+    IdleCheckTargetStatuses,
+)
+from ai.backend.manager.sokovan.reconciler.base import ReconcilerSource
+
+
+class IdleCheckAssignmentSyncSource(
+    ReconcilerSource[
+        IdleCheckAssignmentSyncReconcileInfo,
+        IdleCheckCategory,
+        IdleCheckTargetStatuses,
+    ]
+):
+    _repository: IdleCheckerRepository
+
+    def __init__(self, repository: IdleCheckerRepository) -> None:
+        self._repository = repository
+
+    @override
+    async def fetch_reconcile_info(
+        self,
+        category: IdleCheckCategory,
+        target_statuses: IdleCheckTargetStatuses,
+    ) -> IdleCheckAssignmentSyncReconcileInfo:
+        desired_pairs = await self._repository.fetch_desired_session_idle_check_pairs(
+            target_statuses.session_statuses
+        )
+        current_batch = await self._repository.fetch_current_session_idle_checks()
+        return IdleCheckAssignmentSyncReconcileInfo(
+            desired_pairs=desired_pairs,
+            current_pairs=current_batch.pairs,
+            current_time=current_batch.now,
+        )

--- a/src/ai/backend/manager/sokovan/idle_check/assignment_sync/source.py
+++ b/src/ai/backend/manager/sokovan/idle_check/assignment_sync/source.py
@@ -31,14 +31,11 @@ class IdleCheckAssignmentSyncSource(
         category: IdleCheckCategory,
         target_statuses: IdleCheckTargetStatuses,
     ) -> IdleCheckAssignmentSyncReconcileInfo:
-        desired_pairs = await self._repository.fetch_desired_session_idle_check_pairs(
-            target_statuses.session_statuses
-        )
-        current_batch = await self._repository.fetch_current_session_idle_checks(
+        assignments = await self._repository.fetch_session_idle_check_assignments(
             target_statuses.session_statuses
         )
         return IdleCheckAssignmentSyncReconcileInfo(
-            desired_pairs=desired_pairs,
-            current_pairs=current_batch.pairs,
-            current_time=current_batch.now,
+            desired_pairs=assignments.desired_pairs,
+            current_pairs=assignments.current_pairs,
+            current_time=assignments.now,
         )

--- a/src/ai/backend/manager/sokovan/idle_check/assignment_sync/source.py
+++ b/src/ai/backend/manager/sokovan/idle_check/assignment_sync/source.py
@@ -34,7 +34,9 @@ class IdleCheckAssignmentSyncSource(
         desired_pairs = await self._repository.fetch_desired_session_idle_check_pairs(
             target_statuses.session_statuses
         )
-        current_batch = await self._repository.fetch_current_session_idle_checks()
+        current_batch = await self._repository.fetch_current_session_idle_checks(
+            target_statuses.session_statuses
+        )
         return IdleCheckAssignmentSyncReconcileInfo(
             desired_pairs=desired_pairs,
             current_pairs=current_batch.pairs,

--- a/src/ai/backend/manager/sokovan/idle_check/assignment_sync/types.py
+++ b/src/ai/backend/manager/sokovan/idle_check/assignment_sync/types.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import override
+from uuid import UUID
+
+from ai.backend.manager.repositories.idle_checker.types import SessionIdleCheckPair
+from ai.backend.manager.sokovan.reconciler.base import BaseReconcilerInfo
+
+
+@dataclass
+class IdleCheckAssignmentSyncReconcileInfo(BaseReconcilerInfo):
+    desired_pairs: Sequence[SessionIdleCheckPair]
+    current_pairs: Sequence[SessionIdleCheckPair]
+    current_time: datetime
+
+    @override
+    def entity_ids(self) -> Sequence[UUID]:
+        all_pairs = (*self.desired_pairs, *self.current_pairs)
+        session_ids = (pair.session_id for pair in all_pairs)
+        return list(dict.fromkeys(session_ids))
+
+    @override
+    def now(self) -> datetime:
+        return self.current_time

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -13,6 +13,7 @@ from ai.backend.common.data.idle_checker.types import (
     IdleCheckPhase,
     SessionLifetimeSpec,
 )
+from ai.backend.common.data.permission.types import ScopeType
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
@@ -27,6 +28,7 @@ from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.idle_checker.row import (
+    IdleCheckerBindingRow,
     IdleCheckerRow,
     SessionIdleCheckRow,
 )
@@ -185,6 +187,7 @@ class TestFetchJudgmentBatch:
                 ScalingGroupRow,
                 SessionRow,
                 IdleCheckerRow,
+                IdleCheckerBindingRow,
                 SessionIdleCheckRow,
             ],
         ):
@@ -229,6 +232,14 @@ class TestFetchJudgmentBatch:
                 db_sess.add(_expired_check_session_row(scope, session_id, status))
             db_sess.add(_expired_check_checker_row(checker_id))
             await db_sess.flush()
+            db_sess.add(
+                IdleCheckerBindingRow(
+                    scope_type=ScopeType.DOMAIN.value,
+                    scope_id=scope.domain_id,
+                    idle_checker_id=checker_id,
+                    enabled=True,
+                )
+            )
             for session_id, phase in check_specs:
                 db_sess.add(
                     SessionIdleCheckRow(
@@ -295,6 +306,34 @@ class TestFetchJudgmentBatch:
 
         session_ids = {assignment.session.session_id for assignment in batch.assignments}
         assert judgment_rows.terminated_session_id not in session_ids
+
+    async def test_fetches_desired_and_current_assignment_pairs(
+        self,
+        repository: IdleCheckerRepository,
+        judgment_rows: JudgmentRows,
+    ) -> None:
+        assignments = await repository.fetch_session_idle_check_assignments([SessionStatus.RUNNING])
+
+        assert set(assignments.desired_pairs) == {
+            SessionIdleCheckPair(session_id, judgment_rows.checker_id)
+            for session_id in (
+                judgment_rows.active_session_id,
+                judgment_rows.idle_session_id,
+                judgment_rows.not_checked_session_id,
+                judgment_rows.idle_expired_session_id,
+                judgment_rows.session_without_row_id,
+            )
+        }
+        assert set(assignments.current_pairs) == {
+            SessionIdleCheckPair(session_id, judgment_rows.checker_id)
+            for session_id in (
+                judgment_rows.active_session_id,
+                judgment_rows.idle_session_id,
+                judgment_rows.not_checked_session_id,
+                judgment_rows.idle_expired_session_id,
+            )
+        }
+        assert assignments.now.tzinfo is not None
 
 
 class TestFetchExpiredIdleChecks:
@@ -468,26 +507,3 @@ class TestFetchExpiredIdleChecks:
         assert check_session_ids == {expired_check_session.session_id}
         for check in batch.checks:
             assert check.expire_at <= batch.now
-
-    async def test_fetches_current_pairs_only_for_target_session_statuses(
-        self,
-        repository: IdleCheckerRepository,
-        expired_check_session: ExpiredCheckSessionData,
-        terminated_session_with_expired_check: SessionId,
-    ) -> None:
-        batch = await repository.fetch_current_session_idle_checks([SessionStatus.RUNNING])
-
-        assert set(batch.pairs) == {
-            SessionIdleCheckPair(
-                expired_check_session.session_id,
-                expired_check_session.first_checker_id,
-            ),
-            SessionIdleCheckPair(
-                expired_check_session.session_id,
-                expired_check_session.second_checker_id,
-            ),
-        }
-        assert terminated_session_with_expired_check not in {
-            pair.session_id for pair in batch.pairs
-        }
-        assert batch.now.tzinfo is not None

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -35,6 +35,7 @@ from ai.backend.manager.models.scaling_group import ScalingGroupRow
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
+from ai.backend.manager.repositories.idle_checker.types import SessionIdleCheckPair
 from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.testutils.db import with_tables
 
@@ -467,3 +468,26 @@ class TestFetchExpiredIdleChecks:
         assert check_session_ids == {expired_check_session.session_id}
         for check in batch.checks:
             assert check.expire_at <= batch.now
+
+    async def test_fetches_current_pairs_only_for_target_session_statuses(
+        self,
+        repository: IdleCheckerRepository,
+        expired_check_session: ExpiredCheckSessionData,
+        terminated_session_with_expired_check: SessionId,
+    ) -> None:
+        batch = await repository.fetch_current_session_idle_checks([SessionStatus.RUNNING])
+
+        assert set(batch.pairs) == {
+            SessionIdleCheckPair(
+                expired_check_session.session_id,
+                expired_check_session.first_checker_id,
+            ),
+            SessionIdleCheckPair(
+                expired_check_session.session_id,
+                expired_check_session.second_checker_id,
+            ),
+        }
+        assert terminated_session_with_expired_check not in {
+            pair.session_id for pair in batch.pairs
+        }
+        assert batch.now.tzinfo is not None

--- a/tests/unit/manager/sokovan/idle_check/test_source.py
+++ b/tests/unit/manager/sokovan/idle_check/test_source.py
@@ -104,4 +104,6 @@ class TestIdleCheckAssignmentSyncSource:
         case.repository.fetch_desired_session_idle_check_pairs.assert_awaited_once_with(
             case.target_statuses.session_statuses
         )
-        case.repository.fetch_current_session_idle_checks.assert_awaited_once_with()
+        case.repository.fetch_current_session_idle_checks.assert_awaited_once_with(
+            case.target_statuses.session_statuses
+        )

--- a/tests/unit/manager/sokovan/idle_check/test_source.py
+++ b/tests/unit/manager/sokovan/idle_check/test_source.py
@@ -11,8 +11,8 @@ from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.repositories.idle_checker.types import (
+    SessionIdleCheckAssignmentData,
     SessionIdleCheckPair,
-    SessionIdleCheckPairBatchData,
 )
 from ai.backend.manager.sokovan.idle_check.assignment_sync.source import (
     IdleCheckAssignmentSyncSource,
@@ -63,13 +63,13 @@ class TestIdleCheckAssignmentSyncSource:
             SessionIdleCheckPair(session_id, second_checker_id),
         ]
         now = datetime(2026, 7, 22, tzinfo=UTC)
-        current_batch = SessionIdleCheckPairBatchData(
-            pairs=(existing_pair,),
+        assignments = SessionIdleCheckAssignmentData(
+            desired_pairs=desired_pairs,
+            current_pairs=(existing_pair,),
             now=now,
         )
         repository = MagicMock()
-        repository.fetch_desired_session_idle_check_pairs = AsyncMock(return_value=desired_pairs)
-        repository.fetch_current_session_idle_checks = AsyncMock(return_value=current_batch)
+        repository.fetch_session_idle_check_assignments = AsyncMock(return_value=assignments)
         target_statuses = IdleCheckTargetStatuses(
             session_statuses=frozenset({SessionStatus.RUNNING})
         )
@@ -101,9 +101,6 @@ class TestIdleCheckAssignmentSyncSource:
         ]
         assert reconcile_info.current_pairs == (case.existing_pair,)
         assert reconcile_info.now() == case.now
-        case.repository.fetch_desired_session_idle_check_pairs.assert_awaited_once_with(
-            case.target_statuses.session_statuses
-        )
-        case.repository.fetch_current_session_idle_checks.assert_awaited_once_with(
+        case.repository.fetch_session_idle_check_assignments.assert_awaited_once_with(
             case.target_statuses.session_statuses
         )

--- a/tests/unit/manager/sokovan/idle_check/test_source.py
+++ b/tests/unit/manager/sokovan/idle_check/test_source.py
@@ -1,11 +1,36 @@
 from __future__ import annotations
 
-from datetime import UTC
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
 
+import pytest
+
+from ai.backend.common.identifier.idle_checker import IdleCheckerID
+from ai.backend.common.types import SessionId
 from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.repositories.idle_checker.types import (
+    SessionIdleCheckPair,
+    SessionIdleCheckPairBatchData,
+)
+from ai.backend.manager.sokovan.idle_check.assignment_sync.source import (
+    IdleCheckAssignmentSyncSource,
+)
 from ai.backend.manager.sokovan.idle_check.source import IdleCheckSource
 from ai.backend.manager.sokovan.idle_check.types import IdleCheckCategory, IdleCheckTargetStatuses
+
+
+@dataclass(frozen=True)
+class AssignmentSyncSourceCase:
+    source: IdleCheckAssignmentSyncSource
+    repository: MagicMock
+    target_statuses: IdleCheckTargetStatuses
+    session_id: SessionId
+    first_checker_id: IdleCheckerID
+    second_checker_id: IdleCheckerID
+    existing_pair: SessionIdleCheckPair
+    now: datetime
 
 
 class TestIdleCheckSource:
@@ -24,3 +49,59 @@ class TestIdleCheckSource:
         assert reconcile_info.batch is batch
         repository.fetch_judgment_batch.assert_awaited_once_with(target_statuses.session_statuses)
         assert reconcile_info.current_time.tzinfo == UTC
+
+
+class TestIdleCheckAssignmentSyncSource:
+    @pytest.fixture
+    def assignment_sync_source_case(self) -> AssignmentSyncSourceCase:
+        session_id = SessionId(uuid4())
+        first_checker_id = IdleCheckerID(uuid4())
+        second_checker_id = IdleCheckerID(uuid4())
+        existing_pair = SessionIdleCheckPair(SessionId(uuid4()), IdleCheckerID(uuid4()))
+        desired_pairs = [
+            SessionIdleCheckPair(session_id, first_checker_id),
+            SessionIdleCheckPair(session_id, second_checker_id),
+        ]
+        now = datetime(2026, 7, 22, tzinfo=UTC)
+        current_batch = SessionIdleCheckPairBatchData(
+            pairs=(existing_pair,),
+            now=now,
+        )
+        repository = MagicMock()
+        repository.fetch_desired_session_idle_check_pairs = AsyncMock(return_value=desired_pairs)
+        repository.fetch_current_session_idle_checks = AsyncMock(return_value=current_batch)
+        target_statuses = IdleCheckTargetStatuses(
+            session_statuses=frozenset({SessionStatus.RUNNING})
+        )
+        return AssignmentSyncSourceCase(
+            source=IdleCheckAssignmentSyncSource(repository),
+            repository=repository,
+            target_statuses=target_statuses,
+            session_id=session_id,
+            first_checker_id=first_checker_id,
+            second_checker_id=second_checker_id,
+            existing_pair=existing_pair,
+            now=now,
+        )
+
+    async def test_returns_desired_and_current_pairs(
+        self,
+        assignment_sync_source_case: AssignmentSyncSourceCase,
+    ) -> None:
+        case = assignment_sync_source_case
+
+        reconcile_info = await case.source.fetch_reconcile_info(
+            IdleCheckCategory.IDLE,
+            case.target_statuses,
+        )
+
+        assert reconcile_info.desired_pairs == [
+            SessionIdleCheckPair(case.session_id, case.first_checker_id),
+            SessionIdleCheckPair(case.session_id, case.second_checker_id),
+        ]
+        assert reconcile_info.current_pairs == (case.existing_pair,)
+        assert reconcile_info.now() == case.now
+        case.repository.fetch_desired_session_idle_check_pairs.assert_awaited_once_with(
+            case.target_statuses.session_statuses
+        )
+        case.repository.fetch_current_session_idle_checks.assert_awaited_once_with()

--- a/tests/unit/manager/sokovan/idle_check/test_stage.py
+++ b/tests/unit/manager/sokovan/idle_check/test_stage.py
@@ -11,6 +11,7 @@ from pytest_mock import MockerFixture
 from ai.backend.common.data.idle_checker.types import (
     CheckerType,
     IdleCheckerSpec,
+    IdleCheckPhase,
     SessionLifetimeSpec,
 )
 from ai.backend.common.events.event_types.kernel.types import KernelLifecycleEventReason
@@ -124,7 +125,7 @@ class TestBuildIdleCheckSweepStage:
                     session_id=session_id,
                     checker_id=IdleCheckerID(uuid4()),
                     expire_at=now,
-                    last_status="expired",
+                    last_status=IdleCheckPhase.IDLE_EXPIRED,
                     last_message="maximum lifetime exceeded",
                 ),
             ),

--- a/tests/unit/manager/sokovan/idle_check/test_sweep_handler.py
+++ b/tests/unit/manager/sokovan/idle_check/test_sweep_handler.py
@@ -7,6 +7,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
+from ai.backend.common.data.idle_checker.types import IdleCheckPhase
 from ai.backend.common.events.event_types.kernel.types import KernelLifecycleEventReason
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId
@@ -26,7 +27,7 @@ def _expired_check(
     checker_id: IdleCheckerID,
     *,
     seconds_ago: int,
-    status: str,
+    status: IdleCheckPhase,
     message: str,
 ) -> ExpiredIdleCheckData:
     return ExpiredIdleCheckData(
@@ -55,21 +56,21 @@ class TestIdleCheckSweepHandler:
             first_session_id,
             second_checker_id,
             seconds_ago=10,
-            status="expired",
+            status=IdleCheckPhase.IDLE_EXPIRED,
             message="network timeout",
         )
         second_check = _expired_check(
             first_session_id,
             first_checker_id,
             seconds_ago=20,
-            status="expired",
+            status=IdleCheckPhase.IDLE_EXPIRED,
             message="maximum lifetime exceeded",
         )
         third_check = _expired_check(
             second_session_id,
             first_checker_id,
             seconds_ago=5,
-            status="expired",
+            status=IdleCheckPhase.IDLE_EXPIRED,
             message="maximum lifetime exceeded",
         )
         reconcile_info = IdleCheckSweepReconcileInfo(


### PR DESCRIPTION
## Summary

- Add the assignment-sync Source and repository reads for exact desired and current session-checker pairs.
- Resolve enabled resource-group, project, and domain bindings with two joins and deduplicate pairs in SQL.
- Limit current pairs to target session statuses while retaining `IDLE_EXPIRED` rows for still-running sessions.
- Keep the lifecycle phase enum and ORM mapping outside this PR.

## Test plan

- [x] `pants fmt ::`
- [x] `pants fix ::`
- [x] `pants lint --changed-since=origin/main`
- [x] Push-hook type checks and affected idle-check tests

Resolves BA-6971