### PR TITLE
fix(BA-7051): run the unit-test Postgres fixture on 16.3

### DIFF
--- a/changes/13200.test.md
+++ b/changes/13200.test.md
@@ -1,0 +1,1 @@
+Run the unit-test Postgres fixture on 16.3, the version the product requires, instead of 13.6.

--- a/src/ai/backend/testutils/bootstrap.py
+++ b/src/ai/backend/testutils/bootstrap.py
@@ -143,11 +143,12 @@ def redis_container() -> Iterator[tuple[str, HostPortPairModel]]:
 
 @pytest.fixture(scope="session", autouse=False)
 def postgres_container() -> Iterator[tuple[str, HostPortPairModel]]:
-    # Spawn a single-node PostgreSQL container for a testing session.
+    # Spawn a single-node PostgreSQL container for a testing session. The image tracks the
+    # version halfstack runs, so a test exercises the same server the product requires.
     random_id = secrets.token_hex(8)
     container = (
         PostgresContainer(
-            "postgres:13.6-alpine", username="postgres", password="develove", dbname="testing"
+            "postgres:16.3-alpine", username="postgres", password="develove", dbname="testing"
         )
         .with_name(f"test--postgres-slot-{get_parallel_slot()}-{random_id}")
         .with_exposed_ports(5432)


### PR DESCRIPTION
Resolves BA-7051

## Summary

The unit-test Postgres container spawned `postgres:13.6-alpine` while the README requires PostgreSQL 16+ and halfstack runs 16.3 — tests exercised a server three majors behind the one the product targets. This points the fixture at 16.3.

The gap is not academic: `app_config_fragments` guards its public rows with a partial unique index rather than `UNIQUE NULLS NOT DISTINCT` (Postgres 15+) purely because the fixture runs 13, and that leaves the fragment upsert branching over two conflict targets at the call site. A follow-up PR simplifies that once this lands.

- `src/ai/backend/testutils/bootstrap.py` — `postgres_container` now spawns `postgres:16.3-alpine`, tracking the halfstack image.

## Test plan
- [ ] The database-backed unit tests pass on CI against the new image (this is the point of the PR — the CI run is the verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
