### PR TITLE
test: clean up session groups in deployment component fixtures

### DIFF
--- a/tests/component/deployment/conftest.py
+++ b/tests/component/deployment/conftest.py
@@ -44,6 +44,7 @@ from ai.backend.manager.models.deployment_policy.row import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision.row import DeploymentRevisionRow
 from ai.backend.manager.models.endpoint.row import EndpointRow
 from ai.backend.manager.models.image.row import ImageRow
+from ai.backend.manager.models.session_group.row import SessionGroupRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import vfolders
 from ai.backend.manager.plugin.network import NetworkPluginContext
@@ -373,5 +374,13 @@ async def deployment_seed_data(
         await conn.execute(
             EndpointRow.__table__.delete().where(
                 EndpointRow.__table__.c.domain == domain_fixture.domain_name
+            )
+        )
+        # Session groups are created by the deployment flow and reference the
+        # domain with a RESTRICT FK; deleting endpoints above cascades their
+        # replica groups, so the session groups are unreferenced by now.
+        await conn.execute(
+            SessionGroupRow.__table__.delete().where(
+                SessionGroupRow.__table__.c.domain_id == domain_fixture.domain_id
             )
         )


### PR DESCRIPTION
## Summary
- The deployment component tests started failing at fixture teardown with `ForeignKeyViolationError: update or delete on table "domains" violates foreign key constraint "fk_session_groups_domain_id_domains"` — the deployment flow creates `session_groups` rows referencing the fixture domain, and no fixture cleaned them up.
- Deleting endpoints already cascades their replica groups, leaving the session groups unreferenced (`sessions.session_group_id` is `ON DELETE SET NULL`), so `deployment_seed_data` teardown now drops the fixture domain's session groups right after the endpoint cleanup.

## Test plan
- [x] `tests/component/deployment/test_deployment.py` and `test_deployment_lifecycle.py` fail on current main and pass with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)