### PR TITLE
feat(BA-6996): accept per-request agent selection policy in session enqueue

### DIFF
--- a/changes/13082.feature.md
+++ b/changes/13082.feature.md
@@ -1,0 +1,1 @@
+Accept an optional `agent_selection_policy` in the v2 session enqueue API to override the resource group default per request

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -7102,6 +7102,11 @@ input EnqueueSessionInput
   """Designated agent IDs."""
   agentList: [String!] = null
 
+  """
+  Added in 26.8.0. How agent_list is enforced. null inherits the resource group default.
+  """
+  agentSelectionPolicy: SessionAgentSelectionPolicy = null
+
   """Network UUID to attach."""
   attachNetwork: ID = null
 

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -4795,6 +4795,11 @@ input EnqueueSessionInput {
   """Designated agent IDs."""
   agentList: [String!] = null
 
+  """
+  Added in 26.8.0. How agent_list is enforced. null inherits the resource group default.
+  """
+  agentSelectionPolicy: SessionAgentSelectionPolicy = null
+
   """Network UUID to attach."""
   attachNetwork: ID = null
 

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -20169,7 +20169,7 @@
         "type": "object"
       },
       "MountItemInput": {
-        "description": "A single virtual folder mount specification.",
+        "description": "A single virtual folder mount specification.\n\nShared by the session enqueue input and the session-options kernel\nexecution spec (lives here to avoid a session <-> session_options\ncircular import).",
         "properties": {
           "vfolder_id": {
             "description": "Virtual folder UUID to mount.",
@@ -26933,6 +26933,18 @@
             "default": null,
             "description": "Designated agent IDs for placement constraint.",
             "title": "Agent List"
+          },
+          "agent_selection_policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentSelectionPolicyEnum"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "How agent_list is enforced (strict/preferred). null inherits the resource group default."
           },
           "attach_network": {
             "anyOf": [

--- a/src/ai/backend/common/dto/manager/v2/common.py
+++ b/src/ai/backend/common/dto/manager/v2/common.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from decimal import Decimal
 from enum import StrEnum
 from functools import cached_property
+from uuid import UUID
 
 from pydantic import Field
 
@@ -120,6 +121,31 @@ class VFolderHostPermissionEntryInput(BaseRequestModel):
     host: str = Field(description="Virtual folder host name (e.g., 'default', 'nfs-vol1').")
     permissions: list[str] = Field(
         description="List of permission values (e.g., 'mount-in-session', 'upload-file')."
+    )
+
+
+class MountItemInput(BaseRequestModel):
+    """A single virtual folder mount specification.
+
+    Shared by the session enqueue input and the session-options kernel
+    execution spec (lives here to avoid a session <-> session_options
+    circular import).
+    """
+
+    vfolder_id: UUID = Field(description="Virtual folder UUID to mount.")
+    mount_path: str | None = Field(
+        default=None, description="Custom mount path. Uses default path if omitted."
+    )
+    permission: str | None = Field(
+        default=None, description="Mount permission override ('rw' or 'ro')."
+    )
+    subpath: str | None = Field(
+        default=None,
+        min_length=1,
+        description=(
+            "Subpath within the vfolder to mount. Omit (null) to mount the vfolder root."
+            " Empty string is rejected."
+        ),
     )
 
 

--- a/src/ai/backend/common/dto/manager/v2/session/request.py
+++ b/src/ai/backend/common/dto/manager/v2/session/request.py
@@ -14,7 +14,11 @@ from pydantic import Field, field_validator
 from ai.backend.common.api_handlers import BaseRequestModel
 from ai.backend.common.dto.manager.defs import DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT
 from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter, UUIDFilter
-from ai.backend.common.dto.manager.v2.common import BinarySizeInput, ResourceSlotEntryInput
+from ai.backend.common.dto.manager.v2.common import (
+    BinarySizeInput,
+    MountItemInput,
+    ResourceSlotEntryInput,
+)
 from ai.backend.common.dto.manager.v2.session.types import (
     ClusterModeEnum,
     CreateSessionTypeEnum,
@@ -22,6 +26,7 @@ from ai.backend.common.dto.manager.v2.session.types import (
     SessionOrderField,
     SessionStatusFilter,
 )
+from ai.backend.common.dto.manager.v2.session_options.types import AgentSelectionPolicyEnum
 from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 
@@ -252,26 +257,6 @@ class ResourceOptsInput(BaseRequestModel):
     )
 
 
-class MountItemInput(BaseRequestModel):
-    """A single virtual folder mount specification."""
-
-    vfolder_id: UUID = Field(description="Virtual folder UUID to mount.")
-    mount_path: str | None = Field(
-        default=None, description="Custom mount path. Uses default path if omitted."
-    )
-    permission: str | None = Field(
-        default=None, description="Mount permission override ('rw' or 'ro')."
-    )
-    subpath: str | None = Field(
-        default=None,
-        min_length=1,
-        description=(
-            "Subpath within the vfolder to mount. Omit (null) to mount the vfolder root."
-            " Empty string is rejected."
-        ),
-    )
-
-
 class BatchConfigInput(BaseRequestModel):
     """Batch session specific configuration. Required when session_type is BATCH."""
 
@@ -348,6 +333,13 @@ class EnqueueSessionInput(BaseRequestModel):
     )
     agent_list: list[str] | None = Field(
         default=None, description="Designated agent IDs for placement constraint."
+    )
+    agent_selection_policy: AgentSelectionPolicyEnum | None = Field(
+        default=None,
+        description=(
+            "How agent_list is enforced (strict/preferred). "
+            "null inherits the resource group default."
+        ),
     )
     attach_network: UUID | None = Field(
         default=None, description="Persistent network UUID to attach."

--- a/src/ai/backend/common/dto/manager/v2/session_options/request.py
+++ b/src/ai/backend/common/dto/manager/v2/session_options/request.py
@@ -23,9 +23,9 @@ from pydantic import Field
 from ai.backend.common.api_handlers import BaseRequestModel
 from ai.backend.common.dto.manager.v2.common import (
     BinarySizeInput,
+    MountItemInput,
     ResourceSlotEntryInput,
 )
-from ai.backend.common.dto.manager.v2.session.request import MountItemInput
 from ai.backend.common.dto.manager.v2.session.types import ClusterModeEnum
 from ai.backend.common.dto.manager.v2.session_options.types import (
     AgentSelectionPolicyEnum,

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -92,6 +92,7 @@ from ai.backend.manager.data.kernel.types import KernelInfo, KernelStatus, Kerne
 from ai.backend.manager.data.resource_slot.types import ResourceAllocationAggregate
 from ai.backend.manager.data.session.compute_schedule import ComputeScheduleKernelResult
 from ai.backend.manager.data.session.draft import KernelResourceInput
+from ai.backend.manager.data.session.options import AgentSelectionPolicy
 from ai.backend.manager.data.session.types import SessionData, SessionStatus
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.models.kernel.conditions import KernelConditions
@@ -313,6 +314,11 @@ class SessionAdapter(BaseAdapter):
                 is_preemptible=input.is_preemptible,
                 dependencies=input.dependencies,
                 agent_list=input.agent_list,
+                agent_selection_policy=(
+                    AgentSelectionPolicy(input.agent_selection_policy.value)
+                    if input.agent_selection_policy is not None
+                    else None
+                ),
                 attach_network=input.attach_network,
             ),
             batch=batch_spec,

--- a/src/ai/backend/manager/api/gql/session/types.py
+++ b/src/ai/backend/manager/api/gql/session/types.py
@@ -83,6 +83,7 @@ from ai.backend.manager.api.gql.kernel.types import (
 from ai.backend.manager.api.gql.project_v2.types.node import ProjectV2GQL
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
 from ai.backend.manager.api.gql.resource_group.types import ResourceGroupGQL
+from ai.backend.manager.api.gql.session_options.types import AgentSelectionPolicyGQL
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.api.gql.user.types.node import UserV2GQL
 from ai.backend.manager.errors.user import UserNotFound
@@ -659,6 +660,13 @@ class EnqueueSessionInputGQL(PydanticInputMixin[EnqueueSessionInputDTO]):
     is_preemptible: bool = gql_field(default=True, description="Whether preemptible.")
     dependencies: list[ID] | None = gql_field(default=None, description="Dependent session IDs.")
     agent_list: list[str] | None = gql_field(default=None, description="Designated agent IDs.")
+    agent_selection_policy: AgentSelectionPolicyGQL | None = gql_added_field(
+        BackendAIGQLMeta(
+            description=("How agent_list is enforced. null inherits the resource group default."),
+            added_version=NEXT_RELEASE_VERSION,
+        ),
+        default=None,
+    )
     attach_network: ID | None = gql_field(default=None, description="Network UUID to attach.")
 
     tag: str | None = gql_field(default=None, description="User-defined tag.")

--- a/src/ai/backend/manager/services/session/actions/enqueue_session.py
+++ b/src/ai/backend/manager/services/session/actions/enqueue_session.py
@@ -12,6 +12,7 @@ from ai.backend.common.types import AccessKey, ClusterMode, MountInfoEntry, Sess
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.data.session.options import AgentSelectionPolicy
 from ai.backend.manager.data.session.types import SessionData
 from ai.backend.manager.models.user import UserRole
 from ai.backend.manager.services.session.base import SessionScopeAction
@@ -55,6 +56,7 @@ class SessionSchedulingSpec:
     is_preemptible: bool = True
     dependencies: list[uuid.UUID] | None = None
     agent_list: list[str] | None = None
+    agent_selection_policy: AgentSelectionPolicy | None = None
     attach_network: uuid.UUID | None = None
 
 

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -1713,6 +1713,7 @@ class SessionService:
                             designated_agents=tuple(
                                 AgentId(a) for a in (action.scheduling.agent_list or ())
                             ),
+                            agent_selection_policy=action.scheduling.agent_selection_policy,
                         ),
                         kernel_groups=kernel_groups,
                         handler_options=None,

--- a/tests/unit/common/dto/test_session_v2_dto.py
+++ b/tests/unit/common/dto/test_session_v2_dto.py
@@ -23,6 +23,7 @@ from ai.backend.common.dto.manager.v2.session.types import (
     ClusterModeEnum,
     CreateSessionTypeEnum,
 )
+from ai.backend.common.dto.manager.v2.session_options.types import AgentSelectionPolicyEnum
 from ai.backend.common.exception import BackendAISchemaValidationFailed
 
 
@@ -67,6 +68,31 @@ class TestEnqueueSessionInput:
         # Neutral-baseline design: values may go above 100 and below 0.
         assert _make(500).job_priority == 500
         assert _make(-5).job_priority == -5
+
+    def test_agent_selection_policy_parsing(self) -> None:
+        """agent_selection_policy accepts the enum values and defaults to None."""
+
+        def _make(**kwargs: object) -> EnqueueSessionInput:
+            return EnqueueSessionInput.model_validate({
+                "session_name": "policy-session",
+                "session_type": "interactive",
+                "image_id": str(uuid4()),
+                "resource_entries": [{"resource_type": "cpu", "quantity": "1"}],
+                "project_id": str(uuid4()),
+                **kwargs,
+            })
+
+        assert _make().agent_selection_policy is None
+        assert (
+            _make(agent_selection_policy="strict").agent_selection_policy
+            == AgentSelectionPolicyEnum.STRICT
+        )
+        assert (
+            _make(agent_selection_policy="preferred").agent_selection_policy
+            == AgentSelectionPolicyEnum.PREFERRED
+        )
+        with pytest.raises((BackendAISchemaValidationFailed, ValidationError)):
+            _make(agent_selection_policy="invalid")
 
     def test_valid_batch_session(self) -> None:
         """Valid batch session with batch config."""

--- a/tests/unit/manager/api/adapters/test_session_adapter.py
+++ b/tests/unit/manager/api/adapters/test_session_adapter.py
@@ -19,8 +19,10 @@ from ai.backend.common.dto.manager.v2.session.types import (
     ClusterModeEnum,
     CreateSessionTypeEnum,
 )
+from ai.backend.common.dto.manager.v2.session_options.types import AgentSelectionPolicyEnum
 from ai.backend.common.types import ClusterMode, SessionResult, SessionTypes
 from ai.backend.manager.api.adapters.session.adapter import SessionAdapter
+from ai.backend.manager.data.session.options import AgentSelectionPolicy
 from ai.backend.manager.data.session.types import SessionData, SessionStatus
 
 
@@ -240,6 +242,57 @@ class TestEnqueueActionBuilding:
         action = mock_processors.session.enqueue_session.wait_for_complete.call_args[0][0]
         assert action.resource.cluster_mode == ClusterMode.MULTI_NODE
         assert action.resource.cluster_size == 4
+
+    async def test_enqueue_with_agent_selection_policy(
+        self,
+        adapter: SessionAdapter,
+        mock_processors: MagicMock,
+    ) -> None:
+        """A request-level policy should be converted to the domain enum."""
+        dto = EnqueueSessionInput(
+            session_name="strict-session",
+            session_type=CreateSessionTypeEnum.INTERACTIVE,
+            image_id=uuid4(),
+            resource_entries=[ResourceSlotEntryInput(resource_type="cpu", quantity="1")],
+            project_id=uuid4(),
+            agent_list=["agent-1"],
+            agent_selection_policy=AgentSelectionPolicyEnum.STRICT,
+        )
+        await adapter.enqueue(
+            dto,
+            user_id=uuid4(),
+            user_role="user",
+            access_key="TESTKEY",
+            domain_name="default",
+            group_id=dto.project_id,
+        )
+        action = mock_processors.session.enqueue_session.wait_for_complete.call_args[0][0]
+        assert action.scheduling.agent_list == ["agent-1"]
+        assert action.scheduling.agent_selection_policy == AgentSelectionPolicy.STRICT
+
+    async def test_enqueue_without_agent_selection_policy(
+        self,
+        adapter: SessionAdapter,
+        mock_processors: MagicMock,
+    ) -> None:
+        """An omitted policy should stay None so the RG default applies."""
+        dto = EnqueueSessionInput(
+            session_name="default-policy-session",
+            session_type=CreateSessionTypeEnum.INTERACTIVE,
+            image_id=uuid4(),
+            resource_entries=[ResourceSlotEntryInput(resource_type="cpu", quantity="1")],
+            project_id=uuid4(),
+        )
+        await adapter.enqueue(
+            dto,
+            user_id=uuid4(),
+            user_role="user",
+            access_key="TESTKEY",
+            domain_name="default",
+            group_id=dto.project_id,
+        )
+        action = mock_processors.session.enqueue_session.wait_for_complete.call_args[0][0]
+        assert action.scheduling.agent_selection_policy is None
 
 
 class TestTerminateActionBuilding:

--- a/tests/unit/manager/sokovan/scheduling_controller/test_enqueue_session_from_draft.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/test_enqueue_session_from_draft.py
@@ -73,6 +73,7 @@ from ai.backend.manager.data.session.draft import (
     SessionSpecDraft,
 )
 from ai.backend.manager.data.session.options import (
+    AgentSelectionPolicy,
     DefaultSessionOptions,
     ResourceOpts,
     SessionHandlerOptions,
@@ -209,10 +210,14 @@ def _make_user() -> UserData:
     )
 
 
-def _spec_context(image_id: ImageID) -> SessionSpecContext:
+def _spec_context(
+    image_id: ImageID,
+    *,
+    rg_defaults: DefaultSessionOptions | None = None,
+) -> SessionSpecContext:
     return SessionSpecContext(
         resource_group=ResourceGroupEnqueueInfo(
-            defaults=DefaultSessionOptions(),
+            defaults=rg_defaults if rg_defaults is not None else DefaultSessionOptions(),
             network=ScalingGroupNetworkInfo(use_host_network=False, wsproxy_addr=None),
             allow_fractional=False,
             served_slot_names=frozenset({ResourceSlotName("cpu"), ResourceSlotName("mem")}),
@@ -372,6 +377,80 @@ class TestEnqueueSessionFromDraft:
 
         enqueued_spec = repository.enqueue_session_from_spec.await_args.args[0]
         assert enqueued_spec.resource_spec.options.job_priority == 50
+
+    async def test_agent_selection_policy_override_beats_rg_default(
+        self,
+        draft: SessionSpecDraft,
+        image_id: ImageID,
+    ) -> None:
+        """A request-level STRICT policy survives over the RG default (PREFERRED)."""
+        resource = draft.resource_spec.resource
+        draft_strict = draft.model_copy(
+            update={
+                "resource_spec": draft.resource_spec.model_copy(
+                    update={
+                        "resource": resource.model_copy(
+                            update={
+                                "options": resource.options.model_copy(
+                                    update={
+                                        "scheduling_target": SchedulingTargetDraft(
+                                            agent_selection_policy=AgentSelectionPolicy.STRICT,
+                                        ),
+                                    }
+                                ),
+                            }
+                        ),
+                    }
+                ),
+            }
+        )
+
+        repository = AsyncMock()
+        repository.fetch_session_spec_context.return_value = _spec_context(image_id)
+        repository.query_accessible_resource_group_ids.return_value = frozenset({
+            draft_strict.scope.resource_group_id
+        })
+        repository.enqueue_session_from_spec.return_value = SessionID(uuid.uuid4())
+
+        controller, _, _ = _build_controller(repository)
+
+        with with_user(_make_user()):
+            await controller.enqueue_session_from_draft(draft_strict)
+
+        enqueued_spec = repository.enqueue_session_from_spec.await_args.args[0]
+        assert (
+            enqueued_spec.resource_spec.options.scheduling_target.agent_selection_policy
+            == AgentSelectionPolicy.STRICT
+        )
+
+    async def test_agent_selection_policy_unset_inherits_rg_default(
+        self,
+        draft: SessionSpecDraft,
+        image_id: ImageID,
+    ) -> None:
+        """An unset policy on the draft inherits the RG default."""
+        repository = AsyncMock()
+        repository.fetch_session_spec_context.return_value = _spec_context(
+            image_id,
+            rg_defaults=DefaultSessionOptions(
+                agent_selection_policy=AgentSelectionPolicy.STRICT,
+            ),
+        )
+        repository.query_accessible_resource_group_ids.return_value = frozenset({
+            draft.scope.resource_group_id
+        })
+        repository.enqueue_session_from_spec.return_value = SessionID(uuid.uuid4())
+
+        controller, _, _ = _build_controller(repository)
+
+        with with_user(_make_user()):
+            await controller.enqueue_session_from_draft(draft)
+
+        enqueued_spec = repository.enqueue_session_from_spec.await_args.args[0]
+        assert (
+            enqueued_spec.resource_spec.options.scheduling_target.agent_selection_policy
+            == AgentSelectionPolicy.STRICT
+        )
 
     async def test_pre_enqueue_hook_rejection_raises(
         self,


### PR DESCRIPTION
## Summary
- Expose an optional `agent_selection_policy` (`strict`/`preferred`) on `EnqueueSessionInput` for both REST v2 and GraphQL; an unset value keeps inheriting the resource group's `default_session_options.agent_selection_policy` through the existing merge rule.
- Thread the value through the session adapter and `SessionSchedulingSpec` into `SchedulingTargetDraft`, where the already-merged downstream path (merge rule, persistence, agent selector) consumes it. SDK v2 and the CLI enqueue command pass the DTO through unchanged, so the field is usable end-to-end without client code changes.
- Move `MountItemInput` to `dto/manager/v2/common.py` to break the circular import between the `session` and `session_options` request modules.

## Test plan
- [x] `test_enqueue_session_from_draft.py`: request-level STRICT overrides the RG default (PREFERRED) through the real preparer chain; unset inherits the RG default (STRICT).
- [x] `test_session_adapter.py`: DTO enum converts to the domain enum on the action; omitted stays `None`.
- [x] `test_session_v2_dto.py`: parses `strict`/`preferred`, defaults to `None`, rejects invalid values.
- [x] `pants fmt/fix/lint/check/test` pass for all affected targets (including direct dependents).

Resolves BA-6996

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13082.org.readthedocs.build/en/13082/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13082.org.readthedocs.build/ko/13082/

<!-- readthedocs-preview sorna-ko end -->