### PR TITLE
feat(BA-6993): expose designated agents in the scheduler dry-run API

### DIFF
--- a/changes/13080.feature.md
+++ b/changes/13080.feature.md
@@ -1,0 +1,1 @@
+Support designated agent IDs and an agent selection policy in the scheduler dry-run (compute-schedule) API across REST v2, GraphQL, SDK v2, and CLI, matching the semantics of the real scheduling path

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -3007,6 +3007,16 @@ input ComputeScheduleInput
   kernels: [ComputeScheduleKernelResourceInput!]!
   clusterMode: SessionClusterMode!
   resourceGroupId: ID!
+
+  """
+  Restrict the fitting check to these agents, with the same semantics as the scheduling path. Null means no restriction.
+  """
+  designatedAgentIds: [String!] = null
+
+  """
+  How designated agents are enforced (STRICT fails without capacity, PREFERRED falls back). Null inherits the resource group default.
+  """
+  agentSelectionPolicy: SessionAgentSelectionPolicy = null
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -2151,6 +2151,16 @@ input ComputeScheduleInput {
   kernels: [ComputeScheduleKernelResourceInput!]!
   clusterMode: SessionClusterMode!
   resourceGroupId: ID!
+
+  """
+  Restrict the fitting check to these agents, with the same semantics as the scheduling path. Null means no restriction.
+  """
+  designatedAgentIds: [String!] = null
+
+  """
+  How designated agents are enforced (STRICT fails without capacity, PREFERRED falls back). Null inherits the resource group default.
+  """
+  agentSelectionPolicy: SessionAgentSelectionPolicy = null
 }
 
 """

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -27117,6 +27117,34 @@
             "format": "uuid",
             "title": "Resource Group Id",
             "type": "string"
+          },
+          "designated_agent_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Restrict the fitting check to these agents, with the same semantics as the scheduling path. Null means no restriction.",
+            "title": "Designated Agent Ids"
+          },
+          "agent_selection_policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentSelectionPolicyEnum"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "How `designated_agent_ids` is enforced (STRICT fails without capacity, PREFERRED falls back). Null inherits the resource group default."
           }
         },
         "required": [

--- a/src/ai/backend/client/cli/v2/session/commands.py
+++ b/src/ai/backend/client/cli/v2/session/commands.py
@@ -85,12 +85,32 @@ def enqueue(payload: str) -> None:
         "(overrides --image-id and -r/--resource)."
     ),
 )
+@click.option(
+    "--designated-agent",
+    "designated_agents",
+    multiple=True,
+    help=(
+        "Restrict the fitting check to this agent ID (repeatable), "
+        "with the same semantics as the scheduling path."
+    ),
+)
+@click.option(
+    "--agent-selection-policy",
+    type=click.Choice(["strict", "preferred"]),
+    default=None,
+    help=(
+        "How designated agents are enforced (strict fails without capacity, "
+        "preferred falls back). Omit to inherit the resource group default."
+    ),
+)
 def compute_schedule(
     resource_group_id: UUID,
     cluster_mode: str,
     image_id: UUID | None,
     resources: tuple[str, ...],
     kernels: str | None,
+    designated_agents: tuple[str, ...],
+    agent_selection_policy: str | None,
 ) -> None:
     """Probe whether a would-be session fits a resource group, without provisioning."""
 
@@ -99,8 +119,10 @@ def compute_schedule(
         ComputeScheduleKernelResourceInput,
     )
     from ai.backend.common.dto.manager.v2.session.types import ClusterModeEnum
+    from ai.backend.common.dto.manager.v2.session_options.types import AgentSelectionPolicyEnum
     from ai.backend.common.identifier.resource_group import ResourceGroupID
     from ai.backend.common.json import load_json
+    from ai.backend.common.types import AgentId
 
     if kernels is not None:
         if kernels.startswith("@"):
@@ -129,6 +151,14 @@ def compute_schedule(
         kernels=kernel_inputs,
         cluster_mode=ClusterModeEnum(cluster_mode),
         resource_group_id=ResourceGroupID(resource_group_id),
+        designated_agent_ids=(
+            [AgentId(agent) for agent in designated_agents] if designated_agents else None
+        ),
+        agent_selection_policy=(
+            AgentSelectionPolicyEnum(agent_selection_policy)
+            if agent_selection_policy is not None
+            else None
+        ),
     )
 
     async def _run() -> None:

--- a/src/ai/backend/common/dto/manager/v2/scheduler/request.py
+++ b/src/ai/backend/common/dto/manager/v2/scheduler/request.py
@@ -9,8 +9,10 @@ from pydantic import Field
 from ai.backend.common.api_handlers import BaseRequestModel
 from ai.backend.common.dto.manager.v2.common import ResourceSlotEntryInput
 from ai.backend.common.dto.manager.v2.session.types import ClusterModeEnum
+from ai.backend.common.dto.manager.v2.session_options.types import AgentSelectionPolicyEnum
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.types import AgentId
 
 __all__ = (
     "ComputeScheduleInput",
@@ -55,4 +57,19 @@ class ComputeScheduleInput(BaseRequestModel):
     )
     resource_group_id: ResourceGroupID = Field(
         description="Target resource group to compute the scheduling against.",
+    )
+    designated_agent_ids: list[AgentId] | None = Field(
+        default=None,
+        description=(
+            "Restrict the fitting check to these agents, with the same "
+            "semantics as the scheduling path. Null means no restriction."
+        ),
+    )
+    agent_selection_policy: AgentSelectionPolicyEnum | None = Field(
+        default=None,
+        description=(
+            "How `designated_agent_ids` is enforced (STRICT fails without "
+            "capacity, PREFERRED falls back). Null inherits the resource "
+            "group default."
+        ),
     )

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -371,6 +371,12 @@ class SessionAdapter(BaseAdapter):
             kernels=kernels,
             cluster_mode=cluster_mode,
             resource_group_id=input.resource_group_id,
+            designated_agent_ids=input.designated_agent_ids,
+            agent_selection_policy=(
+                AgentSelectionPolicy(input.agent_selection_policy.value)
+                if input.agent_selection_policy is not None
+                else None
+            ),
         )
         result = await self._processors.session.compute_schedule.wait_for_complete(action)
         return ComputeSchedulePayload(

--- a/src/ai/backend/manager/api/gql/scheduler.py
+++ b/src/ai/backend/manager/api/gql/scheduler.py
@@ -38,6 +38,7 @@ from ai.backend.manager.api.gql.decorators import (
     gql_subscription,
 )
 from ai.backend.manager.api.gql.session.types import SessionClusterModeGQL
+from ai.backend.manager.api.gql.session_options.types import AgentSelectionPolicyGQL
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.errors.kernel import InvalidSessionId
 
@@ -183,6 +184,21 @@ class ComputeScheduleInputGQL(PydanticInputMixin[ComputeScheduleInput]):
     kernels: list[ComputeScheduleKernelResourceInputGQL]
     cluster_mode: SessionClusterModeGQL
     resource_group_id: strawberry.ID
+    designated_agent_ids: list[str] | None = gql_field(
+        default=None,
+        description=(
+            "Restrict the fitting check to these agents, with the same "
+            "semantics as the scheduling path. Null means no restriction."
+        ),
+    )
+    agent_selection_policy: AgentSelectionPolicyGQL | None = gql_field(
+        default=None,
+        description=(
+            "How designated agents are enforced (STRICT fails without "
+            "capacity, PREFERRED falls back). Null inherits the resource "
+            "group default."
+        ),
+    )
 
 
 @gql_pydantic_type(

--- a/src/ai/backend/manager/services/session/actions/compute_schedule.py
+++ b/src/ai/backend/manager/services/session/actions/compute_schedule.py
@@ -5,13 +5,14 @@ from typing import override
 
 from ai.backend.common.data.permission.types import EntityType
 from ai.backend.common.identifier.resource_group import ResourceGroupID
-from ai.backend.common.types import ClusterMode
+from ai.backend.common.types import AgentId, ClusterMode
 from ai.backend.manager.actions.action import BaseAction, BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.compute_schedule import (
     ComputeScheduleResult,
 )
 from ai.backend.manager.data.session.draft import KernelResourceInput
+from ai.backend.manager.data.session.options import AgentSelectionPolicy
 
 
 @dataclass(frozen=True)
@@ -29,6 +30,8 @@ class ComputeScheduleAction(BaseAction):
     kernels: list[KernelResourceInput]
     cluster_mode: ClusterMode
     resource_group_id: ResourceGroupID
+    designated_agent_ids: list[AgentId] | None
+    agent_selection_policy: AgentSelectionPolicy | None
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -340,6 +340,10 @@ class SessionService:
             options=SessionOptionsDraft(
                 cluster_mode=action.cluster_mode,
                 cluster_size=len(action.kernels),
+                scheduling_target=SchedulingTargetDraft(
+                    designated_agents=tuple(action.designated_agent_ids or ()),
+                    agent_selection_policy=action.agent_selection_policy,
+                ),
                 kernel_groups=kernel_groups,
             ),
         )

--- a/tests/component/session_v2/test_session_compute_schedule.py
+++ b/tests/component/session_v2/test_session_compute_schedule.py
@@ -22,10 +22,14 @@ from ai.backend.common.dto.manager.v2.scheduler.request import (
     ComputeScheduleKernelResourceInput,
 )
 from ai.backend.common.dto.manager.v2.session.types import ClusterModeEnum
+from ai.backend.common.dto.manager.v2.session_options.types import AgentSelectionPolicyEnum
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.types import AgentId
 from ai.backend.manager.api.rest.routing import RouteRegistry
 from ai.backend.manager.api.rest.types import RouteDeps
+from ai.backend.manager.data.session.options import AgentSelectionPolicy, DefaultSessionOptions
+from ai.backend.manager.models.scaling_group import scaling_groups
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.services.session.processors import SessionProcessors
 
@@ -51,6 +55,8 @@ def _single_kernel_input(
     cpu: str,
     mem: str,
     cluster_mode: ClusterModeEnum = ClusterModeEnum.SINGLE_NODE,
+    designated_agent_ids: list[AgentId] | None = None,
+    agent_selection_policy: AgentSelectionPolicyEnum | None = None,
 ) -> ComputeScheduleInput:
     return ComputeScheduleInput(
         kernels=[
@@ -64,7 +70,27 @@ def _single_kernel_input(
         ],
         cluster_mode=cluster_mode,
         resource_group_id=resource_group_id,
+        designated_agent_ids=designated_agent_ids,
+        agent_selection_policy=agent_selection_policy,
     )
+
+
+@pytest.fixture()
+async def strict_agent_selection(
+    db_engine: SAEngine,
+    scaling_group_id: ResourceGroupID,
+) -> None:
+    """Make the test resource group enforce designated agents strictly."""
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            sa.update(scaling_groups)
+            .where(scaling_groups.c.id == scaling_group_id)
+            .values(
+                default_session_options=DefaultSessionOptions(
+                    agent_selection_policy=AgentSelectionPolicy.STRICT,
+                )
+            )
+        )
 
 
 class TestComputeSchedule:
@@ -202,3 +228,102 @@ class TestComputeSchedule:
                 .where(SessionRow.__table__.c.name == "compute-schedule")
             )
         assert count == 0
+
+
+class TestComputeScheduleDesignatedAgents:
+    async def test_strict_policy_limits_fitting_to_designated_agents(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        scaling_group_id: ResourceGroupID,
+        compute_image_fixture: ImageID,
+        agent_factory: AgentFactoryFunc,
+        strict_agent_selection: None,
+    ) -> None:
+        """A too-small designated agent fails the fit even though a larger
+        undesignated agent could hold the kernel."""
+        small_agent = await agent_factory({"cpu": "2", "mem": "34359738368"})
+        await agent_factory({"cpu": "8", "mem": "34359738368"})
+        payload = await admin_v2_registry.session.compute_schedule(
+            _single_kernel_input(
+                scaling_group_id,
+                compute_image_fixture,
+                cpu="4",
+                mem="1073741824",
+                designated_agent_ids=[AgentId(small_agent)],
+            )
+        )
+        result = payload.results[0]
+        assert result.success is False
+        assert result.reason_hint is not None
+        assert result.reason_hint.required_reduction is not None
+        reduction = {
+            entry.resource_type: entry.quantity for entry in result.reason_hint.required_reduction
+        }
+        assert reduction["cpu"] == Decimal(2)
+
+    async def test_designated_agent_with_capacity_fits(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        scaling_group_id: ResourceGroupID,
+        compute_image_fixture: ImageID,
+        agent_factory: AgentFactoryFunc,
+        strict_agent_selection: None,
+    ) -> None:
+        await agent_factory({"cpu": "2", "mem": "34359738368"})
+        large_agent = await agent_factory({"cpu": "8", "mem": "34359738368"})
+        payload = await admin_v2_registry.session.compute_schedule(
+            _single_kernel_input(
+                scaling_group_id,
+                compute_image_fixture,
+                cpu="4",
+                mem="1073741824",
+                designated_agent_ids=[AgentId(large_agent)],
+            )
+        )
+        assert payload.results[0].success is True
+
+    async def test_request_policy_overrides_resource_group_default(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        scaling_group_id: ResourceGroupID,
+        compute_image_fixture: ImageID,
+        agent_factory: AgentFactoryFunc,
+    ) -> None:
+        """A STRICT policy in the request overrides the resource group's
+        default PREFERRED policy, so a too-small designated agent fails."""
+        small_agent = await agent_factory({"cpu": "2", "mem": "34359738368"})
+        await agent_factory({"cpu": "8", "mem": "34359738368"})
+        payload = await admin_v2_registry.session.compute_schedule(
+            _single_kernel_input(
+                scaling_group_id,
+                compute_image_fixture,
+                cpu="4",
+                mem="1073741824",
+                designated_agent_ids=[AgentId(small_agent)],
+                agent_selection_policy=AgentSelectionPolicyEnum.STRICT,
+            )
+        )
+        assert payload.results[0].success is False
+
+    async def test_preferred_policy_falls_back_past_designated_agents(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        scaling_group_id: ResourceGroupID,
+        compute_image_fixture: ImageID,
+        agent_factory: AgentFactoryFunc,
+    ) -> None:
+        """Under the default PREFERRED policy a designated agent without
+        capacity does not block fitting onto other agents — the same
+        semantics as the real scheduling path."""
+        small_agent = await agent_factory({"cpu": "2", "mem": "34359738368"})
+        await agent_factory({"cpu": "8", "mem": "34359738368"})
+        payload = await admin_v2_registry.session.compute_schedule(
+            _single_kernel_input(
+                scaling_group_id,
+                compute_image_fixture,
+                cpu="4",
+                mem="1073741824",
+                designated_agent_ids=[AgentId(small_agent)],
+            )
+        )
+        assert payload.results[0].success is True

--- a/tests/unit/common/dto/test_scheduler_v2_dto.py
+++ b/tests/unit/common/dto/test_scheduler_v2_dto.py
@@ -31,9 +31,20 @@ class TestComputeScheduleInput:
             ],
             "cluster_mode": "single-node",
             "resource_group_id": str(uuid.uuid4()),
+            "designated_agent_ids": ["i-agent-01", "i-agent-02"],
+            "agent_selection_policy": "strict",
         })
         restored = ComputeScheduleInput.model_validate(original.model_dump(mode="json"))
         assert restored == original
+
+    def test_designated_agent_ids_and_policy_default_to_none(self) -> None:
+        parsed = ComputeScheduleInput.model_validate({
+            "kernels": [],
+            "cluster_mode": "single-node",
+            "resource_group_id": str(uuid.uuid4()),
+        })
+        assert parsed.designated_agent_ids is None
+        assert parsed.agent_selection_policy is None
 
     def test_image_id_defaults_to_none(self) -> None:
         kernel = ComputeScheduleKernelResourceInput.model_validate({


### PR DESCRIPTION
## Summary
- Add optional `designated_agent_ids` and `agent_selection_policy` to the compute-schedule (dry-run) request DTO, wired through the adapter, service action, and `SchedulingTargetDraft` so the real agent selector enforces them exactly like the scheduling path (BA-6135 already applies designated agents in the fitting computation; only the input surface was missing).
- Unset fields inherit the resource group's `default_session_options` (policy defaults to PREFERRED), keeping dry-run results consistent with what enqueue would do; a follow-up (BA-6996) exposes the per-request policy on enqueue as well.
- Expose the parameters end-to-end: GraphQL `ComputeScheduleInput`, SDK v2 (via the shared DTO), and CLI `--designated-agent` (repeatable) / `--agent-selection-policy` options; regenerate the GraphQL schema snapshots.

## Test plan
- [x] Component: STRICT policy (RG default) limits fitting to designated agents and returns a reduction hint
- [x] Component: designated agent with capacity fits under STRICT
- [x] Component: request-level STRICT overrides the RG default PREFERRED policy
- [x] Component: PREFERRED policy falls back past designated agents without capacity
- [x] Unit: DTO defaults (`None`) and JSON round-trip including the new fields
- [x] `pants fmt/fix/lint/check/test` green on changed files

Resolves BA-6993

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13080.org.readthedocs.build/en/13080/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13080.org.readthedocs.build/ko/13080/

<!-- readthedocs-preview sorna-ko end -->