### PR TITLE
fix: preserve duplicate Set-Cookie headers in appproxy HTTP backend

### DIFF
--- a/changes/13194.fix.md
+++ b/changes/13194.fix.md
@@ -1,0 +1,1 @@
+Fix the app-proxy HTTP backend dropping all but the last duplicate response header (e.g. multiple `Set-Cookie`), which prevented cookie-authenticated apps such as RStudio Server from ever signing in through the proxy (`ERR_TOO_MANY_REDIRECTS`).

--- a/src/ai/backend/appproxy/worker/proxy/backend/base.py
+++ b/src/ai/backend/appproxy/worker/proxy/backend/base.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any, final
 
 from aiohttp.streams import AsyncStreamIterator
+from multidict import CIMultiDict
 from yarl import URL
 
 from ai.backend.appproxy.common.types import RouteInfo
@@ -20,7 +21,7 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 class HttpRequest:
     method: str
     path: str | URL
-    headers: dict[str, Any]
+    headers: CIMultiDict[str] | dict[str, Any]
     body: AsyncStreamIterator[bytes] | None
 
 

--- a/src/ai/backend/appproxy/worker/proxy/backend/http.py
+++ b/src/ai/backend/appproxy/worker/proxy/backend/http.py
@@ -146,11 +146,12 @@ class HTTPBackend(BaseBackend):
         else:
             remote_host = None
             remote_port = None
-        backend_rqst_hdrs = {}
-        # copy frontend request headers without hop-by-hop headers
+        backend_rqst_hdrs: CIMultiDict[str] = CIMultiDict()
+        # copy frontend request headers without hop-by-hop headers,
+        # preserving repeated headers (multidict add(), not dict assignment)
         for key, value in frontend_request.headers.items():
             if key not in HOP_ONLY_HEADERS:
-                backend_rqst_hdrs[key] = value
+                backend_rqst_hdrs.add(key, value)
         # overwrite proxy-related headers
         backend_rqst_hdrs["x-forwarded-proto"] = protocol
         if self.circuit.app == "rstudio":
@@ -191,10 +192,14 @@ class HTTPBackend(BaseBackend):
         )
         try:
             async with self.request_http(route, backend_request) as backend_response:
-                frontend_resp_hdrs = {}
+                # Use a multidict and add() so that repeated response headers
+                # (e.g. multiple Set-Cookie entries) are all preserved; a plain
+                # dict would keep only the last occurrence, breaking cookie-based
+                # auth flows such as RStudio Server's sign-in.
+                frontend_resp_hdrs: CIMultiDict[str] = CIMultiDict()
                 for key, value in backend_response.headers.items():
                     if key not in HOP_ONLY_HEADERS:
-                        frontend_resp_hdrs[key] = value
+                        frontend_resp_hdrs.add(key, value)
                 frontend_resp_hdrs["Access-Control-Allow-Origin"] = "*"
                 frontend_response = web.StreamResponse(
                     status=backend_response.status,


### PR DESCRIPTION
resolves #13193

## What this PR changes

The app-proxy worker's HTTP backend copied upstream response headers into a plain `dict`, so repeated headers overwrote each other and only the **last** occurrence reached the client. HTTP requires one `Set-Cookie` header per cookie (RFC 6265), so any app that establishes its session with multiple cookies could never authenticate through the proxy.

Concretely, RStudio Server's `/auth-sign-in` response sets five cookies (`user-id`, `user-list-id`, `persist-auth`, `rs-csrf-token`, `csrf-token`); only `csrf-token` survived, the login cookie `user-id` was never delivered, and the browser looped between `/` and `/auth-sign-in` until `ERR_TOO_MANY_REDIRECTS`. See #13193 for the full investigation, side-by-side traces, and a 12-line reproduction server.

### Changes

- `HttpBackend`: copy response headers into a `CIMultiDict` with `.add()` instead of plain-dict assignment, preserving duplicates. Same treatment for the request-header copy, which had the identical latent pattern.
- `HttpRequest.headers` type widened to `CIMultiDict[str] | dict[str, Any]`.
- Plain-assignment overwrites of proxy-related headers (`x-forwarded-*`, `Access-Control-Allow-Origin`, ...) keep their replace semantics under `CIMultiDict`.

### Verification

On a live halfstack (worker restarted with this patch):

- RStudio (`rstudio:preopen:8787`, port-mode) signs in and loads normally through the proxy; previously it redirect-looped indefinitely.
- All five `Set-Cookie` headers of the sign-in response now reach the browser.
- JupyterLab / Notebook / ttyd apps remain unaffected.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts
- [ ] Test case(s)
- [ ] Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2qhb3zh9cBMsavC339c2g
