### PR TITLE
refactor(BA-7054): add operation_type and spec to the pure-ABC action bases

### DIFF
--- a/changes/13205.enhance.md
+++ b/changes/13205.enhance.md
@@ -1,0 +1,1 @@
+Add `operation_type()` and `spec()` to the pure-ABC action bases so per-type action monitors can keep emitting the `entity:operation` keys used by reporter subscriptions and audit logs

--- a/src/ai/backend/manager/actions/action/base.py
+++ b/src/ai/backend/manager/actions/action/base.py
@@ -4,7 +4,8 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TypeVar, override
 
-from ai.backend.common.data.permission.types import EntityType
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.common.data.permission.types import EntityType as LegacyEntityType
 from ai.backend.common.exception import ErrorCode
 from ai.backend.manager.actions.types import ActionOperationType, ActionSpec, OperationStatus
 from ai.backend.manager.data.common.types import SearchResult
@@ -20,7 +21,7 @@ class BaseAction(ABC):
 
     @classmethod
     @abstractmethod
-    def entity_type(cls) -> EntityType:
+    def entity_type(cls) -> LegacyEntityType:
         raise NotImplementedError
 
     @classmethod
@@ -31,7 +32,7 @@ class BaseAction(ABC):
     @classmethod
     def spec(cls) -> ActionSpec:
         return ActionSpec(
-            entity_type=cls.entity_type(),
+            entity_type=EntityType(cls.entity_type()),
             operation_type=cls.operation_type(),
         )
 

--- a/src/ai/backend/manager/actions/bulk/base.py
+++ b/src/ai/backend/manager/actions/bulk/base.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.identifier.entity import EntityID
+from ai.backend.manager.actions.types import ActionOperationType, ActionSpec
 
 
 class BaseBulkAction(ABC):
@@ -13,6 +14,12 @@ class BaseBulkAction(ABC):
     @abstractmethod
     def entity_type(cls) -> EntityType:
         """Return the type of entity that this action applies to."""
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def operation_type(cls) -> ActionOperationType:
+        """Return the operation that this action performs on the entities."""
         raise NotImplementedError
 
     @abstractmethod
@@ -25,3 +32,11 @@ class BaseBulkAction(ABC):
     def required_permission(cls) -> Permission:
         """Return the permission required to perform this action."""
         raise NotImplementedError
+
+    @classmethod
+    def spec(cls) -> ActionSpec:
+        """Return the "entity:operation" spec keying reporter subscriptions and audit records."""
+        return ActionSpec(
+            entity_type=cls.entity_type(),
+            operation_type=cls.operation_type(),
+        )

--- a/src/ai/backend/manager/actions/scope/base.py
+++ b/src/ai/backend/manager/actions/scope/base.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 
 from ai.backend.common.data.entity.types import EntityType, ScopeRef
 from ai.backend.common.data.permission.types import Permission
+from ai.backend.manager.actions.types import ActionOperationType, ActionSpec
 
 
 class BaseScopeAction(ABC):
@@ -21,6 +22,20 @@ class BaseScopeAction(ABC):
 
     @classmethod
     @abstractmethod
+    def operation_type(cls) -> ActionOperationType:
+        """Return the operation that this action performs within the scopes."""
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
     def required_permission(cls) -> Permission:
         """Return the permission required to perform this action."""
         raise NotImplementedError
+
+    @classmethod
+    def spec(cls) -> ActionSpec:
+        """Return the "entity:operation" spec keying reporter subscriptions and audit records."""
+        return ActionSpec(
+            entity_type=cls.entity_type(),
+            operation_type=cls.operation_type(),
+        )

--- a/src/ai/backend/manager/actions/single_entity/base.py
+++ b/src/ai/backend/manager/actions/single_entity/base.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.identifier.entity import EntityID
+from ai.backend.manager.actions.types import ActionOperationType, ActionSpec
 
 
 class BaseSingleEntityAction(ABC):
