### PR TITLE
feat(BA-6992): enforce max_pending_session_resource_slots at enqueue

### DIFF
--- a/changes/13085.feature.md
+++ b/changes/13085.feature.md
@@ -1,0 +1,1 @@
+Enforce the `max_pending_session_resource_slots` keypair resource-policy limit at session enqueue, rejecting session creation that would exceed the pending-queue slot caps

--- a/src/ai/backend/manager/data/resource/types.py
+++ b/src/ai/backend/manager/data/resource/types.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
+from decimal import Decimal
 from typing import Any
 
 from ai.backend.common.identifier.resource_slot import ResourceSlotName
@@ -82,4 +83,5 @@ class UserEnqueuePolicy:
 
     max_containers_per_session: int
     max_pending_session_count: int | None
+    max_pending_session_resource_slots: Mapping[ResourceSlotName, Decimal] | None
     allowed_vfolder_hosts: VFolderHostPermissionMap

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -1683,6 +1683,7 @@ class ScheduleDBSource:
                     sa.select(
                         KeyPairResourcePolicyRow.max_containers_per_session,
                         KeyPairResourcePolicyRow.max_pending_session_count,
+                        KeyPairResourcePolicyRow.max_pending_session_resource_slots,
                         KeyPairResourcePolicyRow.allowed_vfolder_hosts,
                     )
                     .select_from(UserRow)
@@ -1698,6 +1699,11 @@ class ScheduleDBSource:
                 user_enqueue_policy = UserEnqueuePolicy(
                     max_containers_per_session=policy_row.max_containers_per_session,
                     max_pending_session_count=policy_row.max_pending_session_count,
+                    max_pending_session_resource_slots=(
+                        _to_slot_quota(policy_row.max_pending_session_resource_slots)
+                        if policy_row.max_pending_session_resource_slots is not None
+                        else None
+                    ),
                     allowed_vfolder_hosts=policy_row.allowed_vfolder_hosts,
                 )
 
@@ -1713,9 +1719,13 @@ class ScheduleDBSource:
                 db_sess, user_scope_for_dotfiles, access_key
             )
 
-        # Global per-user pending-session count for the enqueue queue-depth
-        # gate. Concurrent-session limits are enforced by the scheduler.
+        # Global per-user pending-session count and requested-slot total for
+        # the enqueue queue-depth / queue-resource gates. Concurrent-session
+        # limits are enforced by the scheduler. The slot total is aggregated
+        # from resource_allocations, the same normalized source the
+        # scheduling snapshot reads pending requests from.
         pending_session_count = 0
