### PR TITLE
test: provision project virtual scopes in component fixtures

### DIFF
--- a/changes/13139.test.md
+++ b/changes/13139.test.md
@@ -1,0 +1,1 @@
+Provision project virtual scopes in component test fixtures.

--- a/tests/component/auth/test_auth.py
+++ b/tests/component/auth/test_auth.py
@@ -54,6 +54,8 @@ from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
 )
 from ai.backend.manager.models.user import UserRole, users
+from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.testutils.fixtures import DomainFixtureData
 
@@ -141,10 +143,28 @@ async def signup_default_project(
                 resource_policy=resource_policy_fixture,
             )
         )
+        virtual_scope_id = uuid.uuid4()
         await conn.execute(
             sa.insert(VirtualScopeRow.__table__).values(
+                id=virtual_scope_id,
                 scope_type=ScopeType.PROJECT,
                 scope_id=data.project_id,
+            )
+        )
+        await conn.execute(
+            sa.insert(EntityMembershipRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                entity_type=EntityType.PROJECT,
+                entity_id=data.project_id,
+                permission_cap=None,
+            )
+        )
+        await conn.execute(
+            sa.insert(ScopeBindingRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                scope_type=ScopeType.PROJECT,
+                scope_id=data.project_id,
+                permission_cap=None,
             )
         )
     yield data
@@ -294,10 +314,28 @@ async def cross_domain_fixture(
                 resource_policy=resource_policy_fixture,
             )
         )
+        virtual_scope_id = uuid.uuid4()
         await conn.execute(
             sa.insert(VirtualScopeRow.__table__).values(
+                id=virtual_scope_id,
                 scope_type=ScopeType.PROJECT,
                 scope_id=group_id,
+            )
+        )
+        await conn.execute(
+            sa.insert(EntityMembershipRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                entity_type=EntityType.PROJECT,
+                entity_id=group_id,
+                permission_cap=None,
+            )
+        )
+        await conn.execute(
+            sa.insert(ScopeBindingRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                scope_type=ScopeType.PROJECT,
+                scope_id=group_id,
+                permission_cap=None,
             )
         )
         await conn.execute(

--- a/tests/component/auth/test_auth.py
+++ b/tests/component/auth/test_auth.py
@@ -54,6 +54,7 @@ from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
 )
 from ai.backend.manager.models.user import UserRole, users
+from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.testutils.fixtures import DomainFixtureData
 
 from .conftest import AuthUserFixtureData
@@ -140,6 +141,12 @@ async def signup_default_project(
                 resource_policy=resource_policy_fixture,
             )
         )
