### PR TITLE
fix: validate group and agent existence in the agent resource-group update

### DIFF
--- a/changes/13102.fix.md
+++ b/changes/13102.fix.md
@@ -1,0 +1,1 @@
+Return 404 instead of a silent success or a server error when the agent resource-group update targets an unknown agent or resource group

--- a/src/ai/backend/manager/repositories/agent/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/agent/db_source/db_source.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.orm import selectinload
 
 from ai.backend.common.exception import AgentNotFound
@@ -22,7 +23,7 @@ from ai.backend.manager.data.agent.types import (
 from ai.backend.manager.data.image.types import ImageDataWithDetails, ImageIdentifier
 from ai.backend.manager.data.kernel.types import KernelInfo, KernelStatus
 from ai.backend.manager.errors.agent import AgentHasConflictingSessions
-from ai.backend.manager.errors.resource import UnresolvableResourceGroup
+from ai.backend.manager.errors.resource import ScalingGroupNotFound, UnresolvableResourceGroup
 from ai.backend.manager.models.agent import ADMIN_PERMISSIONS as ADMIN_AGENT_PERMISSIONS
 from ai.backend.manager.models.agent import AgentRow, agents
 from ai.backend.manager.models.image import ImageRow
@@ -208,12 +209,21 @@ class AgentDBSource:
         Finds the active kernels on the agent. If any exist and ``force`` is not
         set, raises without changing anything. Otherwise updates the agent's group
         (name + id columns) and returns those kernels so the caller can transition
-        their sessions. The check and the update run in one transaction.
+        their sessions. The lookup, the check, and the update run in one transaction.
+        Raises ScalingGroupNotFound when no resource group matches
+        ``resource_group_id``, and AgentNotFound when no agent row matches
+        ``agent_id``.
         """
         active_statuses = (
             KernelStatus.resource_occupied_statuses() | KernelStatus.resource_requested_statuses()
         )
         async with self._db.begin_session_read_committed() as session:
+            resource_group_name = await session.scalar(
+                sa.select(ScalingGroupRow.name).where(ScalingGroupRow.id == resource_group_id)
+            )
+            if resource_group_name is None:
+                raise ScalingGroupNotFound(str(resource_group_id))
+
             rows = (
                 (
                     await session.execute(
@@ -231,16 +241,16 @@ class AgentDBSource:
                 distinct_sessions = len({kernel.session.session_id for kernel in kernels})
                 raise AgentHasConflictingSessions(agent_id, distinct_sessions)
 
-            await session.execute(
+            result = await session.execute(
                 sa.update(agents)
                 .where(agents.c.id == agent_id)
                 .values(
                     resource_group_id=resource_group_id,
-                    scaling_group=sa.select(ScalingGroupRow.name)
-                    .where(ScalingGroupRow.id == resource_group_id)
-                    .scalar_subquery(),
+                    scaling_group=resource_group_name,
                 )
             )
+            if cast(CursorResult[Any], result).rowcount == 0:
+                raise AgentNotFound(f"Agent with id {agent_id} not found")
         return kernels
 
     async def search_agents(

--- a/src/ai/backend/manager/repositories/agent/repository.py
+++ b/src/ai/backend/manager/repositories/agent/repository.py
@@ -172,7 +172,9 @@ class AgentRepository:
         """Change the agent's resource group, returning the kernels still on it.
 
         Raises AgentHasConflictingSessions if the agent has active kernels and
-        ``force`` is not set; otherwise updates the group and returns those kernels.
+        ``force`` is not set, ScalingGroupNotFound if the target group does not
+        exist, and AgentNotFound if the agent does not exist; otherwise updates
+        the group and returns those kernels.
         """
         return await self._db_source.update_resource_group(agent_id, resource_group_id, force=force)
 

--- a/tests/unit/manager/repositories/agent/test_repository.py
+++ b/tests/unit/manager/repositories/agent/test_repository.py
@@ -43,7 +43,7 @@ from ai.backend.manager.data.agent.types import AgentHeartbeatUpsert, AgentStatu
 from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.errors.agent import AgentHasConflictingSessions
-from ai.backend.manager.errors.resource import UnresolvableResourceGroup
+from ai.backend.manager.errors.resource import ScalingGroupNotFound, UnresolvableResourceGroup
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
@@ -1590,3 +1590,31 @@ class TestAgentDBSourceKernelFiltering:
         result = await db_source.update_resource_group(agent_id, target_id, force=True)
         assert [kernel.session.session_id for kernel in result] == [str(session_id)]
         assert await self._agent_group(db_with_tables, agent_id) == (target_name, target_id)
+
+    async def test_update_resource_group_nonexistent_agent_raises(
+        self,
+        db_source: AgentDBSource,
+        db_with_tables: ExtendedAsyncSAEngine,
+    ) -> None:
+        _, target_id = await self._seed_target_group(db_with_tables)
+
+        with pytest.raises(AgentNotFound):
+            await db_source.update_resource_group(AgentId(str(uuid4())), target_id, force=False)
+
+    async def test_update_resource_group_nonexistent_group_raises(
+        self,
+        db_source: AgentDBSource,
+        db_with_tables: ExtendedAsyncSAEngine,
+        scaling_group: str,
+        test_scaling_group_id: ResourceGroupID,
+    ) -> None:
+        agent_id = AgentId(str(uuid4()))
+        await self._seed_agent(db_with_tables, agent_id, scaling_group, test_scaling_group_id)
+
+        # An unknown resource group id is rejected before touching the agent
+        with pytest.raises(ScalingGroupNotFound):
+            await db_source.update_resource_group(agent_id, ResourceGroupID(uuid4()), force=False)
+        assert await self._agent_group(db_with_tables, agent_id) == (
+            scaling_group,
+            test_scaling_group_id,
+        )


### PR DESCRIPTION
## Summary
- The repository's `update_resource_group` silently returned success for an unknown agent ID because the UPDATE rowcount was never checked; an unknown resource group ID surfaced as an IntegrityError (500) from the NULL name subquery.
- Look up the target group name inside the update transaction and raise `ScalingGroupNotFound` (404) up front, and gate the UPDATE rowcount with `AgentNotFound` (404).

## Test plan
- [x] `tests/unit/manager/repositories/agent` — new cases: unknown agent ID raises `AgentNotFound`; unknown resource group ID raises `ScalingGroupNotFound` and leaves the agent untouched
- [x] Existing `update_resource_group` repository tests (no-conflict commit, force gating) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)