### PR TITLE
feat(BA-6978): add replica-group scheduling-history query conditions and orders

### DIFF
--- a/changes/13056.feature.md
+++ b/changes/13056.feature.md
@@ -1,0 +1,1 @@
+Add the models-layer query conditions and orders for replica-group scheduling history, along with the ReplicaGroupHistoryID identifier type.

--- a/src/ai/backend/common/data/permission/types.py
+++ b/src/ai/backend/common/data/permission/types.py
@@ -189,6 +189,8 @@ class EntityType(enum.StrEnum):
     DEPLOYMENT_SCOPED_HISTORY = "deployment:scoped_history"
     DEPLOYMENT_ERROR = "deployment:error"
     DEPLOYMENT_TOKEN = "deployment:token"
+    # Replica group sub
+    REPLICA_GROUP_HISTORY = "replica_group:history"
     # Image sub
     IMAGE_ALIAS = "image:alias"
     IMAGE_TAG = "image:tag"

--- a/src/ai/backend/common/dto/manager/v2/scheduling_history/types.py
+++ b/src/ai/backend/common/dto/manager/v2/scheduling_history/types.py
@@ -19,6 +19,7 @@ __all__ = (
     "KernelHistoryOrderField",
     "KernelHistoryScopeDTO",
     "OrderDirection",
+    "ReplicaGroupHistoryOrderField",
     "RouteHistoryOrderField",
     "RouteHistoryScopeDTO",
     "SchedulingResultType",
@@ -71,6 +72,18 @@ class RouteHistoryOrderField(StrEnum):
 
     CREATED_AT = "created_at"
     UPDATED_AT = "updated_at"
+
+
+class ReplicaGroupHistoryOrderField(StrEnum):
+    """Fields available for ordering replica-group scheduling history."""
+
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"
+    PHASE = "phase"
+    FROM_STATUS = "from_status"
+    TO_STATUS = "to_status"
+    RESULT = "result"
+    ATTEMPTS = "attempts"
 
 
 class SubStepResultInfo(BaseResponseModel):

--- a/src/ai/backend/common/identifier/replica_group_history.py
+++ b/src/ai/backend/common/identifier/replica_group_history.py
@@ -1,0 +1,6 @@
+from typing import NewType
+from uuid import UUID
+
+__all__ = ("ReplicaGroupHistoryID",)
+
+ReplicaGroupHistoryID = NewType("ReplicaGroupHistoryID", UUID)

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -27,6 +27,7 @@ from ai.backend.common.identifier.deployment_preset import DeploymentPresetID
 from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.replica_group import ReplicaGroupID
+from ai.backend.common.identifier.replica_group_history import ReplicaGroupHistoryID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.common.identifier.runtime_variant_preset import RuntimeVariantPresetID
 from ai.backend.common.identifier.vfolder import VFolderUUID
@@ -1344,7 +1345,7 @@ class RouteHistoryData:
 class ReplicaGroupHistoryData:
     """Domain model for replica-group history."""
 
-    id: UUID
+    id: ReplicaGroupHistoryID
     replica_group_id: ReplicaGroupID
     deployment_id: DeploymentID
 

--- a/src/ai/backend/manager/models/replica_group_history/conditions.py
+++ b/src/ai/backend/manager/models/replica_group_history/conditions.py
@@ -11,7 +11,6 @@ import sqlalchemy as sa
 from ai.backend.common.data.filter_specs import StringMatchSpec, UUIDEqualMatchSpec, UUIDInMatchSpec
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.replica_group import ReplicaGroupID
-from ai.backend.common.identifier.replica_group_history import ReplicaGroupHistoryID
 from ai.backend.manager.data.deployment.types import ReplicaGroupHandlerCategory
 from ai.backend.manager.data.session.types import SchedulingResult
 from ai.backend.manager.models.clauses import QueryCondition
@@ -38,13 +37,6 @@ class ReplicaGroupHistoryConditions:
             if spec.negated:
                 return ReplicaGroupHistoryRow.id.notin_(spec.values)
             return ReplicaGroupHistoryRow.id.in_(spec.values)
-
-        return inner
-
-    @staticmethod
-    def by_ids(ids: Collection[ReplicaGroupHistoryID]) -> QueryCondition:
-        def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ReplicaGroupHistoryRow.id.in_(ids)
 
         return inner
 

--- a/src/ai/backend/manager/models/replica_group_history/conditions.py
+++ b/src/ai/backend/manager/models/replica_group_history/conditions.py
@@ -102,41 +102,13 @@ class ReplicaGroupHistoryConditions:
 
         return inner
 
-    # UUID filter conditions for replica_group_id
+    # Equality condition for the scope's replica_group_id
     @staticmethod
     def by_replica_group_id_filter(spec: UUIDEqualMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             if spec.negated:
                 return ReplicaGroupHistoryRow.replica_group_id != spec.value
             return ReplicaGroupHistoryRow.replica_group_id == spec.value
-
-        return inner
-
-    @staticmethod
-    def by_replica_group_id_in(spec: UUIDInMatchSpec) -> QueryCondition:
-        def inner() -> sa.sql.expression.ColumnElement[bool]:
-            if spec.negated:
-                return ReplicaGroupHistoryRow.replica_group_id.notin_(spec.values)
-            return ReplicaGroupHistoryRow.replica_group_id.in_(spec.values)
-
-        return inner
-
-    # UUID filter conditions for deployment_id
-    @staticmethod
-    def by_deployment_id_filter(spec: UUIDEqualMatchSpec) -> QueryCondition:
-        def inner() -> sa.sql.expression.ColumnElement[bool]:
-            if spec.negated:
-                return ReplicaGroupHistoryRow.deployment_id != spec.value
-            return ReplicaGroupHistoryRow.deployment_id == spec.value
-
-        return inner
-
-    @staticmethod
-    def by_deployment_id_in(spec: UUIDInMatchSpec) -> QueryCondition:
-        def inner() -> sa.sql.expression.ColumnElement[bool]:
-            if spec.negated:
-                return ReplicaGroupHistoryRow.deployment_id.notin_(spec.values)
-            return ReplicaGroupHistoryRow.deployment_id.in_(spec.values)
 
         return inner
 

--- a/src/ai/backend/manager/models/replica_group_history/conditions.py
+++ b/src/ai/backend/manager/models/replica_group_history/conditions.py
@@ -40,6 +40,13 @@ class ReplicaGroupHistoryConditions:
         return inner
 
     @staticmethod
+    def by_replica_group_id(replica_group_id: ReplicaGroupID) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ReplicaGroupHistoryRow.replica_group_id == replica_group_id
+
+        return inner
+
+    @staticmethod
     def by_replica_group_ids(group_ids: Collection[ReplicaGroupID]) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return ReplicaGroupHistoryRow.replica_group_id.in_(group_ids)
@@ -99,16 +106,6 @@ class ReplicaGroupHistoryConditions:
     def by_to_statuses(statuses: list[str]) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return ReplicaGroupHistoryRow.to_status.in_(statuses)
-
-        return inner
-
-    # Equality condition for the scope's replica_group_id
-    @staticmethod
-    def by_replica_group_id_filter(spec: UUIDEqualMatchSpec) -> QueryCondition:
-        def inner() -> sa.sql.expression.ColumnElement[bool]:
-            if spec.negated:
-                return ReplicaGroupHistoryRow.replica_group_id != spec.value
-            return ReplicaGroupHistoryRow.replica_group_id == spec.value
 
         return inner
 

--- a/src/ai/backend/manager/models/replica_group_history/conditions.py
+++ b/src/ai/backend/manager/models/replica_group_history/conditions.py
@@ -1,17 +1,59 @@
+"""Query conditions for replica group history rows."""
+
 from __future__ import annotations
 
+import uuid
 from collections.abc import Collection
+from datetime import datetime
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.filter_specs import StringMatchSpec, UUIDEqualMatchSpec, UUIDInMatchSpec
+from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.replica_group import ReplicaGroupID
+from ai.backend.common.identifier.replica_group_history import ReplicaGroupHistoryID
 from ai.backend.manager.data.deployment.types import ReplicaGroupHandlerCategory
+from ai.backend.manager.data.session.types import SchedulingResult
 from ai.backend.manager.models.clauses import QueryCondition
+from ai.backend.manager.models.condition_utils import make_string_in_factory
 from ai.backend.manager.models.replica_group_history.row import ReplicaGroupHistoryRow
 
 
 class ReplicaGroupHistoryConditions:
     """Query conditions for replica group history."""
+
+    # UUID filter conditions for history id
+    @staticmethod
+    def by_id_filter(spec: UUIDEqualMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.negated:
+                return ReplicaGroupHistoryRow.id != spec.value
+            return ReplicaGroupHistoryRow.id == spec.value
+
+        return inner
+
+    @staticmethod
+    def by_id_in(spec: UUIDInMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.negated:
+                return ReplicaGroupHistoryRow.id.notin_(spec.values)
+            return ReplicaGroupHistoryRow.id.in_(spec.values)
+
+        return inner
+
+    @staticmethod
+    def by_ids(ids: Collection[ReplicaGroupHistoryID]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ReplicaGroupHistoryRow.id.in_(ids)
+
+        return inner
+
+    @staticmethod
+    def by_replica_group_id(replica_group_id: ReplicaGroupID) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ReplicaGroupHistoryRow.replica_group_id == replica_group_id
+
+        return inner
 
     @staticmethod
     def by_replica_group_ids(group_ids: Collection[ReplicaGroupID]) -> QueryCondition:
@@ -21,8 +63,338 @@ class ReplicaGroupHistoryConditions:
         return inner
 
     @staticmethod
+    def by_deployment_id(deployment_id: DeploymentID) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ReplicaGroupHistoryRow.deployment_id == deployment_id
+
+        return inner
+
+    @staticmethod
     def by_category(category: ReplicaGroupHandlerCategory) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return ReplicaGroupHistoryRow.category == category
+
+        return inner
+
+    @staticmethod
+    def by_categories(categories: list[ReplicaGroupHandlerCategory]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ReplicaGroupHistoryRow.category.in_(categories)
+
+        return inner
+
+    @staticmethod
+    def by_result(result: SchedulingResult) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ReplicaGroupHistoryRow.result == str(result)
+
+        return inner
+
+    @staticmethod
+    def by_results(results: list[SchedulingResult]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ReplicaGroupHistoryRow.result.in_([str(r) for r in results])
+
+        return inner
+
+    @staticmethod
+    def by_result_not_equals(result: SchedulingResult) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ReplicaGroupHistoryRow.result != str(result)
+
+        return inner
+
+    @staticmethod
+    def by_result_not_in(results: list[SchedulingResult]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ReplicaGroupHistoryRow.result.not_in([str(r) for r in results])
+
+        return inner
+
+    @staticmethod
+    def by_from_statuses(statuses: list[str]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ReplicaGroupHistoryRow.from_status.in_(statuses)
+
+        return inner
+
+    @staticmethod
+    def by_to_statuses(statuses: list[str]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ReplicaGroupHistoryRow.to_status.in_(statuses)
+
+        return inner
+
+    # UUID filter conditions for replica_group_id
+    @staticmethod
+    def by_replica_group_id_filter(spec: UUIDEqualMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.negated:
+                return ReplicaGroupHistoryRow.replica_group_id != spec.value
+            return ReplicaGroupHistoryRow.replica_group_id == spec.value
+
+        return inner
+
+    @staticmethod
+    def by_replica_group_id_in(spec: UUIDInMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.negated:
+                return ReplicaGroupHistoryRow.replica_group_id.notin_(spec.values)
+            return ReplicaGroupHistoryRow.replica_group_id.in_(spec.values)
+
+        return inner
+
+    # UUID filter conditions for deployment_id
+    @staticmethod
+    def by_deployment_id_filter(spec: UUIDEqualMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.negated:
+                return ReplicaGroupHistoryRow.deployment_id != spec.value
+            return ReplicaGroupHistoryRow.deployment_id == spec.value
+
+        return inner
+
+    @staticmethod
+    def by_deployment_id_in(spec: UUIDInMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.negated:
+                return ReplicaGroupHistoryRow.deployment_id.notin_(spec.values)
+            return ReplicaGroupHistoryRow.deployment_id.in_(spec.values)
+
+        return inner
+
+    # String filter conditions for error_code
+    @staticmethod
+    def by_error_code_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = ReplicaGroupHistoryRow.error_code.ilike(f"%{spec.value}%")
+            else:
+                condition = ReplicaGroupHistoryRow.error_code.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_error_code_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = sa.func.lower(ReplicaGroupHistoryRow.error_code) == spec.value.lower()
+            else:
+                condition = ReplicaGroupHistoryRow.error_code == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_error_code_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = ReplicaGroupHistoryRow.error_code.ilike(f"{spec.value}%")
+            else:
+                condition = ReplicaGroupHistoryRow.error_code.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_error_code_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = ReplicaGroupHistoryRow.error_code.ilike(f"%{spec.value}")
+            else:
+                condition = ReplicaGroupHistoryRow.error_code.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    # String filter conditions for phase
+    @staticmethod
+    def by_phase_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = ReplicaGroupHistoryRow.phase.ilike(f"%{spec.value}%")
+            else:
+                condition = ReplicaGroupHistoryRow.phase.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_phase_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = sa.func.lower(ReplicaGroupHistoryRow.phase) == spec.value.lower()
+            else:
+                condition = ReplicaGroupHistoryRow.phase == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_phase_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = ReplicaGroupHistoryRow.phase.ilike(f"{spec.value}%")
+            else:
+                condition = ReplicaGroupHistoryRow.phase.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_phase_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = ReplicaGroupHistoryRow.phase.ilike(f"%{spec.value}")
+            else:
+                condition = ReplicaGroupHistoryRow.phase.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    # String filter conditions for message
+    @staticmethod
+    def by_message_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = ReplicaGroupHistoryRow.message.ilike(f"%{spec.value}%")
+            else:
+                condition = ReplicaGroupHistoryRow.message.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_message_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = sa.func.lower(ReplicaGroupHistoryRow.message) == spec.value.lower()
+            else:
+                condition = ReplicaGroupHistoryRow.message == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_message_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = ReplicaGroupHistoryRow.message.ilike(f"{spec.value}%")
+            else:
+                condition = ReplicaGroupHistoryRow.message.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_message_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = ReplicaGroupHistoryRow.message.ilike(f"%{spec.value}")
+            else:
+                condition = ReplicaGroupHistoryRow.message.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    by_phase_in = staticmethod(make_string_in_factory(ReplicaGroupHistoryRow.phase))
+    by_error_code_in = staticmethod(make_string_in_factory(ReplicaGroupHistoryRow.error_code))
+    by_message_in = staticmethod(make_string_in_factory(ReplicaGroupHistoryRow.message))
+
+    @staticmethod
+    def by_cursor_forward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for forward pagination (after cursor)."""
+        cursor_uuid = uuid.UUID(cursor_id)
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            subquery = (
+                sa.select(ReplicaGroupHistoryRow.created_at)
+                .where(ReplicaGroupHistoryRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return ReplicaGroupHistoryRow.created_at < subquery
+
+        return inner
+
+    @staticmethod
+    def by_cursor_backward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for backward pagination (before cursor)."""
+        cursor_uuid = uuid.UUID(cursor_id)
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            subquery = (
+                sa.select(ReplicaGroupHistoryRow.created_at)
+                .where(ReplicaGroupHistoryRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return ReplicaGroupHistoryRow.created_at > subquery
+
+        return inner
+
+    # DateTime filter conditions
+    @staticmethod
+    def by_created_at_before(dt: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ReplicaGroupHistoryRow.created_at < dt
+
+        return inner
+
+    @staticmethod
+    def by_created_at_after(dt: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ReplicaGroupHistoryRow.created_at > dt
+
+        return inner
+
+    @staticmethod
+    def by_created_at_equals(dt: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ReplicaGroupHistoryRow.created_at == dt
+
+        return inner
+
+    @staticmethod
+    def by_updated_at_before(dt: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ReplicaGroupHistoryRow.updated_at < dt
+
+        return inner
+
+    @staticmethod
+    def by_updated_at_after(dt: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ReplicaGroupHistoryRow.updated_at > dt
+
+        return inner
+
+    @staticmethod
+    def by_updated_at_equals(dt: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ReplicaGroupHistoryRow.updated_at == dt
 
         return inner

--- a/src/ai/backend/manager/models/replica_group_history/conditions.py
+++ b/src/ai/backend/manager/models/replica_group_history/conditions.py
@@ -9,7 +9,6 @@ from datetime import datetime
 import sqlalchemy as sa
 
 from ai.backend.common.data.filter_specs import StringMatchSpec, UUIDEqualMatchSpec, UUIDInMatchSpec
-from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.replica_group import ReplicaGroupID
 from ai.backend.manager.data.deployment.types import ReplicaGroupHandlerCategory
 from ai.backend.manager.data.session.types import SchedulingResult
@@ -41,23 +40,9 @@ class ReplicaGroupHistoryConditions:
         return inner
 
     @staticmethod
-    def by_replica_group_id(replica_group_id: ReplicaGroupID) -> QueryCondition:
-        def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ReplicaGroupHistoryRow.replica_group_id == replica_group_id
-
-        return inner
-
-    @staticmethod
     def by_replica_group_ids(group_ids: Collection[ReplicaGroupID]) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return ReplicaGroupHistoryRow.replica_group_id.in_(group_ids)
-
-        return inner
-
-    @staticmethod
-    def by_deployment_id(deployment_id: DeploymentID) -> QueryCondition:
-        def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ReplicaGroupHistoryRow.deployment_id == deployment_id
 
         return inner
 

--- a/src/ai/backend/manager/models/replica_group_history/conditions.py
+++ b/src/ai/backend/manager/models/replica_group_history/conditions.py
@@ -40,13 +40,6 @@ class ReplicaGroupHistoryConditions:
         return inner
 
     @staticmethod
-    def by_replica_group_id(replica_group_id: ReplicaGroupID) -> QueryCondition:
-        def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ReplicaGroupHistoryRow.replica_group_id == replica_group_id
-
-        return inner
-
-    @staticmethod
     def by_replica_group_ids(group_ids: Collection[ReplicaGroupID]) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return ReplicaGroupHistoryRow.replica_group_id.in_(group_ids)

--- a/src/ai/backend/manager/models/replica_group_history/conditions.py
+++ b/src/ai/backend/manager/models/replica_group_history/conditions.py
@@ -54,7 +54,7 @@ class ReplicaGroupHistoryConditions:
         return inner
 
     @staticmethod
-    def by_categories(categories: list[ReplicaGroupHandlerCategory]) -> QueryCondition:
+    def by_categories(categories: Collection[ReplicaGroupHandlerCategory]) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return ReplicaGroupHistoryRow.category.in_(categories)
 
@@ -68,7 +68,7 @@ class ReplicaGroupHistoryConditions:
         return inner
 
     @staticmethod
-    def by_results(results: list[SchedulingResult]) -> QueryCondition:
+    def by_results(results: Collection[SchedulingResult]) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return ReplicaGroupHistoryRow.result.in_([str(r) for r in results])
 
@@ -82,21 +82,21 @@ class ReplicaGroupHistoryConditions:
         return inner
 
     @staticmethod
-    def by_result_not_in(results: list[SchedulingResult]) -> QueryCondition:
+    def by_result_not_in(results: Collection[SchedulingResult]) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return ReplicaGroupHistoryRow.result.not_in([str(r) for r in results])
 
         return inner
 
     @staticmethod
-    def by_from_statuses(statuses: list[str]) -> QueryCondition:
+    def by_from_statuses(statuses: Collection[str]) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return ReplicaGroupHistoryRow.from_status.in_(statuses)
 
         return inner
 
     @staticmethod
-    def by_to_statuses(statuses: list[str]) -> QueryCondition:
+    def by_to_statuses(statuses: Collection[str]) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return ReplicaGroupHistoryRow.to_status.in_(statuses)
 

--- a/src/ai/backend/manager/models/replica_group_history/orders.py
+++ b/src/ai/backend/manager/models/replica_group_history/orders.py
@@ -1,0 +1,41 @@
+"""Query orders for replica group history rows."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.orm import InstrumentedAttribute
+
+from ai.backend.common.dto.manager.v2.scheduling_history.types import (
+    OrderDirection,
+    ReplicaGroupHistoryOrderField,
+)
+from ai.backend.manager.models.clauses import QueryOrder
+from ai.backend.manager.models.replica_group_history.row import ReplicaGroupHistoryRow
+
+_OrderColumn = sa.ColumnElement[Any] | InstrumentedAttribute[Any]
+
+REPLICA_GROUP_ORDER_FIELD_MAP: dict[ReplicaGroupHistoryOrderField, _OrderColumn] = {
+    ReplicaGroupHistoryOrderField.CREATED_AT: ReplicaGroupHistoryRow.created_at,
+    ReplicaGroupHistoryOrderField.UPDATED_AT: ReplicaGroupHistoryRow.updated_at,
+    ReplicaGroupHistoryOrderField.PHASE: ReplicaGroupHistoryRow.phase,
+    ReplicaGroupHistoryOrderField.FROM_STATUS: ReplicaGroupHistoryRow.from_status,
+    ReplicaGroupHistoryOrderField.TO_STATUS: ReplicaGroupHistoryRow.to_status,
+    ReplicaGroupHistoryOrderField.RESULT: ReplicaGroupHistoryRow.result,
+    ReplicaGroupHistoryOrderField.ATTEMPTS: ReplicaGroupHistoryRow.attempts,
+}
+
+REPLICA_GROUP_DEFAULT_FORWARD_ORDER: QueryOrder = ReplicaGroupHistoryRow.created_at.desc()
+REPLICA_GROUP_DEFAULT_BACKWARD_ORDER: QueryOrder = ReplicaGroupHistoryRow.created_at.asc()
+REPLICA_GROUP_TIEBREAKER_ORDER: QueryOrder = ReplicaGroupHistoryRow.id.asc()
+
+
+def resolve_replica_group_order(
+    field: ReplicaGroupHistoryOrderField, direction: OrderDirection
+) -> QueryOrder:
+    """Resolve a DTO order field + direction to a SQLAlchemy order expression."""
+    col = REPLICA_GROUP_ORDER_FIELD_MAP[field]
+    if direction == OrderDirection.DESC:
+        return col.desc()
+    return col.asc()

--- a/src/ai/backend/manager/models/replica_group_history/row.py
+++ b/src/ai/backend/manager/models/replica_group_history/row.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.replica_group import ReplicaGroupID
+from ai.backend.common.identifier.replica_group_history import ReplicaGroupHistoryID
 from ai.backend.manager.data.deployment.types import (
     ReplicaGroupHandlerCategory,
     ReplicaGroupHistoryData,
@@ -36,7 +37,7 @@ class ReplicaGroupHistoryRow(ReconcileHistoryMixin, Base):  # type: ignore[misc]
 
     def to_data(self) -> ReplicaGroupHistoryData:
         return ReplicaGroupHistoryData(
-            id=self.id,
+            id=ReplicaGroupHistoryID(self.id),
             replica_group_id=self.replica_group_id,
             deployment_id=self.deployment_id,
             category=self.category,


### PR DESCRIPTION
## 📚 Stacked PRs

Part of the replica-group scheduling-history stack (epic BA-6881, story BA-6884). **Merge in order (bottom-up):**

1. 👉 **#13056 — `feat(BA-6978)`: query conditions and orders (models layer)** ← you are here
2. #13057 — `feat(BA-6979)`: repository search scope and scoped search
3. #13058 — `feat(BA-6980)`: v2 DTOs and service actions
4. #13059 — `feat(BA-6981)`: adapter and REST v2 endpoints
5. #13060 — `feat(BA-6982)`: SDK v2 client and CLI commands
6. #13061 — `test(BA-6983)`: component tests for the REST v2 endpoints

Resolves #13048 (BA-6978)

## Summary

First PR of the BA-6884 replica-group scheduling-history stack, split the same way as the BA-6882 kernel stack.

- `ReplicaGroupHistoryConditions` grows from the two helpers the sokovan appliers needed into the full filter surface a search API needs: MatchSpec id / `replica_group_id` / `deployment_id` filters, `category`, `result`, from/to status, phase / error_code / message string matching, timestamp comparisons, and the `created_at` cursor conditions.
- New `models/replica_group_history/orders.py`: order field map, default forward/backward orders, id tiebreaker, and `resolve_replica_group_order`. `ReplicaGroupHistoryOrderField` lands in the shared v2 DTO types because that is where the resolver reads its field enum from, same as the kernel and session equivalents.
- `ReplicaGroupHistoryID` gives history rows their own identifier NewType, so `ReplicaGroupHistoryData.id` is no longer a bare `UUID`.
- `EntityType.REPLICA_GROUP_HISTORY` is the entity the admin search action reports.

Nothing calls the new code yet; the repository scope that consumes it is the next PR in the stack.

## Test plan

- [x] `pants check` clean over the touched packages
- [x] `pants lint` / `pants fmt` clean
- [ ] Exercised by the later PRs in the stack (repository tests, then REST component tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
