### PR TITLE
fix(BA-6966): sweep only idle-expired checks

### DIFF
--- a/changes/13075.fix.md
+++ b/changes/13075.fix.md
@@ -1,0 +1,1 @@
+Sweep only idle checks already judged expired.

--- a/src/ai/backend/manager/models/idle_checker/conditions.py
+++ b/src/ai/backend/manager/models/idle_checker/conditions.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-from datetime import datetime
-
 import sqlalchemy as sa
 
 from ai.backend.manager.models.clauses import QueryCondition
 
-from .row import IdleCheckerBindingRow, SessionIdleCheckRow
+from .row import IdleCheckerBindingRow
 
 
 class IdleCheckerBindingConditions:
@@ -14,14 +12,5 @@ class IdleCheckerBindingConditions:
     def enabled() -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return IdleCheckerBindingRow.enabled == sa.true()
-
-        return inner
-
-
-class SessionIdleCheckConditions:
-    @staticmethod
-    def expired(now: datetime) -> QueryCondition:
-        def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return SessionIdleCheckRow.expire_at <= now
 
         return inner

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -19,7 +19,6 @@ from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.data.idle_checker.types import IdleCheckSession
 from ai.backend.manager.data.session.types import SessionStatus
-from ai.backend.manager.models.idle_checker.conditions import SessionIdleCheckConditions
 from ai.backend.manager.models.idle_checker.row import (
     IdleCheckerBindingRow,
     IdleCheckerRow,
@@ -107,15 +106,16 @@ class IdleCheckerDBSource:
         self,
         session_statuses: Collection[SessionStatus],
     ) -> ExpiredIdleCheckBatchData:
