### PR TITLE
fix(alembic): merge diverged migration heads

### DIFF
--- a/changes/13094.misc.md
+++ b/changes/13094.misc.md
@@ -1,0 +1,1 @@
+Merge diverged manager Alembic migration heads.

--- a/src/ai/backend/manager/models/alembic/versions/5405ee0d8eed_merge_heads_339ae21cb8ec_and_.py
+++ b/src/ai/backend/manager/models/alembic/versions/5405ee0d8eed_merge_heads_339ae21cb8ec_and_.py
@@ -1,0 +1,22 @@
+"""merge heads 339ae21cb8ec and 39fadbbea696
+
+Revision ID: 5405ee0d8eed
+Revises: 339ae21cb8ec, 39fadbbea696
+Create Date: 2026-07-23 22:14:46.696886
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "5405ee0d8eed"
+down_revision = ("339ae21cb8ec", "39fadbbea696")
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary

- Add an empty Alembic merge migration for revisions `339ae21cb8ec` and `39fadbbea696`.
- Restore a single manager migration head without rewriting already-merged migrations.
- Follow the same reconciliation pattern used in #12978.

## Root cause

Two independently merged migrations both used `b3e8f1a24c76` as their `down_revision`, leaving `main` with two Alembic heads.

## Developer impact

Manager schema upgrades can target `head` again without Alembic reporting multiple heads.

## Test plan

- [x] `./py -m alembic -c alembic.ini heads --verbose`
- [x] `./py -m alembic -c alembic.ini history -r b3e8f1a24c76:heads`
- [x] `pants fmt ::`
- [x] `pants fix ::`
- [x] `pants lint --changed-since=origin/main`
- [x] Pre-push changed-since lint, type check, and test hook