### PR TITLE
fix(BA-6985): check the scope owner exists when creating a scope-bound entity

### DIFF
--- a/changes/13063.fix.md
+++ b/changes/13063.fix.md
@@ -1,0 +1,1 @@
+Refuse to create an app config fragment at a domain or user scope whose owner does not exist, instead of leaving a row bound to a scope no read can reach.

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -36,6 +36,7 @@ from ai.backend.manager.repositories.app_config_fragment.purgers import (
 )
 from ai.backend.manager.repositories.app_config_fragment.types import (
     ResolvedAppConfigScope,
+    app_config_scope_existence_checks,
 )
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
@@ -90,6 +91,7 @@ class AppConfigFragmentDBSource:
                 if element_type is not None
                 else None
             ),
+            existence_checks=app_config_scope_existence_checks(spec.scope_type, spec.scope_id),
         )
         async with self._rbac_ops_provider.write_ops() as w:
             return (await w.create_scoped(rbac_creator)).row.to_data()

--- a/src/ai/backend/manager/repositories/app_config_fragment/types.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/types.py
@@ -24,7 +24,38 @@ __all__ = (
     "AppConfigFragmentSearchScope",
     "AppConfigScopeArguments",
     "ResolvedAppConfigScope",
+    "app_config_scope_existence_checks",
 )
+
+
+def app_config_scope_existence_checks(
+    scope_type: AppConfigScopeType,
+    scope_id: AppConfigScopeID | None,
+) -> Sequence[ExistenceCheck[Any]]:
+    """The rows that must exist for a fragment to sit at this scope.
+
+    Shared by the scoped search and by the create, so a scope the search calls missing can
+    never be one the create accepts. ``public`` is global and owns no row.
+    """
+    match scope_type:
+        case AppConfigScopeType.PUBLIC:
+            return ()
+        case AppConfigScopeType.DOMAIN:
+            return [
+                ExistenceCheck(
+                    column=DomainRow.id,
+                    value=scope_id,
+                    error=DomainNotFound(extra_data={"domain_id": str(scope_id)}),
+                ),
+            ]
+        case AppConfigScopeType.USER:
+            return [
+                ExistenceCheck(
+                    column=UserRow.uuid,
+                    value=scope_id,
+                    error=UserNotFound(extra_data={"user_id": str(scope_id)}),
+                ),
+            ]
 
 
 @dataclass(frozen=True)
@@ -80,23 +111,4 @@ class AppConfigFragmentSearchScope(SearchScope):
     @property
     @override
     def existence_checks(self) -> Sequence[ExistenceCheck[Any]]:
-        match self.scope_type:
-            case AppConfigScopeType.PUBLIC:
-                # Global scope — no owner row to check.
-                return ()
-            case AppConfigScopeType.DOMAIN:
-                return [
-                    ExistenceCheck(
-                        column=DomainRow.id,
-                        value=self.scope_id,
-                        error=DomainNotFound(extra_data={"domain_id": str(self.scope_id)}),
-                    ),
-                ]
-            case AppConfigScopeType.USER:
-                return [
-                    ExistenceCheck(
-                        column=UserRow.uuid,
-                        value=self.scope_id,
-                        error=UserNotFound(extra_data={"user_id": str(self.scope_id)}),
-                    ),
-                ]
+        return app_config_scope_existence_checks(self.scope_type, self.scope_id)