+        await conn.execute(
+            sa.insert(VirtualScopeRow.__table__).values(
+                scope_type=ScopeType.PROJECT,
+                scope_id=data.project_id,
+            )
+        )
     yield data
     async with db_engine.begin() as conn:
         await conn.execute(
@@ -150,6 +157,12 @@ async def signup_default_project(
         for email in data.cleanup_emails:
             await conn.execute(keypairs.delete().where(keypairs.c.user_id == email))
             await conn.execute(users.delete().where(users.c.email == email))
+        await conn.execute(
+            VirtualScopeRow.__table__.delete().where(
+                VirtualScopeRow.__table__.c.scope_type == ScopeType.PROJECT,
+                VirtualScopeRow.__table__.c.scope_id == data.project_id,
+            )
+        )
         await conn.execute(
             GroupRow.__table__.delete().where(GroupRow.__table__.c.id == data.project_id),
         )
@@ -282,6 +295,12 @@ async def cross_domain_fixture(
             )
         )
         await conn.execute(
+            sa.insert(VirtualScopeRow.__table__).values(
+                scope_type=ScopeType.PROJECT,
+                scope_id=group_id,
+            )
+        )
+        await conn.execute(
             sa.insert(users).values(
                 uuid=str(admin_data.user_uuid),
                 username=f"other-admin-{admin_unique}",
@@ -389,6 +408,12 @@ async def cross_domain_fixture(
         await conn.execute(
             users.delete().where(
                 users.c.uuid.in_([str(admin_data.user_uuid), str(user_data.user_uuid)])
+            )
+        )
+        await conn.execute(
+            VirtualScopeRow.__table__.delete().where(
+                VirtualScopeRow.__table__.c.scope_type == ScopeType.PROJECT,
+                VirtualScopeRow.__table__.c.scope_id == group_id,
             )
         )
         await conn.execute(GroupRow.__table__.delete().where(GroupRow.__table__.c.id == group_id))

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -132,6 +132,8 @@ from ai.backend.manager.models.session_template import session_templates
 from ai.backend.manager.models.user import users
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import vfolders
+from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.notification.notification_center import NotificationCenter
 from ai.backend.manager.plugin.network import NetworkPluginContext
@@ -739,10 +741,28 @@ async def group_fixture(
                 resource_policy=resource_policy_fixture,
             )
         )
+        virtual_scope_id = uuid.uuid4()
         await conn.execute(
             sa.insert(VirtualScopeRow.__table__).values(
+                id=virtual_scope_id,
                 scope_type=ScopeType.PROJECT,
                 scope_id=group_id,
+            )
+        )
+        await conn.execute(
+            sa.insert(EntityMembershipRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                entity_type=EntityType.PROJECT,
+                entity_id=group_id,
+                permission_cap=None,
+            )
+        )
+        await conn.execute(
+            sa.insert(ScopeBindingRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                scope_type=ScopeType.PROJECT,
+                scope_id=group_id,
+                permission_cap=None,
             )
         )
     yield group_id

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -132,6 +132,7 @@ from ai.backend.manager.models.session_template import session_templates
 from ai.backend.manager.models.user import users
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import vfolders
+from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.notification.notification_center import NotificationCenter
 from ai.backend.manager.plugin.network import NetworkPluginContext
 from ai.backend.manager.registry import AgentRegistry
@@ -738,8 +739,20 @@ async def group_fixture(
                 resource_policy=resource_policy_fixture,
             )
         )
+        await conn.execute(
+            sa.insert(VirtualScopeRow.__table__).values(
+                scope_type=ScopeType.PROJECT,
+                scope_id=group_id,
+            )
+        )
     yield group_id
     async with db_engine.begin() as conn:
+        await conn.execute(
+            VirtualScopeRow.__table__.delete().where(
+                VirtualScopeRow.__table__.c.scope_type == ScopeType.PROJECT,
+                VirtualScopeRow.__table__.c.scope_id == group_id,
+            )
+        )
         await conn.execute(GroupRow.__table__.delete().where(GroupRow.__table__.c.id == group_id))
 
 

--- a/tests/component/fair_share/conftest.py
+++ b/tests/component/fair_share/conftest.py
@@ -9,6 +9,7 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
+from ai.backend.common.data.permission.types import ScopeType
 from ai.backend.common.identifier.resource_group import ResourceGroupName
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.api.rest.fair_share.handler import FairShareAPIHandler
@@ -18,6 +19,7 @@ from ai.backend.manager.api.rest.types import RouteDeps
 from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.scaling_group import sgroups_for_groups
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.repositories.fair_share.repository import FairShareRepository
 from ai.backend.manager.repositories.resource_usage_history.repository import (
     ResourceUsageHistoryRepository,
@@ -101,6 +103,12 @@ async def group_fixture(
             )
         )
         await conn.execute(
+            sa.insert(VirtualScopeRow.__table__).values(
+                scope_type=ScopeType.PROJECT,
+                scope_id=group_id,
+            )
+        )
+        await conn.execute(
             sa.insert(sgroups_for_groups).values(
                 scaling_group=scaling_group_name,
                 group=group_id,
@@ -110,5 +118,11 @@ async def group_fixture(
     async with db_engine.begin() as conn:
         await conn.execute(
             sgroups_for_groups.delete().where(sgroups_for_groups.c.group == group_id)
+        )
+        await conn.execute(
+            VirtualScopeRow.__table__.delete().where(
+                VirtualScopeRow.__table__.c.scope_type == ScopeType.PROJECT,
+                VirtualScopeRow.__table__.c.scope_id == group_id,
+            )
         )
         await conn.execute(GroupRow.__table__.delete().where(GroupRow.__table__.c.id == group_id))

--- a/tests/component/fair_share/conftest.py
+++ b/tests/component/fair_share/conftest.py
@@ -9,7 +9,7 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
-from ai.backend.common.data.permission.types import ScopeType
+from ai.backend.common.data.permission.types import EntityType, ScopeType
 from ai.backend.common.identifier.resource_group import ResourceGroupName
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.api.rest.fair_share.handler import FairShareAPIHandler
@@ -19,6 +19,8 @@ from ai.backend.manager.api.rest.types import RouteDeps
 from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.scaling_group import sgroups_for_groups
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.repositories.fair_share.repository import FairShareRepository
 from ai.backend.manager.repositories.resource_usage_history.repository import (
@@ -102,10 +104,28 @@ async def group_fixture(
                 resource_policy=resource_policy_fixture,
             )
         )
+        virtual_scope_id = uuid.uuid4()
         await conn.execute(
             sa.insert(VirtualScopeRow.__table__).values(
+                id=virtual_scope_id,
                 scope_type=ScopeType.PROJECT,
                 scope_id=group_id,
+            )
+        )
+        await conn.execute(
+            sa.insert(EntityMembershipRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                entity_type=EntityType.PROJECT,
+                entity_id=group_id,
+                permission_cap=None,
+            )
+        )
+        await conn.execute(
+            sa.insert(ScopeBindingRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                scope_type=ScopeType.PROJECT,
+                scope_id=group_id,
+                permission_cap=None,
             )
         )
         await conn.execute(

--- a/tests/component/group/conftest.py
+++ b/tests/component/group/conftest.py
@@ -10,6 +10,7 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
+from ai.backend.common.data.permission.types import ScopeType
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.api.rest.group.handler import GroupHandler
 from ai.backend.manager.api.rest.group.registry import register_group_routes
@@ -21,6 +22,7 @@ from ai.backend.manager.dependencies.infrastructure.redis import ValkeyClients
 from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.rbac import ProjectScope
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.repositories.container_registry.repository import (
     ContainerRegistryRepository,
 )
@@ -139,6 +141,18 @@ async def target_group(
                 resource_policy=resource_policy_fixture,
             )
         )
+        await conn.execute(
+            sa.insert(VirtualScopeRow.__table__).values(
+                scope_type=ScopeType.PROJECT,
+                scope_id=group_id,
+            )
+        )
     yield group_id
     async with db_engine.begin() as conn:
+        await conn.execute(
+            VirtualScopeRow.__table__.delete().where(
+                VirtualScopeRow.__table__.c.scope_type == ScopeType.PROJECT,
+                VirtualScopeRow.__table__.c.scope_id == group_id,
+            )
+        )
         await conn.execute(GroupRow.__table__.delete().where(GroupRow.__table__.c.id == group_id))

--- a/tests/component/group/conftest.py
+++ b/tests/component/group/conftest.py
@@ -10,7 +10,7 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
-from ai.backend.common.data.permission.types import ScopeType
+from ai.backend.common.data.permission.types import EntityType, ScopeType
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.api.rest.group.handler import GroupHandler
 from ai.backend.manager.api.rest.group.registry import register_group_routes
@@ -22,6 +22,8 @@ from ai.backend.manager.dependencies.infrastructure.redis import ValkeyClients
 from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.rbac import ProjectScope
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.repositories.container_registry.repository import (
     ContainerRegistryRepository,
@@ -141,10 +143,28 @@ async def target_group(
                 resource_policy=resource_policy_fixture,
             )
         )
+        virtual_scope_id = uuid.uuid4()
         await conn.execute(
             sa.insert(VirtualScopeRow.__table__).values(
+                id=virtual_scope_id,
                 scope_type=ScopeType.PROJECT,
                 scope_id=group_id,
+            )
+        )
+        await conn.execute(
+            sa.insert(EntityMembershipRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                entity_type=EntityType.PROJECT,
+                entity_id=group_id,
+                permission_cap=None,
+            )
+        )
+        await conn.execute(
+            sa.insert(ScopeBindingRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                scope_type=ScopeType.PROJECT,
+                scope_id=group_id,
+                permission_cap=None,
             )
         )
     yield group_id

--- a/tests/component/group/test_group_management.py
+++ b/tests/component/group/test_group_management.py
@@ -25,6 +25,7 @@ from ai.backend.client.v2.exceptions import (
 )
 from ai.backend.client.v2.registry import BackendAIClientRegistry
 from ai.backend.common.container_registry import ContainerRegistryType
+from ai.backend.common.data.permission.types import ScopeType
 from ai.backend.common.dto.manager.deployment.types import OrderDirection
 from ai.backend.common.dto.manager.group.request import GroupFilter, SearchGroupsRequest
 from ai.backend.common.dto.manager.group.response import (
@@ -50,6 +51,7 @@ from ai.backend.manager.models.image import ImageRow, ImageType
 from ai.backend.manager.models.kernel import KernelRow, KernelStatus
 from ai.backend.manager.models.session import SessionRow, SessionStatus
 from ai.backend.manager.models.vfolder import VFolderRow
+from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.testutils.fixtures import DomainFixtureData
 
 
@@ -73,9 +75,21 @@ async def test_group_for_deletion(
                 resource_policy=resource_policy_fixture,
             )
         )
+        await conn.execute(
+            sa.insert(VirtualScopeRow.__table__).values(
+                scope_type=ScopeType.PROJECT,
+                scope_id=group_id,
+            )
+        )
     yield group_id
     # Cleanup: force delete if still exists
     async with db_engine.begin() as conn:
+        await conn.execute(
+            VirtualScopeRow.__table__.delete().where(
+                VirtualScopeRow.__table__.c.scope_type == ScopeType.PROJECT,
+                VirtualScopeRow.__table__.c.scope_id == group_id,
+            )
+        )
         await conn.execute(GroupRow.__table__.delete().where(GroupRow.__table__.c.id == group_id))
 
 
@@ -107,6 +121,12 @@ async def group_with_vfolder_mounted(
                 is_active=True,
                 domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
+            )
+        )
+        await conn.execute(
+            sa.insert(VirtualScopeRow.__table__).values(
+                scope_type=ScopeType.PROJECT,
+                scope_id=group_id,
             )
         )
         # Create vfolder
@@ -184,6 +204,12 @@ async def group_with_vfolder_mounted(
         await conn.execute(
             VFolderRow.__table__.delete().where(VFolderRow.__table__.c.id == vfolder_id)
         )
+        await conn.execute(
+            VirtualScopeRow.__table__.delete().where(
+                VirtualScopeRow.__table__.c.scope_type == ScopeType.PROJECT,
+                VirtualScopeRow.__table__.c.scope_id == group_id,
+            )
+        )
         await conn.execute(GroupRow.__table__.delete().where(GroupRow.__table__.c.id == group_id))
 
 
@@ -214,6 +240,12 @@ async def group_with_active_kernel(
                 is_active=True,
                 domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
+            )
+        )
+        await conn.execute(
+            sa.insert(VirtualScopeRow.__table__).values(
+                scope_type=ScopeType.PROJECT,
+                scope_id=group_id,
             )
         )
         # Create session (required FK for kernel)
@@ -275,6 +307,12 @@ async def group_with_active_kernel(
         await conn.execute(
             SessionRow.__table__.delete().where(SessionRow.__table__.c.id == session_id)
         )
+        await conn.execute(
+            VirtualScopeRow.__table__.delete().where(
+                VirtualScopeRow.__table__.c.scope_type == ScopeType.PROJECT,
+                VirtualScopeRow.__table__.c.scope_id == group_id,
+            )
+        )
         await conn.execute(GroupRow.__table__.delete().where(GroupRow.__table__.c.id == group_id))
 
 
@@ -304,6 +342,12 @@ async def group_with_active_endpoint(
                 is_active=True,
                 domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
+            )
+        )
+        await conn.execute(
+            sa.insert(VirtualScopeRow.__table__).values(
+                scope_type=ScopeType.PROJECT,
+                scope_id=group_id,
             )
         )
         # Create container registry (required by image)
@@ -364,6 +408,12 @@ async def group_with_active_endpoint(
                 ContainerRegistryRow.__table__.c.id == registry_id
             )
         )
+        await conn.execute(
+            VirtualScopeRow.__table__.delete().where(
+                VirtualScopeRow.__table__.c.scope_type == ScopeType.PROJECT,
+                VirtualScopeRow.__table__.c.scope_id == group_id,
+            )
+        )
         await conn.execute(GroupRow.__table__.delete().where(GroupRow.__table__.c.id == group_id))
 
 
@@ -390,6 +440,12 @@ async def multiple_test_groups(
                     resource_policy=resource_policy_fixture,
                 )
             )
+            await conn.execute(
+                sa.insert(VirtualScopeRow.__table__).values(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=group_id,
+                )
+            )
             group_ids.append(group_id)
 
     yield group_ids
@@ -397,6 +453,12 @@ async def multiple_test_groups(
     # Cleanup
     async with db_engine.begin() as conn:
         for group_id in group_ids:
+            await conn.execute(
+                VirtualScopeRow.__table__.delete().where(
+                    VirtualScopeRow.__table__.c.scope_type == ScopeType.PROJECT,
+                    VirtualScopeRow.__table__.c.scope_id == group_id,
+                )
+            )
             await conn.execute(
                 GroupRow.__table__.delete().where(GroupRow.__table__.c.id == group_id)
             )

--- a/tests/component/group/test_group_management.py
+++ b/tests/component/group/test_group_management.py
@@ -25,7 +25,7 @@ from ai.backend.client.v2.exceptions import (
 )
 from ai.backend.client.v2.registry import BackendAIClientRegistry
 from ai.backend.common.container_registry import ContainerRegistryType
-from ai.backend.common.data.permission.types import ScopeType
+from ai.backend.common.data.permission.types import EntityType, ScopeType
 from ai.backend.common.dto.manager.deployment.types import OrderDirection
 from ai.backend.common.dto.manager.group.request import GroupFilter, SearchGroupsRequest
 from ai.backend.common.dto.manager.group.response import (
@@ -51,6 +51,8 @@ from ai.backend.manager.models.image import ImageRow, ImageType
 from ai.backend.manager.models.kernel import KernelRow, KernelStatus
 from ai.backend.manager.models.session import SessionRow, SessionStatus
 from ai.backend.manager.models.vfolder import VFolderRow
+from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.testutils.fixtures import DomainFixtureData
 
@@ -75,10 +77,28 @@ async def test_group_for_deletion(
                 resource_policy=resource_policy_fixture,
             )
         )
+        virtual_scope_id = uuid.uuid4()
         await conn.execute(
             sa.insert(VirtualScopeRow.__table__).values(
+                id=virtual_scope_id,
                 scope_type=ScopeType.PROJECT,
                 scope_id=group_id,
+            )
+        )
+        await conn.execute(
+            sa.insert(EntityMembershipRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                entity_type=EntityType.PROJECT,
+                entity_id=group_id,
+                permission_cap=None,
+            )
+        )
+        await conn.execute(
+            sa.insert(ScopeBindingRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                scope_type=ScopeType.PROJECT,
+                scope_id=group_id,
+                permission_cap=None,
             )
         )
     yield group_id
@@ -123,10 +143,28 @@ async def group_with_vfolder_mounted(
                 resource_policy=resource_policy_fixture,
             )
         )
+        virtual_scope_id = uuid.uuid4()
         await conn.execute(
             sa.insert(VirtualScopeRow.__table__).values(
+                id=virtual_scope_id,
                 scope_type=ScopeType.PROJECT,
                 scope_id=group_id,
+            )
+        )
+        await conn.execute(
+            sa.insert(EntityMembershipRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                entity_type=EntityType.PROJECT,
+                entity_id=group_id,
+                permission_cap=None,
+            )
+        )
+        await conn.execute(
+            sa.insert(ScopeBindingRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                scope_type=ScopeType.PROJECT,
+                scope_id=group_id,
+                permission_cap=None,
             )
         )
         # Create vfolder
@@ -242,10 +280,28 @@ async def group_with_active_kernel(
                 resource_policy=resource_policy_fixture,
             )
         )
+        virtual_scope_id = uuid.uuid4()
         await conn.execute(
             sa.insert(VirtualScopeRow.__table__).values(
+                id=virtual_scope_id,
                 scope_type=ScopeType.PROJECT,
                 scope_id=group_id,
+            )
+        )
+        await conn.execute(
+            sa.insert(EntityMembershipRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                entity_type=EntityType.PROJECT,
+                entity_id=group_id,
+                permission_cap=None,
+            )
+        )
+        await conn.execute(
+            sa.insert(ScopeBindingRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                scope_type=ScopeType.PROJECT,
+                scope_id=group_id,
+                permission_cap=None,
             )
         )
         # Create session (required FK for kernel)
@@ -344,10 +400,28 @@ async def group_with_active_endpoint(
                 resource_policy=resource_policy_fixture,
             )
         )
