### PR TITLE
feat(BA-6999): implement initial grace period handler and applier

### DIFF
--- a/changes/13090.feature.md
+++ b/changes/13090.feature.md
@@ -1,0 +1,1 @@
+Add the initial grace period handler and applier for reconciler-based idle checks.

--- a/src/ai/backend/common/data/idle_checker/types.py
+++ b/src/ai/backend/common/data/idle_checker/types.py
@@ -18,6 +18,7 @@ class CheckerType(enum.StrEnum):
 
 class IdleCheckPhase(enum.StrEnum):
     NOT_CHECKED = "not_checked"
+    READY_TO_CHECK = "ready_to_check"
     ACTIVE = "active"
     IDLE = "idle"
     IDLE_EXPIRED = "idle_expired"

--- a/src/ai/backend/manager/models/idle_checker/conditions.py
+++ b/src/ai/backend/manager/models/idle_checker/conditions.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+from collections.abc import Collection
+
 import sqlalchemy as sa
 
+from ai.backend.common.data.idle_checker.types import IdleCheckPhase
+from ai.backend.common.identifier.idle_checker import IdleCheckerID
+from ai.backend.common.types import SessionId
 from ai.backend.manager.models.clauses import QueryCondition
 
-from .row import IdleCheckerBindingRow
+from .row import IdleCheckerBindingRow, SessionIdleCheckRow
 
 
 class IdleCheckerBindingConditions:
@@ -12,5 +17,26 @@ class IdleCheckerBindingConditions:
     def enabled() -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return IdleCheckerBindingRow.enabled == sa.true()
+
+        return inner
+
+
+class SessionIdleCheckConditions:
+    @staticmethod
+    def by_pairs(
+        pairs: Collection[tuple[SessionId, IdleCheckerID]],
+    ) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return sa.tuple_(
+                SessionIdleCheckRow.session_id,
+                SessionIdleCheckRow.idle_checker_id,
+            ).in_(pairs)
+
+        return inner
+
+    @staticmethod
+    def by_status_equals(status: IdleCheckPhase) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return SessionIdleCheckRow.last_status == status
 
         return inner

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -50,7 +50,7 @@ from ai.backend.manager.repositories.idle_checker.types import (
     SessionIdleCheckPair,
 )
 from ai.backend.manager.repositories.idle_checker.updaters import (
-    SessionIdleCheckReadyBatchUpdaterSpec,
+    SessionIdleCheckPhaseBatchUpdaterSpec,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider
 
@@ -276,19 +276,22 @@ class IdleCheckerDBSource:
                         )
                     )
 
-    async def mark_session_idle_checks_ready_to_check(
+    async def batch_update_session_idle_check_phase(
         self,
         pairs: Sequence[SessionIdleCheckPair],
+        *,
+        from_phase: IdleCheckPhase,
+        to_phase: IdleCheckPhase,
     ) -> None:
         async with self._ops.write_ops() as w:
             for pair_batch in batched(pairs, _IDLE_CHECK_UPDATE_BATCH_SIZE):
                 pair_values = [(pair.session_id, pair.checker_id) for pair in pair_batch]
                 await w.batch_update(
                     BatchUpdater(
-                        spec=SessionIdleCheckReadyBatchUpdaterSpec(),
+                        spec=SessionIdleCheckPhaseBatchUpdaterSpec(to_phase=to_phase),
                         conditions=[
                             SessionIdleCheckConditions.by_pairs(pair_values),
-                            SessionIdleCheckConditions.by_status_equals(IdleCheckPhase.NOT_CHECKED),
+                            SessionIdleCheckConditions.by_status_equals(from_phase),
                         ],
                     )
                 )

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -19,6 +19,7 @@ from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.data.idle_checker.types import IdleCheckSession
 from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.models.idle_checker.conditions import SessionIdleCheckConditions
 from ai.backend.manager.models.idle_checker.row import (
     IdleCheckerBindingRow,
     IdleCheckerRow,
@@ -29,6 +30,7 @@ from ai.backend.manager.models.session.row import SessionRow
 from ai.backend.manager.repositories.base import (
     BatchPurger,
     BatchQuerier,
+    BatchUpdater,
     BulkCreator,
     NoPagination,
 )
@@ -47,9 +49,13 @@ from ai.backend.manager.repositories.idle_checker.types import (
     SessionIdleCheckAssignmentData,
     SessionIdleCheckPair,
 )
+from ai.backend.manager.repositories.idle_checker.updaters import (
+    SessionIdleCheckReadyBatchUpdaterSpec,
+)
 from ai.backend.manager.repositories.ops import DBOpsProvider
 
 _ASSIGNMENT_DELETE_BATCH_SIZE = 1000
+_IDLE_CHECK_UPDATE_BATCH_SIZE = 1000
 
 
 class IdleCheckerDBSource:
@@ -77,7 +83,11 @@ class IdleCheckerDBSource:
             .join(IdleCheckerRow, SessionIdleCheckRow.idle_checker_id == IdleCheckerRow.id)
             .where(
                 SessionRow.status.in_(session_statuses),
-                SessionIdleCheckRow.last_status.in_((IdleCheckPhase.ACTIVE, IdleCheckPhase.IDLE)),
+                SessionIdleCheckRow.last_status.in_((
+                    IdleCheckPhase.READY_TO_CHECK,
+                    IdleCheckPhase.ACTIVE,
+                    IdleCheckPhase.IDLE,
+                )),
             )
         )
         querier = BatchQuerier(pagination=NoPagination())
@@ -265,3 +275,20 @@ class IdleCheckerDBSource:
                             batch_size=_ASSIGNMENT_DELETE_BATCH_SIZE,
                         )
                     )
