### PR TITLE
feat(BA-6972): implement idle check assignment-sync handler and applier

### DIFF
--- a/changes/13045.feature.md
+++ b/changes/13045.feature.md
@@ -1,1 +1,1 @@
-Add assignment synchronization for session idle-check rows.
+Add the idle-check assignment-sync Handler and Applier for session row lifecycle updates.

--- a/changes/13045.feature.md
+++ b/changes/13045.feature.md
@@ -1,0 +1,1 @@
+Add assignment synchronization for session idle-check rows.

--- a/src/ai/backend/manager/repositories/idle_checker/creators.py
+++ b/src/ai/backend/manager/repositories/idle_checker/creators.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import override
+
+from ai.backend.common.data.idle_checker.types import IdleCheckPhase
+from ai.backend.manager.models.idle_checker.row import SessionIdleCheckRow
+from ai.backend.manager.repositories.base import CreatorSpec
+from ai.backend.manager.repositories.idle_checker.types import SessionIdleCheckPair
+
+
+@dataclass
+class SessionIdleCheckCreatorSpec(CreatorSpec[SessionIdleCheckRow]):
+    pair: SessionIdleCheckPair
+    now: datetime
+
+    @override
+    def build_row(self) -> SessionIdleCheckRow:
+        return SessionIdleCheckRow(
+            session_id=self.pair.session_id,
+            idle_checker_id=self.pair.checker_id,
+            expire_at=self.now,
+            last_status=IdleCheckPhase.NOT_CHECKED,
+            last_message="Not checked yet.",
+        )

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Collection, Sequence
+from datetime import datetime
 from typing import cast
 
 import sqlalchemy as sa
@@ -25,7 +26,16 @@ from ai.backend.manager.models.idle_checker.row import (
 )
 from ai.backend.manager.models.session.conditions import SessionConditions
 from ai.backend.manager.models.session.row import SessionRow
-from ai.backend.manager.repositories.base import BatchQuerier, NoPagination
+from ai.backend.manager.repositories.base import (
+    BatchPurger,
+    BatchQuerier,
+    BulkCreator,
+    NoPagination,
+)
+from ai.backend.manager.repositories.idle_checker.creators import SessionIdleCheckCreatorSpec
+from ai.backend.manager.repositories.idle_checker.purgers import (
+    SessionIdleCheckBatchPurgerSpec,
+)
 from ai.backend.manager.repositories.idle_checker.types import (
     ExpiredIdleCheckBatchData,
     ExpiredIdleCheckData,
@@ -190,3 +200,21 @@ class IdleCheckerDBSource:
             ),
             now=now,
         )
+
+    async def sync_session_idle_check_assignments(
+        self,
+        pairs_to_create: Sequence[SessionIdleCheckPair],
+        pairs_to_delete: Sequence[SessionIdleCheckPair],
+        now: datetime,
+    ) -> None:
+        async with self._ops.write_ops() as w:
+            if pairs_to_create:
+                await w.bulk_create(
+                    BulkCreator(
+                        specs=[SessionIdleCheckCreatorSpec(pair, now) for pair in pairs_to_create]
+                    )
+                )
+            if pairs_to_delete:
+                await w.batch_purge(
+                    BatchPurger(spec=SessionIdleCheckBatchPurgerSpec(pairs_to_delete))
+                )

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Collection, Sequence
 from datetime import datetime
+from itertools import batched
 from typing import cast
 
 import sqlalchemy as sa
@@ -46,6 +47,8 @@ from ai.backend.manager.repositories.idle_checker.types import (
     SessionIdleCheckPair,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider
+
+_ASSIGNMENT_DELETE_BATCH_SIZE = 1000
 
 
 class IdleCheckerDBSource:
@@ -215,6 +218,10 @@ class IdleCheckerDBSource:
                     )
                 )
             if pairs_to_delete:
-                await w.batch_purge(
-                    BatchPurger(spec=SessionIdleCheckBatchPurgerSpec(pairs_to_delete))
-                )
+                for pair_batch in batched(pairs_to_delete, _ASSIGNMENT_DELETE_BATCH_SIZE):
+                    await w.batch_purge(
+                        BatchPurger(
+                            spec=SessionIdleCheckBatchPurgerSpec(pair_batch),
+                            batch_size=_ASSIGNMENT_DELETE_BATCH_SIZE,
+                        )
+                    )