+        virtual_scope_id = uuid.uuid4()
         await conn.execute(
             sa.insert(VirtualScopeRow.__table__).values(
+                id=virtual_scope_id,
                 scope_type=ScopeType.PROJECT,
                 scope_id=group_id,
+            )
+        )
+        await conn.execute(
+            sa.insert(EntityMembershipRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                entity_type=EntityType.PROJECT,
+                entity_id=group_id,
+                permission_cap=None,
+            )
+        )
+        await conn.execute(
+            sa.insert(ScopeBindingRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                scope_type=ScopeType.PROJECT,
+                scope_id=group_id,
+                permission_cap=None,
             )
         )
         # Create container registry (required by image)
@@ -440,10 +514,28 @@ async def multiple_test_groups(
                     resource_policy=resource_policy_fixture,
                 )
             )
+            virtual_scope_id = uuid.uuid4()
             await conn.execute(
                 sa.insert(VirtualScopeRow.__table__).values(
+                    id=virtual_scope_id,
                     scope_type=ScopeType.PROJECT,
                     scope_id=group_id,
+                )
+            )
+            await conn.execute(
+                sa.insert(EntityMembershipRow.__table__).values(
+                    virtual_scope_id=virtual_scope_id,
+                    entity_type=EntityType.PROJECT,
+                    entity_id=group_id,
+                    permission_cap=None,
+                )
+            )
+            await conn.execute(
+                sa.insert(ScopeBindingRow.__table__).values(
+                    virtual_scope_id=virtual_scope_id,
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=group_id,
+                    permission_cap=None,
                 )
             )
             group_ids.append(group_id)

