### PR TITLE
feat(BA-7037): add session_groups table with placement policy columns

### DIFF
--- a/changes/13180.feature.md
+++ b/changes/13180.feature.md
@@ -1,0 +1,1 @@
+Add SessionGroup, the placement policy that keeps a set of sessions apart (spread) or together (pack) per agent, and give every deployment replica group one.

--- a/src/ai/backend/common/identifier/session_group.py
+++ b/src/ai/backend/common/identifier/session_group.py
@@ -1,0 +1,7 @@
+from typing import NewType
+from uuid import UUID
+
+__all__ = ("SessionGroupID",)
+
+
+SessionGroupID = NewType("SessionGroupID", UUID)

--- a/src/ai/backend/manager/data/session_group/types.py
+++ b/src/ai/backend/manager/data/session_group/types.py
@@ -1,0 +1,21 @@
+import enum
+
+__all__ = (
+    "SessionGroupPlacementDirection",
+    "SessionGroupPlacementEnforcement",
+)
+
+
+class SessionGroupPlacementDirection(enum.StrEnum):
+    """How the member sessions of a group sit relative to each other, per agent."""
+
+    SPREAD = "spread"
+    PACK = "pack"
+    NONE = "none"
+
+
+class SessionGroupPlacementEnforcement(enum.StrEnum):
+    """How hard the placement direction is enforced when it cannot be satisfied."""
+
+    PREFERRED = "preferred"
+    STRICT = "strict"

--- a/src/ai/backend/manager/models/alembic/env.py
+++ b/src/ai/backend/manager/models/alembic/env.py
@@ -23,8 +23,8 @@ if not logging_active.get():
 
 # Import all model modules to register tables with metadata.
 # Using pkgutil for automatic discovery to ensure all tables are included.
-# This handles both top-level modules (models/*.py) and subpackages (models/{domain}/).
-# Subpackages must export Row classes in their __init__.py.
+# This handles both top-level modules (models/*.py) and subpackages (models/{domain}/),
+# including subpackages that keep their __init__ empty and declare the table in row.py.
 import importlib
 import pkgutil
 
@@ -37,6 +37,10 @@ for module_info in pkgutil.iter_modules(ai.backend.manager.models.__path__):
     if module_info.ispkg:
         if module_info.name not in _SKIP_SUBPACKAGES:
             importlib.import_module(f"ai.backend.manager.models.{module_info.name}")
+            try:
+                importlib.import_module(f"ai.backend.manager.models.{module_info.name}.row")
+            except ModuleNotFoundError:
+                pass
     else:
         importlib.import_module(f"ai.backend.manager.models.{module_info.name}")
 

--- a/src/ai/backend/manager/models/alembic/versions/8f3c1d5a2b47_add_session_groups_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/8f3c1d5a2b47_add_session_groups_table.py
@@ -107,7 +107,10 @@ def upgrade() -> None:
                 ["project_id"], ["groups.id"], name="fk_session_groups_project_id_groups"
             ),
             sa.ForeignKeyConstraint(
-                ["owner_user_id"], ["users.uuid"], name="fk_session_groups_owner_user_id_users"
+                ["owner_user_id"],
+                ["users.uuid"],
+                name="fk_session_groups_owner_user_id_users",
+                ondelete="RESTRICT",
             ),
             sa.PrimaryKeyConstraint("id", name="pk_session_groups"),
         )

--- a/src/ai/backend/manager/models/alembic/versions/8f3c1d5a2b47_add_session_groups_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/8f3c1d5a2b47_add_session_groups_table.py
@@ -17,7 +17,7 @@ existing route sessions join the same group so a running deployment's members
 are visible to the scheduler from the first tick.
 
 Revision ID: 8f3c1d5a2b47
