### PR TITLE
feat(BA-7053): wire pure-ABC RBAC validators into ActionValidators and the DI composer

### DIFF
--- a/changes/13206.enhance.md
+++ b/changes/13206.enhance.md
@@ -1,0 +1,1 @@
+Wire the pure-ABC per-type RBAC validators into the shared `ActionValidators` bundle and the DI composer so entity migrations off `BaseAction` can enforce RBAC through the new framework

--- a/src/ai/backend/manager/actions/validators/__init__.py
+++ b/src/ai/backend/manager/actions/validators/__init__.py
@@ -1,11 +1,12 @@
 from dataclasses import dataclass
 
-from .rbac import LegacyRBACValidators, RBACValidators
+from .rbac import LegacyRBACValidators, RBACValidators, VirtualScopeRBACValidators
 
 
 @dataclass
 class ActionValidators:
     rbac: RBACValidators
+    virtual_scope_rbac: VirtualScopeRBACValidators
     # Optional so existing test fixtures that only pass `rbac=` keep working.
     # Production code (composer) always sets both; processors that need the
     # legacy validator fall back to `rbac` when this is None.

--- a/src/ai/backend/manager/actions/validators/rbac/__init__.py
+++ b/src/ai/backend/manager/actions/validators/rbac/__init__.py
@@ -1,5 +1,14 @@
 from dataclasses import dataclass
 
+from ai.backend.manager.actions.bulk.validator.rbac import (
+    VirtualScopeBulkActionRBACValidator,
+)
+from ai.backend.manager.actions.scope.validator.rbac import (
+    VirtualScopeScopeActionRBACValidator,
+)
+from ai.backend.manager.actions.single_entity.validator.rbac import (
+    VirtualScopeSingleEntityActionRBACValidator,
+)
 from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.legacy import (
     LegacyScopeActionRBACValidator,
@@ -22,3 +31,12 @@ class RBACValidators:
 class LegacyRBACValidators:
     scope: LegacyScopeActionRBACValidator
     single_entity: LegacySingleEntityActionRBACValidator
+
+
+@dataclass
+class VirtualScopeRBACValidators:
+    """RBAC validators for the pure-ABC action bases (actions/{single_entity,bulk,scope})."""
+
+    scope: VirtualScopeScopeActionRBACValidator
+    single_entity: VirtualScopeSingleEntityActionRBACValidator
+    bulk: VirtualScopeBulkActionRBACValidator

--- a/src/ai/backend/manager/dependencies/processing/composer.py
+++ b/src/ai/backend/manager/dependencies/processing/composer.py
@@ -25,11 +25,24 @@ from ai.backend.common.message_queue.abc.queue import AbstractMessageQueue
 from ai.backend.common.plugin.event import EventDispatcherPluginContext
 from ai.backend.common.plugin.hook import HookPluginContext
 from ai.backend.common.plugin.monitor import ErrorPluginContext, StatsPluginContext
+from ai.backend.manager.actions.bulk.validator.rbac import (
+    VirtualScopeBulkActionRBACValidator,
+)
 from ai.backend.manager.actions.monitors.audit_log import AuditLogMonitor
 from ai.backend.manager.actions.monitors.prometheus import PrometheusMonitor
 from ai.backend.manager.actions.monitors.reporter import ReporterMonitor
+from ai.backend.manager.actions.scope.validator.rbac import (
+    VirtualScopeScopeActionRBACValidator,
+)
+from ai.backend.manager.actions.single_entity.validator.rbac import (
+    VirtualScopeSingleEntityActionRBACValidator,
+)
 from ai.backend.manager.actions.validators import ActionValidators
-from ai.backend.manager.actions.validators.rbac import LegacyRBACValidators, RBACValidators
+from ai.backend.manager.actions.validators.rbac import (
+    LegacyRBACValidators,
+    RBACValidators,
+    VirtualScopeRBACValidators,
+)
 from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.legacy import (
     LegacyScopeActionRBACValidator,
@@ -270,6 +283,17 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
             scope=LegacyScopeActionRBACValidator(permission_controller_repository),
             single_entity=LegacySingleEntityActionRBACValidator(permission_controller_repository),
         )
+        virtual_scope_rbac_validators = VirtualScopeRBACValidators(
+            scope=VirtualScopeScopeActionRBACValidator(
+                permission_controller_repository, config_provider
+            ),
+            single_entity=VirtualScopeSingleEntityActionRBACValidator(
+                permission_controller_repository, config_provider
+            ),
+            bulk=VirtualScopeBulkActionRBACValidator(
+                permission_controller_repository, config_provider
+            ),
+        )
 
         processors = await stack.enter_dependency(
             ProcessorsDependency(),
@@ -281,6 +305,7 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
                 validators=ActionValidators(
                     rbac=rbac_validators,
                     legacy_rbac=legacy_rbac_validators,
+                    virtual_scope_rbac=virtual_scope_rbac_validators,
                 ),
             ),
         )