--- a/src/ai/backend/manager/repositories/idle_checker/purgers.py
+++ b/src/ai/backend/manager/repositories/idle_checker/purgers.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+
+import sqlalchemy as sa
+
+from ai.backend.common.data.idle_checker.types import IdleCheckPhase
+from ai.backend.manager.models.idle_checker.row import SessionIdleCheckRow
+from ai.backend.manager.repositories.base import BatchPurgerSpec
+from ai.backend.manager.repositories.idle_checker.types import SessionIdleCheckPair
+
+
+@dataclass
+class SessionIdleCheckBatchPurgerSpec(BatchPurgerSpec[SessionIdleCheckRow]):
+    pairs: Sequence[SessionIdleCheckPair]
+
+    @override
+    def build_subquery(self) -> sa.sql.Select[tuple[SessionIdleCheckRow]]:
+        pair_values = [(pair.session_id, pair.checker_id) for pair in self.pairs]
+        return sa.select(SessionIdleCheckRow).where(
+            sa.tuple_(
+                SessionIdleCheckRow.session_id,
+                SessionIdleCheckRow.idle_checker_id,
+            ).in_(pair_values),
+            SessionIdleCheckRow.last_status != IdleCheckPhase.IDLE_EXPIRED,
+        )

--- a/src/ai/backend/manager/repositories/idle_checker/purgers.py
+++ b/src/ai/backend/manager/repositories/idle_checker/purgers.py
@@ -9,6 +9,7 @@ import sqlalchemy as sa
 from ai.backend.common.data.idle_checker.types import IdleCheckPhase
 from ai.backend.manager.models.idle_checker.row import SessionIdleCheckRow
 from ai.backend.manager.repositories.base import BatchPurgerSpec
+from ai.backend.manager.repositories.base.types import ConflictCheck
 from ai.backend.manager.repositories.idle_checker.types import SessionIdleCheckPair
 
 
@@ -26,3 +27,7 @@ class SessionIdleCheckBatchPurgerSpec(BatchPurgerSpec[SessionIdleCheckRow]):
             ).in_(pair_values),
             SessionIdleCheckRow.last_status != IdleCheckPhase.IDLE_EXPIRED,
         )
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()

--- a/src/ai/backend/manager/repositories/idle_checker/repository.py
+++ b/src/ai/backend/manager/repositories/idle_checker/repository.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Collection
+from collections.abc import Collection, Sequence
+from datetime import datetime
 
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.repositories.idle_checker.db_source.db_source import IdleCheckerDBSource
@@ -8,6 +9,7 @@ from ai.backend.manager.repositories.idle_checker.types import (
     ExpiredIdleCheckBatchData,
     IdleCheckBatchData,
     SessionIdleCheckAssignmentData,
+    SessionIdleCheckPair,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider
 
@@ -37,3 +39,15 @@ class IdleCheckerRepository:
         self, session_statuses: Collection[SessionStatus]
     ) -> ExpiredIdleCheckBatchData:
         return await self._db_source.fetch_expired_idle_checks(session_statuses)
+
+    async def sync_session_idle_check_assignments(
+        self,
+        pairs_to_create: Sequence[SessionIdleCheckPair],
+        pairs_to_delete: Sequence[SessionIdleCheckPair],
+        now: datetime,
+    ) -> None:
+        await self._db_source.sync_session_idle_check_assignments(
+            pairs_to_create,
+            pairs_to_delete,
+            now,
+        )