--- a/src/ai/backend/manager/repositories/base/existence.py
+++ b/src/ai/backend/manager/repositories/base/existence.py
@@ -1,0 +1,40 @@
+"""Existence validation shared by the read and write paths."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession as SASession
+
+from ai.backend.manager.models.scopes import ExistenceCheck
+
+__all__ = ("validate_existence_checks",)
+
+
+async def validate_existence_checks(
+    db_sess: SASession,
+    checks: Sequence[ExistenceCheck[Any]],
+) -> None:
+    """Raise the first failing check's error, testing every check in one query.
+
+    Reads use this to answer 404 for a scope that does not exist rather than an empty page;
+    writes use it to refuse binding a new row to an owner that is not there.
+
+    Raises:
+        The error carried by the first failing :class:`ExistenceCheck`.
+    """
+    if not checks:
+        return
+
+    select_clauses = [
+        sa.exists().where(check.column == check.value).label(f"check_{i}")
+        for i, check in enumerate(checks)
+    ]
+    result = await db_sess.execute(sa.select(*select_clauses))
+    row = result.mappings().one()
+
+    for i, check in enumerate(checks):
+        if not row[f"check_{i}"]:
+            raise check.error

--- a/src/ai/backend/manager/repositories/base/querier.py
+++ b/src/ai/backend/manager/repositories/base/querier.py
@@ -14,6 +14,7 @@ from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.models.scopes import ExistenceCheck, SearchScope
 
+from .existence import validate_existence_checks
 from .pagination import PageInfoResult, QueryPagination
 
 if TYPE_CHECKING:
@@ -121,34 +122,6 @@ class _QueryPair:
     count_query: sa.sql.Select[Any]
 
 
-async def _validate_scope(
-    db_sess: SASession,
-    checks: list[ExistenceCheck[Any]],
-) -> None:
-    """Validate scope existence checks in a single query.
-
-    Args:
-        db_sess: Database session
-        checks: List of existence checks to validate
-
-    Raises:
-        The error specified in the first failing ExistenceCheck.
-    """
-    if not checks:
-        return
-
-    select_clauses = [
-        sa.exists().where(check.column == check.value).label(f"check_{i}")
-        for i, check in enumerate(checks)
-    ]
-    result = await db_sess.execute(sa.select(*select_clauses))
-    row = result.mappings().one()
-
-    for i, check in enumerate(checks):
-        if not row[f"check_{i}"]:
-            raise check.error
-
-
 def _apply_batch_querier(
     query: sa.sql.Select[Any],
     querier: BatchQuerier,
@@ -231,7 +204,7 @@ async def execute_batch_querier(
         for scope in scopes:
             aggregated_checks.extend(scope.existence_checks)
             or_conditions.append(scope.to_condition())
-        await _validate_scope(db_sess, aggregated_checks)
+        await validate_existence_checks(db_sess, aggregated_checks)
 
     query_pair = _apply_batch_querier(query, querier, or_conditions)
     count_query = query_pair.count_query

--- a/src/ai/backend/manager/repositories/base/rbac/entity_creator.py
+++ b/src/ai/backend/manager/repositories/base/rbac/entity_creator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import sqlalchemy as sa
 from sqlalchemy import inspect
@@ -17,7 +17,9 @@ from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
 )
+from ai.backend.manager.models.scopes import ExistenceCheck
 from ai.backend.manager.repositories.base.creator import BulkCreatorError, CreatorSpec
+from ai.backend.manager.repositories.base.existence import validate_existence_checks
 from ai.backend.manager.repositories.base.integrity import (
     match_integrity_error,
     parse_integrity_error,
@@ -50,6 +52,11 @@ class RBACEntityCreator[TRow: Base]:
         additional_scope_refs: Additional scope references for multi-scope entities.
             Only meaningful alongside a ``scope_ref``.
         relation_type: The relation type for the scope-entity association. Defaults to AUTO.
+        existence_checks: Rows that must exist for the association to mean anything —
+            typically the scope owner named by ``scope_ref``. Checked before the insert, so
+            a create against an owner that is not there fails with that owner's own
+            not-found error instead of leaving a row bound to nothing. Empty by default,
+            and an empty sequence costs no query.
     """
 
     spec: CreatorSpec[TRow]
@@ -57,6 +64,7 @@ class RBACEntityCreator[TRow: Base]:
     scope_ref: RBACElementRef | None
     additional_scope_refs: Sequence[RBACElementRef] = field(default_factory=list)
     relation_type: RelationType = RelationType.AUTO