--- a/src/ai/backend/testutils/action_validators.py
+++ b/src/ai/backend/testutils/action_validators.py
@@ -1,0 +1,27 @@
+"""Mock factories for the manager action-validator bundles used by processor tests."""
+
+from unittest.mock import MagicMock
+
+from ai.backend.manager.actions.bulk.validator.rbac import (
+    VirtualScopeBulkActionRBACValidator,
+)
+from ai.backend.manager.actions.scope.validator.rbac import (
+    VirtualScopeScopeActionRBACValidator,
+)
+from ai.backend.manager.actions.single_entity.validator.rbac import (
+    VirtualScopeSingleEntityActionRBACValidator,
+)
+from ai.backend.manager.actions.validators.rbac import VirtualScopeRBACValidators
+
+
+def mock_virtual_scope_rbac_validators() -> VirtualScopeRBACValidators:
+    """Build a bundle of spec'd validator mocks for the pure-ABC action bases.
+
+    ``MagicMock(spec=...)`` turns the async ``validate`` into an ``AsyncMock``
+    automatically, so the mocks are awaitable out of the box.
+    """
+    return VirtualScopeRBACValidators(
+        scope=MagicMock(spec=VirtualScopeScopeActionRBACValidator),
+        single_entity=MagicMock(spec=VirtualScopeSingleEntityActionRBACValidator),
+        bulk=MagicMock(spec=VirtualScopeBulkActionRBACValidator),
+    )

--- a/tests/component/artifact/conftest.py
+++ b/tests/component/artifact/conftest.py
@@ -44,6 +44,7 @@ from ai.backend.manager.services.artifact.processors import ArtifactProcessors
 from ai.backend.manager.services.artifact.service import ArtifactService
 from ai.backend.manager.services.artifact_revision.processors import ArtifactRevisionProcessors
 from ai.backend.manager.services.artifact_revision.service import ArtifactRevisionService
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 
 
 @dataclass
@@ -82,6 +83,7 @@ def artifact_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
             rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
         ),
     )
@@ -121,6 +123,7 @@ def artifact_revision_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
             rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
         ),
     )

--- a/tests/component/artifact_registry/conftest.py
+++ b/tests/component/artifact_registry/conftest.py
@@ -48,6 +48,7 @@ from ai.backend.manager.services.artifact.processors import ArtifactProcessors
 from ai.backend.manager.services.artifact.service import ArtifactService
 from ai.backend.manager.services.artifact_revision.processors import ArtifactRevisionProcessors
 from ai.backend.manager.services.artifact_revision.service import ArtifactRevisionService
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 
 
 @dataclass
@@ -89,6 +90,7 @@ def artifact_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
             rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
         ),
     )
@@ -128,6 +130,7 @@ def artifact_revision_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
             rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
         ),
     )

--- a/tests/component/artifact_revision/conftest.py
+++ b/tests/component/artifact_revision/conftest.py
@@ -49,6 +49,7 @@ from ai.backend.manager.services.artifact.processors import ArtifactProcessors
 from ai.backend.manager.services.artifact.service import ArtifactService
 from ai.backend.manager.services.artifact_revision.processors import ArtifactRevisionProcessors
 from ai.backend.manager.services.artifact_revision.service import ArtifactRevisionService
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 
 
 @dataclass
