### PR TITLE
feat(BA-6981): add replica-group scheduling-history adapter and REST v2 endpoints

### DIFF
--- a/changes/13059.feature.md
+++ b/changes/13059.feature.md
@@ -1,0 +1,1 @@
+Add the replica-group scheduling-history REST v2 endpoints: POST /v2/scheduling-history/replica-groups/admin/search and /replica-groups/scoped/search.

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -26280,6 +26280,30 @@
             "default": null,
             "description": "Filter by history record ID"
           },
+          "replica_group_id": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UUIDFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by replica group ID"
+          },
+          "deployment_id": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UUIDFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by owning deployment ID"
+          },
           "category": {
             "anyOf": [
               {
@@ -26599,7 +26623,7 @@
         "type": "object"
       },
       "ReplicaGroupHistoryScopeDTO": {
-        "description": "Scope for replica-group scheduling history queries.\n\nThe list is OR'd internally. Raises an error if empty. The scoped search is\nstill a single-target scope action, so only one item is dispatchable today;\nthe list shape keeps the wire contract stable for the multi-target case.\n\nA replica group is not an RBAC scope of its own, so the history is scoped by\nthe owning deployment.",
+        "description": "Scope for replica-group scheduling history queries.\n\nEach category list is OR'd internally and across categories. Raises an error\nif every field is empty. The scoped search is still a single-target scope\naction, so only one item is dispatchable today; the list shape keeps the wire\ncontract stable for the multi-target case.\n\nA replica group is not an RBAC scope of its own, so the history is scoped by\nthe owning deployment.",
         "properties": {
           "deployment": {
             "anyOf": [

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -26280,30 +26280,6 @@
             "default": null,
             "description": "Filter by history record ID"
           },
-          "replica_group_id": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/UUIDFilter"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Filter by replica group ID"
-          },
-          "deployment_id": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/UUIDFilter"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Filter by deployment ID"
-          },
           "category": {
             "anyOf": [
               {
@@ -26623,37 +26599,18 @@
         "type": "object"
       },
       "ReplicaGroupHistoryScopeDTO": {
-        "description": "Scope for replica-group scheduling history queries.\n\nBoth axes are optional but at least one is required: a deployment scope\ncovers every replica group under it, a replica-group scope narrows to one\ngroup, and giving both intersects them.",
+        "description": "Scope for replica-group scheduling history queries.",
         "properties": {
-          "deployment_id": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Deployment ID whose replica-group history to get.",
-            "title": "Deployment Id"
-          },
           "replica_group_id": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
             "description": "Replica group ID to get history for.",
-            "title": "Replica Group Id"
+            "format": "uuid",
+            "title": "Replica Group Id",
+            "type": "string"
           }
         },
+        "required": [
+          "replica_group_id"
+        ],
         "title": "ReplicaGroupHistoryScopeDTO",
         "type": "object"
       },

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -26599,18 +26599,41 @@
         "type": "object"
       },
       "ReplicaGroupHistoryScopeDTO": {
-        "description": "Scope for replica-group scheduling history queries.",
+        "description": "Scope for replica-group scheduling history queries.\n\nEach list is OR'd internally and across categories. Raises an error if every\nfield is empty. The scoped search is still a single-target scope action, so\nonly one item is dispatchable today; the list shape keeps the wire contract\nstable for the multi-target case.",
         "properties": {
-          "replica_group_id": {
-            "description": "Replica group ID to get history for.",
-            "format": "uuid",
-            "title": "Replica Group Id",
-            "type": "string"
+          "replica_group": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/UUIDScope"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Replica group IDs to get history for.",
+            "title": "Replica Group"
+          },
+          "deployment": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/UUIDScope"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Deployment IDs to get the history of every owned replica group for.",
+            "title": "Deployment"
           }
         },
-        "required": [
-          "replica_group_id"
-        ],
         "title": "ReplicaGroupHistoryScopeDTO",
         "type": "object"
       },

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -26256,6 +26256,527 @@
         "title": "AdminSearchDeploymentHistoriesInput",
         "type": "object"
       },