--- a/tests/component/model_card/conftest.py
+++ b/tests/component/model_card/conftest.py
@@ -50,6 +50,7 @@ from ai.backend.manager.models.rbac_models.permission.permission import Permissi
 from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import vfolders
+from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.repositories.group.repositories import GroupRepositories
 from ai.backend.manager.repositories.group.repository import GroupRepository
 from ai.backend.manager.repositories.model_card.repository import ModelCardRepository
@@ -200,10 +201,22 @@ async def model_store_project_fixture(
                 type=ProjectType.MODEL_STORE,
             )
         )
+        await conn.execute(
+            sa.insert(VirtualScopeRow.__table__).values(
+                scope_type=ScopeType.PROJECT,
+                scope_id=project_id,
+            )
+        )
     yield project_id
     async with db_engine.begin() as conn:
         await conn.execute(
             ModelCardRow.__table__.delete().where(ModelCardRow.__table__.c.project == project_id)
+        )
+        await conn.execute(
+            VirtualScopeRow.__table__.delete().where(
+                VirtualScopeRow.__table__.c.scope_type == ScopeType.PROJECT,
+                VirtualScopeRow.__table__.c.scope_id == project_id,
+            )
         )
         await conn.execute(GroupRow.__table__.delete().where(GroupRow.__table__.c.id == project_id))
 
