### PR TITLE
fix(BA-6636): classify async GQL resolver errors by severity in admin GQL logging

### DIFF
--- a/changes/13129.fix.md
+++ b/changes/13129.fix.md
@@ -1,0 +1,1 @@
+Fix admin GQL logging to classify expected 4xx errors from async resolvers at debug level instead of ERROR, and include `extensions.code` in their error responses

--- a/src/ai/backend/manager/api/gql_legacy/schema.py
+++ b/src/ai/backend/manager/api/gql_legacy/schema.py
@@ -3341,26 +3341,48 @@ class GQLExceptionMiddleware:
     ) -> Any:
         try:
             res = next(root, info, **args)
+        except GraphQLError:
+            raise
         except BackendAIError as e:
-            if e.status_code // 100 == 4:
-                log.debug("GraphQL client error: {}", e)
-            elif e.status_code // 100 == 5:
-                log.exception("GraphQL Server error: {}", e)
-            raise GraphQLError(
-                message=str(e),
-                extensions={
-                    "code": str(e.error_code()),
-                },
-            ) from e
+            raise self._wrap_backend_error(e) from e
         except Exception as e:
-            log.exception("GraphQL unexpected error: {}", e)
-            raise GraphQLError(
-                message=str(e),
-                extensions={
-                    "code": str(ErrorCode.default()),
-                },
-            ) from e
+            raise self._wrap_unexpected_error(e) from e
+        if asyncio.iscoroutine(res):
+            # Async resolvers raise while being awaited by graphql-core,
+            # outside this try block; wrap the coroutine to catch them.
+            return self._resolve_async(res)
         return res
+
+    async def _resolve_async(self, coro: Awaitable[Any]) -> Any:
+        try:
+            return await coro
+        except GraphQLError:
+            raise
+        except BackendAIError as e:
+            raise self._wrap_backend_error(e) from e
+        except BaseException as e:
+            raise self._wrap_unexpected_error(e) from e
+
+    def _wrap_backend_error(self, e: BackendAIError) -> GraphQLError:
+        if e.status_code // 100 == 4:
+            log.debug("GraphQL client error: {}", e)
+        elif e.status_code // 100 == 5:
+            log.exception("GraphQL Server error: {}", e)
+        return GraphQLError(
+            message=str(e),
+            extensions={
+                "code": str(e.error_code()),
+            },
+        )
+
+    def _wrap_unexpected_error(self, e: BaseException) -> GraphQLError:
+        log.exception("GraphQL unexpected error: {}", e)
+        return GraphQLError(
+            message=str(e),
+            extensions={
+                "code": str(ErrorCode.default()),
+            },
+        )
 
 
 class GQLMetricMiddleware:

--- a/src/ai/backend/manager/api/rest/admin/handler.py
+++ b/src/ai/backend/manager/api/rest/admin/handler.py
@@ -153,8 +153,11 @@ class AdminHandler:
             ),
         )
         if result.errors:
+            # Severity-classified logging is done by GQLExceptionMiddleware;
+            # keep a debug trace here for errors that bypass resolvers
+            # (e.g. query parse/validation errors).
             for e in result.errors:
-                log.error("ADMIN.GQL Exception: {}", e.formatted)
+                log.debug("ADMIN.GQL Exception: {}", e.formatted)
                 log.debug("{}", "".join(traceback.format_exception(e)))
         return result
 
@@ -189,10 +192,7 @@ class AdminHandler:
         params = body.parsed
         result = await self._handle_gql_common(request_ctx, params)
         if result.errors:
-            errors = []
-            for e in result.errors:
-                errors.append(e.formatted)
-                log.error("ADMIN.GQL Exception: {}", e.formatted)
+            errors = [e.formatted for e in result.errors]
             raise BackendGQLError(extra_data=errors)
         resp = GraphQLResponse(data=result.data)
         return APIResponse.build(HTTPStatus.OK, resp)


### PR DESCRIPTION
## Summary
- Fix `GQLExceptionMiddleware` being a no-op for async resolvers: its sync `resolve()` returned coroutines untouched, so exceptions raised while graphql-core awaited them bypassed the middleware's try/except. The middleware now wraps coroutines and awaits them inside the exception handler, restoring 4xx→debug / 5xx→exception log classification and `extensions.code` in error responses.
- Remove the unconditional `log.error("ADMIN.GQL Exception")` calls in the admin GQL handlers, which logged expected 4xx errors (e.g. permission denials) at ERROR level and double-logged on the legacy `/admin/graphql` path. `_handle_gql_common` keeps a debug-level trace for errors that bypass resolvers (query parse/validation errors).

## Test plan
- [x] `pants fmt/fix/lint/check` pass
- [x] Live check (local manager): non-admin `storage_volume_list` → 403 response now includes `extensions.code`, no ERROR log emitted
- [x] Live check: admin `storage_volume_list` with storage-proxy down → 5xx logged as ERROR with traceback by the middleware (`GraphQL Server error`), `extensions.code` included in response

Resolves BA-6636

🤖 Generated with [Claude Code](https://claude.com/claude-code)