### PR TITLE
fix(BA-7002): apply current_hook when creating Metric on first observation (#13144)

### DIFF
--- a/changes/13144.fix.md
+++ b/changes/13144.fix.md
@@ -1,0 +1,1 @@
+Fix spurious first-sample spikes in hook-derived utilization metrics (e.g. `cpu_util`) by applying `current_hook` at `Metric` creation

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -316,6 +316,12 @@ class Metric:
     capacity: Decimal | None = None
     current_hook: Callable[[Metric], Decimal] | None = None
 
+    def __attrs_post_init__(self) -> None:
+        # Hook-derived metrics (e.g., rate-based cpu_util) must never expose the raw
+        # measurement as current; the first observation feeds a cumulative counter here.
+        if self.current_hook is not None:
+            self.current = self.current_hook(self)
+
     def update(self, value: Measurement) -> None:
         if value.capacity is not None:
             self.capacity = value.capacity

--- a/tests/unit/agent/test_stats.py
+++ b/tests/unit/agent/test_stats.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from decimal import Decimal
 from unittest.mock import patch
 
 import pytest
 
-from ai.backend.agent.stats import MovingStatistics
+from ai.backend.agent.stats import Measurement, Metric, MetricTypes, MovingStatistics
 
 
 class TestMovingStatistics:
@@ -84,3 +85,79 @@ class TestMovingStatistics:
             stats.update(case.second_value)
 
         assert stats.rate == case.expected_rate
+
+
+# Large enough that leaking it into `current` reads as an unmistakable spike
+# (pct would be 1,000,000%), never as a plausible utilization value.
+_HUGE_CPU_USED_MSEC = Decimal(10_000_000)
+
+
+class TestMetric:
+    """Tests for Metric class, focusing on current_hook application."""
+
+    @dataclass(frozen=True)
+    class CreationTestCase:
+        id: str
+        initial_value: Decimal
+        current_hook: Callable[[Metric], Decimal] | None
+        expected_current: Decimal
+        expected_pct: str
+
+    @pytest.mark.parametrize(
+        "case",
+        [
+            CreationTestCase(
+                id="rate_hook_applied_to_first_observation",
+                initial_value=_HUGE_CPU_USED_MSEC,
+                current_hook=lambda metric: metric.stats.rate,
+                expected_current=Decimal(0),
+                expected_pct="0",
+            ),
+            CreationTestCase(
+                id="no_hook_keeps_raw_value",
+                initial_value=_HUGE_CPU_USED_MSEC,
+                current_hook=None,
+                expected_current=_HUGE_CPU_USED_MSEC,
+                expected_pct="1000000",
+            ),
+        ],
+        ids=lambda case: case.id,
+    )
+    def test_creation_applies_current_hook(self, case: CreationTestCase) -> None:
+        """Test that a hook-derived metric does not expose the raw cumulative counter
+        as current/pct on the first observation."""
+        metric = Metric(
+            key="cpu_util",
+            type=MetricTypes.UTILIZATION,
+            unit_hint="percent",
+            stats=MovingStatistics(case.initial_value),
+            stats_filter=frozenset({"avg", "max"}),
+            current=case.initial_value,
+            capacity=Decimal(1000),
+            current_hook=case.current_hook,
+        )
+
+        assert metric.current == case.expected_current
+        assert metric.to_serializable_dict()["pct"] == case.expected_pct
+
+    @pytest.fixture
+    def cpu_util_metric(self) -> Metric:
+        with patch("time.perf_counter", return_value=1.0):
+            return Metric(
+                key="cpu_util",
+                type=MetricTypes.UTILIZATION,
+                unit_hint="percent",
+                stats=MovingStatistics(Decimal(1000)),
+                stats_filter=frozenset({"avg", "max"}),
+                current=Decimal(1000),
+                capacity=Decimal(1000),
+                current_hook=lambda metric: metric.stats.rate,
+            )
+
+    def test_update_applies_current_hook(self, cpu_util_metric: Metric) -> None:
+        """Test that subsequent observations report the rate derived from the counter delta."""
+        with patch("time.perf_counter", return_value=2.0):
+            cpu_util_metric.update(Measurement(Decimal(1500)))
+
+        assert cpu_util_metric.current == Decimal(500)
+        assert cpu_util_metric.to_serializable_dict()["pct"] == "50"


### PR DESCRIPTION
This is an auto-generated backport PR of #13144 to the 26.4 release.