-        check_query = sa.select(SessionIdleCheckRow).join(
-            SessionRow, SessionIdleCheckRow.session_id == SessionRow.id
+        check_query = (
+            sa.select(SessionIdleCheckRow)
+            .join(SessionRow, SessionIdleCheckRow.session_id == SessionRow.id)
+            .where(SessionIdleCheckRow.last_status == IdleCheckPhase.IDLE_EXPIRED)
         )
         async with self._ops.read_ops() as r:
             now = await r.current_time()
             querier = BatchQuerier(
                 pagination=NoPagination(),
                 conditions=[
-                    SessionIdleCheckConditions.expired(now),
                     SessionConditions.by_statuses(session_statuses),
                 ],
             )

--- a/src/ai/backend/manager/repositories/idle_checker/types.py
+++ b/src/ai/backend/manager/repositories/idle_checker/types.py
@@ -54,7 +54,7 @@ class SessionIdleCheckAssignmentData:
 
 @dataclass(frozen=True)
 class ExpiredIdleCheckData:
-    """One stored judgment whose deadline has passed, kept per checker as its own reason."""
+    """One stored IDLE_EXPIRED judgment, kept per checker as its own reason."""
 
     session_id: SessionId
     checker_id: IdleCheckerID
@@ -65,9 +65,7 @@ class ExpiredIdleCheckData:
 
 @dataclass(frozen=True)
 class ExpiredIdleCheckBatchData:
-    """Idle checks expired as of the DB timestamp.
-    `now` is the same timestamp passed to the reconciler.
-    """
+    """Stored IDLE_EXPIRED judgments and the DB timestamp for the reconciler."""
 
     checks: Sequence[ExpiredIdleCheckData]
     now: datetime

--- a/src/ai/backend/manager/sokovan/idle_check/handlers/sweep.py
+++ b/src/ai/backend/manager/sokovan/idle_check/handlers/sweep.py
@@ -1,4 +1,4 @@
-"""Handler for grouping elapsed idle-check deadlines by session."""
+"""Handler for grouping IDLE_EXPIRED judgments by session."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from ai.backend.manager.sokovan.scheduling_controller import SchedulingControlle
 
 
 class IdleCheckSweepHandler(ReconcilerHandler[IdleCheckSweepReconcileInfo, IdleCheckSweepResult]):
-    """Group stored due rows and request their session termination."""
+    """Group stored IDLE_EXPIRED rows and request their session termination."""
 
     _scheduling_controller: SchedulingController
 

--- a/src/ai/backend/manager/sokovan/idle_check/sweep/source.py
+++ b/src/ai/backend/manager/sokovan/idle_check/sweep/source.py
@@ -1,4 +1,4 @@
-"""Source of the expiry-sweep stage: stored judgments whose deadline has passed."""
+"""Source of the expiry-sweep stage: stored IDLE_EXPIRED judgments."""
 
 from __future__ import annotations
 

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -561,7 +561,7 @@ class TestFetchExpiredIdleChecks:
         first_checker_id = IdleCheckerID(uuid.uuid4())
         second_checker_id = IdleCheckerID(uuid.uuid4())
         first_expire_at = datetime(2026, 1, 1, tzinfo=UTC)
-        second_expire_at = datetime(2026, 2, 1, tzinfo=UTC)
+        second_expire_at = datetime(2100, 1, 1, tzinfo=UTC)
         async with database.begin_session() as db_sess:
             for scope_row in _expired_check_scope_rows(scope):
                 db_sess.add(scope_row)
@@ -596,11 +596,11 @@ class TestFetchExpiredIdleChecks:
         )
 
     @pytest.fixture
-    async def session_with_future_deadline(
+    async def session_with_elapsed_deadline_still_idle(
         self,
         database: ExtendedAsyncSAEngine,
     ) -> SessionId:
-        scope = _expired_check_scope_fixture("future-deadline")
+        scope = _expired_check_scope_fixture("elapsed-deadline-still-idle")
         session_id = SessionId(uuid.uuid4())
         checker_id = IdleCheckerID(uuid.uuid4())
         async with database.begin_session() as db_sess:
@@ -613,9 +613,9 @@ class TestFetchExpiredIdleChecks:
                 SessionIdleCheckRow(
                     session_id=session_id,
                     idle_checker_id=checker_id,
-                    expire_at=datetime(2100, 1, 1, tzinfo=UTC),
-                    last_status=IdleCheckPhase.ACTIVE,
-                    last_message="The session is active.",
+                    expire_at=datetime(2026, 1, 1, tzinfo=UTC),
+                    last_status=IdleCheckPhase.IDLE,
+                    last_message="The session remains idle.",
                 )
             )
         return session_id
@@ -645,7 +645,7 @@ class TestFetchExpiredIdleChecks:
             )
         return session_id
 
-    async def test_returns_each_expired_check_of_running_session(
+    async def test_returns_each_idle_expired_check_regardless_of_deadline(
         self,
         repository: IdleCheckerRepository,
         expired_check_session: ExpiredCheckSessionData,
@@ -663,17 +663,23 @@ class TestFetchExpiredIdleChecks:
         assert check.expire_at == expired_check_session.first_expire_at
         assert check.last_status == IdleCheckPhase.IDLE_EXPIRED
         assert check.last_message == "Judged expired."
+        assert (
+            checks_by_key[
+                (expired_check_session.session_id, expired_check_session.second_checker_id)
+            ].expire_at
+            == expired_check_session.second_expire_at
+        )
 
-    async def test_excludes_checks_with_future_deadline(
+    async def test_excludes_elapsed_deadline_still_marked_idle(
         self,
         repository: IdleCheckerRepository,
-        session_with_future_deadline: SessionId,
+        session_with_elapsed_deadline_still_idle: SessionId,
     ) -> None:
         batch = await repository.fetch_expired_idle_checks([SessionStatus.RUNNING])
         check_session_ids = {check.session_id for check in batch.checks}
 
         assert batch.checks == ()
-        assert session_with_future_deadline not in check_session_ids
+        assert session_with_elapsed_deadline_still_idle not in check_session_ids
 
     async def test_excludes_sessions_not_in_target_statuses(
         self,
@@ -685,16 +691,3 @@ class TestFetchExpiredIdleChecks:
 
         assert batch.checks == ()
         assert terminated_session_with_expired_check not in check_session_ids
-
-    async def test_now_is_db_sourced_and_covers_every_deadline(
-        self,
-        repository: IdleCheckerRepository,
-        expired_check_session: ExpiredCheckSessionData,
-    ) -> None:
-        batch = await repository.fetch_expired_idle_checks([SessionStatus.RUNNING])
-        check_session_ids = {check.session_id for check in batch.checks}
-
-        assert batch.now.tzinfo is not None
-        assert check_session_ids == {expired_check_session.session_id}
-        for check in batch.checks:
-            assert check.expire_at <= batch.now


### PR DESCRIPTION
## Summary
- Select only stored `IDLE_EXPIRED` judgments for the expiry sweep.
- Leave deadline-elapse detection to the judgment stage instead of re-evaluating `expire_at`.
- Cover status-authoritative sweep selection for running sessions.

## Test plan
- [x] `pants test tests/unit/manager/repositories/idle_checker::`
- [x] Push hook lint, typecheck, and affected tests

Resolves BA-6966