### PR TITLE
feat(BA-7012): expose fragment by-names read and upsert over REST v2

### DIFF
--- a/changes/13118.feature.md
+++ b/changes/13118.feature.md
@@ -1,0 +1,1 @@
+Add `scoped/upsert` and `scoped/by-names` app config fragment endpoints to REST v2, with `my/` variants acting at the caller's own user scope.

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -837,6 +837,58 @@
         "title": "AppConfigFragmentOrderField",
         "type": "string"
       },
+      "AppConfigFragmentScope": {
+        "description": "The scopes a scoped fragment search runs at, keyed by scope kind.\n\nEach category list is OR'd internally and across categories. ``public`` is a flag rather\nthan a list: it names one global scope that owns no id. Raises if every field is empty.",
+        "properties": {
+          "domain": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/UUIDScope"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Domain ids whose fragments to search.",
+            "title": "Domain"
+          },
+          "user": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/UUIDScope"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "User ids whose fragments to search.",
+            "title": "User"
+          },
+          "public": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Search the public scope, which has no owner.",
+            "title": "Public"
+          }
+        },
+        "title": "AppConfigFragmentScope",
+        "type": "object"
+      },
       "AppConfigScopeTypeFilter": {
         "description": "Filter for the scope_type enum field.",
         "properties": {
@@ -961,175 +1013,6 @@
           }
         },
         "title": "DateTimeFilter",