@@ -228,10 +241,22 @@ async def second_project_fixture(
                 type=ProjectType.MODEL_STORE,
             )
         )
+        await conn.execute(
+            sa.insert(VirtualScopeRow.__table__).values(
+                scope_type=ScopeType.PROJECT,
+                scope_id=project_id,
+            )
+        )
     yield project_id
     async with db_engine.begin() as conn:
         await conn.execute(
             ModelCardRow.__table__.delete().where(ModelCardRow.__table__.c.project == project_id)
+        )
+        await conn.execute(
+            VirtualScopeRow.__table__.delete().where(
+                VirtualScopeRow.__table__.c.scope_type == ScopeType.PROJECT,
+                VirtualScopeRow.__table__.c.scope_id == project_id,
+            )
         )
         await conn.execute(GroupRow.__table__.delete().where(GroupRow.__table__.c.id == project_id))
 

--- a/tests/component/model_card/conftest.py
+++ b/tests/component/model_card/conftest.py
@@ -50,6 +50,8 @@ from ai.backend.manager.models.rbac_models.permission.permission import Permissi
 from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import vfolders
+from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.repositories.group.repositories import GroupRepositories
 from ai.backend.manager.repositories.group.repository import GroupRepository
@@ -201,10 +203,28 @@ async def model_store_project_fixture(
                 type=ProjectType.MODEL_STORE,
             )
         )
