### PR TITLE
fix(BA-7002): apply current_hook when creating Metric on first observation

### DIFF
--- a/changes/13144.fix.md
+++ b/changes/13144.fix.md
@@ -1,1 +1,1 @@
-Fix sporadic huge `cpu_util` spikes (tens of thousands of percent) in per-session utilization statistics by applying `current_hook` to the first observation of a metric, so the cumulative CPU time counter is no longer published as the utilization percentage
+Fix spurious first-sample spikes in hook-derived utilization metrics (e.g. `cpu_util`) by applying `current_hook` at `Metric` creation

--- a/changes/13144.fix.md
+++ b/changes/13144.fix.md
@@ -1,0 +1,1 @@
+Fix sporadic huge `cpu_util` spikes (tens of thousands of percent) in per-session utilization statistics by applying `current_hook` to the first observation of a metric, so the cumulative CPU time counter is no longer published as the utilization percentage

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -318,6 +318,12 @@ class Metric:
     capacity: Decimal | None = None
     current_hook: Callable[[Metric], Decimal] | None = None
 
+    def __attrs_post_init__(self) -> None:
+        # Hook-derived metrics (e.g., rate-based cpu_util) must never expose the raw
+        # measurement as current; the first observation feeds a cumulative counter here.
+        if self.current_hook is not None:
+            self.current = self.current_hook(self)
+
     def update(self, value: Measurement) -> None:
         if value.capacity is not None:
             self.capacity = value.capacity

--- a/tests/unit/agent/test_stats.py
+++ b/tests/unit/agent/test_stats.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from decimal import Decimal
 from unittest.mock import patch
 
 import pytest
 
-from ai.backend.agent.stats import MovingStatistics
+from ai.backend.agent.stats import Measurement, Metric, MetricTypes, MovingStatistics
 
 
 class TestMovingStatistics:
@@ -84,3 +85,74 @@ class TestMovingStatistics:
             stats.update(case.second_value)
 
         assert stats.rate == case.expected_rate
+
+
+class TestMetric:
+    """Tests for Metric class, focusing on current_hook application."""
+
+    @dataclass(frozen=True)
+    class CreationTestCase:
+        id: str
+        initial_value: Decimal
+        current_hook: Callable[[Metric], Decimal] | None
+        expected_current: Decimal
+        expected_pct: str
+
+    @pytest.mark.parametrize(
+        "case",
+        [
+            CreationTestCase(
+                id="rate_hook_applied_to_first_observation",
+                initial_value=Decimal("744400.000"),
+                current_hook=lambda metric: metric.stats.rate,
+                expected_current=Decimal(0),
+                expected_pct="0",
+            ),
+            CreationTestCase(
+                id="no_hook_keeps_raw_value",
+                initial_value=Decimal("744400.000"),
+                current_hook=None,
+                expected_current=Decimal("744400.000"),
+                expected_pct="74440",
+            ),
+        ],
+        ids=lambda case: case.id,
+    )
+    def test_creation_applies_current_hook(self, case: CreationTestCase) -> None:
+        """Test that a hook-derived metric does not expose the raw cumulative counter
+        as current/pct on the first observation."""
+        metric = Metric(
+            key="cpu_util",
+            type=MetricTypes.UTILIZATION,
+            unit_hint="percent",
+            stats=MovingStatistics(case.initial_value),
+            stats_filter=frozenset({"avg", "max"}),
+            current=case.initial_value,
+            capacity=Decimal(1000),
+            current_hook=case.current_hook,
+        )
+
+        assert metric.current == case.expected_current
+        assert metric.to_serializable_dict()["pct"] == case.expected_pct
+
+    @pytest.fixture
+    def cpu_util_metric(self) -> Metric:
+        with patch("time.perf_counter", return_value=1.0):
+            return Metric(
+                key="cpu_util",
+                type=MetricTypes.UTILIZATION,
+                unit_hint="percent",
+                stats=MovingStatistics(Decimal("1000.000")),
+                stats_filter=frozenset({"avg", "max"}),
+                current=Decimal("1000.000"),
+                capacity=Decimal(1000),
+                current_hook=lambda metric: metric.stats.rate,
+            )
+
+    def test_update_applies_current_hook(self, cpu_util_metric: Metric) -> None:
+        """Test that subsequent observations report the rate derived from the counter delta."""
+        with patch("time.perf_counter", return_value=2.0):
+            cpu_util_metric.update(Measurement(Decimal("1660.000")))
+
+        assert cpu_util_metric.current == Decimal(660)
+        assert cpu_util_metric.to_serializable_dict()["pct"] == "66"

