### PR TITLE
fix(BA-6986): harden keypair webapp auth (sToken + login verification)

### DIFF
--- a/changes/13095.fix.md
+++ b/changes/13095.fix.md
@@ -1,0 +1,1 @@
+Fix a keypair webapp login flaw where knowing an access key alone could authenticate, and stop embedding the secret key in the (now-expiring) sToken

--- a/src/ai/backend/manager/plugin/keypair/hook.py
+++ b/src/ai/backend/manager/plugin/keypair/hook.py
@@ -31,6 +31,14 @@ plugin_config_checker = t.Dict({
 DEFAULT_STOKEN_COOKIE_VALUE = "BackendAI"
 
 
+def _mask_token(token: str) -> str:
+    """Non-reusable fingerprint of a bearer token for safe logging."""
+    if not token:
+        return "<empty>"
+    digest = hashlib.sha256(token.encode()).hexdigest()[:12]
+    return f"sha256:{digest}...(len={len(token)})"
+
+
 class KeypairAuthHookPlugin(HookPlugin):
     def __init__(self, plugin_config: Mapping[str, Any], local_config: Mapping[str, Any]) -> None:
         super().__init__(plugin_config, local_config)
@@ -161,7 +169,7 @@ class KeypairAuthHookPlugin(HookPlugin):
                     user_id = keypair.user
 
                 except Exception as e:
-                    log.error("AUTHORIZE_KEYPAIR_HOOK: invalid auth token {}", stoken)
+                    log.error("AUTHORIZE_KEYPAIR_HOOK: invalid auth token {}", _mask_token(stoken))
                     log.error(repr(e))
                     raise Reject("Invalid auth token") from None
 

--- a/src/ai/backend/manager/plugin/keypair/utils.py
+++ b/src/ai/backend/manager/plugin/keypair/utils.py
@@ -1,36 +1,50 @@
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import jwt
-import jwt.exceptions
+from pydantic import BaseModel
 
-from ai.backend.common.types import BackendAISchema
 from ai.backend.common.utils import nmget
 
 from .exception import ExpiredSToken, InvalidSToken
 
 KEYPAIR_PLUGIN_CONFIG_KEY = "plugins.webapp.keypair_auth"
 
+# sToken lifetime in seconds.
+DEFAULT_STOKEN_TTL_SECONDS = 60
+# Clock-skew tolerance when validating the `exp` claim.
+STOKEN_LEEWAY_SECONDS = 10
 
-class STokenData(BackendAISchema):
+
+class STokenData(BaseModel):
     access_key: str
-    secret_key: str
 
 
-def get_plugin_config(shared_config: dict[str, Any]) -> Any:
-    return nmget(shared_config, KEYPAIR_PLUGIN_CONFIG_KEY)
+def get_plugin_config(shared_config: dict[str, Any]) -> dict[str, Any]:
+    config: dict[str, Any] = nmget(shared_config, KEYPAIR_PLUGIN_CONFIG_KEY)
+    return config
 
 
 def encode_jwt_token(token_data: dict[str, Any], secret: str) -> str:
     return jwt.encode(token_data, secret, algorithm="HS256")
 
 
-def decode_jwt_token(val: str, secret: str) -> dict[str, Any]:
-    result: dict[str, Any] = jwt.decode(val, secret, algorithms=["HS256"])
+def decode_jwt_token(val: str, secret: str) -> Mapping[str, Any]:
+    result: dict[str, Any] = jwt.decode(
+        val, secret, algorithms=["HS256"], leeway=STOKEN_LEEWAY_SECONDS
+    )
     return result
 
 
-def serialize_stoken(data: STokenData, secret: str) -> str:
-    return encode_jwt_token(data.model_dump(mode="json"), secret=secret)
+def serialize_stoken(
+    data: STokenData, secret: str, ttl_seconds: int = DEFAULT_STOKEN_TTL_SECONDS
+) -> str:
+    payload = data.model_dump(mode="json")
+    now = datetime.now(UTC)
+    payload["iat"] = now
+    payload["exp"] = now + timedelta(seconds=ttl_seconds)
+    return encode_jwt_token(payload, secret=secret)
 
 
 def deserialize_stoken(val: str, secret: str) -> STokenData:

--- a/src/ai/backend/manager/plugin/keypair/utils.py
+++ b/src/ai/backend/manager/plugin/keypair/utils.py
@@ -32,7 +32,11 @@ def encode_jwt_token(token_data: dict[str, Any], secret: str) -> str:
 
 def decode_jwt_token(val: str, secret: str) -> Mapping[str, Any]:
     result: dict[str, Any] = jwt.decode(
-        val, secret, algorithms=["HS256"], leeway=STOKEN_LEEWAY_SECONDS
+        val,
+        secret,
+        algorithms=["HS256"],
+        leeway=STOKEN_LEEWAY_SECONDS,
+        options={"require": ["iat", "exp"]},
     )
     return result
 

--- a/src/ai/backend/manager/plugin/keypair/webapp.py
+++ b/src/ai/backend/manager/plugin/keypair/webapp.py
@@ -1,9 +1,11 @@
 import json
 import logging
+import secrets
 from collections.abc import Mapping, Sequence
-from typing import Any, override
+from typing import Any, cast, override
 
 import aiohttp_cors
+import sqlalchemy as sa
 import yarl
 from aiohttp import web
 from pydantic import ValidationError
@@ -11,6 +13,9 @@ from pydantic import ValidationError
 from ai.backend.common.logging_utils import BraceStyleAdapter
 from ai.backend.common.types import BackendAISchema
 from ai.backend.manager.api.rest.types import CORSOptions, WebMiddleware
+from ai.backend.manager.errors.auth import AuthorizationFailed, InvalidAuthParameters
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.plugin.webapp import WebappPlugin
 
 from .utils import (
@@ -41,15 +46,31 @@ async def login(request: web.Request) -> web.Response:
             "Invalid login request data: {}",
             repr(e),
         )
-        raise web.HTTPBadRequest(reason="Invalid JSON data in request body.") from None
+        raise InvalidAuthParameters("Invalid JSON data in request body.") from None
+
+    db = cast(ExtendedAsyncSAEngine, root_app["_db"])
+    async with db.begin_readonly_session() as db_session:
+        query = sa.select(KeyPairRow.secret_key, KeyPairRow.is_active).where(
+            KeyPairRow.access_key == json_data.access_key
+        )
+        keypair = (await db_session.execute(query)).first()
+
+    authenticated = (
+        keypair is not None
+        and keypair.secret_key is not None
+        and keypair.is_active
+        and secrets.compare_digest(
+            keypair.secret_key.encode("utf-8"), json_data.secret_key.encode("utf-8")
+        )
+    )
+    if not authenticated:
+        log.warning("login failed for access_key {}", json_data.access_key)
+        raise AuthorizationFailed("Invalid credentials.")
 
     token_secret = plugin_config["secret"]
     redirect_uri = yarl.URL(plugin_config["login_uri"])
     token = serialize_stoken(
-        data=STokenData(
-            access_key=json_data.access_key,
-            secret_key=json_data.secret_key,
-        ),
+        data=STokenData(access_key=json_data.access_key),
         secret=token_secret,
     )
     redirect_location = redirect_uri.update_query({"sToken": token})

--- a/src/ai/backend/manager/plugin/keypair/webapp.py
+++ b/src/ai/backend/manager/plugin/keypair/webapp.py
@@ -49,7 +49,7 @@ async def login(request: web.Request) -> web.Response:
         raise InvalidAuthParameters("Invalid JSON data in request body.") from None
 
     db = cast(ExtendedAsyncSAEngine, root_app["_db"])
-    async with db.begin_readonly_session() as db_session:
+    async with db.begin_readonly_session_read_committed() as db_session:
         query = sa.select(KeyPairRow.secret_key, KeyPairRow.is_active).where(
             KeyPairRow.access_key == json_data.access_key
         )

--- a/tests/unit/manager/plugin/test_keypair_utils.py
+++ b/tests/unit/manager/plugin/test_keypair_utils.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from ai.backend.manager.plugin.keypair.exception import ExpiredSToken, InvalidSToken
+from ai.backend.manager.plugin.keypair.utils import (
+    STokenData,
+    decode_jwt_token,
+    deserialize_stoken,
+    serialize_stoken,
+)
+
+_SECRET = "test-token-secret"
+_ACCESS_KEY = "AKIAIOSFODNN7EXAMPLE"
+
+
+class TestSToken:
+    def test_roundtrip_preserves_access_key(self) -> None:
+        token = serialize_stoken(STokenData(access_key=_ACCESS_KEY), _SECRET)
+        restored = deserialize_stoken(token, _SECRET)
+        assert restored.access_key == _ACCESS_KEY
+
+    def test_payload_omits_secret_key(self) -> None:
+        token = serialize_stoken(STokenData(access_key=_ACCESS_KEY), _SECRET)
+        payload = decode_jwt_token(token, _SECRET)
+        assert payload["access_key"] == _ACCESS_KEY
+        assert "secret_key" not in payload
+
+    def test_payload_has_expiry_claims(self) -> None:
+        token = serialize_stoken(STokenData(access_key=_ACCESS_KEY), _SECRET)
+        payload = decode_jwt_token(token, _SECRET)
+        assert "iat" in payload
+        assert "exp" in payload
+        assert payload["exp"] > payload["iat"]
+
+    def test_expired_token_raises(self) -> None:
+        # Negative TTL beyond the leeway window so the token is already expired on decode.
+        token = serialize_stoken(STokenData(access_key=_ACCESS_KEY), _SECRET, ttl_seconds=-20)
+        with pytest.raises(ExpiredSToken):
+            deserialize_stoken(token, _SECRET)
+
+    def test_wrong_secret_raises(self) -> None:
+        token = serialize_stoken(STokenData(access_key=_ACCESS_KEY), _SECRET)
+        with pytest.raises(InvalidSToken):
+            deserialize_stoken(token, "wrong-secret")

--- a/tests/unit/manager/plugin/test_keypair_utils.py
+++ b/tests/unit/manager/plugin/test_keypair_utils.py
@@ -7,6 +7,7 @@ from ai.backend.manager.plugin.keypair.utils import (
     STokenData,
     decode_jwt_token,
     deserialize_stoken,
+    encode_jwt_token,
     serialize_stoken,
 )
 
@@ -32,6 +33,15 @@ class TestSToken:
         assert "iat" in payload
         assert "exp" in payload
         assert payload["exp"] > payload["iat"]
+
+    @pytest.mark.parametrize("missing_claim", ["iat", "exp"])
+    def test_missing_temporal_claim_raises(self, missing_claim: str) -> None:
+        token = serialize_stoken(STokenData(access_key=_ACCESS_KEY), _SECRET)
+        payload = dict(decode_jwt_token(token, _SECRET))
+        payload.pop(missing_claim)
+
+        with pytest.raises(InvalidSToken):
+            deserialize_stoken(encode_jwt_token(payload, _SECRET), _SECRET)
 
     def test_expired_token_raises(self) -> None:
         # Negative TTL beyond the leeway window so the token is already expired on decode.


### PR DESCRIPTION
## Summary
- Remove `secret_key` from the sToken JWT payload — it was exposed via the redirect URL (a JWT payload is signed, not encrypted).
- Add `iat`/`exp` (60s TTL) with 10s clock-skew leeway so sTokens actually expire.
- Verify `secret_key` against the stored keypair (constant-time) at `/login`, closing an auth bypass where knowing an access key alone was enough to log in as its owner. Failures return a uniform 401 to avoid access-key enumeration.
- Mask bearer tokens in error logs.

## Test plan
- [x] `pants test tests/unit/manager/plugin/test_keypair_utils.py` — 5 sToken lifecycle regression tests (roundtrip, no secret_key in payload, iat/exp present, expiry, wrong secret)
- [x] `pants lint check` on changed files
- [ ] Manual: `/login` with correct vs incorrect secret_key, and an expired sToken

Resolves BA-6986