### PR TITLE
feat(BA-6829): add v2 agent resource-group change API

### DIFF
--- a/.claude/skills/bai-cli/SKILL.md
+++ b/.claude/skills/bai-cli/SKILL.md
@@ -42,7 +42,7 @@ Check options with `--help`.
 - **domain**: user(get) · admin(search, create, update, delete, purge)
 - **user**: user(get, create, update, delete, search) · admin(create, delete, search)
 - **project**: user(get, assign-users, unassign-users · sub role: search) · admin(search, create, update, delete, purge)
-- **agent**: user(empty group) · admin(search, total-resources)
+- **agent**: user(empty group) · admin(search, total-resources, update-resource-group)
 - **image**: user(empty group) · admin(search, forget, purge, update · sub alias: create, remove, search)
 - **session**: user(compute-schedule, enqueue, get, logs, project-search, start-service, shutdown-service, terminate, update) · admin(search · sub kernel: search) · my(search)
 

--- a/changes/13093.feature.md
+++ b/changes/13093.feature.md
@@ -1,0 +1,1 @@
+Add a v2 agent resource-group change API (REST v2, GraphQL, SDK v2, CLI) that moves an agent to another resource group with a conflicting-session cleanup policy (`terminate`) and a `force` flag, returning the conflicting and terminating session lists

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -19702,8 +19702,8 @@ type UntagImageFromRegistry
 input UpdateAgentResourceGroupInput
   @join__type(graph: STRAWBERRY)
 {
-  """Name of the target resource group to move the agent into."""
-  resourceGroupName: String!
+  """UUID of the target resource group to move the agent into."""
+  resourceGroupId: UUID!
 
   """
   How to handle sessions still running on the agent under the old resource group. Currently only TERMINATE is supported.
@@ -19725,9 +19725,6 @@ type UpdateAgentResourceGroupPayload
 
   """UUID of the new resource group."""
   resourceGroupId: UUID!
-
-  """Name of the new resource group."""
-  resourceGroupName: String!
 
   """Cleanup policy applied to the conflicting sessions."""
   policy: ConflictingSessionCleanupPolicy!

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -3230,6 +3230,16 @@ type ComputeSessionNode implements Node
   graph(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ComputeSessionConnection @join__field(graph: GRAPHENE)
 }
 
+"""
+Added in 26.8.0. How to clean up sessions that conflict with an agent's resource-group change.
+"""
+enum ConflictingSessionCleanupPolicy
+  @join__type(graph: STRAWBERRY)
+{
+  TERMINATE @join__enumValue(graph: STRAWBERRY)
+  RESCHEDULE @join__enumValue(graph: STRAWBERRY)
+}
+
 """Deprecated since 24.09.0. use `ContainerRegistryNode` instead"""
 type ContainerRegistry implements Node
   @join__implements(graph: GRAPHENE, interface: "Node")
@@ -11592,6 +11602,11 @@ type Mutation
   delete_network(network: String!): DeleteNetwork @join__field(graph: GRAPHENE)
 
   """
+  Added in 26.8.0. Change the resource group of an agent (superadmin only). Sessions still running on the agent under the old resource group are cleaned up per the given policy; without force, the change is rejected with a conflict error when such sessions exist.
+  """
+  adminUpdateAgentResourceGroup(agentId: String!, input: UpdateAgentResourceGroupInput!): UpdateAgentResourceGroupPayload @join__field(graph: STRAWBERRY)
+
+  """
   Added in 26.7.0. Register a new app config allow-list entry (super admin only).
   """
   adminCreateAppConfigAllowList(input: CreateAppConfigAllowListInput!): CreateAppConfigAllowListPayload @join__field(graph: STRAWBERRY)
@@ -19681,6 +19696,51 @@ type UntagImageFromRegistry
 
   """Added since 24.03.1."""
   image: ImageNode
+}
+
+"""Added in 26.8.0. Input for changing the resource group of an agent."""
+input UpdateAgentResourceGroupInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Name of the target resource group to move the agent into."""
+  resourceGroupName: String!
+
+  """
+  How to handle sessions still running on the agent under the old resource group. Currently only TERMINATE is supported.
+  """
+  policy: ConflictingSessionCleanupPolicy!
+
+  """
+  When false, the change is rejected with a conflict error if the agent still has active sessions. When true, the group is changed anyway and the conflicting sessions are cleaned up per the policy.
+  """
+  force: Boolean! = false
+}
+
+"""Added in 26.8.0. Result of changing the resource group of an agent."""
+type UpdateAgentResourceGroupPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """ID of the agent whose resource group was changed."""
+  agentId: String!
+
+  """UUID of the new resource group."""
+  resourceGroupId: UUID!
+
+  """Name of the new resource group."""
+  resourceGroupName: String!
+
+  """Cleanup policy applied to the conflicting sessions."""
+  policy: ConflictingSessionCleanupPolicy!
+
+  """
+  IDs of the sessions that were still running on the agent under the old resource group at the time of the change.
+  """
+  conflictingSessionIds: [UUID!]!
+
+  """
+  IDs of the conflicting sessions that were actually transitioned to TERMINATING by the applied policy. Their container cleanup proceeds asynchronously.
+  """
+  terminatingSessionIds: [UUID!]!
 }
 
 """

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -11604,7 +11604,7 @@ type Mutation
   """
   Added in 26.8.0. Change the resource group of an agent (superadmin only). Sessions still running on the agent under the old resource group are cleaned up per the given policy; without force, the change is rejected with a conflict error when such sessions exist.
   """
-  adminUpdateAgentResourceGroup(agentId: String!, input: UpdateAgentResourceGroupInput!): UpdateAgentResourceGroupPayload @join__field(graph: STRAWBERRY)
+  adminUpdateAgentResourceGroup(input: UpdateAgentResourceGroupInput!): UpdateAgentResourceGroupPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.7.0. Register a new app config allow-list entry (super admin only).
@@ -19702,13 +19702,16 @@ type UntagImageFromRegistry
 input UpdateAgentResourceGroupInput
   @join__type(graph: STRAWBERRY)
 {
+  """ID of the agent to move."""
+  agentId: String!
+
   """UUID of the target resource group to move the agent into."""
   resourceGroupId: UUID!
 
   """