+        virtual_scope_id = uuid.uuid4()
         await conn.execute(
             sa.insert(VirtualScopeRow.__table__).values(
+                id=virtual_scope_id,
                 scope_type=ScopeType.PROJECT,
                 scope_id=project_id,
+            )
+        )
+        await conn.execute(
+            sa.insert(EntityMembershipRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                entity_type=EntityType.PROJECT,
+                entity_id=project_id,
+                permission_cap=None,
+            )
+        )
+        await conn.execute(
+            sa.insert(ScopeBindingRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                scope_type=ScopeType.PROJECT,
+                scope_id=project_id,
+                permission_cap=None,
             )
         )
     yield project_id
@@ -241,10 +261,28 @@ async def second_project_fixture(
                 type=ProjectType.MODEL_STORE,
             )
         )
+        virtual_scope_id = uuid.uuid4()
         await conn.execute(
             sa.insert(VirtualScopeRow.__table__).values(
+                id=virtual_scope_id,
                 scope_type=ScopeType.PROJECT,
                 scope_id=project_id,
+            )
+        )
+        await conn.execute(
+            sa.insert(EntityMembershipRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                entity_type=EntityType.PROJECT,
+                entity_id=project_id,
+                permission_cap=None,
+            )
+        )
+        await conn.execute(
+            sa.insert(ScopeBindingRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                scope_type=ScopeType.PROJECT,
+                scope_id=project_id,
+                permission_cap=None,
             )
         )
     yield project_id

--- a/tests/component/openid/conftest.py
+++ b/tests/component/openid/conftest.py
@@ -30,6 +30,7 @@ from authlib.jose import JsonWebKey  # pants: no-infer-dep
 from authlib.jose import jwt as jose_jwt  # pants: no-infer-dep
 from sqlalchemy.ext.asyncio import create_async_engine
 
+from ai.backend.common.data.permission.types import ScopeType
 from ai.backend.common.typed_validators import HostPortPair as HostPortPairModel
 from ai.backend.common.types import (
     ResourceSlot,
@@ -59,6 +60,7 @@ from ai.backend.manager.models.resource_policy import (
 )
 from ai.backend.manager.models.user import UserRole, UserStatus, users
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.plugin.openid.hook import OIDCHookPlugin
 from ai.backend.manager.plugin.openid.valkey_client import ValkeyOpenIDClient
 from ai.backend.manager.plugin.openid.webapp import OIDCWebAppPlugin
@@ -440,15 +442,20 @@ async def seed_data(
                 allowed_vfolder_hosts=VFolderHostPermissionMap({}),
             )
         )
