### PR TITLE
feat(BA-6747): load preemption victim candidates into the scheduling fetch

### DIFF
--- a/changes/13123.feature.md
+++ b/changes/13123.feature.md
@@ -1,0 +1,1 @@
+Load preemption victim candidates into the scheduling fetch for preemption-enabled resource groups, grouped per owner with per-agent reclaimable allocations for the preemption planner.

--- a/src/ai/backend/common/schema/resource_group.py
+++ b/src/ai/backend/common/schema/resource_group.py
@@ -1,0 +1,47 @@
+"""Resource-group schemas shared between the manager and its data layer.
+
+Pydantic schema definitions usable as pydantic column types (persisted as
+JSON inside the ``scaling_groups.scheduler_opts`` column of the legacy-named
+resource group table).
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from pydantic import ConfigDict, field_serializer
+
+from ai.backend.common.types import BackendAISchema, PreemptionMode, PreemptionOrder
+
+__all__ = ("PreemptionConfig",)
+
+
+class PreemptionConfig(BackendAISchema):
+    model_config = ConfigDict(frozen=True)
+
+    enabled: bool = False
+    """Whether preemption is enabled for this resource group (opt-in)"""
+
+    preemptible_priority: int = 5
+    """Sessions with priority <= this value are preemptible"""
+
+    order: PreemptionOrder = PreemptionOrder.OLDEST
+    """Tie-breaking order for same-priority sessions"""
+
+    mode: PreemptionMode = PreemptionMode.TERMINATE
+    """How to preempt sessions"""
+
+    preemption_min_runtime: timedelta = timedelta(seconds=0)
+    """Minimum session runtime before it becomes preemptible (0 = disabled)"""
+
+    @field_serializer("order", mode="plain")
+    def serialize_order(self, value: PreemptionOrder) -> str:
+        return value.value
+
+    @field_serializer("mode", mode="plain")
+    def serialize_mode(self, value: PreemptionMode) -> str:
+        return value.value
+
+    @field_serializer("preemption_min_runtime", mode="plain")
+    def serialize_preemption_min_runtime(self, value: timedelta) -> float:
+        return value.total_seconds()

--- a/src/ai/backend/manager/data/kernel/types.py
+++ b/src/ai/backend/manager/data/kernel/types.py
@@ -87,6 +87,13 @@ class KernelStatus(CIStrEnum):
 
     @classmethod
     @lru_cache(maxsize=1)
+    def resource_holding_statuses(cls) -> frozenset[KernelStatus]:
+        """Return statuses in which the kernel holds agent resources —
+        usage already reported (occupied) or still reserved (requested)."""
+        return cls.resource_occupied_statuses() | cls.resource_requested_statuses()
+
+    @classmethod
+    @lru_cache(maxsize=1)
     def terminatable_statuses(cls) -> frozenset[KernelStatus]:
         """Return statuses that can transition to TERMINATING."""
         return frozenset(

--- a/src/ai/backend/manager/data/session/types.py
+++ b/src/ai/backend/manager/data/session/types.py
@@ -76,6 +76,7 @@ class SessionStatus(CIStrEnum):
                 cls.PREEMPTED,
                 cls.TERMINATED,
                 cls.CANCELLED,
+                cls.ERROR,
             )
         )
 
@@ -120,6 +121,16 @@ class SessionStatus(CIStrEnum):
         marked PREEMPTED, so those source statuses are rejected.
         """
         return frozenset((cls.RUNNING,))
+
+    @classmethod
+    @lru_cache(maxsize=1)
+    def preemption_victim_statuses(cls) -> frozenset[SessionStatus]:
+        """Return statuses eligible as preemption victim candidates (BEP-1055).
+
+        Still occupying resources and able to transition to termination —
+        strips TERMINATING, whose resources free without preemption.
+        """
+        return cls.resource_occupied_statuses() & cls.terminatable_statuses()
 
     @classmethod
     @lru_cache(maxsize=1)

--- a/src/ai/backend/manager/models/scaling_group/row.py
+++ b/src/ai/backend/manager/models/scaling_group/row.py
@@ -32,11 +32,10 @@ from sqlalchemy.sql.expression import false, true
 
 from ai.backend.common.identifier.project import ProjectID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.schema.resource_group import PreemptionConfig
 from ai.backend.common.types import (
     AgentSelectionStrategy,
     BackendAISchema,
-    PreemptionMode,
-    PreemptionOrder,
     SessionTypes,
 )
 from ai.backend.manager.data.deployment.types import DeploymentOptions
@@ -83,37 +82,6 @@ __all__: Sequence[str] = (
     # functions
     "query_allowed_sgroups",
 )