@@ -87,6 +88,7 @@ def artifact_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
             rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
         ),
     )
@@ -126,6 +128,7 @@ def artifact_revision_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
             rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
         ),
     )

--- a/tests/component/auto_scaling_rule/conftest.py
+++ b/tests/component/auto_scaling_rule/conftest.py
@@ -38,6 +38,7 @@ from ai.backend.manager.repositories.permission_controller.repository import (
 )
 from ai.backend.manager.services.deployment.processors import DeploymentProcessors
 from ai.backend.manager.services.deployment.service import DeploymentService
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 from ai.backend.testutils.fixtures import DomainFixtureData
 
 
@@ -86,6 +87,7 @@ def deployment_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
             rbac=RBACValidators(
                 scope=ScopeActionRBACValidator(permission_controller_repo, MagicMock()),
                 single_entity=SingleEntityActionRBACValidator(

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -150,6 +150,7 @@ from ai.backend.manager.repositories.user_resource_policy.repository import (
 )
 from ai.backend.manager.services.auth.processors import AuthProcessors
 from ai.backend.manager.services.auth.service import AuthService
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 from ai.backend.testutils.bootstrap import (  # noqa: F401
     etcd_container,
     postgres_container,
@@ -1327,6 +1328,7 @@ def auth_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
             rbac=RBACValidators(
                 scope=MagicMock(spec=ScopeActionRBACValidator),
                 single_entity=MagicMock(spec=SingleEntityActionRBACValidator),

--- a/tests/component/deployment/conftest.py
+++ b/tests/component/deployment/conftest.py
@@ -67,6 +67,7 @@ from ai.backend.manager.sokovan.scheduling_controller import (
     SchedulingController,
     SchedulingControllerArgs,
 )
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 from ai.backend.testutils.fixtures import DomainFixtureData
 
 # Type aliases for fixture factories
@@ -156,6 +157,7 @@ def deployment_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
             rbac=RBACValidators(
                 scope=ScopeActionRBACValidator(permission_controller_repo, MagicMock()),
                 single_entity=SingleEntityActionRBACValidator(

--- a/tests/component/image/conftest.py
+++ b/tests/component/image/conftest.py
@@ -35,6 +35,7 @@ from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.repositories.image.repository import ImageRepository
 from ai.backend.manager.services.image.processors import ImageProcessors
 from ai.backend.manager.services.image.service import ImageService
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 
 
 @pytest.fixture()
@@ -53,6 +54,7 @@ def image_processors(
     mock_bulk = MagicMock(spec=BulkActionRBACValidator)
     mock_bulk.validate = AsyncMock()
     validators = ActionValidators(
+        virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
         rbac=RBACValidators(scope=mock_scope, single_entity=mock_single_entity, bulk=mock_bulk),
     )
     return ImageProcessors(service=service, action_monitors=[], validators=validators)

--- a/tests/component/model_card/conftest.py
+++ b/tests/component/model_card/conftest.py
@@ -68,6 +68,7 @@ from ai.backend.manager.services.permission_contoller.processors import (
 )
 from ai.backend.manager.services.permission_contoller.service import PermissionControllerService
 from ai.backend.manager.services.processors import Processors
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 from ai.backend.testutils.fixtures import DomainFixtureData
 
 if TYPE_CHECKING:
@@ -80,6 +81,7 @@ def _build_validators(
 ) -> ActionValidators:
     permission_repo = PermissionControllerRepository(database_engine)
     return ActionValidators(
+        virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
         rbac=RBACValidators(
             scope=ScopeActionRBACValidator(permission_repo, config_provider),
             single_entity=SingleEntityActionRBACValidator(permission_repo, config_provider),

--- a/tests/component/model_serving/conftest.py
+++ b/tests/component/model_serving/conftest.py
@@ -37,6 +37,7 @@ from ai.backend.manager.services.model_serving.processors.model_serving import (
 )
 from ai.backend.manager.services.model_serving.services.auto_scaling import AutoScalingService
 from ai.backend.manager.services.model_serving.services.model_serving import ModelServingService
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 
 
 @pytest.fixture()
@@ -77,6 +78,7 @@ def model_serving_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
             rbac=RBACValidators(
                 scope=ScopeActionRBACValidator(permission_controller_repo, MagicMock()),
                 single_entity=SingleEntityActionRBACValidator(
@@ -100,6 +102,7 @@ def auto_scaling_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
             rbac=RBACValidators(
                 scope=ScopeActionRBACValidator(permission_controller_repo, MagicMock()),
                 single_entity=SingleEntityActionRBACValidator(
@@ -143,6 +146,7 @@ def deployment_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
             rbac=RBACValidators(
                 scope=ScopeActionRBACValidator(permission_controller_repo, MagicMock()),
                 single_entity=SingleEntityActionRBACValidator(

--- a/tests/component/project/conftest.py
+++ b/tests/component/project/conftest.py
@@ -82,6 +82,7 @@ from ai.backend.manager.services.permission_contoller.service import PermissionC
 from ai.backend.manager.services.processors import Processors
 from ai.backend.manager.services.user.processors import UserProcessors
 from ai.backend.manager.services.user.service import UserService
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 from ai.backend.testutils.fixtures import DomainFixtureData
 
 if TYPE_CHECKING:
@@ -94,6 +95,7 @@ def _build_validators(
 ) -> ActionValidators:
     permission_repo = PermissionControllerRepository(database_engine)
     return ActionValidators(
+        virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
         rbac=RBACValidators(
             scope=ScopeActionRBACValidator(permission_repo, config_provider),
             single_entity=SingleEntityActionRBACValidator(permission_repo, config_provider),

--- a/tests/component/scheduling_history/conftest.py
+++ b/tests/component/scheduling_history/conftest.py
@@ -62,6 +62,7 @@ from ai.backend.manager.repositories.scheduling_history.repository import (
 )
 from ai.backend.manager.services.scheduling_history.processors import SchedulingHistoryProcessors
 from ai.backend.manager.services.scheduling_history.service import SchedulingHistoryService
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 from ai.backend.testutils.fixtures import DomainFixtureData
 
 if TYPE_CHECKING:
@@ -78,6 +79,7 @@ def scheduling_history_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
             rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
         ),
     )

--- a/tests/component/session/conftest.py
+++ b/tests/component/session/conftest.py
@@ -40,6 +40,7 @@ from ai.backend.manager.services.auth.processors import AuthProcessors
 from ai.backend.manager.services.session.processors import SessionProcessors
 from ai.backend.manager.services.session.service import SessionService, SessionServiceArgs
 from ai.backend.manager.services.vfolder.processors.vfolder import VFolderProcessors
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 from ai.backend.testutils.fixtures import DomainFixtureData
 
 
@@ -109,7 +110,8 @@ async def session_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
-            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock())
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
         ),
     )
 
@@ -121,7 +123,8 @@ def agent_processors_mock() -> AgentProcessors:
         service=AsyncMock(),
         action_monitors=[],
         validators=ActionValidators(
-            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock())
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
         ),
     )
 
@@ -133,7 +136,8 @@ def vfolder_processors_mock() -> VFolderProcessors:
         service=AsyncMock(),
         action_monitors=[],
         validators=ActionValidators(
-            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock())
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
         ),
     )
 

--- a/tests/component/session_v2/conftest.py
+++ b/tests/component/session_v2/conftest.py
@@ -83,6 +83,7 @@ from ai.backend.manager.sokovan.scheduling_controller import (
     SchedulingController,
     SchedulingControllerArgs,
 )
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 from ai.backend.testutils.fixtures import DomainFixtureData
 
 if TYPE_CHECKING:
@@ -161,11 +162,12 @@ async def session_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
             rbac=RBACValidators(
                 scope=AsyncMock(),
                 single_entity=real_single_entity_validator,
                 bulk=real_bulk_validator,
-            )
+            ),
         ),
     )
 
@@ -710,10 +712,11 @@ async def compute_session_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
             rbac=RBACValidators(
                 scope=AsyncMock(),
                 single_entity=real_single_entity_validator,
                 bulk=real_bulk_validator,
-            )
+            ),
         ),
     )

--- a/tests/component/vfolder/conftest.py
+++ b/tests/component/vfolder/conftest.py
@@ -74,6 +74,7 @@ from ai.backend.manager.services.vfolder.services.file import VFolderFileService
 from ai.backend.manager.services.vfolder.services.invite import VFolderInviteService
 from ai.backend.manager.services.vfolder.services.sharing import VFolderSharingService
 from ai.backend.manager.services.vfolder.services.vfolder import VFolderService
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 from ai.backend.testutils.fixtures import DomainFixtureData
 
 _VFOLDER_SERVER_SUBAPP_MODULES = (_auth_api,)
@@ -131,7 +132,8 @@ def vfolder_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
-            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock())
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
         ),
     )
 