-        sess.add(
-            GroupRow(
-                name="default",
-                domain_name="default",
-                total_resource_slots=ResourceSlot({}),
-                resource_policy="default",
+        project = GroupRow(
+            name="default",
+            domain_name="default",
+            total_resource_slots=ResourceSlot({}),
+            resource_policy="default",
+        )
+        sess.add(project)
+        await sess.flush()
+        await conn.execute(
+            sa.insert(VirtualScopeRow.__table__).values(
+                scope_type=ScopeType.PROJECT,
+                scope_id=project.id,
             )
         )
-        await sess.flush()
 
     yield database_engine
 
@@ -458,6 +465,12 @@ async def seed_data(
         await conn.execute(association_groups_users.delete())
         await conn.execute(keypairs.delete())
         await conn.execute(users.delete())
+        await conn.execute(
+            VirtualScopeRow.__table__.delete().where(
+                VirtualScopeRow.__table__.c.scope_type == ScopeType.PROJECT,
+                VirtualScopeRow.__table__.c.scope_id == project.id,
+            )
+        )
         await conn.execute(groups.delete())
         await conn.execute(keypair_resource_policies.delete())
         await conn.execute(project_resource_policies.delete())

--- a/tests/component/openid/conftest.py
+++ b/tests/component/openid/conftest.py
@@ -30,7 +30,7 @@ from authlib.jose import JsonWebKey  # pants: no-infer-dep
 from authlib.jose import jwt as jose_jwt  # pants: no-infer-dep
 from sqlalchemy.ext.asyncio import create_async_engine
 
-from ai.backend.common.data.permission.types import ScopeType
+from ai.backend.common.data.permission.types import EntityType, ScopeType
 from ai.backend.common.typed_validators import HostPortPair as HostPortPairModel
 from ai.backend.common.types import (
     ResourceSlot,
@@ -60,6 +60,8 @@ from ai.backend.manager.models.resource_policy import (
 )
 from ai.backend.manager.models.user import UserRole, UserStatus, users
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.plugin.openid.hook import OIDCHookPlugin
 from ai.backend.manager.plugin.openid.valkey_client import ValkeyOpenIDClient
@@ -450,10 +452,28 @@ async def seed_data(
         )
         sess.add(project)
         await sess.flush()
+        virtual_scope_id = uuid.uuid4()
         await conn.execute(
             sa.insert(VirtualScopeRow.__table__).values(
+                id=virtual_scope_id,
                 scope_type=ScopeType.PROJECT,
                 scope_id=project.id,
+            )
+        )
+        await conn.execute(
+            sa.insert(EntityMembershipRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                entity_type=EntityType.PROJECT,
+                entity_id=project.id,
+                permission_cap=None,
+            )
+        )
+        await conn.execute(
+            sa.insert(ScopeBindingRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                scope_type=ScopeType.PROJECT,
+                scope_id=project.id,
+                permission_cap=None,
             )
         )
 

--- a/tests/component/project/conftest.py
+++ b/tests/component/project/conftest.py
@@ -63,6 +63,8 @@ from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
 from ai.backend.manager.models.user import users
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.repositories.group.repositories import GroupRepositories
@@ -334,10 +336,28 @@ async def target_project_fixture(
                 resource_policy=resource_policy_fixture,
             )
         )
+        virtual_scope_id = uuid.uuid4()
         await conn.execute(
             sa.insert(VirtualScopeRow.__table__).values(
+                id=virtual_scope_id,
                 scope_type=ScopeType.PROJECT,
                 scope_id=project_id,
+            )
+        )
+        await conn.execute(
+            sa.insert(EntityMembershipRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                entity_type=EntityType.PROJECT,
+                entity_id=project_id,
+                permission_cap=None,
+            )
+        )
+        await conn.execute(
+            sa.insert(ScopeBindingRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                scope_type=ScopeType.PROJECT,
+                scope_id=project_id,
+                permission_cap=None,
             )
         )
     yield project_id
@@ -370,10 +390,28 @@ async def other_project_fixture(
                 resource_policy=resource_policy_fixture,
             )
         )
+        virtual_scope_id = uuid.uuid4()
         await conn.execute(
             sa.insert(VirtualScopeRow.__table__).values(
+                id=virtual_scope_id,
                 scope_type=ScopeType.PROJECT,
                 scope_id=project_id,
+            )
+        )
+        await conn.execute(
+            sa.insert(EntityMembershipRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                entity_type=EntityType.PROJECT,
+                entity_id=project_id,
+                permission_cap=None,
+            )
+        )
+        await conn.execute(
+            sa.insert(ScopeBindingRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                scope_type=ScopeType.PROJECT,
+                scope_id=project_id,
+                permission_cap=None,
             )
         )
     yield project_id

--- a/tests/component/project/conftest.py
+++ b/tests/component/project/conftest.py
@@ -63,6 +63,7 @@ from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
 from ai.backend.manager.models.user import users
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.repositories.group.repositories import GroupRepositories
 from ai.backend.manager.repositories.group.repository import GroupRepository
@@ -333,8 +334,20 @@ async def target_project_fixture(
                 resource_policy=resource_policy_fixture,
             )
         )
+        await conn.execute(
+            sa.insert(VirtualScopeRow.__table__).values(
+                scope_type=ScopeType.PROJECT,
+                scope_id=project_id,
+            )
+        )
     yield project_id
     async with db_engine.begin() as conn:
+        await conn.execute(
+            VirtualScopeRow.__table__.delete().where(
+                VirtualScopeRow.__table__.c.scope_type == ScopeType.PROJECT,
+                VirtualScopeRow.__table__.c.scope_id == project_id,
+            )
+        )
         await conn.execute(GroupRow.__table__.delete().where(GroupRow.__table__.c.id == project_id))
 
 
@@ -357,8 +370,20 @@ async def other_project_fixture(
                 resource_policy=resource_policy_fixture,
             )
         )
+        await conn.execute(
+            sa.insert(VirtualScopeRow.__table__).values(
+                scope_type=ScopeType.PROJECT,
+                scope_id=project_id,
+            )
+        )
     yield project_id
     async with db_engine.begin() as conn:
+        await conn.execute(
+            VirtualScopeRow.__table__.delete().where(
+                VirtualScopeRow.__table__.c.scope_type == ScopeType.PROJECT,
+                VirtualScopeRow.__table__.c.scope_id == project_id,
+            )
+        )
         await conn.execute(GroupRow.__table__.delete().where(GroupRow.__table__.c.id == project_id))
 
 