+      "ReplicaGroupHistoryCategoryType": {
+        "description": "Handler category a replica-group history row was produced by.",
+        "enum": [
+          "lifecycle",
+          "scaling"
+        ],
+        "title": "ReplicaGroupHistoryCategoryType",
+        "type": "string"
+      },
+      "ReplicaGroupHistoryFilter": {
+        "description": "Filter conditions for replica-group scheduling history search.",
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UUIDFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by history record ID"
+          },
+          "replica_group_id": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UUIDFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by replica group ID"
+          },
+          "deployment_id": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UUIDFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by deployment ID"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ReplicaGroupHistoryCategoryType"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by handler category",
+            "title": "Category"
+          },
+          "phase": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StringFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by scheduling phase"
+          },
+          "from_status": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by from_status values",
+            "title": "From Status"
+          },
+          "to_status": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by to_status values",
+            "title": "To Status"
+          },
+          "result": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SchedulingResultFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by scheduling result"
+          },
+          "error_code": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StringFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by error code"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StringFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by message"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DateTimeFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by created_at"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DateTimeFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by updated_at"
+          },
+          "AND": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ReplicaGroupHistoryFilter"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "AND conjunction.",
+            "title": "And"
+          },
+          "OR": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ReplicaGroupHistoryFilter"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "OR conjunction.",
+            "title": "Or"
+          },
+          "NOT": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ReplicaGroupHistoryFilter"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "NOT negation.",
+            "title": "Not"
+          }
+        },
+        "title": "ReplicaGroupHistoryFilter",
+        "type": "object"
+      },
+      "ReplicaGroupHistoryOrder": {
+        "description": "Order specification for replica-group scheduling history.",
+        "properties": {
+          "field": {
+            "$ref": "#/components/schemas/ReplicaGroupHistoryOrderField",
+            "description": "Field to order by"
+          },
+          "direction": {
+            "$ref": "#/components/schemas/OrderDirection",
+            "default": "DESC",
+            "description": "Order direction"
+          }
+        },
+        "required": [
+          "field"
+        ],
+        "title": "ReplicaGroupHistoryOrder",
+        "type": "object"
+      },
+      "ReplicaGroupHistoryOrderField": {
+        "description": "Fields available for ordering replica-group scheduling history.",
+        "enum": [
+          "created_at",
+          "updated_at",
+          "phase",
+          "from_status",
+          "to_status",
+          "result",
+          "attempts"
+        ],
+        "title": "ReplicaGroupHistoryOrderField",
+        "type": "string"
+      },
+      "AdminSearchReplicaGroupHistoriesInput": {
+        "description": "Input for admin search of replica-group scheduling histories.",
+        "properties": {
+          "filter": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReplicaGroupHistoryFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter conditions"
+          },
+          "order": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ReplicaGroupHistoryOrder"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Order specifications",
+            "title": "Order"
+          },
+          "first": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cursor pagination: number of items",
+            "title": "First"
+          },
+          "after": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cursor pagination: after cursor",
+            "title": "After"
+          },
+          "last": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cursor pagination: last N items",
+            "title": "Last"
+          },
+          "before": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cursor pagination: before cursor",
+            "title": "Before"
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Offset pagination: maximum items",
+            "title": "Limit"
+          },
+          "offset": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Offset pagination: number to skip",
+            "title": "Offset"
+          }
+        },
+        "title": "AdminSearchReplicaGroupHistoriesInput",
+        "type": "object"
+      },
+      "ReplicaGroupHistoryScopeDTO": {
+        "description": "Scope for replica-group scheduling history queries.\n\nBoth axes are optional but at least one is required: a deployment scope\ncovers every replica group under it, a replica-group scope narrows to one\ngroup, and giving both intersects them.",
+        "properties": {
+          "deployment_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Deployment ID whose replica-group history to get.",
+            "title": "Deployment Id"
+          },
+          "replica_group_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Replica group ID to get history for.",
+            "title": "Replica Group Id"
+          }
+        },
+        "title": "ReplicaGroupHistoryScopeDTO",
+        "type": "object"
+      },
+      "ScopedSearchReplicaGroupHistoriesInput": {
+        "description": "Input for searching replica-group scheduling histories under a non-admin scope.",
+        "properties": {
+          "scope": {
+            "$ref": "#/components/schemas/ReplicaGroupHistoryScopeDTO",
+            "description": "Scope restricting the rows returned"
+          },
+          "filter": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReplicaGroupHistoryFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter conditions"
+          },
+          "order": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ReplicaGroupHistoryOrder"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Order specifications",
+            "title": "Order"
+          },
+          "first": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cursor pagination: number of items",
+            "title": "First"
+          },
+          "after": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cursor pagination: after cursor",
+            "title": "After"
+          },
+          "last": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cursor pagination: last N items",
+            "title": "Last"
+          },
+          "before": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cursor pagination: before cursor",
+            "title": "Before"
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Offset pagination: maximum items",
+            "title": "Limit"
+          },
+          "offset": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Offset pagination: number to skip",
+            "title": "Offset"
+          }
+        },
+        "required": [
+          "scope"
+        ],
+        "title": "ScopedSearchReplicaGroupHistoriesInput",
+        "type": "object"
+      },
       "RouteHistoryFilter": {
         "description": "Filter for route history.",
         "properties": {
@@ -49369,6 +49890,64 @@
           }
         ],
         "description": "Search deployment histories scoped to a specific deployment.\n\n**Preconditions:**\n* Superadmin privilege required.\n"
