### PR TITLE
fix(BA-6998): converge rollout scaling on current-revision count alone (#13087)

### DIFF
--- a/changes/13087.fix.md
+++ b/changes/13087.fix.md
@@ -1,0 +1,1 @@
+Fix rolling-update livelocks where old-revision replicas stuck in PENDING blocked scaling convergence and dead old-revision replicas were refilled against the new revision; during a rollout the old revision is now drain-only and capacity it loses hands over to the new revision immediately

--- a/src/ai/backend/manager/repositories/replica_group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/replica_group/db_source/db_source.py
@@ -201,9 +201,11 @@ class ReplicaGroupDBSource:
             group_rows: list[ReplicaGroupRow] = [row.ReplicaGroupRow for row in group_result.rows]
             group_ids = [group_row.id for group_row in group_rows]
             deployment_ids = [group_row.deployment_id for group_row in group_rows]
+            counts = await self._count_live_serving_by_revision(db_sess, group_ids)
             last_histories = await self._latest_history_by_group(db_sess, group_ids, category)
             handler_options = await self._handler_options_by_deployment(db_sess, deployment_ids)
             deployment_desired = await self._replicas_by_deployment(db_sess, deployment_ids)
+            empty = RevisionReplicaCount(live=0, serving=0)
             views = [
                 ReplicaGroupLifecycleReconcileView(
                     group_id=group_row.id,
@@ -214,6 +216,11 @@ class ReplicaGroupDBSource:
                     scaling_status=group_row.scaling_status,
                     desired_current_replica_count=group_row.desired_current_replica_count,
                     desired_target_replica_count=group_row.desired_target_replica_count,
+                    current_live_replica_count=(
+                        counts.get(group_row.id, {}).get(group_row.current_revision_id, empty).live
+                        if group_row.current_revision_id is not None
+                        else 0
+                    ),
                     deployment_desired_replica_count=deployment_desired.get(
                         group_row.deployment_id, 0
                     ),

--- a/src/ai/backend/manager/sokovan/deployment/group/lifecycle/handlers/rolling.py
+++ b/src/ai/backend/manager/sokovan/deployment/group/lifecycle/handlers/rolling.py
@@ -50,15 +50,27 @@ class GroupRollingHandler(
                     else:
                         surge = view.rollout.resolve_max_surge(goal)
                         unavailable = view.rollout.resolve_max_unavailable(goal)
-                        # Grow target by surge above what is up; keep the availability floor on
-                        # current. An initial deploy has no current revision to keep serving, so
-                        # there is no floor to maintain and current stays at zero.
-                        next_target = min(goal, target_desired + surge)
+                        # Keep the availability floor on current, but never above its
+                        # live count: the current side is drain-only during a rollout
+                        # (dead replicas are not refilled), so desired above live would
+                        # hold budget for replicas that can never come back. An initial
+                        # deploy has no current revision to keep serving, so there is
+                        # no floor to maintain and current stays at zero.
                         next_current = (
                             0
                             if view.current_revision_id is None
-                            else max(0, (goal - unavailable) - target_desired)
+                            else min(
+                                view.current_live_replica_count,
+                                max(0, (goal - unavailable) - target_desired),
+                            )
                         )
+                        # The surge budget bounds the total (current + target) at
+                        # goal + surge, measured against the post-drain current side.
+                        # With a healthy current side this reduces to the classic
+                        # step (previous target + surge); replicas the current side
+                        # lost hand their slot to the target immediately instead of
+                        # throttling it to one surge increment per step.
+                        next_target = min(goal, max(target_desired, (goal + surge) - next_current))
                         outcome = HandlerOutcome.FAILURE
                         message = "rolling out target revision toward desired"
             decisions.append(

--- a/src/ai/backend/manager/sokovan/deployment/group/scaling/handlers/reconcile.py
+++ b/src/ai/backend/manager/sokovan/deployment/group/scaling/handlers/reconcile.py
@@ -39,7 +39,15 @@ class GroupScalingReconcileHandler(
                         deficit = (
                             view.desired_current_replica_count - view.current_live_replica_count
                         )
-                        if deficit > 0:
+                        if deficit > 0 and view.target_revision_id is None:
+                            # Steady-state self-heal only. During a rollout the current
+                            # revision is never refilled: a replica that died (agent
+                            # failure or user termination — indistinguishable) stays
+                            # gone and its capacity moves to the target revision as the
+                            # rolling step advances. Refilling would re-grab freed
+                            # resources and starve the target side (capacity livelock);
+                            # a target revision that cannot come up is covered by the
+                            # rollout timeout + rollback path instead.
                             create_instructions.append(
                                 GroupRouteCreateInstruction(
                                     replica_group_id=view.group_id,
@@ -75,20 +83,24 @@ class GroupScalingReconcileHandler(
                                     count=-deficit,
                                 )
                             )
+                    # The current revision converges on count alone — serving is never
+                    # required of it. Replicas that cannot be scheduled stay PENDING (live
+                    # but not serving); requiring serving here would livelock the rollout
+                    # when old-revision replicas can never become serving. The no-downtime
+                    # invariant (new replicas serve before the old side drains) is enforced
+                    # by target_matched below, which does require serving.
                     if view.target_revision_id is None:
-                        # Steady-state scaling: converge on count alone. Replicas that cannot
-                        # be scheduled stay PENDING; serving health is judged separately and
-                        # must not block the loop, so a rising/falling goal is always absorbed.
+                        # Steady state: exact count (a deficit is being refilled).
                         current_matched = (
                             view.current_live_replica_count == view.desired_current_replica_count
                         )
                     else:
-                        # Rollout in flight: require serving so the rolling step waits for the
-                        # new replicas before draining the old (no-downtime invariant).
+                        # Rollout in flight: one-sided. The current side is drain-only
+                        # (dead replicas are not refilled), so a shortfall is a final
+                        # state and must not hold the group out of STABLE — only a
+                        # surplus still waiting to drain does.
                         current_matched = (
-                            view.current_live_replica_count == view.desired_current_replica_count
-                            and view.current_serving_replica_count
-                            == view.desired_current_replica_count
+                            view.current_live_replica_count <= view.desired_current_replica_count
                         )
                     target_matched = (
                         view.target_live_replica_count == view.desired_target_replica_count

--- a/src/ai/backend/manager/views/replica_group.py
+++ b/src/ai/backend/manager/views/replica_group.py
@@ -104,6 +104,11 @@ class ReplicaGroupLifecycleReconcileView:
     scaling_status: ReplicaGroupScalingStatus
     desired_current_replica_count: int
     desired_target_replica_count: int
+    # Live routes of the current revision. During a rollout the current side is
+    # drain-only (never refilled), so dead replicas free rollout budget: the
+    # rolling step sizes the target side against this live count, not the
+    # desired count.
+    current_live_replica_count: int
     # The rollout goal: the deployment's desired replica count the target revision rolls to.
     deployment_desired_replica_count: int
     rollout: ReplicaGroupRolloutSpec

--- a/tests/unit/manager/sokovan/deployment/group/lifecycle/test_lifecycle_handlers.py
+++ b/tests/unit/manager/sokovan/deployment/group/lifecycle/test_lifecycle_handlers.py
@@ -40,14 +40,20 @@ def _view(
     goal: int = 4,
     desired_current: int = 4,
     desired_target: int = 0,
+    current_live: int | None = None,
     current_revision_id: DeploymentRevisionID | None = None,
     target_revision_id: DeploymentRevisionID | None = None,
+    rollout: ReplicaGroupRolloutSpec | None = None,
 ) -> ReplicaGroupLifecycleReconcileView:
-    # surge 50%, unavailable 0% baseline.
-    rollout = ReplicaGroupRolloutSpec(
-        max_surge=IntOrPercent(percent=0.5),
-        max_unavailable=IntOrPercent(percent=0.0),
-    )
+    if rollout is None:
+        # surge 50%, unavailable 0% baseline.
+        rollout = ReplicaGroupRolloutSpec(
+            max_surge=IntOrPercent(percent=0.5),
+            max_unavailable=IntOrPercent(percent=0.0),
+        )
+    if current_live is None:
+        # Healthy current side by default: every desired replica is live.
+        current_live = desired_current if current_revision_id is not None else 0
     return ReplicaGroupLifecycleReconcileView(
         group_id=ReplicaGroupID(uuid.uuid4()),
         deployment_id=DeploymentID(uuid.uuid4()),
@@ -57,6 +63,7 @@ def _view(
         scaling_status=ReplicaGroupScalingStatus.STABLE,
         desired_current_replica_count=desired_current,
         desired_target_replica_count=desired_target,
+        current_live_replica_count=current_live,
         deployment_desired_replica_count=goal,
         rollout=rollout,
         last_history=None,
@@ -162,14 +169,14 @@ async def test_rolling_steps_target_up_and_current_down() -> None:
     with RecorderContext[UUID].scope("group_rolling", [view.group_id]):
         result = await GroupRollingHandler().execute(info)
     decision = result.lifecycle_decisions[0]
-    assert decision.next_desired_target_replica_count == 4  # min(4, 2 + 2)
-    assert decision.next_desired_current_replica_count == 2  # max(0, (4 - 0) - 2)
+    assert decision.next_desired_target_replica_count == 4  # min(4, (4 + 2) - 2)
+    assert decision.next_desired_current_replica_count == 2  # min(4, (4 - 0) - 2)
     assert decision.outcome() is HandlerOutcome.FAILURE
 
 
 async def test_rolling_initial_deploy_keeps_current_at_zero() -> None:
     # Initial deploy: no current revision to keep serving, so current stays at zero
-    # while the target ramps up (no availability floor to maintain).
+    # and there is no old side to hold budget — the target goes straight to the goal.
     view = _view(
         lifecycle=ReplicaGroupLifecycle.ROLLING,
         desired_current=0,
@@ -179,8 +186,109 @@ async def test_rolling_initial_deploy_keeps_current_at_zero() -> None:
     with RecorderContext[UUID].scope("group_rolling", [view.group_id]):
         result = await GroupRollingHandler().execute(_info(view))
     decision = result.lifecycle_decisions[0]
-    assert decision.next_desired_target_replica_count == 4  # min(4, 2 + 2)
+    assert decision.next_desired_target_replica_count == 4  # min(4, (4 + 2) - 0)
     assert decision.next_desired_current_replica_count == 0  # no current revision → no floor
+    assert decision.outcome() is HandlerOutcome.FAILURE
+
+
+async def test_rolling_hands_over_all_freed_count_when_current_dead() -> None:
+    # Every old replica died (e.g. the user terminated them all) after the first
+    # step. Dead replicas are never refilled during a rollout, so they no longer
+    # hold surge budget: the target jumps straight to the goal instead of creeping
+    # up one surge increment per step.
+    rollout = ReplicaGroupRolloutSpec(
+        max_surge=IntOrPercent(count=1),
+        max_unavailable=IntOrPercent(count=0),
+    )
+    view = _view(
+        lifecycle=ReplicaGroupLifecycle.ROLLING,
+        goal=10,
+        desired_current=9,
+        desired_target=1,
+        current_live=0,
+        current_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        target_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        rollout=rollout,
+    )
+    with RecorderContext[UUID].scope("group_rolling", [view.group_id]):
+        result = await GroupRollingHandler().execute(_info(view))
+    decision = result.lifecycle_decisions[0]
+    assert decision.next_desired_current_replica_count == 0
+    assert decision.next_desired_target_replica_count == 10  # min(10, (10 + 1) - 0)
+    assert decision.outcome() is HandlerOutcome.FAILURE
+
+
+async def test_rolling_hands_over_partially_freed_count() -> None:
+    # 4 of 9 old replicas died: the target picks up the freed slots plus the surge
+    # allowance, and the current floor is clamped down to what is actually live.
+    rollout = ReplicaGroupRolloutSpec(
+        max_surge=IntOrPercent(count=1),
+        max_unavailable=IntOrPercent(count=0),
+    )
+    view = _view(
+        lifecycle=ReplicaGroupLifecycle.ROLLING,
+        goal=10,
+        desired_current=9,
+        desired_target=1,
+        current_live=5,
+        current_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        target_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        rollout=rollout,
+    )
+    with RecorderContext[UUID].scope("group_rolling", [view.group_id]):
+        result = await GroupRollingHandler().execute(_info(view))
+    decision = result.lifecycle_decisions[0]
+    assert decision.next_desired_current_replica_count == 5  # min(5, (10 - 0) - 1)
+    assert decision.next_desired_target_replica_count == 6  # min(10, (10 + 1) - 5)
+    assert decision.outcome() is HandlerOutcome.FAILURE
+
+
+async def test_rolling_healthy_current_steps_by_surge() -> None:
+    # With every old replica alive the live-based budget reduces to the classic
+    # step: the target grows by exactly the surge each cycle.
+    rollout = ReplicaGroupRolloutSpec(
+        max_surge=IntOrPercent(count=1),
+        max_unavailable=IntOrPercent(count=0),
+    )
+    view = _view(
+        lifecycle=ReplicaGroupLifecycle.ROLLING,
+        goal=10,
+        desired_current=9,
+        desired_target=1,
+        current_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        target_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        rollout=rollout,
+    )
+    with RecorderContext[UUID].scope("group_rolling", [view.group_id]):
+        result = await GroupRollingHandler().execute(_info(view))
+    decision = result.lifecycle_decisions[0]
+    assert decision.next_desired_current_replica_count == 9  # min(9, (10 - 0) - 1)
+    assert decision.next_desired_target_replica_count == 2  # min(10, (10 + 1) - 9)
+    assert decision.outcome() is HandlerOutcome.FAILURE
+
+
+async def test_rolling_progresses_with_zero_surge() -> None:
+    # surge 0 / unavailable > 0: room is made by draining the current side first,
+    # then the target fills the vacated slots. The desired-based step never grew
+    # the target here (0 + surge == 0); the live-based budget does.
+    rollout = ReplicaGroupRolloutSpec(
+        max_surge=IntOrPercent(count=0),
+        max_unavailable=IntOrPercent(count=2),
+    )
+    view = _view(
+        lifecycle=ReplicaGroupLifecycle.ROLLING,
+        goal=4,
+        desired_current=4,
+        desired_target=0,
+        current_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        target_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        rollout=rollout,
+    )
+    with RecorderContext[UUID].scope("group_rolling", [view.group_id]):
+        result = await GroupRollingHandler().execute(_info(view))
+    decision = result.lifecycle_decisions[0]
+    assert decision.next_desired_current_replica_count == 2  # min(4, (4 - 2) - 0)
+    assert decision.next_desired_target_replica_count == 2  # min(4, (4 + 0) - 2)
     assert decision.outcome() is HandlerOutcome.FAILURE
 
 

--- a/tests/unit/manager/sokovan/deployment/group/scaling/test_scaling_reconcile_handler.py
+++ b/tests/unit/manager/sokovan/deployment/group/scaling/test_scaling_reconcile_handler.py
@@ -100,9 +100,11 @@ async def test_steady_state_scale_down_drains_excess() -> None:
     assert result.drain_instructions[0].count == 5
 
 
-async def test_rollout_still_requires_serving() -> None:
-    # A target revision is in flight (rollout): the current side must reach serving, not just
-    # count, so the rolling step waits before draining the old revision (no-downtime).
+async def test_rollout_converges_when_current_pending_but_target_serving() -> None:
+    # Rollout in flight with old-revision replicas stuck PENDING (live but not serving)
+    # while the new revision is fully serving. The current side converges on count alone;
+    # otherwise the group never reaches STABLE and the rolling step can never drain the
+    # old revision (livelock).
     view = _scaling_view(
         current_revision_id=DeploymentRevisionID(uuid.uuid4()),
         target_revision_id=DeploymentRevisionID(uuid.uuid4()),
@@ -112,6 +114,23 @@ async def test_rollout_still_requires_serving() -> None:
         current_serving=2,
         target_live=3,
         target_serving=3,
+    )
+    decision = await _decision(view)
+    assert decision.outcome() is HandlerOutcome.SUCCESS
+
+
+async def test_rollout_still_requires_target_serving() -> None:
+    # The target side must be fully serving before the group converges, so the rolling
+    # step never drains the old revision ahead of the new one (no-downtime invariant).
+    view = _scaling_view(
+        current_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        target_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        desired_current=3,
+        desired_target=3,
+        current_live=3,
+        current_serving=3,
+        target_live=3,
+        target_serving=2,
     )
     decision = await _decision(view)
     assert decision.outcome() is HandlerOutcome.FAILURE
@@ -130,3 +149,76 @@ async def test_rollout_converges_when_both_sides_serving() -> None:
     )
     decision = await _decision(view)
     assert decision.outcome() is HandlerOutcome.SUCCESS
+
+
+async def test_steady_state_refills_deficit() -> None:
+    # No rollout: a dead replica is self-healed back to the desired count.
+    view = _scaling_view(
+        current_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        target_revision_id=None,
+        desired_current=6,
+        current_live=4,
+        current_serving=4,
+    )
+    result = await _execute(view)
+    assert len(result.create_instructions) == 1
+    assert result.create_instructions[0].count == 2
+
+
+async def test_rollout_does_not_refill_current_deficit() -> None:
+    # Rollout in flight: old-revision replicas that died (user kill or agent failure)
+    # are NOT recreated — their capacity is left for the target revision. Only the
+    # target side may create routes.
+    current_rev = DeploymentRevisionID(uuid.uuid4())
+    target_rev = DeploymentRevisionID(uuid.uuid4())
+    view = _scaling_view(
+        current_revision_id=current_rev,
+        target_revision_id=target_rev,
+        desired_current=10,
+        desired_target=5,
+        current_live=0,
+        current_serving=0,
+        target_live=3,
+        target_serving=3,
+    )
+    result = await _execute(view)
+    created_revisions = {c.revision_id for c in result.create_instructions}
+    assert current_rev not in created_revisions
+    assert created_revisions == {target_rev}
+
+
+async def test_rollout_converges_despite_current_shortfall() -> None:
+    # Rollout: all old replicas are gone (drain-only side, no refill), target fully
+    # serving. The shortfall is final, so the group must converge and let the rolling
+    # step hand the freed count over to the target revision.
+    view = _scaling_view(
+        current_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        target_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        desired_current=10,
+        desired_target=5,
+        current_live=0,
+        current_serving=0,
+        target_live=5,
+        target_serving=5,
+    )
+    decision = await _decision(view)
+    assert decision.outcome() is HandlerOutcome.SUCCESS
+
+
+async def test_rollout_not_converged_while_current_surplus_drains() -> None:
+    # Rollout: the step lowered the old side's desired count but the surplus routes
+    # are still draining — the group must not report convergence yet.
+    view = _scaling_view(
+        current_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        target_revision_id=DeploymentRevisionID(uuid.uuid4()),
+        desired_current=5,
+        desired_target=5,
+        current_live=8,
+        current_serving=8,
+        target_live=5,
+        target_serving=5,
+    )
+    result = await _execute(view)
+    assert result.scaling_decisions[0].outcome() is HandlerOutcome.FAILURE
+    assert len(result.drain_instructions) == 1
+    assert result.drain_instructions[0].count == 3


### PR DESCRIPTION
This is an auto-generated backport PR of #13087 to the 26.4 release.