### PR TITLE
feat(BA-6937): cap session priority via keypair policy max_priority

### DIFF
--- a/changes/13125.feature.md
+++ b/changes/13125.feature.md
@@ -1,0 +1,1 @@
+Add `max_priority` to the keypair resource policy to cap the scheduler priority a user may request when creating a session

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -25893,21 +25893,6 @@
         "title": "KernelHistoryScopeDTO",
         "type": "object"
       },
-      "UUIDScope": {
-        "description": "Single-UUID scope item wrapper.\n\nA thin wrapper around a UUID used as a scope item. The wrapper exists so\nthat scope-input lists stay structurally uniform with other scope item\ntypes and leave room for per-item metadata in the future.",
-        "properties": {
-          "value": {
-            "format": "uuid",
-            "title": "Value",
-            "type": "string"
-          }
-        },
-        "required": [
-          "value"
-        ],
-        "title": "UUIDScope",
-        "type": "object"
-      },
       "ScopedSearchKernelHistoriesInput": {
         "description": "Input for searching kernel scheduling histories under a non-admin scope.",
         "properties": {

--- a/src/ai/backend/manager/data/resource/types.py
+++ b/src/ai/backend/manager/data/resource/types.py
@@ -85,3 +85,6 @@ class UserEnqueuePolicy:
     max_pending_session_count: int | None
     max_pending_session_resource_slots: Mapping[ResourceSlotName, Decimal] | None
     allowed_vfolder_hosts: VFolderHostPermissionMap
+    # Cap on the global scheduler priority (None = no cap); unrelated to
+    # the self-scoped, uncapped ``job_priority``.
+    max_priority: int | None

--- a/src/ai/backend/manager/models/alembic/versions/c4e1a7f9b26d_add_keypair_max_priority.py
+++ b/src/ai/backend/manager/models/alembic/versions/c4e1a7f9b26d_add_keypair_max_priority.py
@@ -1,0 +1,39 @@
+"""add max_priority to keypair_resource_policies
+
+Revision ID: c4e1a7f9b26d
+Revises: 5405ee0d8eed
+Create Date: 2026-07-26 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.common.defs.session import SESSION_PRIORITY_MAX, SESSION_PRIORITY_MIN
+
+# revision identifiers, used by Alembic.
+revision = "c4e1a7f9b26d"
+down_revision = "5405ee0d8eed"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+_TABLE = "keypair_resource_policies"
+_RANGE_CHECK = "max_priority_within_session_priority_range"
+
+
+def upgrade() -> None:
+    op.add_column(
+        _TABLE,
+        sa.Column("max_priority", sa.Integer(), nullable=True),
+    )
+    op.create_check_constraint(
+        _RANGE_CHECK,
+        _TABLE,
+        f"max_priority >= {SESSION_PRIORITY_MIN} AND max_priority <= {SESSION_PRIORITY_MAX}",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(_RANGE_CHECK, _TABLE, type_="check")
+    op.drop_column(_TABLE, "max_priority")

--- a/src/ai/backend/manager/models/resource_policy/row.py
+++ b/src/ai/backend/manager/models/resource_policy/row.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Self
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from ai.backend.common.defs.session import SESSION_PRIORITY_MAX, SESSION_PRIORITY_MIN
 from ai.backend.common.types import (
     DefaultForUnspecified,
     ResourceSlot,
@@ -42,6 +43,14 @@ __all__: Sequence[str] = (
 
 class KeyPairResourcePolicyRow(Base):  # type: ignore[misc]
     __tablename__ = "keypair_resource_policies"
+    # A cap outside the requestable priority range is unsatisfiable: a
+    # negative one would reject every session create for the keypair.
+    __table_args__ = (
+        sa.CheckConstraint(
+            f"max_priority >= {SESSION_PRIORITY_MIN} AND max_priority <= {SESSION_PRIORITY_MAX}",
+            name="max_priority_within_session_priority_range",
+        ),
+    )
 
     name: Mapped[str] = mapped_column("name", sa.String(length=256), primary_key=True)
     created_at: Mapped[datetime | None] = mapped_column(
@@ -68,6 +77,8 @@ class KeyPairResourcePolicyRow(Base):  # type: ignore[misc]
     max_pending_session_resource_slots: Mapped[ResourceSlot | None] = mapped_column(
         "max_pending_session_resource_slots", ResourceSlotColumn(), nullable=True
     )
+    # Cap on the global scheduler priority a session may declare (NULL = no cap).
+    max_priority: Mapped[int | None] = mapped_column("max_priority", sa.Integer(), nullable=True)
     max_concurrent_sftp_sessions: Mapped[int] = mapped_column(
         "max_concurrent_sftp_sessions", sa.Integer(), nullable=False, server_default=sa.text("1")
     )

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -1815,6 +1815,7 @@ class ScheduleDBSource:
                         KeyPairResourcePolicyRow.max_containers_per_session,
                         KeyPairResourcePolicyRow.max_pending_session_count,
                         KeyPairResourcePolicyRow.max_pending_session_resource_slots,
+                        KeyPairResourcePolicyRow.max_priority,
                         KeyPairResourcePolicyRow.allowed_vfolder_hosts,
                     )
                     .select_from(UserRow)
@@ -1836,6 +1837,7 @@ class ScheduleDBSource:
                         else None
                     ),
                     allowed_vfolder_hosts=policy_row.allowed_vfolder_hosts,
+                    max_priority=policy_row.max_priority,
                 )
 
         dotfile_bundle = DotfileBundle()

--- a/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
@@ -86,6 +86,7 @@ from .validators import (
     MountNameValidationRule,
     PendingSessionCountLimitRule,
     PendingSessionResourceLimitRule,
+    PriorityLimitRule,
     RequestedSlotTypeRule,
     RequiredResourceSlotRule,
     ResourceLimitRule,
@@ -169,6 +170,7 @@ class SchedulingController:
         self._spec_validator = SessionSpecValidator([
             PendingSessionCountLimitRule(),
             PendingSessionResourceLimitRule(),
+            PriorityLimitRule(),
             ContainerLimitRule(),
             ImageSlotTypeRule(),
             RequestedSlotTypeRule(),

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/__init__.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/__init__.py
@@ -7,6 +7,7 @@ from .inference_model_folder_rule import InferenceModelFolderRule
 from .mount_name_validation_rule import MountNameValidationRule
 from .pending_session_count_limit_rule import PendingSessionCountLimitRule
 from .pending_session_resource_limit_rule import PendingSessionResourceLimitRule
+from .priority_limit_rule import PriorityLimitRule
 from .requested_slot_type_rule import RequestedSlotTypeRule
 from .required_resource_slot_rule import RequiredResourceSlotRule
 from .resource_limit_rule import ResourceLimitRule
@@ -19,6 +20,7 @@ from .session_spec_base import (
 __all__ = [
     "PendingSessionCountLimitRule",
     "PendingSessionResourceLimitRule",
+    "PriorityLimitRule",
     "ContainerLimitRule",
     "DotfileVFolderConflictRule",
     "ImageSlotTypeRule",

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/priority_limit_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/priority_limit_rule.py
@@ -1,0 +1,49 @@
+"""Per-user scheduling-priority cap rule.
+
+Bounds the *global* scheduler ``priority`` a user may declare at enqueue
+time via the ``max_priority`` ceiling of the user's main keypair policy.
+The scope-local ``job_priority`` only ranks the owner's own sessions and
+is therefore deliberately left uncapped.
+"""
+
+from __future__ import annotations
+
+from typing import override
+
+from ai.backend.manager.data.session.spec import SessionSpec
+from ai.backend.manager.errors.kernel import QuotaExceeded
+from ai.backend.manager.sokovan.scheduling_controller.validators.session_spec_base import (
+    SessionSpecValidatorRule,
+)
+from ai.backend.manager.views.sokovan.session_creation import (
+    SessionSpecContext,
+)
+
+
+class PriorityLimitRule(SessionSpecValidatorRule):
+    """Reject enqueue when the requested priority exceeds the user's cap."""
+
+    @override
+    def name(self) -> str:
+        return "priority_limit"
+
+    @override
+    def validate(
+        self,
+        spec: SessionSpec,
+        context: SessionSpecContext,
+    ) -> None:
+        policy = context.user.policy
+        if policy is None:
+            return
+        limit = policy.max_priority
+        if limit is None:
+            return
+        requested = spec.resource_spec.options.priority
+        if requested > limit:
+            raise QuotaExceeded(
+                extra_msg=(
+                    f"The requested session priority {requested} "
+                    f"exceeds the allowed maximum priority of {limit}."
+                ),
+            )

--- a/tests/unit/manager/repositories/keypair_resource_policy/test_keypair_resource_policy.py
+++ b/tests/unit/manager/repositories/keypair_resource_policy/test_keypair_resource_policy.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import pytest
 import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
 
 from ai.backend.common.exception import KeypairResourcePolicyNotFound
 from ai.backend.common.types import (
@@ -452,3 +453,40 @@ class TestKeypairResourcePolicyRepository:
         updater = Updater(spec=allowed_vfolder_updater_spec, pk_value=sample_policy_name)
         result = await repository.update_keypair_resource_policy(updater)
         assert result.allowed_vfolder_hosts == sample_allowed_vfolder_hosts
+
+    @pytest.mark.parametrize("max_priority", [None, 0, 10, 100])
+    async def test_max_priority_accepts_values_within_range(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        sample_creator: KeyPairResourcePolicyCreatorSpec,
+        max_priority: int | None,
+    ) -> None:
+        row = sample_creator.build_row()
+        row.max_priority = max_priority
+        async with db_with_cleanup.begin_session() as db_sess:
+            db_sess.add(row)
+            await db_sess.commit()
+
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            stored = await db_sess.scalar(
+                sa.select(KeyPairResourcePolicyRow.max_priority).where(
+                    KeyPairResourcePolicyRow.name == sample_creator.name
+                )
+            )
+        assert stored == max_priority
+
+    @pytest.mark.parametrize("max_priority", [-1, 101])
+    async def test_max_priority_outside_range_is_rejected(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        sample_creator: KeyPairResourcePolicyCreatorSpec,
+        max_priority: int,
+    ) -> None:
+        # A cap outside the requestable priority range is unsatisfiable —
+        # a negative one would reject every session create for the keypair.
+        row = sample_creator.build_row()
+        row.max_priority = max_priority
+        with pytest.raises(IntegrityError):
+            async with db_with_cleanup.begin_session() as db_sess:
+                db_sess.add(row)
+                await db_sess.commit()

--- a/tests/unit/manager/sokovan/scheduling_controller/test_enqueue_session_from_draft.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/test_enqueue_session_from_draft.py
@@ -197,6 +197,7 @@ def _user_policy() -> UserEnqueuePolicy:
         max_pending_session_count=None,
         max_pending_session_resource_slots=None,
         allowed_vfolder_hosts=VFolderHostPermissionMap(),
+        max_priority=None,
     )
 
 

--- a/tests/unit/manager/sokovan/scheduling_controller/validators/test_session_spec_rules.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/validators/test_session_spec_rules.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import pytest
 
+from ai.backend.common.defs.session import SESSION_PRIORITY_DEFAULT
 from ai.backend.common.identifier.domain import DomainID, DomainName
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.project import ProjectID
@@ -74,6 +75,9 @@ from ai.backend.manager.sokovan.scheduling_controller.validators.pending_session
 )
 from ai.backend.manager.sokovan.scheduling_controller.validators.pending_session_resource_limit_rule import (
     PendingSessionResourceLimitRule,
+)
+from ai.backend.manager.sokovan.scheduling_controller.validators.priority_limit_rule import (
+    PriorityLimitRule,
 )
 from ai.backend.manager.sokovan.scheduling_controller.validators.requested_slot_type_rule import (
     RequestedSlotTypeRule,
@@ -148,6 +152,7 @@ def _spec(
     *,
     session_type: SessionTypes = SessionTypes.INTERACTIVE,
     vfolder_mounts: tuple[VFolderMount, ...] = (),
+    priority: int = 10,
 ) -> SessionSpec:
     # SessionSpec no longer carries session-level vfolder_mounts — they live
     # per-kernel on KernelSpec.vfolder_mounts. Mirror the supplied mounts onto
@@ -167,7 +172,7 @@ def _spec(
             classification=SessionClassification(session_type=session_type),
             network=SessionNetwork(network_type=NetworkType.VOLATILE),
             options=SessionOptions(
-                priority=10,
+                priority=priority,
                 is_preemptible=True,
                 cluster_mode=ClusterMode.SINGLE_NODE,
                 cluster_size=len(kernel_specs),
@@ -252,12 +257,14 @@ def _policy(
     max_containers: int = 4,
     max_pending: int | None = None,
     max_pending_slots: Mapping[ResourceSlotName, Decimal] | None = None,
+    max_priority: int | None = None,
 ) -> UserEnqueuePolicy:
     return UserEnqueuePolicy(
         max_containers_per_session=max_containers,
         max_pending_session_count=max_pending,
         max_pending_session_resource_slots=max_pending_slots,
         allowed_vfolder_hosts=VFolderHostPermissionMap(),
+        max_priority=max_priority,
     )
 
 
@@ -306,6 +313,55 @@ class TestPendingSessionCountLimitRule:
             _spec((_kernel(img),)),
             _ctx(policy=_policy(max_pending=None), pending_session_count=100),
         )
+
+
+class TestPriorityLimitRule:
+    def test_within_limit(self) -> None:
+        img = ImageID(uuid.uuid4())
+        spec = _spec((_kernel(img),), priority=5)
+        PriorityLimitRule().validate(spec, _ctx(policy=_policy(max_priority=5)))
+
+    def test_allows_default_priority_at_default_cap(self) -> None:
+        # The finalized priority defaults to SESSION_PRIORITY_DEFAULT (10),
+        # so a cap of 10 must admit a request that declared nothing.
+        img = ImageID(uuid.uuid4())
+        spec = _spec((_kernel(img),), priority=SESSION_PRIORITY_DEFAULT)
+        PriorityLimitRule().validate(
+            spec, _ctx(policy=_policy(max_priority=SESSION_PRIORITY_DEFAULT))
+        )
+
+    def test_rejects_above_limit(self) -> None:
+        img = ImageID(uuid.uuid4())
+        spec = _spec((_kernel(img),), priority=50)
+        with pytest.raises(QuotaExceeded):
+            PriorityLimitRule().validate(spec, _ctx(policy=_policy(max_priority=10)))
+
+    def test_noop_without_policy(self) -> None:
+        img = ImageID(uuid.uuid4())
+        PriorityLimitRule().validate(_spec((_kernel(img),), priority=100), _ctx())
+
+    def test_noop_when_limit_unset(self) -> None:
+        img = ImageID(uuid.uuid4())
+        PriorityLimitRule().validate(
+            _spec((_kernel(img),), priority=100),
+            _ctx(policy=_policy(max_priority=None)),
+        )
+
+    def test_ignores_job_priority(self) -> None:
+        img = ImageID(uuid.uuid4())
+        spec = _spec((_kernel(img),), priority=5)
+        spec = spec.model_copy(
+            update={
+                "resource_spec": spec.resource_spec.model_copy(
+                    update={
+                        "options": spec.resource_spec.options.model_copy(
+                            update={"job_priority": 100}
+                        )
+                    }
+                )
+            }
+        )
+        PriorityLimitRule().validate(spec, _ctx(policy=_policy(max_priority=5)))
 
 
 class TestPendingSessionResourceLimitRule:


### PR DESCRIPTION
## Summary

- Add a nullable `max_priority` column to `keypair_resource_policies` — a per-user ceiling on the **global** scheduler `priority` a session may declare at creation. `NULL` (the default for every existing row) means no cap, so behavior is unchanged until an operator sets one.
- A CHECK constraint pins the cap to the requestable range `[0, 100]` (`SESSION_PRIORITY_MIN`/`MAX`), so it can never be stored at a value no request could satisfy.
- `PriorityLimitRule` enforces the cap in the `SessionSpecValidator` chain, following the `PendingSessionCountLimitRule` precedent — rejects with `QuotaExceeded` when the finalized spec's `priority` exceeds the cap. The scope-local `job_priority` is deliberately left uncapped.

Notes for reviewers:

- The cap is compared against the **finalized** `SessionSpec.priority`, i.e. after the resource-group default merge. A cap set below the resource-group default (10 by default) therefore rejects creates that never declared a priority, including model-service replicas, which build drafts at `SESSION_PRIORITY_DEFAULT`. Operators should keep the cap at or above the group default.
- `max_priority` is not yet exposed through GraphQL / REST / SDK / CLI (creators, updaters, filters) — out of scope for BA-6937; it is currently settable via SQL only.

## Test plan

- [x] `PriorityLimitRule`: within limit, at limit (priority 10 vs cap 10), above limit, no policy, cap unset, `job_priority` unaffected
- [x] CHECK constraint against a real DB: `NULL/0/10/100` accepted, `-1/101` raise `IntegrityError`
- [x] `pants fmt / fix / lint / check` over the PR diff
- [x] `pants test` for `sokovan/scheduling_controller::`, `repositories/scheduler::`, `repositories/keypair_resource_policy::`
- [ ] `alembic upgrade`/`downgrade` round-trip on a live DB (pure DDL, not exercised locally)

Resolves BA-6937

🤖 Generated with [Claude Code](https://claude.com/claude-code)