### PR TITLE
feat(BA-6579): add idle checker repository CRUD

### DIFF
--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -25893,21 +25893,6 @@
         "title": "KernelHistoryScopeDTO",
         "type": "object"
       },
-      "UUIDScope": {
-        "description": "Single-UUID scope item wrapper.\n\nA thin wrapper around a UUID used as a scope item. The wrapper exists so\nthat scope-input lists stay structurally uniform with other scope item\ntypes and leave room for per-item metadata in the future.",
-        "properties": {
-          "value": {
-            "format": "uuid",
-            "title": "Value",
-            "type": "string"
-          }
-        },
-        "required": [
-          "value"
-        ],
-        "title": "UUIDScope",
-        "type": "object"
-      },
       "ScopedSearchKernelHistoriesInput": {
         "description": "Input for searching kernel scheduling histories under a non-admin scope.",
         "properties": {

--- a/src/ai/backend/manager/data/idle_checker/types.py
+++ b/src/ai/backend/manager/data/idle_checker/types.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 
-from ai.backend.common.types import SessionId
+from ai.backend.common.data.idle_checker.types import CheckerType, IdleCheckerSpec
+from ai.backend.common.identifier.idle_checker import IdleCheckerID
+from ai.backend.common.types import SessionId, SessionTypes
 
 
 @dataclass(frozen=True)
@@ -13,3 +15,16 @@ class IdleCheckSession:
     session_id: SessionId
     created_at: datetime
     starts_at: datetime | None
+
+
+@dataclass(frozen=True)
+class IdleCheckerData:
+    id: IdleCheckerID
+    name: str
+    description: str | None
+    checker_type: CheckerType
+    target_session_types: list[SessionTypes]
+    initial_grace_period_seconds: int
+    spec: IdleCheckerSpec
+    created_at: datetime
+    updated_at: datetime

--- a/src/ai/backend/manager/errors/idle_checker.py
+++ b/src/ai/backend/manager/errors/idle_checker.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from ai.backend.manager.errors.common import GenericBadRequest, ObjectNotFound
+
+__all__ = ("IdleCheckerNotFound", "IdleCheckerTypeChangeNotAllowed")
+
+
+class IdleCheckerNotFound(ObjectNotFound):
+    error_type = "https://api.backend.ai/probs/idle-checker-not-found"
+    object_name = "idle checker"
+
+
+class IdleCheckerTypeChangeNotAllowed(GenericBadRequest):
+    error_type = "https://api.backend.ai/probs/idle-checker-type-change-not-allowed"
+    error_title = "Changing an idle checker's type is not allowed."

--- a/src/ai/backend/manager/models/idle_checker/conditions.py
+++ b/src/ai/backend/manager/models/idle_checker/conditions.py
@@ -1,15 +1,166 @@
 from __future__ import annotations
 
 from collections.abc import Collection
+from datetime import datetime
+from uuid import UUID
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.idle_checker.types import IdleCheckPhase
+from ai.backend.common.data.filter_specs import StringMatchSpec
+from ai.backend.common.data.idle_checker.types import CheckerType, IdleCheckPhase
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId
 from ai.backend.manager.models.clauses import QueryCondition
+from ai.backend.manager.models.condition_utils import make_string_in_factory
 
-from .row import IdleCheckerBindingRow, SessionIdleCheckRow
+from .row import IdleCheckerBindingRow, IdleCheckerRow, SessionIdleCheckRow
+
+
+class IdleCheckerConditions:
+    by_name_in = staticmethod(make_string_in_factory(IdleCheckerRow.name))
+
+    @staticmethod
+    def by_ids(checker_ids: Collection[IdleCheckerID]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return IdleCheckerRow.id.in_(checker_ids)
+
+        return inner
+
+    @staticmethod
+    def by_name_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = IdleCheckerRow.name.ilike(f"%{spec.value}%")
+            else:
+                condition = IdleCheckerRow.name.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_name_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = sa.func.lower(IdleCheckerRow.name) == spec.value.lower()
+            else:
+                condition = IdleCheckerRow.name == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = IdleCheckerRow.name.ilike(f"{spec.value}%")
+            else:
+                condition = IdleCheckerRow.name.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = IdleCheckerRow.name.ilike(f"%{spec.value}")
+            else:
+                condition = IdleCheckerRow.name.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_checker_type_equals(checker_type: CheckerType) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return IdleCheckerRow.checker_type == checker_type
+
+        return inner
+
+    @staticmethod
+    def by_checker_type_in(checker_types: Collection[CheckerType]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return IdleCheckerRow.checker_type.in_(checker_types)
+
+        return inner
+
+    @staticmethod
+    def by_created_at_before(value: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return IdleCheckerRow.created_at < value
+
+        return inner
+
+    @staticmethod
+    def by_created_at_after(value: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return IdleCheckerRow.created_at > value
+
+        return inner
+
+    @staticmethod
+    def by_created_at_equals(value: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return IdleCheckerRow.created_at == value
+
+        return inner
+
+    @staticmethod
+    def by_updated_at_before(value: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return IdleCheckerRow.updated_at < value
+
+        return inner
+
+    @staticmethod
+    def by_updated_at_after(value: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return IdleCheckerRow.updated_at > value
+
+        return inner
+
+    @staticmethod
+    def by_updated_at_equals(value: datetime) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return IdleCheckerRow.updated_at == value
+
+        return inner
+
+    @staticmethod
+    def by_cursor_forward(cursor_id: str) -> QueryCondition:
+        cursor_uuid = IdleCheckerID(UUID(cursor_id))
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            cursor_created_at = (
+                sa.select(IdleCheckerRow.created_at)
+                .where(IdleCheckerRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return IdleCheckerRow.created_at < cursor_created_at
+
+        return inner
+
+    @staticmethod
+    def by_cursor_backward(cursor_id: str) -> QueryCondition:
+        cursor_uuid = IdleCheckerID(UUID(cursor_id))
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            cursor_created_at = (
+                sa.select(IdleCheckerRow.created_at)
+                .where(IdleCheckerRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return IdleCheckerRow.created_at > cursor_created_at
+
+        return inner
 
 
 class IdleCheckerBindingConditions:

--- a/src/ai/backend/manager/models/idle_checker/orders.py
+++ b/src/ai/backend/manager/models/idle_checker/orders.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from ai.backend.manager.models.clauses import QueryOrder
+from ai.backend.manager.models.idle_checker.row import IdleCheckerRow
+
+
+class IdleCheckerOrders:
+    @staticmethod
+    def id(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return IdleCheckerRow.id.asc()
+        return IdleCheckerRow.id.desc()
+
+    @staticmethod
+    def name(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return IdleCheckerRow.name.asc()
+        return IdleCheckerRow.name.desc()
+
+    @staticmethod
+    def checker_type(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return IdleCheckerRow.checker_type.asc()
+        return IdleCheckerRow.checker_type.desc()
+
+    @staticmethod
+    def created_at(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return IdleCheckerRow.created_at.asc()
+        return IdleCheckerRow.created_at.desc()
+
+    @staticmethod
+    def updated_at(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return IdleCheckerRow.updated_at.asc()
+        return IdleCheckerRow.updated_at.desc()

--- a/src/ai/backend/manager/models/idle_checker/row.py
+++ b/src/ai/backend/manager/models/idle_checker/row.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from ai.backend.common.data.idle_checker.types import CheckerType, IdleCheckerSpec, IdleCheckPhase
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
+from ai.backend.manager.data.idle_checker.types import IdleCheckerData
 from ai.backend.manager.models.base import GUID, Base, PydanticColumn, StrEnumType
 from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin, UpdatedAtMixin
 
@@ -44,6 +45,19 @@ class IdleCheckerRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
     spec: Mapped[IdleCheckerSpec] = mapped_column(
         "spec", PydanticColumn(IdleCheckerSpec), nullable=False
     )
+
+    def to_data(self) -> IdleCheckerData:
+        return IdleCheckerData(
+            id=self.id,
+            name=self.name,
+            description=self.description,
+            checker_type=self.checker_type,
+            target_session_types=self.target_session_types,
+            initial_grace_period_seconds=self.initial_grace_period_seconds,
+            spec=self.spec,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+        )
 
 
 class IdleCheckerBindingRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]

--- a/src/ai/backend/manager/repositories/idle_checker/creators.py
+++ b/src/ai/backend/manager/repositories/idle_checker/creators.py
@@ -4,10 +4,32 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import override
 
-from ai.backend.common.data.idle_checker.types import IdleCheckPhase
-from ai.backend.manager.models.idle_checker.row import SessionIdleCheckRow
+from ai.backend.common.data.idle_checker.types import CheckerType, IdleCheckerSpec, IdleCheckPhase
+from ai.backend.common.types import SessionTypes
+from ai.backend.manager.models.idle_checker.row import IdleCheckerRow, SessionIdleCheckRow
 from ai.backend.manager.repositories.base import CreatorSpec
 from ai.backend.manager.repositories.idle_checker.types import SessionIdleCheckPair
+
+
+@dataclass
+class IdleCheckerCreatorSpec(CreatorSpec[IdleCheckerRow]):
+    name: str
+    description: str | None
+    checker_type: CheckerType
+    target_session_types: list[SessionTypes]
+    initial_grace_period_seconds: int
+    spec: IdleCheckerSpec
+
+    @override
+    def build_row(self) -> IdleCheckerRow:
+        return IdleCheckerRow(
+            name=self.name,
+            description=self.description,
+            checker_type=self.checker_type,
+            target_session_types=self.target_session_types,
+            initial_grace_period_seconds=self.initial_grace_period_seconds,
+            spec=self.spec,
+        )
 
 
 @dataclass

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -17,8 +17,13 @@ from ai.backend.common.data.idle_checker.types import (
 from ai.backend.common.data.permission.types import ScopeType
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId, SessionTypes
-from ai.backend.manager.data.idle_checker.types import IdleCheckSession
+from ai.backend.manager.data.common.types import SearchResult
+from ai.backend.manager.data.idle_checker.types import IdleCheckerData, IdleCheckSession
 from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.errors.idle_checker import (
+    IdleCheckerNotFound,
+    IdleCheckerTypeChangeNotAllowed,
+)
 from ai.backend.manager.models.idle_checker.conditions import SessionIdleCheckConditions
 from ai.backend.manager.models.idle_checker.row import (
     IdleCheckerBindingRow,
@@ -32,9 +37,15 @@ from ai.backend.manager.repositories.base import (
     BatchQuerier,
     BatchUpdater,
     BulkCreator,
+    Creator,
     NoPagination,
+    Purger,
+    Querier,
+    Updater,
 )
-from ai.backend.manager.repositories.idle_checker.creators import SessionIdleCheckCreatorSpec
+from ai.backend.manager.repositories.idle_checker.creators import (
+    SessionIdleCheckCreatorSpec,
+)
 from ai.backend.manager.repositories.idle_checker.purgers import (
     SessionIdleCheckBatchPurgerSpec,
 )
@@ -50,6 +61,7 @@ from ai.backend.manager.repositories.idle_checker.types import (
     SessionIdleCheckPair,
 )
 from ai.backend.manager.repositories.idle_checker.updaters import (
+    IdleCheckerUpdaterSpec,
     SessionIdleCheckPhaseBatchUpdaterSpec,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider
@@ -63,6 +75,54 @@ class IdleCheckerDBSource:
 
     def __init__(self, ops_provider: DBOpsProvider) -> None:
         self._ops = ops_provider
+
+    async def create(self, creator: Creator[IdleCheckerRow]) -> IdleCheckerData:
+        async with self._ops.write_ops() as w:
+            checker = (await w.create(creator)).row
+            return checker.to_data()
+
+    async def get(self, querier: Querier[IdleCheckerRow]) -> IdleCheckerData:
+        async with self._ops.read_ops() as r:
+            checker_result = await r.query(querier)
+        if checker_result is None:
+            raise IdleCheckerNotFound(str(querier.pk_value))
+        return checker_result.row.to_data()
+
+    async def update(
+        self,
+        querier: Querier[IdleCheckerRow],
+        updater: Updater[IdleCheckerRow],
+    ) -> IdleCheckerData:
+        async with self._ops.write_ops() as w:
+            checker_result = await w.query(querier)
+            if checker_result is None:
+                raise IdleCheckerNotFound(str(querier.pk_value))
+            spec = cast(IdleCheckerUpdaterSpec, updater.spec).spec.optional_value()
+            if spec is not None and spec.type != checker_result.row.checker_type:
+                raise IdleCheckerTypeChangeNotAllowed(
+                    f"{checker_result.row.checker_type.value} cannot be changed to {spec.type.value}"
+                )
+            result = await w.update(updater)
+            if result is None:
+                raise IdleCheckerNotFound(str(querier.pk_value))
+            return result.row.to_data()
+
+    async def purge(self, purger: Purger[IdleCheckerRow]) -> IdleCheckerData:
+        async with self._ops.write_ops() as w:
+            result = await w.purge(purger)
+            if result is None:
+                raise IdleCheckerNotFound(str(purger.spec.pk_value()))
+            return result.row.to_data()
+
+    async def search(self, querier: BatchQuerier) -> SearchResult[IdleCheckerData]:
+        async with self._ops.read_ops() as r:
+            result = await r.batch_query_in_global(sa.select(IdleCheckerRow), querier)
+        return SearchResult(
+            items=[row.IdleCheckerRow.to_data() for row in result.rows],
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
 
     async def fetch_judgment_batch(
         self,

--- a/src/ai/backend/manager/repositories/idle_checker/purgers.py
+++ b/src/ai/backend/manager/repositories/idle_checker/purgers.py
@@ -7,10 +7,29 @@ from typing import override
 import sqlalchemy as sa
 
 from ai.backend.common.data.idle_checker.types import IdleCheckPhase
-from ai.backend.manager.models.idle_checker.row import SessionIdleCheckRow
+from ai.backend.common.identifier.idle_checker import IdleCheckerID
+from ai.backend.manager.models.idle_checker.row import IdleCheckerRow, SessionIdleCheckRow
 from ai.backend.manager.repositories.base import BatchPurgerSpec
+from ai.backend.manager.repositories.base.purger import PurgerSpec
 from ai.backend.manager.repositories.base.types import ConflictCheck
 from ai.backend.manager.repositories.idle_checker.types import SessionIdleCheckPair
+
+
+@dataclass
+class IdleCheckerPurgerSpec(PurgerSpec[IdleCheckerRow]):
+    checker_id: IdleCheckerID
+
+    @override
+    def row_class(self) -> type[IdleCheckerRow]:
+        return IdleCheckerRow
+
+    @override
+    def pk_value(self) -> IdleCheckerID:
+        return self.checker_id
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
 
 
 @dataclass

--- a/src/ai/backend/manager/repositories/idle_checker/repository.py
+++ b/src/ai/backend/manager/repositories/idle_checker/repository.py
@@ -4,7 +4,17 @@ from collections.abc import Collection, Sequence
 from datetime import datetime
 
 from ai.backend.common.data.idle_checker.types import IdleCheckPhase
+from ai.backend.manager.data.common.types import SearchResult
+from ai.backend.manager.data.idle_checker.types import IdleCheckerData
 from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.models.idle_checker.row import IdleCheckerRow
+from ai.backend.manager.repositories.base import (
+    BatchQuerier,
+    Creator,
+    Purger,
+    Querier,
+    Updater,
+)
 from ai.backend.manager.repositories.idle_checker.db_source.db_source import IdleCheckerDBSource
 from ai.backend.manager.repositories.idle_checker.types import (
     ExpiredIdleCheckBatchData,
@@ -25,6 +35,22 @@ class IdleCheckerRepository:
 
     def __init__(self, ops_provider: DBOpsProvider) -> None:
         self._db_source = IdleCheckerDBSource(ops_provider)
+
+    async def create(self, creator: Creator[IdleCheckerRow]) -> IdleCheckerData:
+        return await self._db_source.create(creator)
+
+    async def get(self, querier: Querier[IdleCheckerRow]) -> IdleCheckerData:
+        return await self._db_source.get(querier)
+
+    async def update(self, updater: Updater[IdleCheckerRow]) -> IdleCheckerData:
+        querier = Querier(row_class=IdleCheckerRow, pk_value=updater.pk_value)
+        return await self._db_source.update(querier, updater)
+
+    async def purge(self, purger: Purger[IdleCheckerRow]) -> IdleCheckerData:
+        return await self._db_source.purge(purger)
+
+    async def search(self, querier: BatchQuerier) -> SearchResult[IdleCheckerData]:
+        return await self._db_source.search(querier)
 
     async def fetch_judgment_batch(
         self, session_statuses: Collection[SessionStatus]

--- a/src/ai/backend/manager/repositories/idle_checker/types.py
+++ b/src/ai/backend/manager/repositories/idle_checker/types.py
@@ -1,4 +1,4 @@
-"""Repository result types for the idle-check reconciler batch."""
+"""Repository result types for idle checkers."""
 
 from __future__ import annotations
 

--- a/src/ai/backend/manager/repositories/idle_checker/updaters.py
+++ b/src/ai/backend/manager/repositories/idle_checker/updaters.py
@@ -1,11 +1,39 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, override
 
-from ai.backend.common.data.idle_checker.types import IdleCheckPhase
-from ai.backend.manager.models.idle_checker.row import SessionIdleCheckRow
-from ai.backend.manager.repositories.base import BatchUpdaterSpec
+from ai.backend.common.data.idle_checker.types import IdleCheckerSpec, IdleCheckPhase
+from ai.backend.common.types import SessionTypes
+from ai.backend.manager.models.idle_checker.row import IdleCheckerRow, SessionIdleCheckRow
+from ai.backend.manager.repositories.base import BatchUpdaterSpec, UpdaterSpec
+from ai.backend.manager.types import OptionalState, TriState
+
+
+@dataclass
+class IdleCheckerUpdaterSpec(UpdaterSpec[IdleCheckerRow]):
+    name: OptionalState[str] = field(default_factory=OptionalState[str].nop)
+    description: TriState[str] = field(default_factory=TriState[str].nop)
+    target_session_types: OptionalState[list[SessionTypes]] = field(
+        default_factory=OptionalState[list[SessionTypes]].nop
+    )
+    initial_grace_period_seconds: OptionalState[int] = field(default_factory=OptionalState[int].nop)
+    spec: OptionalState[IdleCheckerSpec] = field(default_factory=OptionalState[IdleCheckerSpec].nop)
+
+    @property
+    @override
+    def row_class(self) -> type[IdleCheckerRow]:
+        return IdleCheckerRow
+
+    @override
+    def build_values(self) -> dict[str, Any]:
+        to_update: dict[str, Any] = {}
+        self.name.update_dict(to_update, "name")
+        self.description.update_dict(to_update, "description")
+        self.target_session_types.update_dict(to_update, "target_session_types")
+        self.initial_grace_period_seconds.update_dict(to_update, "initial_grace_period_seconds")
+        self.spec.update_dict(to_update, "spec")
+        return to_update
 
 
 @dataclass

--- a/tests/unit/manager/repositories/idle_checker/test_crud.py
+++ b/tests/unit/manager/repositories/idle_checker/test_crud.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from ai.backend.common.data.idle_checker.types import (
+    CheckerType,
+    IdleCheckerSpec,
+    NetworkTimeoutSpec,
+    SessionLifetimeSpec,
+)
+from ai.backend.common.identifier.idle_checker import IdleCheckerID
+from ai.backend.common.types import SessionTypes
+from ai.backend.manager.data.idle_checker.types import IdleCheckerData
+from ai.backend.manager.errors.idle_checker import (
+    IdleCheckerNotFound,
+    IdleCheckerTypeChangeNotAllowed,
+)
+from ai.backend.manager.models.idle_checker.conditions import IdleCheckerConditions
+from ai.backend.manager.models.idle_checker.row import IdleCheckerRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.base import (
+    BatchQuerier,
+    Creator,
+    NoPagination,
+    Purger,
+    Querier,
+    Updater,
+)
+from ai.backend.manager.repositories.idle_checker.creators import IdleCheckerCreatorSpec
+from ai.backend.manager.repositories.idle_checker.purgers import IdleCheckerPurgerSpec
+from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
+from ai.backend.manager.repositories.idle_checker.updaters import IdleCheckerUpdaterSpec
+from ai.backend.manager.repositories.ops import DBOpsProvider
+from ai.backend.manager.types import OptionalState
+from ai.backend.testutils.db import with_tables
+
+
+@pytest.fixture
+async def database(
+    database_connection: ExtendedAsyncSAEngine,
+) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+    async with with_tables(
+        database_connection,
+        [IdleCheckerRow],
+    ):
+        yield database_connection
+
+
+@pytest.fixture
+def repository(database: ExtendedAsyncSAEngine) -> IdleCheckerRepository:
+    return IdleCheckerRepository(DBOpsProvider(database))
+
+
+@pytest.fixture
+def creator_spec() -> IdleCheckerCreatorSpec:
+    return IdleCheckerCreatorSpec(
+        name="personal lifetime",
+        description=None,
+        checker_type=CheckerType.SESSION_LIFETIME,
+        target_session_types=[SessionTypes.INTERACTIVE],
+        initial_grace_period_seconds=30,
+        spec=IdleCheckerSpec(
+            type=CheckerType.SESSION_LIFETIME,
+            session_lifetime=SessionLifetimeSpec(max_lifetime_seconds=3600),
+        ),
+    )
+
+
+@pytest.fixture
+async def created_checker(
+    repository: IdleCheckerRepository,
+    creator_spec: IdleCheckerCreatorSpec,
+) -> IdleCheckerData:
+    return await repository.create(Creator(spec=creator_spec))
+
+
+class TestCreate:
+    async def test_create_returns_checker(
+        self,
+        repository: IdleCheckerRepository,
+        creator_spec: IdleCheckerCreatorSpec,
+    ) -> None:
+        checker = await repository.create(Creator(spec=creator_spec))
+
+        assert checker.name == creator_spec.name
+        assert checker.checker_type == creator_spec.checker_type
+
+
+class TestGet:
+    async def test_get_returns_checker(
+        self,
+        repository: IdleCheckerRepository,
+        created_checker: IdleCheckerData,
+    ) -> None:
+        fetched = await repository.get(
+            Querier(row_class=IdleCheckerRow, pk_value=created_checker.id)
+        )
+
+        assert fetched == created_checker
+
+    async def test_get_missing_checker_raises(
+        self,
+        repository: IdleCheckerRepository,
+    ) -> None:
+        with pytest.raises(IdleCheckerNotFound):
+            await repository.get(
+                Querier(row_class=IdleCheckerRow, pk_value=IdleCheckerID(uuid.uuid4()))
+            )
+
+
+class TestSearch:
+    async def test_search_returns_matching_checker(
+        self,
+        repository: IdleCheckerRepository,
+        created_checker: IdleCheckerData,
+    ) -> None:
+        result = await repository.search(
+            BatchQuerier(
+                conditions=[IdleCheckerConditions.by_ids([created_checker.id])],
+                pagination=NoPagination(),
+            )
+        )
+
+        assert result.items == [created_checker]
+        assert result.total_count == 1
+
+
+class TestUpdate:
+    async def test_update_changes_mutable_fields(
+        self,
+        repository: IdleCheckerRepository,
+        created_checker: IdleCheckerData,
+    ) -> None:
+        updated = await repository.update(
+            Updater(
+                spec=IdleCheckerUpdaterSpec(name=OptionalState.update("renamed lifetime")),
+                pk_value=created_checker.id,
+            )
+        )
+
+        assert updated.name == "renamed lifetime"
+        fetched = await repository.get(
+            Querier(row_class=IdleCheckerRow, pk_value=created_checker.id)
+        )
+        assert fetched.name == "renamed lifetime"
+
+    async def test_rejects_checker_type_change(
+        self,
+        repository: IdleCheckerRepository,
+        created_checker: IdleCheckerData,
+    ) -> None:
+        with pytest.raises(IdleCheckerTypeChangeNotAllowed):
+            await repository.update(
+                Updater(
+                    spec=IdleCheckerUpdaterSpec(
+                        spec=OptionalState.update(
+                            IdleCheckerSpec(
+                                type=CheckerType.NETWORK_TIMEOUT,
+                                network=NetworkTimeoutSpec(),
+                            )
+                        )
+                    ),
+                    pk_value=created_checker.id,
+                )
+            )
+
+    async def test_update_missing_checker_raises(
+        self,
+        repository: IdleCheckerRepository,
+    ) -> None:
+        with pytest.raises(IdleCheckerNotFound):
+            await repository.update(
+                Updater(
+                    spec=IdleCheckerUpdaterSpec(name=OptionalState.update("renamed lifetime")),
+                    pk_value=IdleCheckerID(uuid.uuid4()),
+                )
+            )
+
+
+class TestPurge:
+    async def test_purge_removes_checker(
+        self,
+        database: ExtendedAsyncSAEngine,
+        repository: IdleCheckerRepository,
+        created_checker: IdleCheckerData,
+    ) -> None:
+        purged = await repository.purge(Purger(spec=IdleCheckerPurgerSpec(created_checker.id)))
+
+        async with database.begin_readonly_session() as db_sess:
+            checker = await db_sess.get(IdleCheckerRow, created_checker.id)
+
+        assert purged == created_checker
+        assert checker is None
+
+    async def test_purge_missing_checker_raises(
+        self,
+        repository: IdleCheckerRepository,
+    ) -> None:
+        with pytest.raises(IdleCheckerNotFound):
+            await repository.purge(Purger(spec=IdleCheckerPurgerSpec(IdleCheckerID(uuid.uuid4()))))


### PR DESCRIPTION
## Summary

- Add create, get, search, update, and hard-delete operations for idle checker definitions.
- Add reusable query conditions, ordering, creator/updater/purger specs, and row-to-data conversion.
- Cover the repository contract with real-database CRUD tests.

This PR intentionally excludes bindings, soft deletion, service/API wiring, and user-scoped RBAC.

## Test plan

- [x] `pants lint` for the changed repository targets
- [x] `pants check` for the changed repository targets
- [x] `pants test tests/unit/manager/repositories/idle_checker/test_crud.py`
- [x] Repository branch pre-push lint/check/test suite

Resolves BA-6579
Refs BEP-1054