### PR TITLE
refactor(BA-7052): key fragments with UNIQUE NULLS NOT DISTINCT

### DIFF
--- a/changes/13202.enhance.md
+++ b/changes/13202.enhance.md
@@ -1,0 +1,1 @@
+Key app config fragments with a single `UNIQUE NULLS NOT DISTINCT` constraint, dropping the partial unique index that kept public rows unique.

--- a/src/ai/backend/manager/models/alembic/versions/b93d1c47af52_fragment_unique_nulls_not_distinct.py
+++ b/src/ai/backend/manager/models/alembic/versions/b93d1c47af52_fragment_unique_nulls_not_distinct.py
@@ -1,0 +1,64 @@
+"""key app_config_fragments with UNIQUE NULLS NOT DISTINCT
+
+A public fragment has a ``NULL`` scope_id, and ``NULL``s are distinct to a plain
+unique constraint, so public rows needed a partial unique index of their own. That
+left the table with two arbiter indexes, and every upsert had to pick between them
+by scope kind.
+
+``UNIQUE NULLS NOT DISTINCT`` (Postgres 15+, and the product requires 16+) keys the
+public row like any other, so the partial index goes away and one conflict target
+serves every scope.
+
+Revision ID: b93d1c47af52
+Revises: c4a91d7e05b2
+Create Date: 2026-07-28
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b93d1c47af52"
+down_revision = "c4a91d7e05b2"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+_TABLE = "app_config_fragments"
+_UNIQUE = "uq_app_config_fragments_config_name_scope_type_scope_id"
+_PUBLIC_INDEX = "uq_app_config_fragments_public_config_name"
+
+
+def upgrade() -> None:
+    # The partial index already kept public rows unique, so nothing can collide under the
+    # widened constraint.
+    op.execute(sa.text(f"DROP INDEX IF EXISTS {_PUBLIC_INDEX}"))
+    op.execute(sa.text(f"ALTER TABLE {_TABLE} DROP CONSTRAINT IF EXISTS {_UNIQUE}"))
+    op.execute(
+        sa.text(f"""
+            ALTER TABLE {_TABLE}
+            ADD CONSTRAINT {_UNIQUE}
+            UNIQUE NULLS NOT DISTINCT (config_name, scope_type, scope_id)
+        """)
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text(f"ALTER TABLE {_TABLE} DROP CONSTRAINT IF EXISTS {_UNIQUE}"))
+    op.execute(
+        sa.text(f"""
+            ALTER TABLE {_TABLE}
+            ADD CONSTRAINT {_UNIQUE}
+            UNIQUE (config_name, scope_type, scope_id)
+        """)
+    )
+    # Public rows fall outside the plain constraint again, so restore their own index. A
+    # duplicate public row cannot exist here: NULLS NOT DISTINCT rejected it.
+    op.execute(
+        sa.text(f"""
+            CREATE UNIQUE INDEX IF NOT EXISTS {_PUBLIC_INDEX}
+            ON {_TABLE} (config_name, scope_type)
+            WHERE scope_id IS NULL
+        """)
+    )

--- a/src/ai/backend/manager/models/alembic/versions/b93d1c47af52_fragment_unique_nulls_not_distinct.py
+++ b/src/ai/backend/manager/models/alembic/versions/b93d1c47af52_fragment_unique_nulls_not_distinct.py
@@ -25,40 +25,46 @@ down_revision = "c4a91d7e05b2"
 branch_labels = None
 depends_on = None
 
-_TABLE = "app_config_fragments"
-_UNIQUE = "uq_app_config_fragments_config_name_scope_type_scope_id"
-_PUBLIC_INDEX = "uq_app_config_fragments_public_config_name"
-
 
 def upgrade() -> None:
     # The partial index already kept public rows unique, so nothing can collide under the
     # widened constraint.
-    op.execute(sa.text(f"DROP INDEX IF EXISTS {_PUBLIC_INDEX}"))
-    op.execute(sa.text(f"ALTER TABLE {_TABLE} DROP CONSTRAINT IF EXISTS {_UNIQUE}"))
+    op.execute(sa.text("DROP INDEX IF EXISTS uq_app_config_fragments_public_config_name"))
     op.execute(
-        sa.text(f"""
-            ALTER TABLE {_TABLE}
-            ADD CONSTRAINT {_UNIQUE}
+        sa.text("""
+            ALTER TABLE app_config_fragments
+            DROP CONSTRAINT IF EXISTS uq_app_config_fragments_config_name_scope_type_scope_id
+        """)
+    )
+    op.execute(
+        sa.text("""
+            ALTER TABLE app_config_fragments
+            ADD CONSTRAINT uq_app_config_fragments_config_name_scope_type_scope_id
             UNIQUE NULLS NOT DISTINCT (config_name, scope_type, scope_id)
         """)
     )
 
 
 def downgrade() -> None:
-    op.execute(sa.text(f"ALTER TABLE {_TABLE} DROP CONSTRAINT IF EXISTS {_UNIQUE}"))
     op.execute(
-        sa.text(f"""
-            ALTER TABLE {_TABLE}
-            ADD CONSTRAINT {_UNIQUE}
+        sa.text("""
+            ALTER TABLE app_config_fragments
+            DROP CONSTRAINT IF EXISTS uq_app_config_fragments_config_name_scope_type_scope_id
+        """)
+    )
+    op.execute(
+        sa.text("""
+            ALTER TABLE app_config_fragments
+            ADD CONSTRAINT uq_app_config_fragments_config_name_scope_type_scope_id
             UNIQUE (config_name, scope_type, scope_id)
         """)
     )
     # Public rows fall outside the plain constraint again, so restore their own index. A
     # duplicate public row cannot exist here: NULLS NOT DISTINCT rejected it.
     op.execute(
-        sa.text(f"""
-            CREATE UNIQUE INDEX IF NOT EXISTS {_PUBLIC_INDEX}
-            ON {_TABLE} (config_name, scope_type)
+        sa.text("""
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_app_config_fragments_public_config_name
+            ON app_config_fragments (config_name, scope_type)
             WHERE scope_id IS NULL
         """)
     )

--- a/src/ai/backend/manager/models/app_config_fragment/row.py
+++ b/src/ai/backend/manager/models/app_config_fragment/row.py
@@ -27,19 +27,13 @@ class AppConfigFragmentRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc
 
     __tablename__ = "app_config_fragments"
     __table_args__ = (
+        # NULLS NOT DISTINCT so a public row, whose scope_id is NULL, is keyed like any other.
         sa.UniqueConstraint(
             "config_name",
             "scope_type",
             "scope_id",
             name="uq_app_config_fragments_config_name_scope_type_scope_id",
-        ),
-        # NULLs are distinct to a unique constraint, so public rows need their own index.
-        sa.Index(
-            "uq_app_config_fragments_public_config_name",
-            "config_name",
-            "scope_type",
-            unique=True,
-            postgresql_where=sa.text("scope_id IS NULL"),
+            postgresql_nulls_not_distinct=True,
         ),
         sa.CheckConstraint(
             "(scope_type = 'public') = (scope_id IS NULL)",


### PR DESCRIPTION
## 📚 Stacked PRs

**Merge in order (bottom-up):**

1. #13200 — `fix(BA-7051)`: run the unit-test Postgres fixture on 16.3
2. 👉 **#13202 — `refactor(BA-7052)`: key fragments with UNIQUE NULLS NOT DISTINCT** ← you are here

Resolves BA-7052

## Summary

`app_config_fragments` carried two unique indexes, because a public fragment's `scope_id` is `NULL` and `NULL`s are distinct to a plain unique constraint:

| Index | Covers |
|---|---|
| `UNIQUE (config_name, scope_type, scope_id)` | scoped rows only — a public row can never conflict on it |
| `UNIQUE (config_name, scope_type) WHERE scope_id IS NULL` | public rows |

Two indexes mean two `ON CONFLICT` arbiters, so an upsert has to pick the conflict target by scope kind before it can run. `UNIQUE NULLS NOT DISTINCT` (Postgres 15+; the product requires 16+) keys the public row like any other, so the partial index goes away and one target serves every scope.

- `AppConfigFragmentRow` declares the single constraint with `postgresql_nulls_not_distinct=True`; the check constraint tying `NULL` scope_id to the public scope is unchanged.
- Migration `b93d1c47af52` drops the partial index, recreates the constraint with `NULLS NOT DISTINCT`, and restores both on downgrade. Nothing can collide under the widened constraint — the partial index already kept public rows unique.

Depends on #13200: `NULLS NOT DISTINCT` is a Postgres 15+ feature and the unit-test fixture ran 13.6 until that PR.

## Follow-up

The fragment upsert stack (#13113 → #13122) still branches on `scope_type is PUBLIC` to choose between the two conflict targets. Once this lands, that branch collapses to a single `ConflictTarget(columns=["config_name", "scope_type", "scope_id"])` — I'll rebase the stack and drop it.

## Test plan
- [ ] A second public fragment with the same `config_name` is rejected by the constraint.
- [ ] `alembic upgrade head` then `downgrade -1` round-trips on a database holding public and scoped rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