+      }
+    },
+    "/v2/scheduling-history/replica-groups/admin/search": {
+      "post": {
+        "operationId": "v2/scheduling-history.admin_search_replica_group_history",
+        "tags": [
+          "v2/scheduling-history"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminSearchReplicaGroupHistoriesInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Search replica-group scheduling histories with admin scope.\n\n**Preconditions:**\n* Superadmin privilege required.\n"
+      }
+    },
+    "/v2/scheduling-history/replica-groups/scoped/search": {
+      "post": {
+        "operationId": "v2/scheduling-history.scoped_search_replica_group_history",
+        "tags": [
+          "v2/scheduling-history"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScopedSearchReplicaGroupHistoriesInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Search replica-group scheduling histories under a non-admin scope.\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
     "/v2/scheduling-history/routes/search": {

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -26599,24 +26599,8 @@
         "type": "object"
       },
       "ReplicaGroupHistoryScopeDTO": {
-        "description": "Scope for replica-group scheduling history queries.\n\nEach list is OR'd internally and across categories. Raises an error if every\nfield is empty. The scoped search is still a single-target scope action, so\nonly one item is dispatchable today; the list shape keeps the wire contract\nstable for the multi-target case.",
+        "description": "Scope for replica-group scheduling history queries.\n\nThe list is OR'd internally. Raises an error if empty. The scoped search is\nstill a single-target scope action, so only one item is dispatchable today;\nthe list shape keeps the wire contract stable for the multi-target case.\n\nA replica group is not an RBAC scope of its own, so the history is scoped by\nthe owning deployment.",
         "properties": {
-          "replica_group": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/UUIDScope"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Replica group IDs to get history for.",
-            "title": "Replica Group"
-          },
           "deployment": {
             "anyOf": [
               {

--- a/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
@@ -9,15 +9,18 @@ from ai.backend.common.data.filter_specs import UUIDEqualMatchSpec
 from ai.backend.common.dto.manager.v2.scheduling_history.request import (
     AdminSearchDeploymentHistoriesInput,
     AdminSearchKernelHistoriesInput,
+    AdminSearchReplicaGroupHistoriesInput,
     AdminSearchRouteHistoriesInput,
     AdminSearchSessionHistoriesInput,
     DeploymentHistoryFilter,
     DeploymentHistoryOrder,
     KernelHistoryFilter,
     KernelHistoryOrder,
+    ReplicaGroupHistoryFilter,
     RouteHistoryFilter,
     RouteHistoryOrder,
     ScopedSearchKernelHistoriesInput,
+    ScopedSearchReplicaGroupHistoriesInput,
     SessionHistoryFilter,
     SessionHistoryOrder,
 )
@@ -27,17 +30,25 @@ from ai.backend.common.dto.manager.v2.scheduling_history.response import (
     AdminSearchSessionHistoriesPayload,
     DeploymentHistoryNode,
     KernelHistoryNode,
+    ReplicaGroupHistoryNode,
     RouteHistoryNode,
     SearchKernelHistoriesPayload,
+    SearchReplicaGroupHistoriesPayload,
     SessionHistoryNode,
 )
 from ai.backend.common.dto.manager.v2.scheduling_history.types import SubStepResultInfo
+from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.kernel_scheduling_history import KernelSchedulingHistoryID
 from ai.backend.common.identifier.replica import ReplicaID
 from ai.backend.common.types import KernelId, SessionId
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
-from ai.backend.manager.data.deployment.types import DeploymentHistoryData, RouteHistoryData
+from ai.backend.manager.data.deployment.types import (
+    DeploymentHistoryData,
+    ReplicaGroupHandlerCategory,
+    ReplicaGroupHistoryData,
+    RouteHistoryData,
+)
 from ai.backend.manager.data.kernel.types import KernelSchedulingHistoryData
 from ai.backend.manager.data.session.types import (
     SchedulingResult,
@@ -45,7 +56,17 @@ from ai.backend.manager.data.session.types import (
     SubStepResult,
 )
 from ai.backend.manager.errors.api import InvalidAPIParameters
+from ai.backend.manager.errors.repository import EmptySearchScopeError
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
+from ai.backend.manager.models.replica_group_history.conditions import (
+    ReplicaGroupHistoryConditions,
+)
+from ai.backend.manager.models.replica_group_history.orders import (
+    REPLICA_GROUP_DEFAULT_BACKWARD_ORDER,
+    REPLICA_GROUP_DEFAULT_FORWARD_ORDER,
+    REPLICA_GROUP_TIEBREAKER_ORDER,
+    resolve_replica_group_order,
+)
 from ai.backend.manager.models.scheduling_history.conditions import (
     DeploymentHistoryConditions,
     KernelSchedulingHistoryConditions,
@@ -84,6 +105,9 @@ from ai.backend.manager.repositories.scheduling_history.types import (
 from ai.backend.manager.services.scheduling_history.actions.resolve_kernel_session import (
     ResolveKernelSessionAction,
 )
+from ai.backend.manager.services.scheduling_history.actions.resolve_replica_group_deployment import (
+    ResolveReplicaGroupDeploymentAction,
+)
 from ai.backend.manager.services.scheduling_history.actions.search_deployment_history import (
     SearchDeploymentHistoryAction,
 )
@@ -96,6 +120,12 @@ from ai.backend.manager.services.scheduling_history.actions.search_kernel_histor
 from ai.backend.manager.services.scheduling_history.actions.search_kernel_scoped_history import (
     SearchKernelScopedHistoryAction,
     SessionKernelHistoryTarget,
+)
+from ai.backend.manager.services.scheduling_history.actions.search_replica_group_history import (
+    SearchReplicaGroupHistoryAction,
+)
+from ai.backend.manager.services.scheduling_history.actions.search_replica_group_scoped_history import (
+    SearchReplicaGroupScopedHistoryAction,
 )
 from ai.backend.manager.services.scheduling_history.actions.search_route_history import (
     SearchRouteHistoryAction,
@@ -132,6 +162,14 @@ _DEPLOYMENT_HISTORY_PAGINATION_SPEC = PaginationSpec(
     forward_condition_factory=DeploymentHistoryConditions.by_cursor_forward,
     backward_condition_factory=DeploymentHistoryConditions.by_cursor_backward,
     tiebreaker_order=DEPLOYMENT_TIEBREAKER_ORDER,
+)
+
+_REPLICA_GROUP_HISTORY_PAGINATION_SPEC = PaginationSpec(
+    forward_order=REPLICA_GROUP_DEFAULT_FORWARD_ORDER,
+    backward_order=REPLICA_GROUP_DEFAULT_BACKWARD_ORDER,
+    forward_condition_factory=ReplicaGroupHistoryConditions.by_cursor_forward,
+    backward_condition_factory=ReplicaGroupHistoryConditions.by_cursor_backward,
+    tiebreaker_order=REPLICA_GROUP_TIEBREAKER_ORDER,
 )
 
 _ROUTE_HISTORY_PAGINATION_SPEC = PaginationSpec(
@@ -784,6 +822,216 @@ class SchedulingHistoryAdapter(BaseAdapter):
     def _convert_deployment_orders(order: list[DeploymentHistoryOrder]) -> list[QueryOrder]:
         return [resolve_deployment_order(o.field, o.direction) for o in order]
 
+    # ========== Replica Group History ==========
+
+    async def admin_search_replica_group_history(
+        self,
+        input: AdminSearchReplicaGroupHistoriesInput,
+    ) -> SearchReplicaGroupHistoriesPayload:
+        """Search replica-group scheduling histories (admin, no scope)."""
+        conditions = self._convert_replica_group_filter(input.filter) if input.filter else []
+        orders = (
+            [resolve_replica_group_order(o.field, o.direction) for o in input.order]
+            if input.order
+            else []
+        )
+        querier = self._build_querier(
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=_REPLICA_GROUP_HISTORY_PAGINATION_SPEC,
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+        )
+        action_result = await self._processors.scheduling_history.search_replica_group_history.wait_for_complete(
+            SearchReplicaGroupHistoryAction(querier=querier)
+        )
+        return SearchReplicaGroupHistoriesPayload(
+            items=[self._replica_group_data_to_dto(h) for h in action_result.items],
+            total_count=action_result.total_count,
+            has_next_page=action_result.has_next_page,
+            has_previous_page=action_result.has_previous_page,
+        )
+
+    async def scoped_search_replica_group_history(
+        self,
+        input: ScopedSearchReplicaGroupHistoriesInput,
+    ) -> SearchReplicaGroupHistoriesPayload:
+        """Search replica-group scheduling histories under a non-admin scope."""
+        conditions = self._convert_replica_group_filter(input.filter) if input.filter else []
+        orders = (
+            [resolve_replica_group_order(o.field, o.direction) for o in input.order]
+            if input.order
+            else []
+        )
+        querier = self._build_querier(
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=_REPLICA_GROUP_HISTORY_PAGINATION_SPEC,
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+        )
+        # The owning deployment is the authorization subject; a replica-group-only
+        # scope resolves it first so the RBAC check targets the deployment directly.
+        deployment_id: DeploymentID
+        if input.scope.deployment_id is not None:
+            deployment_id = input.scope.deployment_id
+        elif input.scope.replica_group_id is not None:
+            resolve_result = await self._processors.scheduling_history.resolve_replica_group_deployment.wait_for_complete(
+                ResolveReplicaGroupDeploymentAction(replica_group_id=input.scope.replica_group_id)
+            )
+            deployment_id = resolve_result.deployment_id
+        else:
+            raise EmptySearchScopeError(
+                "A replica-group history scope needs a deployment_id or a replica_group_id."
+            )
+        action_result = await self._processors.scheduling_history.search_replica_group_scoped_history.wait_for_complete(
+            SearchReplicaGroupScopedHistoryAction(
+                deployment_id=deployment_id,
+                replica_group_id=input.scope.replica_group_id,
+                querier=querier,
+            )
+        )
+        return SearchReplicaGroupHistoriesPayload(
+            items=[self._replica_group_data_to_dto(h) for h in action_result.items],
+            total_count=action_result.total_count,
+            has_next_page=action_result.has_next_page,
+            has_previous_page=action_result.has_previous_page,
+        )
+
+    def _convert_replica_group_filter(
+        self, filter: ReplicaGroupHistoryFilter
+    ) -> list[QueryCondition]:
+        conditions: list[QueryCondition] = []
+        if filter.id is not None:
+            condition = self.convert_uuid_filter(
+                filter.id,
+                equals_factory=ReplicaGroupHistoryConditions.by_id_filter,
+                in_factory=ReplicaGroupHistoryConditions.by_id_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if filter.replica_group_id is not None:
+            condition = self.convert_uuid_filter(
+                filter.replica_group_id,
+                equals_factory=ReplicaGroupHistoryConditions.by_replica_group_id_filter,
+                in_factory=ReplicaGroupHistoryConditions.by_replica_group_id_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if filter.deployment_id is not None:
+            condition = self.convert_uuid_filter(
+                filter.deployment_id,
+                equals_factory=ReplicaGroupHistoryConditions.by_deployment_id_filter,
+                in_factory=ReplicaGroupHistoryConditions.by_deployment_id_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if filter.category:
+            conditions.append(
+                ReplicaGroupHistoryConditions.by_categories([
+                    ReplicaGroupHandlerCategory(c) for c in filter.category
+                ])
+            )
+        if filter.phase is not None:
+            condition = self.convert_string_filter(
+                filter.phase,
+                contains_factory=ReplicaGroupHistoryConditions.by_phase_contains,
+                equals_factory=ReplicaGroupHistoryConditions.by_phase_equals,
+                starts_with_factory=ReplicaGroupHistoryConditions.by_phase_starts_with,
+                ends_with_factory=ReplicaGroupHistoryConditions.by_phase_ends_with,
+                in_factory=ReplicaGroupHistoryConditions.by_phase_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if filter.from_status:
+            conditions.append(ReplicaGroupHistoryConditions.by_from_statuses(filter.from_status))
+        if filter.to_status:
+            conditions.append(ReplicaGroupHistoryConditions.by_to_statuses(filter.to_status))
+        if filter.result is not None:
+            r = filter.result
+            if r.equals is not None:
+                conditions.append(
+                    ReplicaGroupHistoryConditions.by_result(SchedulingResult(r.equals))
+                )
+            if r.in_:
+                conditions.append(
+                    ReplicaGroupHistoryConditions.by_results([SchedulingResult(v) for v in r.in_])
+                )
+            if r.not_equals is not None:
+                conditions.append(
+                    ReplicaGroupHistoryConditions.by_result_not_equals(
+                        SchedulingResult(r.not_equals)
+                    )
+                )
+            if r.not_in:
+                conditions.append(
+                    ReplicaGroupHistoryConditions.by_result_not_in([
+                        SchedulingResult(v) for v in r.not_in
+                    ])
+                )
+        if filter.error_code is not None:
+            condition = self.convert_string_filter(
+                filter.error_code,
+                contains_factory=ReplicaGroupHistoryConditions.by_error_code_contains,
+                equals_factory=ReplicaGroupHistoryConditions.by_error_code_equals,
+                starts_with_factory=ReplicaGroupHistoryConditions.by_error_code_starts_with,
+                ends_with_factory=ReplicaGroupHistoryConditions.by_error_code_ends_with,
+                in_factory=ReplicaGroupHistoryConditions.by_error_code_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if filter.message is not None:
+            condition = self.convert_string_filter(
+                filter.message,
+                contains_factory=ReplicaGroupHistoryConditions.by_message_contains,
+                equals_factory=ReplicaGroupHistoryConditions.by_message_equals,
+                starts_with_factory=ReplicaGroupHistoryConditions.by_message_starts_with,
+                ends_with_factory=ReplicaGroupHistoryConditions.by_message_ends_with,
+                in_factory=ReplicaGroupHistoryConditions.by_message_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if filter.created_at is not None:
+            condition = filter.created_at.build_query_condition(
+                before_factory=ReplicaGroupHistoryConditions.by_created_at_before,
+                after_factory=ReplicaGroupHistoryConditions.by_created_at_after,
+                equals_factory=ReplicaGroupHistoryConditions.by_created_at_equals,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if filter.updated_at is not None:
+            condition = filter.updated_at.build_query_condition(
+                before_factory=ReplicaGroupHistoryConditions.by_updated_at_before,
+                after_factory=ReplicaGroupHistoryConditions.by_updated_at_after,
+                equals_factory=ReplicaGroupHistoryConditions.by_updated_at_equals,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if filter.AND:
+            for sub in filter.AND:
+                conditions.extend(self._convert_replica_group_filter(sub))
+        if filter.OR:
+            or_conds: list[QueryCondition] = []
+            for sub in filter.OR:
+                or_conds.extend(self._convert_replica_group_filter(sub))
+            if or_conds:
+                conditions.append(combine_conditions_or(or_conds))
+        if filter.NOT:
+            not_conds: list[QueryCondition] = []
+            for sub in filter.NOT:
+                not_conds.extend(self._convert_replica_group_filter(sub))
+            if not_conds:
+                conditions.append(negate_conditions(not_conds))
+        return conditions
+
     # ========== Route History ==========
 
     async def admin_search_route_history(
@@ -1021,6 +1269,35 @@ class SchedulingHistoryAdapter(BaseAdapter):
             phase=data.phase,
             from_status=data.from_status.value if data.from_status else None,
             to_status=data.to_status.value if data.to_status else None,
+            result=data.result.value,
+            error_code=data.error_code,
+            message=data.message,
+            sub_steps=[
+                SubStepResultInfo(
+                    step=s.step,
+                    result=s.result.value,
+                    error_code=s.error_code,
+                    message=s.message,
+                    started_at=s.started_at,
+                    ended_at=s.ended_at,
+                )
+                for s in data.sub_steps
+            ],
+            attempts=data.attempts,
+            created_at=data.created_at,
+            updated_at=data.updated_at,
+        )
+
+    @staticmethod
+    def _replica_group_data_to_dto(data: ReplicaGroupHistoryData) -> ReplicaGroupHistoryNode:
+        return ReplicaGroupHistoryNode(
+            id=data.id,
+            replica_group_id=data.replica_group_id,
+            deployment_id=data.deployment_id,
+            category=data.category.value,
+            phase=data.phase,
+            from_status=data.from_status,
+            to_status=data.to_status,
             result=data.result.value,
             error_code=data.error_code,
             message=data.message,

--- a/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
@@ -37,7 +37,6 @@ from ai.backend.common.dto.manager.v2.scheduling_history.response import (
     SessionHistoryNode,
 )
 from ai.backend.common.dto.manager.v2.scheduling_history.types import SubStepResultInfo
-from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.kernel_scheduling_history import KernelSchedulingHistoryID
 from ai.backend.common.identifier.replica import ReplicaID
 from ai.backend.common.types import KernelId, SessionId
@@ -56,7 +55,6 @@ from ai.backend.manager.data.session.types import (
     SubStepResult,
 )
 from ai.backend.manager.errors.api import InvalidAPIParameters
-from ai.backend.manager.errors.repository import EmptySearchScopeError
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.models.replica_group_history.conditions import (
     ReplicaGroupHistoryConditions,
@@ -878,24 +876,15 @@ class SchedulingHistoryAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        # The owning deployment is the authorization subject; a replica-group-only
-        # scope resolves it first so the RBAC check targets the deployment directly.
-        deployment_id: DeploymentID
-        if input.scope.deployment_id is not None:
-            deployment_id = input.scope.deployment_id
-        elif input.scope.replica_group_id is not None:
-            resolve_result = await self._processors.scheduling_history.resolve_replica_group_deployment.wait_for_complete(
-                ResolveReplicaGroupDeploymentAction(replica_group_id=input.scope.replica_group_id)
-            )
-            deployment_id = resolve_result.deployment_id
-        else:
-            raise EmptySearchScopeError(
-                "A replica-group history scope needs a deployment_id or a replica_group_id."
-            )
+        # The owning deployment is the authorization subject; resolve it before
+        # dispatching so the RBAC check targets the deployment directly.
+        resolve_result = await self._processors.scheduling_history.resolve_replica_group_deployment.wait_for_complete(
+            ResolveReplicaGroupDeploymentAction(replica_group_id=input.scope.replica_group_id)
+        )
         action_result = await self._processors.scheduling_history.search_replica_group_scoped_history.wait_for_complete(
             SearchReplicaGroupScopedHistoryAction(
-                deployment_id=deployment_id,
                 replica_group_id=input.scope.replica_group_id,
+                deployment_id=resolve_result.deployment_id,
                 querier=querier,
             )
         )
@@ -915,22 +904,6 @@ class SchedulingHistoryAdapter(BaseAdapter):
                 filter.id,
                 equals_factory=ReplicaGroupHistoryConditions.by_id_filter,
                 in_factory=ReplicaGroupHistoryConditions.by_id_in,
-            )
-            if condition is not None:
-                conditions.append(condition)
-        if filter.replica_group_id is not None:
-            condition = self.convert_uuid_filter(
-                filter.replica_group_id,
-                equals_factory=ReplicaGroupHistoryConditions.by_replica_group_id_filter,
-                in_factory=ReplicaGroupHistoryConditions.by_replica_group_id_in,
-            )
-            if condition is not None:
-                conditions.append(condition)
-        if filter.deployment_id is not None:
-            condition = self.convert_uuid_filter(
-                filter.deployment_id,
-                equals_factory=ReplicaGroupHistoryConditions.by_deployment_id_filter,
-                in_factory=ReplicaGroupHistoryConditions.by_deployment_id_in,
             )
             if condition is not None:
                 conditions.append(condition)

--- a/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
@@ -876,8 +876,6 @@ class SchedulingHistoryAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        # The owning deployment is the authorization subject; resolve it before
-        # dispatching so the RBAC check targets the deployment directly.
         resolve_result = await self._processors.scheduling_history.resolve_replica_group_deployment.wait_for_complete(
             ResolveReplicaGroupDeploymentAction(replica_group_id=input.scope.replica_group_id)
         )

--- a/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
@@ -100,11 +100,17 @@ from ai.backend.manager.repositories.scheduling_history.types import (
     RouteHistorySearchScope,
     SessionSchedulingHistorySearchScope,
 )
+from ai.backend.manager.services.scheduling_history.actions.admin_search_replica_group_history import (
+    AdminSearchReplicaGroupHistoryAction,
+)
 from ai.backend.manager.services.scheduling_history.actions.resolve_kernel_session import (
     ResolveKernelSessionAction,
 )
 from ai.backend.manager.services.scheduling_history.actions.resolve_replica_group_deployment import (
     ResolveReplicaGroupDeploymentAction,
+)
+from ai.backend.manager.services.scheduling_history.actions.scoped_search_replica_group_history import (
+    ScopedSearchReplicaGroupHistoryAction,
 )
 from ai.backend.manager.services.scheduling_history.actions.search_deployment_history import (
     SearchDeploymentHistoryAction,
@@ -118,12 +124,6 @@ from ai.backend.manager.services.scheduling_history.actions.search_kernel_histor
 from ai.backend.manager.services.scheduling_history.actions.search_kernel_scoped_history import (
     SearchKernelScopedHistoryAction,
     SessionKernelHistoryTarget,
-)
-from ai.backend.manager.services.scheduling_history.actions.search_replica_group_history import (
-    SearchReplicaGroupHistoryAction,
-)
-from ai.backend.manager.services.scheduling_history.actions.search_replica_group_scoped_history import (
-    SearchReplicaGroupScopedHistoryAction,
 )
 from ai.backend.manager.services.scheduling_history.actions.search_route_history import (
     SearchRouteHistoryAction,
@@ -844,8 +844,8 @@ class SchedulingHistoryAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.scheduling_history.search_replica_group_history.wait_for_complete(
-            SearchReplicaGroupHistoryAction(querier=querier)
+        action_result = await self._processors.scheduling_history.admin_search_replica_group_history.wait_for_complete(
+            AdminSearchReplicaGroupHistoryAction(querier=querier)
         )
         return SearchReplicaGroupHistoriesPayload(
             items=[self._replica_group_data_to_dto(h) for h in action_result.items],
@@ -881,8 +881,8 @@ class SchedulingHistoryAdapter(BaseAdapter):
         resolve_result = await self._processors.scheduling_history.resolve_replica_group_deployment.wait_for_complete(
             ResolveReplicaGroupDeploymentAction(replica_group_id=input.scope.replica_group_id)
         )
-        action_result = await self._processors.scheduling_history.search_replica_group_scoped_history.wait_for_complete(
-            SearchReplicaGroupScopedHistoryAction(
+        action_result = await self._processors.scheduling_history.scoped_search_replica_group_history.wait_for_complete(
+            ScopedSearchReplicaGroupHistoryAction(
                 replica_group_id=input.scope.replica_group_id,
                 deployment_id=resolve_result.deployment_id,
                 querier=querier,

--- a/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
@@ -37,8 +37,10 @@ from ai.backend.common.dto.manager.v2.scheduling_history.response import (
     SessionHistoryNode,
 )
 from ai.backend.common.dto.manager.v2.scheduling_history.types import SubStepResultInfo
+from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.kernel_scheduling_history import KernelSchedulingHistoryID
 from ai.backend.common.identifier.replica import ReplicaID
+from ai.backend.common.identifier.replica_group import ReplicaGroupID
 from ai.backend.common.types import KernelId, SessionId
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
@@ -110,6 +112,7 @@ from ai.backend.manager.services.scheduling_history.actions.resolve_replica_grou
     ResolveReplicaGroupDeploymentAction,
 )
 from ai.backend.manager.services.scheduling_history.actions.scoped_search_replica_group_history import (
+    DeploymentReplicaGroupHistoryTarget,
     ScopedSearchReplicaGroupHistoryAction,
 )
 from ai.backend.manager.services.scheduling_history.actions.search_deployment_history import (
@@ -865,6 +868,32 @@ class SchedulingHistoryAdapter(BaseAdapter):
             if input.order
             else []
         )
+        replica_group_items = input.scope.replica_group or []
+        deployment_items = input.scope.deployment or []
+        # TODO: Drop this rejection once the scoped search becomes a bulk action.
+        # The scope input is already list-shaped and its items are meant to be
+        # OR'd, but ScopedSearchReplicaGroupHistoryAction is a single-target
+        # BaseScopeAction, so only one item is dispatchable today.
+        if len(replica_group_items) + len(deployment_items) != 1:
+            raise InvalidAPIParameters(
+                "Replica-group scheduling history scope accepts exactly one scope item"
+            )
+        # TODO: Pass ReplicaGroupReplicaGroupHistoryTarget(replica_group_id=...) once
+        # virtual scopes land and a replica group becomes a scope of its own. Replica
+        # groups hold no permission records today, so a replica-group scope item is
+        # converted to a target on its owning deployment and narrowed back down with a
+        # replica_group_id query condition.
+        if replica_group_items:
+            replica_group_id = ReplicaGroupID(replica_group_items[0].value)
+            resolve_result = await self._processors.scheduling_history.resolve_replica_group_deployment.wait_for_complete(
+                ResolveReplicaGroupDeploymentAction(replica_group_id=replica_group_id)
+            )
+            deployment_id = resolve_result.deployment_id
+            conditions.append(
+                ReplicaGroupHistoryConditions.by_replica_group_ids([replica_group_id])
+            )
+        else:
+            deployment_id = DeploymentID(deployment_items[0].value)
         querier = self._build_querier(
             conditions=conditions,
             orders=orders,
@@ -876,13 +905,9 @@ class SchedulingHistoryAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        resolve_result = await self._processors.scheduling_history.resolve_replica_group_deployment.wait_for_complete(
-            ResolveReplicaGroupDeploymentAction(replica_group_id=input.scope.replica_group_id)
-        )
         action_result = await self._processors.scheduling_history.scoped_search_replica_group_history.wait_for_complete(
             ScopedSearchReplicaGroupHistoryAction(
-                replica_group_id=input.scope.replica_group_id,
-                deployment_id=resolve_result.deployment_id,
+                target=DeploymentReplicaGroupHistoryTarget(deployment_id=deployment_id),
                 querier=querier,
             )
         )

--- a/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
@@ -101,8 +101,8 @@ from ai.backend.manager.repositories.scheduling_history.types import (
     RouteHistorySearchScope,
     SessionSchedulingHistorySearchScope,
 )
-from ai.backend.manager.services.scheduling_history.actions.admin_search_replica_group_history import (
-    AdminSearchReplicaGroupHistoryAction,
+from ai.backend.manager.services.scheduling_history.actions.global_search_replica_group_history import (
+    GlobalSearchReplicaGroupHistoryAction,
 )
 from ai.backend.manager.services.scheduling_history.actions.resolve_kernel_session import (
     ResolveKernelSessionAction,
@@ -843,8 +843,8 @@ class SchedulingHistoryAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.scheduling_history.admin_search_replica_group_history.wait_for_complete(
-            AdminSearchReplicaGroupHistoryAction(querier=querier)
+        action_result = await self._processors.scheduling_history.global_search_replica_group_history.wait_for_complete(
+            GlobalSearchReplicaGroupHistoryAction(querier=querier)
         )
         return SearchReplicaGroupHistoriesPayload(
             items=[self._replica_group_data_to_dto(h) for h in action_result.items],

--- a/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
@@ -40,7 +40,6 @@ from ai.backend.common.dto.manager.v2.scheduling_history.types import SubStepRes
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.kernel_scheduling_history import KernelSchedulingHistoryID
 from ai.backend.common.identifier.replica import ReplicaID
-from ai.backend.common.identifier.replica_group import ReplicaGroupID
 from ai.backend.common.types import KernelId, SessionId
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
@@ -107,9 +106,6 @@ from ai.backend.manager.services.scheduling_history.actions.admin_search_replica
 )
 from ai.backend.manager.services.scheduling_history.actions.resolve_kernel_session import (
     ResolveKernelSessionAction,
-)
-from ai.backend.manager.services.scheduling_history.actions.resolve_replica_group_deployment import (
-    ResolveReplicaGroupDeploymentAction,
 )
 from ai.backend.manager.services.scheduling_history.actions.scoped_search_replica_group_history import (
     DeploymentReplicaGroupHistoryTarget,
@@ -868,32 +864,18 @@ class SchedulingHistoryAdapter(BaseAdapter):
             if input.order
             else []
         )
-        replica_group_items = input.scope.replica_group or []
         deployment_items = input.scope.deployment or []
         # TODO: Drop this rejection once the scoped search becomes a bulk action.
         # The scope input is already list-shaped and its items are meant to be
         # OR'd, but ScopedSearchReplicaGroupHistoryAction is a single-target
         # BaseScopeAction, so only one item is dispatchable today.
-        if len(replica_group_items) + len(deployment_items) != 1:
+        if len(deployment_items) != 1:
             raise InvalidAPIParameters(
                 "Replica-group scheduling history scope accepts exactly one scope item"
             )
-        # TODO: Pass ReplicaGroupReplicaGroupHistoryTarget(replica_group_id=...) once
-        # virtual scopes land and a replica group becomes a scope of its own. Replica
-        # groups hold no permission records today, so a replica-group scope item is
-        # converted to a target on its owning deployment and narrowed back down with a
-        # replica_group_id query condition.
-        if replica_group_items:
-            replica_group_id = ReplicaGroupID(replica_group_items[0].value)
-            resolve_result = await self._processors.scheduling_history.resolve_replica_group_deployment.wait_for_complete(
-                ResolveReplicaGroupDeploymentAction(replica_group_id=replica_group_id)
-            )
-            deployment_id = resolve_result.deployment_id
-            conditions.append(
-                ReplicaGroupHistoryConditions.by_replica_group_ids([replica_group_id])
-            )
-        else:
-            deployment_id = DeploymentID(deployment_items[0].value)
+        # A replica group is not an RBAC scope of its own, so its history is scoped by
+        # the owning deployment.
+        deployment_id = DeploymentID(deployment_items[0].value)
         querier = self._build_querier(
             conditions=conditions,
             orders=orders,

--- a/src/ai/backend/manager/api/rest/v2/scheduling_history/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/scheduling_history/handler.py
@@ -10,9 +10,11 @@ from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam
 from ai.backend.common.dto.manager.v2.scheduling_history.request import (
     AdminSearchDeploymentHistoriesInput,
     AdminSearchKernelHistoriesInput,
+    AdminSearchReplicaGroupHistoriesInput,
     AdminSearchRouteHistoriesInput,
     AdminSearchSessionHistoriesInput,
     ScopedSearchKernelHistoriesInput,
+    ScopedSearchReplicaGroupHistoriesInput,
 )
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.api.rest.v2.path_params import (
@@ -99,6 +101,28 @@ class V2SchedulingHistoryHandler:
         """Search deployment histories scoped to a specific deployment."""
         result = await self._adapter.deployment_scoped_search(
             path.parsed.deployment_id,
+            body.parsed,
+        )
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    # ========== Replica Group History ==========
+
+    async def admin_search_replica_group_history(
+        self,
+        body: BodyParam[AdminSearchReplicaGroupHistoriesInput],
+    ) -> APIResponse:
+        """Search replica-group scheduling histories with admin scope."""
+        result = await self._adapter.admin_search_replica_group_history(
+            body.parsed,
+        )
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def scoped_search_replica_group_history(
+        self,
+        body: BodyParam[ScopedSearchReplicaGroupHistoriesInput],
+    ) -> APIResponse:
+        """Search replica-group scheduling histories under a non-admin scope."""
+        result = await self._adapter.scoped_search_replica_group_history(
             body.parsed,
         )
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/scheduling_history/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/scheduling_history/registry.py
@@ -62,6 +62,20 @@ def register_v2_scheduling_history_routes(
         middlewares=[superadmin_required],
     )
 
+    # Replica group history
+    registry.add(
+        "POST",
+        "/replica-groups/admin/search",
+        handler.admin_search_replica_group_history,
+        middlewares=[superadmin_required],
+    )
+    registry.add(
+        "POST",
+        "/replica-groups/scoped/search",
+        handler.scoped_search_replica_group_history,
+        middlewares=[auth_required],
+    )
+
     # Route history
     registry.add(
         "POST",


### PR DESCRIPTION
## 📚 Stacked PRs

Part of the replica-group scheduling-history stack (epic BA-6881, story BA-6884). **Merge in order (bottom-up):**

1. ✅ #13056 — `feat(BA-6978)`: query conditions and orders (models layer)
2. #13057 — `feat(BA-6979)`: repository search scope and scoped search
3. #13058 — `feat(BA-6980)`: v2 DTOs and service actions
4. 👉 **#13059 — `feat(BA-6981)`: adapter and REST v2 endpoints** ← you are here
5. #13060 — `feat(BA-6982)`: SDK v2 client and CLI commands
6. #13061 — `test(BA-6983)`: component tests for the REST v2 endpoints

Resolves #13051 (BA-6981)

## Summary

- The adapter converts the replica-group filter (including `category`), orders and pagination into a querier, and maps history data to the node DTO.
- The scoped path names its authorization subject explicitly: the scope carries a replica group, and the adapter resolves the owning deployment before dispatching, so the RBAC check targets the deployment. There is no deployment-carrying variant and no empty-scope branch — the scope field is required.
- Routes: `POST /replica-groups/admin/search` is superadmin-only, `POST /replica-groups/scoped/search` is `auth_required` with the scope in the request body. The paths say `replica-group`, keeping them distinct from the `replica` (=route) endpoints.
- `openapi.json` regenerated with `./backend.ai mgr api dump-openapi`.

Rebased onto the restacked parent after #13056 merged and the kernel-history reshape landed on `main`; the stack now sits on top of both.

## Test plan

- [x] `pants check` clean over the touched packages
- [x] `pants lint` / `pants fmt` clean
- [ ] Exercised end-to-end by the REST component tests at the top of the stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13059.org.readthedocs.build/en/13059/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13059.org.readthedocs.build/ko/13059/

<!-- readthedocs-preview sorna-ko end -->


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13059.org.readthedocs.build/en/13059/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13059.org.readthedocs.build/ko/13059/

<!-- readthedocs-preview sorna-ko end -->