### PR TITLE
fix(BA-6994): split reserved start time from execution start time on sessions

### DIFF
--- a/changes/13081.fix.md
+++ b/changes/13081.fix.md
@@ -1,0 +1,1 @@
+Preserve the reserved start time of batch sessions in a new `sessions.requested_starts_at` column instead of overwriting it at the RUNNING transition, and evaluate batch reservations against DB time instead of per-server clocks

--- a/src/ai/backend/manager/models/alembic/versions/339ae21cb8ec_add_session_requested_starts_at.py
+++ b/src/ai/backend/manager/models/alembic/versions/339ae21cb8ec_add_session_requested_starts_at.py
@@ -1,0 +1,70 @@
+"""add sessions.requested_starts_at
+
+``sessions.starts_at`` carried two meanings: the reserved start time written
+at enqueue for batch sessions, and the actual execution start time written at
+the RUNNING transition (overwriting the former). Split the reserved meaning
+into a new ``requested_starts_at`` column; ``starts_at`` keeps the execution
+meaning.
+
+Backfill: batch sessions that have not reached RUNNING yet still hold the
+reserved time in ``starts_at``, so copy it over. For sessions that already
+ran (or terminated), the reserved time was overwritten and is lost — leave
+``requested_starts_at`` NULL.
+
+Revision ID: 339ae21cb8ec
+Revises: b3e8f1a24c76
+Create Date: 2026-07-23
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "339ae21cb8ec"
+down_revision = "b3e8f1a24c76"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+PRE_RUNNING_STATUSES = (
+    "PENDING",
+    "DEPRIORITIZING",
+    "SCHEDULED",
+    "PREPARING",
+    "PULLING",
+    "PREPARED",
+    "CREATING",
+)
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sessions",
+        sa.Column("requested_starts_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE sessions
+            SET requested_starts_at = starts_at
+            WHERE session_type = 'BATCH'
+              AND starts_at IS NOT NULL
+              AND status IN :statuses
+            """
+        ).bindparams(sa.bindparam("statuses", PRE_RUNNING_STATUSES, expanding=True))
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            UPDATE sessions
+            SET starts_at = requested_starts_at
+            WHERE requested_starts_at IS NOT NULL
+              AND status IN :statuses
+            """
+        ).bindparams(sa.bindparam("statuses", PRE_RUNNING_STATUSES, expanding=True))
+    )
+    op.drop_column("sessions", "requested_starts_at")

--- a/src/ai/backend/manager/models/session/row.py
+++ b/src/ai/backend/manager/models/session/row.py
@@ -537,8 +537,14 @@ class SessionRow(Base):  # type: ignore[misc]
     terminated_at: Mapped[datetime | None] = mapped_column(
         "terminated_at", sa.DateTime(timezone=True), nullable=True, default=sa.null(), index=True
     )
+    # Actual execution start time, written at the RUNNING transition.
     starts_at: Mapped[datetime | None] = mapped_column(
         "starts_at", sa.DateTime(timezone=True), nullable=True, default=sa.null()
+    )
+    # Reserved start time requested at enqueue (batch sessions); the scheduler
+    # holds the session until this time. Never overwritten after enqueue.
+    requested_starts_at: Mapped[datetime | None] = mapped_column(
+        "requested_starts_at", sa.DateTime(timezone=True), nullable=True, default=sa.null()
     )
     status: Mapped[SessionStatus] = mapped_column(
         "status",

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -588,7 +588,9 @@ class AgentRegistry:
                 starts_at = isoparse(starts_at_timestamp)
             except ValueError:
                 _td = str_to_timedelta(starts_at_timestamp)
-                starts_at = datetime.now(tzutc()) + _td
+                # Resolve the relative offset against DB time so the base
+                # point is consistent across managers (HA clock-skew safety)
+                starts_at = await self._scheduler_repository.get_db_now() + _td
 
         if cluster_size > 1:
             log.debug(" -> cluster_mode:{} (replicate)", cluster_mode)

--- a/src/ai/backend/manager/repositories/scheduler/creators.py
+++ b/src/ai/backend/manager/repositories/scheduler/creators.py
@@ -133,7 +133,7 @@ class SessionRowFromSpec(CreatorSpec[SessionRow]):
     """Build one :class:`SessionRow` from a :class:`SessionSpec`.
 
     Session-level snapshot fields (``vfolder_mounts``, ``environ``,
-    ``startup_command``, ``bootstrap_script``, ``starts_at``,
+    ``startup_command``, ``bootstrap_script``, ``requested_starts_at``,
     ``batch_timeout``) are sourced from the main kernel's execution
     spec. ``images`` / ``image_ids`` are deduplicated from each
     kernel's resolved :class:`ImageInfo`, with the main kernel's image