@@ -12,6 +13,12 @@ class BaseSingleEntityAction(ABC):
     @abstractmethod
     def entity_type(cls) -> EntityType:
         """Return the type of entity that this action applies to."""
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def operation_type(cls) -> ActionOperationType:
+        """Return the operation that this action performs on the entity."""
         raise NotImplementedError
 
     @abstractmethod
@@ -24,3 +31,11 @@ class BaseSingleEntityAction(ABC):
     def required_permission(cls) -> Permission:
         """Return the permission required to perform this action."""
         raise NotImplementedError
+
+    @classmethod
+    def spec(cls) -> ActionSpec:
+        """Return the "entity:operation" spec keying reporter subscriptions and audit records."""
+        return ActionSpec(
+            entity_type=cls.entity_type(),
+            operation_type=cls.operation_type(),
+        )

--- a/src/ai/backend/manager/actions/types.py
+++ b/src/ai/backend/manager/actions/types.py
@@ -3,8 +3,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Final
 
-from ai.backend.common.data.entity.types import ScopeType
-from ai.backend.common.data.permission.types import EntityType, OperationType
+from ai.backend.common.data.entity.types import EntityType, ScopeType
+from ai.backend.common.data.permission.types import OperationType
 
 # Placeholder substituted when an id (request_id, entity_id, ...) is absent while
 # materializing action metadata into audit/report records.

--- a/tests/unit/manager/actions/validators/test_virtual_scope_rbac_validators.py
+++ b/tests/unit/manager/actions/validators/test_virtual_scope_rbac_validators.py
@@ -49,6 +49,7 @@ from ai.backend.manager.actions.single_entity.base import BaseSingleEntityAction
 from ai.backend.manager.actions.single_entity.validator.rbac import (
     VirtualScopeSingleEntityActionRBACValidator,
 )
+from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.errors.permission import NotEnoughPermission
 from ai.backend.manager.models.agent import AgentRow
@@ -115,6 +116,11 @@ class _ProjectCreateScopeAction(BaseScopeAction):
 
     @classmethod
     @override
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.CREATE
+
+    @classmethod
+    @override
     def required_permission(cls) -> Permission:
         return Permission.CREATE
 
@@ -129,6 +135,11 @@ class _VfolderUpdateAction(BaseSingleEntityAction):
     @override
     def entity_type(cls) -> EntityType:
         return EntityType("vfolder")
+
+    @classmethod
+    @override
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.UPDATE
 
     @override
     def entity_id(self) -> EntityID:
@@ -150,6 +161,11 @@ class _BulkVfolderUpdateAction(BaseBulkAction):
     @override
     def entity_type(cls) -> EntityType:
         return EntityType("vfolder")
+
+    @classmethod
+    @override
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.UPDATE
 
     @override
     def entity_ids(self) -> Sequence[EntityID]:


### PR DESCRIPTION
## Summary
- Add `operation_type()` (abstract) and `spec()` to each of the three pure-ABC action bases (`BaseSingleEntityAction`, `BaseBulkAction`, `BaseScopeAction`) independently, without reintroducing a shared supertype, so the per-type monitors can emit the "entity:operation" keys that reporter subscriptions (`reporter.action_monitors[].subscribed_actions`) and audit-log records depend on.
- Retype `ActionSpec.entity_type` from the deprecated permission `EntityType` enum to the new open `EntityType` (`NewType(str)`); the legacy `BaseAction.spec()` now wraps its value accordingly. The `"entity:operation"` string produced by `ActionSpec.type()` is unchanged.
- Update the pure-ABC test fixtures to implement the new abstract `operation_type()`.

## Test plan
- [x] CI type check and unit tests pass (`tests/unit/manager/actions/validators/test_virtual_scope_rbac_validators.py` covers the pure-ABC bases)

Resolves BA-7054

🤖 Generated with [Claude Code](https://claude.com/claude-code)