-        "type": "object"
-      },
-      "AdminSearchAppConfigFragmentInput": {
-        "description": "Input for paginated app config fragment search (superadmin only).",
-        "properties": {
-          "filter": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/AppConfigFragmentFilter"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Filter conditions."
-          },
-          "order": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/AppConfigFragmentOrder"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Order specifiers, applied in sequence.",
-            "title": "Order"
-          },
-          "first": {
-            "anyOf": [
-              {
-                "minimum": 1,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Cursor-forward page size.",
-            "title": "First"
-          },
-          "after": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Cursor-forward start cursor.",
-            "title": "After"
-          },
-          "last": {
-            "anyOf": [
-              {
-                "minimum": 1,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Cursor-backward page size.",
-            "title": "Last"
-          },
-          "before": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Cursor-backward end cursor.",
-            "title": "Before"
-          },
-          "limit": {
-            "anyOf": [
-              {
-                "minimum": 1,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Offset-based: maximum number of results.",
-            "title": "Limit"
-          },
-          "offset": {
-            "anyOf": [
-              {
-                "minimum": 0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Offset-based: number of results to skip.",
-            "title": "Offset"
-          }
-        },
-        "title": "AdminSearchAppConfigFragmentInput",
-        "type": "object"
-      },
-      "AppConfigFragmentScope": {
-        "description": "The scopes a scoped fragment search runs at, keyed by scope kind.\n\nEach category list is OR'd internally and across categories. ``public`` is a flag rather\nthan a list: it names one global scope that owns no id. Raises if every field is empty.",
-        "properties": {
-          "domain": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/UUIDScope"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Domain ids whose fragments to search.",
-            "title": "Domain"
-          },
-          "user": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/UUIDScope"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "User ids whose fragments to search.",
-            "title": "User"
-          },
-          "public": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Search the public scope, which has no owner.",
-            "title": "Public"
-          }
-        },
-        "title": "AppConfigFragmentScope",
         "type": "object"
       },
       "UUIDScope": {
@@ -1269,6 +1152,261 @@
           "scope"
         ],
         "title": "ScopedSearchAppConfigFragmentInput",
+        "type": "object"
+      },
+      "AppConfigScopeRef": {
+        "description": "One app config scope: its kind, and its owner id for the kinds that have one.",
+        "properties": {
+          "scope_type": {
+            "$ref": "#/components/schemas/AppConfigScopeType",
+            "description": "Scope the fragments are written at (public | domain | user)."
+          },
+          "scope_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Scope identifier: the domain id or the user id; null for public scope.",
+            "title": "Scope Id"
+          }
+        },
+        "required": [
+          "scope_type"
+        ],
+        "title": "AppConfigScopeRef",
+        "type": "object"
+      },
+      "ScopedAppConfigFragmentsByNamesInput": {
+        "description": "Read the fragments written at one scope for the given config names.",
+        "properties": {
+          "scope": {
+            "$ref": "#/components/schemas/AppConfigScopeRef",
+            "description": "Scope whose fragments to read."
+          },
+          "config_names": {
+            "description": "Config names whose fragments to read. Answered position by position, null where the scope holds no fragment for that name.",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "title": "Config Names",
+            "type": "array"
+          }
+        },
+        "required": [
+          "scope",
+          "config_names"
+        ],
+        "title": "ScopedAppConfigFragmentsByNamesInput",
+        "type": "object"
+      },
+      "AppConfigFragmentUpsertItem": {
+        "description": "One (config_name, config) pair to upsert at the request's scope.",
+        "properties": {
+          "config_name": {
+            "description": "Registered config name.",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Config Name",
+            "type": "string"
+          },
+          "config": {
+            "additionalProperties": true,
+            "description": "The fragment's JSON config document.",
+            "title": "Config",
+            "type": "object"
+          }
+        },
+        "required": [
+          "config_name",
+          "config"
+        ],
+        "title": "AppConfigFragmentUpsertItem",
+        "type": "object"
+      },
+      "ScopedUpsertAppConfigFragmentsInput": {
+        "description": "Upsert many fragments at one scope; the scope is named once for all items.",
+        "properties": {
+          "scope": {
+            "$ref": "#/components/schemas/AppConfigScopeRef",
+            "description": "Scope the fragments are written at."
+          },
+          "items": {
+            "description": "The (config_name, config) pairs to upsert.",
+            "items": {
+              "$ref": "#/components/schemas/AppConfigFragmentUpsertItem"
+            },
+            "minItems": 1,
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "scope",
+          "items"
+        ],
+        "title": "ScopedUpsertAppConfigFragmentsInput",
+        "type": "object"
+      },
+      "MyAppConfigFragmentsByNamesInput": {
+        "description": "Read the current user's own user-scope fragments for the given config names.",
+        "properties": {
+          "config_names": {
+            "description": "Config names whose fragments to read. Answered position by position, null where the scope holds no fragment for that name.",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "title": "Config Names",
+            "type": "array"
+          }
+        },
+        "required": [
+          "config_names"
+        ],
+        "title": "MyAppConfigFragmentsByNamesInput",
+        "type": "object"
+      },
+      "MyUpsertAppConfigFragmentsInput": {
+        "description": "Upsert many fragments at the current user's own user scope.\n\nThe scope is the acting user, resolved server-side, so it carries no scope fields.",
+        "properties": {
+          "items": {
+            "description": "The (config_name, config) pairs to upsert.",
+            "items": {
+              "$ref": "#/components/schemas/AppConfigFragmentUpsertItem"
+            },
+            "minItems": 1,
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "MyUpsertAppConfigFragmentsInput",
+        "type": "object"
+      },
+      "AdminSearchAppConfigFragmentInput": {
+        "description": "Input for paginated app config fragment search (superadmin only).",
+        "properties": {
+          "filter": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AppConfigFragmentFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter conditions."
+          },
+          "order": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/AppConfigFragmentOrder"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Order specifiers, applied in sequence.",
+            "title": "Order"
+          },
+          "first": {
+            "anyOf": [
+              {
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cursor-forward page size.",
+            "title": "First"
+          },
+          "after": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cursor-forward start cursor.",
+            "title": "After"
+          },
+          "last": {
+            "anyOf": [
+              {
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cursor-backward page size.",
+            "title": "Last"
+          },
+          "before": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cursor-backward end cursor.",
+            "title": "Before"
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Offset-based: maximum number of results.",
+            "title": "Limit"
+          },
+          "offset": {
+            "anyOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Offset-based: number of results to skip.",
+            "title": "Offset"
+          }
+        },
+        "title": "AdminSearchAppConfigFragmentInput",
         "type": "object"
       },
       "UpdateAppConfigFragmentInput": {
@@ -41375,35 +41513,6 @@
         "description": "Purge many fragments by id, with per-item partial success (auth, RBAC).\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
-    "/v2/app-config-fragments/admin/search": {
-      "post": {
-        "operationId": "v2/app-config-fragments.admin_search",
-        "tags": [
-          "v2/app-config-fragments"
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful response"
-          }
-        },
-        "security": [
-          {
-            "TokenAuth": []
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AdminSearchAppConfigFragmentInput"
-              }
-            }
-          }
-        },
-        "parameters": [],
-        "description": "Search fragments across all scopes with pagination (superadmin only).\n\n**Preconditions:**\n* Superadmin privilege required.\n"
-      }
-    },
     "/v2/app-config-fragments/scoped/search": {
       "post": {
         "operationId": "v2/app-config-fragments.scoped_search",
@@ -41431,6 +41540,151 @@
         },
         "parameters": [],
         "description": "Search the fragments written at one scope (auth required, RBAC-authorized).\n\n**Preconditions:**\n* User privilege required.\n"
+      }
+    },
+    "/v2/app-config-fragments/scoped/by-names": {
+      "post": {
+        "operationId": "v2/app-config-fragments.scoped_fragments_by_names",
+        "tags": [
+          "v2/app-config-fragments"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScopedAppConfigFragmentsByNamesInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Read one scope's fragments for the given config names (auth, RBAC-authorized).\n\n**Preconditions:**\n* User privilege required.\n"
+      }
+    },
+    "/v2/app-config-fragments/scoped/bulk-upsert": {
+      "post": {
+        "operationId": "v2/app-config-fragments.scoped_bulk_upsert",
+        "tags": [
+          "v2/app-config-fragments"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScopedUpsertAppConfigFragmentsInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Upsert many fragments at one scope, all-or-nothing (auth, RBAC-authorized).\n\n**Preconditions:**\n* User privilege required.\n"
+      }
+    },
+    "/v2/app-config-fragments/my/by-names": {
+      "post": {
+        "operationId": "v2/app-config-fragments.my_fragments_by_names",
+        "tags": [
+          "v2/app-config-fragments"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MyAppConfigFragmentsByNamesInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Read the caller's own user-scope fragments for the given config names (auth).\n\n**Preconditions:**\n* User privilege required.\n"
+      }
+    },
+    "/v2/app-config-fragments/my/bulk-upsert": {
+      "post": {
+        "operationId": "v2/app-config-fragments.my_bulk_upsert",
+        "tags": [
+          "v2/app-config-fragments"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MyUpsertAppConfigFragmentsInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Upsert many fragments at the caller's own user scope, all-or-nothing (auth).\n\n**Preconditions:**\n* User privilege required.\n"
+      }
+    },
+    "/v2/app-config-fragments/admin/search": {
+      "post": {
+        "operationId": "v2/app-config-fragments.admin_search",
+        "tags": [
+          "v2/app-config-fragments"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminSearchAppConfigFragmentInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Search fragments across all scopes with pagination (superadmin only).\n\n**Preconditions:**\n* Superadmin privilege required.\n"
       }
     },
     "/v2/app-config-fragments/{fragment_id}": {

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -837,58 +837,6 @@
         "title": "AppConfigFragmentOrderField",
         "type": "string"
       },
-      "AppConfigFragmentScope": {
-        "description": "The scopes a scoped fragment search runs at, keyed by scope kind.\n\nEach category list is OR'd internally and across categories. ``public`` is a flag rather\nthan a list: it names one global scope that owns no id. Raises if every field is empty.",
-        "properties": {
-          "domain": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/UUIDScope"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Domain ids whose fragments to search.",
-            "title": "Domain"
-          },
-          "user": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/UUIDScope"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "User ids whose fragments to search.",
-            "title": "User"
-          },
-          "public": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Search the public scope, which has no owner.",
-            "title": "Public"
-          }
-        },
-        "title": "AppConfigFragmentScope",
-        "type": "object"
-      },
       "AppConfigScopeTypeFilter": {
         "description": "Filter for the scope_type enum field.",
         "properties": {
@@ -1013,6 +961,175 @@
           }
         },
         "title": "DateTimeFilter",
+        "type": "object"
+      },
+      "AdminSearchAppConfigFragmentInput": {
+        "description": "Input for paginated app config fragment search (superadmin only).",
+        "properties": {
+          "filter": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AppConfigFragmentFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter conditions."
+          },
+          "order": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/AppConfigFragmentOrder"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Order specifiers, applied in sequence.",
+            "title": "Order"
+          },
+          "first": {
+            "anyOf": [
+              {
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cursor-forward page size.",
+            "title": "First"
+          },
+          "after": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cursor-forward start cursor.",
+            "title": "After"
+          },
+          "last": {
+            "anyOf": [
+              {
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cursor-backward page size.",
+            "title": "Last"
+          },
+          "before": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cursor-backward end cursor.",
+            "title": "Before"
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Offset-based: maximum number of results.",
+            "title": "Limit"
+          },
+          "offset": {
+            "anyOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Offset-based: number of results to skip.",
+            "title": "Offset"
+          }
+        },
+        "title": "AdminSearchAppConfigFragmentInput",
+        "type": "object"
+      },
+      "AppConfigFragmentScope": {
+        "description": "The scopes a scoped fragment search runs at, keyed by scope kind.\n\nEach category list is OR'd internally and across categories. ``public`` is a flag rather\nthan a list: it names one global scope that owns no id. Raises if every field is empty.",
+        "properties": {
+          "domain": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/UUIDScope"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Domain ids whose fragments to search.",
+            "title": "Domain"
+          },
+          "user": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/UUIDScope"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "User ids whose fragments to search.",
+            "title": "User"
+          },
+          "public": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Search the public scope, which has no owner.",
+            "title": "Public"
+          }
+        },
+        "title": "AppConfigFragmentScope",
         "type": "object"
       },
       "UUIDScope": {
@@ -1290,123 +1407,6 @@
           "items"
         ],
         "title": "MyUpsertAppConfigFragmentsInput",