-Revises: e7a41b29c8d3
+Revises: 890490020974
 Create Date: 2026-07-28
 
 """
@@ -29,7 +29,7 @@ from ai.backend.manager.models.base import GUID
 
 # revision identifiers, used by Alembic.
 revision = "8f3c1d5a2b47"
-down_revision = "e7a41b29c8d3"
+down_revision = "890490020974"
 # Part of: NEXT_RELEASE_VERSION
 branch_labels = None
 depends_on = None

--- a/src/ai/backend/manager/models/alembic/versions/8f3c1d5a2b47_add_session_groups_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/8f3c1d5a2b47_add_session_groups_table.py
@@ -1,0 +1,150 @@
+"""add session_groups table and placement group FKs
+
+Introduces ``session_groups``, the holder of the per-agent placement policy of
+a set of sessions (BEP-1064). Membership is bound through the two new FKs:
+``sessions.session_group_id`` is nullable (NULL means no placement constraint,
+the default for ordinary sessions) and indexed because it is the join key of
+the scheduler's per-agent membership query, while
+``replica_groups.session_group_id`` is NOT NULL — a replica group always owns
+exactly one group.
+
+Existing replica groups are backfilled with one group each, taking the
+ownership axes from their endpoint's ``(domain, project, session_owner)`` and
+the deployment default policy, ``spread`` + ``preferred``. ``preferred`` rather
+than ``strict``: nothing enforced replica spreading before, so a strict policy
+could turn services that used to deploy fine into placement failures. Their
+existing route sessions join the same group so a running deployment's members
+are visible to the scheduler from the first tick.
+
+Revision ID: 8f3c1d5a2b47
+Revises: e7a41b29c8d3
+Create Date: 2026-07-28
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.base import GUID
+
+# revision identifiers, used by Alembic.
+revision = "8f3c1d5a2b47"
+down_revision = "e7a41b29c8d3"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+# One session group per existing replica group, in a single statement: the
+# ``new_groups`` CTE holds the generated ids so the INSERT and the UPDATE agree
+# on them. Re-running is a no-op thanks to the ``session_group_id IS NULL``
+# guard.
+BACKFILL_SQL = """
+WITH new_groups AS (
+    SELECT
+        rg.id AS replica_group_id,
+        uuid_generate_v4() AS session_group_id,
+        d.id AS domain_id,
+        e.project AS project_id,
+        e.session_owner AS owner_user_id
+    FROM replica_groups rg
+    JOIN endpoints e ON e.id = rg.deployment_id
+    JOIN domains d ON d.name = e.domain
+    WHERE rg.session_group_id IS NULL
+), inserted AS (
+    INSERT INTO session_groups (
+        id, domain_id, project_id, owner_user_id,
+        placement_direction, placement_enforcement
+    )
+    SELECT
+        session_group_id, domain_id, project_id, owner_user_id,
+        'spread', 'preferred'
+    FROM new_groups
+)
+UPDATE replica_groups rg
+SET session_group_id = ng.session_group_id
+FROM new_groups ng
+WHERE rg.id = ng.replica_group_id
+"""
+
+# The route sessions of a replica group are its group's members, so existing
+# ones join the group their route belongs to. Without this the scheduler sees
+# no members for a group whose replicas are already running. Runs after the
+# replica group backfill above, which is where the group ids come from.
+BACKFILL_ROUTE_SESSIONS_SQL = """
+UPDATE sessions s
+SET session_group_id = rg.session_group_id
+FROM routings r
+JOIN replica_groups rg ON rg.id = r.replica_group_id
+WHERE r.session = s.id
+  AND s.session_group_id IS NULL
+"""
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if "session_groups" not in inspector.get_table_names():
+        op.create_table(
+            "session_groups",
+            sa.Column("id", GUID, nullable=False, server_default=sa.text("uuid_generate_v4()")),
+            sa.Column("domain_id", GUID, nullable=False),
+            sa.Column("project_id", GUID, nullable=False),
+            sa.Column("owner_user_id", GUID, nullable=False),
+            sa.Column("placement_direction", sa.String(length=64), nullable=False),
+            sa.Column("placement_enforcement", sa.String(length=64), nullable=False),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+            sa.ForeignKeyConstraint(
+                ["domain_id"], ["domains.id"], name="fk_session_groups_domain_id_domains"
+            ),
+            sa.ForeignKeyConstraint(
+                ["project_id"], ["groups.id"], name="fk_session_groups_project_id_groups"
+            ),
+            sa.ForeignKeyConstraint(
+                ["owner_user_id"], ["users.uuid"], name="fk_session_groups_owner_user_id_users"
+            ),
+            sa.PrimaryKeyConstraint("id", name="pk_session_groups"),
+        )
+
+    session_columns = {c["name"] for c in inspector.get_columns("sessions")}
+    if "session_group_id" not in session_columns:
+        op.add_column("sessions", sa.Column("session_group_id", GUID, nullable=True))
+        op.create_foreign_key(
+            "fk_sessions_session_group_id_session_groups",
+            "sessions",
+            "session_groups",
+            ["session_group_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+    session_indexes = {i["name"] for i in inspector.get_indexes("sessions")}
+    if "ix_sessions_session_group_id" not in session_indexes:
+        op.create_index("ix_sessions_session_group_id", "sessions", ["session_group_id"])
+
+    replica_group_columns = {c["name"] for c in inspector.get_columns("replica_groups")}
+    if "session_group_id" not in replica_group_columns:
+        op.add_column("replica_groups", sa.Column("session_group_id", GUID, nullable=True))
+        op.create_foreign_key(
+            "fk_replica_groups_session_group_id_session_groups",
+            "replica_groups",
+            "session_groups",
+            ["session_group_id"],
+            ["id"],
+        )
+
+    op.execute(BACKFILL_SQL)
+    op.alter_column("replica_groups", "session_group_id", nullable=False)
+    op.execute(BACKFILL_ROUTE_SESSIONS_SQL)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_sessions_session_group_id")
+    op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS session_group_id")
+    op.execute("ALTER TABLE replica_groups DROP COLUMN IF EXISTS session_group_id")
+    op.execute("DROP TABLE IF EXISTS session_groups")

--- a/src/ai/backend/manager/models/endpoint/row.py
+++ b/src/ai/backend/manager/models/endpoint/row.py
@@ -629,7 +629,9 @@ class EndpointRow(Base):  # type: ignore[misc]
         target_user_uuid: UUID,
         target_access_key: AccessKey,
     ) -> None:
+        from ai.backend.manager.models.replica_group.row import ReplicaGroupRow
         from ai.backend.manager.models.session import KernelLoadingStrategy, SessionRow
+        from ai.backend.manager.models.session_group.row import SessionGroupRow
 
         endpoint_rows = await EndpointRow.list_endpoint(
             db_session,
@@ -652,6 +654,19 @@ class EndpointRow(Base):  # type: ignore[misc]
         )
         for session_row in session_rows:
             session_row.delegate_ownership(target_user_uuid, target_access_key)
+        # The placement groups of the delegated replica groups follow their
+        # members: a group's members all belong to its owner (BEP-1064).
+        await db_session.execute(
+            sa.update(SessionGroupRow)
+            .where(
+                SessionGroupRow.id.in_(
+                    sa.select(ReplicaGroupRow.session_group_id).where(
+                        ReplicaGroupRow.deployment_id.in_([row.id for row in endpoint_rows])
+                    )
+                )
+            )
+            .values(owner_user_id=target_user_uuid)
+        )
 
     @property
     def current_revision_id(self) -> DeploymentRevisionID | None:

--- a/src/ai/backend/manager/models/replica_group/row.py
+++ b/src/ai/backend/manager/models/replica_group/row.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
 from ai.backend.common.identifier.replica_group import ReplicaGroupID
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.schema.deployment import ReplicaGroupRolloutSpec
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.deployment.types import (
@@ -118,6 +119,20 @@ class ReplicaGroupRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
         nullable=False,
         default=100,
         server_default=sa.text("100"),
+    )
+
+    # The placement group shared by this group's route sessions (1:1 — a
+    # replica group always owns exactly one). `use_alter` keeps the FK out of
+    # the CREATE TABLE so table subsets that omit ``session_groups`` still build.
+    session_group_id: Mapped[SessionGroupID] = mapped_column(
+        "session_group_id",
+        GUID(SessionGroupID),
+        sa.ForeignKey(
+            "session_groups.id",
+            use_alter=True,
+            name="fk_replica_groups_session_group_id_session_groups",
+        ),
+        nullable=False,
     )
 
     lifecycle: Mapped[ReplicaGroupLifecycle] = mapped_column(

--- a/src/ai/backend/manager/models/session/row.py
+++ b/src/ai/backend/manager/models/session/row.py
@@ -39,6 +39,7 @@ from ai.backend.common.defs.session import JOB_PRIORITY_DEFAULT, SESSION_PRIORIT
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.types import (
     AccessKey,
     ClusterMode,
@@ -432,6 +433,24 @@ class SessionRow(Base):  # type: ignore[misc]
     )
     designated_agent_ids: Mapped[list[str] | None] = mapped_column(
         "designated_agent_ids", sa.ARRAY(sa.String), nullable=True
+    )
+    # The placement group this session belongs to. NULL (the default) means no
+    # placement constraint. ON DELETE SET NULL: a group may be swept before its
+    # members, and a placement already made is never revisited.
+    # `use_alter` keeps the FK out of the CREATE TABLE so table subsets that
+    # omit ``session_groups`` still build.
+    session_group_id: Mapped[SessionGroupID | None] = mapped_column(
+        "session_group_id",
+        GUID(SessionGroupID),
+        sa.ForeignKey(
+            "session_groups.id",
+            ondelete="SET NULL",
+            use_alter=True,
+            name="fk_sessions_session_group_id_session_groups",
+        ),
+        index=True,
+        nullable=True,
+        default=None,
     )
     kernels: Mapped[list[KernelRow]] = relationship("KernelRow", back_populates="session")
 

--- a/src/ai/backend/manager/models/session_group/row.py
+++ b/src/ai/backend/manager/models/session_group/row.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ai.backend.common.identifier.domain import DomainID
+from ai.backend.common.identifier.project import ProjectID
+from ai.backend.common.identifier.session_group import SessionGroupID
+from ai.backend.common.identifier.user import UserID
+from ai.backend.manager.data.session_group.types import (
+    SessionGroupPlacementDirection,
+    SessionGroupPlacementEnforcement,
+)
+from ai.backend.manager.models.base import GUID, Base, StrEnumType
+from ai.backend.manager.models.mixins.timestamp import CreatedAtMixin
+
+__all__ = ("SessionGroupRow",)
+
+
+class SessionGroupRow(CreatedAtMixin, Base):  # type: ignore[misc]
+    """
+    A set of sessions sharing a common concern, holding their placement policy.
+
+    Members are bound through ``sessions.session_group_id`` (nullable — NULL means
+    no placement constraint). Direction and enforcement are separate columns
+    because they are orthogonal (BEP-1064).
+    """
+
+    __tablename__ = "session_groups"
+
+    id: Mapped[SessionGroupID] = mapped_column(
+        "id",
+        GUID(SessionGroupID),
+        primary_key=True,
+        server_default=sa.text("uuid_generate_v4()"),
+    )
+    domain_id: Mapped[DomainID] = mapped_column(
+        "domain_id",
+        GUID(DomainID),
+        sa.ForeignKey("domains.id"),
+        nullable=False,
+    )
+    project_id: Mapped[ProjectID] = mapped_column(
+        "project_id",
+        GUID(ProjectID),
+        sa.ForeignKey("groups.id"),
+        nullable=False,
+    )
+    # Admission is decided by the owner alone: every member session belongs to
+    # this user. ``domain_id`` / ``project_id`` scope visibility and cleanup.
+    owner_user_id: Mapped[UserID] = mapped_column(
+        "owner_user_id",
+        GUID(UserID),
+        sa.ForeignKey("users.uuid"),
+        nullable=False,
+    )
+    placement_direction: Mapped[SessionGroupPlacementDirection] = mapped_column(
+        "placement_direction",
+        StrEnumType(SessionGroupPlacementDirection),
+        nullable=False,
+    )
+    placement_enforcement: Mapped[SessionGroupPlacementEnforcement] = mapped_column(
+        "placement_enforcement",
+        StrEnumType(SessionGroupPlacementEnforcement),
+        nullable=False,
+    )
+    # The retention boundary; the sweep collects groups deleted long enough ago.
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        "deleted_at",
+        sa.DateTime(timezone=True),
+        nullable=True,
+    )

--- a/src/ai/backend/manager/models/session_group/row.py
+++ b/src/ai/backend/manager/models/session_group/row.py
@@ -50,10 +50,14 @@ class SessionGroupRow(CreatedAtMixin, Base):  # type: ignore[misc]
     )
     # Admission is decided by the owner alone: every member session belongs to
     # this user. ``domain_id`` / ``project_id`` scope visibility and cleanup.
