### PR TITLE
feat(BA-6960): implement idle-check judgment applier

### DIFF
--- a/changes/13108.feature.md
+++ b/changes/13108.feature.md
@@ -1,0 +1,1 @@
+Implement the Sokovan idle-check applier to persist checker judgments.

--- a/src/ai/backend/manager/models/idle_checker/conditions.py
+++ b/src/ai/backend/manager/models/idle_checker/conditions.py
@@ -40,3 +40,10 @@ class SessionIdleCheckConditions:
             return SessionIdleCheckRow.last_status == status
 
         return inner
+
+    @staticmethod
+    def by_status_not_equals(status: IdleCheckPhase) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return SessionIdleCheckRow.last_status != status
+
+        return inner

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -300,56 +300,16 @@ class IdleCheckerDBSource:
 
     async def batch_apply_session_idle_check_judgments(
         self,
-        *,
-        idle_expired: Sequence[IdleJudgmentData],
-        idle: Sequence[IdleJudgmentData],
-        active: Sequence[IdleJudgmentData],
+        judgments: Sequence[IdleJudgmentData],
     ) -> None:
-        idle_expired_pairs = [
-            (judgment.session_id, judgment.checker_id) for judgment in idle_expired
-        ]
-        idle_pairs = [(judgment.session_id, judgment.checker_id) for judgment in idle]
-        active_pairs = [(judgment.session_id, judgment.checker_id) for judgment in active]
+        pairs = [(judgment.session_id, judgment.checker_id) for judgment in judgments]
         async with self._ops.write_ops() as w:
-            if idle_expired_pairs:
+            if pairs:
                 await w.batch_update(
                     BatchUpdater(
-                        spec=SessionIdleCheckJudgmentBatchUpdaterSpec(
-                            IdleCheckPhase.IDLE_EXPIRED,
-                            idle_expired,
-                        ),
+                        spec=SessionIdleCheckJudgmentBatchUpdaterSpec(judgments),
                         conditions=[
-                            SessionIdleCheckConditions.by_pairs(idle_expired_pairs),
-                            SessionIdleCheckConditions.by_status_not_equals(
-                                IdleCheckPhase.IDLE_EXPIRED
-                            ),
-                        ],
-                    )
-                )
-            if idle_pairs:
-                await w.batch_update(
-                    BatchUpdater(
-                        spec=SessionIdleCheckJudgmentBatchUpdaterSpec(
-                            IdleCheckPhase.IDLE,
-                            idle,
-                        ),
-                        conditions=[
-                            SessionIdleCheckConditions.by_pairs(idle_pairs),
-                            SessionIdleCheckConditions.by_status_not_equals(
-                                IdleCheckPhase.IDLE_EXPIRED
-                            ),
-                        ],
-                    )
-                )
-            if active_pairs:
-                await w.batch_update(
-                    BatchUpdater(
-                        spec=SessionIdleCheckJudgmentBatchUpdaterSpec(
-                            IdleCheckPhase.ACTIVE,
-                            active,
-                        ),
-                        conditions=[
-                            SessionIdleCheckConditions.by_pairs(active_pairs),
+                            SessionIdleCheckConditions.by_pairs(pairs),
                             SessionIdleCheckConditions.by_status_not_equals(
                                 IdleCheckPhase.IDLE_EXPIRED
                             ),

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -44,12 +44,14 @@ from ai.backend.manager.repositories.idle_checker.types import (
     IdleCheckAssignmentData,
     IdleCheckBatchData,
     IdleCheckerDefinitionData,
+    IdleJudgmentData,
     InitialGracePeriodBatchData,
     InitialGracePeriodCheckData,
     SessionIdleCheckAssignmentData,
     SessionIdleCheckPair,
 )
 from ai.backend.manager.repositories.idle_checker.updaters import (
+    SessionIdleCheckJudgmentBatchUpdaterSpec,
     SessionIdleCheckPhaseBatchUpdaterSpec,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider
@@ -292,6 +294,65 @@ class IdleCheckerDBSource:
                         conditions=[
                             SessionIdleCheckConditions.by_pairs(pair_values),
                             SessionIdleCheckConditions.by_status_equals(from_phase),
+                        ],
+                    )
+                )
+
+    async def batch_apply_session_idle_check_judgments(
+        self,
+        *,
+        idle_expired: Sequence[IdleJudgmentData],
+        idle: Sequence[IdleJudgmentData],
+        active: Sequence[IdleJudgmentData],
+    ) -> None:
+        idle_expired_pairs = [
+            (judgment.session_id, judgment.checker_id) for judgment in idle_expired
+        ]
+        idle_pairs = [(judgment.session_id, judgment.checker_id) for judgment in idle]
+        active_pairs = [(judgment.session_id, judgment.checker_id) for judgment in active]
+        async with self._ops.write_ops() as w:
+            if idle_expired_pairs:
+                await w.batch_update(
+                    BatchUpdater(
+                        spec=SessionIdleCheckJudgmentBatchUpdaterSpec(
+                            IdleCheckPhase.IDLE_EXPIRED,
+                            idle_expired,
+                        ),
+                        conditions=[
+                            SessionIdleCheckConditions.by_pairs(idle_expired_pairs),
+                            SessionIdleCheckConditions.by_status_not_equals(
+                                IdleCheckPhase.IDLE_EXPIRED
+                            ),
+                        ],
+                    )
+                )
+            if idle_pairs:
+                await w.batch_update(
+                    BatchUpdater(
+                        spec=SessionIdleCheckJudgmentBatchUpdaterSpec(
+                            IdleCheckPhase.IDLE,
+                            idle,
+                        ),
+                        conditions=[
+                            SessionIdleCheckConditions.by_pairs(idle_pairs),
+                            SessionIdleCheckConditions.by_status_not_equals(
+                                IdleCheckPhase.IDLE_EXPIRED
+                            ),
+                        ],
+                    )
+                )
+            if active_pairs:
+                await w.batch_update(
+                    BatchUpdater(
+                        spec=SessionIdleCheckJudgmentBatchUpdaterSpec(
+                            IdleCheckPhase.ACTIVE,
+                            active,
+                        ),
+                        conditions=[
+                            SessionIdleCheckConditions.by_pairs(active_pairs),
+                            SessionIdleCheckConditions.by_status_not_equals(
+                                IdleCheckPhase.IDLE_EXPIRED
+                            ),
                         ],
                     )
                 )

--- a/src/ai/backend/manager/repositories/idle_checker/repository.py
+++ b/src/ai/backend/manager/repositories/idle_checker/repository.py
@@ -76,13 +76,6 @@ class IdleCheckerRepository:
 
     async def batch_apply_session_idle_check_judgments(
         self,
-        *,
-        idle_expired: Sequence[IdleJudgmentData],
-        idle: Sequence[IdleJudgmentData],
-        active: Sequence[IdleJudgmentData],
+        judgments: Sequence[IdleJudgmentData],
     ) -> None:
-        await self._db_source.batch_apply_session_idle_check_judgments(
-            idle_expired=idle_expired,
-            idle=idle,
-            active=active,
-        )
+        await self._db_source.batch_apply_session_idle_check_judgments(judgments)

--- a/src/ai/backend/manager/repositories/idle_checker/repository.py
+++ b/src/ai/backend/manager/repositories/idle_checker/repository.py
@@ -9,6 +9,7 @@ from ai.backend.manager.repositories.idle_checker.db_source.db_source import Idl
 from ai.backend.manager.repositories.idle_checker.types import (
     ExpiredIdleCheckBatchData,
     IdleCheckBatchData,
+    IdleJudgmentData,
     InitialGracePeriodBatchData,
     SessionIdleCheckAssignmentData,
     SessionIdleCheckPair,
@@ -71,4 +72,17 @@ class IdleCheckerRepository:
             pairs,
             from_phase=from_phase,
             to_phase=to_phase,
+        )
+
+    async def batch_apply_session_idle_check_judgments(
+        self,
+        *,
+        idle_expired: Sequence[IdleJudgmentData],
+        idle: Sequence[IdleJudgmentData],
+        active: Sequence[IdleJudgmentData],
+    ) -> None:
+        await self._db_source.batch_apply_session_idle_check_judgments(
+            idle_expired=idle_expired,
+            idle=idle,
+            active=active,
         )

--- a/src/ai/backend/manager/repositories/idle_checker/types.py
+++ b/src/ai/backend/manager/repositories/idle_checker/types.py
@@ -44,6 +44,17 @@ class SessionIdleCheckPair:
 
 
 @dataclass(frozen=True)
+class IdleJudgmentData:
+    """One session's judgment from one checker, persisted onto its session_idle_checks row."""
+
+    session_id: SessionId
+    checker_id: IdleCheckerID
+    status: IdleCheckPhase
+    expire_at: datetime
+    message: str
+
+
+@dataclass(frozen=True)
 class InitialGracePeriodCheckData:
     pair: SessionIdleCheckPair
     initial_grace_period_seconds: int

--- a/src/ai/backend/manager/repositories/idle_checker/updaters.py
+++ b/src/ai/backend/manager/repositories/idle_checker/updaters.py
@@ -28,7 +28,6 @@ class SessionIdleCheckPhaseBatchUpdaterSpec(BatchUpdaterSpec[SessionIdleCheckRow
 
 @dataclass
 class SessionIdleCheckJudgmentBatchUpdaterSpec(BatchUpdaterSpec[SessionIdleCheckRow]):
-    status: IdleCheckPhase
     judgments: Sequence[IdleJudgmentData]
 
     @property
@@ -39,7 +38,16 @@ class SessionIdleCheckJudgmentBatchUpdaterSpec(BatchUpdaterSpec[SessionIdleCheck
     @override
     def build_values(self) -> dict[str, Any]:
         return {
-            "last_status": self.status,
+            "last_status": sa.case(*[
+                (
+                    sa.and_(
+                        SessionIdleCheckRow.session_id == judgment.session_id,
+                        SessionIdleCheckRow.idle_checker_id == judgment.checker_id,
+                    ),
+                    judgment.status,
+                )
+                for judgment in self.judgments
+            ]),
             "expire_at": sa.case(*[
                 (
                     sa.and_(

--- a/src/ai/backend/manager/repositories/idle_checker/updaters.py
+++ b/src/ai/backend/manager/repositories/idle_checker/updaters.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, override
+
+import sqlalchemy as sa
 
 from ai.backend.common.data.idle_checker.types import IdleCheckPhase
 from ai.backend.manager.models.idle_checker.row import SessionIdleCheckRow
 from ai.backend.manager.repositories.base import BatchUpdaterSpec
+from ai.backend.manager.repositories.idle_checker.types import IdleJudgmentData
 
 
 @dataclass
@@ -20,3 +24,40 @@ class SessionIdleCheckPhaseBatchUpdaterSpec(BatchUpdaterSpec[SessionIdleCheckRow
     @override
     def build_values(self) -> dict[str, Any]:
         return {"last_status": self.to_phase}
+
+
+@dataclass
+class SessionIdleCheckJudgmentBatchUpdaterSpec(BatchUpdaterSpec[SessionIdleCheckRow]):
+    status: IdleCheckPhase
+    judgments: Sequence[IdleJudgmentData]
+
+    @property
+    @override
+    def row_class(self) -> type[SessionIdleCheckRow]:
+        return SessionIdleCheckRow
+
+    @override
+    def build_values(self) -> dict[str, Any]:
+        return {
+            "last_status": self.status,
+            "expire_at": sa.case(*[
+                (
+                    sa.and_(
+                        SessionIdleCheckRow.session_id == judgment.session_id,
+                        SessionIdleCheckRow.idle_checker_id == judgment.checker_id,
+                    ),
+                    judgment.expire_at,
+                )
+                for judgment in self.judgments
+            ]),
+            "last_message": sa.case(*[
+                (
+                    sa.and_(
+                        SessionIdleCheckRow.session_id == judgment.session_id,
+                        SessionIdleCheckRow.idle_checker_id == judgment.checker_id,
+                    ),
+                    judgment.message,
+                )
+                for judgment in self.judgments
+            ]),
+        }

--- a/src/ai/backend/manager/sokovan/idle_check/applier.py
+++ b/src/ai/backend/manager/sokovan/idle_check/applier.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import override
 
+from ai.backend.common.data.idle_checker.types import IdleCheckPhase
 from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
+from ai.backend.manager.repositories.idle_checker.types import IdleJudgmentData
 from ai.backend.manager.sokovan.idle_check.types import (
     IdleCheckCategory,
     IdleCheckKind,
@@ -29,8 +33,23 @@ class IdleCheckApplier(
         SessionStatus,
     ]
 ):
+    """Persist handler-judged phases onto existing session_idle_checks rows verbatim."""
+
+    _repository: IdleCheckerRepository
+
+    def __init__(self, repository: IdleCheckerRepository) -> None:
+        self._repository = repository
+
     @override
     async def apply(self, apply_input: _IdleCheckApplyInput) -> None:
-        # Placeholder: marking result.reports' sessions TERMINATING via
-        # SchedulingController.mark_sessions_for_termination lands in a follow-up.
-        pass
+        judgments = apply_input.result.judgments
+        if not judgments:
+            return
+        by_status: defaultdict[IdleCheckPhase, list[IdleJudgmentData]] = defaultdict(list)
+        for judgment in judgments:
+            by_status[judgment.status].append(judgment)
+        await self._repository.batch_apply_session_idle_check_judgments(
+            idle_expired=by_status[IdleCheckPhase.IDLE_EXPIRED],
+            idle=by_status[IdleCheckPhase.IDLE],
+            active=by_status[IdleCheckPhase.ACTIVE],
+        )

--- a/src/ai/backend/manager/sokovan/idle_check/applier.py
+++ b/src/ai/backend/manager/sokovan/idle_check/applier.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from collections import defaultdict
 from typing import override
 
-from ai.backend.common.data.idle_checker.types import IdleCheckPhase
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
-from ai.backend.manager.repositories.idle_checker.types import IdleJudgmentData
 from ai.backend.manager.sokovan.idle_check.types import (
     IdleCheckCategory,
     IdleCheckKind,
@@ -45,11 +42,4 @@ class IdleCheckApplier(
         judgments = apply_input.result.judgments
         if not judgments:
             return
-        by_status: defaultdict[IdleCheckPhase, list[IdleJudgmentData]] = defaultdict(list)
-        for judgment in judgments:
-            by_status[judgment.status].append(judgment)
-        await self._repository.batch_apply_session_idle_check_judgments(
-            idle_expired=by_status[IdleCheckPhase.IDLE_EXPIRED],
-            idle=by_status[IdleCheckPhase.IDLE],
-            active=by_status[IdleCheckPhase.ACTIVE],
-        )
+        await self._repository.batch_apply_session_idle_check_judgments(judgments)

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/base.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/base.py
@@ -7,11 +7,11 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 
-from ai.backend.common.data.idle_checker.types import IdleCheckPhase
-from ai.backend.common.identifier.idle_checker import IdleCheckerID
-from ai.backend.common.types import SessionId
 from ai.backend.manager.data.idle_checker.types import IdleCheckSession
-from ai.backend.manager.repositories.idle_checker.types import IdleCheckerDefinitionData
+from ai.backend.manager.repositories.idle_checker.types import (
+    IdleCheckerDefinitionData,
+    IdleJudgmentData,
+)
 
 
 @dataclass(frozen=True)
@@ -29,17 +29,6 @@ class CheckerAssignment:
     sessions: Sequence[IdleCheckSession]
 
 
-@dataclass(frozen=True)
-class IdleJudgment:
-    """One session's judgment from one checker definition."""
-
-    checker_id: IdleCheckerID
-    session_id: SessionId
-    expire_at: datetime
-    status: IdleCheckPhase
-    message: str
-
-
 class IdleChecker(ABC):
     """Per-``CheckerType`` behavior with constructor-injected I/O clients."""
 
@@ -49,7 +38,7 @@ class IdleChecker(ABC):
         assignments: Sequence[CheckerAssignment],
         *,
         context: IdleCheckerContext,
-    ) -> Sequence[IdleJudgment]:
+    ) -> Sequence[IdleJudgmentData]:
         """Evaluate every assignment of this type in one batched call.
 
         Implementations may batch external I/O but must not retain per-call state.

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
@@ -8,11 +8,11 @@ from typing import override
 
 from ai.backend.common.data.idle_checker.types import IdleCheckPhase
 from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.repositories.idle_checker.types import IdleJudgmentData
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
     IdleChecker,
     IdleCheckerContext,
-    IdleJudgment,
 )
 
 log = BraceStyleAdapter(logging.getLogger(__name__))
@@ -27,8 +27,8 @@ class SessionLifetimeChecker(IdleChecker):
         assignments: Sequence[CheckerAssignment],
         *,
         context: IdleCheckerContext,
-    ) -> Sequence[IdleJudgment]:
-        judgments: list[IdleJudgment] = []
+    ) -> Sequence[IdleJudgmentData]:
+        judgments: list[IdleJudgmentData] = []
         for assignment in assignments:
             lifetime_spec = assignment.definition.spec.session_lifetime
             if lifetime_spec is None:
@@ -51,7 +51,7 @@ class SessionLifetimeChecker(IdleChecker):
                     seconds=lifetime_spec.max_lifetime_seconds
                 )
                 judgments.append(
-                    IdleJudgment(
+                    IdleJudgmentData(
                         checker_id=assignment.definition.checker_id,
                         session_id=session.session_id,
                         expire_at=expires_at,

--- a/src/ai/backend/manager/sokovan/idle_check/handlers/reconcile.py
+++ b/src/ai/backend/manager/sokovan/idle_check/handlers/reconcile.py
@@ -11,12 +11,12 @@ from ai.backend.manager.data.idle_checker.types import IdleCheckSession
 from ai.backend.manager.repositories.idle_checker.types import (
     IdleCheckBatchData,
     IdleCheckerDefinitionData,
+    IdleJudgmentData,
 )
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
     IdleChecker,
     IdleCheckerContext,
-    IdleJudgment,
 )
 from ai.backend.manager.sokovan.idle_check.types import IdleCheckReconcileInfo, IdleCheckResult
 from ai.backend.manager.sokovan.reconciler.base import ReconcilerHandler
@@ -34,7 +34,7 @@ class IdleCheckReconcileHandler(ReconcilerHandler[IdleCheckReconcileInfo, IdleCh
     async def execute(self, reconcile_info: IdleCheckReconcileInfo) -> IdleCheckResult:
         assignments_by_type = self._assignments_by_type(reconcile_info.batch)
         context = IdleCheckerContext(current_time=reconcile_info.current_time)
-        all_judgments: list[IdleJudgment] = []
+        all_judgments: list[IdleJudgmentData] = []
         for checker_type, assignments in assignments_by_type.items():
             checker = self._checkers.get(checker_type)
             if checker is None:

--- a/src/ai/backend/manager/sokovan/idle_check/types.py
+++ b/src/ai/backend/manager/sokovan/idle_check/types.py
@@ -16,8 +16,10 @@ from ai.backend.manager.data.reconciler.types import (
 )
 from ai.backend.manager.data.session.options import HandlerPolicyResolver
 from ai.backend.manager.data.session.types import SessionStatus
-from ai.backend.manager.repositories.idle_checker.types import IdleCheckBatchData
-from ai.backend.manager.sokovan.idle_check.checkers.base import IdleJudgment
+from ai.backend.manager.repositories.idle_checker.types import (
+    IdleCheckBatchData,
+    IdleJudgmentData,
+)
 from ai.backend.manager.sokovan.reconciler.base import (
     BaseReconcilerInfo,
     BaseReconcilerKind,
@@ -82,7 +84,7 @@ class IdleCheckDecision(ReconcilerDecision):
 
 @dataclass
 class IdleCheckResult(BaseReconcilerResult):
-    judgments: list[IdleJudgment] = field(default_factory=list)
+    judgments: list[IdleJudgmentData] = field(default_factory=list)
 
     @override
     def processed_count(self) -> int:

--- a/src/ai/backend/manager/sokovan/stages/idle_check_judgment.py
+++ b/src/ai/backend/manager/sokovan/stages/idle_check_judgment.py
@@ -37,8 +37,9 @@ def build_idle_check_judgment_stage(
 ) -> ReconcilerStageRegistration:
     reconcile_type = "idle_check_judgment"
     # Termination runs through the scheduler lifecycle (mark_sessions_for_termination in
-    # the applier) — which also terminates kernels, is idempotent for already-terminating/
-    # terminal sessions, and broadcasts — not this per-entity status-transition map.
+    # the sweep stage handler) — which also terminates kernels, is idempotent for
+    # already-terminating/terminal sessions, and broadcasts — not this per-entity
+    # status-transition map.
     transitions: Mapping[SchedulingResult, SessionStatus] = {}
     metadata = ReconcilerStageMetadata(
         category=IdleCheckCategory.SESSION_IDLE_CHECK,
@@ -57,7 +58,7 @@ def build_idle_check_judgment_stage(
     stage = ReconcilerStage(
         handler=IdleCheckReconcileHandler(checkers),
         source=IdleCheckSource(idle_checker_repository),
-        applier=IdleCheckApplier(),
+        applier=IdleCheckApplier(idle_checker_repository),
         metadata=metadata,
     )
     task_spec = ReconcilerTaskSpec(

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -38,7 +38,10 @@ from ai.backend.manager.models.scaling_group import ScalingGroupRow
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
-from ai.backend.manager.repositories.idle_checker.types import SessionIdleCheckPair
+from ai.backend.manager.repositories.idle_checker.types import (
+    IdleJudgmentData,
+    SessionIdleCheckPair,
+)
 from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.testutils.db import with_tables
 
@@ -70,6 +73,7 @@ class JudgmentRows:
     idle_expired_session_id: SessionId
     session_without_row_id: SessionId
     terminated_session_id: SessionId
+    second_terminated_session_id: SessionId
     checker_id: IdleCheckerID
 
 
@@ -213,6 +217,7 @@ class TestFetchJudgmentBatch:
         idle_expired_session_id = SessionId(uuid.uuid4())
         session_without_row_id = SessionId(uuid.uuid4())
         terminated_session_id = SessionId(uuid.uuid4())
+        second_terminated_session_id = SessionId(uuid.uuid4())
         checker_id = IdleCheckerID(uuid.uuid4())
         session_specs = (
             (active_session_id, SessionStatus.RUNNING),
@@ -222,6 +227,7 @@ class TestFetchJudgmentBatch:
             (idle_expired_session_id, SessionStatus.RUNNING),
             (session_without_row_id, SessionStatus.RUNNING),
             (terminated_session_id, SessionStatus.TERMINATED),
+            (second_terminated_session_id, SessionStatus.TERMINATED),
         )
         check_specs = (
             (active_session_id, IdleCheckPhase.ACTIVE),
@@ -230,6 +236,7 @@ class TestFetchJudgmentBatch:
             (ready_to_check_session_id, IdleCheckPhase.READY_TO_CHECK),
             (idle_expired_session_id, IdleCheckPhase.IDLE_EXPIRED),
             (terminated_session_id, IdleCheckPhase.ACTIVE),
+            (second_terminated_session_id, IdleCheckPhase.ACTIVE),
         )
         async with database.begin_session() as db_sess:
             for scope_row in _expired_check_scope_rows(scope):
@@ -264,6 +271,7 @@ class TestFetchJudgmentBatch:
             idle_expired_session_id=idle_expired_session_id,
             session_without_row_id=session_without_row_id,
             terminated_session_id=terminated_session_id,
+            second_terminated_session_id=second_terminated_session_id,
             checker_id=checker_id,
         )
 
@@ -418,6 +426,148 @@ class TestFetchJudgmentBatch:
             )
         ]
         assert batch.checks[0].initial_grace_period_seconds == 45
+
+    async def test_applies_all_judgment_batches_with_distinct_messages(
+        self,
+        database: ExtendedAsyncSAEngine,
+        repository: IdleCheckerRepository,
+        judgment_rows: JudgmentRows,
+    ) -> None:
+        expire_at = datetime(2026, 3, 1, tzinfo=UTC)
+        idle_expired = [
+            IdleJudgmentData(
+                session_id=judgment_rows.active_session_id,
+                checker_id=judgment_rows.checker_id,
+                status=IdleCheckPhase.IDLE_EXPIRED,
+                expire_at=expire_at,
+                message="idle expired 1",
+            ),
+            IdleJudgmentData(
+                session_id=judgment_rows.not_checked_session_id,
+                checker_id=judgment_rows.checker_id,
+                status=IdleCheckPhase.IDLE_EXPIRED,
+                expire_at=expire_at,
+                message="idle expired 2",
+            ),
+            IdleJudgmentData(
+                session_id=judgment_rows.terminated_session_id,
+                checker_id=judgment_rows.checker_id,
+                status=IdleCheckPhase.IDLE_EXPIRED,
+                expire_at=expire_at,
+                message="idle expired 3",
+            ),
+        ]
+        idle = [
+            IdleJudgmentData(
+                session_id=judgment_rows.idle_session_id,
+                checker_id=judgment_rows.checker_id,
+                status=IdleCheckPhase.IDLE,
+                expire_at=expire_at,
+                message="idle 1",
+            ),
+            IdleJudgmentData(
+                session_id=judgment_rows.ready_to_check_session_id,
+                checker_id=judgment_rows.checker_id,
+                status=IdleCheckPhase.IDLE,
+                expire_at=expire_at,
+                message="idle 2",
+            ),
+        ]
+        active = [
+            IdleJudgmentData(
+                session_id=judgment_rows.second_terminated_session_id,
+                checker_id=judgment_rows.checker_id,
+                status=IdleCheckPhase.ACTIVE,
+                expire_at=expire_at,
+                message="active 1",
+            ),
+        ]
+
+        await repository.batch_apply_session_idle_check_judgments(
+            idle_expired=idle_expired,
+            idle=idle,
+            active=active,
+        )
+
+        async with database.begin_readonly_session() as db_sess:
+            for judgment in [*idle_expired, *idle, *active]:
+                row = await db_sess.get(
+                    SessionIdleCheckRow,
+                    (judgment.session_id, judgment.checker_id),
+                )
+                assert row is not None
+                assert row.last_status is judgment.status
+                assert row.expire_at == judgment.expire_at
+                assert row.last_message == judgment.message
+
+    async def test_accepts_empty_judgment_batch(
+        self,
+        repository: IdleCheckerRepository,
+    ) -> None:
+        await repository.batch_apply_session_idle_check_judgments(
+            idle_expired=[],
+            idle=[],
+            active=[],
+        )
+
+    async def test_never_touches_idle_expired_row(
+        self,
+        database: ExtendedAsyncSAEngine,
+        repository: IdleCheckerRepository,
+        judgment_rows: JudgmentRows,
+    ) -> None:
+        await repository.batch_apply_session_idle_check_judgments(
+            idle_expired=[],
+            idle=[],
+            active=[
+                IdleJudgmentData(
+                    session_id=judgment_rows.idle_expired_session_id,
+                    checker_id=judgment_rows.checker_id,
+                    status=IdleCheckPhase.ACTIVE,
+                    expire_at=datetime(2026, 3, 1, tzinfo=UTC),
+                    message="activity detected",
+                )
+            ],
+        )
+
+        async with database.begin_readonly_session() as db_sess:
+            row = await db_sess.get(
+                SessionIdleCheckRow,
+                (judgment_rows.idle_expired_session_id, judgment_rows.checker_id),
+            )
+        assert row is not None
+        assert row.last_status is IdleCheckPhase.IDLE_EXPIRED
+        assert row.last_message == f"{IdleCheckPhase.IDLE_EXPIRED.value} judgment"
+        assert row.expire_at == datetime(2026, 2, 1, tzinfo=UTC)
+
+    async def test_ignores_missing_pair_without_insert(
+        self,
+        database: ExtendedAsyncSAEngine,
+        repository: IdleCheckerRepository,
+        judgment_rows: JudgmentRows,
+    ) -> None:
+        missing_session_id = SessionId(uuid.uuid4())
+
+        await repository.batch_apply_session_idle_check_judgments(
+            idle_expired=[],
+            idle=[],
+            active=[
+                IdleJudgmentData(
+                    session_id=missing_session_id,
+                    checker_id=judgment_rows.checker_id,
+                    status=IdleCheckPhase.ACTIVE,
+                    expire_at=datetime(2026, 3, 1, tzinfo=UTC),
+                    message="activity detected",
+                )
+            ],
+        )
+
+        async with database.begin_readonly_session() as db_sess:
+            row = await db_sess.get(
+                SessionIdleCheckRow,
+                (missing_session_id, judgment_rows.checker_id),
+            )
+        assert row is None
 
     async def test_excludes_session_without_idle_check_row(
         self,

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -483,14 +483,11 @@ class TestFetchJudgmentBatch:
             ),
         ]
 
-        await repository.batch_apply_session_idle_check_judgments(
-            idle_expired=idle_expired,
-            idle=idle,
-            active=active,
-        )
+        judgments = [*idle_expired, *idle, *active]
+        await repository.batch_apply_session_idle_check_judgments(judgments)
 
         async with database.begin_readonly_session() as db_sess:
-            for judgment in [*idle_expired, *idle, *active]:
+            for judgment in judgments:
                 row = await db_sess.get(
                     SessionIdleCheckRow,
                     (judgment.session_id, judgment.checker_id),
@@ -504,11 +501,7 @@ class TestFetchJudgmentBatch:
         self,
         repository: IdleCheckerRepository,
     ) -> None:
-        await repository.batch_apply_session_idle_check_judgments(
-            idle_expired=[],
-            idle=[],
-            active=[],
-        )
+        await repository.batch_apply_session_idle_check_judgments([])
 
     async def test_never_touches_idle_expired_row(
         self,
@@ -516,19 +509,15 @@ class TestFetchJudgmentBatch:
         repository: IdleCheckerRepository,
         judgment_rows: JudgmentRows,
     ) -> None:
-        await repository.batch_apply_session_idle_check_judgments(
-            idle_expired=[],
-            idle=[],
-            active=[
-                IdleJudgmentData(
-                    session_id=judgment_rows.idle_expired_session_id,
-                    checker_id=judgment_rows.checker_id,
-                    status=IdleCheckPhase.ACTIVE,
-                    expire_at=datetime(2026, 3, 1, tzinfo=UTC),
-                    message="activity detected",
-                )
-            ],
-        )
+        await repository.batch_apply_session_idle_check_judgments([
+            IdleJudgmentData(
+                session_id=judgment_rows.idle_expired_session_id,
+                checker_id=judgment_rows.checker_id,
+                status=IdleCheckPhase.ACTIVE,
+                expire_at=datetime(2026, 3, 1, tzinfo=UTC),
+                message="activity detected",
+            )
+        ])
 
         async with database.begin_readonly_session() as db_sess:
             row = await db_sess.get(
@@ -548,19 +537,15 @@ class TestFetchJudgmentBatch:
     ) -> None:
         missing_session_id = SessionId(uuid.uuid4())
 
-        await repository.batch_apply_session_idle_check_judgments(
-            idle_expired=[],
-            idle=[],
-            active=[
-                IdleJudgmentData(
-                    session_id=missing_session_id,
-                    checker_id=judgment_rows.checker_id,
-                    status=IdleCheckPhase.ACTIVE,
-                    expire_at=datetime(2026, 3, 1, tzinfo=UTC),
-                    message="activity detected",
-                )
-            ],
-        )
+        await repository.batch_apply_session_idle_check_judgments([
+            IdleJudgmentData(
+                session_id=missing_session_id,
+                checker_id=judgment_rows.checker_id,
+                status=IdleCheckPhase.ACTIVE,
+                expire_at=datetime(2026, 3, 1, tzinfo=UTC),
+                message="activity detected",
+            )
+        ])
 
         async with database.begin_readonly_session() as db_sess:
             row = await db_sess.get(

--- a/tests/unit/manager/sokovan/idle_check/test_applier.py
+++ b/tests/unit/manager/sokovan/idle_check/test_applier.py
@@ -73,11 +73,7 @@ class TestIdleCheckApplier:
     ) -> None:
         await applier.apply(apply_input)
 
-        repository.batch_apply_session_idle_check_judgments.assert_awaited_once_with(
-            idle_expired=[judgments[2]],
-            idle=[judgments[1]],
-            active=[judgments[0]],
-        )
+        repository.batch_apply_session_idle_check_judgments.assert_awaited_once_with(judgments)
 
     async def test_skips_empty_result(
         self,

--- a/tests/unit/manager/sokovan/idle_check/test_applier.py
+++ b/tests/unit/manager/sokovan/idle_check/test_applier.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from ai.backend.common.data.idle_checker.types import IdleCheckPhase
+from ai.backend.common.identifier.idle_checker import IdleCheckerID
+from ai.backend.common.types import SessionId
+from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
+from ai.backend.manager.repositories.idle_checker.types import IdleJudgmentData
+from ai.backend.manager.sokovan.idle_check.applier import IdleCheckApplier
+from ai.backend.manager.sokovan.idle_check.types import IdleCheckResult
+
+_EXPIRE_AT = datetime(2026, 1, 2, tzinfo=UTC)
+
+
+class TestIdleCheckApplier:
+    @pytest.fixture
+    def repository(self) -> AsyncMock:
+        return AsyncMock(spec=IdleCheckerRepository)
+
+    @pytest.fixture
+    def applier(self, repository: AsyncMock) -> IdleCheckApplier:
+        return IdleCheckApplier(repository)
+
+    @pytest.fixture
+    def judgments(self) -> list[IdleJudgmentData]:
+        return [
+            IdleJudgmentData(
+                session_id=SessionId(uuid4()),
+                checker_id=IdleCheckerID(uuid4()),
+                status=IdleCheckPhase.ACTIVE,
+                expire_at=_EXPIRE_AT,
+                message="activity detected",
+            ),
+            IdleJudgmentData(
+                session_id=SessionId(uuid4()),
+                checker_id=IdleCheckerID(uuid4()),
+                status=IdleCheckPhase.IDLE,
+                expire_at=_EXPIRE_AT,
+                message="no activity",
+            ),
+            IdleJudgmentData(
+                session_id=SessionId(uuid4()),
+                checker_id=IdleCheckerID(uuid4()),
+                status=IdleCheckPhase.IDLE_EXPIRED,
+                expire_at=_EXPIRE_AT,
+                message="idle expired",
+            ),
+        ]
+
+    @pytest.fixture
+    def apply_input(self, judgments: list[IdleJudgmentData]) -> MagicMock:
+        apply_input = MagicMock()
+        apply_input.result = IdleCheckResult(judgments=judgments)
+        return apply_input
+
+    @pytest.fixture
+    def empty_apply_input(self) -> MagicMock:
+        apply_input = MagicMock()
+        apply_input.result = IdleCheckResult()
+        return apply_input
+
+    async def test_persists_judgments(
+        self,
+        applier: IdleCheckApplier,
+        repository: AsyncMock,
+        judgments: list[IdleJudgmentData],
+        apply_input: MagicMock,
+    ) -> None:
+        await applier.apply(apply_input)
+
+        repository.batch_apply_session_idle_check_judgments.assert_awaited_once_with(
+            idle_expired=[judgments[2]],
+            idle=[judgments[1]],
+            active=[judgments[0]],
+        )
+
+    async def test_skips_empty_result(
+        self,
+        applier: IdleCheckApplier,
+        repository: AsyncMock,
+        empty_apply_input: MagicMock,
+    ) -> None:
+        await applier.apply(empty_apply_input)
+
+        repository.batch_apply_session_idle_check_judgments.assert_not_awaited()

--- a/tests/unit/manager/sokovan/idle_check/test_handler.py
+++ b/tests/unit/manager/sokovan/idle_check/test_handler.py
@@ -22,12 +22,12 @@ from ai.backend.manager.repositories.idle_checker.types import (
     IdleCheckAssignmentData,
     IdleCheckBatchData,
     IdleCheckerDefinitionData,
+    IdleJudgmentData,
 )
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
     IdleChecker,
     IdleCheckerContext,
-    IdleJudgment,
 )
 from ai.backend.manager.sokovan.idle_check.handlers.reconcile import IdleCheckReconcileHandler
 from ai.backend.manager.sokovan.idle_check.types import IdleCheckReconcileInfo
@@ -66,7 +66,7 @@ class FakeChecker(IdleChecker):
         assignments: Sequence[CheckerAssignment],
         *,
         context: IdleCheckerContext,
-    ) -> Sequence[IdleJudgment]:
+    ) -> Sequence[IdleJudgmentData]:
         self.judge_contexts.append(context)
         self.judge_calls.append([
             (
@@ -78,7 +78,7 @@ class FakeChecker(IdleChecker):
         if self.should_fail:
             raise InternalServerError("Fake checker failed")
         return [
-            IdleJudgment(
+            IdleJudgmentData(
                 checker_id=assignment.definition.checker_id,
                 session_id=session.session_id,
                 expire_at=_NOW,
@@ -221,21 +221,21 @@ class TestIdleCheckReconcileHandler:
         result = await handler.execute(reconcile_info)
 
         assert result.judgments == [
-            IdleJudgment(
+            IdleJudgmentData(
                 checker_id=lifetime_definition.checker_id,
                 session_id=first_session_id,
                 expire_at=_NOW,
                 status=IdleCheckPhase.IDLE,
                 message="max lifetime exceeded",
             ),
-            IdleJudgment(
+            IdleJudgmentData(
                 checker_id=lifetime_definition.checker_id,
                 session_id=second_session_id,
                 expire_at=_NOW,
                 status=IdleCheckPhase.IDLE,
                 message="max lifetime exceeded",
             ),
-            IdleJudgment(
+            IdleJudgmentData(
                 checker_id=network_definition.checker_id,
                 session_id=first_session_id,
                 expire_at=_NOW,


### PR DESCRIPTION
resolve #13008 (BA-6960)
## Summary

- promote idle-check judgments to repository data shared by checkers, handlers, and persistence
- wire the idle-check applier to group judgments by phase and batch-update existing `session_idle_checks` rows
- preserve per-row expiry timestamps and messages while preventing terminal `IDLE_EXPIRED` rows from being overwritten
- cover mixed `IDLE_EXPIRED`, `IDLE`, and `ACTIVE` batches, empty input, missing pairs, and terminal-row protection

## Why

The idle-check applier was still a placeholder, so checker judgments were produced but never persisted. This change connects the reconciler output to the repository and applies each phase group atomically with at most three update statements.

## Impact

Idle-check results now update the corresponding session/checker rows without inserting missing assignments or reviving already expired judgments.

## Validation

- `pants fmt --changed-since=HEAD~1`
- `pants fix --changed-since=HEAD~1`
- `pants lint --changed-since=HEAD~1`
- `pants check --changed-since=HEAD~1`
- `pants test --changed-since=HEAD~1`
- pre-commit and pre-push hooks