--- a/tests/unit/agent/test_stats.py
+++ b/tests/unit/agent/test_stats.py
@@ -103,17 +103,17 @@ class TestMetric:
         [
             CreationTestCase(
                 id="rate_hook_applied_to_first_observation",
-                initial_value=Decimal("744400.000"),
+                initial_value=Decimal(5000),
                 current_hook=lambda metric: metric.stats.rate,
                 expected_current=Decimal(0),
                 expected_pct="0",
             ),
             CreationTestCase(
                 id="no_hook_keeps_raw_value",
-                initial_value=Decimal("744400.000"),
+                initial_value=Decimal(5000),
                 current_hook=None,
-                expected_current=Decimal("744400.000"),
-                expected_pct="74440",
+                expected_current=Decimal(5000),
+                expected_pct="500",
             ),
         ],
         ids=lambda case: case.id,
@@ -142,9 +142,9 @@ class TestMetric:
                 key="cpu_util",
                 type=MetricTypes.UTILIZATION,
                 unit_hint="percent",
-                stats=MovingStatistics(Decimal("1000.000")),
+                stats=MovingStatistics(Decimal(1000)),
                 stats_filter=frozenset({"avg", "max"}),
-                current=Decimal("1000.000"),
+                current=Decimal(1000),
                 capacity=Decimal(1000),
                 current_hook=lambda metric: metric.stats.rate,
             )
@@ -152,7 +152,7 @@ class TestMetric:
     def test_update_applies_current_hook(self, cpu_util_metric: Metric) -> None:
         """Test that subsequent observations report the rate derived from the counter delta."""
         with patch("time.perf_counter", return_value=2.0):
-            cpu_util_metric.update(Measurement(Decimal("1660.000")))
+            cpu_util_metric.update(Measurement(Decimal(1500)))
 
-        assert cpu_util_metric.current == Decimal(660)
-        assert cpu_util_metric.to_serializable_dict()["pct"] == "66"
+        assert cpu_util_metric.current == Decimal(500)
+        assert cpu_util_metric.to_serializable_dict()["pct"] == "50"

--- a/tests/unit/agent/test_stats.py
+++ b/tests/unit/agent/test_stats.py
@@ -87,6 +87,11 @@ class TestMovingStatistics:
         assert stats.rate == case.expected_rate
 
 
+# Large enough that leaking it into `current` reads as an unmistakable spike
+# (pct would be 1,000,000%), never as a plausible utilization value.
+_HUGE_CPU_USED_MSEC = Decimal(10_000_000)
+
+
 class TestMetric:
     """Tests for Metric class, focusing on current_hook application."""
 
@@ -103,17 +108,17 @@ class TestMetric:
         [
             CreationTestCase(
                 id="rate_hook_applied_to_first_observation",
-                initial_value=Decimal(5000),
+                initial_value=_HUGE_CPU_USED_MSEC,
                 current_hook=lambda metric: metric.stats.rate,
                 expected_current=Decimal(0),
                 expected_pct="0",
             ),
             CreationTestCase(
                 id="no_hook_keeps_raw_value",
-                initial_value=Decimal(5000),
+                initial_value=_HUGE_CPU_USED_MSEC,
                 current_hook=None,
-                expected_current=Decimal(5000),
-                expected_pct="500",
+                expected_current=_HUGE_CPU_USED_MSEC,
+                expected_pct="1000000",
             ),
         ],
         ids=lambda case: case.id,


### PR DESCRIPTION
## Summary
- When a metric was observed for the first time, the `Metric` constructor stored the raw measurement as `current` without applying `current_hook`. For hook-derived metrics such as `cpu_util`, the first sample therefore published the cumulative CPU time counter (msec) as `current`, and `pct` became `cumulative_msec / capacity(1000) * 100` — surfacing as sporadic per-session CPU utilization MAX values in the tens of thousands of percent (e.g. 74,440% from 744,400 msec of accumulated CPU time at the first observation).
- Apply `current_hook` in `Metric.__attrs_post_init__` so the first observation goes through the same transformation as subsequent `update()` calls. Rate/diff hooks return 0 for a single data point, which matches the existing counter-reset convention of `MovingStatistics.diff`/`rate`.
- Add `TestMetric` unit tests covering hook application at creation (with and without a hook) and on subsequent updates.

## Test plan
- [ ] CI: `tests/unit/agent/test_stats.py` — new `TestMetric` cases pass

Resolves BA-7002

🤖 Generated with [Claude Code](https://claude.com/claude-code)