@@ -154,7 +156,8 @@ def vfolder_file_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
-            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock())
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
         ),
     )
 
@@ -175,7 +178,8 @@ def vfolder_invite_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
-            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock())
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
         ),
     )
 
@@ -196,7 +200,8 @@ def vfolder_sharing_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
-            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock())
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
+            rbac=RBACValidators(scope=AsyncMock(), single_entity=AsyncMock(), bulk=AsyncMock()),
         ),
     )
 

--- a/tests/component/vfolder_v2/conftest.py
+++ b/tests/component/vfolder_v2/conftest.py
@@ -49,6 +49,7 @@ from ai.backend.manager.repositories.vfolder.repository import VfolderRepository
 from ai.backend.manager.services.processors import Processors
 from ai.backend.manager.services.vfolder.processors.vfolder import VFolderProcessors
 from ai.backend.manager.services.vfolder.services.vfolder import VFolderService
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 from ai.backend.testutils.fixtures import DomainFixtureData
 
 if TYPE_CHECKING:
@@ -111,11 +112,12 @@ def vfolder_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
             rbac=RBACValidators(
                 scope=AsyncMock(),
                 single_entity=real_single_entity_validator,
                 bulk=AsyncMock(),
-            )
+            ),
         ),
     )
 

--- a/tests/component/vfolder_v2/test_vfolder_mutation.py
+++ b/tests/component/vfolder_v2/test_vfolder_mutation.py
@@ -68,6 +68,7 @@ from ai.backend.manager.repositories.vfolder.repository import VfolderRepository
 from ai.backend.manager.services.processors import Processors
 from ai.backend.manager.services.vfolder.processors.vfolder import VFolderProcessors
 from ai.backend.manager.services.vfolder.services.vfolder import VFolderService
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 from ai.backend.testutils.fixtures import DomainFixtureData
 
 if TYPE_CHECKING:
@@ -126,11 +127,12 @@ def vfolder_processors(
         service=service,
         action_monitors=[],
         validators=ActionValidators(
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
             rbac=RBACValidators(
                 scope=ScopeActionRBACValidator(rbac_permission_repo, MagicMock()),
                 single_entity=SingleEntityActionRBACValidator(rbac_permission_repo, MagicMock()),
                 bulk=BulkActionRBACValidator(rbac_permission_repo, MagicMock()),
-            )
+            ),
         ),
     )
 

--- a/tests/unit/manager/services/deployment/test_deployment_crud_actions.py
+++ b/tests/unit/manager/services/deployment/test_deployment_crud_actions.py
@@ -84,6 +84,7 @@ from ai.backend.manager.services.deployment.processors import DeploymentProcesso
 from ai.backend.manager.services.deployment.service import DeploymentService
 from ai.backend.manager.sokovan.deployment import DeploymentController
 from ai.backend.manager.sokovan.deployment.types import DeploymentLifecycleType
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 
 
 class DeploymentCRUDBaseFixtures:
@@ -120,6 +121,7 @@ class DeploymentCRUDBaseFixtures:
             deployment_service,
             [],
             ActionValidators(
+                virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
                 rbac=RBACValidators(
                     scope=MagicMock(spec=ScopeActionRBACValidator),
                     single_entity=MagicMock(spec=SingleEntityActionRBACValidator),

--- a/tests/unit/manager/services/deployment/test_deployment_service.py
+++ b/tests/unit/manager/services/deployment/test_deployment_service.py
@@ -86,6 +86,7 @@ from ai.backend.manager.services.deployment.service import (
     _convert_deployment_info_to_legacy_data,
 )
 from ai.backend.manager.sokovan.deployment import DeploymentController
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 
 
 class DeploymentServiceBaseFixtures:
@@ -127,6 +128,7 @@ class DeploymentServiceBaseFixtures:
             deployment_service,
             [],
             ActionValidators(
+                virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
                 rbac=RBACValidators(
                     scope=MagicMock(spec=ScopeActionRBACValidator),
                     single_entity=MagicMock(spec=SingleEntityActionRBACValidator),

--- a/tests/unit/manager/services/image/test_image_service.py
+++ b/tests/unit/manager/services/image/test_image_service.py
@@ -89,6 +89,7 @@ from ai.backend.manager.services.image.processors import ImageProcessors
 from ai.backend.manager.services.image.service import ImageService
 from ai.backend.manager.services.image.types import ImageRefData
 from ai.backend.manager.types import OptionalState, TriState
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 
 
 class ImageServiceBaseFixtures:
@@ -135,6 +136,7 @@ class ImageServiceBaseFixtures:
         mock_bulk = MagicMock(spec=BulkActionRBACValidator)
         mock_bulk.validate = AsyncMock()
         validators = ActionValidators(
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
             rbac=RBACValidators(scope=mock_scope, single_entity=mock_single_entity, bulk=mock_bulk),
         )
         return ImageProcessors(image_service, [], validators)

--- a/tests/unit/manager/services/model_serving/actions/conftest.py
+++ b/tests/unit/manager/services/model_serving/actions/conftest.py
@@ -9,11 +9,13 @@ from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACVali
 from ai.backend.manager.actions.validators.rbac.single_entity import (
     SingleEntityActionRBACValidator,
 )
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 
 
 @pytest.fixture
 def mock_action_validators() -> ActionValidators:
     return ActionValidators(
+        virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
         rbac=RBACValidators(
             scope=MagicMock(spec=ScopeActionRBACValidator),
             single_entity=MagicMock(spec=SingleEntityActionRBACValidator),


### PR DESCRIPTION
## Summary
- Add `VirtualScopeRBACValidators`, bundling the three pure-ABC per-type RBAC validators (`VirtualScope{Scope,SingleEntity,Bulk}ActionRBACValidator`), to the validator registry (`actions/validators/rbac`).
- Expose it as a **required** `ActionValidators.virtual_scope_rbac` field — unlike `legacy_rbac` there is no fallback (a pure-ABC action cannot be validated by the other validator families), so migrated processor packages get non-null access without per-package None handling.
- Construct the bundle in `dependencies/processing/composer.py` from the same inputs as the existing validators (`PermissionControllerRepository`, `ManagerConfigProvider`); the existing `rbac` / `legacy_rbac` wiring is unchanged.
- Add a shared mock factory `ai.backend.testutils.action_validators.mock_virtual_scope_rbac_validators()` and update the 31 `ActionValidators(...)` test construction sites (20 files) to pass the new required field.

This unblocks the per-entity BaseAction migrations (BA-6353..BA-6400): each migrated `processors.py` can pull the pure-ABC validators via `validators.virtual_scope_rbac.{single_entity,bulk,scope}`.

## Test plan
- [x] CI type check and unit/component tests pass (all `ActionValidators` fixtures updated to the new required field)

Resolves BA-7053

🤖 Generated with [Claude Code](https://claude.com/claude-code)