### PR TITLE
fix(BA-7021): mask the Redis password in the agent's startup config log

### DIFF
--- a/changes/13141.fix.md
+++ b/changes/13141.fix.md
@@ -1,0 +1,1 @@
+Mask the Redis password in the agent's startup configuration log instead of printing it in plaintext

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -130,6 +130,7 @@ from ai.backend.common.types import (
     ServiceDiscoveryType,
     SessionId,
     aobject,
+    safe_print_redis_config,
 )
 from ai.backend.logging import BraceStyleAdapter, Logger, LogLevel
 from ai.backend.logging.otel import OpenTelemetrySpec
@@ -526,7 +527,6 @@ class AgentRPCServer(aobject):
         self._redis_config = config.redis_config_iv.check(
             await self.etcd.get_prefix("config/redis"),
         )
-        log.info("configured redis: {0}", self._redis_config)
 
         # Update local_config with redis settings
         # Convert HostPortPair to dict format for compatibility
@@ -537,6 +537,7 @@ class AgentRPCServer(aobject):
                 redis_config_dict["addr"] = f"{addr.host}:{addr.port}"
 
         redis_config = RedisConfig.model_validate(redis_config_dict)
+        log.info("configured redis: {0}", safe_print_redis_config(redis_config))
         self.local_config.overwrite(redis=redis_config)
 
         # Fill up vfolder configs from etcd and store as separate attributes

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -22,6 +22,7 @@ from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
+    Final,
     Literal,
     NewType,
     NotRequired,