-        "type": "object"
-      },
-      "AdminSearchAppConfigFragmentInput": {
-        "description": "Input for paginated app config fragment search (superadmin only).",
-        "properties": {
-          "filter": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/AppConfigFragmentFilter"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Filter conditions."
-          },
-          "order": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/AppConfigFragmentOrder"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Order specifiers, applied in sequence.",
-            "title": "Order"
-          },
-          "first": {
-            "anyOf": [
-              {
-                "minimum": 1,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Cursor-forward page size.",
-            "title": "First"
-          },
-          "after": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Cursor-forward start cursor.",
-            "title": "After"
-          },
-          "last": {
-            "anyOf": [
-              {
-                "minimum": 1,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Cursor-backward page size.",
-            "title": "Last"
-          },
-          "before": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Cursor-backward end cursor.",
-            "title": "Before"
-          },
-          "limit": {
-            "anyOf": [
-              {
-                "minimum": 1,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Offset-based: maximum number of results.",
-            "title": "Limit"
-          },
-          "offset": {
-            "anyOf": [
-              {
-                "minimum": 0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Offset-based: number of results to skip.",
-            "title": "Offset"
-          }
-        },
-        "title": "AdminSearchAppConfigFragmentInput",
         "type": "object"
       },
       "UpdateAppConfigFragmentInput": {
@@ -41513,6 +41513,35 @@
         "description": "Purge many fragments by id, with per-item partial success (auth, RBAC).\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
+    "/v2/app-config-fragments/admin/search": {
+      "post": {
+        "operationId": "v2/app-config-fragments.admin_search",
+        "tags": [
+          "v2/app-config-fragments"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminSearchAppConfigFragmentInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Search fragments across all scopes with pagination (superadmin only).\n\n**Preconditions:**\n* Superadmin privilege required.\n"
+      }
+    },
     "/v2/app-config-fragments/scoped/search": {
       "post": {
         "operationId": "v2/app-config-fragments.scoped_search",
@@ -41656,35 +41685,6 @@
         },
         "parameters": [],
         "description": "Upsert many fragments at the caller's own user scope, all-or-nothing (auth).\n\n**Preconditions:**\n* User privilege required.\n"
-      }
-    },
-    "/v2/app-config-fragments/admin/search": {
-      "post": {
-        "operationId": "v2/app-config-fragments.admin_search",
-        "tags": [
-          "v2/app-config-fragments"
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful response"
-          }
-        },
-        "security": [
-          {
-            "TokenAuth": []
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AdminSearchAppConfigFragmentInput"
-              }
-            }
-          }
-        },
-        "parameters": [],
-        "description": "Search fragments across all scopes with pagination (superadmin only).\n\n**Preconditions:**\n* Superadmin privilege required.\n"
       }
     },
     "/v2/app-config-fragments/{fragment_id}": {

--- a/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
@@ -6,15 +6,25 @@ import logging
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Final
 
-from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam
+from ai.backend.common.api_handlers import (
+    APIResponse,
+    BaseRootResponseModel,
+    BodyParam,
+    PathParam,
+)
 from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AdminSearchAppConfigFragmentInput,
     BulkPurgeAppConfigFragmentInput,
     BulkUpdateAppConfigFragmentInput,
     CreateAppConfigFragmentInput,
+    MyAppConfigFragmentsByNamesInput,
+    MyUpsertAppConfigFragmentsInput,
+    ScopedAppConfigFragmentsByNamesInput,
     ScopedSearchAppConfigFragmentInput,
+    ScopedUpsertAppConfigFragmentsInput,
     UpdateAppConfigFragmentInput,
 )
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import AppConfigFragmentNode
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.api.rest.v2.path_params import AppConfigFragmentIdPathParam
@@ -25,6 +35,10 @@ if TYPE_CHECKING:
     )
 
 log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class AppConfigFragmentsByNamesResponse(BaseRootResponseModel[list[AppConfigFragmentNode | None]]):
+    """One entry per requested config name, null where the scope holds no fragment for it."""
 
 
 class V2AppConfigFragmentHandler:
@@ -100,4 +114,40 @@ class V2AppConfigFragmentHandler:
     ) -> APIResponse:
         """Search the fragments written at one scope (auth required, RBAC-authorized)."""
         result = await self._adapter.scoped_search(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def scoped_fragments_by_names(
+        self,
+        body: BodyParam[ScopedAppConfigFragmentsByNamesInput],
+    ) -> APIResponse:
+        """Read one scope's fragments for the given config names (auth, RBAC-authorized)."""
+        nodes = await self._adapter.scoped_app_config_fragments_by_names(body.parsed)
+        return APIResponse.build(
+            status_code=HTTPStatus.OK, response_model=AppConfigFragmentsByNamesResponse(nodes)
+        )
+
+    async def my_fragments_by_names(
+        self,
+        body: BodyParam[MyAppConfigFragmentsByNamesInput],
+    ) -> APIResponse:
+        """Read the caller's own user-scope fragments for the given config names (auth)."""
+        nodes = await self._adapter.my_app_config_fragments_by_names(body.parsed)
+        return APIResponse.build(
+            status_code=HTTPStatus.OK, response_model=AppConfigFragmentsByNamesResponse(nodes)
+        )
+
+    async def scoped_bulk_upsert(
+        self,
+        body: BodyParam[ScopedUpsertAppConfigFragmentsInput],
+    ) -> APIResponse:
+        """Upsert many fragments at one scope, all-or-nothing (auth, RBAC-authorized)."""
+        result = await self._adapter.scoped_upsert_app_config_fragments(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def my_bulk_upsert(
+        self,
+        body: BodyParam[MyUpsertAppConfigFragmentsInput],
+    ) -> APIResponse:
+        """Upsert many fragments at the caller's own user scope, all-or-nothing (auth)."""
+        result = await self._adapter.my_upsert_app_config_fragments(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/app_config_fragment/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_fragment/registry.py
@@ -31,6 +31,10 @@ def register_v2_app_config_fragment_routes(
         POST   /bulk-delete       purge many by id               (auth, RBAC)
         POST   /admin/search      system-wide paginated search   (superadmin)
         POST   /scoped/search     search one scope's fragments   (auth, RBAC)
+        POST   /scoped/by-names   read one scope's by names      (auth, RBAC)
+        POST   /scoped/bulk-upsert  upsert many at one scope     (auth, RBAC)
+        POST   /my/by-names       read own scope's by names      (auth)
+        POST   /my/bulk-upsert    upsert many at own scope       (auth)
         GET    /{fragment_id}     get by id                      (auth, RBAC)
         PATCH  /{fragment_id}     update config by id            (auth, RBAC)
         DELETE /{fragment_id}     purge by id                    (auth, RBAC)
@@ -42,6 +46,14 @@ def register_v2_app_config_fragment_routes(
     registry.add("POST", "/bulk-delete", handler.bulk_purge, middlewares=[auth_required])
     registry.add("POST", "/admin/search", handler.admin_search, middlewares=[superadmin_required])
     registry.add("POST", "/scoped/search", handler.scoped_search, middlewares=[auth_required])
+    registry.add(
+        "POST", "/scoped/by-names", handler.scoped_fragments_by_names, middlewares=[auth_required]
+    )
+    registry.add(
+        "POST", "/scoped/bulk-upsert", handler.scoped_bulk_upsert, middlewares=[auth_required]
+    )
+    registry.add("POST", "/my/by-names", handler.my_fragments_by_names, middlewares=[auth_required])
+    registry.add("POST", "/my/bulk-upsert", handler.my_bulk_upsert, middlewares=[auth_required])
     registry.add("GET", "/{fragment_id}", handler.get, middlewares=[auth_required])
     registry.add("PATCH", "/{fragment_id}", handler.update, middlewares=[auth_required])
     registry.add("DELETE", "/{fragment_id}", handler.purge, middlewares=[auth_required])


### PR DESCRIPTION
## 📚 Stacked PRs

Part of the app config fragment upsert stack. **Merge in order (bottom-up):**

1. #13113 — `feat(BA-7010)`: add upsert_scoped RBAC write-op primitive
2. #13115 — `feat(BA-7011)`: upsert app config fragments over GraphQL
3. #13110 — `feat(BA-7009)`: read app config fragments by config names over GraphQL
4. 👉 **#13118 — `feat(BA-7012)`: expose fragment by-names read and upsert over REST v2** ← you are here
5. #13196 — `refactor(BA-7013)`: drop the fragment write paths the upsert replaces
6. #13122 — `test(BA-7014)`: cover the scoped app config fragment upsert

Resolves BA-7012

## Summary

A fragment is addressed by `(scope, config_name)`, not by id, so REST v2 gains the routes that address it that way. This PR only adds; the superseded id-addressed routes are dropped in #13196.

| Route | Scope | Auth |
|---|---|---|
| `POST /scoped/upsert` | named in body | auth + RBAC at that scope |
| `POST /scoped/by-names` | named in body | auth + RBAC at that scope |
| `POST /my/upsert` | caller's own user scope | auth |
| `POST /my/by-names` | caller's own user scope | auth |

- Adds `ScopedAppConfigFragmentsByNamesInput` / `MyAppConfigFragmentsByNamesInput` / `AppConfigFragmentsByNamesPayload`, and reshapes the by-names adapter methods (from #13110) to take and return those DTOs — the adapter convention shared with GraphQL — updating the GraphQL resolvers accordingly.
- The scope-taking routes live under `/scoped/` beside the existing `/scoped/search`, mirroring the `/my/` variants.

## Test plan
- [ ] `POST /my/by-names` returns the caller's user-scope fragments for the requested names.
- [ ] `POST /my/upsert` inserts then updates the same config name.
- [ ] `POST /scoped/upsert` at a domain scope is RBAC-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13118.org.readthedocs.build/en/13118/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13118.org.readthedocs.build/ko/13118/

<!-- readthedocs-preview sorna-ko end -->