@@ -169,7 +169,7 @@ class SessionRowFromSpec(CreatorSpec[SessionRow]):
             )
 
         main_mounts = list(main_kernel.vfolder_mounts) if main_kernel else []
-        session_starts_at = main_kernel.execution_spec.starts_at if main_kernel else None
+        session_requested_starts_at = main_kernel.execution_spec.starts_at if main_kernel else None
         session_batch_timeout = (
             main_kernel.execution_spec.batch_timeout_sec if main_kernel else None
         )
@@ -212,7 +212,7 @@ class SessionRowFromSpec(CreatorSpec[SessionRow]):
             vfolder_mounts=main_mounts,
             environ=session_environ,
             tag=spec.resource_spec.classification.tag,
-            starts_at=session_starts_at,
+            requested_starts_at=session_requested_starts_at,
             batch_timeout=session_batch_timeout,
             callback_url=spec.resource_spec.callback_url,
             images=session_images,

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -266,6 +266,7 @@ class ScheduleDBSource:
             )
             session_ids = [s.meta.session_id for s in pending_sessions.sessions]
             session_dependencies = await self._fetch_session_dependencies(db_sess, session_ids)
+            observed_at = await self._get_db_now_in_session(db_sess)
 
             return SchedulingFetch(
                 resource_group=resource_group.meta,
@@ -275,6 +276,7 @@ class ScheduleDBSource:
                 occupancy=occupancy,
                 resource_policy=resource_policy,
                 session_dependencies=SessionDependencySnapshot(by_session=session_dependencies),
+                observed_at=observed_at,
             )
 
     async def _fetch_resource_group_with_slot_inventory(
@@ -391,7 +393,7 @@ class ScheduleDBSource:
                     SessionRow.session_type,
                     SessionRow.cluster_mode,
                     SessionRow.designated_agent_ids,
-                    SessionRow.starts_at,
+                    SessionRow.requested_starts_at,
                     SessionRow.options,
                 )
             )
@@ -483,7 +485,7 @@ class ScheduleDBSource:
                     priority=row.priority,
                     job_priority=row.job_priority,
                     session_type=row.session_type,
-                    starts_at=row.starts_at,
+                    requested_starts_at=row.requested_starts_at,
                     is_preemptible=row.is_preemptible,
                 )
             )

--- a/src/ai/backend/manager/repositories/scheduler/repository.py
+++ b/src/ai/backend/manager/repositories/scheduler/repository.py
@@ -157,6 +157,7 @@ class SchedulerRepository:
                 resource_policy=fetch.resource_policy,
                 agent_limit=agent_limit,
             ),