+    # RESTRICT rather than CASCADE: a user's groups are transferred (endpoint
+    # delegation) or removed by the purge itself, like every other record they
+    # own. Leaving the removal to the database would drop a group while its
+    # delegated member sessions keep running.
     owner_user_id: Mapped[UserID] = mapped_column(
         "owner_user_id",
         GUID(UserID),
-        sa.ForeignKey("users.uuid"),
+        sa.ForeignKey("users.uuid", ondelete="RESTRICT"),
         nullable=False,
     )
     placement_direction: Mapped[SessionGroupPlacementDirection] = mapped_column(

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -31,10 +31,12 @@ from ai.backend.common.identifier.deployment_preset import DeploymentPresetID
 from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.image import ImageID
+from ai.backend.common.identifier.project import ProjectID
 from ai.backend.common.identifier.replica import ReplicaID
 from ai.backend.common.identifier.replica_group import ReplicaGroupID
 from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import (
     AccessKey,
@@ -195,6 +197,7 @@ from ai.backend.manager.repositories.deployment.types import (
 from ai.backend.manager.repositories.scheduling_history.creators import (
     DeploymentHistoryCreatorSpec,
 )
+from ai.backend.manager.repositories.session_group.creators import SessionGroupCreatorSpec
 from ai.backend.manager.utils import query_userinfo_from_session
 
 
@@ -338,12 +341,23 @@ class DeploymentDBSource:
             await execute_rbac_entity_creator(db_sess, policy_creator)
             await db_sess.flush()
 
+            # Every replica group owns a session group (1:1) carrying the
+            # placement policy of its replicas.
+            primary_session_group = SessionGroupCreatorSpec.for_replica_group(
+                domain_name=endpoint.domain,
+                project_id=ProjectID(endpoint.project),
+                owner_user_id=UserID(endpoint.session_owner),
+            ).build_row()
+            db_sess.add(primary_session_group)
+            await db_sess.flush()
+
             # Every deployment owns a primary replica group that holds its
             # revision pointers and per-revision desired replica counts. The
             # revision pointers start empty; the first rollout populates them
             # via ``activate_revision`` / the deployment swap.
             primary_replica_group = ReplicaGroupRow(
                 deployment_id=endpoint.id,
+                session_group_id=primary_session_group.id,
                 desired_current_replica_count=endpoint.replicas,
                 rollout=policy_creator_spec.strategy_spec.to_rollout_spec(),
             )

--- a/src/ai/backend/manager/repositories/replica_group/creators.py
+++ b/src/ai/backend/manager/repositories/replica_group/creators.py
@@ -7,6 +7,7 @@ from typing import override
 
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.schema.deployment import ReplicaGroupRolloutSpec
 from ai.backend.manager.data.deployment.types import (
     ReplicaGroupLifecycle,
@@ -19,6 +20,7 @@ from ai.backend.manager.repositories.base.creator import CreatorSpec
 @dataclass
 class ReplicaGroupCreatorSpec(CreatorSpec[ReplicaGroupRow]):
     deployment_id: DeploymentID
+    session_group_id: SessionGroupID
     target_revision_id: DeploymentRevisionID
     desired_target_replica_count: int
     rollout: ReplicaGroupRolloutSpec
@@ -27,6 +29,7 @@ class ReplicaGroupCreatorSpec(CreatorSpec[ReplicaGroupRow]):
     def build_row(self) -> ReplicaGroupRow:
         return ReplicaGroupRow(
             deployment_id=self.deployment_id,
+            session_group_id=self.session_group_id,
             target_revision_id=self.target_revision_id,
             lifecycle=ReplicaGroupLifecycle.ROLLING,
             scaling_status=ReplicaGroupScalingStatus.SCALING,

--- a/src/ai/backend/manager/repositories/replica_group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/replica_group/db_source/db_source.py
@@ -13,7 +13,9 @@ import sqlalchemy as sa
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
+from ai.backend.common.identifier.project import ProjectID
 from ai.backend.common.identifier.replica_group import ReplicaGroupID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.data.deployment.types import (
     DeploymentHandlerOptions,
@@ -75,6 +77,7 @@ from ai.backend.manager.repositories.replica_group.types import (
     RevisionRouteConfig,
     ScalingReconcileFetch,
 )
+from ai.backend.manager.repositories.session_group.creators import SessionGroupCreatorSpec
 from ai.backend.manager.types import OptionalState, TriState
 from ai.backend.manager.views.replica_group import (
     ReplicaGroupAutoscaleReconcileView,
@@ -423,6 +426,9 @@ class ReplicaGroupDBSource:
                 row.EndpointRow.id: row.EndpointRow.primary_replica_group_id
                 for row in endpoint_rows.rows
             }
+            endpoint_by_deployment = {
+                row.EndpointRow.id: row.EndpointRow for row in endpoint_rows.rows
+            }
             reuse_updaters: list[Updater[ReplicaGroupRow]] = []
             endpoint_updaters: list[Updater[EndpointRow]] = []
             for setup in setups:
@@ -439,10 +445,27 @@ class ReplicaGroupDBSource:
                     )
                     target_group_id = primary_group_id
                 else:
+                    # A fresh replica group (blue-green / canary) brings its own
+                    # session group, inheriting the endpoint's ownership scope.
+                    endpoint_row = endpoint_by_deployment.get(setup.deployment_id)
+                    if endpoint_row is None:
+                        # The deployment disappeared between the read and here;
+                        # its rollout has nothing left to point at.
+                        continue
+                    session_group = await w.create(
+                        Creator(
+                            spec=SessionGroupCreatorSpec.for_replica_group(
+                                domain_name=endpoint_row.domain,
+                                project_id=ProjectID(endpoint_row.project),
+                                owner_user_id=UserID(endpoint_row.session_owner),
+                            )
+                        )
+                    )
                     created = await w.create(
                         Creator(
                             spec=ReplicaGroupCreatorSpec(
                                 deployment_id=setup.deployment_id,
+                                session_group_id=session_group.row.id,
                                 target_revision_id=setup.target_revision_id,
                                 desired_target_replica_count=setup.desired_target_replica_count,
                                 rollout=setup.spec.rollout,

--- a/src/ai/backend/manager/repositories/session_group/creators.py
+++ b/src/ai/backend/manager/repositories/session_group/creators.py
@@ -1,0 +1,63 @@
+"""CreatorSpecs for session group inserts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+import sqlalchemy as sa
+
+from ai.backend.common.identifier.project import ProjectID
+from ai.backend.common.identifier.user import UserID
+from ai.backend.manager.data.session_group.types import (
+    SessionGroupPlacementDirection,
+    SessionGroupPlacementEnforcement,
+)
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.session_group.row import SessionGroupRow
+from ai.backend.manager.repositories.base.creator import CreatorSpec
+
+
+@dataclass
+class SessionGroupCreatorSpec(CreatorSpec[SessionGroupRow]):
+    """A placement group owned by one user within a domain and project.
+
+    The ownership scope is taken as the domain *name* because the creating
+    entities (an endpoint, a replica group) carry the name rather than the id;
+    the id is resolved by the insert itself.
+    """
+
+    domain_name: str
+    project_id: ProjectID
+    owner_user_id: UserID
+    placement_direction: SessionGroupPlacementDirection
+    placement_enforcement: SessionGroupPlacementEnforcement
+
+    @override
+    def build_row(self) -> SessionGroupRow:
+        return SessionGroupRow(
+            domain_id=sa.select(DomainRow.id)
+            .where(DomainRow.name == self.domain_name)
+            .scalar_subquery(),
+            project_id=self.project_id,
+            owner_user_id=self.owner_user_id,
+            placement_direction=self.placement_direction,
+            placement_enforcement=self.placement_enforcement,
+        )
+
+    @classmethod
+    def for_replica_group(
+        cls,
+        domain_name: str,
+        project_id: ProjectID,
+        owner_user_id: UserID,
+    ) -> SessionGroupCreatorSpec:
+        """Build the group a replica group owns: replicas spread across agents
+        where possible, without a full agent stopping a rollout."""
+        return cls(
+            domain_name=domain_name,
+            project_id=project_id,
+            owner_user_id=owner_user_id,
+            placement_direction=SessionGroupPlacementDirection.SPREAD,
+            placement_enforcement=SessionGroupPlacementEnforcement.PREFERRED,
+        )

--- a/src/ai/backend/manager/repositories/user/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/user/db_source/db_source.py
@@ -129,6 +129,7 @@ from ai.backend.manager.repositories.user.purgers import (
     create_user_error_log_purger,
     create_user_group_association_purger,
     create_user_keypair_purger,
+    create_user_session_group_purger,
     create_user_vfolder_permission_purger,
 )
 from ai.backend.manager.repositories.user.types import (
@@ -700,6 +701,9 @@ class UserDBSource:
             await execute_batch_purger(session, create_user_keypair_purger(user_uuid))
             await execute_batch_purger(session, create_user_vfolder_permission_purger(user_uuid))
             await execute_batch_purger(session, create_user_group_association_purger(user_uuid))
+            # Placement groups the user still owns: their deployments were either
+            # delegated (the groups moved with them) or deleted by now.
+            await execute_batch_purger(session, create_user_session_group_purger(user_uuid))
 
             # Finally delete the user itself with RBAC scope/permission cleanup
             # to avoid dangling association_scopes_entities and permission rows.
@@ -716,6 +720,9 @@ class UserDBSource:
             await execute_batch_purger(session, create_user_keypair_purger(user_uuid))
             await execute_batch_purger(session, create_user_vfolder_permission_purger(user_uuid))
             await execute_batch_purger(session, create_user_group_association_purger(user_uuid))
+            # Placement groups the user still owns: their deployments were either
+            # delegated (the groups moved with them) or deleted by now.
+            await execute_batch_purger(session, create_user_session_group_purger(user_uuid))
 
             # Finally delete the user itself with RBAC scope/permission cleanup
             # to avoid dangling association_scopes_entities and permission rows.

--- a/src/ai/backend/manager/repositories/user/purgers.py
+++ b/src/ai/backend/manager/repositories/user/purgers.py
@@ -8,9 +8,14 @@ from uuid import UUID
 import sqlalchemy as sa
 
 from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.manager.errors.user import UserPurgeFailure
 from ai.backend.manager.models.error_logs import ErrorLogRow
 from ai.backend.manager.models.group import AssocGroupUserRow
 from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.replica_group.row import ReplicaGroupRow
+from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.session.row import AGENT_RESOURCE_OCCUPYING_SESSION_STATUSES
+from ai.backend.manager.models.session_group.row import SessionGroupRow
 from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.vfolder import VFolderPermissionRow
 from ai.backend.manager.repositories.base.purger import BatchPurger, BatchPurgerSpec
@@ -79,6 +84,50 @@ class UserGroupAssociationBatchPurgerSpec(BatchPurgerSpec[AssocGroupUserRow]):
 
 
 @dataclass
+class UserSessionGroupBatchPurgerSpec(BatchPurgerSpec[SessionGroupRow]):
+    """PurgerSpec for deleting the placement groups a user owns.
+
+    A group is only a placement policy, but its members are not: dropping it
+    while a member session still holds an agent would hide that session from the
+    scheduler's per-agent member counts before its containers are gone. The
+    purge therefore refuses while any member is still occupying resources, the
+    same way it refuses while the user's vfolders are mounted to active kernels.
+    """
+
+    user_uuid: UUID
+
+    @override
+    def build_subquery(self) -> sa.sql.Select[tuple[SessionGroupRow]]:
+        return sa.select(SessionGroupRow).where(SessionGroupRow.owner_user_id == self.user_uuid)
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return (
+            ConflictCheck(
+                condition=lambda: sa.and_(
+                    ReplicaGroupRow.session_group_id == SessionGroupRow.id,
+                    SessionGroupRow.owner_user_id == self.user_uuid,
+                ),
+                error=UserPurgeFailure(
+                    "Some of the user's placement groups still belong to a replica group. "
+                    "Delegate or remove their deployments first.",
+                ),
+            ),
+            ConflictCheck(
+                condition=lambda: sa.and_(
+                    SessionRow.session_group_id == SessionGroupRow.id,
+                    SessionGroupRow.owner_user_id == self.user_uuid,
+                    SessionRow.status.in_(AGENT_RESOURCE_OCCUPYING_SESSION_STATUSES),
+                ),
+                error=UserPurgeFailure(
+                    "Some sessions of the user's placement groups are still occupying agents. "
+                    "Wait for those sessions to terminate first.",
+                ),
+            ),
+        )
+
+
+@dataclass
 class UserBatchPurgerSpec(RBACEntityBatchPurgerSpec[UserRow]):
     """PurgerSpec for deleting a user with RBAC scope/permission cleanup."""
 
@@ -130,4 +179,11 @@ def create_user_purger(user_uuid: UUID) -> BatchPurger[UserRow]:
     return BatchPurger(
         spec=UserBatchPurgerSpec(user_uuid=user_uuid),
         batch_size=1,  # We expect only one row to be deleted
+    )
+
+
+def create_user_session_group_purger(user_uuid: UUID) -> BatchPurger[SessionGroupRow]:
+    """Create a BatchPurger for deleting the placement groups a user owns."""
+    return BatchPurger(
+        spec=UserSessionGroupBatchPurgerSpec(user_uuid=user_uuid),
     )

--- a/tests/component/scheduling_history/conftest.py
+++ b/tests/component/scheduling_history/conftest.py
@@ -22,6 +22,7 @@ from ai.backend.common.identifier.replica_group import ReplicaGroupID
 from ai.backend.common.identifier.replica_group_history import ReplicaGroupHistoryID
 from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
 from ai.backend.common.identifier.session import SessionID
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.schema.deployment import IntOrPercent, ReplicaGroupRolloutSpec
 from ai.backend.common.types import KernelId, ResourceSlot
 from ai.backend.manager.actions.validators import ActionValidators
@@ -44,12 +45,17 @@ from ai.backend.manager.api.rest.v2.scheduling_history.registry import (
 from ai.backend.manager.data.deployment.types import ReplicaGroupHandlerCategory
 from ai.backend.manager.data.kernel.types import KernelSchedulingPhase
 from ai.backend.manager.data.session.types import SchedulingResult
+from ai.backend.manager.data.session_group.types import (
+    SessionGroupPlacementDirection,
+    SessionGroupPlacementEnforcement,
+)
 from ai.backend.manager.models.endpoint.row import EndpointRow
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.replica_group.row import ReplicaGroupRow
 from ai.backend.manager.models.replica_group_history.row import ReplicaGroupHistoryRow
 from ai.backend.manager.models.scheduling_history.row import KernelSchedulingHistoryRow
 from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.session_group.row import SessionGroupRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.scheduling_history.repository import (
     SchedulingHistoryRepository,
@@ -378,8 +384,29 @@ async def replica_group_history_seed(
             )
         )
         await db_sess.flush()
+        # Each replica group owns its placement group (1:1).
+        session_group_ids = {
+            gid: SessionGroupID(uuid.uuid4()) for gid in (replica_group_id, other_replica_group_id)
+        }
         db_sess.add_all([
-            ReplicaGroupRow(id=gid, deployment_id=deployment_id, rollout=rollout)
+            SessionGroupRow(
+                id=session_group_id,
+                domain_id=domain_fixture.domain_id,
+                project_id=group_fixture,
+                owner_user_id=admin_user_fixture.user_uuid,
+                placement_direction=SessionGroupPlacementDirection.SPREAD,
+                placement_enforcement=SessionGroupPlacementEnforcement.PREFERRED,
+            )
+            for session_group_id in session_group_ids.values()
+        ])
+        await db_sess.flush()
+        db_sess.add_all([
+            ReplicaGroupRow(
+                id=gid,
+                deployment_id=deployment_id,
+                session_group_id=session_group_ids[gid],
+                rollout=rollout,
+            )
             for gid in (replica_group_id, other_replica_group_id)
         ])
         await db_sess.flush()

--- a/tests/component/scheduling_history/conftest.py
+++ b/tests/component/scheduling_history/conftest.py
@@ -484,4 +484,9 @@ async def replica_group_history_seed(
         await conn.execute(
             sa.delete(ReplicaGroupRow).where(ReplicaGroupRow.deployment_id == deployment_id)
         )
+        await conn.execute(
+            sa.delete(SessionGroupRow).where(
+                SessionGroupRow.id.in_(list(session_group_ids.values()))
+            )
+        )
         await conn.execute(sa.delete(EndpointRow).where(EndpointRow.id == deployment_id))

--- a/tests/unit/manager/models/test_replica_group_row.py
+++ b/tests/unit/manager/models/test_replica_group_row.py
@@ -3,6 +3,7 @@ import uuid
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
 from ai.backend.common.identifier.replica_group import ReplicaGroupID
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.manager.data.deployment.types import (
     ReplicaGroupLifecycle,
     ReplicaGroupScalingStatus,
@@ -39,6 +40,7 @@ def test_replica_group_status_columns_default_to_stable() -> None:
 
 def _make_row() -> ReplicaGroupRow:
     return ReplicaGroupRow(
+        session_group_id=SessionGroupID(uuid.uuid4()),
         id=ReplicaGroupID(uuid.uuid4()),
         deployment_id=DeploymentID(uuid.uuid4()),
         current_revision_id=DeploymentRevisionID(uuid.uuid4()),

--- a/tests/unit/manager/models/test_session_group_row.py
+++ b/tests/unit/manager/models/test_session_group_row.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+
+import pytest
+import sqlalchemy as sa
+
+from ai.backend.common.identifier.domain import DomainID
+from ai.backend.common.identifier.project import ProjectID
+from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.identifier.session_group import SessionGroupID
+from ai.backend.common.identifier.user import UserID
+from ai.backend.common.types import BinarySize, ResourceSlot
+from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.data.session_group.types import (
+    SessionGroupPlacementDirection,
+    SessionGroupPlacementEnforcement,
+)
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.group import GroupRow
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.replica_group import ReplicaGroupRow
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.scaling_group import ScalingGroupRow
+from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.session_group.row import SessionGroupRow
+from ai.backend.manager.models.user import UserRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.testutils.db import with_tables
+
+
+@dataclass
+class _OwnershipScope:
+    domain_id: DomainID
+    domain_name: str
+    project_id: ProjectID
+    owner_user_id: UserID
+    resource_group_id: ResourceGroupID
+    resource_group_name: str
+
+
+class TestSessionGroupSchema:
+    """Column contracts the scheduler and the retention sweep rely on."""
+
+    def test_placement_axes_are_separate_columns(self) -> None:
+        columns = SessionGroupRow.__table__.columns
+
+        assert columns["placement_direction"].nullable is False
+        assert columns["placement_enforcement"].nullable is False
+
+    def test_ownership_axes_match_sessions_and_endpoints(self) -> None:
+        columns = SessionGroupRow.__table__.columns
+
+        targets = {
+            name: {fk.target_fullname for fk in columns[name].foreign_keys}
+            for name in ("domain_id", "project_id", "owner_user_id")
+        }
+
+        assert targets == {
+            "domain_id": {"domains.id"},
+            "project_id": {"groups.id"},
+            "owner_user_id": {"users.uuid"},
+        }
+        assert all(not columns[name].nullable for name in targets)
+
+    def test_group_has_no_name_column(self) -> None:
+        assert "name" not in SessionGroupRow.__table__.columns
+
+    def test_session_link_is_nullable_indexed_and_set_null_on_delete(self) -> None:
+        column = SessionRow.__table__.columns["session_group_id"]
+        (foreign_key,) = list(column.foreign_keys)
+
+        assert column.nullable is True
+        assert foreign_key.target_fullname == "session_groups.id"
+        assert foreign_key.ondelete == "SET NULL"
+        assert any(list(index.columns) == [column] for index in SessionRow.__table__.indexes), (
+            "the per-agent membership query joins on this column"
+        )
+
+    def test_replica_group_link_is_mandatory(self) -> None:
+        column = ReplicaGroupRow.__table__.columns["session_group_id"]
+        (foreign_key,) = list(column.foreign_keys)
+
+        assert column.nullable is False
+        assert foreign_key.target_fullname == "session_groups.id"
+
+
+class TestSessionGroupRow:
+    @pytest.fixture
+    async def db(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncIterator[ExtendedAsyncSAEngine]:
+        async with with_tables(
+            database_connection,
+            [
+                # FK dependency order: parents before children
+                DomainRow,
+                ScalingGroupRow,
+                UserResourcePolicyRow,
+                ProjectResourcePolicyRow,
+                KeyPairResourcePolicyRow,
+                UserRow,
+                KeyPairRow,
+                GroupRow,
+                SessionGroupRow,
+                SessionRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    async def scope(self, db: ExtendedAsyncSAEngine) -> AsyncIterator[_OwnershipScope]:
+        domain = DomainRow(id=DomainID(uuid.uuid4()), name=f"test-{uuid.uuid4().hex[:8]}")
+        scaling_group = ScalingGroupRow(
+            id=ResourceGroupID(uuid.uuid4()),
+            name=f"test-sg-{uuid.uuid4().hex[:8]}",
+            driver="static",
+            scheduler="fifo",
+        )
+        user_policy = UserResourcePolicyRow(
+            name=f"{uuid.uuid4()}",
+            max_vfolder_count=10,
+            max_quota_scope_size=BinarySize.finite_from_str("10GiB"),
+            max_session_count_per_model_session=5,
+            max_customized_image_count=3,
+        )
+        project_policy = ProjectResourcePolicyRow(
+            name=f"{uuid.uuid4()}",
+            max_vfolder_count=10,
+            max_quota_scope_size=BinarySize.finite_from_str("10GiB"),
+            max_network_count=5,
+        )
+        user = UserRow(
+            uuid=uuid.uuid4(),
+            email=f"user-{uuid.uuid4().hex[:8]}@example.com",
+            domain_name=domain.name,
+            resource_policy=user_policy.name,
+        )
+        project = GroupRow(
+            id=uuid.uuid4(),
+            name=f"test-group-{uuid.uuid4().hex[:8]}",
+            domain_name=domain.name,
+            resource_policy=project_policy.name,
+        )
+
+        async with db.begin_session() as sess:
+            sess.add_all([domain, scaling_group, user_policy, project_policy])
+            await sess.flush()
+            sess.add_all([user, project])
+            await sess.flush()
+
+        yield _OwnershipScope(
+            domain_id=DomainID(domain.id),
+            domain_name=domain.name,
+            project_id=ProjectID(project.id),
+            owner_user_id=UserID(user.uuid),
+            resource_group_id=ResourceGroupID(scaling_group.id),
+            resource_group_name=scaling_group.name,
+        )
+
+    async def test_placement_policy_round_trips(
+        self, db: ExtendedAsyncSAEngine, scope: _OwnershipScope
+    ) -> None:
+        group_id = SessionGroupID(uuid.uuid4())
+        async with db.begin_session() as sess:
+            sess.add(_make_group(group_id, scope, SessionGroupPlacementDirection.SPREAD))
+
+        async with db.begin_readonly_session() as sess:
+            row = (
+                await sess.execute(sa.select(SessionGroupRow).where(SessionGroupRow.id == group_id))
+            ).scalar_one()
+
+        assert row.placement_direction is SessionGroupPlacementDirection.SPREAD
+        assert row.placement_enforcement is SessionGroupPlacementEnforcement.PREFERRED
+        assert row.domain_id == scope.domain_id
+        assert row.project_id == scope.project_id
+        assert row.owner_user_id == scope.owner_user_id
+        assert row.deleted_at is None
+
+    async def test_session_defaults_to_no_group(
+        self, db: ExtendedAsyncSAEngine, scope: _OwnershipScope
+    ) -> None:
+        session_id = uuid.uuid4()
+        async with db.begin_session() as sess:
+            sess.add(_make_session(session_id, scope, session_group_id=None))
+
+        async with db.begin_readonly_session() as sess:
+            row = (
+                await sess.execute(sa.select(SessionRow).where(SessionRow.id == session_id))
+            ).scalar_one()
+
+        assert row.session_group_id is None
+
+    async def test_deleting_group_unbinds_members_without_removing_them(
+        self, db: ExtendedAsyncSAEngine, scope: _OwnershipScope
+    ) -> None:
+        group_id = SessionGroupID(uuid.uuid4())
+        session_id = uuid.uuid4()
+        async with db.begin_session() as sess:
+            sess.add(_make_group(group_id, scope, SessionGroupPlacementDirection.PACK))
+            await sess.flush()
+            sess.add(_make_session(session_id, scope, session_group_id=group_id))
+
+        async with db.begin_session() as sess:
+            await sess.execute(sa.delete(SessionGroupRow).where(SessionGroupRow.id == group_id))
+
+        async with db.begin_readonly_session() as sess:
+            row = (
+                await sess.execute(sa.select(SessionRow).where(SessionRow.id == session_id))
+            ).scalar_one()
+
+        assert row.session_group_id is None
+
+
+def _make_group(
+    group_id: SessionGroupID,
+    scope: _OwnershipScope,
+    direction: SessionGroupPlacementDirection,
+) -> SessionGroupRow:
+    return SessionGroupRow(
+        id=group_id,
+        domain_id=scope.domain_id,
+        project_id=scope.project_id,
+        owner_user_id=scope.owner_user_id,
+        placement_direction=direction,
+        placement_enforcement=SessionGroupPlacementEnforcement.PREFERRED,
+    )
+
+
+def _make_session(
+    session_id: uuid.UUID,
+    scope: _OwnershipScope,
+    session_group_id: SessionGroupID | None,
+) -> SessionRow:
+    return SessionRow(
+        id=session_id,
+        name=f"test-{session_id}",
+        user_uuid=scope.owner_user_id,
+        group_id=scope.project_id,
+        domain_id=scope.domain_id,
+        domain_name=scope.domain_name,
+        resource_group_id=scope.resource_group_id,
+        scaling_group_name=scope.resource_group_name,
+        status=SessionStatus.PENDING,
+        occupying_slots=ResourceSlot(),
+        requested_slots=ResourceSlot(),
+        vfolder_mounts=[],
+        session_group_id=session_group_id,
+    )

--- a/tests/unit/manager/models/test_session_group_row.py
+++ b/tests/unit/manager/models/test_session_group_row.py
@@ -69,6 +69,13 @@ class TestSessionGroupSchema:
         }
         assert all(not columns[name].nullable for name in targets)
 
+    def test_owner_cannot_be_removed_before_their_groups(self) -> None:
+        # The purge settles a user's groups explicitly (transfer on delegation,
+        # delete otherwise); the database must not silently drop them instead.
+        (owner_fk,) = list(SessionGroupRow.__table__.columns["owner_user_id"].foreign_keys)
+
+        assert owner_fk.ondelete == "RESTRICT"
+
     def test_group_has_no_name_column(self) -> None:
         assert "name" not in SessionGroupRow.__table__.columns
 

--- a/tests/unit/manager/repositories/deployment/test_deployment_repository.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_repository.py
@@ -27,6 +27,7 @@ from ai.backend.common.identifier.replica import ReplicaID
 from ai.backend.common.identifier.replica_group import ReplicaGroupID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.schema.deployment import BlueGreenSpec, IntOrPercent, RollingUpdateSpec
 from ai.backend.common.types import (
@@ -169,6 +170,7 @@ def attach_primary_replica_group(
     """
     group_id = uuid.uuid4()
     group = ReplicaGroupRow(
+        session_group_id=SessionGroupID(uuid.uuid4()),
         id=ReplicaGroupID(group_id),
         deployment_id=endpoint.id,
         current_revision_id=current_revision_id,
@@ -2154,6 +2156,7 @@ class TestDeploymentRevisionOperations:
             # A second group that has already finished draining.
             db_sess.add(
                 ReplicaGroupRow(
+                    session_group_id=SessionGroupID(uuid.uuid4()),
                     id=drained_group_id,
                     deployment_id=test_endpoint_id,
                     lifecycle=ReplicaGroupLifecycle.DRAINED,
@@ -3144,6 +3147,7 @@ class TestRouteOperations:
         async with db_with_cleanup.begin_session() as db_sess:
             db_sess.add(
                 ReplicaGroupRow(
+                    session_group_id=SessionGroupID(uuid.uuid4()),
                     id=group_id,
                     deployment_id=test_endpoint_id,
                 )

--- a/tests/unit/manager/repositories/deployment/test_deployment_repository.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_repository.py
@@ -55,6 +55,10 @@ from ai.backend.manager.data.deployment.types import (
 )
 from ai.backend.manager.data.image.types import ImageType
 from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.data.session_group.types import (
+    SessionGroupPlacementDirection,
+    SessionGroupPlacementEnforcement,
+)
 from ai.backend.manager.errors.deployment import DeploymentRevisionNotFound
 from ai.backend.manager.errors.service import DeploymentPolicyNotFound
 from ai.backend.manager.models.agent import AgentRow, AgentStatus
@@ -94,6 +98,7 @@ from ai.backend.manager.models.session import (
     SessionStatus,
     SessionTypes,
 )
+from ai.backend.manager.models.session_group.row import SessionGroupRow
 from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import VFolderRow
@@ -3344,6 +3349,7 @@ class TestDeploymentRepositoryDuplicateName:
                 ImageRow,
                 ResourceSlotTypeRow,
                 EndpointRow,
+                SessionGroupRow,
                 ReplicaGroupRow,
                 EndpointTokenRow,
                 RuntimeVariantRow,
@@ -3503,6 +3509,50 @@ class TestDeploymentRepositoryDuplicateName:
             return group
 
     @pytest.fixture
+    async def default_user_policy(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> UserResourcePolicyRow:
+        """Create default user resource policy."""
+        async with db_with_cleanup.begin_session() as db_sess:
+            policy = UserResourcePolicyRow(
+                name=f"user-policy-{uuid.uuid4().hex[:8]}",
+                max_vfolder_count=10,
+                max_quota_scope_size=0,
+                max_session_count_per_model_session=5,
+                max_customized_image_count=3,
+            )
+            db_sess.add(policy)
+            await db_sess.commit()
+            return policy
+
+    @pytest.fixture
+    async def test_user(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain: DomainRow,
+        default_user_policy: UserResourcePolicyRow,
+    ) -> UserRow:
+        """Create the user that owns the endpoints created in these tests."""
+        user_uuid = uuid.uuid4()
+        async with db_with_cleanup.begin_session() as db_sess:
+            user = UserRow(
+                uuid=user_uuid,
+                username=f"testuser-{user_uuid.hex[:8]}",
+                email=f"test-{user_uuid.hex[:8]}@example.com",
+                password=create_test_password_info("test_password"),
+                need_password_change=False,
+                status=UserStatus.ACTIVE,
+                status_info="active",
+                domain_name=test_domain.name,
+                role=UserRole.USER,
+                resource_policy=default_user_policy.name,
+            )
+            db_sess.add(user)
+            await db_sess.commit()
+            return user
+
+    @pytest.fixture
     def deployment_repository(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
@@ -3526,10 +3576,11 @@ class TestDeploymentRepositoryDuplicateName:
         domain: DomainRow,
         group: GroupRow,
         scaling_group: ScalingGroupRow,
+        user: UserRow,
         image_id: uuid.UUID | None = None,
     ) -> RBACEntityCreator[EndpointRow]:
         """Helper to create RBACEntityCreator for endpoint creation."""
-        user_id = uuid.uuid4()
+        user_id = user.uuid
         spec = DeploymentCreatorSpec(
             metadata=DeploymentMetadataFields(
                 name=name,
@@ -3560,6 +3611,7 @@ class TestDeploymentRepositoryDuplicateName:
         test_domain: DomainRow,
         test_group: GroupRow,
         test_scaling_group: ScalingGroupRow,
+        test_user: UserRow,
         test_image_id: uuid.UUID,
     ) -> None:
         """Test that create_endpoint succeeds with a different name."""
@@ -3569,6 +3621,7 @@ class TestDeploymentRepositoryDuplicateName:
             domain=test_domain,
             group=test_group,
             scaling_group=test_scaling_group,
+            user=test_user,
             image_id=test_image_id,
         )
         await deployment_repository.create_endpoint(first_creator)
@@ -3579,6 +3632,7 @@ class TestDeploymentRepositoryDuplicateName:
             domain=test_domain,
             group=test_group,
             scaling_group=test_scaling_group,
+            user=test_user,
             image_id=test_image_id,
         )
 
@@ -3594,6 +3648,7 @@ class TestDeploymentRepositoryDuplicateName:
         test_group: GroupRow,
         different_group: GroupRow,
         test_scaling_group: ScalingGroupRow,
+        test_user: UserRow,
         test_image_id: uuid.UUID,
     ) -> None:
         """Test that create_endpoint allows same name in different project."""
@@ -3603,6 +3658,7 @@ class TestDeploymentRepositoryDuplicateName:
             domain=test_domain,
             group=test_group,
             scaling_group=test_scaling_group,
+            user=test_user,
             image_id=test_image_id,
         )
         await deployment_repository.create_endpoint(first_creator)
@@ -3613,6 +3669,7 @@ class TestDeploymentRepositoryDuplicateName:
             domain=test_domain,
             group=different_group,
             scaling_group=test_scaling_group,
+            user=test_user,
             image_id=test_image_id,
         )
 
@@ -3628,6 +3685,7 @@ class TestDeploymentRepositoryDuplicateName:
         test_domain: DomainRow,
         test_group: GroupRow,
         test_scaling_group: ScalingGroupRow,
+        test_user: UserRow,
         test_image_id: uuid.UUID,
     ) -> None:
         """Test that create_endpoint allows same name when existing endpoint is destroyed."""
@@ -3637,6 +3695,7 @@ class TestDeploymentRepositoryDuplicateName:
             domain=test_domain,
             group=test_group,
             scaling_group=test_scaling_group,
+            user=test_user,
             image_id=test_image_id,
         )
         first_result = await deployment_repository.create_endpoint(first_creator)
@@ -3655,6 +3714,7 @@ class TestDeploymentRepositoryDuplicateName:
             domain=test_domain,
             group=test_group,
             scaling_group=test_scaling_group,
+            user=test_user,
             image_id=test_image_id,
         )
 
@@ -3662,6 +3722,45 @@ class TestDeploymentRepositoryDuplicateName:
 
         assert result.metadata.name == "reusable-endpoint"
         assert result.metadata.project == test_group.id
+
+    async def test_create_endpoint_gives_the_primary_replica_group_a_placement_group(
+        self,
+        deployment_repository: DeploymentRepository,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain: DomainRow,
+        test_group: GroupRow,
+        test_scaling_group: ScalingGroupRow,
+        test_user: UserRow,
+        test_image_id: uuid.UUID,
+    ) -> None:
+        creator = self._create_endpoint_creator(
+            name=f"placement-{uuid.uuid4().hex[:8]}",
+            domain=test_domain,
+            group=test_group,
+            scaling_group=test_scaling_group,
+            user=test_user,
+            image_id=test_image_id,
+        )
+
+        result = await deployment_repository.create_endpoint(creator)
+
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            session_group = (
+                await db_sess.execute(
+                    sa.select(SessionGroupRow)
+                    .join(
+                        ReplicaGroupRow,
+                        ReplicaGroupRow.session_group_id == SessionGroupRow.id,
+                    )
+                    .where(ReplicaGroupRow.deployment_id == result.id)
+                )
+            ).scalar_one()
+
+        assert session_group.placement_direction is SessionGroupPlacementDirection.SPREAD
+        assert session_group.placement_enforcement is SessionGroupPlacementEnforcement.PREFERRED
+        assert session_group.domain_id == test_domain.id
+        assert session_group.project_id == test_group.id
+        assert session_group.owner_user_id == result.metadata.session_owner
 
     @pytest.fixture
     async def coexisting_active_and_destroying_endpoints(

--- a/tests/unit/manager/repositories/deployment/test_legacy_extra_mounts_hydration.py
+++ b/tests/unit/manager/repositories/deployment/test_legacy_extra_mounts_hydration.py
@@ -13,6 +13,7 @@ from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.replica_group import ReplicaGroupID
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.types import ClusterMode, MountPermission, ResourceSlot
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.image.types import ImageType
@@ -278,6 +279,7 @@ class TestLegacyExtraMountsHydration:
             group_id = uuid.uuid4()
             db_sess.add(
                 ReplicaGroupRow(
+                    session_group_id=SessionGroupID(uuid.uuid4()),
                     id=ReplicaGroupID(group_id),
                     deployment_id=endpoint_id,
                     current_revision_id=revision_id,

--- a/tests/unit/manager/repositories/model_serving/test_list_endpoints_by_owner_validated.py
+++ b/tests/unit/manager/repositories/model_serving/test_list_endpoints_by_owner_validated.py
@@ -26,6 +26,7 @@ from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.replica_group import ReplicaGroupID
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.image.types import ImageType
@@ -333,6 +334,7 @@ async def listed_endpoint(
         group_id = uuid.uuid4()
         sess.add(
             ReplicaGroupRow(
+                session_group_id=SessionGroupID(uuid.uuid4()),
                 id=ReplicaGroupID(group_id),
                 deployment_id=DeploymentID(endpoint_id),
                 current_revision_id=revision_id,

--- a/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
+++ b/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
@@ -20,6 +20,7 @@ from ai.backend.common.data.user.types import UserData
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.replica_group import ReplicaGroupID
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.image.types import ImageType
@@ -332,6 +333,7 @@ class TestModifyEndpointModelDefinitionRefresh:
             group_id = uuid.uuid4()
             sess.add(
                 ReplicaGroupRow(
+                    session_group_id=SessionGroupID(uuid.uuid4()),
                     id=ReplicaGroupID(group_id),
                     deployment_id=DeploymentID(endpoint_id),
                     current_revision_id=revision_id,

--- a/tests/unit/manager/repositories/model_serving/test_update_route_traffic.py
+++ b/tests/unit/manager/repositories/model_serving/test_update_route_traffic.py
@@ -24,6 +24,7 @@ from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.replica_group import ReplicaGroupID
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.image.types import ImageType
@@ -324,6 +325,7 @@ async def endpoint_with_revision_and_route(
         group_id = uuid.uuid4()
         sess.add(
             ReplicaGroupRow(
+                session_group_id=SessionGroupID(uuid.uuid4()),
                 id=ReplicaGroupID(group_id),
                 deployment_id=DeploymentID(endpoint_id),
                 current_revision_id=revision_id,

--- a/tests/unit/manager/repositories/replica_group/test_replica_group_repository.py
+++ b/tests/unit/manager/repositories/replica_group/test_replica_group_repository.py
@@ -8,12 +8,18 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
 from ai.backend.common.identifier.replica_group import ReplicaGroupID
 from ai.backend.common.identifier.session_group import SessionGroupID
+from ai.backend.common.schema.deployment import (
+    IntOrPercent,
+    ReplicaGroupRolloutSpec,
+    TargetGroupSpec,
+)
 from ai.backend.common.types import BinarySize, ResourceSlot
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.deployment.types import (
@@ -24,6 +30,10 @@ from ai.backend.manager.data.deployment.types import (
     RouteStatus,
     RouteSubStatus,
     RouteTrafficStatus,
+)
+from ai.backend.manager.data.session_group.types import (
+    SessionGroupPlacementDirection,
+    SessionGroupPlacementEnforcement,
 )
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
@@ -43,6 +53,7 @@ from ai.backend.manager.models.resource_preset import ResourcePresetRow
 from ai.backend.manager.models.routing import RoutingRow
 from ai.backend.manager.models.scaling_group import ScalingGroupOpts, ScalingGroupRow
 from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.session_group.row import SessionGroupRow
 from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base.pagination import OffsetPagination
@@ -54,6 +65,7 @@ from ai.backend.manager.repositories.deployment.updaters import (
 )
 from ai.backend.manager.repositories.replica_group import ReplicaGroupRepository
 from ai.backend.manager.repositories.replica_group.types import (
+    GroupRolloutSetup,
     GroupRouteDrainInstruction,
     ReplicaGroupScalingReconcileApply,
 )
@@ -112,6 +124,26 @@ def _provisioning_route(
     )
 
 
+async def _create_session_group(db_sess: SASession, deployment_id: DeploymentID) -> SessionGroupID:
+    """Create the placement group a replica group owns, as ``create_endpoint`` does."""
+    endpoint = (
+        await db_sess.execute(sa.select(EndpointRow).where(EndpointRow.id == deployment_id))
+    ).scalar_one()
+    domain_id = (
+        await db_sess.execute(sa.select(DomainRow.id).where(DomainRow.name == endpoint.domain))
+    ).scalar_one()
+    row = SessionGroupRow(
+        domain_id=domain_id,
+        project_id=endpoint.project,
+        owner_user_id=endpoint.session_owner,
+        placement_direction=SessionGroupPlacementDirection.SPREAD,
+        placement_enforcement=SessionGroupPlacementEnforcement.PREFERRED,
+    )
+    db_sess.add(row)
+    await db_sess.flush()
+    return row.id
+
+
 def _password_info(password: str) -> PasswordInfo:
     return PasswordInfo(
         password=password,
@@ -142,6 +174,7 @@ class TestReplicaGroupRepository:
                 KeyPairRow,
                 GroupRow,
                 EndpointRow,
+                SessionGroupRow,
                 ReplicaGroupRow,
                 ReplicaGroupHistoryRow,
                 SessionRow,
@@ -256,7 +289,7 @@ class TestReplicaGroupRepository:
         async with db_with_cleanup.begin_session() as db_sess:
             db_sess.add(
                 ReplicaGroupRow(
-                    session_group_id=SessionGroupID(uuid.uuid4()),
+                    session_group_id=await _create_session_group(db_sess, test_endpoint_id),
                     id=first,
                     deployment_id=test_endpoint_id,
                     desired_current_replica_count=1,
@@ -267,7 +300,7 @@ class TestReplicaGroupRepository:
             )
             db_sess.add(
                 ReplicaGroupRow(
-                    session_group_id=SessionGroupID(uuid.uuid4()),
+                    session_group_id=await _create_session_group(db_sess, test_endpoint_id),
                     id=second,
                     deployment_id=test_endpoint_id,
                     desired_current_replica_count=2,
@@ -285,6 +318,43 @@ class TestReplicaGroupRepository:
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> ReplicaGroupRepository:
         return ReplicaGroupRepository(db=db_with_cleanup)
+
+    async def test_setup_target_groups_gives_a_fresh_group_its_placement_group(
+        self,
+        replica_group_repository: ReplicaGroupRepository,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_endpoint_id: DeploymentID,
+    ) -> None:
+        setup = GroupRolloutSetup(
+            deployment_id=test_endpoint_id,
+            target_revision_id=DeploymentRevisionID(uuid.uuid4()),
+            spec=TargetGroupSpec(
+                use_primary_group=False,
+                rollout=ReplicaGroupRolloutSpec(
+                    max_surge=IntOrPercent(count=1),
+                    max_unavailable=IntOrPercent(count=0),
+                ),
+            ),
+            desired_target_replica_count=2,
+        )
+
+        updated = await replica_group_repository.setup_target_groups([setup])
+
+        assert updated == {test_endpoint_id}
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            session_group = (
+                await db_sess.execute(
+                    sa.select(SessionGroupRow)
+                    .join(
+                        ReplicaGroupRow,
+                        ReplicaGroupRow.session_group_id == SessionGroupRow.id,
+                    )
+                    .where(ReplicaGroupRow.deployment_id == test_endpoint_id)
+                )
+            ).scalar_one()
+
+        assert session_group.placement_direction is SessionGroupPlacementDirection.SPREAD
+        assert session_group.placement_enforcement is SessionGroupPlacementEnforcement.PREFERRED
 
     async def test_search_deploy_scheduling_views_filters_by_lifecycle(
         self,
@@ -383,7 +453,7 @@ class TestReplicaGroupRepository:
             ).scalar_one()
             db_sess.add(
                 ReplicaGroupRow(
-                    session_group_id=SessionGroupID(uuid.uuid4()),
+                    session_group_id=await _create_session_group(db_sess, test_endpoint_id),
                     id=group_id,
                     deployment_id=test_endpoint_id,
                     current_revision_id=current_revision_id,
@@ -485,7 +555,7 @@ class TestReplicaGroupRepository:
             ).scalar_one()
             db_sess.add(
                 ReplicaGroupRow(
-                    session_group_id=SessionGroupID(uuid.uuid4()),
+                    session_group_id=await _create_session_group(db_sess, test_endpoint_id),
                     id=group_id,
                     deployment_id=test_endpoint_id,
                     current_revision_id=revision_id,
@@ -588,7 +658,7 @@ class TestReplicaGroupRepository:
             ).scalar_one()
             db_sess.add(
                 ReplicaGroupRow(
-                    session_group_id=SessionGroupID(uuid.uuid4()),
+                    session_group_id=await _create_session_group(db_sess, test_endpoint_id),
                     id=group_id,
                     deployment_id=test_endpoint_id,
                     current_revision_id=revision_id,
@@ -662,7 +732,7 @@ class TestReplicaGroupRepository:
             ).scalar_one()
             db_sess.add(
                 ReplicaGroupRow(
-                    session_group_id=SessionGroupID(uuid.uuid4()),
+                    session_group_id=await _create_session_group(db_sess, test_endpoint_id),
                     id=group_id,
                     deployment_id=test_endpoint_id,
                     current_revision_id=revision_id,

--- a/tests/unit/manager/repositories/replica_group/test_replica_group_repository.py
+++ b/tests/unit/manager/repositories/replica_group/test_replica_group_repository.py
@@ -13,6 +13,7 @@ from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
 from ai.backend.common.identifier.replica_group import ReplicaGroupID
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.types import BinarySize, ResourceSlot
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.deployment.types import (
@@ -255,6 +256,7 @@ class TestReplicaGroupRepository:
         async with db_with_cleanup.begin_session() as db_sess:
             db_sess.add(
                 ReplicaGroupRow(
+                    session_group_id=SessionGroupID(uuid.uuid4()),
                     id=first,
                     deployment_id=test_endpoint_id,
                     desired_current_replica_count=1,
@@ -265,6 +267,7 @@ class TestReplicaGroupRepository:
             )
             db_sess.add(
                 ReplicaGroupRow(
+                    session_group_id=SessionGroupID(uuid.uuid4()),
                     id=second,
                     deployment_id=test_endpoint_id,
                     desired_current_replica_count=2,
@@ -380,6 +383,7 @@ class TestReplicaGroupRepository:
             ).scalar_one()
             db_sess.add(
                 ReplicaGroupRow(
+                    session_group_id=SessionGroupID(uuid.uuid4()),
                     id=group_id,
                     deployment_id=test_endpoint_id,
                     current_revision_id=current_revision_id,
@@ -481,6 +485,7 @@ class TestReplicaGroupRepository:
             ).scalar_one()
             db_sess.add(
                 ReplicaGroupRow(
+                    session_group_id=SessionGroupID(uuid.uuid4()),
                     id=group_id,
                     deployment_id=test_endpoint_id,
                     current_revision_id=revision_id,
@@ -583,6 +588,7 @@ class TestReplicaGroupRepository:
             ).scalar_one()
             db_sess.add(
                 ReplicaGroupRow(
+                    session_group_id=SessionGroupID(uuid.uuid4()),
                     id=group_id,
                     deployment_id=test_endpoint_id,
                     current_revision_id=revision_id,
@@ -656,6 +662,7 @@ class TestReplicaGroupRepository:
             ).scalar_one()
             db_sess.add(
                 ReplicaGroupRow(
+                    session_group_id=SessionGroupID(uuid.uuid4()),
                     id=group_id,
                     deployment_id=test_endpoint_id,
                     current_revision_id=revision_id,

--- a/tests/unit/manager/repositories/retention/test_retention_repository.py
+++ b/tests/unit/manager/repositories/retention/test_retention_repository.py
@@ -35,6 +35,7 @@ from ai.backend.common.events.types import EventDomain
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.schema.deployment import IntOrPercent, ReplicaGroupRolloutSpec
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.actions.types import OperationStatus
@@ -1178,6 +1179,7 @@ class TestDeploymentsTerminalChildCleanup:
         async with db.begin_session() as sess:
             sess.add(
                 ReplicaGroupRow(
+                    session_group_id=SessionGroupID(uuid.uuid4()),
                     id=uuid.uuid4(),
                     deployment_id=endpoint_id,
                     lifecycle=lifecycle,

--- a/tests/unit/manager/repositories/scheduling_history/test_replica_group_history_repository.py
+++ b/tests/unit/manager/repositories/scheduling_history/test_replica_group_history_repository.py
@@ -21,6 +21,7 @@ from ai.backend.common.dto.manager.v2.scheduling_history.types import (
 )
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.replica_group import ReplicaGroupID
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.schema.deployment import IntOrPercent, ReplicaGroupRolloutSpec
 from ai.backend.common.types import BinarySize, ResourceSlot
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
@@ -247,6 +248,7 @@ class TestReplicaGroupHistoryRepository:
             for group_id in (target_group_id, sibling_group_id):
                 db_sess.add(
                     ReplicaGroupRow(
+                        session_group_id=SessionGroupID(uuid.uuid4()),
                         id=group_id,
                         deployment_id=deployment_id,
                         desired_current_replica_count=1,

--- a/tests/unit/manager/repositories/user/test_user_purgers.py
+++ b/tests/unit/manager/repositories/user/test_user_purgers.py
@@ -7,34 +7,49 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncGenerator
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import pytest
 import sqlalchemy as sa
 
+from ai.backend.common.identifier.domain import DomainID
+from ai.backend.common.identifier.project import ProjectID
+from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.identifier.session_group import SessionGroupID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import QuotaScopeID, QuotaScopeType, ResourceSlot, VFolderUsageMode
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.error_log.types import ErrorLogSeverity
+from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.data.session_group.types import (
+    SessionGroupPlacementDirection,
+    SessionGroupPlacementEnforcement,
+)
 from ai.backend.manager.data.vfolder.types import (
     VFolderMountPermission,
     VFolderOperationStatus,
     VFolderOwnershipType,
 )
+from ai.backend.manager.errors.user import UserPurgeFailure
 from ai.backend.manager.models.agent import AgentRow  # noqa: F401
 from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.error_logs import ErrorLogRow
 from ai.backend.manager.models.group import AssocGroupUserRow, GroupRow, ProjectType
 from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.image import ImageRow  # noqa: F401
 from ai.backend.manager.models.kernel import KernelRow  # noqa: F401
 from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.replica_group import ReplicaGroupRow
 from ai.backend.manager.models.resource_policy import (
     KeyPairResourcePolicyRow,
     ProjectResourcePolicyRow,
     UserResourcePolicyRow,
 )
-from ai.backend.manager.models.scaling_group import ScalingGroupRow  # noqa: F401
-from ai.backend.manager.models.session import SessionRow  # noqa: F401
+from ai.backend.manager.models.scaling_group import ScalingGroupRow
+from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.session_group.row import SessionGroupRow
 from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
 from ai.backend.manager.models.vfolder.row import VFolderPermissionRow, VFolderRow
 from ai.backend.manager.repositories.base.purger import BatchPurger, execute_batch_purger
@@ -48,6 +63,7 @@ from ai.backend.manager.repositories.user.purgers import (
     create_user_group_association_purger,
     create_user_keypair_purger,
     create_user_purger,
+    create_user_session_group_purger,
     create_user_vfolder_permission_purger,
 )
 from ai.backend.testutils.db import with_tables
@@ -55,6 +71,16 @@ from ai.backend.testutils.fixtures import DomainFactory, DomainFixtureData
 
 if TYPE_CHECKING:
     from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+
+
+@dataclass
+class _PlacementScope:
+    domain_id: DomainID
+    domain_name: str
+    project_id: ProjectID
+    owner_user_id: UserID
+    resource_group_id: ResourceGroupID
+    resource_group_name: str
 
 
 class TestUserPurgerSpecs:
@@ -580,3 +606,190 @@ class TestUserPurgersIntegration:
                 sa.select(sa.func.count()).select_from(UserRow).where(UserRow.uuid == user_uuid)
             )
             assert count == 0
+
+
+class TestUserSessionGroupPurger:
+    """The placement groups a user owns are settled by the purge, not by the DB."""
+
+    @pytest.fixture
+    async def db_with_cleanup(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                # FK dependency order: parents before children
+                DomainRow,
+                ScalingGroupRow,
+                UserResourcePolicyRow,
+                ProjectResourcePolicyRow,
+                KeyPairResourcePolicyRow,
+                UserRow,
+                KeyPairRow,
+                GroupRow,
+                SessionGroupRow,
+                SessionRow,
+                EndpointRow,
+                ReplicaGroupRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    def test_password_info(self) -> PasswordInfo:
+        return PasswordInfo(
+            password="test_password",
+            algorithm=PasswordHashAlgorithm.PBKDF2_SHA256,
+            rounds=100_000,
+            salt_size=32,
+        )
+
+    @pytest.fixture
+    async def scope(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_password_info: PasswordInfo,
+    ) -> _PlacementScope:
+        domain = DomainRow(
+            id=DomainID(uuid.uuid4()),
+            name=f"test-domain-{uuid.uuid4().hex[:8]}",
+            total_resource_slots=ResourceSlot(),
+            allowed_vfolder_hosts={},
+        )
+        scaling_group = ScalingGroupRow(
+            id=ResourceGroupID(uuid.uuid4()),
+            name=f"test-sg-{uuid.uuid4().hex[:8]}",
+            driver="static",
+            scheduler="fifo",
+        )
+        user_policy = UserResourcePolicyRow(
+            name=f"user-policy-{uuid.uuid4().hex[:8]}",
+            max_vfolder_count=0,
+            max_quota_scope_size=-1,
+            max_session_count_per_model_session=10,
+            max_customized_image_count=10,
+        )
+        project_policy = ProjectResourcePolicyRow(
+            name=f"project-policy-{uuid.uuid4().hex[:8]}",
+            max_vfolder_count=0,
+            max_quota_scope_size=-1,
+            max_network_count=3,
+        )
+        user = UserRow(
+            uuid=uuid.uuid4(),
+            username=f"testuser-{uuid.uuid4().hex[:8]}",
+            email=f"test-{uuid.uuid4().hex[:8]}@example.com",
+            password=test_password_info,
+            need_password_change=False,
+            status=UserStatus.ACTIVE,
+            status_info="admin-requested",
+            domain_name=domain.name,
+            role=UserRole.USER,
+            resource_policy=user_policy.name,
+        )
+        project = GroupRow(
+            id=uuid.uuid4(),
+            name=f"test-project-{uuid.uuid4().hex[:8]}",
+            domain_name=domain.name,
+            resource_policy=project_policy.name,
+        )
+
+        async with db_with_cleanup.begin_session() as session:
+            session.add_all([domain, scaling_group, user_policy, project_policy])
+            await session.flush()
+            session.add_all([user, project])
+            await session.flush()
+
+        return _PlacementScope(
+            domain_id=DomainID(domain.id),
+            domain_name=domain.name,
+            project_id=ProjectID(project.id),
+            owner_user_id=UserID(user.uuid),
+            resource_group_id=ResourceGroupID(scaling_group.id),
+            resource_group_name=scaling_group.name,
+        )
+
+    async def _add_group_with_member(
+        self,
+        db: ExtendedAsyncSAEngine,
+        scope: _PlacementScope,
+        member_status: SessionStatus,
+    ) -> SessionGroupID:
+        group_id = SessionGroupID(uuid.uuid4())
+        async with db.begin_session() as session:
+            session.add(
+                SessionGroupRow(
+                    id=group_id,
+                    domain_id=scope.domain_id,
+                    project_id=scope.project_id,
+                    owner_user_id=scope.owner_user_id,
+                    placement_direction=SessionGroupPlacementDirection.SPREAD,
+                    placement_enforcement=SessionGroupPlacementEnforcement.PREFERRED,
+                )
+            )
+            await session.flush()
+            session.add(
+                SessionRow(
+                    id=uuid.uuid4(),
+                    name=f"member-{uuid.uuid4().hex[:8]}",
+                    user_uuid=scope.owner_user_id,
+                    group_id=scope.project_id,
+                    domain_id=scope.domain_id,
+                    domain_name=scope.domain_name,
+                    resource_group_id=scope.resource_group_id,
+                    scaling_group_name=scope.resource_group_name,
+                    status=member_status,
+                    occupying_slots=ResourceSlot(),
+                    requested_slots=ResourceSlot(),
+                    vfolder_mounts=[],
+                    session_group_id=group_id,
+                )
+            )
+        return group_id
+
+    async def test_purges_groups_once_their_members_released_resources(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        scope: _PlacementScope,
+    ) -> None:
+        group_id = await self._add_group_with_member(
+            db_with_cleanup, scope, SessionStatus.TERMINATED
+        )
+
+        async with db_with_cleanup.begin_session() as session:
+            result = await execute_batch_purger(
+                session, create_user_session_group_purger(scope.owner_user_id)
+            )
+
+        assert result.deleted_count == 1
+        async with db_with_cleanup.begin_readonly_session() as session:
+            assert (
+                await session.scalar(
+                    sa.select(sa.func.count())
+                    .select_from(SessionGroupRow)
+                    .where(SessionGroupRow.id == group_id)
+                )
+            ) == 0
+
+    async def test_refuses_while_a_member_still_occupies_an_agent(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        scope: _PlacementScope,
+    ) -> None:
+        group_id = await self._add_group_with_member(db_with_cleanup, scope, SessionStatus.RUNNING)
+
+        with pytest.raises(UserPurgeFailure):
+            async with db_with_cleanup.begin_session() as session:
+                await execute_batch_purger(
+                    session, create_user_session_group_purger(scope.owner_user_id)
+                )
+
+        async with db_with_cleanup.begin_readonly_session() as session:
+            assert (
+                await session.scalar(
+                    sa.select(sa.func.count())
+                    .select_from(SessionGroupRow)
+                    .where(SessionGroupRow.id == group_id)
+                )
+            ) == 1


### PR DESCRIPTION
## Summary

- Add the `session_groups` table — the holder of a session set's per-agent placement policy (BEP-1064) — with direction (`spread`/`pack`/`none`) and enforcement (`preferred`/`strict`) as separate columns, and the ownership axes (`domain_id`/`project_id`/`owner_user_id`) that line up with sessions and endpoints.
- Bind membership through two FKs: `sessions.session_group_id` (nullable, indexed, `ON DELETE SET NULL` — NULL means no placement constraint) and `replica_groups.session_group_id` (NOT NULL — a replica group always owns exactly one group). The migration backfills one group per existing replica group with the deployment default `spread` + `preferred` and joins their existing route sessions to it, so a running deployment's members are visible to the scheduler from the first tick.
- Wire the two paths that create replica groups to bring their own group, move a group's ownership along with `delegate_endpoint_ownership`, and remove whatever the user still owns in the purge — refusing while a live replica group holds the group or its member sessions still occupy agents, rather than dropping placement state while the containers behind it are alive.

Both new FKs are declared with `use_alter` so `with_tables` subsets that omit `session_groups` still build; the resulting schema is identical.

No user-facing API: SessionGroup stays internal, exactly like `replica_groups`.

## Test plan

- [x] Migration verified against a live PostgreSQL: up / re-run (idempotent) / down / re-up
- [x] Every existing replica group backfilled with no NULLs, each with its own group, `spread` + `preferred`
- [x] Backfilled groups carry the endpoint's `(domain, project, session_owner)`; route sessions join their replica group's group; a session with no route stays unconstrained
- [x] Deleting a group leaves its member sessions alive with `session_group_id` NULL; a new ordinary session defaults to NULL
- [x] Removing an owner is refused while their groups remain; the purge deletes them only once no member occupies an agent
- [x] Deployment creation and blue-green/canary rollouts create the group (new repository tests)
- [x] `pants test tests/unit/manager/{models,repositories,services,sokovan/deployment}` and `tests/component/scheduling_history`
- [x] `pants fmt` / `fix` / `lint` / `check`

Resolves BA-7037