--- a/src/ai/backend/manager/sokovan/idle_check/assignment_sync/applier.py
+++ b/src/ai/backend/manager/sokovan/idle_check/assignment_sync/applier.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import override
+
+from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
+from ai.backend.manager.sokovan.idle_check.assignment_sync.types import (
+    IdleCheckAssignmentSyncResult,
+)
+from ai.backend.manager.sokovan.idle_check.types import (
+    IdleCheckCategory,
+    IdleCheckKind,
+    IdleCheckTargetStatuses,
+)
+from ai.backend.manager.sokovan.reconciler.base import ReconcilerApplier, ReconcilerApplyInput
+
+_IdleCheckAssignmentSyncApplyInput = ReconcilerApplyInput[
+    IdleCheckAssignmentSyncResult,
+    IdleCheckCategory,
+    IdleCheckKind,
+    IdleCheckTargetStatuses,
+    SessionStatus,
+]
+
+
+class IdleCheckAssignmentSyncApplier(
+    ReconcilerApplier[
+        IdleCheckAssignmentSyncResult,
+        IdleCheckCategory,
+        IdleCheckKind,
+        IdleCheckTargetStatuses,
+        SessionStatus,
+    ]
+):
+    _repository: IdleCheckerRepository
+
+    def __init__(self, repository: IdleCheckerRepository) -> None:
+        self._repository = repository
+
+    @override
+    async def apply(self, apply_input: _IdleCheckAssignmentSyncApplyInput) -> None:
+        result = apply_input.result
+        if len(result.pairs_to_create) == 0 and len(result.pairs_to_delete) == 0:
+            return
+        await self._repository.sync_session_idle_check_assignments(
+            result.pairs_to_create,
+            result.pairs_to_delete,
+            result.current_time,
+        )

--- a/src/ai/backend/manager/sokovan/idle_check/assignment_sync/handler.py
+++ b/src/ai/backend/manager/sokovan/idle_check/assignment_sync/handler.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import override
+
+from ai.backend.manager.sokovan.idle_check.assignment_sync.types import (
+    IdleCheckAssignmentSyncReconcileInfo,
+    IdleCheckAssignmentSyncResult,
+)
+from ai.backend.manager.sokovan.reconciler.base import ReconcilerHandler
+
+
+class IdleCheckAssignmentSyncHandler(
+    ReconcilerHandler[IdleCheckAssignmentSyncReconcileInfo, IdleCheckAssignmentSyncResult]
+):
+    @override
+    async def execute(
+        self, reconcile_info: IdleCheckAssignmentSyncReconcileInfo
+    ) -> IdleCheckAssignmentSyncResult:
+        desired = set(reconcile_info.desired_pairs)
+        current = set(reconcile_info.current_pairs)
+        return IdleCheckAssignmentSyncResult(
+            pairs_to_create=list(desired - current),
+            pairs_to_delete=list(current - desired),
+            current_time=reconcile_info.current_time,
+        )
+
+    @override
+    async def post_process(self, result: IdleCheckAssignmentSyncResult) -> None:
+        pass

--- a/src/ai/backend/manager/sokovan/idle_check/assignment_sync/types.py
+++ b/src/ai/backend/manager/sokovan/idle_check/assignment_sync/types.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import override
 from uuid import UUID
 
 from ai.backend.manager.repositories.idle_checker.types import SessionIdleCheckPair
-from ai.backend.manager.sokovan.reconciler.base import BaseReconcilerInfo
+from ai.backend.manager.sokovan.reconciler.base import (
+    BaseReconcilerInfo,
+    BaseReconcilerResult,
+    ReconcilerDecision,
+)
 
 
 @dataclass
@@ -25,3 +29,22 @@ class IdleCheckAssignmentSyncReconcileInfo(BaseReconcilerInfo):
     @override
     def now(self) -> datetime:
         return self.current_time
+
+
+@dataclass
+class IdleCheckAssignmentSyncResult(BaseReconcilerResult):
+    current_time: datetime
+    pairs_to_create: list[SessionIdleCheckPair] = field(default_factory=list)
+    pairs_to_delete: list[SessionIdleCheckPair] = field(default_factory=list)
+
+    @override
+    def processed_count(self) -> int:
+        return len(self.pairs_to_create) + len(self.pairs_to_delete)
+
+    @override
+    def failed_count(self) -> int:
+        return 0
+
+    @override
+    def decisions(self) -> Sequence[ReconcilerDecision]:
+        return ()

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -498,6 +498,34 @@ class TestFetchJudgmentBatch:
         assert row is not None
         assert row.last_status is IdleCheckPhase.IDLE_EXPIRED
 