+
+    async def mark_session_idle_checks_ready_to_check(
+        self,
+        pairs: Sequence[SessionIdleCheckPair],
+    ) -> None:
+        async with self._ops.write_ops() as w:
+            for pair_batch in batched(pairs, _IDLE_CHECK_UPDATE_BATCH_SIZE):
+                pair_values = [(pair.session_id, pair.checker_id) for pair in pair_batch]
+                await w.batch_update(
+                    BatchUpdater(
+                        spec=SessionIdleCheckReadyBatchUpdaterSpec(),
+                        conditions=[
+                            SessionIdleCheckConditions.by_pairs(pair_values),
+                            SessionIdleCheckConditions.by_status_equals(IdleCheckPhase.NOT_CHECKED),
+                        ],
+                    )
+                )

--- a/src/ai/backend/manager/repositories/idle_checker/repository.py
+++ b/src/ai/backend/manager/repositories/idle_checker/repository.py
@@ -58,3 +58,9 @@ class IdleCheckerRepository:
             pairs_to_delete,
             now,
         )
+
+    async def mark_session_idle_checks_ready_to_check(
+        self,
+        pairs: Sequence[SessionIdleCheckPair],
+    ) -> None:
+        await self._db_source.mark_session_idle_checks_ready_to_check(pairs)

--- a/src/ai/backend/manager/repositories/idle_checker/repository.py
+++ b/src/ai/backend/manager/repositories/idle_checker/repository.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Collection, Sequence
 from datetime import datetime
 
+from ai.backend.common.data.idle_checker.types import IdleCheckPhase
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.repositories.idle_checker.db_source.db_source import IdleCheckerDBSource
 from ai.backend.manager.repositories.idle_checker.types import (
@@ -59,8 +60,15 @@ class IdleCheckerRepository:
             now,
         )
 