+    existence_checks: Sequence[ExistenceCheck[Any]] = field(default_factory=tuple)
 
     def all_scope_refs(self) -> list[RBACElementRef]:
         """Every scope this entity binds to; empty for a GLOBAL entity (``scope_ref=None``)."""
@@ -79,10 +87,11 @@ async def execute_rbac_entity_creator[TRow: Base](
     """Create a scope-scoped entity with its scope association.
 
     Operations:
-    1. Insert main entity row
-    2. Flush to get DB-generated ID
-    3. Extract RBAC info from spec
-    4. Insert AssociationScopesEntitiesRow (scope -> entity mapping)
+    1. Validate the creator's existence checks (typically the scope owner)
+    2. Insert main entity row
+    3. Flush to get DB-generated ID
+    4. Extract RBAC info from spec
+    5. Insert AssociationScopesEntitiesRow (scope -> entity mapping)
 
     The AssociationScopesEntitiesRow maps the entity to its owning scope,
     enabling scope-based entity discovery and permission inheritance. A creator that
@@ -96,6 +105,8 @@ async def execute_rbac_entity_creator[TRow: Base](
     Returns:
         RBACEntityCreatorResult containing the created row.
     """
+    await validate_existence_checks(db_sess, creator.existence_checks)
+
     spec = creator.spec
     row = spec.build_row()
     mapper = inspect(type(row))

--- a/tests/unit/manager/repositories/app_config_fragment/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_repository.py
@@ -248,6 +248,14 @@ async def fragments_across_scopes(database: ExtendedAsyncSAEngine) -> list[AppCo
         return [row.to_data() for row in rows]
 
 
+@dataclass(frozen=True)
+class _MissingOwnerCase:
+    """A scope whose owner does not exist, and the error the existence check must raise."""
+
+    scope: AppConfigFragmentSearchScope
+    expected_error: type[BackendAIError]
+
+
 class TestCreateAndGet:
     async def test_create_then_get_by_id(
         self, repository: AppConfigFragmentRepository, theme_registered: None
@@ -284,6 +292,60 @@ class TestCreateAndGet:
             )
 
     @pytest.mark.parametrize(
+        "case",
+        [
+            _MissingOwnerCase(
+                scope=AppConfigFragmentSearchScope(
+                    scope_type=AppConfigScopeType.DOMAIN,
+                    scope_id=AppConfigScopeID(uuid.uuid4()),
+                ),
+                expected_error=DomainNotFound,
+            ),
+            _MissingOwnerCase(
+                scope=AppConfigFragmentSearchScope(
+                    scope_type=AppConfigScopeType.USER,
+                    scope_id=AppConfigScopeID(uuid.uuid4()),
+                ),
+                expected_error=UserNotFound,
+            ),
+        ],
+        ids=lambda case: case.scope.scope_type.value,
+    )
+    async def test_create_at_a_missing_scope_owner_is_not_found(
+        self,
+        repository: AppConfigFragmentRepository,
+        theme_registered: None,
+        case: _MissingOwnerCase,
+    ) -> None:
+        # The scoped search answers 404 for this same scope, so the create must too —
+        # otherwise the write leaves a row bound to an owner no read can reach.
+        with pytest.raises(case.expected_error):
+            await repository.create(
+                AppConfigFragmentCreatorSpec(
+                    config_name="theme",
+                    scope_type=case.scope.scope_type,
+                    scope_id=case.scope.scope_id,
+                    config={"theme": "dark"},
+                )
+            )
+
+    async def test_create_at_an_existing_scope_owner_succeeds(
+        self,
+        repository: AppConfigFragmentRepository,
+        theme_registered: None,
+        scope_owners: None,
+    ) -> None:
+        created = await repository.create(
+            AppConfigFragmentCreatorSpec(
+                config_name="theme",
+                scope_type=AppConfigScopeType.USER,
+                scope_id=_USER_SCOPE_ID,
+                config={"theme": "dark"},
+            )
+        )
+        assert created.scope_id == _USER_SCOPE_ID
+
+    @pytest.mark.parametrize(
         "scope_type",
         [AppConfigScopeType.PUBLIC, AppConfigScopeType.DOMAIN, AppConfigScopeType.USER],
         ids=lambda scope_type: scope_type.value,
@@ -292,6 +354,7 @@ class TestCreateAndGet:
         self,
         repository: AppConfigFragmentRepository,
         fragment_at_every_scope: dict[AppConfigScopeType, AppConfigFragmentData],
+        scope_owners: None,
         scope_type: AppConfigScopeType,
     ) -> None:
         # public is carried by the partial index, domain and user by the unique constraint.
@@ -419,14 +482,6 @@ class _ScopedSearchCase:
     scope: AppConfigFragmentSearchScope
     expected_scope_type: AppConfigScopeType
     expected_scope_id: AppConfigScopeID | None
-
-
-@dataclass(frozen=True)
-class _MissingOwnerCase:
-    """A scope whose owner does not exist, and the error the existence check must raise."""
-
-    scope: AppConfigFragmentSearchScope
-    expected_error: type[BackendAIError]
 
 
 _DOMAIN_NAME = "app-config-fragment-test-domain"
@@ -885,6 +940,7 @@ class TestRBACScopeAssociation:
         repository: AppConfigFragmentRepository,
         database: ExtendedAsyncSAEngine,
         theme_registered: None,
+        scope_owners: None,
         case: _FragmentScopeCase,
     ) -> None:
         created = await repository.create(
@@ -923,6 +979,7 @@ class TestRBACScopeAssociation:
         repository: AppConfigFragmentRepository,
         database: ExtendedAsyncSAEngine,
         theme_registered: None,
+        scope_owners: None,
         case: _FragmentScopeCase,
     ) -> None:
         created = await repository.create(
@@ -943,6 +1000,7 @@ class TestRBACScopeAssociation:
         repository: AppConfigFragmentRepository,
         database: ExtendedAsyncSAEngine,
         theme_registered: None,
+        scope_owners: None,
     ) -> None:
         """A bulk purge unbinds each fragment, like the single purge.
 


### PR DESCRIPTION
Resolves #13062 (BA-6985)

## Summary

A scope-bound create accepted a scope owner that does not exist. Found on a live server: creating an AppConfigFragment at `scope_type: USER` with a user id no user row carries **succeeded**, and left a row bound to an element id nothing matches — while a scoped search at that same scope answered `404 UserNotFound`. The write and the read disagreed about whether the scope existed, and the orphan row was reachable by no read path.

The read path already had the machinery for this: a `SearchScope` declares one `ExistenceCheck` per owner, and the batch querier tests them all in a single `EXISTS` query before running. The write path had nothing equivalent.

## What changed

- **`repositories/base/existence.py`** (new): `validate_existence_checks()`, lifted verbatim out of the querier's private `_validate_scope` so reads and writes share one implementation.
- **`RBACEntityCreator.existence_checks`**: a creator now carries the rows that must exist for its association to mean anything, and `execute_rbac_entity_creator` validates them before the insert. Empty by default — a creator that declares none issues no extra query, so no other entity changes behavior.
- **AppConfigFragment**: the per-scope checks move to `app_config_scope_existence_checks()`, which both `AppConfigFragmentSearchScope.existence_checks` and the create now call. A scope the search calls missing can no longer be one the create accepts.

Public scope is unaffected: it is global, owns no row, and declares no checks.

## Test plan

- [x] `tests/unit/manager/repositories/app_config_fragment/test_repository.py`: a create at a missing domain / user owner raises `DomainNotFound` / `UserNotFound`, and a create at an existing owner still succeeds.
- [x] Four existing create-path tests that seeded no owner rows now take the `scope_owners` fixture — they were passing only because the write skipped the check.
- [ ] CI green (not run locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
