### PR TITLE
fix: register RetentionPolicyRow in the retention models package export

### DIFF
--- a/changes/13043.fix.md
+++ b/changes/13043.fix.md
@@ -1,0 +1,1 @@
+Fix the alembic migration check failing with a spurious drop of the retention_policies table by registering RetentionPolicyRow in the models metadata

--- a/src/ai/backend/manager/models/retention/__init__.py
+++ b/src/ai/backend/manager/models/retention/__init__.py
@@ -1,0 +1,3 @@
+from .row import RetentionPolicyRow
+
+__all__ = ("RetentionPolicyRow",)


### PR DESCRIPTION
## Summary
- `models/retention/__init__.py` was empty, so the alembic env's subpackage discovery (which requires Row re-exports in `__init__.py`) never registered `retention_policies` into `Base.metadata`.
- As a result, `alembic revision --autogenerate` emits a drop-table revision for `retention_policies`, and the `check-alembic-migrations` CI job fails on any PR touching `src/ai/backend/manager/models/`.
- Re-export `RetentionPolicyRow` following the established models-subpackage pattern.

## Test plan
- [x] `check-alembic-migrations` CI job passes on this PR (the models change activates it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)