+    async def test_deletes_assignment_after_batch_boundary(
+        self,
+        database: ExtendedAsyncSAEngine,
+        repository: IdleCheckerRepository,
+        judgment_rows: JudgmentRows,
+    ) -> None:
+        pair_to_delete = SessionIdleCheckPair(
+            judgment_rows.active_session_id,
+            judgment_rows.checker_id,
+        )
+        pairs_to_delete = [
+            SessionIdleCheckPair(
+                SessionId(uuid.uuid4()),
+                IdleCheckerID(uuid.uuid4()),
+            )
+            for _ in range(1000)
+        ]
+        pairs_to_delete.append(pair_to_delete)
+
+        await repository.sync_session_idle_check_assignments([], pairs_to_delete, datetime.now(UTC))
+
+        async with database.begin_readonly_session() as db_sess:
+            row = await db_sess.get(
+                SessionIdleCheckRow,
+                (pair_to_delete.session_id, pair_to_delete.checker_id),
+            )
+        assert row is None
+
 
 class TestFetchExpiredIdleChecks:
     @pytest.fixture

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 
 import pytest
+import sqlalchemy as sa
 
 from ai.backend.common.data.idle_checker.types import (
     CheckerType,
@@ -334,6 +335,168 @@ class TestFetchJudgmentBatch:
             )
         }
         assert assignments.now.tzinfo is not None
