### PR TITLE
fix(BA-6988): build the pagination cursor predicate from the column the page is ordered by

### DIFF
--- a/changes/13067.fix.md
+++ b/changes/13067.fix.md
@@ -1,0 +1,1 @@
+Draw the pagination cursor boundary on the column each search is ordered by, and order presets and runtime variants by a readable column instead of a UUID or a non-unique rank.

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -114,8 +114,8 @@ from ai.backend.manager.types import OptionalState, TriState
 
 def _preset_pagination_spec() -> PaginationSpec:
     return PaginationSpec(
-        forward_order=DeploymentRevisionPresetOrders.rank(ascending=True),
-        backward_order=DeploymentRevisionPresetOrders.rank(ascending=False),
+        forward_order=DeploymentRevisionPresetOrders.created_at(ascending=False),
+        backward_order=DeploymentRevisionPresetOrders.created_at(ascending=True),
         forward_condition_factory=DeploymentRevisionPresetConditions.by_cursor_forward,
         backward_condition_factory=DeploymentRevisionPresetConditions.by_cursor_backward,
         tiebreaker_order=DeploymentRevisionPresetRow.id.asc(),

--- a/src/ai/backend/manager/api/adapters/resource_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_preset/adapter.py
@@ -78,8 +78,8 @@ def _resource_slot_entries_to_slot(
 
 def _resource_preset_pagination_spec() -> PaginationSpec:
     return PaginationSpec(
-        forward_order=ResourcePresetOrders.id(ascending=False),
-        backward_order=ResourcePresetOrders.id(ascending=True),
+        forward_order=ResourcePresetOrders.name(ascending=True),
+        backward_order=ResourcePresetOrders.name(ascending=False),
         forward_condition_factory=ResourcePresetConditions.by_cursor_forward,
         backward_condition_factory=ResourcePresetConditions.by_cursor_backward,
         tiebreaker_order=ResourcePresetRow.name.asc(),

--- a/src/ai/backend/manager/api/adapters/runtime_variant/adapter.py
+++ b/src/ai/backend/manager/api/adapters/runtime_variant/adapter.py
@@ -53,8 +53,8 @@ from ai.backend.manager.types import OptionalState, TriState
 
 def _runtime_variant_pagination_spec() -> PaginationSpec:
     return PaginationSpec(
-        forward_order=RuntimeVariantOrders.id(ascending=False),
-        backward_order=RuntimeVariantOrders.id(ascending=True),
+        forward_order=RuntimeVariantOrders.created_at(ascending=False),
+        backward_order=RuntimeVariantOrders.created_at(ascending=True),
         forward_condition_factory=RuntimeVariantConditions.by_cursor_forward,
         backward_condition_factory=RuntimeVariantConditions.by_cursor_backward,
         tiebreaker_order=RuntimeVariantRow.name.asc(),

--- a/src/ai/backend/manager/api/adapters/runtime_variant_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/runtime_variant_preset/adapter.py
@@ -73,8 +73,8 @@ from ai.backend.manager.types import OptionalState, TriState
 
 def _preset_pagination_spec() -> PaginationSpec:
     return PaginationSpec(
-        forward_order=RuntimeVariantPresetOrders.rank(ascending=True),
-        backward_order=RuntimeVariantPresetOrders.rank(ascending=False),
+        forward_order=RuntimeVariantPresetOrders.created_at(ascending=False),
+        backward_order=RuntimeVariantPresetOrders.created_at(ascending=True),
         forward_condition_factory=RuntimeVariantPresetConditions.by_cursor_forward,
         backward_condition_factory=RuntimeVariantPresetConditions.by_cursor_backward,
         tiebreaker_order=RuntimeVariantPresetRow.id.asc(),

--- a/src/ai/backend/manager/models/deployment_revision_preset/conditions.py
+++ b/src/ai/backend/manager/models/deployment_revision_preset/conditions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from uuid import UUID
 
 import sqlalchemy as sa
@@ -122,14 +123,40 @@ class DeploymentRevisionPresetConditions:
 
     @staticmethod
     def by_cursor_forward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for forward pagination (after cursor).
+
+        Reads the cursor row's ``created_at`` and compares against that, because that is what
+        the page is ordered by — comparing ids would draw the page boundary on a column the
+        result is not sorted by.
+        """
+        cursor_uuid = uuid.UUID(cursor_id)
+
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DeploymentRevisionPresetRow.id < sa.text(f"'{cursor_id}'::uuid")
+            subquery = (
+                sa.select(DeploymentRevisionPresetRow.created_at)
+                .where(DeploymentRevisionPresetRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return DeploymentRevisionPresetRow.created_at < subquery
 
         return inner
 
     @staticmethod
     def by_cursor_backward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for backward pagination (before cursor).
+
+        Reads the cursor row's ``created_at`` and compares against that, because that is what
+        the page is ordered by — comparing ids would draw the page boundary on a column the
+        result is not sorted by.
+        """
+        cursor_uuid = uuid.UUID(cursor_id)
+
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DeploymentRevisionPresetRow.id > sa.text(f"'{cursor_id}'::uuid")
+            subquery = (
+                sa.select(DeploymentRevisionPresetRow.created_at)
+                .where(DeploymentRevisionPresetRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return DeploymentRevisionPresetRow.created_at > subquery
 
         return inner

--- a/src/ai/backend/manager/models/model_card/conditions.py
+++ b/src/ai/backend/manager/models/model_card/conditions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import Collection
 from uuid import UUID
 
@@ -254,14 +255,40 @@ class ModelCardConditions:
 
     @staticmethod
     def by_cursor_forward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for forward pagination (after cursor).
+
+        Reads the cursor row's ``created_at`` and compares against that, because ``created_at`` is what
+        the page is ordered by — comparing ids would draw the page boundary on a column the
+        result is not sorted by.
+        """
+        cursor_uuid = uuid.UUID(cursor_id)
+
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ModelCardRow.id < sa.text(f"'{cursor_id}'::uuid")
+            subquery = (
+                sa.select(ModelCardRow.created_at)
+                .where(ModelCardRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return ModelCardRow.created_at < subquery
 
         return inner
 
     @staticmethod
     def by_cursor_backward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for backward pagination (before cursor).
+
+        Reads the cursor row's ``created_at`` and compares against that, because ``created_at`` is what
+        the page is ordered by — comparing ids would draw the page boundary on a column the
+        result is not sorted by.
+        """
+        cursor_uuid = uuid.UUID(cursor_id)
+
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ModelCardRow.id > sa.text(f"'{cursor_id}'::uuid")
+            subquery = (
+                sa.select(ModelCardRow.created_at)
+                .where(ModelCardRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return ModelCardRow.created_at > subquery
 
         return inner

--- a/src/ai/backend/manager/models/rbac_models/role_preset/conditions.py
+++ b/src/ai/backend/manager/models/rbac_models/role_preset/conditions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import uuid
+
 import sqlalchemy as sa
 
 from ai.backend.common.data.filter_specs import StringMatchSpec
@@ -91,14 +93,40 @@ class RolePresetConditions:
 
     @staticmethod
     def by_cursor_forward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for forward pagination (after cursor).
+
+        Reads the cursor row's ``created_at`` and compares against that, because ``created_at`` is what
+        the page is ordered by — comparing ids would draw the page boundary on a column the
+        result is not sorted by.
+        """
+        cursor_uuid = uuid.UUID(cursor_id)
+
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return RolePresetRow.id < sa.text(f"'{cursor_id}'::uuid")
+            subquery = (
+                sa.select(RolePresetRow.created_at)
+                .where(RolePresetRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return RolePresetRow.created_at < subquery
 
         return inner
 
     @staticmethod
     def by_cursor_backward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for backward pagination (before cursor).
+
+        Reads the cursor row's ``created_at`` and compares against that, because ``created_at`` is what
+        the page is ordered by — comparing ids would draw the page boundary on a column the
+        result is not sorted by.
+        """
+        cursor_uuid = uuid.UUID(cursor_id)
+
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return RolePresetRow.id > sa.text(f"'{cursor_id}'::uuid")
+            subquery = (
+                sa.select(RolePresetRow.created_at)
+                .where(RolePresetRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return RolePresetRow.created_at > subquery
 
         return inner

--- a/src/ai/backend/manager/models/resource_preset/conditions.py
+++ b/src/ai/backend/manager/models/resource_preset/conditions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import uuid
+
 import sqlalchemy as sa
 
 from ai.backend.common.data.filter_specs import StringMatchSpec
@@ -128,18 +130,38 @@ class ResourcePresetConditions:
 
     @staticmethod
     def by_cursor_forward(cursor_id: str) -> QueryCondition:
-        """Cursor condition for forward pagination (after cursor)."""
+        """Cursor condition for forward pagination (after cursor).
+
+        Reads the cursor row's ``name`` and compares against that, because that is what the page
+        is ordered by. This table carries no ``created_at`` to key on.
+        """
+        cursor_uuid = uuid.UUID(cursor_id)
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ResourcePresetRow.id < sa.text(f"'{cursor_id}'::uuid")
+            subquery = (
+                sa.select(ResourcePresetRow.name)
+                .where(ResourcePresetRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return ResourcePresetRow.name > subquery
 
         return inner
 
     @staticmethod
     def by_cursor_backward(cursor_id: str) -> QueryCondition:
-        """Cursor condition for backward pagination (before cursor)."""
+        """Cursor condition for backward pagination (before cursor).
+
+        Reads the cursor row's ``name`` and compares against that, because that is what the page
+        is ordered by. This table carries no ``created_at`` to key on.
+        """
+        cursor_uuid = uuid.UUID(cursor_id)
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ResourcePresetRow.id > sa.text(f"'{cursor_id}'::uuid")
+            subquery = (
+                sa.select(ResourcePresetRow.name)
+                .where(ResourcePresetRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return ResourcePresetRow.name < subquery
 
         return inner

--- a/src/ai/backend/manager/models/retention/conditions.py
+++ b/src/ai/backend/manager/models/retention/conditions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import Collection
 from uuid import UUID
 
@@ -45,14 +46,40 @@ class RetentionPolicyConditions:
 
     @staticmethod
     def by_cursor_forward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for forward pagination (after cursor).
+
+        Reads the cursor row's ``category`` and compares against that, because ``category`` is what
+        the page is ordered by — comparing ids would draw the page boundary on a column the
+        result is not sorted by.
+        """
+        cursor_uuid = uuid.UUID(cursor_id)
+
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return RetentionPolicyRow.id < sa.text(f"'{cursor_id}'::uuid")
+            subquery = (
+                sa.select(RetentionPolicyRow.category)
+                .where(RetentionPolicyRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return RetentionPolicyRow.category > subquery
 
         return inner
 
     @staticmethod
     def by_cursor_backward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for backward pagination (before cursor).
+
+        Reads the cursor row's ``category`` and compares against that, because ``category`` is what
+        the page is ordered by — comparing ids would draw the page boundary on a column the
+        result is not sorted by.
+        """
+        cursor_uuid = uuid.UUID(cursor_id)
+
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return RetentionPolicyRow.id > sa.text(f"'{cursor_id}'::uuid")
+            subquery = (
+                sa.select(RetentionPolicyRow.category)
+                .where(RetentionPolicyRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return RetentionPolicyRow.category < subquery
 
         return inner

--- a/src/ai/backend/manager/models/runtime_variant/conditions.py
+++ b/src/ai/backend/manager/models/runtime_variant/conditions.py
@@ -81,14 +81,38 @@ class RuntimeVariantConditions:
 
     @staticmethod
     def by_cursor_forward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for forward pagination (after cursor).
+
+        Reads the cursor row's ``created_at`` and compares against that, because that is what
+        the page is ordered by.
+        """
+        cursor_uuid = uuid.UUID(cursor_id)
+
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return RuntimeVariantRow.id < sa.text(f"'{cursor_id}'::uuid")
+            subquery = (
+                sa.select(RuntimeVariantRow.created_at)
+                .where(RuntimeVariantRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return RuntimeVariantRow.created_at < subquery
 
         return inner
 
     @staticmethod
     def by_cursor_backward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for backward pagination (before cursor).
+
+        Reads the cursor row's ``created_at`` and compares against that, because that is what
+        the page is ordered by.
+        """
+        cursor_uuid = uuid.UUID(cursor_id)
+
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return RuntimeVariantRow.id > sa.text(f"'{cursor_id}'::uuid")
+            subquery = (
+                sa.select(RuntimeVariantRow.created_at)
+                .where(RuntimeVariantRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return RuntimeVariantRow.created_at > subquery
 
         return inner

--- a/src/ai/backend/manager/models/runtime_variant_preset/conditions.py
+++ b/src/ai/backend/manager/models/runtime_variant_preset/conditions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import Collection
 from uuid import UUID
 
@@ -110,14 +111,40 @@ class RuntimeVariantPresetConditions:
 
     @staticmethod
     def by_cursor_forward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for forward pagination (after cursor).
+
+        Reads the cursor row's ``created_at`` and compares against that, because that is what
+        the page is ordered by — comparing ids would draw the page boundary on a column the
+        result is not sorted by.
+        """
+        cursor_uuid = uuid.UUID(cursor_id)
+
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return RuntimeVariantPresetRow.id < sa.text(f"'{cursor_id}'::uuid")
+            subquery = (
+                sa.select(RuntimeVariantPresetRow.created_at)
+                .where(RuntimeVariantPresetRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return RuntimeVariantPresetRow.created_at < subquery
 
         return inner
 
     @staticmethod
     def by_cursor_backward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for backward pagination (before cursor).
+
+        Reads the cursor row's ``created_at`` and compares against that, because that is what
+        the page is ordered by — comparing ids would draw the page boundary on a column the
+        result is not sorted by.
+        """
+        cursor_uuid = uuid.UUID(cursor_id)
+
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return RuntimeVariantPresetRow.id > sa.text(f"'{cursor_id}'::uuid")
+            subquery = (
+                sa.select(RuntimeVariantPresetRow.created_at)
+                .where(RuntimeVariantPresetRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return RuntimeVariantPresetRow.created_at > subquery
 
         return inner


### PR DESCRIPTION
Resolves #13069 (BA-6988)

## Summary

A cursor predicate has to filter on the same column the page is ordered by, or the boundary lands on a column the result is not sorted by and the walk skips and repeats rows. Seven modules got that wrong in one of two ways.

**Predicate on the wrong column.** Five compared the cursor against `Row.id` while their `PaginationSpec` ordered by something else:

| module | ordered by | old predicate |
|---|---|---|
| `retention` | `category ASC` | `id <` |
| `runtime_variant_preset` | `rank ASC` | `id <` |
| `rbac_models/role_preset` | `created_at DESC` | `id <` |
| `deployment_revision_preset` | `rank ASC` | `id <` |
| `model_card` | `created_at DESC` | `id <` |

They now read the cursor row's sort column through a subquery and compare against that, the way `agent`, `session` and `keypair` already do.

**Cursor value spliced into SQL.** The same seven modules built the predicate as `sa.text(f"'{cursor_id}'::uuid")`, so the caller wrote part of the `WHERE` clause. Against a local server, a cursor payload ending in `'::uuid OR true--` made `adminRolePresets` return all four rows where an honest cursor for a missing row returns none, and a payload holding a bare quote reached PostgreSQL as a syntax error. The value is now parsed and bound.

**Sort key nobody can read.** `runtime_variant` and `resource_preset` ordered by `id` — UUID order, which no caller can predict — and the two preset tables ordered by `rank`, which carries no unique constraint (`sa.Index("ix_deployment_revision_presets_variant_rank", …)`, uniqueness is on `(runtime_variant, name)`), so two rows sharing a rank make the cursor skip both.

| module | order now |
|---|---|
| `runtime_variant`, `runtime_variant_preset`, `deployment_revision_preset` | `created_at DESC` — same as the rest of the v2 surface |
| `resource_preset` | `name ASC` — this table has no `created_at` column |
| `retention`, `role_preset`, `model_card` | unchanged (`category ASC` / `created_at DESC`) |

This changes the default order these searches return when the caller passes no `orderBy`: preset lists come back newest-first instead of by rank, and runtime variants newest-first instead of by UUID.

## Known limitation

Rows tying on the sort column are still not separated by the `id` tiebreaker: the predicate compares the sort column alone, so a page whose rows share a `created_at` comes back empty. `adminRolePresets` shows this locally — its four fixture rows were inserted in one transaction and carry the same timestamp. Every entity using this pattern (`app_config_definition`, `agent`, `session`, `keypair`, …) has the same gap; closing it means a composite `(sort_key, id)` comparison everywhere, which belongs with the other pagination work rather than here.

## Test plan

- [x] Live server, `adminRetentionPolicies` (`category ASC`): `first: 2` then `after: <cursor>` returns exactly the next two rows in category order — the id-based predicate could not have done that.
- [ ] Live server, preset and runtime-variant searches after the order change.
- [ ] CI green (not run locally).

## Related

#13065 maps a malformed cursor to a 400 instead of a 500. Independent of this PR; neither depends on the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
