### PR TITLE
fix: reserve /home/work to prevent duplicate container mount points (#12969)

### DIFF
--- a/changes/12969.fix.md
+++ b/changes/12969.fix.md
@@ -1,0 +1,1 @@
+Reject vfolder mount aliases set to exactly `/home/work`, which collided with the intrinsic scratch mount and made container creation fail with "Duplicate mount point"

--- a/src/ai/backend/common/defs/__init__.py
+++ b/src/ai/backend/common/defs/__init__.py
@@ -34,6 +34,10 @@ RESERVED_VFOLDERS = [
     ".jupyter",
     ".tmux.conf",
     ".ssh",
+    # The agent always bind-mounts the scratch directory at /home/work,
+    # so mounting a vfolder exactly there makes dockerd reject the container
+    # with "Duplicate mount point: /home/work".
+    "/home/work",
     "/bin",
     "/boot",
     "/dev",

--- a/src/ai/backend/manager/defs.py
+++ b/src/ai/backend/manager/defs.py
@@ -3,7 +3,6 @@ Common definitions/constants used throughout the manager.
 """
 
 import enum
-import re
 from typing import Final
 
 from ai.backend.common.arch import CURRENT_ARCH
@@ -35,34 +34,7 @@ DEFAULT_ROLE: Final = "main"
 
 PASSWORD_PLACEHOLDER: Final = "*****"
 
-_RESERVED_VFOLDER_PATTERNS = [r"^\.[a-z0-9]+rc$", r"^\.[a-z0-9]+_profile$"]
 RESERVED_DOTFILES = [".terminfo", ".jupyter", ".ssh", ".ssh/authorized_keys", ".local", ".config"]
-RESERVED_VFOLDERS = [
-    ".terminfo",
-    ".jupyter",
-    ".tmux.conf",
-    ".ssh",
-    "/bin",
-    "/boot",
-    "/dev",
-    "/etc",
-    "/lib",
-    "/lib64",
-    "/media",
-    "/mnt",
-    "/opt",
-    "/proc",
-    "/root",
-    "/run",
-    "/sbin",
-    "/srv",
-    "/sys",
-    "/tmp",
-    "/usr",
-    "/var",
-    "/home",
-]
-RESERVED_VFOLDER_PATTERNS = [re.compile(x) for x in _RESERVED_VFOLDER_PATTERNS]
 
 # Mapping between vfolder names and their in-container paths.
 VFOLDER_DSTPATHS_MAP = {

--- a/src/ai/backend/manager/models/vfolder/row.py
+++ b/src/ai/backend/manager/models/vfolder/row.py
@@ -59,7 +59,7 @@ from ai.backend.manager.data.vfolder.types import (
     VFolderOwnershipType,
 )
 from ai.backend.manager.data.vfolder.types import VFolderMountPermission as VFolderPermission
-from ai.backend.manager.defs import is_noop_host
+from ai.backend.manager.defs import VFOLDER_DSTPATHS_MAP
 from ai.backend.manager.errors.api import InvalidAPIParameters
 from ai.backend.manager.errors.common import ObjectNotFound
 from ai.backend.manager.errors.storage import (

--- a/src/ai/backend/manager/models/vfolder/row.py
+++ b/src/ai/backend/manager/models/vfolder/row.py
@@ -27,7 +27,11 @@ from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 from sqlalchemy.orm import Mapped, foreign, load_only, mapped_column, relationship, selectinload
 
-from ai.backend.common.defs import MODEL_VFOLDER_LENGTH_LIMIT
+from ai.backend.common.defs import (
+    MODEL_VFOLDER_LENGTH_LIMIT,
+    RESERVED_VFOLDER_PATTERNS,
+    RESERVED_VFOLDERS,
+)
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import (
     MountPermission,
@@ -55,11 +59,7 @@ from ai.backend.manager.data.vfolder.types import (
     VFolderOwnershipType,
 )
 from ai.backend.manager.data.vfolder.types import VFolderMountPermission as VFolderPermission
-from ai.backend.manager.defs import (
-    RESERVED_VFOLDER_PATTERNS,
-    RESERVED_VFOLDERS,
-    VFOLDER_DSTPATHS_MAP,
-)
+from ai.backend.manager.defs import is_noop_host
 from ai.backend.manager.errors.api import InvalidAPIParameters
 from ai.backend.manager.errors.common import ObjectNotFound
 from ai.backend.manager.errors.storage import (

--- a/tests/unit/manager/api/test_utils.py
+++ b/tests/unit/manager/api/test_utils.py
@@ -63,6 +63,9 @@ def test_vfolder_name_validator() -> None:
     assert verify_vfolder_name("/home/work/boot")
     assert verify_vfolder_name("/home/work/root")
     assert verify_vfolder_name("home/work")
+    # Mounting exactly at /home/work collides with the agent's intrinsic
+    # scratch mount and makes dockerd reject container creation.
+    assert not verify_vfolder_name("/home/work")
 
 
 def test_dotfile_name_validator() -> None:


### PR DESCRIPTION
This is an auto-generated backport PR of #12969 to the 26.4 release.