+
+    async def test_creates_missing_assignment_as_not_checked(
+        self,
+        database: ExtendedAsyncSAEngine,
+        repository: IdleCheckerRepository,
+        judgment_rows: JudgmentRows,
+    ) -> None:
+        assignments = await repository.fetch_session_idle_check_assignments([SessionStatus.RUNNING])
+        pair = SessionIdleCheckPair(
+            judgment_rows.session_without_row_id,
+            judgment_rows.checker_id,
+        )
+
+        await repository.sync_session_idle_check_assignments([pair], [], assignments.now)
+
+        async with database.begin_readonly_session() as db_sess:
+            row = await db_sess.get(
+                SessionIdleCheckRow,
+                (pair.session_id, pair.checker_id),
+            )
+        assert row is not None
+        assert row.expire_at == assignments.now
+        assert row.last_status is IdleCheckPhase.NOT_CHECKED
+        assert row.last_message == "Not checked yet."
+
+    async def test_disabled_binding_deletes_non_expired_rows(
+        self,
+        database: ExtendedAsyncSAEngine,
+        repository: IdleCheckerRepository,
+        judgment_rows: JudgmentRows,
+    ) -> None:
+        async with database.begin_session() as db_sess:
+            await db_sess.execute(sa.update(IdleCheckerBindingRow).values(enabled=False))
+        assignment_snapshot = await repository.fetch_session_idle_check_assignments([
+            SessionStatus.RUNNING
+        ])
+        obsolete_pairs = set(assignment_snapshot.current_pairs) - set(
+            assignment_snapshot.desired_pairs
+        )
+
+        await repository.sync_session_idle_check_assignments(
+            [], list(obsolete_pairs), assignment_snapshot.now
+        )
+
+        async with database.begin_readonly_session() as db_sess:
+            non_expired_rows = (
+                await db_sess.scalars(
+                    sa.select(SessionIdleCheckRow).where(
+                        SessionIdleCheckRow.session_id.in_({
+                            judgment_rows.active_session_id,
+                            judgment_rows.idle_session_id,
+                            judgment_rows.not_checked_session_id,
+                        })
+                    )
+                )
+            ).all()
+        assert non_expired_rows == []
+
+    async def test_disabled_binding_preserves_idle_expired_row(
+        self,
+        database: ExtendedAsyncSAEngine,
+        repository: IdleCheckerRepository,
+        judgment_rows: JudgmentRows,
+    ) -> None:
+        async with database.begin_session() as db_sess:
+            await db_sess.execute(sa.update(IdleCheckerBindingRow).values(enabled=False))
+        assignment_snapshot = await repository.fetch_session_idle_check_assignments([
+            SessionStatus.RUNNING
+        ])
+        obsolete_pairs = set(assignment_snapshot.current_pairs) - set(
+            assignment_snapshot.desired_pairs
+        )
+
+        await repository.sync_session_idle_check_assignments(
+            [], list(obsolete_pairs), assignment_snapshot.now
+        )
+
+        async with database.begin_readonly_session() as db_sess:
+            expired_row = await db_sess.get(
+                SessionIdleCheckRow,
+                (
+                    judgment_rows.idle_expired_session_id,
+                    judgment_rows.checker_id,
+                ),
+            )
+        assert expired_row is not None
+        assert expired_row.last_status is IdleCheckPhase.IDLE_EXPIRED
+
+    async def test_reenabled_binding_creates_fresh_not_checked_row(
+        self,
+        database: ExtendedAsyncSAEngine,
+        repository: IdleCheckerRepository,
+        judgment_rows: JudgmentRows,
+    ) -> None:
+        async with database.begin_session() as db_sess:
+            await db_sess.execute(sa.update(IdleCheckerBindingRow).values(enabled=False))
+        assignment_snapshot = await repository.fetch_session_idle_check_assignments([
+            SessionStatus.RUNNING
+        ])
+        obsolete_pairs = set(assignment_snapshot.current_pairs) - set(
+            assignment_snapshot.desired_pairs
+        )
+        await repository.sync_session_idle_check_assignments(
+            [], list(obsolete_pairs), assignment_snapshot.now
+        )
+
+        async with database.begin_session() as db_sess:
+            await db_sess.execute(sa.update(IdleCheckerBindingRow).values(enabled=True))
+        assignment_snapshot = await repository.fetch_session_idle_check_assignments([
+            SessionStatus.RUNNING
+        ])
+        missing_pairs = set(assignment_snapshot.desired_pairs) - set(
+            assignment_snapshot.current_pairs
+        )
+
+        await repository.sync_session_idle_check_assignments(
+            list(missing_pairs), [], assignment_snapshot.now
+        )
+
+        async with database.begin_readonly_session() as db_sess:
+            recreated_row = await db_sess.get(
+                SessionIdleCheckRow,
+                (
+                    judgment_rows.active_session_id,
+                    judgment_rows.checker_id,
+                ),
+            )
+        assert recreated_row is not None
+        assert recreated_row.last_status is IdleCheckPhase.NOT_CHECKED
+        assert recreated_row.expire_at == assignment_snapshot.now
+
+    async def test_delete_rechecks_expired_status_after_assignment_fetch(
+        self,
+        database: ExtendedAsyncSAEngine,
+        repository: IdleCheckerRepository,
+        judgment_rows: JudgmentRows,
+    ) -> None:
+        pair = SessionIdleCheckPair(
+            judgment_rows.active_session_id,
+            judgment_rows.checker_id,
+        )
+        assignments = await repository.fetch_session_idle_check_assignments([SessionStatus.RUNNING])
+        assert pair in assignments.current_pairs
+        async with database.begin_session() as db_sess:
+            await db_sess.execute(
+                sa.update(SessionIdleCheckRow)
+                .where(
+                    SessionIdleCheckRow.session_id == pair.session_id,
+                    SessionIdleCheckRow.idle_checker_id == pair.checker_id,
+                )
+                .values(last_status=IdleCheckPhase.IDLE_EXPIRED)
+            )
+
+        await repository.sync_session_idle_check_assignments([], [pair], assignments.now)
+
+        async with database.begin_readonly_session() as db_sess:
+            row = await db_sess.get(
+                SessionIdleCheckRow,
+                (pair.session_id, pair.checker_id),
+            )
+        assert row is not None
+        assert row.last_status is IdleCheckPhase.IDLE_EXPIRED
 
 
 class TestFetchExpiredIdleChecks:

