### PR TITLE
fix(BA-7023): defer idle expiration until first judgment

### DIFF
--- a/changes/13148.fix.md
+++ b/changes/13148.fix.md
@@ -1,0 +1,1 @@
+Defer idle-check expiration until sessions become eligible for judgment.

--- a/src/ai/backend/common/data/idle_checker/types.py
+++ b/src/ai/backend/common/data/idle_checker/types.py
@@ -28,11 +28,10 @@ class SessionLifetimeSpec(BackendAISchema):
     """Config for ``CheckerType.SESSION_LIFETIME``."""
 
     max_lifetime_seconds: int = Field(
-        ge=0,
+        ge=1,
         description=(
             "Maximum time in seconds that a session may remain running. "
-            "Zero disables this checker definition. This is the sole lifetime limit "
-            "used by the reconciler idle checker."
+            "This is the sole lifetime limit used by the reconciler idle checker."
         ),
     )
 
@@ -41,10 +40,10 @@ class NetworkTimeoutSpec(BackendAISchema):
     """Config for ``CheckerType.NETWORK_TIMEOUT``."""
 
     max_network_inactivity_seconds: int = Field(
-        ge=0,
+        ge=1,
         description=(
             "Maximum time in seconds that an interactive session may have neither recent "
-            "network access nor an active connection. Zero disables this checker definition."
+            "network access nor an active connection."
         ),
     )
 

--- a/src/ai/backend/manager/data/idle_checker/types.py
+++ b/src/ai/backend/manager/data/idle_checker/types.py
@@ -13,4 +13,4 @@ class IdleCheckSession:
     session_id: SessionId
     created_at: datetime
     starts_at: datetime | None
-    expire_at: datetime
+    expire_at: datetime | None

