### PR TITLE
fix(BA-7046): correct NetworkTimeoutChecker to use IdleJudgmentData

### DIFF
--- a/changes/13177.fix.md
+++ b/changes/13177.fix.md
@@ -1,0 +1,1 @@
+Fix manager startup crash where the network-timeout idle checker imported a non-existent `IdleJudgment` name instead of `IdleJudgmentData`

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/network_timeout.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/network_timeout.py
@@ -13,11 +13,11 @@ from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.types import SessionId
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.idle_checker.types import IdleCheckSession
+from ai.backend.manager.repositories.idle_checker.types import IdleJudgmentData
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
     IdleChecker,
     IdleCheckerContext,
-    IdleJudgment,
 )
 
 log = BraceStyleAdapter(logging.getLogger(__name__))
@@ -45,7 +45,7 @@ class NetworkTimeoutChecker(IdleChecker):
         assignments: Sequence[CheckerAssignment],
         *,
         context: IdleCheckerContext,
-    ) -> Sequence[IdleJudgment]:
+    ) -> Sequence[IdleJudgmentData]:
         # Fetch session states in one batch to avoid repeated I/O per assignment.
         sessions: list[IdleCheckSession] = []
         for assignment in assignments:
@@ -53,7 +53,7 @@ class NetworkTimeoutChecker(IdleChecker):
         states = await self._prepare_states(sessions)
 
         # Judge each assignment in one pass, using the pre-fetched states.
-        judgments: list[IdleJudgment] = []
+        judgments: list[IdleJudgmentData] = []
         for assignment in assignments:
             network_spec = assignment.definition.spec.network
             if network_spec is None:
@@ -88,9 +88,9 @@ class NetworkTimeoutChecker(IdleChecker):
         state: _NetworkIdleState,
         max_inactivity_seconds: int,
         current_time: datetime,
-    ) -> IdleJudgment:
+    ) -> IdleJudgmentData:
         if state.last_access == _ONGOING_ACTIVITY_SENTINEL or state.active_connections > 0:
-            return IdleJudgment(
+            return IdleJudgmentData(
                 checker_id=checker_id,
                 session_id=session_id,
                 expire_at=current_time + timedelta(seconds=max_inactivity_seconds),
@@ -115,7 +115,7 @@ class NetworkTimeoutChecker(IdleChecker):
         else:
             status = IdleCheckPhase.IDLE
             message = "No active network connection"
-        return IdleJudgment(
+        return IdleJudgmentData(
             checker_id=checker_id,
             session_id=session_id,
             expire_at=expire_at,


### PR DESCRIPTION
Resolves #13176 (BA-7046)

## Problem
The manager fails to boot with an `ImportError`:

```
ImportError: cannot import name 'IdleJudgment' from 'ai.backend.manager.sokovan.idle_check.checkers.base'
```

`NetworkTimeoutChecker` imports a name (`IdleJudgment`) that does not exist on `checkers.base`. It surfaces at startup via `server.py → dependencies → orchestration → sokovan/stages/factory.py → idle_check_judgment.py → checkers/network_timeout.py`.

## Root cause
The correct type is `IdleJudgmentData` (`manager.repositories.idle_checker.types`), used by the sibling `session_lifetime` checker and the `IdleChecker.judge` abstract contract in `base.py`. The two have identical constructor fields — `IdleJudgment` is simply a stale name.

This landed as a **semantic merge conflict**: the checker was authored in #12878 (BA-6894) against an earlier name, while #13108 (BA-6960) renamed the type to `IdleJudgmentData`. #12878 merged without a rebase/re-test, so the mismatch reached `main` even though each PR was green on its own branch.

## Fix
In `network_timeout.py`:
- import `IdleJudgmentData` from `repositories.idle_checker.types`
- drop `IdleJudgment` from the `checkers.base` import
- replace all `IdleJudgment` references (return types + constructors)

## Verification
- `pants fmt / fix / lint / check` — clean
- `pants test tests/unit/manager/sokovan/idle_check/test_network_timeout_checker.py` — pass
- `./backend.ai mgr start-server` boots; `./backend.ai mgr health check` → 10/10 HEALTHY

🤖 Generated with [Claude Code](https://claude.com/claude-code)