### PR TITLE
feat(BA-6969): add declarative conflict checks to the purger spec pattern

### DIFF
--- a/changes/13041.feature.md
+++ b/changes/13041.feature.md
@@ -1,0 +1,1 @@
+Add declarative conflict checks to the purger spec pattern, validated in a single query before deletion

--- a/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
@@ -37,10 +37,12 @@ from ai.backend.manager.models.app_config_allow_list.conditions import (
     AppConfigAllowListConditions,
 )
 from ai.backend.manager.models.app_config_allow_list.orders import AppConfigAllowListOrders
-from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.repositories.app_config_allow_list.creators import (
     AppConfigAllowListCreatorSpec,
+)
+from ai.backend.manager.repositories.app_config_allow_list.purgers import (
+    AppConfigAllowListPurgerSpec,
 )
 from ai.backend.manager.repositories.app_config_allow_list.updaters import (
     AppConfigAllowListUpdaterSpec,
@@ -177,7 +179,9 @@ class AppConfigAllowListAdapter(BaseAdapter):
     async def admin_purge(
         self, input: PurgeAppConfigAllowListInput
     ) -> PurgeAppConfigAllowListPayload:
-        purger = Purger(row_class=AppConfigAllowListRow, pk_value=AppConfigAllowListID(input.id))
+        purger = Purger(
+            spec=AppConfigAllowListPurgerSpec(allow_list_id=AppConfigAllowListID(input.id))
+        )
         action_result = await self._processors.app_config_allow_list.purge.wait_for_complete(
             PurgeAppConfigAllowListAction(purger=purger)
         )

--- a/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
@@ -30,10 +30,12 @@ from ai.backend.manager.models.app_config_definition.conditions import (
     AppConfigDefinitionConditions,
 )
 from ai.backend.manager.models.app_config_definition.orders import AppConfigDefinitionOrders
-from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.repositories.app_config_definition.creators import (
     AppConfigDefinitionCreatorSpec,
+)
+from ai.backend.manager.repositories.app_config_definition.purgers import (
+    AppConfigDefinitionPurgerSpec,
 )
 from ai.backend.manager.repositories.base import (
     Purger,
@@ -136,7 +138,9 @@ class AppConfigDefinitionAdapter(BaseAdapter):
     async def admin_purge(
         self, input: PurgeAppConfigDefinitionInput
     ) -> PurgeAppConfigDefinitionPayload:
-        purger = Purger(row_class=AppConfigDefinitionRow, pk_value=AppConfigDefinitionID(input.id))
+        purger = Purger(
+            spec=AppConfigDefinitionPurgerSpec(definition_id=AppConfigDefinitionID(input.id))
+        )
         action_result = await self._processors.app_config_definition.purge.wait_for_complete(
             PurgeAppConfigDefinitionAction(purger=purger)
         )

--- a/src/ai/backend/manager/api/adapters/container_registry/adapter.py
+++ b/src/ai/backend/manager/api/adapters/container_registry/adapter.py
@@ -45,6 +45,9 @@ from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.container_registry.creators import (
     ContainerRegistryCreatorSpec,
 )
+from ai.backend.manager.repositories.container_registry.purgers import (
+    ContainerRegistryPurgerSpec,
+)
 from ai.backend.manager.repositories.container_registry.updaters import (
     ContainerRegistryUpdaterSpec,
 )
@@ -184,8 +187,7 @@ class ContainerRegistryAdapter(BaseAdapter):
     ) -> DeleteContainerRegistryPayload:
         """Delete a container registry (superadmin only). This is a hard delete."""
         purger: Purger[ContainerRegistryRow] = Purger(
-            row_class=ContainerRegistryRow,
-            pk_value=input.id,
+            spec=ContainerRegistryPurgerSpec(registry_id=input.id)
         )
         await self._processors.container_registry.delete_container_registry.wait_for_complete(
             DeleteContainerRegistryAction(purger=purger)

--- a/src/ai/backend/manager/api/adapters/model_card/adapter.py
+++ b/src/ai/backend/manager/api/adapters/model_card/adapter.py
@@ -73,6 +73,7 @@ from ai.backend.manager.repositories.base.purger import Purger
 from ai.backend.manager.repositories.base.rbac.entity_creator import RBACEntityCreator
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.model_card.creators import ModelCardCreatorSpec
+from ai.backend.manager.repositories.model_card.purgers import ModelCardPurgerSpec
 from ai.backend.manager.repositories.model_card.types import (
     ProjectModelCardSearchScope,
     VFolderModelCardSearchScope,
@@ -419,7 +420,7 @@ class ModelCardAdapter(BaseAdapter):
     ) -> DeleteModelCardPayload:
         result = await self._processors.model_card.delete.wait_for_complete(
             DeleteModelCardAction(
-                purger=Purger(row_class=ModelCardRow, pk_value=card_id),
+                purger=Purger(spec=ModelCardPurgerSpec(card_id=card_id)),
                 options=options,
             )
         )
@@ -447,7 +448,7 @@ class ModelCardAdapter(BaseAdapter):
     ) -> BulkDeleteModelCardActionResult:
         return await self._processors.model_card.bulk_delete.wait_for_complete(
             BulkDeleteModelCardAction(
-                purgers=[Purger(row_class=ModelCardRow, pk_value=card_id) for card_id in card_ids],
+                purgers=[Purger(spec=ModelCardPurgerSpec(card_id=card_id)) for card_id in card_ids],
                 options=options,
             )
         )

--- a/src/ai/backend/manager/api/adapters/rbac/adapter.py
+++ b/src/ai/backend/manager/api/adapters/rbac/adapter.py
@@ -234,6 +234,10 @@ from ai.backend.manager.repositories.permission_controller.creators import (
     RoleCreatorSpec,
     UserRoleCreatorSpec,
 )
+from ai.backend.manager.repositories.permission_controller.purgers import (
+    PermissionPurgerSpec,
+    RolePurgerSpec,
+)
 from ai.backend.manager.repositories.permission_controller.types import ScopedRoleSearchScope
 from ai.backend.manager.repositories.permission_controller.updaters import (
     PermissionUpdaterSpec,
@@ -916,7 +920,7 @@ class RBACAdapter(BaseAdapter):
 
     async def purge(self, role_id: UUID) -> PurgeRolePayload:
         """Hard-delete a role from the database."""
-        purger: Purger[RoleRow] = Purger(row_class=RoleRow, pk_value=role_id)
+        purger: Purger[RoleRow] = Purger(spec=RolePurgerSpec(role_id=role_id))
         action_result = await self._processors.permission_controller.purge_role.wait_for_complete(
             PurgeRoleAction(purger=purger)
         )
@@ -926,7 +930,9 @@ class RBACAdapter(BaseAdapter):
 
     async def delete_permission(self, permission_id: UUID) -> DeletePermissionPayloadDTO:
         """Hard-delete a scoped permission."""
-        purger: Purger[PermissionRow] = Purger(row_class=PermissionRow, pk_value=permission_id)
+        purger: Purger[PermissionRow] = Purger(
+            spec=PermissionPurgerSpec(permission_id=permission_id)
+        )
         await self._processors.permission_controller.delete_permission.wait_for_complete(
             DeletePermissionAction(purger=purger)
         )
@@ -1088,7 +1094,7 @@ class RBACAdapter(BaseAdapter):
     ) -> BulkRemoveRolePermissionsPayload:
         """Bulk-delete permission rows by primary key."""
         purgers: list[Purger[PermissionRow]] = [
-            Purger(row_class=PermissionRow, pk_value=pid) for pid in input.permission_ids
+            Purger(spec=PermissionPurgerSpec(permission_id=pid)) for pid in input.permission_ids
         ]
         action_result = await self._processors.permission_controller.bulk_remove_role_permissions.wait_for_complete(
             BulkRemoveRolePermissionsAction(purgers=purgers)

--- a/src/ai/backend/manager/api/adapters/resource_group/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_group/adapter.py
@@ -97,6 +97,7 @@ from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.purger import Purger
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.scaling_group.creators import ScalingGroupCreatorSpec
+from ai.backend.manager.repositories.scaling_group.purgers import ScalingGroupPurgerSpec
 from ai.backend.manager.repositories.scaling_group.updaters import (
     ScalingGroupMetadataUpdaterSpec,
     ScalingGroupNetworkConfigUpdaterSpec,
@@ -658,7 +659,7 @@ class ResourceGroupAdapter(BaseAdapter):
         Returns:
             Pydantic node representing the purged resource group.
         """
-        purger = Purger(row_class=ScalingGroupRow, pk_value=name)
+        purger = Purger(spec=ScalingGroupPurgerSpec(name=name))
         action_result = await self._processors.scaling_group.purge_scaling_group.wait_for_complete(
             PurgeScalingGroupAction(purger=purger)
         )

--- a/src/ai/backend/manager/api/adapters/retention_policy/adapter.py
+++ b/src/ai/backend/manager/api/adapters/retention_policy/adapter.py
@@ -31,6 +31,7 @@ from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.purger import Purger
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.retention_policy.creators import RetentionPolicyCreatorSpec
+from ai.backend.manager.repositories.retention_policy.purgers import RetentionPolicyPurgerSpec
 from ai.backend.manager.repositories.retention_policy.updaters import RetentionPolicyUpdaterSpec
 from ai.backend.manager.services.retention_policy.actions.create import (
     CreateRetentionPolicyAction,
@@ -154,7 +155,7 @@ class RetentionPolicyAdapter(BaseAdapter):
 
     async def purge(self, policy_id: RetentionPolicyID) -> PurgeRetentionPolicyPayload:
         purger: Purger[RetentionPolicyRow] = Purger(
-            row_class=RetentionPolicyRow, pk_value=policy_id
+            spec=RetentionPolicyPurgerSpec(policy_id=policy_id)
         )
         result = await self._processors.retention_policy.purge.wait_for_complete(
             PurgeRetentionPolicyAction(id=policy_id, purger=purger)

--- a/src/ai/backend/manager/api/gql_legacy/container_registry.py
+++ b/src/ai/backend/manager/api/gql_legacy/container_registry.py
@@ -33,6 +33,9 @@ from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.purger import Purger
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.container_registry.creators import ContainerRegistryCreatorSpec
+from ai.backend.manager.repositories.container_registry.purgers import (
+    ContainerRegistryPurgerSpec,
+)
 from ai.backend.manager.repositories.container_registry.updaters import (
     ContainerRegistryUpdaterSpec,
 )
@@ -516,7 +519,7 @@ class DeleteContainerRegistryNode(graphene.Mutation):  # type: ignore[misc]
         result = (
             await ctx.processors.container_registry.delete_container_registry.wait_for_complete(
                 DeleteContainerRegistryAction(
-                    purger=Purger(row_class=ContainerRegistryRow, pk_value=reg_id)
+                    purger=Purger(spec=ContainerRegistryPurgerSpec(registry_id=reg_id))
                 )
             )
         )

--- a/src/ai/backend/manager/api/gql_legacy/container_registry_v2.py
+++ b/src/ai/backend/manager/api/gql_legacy/container_registry_v2.py
@@ -11,7 +11,6 @@ from graphql import Undefined
 from ai.backend.common.container_registry import AllowedGroupsModel
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.models.container_registry import (
-    ContainerRegistryRow,
     ContainerRegistryValidator,
     ContainerRegistryValidatorArgs,
 )
@@ -20,6 +19,9 @@ from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.purger import Purger
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.container_registry.creators import ContainerRegistryCreatorSpec
+from ai.backend.manager.repositories.container_registry.purgers import (
+    ContainerRegistryPurgerSpec,
+)
 from ai.backend.manager.repositories.container_registry.updaters import (
     ContainerRegistryUpdaterSpec,
 )
@@ -242,7 +244,7 @@ class DeleteContainerRegistryNodeV2(graphene.Mutation):  # type: ignore[misc]
         result = (
             await ctx.processors.container_registry.delete_container_registry.wait_for_complete(
                 DeleteContainerRegistryAction(
-                    purger=Purger(row_class=ContainerRegistryRow, pk_value=reg_id)
+                    purger=Purger(spec=ContainerRegistryPurgerSpec(registry_id=reg_id))
                 )
             )
         )

--- a/src/ai/backend/manager/api/gql_legacy/scaling_group.py
+++ b/src/ai/backend/manager/api/gql_legacy/scaling_group.py
@@ -48,6 +48,7 @@ from ai.backend.manager.repositories.scaling_group.creators import (
     ScalingGroupForProjectCreatorSpec,
 )
 from ai.backend.manager.repositories.scaling_group.purgers import (
+    ScalingGroupPurgerSpec,
     create_scaling_group_for_keypairs_purger,
 )
 from ai.backend.manager.repositories.scaling_group.scope_binders import (
@@ -797,7 +798,7 @@ class DeleteScalingGroup(graphene.Mutation):  # type: ignore[misc]
         graph_ctx: GraphQueryContext = info.context
 
         await graph_ctx.processors.scaling_group.purge_scaling_group.wait_for_complete(
-            PurgeScalingGroupAction(purger=Purger(row_class=ScalingGroupRow, pk_value=name))
+            PurgeScalingGroupAction(purger=Purger(spec=ScalingGroupPurgerSpec(name=name)))
         )
 
         return cls(ok=True, msg="success")

--- a/src/ai/backend/manager/api/rest/container_registry/handler.py
+++ b/src/ai/backend/manager/api/rest/container_registry/handler.py
@@ -31,12 +31,14 @@ from ai.backend.common.container_registry import (
 from ai.backend.common.dto.manager.registry.request import HarborWebhookRequestModel
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.dto.context import RequestCtx
-from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.purger import Purger
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.container_registry.creators import (
     ContainerRegistryCreatorSpec,
+)
+from ai.backend.manager.repositories.container_registry.purgers import (
+    ContainerRegistryPurgerSpec,
 )
 from ai.backend.manager.repositories.container_registry.updaters import (
     ContainerRegistryUpdaterSpec,
@@ -144,7 +146,7 @@ class ContainerRegistryHandler:
 
         await self._container_registry.delete_container_registry.wait_for_complete(
             DeleteContainerRegistryAction(
-                purger=Purger(row_class=ContainerRegistryRow, pk_value=registry_id)
+                purger=Purger(spec=ContainerRegistryPurgerSpec(registry_id=registry_id))
             )
         )
         return APIResponse.no_content(HTTPStatus.NO_CONTENT)

--- a/src/ai/backend/manager/api/rest/rbac/permission_adapter.py
+++ b/src/ai/backend/manager/api/rest/rbac/permission_adapter.py
@@ -12,11 +12,11 @@ from ai.backend.common.dto.manager.rbac import (
     PermissionDTO,
 )
 from ai.backend.manager.data.permission.permission import PermissionData
-from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 from ai.backend.manager.repositories.base import Creator, Purger
 from ai.backend.manager.repositories.permission_controller.creators import (
     PermissionCreatorSpec,
 )
+from ai.backend.manager.repositories.permission_controller.purgers import PermissionPurgerSpec
 from ai.backend.manager.services.permission_contoller.actions.permission import (
     CreatePermissionAction,
     DeletePermissionAction,
@@ -54,5 +54,5 @@ class PermissionAdapter:
     @staticmethod
     def to_delete_permission_action(permission_id: uuid.UUID) -> DeletePermissionAction:
         """Convert permission_id to DeletePermissionAction."""
-        purger = Purger(row_class=PermissionRow, pk_value=permission_id)
+        purger = Purger(spec=PermissionPurgerSpec(permission_id=permission_id))
         return DeletePermissionAction(purger=purger)

--- a/src/ai/backend/manager/api/rest/rbac/role_adapter.py
+++ b/src/ai/backend/manager/api/rest/rbac/role_adapter.py
@@ -28,6 +28,7 @@ from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.repositories.base import BatchQuerier, OffsetPagination, Purger
 from ai.backend.manager.repositories.base.filter_adapter import BaseFilterAdapter
 from ai.backend.manager.repositories.base.updater import Updater
+from ai.backend.manager.repositories.permission_controller.purgers import RolePurgerSpec
 from ai.backend.manager.repositories.permission_controller.updaters import RoleUpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -59,10 +60,7 @@ class RoleAdapter(BaseFilterAdapter):
 
     def build_purger(self, role_id: UUID) -> Purger[RoleRow]:
         """Build a purger for the given role ID."""
-        return Purger(
-            row_class=RoleRow,
-            pk_value=role_id,
-        )
+        return Purger(spec=RolePurgerSpec(role_id=role_id))
 
     def build_updater(self, request: UpdateRoleRequest, role_id: UUID) -> Updater[RoleRow]:
         """Convert update request to updater."""

--- a/src/ai/backend/manager/api/rest/vfolder/handler.py
+++ b/src/ai/backend/manager/api/rest/vfolder/handler.py
@@ -120,7 +120,6 @@ from ai.backend.manager.models.vfolder import (
     VFolderOwnershipType,
     VFolderPermission,
     VFolderPermissionSetAlias,
-    VFolderRow,
     VFolderStatusSet,
 )
 from ai.backend.manager.repositories.base.rbac.entity_purger import RBACEntityPurger
@@ -1516,11 +1515,7 @@ class VFolderHandler:
 
         await self._vfolder.purge_vfolder.wait_for_complete(
             PurgeVFolderAction(
-                purger=RBACEntityPurger(
-                    row_class=VFolderRow,
-                    pk_value=folder_id,
-                    spec=VFolderPurgerSpec(vfolder_id=folder_id),
-                ),
+                purger=RBACEntityPurger(spec=VFolderPurgerSpec(vfolder_id=folder_id)),
             )
         )
 

--- a/src/ai/backend/manager/repositories/app_config_allow_list/purgers.py
+++ b/src/ai/backend/manager/repositories/app_config_allow_list/purgers.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.identifier.app_config_allow_list import AppConfigAllowListID
+from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
+from ai.backend.manager.repositories.base.purger import PurgerSpec
+from ai.backend.manager.repositories.base.types import ConflictCheck
+
+
+@dataclass
+class AppConfigAllowListPurgerSpec(PurgerSpec[AppConfigAllowListRow]):
+    """PurgerSpec for deleting an app config allow list entry."""
+
+    allow_list_id: AppConfigAllowListID
+
+    @override
+    def row_class(self) -> type[AppConfigAllowListRow]:
+        return AppConfigAllowListRow
+
+    @override
+    def pk_value(self) -> AppConfigAllowListID:
+        return self.allow_list_id
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()

--- a/src/ai/backend/manager/repositories/app_config_definition/purgers.py
+++ b/src/ai/backend/manager/repositories/app_config_definition/purgers.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.identifier.app_config_definition import AppConfigDefinitionID
+from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
+from ai.backend.manager.repositories.base.purger import PurgerSpec
+from ai.backend.manager.repositories.base.types import ConflictCheck
+
+
+@dataclass
+class AppConfigDefinitionPurgerSpec(PurgerSpec[AppConfigDefinitionRow]):
+    """PurgerSpec for deleting an app config definition."""
+
+    definition_id: AppConfigDefinitionID
+
+    @override
+    def row_class(self) -> type[AppConfigDefinitionRow]:
+        return AppConfigDefinitionRow
+
+    @override
+    def pk_value(self) -> AppConfigDefinitionID:
+        return self.definition_id
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -112,11 +112,7 @@ class AppConfigFragmentDBSource:
 
     @app_config_fragment_db_source_resilience.apply()
     async def purge(self, purger_spec: AppConfigFragmentPurgerSpec) -> AppConfigFragmentData:
-        rbac_purger = RBACEntityPurger(
-            row_class=AppConfigFragmentRow,
-            pk_value=purger_spec.fragment_id,
-            spec=purger_spec,
-        )
+        rbac_purger = RBACEntityPurger(spec=purger_spec)
         async with self._rbac_ops_provider.write_ops() as w:
             result = await w.purge_scoped(rbac_purger)
             if result is None:
@@ -155,14 +151,7 @@ class AppConfigFragmentDBSource:
         purger_specs: Sequence[AppConfigFragmentPurgerSpec],
     ) -> AppConfigFragmentBulkResult:
         """Purge many fragments with per-item partial success, unbinding each from its scope."""
-        purgers = [
-            RBACEntityPurger(
-                row_class=AppConfigFragmentRow,
-                pk_value=spec.fragment_id,
-                spec=spec,
-            )
-            for spec in purger_specs
-        ]
+        purgers = [RBACEntityPurger(spec=spec) for spec in purger_specs]
         async with self._rbac_ops_provider.write_ops() as w:
             result = await w.bulk_purge_scoped_partial(purgers)
             succeeded = [row.to_data() for row in result.successes]

--- a/src/ai/backend/manager/repositories/app_config_fragment/purgers.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/purgers.py
@@ -2,20 +2,31 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
 from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
 from ai.backend.manager.repositories.base.rbac.entity_purger import RBACEntityPurgerSpec
+from ai.backend.manager.repositories.base.types import ConflictCheck
 
 
 @dataclass
-class AppConfigFragmentPurgerSpec(RBACEntityPurgerSpec):
+class AppConfigFragmentPurgerSpec(RBACEntityPurgerSpec[AppConfigFragmentRow]):
     """RBAC purge info for one fragment: identifies it so its scope association is cleared."""
 
     fragment_id: AppConfigFragmentID
+
+    @override
+    def row_class(self) -> type[AppConfigFragmentRow]:
+        return AppConfigFragmentRow
+
+    @override
+    def pk_value(self) -> AppConfigFragmentID:
+        return self.fragment_id
 
     @override
     def element_type(self) -> RBACElementType:
@@ -24,3 +35,7 @@ class AppConfigFragmentPurgerSpec(RBACEntityPurgerSpec):
     @override
     def entity_ref(self) -> RBACElementRef:
         return RBACElementRef(RBACElementType.APP_CONFIG_FRAGMENT, str(self.fragment_id))
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()

--- a/src/ai/backend/manager/repositories/base/purger.py
+++ b/src/ai/backend/manager/repositories/base/purger.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 from uuid import UUID
@@ -12,6 +13,7 @@ from sqlalchemy.engine import CursorResult
 
 from ai.backend.manager.errors.repository import UnsupportedCompositePrimaryKeyError
 from ai.backend.manager.models.base import Base
+from ai.backend.manager.repositories.base.types import ConflictCheck
 
 from .integrity import parse_integrity_error
 
@@ -22,21 +24,63 @@ TRow = TypeVar("TRow", bound=Base)
 
 
 # =============================================================================
+# Purge Precondition Validation
+# =============================================================================
+
+
+async def validate_conflict_checks(
+    db_sess: SASession,
+    conflict_checks: Sequence[ConflictCheck],
+) -> None:
+    """Validate conflict checks in a single query, raising the first failing check's error."""
+    if not conflict_checks:
+        return
+
+    select_clauses = [
+        sa.exists().where(check.condition()).label(f"conflict_{i}")
+        for i, check in enumerate(conflict_checks)
+    ]
+    result = await db_sess.execute(sa.select(*select_clauses))
+    row = result.mappings().one()
+
+    for i, check in enumerate(conflict_checks):
+        if row[f"conflict_{i}"]:
+            raise check.error
+
+
+# =============================================================================
 # Single-row Purger (by PK)
 # =============================================================================
 
 
+class PurgerSpec[TRow: Base](ABC):
+    """Abstract base class defining a single-row purge target."""
+
+    @abstractmethod
+    def row_class(self) -> type[TRow]:
+        """Return the ORM class for table access and PK detection."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def pk_value(self) -> UUID | str | int:
+        """Return the primary key value identifying the target row."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        """Return rows that must not exist before deletion (empty if none)."""
+        raise NotImplementedError
+
+
 @dataclass
 class Purger[TRow: Base]:
-    """Single-row delete by primary key.
+    """Bundles purger spec for single-row delete operations.
 
     Attributes:
-        row_class: ORM class for table access and PK detection.
-        pk_value: Primary key value to identify the target row.
+        spec: PurgerSpec implementation defining what to delete.
     """
 
-    row_class: type[TRow]
-    pk_value: UUID | str | int
+    spec: PurgerSpec[TRow]
 
 
 @dataclass
@@ -95,29 +139,19 @@ async def execute_purger[TRow: Base](
 ) -> PurgerResult[TRow] | None:
     """Execute DELETE for a single row by primary key.
 
-    Args:
-        db_sess: Database session (must be writable)
-        purger: Purger containing row_class and pk_value
+    The spec's ``conflict_checks`` are validated in a single query before
+    deletion.
 
     Returns:
         PurgerResult containing the deleted row, or None if no row matched
 
     Raises:
+        BackendAIError: The error declared by the first failing conflict check.
         RepositoryIntegrityError: If the DELETE violates a database constraint
-            (e.g., foreign key). This is a safety-net fallback; callers should
-            use ``existence_checks`` before invoking the purger to provide
-            user-friendly error messages.
-
-    Example:
-        purger = Purger(
-            row_class=SessionRow,
-            pk_value=session_id,
-        )
-        result = await execute_purger(db_sess, purger)
-        if result:
-            print(result.row.id)  # Deleted row
+            not covered by ``conflict_checks``.
     """
-    row_class = purger.row_class
+    spec = purger.spec
+    row_class = spec.row_class()
     table = row_class.__table__
     pk_columns = list(table.primary_key.columns)
 
@@ -126,7 +160,9 @@ async def execute_purger[TRow: Base](
             f"Purger only supports single-column primary keys (table: {table.name})",
         )
 
-    stmt = sa.delete(table).where(pk_columns[0] == purger.pk_value).returning(*table.columns)
+    await validate_conflict_checks(db_sess, spec.conflict_checks())
+
+    stmt = sa.delete(table).where(pk_columns[0] == spec.pk_value()).returning(*table.columns)
 
     try:
         result = await db_sess.execute(stmt)
@@ -166,6 +202,11 @@ class BatchPurgerSpec[TRow: Base](ABC):
                 SessionRow.status == SessionStatus.TERMINATED
             )
         """
+        raise NotImplementedError
+
+    @abstractmethod
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        """Return rows that must not exist before deletion (empty if none)."""
         raise NotImplementedError
 
 
@@ -225,9 +266,9 @@ async def execute_bulk_purger_partial[TRow: Base](
 
     Example:
         purgers = [
-            Purger(SessionRow, session_id_1),
-            Purger(SessionRow, session_id_2),
-            Purger(SessionRow, session_id_with_fk_constraint),  # Fails
+            Purger(spec=SessionPurgerSpec(session_id_1)),
+            Purger(spec=SessionPurgerSpec(session_id_2)),
+            Purger(spec=SessionPurgerSpec(session_id_with_fk_constraint)),  # Fails
         ]
         result = await execute_bulk_purger_partial(db_sess, purgers)
 
@@ -247,7 +288,8 @@ async def execute_bulk_purger_partial[TRow: Base](
         # If this row fails, only this savepoint is rolled back, not the entire session
         try:
             async with db_sess.begin_nested():
-                row_class = purger.row_class
+                spec = purger.spec
+                row_class = spec.row_class()
                 table = row_class.__table__
                 pk_columns = list(table.primary_key.columns)
 
@@ -256,9 +298,11 @@ async def execute_bulk_purger_partial[TRow: Base](
                         f"Purger only supports single-column primary keys (table: {table.name})",
                     )
 
+                await validate_conflict_checks(db_sess, spec.conflict_checks())
+
                 stmt = (
                     sa.delete(table)
-                    .where(pk_columns[0] == purger.pk_value)
+                    .where(pk_columns[0] == spec.pk_value())
                     .returning(*table.columns)
                 )
 
@@ -300,6 +344,9 @@ async def execute_batch_purger[TRow: Base](
 ) -> BatchPurgerResult:
     """Execute bulk delete with batch purger.
 
+    The spec's ``conflict_checks`` are validated in a single query before
+    deletion starts.
+
     Args:
         db_sess: Database session (must be writable)
         purger: BatchPurger containing spec and batch configuration
@@ -308,10 +355,9 @@ async def execute_batch_purger[TRow: Base](
         BatchPurgerResult containing the total count of deleted rows
 
     Raises:
+        BackendAIError: The error declared by the first failing conflict check.
         RepositoryIntegrityError: If the DELETE violates a database constraint
-            (e.g., foreign key). This is a safety-net fallback; callers should
-            use ``existence_checks`` before invoking the purger to provide
-            user-friendly error messages.
+            (e.g., foreign key) not covered by the spec's ``conflict_checks``.
 
     Note:
         This performs a hard delete. For soft delete, implement
@@ -340,6 +386,8 @@ async def execute_batch_purger[TRow: Base](
     entity = base_subquery.column_descriptions[0]["entity"]
     table = sa.inspect(entity).local_table
     pk_columns = list(table.primary_key.columns)
+
+    await validate_conflict_checks(db_sess, purger.spec.conflict_checks())
 
     total_deleted = 0
 

--- a/src/ai/backend/manager/repositories/base/rbac/entity_purger.py
+++ b/src/ai/backend/manager/repositories/base/rbac/entity_purger.py
@@ -20,20 +20,22 @@ from ai.backend.manager.models.rbac_models.association_scopes_entities import (
 )
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 from ai.backend.manager.repositories.base.integrity import parse_integrity_error
-from ai.backend.manager.repositories.base.purger import BatchPurgerSpec, Purger, PurgerResult, TRow
+from ai.backend.manager.repositories.base.purger import (
+    BatchPurgerSpec,
+    Purger,
+    PurgerResult,
+    PurgerSpec,
+    TRow,
+    validate_conflict_checks,
+)
 
 # =============================================================================
 # Spec Classes
 # =============================================================================
 
 
-class RBACEntityPurgerSpec(ABC):
-    """Spec for building RBAC entity info for single-row purge.
-
-    Implementations specify which entity to purge by providing:
-    - element_type(): Returns the RBACElementType identifying this entity kind
-    - entity_ref(): Returns the RBACElementRef to delete
-    """
+class RBACEntityPurgerSpec[TRow: Base](PurgerSpec[TRow], ABC):
+    """PurgerSpec that additionally provides RBAC entity info for cleanup."""
 
     @abstractmethod
     def element_type(self) -> RBACElementType:
@@ -66,16 +68,14 @@ class RBACEntityBatchPurgerSpec(BatchPurgerSpec[TRow], ABC):
 
 
 @dataclass
-class RBACEntityPurger(Purger[TRow]):
+class RBACEntityPurger[TRow: Base](Purger[TRow]):
     """Single-row RBAC entity purger by primary key.
 
-    Inherits row_class and pk_value from Purger.
-
     Attributes:
-        spec: RBACEntityPurgerSpec providing entity info for RBAC cleanup.
+        spec: RBACEntityPurgerSpec defining what to delete and its RBAC entity info.
     """
 
-    spec: RBACEntityPurgerSpec
+    spec: RBACEntityPurgerSpec[TRow]
 
 
 @dataclass
@@ -292,7 +292,7 @@ async def _delete_row_by_pk_returning(
             error type and constraint name instead of inspecting raw
             ``sqlalchemy.exc.IntegrityError``.
     """
-    row_class = purger.row_class
+    row_class = purger.spec.row_class()
     table = row_class.__table__
     pk_columns = list(table.primary_key.columns)
 
@@ -301,7 +301,7 @@ async def _delete_row_by_pk_returning(
             f"Purger only supports single-column primary keys (table: {table.name})",
         )
 
-    stmt = sa.delete(table).where(pk_columns[0] == purger.pk_value).returning(*table.columns)
+    stmt = sa.delete(table).where(pk_columns[0] == purger.spec.pk_value()).returning(*table.columns)
     try:
         result = await db_sess.execute(stmt)
     except sa.exc.IntegrityError as e:
@@ -348,6 +348,8 @@ async def execute_rbac_entity_purger(
     entity_ref = purger.spec.entity_ref()
     element_type = purger.spec.element_type()
 
+    await validate_conflict_checks(db_sess, purger.spec.conflict_checks())
+
     # 2. Delete RBAC entries
     await _delete_rbac_for_entity(db_sess, entity_ref, element_type)
 
@@ -393,6 +395,8 @@ async def execute_rbac_entity_batch_purger(
 
     pk_col = pk_columns[0]
     element_type = purger.spec.element_type()
+
+    await validate_conflict_checks(db_sess, purger.spec.conflict_checks())
 
     while True:
         # 1. DELETE with RETURNING - get PKs and delete in one query

--- a/src/ai/backend/manager/repositories/base/types.py
+++ b/src/ai/backend/manager/repositories/base/types.py
@@ -15,6 +15,22 @@ if TYPE_CHECKING:
     from ai.backend.manager.errors.repository import RepositoryIntegrityError
 
 
+@dataclass(frozen=True)
+class ConflictCheck:
+    """Defines a conflict check for destructive-operation validation.
+
+    The inverse of ExistenceCheck: validates that no row matching the condition
+    exists before executing a destructive operation (e.g. purge).
+    Multiple checks are combined into a single query for efficiency.
+    """
+
+    condition: QueryCondition
+    """Condition selecting conflicting rows (e.g., lambda: UserRow.domain_name == name)."""
+
+    error: BackendAIError
+    """The error to raise if any conflicting row exists."""
+
+
 # Factory function that creates a cursor condition from a decoded cursor value (str or UUID)
 type CursorConditionFactory = Callable[[str], QueryCondition]
 

--- a/src/ai/backend/manager/repositories/container_registry/purgers.py
+++ b/src/ai/backend/manager/repositories/container_registry/purgers.py
@@ -1,8 +1,9 @@
-"""BatchPurgerSpec implementations for container registry group associations."""
+"""PurgerSpec implementations for container registries and group associations."""
 
 from __future__ import annotations
 
 import uuid
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
@@ -11,7 +12,9 @@ import sqlalchemy as sa
 from ai.backend.manager.models.association_container_registries_groups import (
     AssociationContainerRegistriesGroupsRow,
 )
-from ai.backend.manager.repositories.base.purger import BatchPurgerSpec
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
+from ai.backend.manager.repositories.base.purger import BatchPurgerSpec, PurgerSpec
+from ai.backend.manager.repositories.base.types import ConflictCheck
 
 
 @dataclass
@@ -31,3 +34,26 @@ class ContainerRegistryGroupPurgerSpec(
                 AssociationContainerRegistriesGroupsRow.group_id == self.group_id,
             )
         )
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
+
+@dataclass
+class ContainerRegistryPurgerSpec(PurgerSpec[ContainerRegistryRow]):
+    """PurgerSpec for deleting a container registry."""
+
+    registry_id: uuid.UUID
+
+    @override
+    def row_class(self) -> type[ContainerRegistryRow]:
+        return ContainerRegistryRow
+
+    @override
+    def pk_value(self) -> uuid.UUID:
+        return self.registry_id
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()

--- a/src/ai/backend/manager/repositories/container_registry/repository.py
+++ b/src/ai/backend/manager/repositories/container_registry/repository.py
@@ -155,7 +155,7 @@ class ContainerRegistryRepository:
 
             if result is None:
                 raise ContainerRegistryNotFound(
-                    f"Container registry not found (id:{purger.pk_value})"
+                    f"Container registry not found (id:{purger.spec.pk_value()})"
                 )
 
             return result.row.to_dataclass()

--- a/src/ai/backend/manager/repositories/deployment_revision_preset/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment_revision_preset/db_source/db_source.py
@@ -30,6 +30,7 @@ from ai.backend.manager.repositories.deployment_revision_preset.creators import 
     PresetSlotDependency,
 )
 from ai.backend.manager.repositories.deployment_revision_preset.purgers import (
+    DeploymentRevisionPresetPurgerSpec,
     PresetResourceSlotBatchPurgerSpec,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider
@@ -96,7 +97,7 @@ class DeploymentRevisionPresetDBSource:
     async def delete(self, preset_id: UUID) -> DeploymentRevisionPresetData:
         async with self._ops.write_ops() as w:
             result = await w.purge(
-                Purger(row_class=DeploymentRevisionPresetRow, pk_value=preset_id)
+                Purger(spec=DeploymentRevisionPresetPurgerSpec(preset_id=preset_id))
             )
             if result is None:
                 raise DeploymentRevisionPresetNotFound()

--- a/src/ai/backend/manager/repositories/deployment_revision_preset/purgers.py
+++ b/src/ai/backend/manager/repositories/deployment_revision_preset/purgers.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
 import sqlalchemy as sa
 
+from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
 from ai.backend.manager.models.resource_slot.row import PresetResourceSlotRow
-from ai.backend.manager.repositories.base.purger import BatchPurgerSpec
+from ai.backend.manager.repositories.base.purger import BatchPurgerSpec, PurgerSpec
+from ai.backend.manager.repositories.base.types import ConflictCheck
 
 
 @dataclass
@@ -21,3 +24,26 @@ class PresetResourceSlotBatchPurgerSpec(BatchPurgerSpec[PresetResourceSlotRow]):
         return sa.select(PresetResourceSlotRow).where(
             PresetResourceSlotRow.preset_id == self.preset_id
         )
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
+
+@dataclass
+class DeploymentRevisionPresetPurgerSpec(PurgerSpec[DeploymentRevisionPresetRow]):
+    """PurgerSpec for deleting a deployment revision preset."""
+
+    preset_id: uuid.UUID
+
+    @override
+    def row_class(self) -> type[DeploymentRevisionPresetRow]:
+        return DeploymentRevisionPresetRow
+
+    @override
+    def pk_value(self) -> uuid.UUID:
+        return self.preset_id
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()

--- a/src/ai/backend/manager/repositories/domain/purgers.py
+++ b/src/ai/backend/manager/repositories/domain/purgers.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
 import sqlalchemy as sa
 
+from ai.backend.manager.errors.resource import DomainHasGroups, DomainHasUsers
 from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.kernel.row import KernelRow
-from ai.backend.manager.repositories.base.purger import BatchPurgerSpec
+from ai.backend.manager.models.user import UserRow
+from ai.backend.manager.repositories.base.purger import BatchPurgerSpec, PurgerSpec
+from ai.backend.manager.repositories.base.types import ConflictCheck
 
 
 @dataclass
@@ -20,6 +25,10 @@ class DomainKernelBatchPurgerSpec(BatchPurgerSpec[KernelRow]):
     def build_subquery(self) -> sa.sql.Select[tuple[KernelRow]]:
         return sa.select(KernelRow).where(KernelRow.domain_name == self.domain_name)
 
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
 
 @dataclass
 class DomainBatchPurgerSpec(BatchPurgerSpec[DomainRow]):
@@ -30,3 +39,35 @@ class DomainBatchPurgerSpec(BatchPurgerSpec[DomainRow]):
     @override
     def build_subquery(self) -> sa.sql.Select[tuple[DomainRow]]:
         return sa.select(DomainRow).where(DomainRow.name == self.domain_name)
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
+
+@dataclass
+class DomainPurgerSpec(PurgerSpec[DomainRow]):
+    """PurgerSpec for purging a single domain."""
+
+    domain_name: str
+
+    @override
+    def row_class(self) -> type[DomainRow]:
+        return DomainRow
+
+    @override
+    def pk_value(self) -> str:
+        return self.domain_name
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return (
+            ConflictCheck(
+                condition=lambda: UserRow.domain_name == self.domain_name,
+                error=DomainHasUsers("There are users bound to the domain. Remove users first."),
+            ),
+            ConflictCheck(
+                condition=lambda: GroupRow.domain_name == self.domain_name,
+                error=DomainHasGroups("There are groups bound to the domain. Remove groups first."),
+            ),
+        )

--- a/src/ai/backend/manager/repositories/domain/repository.py
+++ b/src/ai/backend/manager/repositories/domain/repository.py
@@ -24,30 +24,32 @@ from ai.backend.manager.data.permission.permission_defs import (
 from ai.backend.manager.errors.resource import (
     DomainDeletionFailed,
     DomainHasActiveKernels,
-    DomainHasGroups,
-    DomainHasUsers,
     DomainUpdateNotAllowed,
     InvalidDomainConfiguration,
 )
 from ai.backend.manager.models.domain import DomainRow, domains, get_domains
-from ai.backend.manager.models.group import GroupRow, ProjectType, groups
+from ai.backend.manager.models.group import ProjectType, groups
 from ai.backend.manager.models.kernel import AGENT_RESOURCE_OCCUPYING_KERNEL_STATUSES
 from ai.backend.manager.models.kernel.row import KernelRow
 from ai.backend.manager.models.rbac import SystemScope
 from ai.backend.manager.models.rbac.context import ClientContext
 from ai.backend.manager.models.resource_policy import keypair_resource_policies
 from ai.backend.manager.models.scaling_group import ScalingGroupForDomainRow, get_scaling_groups
-from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base.creator import Creator, execute_creator
-from ai.backend.manager.repositories.base.purger import BatchPurger, execute_batch_purger
+from ai.backend.manager.repositories.base.purger import (
+    BatchPurger,
+    Purger,
+    execute_batch_purger,
+    execute_purger,
+)
 from ai.backend.manager.repositories.base.querier import BatchQuerier
 from ai.backend.manager.repositories.base.updater import Updater, execute_updater
 from ai.backend.manager.repositories.domain.creators import DomainCreatorSpec
 from ai.backend.manager.repositories.domain.db_source import DomainDBSource
 from ai.backend.manager.repositories.domain.purgers import (
-    DomainBatchPurgerSpec,
     DomainKernelBatchPurgerSpec,
+    DomainPurgerSpec,
 )
 from ai.backend.manager.repositories.domain.types import DomainSearchResult, DomainSearchScope
 from ai.backend.manager.repositories.permission_controller.role_manager import RoleManager
@@ -135,29 +137,19 @@ class DomainRepository:
         Validates domain purge permissions and prerequisites.
         """
         async with self._db.begin_session() as session:
-            # Validate prerequisites
+            # Must run before the kernel cleanup below deletes the rows it inspects.
             if await self._domain_has_active_kernels(session, domain_name):
                 raise DomainHasActiveKernels(
                     "Domain has some active kernels. Terminate them first."
                 )
 
-            user_count = await self._get_domain_user_count(session, domain_name)
-            if user_count > 0:
-                raise DomainHasUsers("There are users bound to the domain. Remove users first.")
-
-            group_count = await self._get_domain_group_count(session, domain_name)
-            if group_count > 0:
-                raise DomainHasGroups("There are groups bound to the domain. Remove groups first.")
-
-            # Clean up kernels
             await self._delete_kernels(session, domain_name)
 
-            # Delete domain
-            result = await execute_batch_purger(
+            result = await execute_purger(
                 session,
-                BatchPurger(spec=DomainBatchPurgerSpec(domain_name=domain_name), batch_size=1),
+                Purger(spec=DomainPurgerSpec(domain_name=domain_name)),
             )
-            if result.deleted_count == 0:
+            if result is None:
                 raise DomainDeletionFailed(f"Failed to delete domain: {domain_name}")
 
     @domain_repository_resilience.apply()
@@ -278,28 +270,6 @@ class DomainRepository:
         )
         active_kernel_count = await session.scalar(query)
         return (active_kernel_count or 0) > 0
-
-    async def _get_domain_user_count(self, session: SASession, domain_name: str) -> int:
-        """
-        Private method to get user count for a domain.
-        """
-        query = (
-            sa.select(sa.func.count())
-            .select_from(UserRow)
-            .where(UserRow.domain_name == domain_name)
-        )
-        return await session.scalar(query) or 0
-
-    async def _get_domain_group_count(self, session: SASession, domain_name: str) -> int:
-        """
-        Private method to get group count for a domain.
-        """
-        query = (
-            sa.select(sa.func.count())
-            .select_from(GroupRow)
-            .where(GroupRow.domain_name == domain_name)
-        )
-        return await session.scalar(query) or 0
 
     @domain_repository_resilience.apply()
     async def create_domain_node_with_permissions(

--- a/src/ai/backend/manager/repositories/group/purgers.py
+++ b/src/ai/backend/manager/repositories/group/purgers.py
@@ -17,6 +17,7 @@ from ai.backend.manager.models.rbac_models.association_scopes_entities import (
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.repositories.base.purger import BatchPurgerSpec
 from ai.backend.manager.repositories.base.rbac.entity_purger import RBACEntityBatchPurgerSpec
+from ai.backend.manager.repositories.base.types import ConflictCheck
 
 
 @dataclass
@@ -29,6 +30,10 @@ class GroupKernelBatchPurgerSpec(BatchPurgerSpec[KernelRow]):
     def build_subquery(self) -> sa.sql.Select[tuple[KernelRow]]:
         return sa.select(KernelRow).where(KernelRow.group_id == self.group_id)
 
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
 
 @dataclass
 class GroupSessionBatchPurgerSpec(BatchPurgerSpec[SessionRow]):
@@ -39,6 +44,10 @@ class GroupSessionBatchPurgerSpec(BatchPurgerSpec[SessionRow]):
     @override
     def build_subquery(self) -> sa.sql.Select[tuple[SessionRow]]:
         return sa.select(SessionRow).where(SessionRow.group_id == self.group_id)
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
 
 
 @dataclass
@@ -51,6 +60,10 @@ class SessionByIdsBatchPurgerSpec(BatchPurgerSpec[SessionRow]):
     def build_subquery(self) -> sa.sql.Select[tuple[SessionRow]]:
         return sa.select(SessionRow).where(SessionRow.id.in_(self.session_ids))
 
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
 
 @dataclass
 class GroupEndpointBatchPurgerSpec(BatchPurgerSpec[EndpointRow]):
@@ -61,6 +74,10 @@ class GroupEndpointBatchPurgerSpec(BatchPurgerSpec[EndpointRow]):
     @override
     def build_subquery(self) -> sa.sql.Select[tuple[EndpointRow]]:
         return sa.select(EndpointRow).where(EndpointRow.project == self.project_id)
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
 
 
 @dataclass
@@ -76,6 +93,10 @@ class GroupBatchPurgerSpec(RBACEntityBatchPurgerSpec[GroupRow]):
     @override
     def element_type(self) -> RBACElementType:
         return RBACElementType.PROJECT
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
 
 
 @dataclass
@@ -94,3 +115,7 @@ class UsersForProjectPurgerSpec(BatchPurgerSpec[AssociationScopesEntitiesRow]):
             AssociationScopesEntitiesRow.entity_type == EntityType.USER,
             AssociationScopesEntitiesRow.entity_id.in_(entity_ids),
         )
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()

--- a/src/ai/backend/manager/repositories/model_card/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/model_card/db_source/db_source.py
@@ -193,7 +193,7 @@ class ModelCardDBSource:
             for purger in purgers:
                 # ModelCardRow uses a UUID primary key; the Purger generic type permits
                 # UUID/str/int so narrow it once for the failure record.
-                card_id = cast(UUID, purger.pk_value)
+                card_id = cast(UUID, purger.spec.pk_value())
                 try:
                     async with session.begin_nested():
                         deleted_id = await self._delete_card_in_session(session, purger, options)

--- a/src/ai/backend/manager/repositories/model_card/purgers.py
+++ b/src/ai/backend/manager/repositories/model_card/purgers.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.manager.models.model_card.row import ModelCardRow
+from ai.backend.manager.repositories.base.purger import PurgerSpec
+from ai.backend.manager.repositories.base.types import ConflictCheck
+
+
+@dataclass
+class ModelCardPurgerSpec(PurgerSpec[ModelCardRow]):
+    """PurgerSpec for deleting a model card."""
+
+    card_id: uuid.UUID
+
+    @override
+    def row_class(self) -> type[ModelCardRow]:
+        return ModelCardRow
+
+    @override
+    def pk_value(self) -> uuid.UUID:
+        return self.card_id
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -110,6 +110,10 @@ from ai.backend.manager.repositories.permission_controller.creators import (
     PermissionCreatorSpec,
     UserRoleCreatorSpec,
 )
+from ai.backend.manager.repositories.permission_controller.purgers import (
+    ObjectPermissionPurgerSpec,
+    PermissionPurgerSpec,
+)
 from ai.backend.manager.repositories.permission_controller.types import (
     PermissionSearchScope,
     ScopedRoleSearchScope,
@@ -238,7 +242,7 @@ class PermissionDBSource:
         async with self._db.begin_session() as db_session:
             result = await execute_purger(db_session, purger)
             if result is None:
-                raise ObjectNotFound(f"Permission with ID {purger.pk_value} does not exist.")
+                raise ObjectNotFound(f"Permission with ID {purger.spec.pk_value()} does not exist.")
             return result.row
 
     async def update_permission(
@@ -326,7 +330,7 @@ class PermissionDBSource:
         async with self._db.begin_session() as db_session:
             result = await execute_purger(db_session, purger)
             if result is None:
-                raise ObjectNotFound(f"Role with ID {purger.pk_value} does not exist.")
+                raise ObjectNotFound(f"Role with ID {purger.spec.pk_value()} does not exist.")
             return result.row
 
     async def assign_role(self, data: UserRoleAssignmentInput) -> UserRoleRow:
@@ -440,7 +444,7 @@ class PermissionDBSource:
 
             # 2. Remove scoped permissions
             for perm_id in input_data.remove_scoped_permission_ids:
-                perm_purger = Purger(row_class=PermissionRow, pk_value=perm_id)
+                perm_purger = Purger(spec=PermissionPurgerSpec(permission_id=perm_id))
                 await self._remove_permission(db_session, perm_purger)
 
             # 3. Add object permissions
@@ -458,7 +462,9 @@ class PermissionDBSource:
 
             # 4. Remove object permissions
             for obj_perm_id in input_data.remove_object_permission_ids:
-                obj_perm_purger = Purger(row_class=ObjectPermissionRow, pk_value=obj_perm_id)
+                obj_perm_purger = Purger(
+                    spec=ObjectPermissionPurgerSpec(object_permission_id=obj_perm_id)
+                )
                 await self._remove_object_permission_from_role(db_session, obj_perm_purger)
 
             # 5. Refresh and return

--- a/src/ai/backend/manager/repositories/permission_controller/purgers.py
+++ b/src/ai/backend/manager/repositories/permission_controller/purgers.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.manager.models.rbac_models.permission.object_permission import ObjectPermissionRow
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
+from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.repositories.base.purger import PurgerSpec
+from ai.backend.manager.repositories.base.types import ConflictCheck
+
+
+@dataclass
+class RolePurgerSpec(PurgerSpec[RoleRow]):
+    """PurgerSpec for deleting a role."""
+
+    role_id: uuid.UUID
+
+    @override
+    def row_class(self) -> type[RoleRow]:
+        return RoleRow
+
+    @override
+    def pk_value(self) -> uuid.UUID:
+        return self.role_id
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
+
+@dataclass
+class PermissionPurgerSpec(PurgerSpec[PermissionRow]):
+    """PurgerSpec for deleting a permission."""
+
+    permission_id: uuid.UUID
+
+    @override
+    def row_class(self) -> type[PermissionRow]:
+        return PermissionRow
+
+    @override
+    def pk_value(self) -> uuid.UUID:
+        return self.permission_id
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
+
+@dataclass
+class ObjectPermissionPurgerSpec(PurgerSpec[ObjectPermissionRow]):
+    """PurgerSpec for deleting an object permission."""
+
+    object_permission_id: uuid.UUID
+
+    @override
+    def row_class(self) -> type[ObjectPermissionRow]:
+        return ObjectPermissionRow
+
+    @override
+    def pk_value(self) -> uuid.UUID:
+        return self.object_permission_id
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()

--- a/src/ai/backend/manager/repositories/permission_controller/repository.py
+++ b/src/ai/backend/manager/repositories/permission_controller/repository.py
@@ -202,7 +202,7 @@ class PermissionControllerRepository:
         result = await self._db_source.bulk_remove_role_permissions(purgers)
         failures = [
             BulkRolePermissionRemoveFailure(
-                permission_id=cast(uuid.UUID, error.purger.pk_value),
+                permission_id=cast(uuid.UUID, error.purger.spec.pk_value()),
                 message=str(error.exception),
             )
             for error in result.errors

--- a/src/ai/backend/manager/repositories/retention/purgers.py
+++ b/src/ai/backend/manager/repositories/retention/purgers.py
@@ -17,6 +17,7 @@ import sqlalchemy as sa
 
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.repositories.base.purger import BatchPurgerSpec
+from ai.backend.manager.repositories.base.types import ConflictCheck
 
 
 @dataclass
@@ -53,3 +54,7 @@ class RetentionPurgerSpec[TRow: Base](BatchPurgerSpec[TRow]):
         for condition in self.conditions:
             stmt = stmt.where(condition)
         return stmt
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()

--- a/src/ai/backend/manager/repositories/retention_policy/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/retention_policy/db_source/db_source.py
@@ -18,6 +18,7 @@ from ai.backend.manager.errors.retention import RetentionPolicyNotFound
 from ai.backend.manager.models.retention.row import RetentionPolicyRow
 from ai.backend.manager.repositories.base import BatchQuerier, Creator, Purger, Updater
 from ai.backend.manager.repositories.ops import DBOpsProvider
+from ai.backend.manager.repositories.retention_policy.purgers import RetentionPolicyPurgerSpec
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -44,7 +45,7 @@ class RetentionPolicyDBSource:
 
     async def delete(self, policy_id: RetentionPolicyID) -> RetentionPolicyData:
         async with self._ops.write_ops() as w:
-            result = await w.purge(Purger(row_class=RetentionPolicyRow, pk_value=policy_id))
+            result = await w.purge(Purger(spec=RetentionPolicyPurgerSpec(policy_id=policy_id)))
             if result is None:
                 raise RetentionPolicyNotFound()
             return result.row.to_data()

--- a/src/ai/backend/manager/repositories/retention_policy/purgers.py
+++ b/src/ai/backend/manager/repositories/retention_policy/purgers.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.manager.models.retention.row import RetentionPolicyRow
+from ai.backend.manager.repositories.base.purger import PurgerSpec
+from ai.backend.manager.repositories.base.types import ConflictCheck
+
+
+@dataclass
+class RetentionPolicyPurgerSpec(PurgerSpec[RetentionPolicyRow]):
+    """PurgerSpec for deleting a retention policy."""
+
+    policy_id: uuid.UUID
+
+    @override
+    def row_class(self) -> type[RetentionPolicyRow]:
+        return RetentionPolicyRow
+
+    @override
+    def pk_value(self) -> uuid.UUID:
+        return self.policy_id
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()

--- a/src/ai/backend/manager/repositories/role_preset/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/role_preset/db_source/db_source.py
@@ -46,6 +46,10 @@ from ai.backend.manager.repositories.role_preset.creators import (
     RolePermissionPresetDependentCreatorSpec,
     RolePresetCreatorSpec,
 )
+from ai.backend.manager.repositories.role_preset.purgers import (
+    RolePermissionPresetPurgerSpec,
+    RolePresetPurgerSpec,
+)
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -125,14 +129,14 @@ class RolePresetDBSource:
 
     async def purge(self, preset_id: RolePresetID) -> bool:
         async with self._ops.write_ops() as w:
-            result = await w.purge(Purger(row_class=RolePresetRow, pk_value=preset_id))
+            result = await w.purge(Purger(spec=RolePresetPurgerSpec(preset_id=preset_id)))
             return result is not None
 
     async def bulk_purge(
         self,
         ids: Sequence[RolePresetID],
     ) -> RolePresetBulkPurgeResult:
-        purgers = [Purger(row_class=RolePresetRow, pk_value=preset_id) for preset_id in ids]
+        purgers = [Purger(spec=RolePresetPurgerSpec(preset_id=preset_id)) for preset_id in ids]
         async with self._ops.write_ops() as w:
             result = await w.bulk_purge_partial(purgers)
         successes = [row.to_data() for row in result.successes]
@@ -155,7 +159,10 @@ class RolePresetDBSource:
         self,
         ids: Sequence[RolePermissionPresetID],
     ) -> RolePermissionPresetBulkRemoveResult:
-        purgers = [Purger(row_class=RolePermissionPresetRow, pk_value=perm_id) for perm_id in ids]
+        purgers = [
+            Purger(spec=RolePermissionPresetPurgerSpec(permission_preset_id=perm_id))
+            for perm_id in ids
+        ]
         async with self._ops.write_ops() as w:
             result = await w.bulk_purge_partial(purgers)
         successes = [row.to_data() for row in result.successes]

--- a/src/ai/backend/manager/repositories/role_preset/purgers.py
+++ b/src/ai/backend/manager/repositories/role_preset/purgers.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.manager.models.rbac_models.role_permission_preset.row import (
+    RolePermissionPresetRow,
+)
+from ai.backend.manager.models.rbac_models.role_preset.row import RolePresetRow
+from ai.backend.manager.repositories.base.purger import PurgerSpec
+from ai.backend.manager.repositories.base.types import ConflictCheck
+
+
+@dataclass
+class RolePresetPurgerSpec(PurgerSpec[RolePresetRow]):
+    """PurgerSpec for deleting a role preset."""
+
+    preset_id: uuid.UUID
+
+    @override
+    def row_class(self) -> type[RolePresetRow]:
+        return RolePresetRow
+
+    @override
+    def pk_value(self) -> uuid.UUID:
+        return self.preset_id
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
+
+@dataclass
+class RolePermissionPresetPurgerSpec(PurgerSpec[RolePermissionPresetRow]):
+    """PurgerSpec for deleting a role permission preset."""
+
+    permission_preset_id: uuid.UUID
+
+    @override
+    def row_class(self) -> type[RolePermissionPresetRow]:
+        return RolePermissionPresetRow
+
+    @override
+    def pk_value(self) -> uuid.UUID:
+        return self.permission_preset_id
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()

--- a/src/ai/backend/manager/repositories/scaling_group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scaling_group/db_source/db_source.py
@@ -157,7 +157,7 @@ class ScalingGroupDBSource:
         Raises ScalingGroupNotFound if scaling group doesn't exist.
         """
         async with self._db.begin_session() as session:
-            scaling_group_name = purger.pk_value
+            scaling_group_name = purger.spec.pk_value()
 
             # Step 1: Find all sessions belonging to this scaling group
             session_ids_query = sa.select(SessionRow.id).where(
@@ -196,7 +196,9 @@ class ScalingGroupDBSource:
             result = await execute_purger(session, purger)
 
             if result is None:
-                raise ScalingGroupNotFound(f"Scaling group not found (name:{purger.pk_value})")
+                raise ScalingGroupNotFound(
+                    f"Scaling group not found (name:{purger.spec.pk_value()})"
+                )
 
             return result.row.to_dataclass()
 

--- a/src/ai/backend/manager/repositories/scaling_group/purgers.py
+++ b/src/ai/backend/manager/repositories/scaling_group/purgers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 from uuid import UUID
@@ -11,8 +12,29 @@ from ai.backend.manager.models.scaling_group import (
     ScalingGroupForDomainRow,
     ScalingGroupForKeypairsRow,
     ScalingGroupForProjectRow,
+    ScalingGroupRow,
 )
-from ai.backend.manager.repositories.base.purger import BatchPurger, BatchPurgerSpec
+from ai.backend.manager.repositories.base.purger import BatchPurger, BatchPurgerSpec, PurgerSpec
+from ai.backend.manager.repositories.base.types import ConflictCheck
+
+
+@dataclass
+class ScalingGroupPurgerSpec(PurgerSpec[ScalingGroupRow]):
+    """PurgerSpec for deleting a scaling group."""
+
+    name: str
+
+    @override
+    def row_class(self) -> type[ScalingGroupRow]:
+        return ScalingGroupRow
+
+    @override
+    def pk_value(self) -> str:
+        return self.name
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
 
 
 @dataclass
@@ -31,6 +53,10 @@ class ScalingGroupForDomainPurgerSpec(BatchPurgerSpec[ScalingGroupForDomainRow])
             )
         )
 
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
 
 @dataclass
 class ScalingGroupsForDomainPurgerSpec(BatchPurgerSpec[ScalingGroupForDomainRow]):
@@ -48,6 +74,10 @@ class ScalingGroupsForDomainPurgerSpec(BatchPurgerSpec[ScalingGroupForDomainRow]
             )
         )
 
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
 
 @dataclass
 class AllScalingGroupsForDomainPurgerSpec(BatchPurgerSpec[ScalingGroupForDomainRow]):
@@ -60,6 +90,10 @@ class AllScalingGroupsForDomainPurgerSpec(BatchPurgerSpec[ScalingGroupForDomainR
         return sa.select(ScalingGroupForDomainRow).where(
             ScalingGroupForDomainRow.domain == self.domain,
         )
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
 
 
 @dataclass
@@ -78,6 +112,10 @@ class ScalingGroupForKeypairsPurgerSpec(BatchPurgerSpec[ScalingGroupForKeypairsR
             )
         )
 
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
 
 @dataclass
 class ScalingGroupsForKeypairsPurgerSpec(BatchPurgerSpec[ScalingGroupForKeypairsRow]):
@@ -94,6 +132,10 @@ class ScalingGroupsForKeypairsPurgerSpec(BatchPurgerSpec[ScalingGroupForKeypairs
                 ScalingGroupForKeypairsRow.access_key == self.access_key,
             )
         )
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
 
 
 def create_scaling_group_for_domain_purger(
@@ -140,6 +182,10 @@ class ScalingGroupForProjectPurgerSpec(BatchPurgerSpec[ScalingGroupForProjectRow
             )
         )
 
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
 
 @dataclass
 class ScalingGroupsForProjectPurgerSpec(BatchPurgerSpec[ScalingGroupForProjectRow]):
@@ -157,6 +203,10 @@ class ScalingGroupsForProjectPurgerSpec(BatchPurgerSpec[ScalingGroupForProjectRo
             )
         )
 
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
 
 @dataclass
 class AllScalingGroupsForProjectPurgerSpec(BatchPurgerSpec[ScalingGroupForProjectRow]):
@@ -169,6 +219,10 @@ class AllScalingGroupsForProjectPurgerSpec(BatchPurgerSpec[ScalingGroupForProjec
         return sa.select(ScalingGroupForProjectRow).where(
             ScalingGroupForProjectRow.group == self.project,
         )
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
 
 
 def create_scaling_group_for_project_purger(

--- a/src/ai/backend/manager/repositories/user/purgers.py
+++ b/src/ai/backend/manager/repositories/user/purgers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 from uuid import UUID
@@ -14,6 +15,7 @@ from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.vfolder import VFolderPermissionRow
 from ai.backend.manager.repositories.base.purger import BatchPurger, BatchPurgerSpec
 from ai.backend.manager.repositories.base.rbac.entity_purger import RBACEntityBatchPurgerSpec
+from ai.backend.manager.repositories.base.types import ConflictCheck
 
 
 @dataclass
@@ -26,6 +28,10 @@ class UserErrorLogBatchPurgerSpec(BatchPurgerSpec[ErrorLogRow]):
     def build_subquery(self) -> sa.sql.Select[tuple[ErrorLogRow]]:
         return sa.select(ErrorLogRow).where(ErrorLogRow.__table__.c.user == self.user_uuid)
 
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
 
 @dataclass
 class UserKeyPairBatchPurgerSpec(BatchPurgerSpec[KeyPairRow]):
@@ -36,6 +42,10 @@ class UserKeyPairBatchPurgerSpec(BatchPurgerSpec[KeyPairRow]):
     @override
     def build_subquery(self) -> sa.sql.Select[tuple[KeyPairRow]]:
         return sa.select(KeyPairRow).where(KeyPairRow.user == self.user_uuid)
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
 
 
 @dataclass
@@ -48,6 +58,10 @@ class UserVFolderPermissionBatchPurgerSpec(BatchPurgerSpec[VFolderPermissionRow]
     def build_subquery(self) -> sa.sql.Select[tuple[VFolderPermissionRow]]:
         return sa.select(VFolderPermissionRow).where(VFolderPermissionRow.user == self.user_uuid)
 
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
 
 @dataclass
 class UserGroupAssociationBatchPurgerSpec(BatchPurgerSpec[AssocGroupUserRow]):
@@ -58,6 +72,10 @@ class UserGroupAssociationBatchPurgerSpec(BatchPurgerSpec[AssocGroupUserRow]):
     @override
     def build_subquery(self) -> sa.sql.Select[tuple[AssocGroupUserRow]]:
         return sa.select(AssocGroupUserRow).where(AssocGroupUserRow.user_id == self.user_uuid)
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
 
 
 @dataclass
@@ -73,6 +91,10 @@ class UserBatchPurgerSpec(RBACEntityBatchPurgerSpec[UserRow]):
     @override
     def element_type(self) -> RBACElementType:
         return RBACElementType.USER
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
 
 
 def create_user_error_log_purger(user_uuid: UUID) -> BatchPurger[ErrorLogRow]:

--- a/src/ai/backend/manager/repositories/vfolder/purgers.py
+++ b/src/ai/backend/manager/repositories/vfolder/purgers.py
@@ -9,11 +9,16 @@ import sqlalchemy as sa
 
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.manager.data.permission.types import RBACElementRef
-from ai.backend.manager.models.vfolder.row import VFolderInvitationRow, VFolderPermissionRow
+from ai.backend.manager.models.vfolder.row import (
+    VFolderInvitationRow,
+    VFolderPermissionRow,
+    VFolderRow,
+)
 from ai.backend.manager.repositories.base.purger import BatchPurgerSpec
 from ai.backend.manager.repositories.base.rbac.entity_purger import (
     RBACEntityPurgerSpec,
 )
+from ai.backend.manager.repositories.base.types import ConflictCheck
 
 
 @dataclass
@@ -28,6 +33,10 @@ class VFolderInvitationBatchPurgerSpec(BatchPurgerSpec[VFolderInvitationRow]):
             VFolderInvitationRow.vfolder.in_(self.vfolder_ids)
         )
 
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
 
 @dataclass
 class VFolderPermissionBatchPurgerSpec(BatchPurgerSpec[VFolderPermissionRow]):
@@ -41,10 +50,22 @@ class VFolderPermissionBatchPurgerSpec(BatchPurgerSpec[VFolderPermissionRow]):
             VFolderPermissionRow.vfolder.in_(self.vfolder_ids)
         )
 
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
 
 @dataclass
-class VFolderPurgerSpec(RBACEntityPurgerSpec):
+class VFolderPurgerSpec(RBACEntityPurgerSpec[VFolderRow]):
     vfolder_id: UUID
+
+    @override
+    def row_class(self) -> type[VFolderRow]:
+        return VFolderRow
+
+    @override
+    def pk_value(self) -> UUID:
+        return self.vfolder_id
 
     @override
     def element_type(self) -> RBACElementType:
@@ -56,3 +77,7 @@ class VFolderPurgerSpec(RBACEntityPurgerSpec):
             element_type=self.element_type(),
             element_id=str(self.vfolder_id),
         )
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -833,7 +833,7 @@ class VfolderRepository:
             VFolderDeletionNotAllowed: If the vfolder is mounted or endpoint-referenced.
             VFolderHasLinkedModelCard: If a model card still references the vfolder.
         """
-        vfolder_uuid = cast(uuid.UUID, purger.pk_value)
+        vfolder_uuid = cast(uuid.UUID, purger.spec.pk_value())
         async with self._db.begin_session() as session:
             # Fetch vfolder first to validate status/in-use before purging.
             vfolder_row = await self._get_vfolder_by_id(session, vfolder_uuid)

--- a/src/ai/backend/manager/services/app_config_allow_list/actions/purge.py
+++ b/src/ai/backend/manager/services/app_config_allow_list/actions/purge.py
@@ -26,11 +26,13 @@ class PurgeAppConfigAllowListAction(AppConfigAllowListSingleEntityAction):
 
     @override
     def target_entity_id(self) -> str:
-        return str(self.purger.pk_value)
+        return str(self.purger.spec.pk_value())
 
     @override
     def target_element(self) -> RBACElementRef:
-        return RBACElementRef(RBACElementType.APP_CONFIG_ALLOW_LIST, str(self.purger.pk_value))
+        return RBACElementRef(
+            RBACElementType.APP_CONFIG_ALLOW_LIST, str(self.purger.spec.pk_value())
+        )
 
 
 @dataclass

--- a/src/ai/backend/manager/services/app_config_definition/actions/purge.py
+++ b/src/ai/backend/manager/services/app_config_definition/actions/purge.py
@@ -26,11 +26,13 @@ class PurgeAppConfigDefinitionAction(AppConfigDefinitionSingleEntityAction):
 
     @override
     def target_entity_id(self) -> str:
-        return str(self.purger.pk_value)
+        return str(self.purger.spec.pk_value())
 
     @override
     def target_element(self) -> RBACElementRef:
-        return RBACElementRef(RBACElementType.APP_CONFIG_DEFINITION, str(self.purger.pk_value))
+        return RBACElementRef(
+            RBACElementType.APP_CONFIG_DEFINITION, str(self.purger.spec.pk_value())
+        )
 
 
 @dataclass

--- a/src/ai/backend/manager/services/container_registry/actions/delete_container_registry.py
+++ b/src/ai/backend/manager/services/container_registry/actions/delete_container_registry.py
@@ -15,7 +15,7 @@ class DeleteContainerRegistryAction(ContainerRegistryAction):
 
     @override
     def entity_id(self) -> str | None:
-        return str(self.purger.pk_value)
+        return str(self.purger.spec.pk_value())
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/model_card/actions/delete.py
+++ b/src/ai/backend/manager/services/model_card/actions/delete.py
@@ -17,7 +17,7 @@ class DeleteModelCardAction(ModelCardAction):
 
     @override
     def entity_id(self) -> str | None:
-        return str(self.purger.pk_value)
+        return str(self.purger.spec.pk_value())
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/permission_contoller/actions/permission.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/permission.py
@@ -52,7 +52,7 @@ class DeletePermissionAction(PermissionAction):
 
     @override
     def entity_id(self) -> str | None:
-        return str(self.purger.pk_value)
+        return str(self.purger.spec.pk_value())
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/permission_contoller/actions/purge_role.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/purge_role.py
@@ -17,7 +17,7 @@ class PurgeRoleAction(RoleAction):
 
     @override
     def entity_id(self) -> str | None:
-        return str(self.purger.pk_value)
+        return str(self.purger.spec.pk_value())
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/scaling_group/actions/purge_scaling_group.py
+++ b/src/ai/backend/manager/services/scaling_group/actions/purge_scaling_group.py
@@ -24,7 +24,7 @@ class PurgeScalingGroupAction(ScalingGroupAction):
 
     @override
     def entity_id(self) -> str | None:
-        return str(self.purger.pk_value)
+        return str(self.purger.spec.pk_value())
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/services/vfolder/actions/base.py
+++ b/src/ai/backend/manager/services/vfolder/actions/base.py
@@ -424,7 +424,7 @@ class PurgeVFolderAction(VFolderSingleEntityAction):
 
     @override
     def entity_id(self) -> str | None:
-        return str(self.purger.pk_value)
+        return str(self.purger.spec.pk_value())
 
     @override
     @classmethod
@@ -433,13 +433,13 @@ class PurgeVFolderAction(VFolderSingleEntityAction):
 
     @override
     def target_entity_id(self) -> str:
-        return str(self.purger.pk_value)
+        return str(self.purger.spec.pk_value())
 
     @override
     def target_element(self) -> RBACElementRef:
         return RBACElementRef(
             element_type=RBACElementType.VFOLDER,
-            element_id=str(self.purger.pk_value),
+            element_id=str(self.purger.spec.pk_value()),
         )
 
 

--- a/tests/component/rbac/test_rbac_permission.py
+++ b/tests/component/rbac/test_rbac_permission.py
@@ -24,13 +24,13 @@ from ai.backend.manager.errors.common import ObjectNotFound
 from ai.backend.manager.errors.repository import (
     UniqueConstraintViolationError,
 )
-from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.purger import Purger
 from ai.backend.manager.repositories.permission_controller.creators import (
     PermissionCreatorSpec,
 )
+from ai.backend.manager.repositories.permission_controller.purgers import PermissionPurgerSpec
 from ai.backend.manager.repositories.permission_controller.repository import (
     PermissionControllerRepository,
 )
@@ -85,7 +85,9 @@ class TestPermissionCreate:
 
         # Cleanup
         await permission_controller_processors.delete_permission.wait_for_complete(
-            DeletePermissionAction(purger=Purger(row_class=PermissionRow, pk_value=result.data.id))
+            DeletePermissionAction(
+                purger=Purger(spec=PermissionPurgerSpec(permission_id=result.data.id))
+            )
         )
 
     async def test_create_permissions_with_various_combinations(
@@ -139,7 +141,9 @@ class TestPermissionCreate:
         # Cleanup
         for perm_id in created_ids:
             await permission_controller_processors.delete_permission.wait_for_complete(
-                DeletePermissionAction(purger=Purger(row_class=PermissionRow, pk_value=perm_id))
+                DeletePermissionAction(
+                    purger=Purger(spec=PermissionPurgerSpec(permission_id=perm_id))
+                )
             )
 
     async def test_create_duplicate_permission_raises_unique_constraint(
@@ -169,7 +173,9 @@ class TestPermissionCreate:
                 )
         finally:
             await permission_controller_processors.delete_permission.wait_for_complete(
-                DeletePermissionAction(purger=Purger(row_class=PermissionRow, pk_value=perm_id))
+                DeletePermissionAction(
+                    purger=Purger(spec=PermissionPurgerSpec(permission_id=perm_id))
+                )
             )
 
 
@@ -199,7 +205,7 @@ class TestPermissionDelete:
         perm_id = create_result.data.id
 
         delete_result = await permission_controller_processors.delete_permission.wait_for_complete(
-            DeletePermissionAction(purger=Purger(row_class=PermissionRow, pk_value=perm_id))
+            DeletePermissionAction(purger=Purger(spec=PermissionPurgerSpec(permission_id=perm_id)))
         )
 
         assert isinstance(delete_result.data, PermissionData)
@@ -228,13 +234,15 @@ class TestPermissionDelete:
         perm_id = create_result.data.id
 
         await permission_controller_processors.delete_permission.wait_for_complete(
-            DeletePermissionAction(purger=Purger(row_class=PermissionRow, pk_value=perm_id))
+            DeletePermissionAction(purger=Purger(spec=PermissionPurgerSpec(permission_id=perm_id)))
         )
 
         # Second delete must raise ObjectNotFound
         with pytest.raises(ObjectNotFound):
             await permission_controller_processors.delete_permission.wait_for_complete(
-                DeletePermissionAction(purger=Purger(row_class=PermissionRow, pk_value=perm_id))
+                DeletePermissionAction(
+                    purger=Purger(spec=PermissionPurgerSpec(permission_id=perm_id))
+                )
             )
 
     async def test_delete_nonexistent_permission_raises_not_found(
@@ -245,7 +253,7 @@ class TestPermissionDelete:
         with pytest.raises(ObjectNotFound):
             await permission_controller_processors.delete_permission.wait_for_complete(
                 DeletePermissionAction(
-                    purger=Purger(row_class=PermissionRow, pk_value=uuid.uuid4())
+                    purger=Purger(spec=PermissionPurgerSpec(permission_id=uuid.uuid4()))
                 )
             )
 
@@ -322,7 +330,7 @@ class TestCheckPermissionInScope:
             )
             await permission_controller_processors.delete_permission.wait_for_complete(
                 DeletePermissionAction(
-                    purger=Purger(row_class=PermissionRow, pk_value=perm_result.data.id)
+                    purger=Purger(spec=PermissionPurgerSpec(permission_id=perm_result.data.id))
                 )
             )
 

--- a/tests/unit/manager/repositories/app_config_allow_list/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_allow_list/test_repository.py
@@ -30,6 +30,9 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.app_config_allow_list.creators import (
     AppConfigAllowListCreatorSpec,
 )
+from ai.backend.manager.repositories.app_config_allow_list.purgers import (
+    AppConfigAllowListPurgerSpec,
+)
 from ai.backend.manager.repositories.app_config_allow_list.repository import (
     AppConfigAllowListRepository,
 )
@@ -38,6 +41,9 @@ from ai.backend.manager.repositories.app_config_allow_list.updaters import (
 )
 from ai.backend.manager.repositories.app_config_definition.creators import (
     AppConfigDefinitionCreatorSpec,
+)
+from ai.backend.manager.repositories.app_config_definition.purgers import (
+    AppConfigDefinitionPurgerSpec,
 )
 from ai.backend.manager.repositories.app_config_definition.repository import (
     AppConfigDefinitionRepository,
@@ -230,7 +236,7 @@ class TestPurge:
         existing_entry: AppConfigAllowListData,
     ) -> None:
         purged = await repository.purge(
-            Purger(row_class=AppConfigAllowListRow, pk_value=existing_entry.id)
+            Purger(spec=AppConfigAllowListPurgerSpec(allow_list_id=existing_entry.id))
         )
         assert purged.id == existing_entry.id
         with pytest.raises(AppConfigAllowListNotFound):
@@ -238,7 +244,9 @@ class TestPurge:
 
     async def test_purge_missing_raises(self, repository: AppConfigAllowListRepository) -> None:
         with pytest.raises(AppConfigAllowListNotFound):
-            await repository.purge(Purger(row_class=AppConfigAllowListRow, pk_value=_missing_id()))
+            await repository.purge(
+                Purger(spec=AppConfigAllowListPurgerSpec(allow_list_id=_missing_id()))
+            )
 
     async def test_purge_cascades_to_fragments(
         self,
@@ -258,7 +266,9 @@ class TestPurge:
             )
             await db_sess.flush()
 
-        await repository.purge(Purger(row_class=AppConfigAllowListRow, pk_value=existing_entry.id))
+        await repository.purge(
+            Purger(spec=AppConfigAllowListPurgerSpec(allow_list_id=existing_entry.id))
+        )
 
         async with database.begin_readonly_session() as db_sess:
             remaining = await db_sess.scalar(
@@ -289,7 +299,7 @@ class TestPurge:
             await db_sess.flush()
 
         await definition_repository.purge(
-            Purger(row_class=AppConfigDefinitionRow, pk_value=definition.id)
+            Purger(spec=AppConfigDefinitionPurgerSpec(definition_id=definition.id))
         )
 
         async with database.begin_readonly_session() as db_sess:

--- a/tests/unit/manager/repositories/app_config_definition/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_definition/test_repository.py
@@ -20,6 +20,9 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.app_config_definition.creators import (
     AppConfigDefinitionCreatorSpec,
 )
+from ai.backend.manager.repositories.app_config_definition.purgers import (
+    AppConfigDefinitionPurgerSpec,
+)
 from ai.backend.manager.repositories.app_config_definition.repository import (
     AppConfigDefinitionRepository,
 )
@@ -89,7 +92,7 @@ class TestPurge:
         existing_definition: AppConfigDefinitionData,
     ) -> None:
         purged = await repository.purge(
-            Purger(row_class=AppConfigDefinitionRow, pk_value=existing_definition.id)
+            Purger(spec=AppConfigDefinitionPurgerSpec(definition_id=existing_definition.id))
         )
         assert purged.id == existing_definition.id
         with pytest.raises(AppConfigDefinitionNotFound):
@@ -97,7 +100,9 @@ class TestPurge:
 
     async def test_purge_missing_raises(self, repository: AppConfigDefinitionRepository) -> None:
         with pytest.raises(AppConfigDefinitionNotFound):
-            await repository.purge(Purger(row_class=AppConfigDefinitionRow, pk_value=_missing_id()))
+            await repository.purge(
+                Purger(spec=AppConfigDefinitionPurgerSpec(definition_id=_missing_id()))
+            )
 
 
 class TestAdminSearch:

--- a/tests/unit/manager/repositories/base/rbac/test_entity_purger.py
+++ b/tests/unit/manager/repositories/base/rbac/test_entity_purger.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, override
 from uuid import UUID
@@ -44,6 +44,7 @@ from ai.backend.manager.repositories.base.rbac.entity_purger import (
     execute_rbac_entity_batch_purger,
     execute_rbac_entity_purger,
 )
+from ai.backend.manager.repositories.base.types import ConflictCheck
 from ai.backend.testutils.db import with_tables
 
 if TYPE_CHECKING:
@@ -102,11 +103,23 @@ class RBACEntityPurgerRestrictReferrer(Base):  # type: ignore[misc]
 # =============================================================================
 
 
-class SimpleRBACEntityPurgerSpec(RBACEntityPurgerSpec):
+class SimpleRBACEntityPurgerSpec(RBACEntityPurgerSpec[RBACEntityPurgerTestRow]):
     """Simple spec for entity purger testing."""
 
     def __init__(self, entity_uuid: UUID) -> None:
         self._entity_uuid = entity_uuid
+
+    @override
+    def row_class(self) -> type[RBACEntityPurgerTestRow]:
+        return RBACEntityPurgerTestRow
+
+    @override
+    def pk_value(self) -> UUID:
+        return self._entity_uuid
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
 
     @override
     def element_type(self) -> RBACElementType:
@@ -282,8 +295,6 @@ class TestRBACEntityPurgerBasic:
         async with database_connection.begin_session_read_committed() as db_sess:
             spec = SimpleRBACEntityPurgerSpec(entity_uuid=ctx.entity_uuid)
             purger: RBACEntityPurger[RBACEntityPurgerTestRow] = RBACEntityPurger(
-                row_class=RBACEntityPurgerTestRow,
-                pk_value=ctx.entity_uuid,
                 spec=spec,
             )
             result = await execute_rbac_entity_purger(db_sess, purger)
@@ -316,8 +327,6 @@ class TestRBACEntityPurgerBasic:
         async with database_connection.begin_session_read_committed() as db_sess:
             spec = SimpleRBACEntityPurgerSpec(entity_uuid=nonexistent_uuid)
             purger: RBACEntityPurger[RBACEntityPurgerTestRow] = RBACEntityPurger(
-                row_class=RBACEntityPurgerTestRow,
-                pk_value=nonexistent_uuid,
                 spec=spec,
             )
             result = await execute_rbac_entity_purger(db_sess, purger)
@@ -454,8 +463,6 @@ class TestRBACEntityPurgerWithPermissions:
         async with database_connection.begin_session_read_committed() as db_sess:
             spec = SimpleRBACEntityPurgerSpec(entity_uuid=ctx.entity_uuid)
             purger: RBACEntityPurger[RBACEntityPurgerTestRow] = RBACEntityPurger(
-                row_class=RBACEntityPurgerTestRow,
-                pk_value=ctx.entity_uuid,
                 spec=spec,
             )
             await execute_rbac_entity_purger(db_sess, purger)
@@ -476,8 +483,6 @@ class TestRBACEntityPurgerWithPermissions:
             # Delete only entity1
             spec = SimpleRBACEntityPurgerSpec(entity_uuid=ctx.entity_uuid1)
             purger: RBACEntityPurger[RBACEntityPurgerTestRow] = RBACEntityPurger(
-                row_class=RBACEntityPurgerTestRow,
-                pk_value=ctx.entity_uuid1,
                 spec=spec,
             )
             await execute_rbac_entity_purger(db_sess, purger)
@@ -543,8 +548,6 @@ class TestRBACEntityPurgerMultipleScopes:
         async with database_connection.begin_session_read_committed() as db_sess:
             spec = SimpleRBACEntityPurgerSpec(entity_uuid=ctx.entity_uuid)
             purger: RBACEntityPurger[RBACEntityPurgerTestRow] = RBACEntityPurger(
-                row_class=RBACEntityPurgerTestRow,
-                pk_value=ctx.entity_uuid,
                 spec=spec,
             )
             await execute_rbac_entity_purger(db_sess, purger)
@@ -622,8 +625,6 @@ class TestRBACEntityPurgerBidirectionalCleanup:
 
             spec = SimpleRBACEntityPurgerSpec(entity_uuid=ctx.entity_uuid)
             purger: RBACEntityPurger[RBACEntityPurgerTestRow] = RBACEntityPurger(
-                row_class=RBACEntityPurgerTestRow,
-                pk_value=ctx.entity_uuid,
                 spec=spec,
             )
             await execute_rbac_entity_purger(db_sess, purger)
@@ -656,8 +657,6 @@ class TestRBACEntityPurgerBidirectionalCleanup:
 
             spec = SimpleRBACEntityPurgerSpec(entity_uuid=ctx.entity_uuid)
             purger: RBACEntityPurger[RBACEntityPurgerTestRow] = RBACEntityPurger(
-                row_class=RBACEntityPurgerTestRow,
-                pk_value=ctx.entity_uuid,
                 spec=spec,
             )
             await execute_rbac_entity_purger(db_sess, purger)
@@ -680,6 +679,10 @@ class TestEntityBatchPurgerSpec(RBACEntityBatchPurgerSpec[RBACEntityPurgerTestRo
     @override
     def build_subquery(self) -> sa.sql.Select[tuple[RBACEntityPurgerTestRow]]:
         return sa.select(RBACEntityPurgerTestRow)
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
 
     @override
     def element_type(self) -> RBACElementType:
@@ -917,11 +920,24 @@ class CompositePKPurgerTestRow(Base):  # type: ignore[misc]
     name: Mapped[str] = mapped_column(sa.String(50), nullable=False)
 
 
-class CompositePKPurgerSpec(RBACEntityPurgerSpec):
+class CompositePKPurgerSpec(RBACEntityPurgerSpec[CompositePKPurgerTestRow]):
     """Purger spec for composite PK testing."""
 
     def __init__(self, entity_uuid: str) -> None:
         self._entity_uuid = entity_uuid
+
+    @override
+    def row_class(self) -> type[CompositePKPurgerTestRow]:
+        return CompositePKPurgerTestRow
+
+    @override
+    def pk_value(self) -> int:
+        # PK value (error raised before lookup due to composite PK)
+        return 1
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
 
     @override
     def element_type(self) -> RBACElementType:
@@ -941,6 +957,10 @@ class CompositePKBatchPurgerSpec(RBACEntityBatchPurgerSpec[CompositePKPurgerTest
     @override
     def build_subquery(self) -> sa.Select[Any]:
         return sa.select(CompositePKPurgerTestRow)
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
 
     @override
     def element_type(self) -> RBACElementType:
@@ -964,8 +984,6 @@ class TestRBACEntityPurgerCompositePK:
             async with database_connection.begin_session_read_committed() as db_sess:
                 spec = CompositePKPurgerSpec(entity_uuid="test-123")
                 purger = RBACEntityPurger(
-                    row_class=CompositePKPurgerTestRow,
-                    pk_value=1,  # PK value (error raised before lookup due to composite PK)
                     spec=spec,
                 )
 
@@ -1100,8 +1118,6 @@ class TestRBACEntityPurgerTransactionRollback:
         async with database_connection.begin_session_read_committed() as db_sess:
             spec = SimpleRBACEntityPurgerSpec(entity_uuid=ctx.entity_uuid)
             purger: RBACEntityPurger[RBACEntityPurgerTestRow] = RBACEntityPurger(
-                row_class=RBACEntityPurgerTestRow,
-                pk_value=ctx.entity_uuid,
                 spec=spec,
             )
             with pytest.raises(ForeignKeyViolationError):

--- a/tests/unit/manager/repositories/base/rbac/test_scope_unbinder.py
+++ b/tests/unit/manager/repositories/base/rbac/test_scope_unbinder.py
@@ -27,6 +27,7 @@ from ai.backend.manager.repositories.base.rbac.scope_unbinder import (
     RBACUnbinderResult,
     execute_rbac_scope_entity_unbinder,
 )
+from ai.backend.manager.repositories.base.types import ConflictCheck
 from ai.backend.testutils.db import with_tables
 
 if TYPE_CHECKING:
@@ -87,6 +88,10 @@ class TestScopeEntityUnbinder(RBACScopeEntityUnbinder[ScopeUnbinderMappingRow]):
                         ScopeUnbinderMappingRow.entity_id.in_(entity_ids),
                     )
                 return stmt
+
+            @override
+            def conflict_checks(self) -> Sequence[ConflictCheck]:
+                return ()
 
         return _Spec()
 

--- a/tests/unit/manager/repositories/base/test_purger.py
+++ b/tests/unit/manager/repositories/base/test_purger.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Sequence
 from typing import TYPE_CHECKING, override
 from uuid import UUID
 
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from ai.backend.manager.errors.repository import (
     ForeignKeyViolationError,
     RepositoryIntegrityError,
+    UnsupportedCompositePrimaryKeyError,
 )
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.repositories.base import (
@@ -29,12 +30,40 @@ from ai.backend.manager.repositories.base import (
     execute_bulk_purger_partial,
     execute_purger,
 )
+from ai.backend.manager.repositories.base.purger import PurgerSpec
+from ai.backend.manager.repositories.base.types import ConflictCheck
 
 if TYPE_CHECKING:
     from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
 # Note: This test file uses test-specific ORM models defined here, not application models.
 # Tables are created/dropped per test class, which is appropriate for testing the purger itself.
+
+
+class SimplePurgerSpec[TRow: Base](PurgerSpec[TRow]):
+    """Test spec: plain PK delete with optional conflict checks."""
+
+    def __init__(
+        self,
+        row_class: type[TRow],
+        pk_value: UUID | str | int,
+        conflict_checks: Sequence[ConflictCheck] = (),
+    ) -> None:
+        self._row_class = row_class
+        self._pk_value = pk_value
+        self._conflict_checks = conflict_checks
+
+    @override
+    def row_class(self) -> type[TRow]:
+        return self._row_class
+
+    @override
+    def pk_value(self) -> UUID | str | int:
+        return self._pk_value
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return self._conflict_checks
 
 
 # =============================================================================
@@ -107,8 +136,7 @@ class TestPurgerIntPK:
         async with database_connection.begin_session() as db_sess:
             target_id = sample_data[0]
             purger: Purger[PurgerTestRowInt] = Purger(
-                row_class=PurgerTestRowInt,
-                pk_value=target_id,
+                spec=SimplePurgerSpec(PurgerTestRowInt, target_id)
             )
 
             result = await execute_purger(db_sess, purger)
@@ -133,8 +161,7 @@ class TestPurgerIntPK:
         """Test deleting when PK doesn't exist."""
         async with database_connection.begin_session() as db_sess:
             purger: Purger[PurgerTestRowInt] = Purger(
-                row_class=PurgerTestRowInt,
-                pk_value=99999,
+                spec=SimplePurgerSpec(PurgerTestRowInt, 99999)
             )
 
             result = await execute_purger(db_sess, purger)
@@ -193,8 +220,7 @@ class TestPurgerUUIDPK:
         async with database_connection.begin_session() as db_sess:
             target_id = sample_data[0]
             purger: Purger[PurgerTestRowUUID] = Purger(
-                row_class=PurgerTestRowUUID,
-                pk_value=target_id,
+                spec=SimplePurgerSpec(PurgerTestRowUUID, target_id)
             )
 
             result = await execute_purger(db_sess, purger)
@@ -212,8 +238,7 @@ class TestPurgerUUIDPK:
         """Test deleting when UUID PK doesn't exist."""
         async with database_connection.begin_session() as db_sess:
             purger: Purger[PurgerTestRowUUID] = Purger(
-                row_class=PurgerTestRowUUID,
-                pk_value=uuid.uuid4(),
+                spec=SimplePurgerSpec(PurgerTestRowUUID, uuid.uuid4())
             )
 
             result = await execute_purger(db_sess, purger)
@@ -233,9 +258,11 @@ class SimpleBatchPurgerSpec(BatchPurgerSpec[Base]):
         self,
         row_class: type[Base],
         conditions: list[sa.sql.expression.ColumnElement[bool]] | None = None,
+        conflict_checks: Sequence[ConflictCheck] = (),
     ) -> None:
         self._row_class = row_class
         self._conditions = conditions or []
+        self._conflict_checks = conflict_checks
 
     @override
     def build_subquery(self) -> sa.sql.Select[tuple[Base]]:
@@ -243,6 +270,10 @@ class SimpleBatchPurgerSpec(BatchPurgerSpec[Base]):
         for cond in self._conditions:
             query = query.where(cond)
         return query
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return self._conflict_checks
 
 
 class BatchPurgerBasicRow(Base):  # type: ignore[misc]
@@ -544,6 +575,10 @@ class ORMBatchPurgerSpec(BatchPurgerSpec[Base]):
             query = query.where(cond)
         return query
 
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
 
 class TestBatchPurgerWithORMModel:
     """Tests for batch purger operations using ORM model."""
@@ -656,6 +691,10 @@ class CompositePKBatchPurgerSpec(BatchPurgerSpec[BatchPurgerCompositePKRow]):
         for cond in self._conditions:
             query = query.where(cond)
         return query
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
 
 
 class TestBatchPurgerCompositePK:
@@ -830,7 +869,7 @@ class TestPurgerIntegrityError:
 
         # Attempt to delete parent → FK violation
         async with database_connection.begin_session() as db_sess:
-            purger: Purger[PurgerParentRow] = Purger(row_class=parent_cls, pk_value=1)
+            purger: Purger[PurgerParentRow] = Purger(spec=SimplePurgerSpec(parent_cls, 1))
             with pytest.raises(ForeignKeyViolationError) as exc_info:
                 await execute_purger(db_sess, purger)
 
@@ -852,7 +891,7 @@ class TestPurgerIntegrityError:
 
         # Delete parent → should succeed
         async with database_connection.begin_session() as db_sess:
-            purger: Purger[PurgerParentRow] = Purger(row_class=parent_cls, pk_value=1)
+            purger: Purger[PurgerParentRow] = Purger(spec=SimplePurgerSpec(parent_cls, 1))
             result = await execute_purger(db_sess, purger)
 
             assert result is not None
@@ -1035,9 +1074,9 @@ class TestBulkPurgerPartial:
         # Execute bulk purger partial with 3 purgers
         async with database_connection.begin_session() as db_sess:
             purgers = [
-                Purger(row_class=test_row_class, pk_value=1),
-                Purger(row_class=test_row_class, pk_value=2),
-                Purger(row_class=test_row_class, pk_value=3),
+                Purger(spec=SimplePurgerSpec(test_row_class, 1)),
+                Purger(spec=SimplePurgerSpec(test_row_class, 2)),
+                Purger(spec=SimplePurgerSpec(test_row_class, 3)),
             ]
             result = await execute_bulk_purger_partial(db_sess, purgers)
 
@@ -1083,9 +1122,9 @@ class TestBulkPurgerPartial:
         # Execute bulk purger partial with 3 purgers
         async with database_connection.begin_session() as db_sess:
             purgers = [
-                Purger(row_class=parent_cls, pk_value=1),
-                Purger(row_class=parent_cls, pk_value=2),  # Has FK constraint
-                Purger(row_class=parent_cls, pk_value=3),
+                Purger(spec=SimplePurgerSpec(parent_cls, 1)),
+                Purger(spec=SimplePurgerSpec(parent_cls, 2)),  # Has FK constraint
+                Purger(spec=SimplePurgerSpec(parent_cls, 3)),
             ]
             result = await execute_bulk_purger_partial(db_sess, purgers)
 
@@ -1105,7 +1144,7 @@ class TestBulkPurgerPartial:
             # Verify error (parent-2 with FK constraint)
             error = result.errors[0]
             assert isinstance(error, BulkPurgerError)
-            assert error.purger.pk_value == 2
+            assert error.purger.spec.pk_value() == 2
             assert error.index == 1  # Second purger in the list
             assert isinstance(error.exception, ForeignKeyViolationError)
             assert isinstance(error.exception, RepositoryIntegrityError)
@@ -1134,9 +1173,9 @@ class TestBulkPurgerPartial:
         # Execute bulk purger partial with 3 purgers (one targets non-existent id=2)
         async with database_connection.begin_session() as db_sess:
             purgers = [
-                Purger(row_class=test_row_class, pk_value=1),
-                Purger(row_class=test_row_class, pk_value=2),  # Non-existent PK
-                Purger(row_class=test_row_class, pk_value=3),
+                Purger(spec=SimplePurgerSpec(test_row_class, 1)),
+                Purger(spec=SimplePurgerSpec(test_row_class, 2)),  # Non-existent PK
+                Purger(spec=SimplePurgerSpec(test_row_class, 3)),
             ]
             result = await execute_bulk_purger_partial(db_sess, purgers)
 
@@ -1197,11 +1236,11 @@ class TestBulkPurgerPartial:
         # Execute bulk purger partial with 5 purgers
         async with database_connection.begin_session() as db_sess:
             purgers = [
-                Purger(row_class=parent_cls, pk_value=1),  # index 0 - success
-                Purger(row_class=parent_cls, pk_value=2),  # index 1 - FK error
-                Purger(row_class=parent_cls, pk_value=3),  # index 2 - success
-                Purger(row_class=parent_cls, pk_value=4),  # index 3 - FK error
-                Purger(row_class=parent_cls, pk_value=5),  # index 4 - success
+                Purger(spec=SimplePurgerSpec(parent_cls, 1)),  # index 0 - success
+                Purger(spec=SimplePurgerSpec(parent_cls, 2)),  # index 1 - FK error
+                Purger(spec=SimplePurgerSpec(parent_cls, 3)),  # index 2 - success
+                Purger(spec=SimplePurgerSpec(parent_cls, 4)),  # index 3 - FK error
+                Purger(spec=SimplePurgerSpec(parent_cls, 5)),  # index 4 - success
             ]
             result = await execute_bulk_purger_partial(db_sess, purgers)
 
@@ -1211,9 +1250,9 @@ class TestBulkPurgerPartial:
 
             # Verify error indices
             assert result.errors[0].index == 1  # parent-2
-            assert result.errors[0].purger.pk_value == 2
+            assert result.errors[0].purger.spec.pk_value() == 2
             assert result.errors[1].index == 3  # parent-4
-            assert result.errors[1].purger.pk_value == 4
+            assert result.errors[1].purger.spec.pk_value() == 4
 
 
 # =============================================================================
@@ -1309,3 +1348,157 @@ class TestBatchPurgerEagerJoin:
 
             remaining = await db_sess.execute(sa.select(sa.func.count()).select_from(seeded_child))
             assert remaining.scalar() == 2
+
+
+# =============================================================================
+# Conflict Check Tests
+# =============================================================================
+
+
+class TestPurgerConflictChecks:
+    """Tests for spec-declared conflict checks validated before deletion."""
+
+    @pytest.fixture
+    async def fk_tables(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[tuple[type[PurgerParentRow], type[PurgerChildRow]], None]:
+        """Create parent and child tables with FK constraint."""
+        async with database_connection.begin() as conn:
+            await conn.run_sync(
+                lambda c: Base.metadata.create_all(
+                    c, [PurgerParentRow.__table__, PurgerChildRow.__table__]
+                )
+            )
+
+        yield PurgerParentRow, PurgerChildRow
+
+        async with database_connection.begin() as conn:
+            await conn.execute(sa.text("DROP TABLE IF EXISTS test_purger_ie_child CASCADE"))
+            await conn.execute(sa.text("DROP TABLE IF EXISTS test_purger_ie_parent CASCADE"))
+
+    async def test_conflict_check_blocks_deletion(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        fk_tables: tuple[type[PurgerParentRow], type[PurgerChildRow]],
+    ) -> None:
+        """A failing conflict check raises the declared error before the DELETE runs."""
+        parent_cls, child_cls = fk_tables
+
+        async with database_connection.begin_session() as db_sess:
+            db_sess.add(PurgerParentRow(id=1, name="parent-1"))
+            await db_sess.flush()
+            db_sess.add(PurgerChildRow(id=1, parent_id=1, name="child-1"))
+
+        async with database_connection.begin_session() as db_sess:
+            spec = SimplePurgerSpec(
+                parent_cls,
+                1,
+                conflict_checks=(
+                    ConflictCheck(
+                        condition=lambda: child_cls.parent_id == 1,
+                        error=RepositoryIntegrityError("child rows exist"),
+                    ),
+                ),
+            )
+            with pytest.raises(RepositoryIntegrityError) as exc_info:
+                await execute_purger(db_sess, Purger(spec=spec))
+
+            # The declared error is raised, not the FK-violation fallback from the DELETE.
+            assert type(exc_info.value) is RepositoryIntegrityError
+
+            count_result = await db_sess.execute(sa.select(sa.func.count()).select_from(parent_cls))
+            assert count_result.scalar() == 1
+
+    async def test_conflict_check_passes_when_no_conflict(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        fk_tables: tuple[type[PurgerParentRow], type[PurgerChildRow]],
+    ) -> None:
+        """A passing conflict check lets the deletion proceed."""
+        parent_cls, child_cls = fk_tables
+
+        async with database_connection.begin_session() as db_sess:
+            db_sess.add(PurgerParentRow(id=1, name="parent-1"))
+
+        async with database_connection.begin_session() as db_sess:
+            spec = SimplePurgerSpec(
+                parent_cls,
+                1,
+                conflict_checks=(
+                    ConflictCheck(
+                        condition=lambda: child_cls.parent_id == 1,
+                        error=RepositoryIntegrityError("child rows exist"),
+                    ),
+                ),
+            )
+            result = await execute_purger(db_sess, Purger(spec=spec))
+
+            assert result is not None
+            assert result.row.id == 1
+
+            count_result = await db_sess.execute(sa.select(sa.func.count()).select_from(parent_cls))
+            assert count_result.scalar() == 0
+
+    async def test_first_failing_conflict_check_wins(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        fk_tables: tuple[type[PurgerParentRow], type[PurgerChildRow]],
+    ) -> None:
+        """When multiple checks fail, the first declared check's error is raised."""
+        parent_cls, child_cls = fk_tables
+
+        async with database_connection.begin_session() as db_sess:
+            db_sess.add(PurgerParentRow(id=1, name="parent-1"))
+            await db_sess.flush()
+            db_sess.add(PurgerChildRow(id=1, parent_id=1, name="child-1"))
+
+        async with database_connection.begin_session() as db_sess:
+            spec = SimplePurgerSpec(
+                parent_cls,
+                1,
+                conflict_checks=(
+                    ConflictCheck(
+                        condition=lambda: child_cls.parent_id == 1,
+                        error=UnsupportedCompositePrimaryKeyError("first check"),
+                    ),
+                    ConflictCheck(
+                        condition=lambda: child_cls.id == 1,
+                        error=RepositoryIntegrityError("second check"),
+                    ),
+                ),
+            )
+            with pytest.raises(UnsupportedCompositePrimaryKeyError):
+                await execute_purger(db_sess, Purger(spec=spec))
+
+    async def test_batch_purger_conflict_check_blocks_deletion(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        fk_tables: tuple[type[PurgerParentRow], type[PurgerChildRow]],
+    ) -> None:
+        """A failing conflict check blocks the whole batch deletion."""
+        parent_cls, child_cls = fk_tables
+
+        async with database_connection.begin_session() as db_sess:
+            db_sess.add(PurgerParentRow(id=1, name="parent-1"))
+            db_sess.add(PurgerParentRow(id=2, name="parent-2"))
+            await db_sess.flush()
+            db_sess.add(PurgerChildRow(id=1, parent_id=1, name="child-1"))
+
+        async with database_connection.begin_session() as db_sess:
+            spec = SimpleBatchPurgerSpec(
+                row_class=parent_cls,
+                conflict_checks=(
+                    ConflictCheck(
+                        condition=lambda: child_cls.parent_id == 1,
+                        error=RepositoryIntegrityError("child rows exist"),
+                    ),
+                ),
+            )
+            with pytest.raises(RepositoryIntegrityError) as exc_info:
+                await execute_batch_purger(db_sess, BatchPurger(spec=spec))
+
+            assert type(exc_info.value) is RepositoryIntegrityError
+
+            count_result = await db_sess.execute(sa.select(sa.func.count()).select_from(parent_cls))
+            assert count_result.scalar() == 2

--- a/tests/unit/manager/repositories/container_registry/test_container_registry_repository.py
+++ b/tests/unit/manager/repositories/container_registry/test_container_registry_repository.py
@@ -60,6 +60,7 @@ from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.container_registry.creators import (
     ContainerRegistryCreatorSpec,
 )
+from ai.backend.manager.repositories.container_registry.purgers import ContainerRegistryPurgerSpec
 from ai.backend.manager.repositories.container_registry.repository import (
     ContainerRegistryRepository,
 )
@@ -1259,7 +1260,7 @@ class TestContainerRegistryRepository:
         registry_name = test_registry.registry_name
 
         # When: Delete the registry
-        purger = Purger(row_class=ContainerRegistryRow, pk_value=registry_id)
+        purger = Purger(spec=ContainerRegistryPurgerSpec(registry_id=registry_id))
         result = await repository.delete_registry(purger)
 
         # Then: Returns deleted registry data
@@ -1268,7 +1269,7 @@ class TestContainerRegistryRepository:
 
         # And: Registry no longer exists
         with pytest.raises(ContainerRegistryNotFound):
-            purger = Purger(row_class=ContainerRegistryRow, pk_value=registry_id)
+            purger = Purger(spec=ContainerRegistryPurgerSpec(registry_id=registry_id))
             await repository.delete_registry(purger)
 
     async def test_delete_registry_not_found(
@@ -1281,7 +1282,7 @@ class TestContainerRegistryRepository:
 
         # When/Then: Raises ContainerRegistryNotFound
         with pytest.raises(ContainerRegistryNotFound):
-            purger = Purger(row_class=ContainerRegistryRow, pk_value=non_existent_id)
+            purger = Purger(spec=ContainerRegistryPurgerSpec(registry_id=non_existent_id))
             await repository.delete_registry(purger)
 
     async def test_delete_registry_returns_data_before_deletion(
@@ -1294,7 +1295,7 @@ class TestContainerRegistryRepository:
         registry = test_registry_with_custom_props
 
         # When: Delete the registry
-        purger = Purger(row_class=ContainerRegistryRow, pk_value=registry.id)
+        purger = Purger(spec=ContainerRegistryPurgerSpec(registry_id=registry.id))
         result = await repository.delete_registry(purger)
 
         # Then: Returns all registry data with correct properties

--- a/tests/unit/manager/repositories/deployment/test_deployment_repository.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_repository.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Sequence
+from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
-from typing import Any
+from typing import Any, override
 from unittest.mock import MagicMock
 
 import pytest
@@ -96,9 +97,10 @@ from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import VFolderRow
 from ai.backend.manager.repositories.base.pagination import OffsetPagination
-from ai.backend.manager.repositories.base.purger import Purger
+from ai.backend.manager.repositories.base.purger import Purger, PurgerSpec
 from ai.backend.manager.repositories.base.querier import BatchQuerier
 from ai.backend.manager.repositories.base.rbac.entity_creator import RBACEntityCreator
+from ai.backend.manager.repositories.base.types import ConflictCheck
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.base.upserter import Upserter
 from ai.backend.manager.repositories.deployment import DeploymentRepository
@@ -120,6 +122,25 @@ from ai.backend.manager.repositories.deployment.updaters import (
 from ai.backend.manager.repositories.deployment.upserters import DeploymentPolicyUpserterSpec
 from ai.backend.manager.types import OptionalState
 from ai.backend.testutils.db import with_tables
+
+
+@dataclass
+class DeploymentPolicyPurgerSpec(PurgerSpec[DeploymentPolicyRow]):
+    """Test-local PurgerSpec for deleting a deployment policy."""
+
+    policy_id: uuid.UUID
+
+    @override
+    def row_class(self) -> type[DeploymentPolicyRow]:
+        return DeploymentPolicyRow
+
+    @override
+    def pk_value(self) -> uuid.UUID:
+        return self.policy_id
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
 
 
 def create_test_password_info(password: str) -> PasswordInfo:
@@ -2486,8 +2507,7 @@ class TestDeploymentPolicyOperations:
     ) -> None:
         """Test deleting a deployment policy using Purger."""
         purger = Purger(
-            row_class=DeploymentPolicyRow,
-            pk_value=test_deployment_policy_data.id,
+            spec=DeploymentPolicyPurgerSpec(policy_id=test_deployment_policy_data.id),
         )
 
         result = await deployment_repository.delete_deployment_policy(purger)
@@ -2506,8 +2526,7 @@ class TestDeploymentPolicyOperations:
         """Test that delete_deployment_policy returns None for nonexistent policy."""
         nonexistent_id = uuid.uuid4()
         purger = Purger(
-            row_class=DeploymentPolicyRow,
-            pk_value=nonexistent_id,
+            spec=DeploymentPolicyPurgerSpec(policy_id=nonexistent_id),
         )
 
         result = await deployment_repository.delete_deployment_policy(purger)

--- a/tests/unit/manager/repositories/domain/test_domain_purgers.py
+++ b/tests/unit/manager/repositories/domain/test_domain_purgers.py
@@ -16,6 +16,7 @@ from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.kernel.types import KernelStatus
+from ai.backend.manager.errors.resource import DomainHasGroups, DomainHasUsers
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
@@ -32,10 +33,16 @@ from ai.backend.manager.models.resource_policy import (
 from ai.backend.manager.models.scaling_group import ScalingGroupOpts, ScalingGroupRow
 from ai.backend.manager.models.session import SessionRow, SessionStatus, SessionTypes
 from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
-from ai.backend.manager.repositories.base.purger import BatchPurger, execute_batch_purger
+from ai.backend.manager.repositories.base.purger import (
+    BatchPurger,
+    Purger,
+    execute_batch_purger,
+    execute_purger,
+)
 from ai.backend.manager.repositories.domain.purgers import (
     DomainBatchPurgerSpec,
     DomainKernelBatchPurgerSpec,
+    DomainPurgerSpec,
 )
 from ai.backend.testutils.db import with_tables
 from ai.backend.testutils.fixtures import DomainFactory, DomainFixtureData
@@ -307,3 +314,72 @@ class TestDomainPurgersIntegration:
                 .where(DomainRow.name == domain_name)
             )
             assert count == 0
+
+    async def test_purge_domain_spec_succeeds_without_conflicts(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        sample_domain: DomainFixtureData,
+    ) -> None:
+        """DomainPurgerSpec deletes a domain with no bound users or groups."""
+        domain_name = sample_domain.domain_name
+
+        async with db_with_cleanup.begin_session() as session:
+            result = await execute_purger(
+                session, Purger(spec=DomainPurgerSpec(domain_name=domain_name))
+            )
+            assert result is not None
+            assert result.row.name == domain_name
+
+        async with db_with_cleanup.begin_session() as session:
+            count = await session.scalar(
+                sa.select(sa.func.count())
+                .select_from(DomainRow)
+                .where(DomainRow.name == domain_name)
+            )
+            assert count == 0
+
+    async def test_purge_domain_spec_blocked_by_users(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        sample_domain: DomainFixtureData,
+        sample_user: UserRow,
+    ) -> None:
+        """DomainPurgerSpec raises DomainHasUsers while users remain bound."""
+        domain_name = sample_domain.domain_name
+
+        async with db_with_cleanup.begin_session() as session:
+            with pytest.raises(DomainHasUsers):
+                await execute_purger(
+                    session, Purger(spec=DomainPurgerSpec(domain_name=domain_name))
+                )
+
+        async with db_with_cleanup.begin_session() as session:
+            count = await session.scalar(
+                sa.select(sa.func.count())
+                .select_from(DomainRow)
+                .where(DomainRow.name == domain_name)
+            )
+            assert count == 1
+
+    async def test_purge_domain_spec_blocked_by_groups(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        sample_domain: DomainFixtureData,
+        sample_group: GroupRow,
+    ) -> None:
+        """DomainPurgerSpec raises DomainHasGroups while groups remain bound."""
+        domain_name = sample_domain.domain_name
+
+        async with db_with_cleanup.begin_session() as session:
+            with pytest.raises(DomainHasGroups):
+                await execute_purger(
+                    session, Purger(spec=DomainPurgerSpec(domain_name=domain_name))
+                )
+
+        async with db_with_cleanup.begin_session() as session:
+            count = await session.scalar(
+                sa.select(sa.func.count())
+                .select_from(DomainRow)
+                .where(DomainRow.name == domain_name)
+            )
+            assert count == 1

--- a/tests/unit/manager/repositories/model_card/test_model_card_delete.py
+++ b/tests/unit/manager/repositories/model_card/test_model_card_delete.py
@@ -59,6 +59,7 @@ from ai.backend.manager.repositories.base.purger import Purger
 from ai.backend.manager.repositories.base.rbac.entity_creator import RBACEntityCreator
 from ai.backend.manager.repositories.model_card.creators import ModelCardCreatorSpec
 from ai.backend.manager.repositories.model_card.db_source.db_source import ModelCardDBSource
+from ai.backend.manager.repositories.model_card.purgers import ModelCardPurgerSpec
 from ai.backend.testutils.db import with_tables
 
 if TYPE_CHECKING:
@@ -418,7 +419,7 @@ class TestModelCardDelete:
         assert target.vfolder_id == sibling.vfolder_id
 
         await db_source.delete(
-            Purger(row_class=ModelCardRow, pk_value=target.id),
+            Purger(spec=ModelCardPurgerSpec(card_id=target.id)),
             case.options,
         )
 
@@ -457,9 +458,9 @@ class TestModelCardDelete:
 
         result = await db_source.bulk_delete(
             [
-                Purger(row_class=ModelCardRow, pk_value=valid_a.id),
-                Purger(row_class=ModelCardRow, pk_value=missing_id),
-                Purger(row_class=ModelCardRow, pk_value=valid_b.id),
+                Purger(spec=ModelCardPurgerSpec(card_id=valid_a.id)),
+                Purger(spec=ModelCardPurgerSpec(card_id=missing_id)),
+                Purger(spec=ModelCardPurgerSpec(card_id=valid_b.id)),
             ],
             DeleteModelCardOptions(delete_associated_vfolder=False),
         )
@@ -495,8 +496,8 @@ class TestModelCardDelete:
 
         result = await db_source.bulk_delete(
             [
-                Purger(row_class=ModelCardRow, pk_value=free_card.id),
-                Purger(row_class=ModelCardRow, pk_value=mounted_card.id),
+                Purger(spec=ModelCardPurgerSpec(card_id=free_card.id)),
+                Purger(spec=ModelCardPurgerSpec(card_id=mounted_card.id)),
             ],
             DeleteModelCardOptions(delete_associated_vfolder=True),
         )

--- a/tests/unit/manager/repositories/ops/rbac/test_provider.py
+++ b/tests/unit/manager/repositories/ops/rbac/test_provider.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncGenerator, Collection
+from collections.abc import AsyncGenerator, Collection, Sequence
 from dataclasses import dataclass, field
 from typing import override
 from uuid import UUID
@@ -55,6 +55,7 @@ from ai.backend.manager.repositories.base.rbac.entity_purger import (
     RBACEntityPurger,
     RBACEntityPurgerSpec,
 )
+from ai.backend.manager.repositories.base.types import ConflictCheck
 from ai.backend.manager.repositories.ops.rbac.provider import (
     EntityMembersAddition,
     RBACOpsProvider,
@@ -189,8 +190,20 @@ class RBACOpsCreatorSpec(CreatorSpec[RBACOpsTestRow]):
 
 
 @dataclass
-class RBACOpsPurgerSpec(RBACEntityPurgerSpec):
+class RBACOpsPurgerSpec(RBACEntityPurgerSpec[RBACOpsTestRow]):
     entity_id: str
+
+    @override
+    def row_class(self) -> type[RBACOpsTestRow]:
+        return RBACOpsTestRow
+
+    @override
+    def pk_value(self) -> int:
+        return int(self.entity_id)
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
 
     @override
     def element_type(self) -> RBACElementType:
@@ -671,8 +684,6 @@ class TestBulkPurgeScopedPartial:
         async with provider.write_ops() as w:
             result = await w.bulk_purge_scoped_partial([
                 RBACEntityPurger(
-                    row_class=RBACOpsTestRow,
-                    pk_value=doomed.id,
                     spec=RBACOpsPurgerSpec(entity_id=str(doomed.id)),
                 )
             ])
@@ -700,8 +711,6 @@ class TestBulkPurgeScopedPartial:
         async with provider.write_ops() as w:
             result = await w.bulk_purge_scoped_partial([
                 RBACEntityPurger(
-                    row_class=RBACOpsTestRow,
-                    pk_value=9_999_999,  # never existed
                     spec=RBACOpsPurgerSpec(entity_id="9999999"),
                 )
             ])
@@ -730,13 +739,9 @@ class TestBulkPurgeScopedPartial:
         async with provider.write_ops() as w:
             result = await w.bulk_purge_scoped_partial([
                 RBACEntityPurger(  # RESTRICT foreign key -> delete rejected
-                    row_class=RBACOpsTestRow,
-                    pk_value=blocked.id,
                     spec=RBACOpsPurgerSpec(entity_id=str(blocked.id)),
                 ),
                 RBACEntityPurger(
-                    row_class=RBACOpsTestRow,
-                    pk_value=free.id,
                     spec=RBACOpsPurgerSpec(entity_id=str(free.id)),
                 ),
             ])

--- a/tests/unit/manager/repositories/ops/test_provider.py
+++ b/tests/unit/manager/repositories/ops/test_provider.py
@@ -32,6 +32,8 @@ from ai.backend.manager.repositories.base import (
     Updater,
     UpdaterSpec,
 )
+from ai.backend.manager.repositories.base.purger import PurgerSpec
+from ai.backend.manager.repositories.base.types import ConflictCheck
 from ai.backend.manager.repositories.ops import DBOpsProvider, ReadOps
 from ai.backend.testutils.db import with_tables
 
@@ -78,6 +80,23 @@ class ParentUpdaterSpec(UpdaterSpec[OpsTestParentRow]):
     @override
     def build_values(self) -> dict[str, Any]:
         return {"name": self.new_name}
+
+
+@dataclass
+class ParentPurgerSpec(PurgerSpec[OpsTestParentRow]):
+    parent_id: int
+
+    @override
+    def row_class(self) -> type[OpsTestParentRow]:
+        return OpsTestParentRow
+
+    @override
+    def pk_value(self) -> int:
+        return self.parent_id
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
 
 
 @dataclass(frozen=True)
@@ -158,7 +177,7 @@ class TestWriteRoundTrip:
         async with provider.write_ops() as w:
             created = await w.create(Creator(spec=ParentCreatorSpec(name="p1", domain_name="d1")))
             parent_id = created.row.id
-            await w.purge(Purger(row_class=OpsTestParentRow, pk_value=parent_id))
+            await w.purge(Purger(spec=ParentPurgerSpec(parent_id=parent_id)))
 
         async with provider.read_ops() as r:
             fetched = await r.query(Querier(row_class=OpsTestParentRow, pk_value=parent_id))

--- a/tests/unit/manager/repositories/permission_controller/test_role_permissions_bulk.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_permissions_bulk.py
@@ -38,6 +38,7 @@ from ai.backend.manager.repositories.permission_controller.creators import (
 from ai.backend.manager.repositories.permission_controller.db_source.db_source import (
     PermissionDBSource,
 )
+from ai.backend.manager.repositories.permission_controller.purgers import PermissionPurgerSpec
 from ai.backend.testutils.db import TableOrORM, with_tables
 
 if TYPE_CHECKING:
@@ -238,7 +239,7 @@ class TestBulkRolePermissions:
     async def test_bulk_remove_unknown_pk_returns_no_success(
         self, perm_db_source: PermissionDBSource
     ) -> None:
-        purgers = [Purger(row_class=PermissionRow, pk_value=uuid.uuid4())]
+        purgers = [Purger(spec=PermissionPurgerSpec(permission_id=uuid.uuid4()))]
         result = await perm_db_source.bulk_remove_role_permissions(purgers)
         assert result.success_count() == 0
         assert not result.has_failures()
@@ -258,7 +259,7 @@ class TestBulkRolePermissions:
             _spec(role_id, RBACElementType.SESSION, OperationType.HARD_DELETE),
         )
         result = await perm_db_source.bulk_remove_role_permissions([
-            Purger(row_class=PermissionRow, pk_value=drop_id)
+            Purger(spec=PermissionPurgerSpec(permission_id=drop_id))
         ])
         assert result.success_count() == 1
         remaining_ids = {keep_id}

--- a/tests/unit/manager/repositories/scaling_group/test_scaling_group_repository.py
+++ b/tests/unit/manager/repositories/scaling_group/test_scaling_group_repository.py
@@ -66,6 +66,7 @@ from ai.backend.manager.repositories.scaling_group.creators import (
     ScalingGroupForProjectCreatorSpec,
 )
 from ai.backend.manager.repositories.scaling_group.purgers import (
+    ScalingGroupPurgerSpec,
     create_scaling_group_for_keypairs_purger,
 )
 from ai.backend.manager.repositories.scaling_group.scope_binders import (
@@ -748,7 +749,7 @@ class TestScalingGroupRepositoryDB:
         sgroup_name = sample_scaling_group_for_purge
 
         # When: Purge the scaling group
-        purger = Purger(row_class=ScalingGroupRow, pk_value=sgroup_name)
+        purger = Purger(spec=ScalingGroupPurgerSpec(name=sgroup_name))
         result = await scaling_group_repository.purge_scaling_group(purger)
 
         # Then: Should return the deleted scaling group data
@@ -768,7 +769,7 @@ class TestScalingGroupRepositoryDB:
         """Test purging non-existent scaling group raises ScalingGroupNotFound"""
         # Given: A purger for non-existent scaling group with uuid-based name
         non_existent_name = f"test-sgroup-nonexistent-{uuid.uuid4().hex[:8]}"
-        purger = Purger(row_class=ScalingGroupRow, pk_value=non_existent_name)
+        purger = Purger(spec=ScalingGroupPurgerSpec(name=non_existent_name))
 
         # When/Then: Purging should raise ScalingGroupNotFound
         with pytest.raises(ScalingGroupNotFound):
@@ -784,7 +785,7 @@ class TestScalingGroupRepositoryDB:
         sgroup_name = sample_scaling_group_with_sessions_and_routes
 
         # When: Purge the scaling group
-        purger = Purger(row_class=ScalingGroupRow, pk_value=sgroup_name)
+        purger = Purger(spec=ScalingGroupPurgerSpec(name=sgroup_name))
         result = await scaling_group_repository.purge_scaling_group(purger)
 
         # Then: Should return the deleted scaling group data
@@ -1420,7 +1421,7 @@ class TestScalingGroupRepositoryDB:
         endpoint_id = sample_endpoint
         route_id = sample_route
 
-        purger = Purger(row_class=ScalingGroupRow, pk_value=sgroup_name)
+        purger = Purger(spec=ScalingGroupPurgerSpec(name=sgroup_name))
         # FK Error should not occur, and all related records should be deleted
         result = await scaling_group_repository.purge_scaling_group(purger)
 

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_repository.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_repository.py
@@ -834,8 +834,6 @@ class TestVfolderRepositoryPurge:
         assert await self._vfolder_exists(db_with_cleanup, vfolder_id)
 
         purger = RBACEntityPurger(
-            row_class=VFolderRow,
-            pk_value=vfolder_id,
             spec=VFolderPurgerSpec(vfolder_id=vfolder_id),
         )
         result = await vfolder_repository.purge_vfolder(purger)
@@ -852,8 +850,6 @@ class TestVfolderRepositoryPurge:
         """Test purge fails when vfolder doesn't exist."""
         non_existent_id = uuid.uuid4()
         purger = RBACEntityPurger(
-            row_class=VFolderRow,
-            pk_value=non_existent_id,
             spec=VFolderPurgerSpec(vfolder_id=non_existent_id),
         )
 
@@ -883,8 +879,6 @@ class TestVfolderRepositoryPurge:
         vfolder_id = vfolder_in_db
 
         purger = RBACEntityPurger(
-            row_class=VFolderRow,
-            pk_value=vfolder_id,
             spec=VFolderPurgerSpec(vfolder_id=vfolder_id),
         )
 
@@ -988,8 +982,6 @@ class TestVfolderRepositoryPurge:
         vfolder_id = vfolder_in_db
 
         purger = RBACEntityPurger(
-            row_class=VFolderRow,
-            pk_value=vfolder_id,
             spec=VFolderPurgerSpec(vfolder_id=vfolder_id),
         )
 

--- a/tests/unit/manager/services/app_config_allow_list/test_service.py
+++ b/tests/unit/manager/services/app_config_allow_list/test_service.py
@@ -15,9 +15,11 @@ from ai.backend.manager.data.app_config_allow_list.types import (
     AppConfigAllowListSearchResult,
 )
 from ai.backend.manager.errors.app_config import AppConfigAllowListNotFound
-from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
 from ai.backend.manager.repositories.app_config_allow_list.creators import (
     AppConfigAllowListCreatorSpec,
+)
+from ai.backend.manager.repositories.app_config_allow_list.purgers import (
+    AppConfigAllowListPurgerSpec,
 )
 from ai.backend.manager.repositories.app_config_allow_list.repository import (
     AppConfigAllowListRepository,
@@ -163,7 +165,7 @@ class TestAppConfigAllowListService:
         allow_list_data: AppConfigAllowListData,
     ) -> None:
         mock_repository.purge = AsyncMock(return_value=allow_list_data)
-        purger = Purger(row_class=AppConfigAllowListRow, pk_value=allow_list_data.id)
+        purger = Purger(spec=AppConfigAllowListPurgerSpec(allow_list_id=allow_list_data.id))
 
         result = await service.purge(PurgeAppConfigAllowListAction(purger=purger))
 

--- a/tests/unit/manager/services/app_config_definition/test_service.py
+++ b/tests/unit/manager/services/app_config_definition/test_service.py
@@ -14,9 +14,11 @@ from ai.backend.manager.data.app_config_definition.types import (
     AppConfigDefinitionListResult,
 )
 from ai.backend.manager.errors.app_config import AppConfigDefinitionNotFound
-from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
 from ai.backend.manager.repositories.app_config_definition.creators import (
     AppConfigDefinitionCreatorSpec,
+)
+from ai.backend.manager.repositories.app_config_definition.purgers import (
+    AppConfigDefinitionPurgerSpec,
 )
 from ai.backend.manager.repositories.app_config_definition.repository import (
     AppConfigDefinitionRepository,
@@ -131,7 +133,7 @@ class TestAppConfigDefinitionService:
         definition_data: AppConfigDefinitionData,
     ) -> None:
         mock_repository.purge = AsyncMock(return_value=definition_data)
-        purger = Purger(row_class=AppConfigDefinitionRow, pk_value=definition_data.id)
+        purger = Purger(spec=AppConfigDefinitionPurgerSpec(definition_id=definition_data.id))
 
         result = await service.purge(PurgeAppConfigDefinitionAction(purger=purger))
 

--- a/tests/unit/manager/services/scaling_group/test_scaling_group_crud.py
+++ b/tests/unit/manager/services/scaling_group/test_scaling_group_crud.py
@@ -25,7 +25,6 @@ from ai.backend.common.types import AccessKey
 from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.data.scaling_group.types import ScalingGroupData
 from ai.backend.manager.errors.resource import ScalingGroupNotFound
-from ai.backend.manager.models.scaling_group import ScalingGroupRow
 from ai.backend.manager.repositories.base.creator import BulkCreator, Creator
 from ai.backend.manager.repositories.base.purger import Purger
 from ai.backend.manager.repositories.base.rbac.scope_binder import (
@@ -39,6 +38,7 @@ from ai.backend.manager.repositories.scaling_group.creators import (
     ScalingGroupForKeypairsCreatorSpec,
 )
 from ai.backend.manager.repositories.scaling_group.purgers import (
+    ScalingGroupPurgerSpec,
     create_scaling_group_for_keypairs_purger,
 )
 from ai.backend.manager.repositories.scaling_group.repository import ScalingGroupRepository
@@ -111,7 +111,7 @@ async def _purge_sgroup(
     name: str,
 ) -> None:
     """Purge a scaling group via the processor."""
-    action = PurgeScalingGroupAction(purger=Purger(row_class=ScalingGroupRow, pk_value=name))
+    action = PurgeScalingGroupAction(purger=Purger(spec=ScalingGroupPurgerSpec(name=name)))
     await processors.purge_scaling_group.wait_for_complete(action)
 
 
@@ -278,7 +278,7 @@ class TestScalingGroupCRUD:
         name = f"crud-purge-{uuid.uuid4().hex[:8]}"
         await _create_sgroup(scaling_group_processors, name)
 
-        action = PurgeScalingGroupAction(purger=Purger(row_class=ScalingGroupRow, pk_value=name))
+        action = PurgeScalingGroupAction(purger=Purger(spec=ScalingGroupPurgerSpec(name=name)))
         result = await scaling_group_processors.purge_scaling_group.wait_for_complete(action)
         assert result.data.name == name
 

--- a/tests/unit/manager/services/vfolder/test_vfolder_service.py
+++ b/tests/unit/manager/services/vfolder/test_vfolder_service.py
@@ -119,8 +119,6 @@ class TestVFolderServicePurge:
     @pytest.fixture
     def sample_purger(self, sample_vfolder_uuid: uuid.UUID) -> RBACEntityPurger[VFolderRow]:
         return RBACEntityPurger(
-            row_class=VFolderRow,
-            pk_value=sample_vfolder_uuid,
             spec=VFolderPurgerSpec(vfolder_id=sample_vfolder_uuid),
         )
 


### PR DESCRIPTION
## Summary
- Add `ConflictCheck` (`models/scopes.py`) and validate spec-declared checks in a single query before deletion in all purger executors (`execute_purger`, `execute_bulk_purger_partial`, `execute_batch_purger`, RBAC variants).
- Convert `Purger` to a pure ABC spec pattern: `PurgerSpec` declares `row_class()` / `pk_value()` / `conflict_checks()`, `RBACEntityPurgerSpec` extends `PurgerSpec`, and per-entity specs replace ad-hoc `Purger(row_class=..., pk_value=...)` construction across all call sites.
- Migrate domain purge to declare user/group conflict checks on `DomainPurgerSpec` instead of ad-hoc pre-flight SELECTs, as the reference usage; cover conflict-check success/failure paths with repository tests.

## Test plan
- [x] `pants test tests/unit/manager/repositories/base/test_purger.py` (conflict check success/failure/ordering/batch)
- [x] `pants test tests/unit/manager/repositories/domain/test_domain_purgers.py` (`DomainPurgerSpec` success / `DomainHasUsers` / `DomainHasGroups`)
- [x] `pants test --changed-since=origin/main --changed-dependents=transitive`

Resolves BA-6969

🤖 Generated with [Claude Code](https://claude.com/claude-code)