--- a/tests/component/project/test_project_purge.py
+++ b/tests/component/project/test_project_purge.py
@@ -29,6 +29,7 @@ from ai.backend.manager.models.rbac_models.association_scopes_entities import (
 )
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.testutils.fixtures import DomainFixtureData
 
 
@@ -58,6 +59,12 @@ async def project_with_rbac_rows(
                 is_active=True,
                 domain_name=domain_fixture.domain_name,
                 resource_policy=resource_policy_fixture,
+            )
+        )
+        await conn.execute(
+            sa.insert(VirtualScopeRow.__table__).values(
+                scope_type=ScopeType.PROJECT,
+                scope_id=project_id,
             )
         )
         await conn.execute(
@@ -142,6 +149,12 @@ async def project_with_rbac_rows(
         await conn.execute(
             RoleRow.__table__.delete().where(
                 RoleRow.__table__.c.id.in_([admin_role_id, member_role_id])
+            )
+        )
+        await conn.execute(
+            VirtualScopeRow.__table__.delete().where(
+                VirtualScopeRow.__table__.c.scope_type == ScopeType.PROJECT,
+                VirtualScopeRow.__table__.c.scope_id == project_id,
             )
         )
         await conn.execute(GroupRow.__table__.delete().where(GroupRow.__table__.c.id == project_id))

--- a/tests/component/project/test_project_purge.py
+++ b/tests/component/project/test_project_purge.py
@@ -29,6 +29,8 @@ from ai.backend.manager.models.rbac_models.association_scopes_entities import (
 )
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.testutils.fixtures import DomainFixtureData
 
@@ -61,10 +63,28 @@ async def project_with_rbac_rows(
                 resource_policy=resource_policy_fixture,
             )
         )
+        virtual_scope_id = uuid.uuid4()
         await conn.execute(
             sa.insert(VirtualScopeRow.__table__).values(
+                id=virtual_scope_id,
                 scope_type=ScopeType.PROJECT,
                 scope_id=project_id,
+            )
+        )
+        await conn.execute(
+            sa.insert(EntityMembershipRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                entity_type=EntityType.PROJECT,
+                entity_id=project_id,
+                permission_cap=None,
+            )
+        )
+        await conn.execute(
+            sa.insert(ScopeBindingRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                scope_type=ScopeType.PROJECT,
+                scope_id=project_id,
+                permission_cap=None,
             )
         )
         await conn.execute(

--- a/tests/component/user/test_user_crud.py
+++ b/tests/component/user/test_user_crud.py
@@ -30,6 +30,8 @@ from ai.backend.manager.models.rbac_models.association_scopes_entities import (
 from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
 from ai.backend.manager.models.user import users
+from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.testutils.fixtures import DomainFixtureData
 
@@ -415,10 +417,28 @@ class TestUserCreateAutoAssignRoles:
                     type=ProjectType.MODEL_STORE,
                 )
             )
+            virtual_scope_id = uuid.uuid4()
             await conn.execute(
                 sa.insert(VirtualScopeRow.__table__).values(
+                    id=virtual_scope_id,
                     scope_type=ScopeType.PROJECT,
                     scope_id=project_id,
+                )
+            )
+            await conn.execute(
+                sa.insert(EntityMembershipRow.__table__).values(
+                    virtual_scope_id=virtual_scope_id,
+                    entity_type=EntityType.PROJECT,
+                    entity_id=project_id,
+                    permission_cap=None,
+                )
+            )
+            await conn.execute(
+                sa.insert(ScopeBindingRow.__table__).values(
+                    virtual_scope_id=virtual_scope_id,
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=project_id,
+                    permission_cap=None,
                 )
             )
         yield project_id

--- a/tests/component/user/test_user_crud.py
+++ b/tests/component/user/test_user_crud.py
@@ -30,6 +30,7 @@ from ai.backend.manager.models.rbac_models.association_scopes_entities import (
 from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
 from ai.backend.manager.models.user import users
+from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.testutils.fixtures import DomainFixtureData
 
 from .conftest import UserFactory
@@ -414,8 +415,20 @@ class TestUserCreateAutoAssignRoles:
                     type=ProjectType.MODEL_STORE,
                 )
             )
+            await conn.execute(
+                sa.insert(VirtualScopeRow.__table__).values(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=project_id,
+                )
+            )
         yield project_id
         async with db_engine.begin() as conn:
+            await conn.execute(
+                VirtualScopeRow.__table__.delete().where(
+                    VirtualScopeRow.__table__.c.scope_type == ScopeType.PROJECT,
+                    VirtualScopeRow.__table__.c.scope_id == project_id,
+                )
+            )
             await conn.execute(
                 GroupRow.__table__.delete().where(GroupRow.__table__.c.id == project_id)
             )


### PR DESCRIPTION
## Summary

- Provision a project virtual scope whenever component-test fixtures insert `GroupRow` directly.
- Remove the matching virtual scope during fixture teardown.
- Prevent `VirtualScopeNotFound` failures now that project-scoped RBAC operations require the owner scope to be materialized.

## Test plan

- [x] `pants fmt ::`
- [x] `pants fix ::`
- [x] `pants lint --changed-since=origin/main`
- [x] Pre-push MyPy checks and selected component tests