+        pending_session_resource_slots: dict[ResourceSlotName, Decimal] = {}
         if user_uuid is not None:
             pending_count_result = await db_sess.execute(
                 sa.select(sa.func.count()).where(
@@ -1725,11 +1735,30 @@ class ScheduleDBSource:
             )
             pending_session_count = int(pending_count_result.scalar_one())
 
+            pending_slots_result = await db_sess.execute(
+                sa.select(
+                    ResourceAllocationRow.slot_name,
+                    sa.func.sum(ResourceAllocationRow.requested),
+                )
+                .join(KernelRow, ResourceAllocationRow.kernel_id == KernelRow.id)
+                .where(
+                    KernelRow.user_uuid == user_uuid,
+                    KernelRow.status == KernelStatus.PENDING,
+                    ResourceAllocationRow.free_at.is_(None),
+                )
+                .group_by(ResourceAllocationRow.slot_name)
+            )
+            pending_session_resource_slots = {
+                ResourceSlotName(slot_name): Decimal(total)
+                for slot_name, total in pending_slots_result
+            }
+
         return UserEnqueueFetch(
             policy=user_enqueue_policy,
             container_user=user_container,
             dotfiles=dotfile_bundle,
             pending_session_count=pending_session_count,
+            pending_session_resource_slots=pending_session_resource_slots,
         )
 
     async def pick_default_resource_group(

--- a/src/ai/backend/manager/repositories/scheduler/repository.py
+++ b/src/ai/backend/manager/repositories/scheduler/repository.py
@@ -206,6 +206,7 @@ class SchedulerRepository:
                     container_user=ContainerUserInfo(),
                     dotfiles=DotfileBundle(),
                     pending_session_count=0,
+                    pending_session_resource_slots={},
                     vfolder_mounts_by_role={},
                 ),
                 global_info=fetch.global_info,

--- a/src/ai/backend/manager/repositories/scheduler/types/session_creation.py
+++ b/src/ai/backend/manager/repositories/scheduler/types/session_creation.py
@@ -2,8 +2,10 @@
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from decimal import Decimal
 
 from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
+from ai.backend.common.identifier.resource_slot import ResourceSlotName
 from ai.backend.common.types import (
     SessionId,
     VFolderMount,
@@ -46,6 +48,7 @@ class UserEnqueueFetch:
     container_user: ContainerUserInfo
     dotfiles: DotfileBundle
     pending_session_count: int
+    pending_session_resource_slots: Mapping[ResourceSlotName, Decimal]
 
     def to_info(
         self,
@@ -57,6 +60,7 @@ class UserEnqueueFetch:
             container_user=self.container_user,
             dotfiles=self.dotfiles,
             pending_session_count=self.pending_session_count,
+            pending_session_resource_slots=self.pending_session_resource_slots,
             vfolder_mounts_by_role=vfolder_mounts_by_role,
         )
 

--- a/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
@@ -85,6 +85,7 @@ from .validators import (
     InferenceModelFolderRule,
     MountNameValidationRule,
     PendingSessionCountLimitRule,
+    PendingSessionResourceLimitRule,
     RequestedSlotTypeRule,
     RequiredResourceSlotRule,
     ResourceLimitRule,
@@ -167,6 +168,7 @@ class SchedulingController:
         # ``SessionSpec`` + ``SessionSpecContext``.
         self._spec_validator = SessionSpecValidator([
             PendingSessionCountLimitRule(),
+            PendingSessionResourceLimitRule(),
             ContainerLimitRule(),
             ImageSlotTypeRule(),
             RequestedSlotTypeRule(),

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/__init__.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/__init__.py
@@ -6,6 +6,7 @@ from .image_slot_type_rule import ImageSlotTypeRule
 from .inference_model_folder_rule import InferenceModelFolderRule
 from .mount_name_validation_rule import MountNameValidationRule
 from .pending_session_count_limit_rule import PendingSessionCountLimitRule
+from .pending_session_resource_limit_rule import PendingSessionResourceLimitRule
 from .requested_slot_type_rule import RequestedSlotTypeRule
 from .required_resource_slot_rule import RequiredResourceSlotRule
 from .resource_limit_rule import ResourceLimitRule
@@ -17,6 +18,7 @@ from .session_spec_base import (
 
 __all__ = [
     "PendingSessionCountLimitRule",
+    "PendingSessionResourceLimitRule",
     "ContainerLimitRule",
     "DotfileVFolderConflictRule",
     "ImageSlotTypeRule",

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/pending_session_resource_limit_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/pending_session_resource_limit_rule.py
@@ -1,0 +1,69 @@
+"""Per-user pending-session resource-slot limit rule.
+
+The resource-side counterpart of ``PendingSessionCountLimitRule``: the
+total resource slots parked in a user's pending queue are bounded at
+enqueue time by the ``max_pending_session_resource_slots`` ceiling of
+the user's main keypair policy. Only the slot names the policy lists
+are capped; slots absent from the policy stay unbounded.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import override
+
+from ai.backend.common.identifier.resource_slot import ResourceSlotName
+from ai.backend.manager.data.session.spec import SessionSpec
+from ai.backend.manager.errors.kernel import QuotaExceeded
+from ai.backend.manager.sokovan.scheduling_controller.resource_parse import (
+    parse_quantity,
+)
+from ai.backend.manager.sokovan.scheduling_controller.validators.session_spec_base import (
+    SessionSpecValidatorRule,
+)
+from ai.backend.manager.views.sokovan.session_creation import (
+    SessionSpecContext,
+)
+
+
+class PendingSessionResourceLimitRule(SessionSpecValidatorRule):
+    """Reject enqueue when the pending queue's slot total would exceed its cap."""
+
+    @override
+    def name(self) -> str:
+        return "pending_session_resource_limit"
+
+    @override
+    def validate(
+        self,
+        spec: SessionSpec,
+        context: SessionSpecContext,
+    ) -> None:
+        policy = context.user.policy
+        if policy is None:
+            return
+        limit = policy.max_pending_session_resource_slots
+        if limit is None:
+            return
+        requested: dict[ResourceSlotName, Decimal] = {}
+        for kernel in spec.resource_spec.kernel_specs:
+            for entry in kernel.execution_spec.resource_input.resources:
+                slot_name = entry.resource_type
+                requested[slot_name] = requested.get(slot_name, Decimal(0)) + parse_quantity(
+                    entry.quantity
+                )
+        pending = context.user.pending_session_resource_slots
+        totals = {
+            slot_name: pending.get(slot_name, Decimal(0)) + requested.get(slot_name, Decimal(0))
+            for slot_name in limit
+        }
+        exceeded = [slot_name for slot_name, total in totals.items() if total > limit[slot_name]]
+        if exceeded:
+            total_repr = ", ".join(f"{name}={totals[name]}" for name in exceeded)
+            limit_repr = ", ".join(f"{name}={limit[name]}" for name in exceeded)
+            raise QuotaExceeded(
+                extra_msg=(
+                    f"Your pending sessions would occupy {total_repr}, "
+                    f"which exceeds the pending-session resource limit of {limit_repr}."
+                ),
+            )

--- a/src/ai/backend/manager/views/sokovan/session_creation.py
+++ b/src/ai/backend/manager/views/sokovan/session_creation.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from decimal import Decimal
 
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.resource_slot import ResourceSlotName
@@ -45,6 +46,7 @@ class UserEnqueueInfo:
     container_user: ContainerUserInfo
     dotfiles: DotfileBundle
     pending_session_count: int
+    pending_session_resource_slots: Mapping[ResourceSlotName, Decimal]
     vfolder_mounts_by_role: Mapping[str, tuple[VFolderMount, ...]]
 
 

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_assign_container_user_mapping_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_assign_container_user_mapping_rule.py
@@ -42,6 +42,7 @@ def _context(info: ContainerUserInfo) -> SessionSpecContext:
             container_user=info,
             dotfiles=DotfileBundle(),
             pending_session_count=0,
+            pending_session_resource_slots={},
             vfolder_mounts_by_role={},
         ),
         global_info=GlobalEnqueueInfo(

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_assign_network_config_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_assign_network_config_rule.py
@@ -59,6 +59,7 @@ def _context(*, use_host_network: bool = False, scaling_group: bool = True) -> S
             container_user=ContainerUserInfo(),
             dotfiles=DotfileBundle(),
             pending_session_count=0,
+            pending_session_resource_slots={},
             vfolder_mounts_by_role={},
         ),
         global_info=GlobalEnqueueInfo(

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_assign_user_identity_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_assign_user_identity_rule.py
@@ -46,6 +46,7 @@ def context() -> SessionSpecContext:
             container_user=ContainerUserInfo(),
             dotfiles=DotfileBundle(),
             pending_session_count=0,
+            pending_session_resource_slots={},
             vfolder_mounts_by_role={},
         ),
         global_info=GlobalEnqueueInfo(

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_build_internal_data_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_build_internal_data_rule.py
@@ -62,6 +62,7 @@ def _context(*, dotfiles: DotfileBundle | None = None) -> SessionSpecContext:
             container_user=ContainerUserInfo(),
             dotfiles=dotfiles or DotfileBundle(),
             pending_session_count=0,
+            pending_session_resource_slots={},
             vfolder_mounts_by_role={},
         ),
         global_info=GlobalEnqueueInfo(

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_compute_kernel_resources_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_compute_kernel_resources_rule.py
@@ -82,6 +82,7 @@ def _context(
             container_user=ContainerUserInfo(),
             dotfiles=DotfileBundle(),
             pending_session_count=0,
+            pending_session_resource_slots={},
             vfolder_mounts_by_role={},
         ),
         global_info=GlobalEnqueueInfo(

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_expand_kernel_groups_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_expand_kernel_groups_rule.py
@@ -57,6 +57,7 @@ def context() -> SessionSpecContext:
             container_user=ContainerUserInfo(),
             dotfiles=DotfileBundle(),
             pending_session_count=0,
+            pending_session_resource_slots={},
             vfolder_mounts_by_role={},
         ),
         global_info=GlobalEnqueueInfo(

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_inject_session_environ_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_inject_session_environ_rule.py
@@ -46,6 +46,7 @@ def _context() -> SessionSpecContext:
             container_user=ContainerUserInfo(),
             dotfiles=DotfileBundle(),
             pending_session_count=0,
+            pending_session_resource_slots={},
             vfolder_mounts_by_role={},
         ),
         global_info=GlobalEnqueueInfo(

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_merge_resource_group_defaults_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_merge_resource_group_defaults_rule.py
@@ -101,6 +101,7 @@ def _context(rg: DefaultSessionOptions) -> SessionSpecContext:
             container_user=ContainerUserInfo(),
             dotfiles=DotfileBundle(),
             pending_session_count=0,
+            pending_session_resource_slots={},
             vfolder_mounts_by_role={},
         ),
         global_info=GlobalEnqueueInfo(

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_resolve_vfolder_mounts_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_resolve_vfolder_mounts_rule.py
@@ -58,6 +58,7 @@ def _context(
             container_user=ContainerUserInfo(),
             dotfiles=DotfileBundle(),
             pending_session_count=0,
+            pending_session_resource_slots={},
             vfolder_mounts_by_role=vfolder_mounts_by_role or {},
         ),
         global_info=GlobalEnqueueInfo(

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_session_spec_preparer.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_session_spec_preparer.py
@@ -26,7 +26,12 @@ import pytest
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.resource_slot import ResourceSlotName
 from ai.backend.common.identifier.session import SessionID
-from ai.backend.common.types import AccessKey, ClusterMode, ResourceSlotEntry, SessionTypes
+from ai.backend.common.types import (
+    AccessKey,
+    ClusterMode,
+    ResourceSlotEntry,
+    SessionTypes,
+)
 from ai.backend.manager.data.dotfile.types import DotfileBundle
 from ai.backend.manager.data.resource.types import SlotTypeInfo
 from ai.backend.manager.data.session.creation import ContainerUserInfo
@@ -106,6 +111,7 @@ def context() -> SessionSpecContext:
             container_user=ContainerUserInfo(),
             dotfiles=DotfileBundle(),
             pending_session_count=0,
+            pending_session_resource_slots={},
             vfolder_mounts_by_role={},
         ),
         global_info=GlobalEnqueueInfo(

--- a/tests/unit/manager/sokovan/scheduling_controller/test_enqueue_session_from_draft.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/test_enqueue_session_from_draft.py
@@ -194,6 +194,7 @@ def _user_policy() -> UserEnqueuePolicy:
     return UserEnqueuePolicy(
         max_containers_per_session=4,
         max_pending_session_count=None,
+        max_pending_session_resource_slots=None,
         allowed_vfolder_hosts=VFolderHostPermissionMap(),
     )
 
@@ -222,6 +223,7 @@ def _spec_context(image_id: ImageID) -> SessionSpecContext:
             container_user=ContainerUserInfo(uid=1000, main_gid=1000, supplementary_gids=[]),
             dotfiles=DotfileBundle(),
             pending_session_count=0,
+            pending_session_resource_slots={},
             vfolder_mounts_by_role={"main": (_vfolder_mount(),)},
         ),
         global_info=GlobalEnqueueInfo(

--- a/tests/unit/manager/sokovan/scheduling_controller/validators/test_session_spec_rules.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/validators/test_session_spec_rules.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Mapping
 from decimal import Decimal
 from pathlib import PurePosixPath
 from typing import Any
@@ -70,6 +71,9 @@ from ai.backend.manager.sokovan.scheduling_controller.validators.mount_name_vali
 )
 from ai.backend.manager.sokovan.scheduling_controller.validators.pending_session_count_limit_rule import (
     PendingSessionCountLimitRule,
+)
+from ai.backend.manager.sokovan.scheduling_controller.validators.pending_session_resource_limit_rule import (
+    PendingSessionResourceLimitRule,
 )
 from ai.backend.manager.sokovan.scheduling_controller.validators.requested_slot_type_rule import (
     RequestedSlotTypeRule,
@@ -192,6 +196,7 @@ def _ctx(
     required_slot_names: frozenset[ResourceSlotName] | None = None,
     dotfiles: DotfileBundle | None = None,
     pending_session_count: int = 0,
+    pending_session_resource_slots: Mapping[ResourceSlotName, Decimal] | None = None,
 ) -> SessionSpecContext:
     slot_types_val = slot_types or {}
     served = (
@@ -209,6 +214,7 @@ def _ctx(
             container_user=ContainerUserInfo(),
             dotfiles=dotfiles or DotfileBundle(),
             pending_session_count=pending_session_count,
+            pending_session_resource_slots=pending_session_resource_slots or {},
             vfolder_mounts_by_role={},
         ),
         global_info=GlobalEnqueueInfo(
@@ -245,10 +251,12 @@ def _policy(
     *,
     max_containers: int = 4,
     max_pending: int | None = None,
+    max_pending_slots: Mapping[ResourceSlotName, Decimal] | None = None,
 ) -> UserEnqueuePolicy:
     return UserEnqueuePolicy(
         max_containers_per_session=max_containers,
         max_pending_session_count=max_pending,
+        max_pending_session_resource_slots=max_pending_slots,
         allowed_vfolder_hosts=VFolderHostPermissionMap(),
     )
 
@@ -297,6 +305,62 @@ class TestPendingSessionCountLimitRule:
         PendingSessionCountLimitRule().validate(
             _spec((_kernel(img),)),
             _ctx(policy=_policy(max_pending=None), pending_session_count=100),
+        )
+
+
+class TestPendingSessionResourceLimitRule:
+    def test_within_limit(self) -> None:
+        img = ImageID(uuid.uuid4())
+        spec = _spec((_kernel(img, cpu="1"),))
+        PendingSessionResourceLimitRule().validate(
+            spec,
+            _ctx(
+                policy=_policy(max_pending_slots={ResourceSlotName("cpu"): Decimal(4)}),
+                pending_session_resource_slots={ResourceSlotName("cpu"): Decimal(2)},
+            ),
+        )
+
+    def test_rejects_when_queue_resources_exceed_cap(self) -> None:
+        img = ImageID(uuid.uuid4())
+        spec = _spec((_kernel(img, cpu="1"),))
+        with pytest.raises(QuotaExceeded):
+            PendingSessionResourceLimitRule().validate(
+                spec,
+                _ctx(
+                    policy=_policy(max_pending_slots={ResourceSlotName("cpu"): Decimal(3)}),
+                    pending_session_resource_slots={ResourceSlotName("cpu"): Decimal(3)},
+                ),
+            )
+
+    def test_uncapped_slot_stays_unbounded(self) -> None:
+        img = ImageID(uuid.uuid4())
+        spec = _spec((_kernel(img, cpu="1"),))
+        PendingSessionResourceLimitRule().validate(
+            spec,
+            _ctx(
+                policy=_policy(max_pending_slots={ResourceSlotName("cpu"): Decimal(10)}),
+                pending_session_resource_slots={
+                    ResourceSlotName("cpu"): Decimal(1),
+                    ResourceSlotName("mem"): Decimal(1024**4),
+                },
+            ),
+        )
+
+    def test_noop_without_policy(self) -> None:
+        img = ImageID(uuid.uuid4())
+        PendingSessionResourceLimitRule().validate(
+            _spec((_kernel(img),)),
+            _ctx(pending_session_resource_slots={ResourceSlotName("cpu"): Decimal(100)}),
+        )
+
+    def test_noop_when_limit_unset(self) -> None:
+        img = ImageID(uuid.uuid4())
+        PendingSessionResourceLimitRule().validate(
+            _spec((_kernel(img),)),
+            _ctx(
+                policy=_policy(max_pending_slots=None),
+                pending_session_resource_slots={ResourceSlotName("cpu"): Decimal(100)},
+            ),
         )
 
 


### PR DESCRIPTION
## Summary
- Enforce the `max_pending_session_resource_slots` keypair resource-policy limit at session enqueue: `PendingSessionResourceLimitRule` rejects creation with `QuotaExceeded` when the user's pending-queue slot total plus the new request exceeds any slot listed in the cap (unlisted slots stay unbounded).
- Aggregate the pending-queue slot total from `resource_allocations` (`SUM(requested)` over the user's PENDING kernels), the same normalized source the scheduling snapshot reads; the cap and totals flow as plain `Mapping[ResourceSlotName, Decimal]` per the BA-6135 direction (no `ResourceSlot` above the repository).

## Test plan
- [x] Rule unit tests: within limit / exceeds cap / uncapped slot unbounded / no policy / cap unset
- [x] `pants fmt/fix/lint/check/test --changed-since` all green locally

Resolves BA-6992

🤖 Generated with [Claude Code](https://claude.com/claude-code)