@@ -75,6 +76,7 @@ from .models.minilang.mount import MountPointParser
 __all__ = (
     "MODEL_SERVICE_RUNTIME_PROFILES",
     "PID",
+    "REDIS_PASSWORD_MASK",
     "AbstractPermission",
     "AbuseReport",
     "AbuseReportValue",
@@ -176,7 +178,7 @@ __all__ = (
 
 
 if TYPE_CHECKING:
-    from ai.backend.common.configs.redis import RedisConfig
+    from ai.backend.common.configs.redis import RedisConfig, SingleRedisConfig
     from ai.backend.common.data.vfolder.types import VFolderMountData
     from ai.backend.common.dto.manager.v2.common import BinarySizeInfo
 
@@ -2193,12 +2195,20 @@ class RedisProfileTarget:
         )
 
 
+REDIS_PASSWORD_MASK: Final = "********"
+
+
 def safe_print_redis_config(config: RedisConfig) -> str:
     safe_config = copy.deepcopy(config)
-    if config.password is not None:
-        safe_config.password = "********"
-    if config.sentinel_password is not None:
-        safe_config.sentinel_password = "********"
+    # The overrides carry their own credentials, so they must be masked as well.
+    masking_targets: list[SingleRedisConfig] = [safe_config]
+    if safe_config.override_configs is not None:
+        masking_targets.extend(safe_config.override_configs.values())
+    for target in masking_targets:
+        if target.password is not None:
+            target.password = REDIS_PASSWORD_MASK
+        if target.sentinel_password is not None:
+            target.sentinel_password = REDIS_PASSWORD_MASK
     return str(safe_config)
 
 

--- a/tests/unit/common/test_types.py
+++ b/tests/unit/common/test_types.py
@@ -1,12 +1,13 @@
 import asyncio
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Any, override
 
 import pytest
 from typeguard import TypeCheckError
 
+from ai.backend.common.configs.redis import RedisConfig
 from ai.backend.common.exception import (
     BackendAISchemaValidationFailed,
     InvalidResourceSlotQuantity,
@@ -15,6 +16,7 @@ from ai.backend.common.exception import (
 from ai.backend.common.identifier.resource_slot import ResourceSlotName
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import (
+    REDIS_PASSWORD_MASK,
     BinarySize,
     DefaultForUnspecified,
     HardwareMetadata,
@@ -27,6 +29,7 @@ from ai.backend.common.types import (
     _stringify_number,
     aobject,
     check_typed_dict,
+    safe_print_redis_config,
 )
 
 
@@ -632,3 +635,75 @@ class TestResourceSlotEntryToResourceSlot:
 
     def test_empty_entries(self) -> None:
         assert ResourceSlotEntry.inputs_to_resource_slot([]) == ResourceSlot()
+
+
+@dataclass(frozen=True)
+class _RedisMaskingCase:
+    label: str
+    raw_config: dict[str, Any]
+    leaked_secrets: list[str] = field(default_factory=list)
+    expected_mask_count: int = 0
+
+
+class TestSafePrintRedisConfig:
+    @pytest.mark.parametrize(
+        "case",
+        [
+            _RedisMaskingCase(
+                label="no-credentials",
+                raw_config={"addr": "127.0.0.1:6379"},
+            ),
+            _RedisMaskingCase(
+                label="password",
+                raw_config={"addr": "127.0.0.1:6379", "password": "s3cr3t"},
+                leaked_secrets=["s3cr3t"],
+                expected_mask_count=1,
+            ),
+            _RedisMaskingCase(
+                label="sentinel-password",
+                raw_config={
+                    "sentinel": ["127.0.0.1:26379"],
+                    "service_name": "mymaster",
+                    "password": "s3cr3t",
+                    "sentinel_password": "s3ntin3l",
+                },
+                leaked_secrets=["s3cr3t", "s3ntin3l"],
+                expected_mask_count=2,
+            ),
+            _RedisMaskingCase(
+                label="override-configs",
+                raw_config={
+                    "addr": "127.0.0.1:6379",
+                    "password": "s3cr3t",
+                    "override_configs": {
+                        "stream": {
+                            "addr": "127.0.0.1:6380",
+                            "password": "0verr1de",
+                            "sentinel_password": "0verr1de-s3ntin3l",
+                        },
+                    },
+                },
+                leaked_secrets=["s3cr3t", "0verr1de", "0verr1de-s3ntin3l"],
+                expected_mask_count=3,
+            ),
+        ],
+        ids=lambda case: case.label,
+    )
+    def test_passwords_are_masked(self, case: _RedisMaskingCase) -> None:
+        printed = safe_print_redis_config(RedisConfig.model_validate(case.raw_config))
+        for secret in case.leaked_secrets:
+            assert secret not in printed
+        assert printed.count(REDIS_PASSWORD_MASK) == case.expected_mask_count
+
+    def test_source_config_is_left_intact(self) -> None:
+        redis_config = RedisConfig.model_validate({
+            "addr": "127.0.0.1:6379",
+            "password": "s3cr3t",
+            "override_configs": {
+                "stream": {"addr": "127.0.0.1:6380", "password": "0verr1de"},
+            },
+        })
+        safe_print_redis_config(redis_config)
+        assert redis_config.password == "s3cr3t"
+        assert redis_config.override_configs is not None
+        assert redis_config.override_configs["stream"].password == "0verr1de"

--- a/tests/unit/common/test_types.py
+++ b/tests/unit/common/test_types.py
@@ -690,20 +690,10 @@ class TestSafePrintRedisConfig:
         ids=lambda case: case.label,
     )
     def test_passwords_are_masked(self, case: _RedisMaskingCase) -> None:
-        printed = safe_print_redis_config(RedisConfig.model_validate(case.raw_config))
+        redis_config = RedisConfig.model_validate(case.raw_config)
+        printed = safe_print_redis_config(redis_config)
         for secret in case.leaked_secrets:
             assert secret not in printed
+            # The helper masks a copy; the caller's config keeps its credentials.
+            assert secret in str(redis_config)
         assert printed.count(REDIS_PASSWORD_MASK) == case.expected_mask_count
-
-    def test_source_config_is_left_intact(self) -> None:
-        redis_config = RedisConfig.model_validate({
-            "addr": "127.0.0.1:6379",
-            "password": "s3cr3t",
-            "override_configs": {
-                "stream": {"addr": "127.0.0.1:6380", "password": "0verr1de"},
-            },
-        })
-        safe_print_redis_config(redis_config)
-        assert redis_config.password == "s3cr3t"
-        assert redis_config.override_configs is not None
-        assert redis_config.override_configs["stream"].password == "0verr1de"


### PR DESCRIPTION
Resolves #13140 (BA-7021)

## Summary

- `Agent.read_agent_config()` logged the Redis configuration read from etcd verbatim, so the Redis password and the sentinel password ended up in the agent log in plaintext on every startup. Agent logs are aggregated and routinely attached to bug reports, so this exposed the credential far more widely than the etcd value it came from.
- `agent/server.py` now logs the parsed `RedisConfig` through `safe_print_redis_config()`, matching what the storage-proxy already does. The log line moves below `RedisConfig.model_validate()` because the helper takes the parsed model, not the raw trafaret dict.
- `safe_print_redis_config()` itself masked only the top-level `password` / `sentinel_password`, leaving the per-context credentials under `override_configs` in plaintext — so it now masks those as well. Without that, a deployment using Redis overrides would still leak through the very call meant to make the log safe. The mask string is exported as `REDIS_PASSWORD_MASK`.

Both fields are already annotated `secret=True` in `common/configs/redis.py`, so masking them in logs is the documented intent.

## Test plan

- [x] `pants fmt` / `fix` / `lint` / `check` pass on the changed files
- [x] Unit tests cover masking of the top-level, sentinel, and `override_configs` passwords, and that the source config is left unmutated
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