+            observed_at=fetch.observed_at,
         )
         return SchedulingData(
             resource_group=fetch.resource_group,

--- a/src/ai/backend/manager/repositories/scheduler/types/scheduling.py
+++ b/src/ai/backend/manager/repositories/scheduler/types/scheduling.py
@@ -1,6 +1,7 @@
 """Repository-internal scheduling fetch types."""
 
 from dataclasses import dataclass
+from datetime import datetime
 
 from ai.backend.manager.views.sokovan.agent import AgentMeta
 from ai.backend.manager.views.sokovan.resource_group import ResourceGroupMeta
@@ -28,3 +29,5 @@ class SchedulingFetch:
     occupancy: ResourceOccupancySnapshot
     resource_policy: ResourcePolicySnapshot
     session_dependencies: SessionDependencySnapshot
+    # DB-sourced time the fetch ran (single time authority across managers)
+    observed_at: datetime

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/reserved_batch.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/reserved_batch.py
@@ -1,9 +1,6 @@
 """Validator for reserved batch sessions."""
 
-from datetime import datetime
 from typing import override
-
-from dateutil.tz import tzutc
 
 from ai.backend.common.types import SessionTypes
 from ai.backend.manager.views.sokovan.snapshot import SystemSnapshot
@@ -30,9 +27,9 @@ class ReservedBatchSessionValidator(ValidatorRule):
         return "Batch session has reached its scheduled start time"
 
     @override
-    def validate(self, _snapshot: SystemSnapshot, workload: SessionWorkload) -> None:
+    def validate(self, snapshot: SystemSnapshot, workload: SessionWorkload) -> None:
         # Check if this is a batch session with a scheduled start time
-        if workload.session_type == SessionTypes.BATCH and workload.starts_at is not None:
-            # Check if the current time is before the scheduled start time
-            if datetime.now(tzutc()) < workload.starts_at:
-                raise ReservedBatchSessionNotReady(scheduled_start=workload.starts_at)
+        if workload.session_type == SessionTypes.BATCH and workload.requested_starts_at is not None:
+            # Compare against the DB-sourced snapshot time, not a per-server clock
+            if snapshot.observed_at < workload.requested_starts_at:
+                raise ReservedBatchSessionNotReady(scheduled_start=workload.requested_starts_at)

--- a/src/ai/backend/manager/views/sokovan/snapshot.py
+++ b/src/ai/backend/manager/views/sokovan/snapshot.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, MutableMapping
 from dataclasses import dataclass
+from datetime import datetime
 from decimal import Decimal
 from typing import override
 
@@ -242,3 +243,6 @@ class SystemSnapshot:
 
     resource_group: ResourceGroupScopeSnapshot
     global_scope: GlobalScopeSnapshot
+    # DB-sourced time the snapshot was taken; time-based validations compare
+    # against this instead of per-server clocks (HA clock-skew safety)
+    observed_at: datetime

--- a/src/ai/backend/manager/views/sokovan/workload.py
+++ b/src/ai/backend/manager/views/sokovan/workload.py
@@ -113,9 +113,9 @@ class SessionWorkload:
     job_priority: int
     # Session type (INTERACTIVE, BATCH, INFERENCE)
     session_type: SessionTypes
-    # Reserved start time for batch sessions (the enqueue-time value; the
-    # column is overwritten with the actual start at the RUNNING transition)
-    starts_at: datetime | None
+    # Reserved start time requested at enqueue (batch sessions); the
+    # scheduler holds the session until this time
+    requested_starts_at: datetime | None
     # Whether this session can be preempted
     is_preemptible: bool
 

--- a/tests/unit/manager/repositories/scheduler/test_update_with_history.py
+++ b/tests/unit/manager/repositories/scheduler/test_update_with_history.py
@@ -1057,3 +1057,78 @@ class TestUpdateWithHistory:
             records = (await db_sess.execute(history_stmt)).scalars().all()
             assert len(records) == 3
             assert all(r.attempts == 2 for r in records)
+
+    async def test_running_transition_preserves_requested_starts_at(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain_id: DomainID,
+        test_domain_name: str,
+        test_scaling_group_id: ResourceGroupID,
+        test_scaling_group_name: str,
+        test_group_id: uuid.UUID,
+    ) -> None:
+        """The RUNNING transition writes starts_at without touching the
+        reserved start time recorded at enqueue."""
+        session_id = SessionId(uuid.uuid4())
+        requested_starts_at = datetime.now(tzutc()) - timedelta(minutes=30)
+
+        async with db_with_cleanup.begin_session() as db_sess:
+            session = SessionRow(
+                id=session_id,
+                creation_id=f"creation-{uuid.uuid4().hex[:8]}",
+                name=f"test-session-{uuid.uuid4().hex[:8]}",
+                session_type=SessionTypes.BATCH,
+                domain_id=test_domain_id,
+                domain_name=test_domain_name,
+                group_id=test_group_id,
+                resource_group_id=test_scaling_group_id,
+                scaling_group_name=test_scaling_group_name,
+                status=SessionStatus.CREATING,
+                result=SessionResult.UNDEFINED,
+                cluster_mode=ClusterMode.SINGLE_NODE,
+                cluster_size=1,
+                occupying_slots=ResourceSlot(),
+                requested_slots=ResourceSlot(),
+                vfolder_mounts={},
+                environ={},
+                priority=0,
+                created_at=datetime.now(tzutc()),
+                requested_starts_at=requested_starts_at,
+                num_queries=0,
+                use_host_network=False,
+            )
+            db_sess.add(session)
+            await db_sess.flush()
+
+        status_changed_at = datetime.now(tzutc())
+        updater = BatchUpdater(
+            spec=SessionStatusBatchUpdaterSpec(
+                to_status=SessionStatus.RUNNING,
+                status_changed_at=status_changed_at,
+            ),
+            conditions=[lambda: SessionRow.id.in_([session_id])],
+        )
+        bulk_creator = BulkCreator(
+            specs=[
+                SessionSchedulingHistoryCreatorSpec(
+                    session_id=session_id,
+                    phase="start",
+                    result=SchedulingResult.SUCCESS,
+                    message="Session started",
+                    from_status=SessionStatus.CREATING,
+                    to_status=SessionStatus.RUNNING,
+                )
+            ]
+        )
+
+        db_source = ScheduleDBSource(db_with_cleanup)
+        updated_count = await db_source.update_with_history(updater, bulk_creator)
+        assert updated_count == 1
+
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            stmt = sa.select(SessionRow).where(SessionRow.id == session_id)
+            updated_session = await db_sess.scalar(stmt)
+            assert updated_session is not None
+            assert updated_session.status == SessionStatus.RUNNING
+            assert updated_session.starts_at == status_changed_at
+            assert updated_session.requested_starts_at == requested_starts_at

--- a/tests/unit/manager/sokovan/scheduler/conftest.py
+++ b/tests/unit/manager/sokovan/scheduler/conftest.py
@@ -93,7 +93,7 @@ def create_session_workload(
     priority: int = 0,
     job_priority: int = 0,
     session_type: SessionTypes = SessionTypes.INTERACTIVE,
-    starts_at: datetime | None = None,
+    requested_starts_at: datetime | None = None,
     is_preemptible: bool = False,
 ) -> SessionWorkload:
     """Create a SessionWorkload for testing.
@@ -123,7 +123,7 @@ def create_session_workload(
         priority=priority,
         job_priority=job_priority,
         session_type=session_type,
-        starts_at=starts_at,
+        requested_starts_at=requested_starts_at,
         is_preemptible=is_preemptible,
     )
 
@@ -137,6 +137,7 @@ def create_system_snapshot(
     occupancy: ResourceOccupancySnapshot | None = None,
     resource_policy: ResourcePolicySnapshot | None = None,
     max_container_count: int | None = None,
+    observed_at: datetime | None = None,
 ) -> SystemSnapshot:
     """Create a SystemSnapshot for testing."""
     return SystemSnapshot(
@@ -155,6 +156,7 @@ def create_system_snapshot(
             or ResourcePolicySnapshot(by_user={}, by_project={}, by_domain={}),
             agent_limit=AgentLimit(max_container_count=max_container_count),
         ),
+        observed_at=observed_at if observed_at is not None else datetime.now(tzutc()),
     )
 
 
@@ -283,14 +285,14 @@ def user_specific_minimal_workload(test_user_id: UserID) -> SessionWorkload:
 def batch_session_past_start_time() -> SessionWorkload:
     """Batch session with start time in the past."""
     past_time = datetime.now(tzutc()) - timedelta(hours=1)
-    return create_session_workload(session_type=SessionTypes.BATCH, starts_at=past_time)
+    return create_session_workload(session_type=SessionTypes.BATCH, requested_starts_at=past_time)
 
 
 @pytest.fixture
 def batch_session_future_start_time() -> SessionWorkload:
     """Batch session with start time in the future."""
     future_time = datetime.now(tzutc()) + timedelta(hours=1)
-    return create_session_workload(session_type=SessionTypes.BATCH, starts_at=future_time)
+    return create_session_workload(session_type=SessionTypes.BATCH, requested_starts_at=future_time)
 
 
 # =============================================================================

--- a/tests/unit/manager/sokovan/scheduler/provisioner/conftest.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/conftest.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Callable, Mapping
+from datetime import UTC, datetime
 from decimal import Decimal
 
 import pytest
@@ -103,7 +104,7 @@ def _make_workload(
         priority=priority,
         job_priority=0,
         session_type=SessionTypes.INTERACTIVE,
-        starts_at=None,
+        requested_starts_at=None,
         is_preemptible=False,
     )
 
@@ -156,6 +157,7 @@ def _make_scheduling_data(
                 resource_policy=ResourcePolicySnapshot(by_user={}, by_project={}, by_domain={}),
                 agent_limit=AgentLimit(max_container_count=None),
             ),
+            observed_at=datetime.now(UTC),
         ),
     )
 

--- a/tests/unit/manager/sokovan/scheduler/provisioner/sequencers/conftest.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/sequencers/conftest.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Callable, Mapping
+from datetime import UTC, datetime
 from decimal import Decimal
 
 import pytest
@@ -104,7 +105,7 @@ def _make_workload(
         priority=priority,
         job_priority=0,
         session_type=session_type,
-        starts_at=None,
+        requested_starts_at=None,
         is_preemptible=False,
     )
 
@@ -169,6 +170,7 @@ def _make_snapshot(
             resource_policy=ResourcePolicySnapshot(by_user={}, by_project={}, by_domain={}),
             agent_limit=AgentLimit(max_container_count=None),
         ),
+        observed_at=datetime.now(UTC),
     )
 
 

--- a/tests/unit/manager/sokovan/scheduler/provisioner/validators/conftest.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/validators/conftest.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Callable, Mapping
-from datetime import datetime
+from datetime import UTC, datetime
 from decimal import Decimal
 
 import pytest
@@ -82,7 +82,7 @@ def _make_workload(
     session_id: SessionId | None = None,
     slots: Mapping[str, str] | None = None,
     session_type: SessionTypes = SessionTypes.INTERACTIVE,
-    starts_at: datetime | None = None,
+    requested_starts_at: datetime | None = None,
 ) -> SessionWorkload:
     if session_id is None:
         session_id = SessionId(uuid.uuid4())
@@ -114,7 +114,7 @@ def _make_workload(
         priority=0,
         job_priority=0,
         session_type=session_type,
-        starts_at=starts_at,
+        requested_starts_at=requested_starts_at,
         is_preemptible=False,
     )
 
@@ -126,6 +126,7 @@ def _make_snapshot(
     project_limit: ResourceLimit | None = None,
     domain_limit: ResourceLimit | None = None,
     occupancy: ResourceOccupancySnapshot | None = None,
+    observed_at: datetime | None = None,
 ) -> SystemSnapshot:
     if occupancy is None:
         occupancy = ResourceOccupancySnapshot(by_user={}, by_project={}, by_domain={})
@@ -147,6 +148,7 @@ def _make_snapshot(
             ),
             agent_limit=AgentLimit(max_container_count=None),
         ),
+        observed_at=observed_at if observed_at is not None else datetime.now(UTC),
     )
 
 

--- a/tests/unit/manager/sokovan/scheduler/provisioner/validators/test_reserved_batch.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/validators/test_reserved_batch.py
@@ -18,6 +18,8 @@ from ai.backend.manager.views.sokovan.snapshot import SystemSnapshot
 
 from .conftest import SnapshotFactory, WorkloadFactory
 
+OBSERVED_AT = datetime(2026, 7, 23, 12, 0, 0, tzinfo=tzutc())
+
 
 class TestReservedBatchSessionValidator:
     @pytest.fixture
@@ -26,7 +28,7 @@ class TestReservedBatchSessionValidator:
 
     @pytest.fixture
     def snapshot(self, snapshot_factory: SnapshotFactory) -> SystemSnapshot:
-        return snapshot_factory()
+        return snapshot_factory(observed_at=OBSERVED_AT)
 
     def test_non_batch_session_passes(
         self,
@@ -36,7 +38,7 @@ class TestReservedBatchSessionValidator:
     ) -> None:
         workload = workload_factory(
             session_type=SessionTypes.INTERACTIVE,
-            starts_at=datetime.now(tzutc()) + timedelta(hours=1),
+            requested_starts_at=OBSERVED_AT + timedelta(hours=1),
         )
 
         validator.validate(snapshot, workload)
@@ -47,7 +49,7 @@ class TestReservedBatchSessionValidator:
         snapshot: SystemSnapshot,
         workload_factory: WorkloadFactory,
     ) -> None:
-        workload = workload_factory(session_type=SessionTypes.BATCH, starts_at=None)
+        workload = workload_factory(session_type=SessionTypes.BATCH, requested_starts_at=None)
 
         validator.validate(snapshot, workload)
 
@@ -59,7 +61,20 @@ class TestReservedBatchSessionValidator:
     ) -> None:
         workload = workload_factory(
             session_type=SessionTypes.BATCH,
-            starts_at=datetime.now(tzutc()) - timedelta(minutes=5),
+            requested_starts_at=OBSERVED_AT - timedelta(minutes=5),
+        )
+
+        validator.validate(snapshot, workload)
+
+    def test_batch_session_at_exact_start_time_passes(
+        self,
+        validator: ReservedBatchSessionValidator,
+        snapshot: SystemSnapshot,
+        workload_factory: WorkloadFactory,
+    ) -> None:
+        workload = workload_factory(
+            session_type=SessionTypes.BATCH,
+            requested_starts_at=OBSERVED_AT,
         )
 
         validator.validate(snapshot, workload)
@@ -72,7 +87,7 @@ class TestReservedBatchSessionValidator:
     ) -> None:
         workload = workload_factory(
             session_type=SessionTypes.BATCH,
-            starts_at=datetime.now(tzutc()) + timedelta(hours=1),
+            requested_starts_at=OBSERVED_AT + timedelta(hours=1),
         )
 
         with pytest.raises(ReservedBatchSessionNotReady):


### PR DESCRIPTION
## Summary
- Split the double meaning of `sessions.starts_at` (reserved start time at enqueue vs. actual execution start at the RUNNING transition) into a new `requested_starts_at` column, so the reservation is no longer lost when a batch session starts running.
- The reserved-batch validator now reads `requested_starts_at` and compares it against a DB-sourced snapshot timestamp (`SystemSnapshot.observed_at`) instead of per-server clocks; relative `starts_at` offsets are also resolved against DB time at enqueue (HA clock-skew safety).
- Alembic migration adds the column and backfills batch sessions that have not reached RUNNING yet (already-running/terminated sessions have lost the reservation, left NULL).

## Test plan
- [x] Reserved-batch validator hold/release scenarios with a fixed snapshot time, including the exact-boundary case
- [x] RUNNING transition writes `starts_at` without touching `requested_starts_at` (real-DB test)
- [x] Migration upgrade/downgrade verified against a scratch Postgres DB (9 cases across statuses/types)
- [x] Existing idle session-lifetime / fair-share tests unchanged and green

Resolves BA-6994

🤖 Generated with [Claude Code](https://claude.com/claude-code)