-  How to handle sessions still running on the agent under the old resource group. Currently only TERMINATE is supported.
+  How to handle sessions still running on the agent under the old resource group. Defaults to TERMINATE, which is currently the only supported policy.
   """
-  policy: ConflictingSessionCleanupPolicy!
+  policy: ConflictingSessionCleanupPolicy = null
 
   """
   When false, the change is rejected with a conflict error if the agent still has active sessions. When true, the group is changed anyway and the conflicting sessions are cleaned up per the policy.

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -13835,8 +13835,8 @@ type UnschedulableReasonHint {
 
 """Added in 26.8.0. Input for changing the resource group of an agent."""
 input UpdateAgentResourceGroupInput {
-  """Name of the target resource group to move the agent into."""
-  resourceGroupName: String!
+  """UUID of the target resource group to move the agent into."""
+  resourceGroupId: UUID!
 
   """
   How to handle sessions still running on the agent under the old resource group. Currently only TERMINATE is supported.
@@ -13856,9 +13856,6 @@ type UpdateAgentResourceGroupPayload {
 
   """UUID of the new resource group."""
   resourceGroupId: UUID!
-
-  """Name of the new resource group."""
-  resourceGroupName: String!
 
   """Cleanup policy applied to the conflicting sessions."""
   policy: ConflictingSessionCleanupPolicy!

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -2201,6 +2201,14 @@ extend type ComputeSessionNode implements Node @key(fields: "id") {
   id: ID!
 }
 
+"""
+Added in 26.8.0. How to clean up sessions that conflict with an agent's resource-group change.
+"""
+enum ConflictingSessionCleanupPolicy {
+  TERMINATE
+  RESCHEDULE
+}
+
 extend type ContainerRegistryNode implements Node @key(fields: "id") {
   """The Globally Unique ID of this object"""
   id: ID!
@@ -7421,6 +7429,11 @@ type MoveFileV2Payload {
 }
 
 type Mutation {
+  """
+  Added in 26.8.0. Change the resource group of an agent (superadmin only). Sessions still running on the agent under the old resource group are cleaned up per the given policy; without force, the change is rejected with a conflict error when such sessions exist.
+  """
+  adminUpdateAgentResourceGroup(agentId: String!, input: UpdateAgentResourceGroupInput!): UpdateAgentResourceGroupPayload
+
   """
   Added in 26.7.0. Register a new app config allow-list entry (super admin only).
   """
@@ -13818,6 +13831,47 @@ Added in 26.8.0. What the caller could change so an unschedulable kernel would f
 type UnschedulableReasonHint {
   """Subtract these slots to fit the best-fitting node."""
   requiredReduction: [ResourceSlotEntry!]
+}
+
+"""Added in 26.8.0. Input for changing the resource group of an agent."""
+input UpdateAgentResourceGroupInput {
+  """Name of the target resource group to move the agent into."""
+  resourceGroupName: String!
+
+  """
+  How to handle sessions still running on the agent under the old resource group. Currently only TERMINATE is supported.
+  """
+  policy: ConflictingSessionCleanupPolicy!
+
+  """
+  When false, the change is rejected with a conflict error if the agent still has active sessions. When true, the group is changed anyway and the conflicting sessions are cleaned up per the policy.
+  """
+  force: Boolean! = false
+}
+
+"""Added in 26.8.0. Result of changing the resource group of an agent."""
+type UpdateAgentResourceGroupPayload {
+  """ID of the agent whose resource group was changed."""
+  agentId: String!
+
+  """UUID of the new resource group."""
+  resourceGroupId: UUID!
+
+  """Name of the new resource group."""
+  resourceGroupName: String!
+
+  """Cleanup policy applied to the conflicting sessions."""
+  policy: ConflictingSessionCleanupPolicy!
+
+  """
+  IDs of the sessions that were still running on the agent under the old resource group at the time of the change.
+  """
+  conflictingSessionIds: [UUID!]!
+
+  """
+  IDs of the conflicting sessions that were actually transitioned to TERMINATING by the applied policy. Their container cleanup proceeds asynchronously.
+  """
+  terminatingSessionIds: [UUID!]!
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -7432,7 +7432,7 @@ type Mutation {
   """
   Added in 26.8.0. Change the resource group of an agent (superadmin only). Sessions still running on the agent under the old resource group are cleaned up per the given policy; without force, the change is rejected with a conflict error when such sessions exist.
   """
-  adminUpdateAgentResourceGroup(agentId: String!, input: UpdateAgentResourceGroupInput!): UpdateAgentResourceGroupPayload
+  adminUpdateAgentResourceGroup(input: UpdateAgentResourceGroupInput!): UpdateAgentResourceGroupPayload
 
   """
   Added in 26.7.0. Register a new app config allow-list entry (super admin only).
@@ -13835,13 +13835,16 @@ type UnschedulableReasonHint {
 
 """Added in 26.8.0. Input for changing the resource group of an agent."""
 input UpdateAgentResourceGroupInput {
+  """ID of the agent to move."""
+  agentId: String!
+
   """UUID of the target resource group to move the agent into."""
   resourceGroupId: UUID!
 
   """
-  How to handle sessions still running on the agent under the old resource group. Currently only TERMINATE is supported.
+  How to handle sessions still running on the agent under the old resource group. Defaults to TERMINATE, which is currently the only supported policy.
   """
-  policy: ConflictingSessionCleanupPolicy!
+  policy: ConflictingSessionCleanupPolicy = null
 
   """
   When false, the change is rejected with a conflict error if the agent still has active sessions. When true, the group is changed anyway and the conflicting sessions are cleaned up per the policy.

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -547,6 +547,42 @@
         "title": "AdminSearchAgentsInput",
         "type": "object"
       },
+      "ConflictingSessionCleanupPolicyEnum": {
+        "description": "How to clean up sessions that conflict with an agent's resource group change.",
+        "enum": [
+          "terminate",
+          "reschedule"
+        ],
+        "title": "ConflictingSessionCleanupPolicyEnum",
+        "type": "string"
+      },
+      "UpdateAgentResourceGroupInput": {
+        "description": "Input for changing the resource group of an agent.",
+        "properties": {
+          "resource_group_name": {
+            "description": "Name of the target resource group to move the agent into.",
+            "minLength": 1,
+            "title": "Resource Group Name",
+            "type": "string"
+          },
+          "policy": {
+            "$ref": "#/components/schemas/ConflictingSessionCleanupPolicyEnum",
+            "description": "How to handle sessions still running on the agent under the old resource group. Currently only 'terminate' is supported."
+          },
+          "force": {
+            "default": false,
+            "description": "When false, the change is rejected with a conflict error if the agent still has active sessions. When true, the group is changed anyway and the conflicting sessions are cleaned up per the policy.",
+            "title": "Force",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "resource_group_name",
+          "policy"
+        ],
+        "title": "UpdateAgentResourceGroupInput",
+        "type": "object"
+      },
       "AppConfigScopeType": {
         "description": "Scope at which an app config fragment is written (BEP-1052).\n\nThe single definition shared across the data, DTO, GraphQL, and API layers.",
         "enum": [
@@ -40208,6 +40244,44 @@
         },
         "parameters": [],
         "description": "Search agents with filters, orders, and pagination (superadmin only).\n\n**Preconditions:**\n* Superadmin privilege required.\n"
+      }
+    },
+    "/v2/agents/{agent_id}/resource-group": {
+      "patch": {
+        "operationId": "v2/agents.update_resource_group",
+        "tags": [
+          "v2/agents"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAgentResourceGroupInput"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "description": "Change an agent's resource group (superadmin only).\n\n**Preconditions:**\n* Superadmin privilege required.\n"
       }
     },
     "/v2/agents/total-resources": {

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -559,10 +559,10 @@
       "UpdateAgentResourceGroupInput": {
         "description": "Input for changing the resource group of an agent.",
         "properties": {
-          "resource_group_name": {
-            "description": "Name of the target resource group to move the agent into.",
-            "minLength": 1,
-            "title": "Resource Group Name",
+          "resource_group_id": {
+            "description": "UUID of the target resource group to move the agent into.",
+            "format": "uuid",
+            "title": "Resource Group Id",
             "type": "string"
           },
           "policy": {
@@ -577,7 +577,7 @@
           }
         },
         "required": [
-          "resource_group_name",
+          "resource_group_id",
           "policy"
         ],
         "title": "UpdateAgentResourceGroupInput",

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -556,8 +556,8 @@
         "title": "ConflictingSessionCleanupPolicyEnum",
         "type": "string"
       },
-      "UpdateAgentResourceGroupInput": {
-        "description": "Input for changing the resource group of an agent.",
+      "UpdateAgentResourceGroupBody": {
+        "description": "Mutable part of an agent resource-group change.\n\nUsed directly as the REST request body, where the agent ID is supplied as a\nURL path segment instead of a body field. ``UpdateAgentResourceGroupInput``\nextends this with the agent ID for the GQL/adapter call path.",
         "properties": {
           "resource_group_id": {
             "description": "UUID of the target resource group to move the agent into.",
@@ -566,8 +566,16 @@
             "type": "string"
           },
           "policy": {
-            "$ref": "#/components/schemas/ConflictingSessionCleanupPolicyEnum",
-            "description": "How to handle sessions still running on the agent under the old resource group. Currently only 'terminate' is supported."
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ConflictingSessionCleanupPolicyEnum"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "How to handle sessions still running on the agent under the old resource group. Defaults to 'terminate', which is currently the only supported policy."
           },
           "force": {
             "default": false,
@@ -577,10 +585,9 @@
           }
         },
         "required": [
-          "resource_group_id",
-          "policy"
+          "resource_group_id"
         ],
-        "title": "UpdateAgentResourceGroupInput",
+        "title": "UpdateAgentResourceGroupBody",
         "type": "object"
       },
       "AppConfigScopeType": {
@@ -40266,7 +40273,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateAgentResourceGroupInput"
+                "$ref": "#/components/schemas/UpdateAgentResourceGroupBody"
               }
             }
           }
@@ -40281,7 +40288,7 @@
             }
           }
         ],
-        "description": "Change an agent's resource group (superadmin only).\n\n**Preconditions:**\n* Superadmin privilege required.\n"
+        "description": "Change an agent's resource group (superadmin only).\n\nThe agent ID comes from the URL path; the adapter merges it with the body.\n\n\n**Preconditions:**\n* Superadmin privilege required.\n"
       }
     },
     "/v2/agents/total-resources": {

--- a/src/ai/backend/client/cli/v2/admin/agent.py
+++ b/src/ai/backend/client/cli/v2/admin/agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import uuid
 
 import click
 
@@ -102,9 +103,10 @@ def search(
 @agent.command(name="update-resource-group")
 @click.argument("agent_id")
 @click.option(
-    "--resource-group",
+    "--resource-group-id",
     required=True,
-    help="Name of the target resource group to move the agent into.",
+    type=click.UUID,
+    help="UUID of the target resource group to move the agent into.",
 )
 @click.option(
     "--policy",
@@ -125,7 +127,7 @@ def search(
 )
 def update_resource_group(
     agent_id: str,
-    resource_group: str,
+    resource_group_id: uuid.UUID,
     policy: str,
     force: bool,
 ) -> None:
@@ -136,7 +138,7 @@ def update_resource_group(
     from ai.backend.common.dto.manager.v2.agent.types import (
         ConflictingSessionCleanupPolicyEnum,
     )
-    from ai.backend.common.identifier.resource_group import ResourceGroupName
+    from ai.backend.common.identifier.resource_group import ResourceGroupID
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
@@ -144,7 +146,7 @@ def update_resource_group(
             result = await registry.agent.update_resource_group(
                 agent_id,
                 UpdateAgentResourceGroupInput(
-                    resource_group_name=ResourceGroupName(resource_group),
+                    resource_group_id=ResourceGroupID(resource_group_id),
                     policy=ConflictingSessionCleanupPolicyEnum(policy.lower()),
                     force=force,
                 ),

--- a/src/ai/backend/client/cli/v2/admin/agent.py
+++ b/src/ai/backend/client/cli/v2/admin/agent.py
@@ -99,6 +99,63 @@ def search(
     asyncio.run(_run())
 
 
+@agent.command(name="update-resource-group")
+@click.argument("agent_id")
+@click.option(
+    "--resource-group",
+    required=True,
+    help="Name of the target resource group to move the agent into.",
+)
+@click.option(
+    "--policy",
+    default="terminate",
+    show_default=True,
+    type=click.Choice(["terminate", "reschedule"], case_sensitive=False),
+    help="How to handle sessions still running on the agent under the old resource group.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help=(
+        "Change the group even if the agent still has active sessions; "
+        "they are cleaned up per the policy. Without this flag, the change "
+        "is rejected when such sessions exist."
+    ),
+)
+def update_resource_group(
+    agent_id: str,
+    resource_group: str,
+    policy: str,
+    force: bool,
+) -> None:
+    """Change an agent's resource group (superadmin only)."""
+    from ai.backend.common.dto.manager.v2.agent.request import (
+        UpdateAgentResourceGroupInput,
+    )
+    from ai.backend.common.dto.manager.v2.agent.types import (
+        ConflictingSessionCleanupPolicyEnum,
+    )
+    from ai.backend.common.identifier.resource_group import ResourceGroupName
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.agent.update_resource_group(
+                agent_id,
+                UpdateAgentResourceGroupInput(
+                    resource_group_name=ResourceGroupName(resource_group),
+                    policy=ConflictingSessionCleanupPolicyEnum(policy.lower()),
+                    force=force,
+                ),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
 @agent.command(name="total-resources")
 def total_resources() -> None:
     """Get aggregate resource statistics across all agents (superadmin only)."""

--- a/src/ai/backend/client/cli/v2/admin/agent.py
+++ b/src/ai/backend/client/cli/v2/admin/agent.py
@@ -110,10 +110,12 @@ def search(
 )
 @click.option(
     "--policy",
-    default="terminate",
-    show_default=True,
+    default=None,
     type=click.Choice(["terminate", "reschedule"], case_sensitive=False),
-    help="How to handle sessions still running on the agent under the old resource group.",
+    help=(
+        "How to handle sessions still running on the agent under the old resource group. "
+        "Defaults to the server-side default (terminate)."
+    ),
 )
 @click.option(
     "--force",
@@ -128,12 +130,12 @@ def search(
 def update_resource_group(
     agent_id: str,
     resource_group_id: uuid.UUID,
-    policy: str,
+    policy: str | None,
     force: bool,
 ) -> None:
     """Change an agent's resource group (superadmin only)."""
     from ai.backend.common.dto.manager.v2.agent.request import (
-        UpdateAgentResourceGroupInput,
+        UpdateAgentResourceGroupBody,
     )
     from ai.backend.common.dto.manager.v2.agent.types import (
         ConflictingSessionCleanupPolicyEnum,
@@ -145,9 +147,11 @@ def update_resource_group(
         try:
             result = await registry.agent.update_resource_group(
                 agent_id,
-                UpdateAgentResourceGroupInput(
+                UpdateAgentResourceGroupBody(
                     resource_group_id=ResourceGroupID(resource_group_id),
-                    policy=ConflictingSessionCleanupPolicyEnum(policy.lower()),
+                    policy=(
+                        ConflictingSessionCleanupPolicyEnum(policy.lower()) if policy else None
+                    ),
                     force=force,
                 ),
             )

--- a/src/ai/backend/client/v2/domains_v2/agent.py
+++ b/src/ai/backend/client/v2/domains_v2/agent.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 from ai.backend.client.v2.base_domain import BaseDomainClient
 from ai.backend.common.dto.manager.v2.agent.request import (
     AdminSearchAgentsInput,
+    UpdateAgentResourceGroupInput,
 )
 from ai.backend.common.dto.manager.v2.agent.response import (
     AdminSearchAgentsPayload,
     AgentResourceStatsPayload,
+    UpdateAgentResourceGroupPayload,
 )
 
 _PATH = "/v2/agents"
@@ -27,6 +29,19 @@ class V2AgentClient(BaseDomainClient):
             f"{_PATH}/search",
             request=request,
             response_model=AdminSearchAgentsPayload,
+        )
+
+    async def update_resource_group(
+        self,
+        agent_id: str,
+        request: UpdateAgentResourceGroupInput,
+    ) -> UpdateAgentResourceGroupPayload:
+        """Change an agent's resource group (superadmin only)."""
+        return await self._client.typed_request(
+            "PATCH",
+            f"{_PATH}/{agent_id}/resource-group",
+            request=request,
+            response_model=UpdateAgentResourceGroupPayload,
         )
 
     async def get_total_resources(self) -> AgentResourceStatsPayload:

--- a/src/ai/backend/client/v2/domains_v2/agent.py
+++ b/src/ai/backend/client/v2/domains_v2/agent.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from ai.backend.client.v2.base_domain import BaseDomainClient
 from ai.backend.common.dto.manager.v2.agent.request import (
     AdminSearchAgentsInput,
-    UpdateAgentResourceGroupInput,
+    UpdateAgentResourceGroupBody,
 )
 from ai.backend.common.dto.manager.v2.agent.response import (
     AdminSearchAgentsPayload,
@@ -34,7 +34,7 @@ class V2AgentClient(BaseDomainClient):
     async def update_resource_group(
         self,
         agent_id: str,
-        request: UpdateAgentResourceGroupInput,
+        request: UpdateAgentResourceGroupBody,
     ) -> UpdateAgentResourceGroupPayload:
         """Change an agent's resource group (superadmin only)."""
         return await self._client.typed_request(

--- a/src/ai/backend/common/dto/manager/v2/agent/request.py
+++ b/src/ai/backend/common/dto/manager/v2/agent/request.py
@@ -17,7 +17,7 @@ from ai.backend.common.dto.manager.v2.agent.types import (
     ConflictingSessionCleanupPolicyEnum,
     OrderDirection,
 )
-from ai.backend.common.identifier.resource_group import ResourceGroupName
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 
 __all__ = (
     "AdminSearchAgentsInput",
@@ -106,9 +106,8 @@ class SearchAgentsInput(BaseRequestModel):
 class UpdateAgentResourceGroupInput(BaseRequestModel):
     """Input for changing the resource group of an agent."""
 
-    resource_group_name: ResourceGroupName = Field(
-        min_length=1,
-        description="Name of the target resource group to move the agent into.",
+    resource_group_id: ResourceGroupID = Field(
+        description="UUID of the target resource group to move the agent into.",
     )
     policy: ConflictingSessionCleanupPolicyEnum = Field(
         description=(

--- a/src/ai/backend/common/dto/manager/v2/agent/request.py
+++ b/src/ai/backend/common/dto/manager/v2/agent/request.py
@@ -14,8 +14,10 @@ from ai.backend.common.dto.manager.query import StringFilter
 from ai.backend.common.dto.manager.v2.agent.types import (
     AgentOrderField,
     AgentStatusFilter,
+    ConflictingSessionCleanupPolicyEnum,
     OrderDirection,
 )
+from ai.backend.common.identifier.resource_group import ResourceGroupName
 
 __all__ = (
     "AdminSearchAgentsInput",
@@ -23,6 +25,7 @@ __all__ = (
     "AgentOrder",
     "AgentPathParam",
     "SearchAgentsInput",
+    "UpdateAgentResourceGroupInput",
 )
 
 
@@ -98,6 +101,29 @@ class SearchAgentsInput(BaseRequestModel):
     order: list[AgentOrder] | None = None
     limit: int = Field(default=DEFAULT_PAGE_LIMIT, ge=1, le=MAX_PAGE_LIMIT)
     offset: int = Field(default=0, ge=0)
+
+
+class UpdateAgentResourceGroupInput(BaseRequestModel):
+    """Input for changing the resource group of an agent."""
+
+    resource_group_name: ResourceGroupName = Field(
+        min_length=1,
+        description="Name of the target resource group to move the agent into.",
+    )
+    policy: ConflictingSessionCleanupPolicyEnum = Field(
+        description=(
+            "How to handle sessions still running on the agent under the old "
+            "resource group. Currently only 'terminate' is supported."
+        ),
+    )
+    force: bool = Field(
+        default=False,
+        description=(
+            "When false, the change is rejected with a conflict error if the agent "
+            "still has active sessions. When true, the group is changed anyway and "
+            "the conflicting sessions are cleaned up per the policy."
+        ),
+    )
 
 
 class AdminSearchAgentsInput(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/agent/request.py
+++ b/src/ai/backend/common/dto/manager/v2/agent/request.py
@@ -18,6 +18,7 @@ from ai.backend.common.dto.manager.v2.agent.types import (
     OrderDirection,
 )
 from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.types import AgentId
 
 __all__ = (
     "AdminSearchAgentsInput",
@@ -25,6 +26,7 @@ __all__ = (
     "AgentOrder",
     "AgentPathParam",
     "SearchAgentsInput",
+    "UpdateAgentResourceGroupBody",
     "UpdateAgentResourceGroupInput",
 )
 
@@ -103,16 +105,23 @@ class SearchAgentsInput(BaseRequestModel):
     offset: int = Field(default=0, ge=0)
 
 
-class UpdateAgentResourceGroupInput(BaseRequestModel):
-    """Input for changing the resource group of an agent."""
+class UpdateAgentResourceGroupBody(BaseRequestModel):
+    """Mutable part of an agent resource-group change.
+
+    Used directly as the REST request body, where the agent ID is supplied as a
+    URL path segment instead of a body field. ``UpdateAgentResourceGroupInput``
+    extends this with the agent ID for the GQL/adapter call path.
+    """
 
     resource_group_id: ResourceGroupID = Field(
         description="UUID of the target resource group to move the agent into.",
     )
-    policy: ConflictingSessionCleanupPolicyEnum = Field(
+    policy: ConflictingSessionCleanupPolicyEnum | None = Field(
+        default=None,
         description=(
             "How to handle sessions still running on the agent under the old "
-            "resource group. Currently only 'terminate' is supported."
+            "resource group. Defaults to 'terminate', which is currently the "
+            "only supported policy."
         ),
     )
     force: bool = Field(
@@ -123,6 +132,16 @@ class UpdateAgentResourceGroupInput(BaseRequestModel):
             "the conflicting sessions are cleaned up per the policy."
         ),
     )
+
+
+class UpdateAgentResourceGroupInput(UpdateAgentResourceGroupBody):
+    """Input for changing the resource group of an agent, carrying the agent ID.
+
+    Extends ``UpdateAgentResourceGroupBody`` with ``agent_id`` for the GQL
+    mutation and adapter call path.
+    """
+
+    agent_id: AgentId = Field(description="ID of the agent to move.")
 
 
 class AdminSearchAgentsInput(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/agent/response.py
+++ b/src/ai/backend/common/dto/manager/v2/agent/response.py
@@ -15,7 +15,7 @@ from pydantic import Field
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.pagination import PaginationInfo
 from ai.backend.common.dto.manager.v2.agent.types import ConflictingSessionCleanupPolicyEnum
-from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.identifier.session import SessionID
 from ai.backend.common.types import AgentId
 
@@ -199,7 +199,6 @@ class UpdateAgentResourceGroupPayload(BaseResponseModel):
 
     agent_id: AgentId = Field(description="ID of the agent whose resource group was changed.")
     resource_group_id: ResourceGroupID = Field(description="UUID of the new resource group.")
-    resource_group_name: ResourceGroupName = Field(description="Name of the new resource group.")
     policy: ConflictingSessionCleanupPolicyEnum = Field(
         description="Cleanup policy applied to the conflicting sessions."
     )

--- a/src/ai/backend/common/dto/manager/v2/agent/response.py
+++ b/src/ai/backend/common/dto/manager/v2/agent/response.py
@@ -14,6 +14,10 @@ from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.pagination import PaginationInfo
+from ai.backend.common.dto.manager.v2.agent.types import ConflictingSessionCleanupPolicyEnum
+from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
+from ai.backend.common.identifier.session import SessionID
+from ai.backend.common.types import AgentId
 
 __all__ = (
     "AdminSearchAgentsPayload",
@@ -32,6 +36,7 @@ __all__ = (
     "ComputePluginsGQLDTO",
     "GetAgentDetailPayload",
     "SearchAgentsPayload",
+    "UpdateAgentResourceGroupPayload",
 )
 
 
@@ -187,6 +192,30 @@ class AdminSearchAgentsPayload(BaseResponseModel):
     total_count: int = Field(description="Total number of agents matching the filter.")
     has_next_page: bool = Field(description="Whether there is a next page.")
     has_previous_page: bool = Field(description="Whether there is a previous page.")
+
+
+class UpdateAgentResourceGroupPayload(BaseResponseModel):
+    """Payload for an agent resource-group change."""
+
+    agent_id: AgentId = Field(description="ID of the agent whose resource group was changed.")
+    resource_group_id: ResourceGroupID = Field(description="UUID of the new resource group.")
+    resource_group_name: ResourceGroupName = Field(description="Name of the new resource group.")
+    policy: ConflictingSessionCleanupPolicyEnum = Field(
+        description="Cleanup policy applied to the conflicting sessions."
+    )
+    conflicting_session_ids: list[SessionID] = Field(
+        description=(
+            "IDs of the sessions that were still running on the agent under the "
+            "old resource group at the time of the change."
+        )
+    )
+    terminating_session_ids: list[SessionID] = Field(
+        description=(
+            "IDs of the conflicting sessions that were actually transitioned to "
+            "TERMINATING by the applied policy. Their container cleanup proceeds "
+            "asynchronously."
+        )
+    )
 
 
 class AgentResourceStatsPayload(BaseResponseModel):

--- a/src/ai/backend/common/dto/manager/v2/agent/types.py
+++ b/src/ai/backend/common/dto/manager/v2/agent/types.py
@@ -15,6 +15,7 @@ __all__ = (
     "AgentOrderField",
     "AgentStatusEnum",
     "AgentStatusFilter",
+    "ConflictingSessionCleanupPolicyEnum",
     "OrderDirection",
 )
 
@@ -26,6 +27,14 @@ class AgentStatusEnum(StrEnum):
     LOST = "LOST"
     RESTARTING = "RESTARTING"
     TERMINATED = "TERMINATED"
+
+
+class ConflictingSessionCleanupPolicyEnum(StrEnum):
+    """How to clean up sessions that conflict with an agent's resource group change."""
+
+    TERMINATE = "terminate"
+    # Re-enqueue conflicting sessions back to PENDING. Not implemented yet.
+    RESCHEDULE = "reschedule"
 
 
 class AgentOrderField(StrEnum):

--- a/src/ai/backend/manager/api/adapters/agent/adapter.py
+++ b/src/ai/backend/manager/api/adapters/agent/adapter.py
@@ -56,9 +56,6 @@ from ai.backend.manager.services.agent.actions.update_resource_group import (
     UpdateAgentResourceGroupAction,
 )
 from ai.backend.manager.services.agent.types import ConflictingSessionCleanupPolicy
-from ai.backend.manager.services.scaling_group.actions.resolve_resource_group_id_by_name import (
-    ResolveResourceGroupIDByNameAction,
-)
 
 _AGENT_PAGINATION_SPEC = PaginationSpec(
     forward_order=DEFAULT_FORWARD_ORDER,
@@ -216,13 +213,10 @@ class AgentAdapter(BaseAdapter):
         input: UpdateAgentResourceGroupInput,
     ) -> UpdateAgentResourceGroupPayload:
         """Change an agent's resource group, cleaning up conflicting sessions per policy."""
-        resolve_result = await self._processors.scaling_group.resolve_resource_group_id_by_name.wait_for_complete(
-            ResolveResourceGroupIDByNameAction(name=input.resource_group_name)
-        )
         action_result = await self._processors.agent.update_resource_group.wait_for_complete(
             UpdateAgentResourceGroupAction(
                 agent_id=agent_id,
-                resource_group_id=resolve_result.resource_group_id,
+                resource_group_id=input.resource_group_id,
                 policy=ConflictingSessionCleanupPolicy(input.policy.value),
                 force=input.force,
             )
@@ -230,7 +224,6 @@ class AgentAdapter(BaseAdapter):
         return UpdateAgentResourceGroupPayload(
             agent_id=action_result.agent_id,
             resource_group_id=action_result.resource_group_id,
-            resource_group_name=input.resource_group_name,
             policy=input.policy,
             conflicting_session_ids=[
                 SessionID(sid) for sid in action_result.conflicting_session_ids

--- a/src/ai/backend/manager/api/adapters/agent/adapter.py
+++ b/src/ai/backend/manager/api/adapters/agent/adapter.py
@@ -10,6 +10,7 @@ from ai.backend.common.dto.manager.v2.agent.request import (
     AdminSearchAgentsInput,
     AgentFilter,
     AgentOrder,
+    UpdateAgentResourceGroupInput,
 )
 from ai.backend.common.dto.manager.v2.agent.response import (
     AdminSearchAgentsPayload,
@@ -20,8 +21,10 @@ from ai.backend.common.dto.manager.v2.agent.response import (
     AgentSystemInfo,
     ComputePluginEntryDTO,
     ComputePluginsGQLDTO,
+    UpdateAgentResourceGroupPayload,
 )
 from ai.backend.common.dto.manager.v2.agent.types import AgentStatusFilter
+from ai.backend.common.identifier.session import SessionID
 from ai.backend.common.resource.types import TotalResourceData
 from ai.backend.common.types import AgentId
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
@@ -49,6 +52,13 @@ from ai.backend.manager.services.agent.actions.load_container_counts import (
     LoadContainerCountsAction,
 )
 from ai.backend.manager.services.agent.actions.search_agents import SearchAgentsAction
+from ai.backend.manager.services.agent.actions.update_resource_group import (
+    UpdateAgentResourceGroupAction,
+)
+from ai.backend.manager.services.agent.types import ConflictingSessionCleanupPolicy
+from ai.backend.manager.services.scaling_group.actions.resolve_resource_group_id_by_name import (
+    ResolveResourceGroupIDByNameAction,
+)
 
 _AGENT_PAGINATION_SPEC = PaginationSpec(
     forward_order=DEFAULT_FORWARD_ORDER,
@@ -197,6 +207,38 @@ class AgentAdapter(BaseAdapter):
     @staticmethod
     def _convert_orders(order: list[AgentOrder]) -> list[QueryOrder]:
         return [resolve_order(o.field, o.direction) for o in order]
+
+    # ------------------------------------------------------------------ update
+
+    async def update_resource_group(
+        self,
+        agent_id: AgentId,
+        input: UpdateAgentResourceGroupInput,
+    ) -> UpdateAgentResourceGroupPayload:
+        """Change an agent's resource group, cleaning up conflicting sessions per policy."""
+        resolve_result = await self._processors.scaling_group.resolve_resource_group_id_by_name.wait_for_complete(
+            ResolveResourceGroupIDByNameAction(name=input.resource_group_name)
+        )
+        action_result = await self._processors.agent.update_resource_group.wait_for_complete(
+            UpdateAgentResourceGroupAction(
+                agent_id=agent_id,
+                resource_group_id=resolve_result.resource_group_id,
+                policy=ConflictingSessionCleanupPolicy(input.policy.value),
+                force=input.force,
+            )
+        )
+        return UpdateAgentResourceGroupPayload(
+            agent_id=action_result.agent_id,
+            resource_group_id=action_result.resource_group_id,
+            resource_group_name=input.resource_group_name,
+            policy=input.policy,
+            conflicting_session_ids=[
+                SessionID(sid) for sid in action_result.conflicting_session_ids
+            ],
+            terminating_session_ids=[
+                SessionID(sid) for sid in action_result.terminating_session_ids
+            ],
+        )
 
     async def get_total_resources(self) -> TotalResourceData:
         """Retrieve aggregate resource capacity/usage across all agents."""

--- a/src/ai/backend/manager/api/adapters/agent/adapter.py
+++ b/src/ai/backend/manager/api/adapters/agent/adapter.py
@@ -10,6 +10,7 @@ from ai.backend.common.dto.manager.v2.agent.request import (
     AdminSearchAgentsInput,
     AgentFilter,
     AgentOrder,
+    UpdateAgentResourceGroupBody,
     UpdateAgentResourceGroupInput,
 )
 from ai.backend.common.dto.manager.v2.agent.response import (
@@ -23,7 +24,10 @@ from ai.backend.common.dto.manager.v2.agent.response import (
     ComputePluginsGQLDTO,
     UpdateAgentResourceGroupPayload,
 )
-from ai.backend.common.dto.manager.v2.agent.types import AgentStatusFilter
+from ai.backend.common.dto.manager.v2.agent.types import (
+    AgentStatusFilter,
+    ConflictingSessionCleanupPolicyEnum,
+)
 from ai.backend.common.identifier.session import SessionID
 from ai.backend.common.resource.types import TotalResourceData
 from ai.backend.common.types import AgentId
@@ -207,24 +211,43 @@ class AgentAdapter(BaseAdapter):
 
     # ------------------------------------------------------------------ update
 
-    async def update_resource_group(
+    async def update_resource_group_from_body(
         self,
         agent_id: AgentId,
+        body: UpdateAgentResourceGroupBody,
+    ) -> UpdateAgentResourceGroupPayload:
+        """Change the resource group of an agent whose ID is carried separately.
+
+        Used by the REST handler, where the agent ID comes from the URL path
+        while the body only carries the mutable part.
+        """
+        return await self.update_resource_group(
+            UpdateAgentResourceGroupInput(
+                agent_id=agent_id,
+                resource_group_id=body.resource_group_id,
+                policy=body.policy,
+                force=body.force,
+            )
+        )
+
+    async def update_resource_group(
+        self,
         input: UpdateAgentResourceGroupInput,
     ) -> UpdateAgentResourceGroupPayload:
         """Change an agent's resource group, cleaning up conflicting sessions per policy."""
+        applied_policy = input.policy or ConflictingSessionCleanupPolicyEnum.TERMINATE
         action_result = await self._processors.agent.update_resource_group.wait_for_complete(
             UpdateAgentResourceGroupAction(
-                agent_id=agent_id,
+                agent_id=input.agent_id,
                 resource_group_id=input.resource_group_id,
-                policy=ConflictingSessionCleanupPolicy(input.policy.value),
+                policy=ConflictingSessionCleanupPolicy(applied_policy.value),
                 force=input.force,
             )
         )
         return UpdateAgentResourceGroupPayload(
             agent_id=action_result.agent_id,
             resource_group_id=action_result.resource_group_id,
-            policy=input.policy,
+            policy=applied_policy,
             conflicting_session_ids=[
                 SessionID(sid) for sid in action_result.conflicting_session_ids
             ],

--- a/src/ai/backend/manager/api/gql/agent/__init__.py
+++ b/src/ai/backend/manager/api/gql/agent/__init__.py
@@ -1,4 +1,4 @@
-from .resolver import agent_stats, agents_v2
+from .resolver import admin_update_agent_resource_group, agent_stats, agents_v2
 from .types import (
     AgentFilterGQL,
     AgentOrderByGQL,
@@ -7,6 +7,9 @@ from .types import (
     AgentV2Connection,
     AgentV2Edge,
     AgentV2GQL,
+    ConflictingSessionCleanupPolicyGQL,
+    UpdateAgentResourceGroupInputGQL,
+    UpdateAgentResourceGroupPayloadGQL,
 )
 
 __all__ = (
@@ -18,7 +21,11 @@ __all__ = (
     "AgentV2GQL",
     "AgentV2Connection",
     "AgentV2Edge",
+    "ConflictingSessionCleanupPolicyGQL",
+    "UpdateAgentResourceGroupInputGQL",
+    "UpdateAgentResourceGroupPayloadGQL",
     # Resolvers
+    "admin_update_agent_resource_group",
     "agent_stats",
     "agents_v2",
 )

--- a/src/ai/backend/manager/api/gql/agent/resolver.py
+++ b/src/ai/backend/manager/api/gql/agent/resolver.py
@@ -7,6 +7,8 @@ from strawberry import Info
 from strawberry.scalars import JSON
 
 from ai.backend.common.dto.manager.v2.agent.request import AdminSearchAgentsInput
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.common.types import AgentId
 from ai.backend.manager.api.gql.agent.types import (
     AgentFilterGQL,
     AgentOrderByGQL,
@@ -15,10 +17,13 @@ from ai.backend.manager.api.gql.agent.types import (
     AgentV2Connection,
     AgentV2Edge,
     AgentV2GQL,
+    UpdateAgentResourceGroupInputGQL,
+    UpdateAgentResourceGroupPayloadGQL,
 )
 from ai.backend.manager.api.gql.base import to_global_id
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
+    gql_mutation,
     gql_root_field,
 )
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
@@ -79,3 +84,27 @@ async def agents_v2(
         ),
         count=result.total_count,
     )
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Change the resource group of an agent (superadmin only). Sessions still running"
+            " on the agent under the old resource group are cleaned up per the given policy;"
+            " without force, the change is rejected with a conflict error when such sessions"
+            " exist."
+        ),
+    )
+)
+async def admin_update_agent_resource_group(
+    info: Info[StrawberryGQLContext],
+    agent_id: str,
+    input: UpdateAgentResourceGroupInputGQL,
+) -> UpdateAgentResourceGroupPayloadGQL | None:
+    """Change an agent's resource group."""
+    check_admin_only()
+    payload = await info.context.adapters.agent.update_resource_group(
+        AgentId(agent_id), input.to_pydantic()
+    )
+    return UpdateAgentResourceGroupPayloadGQL.from_pydantic(payload)

--- a/src/ai/backend/manager/api/gql/agent/resolver.py
+++ b/src/ai/backend/manager/api/gql/agent/resolver.py
@@ -8,7 +8,6 @@ from strawberry.scalars import JSON
 
 from ai.backend.common.dto.manager.v2.agent.request import AdminSearchAgentsInput
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
-from ai.backend.common.types import AgentId
 from ai.backend.manager.api.gql.agent.types import (
     AgentFilterGQL,
     AgentOrderByGQL,
@@ -99,12 +98,9 @@ async def agents_v2(
 )
 async def admin_update_agent_resource_group(
     info: Info[StrawberryGQLContext],
-    agent_id: str,
     input: UpdateAgentResourceGroupInputGQL,
 ) -> UpdateAgentResourceGroupPayloadGQL | None:
     """Change an agent's resource group."""
     check_admin_only()
-    payload = await info.context.adapters.agent.update_resource_group(
-        AgentId(agent_id), input.to_pydantic()
-    )
+    payload = await info.context.adapters.agent.update_resource_group(input.to_pydantic())
     return UpdateAgentResourceGroupPayloadGQL.from_pydantic(payload)

--- a/src/ai/backend/manager/api/gql/agent/types.py
+++ b/src/ai/backend/manager/api/gql/agent/types.py
@@ -4,13 +4,18 @@ from collections.abc import Iterable
 from datetime import datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Annotated, Any, Self, cast, override
+from uuid import UUID
 
 import strawberry
 from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID
 from strawberry.scalars import JSON
 
-from ai.backend.common.dto.manager.v2.agent.request import AgentFilter, AgentOrder
+from ai.backend.common.dto.manager.v2.agent.request import (
+    AgentFilter,
+    AgentOrder,
+    UpdateAgentResourceGroupInput,
+)
 from ai.backend.common.dto.manager.v2.agent.response import (
     AgentNetworkInfoGQLDTO,
     AgentNode,
@@ -20,11 +25,13 @@ from ai.backend.common.dto.manager.v2.agent.response import (
     AgentSystemInfoGQLDTO,
     ComputePluginEntryDTO,
     ComputePluginsGQLDTO,
+    UpdateAgentResourceGroupPayload,
 )
 from ai.backend.common.dto.manager.v2.agent.types import (
     AgentStatusEnum,
     AgentStatusFilter,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.common.types import AgentId
 from ai.backend.manager.api.gql.base import OrderDirection, StringFilter
 from ai.backend.manager.api.gql.decorators import (
@@ -37,7 +44,11 @@ from ai.backend.manager.api.gql.decorators import (
     gql_pydantic_input,
     gql_pydantic_type,
 )
-from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin, PydanticNodeMixin
+from ai.backend.manager.api.gql.pydantic_compat import (
+    PydanticInputMixin,
+    PydanticNodeMixin,
+    PydanticOutputMixin,
+)
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.api.gql.utils import dedent_strip
 
@@ -121,6 +132,76 @@ class AgentFilterGQL(PydanticInputMixin[AgentFilter]):
 class AgentOrderByGQL(PydanticInputMixin[AgentOrder]):
     field: AgentOrderFieldGQL
     direction: OrderDirection = OrderDirection.ASC
+
+
+@gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "How to clean up sessions that conflict with an agent's resource-group change."
+        ),
+    ),
+    name="ConflictingSessionCleanupPolicy",
+)
+class ConflictingSessionCleanupPolicyGQL(StrEnum):
+    TERMINATE = "terminate"
+    RESCHEDULE = "reschedule"
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Input for changing the resource group of an agent.",
+    ),
+    name="UpdateAgentResourceGroupInput",
+)
+class UpdateAgentResourceGroupInputGQL(PydanticInputMixin[UpdateAgentResourceGroupInput]):
+    resource_group_name: str = gql_field(
+        description="Name of the target resource group to move the agent into."
+    )
+    policy: ConflictingSessionCleanupPolicyGQL = gql_field(
+        description=(
+            "How to handle sessions still running on the agent under the old resource group. "
+            "Currently only TERMINATE is supported."
+        )
+    )
+    force: bool = gql_field(
+        default=False,
+        description=(
+            "When false, the change is rejected with a conflict error if the agent still has "
+            "active sessions. When true, the group is changed anyway and the conflicting "
+            "sessions are cleaned up per the policy."
+        ),
+    )
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Result of changing the resource group of an agent.",
+    ),
+    model=UpdateAgentResourceGroupPayload,
+    name="UpdateAgentResourceGroupPayload",
+)
+class UpdateAgentResourceGroupPayloadGQL(PydanticOutputMixin[UpdateAgentResourceGroupPayload]):
+    agent_id: str = gql_field(description="ID of the agent whose resource group was changed.")
+    resource_group_id: UUID = gql_field(description="UUID of the new resource group.")
+    resource_group_name: str = gql_field(description="Name of the new resource group.")
+    policy: ConflictingSessionCleanupPolicyGQL = gql_field(
+        description="Cleanup policy applied to the conflicting sessions."
+    )
+    conflicting_session_ids: list[UUID] = gql_field(
+        description=(
+            "IDs of the sessions that were still running on the agent under the old resource "
+            "group at the time of the change."
+        )
+    )
+    terminating_session_ids: list[UUID] = gql_field(
+        description=(
+            "IDs of the conflicting sessions that were actually transitioned to TERMINATING "
+            "by the applied policy. Their container cleanup proceeds asynchronously."
+        )
+    )
 
 
 @gql_pydantic_type(

--- a/src/ai/backend/manager/api/gql/agent/types.py
+++ b/src/ai/backend/manager/api/gql/agent/types.py
@@ -156,8 +156,8 @@ class ConflictingSessionCleanupPolicyGQL(StrEnum):
     name="UpdateAgentResourceGroupInput",
 )
 class UpdateAgentResourceGroupInputGQL(PydanticInputMixin[UpdateAgentResourceGroupInput]):
-    resource_group_name: str = gql_field(
-        description="Name of the target resource group to move the agent into."
+    resource_group_id: UUID = gql_field(
+        description="UUID of the target resource group to move the agent into."
     )
     policy: ConflictingSessionCleanupPolicyGQL = gql_field(
         description=(
@@ -186,7 +186,6 @@ class UpdateAgentResourceGroupInputGQL(PydanticInputMixin[UpdateAgentResourceGro
 class UpdateAgentResourceGroupPayloadGQL(PydanticOutputMixin[UpdateAgentResourceGroupPayload]):
     agent_id: str = gql_field(description="ID of the agent whose resource group was changed.")
     resource_group_id: UUID = gql_field(description="UUID of the new resource group.")
-    resource_group_name: str = gql_field(description="Name of the new resource group.")
     policy: ConflictingSessionCleanupPolicyGQL = gql_field(
         description="Cleanup policy applied to the conflicting sessions."
     )

--- a/src/ai/backend/manager/api/gql/agent/types.py
+++ b/src/ai/backend/manager/api/gql/agent/types.py
@@ -156,14 +156,16 @@ class ConflictingSessionCleanupPolicyGQL(StrEnum):
     name="UpdateAgentResourceGroupInput",
 )
 class UpdateAgentResourceGroupInputGQL(PydanticInputMixin[UpdateAgentResourceGroupInput]):
+    agent_id: str = gql_field(description="ID of the agent to move.")
     resource_group_id: UUID = gql_field(
         description="UUID of the target resource group to move the agent into."
     )
-    policy: ConflictingSessionCleanupPolicyGQL = gql_field(
+    policy: ConflictingSessionCleanupPolicyGQL | None = gql_field(
+        default=None,
         description=(
             "How to handle sessions still running on the agent under the old resource group. "
-            "Currently only TERMINATE is supported."
-        )
+            "Defaults to TERMINATE, which is currently the only supported policy."
+        ),
     )
     force: bool = gql_field(
         default=False,

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -15,6 +15,7 @@ from ai.backend.manager.api.gql.extensions import (
 )
 
 from .agent import (
+    admin_update_agent_resource_group,
     agent_stats,
     agents_v2,
 )
@@ -724,6 +725,7 @@ class Query:
 
 @strawberry.type
 class Mutation:
+    admin_update_agent_resource_group = admin_update_agent_resource_group
     admin_create_app_config_allow_list = admin_create_app_config_allow_list
     admin_purge_app_config_allow_list = admin_purge_app_config_allow_list
     admin_update_app_config_allow_list = admin_update_app_config_allow_list

--- a/src/ai/backend/manager/api/rest/v2/agent/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/agent/handler.py
@@ -6,10 +6,15 @@ import logging
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Final
 
-from ai.backend.common.api_handlers import APIResponse, BodyParam
-from ai.backend.common.dto.manager.v2.agent.request import AdminSearchAgentsInput
+from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam
+from ai.backend.common.dto.manager.v2.agent.request import (
+    AdminSearchAgentsInput,
+    UpdateAgentResourceGroupInput,
+)
 from ai.backend.common.dto.manager.v2.agent.response import AgentResourceStatsPayload
+from ai.backend.common.types import AgentId
 from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.api.rest.v2.path_params import AgentIdPathParam
 
 if TYPE_CHECKING:
     from ai.backend.manager.api.adapters.agent.adapter import AgentAdapter
@@ -29,6 +34,17 @@ class V2AgentHandler:
     ) -> APIResponse:
         """Search agents with filters, orders, and pagination (superadmin only)."""
         result = await self._adapter.admin_search(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def update_resource_group(
+        self,
+        path: PathParam[AgentIdPathParam],
+        body: BodyParam[UpdateAgentResourceGroupInput],
+    ) -> APIResponse:
+        """Change an agent's resource group (superadmin only)."""
+        result = await self._adapter.update_resource_group(
+            AgentId(path.parsed.agent_id), body.parsed
+        )
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
     async def get_total_resources(self) -> APIResponse:

--- a/src/ai/backend/manager/api/rest/v2/agent/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/agent/handler.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Final
 from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam
 from ai.backend.common.dto.manager.v2.agent.request import (
     AdminSearchAgentsInput,
-    UpdateAgentResourceGroupInput,
+    UpdateAgentResourceGroupBody,
 )
 from ai.backend.common.dto.manager.v2.agent.response import AgentResourceStatsPayload
 from ai.backend.common.types import AgentId
@@ -39,10 +39,13 @@ class V2AgentHandler:
     async def update_resource_group(
         self,
         path: PathParam[AgentIdPathParam],
-        body: BodyParam[UpdateAgentResourceGroupInput],
+        body: BodyParam[UpdateAgentResourceGroupBody],
     ) -> APIResponse:
-        """Change an agent's resource group (superadmin only)."""
-        result = await self._adapter.update_resource_group(
+        """Change an agent's resource group (superadmin only).
+
+        The agent ID comes from the URL path; the adapter merges it with the body.
+        """
+        result = await self._adapter.update_resource_group_from_body(
             AgentId(path.parsed.agent_id), body.parsed
         )
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/agent/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/agent/registry.py
@@ -21,6 +21,12 @@ def register_v2_agent_routes(
     reg = RouteRegistry.create("agents", route_deps.cors_options)
     reg.add("POST", "/search", handler.admin_search, middlewares=[superadmin_required])
     reg.add(
+        "PATCH",
+        "/{agent_id}/resource-group",
+        handler.update_resource_group,
+        middlewares=[superadmin_required],
+    )
+    reg.add(
         "GET", "/total-resources", handler.get_total_resources, middlewares=[superadmin_required]
     )
     return reg


### PR DESCRIPTION
## Summary
- Expose the conflicting-session cleanup service (BA-6827) through the full v2 stack: REST v2 `PATCH /v2/agents/{agent_id}/resource-group`, Strawberry GQL mutation `adminUpdateAgentResourceGroup` (shared agent adapter), v2 DTOs, SDK v2 client, and the `bai admin agent update-resource-group` CLI command.
- The request takes the target resource group name, a cleanup policy enum (`terminate`; `reschedule` reserved for the preemption work), and a `force` flag; the adapter resolves the group name to its ID and invokes the existing `UpdateAgentResourceGroupAction`.
- The response surfaces the conflicting sessions, the applied policy, and the sessions actually transitioned to TERMINATING.

## Test plan
- [x] `pants test` for affected packages passes in CI
- [x] Live-server verification: move an idle agent between resource groups via REST v2 and GQL (superadmin)
- [x] Live-server verification: agent with active sessions is rejected without `force` (409) and cleaned up with `force` + `policy=terminate` (tracked by BA-6831 e2e)

Resolves BA-6829

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13093.org.readthedocs.build/en/13093/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13093.org.readthedocs.build/ko/13093/

<!-- readthedocs-preview sorna-ko end -->