--- a/src/ai/backend/manager/models/alembic/versions/890490020974_make_session_idle_check_expire_at_nullable.py
+++ b/src/ai/backend/manager/models/alembic/versions/890490020974_make_session_idle_check_expire_at_nullable.py
@@ -1,0 +1,36 @@
+"""make session idle check expire_at nullable
+
+Revision ID: 890490020974
+Revises: e7a41b29c8d3
+Create Date: 2026-07-27
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "890490020974"
+down_revision = "e7a41b29c8d3"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "session_idle_checks",
+        "expire_at",
+        existing_type=sa.DateTime(timezone=True),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DELETE FROM session_idle_checks WHERE expire_at IS NULL"))
+    op.alter_column(
+        "session_idle_checks",
+        "expire_at",
+        existing_type=sa.DateTime(timezone=True),
+        nullable=False,
+    )

--- a/src/ai/backend/manager/models/idle_checker/row.py
+++ b/src/ai/backend/manager/models/idle_checker/row.py
@@ -108,8 +108,8 @@ class SessionIdleCheckRow(UpdatedAtMixin, Base):  # type: ignore[misc]
     idle_checker_id: Mapped[IdleCheckerID] = mapped_column(
         "idle_checker_id", GUID(IdleCheckerID), nullable=False
     )
-    expire_at: Mapped[datetime] = mapped_column(
-        "expire_at", sa.DateTime(timezone=True), nullable=False
+    expire_at: Mapped[datetime | None] = mapped_column(
+        "expire_at", sa.DateTime(timezone=True), nullable=True
     )
     last_status: Mapped[IdleCheckPhase] = mapped_column(
         "last_status", StrEnumType(IdleCheckPhase), nullable=False

--- a/src/ai/backend/manager/repositories/idle_checker/creators.py
+++ b/src/ai/backend/manager/repositories/idle_checker/creators.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 from typing import override
 
 from ai.backend.common.data.idle_checker.types import IdleCheckPhase
@@ -13,14 +12,13 @@ from ai.backend.manager.repositories.idle_checker.types import SessionIdleCheckP
 @dataclass
 class SessionIdleCheckCreatorSpec(CreatorSpec[SessionIdleCheckRow]):
     pair: SessionIdleCheckPair
-    now: datetime
 
     @override
     def build_row(self) -> SessionIdleCheckRow:
         return SessionIdleCheckRow(
             session_id=self.pair.session_id,
             idle_checker_id=self.pair.checker_id,
-            expire_at=self.now,
+            expire_at=None,
             last_status=IdleCheckPhase.NOT_CHECKED,
             last_message="Not checked yet.",
         )

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -125,7 +125,10 @@ class IdleCheckerDBSource:
         check_query = (
             sa.select(SessionIdleCheckRow)
             .join(SessionRow, SessionIdleCheckRow.session_id == SessionRow.id)
-            .where(SessionIdleCheckRow.last_status == IdleCheckPhase.IDLE_EXPIRED)
+            .where(
+                SessionIdleCheckRow.last_status == IdleCheckPhase.IDLE_EXPIRED,
+                SessionIdleCheckRow.expire_at.is_not(None),
+            )
         )
         async with self._ops.read_ops() as r:
             now = await r.current_time()
@@ -143,7 +146,7 @@ class IdleCheckerDBSource:
                 ExpiredIdleCheckData(
                     session_id=check_row.session_id,
                     checker_id=check_row.idle_checker_id,
-                    expire_at=check_row.expire_at,
+                    expire_at=cast(datetime, check_row.expire_at),
                     last_status=check_row.last_status,
                     last_message=check_row.last_message,
                 )
@@ -262,13 +265,12 @@ class IdleCheckerDBSource:
         self,
         pairs_to_create: Sequence[SessionIdleCheckPair],
         pairs_to_delete: Sequence[SessionIdleCheckPair],
-        now: datetime,
     ) -> None:
         async with self._ops.write_ops() as w:
             if pairs_to_create:
                 await w.bulk_create(
                     BulkCreator(
-                        specs=[SessionIdleCheckCreatorSpec(pair, now) for pair in pairs_to_create]
+                        specs=[SessionIdleCheckCreatorSpec(pair) for pair in pairs_to_create]
                     )
                 )
             if pairs_to_delete:

--- a/src/ai/backend/manager/repositories/idle_checker/repository.py
+++ b/src/ai/backend/manager/repositories/idle_checker/repository.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Collection, Sequence
-from datetime import datetime
 
 from ai.backend.common.data.idle_checker.types import IdleCheckPhase
 from ai.backend.manager.data.session.types import SessionStatus
@@ -53,12 +52,10 @@ class IdleCheckerRepository:
         self,
         pairs_to_create: Sequence[SessionIdleCheckPair],
         pairs_to_delete: Sequence[SessionIdleCheckPair],
-        now: datetime,
     ) -> None:
         await self._db_source.sync_session_idle_check_assignments(
             pairs_to_create,
             pairs_to_delete,
-            now,
         )
 
     async def batch_update_session_idle_check_phase(

--- a/src/ai/backend/manager/sokovan/idle_check/assignment_sync/applier.py
+++ b/src/ai/backend/manager/sokovan/idle_check/assignment_sync/applier.py
@@ -45,5 +45,4 @@ class IdleCheckAssignmentSyncApplier(
         await self._repository.sync_session_idle_check_assignments(
             result.pairs_to_create,
             result.pairs_to_delete,
-            result.current_time,
         )

--- a/src/ai/backend/manager/sokovan/idle_check/assignment_sync/types.py
+++ b/src/ai/backend/manager/sokovan/idle_check/assignment_sync/types.py
@@ -33,7 +33,6 @@ class IdleCheckAssignmentSyncReconcileInfo(BaseReconcilerInfo):
 
 @dataclass
 class IdleCheckAssignmentSyncResult(BaseReconcilerResult):
-    current_time: datetime
     pairs_to_create: list[SessionIdleCheckPair] = field(default_factory=list)
     pairs_to_delete: list[SessionIdleCheckPair] = field(default_factory=list)
 

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/network_timeout.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/network_timeout.py
@@ -100,7 +100,7 @@ class NetworkTimeoutChecker(IdleChecker):
                     f"active_connections={state.active_connections}"
                 ),
             )
-        effective_expire_at = expire_at or refreshed_expire_at
+        effective_expire_at = expire_at if expire_at is not None else refreshed_expire_at
         if state.last_access is None:
             last_access_message = "last_access_at=None"
         else:

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/network_timeout.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/network_timeout.py
@@ -13,11 +13,11 @@ from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.idle_checker.types import IdleCheckSession
+from ai.backend.manager.repositories.idle_checker.types import IdleJudgmentData
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
     IdleChecker,
     IdleCheckerContext,
-    IdleJudgment,
 )
 
 log = BraceStyleAdapter(logging.getLogger(__name__))
@@ -45,7 +45,7 @@ class NetworkTimeoutChecker(IdleChecker):
         assignments: Sequence[CheckerAssignment],
         *,
         context: IdleCheckerContext,
-    ) -> Sequence[IdleJudgment]:
+    ) -> Sequence[IdleJudgmentData]:
         # Fetch session states in one batch to avoid repeated I/O per assignment.
         sessions: list[IdleCheckSession] = []
         for assignment in assignments:
@@ -53,7 +53,7 @@ class NetworkTimeoutChecker(IdleChecker):
         states = await self._prepare_states(sessions)
 
         # Judge each assignment in one pass, using the pre-fetched states.
-        judgments: list[IdleJudgment] = []
+        judgments: list[IdleJudgmentData] = []
         for assignment in assignments:
             network_spec = assignment.definition.spec.network
             if network_spec is None:
@@ -64,8 +64,6 @@ class NetworkTimeoutChecker(IdleChecker):
                 )
                 continue
             max_inactivity_seconds = network_spec.max_network_inactivity_seconds
-            if max_inactivity_seconds == 0:
-                continue
             for session in assignment.sessions:
                 judgments.append(
                     self._judge_session(
@@ -84,16 +82,17 @@ class NetworkTimeoutChecker(IdleChecker):
         *,
         checker_id: IdleCheckerID,
         session_id: SessionId,
-        expire_at: datetime,
+        expire_at: datetime | None,
         state: _NetworkIdleState,
         max_inactivity_seconds: int,
         current_time: datetime,
-    ) -> IdleJudgment:
+    ) -> IdleJudgmentData:
+        refreshed_expire_at = current_time + timedelta(seconds=max_inactivity_seconds)
         if state.last_access == _ONGOING_ACTIVITY_SENTINEL or state.active_connections > 0:
-            return IdleJudgment(
+            return IdleJudgmentData(
                 checker_id=checker_id,
                 session_id=session_id,
-                expire_at=current_time + timedelta(seconds=max_inactivity_seconds),
+                expire_at=refreshed_expire_at,
                 status=IdleCheckPhase.ACTIVE,
                 message=(
                     "Network activity detected: "
@@ -101,6 +100,7 @@ class NetworkTimeoutChecker(IdleChecker):
                     f"active_connections={state.active_connections}"
                 ),
             )
+        effective_expire_at = expire_at or refreshed_expire_at
         if state.last_access is None:
             last_access_message = "last_access_at=None"
         else:
@@ -109,16 +109,16 @@ class NetworkTimeoutChecker(IdleChecker):
                 f"last_access_at={last_access_at:%Y-%m-%d %H:%M:%S} UTC, "
                 f"inactive_seconds={(current_time - last_access_at).total_seconds():f}"
             )
-        if current_time >= expire_at:
+        if current_time >= effective_expire_at:
             status = IdleCheckPhase.IDLE_EXPIRED
             message = "Maximum network inactivity exceeded"
         else:
             status = IdleCheckPhase.IDLE
             message = "No active network connection"
-        return IdleJudgment(
+        return IdleJudgmentData(
             checker_id=checker_id,
             session_id=session_id,
-            expire_at=expire_at,
+            expire_at=effective_expire_at,
             status=status,
             message=(
                 f"{message}: "

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
@@ -38,8 +38,6 @@ class SessionLifetimeChecker(IdleChecker):
                     assignment.definition.spec.type,
                 )
                 continue
-            if lifetime_spec.max_lifetime_seconds == 0:
-                continue
             max_lifetime_seconds = Decimal(lifetime_spec.max_lifetime_seconds)
             for session in assignment.sessions:
                 if session.starts_at is None:

--- a/src/ai/backend/manager/sokovan/idle_check/handlers/assignment_sync.py
+++ b/src/ai/backend/manager/sokovan/idle_check/handlers/assignment_sync.py
@@ -21,7 +21,6 @@ class IdleCheckAssignmentSyncHandler(
         return IdleCheckAssignmentSyncResult(
             pairs_to_create=list(desired - current),
             pairs_to_delete=list(current - desired),
-            current_time=reconcile_info.current_time,
         )
 
     @override

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -258,7 +258,11 @@ class TestFetchJudgmentBatch:
                     SessionIdleCheckRow(
                         session_id=session_id,
                         idle_checker_id=checker_id,
-                        expire_at=datetime(2026, 2, 1, tzinfo=UTC),
+                        expire_at=(
+                            None
+                            if phase in (IdleCheckPhase.NOT_CHECKED, IdleCheckPhase.READY_TO_CHECK)
+                            else datetime(2026, 2, 1, tzinfo=UTC)
+                        ),
                         last_status=phase,
                         last_message=f"{phase.value} judgment",
                     )
@@ -291,9 +295,16 @@ class TestFetchJudgmentBatch:
             (judgment_rows.active_session_id, judgment_rows.checker_id),
             (judgment_rows.idle_session_id, judgment_rows.checker_id),
         }
-        assert all(
-            assignment.session.expire_at == datetime(2026, 2, 1, tzinfo=UTC)
+        expire_at_by_session = {
+            assignment.session.session_id: assignment.session.expire_at
             for assignment in batch.assignments
+        }
+        assert expire_at_by_session[judgment_rows.ready_to_check_session_id] is None
+        assert expire_at_by_session[judgment_rows.active_session_id] == datetime(
+            2026, 2, 1, tzinfo=UTC
+        )
+        assert expire_at_by_session[judgment_rows.idle_session_id] == datetime(
+            2026, 2, 1, tzinfo=UTC
         )
 
     async def test_excludes_non_judgment_phases(
@@ -331,6 +342,7 @@ class TestFetchJudgmentBatch:
             )
         assert row is not None
         assert row.last_status is IdleCheckPhase.READY_TO_CHECK
+        assert row.expire_at is None
 
     async def test_does_not_overwrite_row_that_is_no_longer_not_checked(
         self,
@@ -614,13 +626,12 @@ class TestFetchJudgmentBatch:
         repository: IdleCheckerRepository,
         judgment_rows: JudgmentRows,
     ) -> None:
-        assignments = await repository.fetch_session_idle_check_assignments([SessionStatus.RUNNING])
         pair = SessionIdleCheckPair(
             judgment_rows.session_without_row_id,
             judgment_rows.checker_id,
         )
 
-        await repository.sync_session_idle_check_assignments([pair], [], assignments.now)
+        await repository.sync_session_idle_check_assignments([pair], [])
 
         async with database.begin_readonly_session() as db_sess:
             row = await db_sess.get(
@@ -628,7 +639,7 @@ class TestFetchJudgmentBatch:
                 (pair.session_id, pair.checker_id),
             )
         assert row is not None
-        assert row.expire_at == assignments.now
+        assert row.expire_at is None
         assert row.last_status is IdleCheckPhase.NOT_CHECKED
         assert row.last_message == "Not checked yet."
 
@@ -647,9 +658,7 @@ class TestFetchJudgmentBatch:
             assignment_snapshot.desired_pairs
         )
 
-        await repository.sync_session_idle_check_assignments(
-            [], list(obsolete_pairs), assignment_snapshot.now
-        )
+        await repository.sync_session_idle_check_assignments([], list(obsolete_pairs))
 
         async with database.begin_readonly_session() as db_sess:
             non_expired_rows = (
@@ -680,9 +689,7 @@ class TestFetchJudgmentBatch:
             assignment_snapshot.desired_pairs
         )
 
-        await repository.sync_session_idle_check_assignments(
-            [], list(obsolete_pairs), assignment_snapshot.now
-        )
+        await repository.sync_session_idle_check_assignments([], list(obsolete_pairs))
 
         async with database.begin_readonly_session() as db_sess:
             expired_row = await db_sess.get(
@@ -709,9 +716,7 @@ class TestFetchJudgmentBatch:
         obsolete_pairs = set(assignment_snapshot.current_pairs) - set(
             assignment_snapshot.desired_pairs
         )
-        await repository.sync_session_idle_check_assignments(
-            [], list(obsolete_pairs), assignment_snapshot.now
-        )
+        await repository.sync_session_idle_check_assignments([], list(obsolete_pairs))
 
         async with database.begin_session() as db_sess:
             await db_sess.execute(sa.update(IdleCheckerBindingRow).values(enabled=True))
@@ -722,9 +727,7 @@ class TestFetchJudgmentBatch:
             assignment_snapshot.current_pairs
         )
 
-        await repository.sync_session_idle_check_assignments(
-            list(missing_pairs), [], assignment_snapshot.now
-        )
+        await repository.sync_session_idle_check_assignments(list(missing_pairs), [])
 
         async with database.begin_readonly_session() as db_sess:
             recreated_row = await db_sess.get(
@@ -736,7 +739,7 @@ class TestFetchJudgmentBatch:
             )
         assert recreated_row is not None
         assert recreated_row.last_status is IdleCheckPhase.NOT_CHECKED
-        assert recreated_row.expire_at == assignment_snapshot.now
+        assert recreated_row.expire_at is None
 
     async def test_delete_rechecks_expired_status_after_assignment_fetch(
         self,
@@ -760,7 +763,7 @@ class TestFetchJudgmentBatch:
                 .values(last_status=IdleCheckPhase.IDLE_EXPIRED)
             )
 
-        await repository.sync_session_idle_check_assignments([], [pair], assignments.now)
+        await repository.sync_session_idle_check_assignments([], [pair])
 
         async with database.begin_readonly_session() as db_sess:
             row = await db_sess.get(
@@ -789,7 +792,7 @@ class TestFetchJudgmentBatch:
         ]
         pairs_to_delete.append(pair_to_delete)
 
-        await repository.sync_session_idle_check_assignments([], pairs_to_delete, datetime.now(UTC))
+        await repository.sync_session_idle_check_assignments([], pairs_to_delete)
 
         async with database.begin_readonly_session() as db_sess:
             row = await db_sess.get(

--- a/tests/unit/manager/sokovan/idle_check/test_assignment_sync.py
+++ b/tests/unit/manager/sokovan/idle_check/test_assignment_sync.py
@@ -74,7 +74,6 @@ class TestIdleCheckAssignmentSyncHandler:
 
         assert set(result.pairs_to_create) == {pair_to_create}
         assert set(result.pairs_to_delete) == {pair_to_delete}
-        assert result.current_time == current_time
         assert result.processed_count() == 2
 
 
@@ -91,13 +90,11 @@ class TestIdleCheckAssignmentSyncApplier:
         self,
         applier: IdleCheckAssignmentSyncApplier,
         repository: AsyncMock,
-        current_time: datetime,
         pair_to_create: SessionIdleCheckPair,
         pair_to_delete: SessionIdleCheckPair,
     ) -> None:
         apply_input = MagicMock()
         apply_input.result = IdleCheckAssignmentSyncResult(
-            current_time=current_time,
             pairs_to_create=[pair_to_create],
             pairs_to_delete=[pair_to_delete],
         )
@@ -107,17 +104,15 @@ class TestIdleCheckAssignmentSyncApplier:
         repository.sync_session_idle_check_assignments.assert_awaited_once_with(
             [pair_to_create],
             [pair_to_delete],
-            current_time,
         )
 
     async def test_skips_empty_assignment_changes(
         self,
         applier: IdleCheckAssignmentSyncApplier,
         repository: AsyncMock,
-        current_time: datetime,
     ) -> None:
         apply_input = MagicMock()
-        apply_input.result = IdleCheckAssignmentSyncResult(current_time=current_time)
+        apply_input.result = IdleCheckAssignmentSyncResult()
 
         await applier.apply(apply_input)
 

--- a/tests/unit/manager/sokovan/idle_check/test_network_timeout_checker.py
+++ b/tests/unit/manager/sokovan/idle_check/test_network_timeout_checker.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 
 from ai.backend.common.clients.valkey_client.valkey_live.client import ValkeyLiveClient
 from ai.backend.common.data.idle_checker.types import (
@@ -40,6 +41,12 @@ class AssignmentFactory(Protocol):
         max_network_inactivity_seconds: int,
         sessions: Sequence[IdleCheckSession],
     ) -> CheckerAssignment: ...
+
+
+class TestNetworkTimeoutSpec:
+    def test_rejects_zero_timeout(self) -> None:
+        with pytest.raises(ValidationError):
+            NetworkTimeoutSpec(max_network_inactivity_seconds=0)
 
 
 class TestNetworkTimeoutChecker:
@@ -143,14 +150,6 @@ class TestNetworkTimeoutChecker:
         return missing_last_access_valkey
 
     @pytest.fixture()
-    def disabled_assignment(
-        self,
-        session: IdleCheckSession,
-        assignment_factory: AssignmentFactory,
-    ) -> CheckerAssignment:
-        return assignment_factory(max_network_inactivity_seconds=0, sessions=(session,))
-
-    @pytest.fixture()
     def definition_specific_assignments(
         self,
         session: IdleCheckSession,
@@ -183,6 +182,25 @@ class TestNetworkTimeoutChecker:
         assert judgments[0].status is IdleCheckPhase.IDLE
         assert judgments[0].expire_at == _EXISTING_EXPIRE_AT
         assert judgments[0].message.startswith("No active network connection:")
+
+    async def test_disconnected_session_without_expiration_starts_timeout(
+        self,
+        checker: NetworkTimeoutChecker,
+        session: IdleCheckSession,
+        assignment_factory: AssignmentFactory,
+    ) -> None:
+        assignment = assignment_factory(
+            max_network_inactivity_seconds=30,
+            sessions=(replace(session, expire_at=None),),
+        )
+
+        judgments = await checker.judge(
+            (assignment,),
+            context=IdleCheckerContext(current_time=_BASE_TIME + timedelta(seconds=10)),
+        )
+
+        assert judgments[0].status is IdleCheckPhase.IDLE
+        assert judgments[0].expire_at == _BASE_TIME + timedelta(seconds=40)
 
     async def test_disconnected_session_at_expiration_is_idle_expired(
         self,
@@ -273,18 +291,6 @@ class TestNetworkTimeoutChecker:
 
         assert judgments[0].status is IdleCheckPhase.ACTIVE
         assert judgments[0].expire_at == _BASE_TIME + timedelta(seconds=90)
-
-    async def test_disabled_checker_skips_assignment(
-        self,
-        checker: NetworkTimeoutChecker,
-        disabled_assignment: CheckerAssignment,
-    ) -> None:
-        judgments = await checker.judge(
-            (disabled_assignment,),
-            context=IdleCheckerContext(current_time=_BASE_TIME + timedelta(days=1)),
-        )
-
-        assert judgments == []
 
     async def test_evaluates_definition_specific_timeouts(
         self,

--- a/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
+++ b/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
@@ -49,10 +49,9 @@ class AssignmentFactory(Protocol):
 
 
 class TestSessionLifetimeSpec:
-    def test_accepts_zero_as_disabled_lifetime(self) -> None:
-        spec = SessionLifetimeSpec(max_lifetime_seconds=0)
-
-        assert spec.max_lifetime_seconds == 0
+    def test_rejects_zero_lifetime(self) -> None:
+        with pytest.raises(ValidationError):
+            SessionLifetimeSpec(max_lifetime_seconds=0)
 
     def test_rejects_negative_lifetime(self) -> None:
         with pytest.raises(ValidationError):
@@ -173,24 +172,6 @@ class TestSessionLifetimeChecker:
         assert judgments[0].message == (
             "Session lifetime check: max_lifetime_seconds=30, running_seconds=31.2"
         )
-
-    async def test_disabled_lifetime_skips_assignment(
-        self,
-        checker: SessionLifetimeChecker,
-        session_factory: SessionFactory,
-        assignment_factory: AssignmentFactory,
-    ) -> None:
-        assignment = assignment_factory(
-            max_lifetime_seconds=0,
-            sessions=(session_factory(),),
-        )
-
-        judgments = await checker.judge(
-            (assignment,),
-            context=IdleCheckerContext(current_time=_BASE_TIME + timedelta(days=1)),
-        )
-
-        assert judgments == []
 
     async def test_excludes_session_when_starts_at_is_missing(
         self,


### PR DESCRIPTION
## Summary

- Store new session idle-check assignments with a nullable expiration until they become eligible for judgment.
- Initialize a missing network inactivity deadline during the first judgment while preserving or refreshing existing deadlines according to activity.
- Require positive checker timeouts and use binding enablement as the sole enable/disable mechanism.

## Test plan

- [x] `pants fmt ::`
- [x] `pants fix ::`
- [x] `pants lint --changed-since=origin/main`
- [x] `pants check --changed-since=HEAD~1`
- [x] `pants test --changed-since=HEAD~1`
- [x] Alembic upgrade/downgrade SQL generation

Resolves BA-7023