-
-
-class PreemptionConfig(BackendAISchema):
-    model_config = ConfigDict(frozen=True)
-
-    enabled: bool = False
-    """Whether preemption is enabled for this resource group (opt-in)"""
-
-    preemptible_priority: int = 5
-    """Sessions with priority <= this value are preemptible"""
-
-    order: PreemptionOrder = PreemptionOrder.OLDEST
-    """Tie-breaking order for same-priority sessions"""
-
-    mode: PreemptionMode = PreemptionMode.TERMINATE
-    """How to preempt sessions"""
-
-    preemption_min_runtime: timedelta = timedelta(seconds=0)
-    """Minimum session runtime before it becomes preemptible (0 = disabled)"""
-
-    @field_serializer("order", mode="plain")
-    def serialize_order(self, value: PreemptionOrder) -> str:
-        return value.value
-
-    @field_serializer("mode", mode="plain")
-    def serialize_mode(self, value: PreemptionMode) -> str:
-        return value.value
-
-    @field_serializer("preemption_min_runtime", mode="plain")
-    def serialize_preemption_min_runtime(self, value: timedelta) -> float:
-        return value.total_seconds()
 
 
 class ScalingGroupOpts(BackendAISchema):

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -166,6 +166,8 @@ from ai.backend.manager.views.sokovan.session_creation import (
     ResourceGroupEnqueueInfo,
 )
 from ai.backend.manager.views.sokovan.snapshot import (
+    PreemptionCandidate,
+    PreemptionCandidateSnapshot,
     ResourceAllocation,
     ResourceGroupSchedulingPolicy,
     ResourceLimit,
@@ -175,6 +177,7 @@ from ai.backend.manager.views.sokovan.snapshot import (
     SlotAllocation,
     UserResourceAllocation,
     UserResourceLimit,
+    UserVictimCandidates,
 )
 from ai.backend.manager.views.sokovan.workload import (
     KernelWorkload,
@@ -222,6 +225,16 @@ class _ScalingGroupWithSlotInventory:
     served_slot_names: frozenset[ResourceSlotName]
 
 
+@dataclass
+class _PreemptionCandidateAccumulator:
+    """Per-session build state: the session-level row shared by the
+    session's result rows plus the per-(agent, slot) amounts folded
+    across them."""
+
+    row: sa.Row[Any]
+    slots_by_agent: dict[AgentId, dict[ResourceSlotName, Decimal]]
+
+
 class ScheduleDBSource:
     """
     Database source for schedule-related operations.
@@ -266,6 +279,9 @@ class ScheduleDBSource:
             )
             session_ids = [s.meta.session_id for s in pending_sessions.sessions]
             session_dependencies = await self._fetch_session_dependencies(db_sess, session_ids)
+            preemption_candidates = await self._fetch_preemption_candidates(
+                db_sess, resource_group, pending_sessions
+            )
             observed_at = await self._get_db_now_in_session(db_sess)
 
             return SchedulingFetch(
@@ -277,6 +293,7 @@ class ScheduleDBSource:
                 resource_policy=resource_policy,
                 session_dependencies=SessionDependencySnapshot(by_session=session_dependencies),
                 observed_at=observed_at,
+                preemption_candidates=preemption_candidates,
             )
 
     async def _fetch_resource_group_with_slot_inventory(
@@ -364,6 +381,7 @@ class ScheduleDBSource:
                 scheduler=rg_row.scheduler,
                 agent_selection_strategy=rg_row.scheduler_opts.agent_selection_strategy,
             ),
+            preemption=rg_row.scheduler_opts.preemption,
         )
 
     async def _fetch_pending_sessions(
@@ -852,6 +870,117 @@ class ScheduleDBSource:
             )
 
         return dict(dependencies_by_session)
+
+    async def _fetch_preemption_candidates(
+        self,
+        db_sess: SASession,
+        resource_group: ResourceGroupFetch,
+        pending_sessions: PendingSessions,
+    ) -> PreemptionCandidateSnapshot:
+        """Load this resource group's preemption victim candidates per owner.
+
+        A candidate is one whole session (the preemption unit): a
+        preemptible, non-private session that holds unfreed agent
+        allocations (SCHEDULED onward, terminatable — same hold definition
+        as the occupancy scan), owned by a pending owner, with
+        ``job_priority`` strictly below that owner's max pending
+        ``job_priority`` — a superset of every per-pending comparison, so
+        no valid victim is dropped. Min-runtime exemption and victim
+        selection stay in the planner; only the freed-resource accounting
+        is kept per agent. No query runs when preemption is disabled on
+        the group.
+        """
+        if not resource_group.preemption.enabled:
+            return PreemptionCandidateSnapshot.empty()
+        max_pending_priority: dict[UserID, int] = {}
+        for workload in pending_sessions.sessions:
+            # Private (SFTP/system) sessions never initiate preemption,
+            # just as they are never victims
+            if workload.is_private:
+                continue
+            owner = workload.meta.owner.user_uuid
+            current = max_pending_priority.get(owner)
+            if current is None or workload.job_priority > current:
+                max_pending_priority[owner] = workload.job_priority
+        if not max_pending_priority:
+            return PreemptionCandidateSnapshot.empty()
+
+        ra = ResourceAllocationRow.__table__
+        k = KernelRow.__table__
+        s = SessionRow.__table__
+        # Victim prefilter: owned by a pending owner AND strictly below
+        # that owner's own max pending job_priority
+        candidate_filter = sa.or_(
+            *(
+                sa.and_(s.c.user_uuid == user_uuid, s.c.job_priority < threshold)
+                for user_uuid, threshold in max_pending_priority.items()
+            )
+        )
+        # Per allocation row the agent holds ``used`` once reported, else
+        # the ``requested`` reservation — the amount freed on preemption.
+        allocated_sum = sa.func.sum(sa.func.coalesce(ra.c.used, ra.c.requested)).label("allocated")
+        stmt = (
+            sa.select(
+                s.c.id,
+                s.c.user_uuid,
+                s.c.job_priority,
+                s.c.starts_at,
+                k.c.agent,
+                ra.c.slot_name,
+                allocated_sum,
+            )
+            .select_from(ra.join(k, ra.c.kernel_id == k.c.id).join(s, k.c.session_id == s.c.id))
+            .where(
+                s.c.resource_group_id == resource_group.meta.id,
+                s.c.status.in_(SessionStatus.preemption_victim_statuses()),
+                s.c.is_preemptible == sa.true(),
+                # Private (SFTP/system) sessions are never preemption victims
+                s.c.session_type.not_in(SessionTypes.private_types()),
+                candidate_filter,
+                k.c.status.in_(KernelStatus.resource_holding_statuses()),
+                k.c.agent.is_not(None),
+                ra.c.free_at.is_(None),
+            )
+            .group_by(
+                s.c.id,
+                s.c.user_uuid,
+                s.c.job_priority,
+                s.c.starts_at,
+                k.c.agent,
+                ra.c.slot_name,
+            )
+        )
+        rows = (await db_sess.execute(stmt)).all()
+
+        # One accumulator per session: the session-level values from any of
+        # its rows plus the per-(agent, slot) amounts folded across rows
+        candidates: dict[SessionId, _PreemptionCandidateAccumulator] = {}
+        for row in rows:
+            session_id = SessionId(row.id)
+            accumulator = candidates.get(session_id)
+            if accumulator is None:
+                accumulator = _PreemptionCandidateAccumulator(row=row, slots_by_agent={})
+                candidates[session_id] = accumulator
+            accumulator.slots_by_agent.setdefault(AgentId(row.agent), {})[
+                ResourceSlotName(row.slot_name)
+            ] = row.allocated
+
+        by_user: dict[UserID, list[PreemptionCandidate]] = defaultdict(list)
+        for session_id, accumulator in candidates.items():
+            by_user[UserID(accumulator.row.user_uuid)].append(
+                PreemptionCandidate(
+                    session_id=session_id,
+                    job_priority=accumulator.row.job_priority,
+                    started_at=accumulator.row.starts_at,
+                    allocated_slots_by_agent=accumulator.slots_by_agent,
+                )
+            )
+        return PreemptionCandidateSnapshot(
+            by_user={
+                user_uuid: UserVictimCandidates(candidates=user_candidates)
+                for user_uuid, user_candidates in by_user.items()
+            }
+        )
 
     async def mark_sessions_terminating(
         self,

--- a/src/ai/backend/manager/repositories/scheduler/repository.py
+++ b/src/ai/backend/manager/repositories/scheduler/repository.py
@@ -151,6 +151,7 @@ class SchedulerRepository:
                 ),
                 session_dependencies=fetch.session_dependencies,
                 policy=fetch.policy,
+                preemption_candidates=fetch.preemption_candidates,
             ),
             global_scope=GlobalScopeSnapshot(
                 occupancy=fetch.occupancy,

--- a/src/ai/backend/manager/repositories/scheduler/types/resource_group.py
+++ b/src/ai/backend/manager/repositories/scheduler/types/resource_group.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 
+from ai.backend.common.schema.resource_group import PreemptionConfig
 from ai.backend.manager.views.sokovan.resource_group import ResourceGroupMeta
 from ai.backend.manager.views.sokovan.snapshot import ResourceGroupSchedulingPolicy
 
@@ -12,3 +13,4 @@ class ResourceGroupFetch:
 
     meta: ResourceGroupMeta
     policy: ResourceGroupSchedulingPolicy
+    preemption: PreemptionConfig

--- a/src/ai/backend/manager/repositories/scheduler/types/scheduling.py
+++ b/src/ai/backend/manager/repositories/scheduler/types/scheduling.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from ai.backend.manager.views.sokovan.agent import AgentMeta
 from ai.backend.manager.views.sokovan.resource_group import ResourceGroupMeta
 from ai.backend.manager.views.sokovan.snapshot import (
+    PreemptionCandidateSnapshot,
     ResourceGroupSchedulingPolicy,
     ResourceOccupancySnapshot,
     ResourcePolicySnapshot,
@@ -31,3 +32,5 @@ class SchedulingFetch:
     session_dependencies: SessionDependencySnapshot
     # DB-sourced time the fetch ran (single time authority across managers)
     observed_at: datetime
+    # Preemption victim candidates per owner (empty when preemption disabled)
+    preemption_candidates: PreemptionCandidateSnapshot

--- a/src/ai/backend/manager/views/sokovan/snapshot.py
+++ b/src/ai/backend/manager/views/sokovan/snapshot.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, MutableMapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from decimal import Decimal
+from functools import cached_property
 from typing import override
 
 from ai.backend.common.identifier.domain import DomainID
@@ -13,6 +14,7 @@ from ai.backend.common.identifier.project import ProjectID
 from ai.backend.common.identifier.resource_slot import ResourceSlotName
 from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import (
+    AgentId,
     AgentSelectionStrategy,
     SessionId,
 )
@@ -198,6 +200,80 @@ class SessionDependencySnapshot:
     by_session: Mapping[SessionId, list[SessionDependencyInfo]]
 
 
+@dataclass(frozen=True)
+class PreemptionCandidate:
+    """One preemption victim candidate (a whole session — the preemption unit).
+
+    Prefiltered at load time (the filter is defined at the load site);
+    min-runtime exemption, per-pending comparison, and victim selection
+    stay in the preemption planner.
+    """
+
+    session_id: SessionId
+    job_priority: int
+    # Execution start time (written at the RUNNING transition); the
+    # min-runtime exemption and oldest/newest tie-break basis. None for
+    # candidates preempted before running — nothing ran, so no exemption
+    started_at: datetime | None
+    # Per-agent live allocations freed by preempting this session
+    # (resource_allocations rows, not the legacy kernels.occupied_slots)
+    allocated_slots_by_agent: Mapping[AgentId, Mapping[ResourceSlotName, Decimal]]
+
+
+@dataclass(frozen=True)
+class AgentVictimCandidates:
+    """Victim candidates holding allocations on one agent."""
+
+    agent_id: AgentId
+    # Candidates with a portion on this agent (shared with the owner's list)
+    candidates: list[PreemptionCandidate]
+
+    @cached_property
+    def total_reclaimable(self) -> Mapping[ResourceSlotName, Decimal]:
+        """Upper bound freed on this agent if every candidate is preempted."""
+        totals: dict[ResourceSlotName, Decimal] = {}
+        for candidate in self.candidates:
+            for slot_name, amount in candidate.allocated_slots_by_agent[self.agent_id].items():
+                totals[slot_name] = totals.get(slot_name, Decimal(0)) + amount
+        return totals
+
+
+@dataclass(frozen=True)
+class UserVictimCandidates:
+    """One owner's victim candidates with the per-agent decomposition derived.
+
+    ``candidates`` is the stored form (one entry per session — the
+    preemption unit); the per-agent grouping and reclaimable totals are
+    computed on construction-time reads, so re-instantiating with a
+    filtered subset (e.g. the planner's per-pending eligible set) yields
+    consistent sums for free.
+    """
+
+    candidates: list[PreemptionCandidate]
+
+    @cached_property
+    def by_agent(self) -> Mapping[AgentId, AgentVictimCandidates]:
+        grouped: dict[AgentId, list[PreemptionCandidate]] = {}
+        for candidate in self.candidates:
+            for agent_id in candidate.allocated_slots_by_agent:
+                grouped.setdefault(agent_id, []).append(candidate)
+        return {
+            agent_id: AgentVictimCandidates(agent_id=agent_id, candidates=agent_candidates)
+            for agent_id, agent_candidates in grouped.items()
+        }
+
+
+@dataclass(frozen=True)
+class PreemptionCandidateSnapshot:
+    """Preemption victim candidates of the resource group, grouped per owner."""
+
+    by_user: Mapping[UserID, UserVictimCandidates]
+
+    @classmethod
+    def empty(cls) -> PreemptionCandidateSnapshot:
+        return PreemptionCandidateSnapshot(by_user={})
+
+
 @dataclass
 class ResourceGroupSchedulingPolicy:
     """How the resource group schedules: pool keys for sequencer/selector."""
@@ -218,6 +294,10 @@ class ResourceGroupScopeSnapshot:
     session_dependencies: SessionDependencySnapshot
     # Scheduling policy configured on the resource group
     policy: ResourceGroupSchedulingPolicy
+    # Preemption victim candidates per owner (empty when preemption disabled)
+    preemption_candidates: PreemptionCandidateSnapshot = field(
+        default_factory=PreemptionCandidateSnapshot.empty
+    )
 
 
 @dataclass

--- a/tests/unit/manager/data/session/test_session_status.py
+++ b/tests/unit/manager/data/session/test_session_status.py
@@ -48,3 +48,17 @@ class TestPreemptedStatus:
         occupied = SessionStatus.resource_occupied_statuses()
         assert SessionStatus.PREEMPTED not in occupied
         assert SessionStatus.DEPRIORITIZING not in occupied
+
+    def test_error_is_not_resource_occupying(self) -> None:
+        """ERROR sessions do not count toward resource occupancy."""
+        assert SessionStatus.ERROR not in SessionStatus.resource_occupied_statuses()
+
+    def test_preemption_victim_statuses_strip_terminating(self) -> None:
+        """Victim candidates occupy resources and can still be terminated."""
+        victims = SessionStatus.preemption_victim_statuses()
+        assert victims == (
+            SessionStatus.resource_occupied_statuses() & SessionStatus.terminatable_statuses()
+        )
+        assert SessionStatus.SCHEDULED in victims
+        assert SessionStatus.RUNNING in victims
+        assert SessionStatus.TERMINATING not in victims

--- a/tests/unit/manager/models/scaling_group/test_row.py
+++ b/tests/unit/manager/models/scaling_group/test_row.py
@@ -8,13 +8,14 @@ import pytest
 from pydantic import ValidationError
 
 from ai.backend.common.exception import BackendAISchemaValidationFailed
+from ai.backend.common.schema.resource_group import PreemptionConfig
 from ai.backend.common.types import (
     AgentSelectionStrategy,
     PreemptionMode,
     PreemptionOrder,
     SessionTypes,
 )
-from ai.backend.manager.models.scaling_group.row import PreemptionConfig, ScalingGroupOpts
+from ai.backend.manager.models.scaling_group.row import ScalingGroupOpts
 
 
 class TestScalingGroupOptsDefaults:

--- a/tests/unit/manager/repositories/scheduler/conftest.py
+++ b/tests/unit/manager/repositories/scheduler/conftest.py
@@ -396,26 +396,39 @@ async def create_pending_session_with_kernels(
     user_uuid: uuid.UUID,
     access_key: AccessKey,
     agent_assignments: list[tuple[str, Decimal, Decimal]],
+    job_priority: int = 0,
+    is_preemptible: bool = True,
+    session_type: SessionTypes = SessionTypes.INTERACTIVE,
+    session_status: SessionStatus = SessionStatus.PENDING,
+    kernel_status: KernelStatus = KernelStatus.PENDING,
+    assign_agents: bool = False,
 ) -> tuple[SessionId, list[KernelId]]:
-    """Create a PENDING session with one kernel per agent assignment.
+    """Create a session with one kernel per agent assignment.
 
-    Each entry in ``agent_assignments`` is ``(agent_id, cpu_requested,
-    mem_requested)``. Each kernel is created in PENDING status with pending
-    ``resource_allocations`` rows (``used``/``used_at``/``free_at`` all NULL).
-    Returns the session id and the kernel ids in assignment order.
+    The defaults create the PENDING shape: unassigned kernels with pending
+    ``resource_allocations`` rows (``used``/``used_at``/``free_at`` all
+    NULL). With ``assign_agents`` each kernel is placed on its assigned
+    agent, RUNNING kernels get usage-reported allocation rows, and
+    ``starts_at`` is set only for RUNNING sessions, mirroring the real
+    transitions. Each entry in ``agent_assignments`` is ``(agent_id, cpu,
+    mem)``. Returns the session id and the kernel ids in assignment order.
     """
     session_id = SessionId(uuid.uuid4())
     kernel_ids: list[KernelId] = []
+    now = datetime.now(tzutc())
 
     total_cpu = sum((cpu for _, cpu, _ in agent_assignments), Decimal("0"))
     total_mem = sum((mem for _, _, mem in agent_assignments), Decimal("0"))
+    cluster_mode = (
+        ClusterMode.SINGLE_NODE if len(agent_assignments) == 1 else ClusterMode.MULTI_NODE
+    )
 
     async with db.begin_session() as db_sess:
         db_sess.add(
             SessionRow(
                 id=session_id,
                 name=f"test-session-{uuid.uuid4().hex[:8]}",
-                session_type=SessionTypes.INTERACTIVE,
+                session_type=session_type,
                 domain_id=domain_id,
                 domain_name=domain_name,
                 group_id=group_id,
@@ -423,11 +436,14 @@ async def create_pending_session_with_kernels(
                 access_key=access_key,
                 resource_group_id=resource_group_id,
                 scaling_group_name=scaling_group_name,
-                status=SessionStatus.PENDING,
+                status=session_status,
                 status_info="test",
-                cluster_mode=ClusterMode.SINGLE_NODE,
+                job_priority=job_priority,
+                is_preemptible=is_preemptible,
+                cluster_mode=cluster_mode,
                 requested_slots=ResourceSlot({"cpu": total_cpu, "mem": total_mem}),
-                created_at=datetime.now(tzutc()),
+                created_at=now,
+                starts_at=now if session_status == SessionStatus.RUNNING else None,
                 images=["python:3.8"],
                 vfolder_mounts=[],
                 environ={},
@@ -436,6 +452,7 @@ async def create_pending_session_with_kernels(
         )
         await db_sess.flush()
 
+        usage_reported = kernel_status == KernelStatus.RUNNING
         for idx, (agent_id, cpu_requested, mem_requested) in enumerate(agent_assignments):
             kernel_id = KernelId(uuid.uuid4())
             kernel_ids.append(kernel_id)
@@ -443,8 +460,8 @@ async def create_pending_session_with_kernels(
                 KernelRow(
                     id=kernel_id,
                     session_id=session_id,
-                    agent=None,
-                    agent_addr=None,
+                    agent=agent_id if assign_agents else None,
+                    agent_addr="127.0.0.1:6001" if assign_agents else None,
                     scaling_group=scaling_group_name,
                     resource_group_id=resource_group_id,
                     cluster_idx=idx,
@@ -453,9 +470,13 @@ async def create_pending_session_with_kernels(
                     image="python:3.8",
                     architecture="x86_64",
                     registry="docker.io",
-                    status=KernelStatus.PENDING,
-                    status_changed=datetime.now(tzutc()),
-                    occupied_slots=ResourceSlot(),
+                    status=kernel_status,
+                    status_changed=now,
+                    occupied_slots=(
+                        ResourceSlot({"cpu": cpu_requested, "mem": mem_requested})
+                        if usage_reported
+                        else ResourceSlot()
+                    ),
                     requested_slots=ResourceSlot({"cpu": cpu_requested, "mem": mem_requested}),
                     domain_name=domain_name,
                     group_id=group_id,
@@ -479,6 +500,8 @@ async def create_pending_session_with_kernels(
                         kernel_id=kernel_id,
                         slot_name=slot_name,
                         requested=requested,
+                        used=requested if usage_reported else None,
+                        used_at=now if usage_reported else None,
                     )
                 )
             await db_sess.flush()

--- a/tests/unit/manager/repositories/scheduler/test_preemption_candidates.py
+++ b/tests/unit/manager/repositories/scheduler/test_preemption_candidates.py
@@ -1,0 +1,721 @@
+"""BA-6747: preemption victim candidate loading in the scheduling fetch.
+
+The candidate prefilter is defined at the load site
+(``ScheduleDBSource._fetch_preemption_candidates``); these tests verify it
+against a real database.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+import sqlalchemy as sa
+
+from ai.backend.common.data.user.types import UserRole
+from ai.backend.common.identifier.domain import DomainID
+from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.identifier.user import UserID
+from ai.backend.common.schema.resource_group import PreemptionConfig
+from ai.backend.common.types import (
+    AccessKey,
+    AgentId,
+    ResourceSlot,
+    SecretKey,
+    SessionId,
+    SessionTypes,
+)
+from ai.backend.manager.data.agent.types import AgentStatus
+from ai.backend.manager.data.kernel.types import KernelStatus
+from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.data.user.types import UserStatus
+from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.scaling_group import ScalingGroupOpts, ScalingGroupRow
+from ai.backend.manager.models.user import UserRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.scheduler.db_source.db_source import ScheduleDBSource
+
+from .conftest import create_pending_session_with_kernels
+
+
+async def _create_allocated_session(
+    db: ExtendedAsyncSAEngine,
+    *,
+    domain_id: DomainID,
+    domain_name: str,
+    resource_group_id: ResourceGroupID,
+    scaling_group_name: str,
+    group_id: uuid.UUID,
+    user_uuid: uuid.UUID,
+    access_key: AccessKey,
+    agent_assignments: list[tuple[str, Decimal, Decimal]],
+    job_priority: int = 0,
+    is_preemptible: bool = True,
+    session_type: SessionTypes = SessionTypes.INTERACTIVE,
+    session_status: SessionStatus = SessionStatus.RUNNING,
+    kernel_status: KernelStatus = KernelStatus.RUNNING,
+) -> SessionId:
+    """A resource-holding session: the shared factory with agents assigned."""
+    session_id, _ = await create_pending_session_with_kernels(
+        db,
+        domain_id=domain_id,
+        domain_name=domain_name,
+        resource_group_id=resource_group_id,
+        scaling_group_name=scaling_group_name,
+        group_id=group_id,
+        user_uuid=user_uuid,
+        access_key=access_key,
+        agent_assignments=agent_assignments,
+        job_priority=job_priority,
+        is_preemptible=is_preemptible,
+        session_type=session_type,
+        session_status=session_status,
+        kernel_status=kernel_status,
+        assign_agents=True,
+    )
+    return session_id
+
+
+async def _create_extra_user(
+    db: ExtendedAsyncSAEngine,
+    *,
+    domain_name: str,
+    user_resource_policy: str,
+    keypair_resource_policy: str,
+) -> tuple[uuid.UUID, AccessKey]:
+    """Create a second user with its own keypair."""
+    user_uuid = uuid.uuid4()
+    suffix = uuid.uuid4().hex[:8]
+    email = f"extra-user-{suffix}@test.com"
+    access_key = AccessKey(f"AKIA{uuid.uuid4().hex[:16].upper()}")
+    async with db.begin_session() as db_sess:
+        db_sess.add(
+            UserRow(
+                uuid=user_uuid,
+                email=email,
+                username=f"extra-user-{suffix}",
+                role=UserRole.USER,
+                status=UserStatus.ACTIVE,
+                domain_name=domain_name,
+                resource_policy=user_resource_policy,
+            )
+        )
+        await db_sess.flush()
+        db_sess.add(
+            KeyPairRow(
+                user_id=email,
+                access_key=access_key,
+                secret_key=SecretKey(f"SK{uuid.uuid4().hex}"),
+                is_active=True,
+                is_admin=False,
+                resource_policy=keypair_resource_policy,
+                rate_limit=1000,
+                num_queries=0,
+                user=user_uuid,
+            )
+        )
+        await db_sess.flush()
+    return user_uuid, access_key
+
+
+async def _create_extra_agent(
+    db: ExtendedAsyncSAEngine,
+    *,
+    scaling_group_name: str,
+    resource_group_id: ResourceGroupID,
+) -> str:
+    agent_id = f"test-agent-{uuid.uuid4().hex[:8]}"
+    async with db.begin_session() as db_sess:
+        db_sess.add(
+            AgentRow(
+                id=agent_id,
+                status=AgentStatus.ALIVE,
+                region="local",
+                scaling_group=scaling_group_name,
+                resource_group_id=resource_group_id,
+                available_slots=ResourceSlot({"cpu": Decimal("10"), "mem": Decimal("10240")}),
+                occupied_slots=ResourceSlot(),
+                addr="127.0.0.1:6001",
+                version="1.0.0",
+                architecture="x86_64",
+            )
+        )
+        await db_sess.flush()
+    return agent_id
+
+
+@pytest.fixture
+async def preemption_enabled(
+    db_with_cleanup: ExtendedAsyncSAEngine,
+    test_scaling_group_name: str,
+    test_scaling_group_id: ResourceGroupID,
+) -> None:
+    """Turn on preemption for the test scaling group."""
+    async with db_with_cleanup.begin_session() as db_sess:
+        await db_sess.execute(
+            sa.update(ScalingGroupRow)
+            .where(ScalingGroupRow.id == test_scaling_group_id)
+            .values(
+                scheduler_opts=ScalingGroupOpts(
+                    allowed_session_types=[],
+                    pending_timeout=timedelta(hours=1),
+                    config={},
+                    preemption=PreemptionConfig(enabled=True),
+                )
+            )
+        )
+
+
+class TestFetchPreemptionCandidates:
+    """Preemption candidate loading in ScheduleDBSource.fetch_scheduling_fetch."""
+
+    async def test_disabled_group_returns_empty_snapshot(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain_id: DomainID,
+        test_domain_name: str,
+        test_scaling_group_id: ResourceGroupID,
+        test_scaling_group_name: str,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_access_key: AccessKey,
+        test_agent_id: str,
+        resource_slot_types: None,
+    ) -> None:
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=10,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+        )
+        # A session that would qualify if preemption were enabled
+        await _create_allocated_session(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("2"), Decimal("4096"))],
+            job_priority=0,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+        )
+
+        fetch = await ScheduleDBSource(db_with_cleanup).fetch_scheduling_fetch(
+            test_scaling_group_id
+        )
+
+        assert fetch is not None
+        assert fetch.preemption_candidates.by_user == {}
+
+    async def test_excludes_non_victim_sessions(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain_id: DomainID,
+        test_domain_name: str,
+        test_scaling_group_id: ResourceGroupID,
+        test_scaling_group_name: str,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_access_key: AccessKey,
+        test_agent_id: str,
+        resource_slot_types: None,
+        preemption_enabled: None,
+    ) -> None:
+        """Equal-priority, non-preemptible, TERMINATING, and private sessions never load."""
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=10,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+        )
+        # Included: same owner, strictly lower job_priority, preemptible
+        victim_id = await _create_allocated_session(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("2"), Decimal("4096"))],
+            job_priority=5,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+        )
+        # Excluded: job_priority equals the owner's max pending (not strictly lower)
+        await _create_allocated_session(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=10,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+        )
+        # Excluded: not preemptible
+        await _create_allocated_session(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=5,
+            is_preemptible=False,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+        )
+        # Excluded: already terminating — its resources free without preemption
+        await _create_allocated_session(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=0,
+            session_status=SessionStatus.TERMINATING,
+            kernel_status=KernelStatus.TERMINATING,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+        )
+        # Excluded: private (system) sessions are never victims
+        await _create_allocated_session(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=0,
+            session_type=SessionTypes.SYSTEM,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+        )
+
+        fetch = await ScheduleDBSource(db_with_cleanup).fetch_scheduling_fetch(
+            test_scaling_group_id
+        )
+
+        assert fetch is not None
+        by_user = fetch.preemption_candidates.by_user
+        assert set(by_user.keys()) == {UserID(test_user_uuid)}
+        candidates = by_user[UserID(test_user_uuid)].candidates
+        assert [c.session_id for c in candidates] == [victim_id]
+        candidate = candidates[0]
+        assert candidate.job_priority == 5
+        assert candidate.started_at is not None
+        assert candidate.allocated_slots_by_agent == {
+            AgentId(test_agent_id): {
+                "cpu": Decimal("2"),
+                "mem": Decimal("4096"),
+            },
+        }
+
+    async def test_scheduled_victim_included_without_started_at(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain_id: DomainID,
+        test_domain_name: str,
+        test_scaling_group_id: ResourceGroupID,
+        test_scaling_group_name: str,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_access_key: AccessKey,
+        test_agent_id: str,
+        resource_slot_types: None,
+        preemption_enabled: None,
+    ) -> None:
+        """SCHEDULED sessions hold agent resources and qualify as victims."""
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=10,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+        )
+        scheduled_victim_id = await _create_allocated_session(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("2"), Decimal("1024"))],
+            job_priority=1,
+            session_status=SessionStatus.SCHEDULED,
+            kernel_status=KernelStatus.SCHEDULED,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+        )
+
+        fetch = await ScheduleDBSource(db_with_cleanup).fetch_scheduling_fetch(
+            test_scaling_group_id
+        )
+
+        assert fetch is not None
+        candidates = fetch.preemption_candidates.by_user[UserID(test_user_uuid)].candidates
+        assert [c.session_id for c in candidates] == [scheduled_victim_id]
+        # Pre-running candidate: reservation amounts, no execution start
+        candidate = candidates[0]
+        assert candidate.started_at is None
+        assert candidate.allocated_slots_by_agent == {
+            AgentId(test_agent_id): {
+                "cpu": Decimal("2"),
+                "mem": Decimal("1024"),
+            },
+        }
+
+    async def test_per_owner_thresholds_do_not_leak(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain_id: DomainID,
+        test_domain_name: str,
+        test_scaling_group_id: ResourceGroupID,
+        test_scaling_group_name: str,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_access_key: AccessKey,
+        test_agent_id: str,
+        test_user_resource_policy_name: str,
+        test_keypair_resource_policy_name: str,
+        resource_slot_types: None,
+        preemption_enabled: None,
+    ) -> None:
+        """Each owner's candidates compare against that owner's own max pending."""
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=10,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+        )
+        victim_id = await _create_allocated_session(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("2"), Decimal("4096"))],
+            job_priority=5,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+        )
+        # Second owner with their own, lower pending threshold (max pending
+        # job_priority = 3). Their thresholds must not leak across owners.
+        other_user, other_access_key = await _create_extra_user(
+            db_with_cleanup,
+            domain_name=test_domain_name,
+            user_resource_policy=test_user_resource_policy_name,
+            keypair_resource_policy=test_keypair_resource_policy_name,
+        )
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=3,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=other_user,
+            access_key=other_access_key,
+        )
+        # Excluded: below the FIRST owner's max (10) but not below its own
+        # owner's max (3) — would leak in if the threshold were global
+        await _create_allocated_session(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=5,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=other_user,
+            access_key=other_access_key,
+        )
+        # Included: strictly below its own owner's max (3)
+        other_victim_id = await _create_allocated_session(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("3"), Decimal("2048"))],
+            job_priority=2,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=other_user,
+            access_key=other_access_key,
+        )
+
+        fetch = await ScheduleDBSource(db_with_cleanup).fetch_scheduling_fetch(
+            test_scaling_group_id
+        )
+
+        assert fetch is not None
+        by_user = fetch.preemption_candidates.by_user
+        assert set(by_user.keys()) == {UserID(test_user_uuid), UserID(other_user)}
+        assert [c.session_id for c in by_user[UserID(test_user_uuid)].candidates] == [victim_id]
+        other_candidates = by_user[UserID(other_user)].candidates
+        assert [c.session_id for c in other_candidates] == [other_victim_id]
+        assert other_candidates[0].job_priority == 2
+
+    async def test_private_pending_does_not_initiate_preemption(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain_id: DomainID,
+        test_domain_name: str,
+        test_scaling_group_id: ResourceGroupID,
+        test_scaling_group_name: str,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_access_key: AccessKey,
+        test_agent_id: str,
+        test_user_resource_policy_name: str,
+        test_keypair_resource_policy_name: str,
+        resource_slot_types: None,
+        preemption_enabled: None,
+    ) -> None:
+        """A pending private (SFTP/system) session sets no preemption threshold."""
+        # First owner's only pending is private: their running session must
+        # not become a candidate on its behalf
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=10,
+            session_type=SessionTypes.SYSTEM,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+        )
+        await _create_allocated_session(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("2"), Decimal("4096"))],
+            job_priority=0,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+        )
+        # Second owner with a regular pending keeps the candidate query alive
+        other_user, other_access_key = await _create_extra_user(
+            db_with_cleanup,
+            domain_name=test_domain_name,
+            user_resource_policy=test_user_resource_policy_name,
+            keypair_resource_policy=test_keypair_resource_policy_name,
+        )
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=10,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=other_user,
+            access_key=other_access_key,
+        )
+        other_victim_id = await _create_allocated_session(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=5,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=other_user,
+            access_key=other_access_key,
+        )
+
+        fetch = await ScheduleDBSource(db_with_cleanup).fetch_scheduling_fetch(
+            test_scaling_group_id
+        )
+
+        assert fetch is not None
+        by_user = fetch.preemption_candidates.by_user
+        assert set(by_user.keys()) == {UserID(other_user)}
+        assert [c.session_id for c in by_user[UserID(other_user)].candidates] == [other_victim_id]
+
+    async def test_reclaimable_totals_sum_owner_victims_per_agent(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain_id: DomainID,
+        test_domain_name: str,
+        test_scaling_group_id: ResourceGroupID,
+        test_scaling_group_name: str,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_access_key: AccessKey,
+        test_agent_id: str,
+        resource_slot_types: None,
+        preemption_enabled: None,
+    ) -> None:
+        """The derived per-agent view sums all of the owner's victims."""
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=10,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+        )
+        victim_ids: set[SessionId] = set()
+        for job_priority, cpu, mem, session_status, kernel_status in (
+            (5, "2", "4096", SessionStatus.RUNNING, KernelStatus.RUNNING),
+            (4, "1", "1024", SessionStatus.RUNNING, KernelStatus.RUNNING),
+            (1, "2", "1024", SessionStatus.SCHEDULED, KernelStatus.SCHEDULED),
+        ):
+            victim_ids.add(
+                await _create_allocated_session(
+                    db_with_cleanup,
+                    agent_assignments=[(test_agent_id, Decimal(cpu), Decimal(mem))],
+                    job_priority=job_priority,
+                    session_status=session_status,
+                    kernel_status=kernel_status,
+                    domain_id=test_domain_id,
+                    domain_name=test_domain_name,
+                    resource_group_id=test_scaling_group_id,
+                    scaling_group_name=test_scaling_group_name,
+                    group_id=test_group_id,
+                    user_uuid=test_user_uuid,
+                    access_key=test_access_key,
+                )
+            )
+
+        fetch = await ScheduleDBSource(db_with_cleanup).fetch_scheduling_fetch(
+            test_scaling_group_id
+        )
+
+        assert fetch is not None
+        user_entry = fetch.preemption_candidates.by_user[UserID(test_user_uuid)]
+        agent_entry = user_entry.by_agent[AgentId(test_agent_id)]
+        assert {c.session_id for c in agent_entry.candidates} == victim_ids
+        assert agent_entry.total_reclaimable == {
+            "cpu": Decimal("5"),
+            "mem": Decimal("6144"),
+        }
+
+    async def test_multi_node_session_is_one_candidate_with_per_agent_slots(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain_id: DomainID,
+        test_domain_name: str,
+        test_scaling_group_id: ResourceGroupID,
+        test_scaling_group_name: str,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_access_key: AccessKey,
+        test_agent_id: str,
+        resource_slot_types: None,
+        preemption_enabled: None,
+    ) -> None:
+        second_agent_id = await _create_extra_agent(
+            db_with_cleanup,
+            scaling_group_name=test_scaling_group_name,
+            resource_group_id=test_scaling_group_id,
+        )
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=10,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+        )
+        victim_id = await _create_allocated_session(
+            db_with_cleanup,
+            agent_assignments=[
+                (test_agent_id, Decimal("1"), Decimal("1024")),
+                (second_agent_id, Decimal("2"), Decimal("2048")),
+            ],
+            job_priority=0,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+        )
+
+        fetch = await ScheduleDBSource(db_with_cleanup).fetch_scheduling_fetch(
+            test_scaling_group_id
+        )
+
+        assert fetch is not None
+        by_user = fetch.preemption_candidates.by_user
+        assert set(by_user.keys()) == {UserID(test_user_uuid)}
+        user_entry = by_user[UserID(test_user_uuid)]
+        assert len(user_entry.candidates) == 1
+        candidate = user_entry.candidates[0]
+        assert candidate.session_id == victim_id
+        assert candidate.allocated_slots_by_agent == {
+            AgentId(test_agent_id): {"cpu": Decimal("1"), "mem": Decimal("1024")},
+            AgentId(second_agent_id): {"cpu": Decimal("2"), "mem": Decimal("2048")},
+        }
+        # Derived per-agent view: the same single candidate under both agents,
+        # each with agent-scoped reclaimable totals
+        assert set(user_entry.by_agent.keys()) == {
+            AgentId(test_agent_id),
+            AgentId(second_agent_id),
+        }
+        assert user_entry.by_agent[AgentId(test_agent_id)].candidates == [candidate]
+        assert user_entry.by_agent[AgentId(test_agent_id)].total_reclaimable == {
+            "cpu": Decimal("1"),
+            "mem": Decimal("1024"),
+        }
+        assert user_entry.by_agent[AgentId(second_agent_id)].total_reclaimable == {
+            "cpu": Decimal("2"),
+            "mem": Decimal("2048"),
+        }


### PR DESCRIPTION
## Summary
- Load a `PreemptionCandidateSnapshot` in `fetch_scheduling_fetch` for preemption-enabled resource groups only (disabled groups skip the query entirely): candidates are grouped per owner (`by_user`), one candidate per session (the preemption unit), carrying `session_id` / `job_priority` / `started_at` / per-agent reclaimable allocations summed from `resource_allocations` (`coalesce(used, requested)`), with derived per-agent views (`UserVictimCandidates.by_agent`, `AgentVictimCandidates.total_reclaimable`) computed as cached properties for the BA-6748 planner.
- Prefilter in SQL: preemptible, non-private sessions in the new `SessionStatus.preemption_victim_statuses()` (resource-occupying AND still terminatable — SCHEDULED onward, strips TERMINATING) whose `job_priority` is strictly below their owner's max pending `job_priority`; pending private (SFTP/system) sessions never establish preemption thresholds. Kernel-level holds use the new `KernelStatus.resource_holding_statuses()` (occupied | requested), matching the occupancy scan.
- Relocate `PreemptionConfig` to `ai.backend.common.schema.resource_group` (new schema module; resource_group naming for new code) and exclude `ERROR` from `SessionStatus.resource_occupied_statuses()` — ERROR sessions no longer count as resource-occupying (this also stops them from counting toward the per-user concurrency session count).

## Test plan
- [x] `tests/unit/manager/repositories/scheduler/test_preemption_candidates.py` (real DB): disabled-group skip, non-victim exclusions (equal priority / non-preemptible / TERMINATING / private), SCHEDULED victim without `started_at`, per-owner threshold isolation, private-pending-does-not-initiate, per-agent reclaimable totals, multi-node single candidate with per-agent slots
- [x] `pants fmt/fix/lint/check` and the scheduler/repositories, data/session, models/scaling_group unit suites pass locally

Resolves BA-6747

🤖 Generated with [Claude Code](https://claude.com/claude-code)