--- a/tests/unit/manager/sokovan/idle_check/test_assignment_sync.py
+++ b/tests/unit/manager/sokovan/idle_check/test_assignment_sync.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from ai.backend.common.identifier.idle_checker import IdleCheckerID
+from ai.backend.common.types import SessionId
+from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
+from ai.backend.manager.repositories.idle_checker.types import SessionIdleCheckPair
+from ai.backend.manager.sokovan.idle_check.assignment_sync.applier import (
+    IdleCheckAssignmentSyncApplier,
+)
+from ai.backend.manager.sokovan.idle_check.assignment_sync.handler import (
+    IdleCheckAssignmentSyncHandler,
+)
+from ai.backend.manager.sokovan.idle_check.assignment_sync.types import (
+    IdleCheckAssignmentSyncReconcileInfo,
+    IdleCheckAssignmentSyncResult,
+)
+
+
+@pytest.fixture
+def current_time() -> datetime:
+    return datetime(2026, 1, 1, tzinfo=UTC)
+
+
+@pytest.fixture
+def pair_to_create() -> SessionIdleCheckPair:
+    return SessionIdleCheckPair(
+        session_id=SessionId(uuid4()),
+        checker_id=IdleCheckerID(uuid4()),
+    )
+
+
+@pytest.fixture
+def pair_to_delete() -> SessionIdleCheckPair:
+    return SessionIdleCheckPair(
+        session_id=SessionId(uuid4()),
+        checker_id=IdleCheckerID(uuid4()),
+    )
+
+
+@pytest.fixture
+def pair_to_keep() -> SessionIdleCheckPair:
+    return SessionIdleCheckPair(
+        session_id=SessionId(uuid4()),
+        checker_id=IdleCheckerID(uuid4()),
+    )
+
+
+class TestIdleCheckAssignmentSyncHandler:
+    @pytest.fixture
+    def handler(self) -> IdleCheckAssignmentSyncHandler:
+        return IdleCheckAssignmentSyncHandler()
+
+    async def test_computes_create_and_delete_pairs(
+        self,
+        handler: IdleCheckAssignmentSyncHandler,
+        current_time: datetime,
+        pair_to_create: SessionIdleCheckPair,
+        pair_to_delete: SessionIdleCheckPair,
+        pair_to_keep: SessionIdleCheckPair,
+    ) -> None:
+        result = await handler.execute(
+            IdleCheckAssignmentSyncReconcileInfo(
+                desired_pairs=[pair_to_create, pair_to_keep, pair_to_keep],
+                current_pairs=[pair_to_delete, pair_to_keep],
+                current_time=current_time,
+            )
+        )
+
+        assert set(result.pairs_to_create) == {pair_to_create}
+        assert set(result.pairs_to_delete) == {pair_to_delete}
+        assert result.current_time == current_time
+        assert result.processed_count() == 2
+
+
+class TestIdleCheckAssignmentSyncApplier:
+    @pytest.fixture
+    def repository(self) -> AsyncMock:
+        return AsyncMock(spec=IdleCheckerRepository)
+
+    @pytest.fixture
+    def applier(self, repository: AsyncMock) -> IdleCheckAssignmentSyncApplier:
+        return IdleCheckAssignmentSyncApplier(repository)
+
+    async def test_applies_assignment_changes(
+        self,
+        applier: IdleCheckAssignmentSyncApplier,
+        repository: AsyncMock,
+        current_time: datetime,
+        pair_to_create: SessionIdleCheckPair,
+        pair_to_delete: SessionIdleCheckPair,
+    ) -> None:
+        apply_input = MagicMock()
+        apply_input.result = IdleCheckAssignmentSyncResult(
+            current_time=current_time,
+            pairs_to_create=[pair_to_create],
+            pairs_to_delete=[pair_to_delete],
+        )
+
+        await applier.apply(apply_input)
+
+        repository.sync_session_idle_check_assignments.assert_awaited_once_with(
+            [pair_to_create],
+            [pair_to_delete],
+            current_time,
+        )
+
+    async def test_skips_empty_assignment_changes(
+        self,
+        applier: IdleCheckAssignmentSyncApplier,
+        repository: AsyncMock,
+        current_time: datetime,
+    ) -> None:
+        apply_input = MagicMock()
+        apply_input.result = IdleCheckAssignmentSyncResult(current_time=current_time)
+
+        await applier.apply(apply_input)
+
+        repository.sync_session_idle_check_assignments.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Add an assignment-sync Handler that computes missing and obsolete session-idle-check pairs from desired and current assignments.
- Add an assignment-sync Applier and repository operations that create fresh `NOT_CHECKED` rows and delete obsolete non-expired rows atomically while preserving `IDLE_EXPIRED` rows.
- Cover Handler/Applier behavior, binding disable and re-enable, and concurrent expiry with unit and repository tests.

## Test plan

- [x] `pants fmt ::`
- [x] `pants fix ::`
- [x] `pants lint --changed-since=origin/main`
- [x] `pants check` for affected idle-check packages
- [x] `pants test` for affected idle-check packages

Category splitting and stage wiring remain deferred to the follow-up wiring change.

Resolves BA-6972