-    async def mark_session_idle_checks_ready_to_check(
+    async def batch_update_session_idle_check_phase(
         self,
         pairs: Sequence[SessionIdleCheckPair],
+        *,
+        from_phase: IdleCheckPhase,
+        to_phase: IdleCheckPhase,
     ) -> None:
-        await self._db_source.mark_session_idle_checks_ready_to_check(pairs)
+        await self._db_source.batch_update_session_idle_check_phase(
+            pairs,
+            from_phase=from_phase,
+            to_phase=to_phase,
+        )

--- a/src/ai/backend/manager/repositories/idle_checker/updaters.py
+++ b/src/ai/backend/manager/repositories/idle_checker/updaters.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.idle_checker.types import IdleCheckPhase
@@ -7,7 +8,10 @@ from ai.backend.manager.models.idle_checker.row import SessionIdleCheckRow
 from ai.backend.manager.repositories.base import BatchUpdaterSpec
 
 
-class SessionIdleCheckReadyBatchUpdaterSpec(BatchUpdaterSpec[SessionIdleCheckRow]):
+@dataclass
+class SessionIdleCheckPhaseBatchUpdaterSpec(BatchUpdaterSpec[SessionIdleCheckRow]):
+    to_phase: IdleCheckPhase
+
     @property
     @override
     def row_class(self) -> type[SessionIdleCheckRow]:
@@ -15,4 +19,4 @@ class SessionIdleCheckReadyBatchUpdaterSpec(BatchUpdaterSpec[SessionIdleCheckRow
 
     @override
     def build_values(self) -> dict[str, Any]:
-        return {"last_status": IdleCheckPhase.READY_TO_CHECK}
+        return {"last_status": self.to_phase}

--- a/src/ai/backend/manager/repositories/idle_checker/updaters.py
+++ b/src/ai/backend/manager/repositories/idle_checker/updaters.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any, override
+
+from ai.backend.common.data.idle_checker.types import IdleCheckPhase
+from ai.backend.manager.models.idle_checker.row import SessionIdleCheckRow
+from ai.backend.manager.repositories.base import BatchUpdaterSpec
+
+
+class SessionIdleCheckReadyBatchUpdaterSpec(BatchUpdaterSpec[SessionIdleCheckRow]):
+    @property
+    @override
+    def row_class(self) -> type[SessionIdleCheckRow]:
+        return SessionIdleCheckRow
+
+    @override
+    def build_values(self) -> dict[str, Any]:
+        return {"last_status": IdleCheckPhase.READY_TO_CHECK}

--- a/src/ai/backend/manager/sokovan/idle_check/initial_grace/applier.py
+++ b/src/ai/backend/manager/sokovan/idle_check/initial_grace/applier.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import override
 
+from ai.backend.common.data.idle_checker.types import IdleCheckPhase
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
 from ai.backend.manager.sokovan.idle_check.initial_grace.types import (
@@ -42,4 +43,8 @@ class IdleCheckInitialGraceApplier(
         pairs = apply_input.result.pairs_to_ready
         if not pairs:
             return
-        await self._repository.mark_session_idle_checks_ready_to_check(pairs)
+        await self._repository.batch_update_session_idle_check_phase(
+            pairs,
+            from_phase=IdleCheckPhase.NOT_CHECKED,
+            to_phase=IdleCheckPhase.READY_TO_CHECK,
+        )

--- a/src/ai/backend/manager/sokovan/idle_check/initial_grace/applier.py
+++ b/src/ai/backend/manager/sokovan/idle_check/initial_grace/applier.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import override
+
+from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
+from ai.backend.manager.sokovan.idle_check.initial_grace.types import (
+    IdleCheckInitialGraceResult,
+)
+from ai.backend.manager.sokovan.idle_check.types import (
+    IdleCheckCategory,
+    IdleCheckKind,
+    IdleCheckTargetStatuses,
+)
+from ai.backend.manager.sokovan.reconciler.base import ReconcilerApplier, ReconcilerApplyInput
+
+_IdleCheckInitialGraceApplyInput = ReconcilerApplyInput[
+    IdleCheckInitialGraceResult,
+    IdleCheckCategory,
+    IdleCheckKind,
+    IdleCheckTargetStatuses,
+    SessionStatus,
+]
+
+
+class IdleCheckInitialGraceApplier(
+    ReconcilerApplier[
+        IdleCheckInitialGraceResult,
+        IdleCheckCategory,
+        IdleCheckKind,
+        IdleCheckTargetStatuses,
+        SessionStatus,
+    ]
+):
+    _repository: IdleCheckerRepository
+
+    def __init__(self, repository: IdleCheckerRepository) -> None:
+        self._repository = repository
+
+    @override
+    async def apply(self, apply_input: _IdleCheckInitialGraceApplyInput) -> None:
+        pairs = apply_input.result.pairs_to_ready
+        if not pairs:
+            return
+        await self._repository.mark_session_idle_checks_ready_to_check(pairs)

--- a/src/ai/backend/manager/sokovan/idle_check/initial_grace/handler.py
+++ b/src/ai/backend/manager/sokovan/idle_check/initial_grace/handler.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import override
+
+from ai.backend.manager.sokovan.idle_check.initial_grace.types import (
+    IdleCheckInitialGraceReconcileInfo,
+    IdleCheckInitialGraceResult,
+)
+from ai.backend.manager.sokovan.reconciler.base import ReconcilerHandler
+
+
+class IdleCheckInitialGraceHandler(
+    ReconcilerHandler[IdleCheckInitialGraceReconcileInfo, IdleCheckInitialGraceResult]
+):
+    @override
+    async def execute(
+        self,
+        reconcile_info: IdleCheckInitialGraceReconcileInfo,
+    ) -> IdleCheckInitialGraceResult:
+        now = reconcile_info.batch.now
+        pairs_to_ready = []
+        for check in reconcile_info.batch.checks:
+            grace_period = timedelta(seconds=check.initial_grace_period_seconds)
+            grace_period_end = check.grace_started_at + grace_period
+            if grace_period_end <= now:
+                pairs_to_ready.append(check.pair)
+        return IdleCheckInitialGraceResult(pairs_to_ready=pairs_to_ready)
+
+    @override
+    async def post_process(self, result: IdleCheckInitialGraceResult) -> None:
+        pass

--- a/src/ai/backend/manager/sokovan/idle_check/initial_grace/types.py
+++ b/src/ai/backend/manager/sokovan/idle_check/initial_grace/types.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import override
 from uuid import UUID
 
 from ai.backend.manager.repositories.idle_checker.types import (
     InitialGracePeriodBatchData,
+    SessionIdleCheckPair,
 )
-from ai.backend.manager.sokovan.reconciler.base import BaseReconcilerInfo
+from ai.backend.manager.sokovan.reconciler.base import (
+    BaseReconcilerInfo,
+    BaseReconcilerResult,
+    ReconcilerDecision,
+)
 
 
 @dataclass
@@ -23,3 +28,20 @@ class IdleCheckInitialGraceReconcileInfo(BaseReconcilerInfo):
     @override
     def now(self) -> datetime:
         return self.batch.now
+
+
+@dataclass
+class IdleCheckInitialGraceResult(BaseReconcilerResult):
+    pairs_to_ready: list[SessionIdleCheckPair] = field(default_factory=list)
+
+    @override
+    def processed_count(self) -> int:
+        return len(self.pairs_to_ready)
+
+    @override
+    def failed_count(self) -> int:
+        return 0
+
+    @override
+    def decisions(self) -> Sequence[ReconcilerDecision]:
+        return ()

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -66,6 +66,7 @@ class JudgmentRows:
     active_session_id: SessionId
     idle_session_id: SessionId
     not_checked_session_id: SessionId
+    ready_to_check_session_id: SessionId
     idle_expired_session_id: SessionId
     session_without_row_id: SessionId
     terminated_session_id: SessionId
@@ -208,6 +209,7 @@ class TestFetchJudgmentBatch:
         active_session_id = SessionId(uuid.uuid4())
         idle_session_id = SessionId(uuid.uuid4())
         not_checked_session_id = SessionId(uuid.uuid4())
+        ready_to_check_session_id = SessionId(uuid.uuid4())
         idle_expired_session_id = SessionId(uuid.uuid4())
         session_without_row_id = SessionId(uuid.uuid4())
         terminated_session_id = SessionId(uuid.uuid4())
@@ -216,6 +218,7 @@ class TestFetchJudgmentBatch:
             (active_session_id, SessionStatus.RUNNING),
             (idle_session_id, SessionStatus.RUNNING),
             (not_checked_session_id, SessionStatus.RUNNING),
+            (ready_to_check_session_id, SessionStatus.RUNNING),
             (idle_expired_session_id, SessionStatus.RUNNING),
             (session_without_row_id, SessionStatus.RUNNING),
             (terminated_session_id, SessionStatus.TERMINATED),
@@ -224,6 +227,7 @@ class TestFetchJudgmentBatch:
             (active_session_id, IdleCheckPhase.ACTIVE),
             (idle_session_id, IdleCheckPhase.IDLE),
             (not_checked_session_id, IdleCheckPhase.NOT_CHECKED),
+            (ready_to_check_session_id, IdleCheckPhase.READY_TO_CHECK),
             (idle_expired_session_id, IdleCheckPhase.IDLE_EXPIRED),
             (terminated_session_id, IdleCheckPhase.ACTIVE),
         )
@@ -256,13 +260,14 @@ class TestFetchJudgmentBatch:
             active_session_id=active_session_id,
             idle_session_id=idle_session_id,
             not_checked_session_id=not_checked_session_id,
+            ready_to_check_session_id=ready_to_check_session_id,
             idle_expired_session_id=idle_expired_session_id,
             session_without_row_id=session_without_row_id,
             terminated_session_id=terminated_session_id,
             checker_id=checker_id,
         )
 
-    async def test_returns_active_and_idle_rows(
+    async def test_returns_ready_active_and_idle_rows(
         self,
         repository: IdleCheckerRepository,
         judgment_rows: JudgmentRows,
@@ -274,6 +279,7 @@ class TestFetchJudgmentBatch:
             for assignment in batch.assignments
         }
         assert pairs == {
+            (judgment_rows.ready_to_check_session_id, judgment_rows.checker_id),
             (judgment_rows.active_session_id, judgment_rows.checker_id),
             (judgment_rows.idle_session_id, judgment_rows.checker_id),
         }
@@ -288,6 +294,78 @@ class TestFetchJudgmentBatch:
         session_ids = {assignment.session.session_id for assignment in batch.assignments}
         assert judgment_rows.not_checked_session_id not in session_ids
         assert judgment_rows.idle_expired_session_id not in session_ids
+
+    async def test_marks_not_checked_row_ready_to_check(
+        self,
+        database: ExtendedAsyncSAEngine,
+        repository: IdleCheckerRepository,
+        judgment_rows: JudgmentRows,
+    ) -> None:
+        pair = SessionIdleCheckPair(
+            judgment_rows.not_checked_session_id,
+            judgment_rows.checker_id,
+        )
+
+        await repository.mark_session_idle_checks_ready_to_check([pair])
+
+        async with database.begin_readonly_session() as db_sess:
+            row = await db_sess.get(
+                SessionIdleCheckRow,
+                (pair.session_id, pair.checker_id),
+            )
+        assert row is not None
+        assert row.last_status is IdleCheckPhase.READY_TO_CHECK
+
+    async def test_does_not_overwrite_row_that_is_no_longer_not_checked(
+        self,
+        database: ExtendedAsyncSAEngine,
+        repository: IdleCheckerRepository,
+        judgment_rows: JudgmentRows,
+    ) -> None:
+        pair = SessionIdleCheckPair(
+            judgment_rows.active_session_id,
+            judgment_rows.checker_id,
+        )
+
+        await repository.mark_session_idle_checks_ready_to_check([pair])
+
+        async with database.begin_readonly_session() as db_sess:
+            row = await db_sess.get(
+                SessionIdleCheckRow,
+                (pair.session_id, pair.checker_id),
+            )
+        assert row is not None
+        assert row.last_status is IdleCheckPhase.ACTIVE
+
+    async def test_marks_existing_row_when_batch_contains_missing_pair(
+        self,
+        database: ExtendedAsyncSAEngine,
+        repository: IdleCheckerRepository,
+        judgment_rows: JudgmentRows,
+    ) -> None:
+        existing_pair = SessionIdleCheckPair(
+            judgment_rows.not_checked_session_id,
+            judgment_rows.checker_id,
+        )
+        missing_pair = SessionIdleCheckPair(
+            SessionId(uuid.uuid4()),
+            judgment_rows.checker_id,
+        )
+
+        await repository.mark_session_idle_checks_ready_to_check([existing_pair, missing_pair])
+
+        async with database.begin_readonly_session() as db_sess:
+            row = await db_sess.get(
+                SessionIdleCheckRow,
+                (existing_pair.session_id, existing_pair.checker_id),
+            )
+            missing_row = await db_sess.get(
+                SessionIdleCheckRow,
+                (missing_pair.session_id, missing_pair.checker_id),
+            )
+        assert row is not None
+        assert row.last_status is IdleCheckPhase.READY_TO_CHECK
+        assert missing_row is None
 
     async def test_fetches_only_not_checked_rows_for_initial_grace(
         self,
@@ -337,6 +415,7 @@ class TestFetchJudgmentBatch:
                 judgment_rows.active_session_id,
                 judgment_rows.idle_session_id,
                 judgment_rows.not_checked_session_id,
+                judgment_rows.ready_to_check_session_id,
                 judgment_rows.idle_expired_session_id,
                 judgment_rows.session_without_row_id,
             )
@@ -347,6 +426,7 @@ class TestFetchJudgmentBatch:
                 judgment_rows.active_session_id,
                 judgment_rows.idle_session_id,
                 judgment_rows.not_checked_session_id,
+                judgment_rows.ready_to_check_session_id,
                 judgment_rows.idle_expired_session_id,
             )
         }

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -306,7 +306,11 @@ class TestFetchJudgmentBatch:
             judgment_rows.checker_id,
         )
 
-        await repository.mark_session_idle_checks_ready_to_check([pair])
+        await repository.batch_update_session_idle_check_phase(
+            [pair],
+            from_phase=IdleCheckPhase.NOT_CHECKED,
+            to_phase=IdleCheckPhase.READY_TO_CHECK,
+        )
 
         async with database.begin_readonly_session() as db_sess:
             row = await db_sess.get(
@@ -327,7 +331,11 @@ class TestFetchJudgmentBatch:
             judgment_rows.checker_id,
         )
 
-        await repository.mark_session_idle_checks_ready_to_check([pair])
+        await repository.batch_update_session_idle_check_phase(
+            [pair],
+            from_phase=IdleCheckPhase.NOT_CHECKED,
+            to_phase=IdleCheckPhase.READY_TO_CHECK,
+        )
 
         async with database.begin_readonly_session() as db_sess:
             row = await db_sess.get(
@@ -336,6 +344,31 @@ class TestFetchJudgmentBatch:
             )
         assert row is not None
         assert row.last_status is IdleCheckPhase.ACTIVE
+
+    async def test_transitions_between_injected_phases(
+        self,
+        database: ExtendedAsyncSAEngine,
+        repository: IdleCheckerRepository,
+        judgment_rows: JudgmentRows,
+    ) -> None:
+        pair = SessionIdleCheckPair(
+            judgment_rows.active_session_id,
+            judgment_rows.checker_id,
+        )
+
+        await repository.batch_update_session_idle_check_phase(
+            [pair],
+            from_phase=IdleCheckPhase.ACTIVE,
+            to_phase=IdleCheckPhase.IDLE,
+        )
+
+        async with database.begin_readonly_session() as db_sess:
+            row = await db_sess.get(
+                SessionIdleCheckRow,
+                (pair.session_id, pair.checker_id),
+            )
+        assert row is not None
+        assert row.last_status is IdleCheckPhase.IDLE
 
     async def test_marks_existing_row_when_batch_contains_missing_pair(
         self,
@@ -352,7 +385,11 @@ class TestFetchJudgmentBatch:
             judgment_rows.checker_id,
         )
 
-        await repository.mark_session_idle_checks_ready_to_check([existing_pair, missing_pair])
+        await repository.batch_update_session_idle_check_phase(
+            [existing_pair, missing_pair],
+            from_phase=IdleCheckPhase.NOT_CHECKED,
+            to_phase=IdleCheckPhase.READY_TO_CHECK,
+        )
 
         async with database.begin_readonly_session() as db_sess:
             row = await db_sess.get(

--- a/tests/unit/manager/sokovan/idle_check/test_initial_grace.py
+++ b/tests/unit/manager/sokovan/idle_check/test_initial_grace.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 import pytest
 
+from ai.backend.common.data.idle_checker.types import IdleCheckPhase
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId
 from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
@@ -210,7 +211,11 @@ class TestIdleCheckInitialGraceApplier:
     ) -> None:
         await applier.apply(ready_apply_input)
 
-        repository.mark_session_idle_checks_ready_to_check.assert_awaited_once_with([ready_pair])
+        repository.batch_update_session_idle_check_phase.assert_awaited_once_with(
+            [ready_pair],
+            from_phase=IdleCheckPhase.NOT_CHECKED,
+            to_phase=IdleCheckPhase.READY_TO_CHECK,
+        )
 
     async def test_skips_empty_result(
         self,
@@ -220,4 +225,4 @@ class TestIdleCheckInitialGraceApplier:
     ) -> None:
         await applier.apply(empty_apply_input)
 
-        repository.mark_session_idle_checks_ready_to_check.assert_not_awaited()
+        repository.batch_update_session_idle_check_phase.assert_not_awaited()

--- a/tests/unit/manager/sokovan/idle_check/test_initial_grace.py
+++ b/tests/unit/manager/sokovan/idle_check/test_initial_grace.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from ai.backend.common.identifier.idle_checker import IdleCheckerID
+from ai.backend.common.types import SessionId
+from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
+from ai.backend.manager.repositories.idle_checker.types import (
+    InitialGracePeriodBatchData,
+    InitialGracePeriodCheckData,
+    SessionIdleCheckPair,
+)
+from ai.backend.manager.sokovan.idle_check.initial_grace.applier import (
+    IdleCheckInitialGraceApplier,
+)
+from ai.backend.manager.sokovan.idle_check.initial_grace.handler import (
+    IdleCheckInitialGraceHandler,
+)
+from ai.backend.manager.sokovan.idle_check.initial_grace.types import (
+    IdleCheckInitialGraceReconcileInfo,
+    IdleCheckInitialGraceResult,
+)
+
+
+@pytest.fixture
+def now() -> datetime:
+    return datetime(2026, 1, 1, 0, 1, tzinfo=UTC)
+
+
+@dataclass(frozen=True)
+class InitialGraceCheckParam:
+    initial_grace_period_seconds: int
+    elapsed_seconds: int
+    expected_ready: bool
+
+
+@dataclass(frozen=True)
+class InitialGraceHandlerCase:
+    reconcile_info: IdleCheckInitialGraceReconcileInfo
+    expected_ready_pairs: list[SessionIdleCheckPair]
+
+
+class TestIdleCheckInitialGraceHandler:
+    @pytest.fixture
+    def handler(self) -> IdleCheckInitialGraceHandler:
+        return IdleCheckInitialGraceHandler()
+
+    @pytest.fixture
+    def handler_case(
+        self,
+        request: pytest.FixtureRequest,
+        now: datetime,
+    ) -> InitialGraceHandlerCase:
+        param: InitialGraceCheckParam = request.param
+        check = InitialGracePeriodCheckData(
+            pair=SessionIdleCheckPair(
+                session_id=SessionId(uuid4()),
+                checker_id=IdleCheckerID(uuid4()),
+            ),
+            initial_grace_period_seconds=param.initial_grace_period_seconds,
+            grace_started_at=now - timedelta(seconds=param.elapsed_seconds),
+        )
+        reconcile_info = IdleCheckInitialGraceReconcileInfo(
+            batch=InitialGracePeriodBatchData(checks=[check], now=now)
+        )
+        expected_ready_pairs = [check.pair] if param.expected_ready else []
+        return InitialGraceHandlerCase(
+            reconcile_info=reconcile_info,
+            expected_ready_pairs=expected_ready_pairs,
+        )
+
+    @pytest.fixture
+    def mixed_reconcile_info(self, now: datetime) -> IdleCheckInitialGraceReconcileInfo:
+        elapsed_check = InitialGracePeriodCheckData(
+            pair=SessionIdleCheckPair(
+                session_id=SessionId(uuid4()),
+                checker_id=IdleCheckerID(uuid4()),
+            ),
+            initial_grace_period_seconds=60,
+            grace_started_at=now - timedelta(seconds=60),
+        )
+        waiting_check = InitialGracePeriodCheckData(
+            pair=SessionIdleCheckPair(
+                session_id=SessionId(uuid4()),
+                checker_id=IdleCheckerID(uuid4()),
+            ),
+            initial_grace_period_seconds=60,
+            grace_started_at=now - timedelta(seconds=59),
+        )
+        return IdleCheckInitialGraceReconcileInfo(
+            batch=InitialGracePeriodBatchData(
+                checks=[elapsed_check, waiting_check],
+                now=now,
+            )
+        )
+
+    @pytest.fixture
+    def empty_reconcile_info(self, now: datetime) -> IdleCheckInitialGraceReconcileInfo:
+        return IdleCheckInitialGraceReconcileInfo(
+            batch=InitialGracePeriodBatchData(checks=[], now=now)
+        )
+
+    @pytest.mark.parametrize(
+        "handler_case",
+        [
+            pytest.param(
+                InitialGraceCheckParam(
+                    initial_grace_period_seconds=60,
+                    elapsed_seconds=61,
+                    expected_ready=True,
+                ),
+                id="elapsed",
+            ),
+            pytest.param(
+                InitialGraceCheckParam(
+                    initial_grace_period_seconds=60,
+                    elapsed_seconds=60,
+                    expected_ready=True,
+                ),
+                id="boundary",
+            ),
+            pytest.param(
+                InitialGraceCheckParam(
+                    initial_grace_period_seconds=60,
+                    elapsed_seconds=59,
+                    expected_ready=False,
+                ),
+                id="waiting",
+            ),
+            pytest.param(
+                InitialGraceCheckParam(
+                    initial_grace_period_seconds=0,
+                    elapsed_seconds=0,
+                    expected_ready=True,
+                ),
+                id="zero-grace",
+            ),
+        ],
+        indirect=True,
+    )
+    async def test_selects_check_after_grace_period(
+        self,
+        handler: IdleCheckInitialGraceHandler,
+        handler_case: InitialGraceHandlerCase,
+    ) -> None:
+        result = await handler.execute(handler_case.reconcile_info)
+
+        assert result.pairs_to_ready == handler_case.expected_ready_pairs
+        assert result.processed_count() == len(handler_case.expected_ready_pairs)
+
+    async def test_selects_only_elapsed_checks(
+        self,
+        handler: IdleCheckInitialGraceHandler,
+        mixed_reconcile_info: IdleCheckInitialGraceReconcileInfo,
+    ) -> None:
+        result = await handler.execute(mixed_reconcile_info)
+
+        assert result.pairs_to_ready == [mixed_reconcile_info.batch.checks[0].pair]
+
+    async def test_returns_empty_result_for_empty_batch(
+        self,
+        handler: IdleCheckInitialGraceHandler,
+        empty_reconcile_info: IdleCheckInitialGraceReconcileInfo,
+    ) -> None:
+        result = await handler.execute(empty_reconcile_info)
+
+        assert result.pairs_to_ready == []
+        assert result.processed_count() == 0
+
+
+class TestIdleCheckInitialGraceApplier:
+    @pytest.fixture
+    def repository(self) -> AsyncMock:
+        return AsyncMock(spec=IdleCheckerRepository)
+
+    @pytest.fixture
+    def applier(self, repository: AsyncMock) -> IdleCheckInitialGraceApplier:
+        return IdleCheckInitialGraceApplier(repository)
+
+    @pytest.fixture
+    def ready_pair(self) -> SessionIdleCheckPair:
+        return SessionIdleCheckPair(
+            session_id=SessionId(uuid4()),
+            checker_id=IdleCheckerID(uuid4()),
+        )
+
+    @pytest.fixture
+    def ready_apply_input(self, ready_pair: SessionIdleCheckPair) -> MagicMock:
+        apply_input = MagicMock()
+        apply_input.result = IdleCheckInitialGraceResult(pairs_to_ready=[ready_pair])
+        return apply_input
+
+    @pytest.fixture
+    def empty_apply_input(self) -> MagicMock:
+        apply_input = MagicMock()
+        apply_input.result = IdleCheckInitialGraceResult()
+        return apply_input
+
+    async def test_marks_ready_pairs(
+        self,
+        applier: IdleCheckInitialGraceApplier,
+        repository: AsyncMock,
+        ready_pair: SessionIdleCheckPair,
+        ready_apply_input: MagicMock,
+    ) -> None:
+        await applier.apply(ready_apply_input)
+
+        repository.mark_session_idle_checks_ready_to_check.assert_awaited_once_with([ready_pair])
+
+    async def test_skips_empty_result(
+        self,
+        applier: IdleCheckInitialGraceApplier,
+        repository: AsyncMock,
+        empty_apply_input: MagicMock,
+    ) -> None:
+        await applier.apply(empty_apply_input)
+
+        repository.mark_session_idle_checks_ready_to_check.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Add an initial grace period handler that selects session-checker pairs whose grace period has elapsed.
- Add an applier and repository batch update that conditionally transitions `NOT_CHECKED` rows to `READY_TO_CHECK`.
- Include `READY_TO_CHECK` rows in idle judgment batches and cover handler, applier, and repository behavior with tests.

## Test plan
- [x] `pants fmt ::`
- [x] `pants fix ::`
- [x] `pants lint --changed-since=origin/main`
- [x] Push-hook MyPy checks for `origin/main..HEAD`
- [x] Push-hook idle-check unit and repository tests

Resolves BA-6999
