### PR TITLE
feat(BA-6989): reshape KernelScope into scope-item lists and accept a session scope

### DIFF
--- a/changes/13071.enhance.md
+++ b/changes/13071.enhance.md
@@ -1,1 +1,1 @@
-Accept the scoped kernel scheduling-history scope as a list of scope items (`kernel: [UUIDScope!]`) instead of a single `kernel_id`, rejecting a multi-item scope until the underlying scope action becomes multi-target
+Accept the scoped kernel scheduling-history scope as lists of scope items (`kernel: [UUIDScope!]`, `session: [UUIDScope!]`) instead of a single `kernel_id`, so the history can also be queried for every kernel a session owns

--- a/changes/13071.enhance.md
+++ b/changes/13071.enhance.md
@@ -1,0 +1,1 @@
+Accept the scoped kernel scheduling-history scope as a list of scope items (`kernel: [UUIDScope!]`) instead of a single `kernel_id`, rejecting a multi-item scope until the underlying scope action becomes multi-target

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -8594,12 +8594,16 @@ enum KernelSchedulingHistoryOrderField
   ATTEMPTS @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 26.8.0. Scope for kernel scheduling history query"""
+"""
+Added in 26.8.0. Scope for kernel scheduling history query. All items are OR'd; raises an error if every field is empty.
+"""
 input KernelScope
   @join__type(graph: STRAWBERRY)
 {
-  """Kernel ID to get history for"""
-  kernelId: UUID!
+  """
+  Kernel IDs to get history for. The scoped search is single-target for now, so exactly one item is accepted.
+  """
+  kernel: [UUIDScope!] = null
 }
 
 """

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -8601,9 +8601,14 @@ input KernelScope
   @join__type(graph: STRAWBERRY)
 {
   """
-  Kernel IDs to get history for. The scoped search is single-target for now, so exactly one item is accepted.
+  Kernel IDs to get history for. The scoped search is single-target for now, so exactly one item is accepted across all fields.
   """
   kernel: [UUIDScope!] = null
+
+  """
+  Session IDs to get the history of every owned kernel for. The scoped search is single-target for now, so exactly one item is accepted across all fields.
+  """
+  session: [UUIDScope!] = null
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -5710,9 +5710,14 @@ Added in 26.8.0. Scope for kernel scheduling history query. All items are OR'd; 
 """
 input KernelScope {
   """
-  Kernel IDs to get history for. The scoped search is single-target for now, so exactly one item is accepted.
+  Kernel IDs to get history for. The scoped search is single-target for now, so exactly one item is accepted across all fields.
   """
   kernel: [UUIDScope!] = null
+
+  """
+  Session IDs to get the history of every owned kernel for. The scoped search is single-target for now, so exactly one item is accepted across all fields.
+  """
+  session: [UUIDScope!] = null
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -5705,10 +5705,14 @@ enum KernelSchedulingHistoryOrderField {
   ATTEMPTS
 }
 
-"""Added in 26.8.0. Scope for kernel scheduling history query"""
+"""
+Added in 26.8.0. Scope for kernel scheduling history query. All items are OR'd; raises an error if every field is empty.
+"""
 input KernelScope {
-  """Kernel ID to get history for"""
-  kernelId: UUID!
+  """
+  Kernel IDs to get history for. The scoped search is single-target for now, so exactly one item is accepted.
+  """
+  kernel: [UUIDScope!] = null
 }
 
 """

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -25761,7 +25761,7 @@
         "type": "object"
       },
       "KernelHistoryScopeDTO": {
-        "description": "Scope for kernel scheduling history queries.\n\nItems are OR'd. Raises an error if the list is empty. The scoped search is\nstill a single-target scope action, so only one item is dispatchable today;\nthe list shape keeps the wire contract stable for the multi-target case.",
+        "description": "Scope for kernel scheduling history queries.\n\nEach list is OR'd internally and across categories. Raises an error if every\nfield is empty. The scoped search is still a single-target scope action, so\nonly one item is dispatchable today; the list shape keeps the wire contract\nstable for the multi-target case.",
         "properties": {
           "kernel": {
             "anyOf": [
@@ -25778,6 +25778,22 @@
             "default": null,
             "description": "Kernel IDs to get history for.",
             "title": "Kernel"
+          },
+          "session": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/UUIDScope"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Session IDs to get the history of every owned kernel for.",
+            "title": "Session"
           }
         },
         "title": "KernelHistoryScopeDTO",

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -25761,19 +25761,41 @@
         "type": "object"
       },
       "KernelHistoryScopeDTO": {
-        "description": "Scope for kernel scheduling history queries.",
+        "description": "Scope for kernel scheduling history queries.\n\nItems are OR'd. Raises an error if the list is empty. The scoped search is\nstill a single-target scope action, so only one item is dispatchable today;\nthe list shape keeps the wire contract stable for the multi-target case.",
         "properties": {
-          "kernel_id": {
-            "description": "Kernel ID to get history for.",
+          "kernel": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/UUIDScope"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Kernel IDs to get history for.",
+            "title": "Kernel"
+          }
+        },
+        "title": "KernelHistoryScopeDTO",
+        "type": "object"
+      },
+      "UUIDScope": {
+        "description": "Single-UUID scope item wrapper.\n\nA thin wrapper around a UUID used as a scope item. The wrapper exists so\nthat scope-input lists stay structurally uniform with other scope item\ntypes and leave room for per-item metadata in the future.",
+        "properties": {
+          "value": {
             "format": "uuid",
-            "title": "Kernel Id",
+            "title": "Value",
             "type": "string"
           }
         },
         "required": [
-          "kernel_id"
+          "value"
         ],
-        "title": "KernelHistoryScopeDTO",
+        "title": "UUIDScope",
         "type": "object"
       },
       "ScopedSearchKernelHistoriesInput": {

--- a/src/ai/backend/common/dto/manager/v2/scheduling_history/types.py
+++ b/src/ai/backend/common/dto/manager/v2/scheduling_history/types.py
@@ -6,12 +6,14 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
+from typing import Self
 from uuid import UUID
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from ai.backend.common.api_handlers import BaseRequestModel, BaseResponseModel
 from ai.backend.common.dto.manager.v2.common import OrderDirection
+from ai.backend.common.dto.manager.v2.rbac.types import UUIDScope
 
 __all__ = (
     "DeploymentHistoryOrderField",
@@ -104,9 +106,22 @@ class SessionHistoryScopeDTO(BaseRequestModel):
 
 
 class KernelHistoryScopeDTO(BaseRequestModel):
-    """Scope for kernel scheduling history queries."""
+    """Scope for kernel scheduling history queries.
 
-    kernel_id: UUID = Field(description="Kernel ID to get history for.")
+    Items are OR'd. Raises an error if the list is empty. The scoped search is
+    still a single-target scope action, so only one item is dispatchable today;
+    the list shape keeps the wire contract stable for the multi-target case.
+    """
+
+    kernel: list[UUIDScope] | None = Field(
+        default=None, description="Kernel IDs to get history for."
+    )
+
+    @model_validator(mode="after")
+    def _require_non_empty(self) -> Self:
+        if not self.kernel:
+            raise ValueError("KernelHistoryScopeDTO requires a non-empty value for 'kernel'")
+        return self
 
 
 class DeploymentHistoryScopeDTO(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/scheduling_history/types.py
+++ b/src/ai/backend/common/dto/manager/v2/scheduling_history/types.py
@@ -108,19 +108,26 @@ class SessionHistoryScopeDTO(BaseRequestModel):
 class KernelHistoryScopeDTO(BaseRequestModel):
     """Scope for kernel scheduling history queries.
 
-    Items are OR'd. Raises an error if the list is empty. The scoped search is
-    still a single-target scope action, so only one item is dispatchable today;
-    the list shape keeps the wire contract stable for the multi-target case.
+    Each list is OR'd internally and across categories. Raises an error if every
+    field is empty. The scoped search is still a single-target scope action, so
+    only one item is dispatchable today; the list shape keeps the wire contract
+    stable for the multi-target case.
     """
 
     kernel: list[UUIDScope] | None = Field(
         default=None, description="Kernel IDs to get history for."
     )
+    session: list[UUIDScope] | None = Field(
+        default=None,
+        description="Session IDs to get the history of every owned kernel for.",
+    )
 
     @model_validator(mode="after")
     def _require_non_empty(self) -> Self:
-        if not self.kernel:
-            raise ValueError("KernelHistoryScopeDTO requires a non-empty value for 'kernel'")
+        if not self.kernel and not self.session:
+            raise ValueError(
+                "KernelHistoryScopeDTO requires a non-empty value for 'kernel' or 'session'"
+            )
         return self
 
 

--- a/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
@@ -456,6 +456,10 @@ class SchedulingHistoryAdapter(BaseAdapter):
         )
         kernel_items = input.scope.kernel or []
         session_items = input.scope.session or []
+        # TODO: Drop this rejection once the scoped search becomes a bulk action.
+        # The scope input is already list-shaped and its items are meant to be
+        # OR'd, but SearchKernelScopedHistoryAction is a single-target
+        # BaseScopeAction, so only one item is dispatchable today.
         if len(kernel_items) + len(session_items) != 1:
             raise InvalidAPIParameters(
                 "Kernel scheduling history scope accepts exactly one scope item"

--- a/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
@@ -30,7 +30,10 @@ from ai.backend.common.dto.manager.v2.scheduling_history.response import (
     SearchKernelHistoriesPayload,
     SessionHistoryNode,
 )
-from ai.backend.common.dto.manager.v2.scheduling_history.types import SubStepResultInfo
+from ai.backend.common.dto.manager.v2.scheduling_history.types import (
+    KernelHistoryScopeDTO,
+    SubStepResultInfo,
+)
 from ai.backend.common.identifier.kernel_scheduling_history import KernelSchedulingHistoryID
 from ai.backend.common.identifier.replica import ReplicaID
 from ai.backend.common.types import KernelId
@@ -43,6 +46,7 @@ from ai.backend.manager.data.session.types import (
     SessionSchedulingHistoryData,
     SubStepResult,
 )
+from ai.backend.manager.errors.api import InvalidAPIParameters
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.models.scheduling_history.conditions import (
     DeploymentHistoryConditions,
@@ -450,16 +454,17 @@ class SchedulingHistoryAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
+        kernel_id = self._scope_to_kernel_id(input.scope)
         # The owning session is the authorization subject; resolve it before
         # dispatching so the RBAC check targets the session directly.
         resolve_result = (
             await self._processors.scheduling_history.resolve_kernel_session.wait_for_complete(
-                ResolveKernelSessionAction(kernel_id=KernelId(input.scope.kernel_id))
+                ResolveKernelSessionAction(kernel_id=kernel_id)
             )
         )
         action_result = await self._processors.scheduling_history.search_kernel_scoped_history.wait_for_complete(
             SearchKernelScopedHistoryAction(
-                kernel_id=KernelId(input.scope.kernel_id),
+                kernel_id=kernel_id,
                 session_id=resolve_result.session_id,
                 querier=querier,
             )
@@ -470,6 +475,21 @@ class SchedulingHistoryAdapter(BaseAdapter):
             has_next_page=action_result.has_next_page,
             has_previous_page=action_result.has_previous_page,
         )
+
+    @staticmethod
+    def _scope_to_kernel_id(scope: KernelHistoryScopeDTO) -> KernelId:
+        """Reduce the scope item list to the single target the scope action takes.
+
+        ``SearchKernelScopedHistoryAction`` is a ``BaseScopeAction``, so it
+        authorizes and queries exactly one kernel; reject multi-item scopes
+        instead of silently dropping the rest.
+        """
+        items = scope.kernel or []
+        if len(items) > 1:
+            raise InvalidAPIParameters(
+                "Kernel scheduling history scope accepts at most one kernel item"
+            )
+        return KernelId(items[0].value)
 
     def _convert_kernel_filter(self, filter: KernelHistoryFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []

--- a/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
@@ -465,10 +465,10 @@ class SchedulingHistoryAdapter(BaseAdapter):
                 "Kernel scheduling history scope accepts exactly one scope item"
             )
         target: KernelHistoryTarget
-        # TODO: Drop `authorized_session_id` and the kernel -> session resolution
-        # once virtual scopes land; the action can then authorize on the target's
-        # own RBAC element ref.
-        authorized_session_id: SessionId
+        # TODO: Drop `session_id` and the kernel -> session resolution once
+        # virtual scopes land; the action can then authorize on the target's own
+        # RBAC element ref.
+        session_id: SessionId
         if kernel_items:
             kernel_id = KernelId(kernel_items[0].value)
             target = KernelKernelHistoryTarget(kernel_id=kernel_id)
@@ -477,15 +477,14 @@ class SchedulingHistoryAdapter(BaseAdapter):
                     ResolveKernelSessionAction(kernel_id=kernel_id)
                 )
             )
-            authorized_session_id = resolve_result.session_id
+            session_id = resolve_result.session_id
         else:
             session_id = SessionId(session_items[0].value)
             target = SessionKernelHistoryTarget(session_id=session_id)
-            authorized_session_id = session_id
         action_result = await self._processors.scheduling_history.search_kernel_scoped_history.wait_for_complete(
             SearchKernelScopedHistoryAction(
                 target=target,
-                authorized_session_id=authorized_session_id,
+                _session_id=session_id,
                 querier=querier,
             )
         )

--- a/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
@@ -93,10 +93,10 @@ from ai.backend.manager.services.scheduling_history.actions.search_kernel_histor
     SearchKernelHistoryAction,
 )
 from ai.backend.manager.services.scheduling_history.actions.search_kernel_scoped_history import (
-    KernelSchedulingHistoryByKernelTarget,
-    KernelSchedulingHistoryBySessionTarget,
-    KernelSchedulingHistoryTarget,
+    KernelHistoryTarget,
+    KernelKernelHistoryTarget,
     SearchKernelScopedHistoryAction,
+    SessionKernelHistoryTarget,
 )
 from ai.backend.manager.services.scheduling_history.actions.search_route_history import (
     SearchRouteHistoryAction,
@@ -463,7 +463,7 @@ class SchedulingHistoryAdapter(BaseAdapter):
             raise InvalidAPIParameters(
                 "Kernel scheduling history scope accepts exactly one scope item"
             )
-        target: KernelSchedulingHistoryTarget
+        target: KernelHistoryTarget
         if kernel_items:
             kernel_id = KernelId(kernel_items[0].value)
             resolve_result = (
@@ -471,11 +471,11 @@ class SchedulingHistoryAdapter(BaseAdapter):
                     ResolveKernelSessionAction(kernel_id=kernel_id)
                 )
             )
-            target = KernelSchedulingHistoryByKernelTarget(
+            target = KernelKernelHistoryTarget(
                 session_id=resolve_result.session_id, kernel_id=kernel_id
             )
         else:
-            target = KernelSchedulingHistoryBySessionTarget(
+            target = SessionKernelHistoryTarget(
                 session_id=SessionId(session_items[0].value)
             )
         action_result = await self._processors.scheduling_history.search_kernel_scoped_history.wait_for_complete(

--- a/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
@@ -30,13 +30,10 @@ from ai.backend.common.dto.manager.v2.scheduling_history.response import (
     SearchKernelHistoriesPayload,
     SessionHistoryNode,
 )
-from ai.backend.common.dto.manager.v2.scheduling_history.types import (
-    KernelHistoryScopeDTO,
-    SubStepResultInfo,
-)
+from ai.backend.common.dto.manager.v2.scheduling_history.types import SubStepResultInfo
 from ai.backend.common.identifier.kernel_scheduling_history import KernelSchedulingHistoryID
 from ai.backend.common.identifier.replica import ReplicaID
-from ai.backend.common.types import KernelId
+from ai.backend.common.types import KernelId, SessionId
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.deployment.types import DeploymentHistoryData, RouteHistoryData
@@ -454,18 +451,31 @@ class SchedulingHistoryAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        kernel_id = self._scope_to_kernel_id(input.scope)
-        # The owning session is the authorization subject; resolve it before
-        # dispatching so the RBAC check targets the session directly.
-        resolve_result = (
-            await self._processors.scheduling_history.resolve_kernel_session.wait_for_complete(
-                ResolveKernelSessionAction(kernel_id=kernel_id)
+        # The session is the authorization subject in both cases; a kernel-scoped
+        # request resolves its owning session before dispatching so the RBAC check
+        # targets the session directly.
+        kernel_items = input.scope.kernel or []
+        session_items = input.scope.session or []
+        if len(kernel_items) + len(session_items) != 1:
+            raise InvalidAPIParameters(
+                "Kernel scheduling history scope accepts exactly one scope item"
             )
-        )
+        kernel_id: KernelId | None
+        if kernel_items:
+            kernel_id = KernelId(kernel_items[0].value)
+            resolve_result = (
+                await self._processors.scheduling_history.resolve_kernel_session.wait_for_complete(
+                    ResolveKernelSessionAction(kernel_id=kernel_id)
+                )
+            )
+            session_id = resolve_result.session_id
+        else:
+            kernel_id = None
+            session_id = SessionId(session_items[0].value)
         action_result = await self._processors.scheduling_history.search_kernel_scoped_history.wait_for_complete(
             SearchKernelScopedHistoryAction(
                 kernel_id=kernel_id,
-                session_id=resolve_result.session_id,
+                session_id=session_id,
                 querier=querier,
             )
         )
@@ -475,21 +485,6 @@ class SchedulingHistoryAdapter(BaseAdapter):
             has_next_page=action_result.has_next_page,
             has_previous_page=action_result.has_previous_page,
         )
-
-    @staticmethod
-    def _scope_to_kernel_id(scope: KernelHistoryScopeDTO) -> KernelId:
-        """Reduce the scope item list to the single target the scope action takes.
-
-        ``SearchKernelScopedHistoryAction`` is a ``BaseScopeAction``, so it
-        authorizes and queries exactly one kernel; reject multi-item scopes
-        instead of silently dropping the rest.
-        """
-        items = scope.kernel or []
-        if len(items) > 1:
-            raise InvalidAPIParameters(
-                "Kernel scheduling history scope accepts at most one kernel item"
-            )
-        return KernelId(items[0].value)
 
     def _convert_kernel_filter(self, filter: KernelHistoryFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []

--- a/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
@@ -454,9 +454,6 @@ class SchedulingHistoryAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        # The session is the authorization subject of every scope item; a
-        # kernel-scoped request resolves its owning session before dispatching so
-        # the RBAC check targets the session directly.
         kernel_items = input.scope.kernel or []
         session_items = input.scope.session or []
         if len(kernel_items) + len(session_items) != 1:
@@ -464,22 +461,29 @@ class SchedulingHistoryAdapter(BaseAdapter):
                 "Kernel scheduling history scope accepts exactly one scope item"
             )
         target: KernelHistoryTarget
+        # TODO: Drop `authorized_session_id` and the kernel -> session resolution
+        # once virtual scopes land; the action can then authorize on the target's
+        # own RBAC element ref.
+        authorized_session_id: SessionId
         if kernel_items:
             kernel_id = KernelId(kernel_items[0].value)
+            target = KernelKernelHistoryTarget(kernel_id=kernel_id)
             resolve_result = (
                 await self._processors.scheduling_history.resolve_kernel_session.wait_for_complete(
                     ResolveKernelSessionAction(kernel_id=kernel_id)
                 )
             )
-            target = KernelKernelHistoryTarget(
-                session_id=resolve_result.session_id, kernel_id=kernel_id
-            )
+            authorized_session_id = resolve_result.session_id
         else:
-            target = SessionKernelHistoryTarget(
-                session_id=SessionId(session_items[0].value)
-            )
+            session_id = SessionId(session_items[0].value)
+            target = SessionKernelHistoryTarget(session_id=session_id)
+            authorized_session_id = session_id
         action_result = await self._processors.scheduling_history.search_kernel_scoped_history.wait_for_complete(
-            SearchKernelScopedHistoryAction(target=target, querier=querier)
+            SearchKernelScopedHistoryAction(
+                target=target,
+                authorized_session_id=authorized_session_id,
+                querier=querier,
+            )
         )
         return SearchKernelHistoriesPayload(
             items=[self._kernel_data_to_dto(h) for h in action_result.items],

--- a/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
@@ -93,6 +93,9 @@ from ai.backend.manager.services.scheduling_history.actions.search_kernel_histor
     SearchKernelHistoryAction,
 )
 from ai.backend.manager.services.scheduling_history.actions.search_kernel_scoped_history import (
+    KernelSchedulingHistoryByKernelTarget,
+    KernelSchedulingHistoryBySessionTarget,
+    KernelSchedulingHistoryTarget,
     SearchKernelScopedHistoryAction,
 )
 from ai.backend.manager.services.scheduling_history.actions.search_route_history import (
@@ -451,16 +454,16 @@ class SchedulingHistoryAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        # The session is the authorization subject in both cases; a kernel-scoped
-        # request resolves its owning session before dispatching so the RBAC check
-        # targets the session directly.
+        # The session is the authorization subject of every scope item; a
+        # kernel-scoped request resolves its owning session before dispatching so
+        # the RBAC check targets the session directly.
         kernel_items = input.scope.kernel or []
         session_items = input.scope.session or []
         if len(kernel_items) + len(session_items) != 1:
             raise InvalidAPIParameters(
                 "Kernel scheduling history scope accepts exactly one scope item"
             )
-        kernel_id: KernelId | None
+        target: KernelSchedulingHistoryTarget
         if kernel_items:
             kernel_id = KernelId(kernel_items[0].value)
             resolve_result = (
@@ -468,16 +471,15 @@ class SchedulingHistoryAdapter(BaseAdapter):
                     ResolveKernelSessionAction(kernel_id=kernel_id)
                 )
             )
-            session_id = resolve_result.session_id
-        else:
-            kernel_id = None
-            session_id = SessionId(session_items[0].value)
-        action_result = await self._processors.scheduling_history.search_kernel_scoped_history.wait_for_complete(
-            SearchKernelScopedHistoryAction(
-                kernel_id=kernel_id,
-                session_id=session_id,
-                querier=querier,
+            target = KernelSchedulingHistoryByKernelTarget(
+                session_id=resolve_result.session_id, kernel_id=kernel_id
             )
+        else:
+            target = KernelSchedulingHistoryBySessionTarget(
+                session_id=SessionId(session_items[0].value)
+            )
+        action_result = await self._processors.scheduling_history.search_kernel_scoped_history.wait_for_complete(
+            SearchKernelScopedHistoryAction(target=target, querier=querier)
         )
         return SearchKernelHistoriesPayload(
             items=[self._kernel_data_to_dto(h) for h in action_result.items],

--- a/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from uuid import UUID
 
+from ai.backend.common.data.filter_specs import UUIDEqualMatchSpec
 from ai.backend.common.dto.manager.v2.scheduling_history.request import (
     AdminSearchDeploymentHistoriesInput,
     AdminSearchKernelHistoriesInput,
@@ -93,8 +94,6 @@ from ai.backend.manager.services.scheduling_history.actions.search_kernel_histor
     SearchKernelHistoryAction,
 )
 from ai.backend.manager.services.scheduling_history.actions.search_kernel_scoped_history import (
-    KernelHistoryTarget,
-    KernelKernelHistoryTarget,
     SearchKernelScopedHistoryAction,
     SessionKernelHistoryTarget,
 )
@@ -443,6 +442,35 @@ class SchedulingHistoryAdapter(BaseAdapter):
         """Search kernel scheduling histories under a non-admin scope."""
         conditions = self._convert_kernel_filter(input.filter) if input.filter else []
         orders = self._convert_kernel_orders(input.order) if input.order else []
+        kernel_items = input.scope.kernel or []
+        session_items = input.scope.session or []
+        # TODO: Drop this rejection once the scoped search becomes a bulk action.
+        # The scope input is already list-shaped and its items are meant to be
+        # OR'd, but SearchKernelScopedHistoryAction is a single-target
+        # BaseScopeAction, so only one item is dispatchable today.
+        if len(kernel_items) + len(session_items) != 1:
+            raise InvalidAPIParameters(
+                "Kernel scheduling history scope accepts exactly one scope item"
+            )
+        # TODO: Drop the kernel -> session conversion once virtual scopes land and
+        # a kernel becomes a scope of its own. Kernels hold no permission records,
+        # so a kernel scope item is authorized on its owning session and narrowed
+        # back down to that kernel with a query condition.
+        if kernel_items:
+            kernel_id = KernelId(kernel_items[0].value)
+            resolve_result = (
+                await self._processors.scheduling_history.resolve_kernel_session.wait_for_complete(
+                    ResolveKernelSessionAction(kernel_id=kernel_id)
+                )
+            )
+            session_id = resolve_result.session_id
+            conditions.append(
+                KernelSchedulingHistoryConditions.by_kernel_id_filter(
+                    UUIDEqualMatchSpec(value=kernel_id, negated=False)
+                )
+            )
+        else:
+            session_id = SessionId(session_items[0].value)
         querier = self._build_querier(
             conditions=conditions,
             orders=orders,
@@ -454,37 +482,9 @@ class SchedulingHistoryAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        kernel_items = input.scope.kernel or []
-        session_items = input.scope.session or []
-        # TODO: Drop this rejection once the scoped search becomes a bulk action.
-        # The scope input is already list-shaped and its items are meant to be
-        # OR'd, but SearchKernelScopedHistoryAction is a single-target
-        # BaseScopeAction, so only one item is dispatchable today.
-        if len(kernel_items) + len(session_items) != 1:
-            raise InvalidAPIParameters(
-                "Kernel scheduling history scope accepts exactly one scope item"
-            )
-        target: KernelHistoryTarget
-        # TODO: Drop `session_id` and the kernel -> session resolution once
-        # virtual scopes land; the action can then authorize on the target's own
-        # RBAC element ref.
-        session_id: SessionId
-        if kernel_items:
-            kernel_id = KernelId(kernel_items[0].value)
-            target = KernelKernelHistoryTarget(kernel_id=kernel_id)
-            resolve_result = (
-                await self._processors.scheduling_history.resolve_kernel_session.wait_for_complete(
-                    ResolveKernelSessionAction(kernel_id=kernel_id)
-                )
-            )
-            session_id = resolve_result.session_id
-        else:
-            session_id = SessionId(session_items[0].value)
-            target = SessionKernelHistoryTarget(session_id=session_id)
         action_result = await self._processors.scheduling_history.search_kernel_scoped_history.wait_for_complete(
             SearchKernelScopedHistoryAction(
-                target=target,
-                _session_id=session_id,
+                target=SessionKernelHistoryTarget(session_id=session_id),
                 querier=querier,
             )
         )

--- a/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
@@ -452,10 +452,10 @@ class SchedulingHistoryAdapter(BaseAdapter):
             raise InvalidAPIParameters(
                 "Kernel scheduling history scope accepts exactly one scope item"
             )
-        # TODO: Drop the kernel -> session conversion once virtual scopes land and
-        # a kernel becomes a scope of its own. Kernels hold no permission records,
-        # so a kernel scope item is authorized on its owning session and narrowed
-        # back down to that kernel with a query condition.
+        # TODO: Pass KernelKernelHistoryTarget(kernel_id=...) once virtual scopes
+        # land and a kernel becomes a scope of its own. Kernels hold no permission
+        # records today, so a kernel scope item is converted to a target on its
+        # owning session and narrowed back down with a kernel_id query condition.
         if kernel_items:
             kernel_id = KernelId(kernel_items[0].value)
             resolve_result = (

--- a/src/ai/backend/manager/api/gql/kernel/types.py
+++ b/src/ai/backend/manager/api/gql/kernel/types.py
@@ -599,6 +599,7 @@ class KernelV2GQL(PydanticNodeMixin[KernelNode]):
         """Fetch the scheduling history of this kernel."""
         from uuid import UUID
 
+        from ai.backend.common.dto.manager.v2.rbac.types import UUIDScope
         from ai.backend.common.dto.manager.v2.scheduling_history.request import (
             ScopedSearchKernelHistoriesInput,
         )
@@ -616,7 +617,7 @@ class KernelV2GQL(PydanticNodeMixin[KernelNode]):
 
         result = await info.context.adapters.scheduling_history.scoped_search_kernel_history(
             ScopedSearchKernelHistoriesInput(
-                scope=KernelHistoryScopeDTO(kernel_id=UUID(str(self.id))),
+                scope=KernelHistoryScopeDTO(kernel=[UUIDScope(value=UUID(str(self.id)))]),
                 filter=filter.to_pydantic() if filter else None,
                 order=[o.to_pydantic() for o in order_by] if order_by else None,
                 first=first,

--- a/src/ai/backend/manager/api/gql/scheduling_history/types.py
+++ b/src/ai/backend/manager/api/gql/scheduling_history/types.py
@@ -453,7 +453,16 @@ class KernelScopeGQL(PydanticInputMixin[KernelHistoryScopeDTO]):
     kernel: list[UUIDScopeGQL] | None = gql_field(
         description=(
             "Kernel IDs to get history for. "
-            "The scoped search is single-target for now, so exactly one item is accepted."
+            "The scoped search is single-target for now, so exactly one item is accepted "
+            "across all fields."
+        ),
+        default=None,
+    )
+    session: list[UUIDScopeGQL] | None = gql_field(
+        description=(
+            "Session IDs to get the history of every owned kernel for. "
+            "The scoped search is single-target for now, so exactly one item is accepted "
+            "across all fields."
         ),
         default=None,
     )

--- a/src/ai/backend/manager/api/gql/scheduling_history/types.py
+++ b/src/ai/backend/manager/api/gql/scheduling_history/types.py
@@ -74,6 +74,7 @@ from ai.backend.manager.api.gql.pydantic_compat import (
     PydanticNodeMixin,
     PydanticOutputMixin,
 )
+from ai.backend.manager.api.gql.rbac.types.scope import UUIDScopeGQL
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 
 if TYPE_CHECKING:
@@ -438,7 +439,10 @@ class SessionScope(PydanticInputMixin[SessionHistoryScopeDTO]):
 
 @gql_pydantic_input(
     BackendAIGQLMeta(
-        description="Scope for kernel scheduling history query",
+        description=(
+            "Scope for kernel scheduling history query. "
+            "All items are OR'd; raises an error if every field is empty."
+        ),
         added_version=NEXT_RELEASE_VERSION,
     ),
     name="KernelScope",
@@ -446,7 +450,13 @@ class SessionScope(PydanticInputMixin[SessionHistoryScopeDTO]):
 class KernelScopeGQL(PydanticInputMixin[KernelHistoryScopeDTO]):
     """Scope for kernel-level scheduling history queries."""
 
-    kernel_id: UUID = gql_field(description="Kernel ID to get history for")
+    kernel: list[UUIDScopeGQL] | None = gql_field(
+        description=(
+            "Kernel IDs to get history for. "
+            "The scoped search is single-target for now, so exactly one item is accepted."
+        ),
+        default=None,
+    )
 
 
 @gql_pydantic_input(

--- a/src/ai/backend/manager/repositories/scheduling_history/__init__.py
+++ b/src/ai/backend/manager/repositories/scheduling_history/__init__.py
@@ -8,7 +8,7 @@ from .repositories import SchedulingHistoryRepositories
 from .repository import SchedulingHistoryRepository
 from .types import (
     DeploymentHistorySearchScope,
-    KernelSchedulingHistorySearchScope,
+    KernelKernelHistorySearchScope,
     RouteHistorySearchScope,
     SessionSchedulingHistorySearchScope,
 )
@@ -17,7 +17,7 @@ __all__ = (
     "DeploymentHistoryCreatorSpec",
     "DeploymentHistorySearchScope",
     "KernelSchedulingHistoryCreatorSpec",
-    "KernelSchedulingHistorySearchScope",
+    "KernelKernelHistorySearchScope",
     "RouteHistoryCreatorSpec",
     "RouteHistorySearchScope",
     "SchedulingHistoryRepositories",

--- a/src/ai/backend/manager/repositories/scheduling_history/__init__.py
+++ b/src/ai/backend/manager/repositories/scheduling_history/__init__.py
@@ -8,18 +8,22 @@ from .repositories import SchedulingHistoryRepositories
 from .repository import SchedulingHistoryRepository
 from .types import (
     DeploymentHistorySearchScope,
+    KernelKernelHistorySearchScope,
     RouteHistorySearchScope,
+    SessionKernelHistorySearchScope,
     SessionSchedulingHistorySearchScope,
 )
 
 __all__ = (
     "DeploymentHistoryCreatorSpec",
     "DeploymentHistorySearchScope",
+    "KernelKernelHistorySearchScope",
     "KernelSchedulingHistoryCreatorSpec",
     "RouteHistoryCreatorSpec",
     "RouteHistorySearchScope",
     "SchedulingHistoryRepositories",
     "SchedulingHistoryRepository",
+    "SessionKernelHistorySearchScope",
     "SessionSchedulingHistoryCreatorSpec",
     "SessionSchedulingHistorySearchScope",
 )

--- a/src/ai/backend/manager/repositories/scheduling_history/__init__.py
+++ b/src/ai/backend/manager/repositories/scheduling_history/__init__.py
@@ -8,7 +8,6 @@ from .repositories import SchedulingHistoryRepositories
 from .repository import SchedulingHistoryRepository
 from .types import (
     DeploymentHistorySearchScope,
-    KernelKernelHistorySearchScope,
     RouteHistorySearchScope,
     SessionSchedulingHistorySearchScope,
 )
@@ -17,7 +16,6 @@ __all__ = (
     "DeploymentHistoryCreatorSpec",
     "DeploymentHistorySearchScope",
     "KernelSchedulingHistoryCreatorSpec",
-    "KernelKernelHistorySearchScope",
     "RouteHistoryCreatorSpec",
     "RouteHistorySearchScope",
     "SchedulingHistoryRepositories",

--- a/src/ai/backend/manager/repositories/scheduling_history/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduling_history/db_source/db_source.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
@@ -141,13 +142,13 @@ class SchedulingHistoryDBSource:
     async def search_kernel_scoped_history(
         self,
         querier: BatchQuerier,
-        scope: SearchScope,
+        scopes: Sequence[SearchScope],
     ) -> KernelSchedulingHistoryListResult:
         """Search kernel history whose rows match any of ``scopes`` (OR), narrowed by ``querier``."""
         async with self._db.begin_readonly_session() as db_sess:
             query = sa.select(KernelSchedulingHistoryRow)
 
-            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
+            result = await execute_batch_querier(db_sess, query, querier, scopes=scopes)
 
             items = [row.KernelSchedulingHistoryRow.to_data() for row in result.rows]
 

--- a/src/ai/backend/manager/repositories/scheduling_history/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduling_history/db_source/db_source.py
@@ -25,13 +25,13 @@ from ai.backend.manager.models.scheduling_history import (
     RouteHistoryRow,
     SessionSchedulingHistoryRow,
 )
+from ai.backend.manager.models.scopes import SearchScope
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
     execute_batch_querier,
 )
 from ai.backend.manager.repositories.scheduling_history.types import (
     DeploymentHistorySearchScope,
-    KernelSchedulingHistorySearchScope,
     RouteHistorySearchScope,
     SessionSchedulingHistorySearchScope,
 )
@@ -141,7 +141,7 @@ class SchedulingHistoryDBSource:
     async def search_kernel_scoped_history(
         self,
         querier: BatchQuerier,
-        scope: KernelSchedulingHistorySearchScope,
+        scope: SearchScope,
     ) -> KernelSchedulingHistoryListResult:
         """Search kernel history whose rows match any of ``scopes`` (OR), narrowed by ``querier``."""
         async with self._db.begin_readonly_session() as db_sess:

--- a/src/ai/backend/manager/repositories/scheduling_history/repository.py
+++ b/src/ai/backend/manager/repositories/scheduling_history/repository.py
@@ -22,12 +22,12 @@ from ai.backend.manager.data.kernel.types import (
 from ai.backend.manager.data.session.types import (
     SessionSchedulingHistoryListResult,
 )
+from ai.backend.manager.models.scopes import SearchScope
 from ai.backend.manager.repositories.base import BatchQuerier
 
 from .db_source import SchedulingHistoryDBSource
 from .types import (
     DeploymentHistorySearchScope,
-    KernelSchedulingHistorySearchScope,
     RouteHistorySearchScope,
     SessionSchedulingHistorySearchScope,
 )
@@ -107,7 +107,7 @@ class SchedulingHistoryRepository:
     async def search_kernel_scoped_history(
         self,
         querier: BatchQuerier,
-        scope: KernelSchedulingHistorySearchScope,
+        scope: SearchScope,
     ) -> KernelSchedulingHistoryListResult:
         """Search kernel history whose rows match any of ``scopes`` (OR)."""
         return await self._db_source.search_kernel_scoped_history(querier, scope)

--- a/src/ai/backend/manager/repositories/scheduling_history/repository.py
+++ b/src/ai/backend/manager/repositories/scheduling_history/repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from ai.backend.common.metrics.metric import DomainType, LayerType
@@ -107,10 +108,10 @@ class SchedulingHistoryRepository:
     async def search_kernel_scoped_history(
         self,
         querier: BatchQuerier,
-        scope: SearchScope,
+        scopes: Sequence[SearchScope],
     ) -> KernelSchedulingHistoryListResult:
         """Search kernel history whose rows match any of ``scopes`` (OR)."""
-        return await self._db_source.search_kernel_scoped_history(querier, scope)
+        return await self._db_source.search_kernel_scoped_history(querier, scopes)
 
     # ========== Deployment History (Admin) ==========
 

--- a/src/ai/backend/manager/repositories/scheduling_history/types.py
+++ b/src/ai/backend/manager/repositories/scheduling_history/types.py
@@ -30,8 +30,8 @@ from ai.backend.manager.models.session import SessionRow
 
 __all__ = (
     "SessionSchedulingHistorySearchScope",
-    "KernelSchedulingHistoryBySessionSearchScope",
-    "KernelSchedulingHistorySearchScope",
+    "KernelKernelHistorySearchScope",
+    "SessionKernelHistorySearchScope",
     "DeploymentHistorySearchScope",
     "RouteHistorySearchScope",
 )
@@ -74,7 +74,7 @@ class SessionSchedulingHistorySearchScope(SearchScope):
 
 
 @dataclass(frozen=True)
-class KernelSchedulingHistorySearchScope(SearchScope):
+class KernelKernelHistorySearchScope(SearchScope):
     """Scope for kernel scheduling history search.
 
     Used for entity-scoped queries where kernel_id is the scope parameter.
@@ -104,11 +104,11 @@ class KernelSchedulingHistorySearchScope(SearchScope):
 
 
 @dataclass(frozen=True)
-class KernelSchedulingHistoryBySessionSearchScope(SearchScope):
+class SessionKernelHistorySearchScope(SearchScope):
     """Scope for kernel scheduling history search bounded by the owning session.
 
     Returns the history of every kernel belonging to the session, as opposed to
-    ``KernelSchedulingHistorySearchScope`` which bounds the query to one kernel.
+    ``KernelKernelHistorySearchScope`` which bounds the query to one kernel.
     """
 
     session_id: SessionId

--- a/src/ai/backend/manager/repositories/scheduling_history/types.py
+++ b/src/ai/backend/manager/repositories/scheduling_history/types.py
@@ -8,12 +8,16 @@ from uuid import UUID
 
 from ai.backend.common.data.filter_specs import UUIDEqualMatchSpec
 from ai.backend.common.identifier.replica import ReplicaID
-from ai.backend.common.types import SessionId
+from ai.backend.common.types import KernelId, SessionId
 from ai.backend.manager.errors.deployment import EndpointNotFound
-from ai.backend.manager.errors.kernel import SessionNotFound
+from ai.backend.manager.errors.kernel import (
+    KernelNotFound,
+    SessionNotFound,
+)
 from ai.backend.manager.errors.service import RouteNotFound
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.endpoint import EndpointRow
+from ai.backend.manager.models.kernel.row import KernelRow
 from ai.backend.manager.models.routing import RoutingRow
 from ai.backend.manager.models.scheduling_history.conditions import (
     DeploymentHistoryConditions,
@@ -26,6 +30,7 @@ from ai.backend.manager.models.session import SessionRow
 
 __all__ = (
     "SessionSchedulingHistorySearchScope",
+    "KernelKernelHistorySearchScope",
     "SessionKernelHistorySearchScope",
     "DeploymentHistorySearchScope",
     "RouteHistorySearchScope",
@@ -66,6 +71,39 @@ class SessionSchedulingHistorySearchScope(SearchScope):
 
 
 # Kernel Scheduling History Scope
+
+
+@dataclass(frozen=True)
+class KernelKernelHistorySearchScope(SearchScope):
+    """Scope for kernel scheduling history search bounded by one kernel.
+
+    Not reachable yet: kernels hold no RBAC permission records of their own, so
+    a kernel-keyed query is authorized on the owning session and narrowed with a
+    ``kernel_id`` condition instead. This is what it should scope by once
+    virtual scopes land.
+    """
+
+    kernel_id: KernelId
+    """Required. The kernel to search history for."""
+
+    @override
+    def to_condition(self) -> QueryCondition:
+        """Convert scope to a query condition for KernelSchedulingHistoryRow."""
+        return KernelSchedulingHistoryConditions.by_kernel_id_filter(
+            UUIDEqualMatchSpec(value=self.kernel_id, negated=False)
+        )
+
+    @property
+    @override
+    def existence_checks(self) -> list[ExistenceCheck[Any]]:
+        """Check that the kernel exists."""
+        return [
+            ExistenceCheck(
+                column=KernelRow.id,
+                value=self.kernel_id,
+                error=KernelNotFound(str(self.kernel_id)),
+            ),
+        ]
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/repositories/scheduling_history/types.py
+++ b/src/ai/backend/manager/repositories/scheduling_history/types.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 from ai.backend.common.data.filter_specs import UUIDEqualMatchSpec
 from ai.backend.common.identifier.replica import ReplicaID
-from ai.backend.common.types import KernelId
+from ai.backend.common.types import KernelId, SessionId
 from ai.backend.manager.errors.deployment import EndpointNotFound
 from ai.backend.manager.errors.kernel import (
     KernelNotFound,
@@ -30,6 +30,7 @@ from ai.backend.manager.models.session import SessionRow
 
 __all__ = (
     "SessionSchedulingHistorySearchScope",
+    "KernelSchedulingHistoryBySessionSearchScope",
     "KernelSchedulingHistorySearchScope",
     "DeploymentHistorySearchScope",
     "RouteHistorySearchScope",
@@ -98,6 +99,37 @@ class KernelSchedulingHistorySearchScope(SearchScope):
                 column=KernelRow.id,
                 value=self.kernel_id,
                 error=KernelNotFound(str(self.kernel_id)),
+            ),
+        ]
+
+
+@dataclass(frozen=True)
+class KernelSchedulingHistoryBySessionSearchScope(SearchScope):
+    """Scope for kernel scheduling history search bounded by the owning session.
+
+    Returns the history of every kernel belonging to the session, as opposed to
+    ``KernelSchedulingHistorySearchScope`` which bounds the query to one kernel.
+    """
+
+    session_id: SessionId
+    """Required. The session whose kernels' history is searched."""
+
+    @override
+    def to_condition(self) -> QueryCondition:
+        """Convert scope to a query condition for KernelSchedulingHistoryRow."""
+        return KernelSchedulingHistoryConditions.by_session_id_filter(
+            UUIDEqualMatchSpec(value=self.session_id, negated=False)
+        )
+
+    @property
+    @override
+    def existence_checks(self) -> list[ExistenceCheck[Any]]:
+        """Check that the session exists."""
+        return [
+            ExistenceCheck(
+                column=SessionRow.id,
+                value=self.session_id,
+                error=SessionNotFound(str(self.session_id)),
             ),
         ]
 

--- a/src/ai/backend/manager/repositories/scheduling_history/types.py
+++ b/src/ai/backend/manager/repositories/scheduling_history/types.py
@@ -8,16 +8,12 @@ from uuid import UUID
 
 from ai.backend.common.data.filter_specs import UUIDEqualMatchSpec
 from ai.backend.common.identifier.replica import ReplicaID
-from ai.backend.common.types import KernelId, SessionId
+from ai.backend.common.types import SessionId
 from ai.backend.manager.errors.deployment import EndpointNotFound
-from ai.backend.manager.errors.kernel import (
-    KernelNotFound,
-    SessionNotFound,
-)
+from ai.backend.manager.errors.kernel import SessionNotFound
 from ai.backend.manager.errors.service import RouteNotFound
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.endpoint import EndpointRow
-from ai.backend.manager.models.kernel.row import KernelRow
 from ai.backend.manager.models.routing import RoutingRow
 from ai.backend.manager.models.scheduling_history.conditions import (
     DeploymentHistoryConditions,
@@ -30,7 +26,6 @@ from ai.backend.manager.models.session import SessionRow
 
 __all__ = (
     "SessionSchedulingHistorySearchScope",
-    "KernelKernelHistorySearchScope",
     "SessionKernelHistorySearchScope",
     "DeploymentHistorySearchScope",
     "RouteHistorySearchScope",
@@ -74,41 +69,10 @@ class SessionSchedulingHistorySearchScope(SearchScope):
 
 
 @dataclass(frozen=True)
-class KernelKernelHistorySearchScope(SearchScope):
-    """Scope for kernel scheduling history search.
-
-    Used for entity-scoped queries where kernel_id is the scope parameter.
-    """
-
-    kernel_id: KernelId
-    """Required. The kernel to search history for."""
-
-    @override
-    def to_condition(self) -> QueryCondition:
-        """Convert scope to a query condition for KernelSchedulingHistoryRow."""
-        return KernelSchedulingHistoryConditions.by_kernel_id_filter(
-            UUIDEqualMatchSpec(value=self.kernel_id, negated=False)
-        )
-
-    @property
-    @override
-    def existence_checks(self) -> list[ExistenceCheck[Any]]:
-        """Check that the kernel exists."""
-        return [
-            ExistenceCheck(
-                column=KernelRow.id,
-                value=self.kernel_id,
-                error=KernelNotFound(str(self.kernel_id)),
-            ),
-        ]
-
-
-@dataclass(frozen=True)
 class SessionKernelHistorySearchScope(SearchScope):
     """Scope for kernel scheduling history search bounded by the owning session.
 
-    Returns the history of every kernel belonging to the session, as opposed to
-    ``KernelKernelHistorySearchScope`` which bounds the query to one kernel.
+    Returns the history of every kernel belonging to the session.
     """
 
     session_id: SessionId

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
@@ -65,12 +65,11 @@ class SessionKernelHistoryTarget(KernelHistoryTarget):
 
 @dataclass
 class SearchKernelScopedHistoryAction(BaseScopeAction):
-    """Action to search kernel scheduling history under one scope item.
+    """Action to search kernel scheduling history under one scope item."""
 
-    This is still a single-target scope action, so it carries exactly one
-    ``KernelHistoryTarget``.
-    """
-
+    # TODO: Widen to a list of targets once this becomes a bulk action; the scope
+    # input already accepts several items and means them to be OR'd, but a
+    # BaseScopeAction authorizes exactly one target.
     target: KernelHistoryTarget
     # TODO: Drop once virtual scopes land, and authorize on
     # ``target.to_rbac_element_ref()`` instead. Kernels hold no permission

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
@@ -20,14 +20,40 @@ from ai.backend.manager.repositories.scheduling_history.types import (
 
 @dataclass(frozen=True)
 class KernelHistoryTarget(SearchableActionTarget):
-    """Scope item of a kernel scheduling-history search.
+    """One scope item of a kernel scheduling-history search.
 
-    The owning session is the authorization subject of every variant, so
-    ``session_id`` alone decides the RBAC element ref; each variant only differs
-    in how far ``to_search_scope()`` narrows the rows.
+    Each variant carries only the id its own dimension is keyed by and derives
+    both the row filter and the RBAC element ref from it.
     """
 
+
+@dataclass(frozen=True)
+class KernelKernelHistoryTarget(KernelHistoryTarget):
+    """Scope item narrowing the history to one kernel."""
+
+    kernel_id: KernelId
+
+    @override
+    def to_search_scope(self) -> SearchScope:
+        return KernelSchedulingHistorySearchScope(kernel_id=self.kernel_id)
+
+    @override
+    def to_rbac_element_ref(self) -> RBACElementRef:
+        return RBACElementRef(
+            element_type=RBACElementType.KERNEL,
+            element_id=str(self.kernel_id),
+        )
+
+
+@dataclass(frozen=True)
+class SessionKernelHistoryTarget(KernelHistoryTarget):
+    """Scope item covering the history of every kernel the session owns."""
+
     session_id: SessionId
+
+    @override
+    def to_search_scope(self) -> SearchScope:
+        return KernelSchedulingHistoryBySessionSearchScope(session_id=self.session_id)
 
     @override
     def to_rbac_element_ref(self) -> RBACElementRef:
@@ -37,43 +63,21 @@ class KernelHistoryTarget(SearchableActionTarget):
         )
 
 
-@dataclass(frozen=True)
-class KernelKernelHistoryTarget(KernelHistoryTarget):
-    """Scope item narrowing the history to one kernel of the session.
-
-    The caller resolves ``kernel_id -> session_id`` first
-    (``ResolveKernelSessionAction``) and passes both in.
-    """
-
-    kernel_id: KernelId
-
-    @override
-    def to_search_scope(self) -> SearchScope:
-        return KernelSchedulingHistorySearchScope(kernel_id=self.kernel_id)
-
-
-@dataclass(frozen=True)
-class SessionKernelHistoryTarget(KernelHistoryTarget):
-    """Scope item covering the history of every kernel the session owns."""
-
-    @override
-    def to_search_scope(self) -> SearchScope:
-        return KernelSchedulingHistoryBySessionSearchScope(session_id=self.session_id)
-
-
 @dataclass
 class SearchKernelScopedHistoryAction(BaseScopeAction):
-    """Action to search kernel scheduling history within one session.
-
-    The session is the authorization subject, scope, and target: kernel
-    permission records are intentionally kept empty, so whoever may read the
-    session may read its kernels' scheduling history.
+    """Action to search kernel scheduling history under one scope item.
 
     This is still a single-target scope action, so it carries exactly one
     ``KernelHistoryTarget``.
     """
 
     target: KernelHistoryTarget
+    # TODO: Drop once virtual scopes land, and authorize on
+    # ``target.to_rbac_element_ref()`` instead. Kernels hold no permission
+    # records of their own, so the RBAC check has to be redirected to the owning
+    # session; a kernel-keyed caller must resolve ``kernel_id -> session_id``
+    # (``ResolveKernelSessionAction``) for no reason other than filling this in.
+    authorized_session_id: SessionId
     querier: BatchQuerier
 
     @override
@@ -92,22 +96,26 @@ class SearchKernelScopedHistoryAction(BaseScopeAction):
 
     @override
     def scope_id(self) -> str:
-        return str(self.target.session_id)
+        return str(self.authorized_session_id)
 
     @override
     def target_element(self) -> RBACElementRef:
-        return self.target.to_rbac_element_ref()
+        return RBACElementRef(
+            element_type=RBACElementType.SESSION,
+            element_id=str(self.authorized_session_id),
+        )
 
 
 @dataclass
 class SearchKernelScopedHistoryActionResult(BaseScopeActionResult):
-    """Result of searching kernel scheduling history within one session."""
+    """Result of searching kernel scheduling history under one scope item."""
 
     items: list[KernelSchedulingHistoryData]
     total_count: int
     has_next_page: bool
     has_previous_page: bool
     target: KernelHistoryTarget
+    authorized_session_id: SessionId
 
     @override
     def scope_type(self) -> ScopeType:
@@ -115,4 +123,4 @@ class SearchKernelScopedHistoryActionResult(BaseScopeActionResult):
 
     @override
     def scope_id(self) -> str:
-        return str(self.target.session_id)
+        return str(self.authorized_session_id)

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.permission.types import EntityType, RBACElementType, ScopeType
-from ai.backend.common.types import KernelId, SessionId
+from ai.backend.common.types import SessionId
 from ai.backend.manager.actions.action.scope import BaseScopeAction, BaseScopeActionResult
 from ai.backend.manager.actions.action.types import SearchableActionTarget
 from ai.backend.manager.actions.types import ActionOperationType
@@ -13,41 +13,19 @@ from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.models.scopes import SearchScope
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.scheduling_history.types import (
-    KernelKernelHistorySearchScope,
     SessionKernelHistorySearchScope,
 )
 
 
 @dataclass(frozen=True)
-class KernelHistoryTarget(SearchableActionTarget):
-    """One scope item of a kernel scheduling-history search.
+class SessionKernelHistoryTarget(SearchableActionTarget):
+    """Scope item covering the history of every kernel the session owns.
 
-    Each variant carries only the id its own dimension is keyed by and derives
-    both the row filter and the RBAC element ref from it.
+    The session is the only dimension kernel scheduling history can be scoped by
+    today: kernels hold no permission records of their own, so a caller asking
+    for one kernel is authorized on its owning session and narrows the rows back
+    down with a ``kernel_id`` query condition.
     """
-
-
-@dataclass(frozen=True)
-class KernelKernelHistoryTarget(KernelHistoryTarget):
-    """Scope item narrowing the history to one kernel."""
-
-    kernel_id: KernelId
-
-    @override
-    def to_search_scope(self) -> SearchScope:
-        return KernelKernelHistorySearchScope(kernel_id=self.kernel_id)
-
-    @override
-    def to_rbac_element_ref(self) -> RBACElementRef:
-        return RBACElementRef(
-            element_type=RBACElementType.KERNEL,
-            element_id=str(self.kernel_id),
-        )
-
-
-@dataclass(frozen=True)
-class SessionKernelHistoryTarget(KernelHistoryTarget):
-    """Scope item covering the history of every kernel the session owns."""
 
     session_id: SessionId
 
@@ -70,13 +48,7 @@ class SearchKernelScopedHistoryAction(BaseScopeAction):
     # TODO: Widen to a list of targets once this becomes a bulk action; the scope
     # input already accepts several items and means them to be OR'd, but a
     # BaseScopeAction authorizes exactly one target.
-    target: KernelHistoryTarget
-    # TODO: Drop once virtual scopes land, and authorize on
-    # ``target.to_rbac_element_ref()`` instead. Kernels hold no permission
-    # records of their own, so the RBAC check has to be redirected to the owning
-    # session; a kernel-keyed caller must resolve ``kernel_id -> session_id``
-    # (``ResolveKernelSessionAction``) for no reason other than filling this in.
-    _session_id: SessionId
+    target: SessionKernelHistoryTarget
     querier: BatchQuerier
 
     @override
@@ -95,14 +67,11 @@ class SearchKernelScopedHistoryAction(BaseScopeAction):
 
     @override
     def scope_id(self) -> str:
-        return str(self._session_id)
+        return str(self.target.session_id)
 
     @override
     def target_element(self) -> RBACElementRef:
-        return RBACElementRef(
-            element_type=RBACElementType.SESSION,
-            element_id=str(self._session_id),
-        )
+        return self.target.to_rbac_element_ref()
 
 
 @dataclass
@@ -113,8 +82,7 @@ class SearchKernelScopedHistoryActionResult(BaseScopeActionResult):
     total_count: int
     has_next_page: bool
     has_previous_page: bool
-    # TODO: Drop once virtual scopes land, together with the action's own field.
-    _session_id: SessionId
+    session_id: SessionId
 
     @override
     def scope_type(self) -> ScopeType:
@@ -122,4 +90,4 @@ class SearchKernelScopedHistoryActionResult(BaseScopeActionResult):
 
     @override
     def scope_id(self) -> str:
-        return str(self._session_id)
+        return str(self.session_id)

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.permission.types import EntityType, RBACElementType, ScopeType
-from ai.backend.common.types import SessionId
+from ai.backend.common.types import KernelId, SessionId
 from ai.backend.manager.actions.action.scope import BaseScopeAction, BaseScopeActionResult
 from ai.backend.manager.actions.action.types import SearchableActionTarget
 from ai.backend.manager.actions.types import ActionOperationType
@@ -13,19 +13,48 @@ from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.models.scopes import SearchScope
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.scheduling_history.types import (
+    KernelKernelHistorySearchScope,
     SessionKernelHistorySearchScope,
 )
 
 
 @dataclass(frozen=True)
-class SessionKernelHistoryTarget(SearchableActionTarget):
-    """Scope item covering the history of every kernel the session owns.
+class KernelHistoryTarget(SearchableActionTarget):
+    """One scope item of a kernel scheduling-history search.
 
-    The session is the only dimension kernel scheduling history can be scoped by
-    today: kernels hold no permission records of their own, so a caller asking
-    for one kernel is authorized on its owning session and narrows the rows back
-    down with a ``kernel_id`` query condition.
+    Each variant carries only the id its own dimension is keyed by and derives
+    both the row filter and the RBAC element ref from it.
     """
+
+
+@dataclass(frozen=True)
+class KernelKernelHistoryTarget(KernelHistoryTarget):
+    """Scope item narrowing the history to one kernel.
+
+    Not dispatchable yet: kernels hold no RBAC permission records of their own,
+    so the adapter converts a kernel scope item into a
+    ``SessionKernelHistoryTarget`` on the owning session and narrows the rows
+    back down with a ``kernel_id`` query condition. This is the target it must
+    pass once virtual scopes land.
+    """
+
+    kernel_id: KernelId
+
+    @override
+    def to_search_scope(self) -> SearchScope:
+        return KernelKernelHistorySearchScope(kernel_id=self.kernel_id)
+
+    @override
+    def to_rbac_element_ref(self) -> RBACElementRef:
+        return RBACElementRef(
+            element_type=RBACElementType.KERNEL,
+            element_id=str(self.kernel_id),
+        )
+
+
+@dataclass(frozen=True)
+class SessionKernelHistoryTarget(KernelHistoryTarget):
+    """Scope item covering the history of every kernel the session owns."""
 
     session_id: SessionId
 
@@ -48,7 +77,7 @@ class SearchKernelScopedHistoryAction(BaseScopeAction):
     # TODO: Widen to a list of targets once this becomes a bulk action; the scope
     # input already accepts several items and means them to be OR'd, but a
     # BaseScopeAction authorizes exactly one target.
-    target: SessionKernelHistoryTarget
+    target: KernelHistoryTarget
     querier: BatchQuerier
 
     @override
@@ -63,11 +92,13 @@ class SearchKernelScopedHistoryAction(BaseScopeAction):
 
     @override
     def scope_type(self) -> ScopeType:
+        # TODO: Derive from the target once a KernelKernelHistoryTarget becomes
+        # dispatchable; the session is the only scope a caller can reach today.
         return ScopeType.SESSION
 
     @override
     def scope_id(self) -> str:
-        return str(self.target.session_id)
+        return self.target.to_rbac_element_ref().element_id
 
     @override
     def target_element(self) -> RBACElementRef:
@@ -82,7 +113,7 @@ class SearchKernelScopedHistoryActionResult(BaseScopeActionResult):
     total_count: int
     has_next_page: bool
     has_previous_page: bool
-    session_id: SessionId
+    target: KernelHistoryTarget
 
     @override
     def scope_type(self) -> ScopeType:
@@ -90,4 +121,4 @@ class SearchKernelScopedHistoryActionResult(BaseScopeActionResult):
 
     @override
     def scope_id(self) -> str:
-        return str(self.session_id)
+        return self.target.to_rbac_element_ref().element_id

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
@@ -113,7 +113,7 @@ class SearchKernelScopedHistoryActionResult(BaseScopeActionResult):
     total_count: int
     has_next_page: bool
     has_previous_page: bool
-    target: KernelHistoryTarget
+    # TODO: Drop once virtual scopes land, together with the action's own field.
     _session_id: SessionId
 
     @override

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
@@ -14,16 +14,20 @@ from ai.backend.manager.repositories.base import BatchQuerier
 
 @dataclass
 class SearchKernelScopedHistoryAction(BaseScopeAction):
-    """Action to search the scheduling history of one kernel.
+    """Action to search kernel scheduling history within one session.
 
-    The owning session is the authorization subject, scope, and target: kernel
+    The session is the authorization subject, scope, and target: kernel
     permission records are intentionally kept empty, so whoever may read the
-    session may read its kernels' scheduling history. The caller resolves
-    ``kernel_id -> session_id`` first (``ResolveKernelSessionAction``) and
-    passes both in; ``kernel_id`` bounds the repository query.
+    session may read its kernels' scheduling history.
+
+    ``kernel_id`` only bounds the repository query. When the caller scopes by
+    kernel it resolves ``kernel_id -> session_id`` first
+    (``ResolveKernelSessionAction``) and passes both in; when it scopes by
+    session it passes ``kernel_id=None`` and the history of every kernel in the
+    session is returned.
     """
 
-    kernel_id: KernelId
+    kernel_id: KernelId | None
     session_id: SessionId
     querier: BatchQuerier
 
@@ -55,13 +59,13 @@ class SearchKernelScopedHistoryAction(BaseScopeAction):
 
 @dataclass
 class SearchKernelScopedHistoryActionResult(BaseScopeActionResult):
-    """Result of searching the scheduling history of one kernel."""
+    """Result of searching kernel scheduling history within one session."""
 
     items: list[KernelSchedulingHistoryData]
     total_count: int
     has_next_page: bool
     has_previous_page: bool
-    kernel_id: KernelId
+    kernel_id: KernelId | None
     session_id: SessionId
 
     @override

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
@@ -6,10 +6,59 @@ from typing import override
 from ai.backend.common.data.permission.types import EntityType, RBACElementType, ScopeType
 from ai.backend.common.types import KernelId, SessionId
 from ai.backend.manager.actions.action.scope import BaseScopeAction, BaseScopeActionResult
+from ai.backend.manager.actions.action.types import SearchableActionTarget
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.kernel.types import KernelSchedulingHistoryData
 from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.models.scopes import SearchScope
 from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.repositories.scheduling_history.types import (
+    KernelSchedulingHistoryBySessionSearchScope,
+    KernelSchedulingHistorySearchScope,
+)
+
+
+@dataclass(frozen=True)
+class KernelSchedulingHistoryTarget(SearchableActionTarget):
+    """Scope item of a kernel scheduling-history search.
+
+    The owning session is the authorization subject of every variant, so
+    ``session_id`` alone decides the RBAC element ref; each variant only differs
+    in how far ``to_search_scope()`` narrows the rows.
+    """
+
+    session_id: SessionId
+
+    @override
+    def to_rbac_element_ref(self) -> RBACElementRef:
+        return RBACElementRef(
+            element_type=RBACElementType.SESSION,
+            element_id=str(self.session_id),
+        )
+
+
+@dataclass(frozen=True)
+class KernelSchedulingHistoryByKernelTarget(KernelSchedulingHistoryTarget):
+    """Scope item narrowing the history to one kernel of the session.
+
+    The caller resolves ``kernel_id -> session_id`` first
+    (``ResolveKernelSessionAction``) and passes both in.
+    """
+
+    kernel_id: KernelId
+
+    @override
+    def to_search_scope(self) -> SearchScope:
+        return KernelSchedulingHistorySearchScope(kernel_id=self.kernel_id)
+
+
+@dataclass(frozen=True)
+class KernelSchedulingHistoryBySessionTarget(KernelSchedulingHistoryTarget):
+    """Scope item covering the history of every kernel the session owns."""
+
+    @override
+    def to_search_scope(self) -> SearchScope:
+        return KernelSchedulingHistoryBySessionSearchScope(session_id=self.session_id)
 
 
 @dataclass
@@ -20,15 +69,11 @@ class SearchKernelScopedHistoryAction(BaseScopeAction):
     permission records are intentionally kept empty, so whoever may read the
     session may read its kernels' scheduling history.
 
-    ``kernel_id`` only bounds the repository query. When the caller scopes by
-    kernel it resolves ``kernel_id -> session_id`` first
-    (``ResolveKernelSessionAction``) and passes both in; when it scopes by
-    session it passes ``kernel_id=None`` and the history of every kernel in the
-    session is returned.
+    This is still a single-target scope action, so it carries exactly one
+    ``KernelSchedulingHistoryTarget``.
     """
 
-    kernel_id: KernelId | None
-    session_id: SessionId
+    target: KernelSchedulingHistoryTarget
     querier: BatchQuerier
 
     @override
@@ -47,14 +92,11 @@ class SearchKernelScopedHistoryAction(BaseScopeAction):
 
     @override
     def scope_id(self) -> str:
-        return str(self.session_id)
+        return str(self.target.session_id)
 
     @override
     def target_element(self) -> RBACElementRef:
-        return RBACElementRef(
-            element_type=RBACElementType.SESSION,
-            element_id=str(self.session_id),
-        )
+        return self.target.to_rbac_element_ref()
 
 
 @dataclass
@@ -65,8 +107,7 @@ class SearchKernelScopedHistoryActionResult(BaseScopeActionResult):
     total_count: int
     has_next_page: bool
     has_previous_page: bool
-    kernel_id: KernelId | None
-    session_id: SessionId
+    target: KernelSchedulingHistoryTarget
 
     @override
     def scope_type(self) -> ScopeType:
@@ -74,4 +115,4 @@ class SearchKernelScopedHistoryActionResult(BaseScopeActionResult):
 
     @override
     def scope_id(self) -> str:
-        return str(self.session_id)
+        return str(self.target.session_id)

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
@@ -19,7 +19,7 @@ from ai.backend.manager.repositories.scheduling_history.types import (
 
 
 @dataclass(frozen=True)
-class KernelSchedulingHistoryTarget(SearchableActionTarget):
+class KernelHistoryTarget(SearchableActionTarget):
     """Scope item of a kernel scheduling-history search.
 
     The owning session is the authorization subject of every variant, so
@@ -38,7 +38,7 @@ class KernelSchedulingHistoryTarget(SearchableActionTarget):
 
 
 @dataclass(frozen=True)
-class KernelSchedulingHistoryByKernelTarget(KernelSchedulingHistoryTarget):
+class KernelKernelHistoryTarget(KernelHistoryTarget):
     """Scope item narrowing the history to one kernel of the session.
 
     The caller resolves ``kernel_id -> session_id`` first
@@ -53,7 +53,7 @@ class KernelSchedulingHistoryByKernelTarget(KernelSchedulingHistoryTarget):
 
 
 @dataclass(frozen=True)
-class KernelSchedulingHistoryBySessionTarget(KernelSchedulingHistoryTarget):
+class SessionKernelHistoryTarget(KernelHistoryTarget):
     """Scope item covering the history of every kernel the session owns."""
 
     @override
@@ -70,10 +70,10 @@ class SearchKernelScopedHistoryAction(BaseScopeAction):
     session may read its kernels' scheduling history.
 
     This is still a single-target scope action, so it carries exactly one
-    ``KernelSchedulingHistoryTarget``.
+    ``KernelHistoryTarget``.
     """
 
-    target: KernelSchedulingHistoryTarget
+    target: KernelHistoryTarget
     querier: BatchQuerier
 
     @override
@@ -107,7 +107,7 @@ class SearchKernelScopedHistoryActionResult(BaseScopeActionResult):
     total_count: int
     has_next_page: bool
     has_previous_page: bool
-    target: KernelSchedulingHistoryTarget
+    target: KernelHistoryTarget
 
     @override
     def scope_type(self) -> ScopeType:

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
@@ -13,8 +13,8 @@ from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.models.scopes import SearchScope
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.scheduling_history.types import (
-    KernelSchedulingHistoryBySessionSearchScope,
-    KernelSchedulingHistorySearchScope,
+    KernelKernelHistorySearchScope,
+    SessionKernelHistorySearchScope,
 )
 
 
@@ -35,7 +35,7 @@ class KernelKernelHistoryTarget(KernelHistoryTarget):
 
     @override
     def to_search_scope(self) -> SearchScope:
-        return KernelSchedulingHistorySearchScope(kernel_id=self.kernel_id)
+        return KernelKernelHistorySearchScope(kernel_id=self.kernel_id)
 
     @override
     def to_rbac_element_ref(self) -> RBACElementRef:
@@ -53,7 +53,7 @@ class SessionKernelHistoryTarget(KernelHistoryTarget):
 
     @override
     def to_search_scope(self) -> SearchScope:
-        return KernelSchedulingHistoryBySessionSearchScope(session_id=self.session_id)
+        return SessionKernelHistorySearchScope(session_id=self.session_id)
 
     @override
     def to_rbac_element_ref(self) -> RBACElementRef:

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
@@ -76,7 +76,7 @@ class SearchKernelScopedHistoryAction(BaseScopeAction):
     # records of their own, so the RBAC check has to be redirected to the owning
     # session; a kernel-keyed caller must resolve ``kernel_id -> session_id``
     # (``ResolveKernelSessionAction``) for no reason other than filling this in.
-    authorized_session_id: SessionId
+    _session_id: SessionId
     querier: BatchQuerier
 
     @override
@@ -95,13 +95,13 @@ class SearchKernelScopedHistoryAction(BaseScopeAction):
 
     @override
     def scope_id(self) -> str:
-        return str(self.authorized_session_id)
+        return str(self._session_id)
 
     @override
     def target_element(self) -> RBACElementRef:
         return RBACElementRef(
             element_type=RBACElementType.SESSION,
-            element_id=str(self.authorized_session_id),
+            element_id=str(self._session_id),
         )
 
 
@@ -114,7 +114,7 @@ class SearchKernelScopedHistoryActionResult(BaseScopeActionResult):
     has_next_page: bool
     has_previous_page: bool
     target: KernelHistoryTarget
-    authorized_session_id: SessionId
+    _session_id: SessionId
 
     @override
     def scope_type(self) -> ScopeType:
@@ -122,4 +122,4 @@ class SearchKernelScopedHistoryActionResult(BaseScopeActionResult):
 
     @override
     def scope_id(self) -> str:
-        return str(self.authorized_session_id)
+        return str(self._session_id)

--- a/src/ai/backend/manager/services/scheduling_history/service.py
+++ b/src/ai/backend/manager/services/scheduling_history/service.py
@@ -158,7 +158,7 @@ class SchedulingHistoryService:
             scope = KernelSchedulingHistoryBySessionSearchScope(session_id=action.session_id)
         result = await self._repository.search_kernel_scoped_history(
             querier=action.querier,
-            scope=scope,
+            scopes=[scope],
         )
 
         return SearchKernelScopedHistoryActionResult(

--- a/src/ai/backend/manager/services/scheduling_history/service.py
+++ b/src/ai/backend/manager/services/scheduling_history/service.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from ai.backend.manager.models.scopes import SearchScope
 from ai.backend.manager.repositories.scheduling_history import SchedulingHistoryRepository
 from ai.backend.manager.repositories.scheduling_history.types import (
+    KernelSchedulingHistoryBySessionSearchScope,
     KernelSchedulingHistorySearchScope,
 )
 
@@ -149,9 +151,14 @@ class SchedulingHistoryService:
         action: SearchKernelScopedHistoryAction,
     ) -> SearchKernelScopedHistoryActionResult:
         """Searches kernel scheduling history within the caller's authorized scopes."""
+        scope: SearchScope
+        if action.kernel_id is not None:
+            scope = KernelSchedulingHistorySearchScope(kernel_id=action.kernel_id)
+        else:
+            scope = KernelSchedulingHistoryBySessionSearchScope(session_id=action.session_id)
         result = await self._repository.search_kernel_scoped_history(
             querier=action.querier,
-            scope=KernelSchedulingHistorySearchScope(kernel_id=action.kernel_id),
+            scope=scope,
         )
 
         return SearchKernelScopedHistoryActionResult(

--- a/src/ai/backend/manager/services/scheduling_history/service.py
+++ b/src/ai/backend/manager/services/scheduling_history/service.py
@@ -157,6 +157,7 @@ class SchedulingHistoryService:
             has_next_page=result.has_next_page,
             has_previous_page=result.has_previous_page,
             target=action.target,
+            authorized_session_id=action.authorized_session_id,
         )
 
     async def search_deployment_scoped_history(

--- a/src/ai/backend/manager/services/scheduling_history/service.py
+++ b/src/ai/backend/manager/services/scheduling_history/service.py
@@ -157,7 +157,7 @@ class SchedulingHistoryService:
             has_next_page=result.has_next_page,
             has_previous_page=result.has_previous_page,
             target=action.target,
-            authorized_session_id=action.authorized_session_id,
+            _session_id=action._session_id,
         )
 
     async def search_deployment_scoped_history(

--- a/src/ai/backend/manager/services/scheduling_history/service.py
+++ b/src/ai/backend/manager/services/scheduling_history/service.py
@@ -156,7 +156,7 @@ class SchedulingHistoryService:
             total_count=result.total_count,
             has_next_page=result.has_next_page,
             has_previous_page=result.has_previous_page,
-            _session_id=action._session_id,
+            session_id=action.target.session_id,
         )
 
     async def search_deployment_scoped_history(

--- a/src/ai/backend/manager/services/scheduling_history/service.py
+++ b/src/ai/backend/manager/services/scheduling_history/service.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 
-from ai.backend.manager.models.scopes import SearchScope
 from ai.backend.manager.repositories.scheduling_history import SchedulingHistoryRepository
-from ai.backend.manager.repositories.scheduling_history.types import (
-    KernelSchedulingHistoryBySessionSearchScope,
-    KernelSchedulingHistorySearchScope,
-)
 
 from .actions.resolve_kernel_session import (
     ResolveKernelSessionAction,
@@ -151,14 +146,9 @@ class SchedulingHistoryService:
         action: SearchKernelScopedHistoryAction,
     ) -> SearchKernelScopedHistoryActionResult:
         """Searches kernel scheduling history within the caller's authorized scopes."""
-        scope: SearchScope
-        if action.kernel_id is not None:
-            scope = KernelSchedulingHistorySearchScope(kernel_id=action.kernel_id)
-        else:
-            scope = KernelSchedulingHistoryBySessionSearchScope(session_id=action.session_id)
         result = await self._repository.search_kernel_scoped_history(
             querier=action.querier,
-            scopes=[scope],
+            scopes=[action.target.to_search_scope()],
         )
 
         return SearchKernelScopedHistoryActionResult(
@@ -166,8 +156,7 @@ class SchedulingHistoryService:
             total_count=result.total_count,
             has_next_page=result.has_next_page,
             has_previous_page=result.has_previous_page,
-            kernel_id=action.kernel_id,
-            session_id=action.session_id,
+            target=action.target,
         )
 
     async def search_deployment_scoped_history(

--- a/src/ai/backend/manager/services/scheduling_history/service.py
+++ b/src/ai/backend/manager/services/scheduling_history/service.py
@@ -156,7 +156,6 @@ class SchedulingHistoryService:
             total_count=result.total_count,
             has_next_page=result.has_next_page,
             has_previous_page=result.has_previous_page,
-            target=action.target,
             _session_id=action._session_id,
         )
 

--- a/src/ai/backend/manager/services/scheduling_history/service.py
+++ b/src/ai/backend/manager/services/scheduling_history/service.py
@@ -156,7 +156,7 @@ class SchedulingHistoryService:
             total_count=result.total_count,
             has_next_page=result.has_next_page,
             has_previous_page=result.has_previous_page,
-            session_id=action.target.session_id,
+            target=action.target,
         )
 
     async def search_deployment_scoped_history(

--- a/tests/unit/manager/services/scheduling_history/test_scheduling_history_service.py
+++ b/tests/unit/manager/services/scheduling_history/test_scheduling_history_service.py
@@ -5,7 +5,6 @@ Tests the service layer with mocked repositories.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import datetime
 from unittest.mock import MagicMock, create_autospec
 from uuid import UUID, uuid4
@@ -36,13 +35,11 @@ from ai.backend.manager.data.session.types import (
     SessionSchedulingHistoryData,
     SessionSchedulingHistoryListResult,
 )
-from ai.backend.manager.models.scopes import SearchScope
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.base.pagination import NoPagination
 from ai.backend.manager.repositories.scheduling_history import SchedulingHistoryRepository
 from ai.backend.manager.repositories.scheduling_history.types import (
     DeploymentHistorySearchScope,
-    KernelKernelHistorySearchScope,
     RouteHistorySearchScope,
     SessionKernelHistorySearchScope,
     SessionSchedulingHistorySearchScope,
@@ -60,8 +57,6 @@ from ai.backend.manager.services.scheduling_history.actions.search_kernel_histor
     SearchKernelHistoryAction,
 )
 from ai.backend.manager.services.scheduling_history.actions.search_kernel_scoped_history import (
-    KernelHistoryTarget,
-    KernelKernelHistoryTarget,
     SearchKernelScopedHistoryAction,
     SessionKernelHistoryTarget,
 )
@@ -80,7 +75,6 @@ from ai.backend.manager.services.scheduling_history.actions.search_session_scope
 from ai.backend.manager.services.scheduling_history.service import SchedulingHistoryService
 
 _NOW = datetime.now(tz=tzutc())
-_KERNEL_ID = KernelId(UUID("fa6a3549-2020-43c5-b451-a9a3d7309732"))
 _SESSION_ID = SessionId(UUID("6ad4b5d1-3a4e-4a1f-9f6a-1c4a3f9d2b70"))
 
 
@@ -387,33 +381,9 @@ class TestResolveKernelSessionAction:
         mock_repository.resolve_session_id.assert_awaited_once_with(kernel_id)
 
 
-@dataclass(frozen=True)
-class _KernelScopedHistoryCase:
-    label: str
-    target: KernelHistoryTarget
-    expected_scope: SearchScope
-
-
 class TestSearchKernelScopedHistoryAction:
-    @pytest.mark.parametrize(
-        "case",
-        [
-            _KernelScopedHistoryCase(
-                label="bound-to-kernel",
-                target=KernelKernelHistoryTarget(kernel_id=_KERNEL_ID),
-                expected_scope=KernelKernelHistorySearchScope(kernel_id=_KERNEL_ID),
-            ),
-            _KernelScopedHistoryCase(
-                label="bound-to-session",
-                target=SessionKernelHistoryTarget(session_id=_SESSION_ID),
-                expected_scope=SessionKernelHistorySearchScope(session_id=_SESSION_ID),
-            ),
-        ],
-        ids=lambda case: case.label,
-    )
-    async def test_scopes_to_the_owning_session_and_narrows_by_the_target(
+    async def test_scopes_to_the_session_owning_the_kernels(
         self,
-        case: _KernelScopedHistoryCase,
         service: SchedulingHistoryService,
         mock_repository: MagicMock,
         querier: BatchQuerier,
@@ -429,14 +399,13 @@ class TestSearchKernelScopedHistoryAction:
         )
 
         action = SearchKernelScopedHistoryAction(
-            target=case.target, _session_id=_SESSION_ID, querier=querier
+            target=SessionKernelHistoryTarget(session_id=_SESSION_ID), querier=querier
         )
         result = await service.search_kernel_scoped_history(action)
 
         assert result.items == [history_item]
         # Authorized via session read: kernel permission records are intentionally
-        # empty, so the RBAC check is redirected to the session for every target
-        # variant; the target only narrows the repository query.
+        # empty, so the session is the subject, scope, and target of the RBAC check.
         assert action.target_element() == RBACElementRef(
             element_type=RBACElementType.SESSION, element_id=str(_SESSION_ID)
         )
@@ -445,5 +414,5 @@ class TestSearchKernelScopedHistoryAction:
         assert action.entity_type() is EntityType.SESSION
         mock_repository.search_kernel_scoped_history.assert_awaited_once_with(
             querier=querier,
-            scopes=[case.expected_scope],
+            scopes=[SessionKernelHistorySearchScope(session_id=_SESSION_ID)],
         )

--- a/tests/unit/manager/services/scheduling_history/test_scheduling_history_service.py
+++ b/tests/unit/manager/services/scheduling_history/test_scheduling_history_service.py
@@ -400,9 +400,7 @@ class TestSearchKernelScopedHistoryAction:
         [
             _KernelScopedHistoryCase(
                 label="bound-to-kernel",
-                target=KernelKernelHistoryTarget(
-                    session_id=_SESSION_ID, kernel_id=_KERNEL_ID
-                ),
+                target=KernelKernelHistoryTarget(kernel_id=_KERNEL_ID),
                 expected_scope=KernelSchedulingHistorySearchScope(kernel_id=_KERNEL_ID),
             ),
             _KernelScopedHistoryCase(
@@ -430,13 +428,15 @@ class TestSearchKernelScopedHistoryAction:
             )
         )
 
-        action = SearchKernelScopedHistoryAction(target=case.target, querier=querier)
+        action = SearchKernelScopedHistoryAction(
+            target=case.target, authorized_session_id=_SESSION_ID, querier=querier
+        )
         result = await service.search_kernel_scoped_history(action)
 
         assert result.items == [history_item]
         # Authorized via session read: kernel permission records are intentionally
-        # empty, so the session is the subject, scope, and target of the RBAC check
-        # for every target variant; the target only narrows the repository query.
+        # empty, so the RBAC check is redirected to the session for every target
+        # variant; the target only narrows the repository query.
         assert action.target_element() == RBACElementRef(
             element_type=RBACElementType.SESSION, element_id=str(_SESSION_ID)
         )

--- a/tests/unit/manager/services/scheduling_history/test_scheduling_history_service.py
+++ b/tests/unit/manager/services/scheduling_history/test_scheduling_history_service.py
@@ -42,9 +42,9 @@ from ai.backend.manager.repositories.base.pagination import NoPagination
 from ai.backend.manager.repositories.scheduling_history import SchedulingHistoryRepository
 from ai.backend.manager.repositories.scheduling_history.types import (
     DeploymentHistorySearchScope,
-    KernelSchedulingHistoryBySessionSearchScope,
-    KernelSchedulingHistorySearchScope,
+    KernelKernelHistorySearchScope,
     RouteHistorySearchScope,
+    SessionKernelHistorySearchScope,
     SessionSchedulingHistorySearchScope,
 )
 from ai.backend.manager.services.scheduling_history.actions.resolve_kernel_session import (
@@ -401,12 +401,12 @@ class TestSearchKernelScopedHistoryAction:
             _KernelScopedHistoryCase(
                 label="bound-to-kernel",
                 target=KernelKernelHistoryTarget(kernel_id=_KERNEL_ID),
-                expected_scope=KernelSchedulingHistorySearchScope(kernel_id=_KERNEL_ID),
+                expected_scope=KernelKernelHistorySearchScope(kernel_id=_KERNEL_ID),
             ),
             _KernelScopedHistoryCase(
                 label="bound-to-session",
                 target=SessionKernelHistoryTarget(session_id=_SESSION_ID),
-                expected_scope=KernelSchedulingHistoryBySessionSearchScope(session_id=_SESSION_ID),
+                expected_scope=SessionKernelHistorySearchScope(session_id=_SESSION_ID),
             ),
         ],
         ids=lambda case: case.label,

--- a/tests/unit/manager/services/scheduling_history/test_scheduling_history_service.py
+++ b/tests/unit/manager/services/scheduling_history/test_scheduling_history_service.py
@@ -429,7 +429,7 @@ class TestSearchKernelScopedHistoryAction:
         )
 
         action = SearchKernelScopedHistoryAction(
-            target=case.target, authorized_session_id=_SESSION_ID, querier=querier
+            target=case.target, _session_id=_SESSION_ID, querier=querier
         )
         result = await service.search_kernel_scoped_history(action)
 

--- a/tests/unit/manager/services/scheduling_history/test_scheduling_history_service.py
+++ b/tests/unit/manager/services/scheduling_history/test_scheduling_history_service.py
@@ -5,9 +5,10 @@ Tests the service layer with mocked repositories.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from unittest.mock import MagicMock, create_autospec
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from dateutil.tz import tzutc
@@ -35,11 +36,13 @@ from ai.backend.manager.data.session.types import (
     SessionSchedulingHistoryData,
     SessionSchedulingHistoryListResult,
 )
+from ai.backend.manager.models.scopes import SearchScope
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.base.pagination import NoPagination
 from ai.backend.manager.repositories.scheduling_history import SchedulingHistoryRepository
 from ai.backend.manager.repositories.scheduling_history.types import (
     DeploymentHistorySearchScope,
+    KernelSchedulingHistoryBySessionSearchScope,
     KernelSchedulingHistorySearchScope,
     RouteHistorySearchScope,
     SessionSchedulingHistorySearchScope,
@@ -74,6 +77,8 @@ from ai.backend.manager.services.scheduling_history.actions.search_session_scope
 from ai.backend.manager.services.scheduling_history.service import SchedulingHistoryService
 
 _NOW = datetime.now(tz=tzutc())
+_KERNEL_ID = KernelId(UUID("fa6a3549-2020-43c5-b451-a9a3d7309732"))
+_SESSION_ID = SessionId(UUID("6ad4b5d1-3a4e-4a1f-9f6a-1c4a3f9d2b70"))
 
 
 @pytest.fixture
@@ -379,9 +384,33 @@ class TestResolveKernelSessionAction:
         mock_repository.resolve_session_id.assert_awaited_once_with(kernel_id)
 
 
+@dataclass(frozen=True)
+class _KernelScopedHistoryCase:
+    label: str
+    kernel_id: KernelId | None
+    expected_scope: SearchScope
+
+
 class TestSearchKernelScopedHistoryAction:
-    async def test_scopes_to_the_owning_session_and_narrows_to_the_kernel(
+    @pytest.mark.parametrize(
+        "case",
+        [
+            _KernelScopedHistoryCase(
+                label="bound-to-kernel",
+                kernel_id=_KERNEL_ID,
+                expected_scope=KernelSchedulingHistorySearchScope(kernel_id=_KERNEL_ID),
+            ),
+            _KernelScopedHistoryCase(
+                label="bound-to-session",
+                kernel_id=None,
+                expected_scope=KernelSchedulingHistoryBySessionSearchScope(session_id=_SESSION_ID),
+            ),
+        ],
+        ids=lambda case: case.label,
+    )
+    async def test_scopes_to_the_owning_session_and_narrows_by_the_query_bound(
         self,
+        case: _KernelScopedHistoryCase,
         service: SchedulingHistoryService,
         mock_repository: MagicMock,
         querier: BatchQuerier,
@@ -395,25 +424,23 @@ class TestSearchKernelScopedHistoryAction:
                 has_previous_page=False,
             )
         )
-        kernel_id = KernelId(uuid4())
-        session_id = SessionId(uuid4())
 
         action = SearchKernelScopedHistoryAction(
-            kernel_id=kernel_id, session_id=session_id, querier=querier
+            kernel_id=case.kernel_id, session_id=_SESSION_ID, querier=querier
         )
         result = await service.search_kernel_scoped_history(action)
 
         assert result.items == [history_item]
         # Authorized via session read: kernel permission records are intentionally
-        # empty, so the owning session is the subject, scope, and target of the
-        # RBAC check; kernel_id bounds the repository query.
+        # empty, so the session is the subject, scope, and target of the RBAC check
+        # in both cases; kernel_id only bounds the repository query.
         assert action.target_element() == RBACElementRef(
-            element_type=RBACElementType.SESSION, element_id=str(session_id)
+            element_type=RBACElementType.SESSION, element_id=str(_SESSION_ID)
         )
         assert action.scope_type() is ScopeType.SESSION
-        assert action.scope_id() == str(session_id)
+        assert action.scope_id() == str(_SESSION_ID)
         assert action.entity_type() is EntityType.SESSION
         mock_repository.search_kernel_scoped_history.assert_awaited_once_with(
             querier=querier,
-            scope=KernelSchedulingHistorySearchScope(kernel_id=kernel_id),
+            scopes=[case.expected_scope],
         )

--- a/tests/unit/manager/services/scheduling_history/test_scheduling_history_service.py
+++ b/tests/unit/manager/services/scheduling_history/test_scheduling_history_service.py
@@ -60,6 +60,9 @@ from ai.backend.manager.services.scheduling_history.actions.search_kernel_histor
     SearchKernelHistoryAction,
 )
 from ai.backend.manager.services.scheduling_history.actions.search_kernel_scoped_history import (
+    KernelSchedulingHistoryByKernelTarget,
+    KernelSchedulingHistoryBySessionTarget,
+    KernelSchedulingHistoryTarget,
     SearchKernelScopedHistoryAction,
 )
 from ai.backend.manager.services.scheduling_history.actions.search_route_history import (
@@ -387,7 +390,7 @@ class TestResolveKernelSessionAction:
 @dataclass(frozen=True)
 class _KernelScopedHistoryCase:
     label: str
-    kernel_id: KernelId | None
+    target: KernelSchedulingHistoryTarget
     expected_scope: SearchScope
 
 
@@ -397,18 +400,20 @@ class TestSearchKernelScopedHistoryAction:
         [
             _KernelScopedHistoryCase(
                 label="bound-to-kernel",
-                kernel_id=_KERNEL_ID,
+                target=KernelSchedulingHistoryByKernelTarget(
+                    session_id=_SESSION_ID, kernel_id=_KERNEL_ID
+                ),
                 expected_scope=KernelSchedulingHistorySearchScope(kernel_id=_KERNEL_ID),
             ),
             _KernelScopedHistoryCase(
                 label="bound-to-session",
-                kernel_id=None,
+                target=KernelSchedulingHistoryBySessionTarget(session_id=_SESSION_ID),
                 expected_scope=KernelSchedulingHistoryBySessionSearchScope(session_id=_SESSION_ID),
             ),
         ],
         ids=lambda case: case.label,
     )
-    async def test_scopes_to_the_owning_session_and_narrows_by_the_query_bound(
+    async def test_scopes_to_the_owning_session_and_narrows_by_the_target(
         self,
         case: _KernelScopedHistoryCase,
         service: SchedulingHistoryService,
@@ -425,15 +430,13 @@ class TestSearchKernelScopedHistoryAction:
             )
         )
 
-        action = SearchKernelScopedHistoryAction(
-            kernel_id=case.kernel_id, session_id=_SESSION_ID, querier=querier
-        )
+        action = SearchKernelScopedHistoryAction(target=case.target, querier=querier)
         result = await service.search_kernel_scoped_history(action)
 
         assert result.items == [history_item]
         # Authorized via session read: kernel permission records are intentionally
         # empty, so the session is the subject, scope, and target of the RBAC check
-        # in both cases; kernel_id only bounds the repository query.
+        # for every target variant; the target only narrows the repository query.
         assert action.target_element() == RBACElementRef(
             element_type=RBACElementType.SESSION, element_id=str(_SESSION_ID)
         )

--- a/tests/unit/manager/services/scheduling_history/test_scheduling_history_service.py
+++ b/tests/unit/manager/services/scheduling_history/test_scheduling_history_service.py
@@ -60,10 +60,10 @@ from ai.backend.manager.services.scheduling_history.actions.search_kernel_histor
     SearchKernelHistoryAction,
 )
 from ai.backend.manager.services.scheduling_history.actions.search_kernel_scoped_history import (
-    KernelSchedulingHistoryByKernelTarget,
-    KernelSchedulingHistoryBySessionTarget,
-    KernelSchedulingHistoryTarget,
+    KernelHistoryTarget,
+    KernelKernelHistoryTarget,
     SearchKernelScopedHistoryAction,
+    SessionKernelHistoryTarget,
 )
 from ai.backend.manager.services.scheduling_history.actions.search_route_history import (
     SearchRouteHistoryAction,
@@ -390,7 +390,7 @@ class TestResolveKernelSessionAction:
 @dataclass(frozen=True)
 class _KernelScopedHistoryCase:
     label: str
-    target: KernelSchedulingHistoryTarget
+    target: KernelHistoryTarget
     expected_scope: SearchScope
 
 
@@ -400,14 +400,14 @@ class TestSearchKernelScopedHistoryAction:
         [
             _KernelScopedHistoryCase(
                 label="bound-to-kernel",
-                target=KernelSchedulingHistoryByKernelTarget(
+                target=KernelKernelHistoryTarget(
                     session_id=_SESSION_ID, kernel_id=_KERNEL_ID
                 ),
                 expected_scope=KernelSchedulingHistorySearchScope(kernel_id=_KERNEL_ID),
             ),
             _KernelScopedHistoryCase(
                 label="bound-to-session",
-                target=KernelSchedulingHistoryBySessionTarget(session_id=_SESSION_ID),
+                target=SessionKernelHistoryTarget(session_id=_SESSION_ID),
                 expected_scope=KernelSchedulingHistoryBySessionSearchScope(session_id=_SESSION_ID),
             ),
         ],


### PR DESCRIPTION
## Summary

Reshape the scoped kernel scheduling-history scope input from a bare `kernel_id: UUID` into category-keyed lists of scope items, mirroring `AuditLogScope`, and add a **session** category so the history of every kernel a session owns can be queried in one call.

| Layer | Before | After |
| --- | --- | --- |
| `KernelHistoryScopeDTO` | `kernel_id: UUID` | `kernel: list[UUIDScope] \| None`, `session: list[UUIDScope] \| None` |
| `KernelScope` (GraphQL) | `kernelId: UUID!` | `kernel: [UUIDScope!]`, `session: [UUIDScope!]` |
| `ScopedSearchKernelHistoriesInput` (REST v2) | `{"scope": {"kernel_id": "..."}}` | `{"scope": {"kernel": [{"value": "..."}]}}` or `{"scope": {"session": [{"value": "..."}]}}` |
| `SearchKernelScopedHistoryAction` | `kernel_id` + `session_id` | one `KernelHistoryTarget` |
| `SchedulingHistoryRepository.search_kernel_scoped_history` | `scope: KernelSchedulingHistorySearchScope` | `scopes: Sequence[SearchScope]` |

`KernelScope` is unreleased (`added_version` is the next release), so widening the field is not a breaking change.

## Scope items are `SearchableActionTarget`s

Each scope category maps to its own target, the same shape the audit-log scoped search uses (`EntityAuditLogTarget` / `TriggeredByAuditLogTarget`). A target derives both the row filter and its own RBAC element ref, so adding a category is adding a class — no branching in the service:

```
KernelHistoryTarget(SearchableActionTarget)
├── KernelKernelHistoryTarget(kernel_id)   → KernelKernelHistorySearchScope,   RBACElementRef(KERNEL, …)
└── SessionKernelHistoryTarget(session_id) → SessionKernelHistorySearchScope,  RBACElementRef(SESSION, …)
```

The repository takes `Sequence[SearchScope]` — the db source already wrapped the single scope into a one-element list for `execute_batch_querier` — so OR-ing several scope items later needs no signature change.

## What is temporary, and marked as such

Two current-implementation constraints are carried explicitly with `TODO`s rather than folded into the design:

- **Kernels hold no RBAC permission records.** `KernelKernelHistoryTarget` is therefore not dispatchable yet: the adapter converts a kernel scope item into a `SessionKernelHistoryTarget` on the owning session (via `ResolveKernelSessionAction`) and narrows the rows back down with a `kernel_id` query condition. Rows returned are identical to before. The kernel target and its search scope stay in the tree as the shape to switch to once virtual scopes land.
- **`SearchKernelScopedHistoryAction` is a single-target `BaseScopeAction`.** The scope input is already list-shaped and its items are meant to be OR'd, so the adapter rejects a scope carrying two or more items; both the rejection and the single `target` field go away when this becomes a bulk action.

Empty scopes are rejected by the DTO validator.

## Test plan
- [x] Service-layer unit test covers the session-scoped search (target → search scope → repository call, RBAC scope/target/entity type)
- [x] GraphQL v2 schema, supergraph, and OpenAPI regeneration succeed and show the new input shape
- [x] CI lint / typecheck / unit / component / integration green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
