### PR TITLE
feat(BA-6976): add idle check lifecycle phases

### DIFF
--- a/changes/13040.feature.md
+++ b/changes/13040.feature.md
@@ -1,0 +1,1 @@
+Add idle-check lifecycle phases.

--- a/src/ai/backend/common/data/idle_checker/types.py
+++ b/src/ai/backend/common/data/idle_checker/types.py
@@ -16,6 +16,13 @@ class CheckerType(enum.StrEnum):
     UTILIZATION = "utilization"
 
 
+class IdleCheckPhase(enum.StrEnum):
+    NOT_CHECKED = "not_checked"
+    ACTIVE = "active"
+    IDLE = "idle"
+    IDLE_EXPIRED = "idle_expired"
+
+
 class SessionLifetimeSpec(BackendAISchema):
     """Config for ``CheckerType.SESSION_LIFETIME``."""
 

--- a/src/ai/backend/manager/models/idle_checker/row.py
+++ b/src/ai/backend/manager/models/idle_checker/row.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
-from ai.backend.common.data.idle_checker.types import CheckerType, IdleCheckerSpec
+from ai.backend.common.data.idle_checker.types import CheckerType, IdleCheckerSpec, IdleCheckPhase
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.models.base import GUID, Base, PydanticColumn, StrEnumType
@@ -99,5 +99,7 @@ class SessionIdleCheckRow(UpdatedAtMixin, Base):  # type: ignore[misc]
     expire_at: Mapped[datetime] = mapped_column(
         "expire_at", sa.DateTime(timezone=True), nullable=False
     )
-    last_status: Mapped[str] = mapped_column("last_status", sa.String(length=64), nullable=False)
+    last_status: Mapped[IdleCheckPhase] = mapped_column(
+        "last_status", StrEnumType(IdleCheckPhase), nullable=False
+    )
     last_message: Mapped[str] = mapped_column("last_message", sa.Text, nullable=False)

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -10,6 +10,7 @@ import pytest
 from ai.backend.common.data.idle_checker.types import (
     CheckerType,
     IdleCheckerSpec,
+    IdleCheckPhase,
     NetworkTimeoutSpec,
     SessionLifetimeSpec,
     UtilizationSpec,
@@ -939,7 +940,7 @@ class TestFetchExpiredIdleChecks:
                     session_id=session_id,
                     idle_checker_id=first_checker_id,
                     expire_at=first_expire_at,
-                    last_status="expired",
+                    last_status=IdleCheckPhase.IDLE_EXPIRED,
                     last_message="Judged expired.",
                 )
             )
@@ -948,7 +949,7 @@ class TestFetchExpiredIdleChecks:
                     session_id=session_id,
                     idle_checker_id=second_checker_id,
                     expire_at=second_expire_at,
-                    last_status="expired",
+                    last_status=IdleCheckPhase.IDLE_EXPIRED,
                     last_message="Judged expired.",
                 )
             )
@@ -979,7 +980,7 @@ class TestFetchExpiredIdleChecks:
                     session_id=session_id,
                     idle_checker_id=checker_id,
                     expire_at=datetime(2100, 1, 1, tzinfo=UTC),
-                    last_status="active",
+                    last_status=IdleCheckPhase.ACTIVE,
                     last_message="The session is active.",
                 )
             )
@@ -1004,7 +1005,7 @@ class TestFetchExpiredIdleChecks:
                     session_id=session_id,
                     idle_checker_id=checker_id,
                     expire_at=datetime(2026, 1, 1, tzinfo=UTC),
-                    last_status="expired",
+                    last_status=IdleCheckPhase.IDLE_EXPIRED,
                     last_message="Judged expired.",
                 )
             )
@@ -1026,7 +1027,7 @@ class TestFetchExpiredIdleChecks:
             (expired_check_session.session_id, expired_check_session.first_checker_id)
         ]
         assert check.expire_at == expired_check_session.first_expire_at
-        assert check.last_status == "expired"
+        assert check.last_status == IdleCheckPhase.IDLE_EXPIRED
         assert check.last_message == "Judged expired."
 
     async def test_excludes_checks_with_future_deadline(

--- a/tests/unit/manager/repositories/idle_checker/test_row.py
+++ b/tests/unit/manager/repositories/idle_checker/test_row.py
@@ -11,6 +11,7 @@ import sqlalchemy as sa
 from ai.backend.common.data.idle_checker.types import (
     CheckerType,
     IdleCheckerSpec,
+    IdleCheckPhase,
     SessionLifetimeSpec,
 )
 from ai.backend.common.identifier.domain import DomainID
@@ -165,7 +166,7 @@ class TestSessionIdleCheckRow:
                     session_id=session_id,
                     idle_checker_id=checker_id,
                     expire_at=expire_at,
-                    last_status="active",
+                    last_status=IdleCheckPhase.ACTIVE,
                     last_message="The session is active.",
                 )
             )
@@ -184,7 +185,7 @@ class TestSessionIdleCheckRow:
 
         assert row is not None
         assert row.expire_at == datetime(2026, 1, 2, tzinfo=UTC)
-        assert row.last_status == "active"
+        assert row.last_status is IdleCheckPhase.ACTIVE
         assert row.updated_at is not None
 
     async def test_rejects_duplicate_session_checker_pair(
@@ -199,7 +200,7 @@ class TestSessionIdleCheckRow:
                         session_id=persisted_idle_check.session_id,
                         idle_checker_id=persisted_idle_check.checker_id,
                         expire_at=datetime(2026, 1, 2, tzinfo=UTC),
-                        last_status="active",
+                        last_status=IdleCheckPhase.ACTIVE,
                         last_message="The session is active.",
                     )
                 )


### PR DESCRIPTION
## Summary

- Add the four idle-check lifecycle phases as a shared string enum.
- Map `session_idle_checks.last_status` through `StrEnumType` without changing the existing database column.
- Update real database tests to verify enum persistence and loading.

## Test plan

- [x] `pants fmt ::`
- [x] `pants fix ::`
- [x] `pants lint --changed-since=origin/main`
- [x] Push-hook type checks and affected idle-check tests

Resolves BA-6976
