### PR TITLE
refactor(BA-6973): make idle check source judgment-only

### DIFF
--- a/changes/13042.enhance.md
+++ b/changes/13042.enhance.md
@@ -1,0 +1,1 @@
+Read idle-check judgments only from existing session-check assignments.

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -1,4 +1,4 @@
-"""DB reads backing the idle-check Source: the per-session checker batch."""
+"""DB reads backing idle-check judgment and expiry-sweep Sources."""
 
 from __future__ import annotations
 
@@ -7,16 +7,17 @@ from typing import cast
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.idle_checker.types import CheckerType, IdleCheckerSpec
-from ai.backend.common.data.permission.types import ScopeType
+from ai.backend.common.data.idle_checker.types import (
+    CheckerType,
+    IdleCheckerSpec,
+    IdleCheckPhase,
+)
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.data.idle_checker.types import IdleCheckSession
-from ai.backend.manager.data.permission.id import ScopeId
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.models.idle_checker.conditions import SessionIdleCheckConditions
 from ai.backend.manager.models.idle_checker.row import (
-    IdleCheckerBindingRow,
     IdleCheckerRow,
     SessionIdleCheckRow,
 )
@@ -24,11 +25,11 @@ from ai.backend.manager.models.session.conditions import SessionConditions
 from ai.backend.manager.models.session.row import SessionRow
 from ai.backend.manager.repositories.base import BatchQuerier, NoPagination
 from ai.backend.manager.repositories.idle_checker.types import (
-    BoundCheckerData,
     ExpiredIdleCheckBatchData,
     ExpiredIdleCheckData,
+    IdleCheckAssignmentData,
+    IdleCheckBatchData,
     IdleCheckerDefinitionData,
-    IdleCheckSessionData,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider
 
@@ -39,75 +40,50 @@ class IdleCheckerDBSource:
     def __init__(self, ops_provider: DBOpsProvider) -> None:
         self._ops = ops_provider
 
-    async def fetch_bound_checkers(
+    async def fetch_judgment_batch(
         self,
-        querier: BatchQuerier,
-    ) -> Sequence[BoundCheckerData]:
-        binding_query = sa.select(
-            IdleCheckerBindingRow.scope_type,
-            IdleCheckerBindingRow.scope_id,
-            IdleCheckerBindingRow.created_at,
-            IdleCheckerBindingRow.idle_checker_id,
-            IdleCheckerRow.checker_type,
-            IdleCheckerRow.target_session_types,
-            IdleCheckerRow.spec,
-        ).join(IdleCheckerRow, IdleCheckerBindingRow.idle_checker_id == IdleCheckerRow.id)
-
-        async with self._ops.read_ops() as r:
-            binding_rows = (await r.batch_query_in_global(binding_query, querier)).rows
-        bound_checkers: list[BoundCheckerData] = []
-        for row in binding_rows:
-            scope = ScopeId(
-                scope_type=ScopeType(row.scope_type),
-                scope_id=str(row.scope_id),
+        session_statuses: Collection[SessionStatus],
+    ) -> IdleCheckBatchData:
+        query = (
+            sa.select(
+                SessionRow.id.label("session_id"),
+                SessionRow.created_at.label("session_created_at"),
+                SessionRow.starts_at.label("session_starts_at"),
+                IdleCheckerRow.id.label("checker_id"),
+                IdleCheckerRow.checker_type,
+                IdleCheckerRow.target_session_types,
+                IdleCheckerRow.spec,
             )
-            checker = IdleCheckerDefinitionData(
-                checker_id=cast(IdleCheckerID, row.idle_checker_id),
-                checker_type=cast(CheckerType, row.checker_type),
-                target_session_types=frozenset(
-                    cast(Sequence[SessionTypes], row.target_session_types)
-                ),
-                spec=cast(IdleCheckerSpec, row.spec),
+            .select_from(SessionIdleCheckRow)
+            .join(SessionRow, SessionIdleCheckRow.session_id == SessionRow.id)
+            .join(IdleCheckerRow, SessionIdleCheckRow.idle_checker_id == IdleCheckerRow.id)
+            .where(
+                SessionRow.status.in_(session_statuses),
+                SessionIdleCheckRow.last_status.in_((IdleCheckPhase.ACTIVE, IdleCheckPhase.IDLE)),
             )
-            bound_checkers.append(
-                BoundCheckerData(
-                    scope=scope,
-                    binding_created_at=row.created_at,
-                    checker=checker,
-                )
-            )
-        return bound_checkers
-
-    async def fetch_candidate_sessions(
-        self,
-        querier: BatchQuerier,
-    ) -> Sequence[IdleCheckSessionData]:
-        session_query = sa.select(
-            SessionRow.id,
-            SessionRow.created_at,
-            SessionRow.starts_at,
-            SessionRow.session_type,
-            SessionRow.resource_group_id,
-            SessionRow.group_id,
-            SessionRow.domain_id,
         )
+        querier = BatchQuerier(pagination=NoPagination())
         async with self._ops.read_ops() as r:
-            session_rows = (await r.batch_query_in_global(session_query, querier)).rows
-        return tuple(
-            IdleCheckSessionData(
-                session=IdleCheckSession(
-                    session_id=SessionId(row.id),
-                    created_at=row.created_at,
-                    starts_at=row.starts_at,
-                ),
-                session_type=row.session_type,
-                scopes=(
-                    ScopeId(ScopeType.RESOURCE_GROUP, str(row.resource_group_id)),
-                    ScopeId(ScopeType.PROJECT, str(row.group_id)),
-                    ScopeId(ScopeType.DOMAIN, str(row.domain_id)),
-                ),
-            )
-            for row in session_rows
+            rows = (await r.batch_query_in_global(query, querier)).rows
+        return IdleCheckBatchData(
+            assignments=[
+                IdleCheckAssignmentData(
+                    session=IdleCheckSession(
+                        session_id=SessionId(row.session_id),
+                        created_at=row.session_created_at,
+                        starts_at=row.session_starts_at,
+                    ),
+                    checker=IdleCheckerDefinitionData(
+                        checker_id=cast(IdleCheckerID, row.checker_id),
+                        checker_type=cast(CheckerType, row.checker_type),
+                        target_session_types=frozenset(
+                            cast(Sequence[SessionTypes], row.target_session_types)
+                        ),
+                        spec=cast(IdleCheckerSpec, row.spec),
+                    ),
+                )
+                for row in rows
+            ]
         )
 
     async def fetch_expired_idle_checks(

--- a/src/ai/backend/manager/repositories/idle_checker/repository.py
+++ b/src/ai/backend/manager/repositories/idle_checker/repository.py
@@ -1,20 +1,12 @@
 from __future__ import annotations
 
-from collections import defaultdict
 from collections.abc import Collection
 
-from ai.backend.common.types import SessionTypes
-from ai.backend.manager.data.permission.id import ScopeId
 from ai.backend.manager.data.session.types import SessionStatus
-from ai.backend.manager.models.idle_checker.conditions import IdleCheckerBindingConditions
-from ai.backend.manager.models.session.conditions import SessionConditions
-from ai.backend.manager.repositories.base import BatchQuerier, NoPagination
 from ai.backend.manager.repositories.idle_checker.db_source.db_source import IdleCheckerDBSource
 from ai.backend.manager.repositories.idle_checker.types import (
-    BoundCheckerData,
     ExpiredIdleCheckBatchData,
     IdleCheckBatchData,
-    IdleCheckTargetData,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider
 
@@ -22,70 +14,17 @@ __all__ = ("IdleCheckerRepository",)
 
 
 class IdleCheckerRepository:
-    """Reads for the idle-check Source."""
+    """Reads for idle-check reconciler Sources."""
 
     _db_source: IdleCheckerDBSource
 
     def __init__(self, ops_provider: DBOpsProvider) -> None:
         self._db_source = IdleCheckerDBSource(ops_provider)
 
-    async def fetch_idle_check_batch(
+    async def fetch_judgment_batch(
         self, session_statuses: Collection[SessionStatus]
     ) -> IdleCheckBatchData:
-        binding_querier = BatchQuerier(
-            pagination=NoPagination(),
-            conditions=[
-                IdleCheckerBindingConditions.enabled(),
-            ],
-        )
-        bound_checkers = await self._db_source.fetch_bound_checkers(binding_querier)
-        if not bound_checkers:
-            return IdleCheckBatchData(targets=())
-
-        seen_candidates = set()
-        idle_check_candidates: list[tuple[ScopeId, Collection[SessionTypes]]] = []
-        for bound_checker in bound_checkers:
-            target_session_types = bound_checker.checker.target_session_types
-            candidate_key = (
-                bound_checker.scope.scope_type,
-                bound_checker.scope.scope_id,
-                target_session_types,
-            )
-            if candidate_key in seen_candidates:
-                continue
-            seen_candidates.add(candidate_key)
-            idle_check_candidates.append((bound_checker.scope, target_session_types))
-
-        session_querier = BatchQuerier(
-            pagination=NoPagination(),
-            conditions=[
-                SessionConditions.by_statuses(session_statuses),
-                SessionConditions.by_started_at(),
-                SessionConditions.by_idle_check_candidates(idle_check_candidates),
-            ],
-        )
-        candidate_sessions = await self._db_source.fetch_candidate_sessions(session_querier)
-        checkers_by_scope: defaultdict[ScopeId, list[BoundCheckerData]] = defaultdict(list)
-        for bound_checker in bound_checkers:
-            checkers_by_scope[bound_checker.scope].append(bound_checker)
-
-        targets: list[IdleCheckTargetData] = []
-        for session_row in candidate_sessions:
-            checkers: list[BoundCheckerData] = []
-            for scope in session_row.scopes:
-                for bound in checkers_by_scope.get(scope, ()):
-                    if session_row.session_type in bound.checker.target_session_types:
-                        checkers.append(bound)
-            if not checkers:
-                continue
-            targets.append(
-                IdleCheckTargetData(
-                    session=session_row.session,
-                    checkers=tuple(checkers),
-                )
-            )
-
-        return IdleCheckBatchData(targets=tuple(targets))
+        return await self._db_source.fetch_judgment_batch(session_statuses)
 
     async def fetch_expired_idle_checks(
         self, session_statuses: Collection[SessionStatus]

--- a/src/ai/backend/manager/repositories/idle_checker/types.py
+++ b/src/ai/backend/manager/repositories/idle_checker/types.py
@@ -10,7 +10,6 @@ from ai.backend.common.data.idle_checker.types import CheckerType, IdleCheckerSp
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.data.idle_checker.types import IdleCheckSession
-from ai.backend.manager.data.permission.id import ScopeId
 
 
 @dataclass(frozen=True)
@@ -24,39 +23,18 @@ class IdleCheckerDefinitionData:
 
 
 @dataclass(frozen=True)
-class BoundCheckerData:
-    """A checker applied through a concrete scope binding.
+class IdleCheckAssignmentData:
+    """One existing session idle-check row with data needed for judgment."""
 
-    ``binding_created_at`` is the stable tiebreak within the same scope.
-    """
-
-    scope: ScopeId
-    binding_created_at: datetime
+    session: IdleCheckSession
     checker: IdleCheckerDefinitionData
-
-
-@dataclass(frozen=True)
-class IdleCheckSessionData:
-    """Session data plus scope refs needed to attach bound idle checkers."""
-
-    session: IdleCheckSession
-    session_type: SessionTypes
-    scopes: Sequence[ScopeId]
-
-
-@dataclass(frozen=True)
-class IdleCheckTargetData:
-    """One session and the checkers applicable to it in this batch."""
-
-    session: IdleCheckSession
-    checkers: Sequence[BoundCheckerData]
 
 
 @dataclass(frozen=True)
 class IdleCheckBatchData:
     """Handler-oriented idle-check input for one reconciler tick."""
 
-    targets: Sequence[IdleCheckTargetData]
+    assignments: Sequence[IdleCheckAssignmentData]
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/sokovan/idle_check/handlers/reconcile.py
+++ b/src/ai/backend/manager/sokovan/idle_check/handlers/reconcile.py
@@ -66,12 +66,10 @@ class IdleCheckReconcileHandler(ReconcilerHandler[IdleCheckReconcileInfo, IdleCh
         sessions_by_checker: defaultdict[IdleCheckerID, dict[SessionId, IdleCheckSession]] = (
             defaultdict(dict)
         )
-        for target in batch.targets:
-            for bound in target.checkers:
-                definitions[bound.checker.checker_id] = bound.checker
-                sessions_by_checker[bound.checker.checker_id][target.session.session_id] = (
-                    target.session
-                )
+        for assignment in batch.assignments:
+            checker_id = assignment.checker.checker_id
+            definitions[checker_id] = assignment.checker
+            sessions_by_checker[checker_id][assignment.session.session_id] = assignment.session
         assignments_by_type: defaultdict[CheckerType, list[CheckerAssignment]] = defaultdict(list)
         for checker_id, definition in definitions.items():
             assignments_by_type[definition.checker_type].append(

--- a/src/ai/backend/manager/sokovan/idle_check/source.py
+++ b/src/ai/backend/manager/sokovan/idle_check/source.py
@@ -26,5 +26,5 @@ class IdleCheckSource(
         category: IdleCheckCategory,
         target_statuses: IdleCheckTargetStatuses,
     ) -> IdleCheckReconcileInfo:
-        batch = await self._repository.fetch_idle_check_batch(target_statuses.session_statuses)
+        batch = await self._repository.fetch_judgment_batch(target_statuses.session_statuses)
         return IdleCheckReconcileInfo(batch=batch, current_time=datetime.now(UTC))

--- a/src/ai/backend/manager/sokovan/idle_check/types.py
+++ b/src/ai/backend/manager/sokovan/idle_check/types.py
@@ -47,7 +47,8 @@ class IdleCheckReconcileInfo(BaseReconcilerInfo):
 
     @override
     def entity_ids(self) -> Sequence[UUID]:
-        return [target.session.session_id for target in self.batch.targets]
+        session_ids = (assignment.session.session_id for assignment in self.batch.assignments)
+        return list(dict.fromkeys(session_ids))
 
     @override
     def now(self) -> datetime:

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -11,11 +11,8 @@ from ai.backend.common.data.idle_checker.types import (
     CheckerType,
     IdleCheckerSpec,
     IdleCheckPhase,
-    NetworkTimeoutSpec,
     SessionLifetimeSpec,
-    UtilizationSpec,
 )
-from ai.backend.common.data.permission.types import ScopeType
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
@@ -30,7 +27,6 @@ from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.idle_checker.row import (
-    IdleCheckerBindingRow,
     IdleCheckerRow,
     SessionIdleCheckRow,
 )
@@ -53,32 +49,23 @@ class ScopeFixture:
 
 
 @dataclass(frozen=True)
-class SeededIdleCheckData:
-    resource_group_session_id: SessionId
-    project_session_id: SessionId
-    domain_session_id: SessionId
-    inference_session_id: SessionId
-    not_started_session_id: SessionId
-    resource_group_checker_id: IdleCheckerID
-    project_checker_id: IdleCheckerID
-    domain_checker_id: IdleCheckerID
-
-
-@dataclass(frozen=True)
-class PerTypeCheckerData:
-    interactive_session_id: SessionId
-    batch_session_id: SessionId
-    interactive_checker_id: IdleCheckerID
-    batch_checker_id: IdleCheckerID
-
-
-@dataclass(frozen=True)
 class ExpiredCheckSessionData:
     session_id: SessionId
     first_checker_id: IdleCheckerID
     second_checker_id: IdleCheckerID
     first_expire_at: datetime
     second_expire_at: datetime
+
+
+@dataclass(frozen=True)
+class JudgmentRows:
+    active_session_id: SessionId
+    idle_session_id: SessionId
+    not_checked_session_id: SessionId
+    idle_expired_session_id: SessionId
+    session_without_row_id: SessionId
+    terminated_session_id: SessionId
+    checker_id: IdleCheckerID
 
 
 def _expired_check_scope_rows(
@@ -182,7 +169,7 @@ def _expired_check_scope_fixture(prefix: str) -> ScopeFixture:
     )
 
 
-class TestFetchIdleCheckBatch:
+class TestFetchJudgmentBatch:
     @pytest.fixture
     async def database(
         self,
@@ -197,7 +184,7 @@ class TestFetchIdleCheckBatch:
                 ScalingGroupRow,
                 SessionRow,
                 IdleCheckerRow,
-                IdleCheckerBindingRow,
+                SessionIdleCheckRow,
             ],
         ):
             yield database_connection
@@ -207,690 +194,106 @@ class TestFetchIdleCheckBatch:
         return IdleCheckerRepository(DBOpsProvider(database))
 
     @pytest.fixture
-    async def running_session_without_bindings(
+    async def judgment_rows(
         self,
         database: ExtendedAsyncSAEngine,
-        request: pytest.FixtureRequest,
-    ) -> SessionId:
-        prefix = str(request.param)
-        scope = ScopeFixture(
-            domain_name=f"{prefix}-domain",
-            domain_id=DomainID(uuid.uuid4()),
-            project_id=uuid.uuid4(),
-            scaling_group_name=f"{prefix}-sgroup",
-            scaling_group_id=ResourceGroupID(uuid.uuid4()),
-        )
-        session_id = SessionId(uuid.uuid4())
-        async with database.begin_session() as db_sess:
-            db_sess.add(
-                ProjectResourcePolicyRow(
-                    name=f"{scope.domain_name}-policy",
-                    max_vfolder_count=10,
-                    max_quota_scope_size=1024,
-                    max_network_count=10,
-                )
-            )
-            db_sess.add(
-                DomainRow(
-                    id=scope.domain_id,
-                    name=scope.domain_name,
-                    description=None,
-                    is_active=True,
-                )
-            )
-            db_sess.add(
-                GroupRow(
-                    id=scope.project_id,
-                    name=f"{scope.domain_name}-project",
-                    description=None,
-                    is_active=True,
-                    domain_name=scope.domain_name,
-                    resource_policy=f"{scope.domain_name}-policy",
-                )
-            )
-            db_sess.add(
-                ScalingGroupRow(
-                    id=scope.scaling_group_id,
-                    name=scope.scaling_group_name,
-                    description=None,
-                    is_active=True,
-                    is_public=True,
-                    driver="static",
-                    driver_opts={},
-                    scheduler="fifo",
-                    use_host_network=False,
-                )
-            )
-            db_sess.add(
-                SessionRow(
-                    id=session_id,
-                    creation_id=str(session_id)[:32],
-                    name=f"session-{session_id}",
-                    session_type=SessionTypes.INTERACTIVE,
-                    cluster_mode=ClusterMode.SINGLE_NODE,
-                    cluster_size=1,
-                    domain_name=scope.domain_name,
-                    domain_id=scope.domain_id,
-                    resource_group_id=scope.scaling_group_id,
-                    group_id=scope.project_id,
-                    user_uuid=uuid.uuid4(),
-                    access_key=None,
-                    tag=None,
-                    status=SessionStatus.RUNNING,
-                    status_info=None,
-                    status_data=None,
-                    status_history={},
-                    result=SessionResult.UNDEFINED,
-                    created_at=datetime(2026, 1, 1, tzinfo=UTC),
-                    terminated_at=None,
-                    starts_at=datetime(2026, 1, 1, tzinfo=UTC),
-                    startup_command=None,
-                    callback_url=None,
-                    occupying_slots=ResourceSlot({"cpu": "1"}),
-                    requested_slots=ResourceSlot({"cpu": "1"}),
-                    vfolder_mounts=[],
-                    environ=None,
-                    bootstrap_script=None,
-                    use_host_network=False,
-                    scaling_group_name=scope.scaling_group_name,
-                )
-            )
-        return session_id
-
-    @pytest.fixture
-    async def running_session_with_disabled_binding(
-        self,
-        database: ExtendedAsyncSAEngine,
-    ) -> SessionId:
-        scope = ScopeFixture(
-            domain_name="disabled-binding-domain",
-            domain_id=DomainID(uuid.uuid4()),
-            project_id=uuid.uuid4(),
-            scaling_group_name="disabled-binding-sgroup",
-            scaling_group_id=ResourceGroupID(uuid.uuid4()),
-        )
-        session_id = SessionId(uuid.uuid4())
+    ) -> JudgmentRows:
+        scope = _expired_check_scope_fixture("judgment")
+        active_session_id = SessionId(uuid.uuid4())
+        idle_session_id = SessionId(uuid.uuid4())
+        not_checked_session_id = SessionId(uuid.uuid4())
+        idle_expired_session_id = SessionId(uuid.uuid4())
+        session_without_row_id = SessionId(uuid.uuid4())
+        terminated_session_id = SessionId(uuid.uuid4())
         checker_id = IdleCheckerID(uuid.uuid4())
-        async with database.begin_session() as db_sess:
-            db_sess.add(
-                ProjectResourcePolicyRow(
-                    name=f"{scope.domain_name}-policy",
-                    max_vfolder_count=10,
-                    max_quota_scope_size=1024,
-                    max_network_count=10,
-                )
-            )
-            db_sess.add(
-                DomainRow(
-                    id=scope.domain_id,
-                    name=scope.domain_name,
-                    description=None,
-                    is_active=True,
-                )
-            )
-            db_sess.add(
-                GroupRow(
-                    id=scope.project_id,
-                    name=f"{scope.domain_name}-project",
-                    description=None,
-                    is_active=True,
-                    domain_name=scope.domain_name,
-                    resource_policy=f"{scope.domain_name}-policy",
-                )
-            )
-            db_sess.add(
-                ScalingGroupRow(
-                    id=scope.scaling_group_id,
-                    name=scope.scaling_group_name,
-                    description=None,
-                    is_active=True,
-                    is_public=True,
-                    driver="static",
-                    driver_opts={},
-                    scheduler="fifo",
-                    use_host_network=False,
-                )
-            )
-            db_sess.add(
-                SessionRow(
-                    id=session_id,
-                    creation_id=str(session_id)[:32],
-                    name=f"session-{session_id}",
-                    session_type=SessionTypes.INTERACTIVE,
-                    cluster_mode=ClusterMode.SINGLE_NODE,
-                    cluster_size=1,
-                    domain_name=scope.domain_name,
-                    domain_id=scope.domain_id,
-                    resource_group_id=scope.scaling_group_id,
-                    group_id=scope.project_id,
-                    user_uuid=uuid.uuid4(),
-                    access_key=None,
-                    tag=None,
-                    status=SessionStatus.RUNNING,
-                    status_info=None,
-                    status_data=None,
-                    status_history={},
-                    result=SessionResult.UNDEFINED,
-                    created_at=datetime(2026, 1, 1, tzinfo=UTC),
-                    terminated_at=None,
-                    starts_at=datetime(2026, 1, 1, tzinfo=UTC),
-                    startup_command=None,
-                    callback_url=None,
-                    occupying_slots=ResourceSlot({"cpu": "1"}),
-                    requested_slots=ResourceSlot({"cpu": "1"}),
-                    vfolder_mounts=[],
-                    environ=None,
-                    bootstrap_script=None,
-                    use_host_network=False,
-                    scaling_group_name=scope.scaling_group_name,
-                )
-            )
-            db_sess.add(
-                IdleCheckerRow(
-                    id=checker_id,
-                    name=f"checker-{checker_id}",
-                    description=None,
-                    checker_type=CheckerType.SESSION_LIFETIME,
-                    target_session_types=[SessionTypes.INTERACTIVE, SessionTypes.BATCH],
-                    spec=IdleCheckerSpec(
-                        type=CheckerType.SESSION_LIFETIME,
-                        session_lifetime=SessionLifetimeSpec(max_lifetime_seconds=3600),
-                    ),
-                )
-            )
-            await db_sess.flush()
-            db_sess.add(
-                IdleCheckerBindingRow(
-                    scope_type=ScopeType.DOMAIN.value,
-                    scope_id=scope.domain_id,
-                    idle_checker_id=checker_id,
-                    enabled=False,
-                )
-            )
-        return session_id
-
-    @pytest.fixture
-    async def seeded_idle_check_data(
-        self,
-        database: ExtendedAsyncSAEngine,
-        request: pytest.FixtureRequest,
-    ) -> SeededIdleCheckData:
-        resource_group_prefix, project_prefix, domain_prefix = request.param
-        resource_group_scope = ScopeFixture(
-            domain_name=f"{resource_group_prefix}-domain",
-            domain_id=DomainID(uuid.uuid4()),
-            project_id=uuid.uuid4(),
-            scaling_group_name=f"{resource_group_prefix}-sgroup",
-            scaling_group_id=ResourceGroupID(uuid.uuid4()),
-        )
-        project_scope = ScopeFixture(
-            domain_name=f"{project_prefix}-domain",
-            domain_id=DomainID(uuid.uuid4()),
-            project_id=uuid.uuid4(),
-            scaling_group_name=f"{project_prefix}-sgroup",
-            scaling_group_id=ResourceGroupID(uuid.uuid4()),
-        )
-        domain_scope = ScopeFixture(
-            domain_name=f"{domain_prefix}-domain",
-            domain_id=DomainID(uuid.uuid4()),
-            project_id=uuid.uuid4(),
-            scaling_group_name=f"{domain_prefix}-sgroup",
-            scaling_group_id=ResourceGroupID(uuid.uuid4()),
-        )
-        scopes = (resource_group_scope, project_scope, domain_scope)
-        resource_group_session_id = SessionId(uuid.uuid4())
-        project_session_id = SessionId(uuid.uuid4())
-        domain_session_id = SessionId(uuid.uuid4())
-        inference_session_id = SessionId(uuid.uuid4())
-        not_started_session_id = SessionId(uuid.uuid4())
         session_specs = (
-            (
-                resource_group_scope,
-                resource_group_session_id,
-                datetime(2026, 1, 1, tzinfo=UTC),
-                datetime(2026, 1, 1, tzinfo=UTC),
-                SessionTypes.INTERACTIVE,
-            ),
-            (
-                project_scope,
-                project_session_id,
-                datetime(2026, 1, 2, tzinfo=UTC),
-                datetime(2026, 1, 2, tzinfo=UTC),
-                SessionTypes.INTERACTIVE,
-            ),
-            (
-                domain_scope,
-                domain_session_id,
-                datetime(2026, 1, 3, tzinfo=UTC),
-                datetime(2026, 1, 3, tzinfo=UTC),
-                SessionTypes.INTERACTIVE,
-            ),
-            (
-                resource_group_scope,
-                inference_session_id,
-                datetime(2026, 1, 4, tzinfo=UTC),
-                datetime(2026, 1, 4, tzinfo=UTC),
-                SessionTypes.INFERENCE,
-            ),
-            (
-                domain_scope,
-                not_started_session_id,
-                datetime(2026, 1, 5, tzinfo=UTC),
-                None,
-                SessionTypes.INTERACTIVE,
-            ),
+            (active_session_id, SessionStatus.RUNNING),
+            (idle_session_id, SessionStatus.RUNNING),
+            (not_checked_session_id, SessionStatus.RUNNING),
+            (idle_expired_session_id, SessionStatus.RUNNING),
+            (session_without_row_id, SessionStatus.RUNNING),
+            (terminated_session_id, SessionStatus.TERMINATED),
         )
-        resource_group_checker_id = IdleCheckerID(uuid.uuid4())
-        project_checker_id = IdleCheckerID(uuid.uuid4())
-        domain_checker_id = IdleCheckerID(uuid.uuid4())
-        binding_specs = (
-            (
-                resource_group_checker_id,
-                CheckerType.SESSION_LIFETIME,
-                IdleCheckerSpec(
-                    type=CheckerType.SESSION_LIFETIME,
-                    session_lifetime=SessionLifetimeSpec(max_lifetime_seconds=3600),
-                ),
-                ScopeType.RESOURCE_GROUP,
-                resource_group_scope.scaling_group_id,
-            ),
-            (
-                project_checker_id,
-                CheckerType.NETWORK_TIMEOUT,
-                IdleCheckerSpec(
-                    type=CheckerType.NETWORK_TIMEOUT,
-                    network=NetworkTimeoutSpec(),
-                ),
-                ScopeType.PROJECT,
-                project_scope.project_id,
-            ),
-            (
-                domain_checker_id,
-                CheckerType.UTILIZATION,
-                IdleCheckerSpec(
-                    type=CheckerType.UTILIZATION,
-                    utilization=UtilizationSpec(),
-                ),
-                ScopeType.DOMAIN,
-                domain_scope.domain_id,
-            ),
+        check_specs = (
+            (active_session_id, IdleCheckPhase.ACTIVE),
+            (idle_session_id, IdleCheckPhase.IDLE),
+            (not_checked_session_id, IdleCheckPhase.NOT_CHECKED),
+            (idle_expired_session_id, IdleCheckPhase.IDLE_EXPIRED),
+            (terminated_session_id, IdleCheckPhase.ACTIVE),
         )
         async with database.begin_session() as db_sess:
-            for scope in scopes:
-                db_sess.add(
-                    ProjectResourcePolicyRow(
-                        name=f"{scope.domain_name}-policy",
-                        max_vfolder_count=10,
-                        max_quota_scope_size=1024,
-                        max_network_count=10,
-                    )
-                )
-                db_sess.add(
-                    DomainRow(
-                        id=scope.domain_id,
-                        name=scope.domain_name,
-                        description=None,
-                        is_active=True,
-                    )
-                )
-                db_sess.add(
-                    GroupRow(
-                        id=scope.project_id,
-                        name=f"{scope.domain_name}-project",
-                        description=None,
-                        is_active=True,
-                        domain_name=scope.domain_name,
-                        resource_policy=f"{scope.domain_name}-policy",
-                    )
-                )
-                db_sess.add(
-                    ScalingGroupRow(
-                        id=scope.scaling_group_id,
-                        name=scope.scaling_group_name,
-                        description=None,
-                        is_active=True,
-                        is_public=True,
-                        driver="static",
-                        driver_opts={},
-                        scheduler="fifo",
-                        use_host_network=False,
-                    )
-                )
-            for scope, session_id, created_at, starts_at, session_type in session_specs:
-                db_sess.add(
-                    SessionRow(
-                        id=session_id,
-                        creation_id=str(session_id)[:32],
-                        name=f"session-{session_id}",
-                        session_type=session_type,
-                        cluster_mode=ClusterMode.SINGLE_NODE,
-                        cluster_size=1,
-                        domain_name=scope.domain_name,
-                        domain_id=scope.domain_id,
-                        resource_group_id=scope.scaling_group_id,
-                        group_id=scope.project_id,
-                        user_uuid=uuid.uuid4(),
-                        access_key=None,
-                        tag=None,
-                        status=SessionStatus.RUNNING,
-                        status_info=None,
-                        status_data=None,
-                        status_history={},
-                        result=SessionResult.UNDEFINED,
-                        created_at=created_at,
-                        terminated_at=None,
-                        starts_at=starts_at,
-                        startup_command=None,
-                        callback_url=None,
-                        occupying_slots=ResourceSlot({"cpu": "1"}),
-                        requested_slots=ResourceSlot({"cpu": "1"}),
-                        vfolder_mounts=[],
-                        environ=None,
-                        bootstrap_script=None,
-                        use_host_network=False,
-                        scaling_group_name=scope.scaling_group_name,
-                    )
-                )
-            for checker_id, checker_type, spec, _, _ in binding_specs:
-                db_sess.add(
-                    IdleCheckerRow(
-                        id=checker_id,
-                        name=f"{checker_type.value}-{checker_id}",
-                        description=None,
-                        checker_type=checker_type,
-                        target_session_types=[SessionTypes.INTERACTIVE, SessionTypes.BATCH],
-                        spec=spec,
-                    )
-                )
+            for scope_row in _expired_check_scope_rows(scope):
+                db_sess.add(scope_row)
+            for session_id, status in session_specs:
+                db_sess.add(_expired_check_session_row(scope, session_id, status))
+            db_sess.add(_expired_check_checker_row(checker_id))
             await db_sess.flush()
-            for checker_id, _, _, scope_type, scope_id in binding_specs:
+            for session_id, phase in check_specs:
                 db_sess.add(
-                    IdleCheckerBindingRow(
-                        scope_type=scope_type.value,
-                        scope_id=scope_id,
+                    SessionIdleCheckRow(
+                        session_id=session_id,
                         idle_checker_id=checker_id,
-                        enabled=True,
+                        expire_at=datetime(2026, 2, 1, tzinfo=UTC),
+                        last_status=phase,
+                        last_message=f"{phase.value} judgment",
                     )
                 )
-
-        return SeededIdleCheckData(
-            resource_group_session_id=resource_group_session_id,
-            project_session_id=project_session_id,
-            domain_session_id=domain_session_id,
-            inference_session_id=inference_session_id,
-            not_started_session_id=not_started_session_id,
-            resource_group_checker_id=resource_group_checker_id,
-            project_checker_id=project_checker_id,
-            domain_checker_id=domain_checker_id,
+        return JudgmentRows(
+            active_session_id=active_session_id,
+            idle_session_id=idle_session_id,
+            not_checked_session_id=not_checked_session_id,
+            idle_expired_session_id=idle_expired_session_id,
+            session_without_row_id=session_without_row_id,
+            terminated_session_id=terminated_session_id,
+            checker_id=checker_id,
         )
 
-    @pytest.mark.parametrize("running_session_without_bindings", ["empty"], indirect=True)
-    @pytest.mark.usefixtures("running_session_without_bindings")
-    async def test_returns_empty_batch_without_enabled_bindings(
+    async def test_returns_active_and_idle_rows(
         self,
         repository: IdleCheckerRepository,
+        judgment_rows: JudgmentRows,
     ) -> None:
-        batch = await repository.fetch_idle_check_batch([SessionStatus.RUNNING])
+        batch = await repository.fetch_judgment_batch([SessionStatus.RUNNING])
 
-        assert batch.targets == ()
-
-    async def test_ignores_disabled_bindings(
-        self,
-        repository: IdleCheckerRepository,
-        running_session_with_disabled_binding: SessionId,
-    ) -> None:
-        batch = await repository.fetch_idle_check_batch([SessionStatus.RUNNING])
-        target_session_ids = {target.session.session_id for target in batch.targets}
-
-        assert batch.targets == ()
-        assert running_session_with_disabled_binding not in target_session_ids
-
-    @pytest.mark.parametrize(
-        "seeded_idle_check_data",
-        [("resource-group", "project", "domain")],
-        indirect=True,
-    )
-    async def test_fetches_resource_group_scope_bound_checker(
-        self,
-        repository: IdleCheckerRepository,
-        seeded_idle_check_data: SeededIdleCheckData,
-    ) -> None:
-        batch = await repository.fetch_idle_check_batch([SessionStatus.RUNNING])
-        targets_by_session_id = {target.session.session_id: target for target in batch.targets}
-        resource_group_target = targets_by_session_id[
-            seeded_idle_check_data.resource_group_session_id
-        ]
-        checkers = resource_group_target.checkers
-
-        assert len(checkers) == 1
-        assert checkers[0].checker.checker_id == seeded_idle_check_data.resource_group_checker_id
-        assert checkers[0].scope.scope_type is ScopeType.RESOURCE_GROUP
-
-    @pytest.mark.parametrize(
-        "seeded_idle_check_data",
-        [("resource-group", "project", "domain")],
-        indirect=True,
-    )
-    async def test_fetches_project_scope_bound_checker(
-        self,
-        repository: IdleCheckerRepository,
-        seeded_idle_check_data: SeededIdleCheckData,
-    ) -> None:
-        batch = await repository.fetch_idle_check_batch([SessionStatus.RUNNING])
-        targets_by_session_id = {target.session.session_id: target for target in batch.targets}
-        project_target = targets_by_session_id[seeded_idle_check_data.project_session_id]
-        checkers = project_target.checkers
-
-        assert len(checkers) == 1
-        assert checkers[0].checker.checker_id == seeded_idle_check_data.project_checker_id
-        assert checkers[0].scope.scope_type is ScopeType.PROJECT
-
-    @pytest.mark.parametrize(
-        "seeded_idle_check_data",
-        [("resource-group", "project", "domain")],
-        indirect=True,
-    )
-    async def test_fetches_domain_scope_bound_checker(
-        self,
-        repository: IdleCheckerRepository,
-        seeded_idle_check_data: SeededIdleCheckData,
-    ) -> None:
-        batch = await repository.fetch_idle_check_batch([SessionStatus.RUNNING])
-        targets_by_session_id = {target.session.session_id: target for target in batch.targets}
-        domain_target = targets_by_session_id[seeded_idle_check_data.domain_session_id]
-        checkers = domain_target.checkers
-
-        assert len(checkers) == 1
-        assert checkers[0].checker.checker_id == seeded_idle_check_data.domain_checker_id
-        assert checkers[0].scope.scope_type is ScopeType.DOMAIN
-
-    @pytest.mark.parametrize(
-        "seeded_idle_check_data",
-        [("resource-group", "project", "domain")],
-        indirect=True,
-    )
-    async def test_excludes_inference_sessions(
-        self,
-        repository: IdleCheckerRepository,
-        seeded_idle_check_data: SeededIdleCheckData,
-    ) -> None:
-        batch = await repository.fetch_idle_check_batch([SessionStatus.RUNNING])
-        target_session_ids = {target.session.session_id for target in batch.targets}
-
-        assert target_session_ids == {
-            seeded_idle_check_data.resource_group_session_id,
-            seeded_idle_check_data.project_session_id,
-            seeded_idle_check_data.domain_session_id,
+        pairs = {
+            (assignment.session.session_id, assignment.checker.checker_id)
+            for assignment in batch.assignments
         }
-        assert seeded_idle_check_data.inference_session_id not in target_session_ids
-
-    @pytest.mark.parametrize(
-        "seeded_idle_check_data",
-        [("resource-group", "project", "domain")],
-        indirect=True,
-    )
-    async def test_excludes_sessions_without_starts_at(
-        self,
-        repository: IdleCheckerRepository,
-        seeded_idle_check_data: SeededIdleCheckData,
-    ) -> None:
-        batch = await repository.fetch_idle_check_batch([SessionStatus.RUNNING])
-        target_session_ids = {target.session.session_id for target in batch.targets}
-
-        assert target_session_ids == {
-            seeded_idle_check_data.resource_group_session_id,
-            seeded_idle_check_data.project_session_id,
-            seeded_idle_check_data.domain_session_id,
+        assert pairs == {
+            (judgment_rows.active_session_id, judgment_rows.checker_id),
+            (judgment_rows.idle_session_id, judgment_rows.checker_id),
         }
-        assert seeded_idle_check_data.not_started_session_id not in target_session_ids
 
-    @pytest.fixture
-    async def per_type_checker_data(
-        self,
-        database: ExtendedAsyncSAEngine,
-    ) -> PerTypeCheckerData:
-        scope = ScopeFixture(
-            domain_name="per-type-domain",
-            domain_id=DomainID(uuid.uuid4()),
-            project_id=uuid.uuid4(),
-            scaling_group_name="per-type-sgroup",
-            scaling_group_id=ResourceGroupID(uuid.uuid4()),
-        )
-        interactive_session_id = SessionId(uuid.uuid4())
-        batch_session_id = SessionId(uuid.uuid4())
-        interactive_checker_id = IdleCheckerID(uuid.uuid4())
-        batch_checker_id = IdleCheckerID(uuid.uuid4())
-        session_specs = (
-            (interactive_session_id, SessionTypes.INTERACTIVE, datetime(2026, 1, 1, tzinfo=UTC)),
-            (batch_session_id, SessionTypes.BATCH, datetime(2026, 1, 2, tzinfo=UTC)),
-        )
-        checker_specs = (
-            (interactive_checker_id, frozenset({SessionTypes.INTERACTIVE})),
-            (batch_checker_id, frozenset({SessionTypes.BATCH})),
-        )
-        async with database.begin_session() as db_sess:
-            db_sess.add(
-                ProjectResourcePolicyRow(
-                    name=f"{scope.domain_name}-policy",
-                    max_vfolder_count=10,
-                    max_quota_scope_size=1024,
-                    max_network_count=10,
-                )
-            )
-            db_sess.add(
-                DomainRow(
-                    id=scope.domain_id,
-                    name=scope.domain_name,
-                    description=None,
-                    is_active=True,
-                )
-            )
-            db_sess.add(
-                GroupRow(
-                    id=scope.project_id,
-                    name=f"{scope.domain_name}-project",
-                    description=None,
-                    is_active=True,
-                    domain_name=scope.domain_name,
-                    resource_policy=f"{scope.domain_name}-policy",
-                )
-            )
-            db_sess.add(
-                ScalingGroupRow(
-                    id=scope.scaling_group_id,
-                    name=scope.scaling_group_name,
-                    description=None,
-                    is_active=True,
-                    is_public=True,
-                    driver="static",
-                    driver_opts={},
-                    scheduler="fifo",
-                    use_host_network=False,
-                )
-            )
-            for session_id, session_type, created_at in session_specs:
-                db_sess.add(
-                    SessionRow(
-                        id=session_id,
-                        creation_id=str(session_id)[:32],
-                        name=f"session-{session_id}",
-                        session_type=session_type,
-                        cluster_mode=ClusterMode.SINGLE_NODE,
-                        cluster_size=1,
-                        domain_name=scope.domain_name,
-                        domain_id=scope.domain_id,
-                        resource_group_id=scope.scaling_group_id,
-                        group_id=scope.project_id,
-                        user_uuid=uuid.uuid4(),
-                        access_key=None,
-                        tag=None,
-                        status=SessionStatus.RUNNING,
-                        status_info=None,
-                        status_data=None,
-                        status_history={},
-                        result=SessionResult.UNDEFINED,
-                        created_at=created_at,
-                        terminated_at=None,
-                        starts_at=created_at,
-                        startup_command=None,
-                        callback_url=None,
-                        occupying_slots=ResourceSlot({"cpu": "1"}),
-                        requested_slots=ResourceSlot({"cpu": "1"}),
-                        vfolder_mounts=[],
-                        environ=None,
-                        bootstrap_script=None,
-                        use_host_network=False,
-                        scaling_group_name=scope.scaling_group_name,
-                    )
-                )
-            for checker_id, target_types in checker_specs:
-                db_sess.add(
-                    IdleCheckerRow(
-                        id=checker_id,
-                        name=f"checker-{checker_id}",
-                        description=None,
-                        checker_type=CheckerType.SESSION_LIFETIME,
-                        target_session_types=list(target_types),
-                        spec=IdleCheckerSpec(
-                            type=CheckerType.SESSION_LIFETIME,
-                            session_lifetime=SessionLifetimeSpec(max_lifetime_seconds=3600),
-                        ),
-                    )
-                )
-            await db_sess.flush()
-            for checker_id, _ in checker_specs:
-                db_sess.add(
-                    IdleCheckerBindingRow(
-                        scope_type=ScopeType.DOMAIN.value,
-                        scope_id=scope.domain_id,
-                        idle_checker_id=checker_id,
-                        enabled=True,
-                    )
-                )
-        return PerTypeCheckerData(
-            interactive_session_id=interactive_session_id,
-            batch_session_id=batch_session_id,
-            interactive_checker_id=interactive_checker_id,
-            batch_checker_id=batch_checker_id,
-        )
-
-    async def test_applies_only_checkers_targeting_session_type(
+    async def test_excludes_non_judgment_phases(
         self,
         repository: IdleCheckerRepository,
-        per_type_checker_data: PerTypeCheckerData,
+        judgment_rows: JudgmentRows,
     ) -> None:
-        batch = await repository.fetch_idle_check_batch([SessionStatus.RUNNING])
-        targets_by_session_id = {target.session.session_id: target for target in batch.targets}
+        batch = await repository.fetch_judgment_batch([SessionStatus.RUNNING])
 
-        interactive_target = targets_by_session_id[per_type_checker_data.interactive_session_id]
-        interactive_checker_ids = [
-            bound.checker.checker_id for bound in interactive_target.checkers
-        ]
-        assert interactive_checker_ids == [per_type_checker_data.interactive_checker_id]
+        session_ids = {assignment.session.session_id for assignment in batch.assignments}
+        assert judgment_rows.not_checked_session_id not in session_ids
+        assert judgment_rows.idle_expired_session_id not in session_ids
 
-        batch_target = targets_by_session_id[per_type_checker_data.batch_session_id]
-        batch_checker_ids = [bound.checker.checker_id for bound in batch_target.checkers]
-        assert batch_checker_ids == [per_type_checker_data.batch_checker_id]
+    async def test_excludes_session_without_idle_check_row(
+        self,
+        repository: IdleCheckerRepository,
+        judgment_rows: JudgmentRows,
+    ) -> None:
+        batch = await repository.fetch_judgment_batch([SessionStatus.RUNNING])
+
+        session_ids = {assignment.session.session_id for assignment in batch.assignments}
+        assert judgment_rows.session_without_row_id not in session_ids
+
+    async def test_excludes_sessions_not_in_target_statuses(
+        self,
+        repository: IdleCheckerRepository,
+        judgment_rows: JudgmentRows,
+    ) -> None:
+        batch = await repository.fetch_judgment_batch([SessionStatus.RUNNING])
+
+        session_ids = {assignment.session.session_id for assignment in batch.assignments}
+        assert judgment_rows.terminated_session_id not in session_ids
 
 
 class TestFetchExpiredIdleChecks:

--- a/tests/unit/manager/sokovan/idle_check/test_handler.py
+++ b/tests/unit/manager/sokovan/idle_check/test_handler.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import replace
 from datetime import UTC, datetime
 from typing import Final, override
 from uuid import uuid4
@@ -14,17 +13,14 @@ from ai.backend.common.data.idle_checker.types import (
     NetworkTimeoutSpec,
     SessionLifetimeSpec,
 )
-from ai.backend.common.data.permission.types import ScopeType
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.data.idle_checker.types import IdleCheckSession
-from ai.backend.manager.data.permission.id import ScopeId
 from ai.backend.manager.errors.common import InternalServerError
 from ai.backend.manager.repositories.idle_checker.types import (
-    BoundCheckerData,
+    IdleCheckAssignmentData,
     IdleCheckBatchData,
     IdleCheckerDefinitionData,
-    IdleCheckTargetData,
 )
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
@@ -47,14 +43,13 @@ _SPECS: Final[dict[CheckerType, IdleCheckerSpec]] = {
         session_lifetime=SessionLifetimeSpec(max_lifetime_seconds=3600),
     ),
     CheckerType.NETWORK_TIMEOUT: IdleCheckerSpec(
-        type=CheckerType.NETWORK_TIMEOUT, network=NetworkTimeoutSpec()
+        type=CheckerType.NETWORK_TIMEOUT,
+        network=NetworkTimeoutSpec(),
     ),
 }
 
 
 class FakeChecker(IdleChecker):
-    """Records the single batched call and returns configured session judgments."""
-
     idle_session_ids: set[SessionId]
     judge_calls: list[list[tuple[IdleCheckerID, list[SessionId]]]]
     judge_contexts: list[IdleCheckerContext]
@@ -76,48 +71,47 @@ class FakeChecker(IdleChecker):
         context: IdleCheckerContext,
     ) -> Sequence[IdleJudgment]:
         self.judge_contexts.append(context)
-        call_record: list[tuple[IdleCheckerID, list[SessionId]]] = []
-        for assignment in assignments:
-            session_ids = [session.session_id for session in assignment.sessions]
-            call_record.append((assignment.definition.checker_id, session_ids))
-        self.judge_calls.append(call_record)
+        self.judge_calls.append([
+            (
+                assignment.definition.checker_id,
+                [session.session_id for session in assignment.sessions],
+            )
+            for assignment in assignments
+        ])
         if self.should_fail:
             raise InternalServerError("Fake checker failed")
-        judgments: list[IdleJudgment] = []
-        for assignment in assignments:
-            for session in assignment.sessions:
-                judgments.append(
-                    IdleJudgment(
-                        checker_id=assignment.definition.checker_id,
-                        session_id=session.session_id,
-                        is_idle=session.session_id in self.idle_session_ids,
-                        message=self._message,
-                    )
-                )
-        return judgments
+        return [
+            IdleJudgment(
+                checker_id=assignment.definition.checker_id,
+                session_id=session.session_id,
+                is_idle=session.session_id in self.idle_session_ids,
+                message=self._message,
+            )
+            for assignment in assignments
+            for session in assignment.sessions
+        ]
 
 
-def _bound_checker(checker_type: CheckerType) -> BoundCheckerData:
-    return BoundCheckerData(
-        scope=ScopeId(ScopeType.RESOURCE_GROUP, str(uuid4())),
-        binding_created_at=datetime(2026, 1, 1, tzinfo=UTC),
-        checker=IdleCheckerDefinitionData(
-            checker_id=IdleCheckerID(uuid4()),
-            checker_type=checker_type,
-            target_session_types=frozenset({SessionTypes.INTERACTIVE}),
-            spec=_SPECS[checker_type],
-        ),
+def _checker_definition(checker_type: CheckerType) -> IdleCheckerDefinitionData:
+    return IdleCheckerDefinitionData(
+        checker_id=IdleCheckerID(uuid4()),
+        checker_type=checker_type,
+        target_session_types=frozenset({SessionTypes.INTERACTIVE}),
+        spec=_SPECS[checker_type],
     )
 
 
-def _target(session_id: SessionId, checkers: Sequence[BoundCheckerData]) -> IdleCheckTargetData:
-    return IdleCheckTargetData(
+def _assignment(
+    session_id: SessionId,
+    checker: IdleCheckerDefinitionData,
+) -> IdleCheckAssignmentData:
+    return IdleCheckAssignmentData(
         session=IdleCheckSession(
             session_id=session_id,
             created_at=datetime(2026, 1, 1, tzinfo=UTC),
             starts_at=None,
         ),
-        checkers=checkers,
+        checker=checker,
     )
 
 
@@ -131,16 +125,16 @@ class TestIdleCheckReconcileHandler:
         return SessionId(uuid4())
 
     @pytest.fixture()
-    def lifetime_bound(self) -> BoundCheckerData:
-        return _bound_checker(CheckerType.SESSION_LIFETIME)
+    def lifetime_definition(self) -> IdleCheckerDefinitionData:
+        return _checker_definition(CheckerType.SESSION_LIFETIME)
 
     @pytest.fixture()
-    def second_lifetime_bound(self) -> BoundCheckerData:
-        return _bound_checker(CheckerType.SESSION_LIFETIME)
+    def second_lifetime_definition(self) -> IdleCheckerDefinitionData:
+        return _checker_definition(CheckerType.SESSION_LIFETIME)
 
     @pytest.fixture()
-    def network_bound(self) -> BoundCheckerData:
-        return _bound_checker(CheckerType.NETWORK_TIMEOUT)
+    def network_definition(self) -> IdleCheckerDefinitionData:
+        return _checker_definition(CheckerType.NETWORK_TIMEOUT)
 
     @pytest.fixture()
     def lifetime_checker(self) -> FakeChecker:
@@ -166,22 +160,20 @@ class TestIdleCheckReconcileHandler:
         handler: IdleCheckReconcileHandler,
         first_session_id: SessionId,
         second_session_id: SessionId,
-        lifetime_bound: BoundCheckerData,
-        second_lifetime_bound: BoundCheckerData,
-        network_bound: BoundCheckerData,
+        lifetime_definition: IdleCheckerDefinitionData,
+        second_lifetime_definition: IdleCheckerDefinitionData,
+        network_definition: IdleCheckerDefinitionData,
         lifetime_checker: FakeChecker,
         network_checker: FakeChecker,
     ) -> None:
-        """Two sessions sharing one definition; the second adds a same-type and another-type one."""
         reconcile_info = IdleCheckReconcileInfo(
             batch=IdleCheckBatchData(
-                targets=(
-                    _target(first_session_id, [lifetime_bound]),
-                    _target(
-                        second_session_id,
-                        [lifetime_bound, second_lifetime_bound, network_bound],
-                    ),
-                )
+                assignments=[
+                    _assignment(first_session_id, lifetime_definition),
+                    _assignment(second_session_id, lifetime_definition),
+                    _assignment(second_session_id, second_lifetime_definition),
+                    _assignment(second_session_id, network_definition),
+                ]
             ),
             current_time=_NOW,
         )
@@ -190,60 +182,36 @@ class TestIdleCheckReconcileHandler:
 
         assert lifetime_checker.judge_calls == [
             [
-                (lifetime_bound.checker.checker_id, [first_session_id, second_session_id]),
-                (second_lifetime_bound.checker.checker_id, [second_session_id]),
-            ],
+                (lifetime_definition.checker_id, [first_session_id, second_session_id]),
+                (second_lifetime_definition.checker_id, [second_session_id]),
+            ]
         ]
         assert network_checker.judge_calls == [
-            [(network_bound.checker.checker_id, [second_session_id])],
+            [(network_definition.checker_id, [second_session_id])]
         ]
         expected_context = IdleCheckerContext(current_time=_NOW)
         assert lifetime_checker.judge_contexts == [expected_context]
         assert network_checker.judge_contexts == [expected_context]
-
-    async def test_deduplicates_cross_scope_assignments(
-        self,
-        handler: IdleCheckReconcileHandler,
-        first_session_id: SessionId,
-        lifetime_bound: BoundCheckerData,
-        lifetime_checker: FakeChecker,
-    ) -> None:
-        duplicate_binding = replace(
-            lifetime_bound,
-            scope=ScopeId(ScopeType.DOMAIN, str(uuid4())),
-        )
-        reconcile_info = IdleCheckReconcileInfo(
-            batch=IdleCheckBatchData(
-                targets=(_target(first_session_id, [lifetime_bound, duplicate_binding]),)
-            ),
-            current_time=_NOW,
-        )
-
-        await handler.execute(reconcile_info)
-
-        assert lifetime_checker.judge_calls == [
-            [(lifetime_bound.checker.checker_id, [first_session_id])],
-        ]
 
     async def test_merges_idle_reasons(
         self,
         handler: IdleCheckReconcileHandler,
         first_session_id: SessionId,
         second_session_id: SessionId,
-        lifetime_bound: BoundCheckerData,
-        network_bound: BoundCheckerData,
+        lifetime_definition: IdleCheckerDefinitionData,
+        network_definition: IdleCheckerDefinitionData,
         lifetime_checker: FakeChecker,
         network_checker: FakeChecker,
     ) -> None:
-        """A session idle by two checkers gets one report listing each checker's reason."""
         lifetime_checker.idle_session_ids = {first_session_id, second_session_id}
         network_checker.idle_session_ids = {first_session_id}
         reconcile_info = IdleCheckReconcileInfo(
             batch=IdleCheckBatchData(
-                targets=(
-                    _target(first_session_id, [lifetime_bound, network_bound]),
-                    _target(second_session_id, [lifetime_bound]),
-                )
+                assignments=[
+                    _assignment(first_session_id, lifetime_definition),
+                    _assignment(first_session_id, network_definition),
+                    _assignment(second_session_id, lifetime_definition),
+                ]
             ),
             current_time=_NOW,
         )
@@ -255,11 +223,11 @@ class TestIdleCheckReconcileHandler:
                 session_id=first_session_id,
                 reasons=[
                     IdleReason(
-                        checker_id=lifetime_bound.checker.checker_id,
+                        checker_id=lifetime_definition.checker_id,
                         message="max lifetime exceeded",
                     ),
                     IdleReason(
-                        checker_id=network_bound.checker.checker_id,
+                        checker_id=network_definition.checker_id,
                         message="no network activity",
                     ),
                 ],
@@ -268,26 +236,26 @@ class TestIdleCheckReconcileHandler:
                 session_id=second_session_id,
                 reasons=[
                     IdleReason(
-                        checker_id=lifetime_bound.checker.checker_id,
+                        checker_id=lifetime_definition.checker_id,
                         message="max lifetime exceeded",
-                    ),
+                    )
                 ],
             ),
         ]
-        assert result.processed_count() == 2
 
     async def test_active_session_has_no_report(
         self,
         handler: IdleCheckReconcileHandler,
         first_session_id: SessionId,
-        lifetime_bound: BoundCheckerData,
-        network_bound: BoundCheckerData,
-        lifetime_checker: FakeChecker,
-        network_checker: FakeChecker,
+        lifetime_definition: IdleCheckerDefinitionData,
+        network_definition: IdleCheckerDefinitionData,
     ) -> None:
         reconcile_info = IdleCheckReconcileInfo(
             batch=IdleCheckBatchData(
-                targets=(_target(first_session_id, [lifetime_bound, network_bound]),)
+                assignments=[
+                    _assignment(first_session_id, lifetime_definition),
+                    _assignment(first_session_id, network_definition),
+                ]
             ),
             current_time=_NOW,
         )
@@ -295,24 +263,22 @@ class TestIdleCheckReconcileHandler:
         result = await handler.execute(reconcile_info)
 
         assert result.reports == []
-        expected_call = [(lifetime_bound.checker.checker_id, [first_session_id])]
-        assert lifetime_checker.judge_calls == [expected_call]
-        assert network_checker.judge_calls == [
-            [(network_bound.checker.checker_id, [first_session_id])]
-        ]
 
     async def test_skips_unimplemented_checker_types(
         self,
         first_session_id: SessionId,
-        lifetime_bound: BoundCheckerData,
-        network_bound: BoundCheckerData,
+        lifetime_definition: IdleCheckerDefinitionData,
+        network_definition: IdleCheckerDefinitionData,
         lifetime_checker: FakeChecker,
     ) -> None:
         lifetime_checker.idle_session_ids = {first_session_id}
         handler = IdleCheckReconcileHandler({CheckerType.SESSION_LIFETIME: lifetime_checker})
         reconcile_info = IdleCheckReconcileInfo(
             batch=IdleCheckBatchData(
-                targets=(_target(first_session_id, [network_bound, lifetime_bound]),)
+                assignments=[
+                    _assignment(first_session_id, network_definition),
+                    _assignment(first_session_id, lifetime_definition),
+                ]
             ),
             current_time=_NOW,
         )
@@ -324,9 +290,9 @@ class TestIdleCheckReconcileHandler:
                 session_id=first_session_id,
                 reasons=[
                     IdleReason(
-                        checker_id=lifetime_bound.checker.checker_id,
+                        checker_id=lifetime_definition.checker_id,
                         message="max lifetime exceeded",
-                    ),
+                    )
                 ],
-            ),
+            )
         ]

--- a/tests/unit/manager/sokovan/idle_check/test_source.py
+++ b/tests/unit/manager/sokovan/idle_check/test_source.py
@@ -12,7 +12,7 @@ class TestIdleCheckSource:
     async def test_returns_fetched_batch_with_current_time(self) -> None:
         batch = MagicMock()
         repository = MagicMock()
-        repository.fetch_idle_check_batch = AsyncMock(return_value=batch)
+        repository.fetch_judgment_batch = AsyncMock(return_value=batch)
         target_statuses = IdleCheckTargetStatuses(
             session_statuses=frozenset([SessionStatus.RUNNING])
         )
@@ -22,5 +22,5 @@ class TestIdleCheckSource:
         )
 
         assert reconcile_info.batch is batch
-        repository.fetch_idle_check_batch.assert_awaited_once_with(target_statuses.session_statuses)
+        repository.fetch_judgment_batch.assert_awaited_once_with(target_statuses.session_statuses)
         assert reconcile_info.current_time.tzinfo == UTC

--- a/tests/unit/manager/sokovan/idle_check/test_stage.py
+++ b/tests/unit/manager/sokovan/idle_check/test_stage.py
@@ -13,22 +13,19 @@ from ai.backend.common.data.idle_checker.types import (
     IdleCheckerSpec,
     SessionLifetimeSpec,
 )
-from ai.backend.common.data.permission.types import ScopeType
 from ai.backend.common.events.event_types.kernel.types import KernelLifecycleEventReason
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.data.idle_checker.types import IdleCheckSession
-from ai.backend.manager.data.permission.id import ScopeId
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.defs import LockID
 from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
 from ai.backend.manager.repositories.idle_checker.types import (
-    BoundCheckerData,
     ExpiredIdleCheckBatchData,
     ExpiredIdleCheckData,
+    IdleCheckAssignmentData,
     IdleCheckBatchData,
     IdleCheckerDefinitionData,
-    IdleCheckTargetData,
 )
 from ai.backend.manager.sokovan.idle_check.checkers.session_lifetime import (
     SessionLifetimeChecker,
@@ -73,24 +70,13 @@ class TestBuildIdleCheckStage:
             ),
         )
         return IdleCheckBatchData(
-            targets=(
-                IdleCheckTargetData(
-                    session=session,
-                    checkers=(
-                        BoundCheckerData(
-                            scope=ScopeId(ScopeType.DOMAIN, str(uuid4())),
-                            binding_created_at=datetime(2026, 1, 1, tzinfo=UTC),
-                            checker=definition,
-                        ),
-                    ),
-                ),
-            )
+            assignments=[IdleCheckAssignmentData(session=session, checker=definition)]
         )
 
     @pytest.fixture()
     def idle_checker_repository(self, idle_check_batch: IdleCheckBatchData) -> AsyncMock:
         repository = AsyncMock(spec=IdleCheckerRepository)
-        repository.fetch_idle_check_batch.return_value = idle_check_batch
+        repository.fetch_judgment_batch.return_value = idle_check_batch
         return repository
 
     @pytest.fixture()


### PR DESCRIPTION
## Summary

- Read judgment assignments only from existing ACTIVE and IDLE session idle-check rows.
- Remove binding and scope resolution from the judgment Source.
- Pass flat row-based assignments through the Source and Handler, excluding sessions without rows and non-judgment phases.

## Test plan

- [x] `pants fmt ::`
- [x] `pants fix ::`
- [x] `pants lint --changed-since=origin/main`
- [x] Push-hook MyPy checks
- [x] Push-hook affected tests

Resolves BA-6973