### PR TITLE
feat(BA-7039): apply SessionGroup placement policy in the scheduler

### DIFF
--- a/changes/13185.feature.md
+++ b/changes/13185.feature.md
@@ -1,0 +1,1 @@
+Place the sessions of a SessionGroup by its policy: `spread` keeps them on distinct agents and `pack` gathers them onto the same ones, either as a preference or as a strict requirement.

--- a/proposals/BEP-1064-session-group-placement.md
+++ b/proposals/BEP-1064-session-group-placement.md
@@ -164,9 +164,9 @@ Which pipeline stage the enforcement level attaches to *is* the semantics. `desi
 | Direction | Rank | Effect |
 |-----------|------|--------|
 | `spread` | The agent's member count | Narrows to the agents holding the fewest members; if any hold none, only that tier survives |
-| `pack` | 0 when the agent holds at least one member, 1 otherwise | Narrows to agents that already hold members and **leaves the choice among them to the RG strategy** |
+| `pack` | The agent's member count, negated | Narrows to the agents holding the most members; the group converges onto as few agents as possible |
 
-`pack` is not defined as "the agent with the most members" because an order ranks one tracker at a time and cannot see a global maximum. Narrowing to "where the group already is" and letting the RG strategy pick also fits the orthogonality of the two axes.
+The two directions are the same rank in opposite signs. The pipeline takes the minimum rank **across every candidate**, so a negated count selects the global maximum — `pack` can express "the fullest agent" and does. The RG strategy still picks within whatever tier is left, which matters when several agents tie.
 
 **Filter conditions (strict):**
 
@@ -262,7 +262,7 @@ The RG axis keeps its existing `dispersed`/`concentrated`. Distinct vocabulary f
 | Orthogonality | A separate axis from the RG `agent_selection_strategy`; the RG strategy operates on the candidate set the SessionGroup leaves |
 | Precedence | `designated_agents` > **SessionGroup** > RG strategy. The more local target always applies first |
 | Implementation point | `preferred` is a tracker **order**, `strict` is an **exclusion filter**, following the existing `designated_agents` precedent — no arbitration logic |
-| Ranks | spread = member count; pack = 0 when members present, 1 otherwise. `pack` skips the constraint for the first member (**anchor rule**) |
+| Ranks | The same rank in opposite signs: spread = member count, pack = negated member count (the pipeline's minimum over all candidates makes that the global maximum). `pack` skips the constraint for the first member (**anchor rule**) |
 | Unsatisfiable strict | **No preemption, recorded as an error.** The exclusion stage is where conditions unsalvageable by any state change (preemption included) belong. The session stays PENDING and retries |
 | Observation | `resource_allocations` joined with `sessions.session_group_id`; every agent-bound live session counts; a multi-node session counts once per agent; only this pass's groups are loaded |
 | In-batch accumulation | Per-group increments on `AgentStateTracker` under the existing commit/rollback contract |

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -34,6 +34,7 @@ from ai.backend.common.identifier.resource_group import (
     ResourceGroupName,
 )
 from ai.backend.common.identifier.resource_slot import ResourceSlotName
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.identifier.user import UserID
 from ai.backend.common.resource.types import TotalResourceData
 from ai.backend.common.types import (
@@ -92,6 +93,7 @@ from ai.backend.manager.models.session import (
     SessionDependencyRow,
     SessionRow,
 )
+from ai.backend.manager.models.session_group.row import SessionGroupRow
 from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import (
     ExtendedAsyncSAEngine,
@@ -181,6 +183,7 @@ from ai.backend.manager.views.sokovan.workload import (
     KernelWorkload,
     ResourceRequest,
     SessionDependencyInfo,
+    SessionGroupPolicy,
     SessionPlacement,
     SessionWorkload,
     WorkloadMeta,
@@ -281,6 +284,9 @@ class ScheduleDBSource:
             preemption_candidates = await self._fetch_preemption_candidates(
                 db_sess, resource_group, pending_sessions, observed_at
             )
+            session_group_members = await self._fetch_session_group_members(
+                db_sess, resource_group.meta.id, pending_sessions
+            )
 
             return SchedulingFetch(
                 resource_group=resource_group.meta,
@@ -292,6 +298,7 @@ class ScheduleDBSource:
                 session_dependencies=SessionDependencySnapshot(by_session=session_dependencies),
                 observed_at=observed_at,
                 preemption_candidates=preemption_candidates,
+                session_group_members=session_group_members,
             )
 
     async def _fetch_resource_group_with_slot_inventory(
@@ -412,6 +419,7 @@ class ScheduleDBSource:
                     SessionRow.designated_agent_ids,
                     SessionRow.requested_starts_at,
                     SessionRow.options,
+                    SessionRow.session_group_id,
                 )
             )
             .where(
@@ -461,6 +469,11 @@ class ScheduleDBSource:
                     row.requested
                 )
 
+        group_policies = await self._fetch_session_group_policies(
+            db_sess,
+            {row.session_group_id for row in session_rows.values() if row.session_group_id},
+        )
+
         workloads: list[SessionWorkload] = []
         for session_id, row in session_rows.items():
             kernels = [
@@ -498,6 +511,9 @@ class ScheduleDBSource:
                         designated_agent_ids=[AgentId(a) for a in row.designated_agent_ids]
                         if row.designated_agent_ids is not None
                         else None,
+                        session_group=group_policies.get(row.session_group_id)
+                        if row.session_group_id is not None
+                        else None,
                     ),
                     priority=row.priority,
                     job_priority=row.job_priority,
@@ -508,6 +524,85 @@ class ScheduleDBSource:
             )
 
         return PendingSessions(sessions=workloads)
+
+    async def _fetch_session_group_policies(
+        self,
+        db_sess: SASession,
+        session_group_ids: set[SessionGroupID],
+    ) -> dict[SessionGroupID, SessionGroupPolicy]:
+        """Load the placement policy of the groups the pending sessions belong to.
+
+        A group already soft-deleted is left out: its members place
+        unconstrained, matching the NULL-group default.
+        """
+        if not session_group_ids:
+            return {}
+        rows = (
+            await db_sess.execute(
+                sa.select(
+                    SessionGroupRow.id,
+                    SessionGroupRow.placement_direction,
+                    SessionGroupRow.placement_enforcement,
+                ).where(
+                    SessionGroupRow.id.in_(session_group_ids),
+                    SessionGroupRow.deleted_at.is_(None),
+                )
+            )
+        ).all()
+        return {
+            row.id: SessionGroupPolicy(
+                group_id=row.id,
+                direction=row.placement_direction,
+                enforcement=row.placement_enforcement,
+            )
+            for row in rows
+        }
+
+    async def _fetch_session_group_members(
+        self,
+        db_sess: SASession,
+        resource_group_id: ResourceGroupID,
+        pending_sessions: PendingSessions,
+    ) -> dict[AgentId, dict[SessionGroupID, int]]:
+        """Count the live members each agent holds, per session group.
+
+        Occupancy comes from ``resource_allocations`` (the authority) joined
+        with ``sessions.session_group_id``; a kernel counts while it holds
+        agent resources, so sessions merely reserved (SCHEDULED/PREPARING)
+        count as well. Sessions are counted DISTINCT per agent, so a
+        multi-node session counts once on each agent hosting its kernels.
+        No query runs when this pass has no placement-engaged group.
+        """
+        group_ids = pending_sessions.placement_group_ids
+        if not group_ids:
+            return {}
+
+        ra = ResourceAllocationRow.__table__
+        k = KernelRow.__table__
+        s = SessionRow.__table__
+        stmt = (
+            sa.select(
+                s.c.session_group_id,
+                k.c.agent,
+                sa.func.count(sa.distinct(s.c.id)).label("member_count"),
+            )
+            .select_from(ra.join(k, ra.c.kernel_id == k.c.id).join(s, k.c.session_id == s.c.id))
+            .where(
+                s.c.session_group_id.in_(group_ids),
+                s.c.resource_group_id == resource_group_id,
+                k.c.status.in_(KernelStatus.resource_holding_statuses()),
+                k.c.agent.is_not(None),
+                ra.c.free_at.is_(None),
+            )
+            .group_by(s.c.session_group_id, k.c.agent)
+        )
+        rows = (await db_sess.execute(stmt)).all()
+        members_by_agent: dict[AgentId, dict[SessionGroupID, int]] = defaultdict(dict)
+        for row in rows:
+            members_by_agent[AgentId(row.agent)][SessionGroupID(row.session_group_id)] = (
+                row.member_count
+            )
+        return dict(members_by_agent)
 
     async def _fetch_agents(
         self, db_sess: SASession, resource_group_id: ResourceGroupID

--- a/src/ai/backend/manager/repositories/scheduler/repository.py
+++ b/src/ai/backend/manager/repositories/scheduler/repository.py
@@ -147,6 +147,7 @@ class SchedulerRepository:
                 resources=ResourceGroupResource(
                     agents=fetch.agents,
                     failed_sessions_by_agent=failed_sessions_by_agent,
+                    group_members_by_agent=fetch.session_group_members,
                 ),
                 session_dependencies=fetch.session_dependencies,
                 policy=fetch.policy,

--- a/src/ai/backend/manager/repositories/scheduler/types/scheduling.py
+++ b/src/ai/backend/manager/repositories/scheduler/types/scheduling.py
@@ -1,8 +1,11 @@
 """Repository-internal scheduling fetch types."""
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 
+from ai.backend.common.identifier.session_group import SessionGroupID
+from ai.backend.common.types import AgentId
 from ai.backend.manager.views.sokovan.agent import AgentMeta
 from ai.backend.manager.views.sokovan.resource_group import ResourceGroupMeta
 from ai.backend.manager.views.sokovan.snapshot import (
@@ -34,3 +37,6 @@ class SchedulingFetch:
     observed_at: datetime
     # Preemption victim candidates per owner (empty when preemption disabled)
     preemption_candidates: PreemptionCandidateSnapshot
+    # Live session-group members per agent (empty when no pending session
+    # carries a placement-engaged group)
+    session_group_members: Mapping[AgentId, Mapping[SessionGroupID, int]]

--- a/src/ai/backend/manager/repositories/scheduler/types/session.py
+++ b/src/ai/backend/manager/repositories/scheduler/types/session.py
@@ -5,7 +5,9 @@ from functools import cached_property
 
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.project import ProjectID
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.identifier.user import UserID
+from ai.backend.manager.data.session_group.types import SessionGroupPlacementDirection
 from ai.backend.manager.views.sokovan.workload import SessionWorkload
 
 
@@ -29,3 +31,18 @@ class PendingSessions:
     def domain_ids(self) -> set[DomainID]:
         """Extract unique domain IDs from pending sessions."""
         return {s.meta.owner.domain_id for s in self.sessions}
+
+    @cached_property
+    def placement_group_ids(self) -> set[SessionGroupID]:
+        """Session groups that actually constrain this pass's placements.
+
+        Groups with a ``none`` direction are left out: they keep the
+        membership but do not participate in placement, so their per-agent
+        member counts are never read.
+        """
+        return {
+            s.placement.session_group.group_id
+            for s in self.sessions
+            if s.placement.session_group is not None
+            and s.placement.session_group.direction is not SessionGroupPlacementDirection.NONE
+        }

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/exceptions.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/exceptions.py
@@ -90,10 +90,12 @@ class NoCompatibleAgentError(AgentSelectionError):
     error_title = "No compatible agents for the request."
 
     filter_name: str
+    failure_reason: str
 
-    def __init__(self, filter_name: str) -> None:
+    def __init__(self, filter_name: str, failure_reason: str) -> None:
         self.filter_name = filter_name
-        super().__init__(f"no agents passed the '{filter_name}' filter")
+        self.failure_reason = failure_reason
+        super().__init__(f"no agents passed the '{filter_name}' filter: {failure_reason}")
 
     @override
     def error_code(self) -> ErrorCode:

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/filters/exclusion/architecture.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/filters/exclusion/architecture.py
@@ -29,6 +29,14 @@ class ArchitectureTrackerFilter(AbstractExclusionTrackerFilter):
         return "Agents with a matching architecture found"
 
     @override
+    def failure_message(
+        self,
+        criteria: AgentSelectionCriteria,
+        resource_req: ResourceRequirements,
+    ) -> str:
+        return f"no agent serves the required architecture '{resource_req.required_architecture}'"
+
+    @override
     def filter(
         self,
         trackers: Sequence[AgentStateTracker],

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/filters/exclusion/designated_strict.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/filters/exclusion/designated_strict.py
@@ -31,6 +31,15 @@ class DesignatedStrictTrackerFilter(AbstractExclusionTrackerFilter):
         return "Designated agents present (or no strict designation)"
 
     @override
+    def failure_message(
+        self,
+        criteria: AgentSelectionCriteria,
+        resource_req: ResourceRequirements,
+    ) -> str:
+        designated = ", ".join(str(agent_id) for agent_id in criteria.designated_agent_ids or [])
+        return f"none of the strictly designated agents [{designated}] is available"
+
+    @override
     def filter(
         self,
         trackers: Sequence[AgentStateTracker],

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/filters/exclusion/filter.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/filters/exclusion/filter.py
@@ -31,6 +31,16 @@ class AbstractExclusionTrackerFilter(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def failure_message(
+        self,
+        criteria: AgentSelectionCriteria,
+        resource_req: ResourceRequirements,
+    ) -> str:
+        """Why this filter left no candidates, in the terms of what it
+        enforced — it becomes the session's scheduling-failure reason."""
+        raise NotImplementedError
+
+    @abstractmethod
     def filter(
         self,
         trackers: Sequence[AgentStateTracker],

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/filters/exclusion/session_group_strict.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/filters/exclusion/session_group_strict.py
@@ -1,0 +1,83 @@
+"""Exclusion filter: a strict session-group direction removes non-conforming agents."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, override
+
+from ai.backend.manager.data.session_group.types import (
+    SessionGroupPlacementDirection,
+    SessionGroupPlacementEnforcement,
+)
+from ai.backend.manager.sokovan.scheduler.provisioner.selectors.filters.exclusion.filter import (
+    AbstractExclusionTrackerFilter,
+)
+from ai.backend.manager.sokovan.scheduler.provisioner.selectors.tracker import AgentStateTracker
+from ai.backend.manager.sokovan.scheduler.provisioner.selectors.types import ResourceRequirements
+
+if TYPE_CHECKING:
+    from ai.backend.manager.sokovan.scheduler.provisioner.selectors.selector import (
+        AgentSelectionCriteria,
+    )
+
+
+class SessionGroupStrictTrackerFilter(AbstractExclusionTrackerFilter):
+    """Under STRICT enforcement the group's direction is a hard condition;
+    PREFERRED enforcement is an ordering concern, not a filter.
+
+    An emptied pool is an absolute failure by design: every agent already
+    holds a member of this group, and freeing resources on one of them does
+    not remove that member, so no state change (preemption included) can
+    make the placement conform.
+    """
+
+    @override
+    def name(self) -> str:
+        return "session-group-strict"
+
+    @override
+    def success_message(self) -> str:
+        return "Agents conforming to the session group's placement direction found"
+
+    @override
+    def failure_message(
+        self,
+        criteria: AgentSelectionCriteria,
+        resource_req: ResourceRequirements,
+    ) -> str:
+        policy = criteria.session_group
+        if policy is None:
+            return "no agent conforms to the session group's placement direction"
+        return (
+            f"session group {policy.group_id} enforces strict "
+            f"'{policy.direction}' placement and no agent satisfies it"
+        )
+
+    @override
+    def filter(
+        self,
+        trackers: Sequence[AgentStateTracker],
+        criteria: AgentSelectionCriteria,
+        resource_req: ResourceRequirements,
+    ) -> Sequence[AgentStateTracker]:
+        policy = criteria.session_group
+        if policy is None or policy.enforcement is not SessionGroupPlacementEnforcement.STRICT:
+            return trackers
+        match policy.direction:
+            case SessionGroupPlacementDirection.SPREAD:
+                return [
+                    tracker
+                    for tracker in trackers
+                    if tracker.current_group_member_count(policy.group_id) == 0
+                ]
+            case SessionGroupPlacementDirection.PACK:
+                holders = [
+                    tracker
+                    for tracker in trackers
+                    if tracker.current_group_member_count(policy.group_id) > 0
+                ]
+                # Anchor rule: with no member placed yet there is nothing to
+                # pack onto, so the first member is unconstrained.
+                return holders or trackers
+            case SessionGroupPlacementDirection.NONE:
+                return trackers

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/orders/session_group.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/orders/session_group.py
@@ -1,0 +1,45 @@
+"""Order: the session group's placement direction narrows the tier."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, override
+
+from ai.backend.manager.data.session_group.types import SessionGroupPlacementDirection
+from ai.backend.manager.sokovan.scheduler.provisioner.selectors.tracker import AgentStateTracker
+
+from .order import AbstractTrackerOrder
+
+if TYPE_CHECKING:
+    from ai.backend.manager.sokovan.scheduler.provisioner.selectors.selector import (
+        AgentSelectionCriteria,
+    )
+
+
+class SessionGroupOrder(AbstractTrackerOrder):
+    """Narrows to the tier the group's direction prefers, leaving the final
+    pick to the resource group's strategy.
+
+    Both directions rank by the member count, in opposite signs: ``spread``
+    keeps the emptiest agents, ``pack`` the fullest ones (the pipeline takes
+    the minimum rank across every candidate, so a negated count selects the
+    maximum). Under STRICT the filter has already restricted the candidates,
+    so this is a no-op there — the same way the designated-agent order defers
+    to its strict filter.
+    """
+
+    @override
+    def name(self) -> str:
+        return "session-group"
+
+    @override
+    def rank(self, tracker: AgentStateTracker, criteria: AgentSelectionCriteria) -> int:
+        policy = criteria.session_group
+        if policy is None:
+            return 0
+        match policy.direction:
+            case SessionGroupPlacementDirection.SPREAD:
+                return tracker.current_group_member_count(policy.group_id)
+            case SessionGroupPlacementDirection.PACK:
+                return -tracker.current_group_member_count(policy.group_id)
+            case SessionGroupPlacementDirection.NONE:
+                return 0

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/pool.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/pool.py
@@ -14,11 +14,13 @@ from .concentrated import ConcentratedAgentSelector
 from .dispersed import DispersedAgentSelector
 from .filters.exclusion.architecture import ArchitectureTrackerFilter
 from .filters.exclusion.designated_strict import DesignatedStrictTrackerFilter
+from .filters.exclusion.session_group_strict import SessionGroupStrictTrackerFilter
 from .filters.stateful.container_limit import ContainerLimitTrackerFilter
 from .filters.stateful.resource import ResourceTrackerFilter
 from .legacy import LegacyAgentSelector
 from .orders.designated_preferred import DesignatedPreferredOrder
 from .orders.failed_session import FailedSessionOrder
+from .orders.session_group import SessionGroupOrder
 from .roundrobin import RoundRobinAgentSelector
 from .selector import AbstractAgentSelector, AgentSelector
 from .victims.pool import create_victim_selector
@@ -40,10 +42,17 @@ def create_agent_selector(agent_selection_resource_priority: list[str]) -> Agent
     strategy_pool[AgentSelectionStrategy.LEGACY] = LegacyAgentSelector(
         agent_selection_resource_priority
     )
+    # Filter and order sequence carry the placement precedence: the more
+    # local target applies first (designated agents > session group > the
+    # resource group's strategy, which picks from what is left).
     return AgentSelector(
         strategy_pool,
-        exclusion_filters=[ArchitectureTrackerFilter(), DesignatedStrictTrackerFilter()],
+        exclusion_filters=[
+            ArchitectureTrackerFilter(),
+            DesignatedStrictTrackerFilter(),
+            SessionGroupStrictTrackerFilter(),
+        ],
         stateful_filters=[ResourceTrackerFilter(), ContainerLimitTrackerFilter()],
-        orders=[DesignatedPreferredOrder(), FailedSessionOrder()],
+        orders=[DesignatedPreferredOrder(), SessionGroupOrder(), FailedSessionOrder()],
         victim_selector=create_victim_selector(),
     )

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/selector.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/selector.py
@@ -16,6 +16,7 @@ from decimal import Decimal
 
 from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.identifier.resource_slot import ResourceSlotName
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.types import (
     AgentId,
     AgentSelectionStrategy,
@@ -31,6 +32,7 @@ from ai.backend.manager.views.sokovan.agent import AgentInfo, AgentLimit
 from ai.backend.manager.views.sokovan.snapshot import PreemptionCandidate, UserVictimCandidates
 from ai.backend.manager.views.sokovan.workload import (
     ResourceRequest,
+    SessionGroupPolicy,
     SessionPlacement,
     SessionWorkload,
 )
@@ -98,6 +100,8 @@ class AgentSelectionCriteria:
     # The owner's preemption victim candidates (None disables the
     # preemption path, e.g. the fitting check)
     victim_candidates: UserVictimCandidates | None
+    # Placement policy of the session's group (None means unconstrained)
+    session_group: SessionGroupPolicy | None
 
     @classmethod
     def from_workload(
@@ -115,7 +119,14 @@ class AgentSelectionCriteria:
             designated_agent_ids=workload.placement.designated_agent_ids,
             job_priority=workload.job_priority,
             victim_candidates=victim_candidates,
+            session_group=workload.placement.session_group,
         )
+
+    def session_group_id(self) -> SessionGroupID | None:
+        """The group the placement counts toward (None when unconstrained)."""
+        if self.session_group is None:
+            return None
+        return self.session_group.group_id
 
 
 @dataclass
@@ -430,7 +441,11 @@ class AgentSelector:
             candidates, resource_req
         )
         # Track the in-flight allocation for the selected agent
-        selected_tracker.apply_diff(resource_req.requested_slots, resource_req.container_count)
+        selected_tracker.apply_diff(
+            resource_req.requested_slots,
+            resource_req.container_count,
+            criteria.session_group_id(),
+        )
         return AgentSelection(
             resource_requirements=resource_req,
             selected_agent=selected_tracker.original_agent,
@@ -502,7 +517,11 @@ class AgentSelector:
         # once, freeing everywhere); the requirement consumes from the
         # chosen agent.
         self._apply_victim_reclaims(trackers, chosen)
-        selected_tracker.apply_diff(resource_req.requested_slots, resource_req.container_count)
+        selected_tracker.apply_diff(
+            resource_req.requested_slots,
+            resource_req.container_count,
+            criteria.session_group_id(),
+        )
         return AgentSelection(
             resource_requirements=resource_req,
             selected_agent=selected_tracker.original_agent,
@@ -596,7 +615,9 @@ class AgentSelector:
                 candidates = exclusion.filter(candidates, criteria, resource_req)
                 if not candidates:
                     # Raised inside the step so the record names the filter.
-                    raise NoCompatibleAgentError(exclusion.name())
+                    raise NoCompatibleAgentError(
+                        exclusion.name(), exclusion.failure_message(criteria, resource_req)
+                    )
         return candidates
 
     def _run_stateful_filters(

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/tracker.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/tracker.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 
 from ai.backend.common.identifier.resource_slot import ResourceSlotName
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.types import SessionId
 from ai.backend.manager.views.sokovan.agent import AgentInfo, ResourceGroupResource
 from ai.backend.manager.views.sokovan.workload import ResourceRequest
@@ -29,10 +30,17 @@ class AgentStateTracker:
     original_agent: AgentInfo
     # Sessions that previously failed on this agent (retry deprioritization hint)
     failed_session_ids: frozenset[SessionId] = frozenset()
+    # Observed live members this agent holds, per session group
+    group_member_counts: Mapping[SessionGroupID, int] = field(default_factory=dict)
     committed_slots: dict[ResourceSlotName, Decimal] = field(default_factory=dict)
     committed_containers: int = 0
+    committed_group_members: dict[SessionGroupID, int] = field(default_factory=dict)
     pending_slots: dict[ResourceSlotName, Decimal] = field(default_factory=dict)
     pending_containers: int = 0
+    # Group of the session being placed, once it lands here. A session counts
+    # once per agent no matter how many of its kernels land on it, so this is
+    # a membership mark rather than a counter.
+    pending_group_id: SessionGroupID | None = None
     # Provisional victim reclaims of the preemption probe; always cleared
     # before real placements continue (see apply_reclaim)
     reclaimed_slots: dict[ResourceSlotName, Decimal] = field(default_factory=dict)
@@ -59,11 +67,27 @@ class AgentStateTracker:
             + self.pending_containers
         )
 
-    def apply_diff(self, request: ResourceRequest, containers: int) -> None:
+    def current_group_member_count(self, session_group_id: SessionGroupID) -> int:
+        """Members of the group on this agent = observed + in-batch increments."""
+        count = self.group_member_counts.get(
+            session_group_id, 0
+        ) + self.committed_group_members.get(session_group_id, 0)
+        if self.pending_group_id == session_group_id:
+            count += 1
+        return count
+
+    def apply_diff(
+        self,
+        request: ResourceRequest,
+        containers: int,
+        session_group_id: SessionGroupID | None,
+    ) -> None:
         """Apply an in-flight allocation of the session being placed."""
         for slot_name, amount in request.slots.items():
             self.pending_slots[slot_name] = self.pending_slots.get(slot_name, Decimal(0)) + amount
         self.pending_containers += containers
+        if session_group_id is not None:
+            self.pending_group_id = session_group_id
 
     def commit(self) -> None:
         """Fold the in-flight allocation into the batch state (session placed)."""
@@ -72,12 +96,17 @@ class AgentStateTracker:
                 self.committed_slots.get(slot_name, Decimal(0)) + amount
             )
         self.committed_containers += self.pending_containers
+        if self.pending_group_id is not None:
+            self.committed_group_members[self.pending_group_id] = (
+                self.committed_group_members.get(self.pending_group_id, 0) + 1
+            )
         self.rollback()
 
     def rollback(self) -> None:
         """Discard the in-flight allocation (session placement failed)."""
         self.pending_slots = {}
         self.pending_containers = 0
+        self.pending_group_id = None
 
     def apply_reclaim(self, slots: Mapping[ResourceSlotName, Decimal]) -> None:
         """Provisionally reclaim a preemption victim's allocation back onto
@@ -104,6 +133,7 @@ def build_agent_trackers(resources: ResourceGroupResource) -> list[AgentStateTra
             failed_session_ids=frozenset(
                 resources.failed_sessions_by_agent.get(agent.id, frozenset())
             ),
+            group_member_counts=resources.group_members_by_agent.get(agent.id, {}),
         )
         for agent in resources.agents
     ]

--- a/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
@@ -384,6 +384,10 @@ class SchedulingController:
                 # The fitting check has no preemption context
                 job_priority=0,
                 victim_candidates=None,
+                # Group constraints are not applied to the fitting check: it
+                # answers "does this fit", and loading the group observations
+                # on this path is a separate decision (BEP-1064 open question).
+                session_group=None,
             )
             # Trackers are throwaway here: the fitting check only needs the
             # immutable observations, never the committed batch state. The

--- a/src/ai/backend/manager/views/sokovan/agent.py
+++ b/src/ai/backend/manager/views/sokovan/agent.py
@@ -9,6 +9,7 @@ from functools import cached_property
 
 from ai.backend.common.identifier.architecture import ArchName
 from ai.backend.common.identifier.resource_slot import ResourceSlotName
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.types import AgentId, SessionId
 
 
@@ -84,6 +85,12 @@ class ResourceGroupResource:
     # Sessions that previously failed per agent (retry deprioritization
     # hints from Valkey; empty for the fitting check)
     failed_sessions_by_agent: Mapping[AgentId, frozenset[SessionId]] = field(default_factory=dict)
+    # Live members each agent already holds, per session group (loaded only
+    # for the groups of this pass's pending sessions; empty for the fitting
+    # check)
+    group_members_by_agent: Mapping[AgentId, Mapping[SessionGroupID, int]] = field(
+        default_factory=dict
+    )
 
     @cached_property
     def slots(self) -> Mapping[ResourceSlotName, SlotResource]:

--- a/src/ai/backend/manager/views/sokovan/workload.py
+++ b/src/ai/backend/manager/views/sokovan/workload.py
@@ -13,6 +13,7 @@ from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.project import ProjectID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.identifier.resource_slot import ResourceSlotName
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import (
     AccessKey,
@@ -25,6 +26,10 @@ from ai.backend.common.types import (
 )
 from ai.backend.manager.data.session.options import AgentSelectionPolicy
 from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.data.session_group.types import (
+    SessionGroupPlacementDirection,
+    SessionGroupPlacementEnforcement,
+)
 
 
 @dataclass(frozen=True)
@@ -89,6 +94,20 @@ class WorkloadMeta:
 
 
 @dataclass(frozen=True)
+class SessionGroupPolicy:
+    """The placement policy of the session group this session belongs to.
+
+    Direction and enforcement are orthogonal: the direction says how members
+    sit relative to each other, the enforcement decides which pipeline stage
+    applies it (PREFERRED narrows, STRICT excludes).
+    """
+
+    group_id: SessionGroupID
+    direction: SessionGroupPlacementDirection
+    enforcement: SessionGroupPlacementEnforcement
+
+
+@dataclass(frozen=True)
 class SessionPlacement:
     """Selection-facing part of the workload: what must land on agents."""
 
@@ -98,6 +117,9 @@ class SessionPlacement:
     agent_selection_policy: AgentSelectionPolicy
     # Manually designated agents (user's explicit choice takes precedence)
     designated_agent_ids: list[AgentId] | None
+    # Placement policy of the session's group (None when the session has no
+    # group, or its group is gone — either way it is placed unconstrained)
+    session_group: SessionGroupPolicy | None
 
 
 @dataclass

--- a/tests/component/deployment/conftest.py
+++ b/tests/component/deployment/conftest.py
@@ -44,6 +44,7 @@ from ai.backend.manager.models.deployment_policy.row import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision.row import DeploymentRevisionRow
 from ai.backend.manager.models.endpoint.row import EndpointRow
 from ai.backend.manager.models.image.row import ImageRow
+from ai.backend.manager.models.session_group.row import SessionGroupRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import vfolders
 from ai.backend.manager.plugin.network import NetworkPluginContext
@@ -373,5 +374,13 @@ async def deployment_seed_data(
         await conn.execute(
             EndpointRow.__table__.delete().where(
                 EndpointRow.__table__.c.domain == domain_fixture.domain_name
+            )
+        )
+        # Replica group creation makes a SessionGroup with it; the rows
+        # outlive the endpoint delete and hold RESTRICT FKs on the domain
+        # and project fixtures torn down after this one.
+        await conn.execute(
+            SessionGroupRow.__table__.delete().where(
+                SessionGroupRow.__table__.c.domain_id == domain_fixture.domain_id
             )
         )

--- a/tests/unit/manager/repositories/scheduler/conftest.py
+++ b/tests/unit/manager/repositories/scheduler/conftest.py
@@ -21,6 +21,7 @@ from dateutil.tz import tzutc
 from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.types import (
     AccessKey,
     AgentId,
@@ -60,6 +61,7 @@ from ai.backend.manager.models.resource_slot.row import ResourceSlotTypeRow
 from ai.backend.manager.models.scaling_group import ScalingGroupOpts, ScalingGroupRow
 from ai.backend.manager.models.scheduling_history.row import SessionSchedulingHistoryRow
 from ai.backend.manager.models.session import SessionDependencyRow, SessionRow
+from ai.backend.manager.models.session_group.row import SessionGroupRow
 from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.views.sokovan.allocation import (
@@ -86,6 +88,7 @@ _SCHEDULER_ROWS: list[type] = [
     AgentRow,
     ContainerRegistryRow,
     ImageRow,
+    SessionGroupRow,
     SessionRow,
     KernelRow,
     ResourceSlotTypeRow,
@@ -402,6 +405,7 @@ async def create_pending_session_with_kernels(
     session_status: SessionStatus = SessionStatus.PENDING,
     kernel_status: KernelStatus = KernelStatus.PENDING,
     assign_agents: bool = False,
+    session_group_id: SessionGroupID | None = None,
 ) -> tuple[SessionId, list[KernelId]]:
     """Create a session with one kernel per agent assignment.
 
@@ -444,6 +448,7 @@ async def create_pending_session_with_kernels(
                 requested_slots=ResourceSlot({"cpu": total_cpu, "mem": total_mem}),
                 created_at=now,
                 starts_at=now if session_status == SessionStatus.RUNNING else None,
+                session_group_id=session_group_id,
                 images=["python:3.8"],
                 vfolder_mounts=[],
                 environ={},

--- a/tests/unit/manager/repositories/scheduler/test_session_group_observation.py
+++ b/tests/unit/manager/repositories/scheduler/test_session_group_observation.py
@@ -1,0 +1,434 @@
+"""BA-7039: session-group policy and per-agent member counts in the scheduling fetch.
+
+The load sites are ``ScheduleDBSource._fetch_session_group_policies`` (the
+policy carried on the pending workload) and
+``ScheduleDBSource._fetch_session_group_members`` (the per-agent observation);
+both are verified against a real database.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import TypedDict
+
+import pytest
+
+from ai.backend.common.identifier.domain import DomainID
+from ai.backend.common.identifier.project import ProjectID
+from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.identifier.session_group import SessionGroupID
+from ai.backend.common.identifier.user import UserID
+from ai.backend.common.types import AccessKey, AgentId, ResourceSlot, SessionTypes
+from ai.backend.manager.data.agent.types import AgentStatus
+from ai.backend.manager.data.kernel.types import KernelStatus
+from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.data.session_group.types import (
+    SessionGroupPlacementDirection,
+    SessionGroupPlacementEnforcement,
+)
+from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.session_group.row import SessionGroupRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.scheduler.db_source.db_source import ScheduleDBSource
+
+from .conftest import create_pending_session_with_kernels
+
+
+class SessionScope(TypedDict):
+    """Ownership-scope arguments shared by every session in these tests."""
+
+    domain_id: DomainID
+    domain_name: str
+    resource_group_id: ResourceGroupID
+    scaling_group_name: str
+    group_id: uuid.UUID
+    user_uuid: uuid.UUID
+    access_key: AccessKey
+
+
+async def _create_session_group(
+    db: ExtendedAsyncSAEngine,
+    *,
+    domain_id: DomainID,
+    group_id: uuid.UUID,
+    user_uuid: uuid.UUID,
+    direction: SessionGroupPlacementDirection = SessionGroupPlacementDirection.SPREAD,
+    enforcement: SessionGroupPlacementEnforcement = SessionGroupPlacementEnforcement.PREFERRED,
+    deleted_at: datetime | None = None,
+) -> SessionGroupID:
+    session_group_id = SessionGroupID(uuid.uuid4())
+    async with db.begin_session() as db_sess:
+        db_sess.add(
+            SessionGroupRow(
+                id=session_group_id,
+                domain_id=domain_id,
+                project_id=ProjectID(group_id),
+                owner_user_id=UserID(user_uuid),
+                placement_direction=direction,
+                placement_enforcement=enforcement,
+                deleted_at=deleted_at,
+            )
+        )
+        await db_sess.flush()
+    return session_group_id
+
+
+async def _create_extra_agent(
+    db: ExtendedAsyncSAEngine,
+    *,
+    scaling_group_name: str,
+    resource_group_id: ResourceGroupID,
+) -> str:
+    agent_id = f"test-agent-{uuid.uuid4().hex[:8]}"
+    async with db.begin_session() as db_sess:
+        db_sess.add(
+            AgentRow(
+                id=agent_id,
+                status=AgentStatus.ALIVE,
+                region="local",
+                scaling_group=scaling_group_name,
+                resource_group_id=resource_group_id,
+                available_slots=ResourceSlot({"cpu": Decimal("10"), "mem": Decimal("10240")}),
+                occupied_slots=ResourceSlot(),
+                addr="127.0.0.1:6001",
+                version="1.0.0",
+                architecture="x86_64",
+            )
+        )
+        await db_sess.flush()
+    return agent_id
+
+
+@pytest.fixture
+def session_scope(
+    test_domain_id: DomainID,
+    test_domain_name: str,
+    test_scaling_group_id: ResourceGroupID,
+    test_scaling_group_name: str,
+    test_group_id: uuid.UUID,
+    test_user_uuid: uuid.UUID,
+    test_access_key: AccessKey,
+) -> SessionScope:
+    return {
+        "domain_id": test_domain_id,
+        "domain_name": test_domain_name,
+        "resource_group_id": test_scaling_group_id,
+        "scaling_group_name": test_scaling_group_name,
+        "group_id": test_group_id,
+        "user_uuid": test_user_uuid,
+        "access_key": test_access_key,
+    }
+
+
+class TestSessionGroupPolicyOnWorkload:
+    async def test_pending_workload_carries_the_group_policy(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain_id: DomainID,
+        test_scaling_group_id: ResourceGroupID,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_agent_id: str,
+        resource_slot_types: None,
+        session_scope: SessionScope,
+    ) -> None:
+        session_group_id = await _create_session_group(
+            db_with_cleanup,
+            domain_id=test_domain_id,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            direction=SessionGroupPlacementDirection.PACK,
+            enforcement=SessionGroupPlacementEnforcement.STRICT,
+        )
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            session_group_id=session_group_id,
+            **session_scope,
+        )
+
+        fetch = await ScheduleDBSource(db_with_cleanup).fetch_scheduling_fetch(
+            test_scaling_group_id
+        )
+
+        assert fetch is not None
+        policy = fetch.workloads[0].placement.session_group
+        assert policy is not None
+        assert policy.group_id == session_group_id
+        assert policy.direction is SessionGroupPlacementDirection.PACK
+        assert policy.enforcement is SessionGroupPlacementEnforcement.STRICT
+
+    async def test_ungrouped_workload_has_no_policy(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_scaling_group_id: ResourceGroupID,
+        test_agent_id: str,
+        resource_slot_types: None,
+        session_scope: SessionScope,
+    ) -> None:
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            **session_scope,
+        )
+
+        fetch = await ScheduleDBSource(db_with_cleanup).fetch_scheduling_fetch(
+            test_scaling_group_id
+        )
+
+        assert fetch is not None
+        assert fetch.workloads[0].placement.session_group is None
+        # No group in this pass: the observation query never runs.
+        assert fetch.session_group_members == {}
+
+    async def test_soft_deleted_group_leaves_the_session_unconstrained(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain_id: DomainID,
+        test_scaling_group_id: ResourceGroupID,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_agent_id: str,
+        resource_slot_types: None,
+        session_scope: SessionScope,
+    ) -> None:
+        session_group_id = await _create_session_group(
+            db_with_cleanup,
+            domain_id=test_domain_id,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            deleted_at=datetime.now(UTC),
+        )
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            session_group_id=session_group_id,
+            **session_scope,
+        )
+
+        fetch = await ScheduleDBSource(db_with_cleanup).fetch_scheduling_fetch(
+            test_scaling_group_id
+        )
+
+        assert fetch is not None
+        assert fetch.workloads[0].placement.session_group is None
+        assert fetch.session_group_members == {}
+
+
+class TestSessionGroupMemberObservation:
+    async def test_counts_running_and_reserved_members_per_agent(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain_id: DomainID,
+        test_scaling_group_id: ResourceGroupID,
+        test_scaling_group_name: str,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_agent_id: str,
+        resource_slot_types: None,
+        session_scope: SessionScope,
+    ) -> None:
+        """A member that only holds a reservation (SCHEDULED) counts too."""
+        session_group_id = await _create_session_group(
+            db_with_cleanup,
+            domain_id=test_domain_id,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+        )
+        other_agent_id = await _create_extra_agent(
+            db_with_cleanup,
+            scaling_group_name=test_scaling_group_name,
+            resource_group_id=test_scaling_group_id,
+        )
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            session_group_id=session_group_id,
+            **session_scope,
+        )
+        # RUNNING member on the first agent
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            session_group_id=session_group_id,
+            session_status=SessionStatus.RUNNING,
+            kernel_status=KernelStatus.RUNNING,
+            assign_agents=True,
+            **session_scope,
+        )
+        # SCHEDULED member (reservation only) on the second agent
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(other_agent_id, Decimal("1"), Decimal("1024"))],
+            session_group_id=session_group_id,
+            session_status=SessionStatus.SCHEDULED,
+            kernel_status=KernelStatus.SCHEDULED,
+            assign_agents=True,
+            **session_scope,
+        )
+
+        fetch = await ScheduleDBSource(db_with_cleanup).fetch_scheduling_fetch(
+            test_scaling_group_id
+        )
+
+        assert fetch is not None
+        assert fetch.session_group_members == {
+            AgentId(test_agent_id): {session_group_id: 1},
+            AgentId(other_agent_id): {session_group_id: 1},
+        }
+
+    async def test_multi_node_member_counts_once_on_each_agent(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain_id: DomainID,
+        test_scaling_group_id: ResourceGroupID,
+        test_scaling_group_name: str,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_agent_id: str,
+        resource_slot_types: None,
+        session_scope: SessionScope,
+    ) -> None:
+        session_group_id = await _create_session_group(
+            db_with_cleanup,
+            domain_id=test_domain_id,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+        )
+        other_agent_id = await _create_extra_agent(
+            db_with_cleanup,
+            scaling_group_name=test_scaling_group_name,
+            resource_group_id=test_scaling_group_id,
+        )
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            session_group_id=session_group_id,
+            **session_scope,
+        )
+        # One cluster session with two kernels on the first agent and one on
+        # the second: 1 on each, not 2 and 1.
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[
+                (test_agent_id, Decimal("1"), Decimal("1024")),
+                (test_agent_id, Decimal("1"), Decimal("1024")),
+                (other_agent_id, Decimal("1"), Decimal("1024")),
+            ],
+            session_group_id=session_group_id,
+            session_status=SessionStatus.RUNNING,
+            kernel_status=KernelStatus.RUNNING,
+            assign_agents=True,
+            **session_scope,
+        )
+
+        fetch = await ScheduleDBSource(db_with_cleanup).fetch_scheduling_fetch(
+            test_scaling_group_id
+        )
+
+        assert fetch is not None
+        assert fetch.session_group_members == {
+            AgentId(test_agent_id): {session_group_id: 1},
+            AgentId(other_agent_id): {session_group_id: 1},
+        }
+
+    async def test_terminated_members_and_other_groups_are_excluded(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain_id: DomainID,
+        test_scaling_group_id: ResourceGroupID,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_agent_id: str,
+        resource_slot_types: None,
+        session_scope: SessionScope,
+    ) -> None:
+        session_group_id = await _create_session_group(
+            db_with_cleanup,
+            domain_id=test_domain_id,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+        )
+        other_group_id = await _create_session_group(
+            db_with_cleanup,
+            domain_id=test_domain_id,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+        )
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            session_group_id=session_group_id,
+            **session_scope,
+        )
+        # Terminated: holds nothing on the agent anymore
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            session_group_id=session_group_id,
+            session_status=SessionStatus.TERMINATED,
+            kernel_status=KernelStatus.TERMINATED,
+            assign_agents=True,
+            **session_scope,
+        )
+        # A live member of a group nobody is scheduling for
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            session_group_id=other_group_id,
+            session_status=SessionStatus.RUNNING,
+            kernel_status=KernelStatus.RUNNING,
+            assign_agents=True,
+            **session_scope,
+        )
+
+        fetch = await ScheduleDBSource(db_with_cleanup).fetch_scheduling_fetch(
+            test_scaling_group_id
+        )
+
+        assert fetch is not None
+        assert fetch.session_group_members == {}
+
+    async def test_none_direction_group_loads_no_observation(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain_id: DomainID,
+        test_scaling_group_id: ResourceGroupID,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_agent_id: str,
+        resource_slot_types: None,
+        session_scope: SessionScope,
+    ) -> None:
+        session_group_id = await _create_session_group(
+            db_with_cleanup,
+            domain_id=test_domain_id,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            direction=SessionGroupPlacementDirection.NONE,
+        )
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            session_group_id=session_group_id,
+            session_type=SessionTypes.INTERACTIVE,
+            **session_scope,
+        )
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            session_group_id=session_group_id,
+            session_status=SessionStatus.RUNNING,
+            kernel_status=KernelStatus.RUNNING,
+            assign_agents=True,
+            **session_scope,
+        )
+
+        fetch = await ScheduleDBSource(db_with_cleanup).fetch_scheduling_fetch(
+            test_scaling_group_id
+        )
+
+        assert fetch is not None
+        assert fetch.session_group_members == {}

--- a/tests/unit/manager/sokovan/scheduler/conftest.py
+++ b/tests/unit/manager/sokovan/scheduler/conftest.py
@@ -49,6 +49,7 @@ from ai.backend.manager.views.sokovan.snapshot import (
 from ai.backend.manager.views.sokovan.workload import (
     KernelWorkload,
     ResourceRequest,
+    SessionGroupPolicy,
     SessionPlacement,
     SessionWorkload,
     WorkloadMeta,
@@ -96,6 +97,7 @@ def create_session_workload(
     session_type: SessionTypes = SessionTypes.INTERACTIVE,
     requested_starts_at: datetime | None = None,
     is_preemptible: bool = False,
+    session_group: SessionGroupPolicy | None = None,
 ) -> SessionWorkload:
     """Create a SessionWorkload for testing.
 
@@ -120,6 +122,7 @@ def create_session_workload(
             kernels=kernels,
             agent_selection_policy=agent_selection_policy,
             designated_agent_ids=designated_agent_ids,
+            session_group=session_group,
         ),
         priority=priority,
         job_priority=job_priority,

--- a/tests/unit/manager/sokovan/scheduler/provisioner/conftest.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/conftest.py
@@ -51,6 +51,7 @@ from ai.backend.manager.views.sokovan.snapshot import (
 from ai.backend.manager.views.sokovan.workload import (
     KernelWorkload,
     ResourceRequest,
+    SessionGroupPolicy,
     SessionPlacement,
     SessionWorkload,
     WorkloadMeta,
@@ -70,6 +71,7 @@ def _make_workload(
     kernel_slots: list[Mapping[str, str]] | None = None,
     priority: int = 0,
     cluster_mode: ClusterMode = ClusterMode.SINGLE_NODE,
+    session_group: SessionGroupPolicy | None = None,
 ) -> SessionWorkload:
     if kernel_slots is None:
         kernel_slots = [{"cpu": "1", "mem": "1024"}]
@@ -101,6 +103,7 @@ def _make_workload(
             ],
             agent_selection_policy=AgentSelectionPolicy.STRICT,
             designated_agent_ids=None,
+            session_group=session_group,
         ),
         priority=priority,
         job_priority=0,

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_agent_selection_with_resources.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_agent_selection_with_resources.py
@@ -67,6 +67,7 @@ def _criteria(
         designated_agent_ids=designated_agent_ids,
         job_priority=0,
         victim_candidates=None,
+        session_group=None,
     )
 
 

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_concentrated_selector.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_concentrated_selector.py
@@ -161,6 +161,7 @@ class TestConcentratedAgentSelector:
                 }
             ),
             containers=1,
+            session_group_id=None,
         )
 
         remaining_low = low.remaining_slots()

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_failed_agent_filtering.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_failed_agent_filtering.py
@@ -100,6 +100,7 @@ def _criteria(
         designated_agent_ids=designated_agent_ids,
         job_priority=0,
         victim_candidates=None,
+        session_group=None,
     )
 
 

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_failure_message_format.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_failure_message_format.py
@@ -96,6 +96,7 @@ def _criteria(requirements: list[ResourceRequirements]) -> AgentSelectionCriteri
         designated_agent_ids=None,
         job_priority=0,
         victim_candidates=None,
+        session_group=None,
     )
 
 
@@ -111,6 +112,7 @@ def _designated_criteria(
         designated_agent_ids=designated_agent_ids,
         job_priority=0,
         victim_candidates=None,
+        session_group=None,
     )
 
 
@@ -253,7 +255,10 @@ class TestGoldenDesignatedAgentAbsent:
             )
 
         assert exc_info.value.filter_name == "designated-strict"
-        assert exc_info.value.extra_msg == "no agents passed the 'designated-strict' filter"
+        assert exc_info.value.extra_msg == (
+            "no agents passed the 'designated-strict' filter: none of the strictly "
+            "designated agents [designated-a, designated-b] is available"
+        )
 
 
 class TestGoldenBatchErrorDirectConstruction:

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_placement_computation.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_placement_computation.py
@@ -82,6 +82,7 @@ def _criteria(requirements: list[ResourceRequirements]) -> AgentSelectionCriteri
         designated_agent_ids=None,
         job_priority=0,
         victim_candidates=None,
+        session_group=None,
     )
 
 

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_preemption_selection.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_preemption_selection.py
@@ -104,6 +104,7 @@ def _criteria(
         designated_agent_ids=None,
         job_priority=job_priority,
         victim_candidates=victim_candidates,
+        session_group=None,
     )
 
 

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_resource_requirements.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_resource_requirements.py
@@ -131,6 +131,7 @@ class TestPlacementPlanFromPlacement:
             kernels=kernels,
             agent_selection_policy=AgentSelectionPolicy.STRICT,
             designated_agent_ids=None,
+            session_group=None,
         )
 
         plan = PlacementPlan.from_placement(placement)

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_selector_edge_cases.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_selector_edge_cases.py
@@ -64,6 +64,7 @@ def _criteria(requirements: list[ResourceRequirements]) -> AgentSelectionCriteri
         designated_agent_ids=None,
         job_priority=0,
         victim_candidates=None,
+        session_group=None,
     )
 
 

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_session_group_placement.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_session_group_placement.py
@@ -1,0 +1,375 @@
+"""Tests for SessionGroup placement in agent selection (BEP-1064).
+
+The observed per-agent membership (``ResourceGroupResource.group_members_by_agent``)
+reaches the trackers, ``SessionGroupOrder`` narrows the preferred tier and
+``SessionGroupStrictTrackerFilter`` excludes non-conforming agents. Within one
+pass the trackers accumulate the placements made so far, so several members of
+one group placed in the same tick see each other.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping
+from decimal import Decimal
+
+import pytest
+
+from ai.backend.common.identifier.architecture import ArchName
+from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.identifier.resource_slot import ResourceSlotName
+from ai.backend.common.identifier.session_group import SessionGroupID
+from ai.backend.common.types import AgentId, AgentSelectionStrategy, PreemptionOrder, SessionId
+from ai.backend.manager.data.session.options import AgentSelectionPolicy
+from ai.backend.manager.data.session_group.types import (
+    SessionGroupPlacementDirection,
+    SessionGroupPlacementEnforcement,
+)
+from ai.backend.manager.sokovan.scheduler.provisioner.selectors.exceptions import (
+    NoCompatibleAgentError,
+)
+from ai.backend.manager.sokovan.scheduler.provisioner.selectors.pool import create_agent_selector
+from ai.backend.manager.sokovan.scheduler.provisioner.selectors.selector import (
+    AgentSelectionCriteria,
+    AgentSelector,
+)
+from ai.backend.manager.sokovan.scheduler.provisioner.selectors.tracker import (
+    AgentStateTracker,
+    build_agent_trackers,
+)
+from ai.backend.manager.sokovan.scheduler.provisioner.selectors.types import ResourceRequirements
+from ai.backend.manager.views.sokovan.agent import (
+    AgentLimit,
+    AgentMeta,
+    AgentResource,
+    ResourceGroupResource,
+    SlotResource,
+)
+from ai.backend.manager.views.sokovan.workload import ResourceRequest, SessionGroupPolicy
+
+AGENT_A = AgentId("agent-a")
+AGENT_B = AgentId("agent-b")
+GROUP_ID = SessionGroupID(uuid.uuid4())
+OTHER_GROUP_ID = SessionGroupID(uuid.uuid4())
+NO_LIMIT = AgentLimit(max_container_count=None)
+CPU = ResourceSlotName("cpu")
+MEM = ResourceSlotName("mem")
+
+
+def _agent_meta(agent_id: AgentId, *, cpu: str = "8") -> AgentMeta:
+    return AgentMeta(
+        id=agent_id,
+        addr=f"{agent_id}:6001",
+        architecture=ArchName("x86_64"),
+        resources=AgentResource(
+            slots={
+                CPU: SlotResource(capacity=Decimal(cpu), reserved=Decimal(0), used=Decimal(0)),
+                MEM: SlotResource(capacity=Decimal("16384"), reserved=Decimal(0), used=Decimal(0)),
+            }
+        ),
+        container_count=0,
+    )
+
+
+def _trackers(
+    members: Mapping[AgentId, Mapping[SessionGroupID, int]] | None = None,
+    *,
+    agent_cpus: Mapping[AgentId, str] | None = None,
+) -> list[AgentStateTracker]:
+    capacities = agent_cpus or {}
+    return build_agent_trackers(
+        ResourceGroupResource(
+            agents=[
+                _agent_meta(agent_id, cpu=capacities.get(agent_id, "8"))
+                for agent_id in (AGENT_A, AGENT_B)
+            ],
+            group_members_by_agent=members or {},
+        )
+    )
+
+
+def _criteria(
+    *,
+    direction: SessionGroupPlacementDirection | None = None,
+    enforcement: SessionGroupPlacementEnforcement = (SessionGroupPlacementEnforcement.PREFERRED),
+    group_id: SessionGroupID = GROUP_ID,
+    cpu: str = "1",
+) -> AgentSelectionCriteria:
+    session_group = (
+        None
+        if direction is None
+        else SessionGroupPolicy(
+            group_id=group_id,
+            direction=direction,
+            enforcement=enforcement,
+        )
+    )
+    return AgentSelectionCriteria(
+        session_id=SessionId(uuid.uuid4()),
+        resource_group_id=ResourceGroupID(uuid.UUID(int=0)),
+        requirements=[
+            ResourceRequirements(
+                requested_slots=ResourceRequest(slots={CPU: Decimal(cpu), MEM: Decimal("1024")}),
+                required_architecture=ArchName("x86_64"),
+                container_count=1,
+            )
+        ],
+        agent_selection_policy=AgentSelectionPolicy.PREFERRED,
+        designated_agent_ids=None,
+        job_priority=0,
+        victim_candidates=None,
+        session_group=session_group,
+    )
+
+
+@pytest.fixture
+def selector() -> AgentSelector:
+    return create_agent_selector(["cpu", "mem"])
+
+
+async def _place(
+    selector: AgentSelector,
+    trackers: list[AgentStateTracker],
+    criteria: AgentSelectionCriteria,
+    strategy: AgentSelectionStrategy = AgentSelectionStrategy.CONCENTRATED,
+) -> AgentId:
+    selections = await selector.select_agents_for_batch_requirements(
+        strategy,
+        trackers,
+        criteria,
+        NO_LIMIT,
+        PreemptionOrder.OLDEST,
+    )
+    assert len(selections) == 1
+    return selections[0].selected_agent.agent_id
+
+
+class TestSpreadPreferred:
+    async def test_narrows_to_the_agent_without_members(self, selector: AgentSelector) -> None:
+        """An agent already holding a member loses to an empty one."""
+        trackers = _trackers({AGENT_A: {GROUP_ID: 1}})
+
+        selected = await _place(
+            selector, trackers, _criteria(direction=SessionGroupPlacementDirection.SPREAD)
+        )
+
+        assert selected == AGENT_B
+
+    async def test_falls_back_when_the_empty_agent_cannot_fit(
+        self, selector: AgentSelector
+    ) -> None:
+        """Preferred never excludes: a full preferred agent still yields a placement."""
+        trackers = _trackers(
+            {AGENT_A: {GROUP_ID: 1}},
+            agent_cpus={AGENT_B: "1"},
+        )
+
+        selected = await _place(
+            selector,
+            trackers,
+            _criteria(direction=SessionGroupPlacementDirection.SPREAD, cpu="4"),
+        )
+
+        assert selected == AGENT_A
+
+    async def test_other_groups_members_do_not_count(self, selector: AgentSelector) -> None:
+        """Only this group's members matter; another group's are invisible."""
+        trackers = _trackers({AGENT_B: {OTHER_GROUP_ID: 3}})
+
+        selected = await _place(
+            selector, trackers, _criteria(direction=SessionGroupPlacementDirection.SPREAD)
+        )
+
+        # Both agents hold zero members of GROUP_ID, so the RG strategy decides.
+        assert selected in {AGENT_A, AGENT_B}
+
+    async def test_resource_group_strategy_picks_within_the_group_tier(
+        self, selector: AgentSelector
+    ) -> None:
+        """A concentrated RG picks inside the candidate set spread left behind."""
+        trackers = _trackers(
+            {AGENT_A: {GROUP_ID: 1}},
+            agent_cpus={AGENT_A: "16", AGENT_B: "8"},
+        )
+
+        selected = await _place(
+            selector,
+            trackers,
+            _criteria(direction=SessionGroupPlacementDirection.SPREAD),
+            strategy=AgentSelectionStrategy.CONCENTRATED,
+        )
+
+        # Concentrated alone would prefer the tighter-fitting agent-b anyway;
+        # the point is that agent-a (the member holder) is never considered.
+        assert selected == AGENT_B
+
+
+class TestPackPreferred:
+    async def test_narrows_to_agents_already_holding_members(self, selector: AgentSelector) -> None:
+        trackers = _trackers({AGENT_B: {GROUP_ID: 1}})
+
+        selected = await _place(
+            selector, trackers, _criteria(direction=SessionGroupPlacementDirection.PACK)
+        )
+
+        assert selected == AGENT_B
+
+    async def test_narrows_to_the_agent_holding_the_most_members(
+        self, selector: AgentSelector
+    ) -> None:
+        """The fullest agent wins the tier, even against the RG strategy's pick."""
+        trackers = _trackers(
+            {AGENT_A: {GROUP_ID: 5}, AGENT_B: {GROUP_ID: 1}},
+            agent_cpus={AGENT_A: "16", AGENT_B: "8"},
+        )
+
+        selected = await _place(
+            selector,
+            trackers,
+            _criteria(direction=SessionGroupPlacementDirection.PACK),
+            strategy=AgentSelectionStrategy.CONCENTRATED,
+        )
+
+        # Concentrated alone would take the tighter-fitting agent-b.
+        assert selected == AGENT_A
+
+
+class TestStrictEnforcement:
+    async def test_spread_strict_excludes_member_holders(self, selector: AgentSelector) -> None:
+        trackers = _trackers({AGENT_A: {GROUP_ID: 1}})
+
+        selected = await _place(
+            selector,
+            trackers,
+            _criteria(
+                direction=SessionGroupPlacementDirection.SPREAD,
+                enforcement=SessionGroupPlacementEnforcement.STRICT,
+            ),
+        )
+
+        assert selected == AGENT_B
+
+    async def test_spread_strict_without_candidates_names_the_group(
+        self, selector: AgentSelector
+    ) -> None:
+        """Every agent holds a member: an absolute failure naming group and direction."""
+        trackers = _trackers({AGENT_A: {GROUP_ID: 1}, AGENT_B: {GROUP_ID: 2}})
+
+        with pytest.raises(NoCompatibleAgentError) as exc_info:
+            await _place(
+                selector,
+                trackers,
+                _criteria(
+                    direction=SessionGroupPlacementDirection.SPREAD,
+                    enforcement=SessionGroupPlacementEnforcement.STRICT,
+                ),
+            )
+
+        message = str(exc_info.value)
+        assert str(GROUP_ID) in message
+        assert "spread" in message
+
+    async def test_pack_strict_anchors_the_first_member(self, selector: AgentSelector) -> None:
+        """With no member anywhere the filter does not apply (anchor rule)."""
+        trackers = _trackers()
+
+        selected = await _place(
+            selector,
+            trackers,
+            _criteria(
+                direction=SessionGroupPlacementDirection.PACK,
+                enforcement=SessionGroupPlacementEnforcement.STRICT,
+            ),
+        )
+
+        assert selected in {AGENT_A, AGENT_B}
+
+    async def test_pack_strict_excludes_agents_without_members(
+        self, selector: AgentSelector
+    ) -> None:
+        trackers = _trackers(
+            {AGENT_A: {GROUP_ID: 1}},
+            agent_cpus={AGENT_A: "8", AGENT_B: "16"},
+        )
+
+        selected = await _place(
+            selector,
+            trackers,
+            _criteria(
+                direction=SessionGroupPlacementDirection.PACK,
+                enforcement=SessionGroupPlacementEnforcement.STRICT,
+            ),
+            strategy=AgentSelectionStrategy.DISPERSED,
+        )
+
+        # Dispersed would prefer the roomier agent-b; the strict filter removed it.
+        assert selected == AGENT_A
+
+
+class TestUnconstrainedPlacement:
+    async def test_no_group_leaves_selection_unchanged(self, selector: AgentSelector) -> None:
+        trackers = _trackers({AGENT_A: {GROUP_ID: 1}, AGENT_B: {GROUP_ID: 5}})
+
+        selected = await _place(selector, trackers, _criteria())
+
+        assert selected in {AGENT_A, AGENT_B}
+
+    async def test_none_direction_does_not_participate(self, selector: AgentSelector) -> None:
+        """A ``none`` group keeps its membership but places like an ungrouped session."""
+        trackers = _trackers(
+            {AGENT_A: {GROUP_ID: 1}},
+            agent_cpus={AGENT_A: "8", AGENT_B: "16"},
+        )
+
+        selected = await _place(
+            selector,
+            trackers,
+            _criteria(direction=SessionGroupPlacementDirection.NONE),
+            strategy=AgentSelectionStrategy.DISPERSED,
+        )
+
+        # Dispersed picks the roomiest agent even though it would be the
+        # member-free one under spread — the direction is disengaged.
+        assert selected == AGENT_B
+
+
+class TestInBatchAccumulation:
+    async def test_three_members_of_one_group_land_on_distinct_agents(
+        self, selector: AgentSelector
+    ) -> None:
+        """A three-replica scale-out in one pass spreads instead of piling up."""
+        resources = ResourceGroupResource(
+            agents=[
+                _agent_meta(AgentId("agent-a")),
+                _agent_meta(AgentId("agent-b")),
+                _agent_meta(AgentId("agent-c")),
+            ],
+        )
+        trackers = build_agent_trackers(resources)
+
+        selected = [
+            await _place(
+                selector, trackers, _criteria(direction=SessionGroupPlacementDirection.SPREAD)
+            )
+            for _ in range(3)
+        ]
+
+        assert len(set(selected)) == 3
+
+    async def test_rolled_back_placement_leaves_no_member(self, selector: AgentSelector) -> None:
+        """A failed placement must not leave a phantom member behind."""
+        trackers = _trackers()
+        # Requests more CPU than any agent has: the batch fails and rolls back.
+        with pytest.raises(Exception):
+            await _place(
+                selector,
+                trackers,
+                _criteria(direction=SessionGroupPlacementDirection.SPREAD, cpu="99"),
+            )
+
+        assert all(tracker.current_group_member_count(GROUP_ID) == 0 for tracker in trackers)
+
+        selected = await _place(
+            selector, trackers, _criteria(direction=SessionGroupPlacementDirection.SPREAD)
+        )
+        assert selected in {AGENT_A, AGENT_B}

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_tracker.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_tracker.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 
 from ai.backend.common.identifier.architecture import ArchName
 from ai.backend.common.identifier.resource_slot import ResourceSlotName
+from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.types import AgentId, SessionId
 from ai.backend.manager.sokovan.scheduler.provisioner.selectors.tracker import (
     AgentStateTracker,
@@ -24,6 +25,8 @@ from ai.backend.manager.views.sokovan.workload import ResourceRequest
 
 CPU = ResourceSlotName("cpu")
 MEM = ResourceSlotName("mem")
+GROUP_ID = SessionGroupID(uuid.uuid4())
+OTHER_GROUP_ID = SessionGroupID(uuid.uuid4())
 
 
 def _agent_info(
@@ -75,7 +78,7 @@ class TestAgentStateTracker:
     def test_apply_diff_tracks_pending_allocation(self) -> None:
         tracker = AgentStateTracker(original_agent=_agent_info({"cpu": "8"}))
 
-        tracker.apply_diff(_request({"cpu": "3"}), containers=2)
+        tracker.apply_diff(_request({"cpu": "3"}), containers=2, session_group_id=None)
 
         assert tracker.remaining_slots()[CPU] == Decimal("5")
         assert tracker.current_container_count() == 2
@@ -83,7 +86,7 @@ class TestAgentStateTracker:
 
     def test_commit_folds_pending_into_committed(self) -> None:
         tracker = AgentStateTracker(original_agent=_agent_info({"cpu": "8"}))
-        tracker.apply_diff(_request({"cpu": "3"}), containers=1)
+        tracker.apply_diff(_request({"cpu": "3"}), containers=1, session_group_id=None)
 
         tracker.commit()
 
@@ -96,9 +99,9 @@ class TestAgentStateTracker:
 
     def test_rollback_discards_pending_only(self) -> None:
         tracker = AgentStateTracker(original_agent=_agent_info({"cpu": "8"}))
-        tracker.apply_diff(_request({"cpu": "2"}), containers=1)
+        tracker.apply_diff(_request({"cpu": "2"}), containers=1, session_group_id=None)
         tracker.commit()
-        tracker.apply_diff(_request({"cpu": "4"}), containers=1)
+        tracker.apply_diff(_request({"cpu": "4"}), containers=1, session_group_id=None)
 
         tracker.rollback()
 
@@ -108,9 +111,9 @@ class TestAgentStateTracker:
 
     def test_container_count_includes_base_count(self) -> None:
         tracker = AgentStateTracker(original_agent=_agent_info({"cpu": "8"}, container_count=3))
-        tracker.apply_diff(_request({"cpu": "1"}), containers=1)
+        tracker.apply_diff(_request({"cpu": "1"}), containers=1, session_group_id=None)
         tracker.commit()
-        tracker.apply_diff(_request({"cpu": "1"}), containers=1)
+        tracker.apply_diff(_request({"cpu": "1"}), containers=1, session_group_id=None)
 
         assert tracker.current_container_count() == 5
 
@@ -139,7 +142,7 @@ class TestAgentStateTracker:
 
     def test_reclaim_is_independent_of_pending_and_committed(self) -> None:
         tracker = AgentStateTracker(original_agent=_agent_info({"cpu": "8"}))
-        tracker.apply_diff(_request({"cpu": "2"}), containers=1)
+        tracker.apply_diff(_request({"cpu": "2"}), containers=1, session_group_id=None)
         tracker.commit()
         tracker.apply_reclaim({CPU: Decimal("3")})
 
@@ -148,6 +151,59 @@ class TestAgentStateTracker:
         tracker.clear_reclaim()
         assert tracker.remaining_slots()[CPU] == Decimal("6")
         assert tracker.committed_slots[CPU] == Decimal("2")
+
+
+class TestGroupMemberTracking:
+    """Per-group in-batch increments follow the commit/rollback contract."""
+
+    def test_observed_members_are_the_baseline(self) -> None:
+        tracker = AgentStateTracker(
+            original_agent=_agent_info({"cpu": "8"}),
+            group_member_counts={GROUP_ID: 2},
+        )
+
+        assert tracker.current_group_member_count(GROUP_ID) == 2
+        assert tracker.current_group_member_count(OTHER_GROUP_ID) == 0
+
+    def test_pending_placement_counts_once_per_agent(self) -> None:
+        """Several kernels of one session on one agent still count as one member."""
+        tracker = AgentStateTracker(original_agent=_agent_info({"cpu": "8"}))
+
+        tracker.apply_diff(_request({"cpu": "1"}), containers=1, session_group_id=GROUP_ID)
+        tracker.apply_diff(_request({"cpu": "1"}), containers=1, session_group_id=GROUP_ID)
+
+        assert tracker.current_group_member_count(GROUP_ID) == 1
+
+    def test_commit_keeps_the_increment(self) -> None:
+        tracker = AgentStateTracker(
+            original_agent=_agent_info({"cpu": "8"}),
+            group_member_counts={GROUP_ID: 1},
+        )
+        tracker.apply_diff(_request({"cpu": "1"}), containers=1, session_group_id=GROUP_ID)
+
+        tracker.commit()
+
+        assert tracker.current_group_member_count(GROUP_ID) == 2
+        assert tracker.pending_group_id is None
+
+    def test_rollback_discards_the_increment(self) -> None:
+        tracker = AgentStateTracker(
+            original_agent=_agent_info({"cpu": "8"}),
+            group_member_counts={GROUP_ID: 1},
+        )
+        tracker.apply_diff(_request({"cpu": "1"}), containers=1, session_group_id=GROUP_ID)
+
+        tracker.rollback()
+
+        assert tracker.current_group_member_count(GROUP_ID) == 1
+
+    def test_ungrouped_placement_adds_no_member(self) -> None:
+        tracker = AgentStateTracker(original_agent=_agent_info({"cpu": "8"}))
+
+        tracker.apply_diff(_request({"cpu": "1"}), containers=1, session_group_id=None)
+        tracker.commit()
+
+        assert tracker.current_group_member_count(GROUP_ID) == 0
 
 
 class TestBuildAgentTrackers:
@@ -179,6 +235,7 @@ class TestBuildAgentTrackers:
                 ),
             ],
             failed_sessions_by_agent={AgentId("agent-a"): frozenset({session_id})},
+            group_members_by_agent={AgentId("agent-a"): {GROUP_ID: 2}},
         )
 
         trackers = build_agent_trackers(resources)
@@ -186,6 +243,8 @@ class TestBuildAgentTrackers:
         assert len(trackers) == 2
         by_id = {tracker.original_agent.agent_id: tracker for tracker in trackers}
         assert by_id[AgentId("agent-a")].failed_session_ids == frozenset({session_id})
+        assert by_id[AgentId("agent-a")].current_group_member_count(GROUP_ID) == 2
+        assert by_id[AgentId("agent-b")].current_group_member_count(GROUP_ID) == 0
         assert by_id[AgentId("agent-b")].failed_session_ids == frozenset()
         assert by_id[AgentId("agent-a")].original_agent.container_count == 1
         assert by_id[AgentId("agent-b")].original_agent.architecture == ArchName("aarch64")

--- a/tests/unit/manager/sokovan/scheduler/provisioner/sequencers/conftest.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/sequencers/conftest.py
@@ -102,6 +102,7 @@ def _make_workload(
             ],
             agent_selection_policy=AgentSelectionPolicy.STRICT,
             designated_agent_ids=None,
+            session_group=None,
         ),
         priority=priority,
         job_priority=0,

--- a/tests/unit/manager/sokovan/scheduler/provisioner/validators/conftest.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/validators/conftest.py
@@ -111,6 +111,7 @@ def _make_workload(
             ],
             agent_selection_policy=AgentSelectionPolicy.STRICT,
             designated_agent_ids=None,
+            session_group=None,
         ),
         priority=0,
         job_priority=0,


### PR DESCRIPTION
## Summary

- **Read path (BA-7039)**: pending sessions now carry their SessionGroup policy (direction x enforcement) on `SessionPlacement`, and the snapshot carries per-agent live member counts per group. The observation joins `resource_allocations` with `sessions.session_group_id` (never `kernels.occupied_slots`), counts DISTINCT sessions per agent so a multi-node session counts once on each agent it occupies, includes reservation-holding kernels (SCHEDULED/PREPARING), and does not run at all when this pass has no placement-engaged group.
- **In-batch accumulation**: `AgentStateTracker` keeps per-group increments alongside slots and container counts under the same all-or-nothing `commit()`/`rollback()` contract, so three replicas of one group placed in a single tick see each other and land on distinct agents.
- **Policy application (BA-7040)**: `SessionGroupOrder` (preferred) and `SessionGroupStrictTrackerFilter` (exclusion, strict) join the existing pipeline — no arbitration logic, just two registrations in `create_agent_selector()`. Filter and order sequence encode the precedence `designated_agents > SessionGroup > RG strategy`.
- **Failure reason**: exclusion filters gained a `failure_message()` hook, so an unsatisfiable strict constraint records a `SchedulingFailure` naming the blocking group and direction. The session stays PENDING and retries; preemption is never attempted (the exclusion stage runs before the preemption planner).
- **BEP-1064 correction**: the `pack` rank is now the negated member count rather than a boolean. Orders narrow on the minimum rank across every candidate, so a negated count does select the global maximum — the previous rationale ("an order cannot see a global maximum") was wrong.

- **Unrelated test fix carried along**: the component deployment fixtures leave the SessionGroup rows that replica group creation makes, so the domain/project fixture teardowns hit their RESTRICT FKs. That has been broken on `main` since the `session_groups` table landed — `tests/component/deployment/` fails at teardown with or without this branch — and the fixture now drains them.

Not in scope: session-group selection at enqueue, the v2 API/SDK/CLI, and group constraints in the compute-schedule fitting check (a BEP-1064 open question — that path passes `session_group=None`).

## Test plan

- [x] `tests/unit/manager/repositories/scheduler/test_session_group_observation.py` (real DB): policy on the workload, soft-deleted group leaves the session unconstrained, RUNNING + SCHEDULED members counted per agent, multi-node counted once per agent, terminated/other-group members excluded, `none` direction and ungrouped passes load no observation
- [x] `tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_session_group_placement.py`: spread/pack under preferred and strict, the pack anchor rule, `NoCompatibleAgentError` naming the group, RG strategy picking within the group's tier, three members of one group landing on distinct agents in one pass, rollback leaving no phantom member
- [x] `test_tracker.py`: observed + committed + pending member counts, one member per agent per session, commit/rollback
- [x] `pants fmt / fix / lint / check` clean; `tests/unit/manager/sokovan/scheduler/provisioner::` and `tests/unit/manager/repositories/scheduler::` all pass

Resolves BA-7039, BA-7040

🤖 Generated with [Claude Code](https://claude.com/claude-code)
