### PR TITLE
fix(BA-7036): preserve kernel termination reason and unblock idle checks

### DIFF
--- a/changes/13166.fix.md
+++ b/changes/13166.fix.md
@@ -1,0 +1,1 @@
+Preserve the recorded kernel termination reason against duplicate container lifecycle events, and keep the idle checker from skipping the rest of a cycle when a session's keypair has been deleted

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1834,6 +1834,16 @@ class AbstractAgent[
                     for kernel_id, container in dead_containers:
                         if kernel_id in self.restarting_kernels:
                             continue
+                        # A kernel we still track but that already left RUNNING is
+                        # being torn down by its own destroy flow, which reports the
+                        # real termination reason. Kernels missing from the registry
+                        # (e.g. after an agent restart) must still be picked up here.
+                        tracked_kernel = self.kernel_registry.get(kernel_id)
+                        if (
+                            tracked_kernel is not None
+                            and tracked_kernel.state != KernelLifecycleStatus.RUNNING
+                        ):
+                            continue
                         log.info(
                             "detected dead container during lifeycle sync (k:{}, c:{})",
                             kernel_id,

--- a/src/ai/backend/manager/idle.py
+++ b/src/ai/backend/manager/idle.py
@@ -233,9 +233,32 @@ class IdleCheckerHost:
         await self._valkey_stat.close()
         await self._valkey_live.close()
 
+    async def _fetch_idle_policy(
+        self, conn: SAConnection, access_key: AccessKey
+    ) -> Row[Any] | None:
+        query = (
+            sa.select(
+                keypair_resource_policies.c.max_session_lifetime,
+                keypair_resource_policies.c.idle_timeout,
+            )
+            .select_from(
+                sa.join(
+                    keypairs,
+                    keypair_resource_policies,
+                    keypair_resource_policies.c.name == keypairs.c.resource_policy,
+                ),
+            )
+            .where(keypairs.c.access_key == access_key)
+        )
+        result = await conn.execute(query)
+        return result.first()
+
     async def do_idle_check(self) -> None:
         log.debug("do_idle_check(): triggered")
-        policy_cache: dict[AccessKey, Row[Any]] = {}
+        # A missing policy is cached as None so that an orphaned access key is
+        # queried and warned about only once per cycle.
+        policy_cache: dict[AccessKey | None, Row[Any] | None] = {}
+        errors: list[BaseException] = []
         async with self._db.begin_readonly() as conn:
             j = sa.join(kernels, users, kernels.c.user_uuid == users.c.uuid)
             query = (
@@ -250,6 +273,7 @@ class IdleCheckerHost:
                     kernels.c.requested_slots,
                     kernels.c.cluster_size,
                     users.c.created_at.label("user_created_at"),
+                    users.c.main_access_key,
                 )
                 .select_from(j)
                 .where(
@@ -262,29 +286,26 @@ class IdleCheckerHost:
             rows = result.fetchall()
             for kernel in rows:
                 grace_period_end = await self._grace_period_checker.get_grace_period_end(kernel)
-                policy = policy_cache.get(kernel.access_key, None)
-                if policy is None:
-                    query = (
-                        sa.select(
-                            keypair_resource_policies.c.max_session_lifetime,
-                            keypair_resource_policies.c.idle_timeout,
-                        )
-                        .select_from(
-                            sa.join(
-                                keypairs,
-                                keypair_resource_policies,
-                                keypair_resource_policies.c.name == keypairs.c.resource_policy,
-                            ),
-                        )
-                        .where(keypairs.c.access_key == kernel.access_key)
+                # The idle policy is resolved through the user's main access key,
+                # which is a real foreign key, instead of the kernel's own access
+                # key, which may be left orphaned by a keypair deletion.
+                main_access_key = cast(AccessKey | None, kernel.main_access_key)
+                if main_access_key not in policy_cache:
+                    policy = (
+                        await self._fetch_idle_policy(conn, main_access_key)
+                        if main_access_key is not None
+                        else None
                     )
-                    result = await conn.execute(query)
-                    policy = result.first()
                     if policy is None:
-                        raise IdlePolicyNotFound(
-                            f"Resource policy not found for access_key={kernel.access_key}"
+                        log.warning(
+                            "idle policy not found for main_access_key={}; "
+                            "skipping its kernels in this cycle",
+                            main_access_key,
                         )
-                    policy_cache[kernel.access_key] = policy
+                    policy_cache[main_access_key] = policy
+                policy = policy_cache[main_access_key]
+                if policy is None:
+                    continue
 
                 check_tasks = [
                     checker.check_idleness(kernel, conn, policy, grace_period_end=grace_period_end)
@@ -292,7 +313,6 @@ class IdleCheckerHost:
                 ]
                 check_results = await aiotools.gather_safe(check_tasks)
                 terminated = False
-                errors: list[BaseException] = []
                 for checker, check_result in zip(self._checkers, check_results, strict=True):
                     if isinstance(check_result, BaseExceptionGroup):
                         errors.extend(check_result.exceptions)
@@ -310,8 +330,8 @@ class IdleCheckerHost:
                         if not terminated:
                             terminated = True
                             await checker.callback_idle_session(kernel.session_id)
-                if errors:
-                    raise IdleCheckerError("idle checker(s) raise errors", errors)
+        if errors:
+            raise IdleCheckerError("idle checker(s) raise errors", errors)
 
     async def get_idle_check_report(
         self,

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -2902,6 +2902,10 @@ class ScheduleDBSource:
         Also frees normalized resource allocations and releases the kernel's
         reserved/used hold on agent_resources.
 
+        The status guard keeps a late or duplicate termination event from
+        overwriting a kernel that already reached a terminal status, which would
+        replace its recorded reason and timestamps.
+
         :param kernel_id: Kernel ID to update
         :param reason: Termination reason
         :param exit_code: Process exit code
@@ -2912,7 +2916,10 @@ class ScheduleDBSource:
             stmt = (
                 sa.update(KernelRow)
                 .where(
-                    KernelRow.id == kernel_id,
+                    sa.and_(
+                        KernelRow.id == kernel_id,
+                        KernelRow.status.in_(KernelStatus.force_terminatable_statuses()),
+                    ),
                 )
                 .values(
                     status=KernelStatus.TERMINATED,
@@ -2933,13 +2940,13 @@ class ScheduleDBSource:
                 .returning(KernelRow.id)
             )
             result = await db_sess.execute(stmt)
-            row = result.first()
-            if row is None:
-                return False
+            updated = result.first() is not None
 
-            # Free allocations and release the kernel's reserved/used hold.
+            # Free allocations and release the kernel's reserved/used hold. This
+            # runs even when the status guard blocked the update so that a kernel
+            # already in a terminal status never keeps its hold; it is idempotent.
             await self._free_allocations_and_release(db_sess, [kernel_id], now)
-        return True
+        return updated
 
     async def reset_kernels_to_pending_for_sessions(
         self, session_ids: list[SessionId], reason: str
@@ -3091,6 +3098,9 @@ class ScheduleDBSource:
         """
         Update multiple kernels to TERMINATED status.
 
+        Kernels that already reached a terminal status are left untouched so
+        their recorded reason and timestamps survive a late termination event.
+
         :param kernel_ids: List of kernel ID strings to update
         :param reason: Termination reason
         :return: Number of kernels updated
@@ -3105,7 +3115,12 @@ class ScheduleDBSource:
 
             stmt = (
                 sa.update(KernelRow)
-                .where(KernelRow.id.in_(kernel_uuids))
+                .where(
+                    sa.and_(
+                        KernelRow.id.in_(kernel_uuids),
+                        KernelRow.status.in_(KernelStatus.force_terminatable_statuses()),
+                    )
+                )
                 .values(
                     status=KernelStatus.TERMINATED,
                     status_info=reason,

--- a/tests/unit/agent/test_sync_container_lifecycles.py
+++ b/tests/unit/agent/test_sync_container_lifecycles.py
@@ -1,0 +1,134 @@
+"""
+Tests for the registry-state guard in ``AbstractAgent.sync_container_lifecycles()``.
+
+A kernel that is already being destroyed (its own destroy flow reports the real
+termination reason) must not be re-reported as self-terminated just because its
+container has already exited. Containers the agent no longer tracks — e.g. ones
+it missed across a restart — must still be picked up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from ai.backend.agent.agent import AbstractAgent
+from ai.backend.agent.types import (
+    Container,
+    ContainerLifecycleEvent,
+    KernelLifecycleStatus,
+    LifecycleEvent,
+)
+from ai.backend.common.docker import LabelName
+from ai.backend.common.events.event_types.kernel.types import KernelLifecycleEventReason
+from ai.backend.common.types import (
+    AgentId,
+    ContainerId,
+    ContainerStatus,
+    KernelId,
+    SessionId,
+)
+
+
+def _dead_container(session_id: SessionId) -> Container:
+    return Container(
+        id=ContainerId(f"container-{uuid4().hex[:12]}"),
+        status=ContainerStatus.EXITED,
+        image="python:3.8",
+        labels={LabelName.SESSION_ID: str(session_id)},
+        ports=[],
+        backend_obj=None,
+    )
+
+
+def _tracked_kernel(session_id: SessionId, state: KernelLifecycleStatus) -> MagicMock:
+    kernel_obj = MagicMock()
+    kernel_obj.session_id = session_id
+    kernel_obj.state = state
+    kernel_obj.container_id = None
+    return kernel_obj
+
+
+def _make_agent(
+    *,
+    containers: list[tuple[KernelId, Container]],
+    kernel_registry: dict[KernelId, MagicMock],
+) -> Any:
+    """A stub carrying only what ``sync_container_lifecycles()`` touches."""
+    agent = MagicMock()
+    agent.id = AgentId("test-agent")
+    agent.enumerate_containers = AsyncMock(return_value=containers)
+    agent.registry_lock = asyncio.Lock()
+    agent.restarting_kernels = {}
+    agent.kernel_registry = kernel_registry
+    agent.container_lifecycle_queue = asyncio.Queue()
+    agent.set_container_count = AsyncMock()
+    agent.produce_error_event = AsyncMock()
+    return agent
+
+
+def _drain(queue: asyncio.Queue[ContainerLifecycleEvent]) -> list[ContainerLifecycleEvent]:
+    events: list[ContainerLifecycleEvent] = []
+    while not queue.empty():
+        events.append(queue.get_nowait())
+    return events
+
+
+class TestSyncContainerLifecycles:
+    async def test_untracked_dead_container_is_still_cleaned_up(self) -> None:
+        """A dead container missing from the registry is still reported as self-terminated."""
+        kernel_id = KernelId(uuid4())
+        session_id = SessionId(uuid4())
+        agent = _make_agent(
+            containers=[(kernel_id, _dead_container(session_id))],
+            kernel_registry={},
+        )
+
+        await AbstractAgent.sync_container_lifecycles(agent)
+
+        events = _drain(agent.container_lifecycle_queue)
+        assert len(events) == 1
+        assert events[0].kernel_id == kernel_id
+        assert events[0].event == LifecycleEvent.CLEAN
+        assert events[0].reason == KernelLifecycleEventReason.SELF_TERMINATED
+
+    async def test_running_kernel_with_dead_container_is_cleaned_up(self) -> None:
+        """A kernel the agent still believes is RUNNING is cleaned up as before."""
+        kernel_id = KernelId(uuid4())
+        session_id = SessionId(uuid4())
+        agent = _make_agent(
+            containers=[(kernel_id, _dead_container(session_id))],
+            kernel_registry={kernel_id: _tracked_kernel(session_id, KernelLifecycleStatus.RUNNING)},
+        )
+
+        await AbstractAgent.sync_container_lifecycles(agent)
+
+        events = _drain(agent.container_lifecycle_queue)
+        assert len(events) == 1
+        assert events[0].kernel_id == kernel_id
+        assert events[0].event == LifecycleEvent.CLEAN
+
+    @pytest.mark.parametrize(
+        "state",
+        [KernelLifecycleStatus.PREPARING, KernelLifecycleStatus.TERMINATING],
+    )
+    async def test_tracked_kernel_outside_running_is_skipped(
+        self, state: KernelLifecycleStatus
+    ) -> None:
+        """A TERMINATING kernel whose container already exited keeps the reason its
+        own destroy flow records, instead of being re-reported as self-terminated."""
+        kernel_id = KernelId(uuid4())
+        session_id = SessionId(uuid4())
+        agent = _make_agent(
+            containers=[(kernel_id, _dead_container(session_id))],
+            kernel_registry={kernel_id: _tracked_kernel(session_id, state)},
+        )
+
+        await AbstractAgent.sync_container_lifecycles(agent)
+
+        agent.produce_error_event.assert_not_called()
+        assert _drain(agent.container_lifecycle_queue) == []

--- a/tests/unit/manager/repositories/scheduler/test_resource_deallocation.py
+++ b/tests/unit/manager/repositories/scheduler/test_resource_deallocation.py
@@ -1482,10 +1482,10 @@ class TestNegativeValueGuard:
         result1 = await db_source.update_kernel_status_terminated(kernel_id, "first-terminate")
         assert result1 is True
 
-        # Second terminate - free_at already set, so no allocations to free;
-        # agent_resources.used should remain at 0, not go negative
+        # Second terminate - blocked by the terminal-status guard, and free_at is
+        # already set, so agent_resources.used should remain at 0, not go negative
         result2 = await db_source.update_kernel_status_terminated(kernel_id, "second-terminate")
-        assert result2 is True
+        assert result2 is False
 
         async with db_with_cleanup.begin_readonly_session() as db_sess:
             agent_resources = (

--- a/tests/unit/manager/repositories/scheduler/test_terminated_status_guard.py
+++ b/tests/unit/manager/repositories/scheduler/test_terminated_status_guard.py
@@ -1,0 +1,282 @@
+"""
+Tests for the terminal-status guard on the TERMINATED transitions of
+``ScheduleDBSource``.
+
+A duplicate or late termination event (e.g. the agent's container lifecycle
+sync re-reporting an already destroyed container) must not overwrite the
+reason and timestamps a kernel already recorded, and must not drag a
+CANCELLED / ERROR kernel into TERMINATED.
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+import pytest
+import sqlalchemy as sa
+
+from ai.backend.common.identifier.domain import DomainID
+from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.types import AccessKey, KernelId, SessionId
+from ai.backend.manager.data.kernel.types import KernelStatus
+from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.models.kernel import KernelRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.scheduler.db_source.db_source import ScheduleDBSource
+
+from .conftest import create_pending_session_with_kernels, seed_agent_resources
+
+_IDLE_REASON = "idle-utilization"
+_LATE_REASON = "self-terminated"
+
+
+async def _set_kernel_status(
+    db: ExtendedAsyncSAEngine,
+    kernel_id: KernelId,
+    status: KernelStatus,
+    status_info: str,
+) -> None:
+    async with db.begin_session() as db_sess:
+        await db_sess.execute(
+            sa.update(KernelRow)
+            .where(KernelRow.id == kernel_id)
+            .values(status=status, status_info=status_info)
+        )
+
+
+async def _fetch_kernel(db: ExtendedAsyncSAEngine, kernel_id: KernelId) -> KernelRow:
+    async with db.begin_readonly_session() as db_sess:
+        return (
+            await db_sess.execute(sa.select(KernelRow).where(KernelRow.id == kernel_id))
+        ).scalar_one()
+
+
+class TestTerminatedStatusGuard:
+    """The TERMINATED transitions only accept force-terminatable statuses."""
+
+    @pytest.fixture
+    async def seeded_agent_id(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_agent_id: str,
+        resource_slot_types: None,
+    ) -> str:
+        await seed_agent_resources(
+            db_with_cleanup,
+            test_agent_id,
+            cpu_capacity=Decimal("10"),
+            mem_capacity=Decimal("10240"),
+        )
+        return test_agent_id
+
+    @pytest.fixture
+    def db_source(self, db_with_cleanup: ExtendedAsyncSAEngine) -> ScheduleDBSource:
+        return ScheduleDBSource(db_with_cleanup)
+
+    async def _create_kernels(
+        self,
+        db: ExtendedAsyncSAEngine,
+        *,
+        domain_id: DomainID,
+        domain_name: str,
+        resource_group_id: ResourceGroupID,
+        scaling_group_name: str,
+        group_id: uuid.UUID,
+        user_uuid: uuid.UUID,
+        access_key: AccessKey,
+        agent_id: str,
+        kernel_status: KernelStatus,
+        count: int = 1,
+    ) -> tuple[SessionId, list[KernelId]]:
+        return await create_pending_session_with_kernels(
+            db,
+            domain_id=domain_id,
+            domain_name=domain_name,
+            resource_group_id=resource_group_id,
+            scaling_group_name=scaling_group_name,
+            group_id=group_id,
+            user_uuid=user_uuid,
+            access_key=access_key,
+            agent_assignments=[(agent_id, Decimal("2"), Decimal("2048"))] * count,
+            session_status=SessionStatus.RUNNING,
+            kernel_status=kernel_status,
+            assign_agents=kernel_status is not KernelStatus.PENDING,
+        )
+
+    async def test_late_event_does_not_overwrite_terminated_kernel(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        db_source: ScheduleDBSource,
+        test_domain_id: DomainID,
+        test_domain_name: str,
+        test_scaling_group_id: ResourceGroupID,
+        test_scaling_group_name: str,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_access_key: AccessKey,
+        seeded_agent_id: str,
+    ) -> None:
+        """A second termination event keeps the reason and timestamps of the first."""
+        _, kernel_ids = await self._create_kernels(
+            db_with_cleanup,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+            agent_id=seeded_agent_id,
+            kernel_status=KernelStatus.RUNNING,
+        )
+        kernel_id = kernel_ids[0]
+
+        assert await db_source.update_kernel_status_terminated(kernel_id, _IDLE_REASON) is True
+        first = await _fetch_kernel(db_with_cleanup, kernel_id)
+        first_terminated_at = first.terminated_at
+        first_status_changed = first.status_changed
+        first_history = first.status_history
+        assert first_history is not None
+
+        assert await db_source.update_kernel_status_terminated(kernel_id, _LATE_REASON) is False
+
+        second = await _fetch_kernel(db_with_cleanup, kernel_id)
+        assert second.status == KernelStatus.TERMINATED
+        assert second.status_info == _IDLE_REASON
+        assert second.terminated_at == first_terminated_at
+        assert second.status_changed == first_status_changed
+        assert second.status_history == first_history
+
+    @pytest.mark.parametrize(
+        "blocked_status",
+        [KernelStatus.CANCELLED, KernelStatus.ERROR, KernelStatus.PENDING],
+    )
+    async def test_late_event_does_not_terminate_blocked_status(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        db_source: ScheduleDBSource,
+        test_domain_id: DomainID,
+        test_domain_name: str,
+        test_scaling_group_id: ResourceGroupID,
+        test_scaling_group_name: str,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_access_key: AccessKey,
+        seeded_agent_id: str,
+        blocked_status: KernelStatus,
+    ) -> None:
+        """CANCELLED / ERROR / PENDING kernels are never moved to TERMINATED."""
+        _, kernel_ids = await self._create_kernels(
+            db_with_cleanup,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+            agent_id=seeded_agent_id,
+            kernel_status=blocked_status,
+        )
+        kernel_id = kernel_ids[0]
+
+        assert await db_source.update_kernel_status_terminated(kernel_id, _LATE_REASON) is False
+
+        kernel = await _fetch_kernel(db_with_cleanup, kernel_id)
+        assert kernel.status == blocked_status
+        assert kernel.status_info != _LATE_REASON
+        assert kernel.terminated_at is None
+
+    @pytest.mark.parametrize(
+        "live_status",
+        [KernelStatus.RUNNING, KernelStatus.TERMINATING],
+    )
+    async def test_live_kernel_still_terminates(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        db_source: ScheduleDBSource,
+        test_domain_id: DomainID,
+        test_domain_name: str,
+        test_scaling_group_id: ResourceGroupID,
+        test_scaling_group_name: str,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_access_key: AccessKey,
+        seeded_agent_id: str,
+        live_status: KernelStatus,
+    ) -> None:
+        """The normal RUNNING / TERMINATING -> TERMINATED transition still succeeds."""
+        _, kernel_ids = await self._create_kernels(
+            db_with_cleanup,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+            agent_id=seeded_agent_id,
+            kernel_status=live_status,
+        )
+        kernel_id = kernel_ids[0]
+
+        assert await db_source.update_kernel_status_terminated(kernel_id, _IDLE_REASON) is True
+
+        kernel = await _fetch_kernel(db_with_cleanup, kernel_id)
+        assert kernel.status == KernelStatus.TERMINATED
+        assert kernel.status_info == _IDLE_REASON
+        assert kernel.terminated_at is not None
+
+    async def test_bulk_terminate_skips_terminal_kernels(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        db_source: ScheduleDBSource,
+        test_domain_id: DomainID,
+        test_domain_name: str,
+        test_scaling_group_id: ResourceGroupID,
+        test_scaling_group_name: str,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_access_key: AccessKey,
+        seeded_agent_id: str,
+    ) -> None:
+        """The bulk update carries the same guard: only the live kernel is updated."""
+        _, kernel_ids = await self._create_kernels(
+            db_with_cleanup,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+            agent_id=seeded_agent_id,
+            kernel_status=KernelStatus.RUNNING,
+            count=3,
+        )
+        running_id, terminated_id, cancelled_id = kernel_ids
+        await _set_kernel_status(
+            db_with_cleanup, terminated_id, KernelStatus.TERMINATED, _IDLE_REASON
+        )
+        await _set_kernel_status(
+            db_with_cleanup, cancelled_id, KernelStatus.CANCELLED, "pending-timeout"
+        )
+
+        updated = await db_source.update_kernels_to_terminated(
+            [str(kid) for kid in kernel_ids], _LATE_REASON
+        )
+        assert updated == 1
+
+        running = await _fetch_kernel(db_with_cleanup, running_id)
+        assert running.status == KernelStatus.TERMINATED
+        assert running.status_info == _LATE_REASON
+
+        terminated = await _fetch_kernel(db_with_cleanup, terminated_id)
+        assert terminated.status == KernelStatus.TERMINATED
+        assert terminated.status_info == _IDLE_REASON
+        assert terminated.terminated_at is None
+
+        cancelled = await _fetch_kernel(db_with_cleanup, cancelled_id)
+        assert cancelled.status == KernelStatus.CANCELLED
+        assert cancelled.status_info == "pending-timeout"

--- a/tests/unit/manager/test_idle_check_host.py
+++ b/tests/unit/manager/test_idle_check_host.py
@@ -1,0 +1,582 @@
+"""
+Tests for ``IdleCheckerHost.do_idle_check()`` against a real database.
+
+The idle policy is resolved through ``users.main_access_key`` — a real foreign
+key — instead of the kernel's own ``access_key``, which a keypair deletion can
+leave orphaned. A kernel whose policy cannot be resolved, or whose checker
+raises, must not stop the remaining kernels of the same cycle from being
+checked.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import AsyncGenerator, AsyncIterator, Mapping
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, ClassVar, override
+from unittest.mock import MagicMock
+
+import pytest
+import sqlalchemy as sa
+from dateutil.tz import tzutc
+from sqlalchemy.engine import Row
+from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
+
+from ai.backend.common.clients.valkey_client.valkey_live.client import ValkeyLiveClient
+from ai.backend.common.data.user.types import UserRole
+from ai.backend.common.events.event_types.kernel.types import KernelLifecycleEventReason
+from ai.backend.common.identifier.domain import DomainID
+from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.typed_validators import HostPortPair as HostPortPairModel
+from ai.backend.common.types import (
+    AccessKey,
+    ClusterMode,
+    DefaultForUnspecified,
+    KernelId,
+    ResourceSlot,
+    SecretKey,
+    SessionId,
+    SessionResult,
+    SessionTypes,
+)
+from ai.backend.manager.data.kernel.types import KernelStatus
+from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.data.user.types import UserStatus
+from ai.backend.manager.idle import (
+    BaseIdleChecker,
+    IdleCheckerError,
+    IdleCheckerHost,
+    RemainingTimeType,
+)
+from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.group import GroupRow
+from ai.backend.manager.models.image import ImageRow
+from ai.backend.manager.models.kernel import KernelRow
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.rbac_models import RoleRow, UserRoleRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.scaling_group import ScalingGroupOpts, ScalingGroupRow
+from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.user import UserRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.db.engine import create_async_engine
+from ai.backend.testutils.db import with_tables
+
+IDLE_LOGGER_NAME = "ai.backend.manager.idle"
+
+_IDLE_ROWS = [
+    DomainRow,
+    ScalingGroupRow,
+    UserResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    KeyPairResourcePolicyRow,
+    RoleRow,
+    UserRoleRow,
+    UserRow,
+    KeyPairRow,
+    GroupRow,
+    AssociationScopesEntitiesRow,
+    AgentRow,
+    ContainerRegistryRow,
+    ImageRow,
+    SessionRow,
+    KernelRow,
+]
+
+
+class _RecordingChecker(BaseIdleChecker):
+    """Records which kernels were checked and with which policy."""
+
+    name: ClassVar[str] = "recording"
+    remaining_time_type: RemainingTimeType = RemainingTimeType.EXPIRE_AFTER
+
+    checked_kernel_ids: list[uuid.UUID]
+    seen_idle_timeouts: dict[uuid.UUID, int | None]
+    _failing_kernel_ids: frozenset[uuid.UUID]
+
+    def __init__(self, failing_kernel_ids: frozenset[uuid.UUID] = frozenset()) -> None:
+        self.checked_kernel_ids = []
+        self.seen_idle_timeouts = {}
+        self._failing_kernel_ids = failing_kernel_ids
+
+    @override
+    async def populate_config(self, config: Mapping[str, Any]) -> None:
+        return None
+
+    @override
+    async def get_extra_info(
+        self, redis_obj: ValkeyLiveClient, session_id: SessionId
+    ) -> dict[str, Any] | None:
+        return None
+
+    @override
+    async def get_checker_result(
+        self, redis_obj: ValkeyLiveClient, session_id: SessionId
+    ) -> float | None:
+        return None
+
+    @override
+    def terminate_reason(self) -> KernelLifecycleEventReason:
+        return KernelLifecycleEventReason.IDLE_TIMEOUT
+
+    @override
+    async def check_idleness(
+        self,
+        kernel: Row[Any],
+        dbconn: SAConnection,
+        policy: Row[Any],
+        *,
+        grace_period_end: datetime | None = None,
+    ) -> bool:
+        self.checked_kernel_ids.append(kernel.id)
+        self.seen_idle_timeouts[kernel.id] = policy.idle_timeout
+        if kernel.id in self._failing_kernel_ids:
+            raise RuntimeError("checker failed for this kernel")
+        return True
+
+    @override
+    async def callback_idle_session(self, session_id: SessionId) -> None:
+        return None
+
+
+@pytest.fixture
+async def database_connection(
+    postgres_container: tuple[str, HostPortPairModel],
+) -> AsyncIterator[ExtendedAsyncSAEngine]:
+    _, addr = postgres_container
+    url = f"postgresql+asyncpg://postgres:develove@{addr.host}:{addr.port}/testing"
+    engine = create_async_engine(url, pool_size=8, pool_pre_ping=False, max_overflow=64)
+    yield engine
+    await engine.dispose()
+
+
+class TestDoIdleCheck:
+    @pytest.fixture
+    async def db(
+        self, database_connection: ExtendedAsyncSAEngine
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(database_connection, _IDLE_ROWS):
+            yield database_connection
+
+    @pytest.fixture
+    async def domain(self, db: ExtendedAsyncSAEngine) -> tuple[DomainID, str]:
+        domain_id = DomainID(uuid.uuid4())
+        name = f"test-domain-{uuid.uuid4().hex[:8]}"
+        async with db.begin_session() as db_sess:
+            db_sess.add(
+                DomainRow(
+                    id=domain_id,
+                    name=name,
+                    total_resource_slots=ResourceSlot({
+                        "cpu": Decimal("1000"),
+                        "mem": Decimal("1048576"),
+                    }),
+                )
+            )
+            await db_sess.flush()
+        return domain_id, name
+
+    @pytest.fixture
+    async def scaling_group(self, db: ExtendedAsyncSAEngine) -> tuple[ResourceGroupID, str]:
+        sg_id = ResourceGroupID(uuid.uuid4())
+        name = f"test-sgroup-{uuid.uuid4().hex[:8]}"
+        async with db.begin_session() as db_sess:
+            db_sess.add(
+                ScalingGroupRow(
+                    id=sg_id,
+                    name=name,
+                    driver="static",
+                    scheduler="fifo",
+                    scheduler_opts=ScalingGroupOpts(
+                        allowed_session_types=[],
+                        config={},
+                    ),
+                    driver_opts={},
+                    is_active=True,
+                )
+            )
+            await db_sess.flush()
+        return sg_id, name
+
+    @pytest.fixture
+    async def group_id(self, db: ExtendedAsyncSAEngine, domain: tuple[DomainID, str]) -> uuid.UUID:
+        _, domain_name = domain
+        project_policy_name = f"test-proj-policy-{uuid.uuid4().hex[:8]}"
+        gid = uuid.uuid4()
+        async with db.begin_session() as db_sess:
+            db_sess.add(
+                ProjectResourcePolicyRow(
+                    name=project_policy_name,
+                    max_vfolder_count=10,
+                    max_quota_scope_size=-1,
+                    max_network_count=10,
+                )
+            )
+            await db_sess.flush()
+            db_sess.add(
+                GroupRow(
+                    id=gid,
+                    name=f"test-group-{uuid.uuid4().hex[:8]}",
+                    domain_name=domain_name,
+                    total_resource_slots=ResourceSlot({
+                        "cpu": Decimal("500"),
+                        "mem": Decimal("524288"),
+                    }),
+                    resource_policy=project_policy_name,
+                    integration_id=None,
+                )
+            )
+            await db_sess.flush()
+        return gid
+
+    @pytest.fixture
+    async def user_resource_policy_name(self, db: ExtendedAsyncSAEngine) -> str:
+        name = f"test-user-policy-{uuid.uuid4().hex[:8]}"
+        async with db.begin_session() as db_sess:
+            db_sess.add(
+                UserResourcePolicyRow(
+                    name=name,
+                    max_vfolder_count=10,
+                    max_quota_scope_size=-1,
+                    max_session_count_per_model_session=10,
+                    max_customized_image_count=3,
+                )
+            )
+            await db_sess.flush()
+        return name
+
+    async def _create_keypair_policy(self, db: ExtendedAsyncSAEngine, idle_timeout: int) -> str:
+        name = f"test-kp-policy-{uuid.uuid4().hex[:8]}"
+        async with db.begin_session() as db_sess:
+            db_sess.add(
+                KeyPairResourcePolicyRow(
+                    name=name,
+                    default_for_unspecified=DefaultForUnspecified.LIMITED,
+                    total_resource_slots=ResourceSlot({
+                        "cpu": Decimal("100"),
+                        "mem": Decimal("102400"),
+                    }),
+                    max_concurrent_sessions=10,
+                    max_containers_per_session=1,
+                    idle_timeout=idle_timeout,
+                    max_session_lifetime=0,
+                    allowed_vfolder_hosts={},
+                )
+            )
+            await db_sess.flush()
+        return name
+
+    async def _create_user(
+        self,
+        db: ExtendedAsyncSAEngine,
+        *,
+        domain_name: str,
+        user_resource_policy_name: str,
+        main_keypair_idle_timeout: int | None,
+    ) -> tuple[uuid.UUID, AccessKey | None]:
+        """Create a user; ``None`` idle timeout leaves ``main_access_key`` unset."""
+        user_uuid = uuid.uuid4()
+        async with db.begin_session() as db_sess:
+            db_sess.add(
+                UserRow(
+                    uuid=user_uuid,
+                    email=f"test-user-{uuid.uuid4().hex[:8]}@test.com",
+                    username=f"test-user-{uuid.uuid4().hex[:8]}",
+                    role=UserRole.USER,
+                    status=UserStatus.ACTIVE,
+                    domain_name=domain_name,
+                    resource_policy=user_resource_policy_name,
+                )
+            )
+            await db_sess.flush()
+        if main_keypair_idle_timeout is None:
+            return user_uuid, None
+        access_key = await self._create_keypair(
+            db, user_uuid=user_uuid, idle_timeout=main_keypair_idle_timeout
+        )
+        async with db.begin_session() as db_sess:
+            await db_sess.execute(
+                sa.update(UserRow)
+                .where(UserRow.uuid == user_uuid)
+                .values(main_access_key=access_key)
+            )
+        return user_uuid, access_key
+
+    async def _create_keypair(
+        self,
+        db: ExtendedAsyncSAEngine,
+        *,
+        user_uuid: uuid.UUID,
+        idle_timeout: int,
+    ) -> AccessKey:
+        policy_name = await self._create_keypair_policy(db, idle_timeout)
+        access_key = AccessKey(f"AKTEST{uuid.uuid4().hex[:14]}")
+        async with db.begin_session() as db_sess:
+            db_sess.add(
+                KeyPairRow(
+                    access_key=access_key,
+                    secret_key=SecretKey(f"SK{uuid.uuid4().hex[:38]}"),
+                    user=user_uuid,
+                    user_id=str(user_uuid),
+                    is_active=True,
+                    is_admin=False,
+                    resource_policy=policy_name,
+                )
+            )
+            await db_sess.flush()
+        return access_key
+
+    async def _create_running_kernel(
+        self,
+        db: ExtendedAsyncSAEngine,
+        *,
+        domain: tuple[DomainID, str],
+        scaling_group: tuple[ResourceGroupID, str],
+        group_id: uuid.UUID,
+        user_uuid: uuid.UUID,
+        access_key: AccessKey,
+    ) -> KernelId:
+        domain_id, domain_name = domain
+        sg_id, sg_name = scaling_group
+        session_id = SessionId(uuid.uuid4())
+        kernel_id = KernelId(uuid.uuid4())
+        now = datetime.now(tzutc())
+        slots = ResourceSlot({"cpu": Decimal("2"), "mem": Decimal("2048")})
+        async with db.begin_session() as db_sess:
+            db_sess.add(
+                SessionRow(
+                    id=session_id,
+                    name=f"test-session-{uuid.uuid4().hex[:8]}",
+                    session_type=SessionTypes.INTERACTIVE,
+                    domain_id=domain_id,
+                    domain_name=domain_name,
+                    group_id=group_id,
+                    user_uuid=user_uuid,
+                    access_key=access_key,
+                    resource_group_id=sg_id,
+                    scaling_group_name=sg_name,
+                    status=SessionStatus.RUNNING,
+                    status_info="test",
+                    cluster_mode=ClusterMode.SINGLE_NODE,
+                    requested_slots=slots,
+                    created_at=now,
+                    starts_at=now,
+                    images=["python:3.8"],
+                    vfolder_mounts=[],
+                    environ={},
+                    result=SessionResult.UNDEFINED,
+                )
+            )
+            await db_sess.flush()
+            db_sess.add(
+                KernelRow(
+                    id=kernel_id,
+                    session_id=session_id,
+                    scaling_group=sg_name,
+                    resource_group_id=sg_id,
+                    cluster_idx=0,
+                    cluster_role="main",
+                    cluster_hostname=f"kernel-{uuid.uuid4().hex[:8]}",
+                    image="python:3.8",
+                    architecture="x86_64",
+                    registry="docker.io",
+                    status=KernelStatus.RUNNING,
+                    status_changed=now,
+                    session_type=SessionTypes.INTERACTIVE,
+                    occupied_slots=slots,
+                    requested_slots=slots,
+                    domain_name=domain_name,
+                    group_id=group_id,
+                    user_uuid=user_uuid,
+                    access_key=access_key,
+                    created_at=now,
+                    starts_at=now,
+                    mounts=[],
+                    environ={},
+                    vfolder_mounts=[],
+                    preopen_ports=[],
+                    repl_in_port=2001,
+                    repl_out_port=2002,
+                    stdin_port=2003,
+                    stdout_port=2004,
+                )
+            )
+            await db_sess.flush()
+        return kernel_id
+
+    def _make_host(self, db: ExtendedAsyncSAEngine, checker: BaseIdleChecker) -> IdleCheckerHost:
+        host = IdleCheckerHost(
+            db,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        )
+        host.add_checker(checker)
+        return host
+
+    async def test_policy_resolved_via_main_access_key(
+        self,
+        db: ExtendedAsyncSAEngine,
+        domain: tuple[DomainID, str],
+        scaling_group: tuple[ResourceGroupID, str],
+        group_id: uuid.UUID,
+        user_resource_policy_name: str,
+    ) -> None:
+        """A kernel created with a secondary keypair uses the main keypair's policy."""
+        user_uuid, main_access_key = await self._create_user(
+            db,
+            domain_name=domain[1],
+            user_resource_policy_name=user_resource_policy_name,
+            main_keypair_idle_timeout=600,
+        )
+        assert main_access_key is not None
+        secondary_access_key = await self._create_keypair(db, user_uuid=user_uuid, idle_timeout=30)
+        kernel_id = await self._create_running_kernel(
+            db,
+            domain=domain,
+            scaling_group=scaling_group,
+            group_id=group_id,
+            user_uuid=user_uuid,
+            access_key=secondary_access_key,
+        )
+
+        checker = _RecordingChecker()
+        await self._make_host(db, checker).do_idle_check()
+
+        assert checker.checked_kernel_ids == [kernel_id]
+        assert checker.seen_idle_timeouts[kernel_id] == 600
+
+    async def test_orphaned_kernel_access_key_is_still_checked(
+        self,
+        db: ExtendedAsyncSAEngine,
+        domain: tuple[DomainID, str],
+        scaling_group: tuple[ResourceGroupID, str],
+        group_id: uuid.UUID,
+        user_resource_policy_name: str,
+    ) -> None:
+        """A kernel whose own access key has no keypair row is checked all the same."""
+        user_uuid, _ = await self._create_user(
+            db,
+            domain_name=domain[1],
+            user_resource_policy_name=user_resource_policy_name,
+            main_keypair_idle_timeout=600,
+        )
+        kernel_id = await self._create_running_kernel(
+            db,
+            domain=domain,
+            scaling_group=scaling_group,
+            group_id=group_id,
+            user_uuid=user_uuid,
+            access_key=AccessKey(f"AKDELETED{uuid.uuid4().hex[:11]}"),
+        )
+
+        checker = _RecordingChecker()
+        await self._make_host(db, checker).do_idle_check()
+
+        assert checker.checked_kernel_ids == [kernel_id]
+        assert checker.seen_idle_timeouts[kernel_id] == 600
+
+    async def test_unresolvable_policy_skips_only_its_own_kernels(
+        self,
+        db: ExtendedAsyncSAEngine,
+        domain: tuple[DomainID, str],
+        scaling_group: tuple[ResourceGroupID, str],
+        group_id: uuid.UUID,
+        user_resource_policy_name: str,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A user without a main access key never blocks the rest of the cycle,
+        and its missing policy is warned about only once."""
+        policyless_uuid, _ = await self._create_user(
+            db,
+            domain_name=domain[1],
+            user_resource_policy_name=user_resource_policy_name,
+            main_keypair_idle_timeout=None,
+        )
+        normal_uuid, normal_access_key = await self._create_user(
+            db,
+            domain_name=domain[1],
+            user_resource_policy_name=user_resource_policy_name,
+            main_keypair_idle_timeout=600,
+        )
+        assert normal_access_key is not None
+        orphan_access_key = AccessKey(f"AKDELETED{uuid.uuid4().hex[:11]}")
+        for _ in range(2):
+            await self._create_running_kernel(
+                db,
+                domain=domain,
+                scaling_group=scaling_group,
+                group_id=group_id,
+                user_uuid=policyless_uuid,
+                access_key=orphan_access_key,
+            )
+        normal_kernel_ids = [
+            await self._create_running_kernel(
+                db,
+                domain=domain,
+                scaling_group=scaling_group,
+                group_id=group_id,
+                user_uuid=normal_uuid,
+                access_key=normal_access_key,
+            )
+            for _ in range(2)
+        ]
+
+        checker = _RecordingChecker()
+        with caplog.at_level(logging.WARNING, logger=IDLE_LOGGER_NAME):
+            await self._make_host(db, checker).do_idle_check()
+
+        assert sorted(checker.checked_kernel_ids) == sorted(normal_kernel_ids)
+        warnings = [
+            record
+            for record in caplog.records
+            if record.name == IDLE_LOGGER_NAME and "idle policy not found" in record.getMessage()
+        ]
+        assert len(warnings) == 1
+
+    async def test_checker_error_does_not_skip_remaining_kernels(
+        self,
+        db: ExtendedAsyncSAEngine,
+        domain: tuple[DomainID, str],
+        scaling_group: tuple[ResourceGroupID, str],
+        group_id: uuid.UUID,
+        user_resource_policy_name: str,
+    ) -> None:
+        """A checker failing on one kernel still lets the others be checked."""
+        user_uuid, access_key = await self._create_user(
+            db,
+            domain_name=domain[1],
+            user_resource_policy_name=user_resource_policy_name,
+            main_keypair_idle_timeout=600,
+        )
+        assert access_key is not None
+        kernel_ids = [
+            await self._create_running_kernel(
+                db,
+                domain=domain,
+                scaling_group=scaling_group,
+                group_id=group_id,
+                user_uuid=user_uuid,
+                access_key=access_key,
+            )
+            for _ in range(3)
+        ]
+
+        checker = _RecordingChecker(failing_kernel_ids=frozenset({kernel_ids[0]}))
+        with pytest.raises(IdleCheckerError):
+            await self._make_host(db, checker).do_idle_check()
+
+        assert sorted(checker.checked_kernel_ids) == sorted(kernel_ids)


### PR DESCRIPTION
## Summary

- **Termination reason overwrite**: the agent's `sync_container_lifecycles()` re-reported the exited container of a kernel whose destroy flow was still finishing, emitting a second CLEAN event that overwrote `status_info` with `self-terminated` (along with `terminated_at`, `status_changed`, and `status_history["TERMINATED"]`). The dead-container branch now carries the same registry-state guard the missing-container branch already had — kernels absent from the registry (e.g. missed across an agent restart) are still picked up. As defense in depth, `update_kernel_status_terminated()` and `update_kernels_to_terminated()` now guard on `KernelStatus.force_terminatable_statuses()`, matching the existing force-terminate paths in the same file, so a late event cannot overwrite a kernel that already reached a terminal status. Resource accounting is unchanged: allocations are still freed on every call and remain idempotent via the `free_at IS NULL` guard.
- **Idle check aborted mid-cycle**: `do_idle_check()` raised `IdlePolicyNotFound` inside the per-kernel loop when a RUNNING kernel referenced a deleted keypair (`kernels.access_key` has no FK), so every kernel after it was skipped for that cycle — and with no `ORDER BY`, the row order shifted each cycle, leaving affected sessions with sparse utilization samples (a session due to die after 6h was observed surviving 17h). The policy is now resolved through `users.main_access_key`, a real FK whose deletion `DeleteKeyPair` refuses, following the existing joins in `scheduler/db_source`. A still-unresolvable policy logs one warning per access key per cycle and skips only its own kernels. `IdleCheckerError` from per-kernel checkers is likewise collected and raised after the loop instead of aborting it.

### Behavior change

The idle policy applied to a session moves from "the keypair that created the session" to "the user's main keypair". Deployments that set different `idle_timeout` / `max_session_lifetime` per keypair will see different timeouts, and `switch_my_main_access_key` changes the policy of already-running sessions at that moment.

### Backport scope

- Backportable: the `force_terminatable_statuses()` guards and the `raise` → skip change (no change in intended semantics).
- main only: the `users.main_access_key` join switch, since it changes which policy applies.

### Out of scope (separate issues if wanted)

Adding a running-session guard to keypair deletion, adding an FK on `kernels.access_key`, and snapshotting the policy onto the kernel/session at creation time.

## Test plan

- [x] `tests/unit/agent/test_sync_container_lifecycles.py` — a tracked kernel outside RUNNING is skipped; an untracked dead container is still cleaned up as `self-terminated`; a RUNNING kernel is cleaned up as before
- [x] `tests/unit/manager/repositories/scheduler/test_terminated_status_guard.py` — a second termination event leaves `status_info` / `terminated_at` / `status_changed` / `status_history` intact; CANCELLED, ERROR and PENDING kernels are never moved to TERMINATED; RUNNING and TERMINATING still transition and return True; the bulk update carries the same guard
- [x] `tests/unit/manager/test_idle_check_host.py` — a kernel created with a secondary keypair takes the main keypair's policy; a kernel whose own access key has no keypair row is still checked; a user without a resolvable policy neither blocks the rest of the cycle nor warns more than once; a checker failing on one kernel still lets the others be checked before `IdleCheckerError` is raised
- [x] `pants fmt` / `fix` / `lint` / `check` (mypy) pass with no `# noqa` or `# type: ignore`
- [ ] CI test run

Resolves BA-7036