### PR TITLE
feat(BA-7057): add idle checker assignment SDK client and CLI

### DIFF
--- a/.claude/skills/bai-cli/SKILL.md
+++ b/.claude/skills/bai-cli/SKILL.md
@@ -100,6 +100,7 @@ Check options with `--help`.
 
 - **audit-log**: user(search)
 - **fair-share**: sub domain / project / user — each (get, search)
+- **idle-checker-assignment**: user(scoped-search, update, purge) · admin(create, search)
 - **notification**: sub channel(get, search, delete), rule(get, search, delete)
 - **prometheus-query-definition**: user(get, search, execute) · admin(create, update, delete, preview)
 - **prometheus-query-definition-category**: user(get, search) · admin(create, delete)

--- a/changes/13209.feature.md
+++ b/changes/13209.feature.md
@@ -1,0 +1,1 @@
+Add the idle checker assignment v2 SDK client and `bai idle-checker-assignment` CLI commands.

--- a/src/ai/backend/client/cli/v2/__init__.py
+++ b/src/ai/backend/client/cli/v2/__init__.py
@@ -244,6 +244,15 @@ def audit_log() -> None:
 
 @v2.group(
     cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.idle_checker_assignment:idle_checker_assignment",
+    name="idle-checker-assignment",
+)
+def idle_checker_assignment() -> None:
+    """Idle checker assignment commands."""
+
+
+@v2.group(
+    cls=LazyGroup,
     import_name="ai.backend.client.cli.v2.scheduling_history:scheduling_history",
 )
 def scheduling_history() -> None:

--- a/src/ai/backend/client/cli/v2/admin/__init__.py
+++ b/src/ai/backend/client/cli/v2/admin/__init__.py
@@ -68,6 +68,15 @@ def deployment() -> None:
     """Admin deployment commands."""
 
 
+@admin.group(
+    cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.admin.idle_checker_assignment:idle_checker_assignment",
+    name="idle-checker-assignment",
+)
+def idle_checker_assignment() -> None:
+    """Admin idle checker assignment commands."""
+
+
 @admin.group(cls=LazyGroup, import_name="ai.backend.client.cli.v2.admin.image:image")
 def image() -> None:
     """Admin image commands."""

--- a/src/ai/backend/client/cli/v2/admin/idle_checker_assignment.py
+++ b/src/ai/backend/client/cli/v2/admin/idle_checker_assignment.py
@@ -1,0 +1,152 @@
+"""Admin CLI commands for idle checker assignments."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    parse_order_options,
+    print_result,
+)
+from ai.backend.common.dto.manager.v2.idle_checker_assignment.types import IdleCheckerScopeTypeDTO
+
+
+@click.group()
+def idle_checker_assignment() -> None:
+    """Idle checker assignment admin commands (superadmin required)."""
+
+
+@idle_checker_assignment.command()
+@click.option(
+    "--scope-type",
+    required=True,
+    type=click.Choice([scope_type.value for scope_type in IdleCheckerScopeTypeDTO]),
+    help="Kind of the scope to bind.",
+)
+@click.option(
+    "--scope-id",
+    required=True,
+    type=str,
+    help="Scope identifier (UUID), interpreted according to the scope type.",
+)
+@click.option("--idle-checker-id", required=True, type=click.UUID, help="Idle checker to bind.")
+@click.option(
+    "--enabled/--disabled",
+    default=True,
+    help="Whether the assignment participates in idle checking (default: enabled).",
+)
+def create(scope_type: str, scope_id: str, idle_checker_id: uuid.UUID, enabled: bool) -> None:
+    """Bind a global idle checker to a scope."""
+    from ai.backend.common.dto.manager.v2.idle_checker_assignment.request import (
+        CreateIdleCheckerAssignmentInput,
+        IdleCheckerScopeRefDTO,
+    )
+    from ai.backend.common.identifier.idle_checker import IdleCheckerID
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.idle_checker_assignment.admin_create(
+                CreateIdleCheckerAssignmentInput(
+                    scope=IdleCheckerScopeRefDTO(
+                        scope_type=IdleCheckerScopeTypeDTO(scope_type),
+                        scope_id=scope_id,
+                    ),
+                    idle_checker_id=IdleCheckerID(idle_checker_id),
+                    enabled=enabled,
+                )
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@idle_checker_assignment.command()
+@click.option("--limit", type=int, default=20, help="Maximum number of items to return.")
+@click.option("--offset", type=int, default=0, help="Number of items to skip.")
+@click.option(
+    "--scope-type",
+    default=None,
+    type=click.Choice([scope_type.value for scope_type in IdleCheckerScopeTypeDTO]),
+    help="Filter by scope type (exact match).",
+)
+@click.option(
+    "--idle-checker-id",
+    default=None,
+    type=click.UUID,
+    help="Filter by bound idle checker ID (exact match).",
+)
+@click.option(
+    "--enabled/--disabled",
+    "enabled",
+    default=None,
+    help="Filter by the enabled flag.",
+)
+@click.option(
+    "--order-by",
+    multiple=True,
+    help="Order by field:direction (e.g., created_at:desc, scope_type:asc).",
+)
+def search(
+    limit: int,
+    offset: int,
+    scope_type: str | None,
+    idle_checker_id: uuid.UUID | None,
+    enabled: bool | None,
+    order_by: tuple[str, ...],
+) -> None:
+    """Search idle checker assignments across all scopes."""
+    from ai.backend.common.dto.manager.query import UUIDFilter
+    from ai.backend.common.dto.manager.v2.idle_checker_assignment.request import (
+        IdleCheckerAssignmentFilter,
+        IdleCheckerAssignmentOrder,
+        SearchIdleCheckerAssignmentsInput,
+    )
+    from ai.backend.common.dto.manager.v2.idle_checker_assignment.types import (
+        IdleCheckerAssignmentOrderField,
+        ScopeTypeFilter,
+    )
+
+    filter_dto: IdleCheckerAssignmentFilter | None = None
+    if scope_type is not None or idle_checker_id is not None or enabled is not None:
+        filter_dto = IdleCheckerAssignmentFilter(
+            scope_type=(
+                ScopeTypeFilter(equals=IdleCheckerScopeTypeDTO(scope_type))
+                if scope_type is not None
+                else None
+            ),
+            idle_checker_id=(
+                UUIDFilter(equals=idle_checker_id) if idle_checker_id is not None else None
+            ),
+            enabled=enabled,
+        )
+
+    orders = (
+        parse_order_options(order_by, IdleCheckerAssignmentOrderField, IdleCheckerAssignmentOrder)
+        if order_by
+        else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.idle_checker_assignment.admin_search(
+                SearchIdleCheckerAssignmentsInput(
+                    filter=filter_dto,
+                    order=orders,
+                    limit=limit,
+                    offset=offset,
+                )
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())

--- a/src/ai/backend/client/cli/v2/admin/idle_checker_assignment.py
+++ b/src/ai/backend/client/cli/v2/admin/idle_checker_assignment.py
@@ -31,7 +31,7 @@ def idle_checker_assignment() -> None:
 @click.option(
     "--scope-id",
     required=True,
-    type=str,
+    type=click.UUID,
     help="Scope identifier (UUID), interpreted according to the scope type.",
 )
 @click.option("--idle-checker-id", required=True, type=click.UUID, help="Idle checker to bind.")
@@ -40,7 +40,7 @@ def idle_checker_assignment() -> None:
     default=True,
     help="Whether the assignment participates in idle checking (default: enabled).",
 )
-def create(scope_type: str, scope_id: str, idle_checker_id: uuid.UUID, enabled: bool) -> None:
+def create(scope_type: str, scope_id: uuid.UUID, idle_checker_id: uuid.UUID, enabled: bool) -> None:
     """Bind a global idle checker to a scope."""
     from ai.backend.common.dto.manager.v2.idle_checker_assignment.request import (
         CreateIdleCheckerAssignmentInput,

--- a/src/ai/backend/client/cli/v2/idle_checker_assignment/__init__.py
+++ b/src/ai/backend/client/cli/v2/idle_checker_assignment/__init__.py
@@ -1,0 +1,3 @@
+from .commands import idle_checker_assignment as idle_checker_assignment
+
+__all__ = ("idle_checker_assignment",)

--- a/src/ai/backend/client/cli/v2/idle_checker_assignment/commands.py
+++ b/src/ai/backend/client/cli/v2/idle_checker_assignment/commands.py
@@ -1,0 +1,163 @@
+"""User-facing CLI commands for idle checker assignments."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    parse_order_options,
+    print_result,
+)
+from ai.backend.common.dto.manager.v2.idle_checker_assignment.types import IdleCheckerScopeTypeDTO
+
+
+@click.group()
+def idle_checker_assignment() -> None:
+    """Idle checker assignment commands."""
+
+
+def _parse_scope_items(scopes: tuple[str, ...]) -> list[tuple[IdleCheckerScopeTypeDTO, str]]:
+    items: list[tuple[IdleCheckerScopeTypeDTO, str]] = []
+    for raw in scopes:
+        scope_type_raw, sep, scope_id = raw.partition(":")
+        if not sep or not scope_id:
+            raise click.BadParameter(
+                f"Invalid scope item {raw!r}; expected '<scope_type>:<scope_id>'.",
+                param_hint="--scope",
+            )
+        try:
+            scope_type = IdleCheckerScopeTypeDTO(scope_type_raw)
+        except ValueError:
+            valid = ", ".join(member.value for member in IdleCheckerScopeTypeDTO)
+            raise click.BadParameter(
+                f"Unknown scope type {scope_type_raw!r}; expected one of: {valid}.",
+                param_hint="--scope",
+            ) from None
+        items.append((scope_type, scope_id))
+    return items
+
+
+@idle_checker_assignment.command(name="scoped-search")
+@click.option(
+    "--scope",
+    "scopes",
+    multiple=True,
+    required=True,
+    help=(
+        "Scope item as '<scope_type>:<scope_id>' (repeatable; OR across items). "
+        "Example: --scope domain:33db45ef-... --scope project:7b56b1f4-..."
+    ),
+)
+@click.option("--limit", type=int, default=20, help="Maximum number of items to return.")
+@click.option("--offset", type=int, default=0, help="Number of items to skip.")
+@click.option(
+    "--enabled/--disabled",
+    "enabled",
+    default=None,
+    help="Filter by the enabled flag.",
+)
+@click.option(
+    "--order-by",
+    multiple=True,
+    help="Order by field:direction (e.g., created_at:desc, scope_type:asc).",
+)
+def scoped_search(
+    scopes: tuple[str, ...],
+    limit: int,
+    offset: int,
+    enabled: bool | None,
+    order_by: tuple[str, ...],
+) -> None:
+    """Search idle checker assignments within the given scopes (per-item RBAC)."""
+    from ai.backend.common.dto.manager.v2.idle_checker_assignment.request import (
+        IdleCheckerAssignmentFilter,
+        IdleCheckerAssignmentOrder,
+        IdleCheckerAssignmentScopeDTO,
+        IdleCheckerScopeRefDTO,
+        ScopedSearchIdleCheckerAssignmentsInput,
+    )
+    from ai.backend.common.dto.manager.v2.idle_checker_assignment.types import (
+        IdleCheckerAssignmentOrderField,
+    )
+
+    scope_refs: list[IdleCheckerScopeRefDTO] = []
+    for scope_type, scope_id in _parse_scope_items(scopes):
+        scope_refs.append(IdleCheckerScopeRefDTO(scope_type=scope_type, scope_id=scope_id))
+
+    filter_dto = IdleCheckerAssignmentFilter(enabled=enabled) if enabled is not None else None
+    orders = (
+        parse_order_options(order_by, IdleCheckerAssignmentOrderField, IdleCheckerAssignmentOrder)
+        if order_by
+        else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.idle_checker_assignment.scoped_search(
+                ScopedSearchIdleCheckerAssignmentsInput(
+                    scope=IdleCheckerAssignmentScopeDTO(items=scope_refs),
+                    filter=filter_dto,
+                    order=orders,
+                    limit=limit,
+                    offset=offset,
+                )
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@idle_checker_assignment.command()
+@click.argument("idle_checker_assignment_id", type=click.UUID)
+@click.option(
+    "--enabled/--disabled",
+    "enabled",
+    required=True,
+    help="New enabled state.",
+)
+def update(idle_checker_assignment_id: uuid.UUID, enabled: bool) -> None:
+    """Update an idle checker assignment's enabled state by ID."""
+    from ai.backend.common.dto.manager.v2.idle_checker_assignment.request import (
+        UpdateIdleCheckerAssignmentInput,
+    )
+    from ai.backend.common.identifier.idle_checker import IdleCheckerAssignmentID
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.idle_checker_assignment.update(
+                idle_checker_assignment_id,
+                UpdateIdleCheckerAssignmentInput(
+                    id=IdleCheckerAssignmentID(idle_checker_assignment_id),
+                    enabled=enabled,
+                ),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@idle_checker_assignment.command()
+@click.argument("idle_checker_assignment_id", type=click.UUID)
+def purge(idle_checker_assignment_id: uuid.UUID) -> None:
+    """Permanently remove an idle checker assignment by ID."""
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.idle_checker_assignment.purge(idle_checker_assignment_id)
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())

--- a/src/ai/backend/client/cli/v2/idle_checker_assignment/commands.py
+++ b/src/ai/backend/client/cli/v2/idle_checker_assignment/commands.py
@@ -21,8 +21,8 @@ def idle_checker_assignment() -> None:
     """Idle checker assignment commands."""
 
 
-def _parse_scope_items(scopes: tuple[str, ...]) -> list[tuple[IdleCheckerScopeTypeDTO, str]]:
-    items: list[tuple[IdleCheckerScopeTypeDTO, str]] = []
+def _parse_scope_items(scopes: tuple[str, ...]) -> list[tuple[IdleCheckerScopeTypeDTO, uuid.UUID]]:
+    items: list[tuple[IdleCheckerScopeTypeDTO, uuid.UUID]] = []
     for raw in scopes:
         scope_type_raw, sep, scope_id = raw.partition(":")
         if not sep or not scope_id:
@@ -38,7 +38,14 @@ def _parse_scope_items(scopes: tuple[str, ...]) -> list[tuple[IdleCheckerScopeTy
                 f"Unknown scope type {scope_type_raw!r}; expected one of: {valid}.",
                 param_hint="--scope",
             ) from None
-        items.append((scope_type, scope_id))
+        try:
+            scope_uuid = uuid.UUID(scope_id)
+        except ValueError:
+            raise click.BadParameter(
+                f"Scope identifier {scope_id!r} must be a UUID.",
+                param_hint="--scope",
+            ) from None
+        items.append((scope_type, scope_uuid))
     return items
 
 

--- a/src/ai/backend/client/v2/domains_v2/idle_checker_assignment.py
+++ b/src/ai/backend/client/v2/domains_v2/idle_checker_assignment.py
@@ -1,0 +1,85 @@
+"""V2 SDK client for the idle checker assignment domain."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from ai.backend.client.v2.base_domain import BaseDomainClient
+from ai.backend.common.dto.manager.v2.idle_checker_assignment.request import (
+    CreateIdleCheckerAssignmentInput,
+    ScopedSearchIdleCheckerAssignmentsInput,
+    SearchIdleCheckerAssignmentsInput,
+    UpdateIdleCheckerAssignmentInput,
+)
+from ai.backend.common.dto.manager.v2.idle_checker_assignment.response import (
+    CreateIdleCheckerAssignmentPayload,
+    PurgeIdleCheckerAssignmentPayload,
+    SearchIdleCheckerAssignmentPayload,
+    UpdateIdleCheckerAssignmentPayload,
+)
+
+_PATH = "/v2/idle-checker-assignments"
+
+
+class V2IdleCheckerAssignmentClient(BaseDomainClient):
+    """SDK client for idle checker assignment operations."""
+
+    async def admin_create(
+        self,
+        request: CreateIdleCheckerAssignmentInput,
+    ) -> CreateIdleCheckerAssignmentPayload:
+        """Bind a global idle checker to a scope (superadmin only)."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/",
+            request=request,
+            response_model=CreateIdleCheckerAssignmentPayload,
+        )
+
+    async def admin_search(
+        self,
+        request: SearchIdleCheckerAssignmentsInput,
+    ) -> SearchIdleCheckerAssignmentPayload:
+        """Search idle checker assignments across all scopes (superadmin only)."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/search",
+            request=request,
+            response_model=SearchIdleCheckerAssignmentPayload,
+        )
+
+    async def scoped_search(
+        self,
+        request: ScopedSearchIdleCheckerAssignmentsInput,
+    ) -> SearchIdleCheckerAssignmentPayload:
+        """Search idle checker assignments within the given scopes (per-item RBAC)."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/scoped/search",
+            request=request,
+            response_model=SearchIdleCheckerAssignmentPayload,
+        )
+
+    async def update(
+        self,
+        idle_checker_assignment_id: UUID,
+        request: UpdateIdleCheckerAssignmentInput,
+    ) -> UpdateIdleCheckerAssignmentPayload:
+        """Update an idle checker assignment's enabled state by ID."""
+        return await self._client.typed_request(
+            "PATCH",
+            f"{_PATH}/{idle_checker_assignment_id}",
+            request=request,
+            response_model=UpdateIdleCheckerAssignmentPayload,
+        )
+
+    async def purge(
+        self,
+        idle_checker_assignment_id: UUID,
+    ) -> PurgeIdleCheckerAssignmentPayload:
+        """Permanently remove an idle checker assignment by ID."""
+        return await self._client.typed_request(
+            "DELETE",
+            f"{_PATH}/{idle_checker_assignment_id}",
+            response_model=PurgeIdleCheckerAssignmentPayload,
+        )

--- a/src/ai/backend/client/v2/v2_registry.py
+++ b/src/ai/backend/client/v2/v2_registry.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from .domains_v2.gql import V2GQLClient
     from .domains_v2.huggingface_registry import V2HuggingFaceRegistryClient
     from .domains_v2.idle_checker import V2IdleCheckerClient
+    from .domains_v2.idle_checker_assignment import V2IdleCheckerAssignmentClient
     from .domains_v2.image import V2ImageClient
     from .domains_v2.keypair import V2KeypairClient
     from .domains_v2.login_client_type import V2LoginClientTypeClient
@@ -122,6 +123,12 @@ class V2ClientRegistry:
         from .domains_v2.audit_log import V2AuditLogClient
 
         return V2AuditLogClient(self._client)
+
+    @cached_property
+    def idle_checker_assignment(self) -> V2IdleCheckerAssignmentClient:
+        from .domains_v2.idle_checker_assignment import V2IdleCheckerAssignmentClient
+
+        return V2IdleCheckerAssignmentClient(self._client)
 
     @cached_property
     def container_registry(self) -> V2ContainerRegistryClient:

--- a/tests/component/idle_checker_assignment/BUILD
+++ b/tests/component/idle_checker_assignment/BUILD
@@ -1,0 +1,5 @@
+python_test_utils()
+
+python_tests(
+    name="tests",
+)

--- a/tests/component/idle_checker_assignment/conftest.py
+++ b/tests/component/idle_checker_assignment/conftest.py
@@ -1,0 +1,374 @@
+"""Component-test fixtures for idle checker assignment v2 endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yarl
+
+from ai.backend.client.v2.auth import HMACAuth
+from ai.backend.client.v2.config import ClientConfig
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.data.idle_checker.types import (
+    CheckerType,
+    IdleCheckerSpec,
+    SessionLifetimeSpec,
+)
+from ai.backend.common.data.permission.types import (
+    EntityType,
+    OperationType,
+    Permission,
+    RelationType,
+    ScopeType,
+)
+from ai.backend.common.types import ResourceSlot, SessionTypes
+from ai.backend.manager.actions.validators import ActionValidators
+from ai.backend.manager.actions.validators.rbac import RBACValidators
+from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
+from ai.backend.manager.actions.validators.rbac.single_entity import (
+    SingleEntityActionRBACValidator,
+)
+from ai.backend.manager.api.adapters.idle_checker_assignment.adapter import (
+    IdleCheckerAssignmentAdapter,
+)
+from ai.backend.manager.api.rest.routing import RouteRegistry
+from ai.backend.manager.api.rest.types import RouteDeps
+from ai.backend.manager.api.rest.v2.idle_checker_assignment.handler import (
+    V2IdleCheckerAssignmentHandler,
+)
+from ai.backend.manager.api.rest.v2.idle_checker_assignment.registry import (
+    register_v2_idle_checker_assignment_routes,
+)
+from ai.backend.manager.models.domain.row import DomainRow
+from ai.backend.manager.models.group.row import GroupRow
+from ai.backend.manager.models.idle_checker.row import IdleCheckerBindingRow, IdleCheckerRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
+from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
+from ai.backend.manager.models.resource_policy import ProjectResourcePolicyRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
+from ai.backend.manager.repositories.ops import DBOpsProvider
+from ai.backend.manager.repositories.permission_controller.repository import (
+    PermissionControllerRepository,
+)
+from ai.backend.manager.services.idle_checker_assignment.processors import (
+    IdleCheckerAssignmentProcessors,
+)
+from ai.backend.manager.services.idle_checker_assignment.service import IdleCheckerAssignmentService
+from ai.backend.manager.services.processors import Processors
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
+
+if TYPE_CHECKING:
+    from tests.component.conftest import ServerInfo, UserFixtureData
+
+
+@dataclass
+class AssignmentSeedData:
+    domain_id: uuid.UUID
+    project_id: uuid.UUID
+    other_project_id: uuid.UUID
+    domain_assignment_id: uuid.UUID
+    project_assignment_id: uuid.UUID
+    other_project_assignment_id: uuid.UUID
+
+
+@pytest.fixture()
+def idle_checker_assignment_processors(
+    database_engine: ExtendedAsyncSAEngine,
+) -> IdleCheckerAssignmentProcessors:
+    """Assignment processors with real RBAC validators against the real DB."""
+    service = IdleCheckerAssignmentService(IdleCheckerRepository(DBOpsProvider(database_engine)))
+    permission_repo = PermissionControllerRepository(database_engine)
+    return IdleCheckerAssignmentProcessors(
+        service=service,
+        action_monitors=[],
+        validators=ActionValidators(
+            rbac=RBACValidators(
+                scope=AsyncMock(),
+                single_entity=SingleEntityActionRBACValidator(permission_repo, MagicMock()),
+                bulk=BulkActionRBACValidator(permission_repo, MagicMock()),
+            ),
+            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
+        ),
+    )
+
+
+@pytest.fixture()
+def server_module_registries(
+    route_deps: RouteDeps,
+    idle_checker_assignment_processors: IdleCheckerAssignmentProcessors,
+) -> list[RouteRegistry]:
+    """Register v2 idle checker assignment routes for testing."""
+    processors = MagicMock(spec=Processors)
+    processors.idle_checker_assignment = idle_checker_assignment_processors
+    handler = V2IdleCheckerAssignmentHandler(adapter=IdleCheckerAssignmentAdapter(processors))
+    v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
+    v2_reg.add_subregistry(register_v2_idle_checker_assignment_routes(handler, route_deps))
+    return [v2_reg]
+
+
+@pytest.fixture()
+async def admin_v2_registry(
+    server: ServerInfo,
+    admin_user_fixture: UserFixtureData,
+) -> AsyncIterator[V2ClientRegistry]:
+    """V2 client registry authenticated as superadmin."""
+    registry = await V2ClientRegistry.create(
+        ClientConfig(endpoint=yarl.URL(server.url)),
+        HMACAuth(
+            access_key=admin_user_fixture.keypair.access_key,
+            secret_key=admin_user_fixture.keypair.secret_key,
+        ),
+    )
+    try:
+        yield registry
+    finally:
+        await registry.close()
+
+
+@pytest.fixture()
+async def user_v2_registry(
+    server: ServerInfo,
+    regular_user_fixture: UserFixtureData,
+) -> AsyncIterator[V2ClientRegistry]:
+    """V2 client registry authenticated as a regular (non-admin) user."""
+    registry = await V2ClientRegistry.create(
+        ClientConfig(endpoint=yarl.URL(server.url)),
+        HMACAuth(
+            access_key=regular_user_fixture.keypair.access_key,
+            secret_key=regular_user_fixture.keypair.secret_key,
+        ),
+    )
+    try:
+        yield registry
+    finally:
+        await registry.close()
+
+
+@pytest.fixture()
+async def assignment_seed(
+    database_engine: ExtendedAsyncSAEngine,
+    database_fixture: None,
+) -> AsyncIterator[AssignmentSeedData]:
+    """Seed a domain and two projects, one checker, and one assignment per scope.
+
+    The assignments model super-admin-created rows; each also gets its RBAC scope
+    association row so that single-entity scope-chain checks can resolve the
+    assignment back to its scope.
+    """
+    domain_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    other_project_id = uuid.uuid4()
+    domain_name = f"icb-domain-{domain_id.hex[:8]}"
+    policy_name = f"icb-prp-{project_id.hex[:8]}"
+    async with database_engine.begin_session() as db_sess:
+        db_sess.add(DomainRow(id=domain_id, name=domain_name, total_resource_slots=ResourceSlot()))
+        db_sess.add(
+            ProjectResourcePolicyRow(
+                name=policy_name,
+                max_vfolder_count=0,
+                max_quota_scope_size=-1,
+                max_network_count=0,
+            )
+        )
+        await db_sess.flush()
+        db_sess.add(
+            GroupRow(
+                id=project_id,
+                name=f"icb-project-{project_id.hex[:8]}",
+                domain_name=domain_name,
+                total_resource_slots=ResourceSlot(),
+                resource_policy=policy_name,
+            )
+        )
+        db_sess.add(
+            GroupRow(
+                id=other_project_id,
+                name=f"icb-project-{other_project_id.hex[:8]}",
+                domain_name=domain_name,
+                total_resource_slots=ResourceSlot(),
+                resource_policy=policy_name,
+            )
+        )
+        checker = IdleCheckerRow(
+            name=f"icb-checker-{domain_id.hex[:8]}",
+            description=None,
+            target_session_types=[SessionTypes.INTERACTIVE],
+            initial_grace_period_seconds=0,
+            spec=IdleCheckerSpec(
+                type=CheckerType.SESSION_LIFETIME,
+                session_lifetime=SessionLifetimeSpec(max_lifetime_seconds=3600),
+            ),
+        )
+        db_sess.add(checker)
+        await db_sess.flush()
+        checker_id = checker.id
+        domain_assignment = IdleCheckerBindingRow(
+            scope_type=ScopeType.DOMAIN,
+            scope_id=domain_id,
+            idle_checker_id=checker_id,
+            enabled=True,
+        )
+        project_assignment = IdleCheckerBindingRow(
+            scope_type=ScopeType.PROJECT,
+            scope_id=project_id,
+            idle_checker_id=checker_id,
+            enabled=True,
+        )
+        other_project_assignment = IdleCheckerBindingRow(
+            scope_type=ScopeType.PROJECT,
+            scope_id=other_project_id,
+            idle_checker_id=checker_id,
+            enabled=True,
+        )
+        db_sess.add(domain_assignment)
+        db_sess.add(project_assignment)
+        db_sess.add(other_project_assignment)
+        await db_sess.flush()
+        assignment_scopes = [
+            (domain_assignment.id, ScopeType.DOMAIN, str(domain_id)),
+            (project_assignment.id, ScopeType.PROJECT, str(project_id)),
+            (other_project_assignment.id, ScopeType.PROJECT, str(other_project_id)),
+        ]
+        for assignment_id, scope_type, scope_id in assignment_scopes:
+            db_sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=scope_type,
+                    scope_id=scope_id,
+                    entity_type=EntityType.IDLE_CHECKER_ASSIGNMENT,
+                    entity_id=str(assignment_id),
+                    relation_type=RelationType.AUTO,
+                )
+            )
+        await db_sess.flush()
+        seed = AssignmentSeedData(
+            domain_id=domain_id,
+            project_id=project_id,
+            other_project_id=other_project_id,
+            domain_assignment_id=domain_assignment.id,
+            project_assignment_id=project_assignment.id,
+            other_project_assignment_id=other_project_assignment.id,
+        )
+    yield seed
+    async with database_engine.begin() as conn:
+        # Assignments are removed by the checker FK cascade.
+        await conn.execute(
+            AssociationScopesEntitiesRow.__table__.delete().where(
+                AssociationScopesEntitiesRow.__table__.c.entity_id.in_([
+                    str(seed.domain_assignment_id),
+                    str(seed.project_assignment_id),
+                    str(seed.other_project_assignment_id),
+                ])
+            )
+        )
+        await conn.execute(
+            IdleCheckerRow.__table__.delete().where(IdleCheckerRow.__table__.c.id == checker_id)
+        )
+        await conn.execute(
+            GroupRow.__table__.delete().where(
+                GroupRow.__table__.c.id.in_([project_id, other_project_id])
+            )
+        )
+        await conn.execute(
+            ProjectResourcePolicyRow.__table__.delete().where(
+                ProjectResourcePolicyRow.__table__.c.name == policy_name
+            )
+        )
+        await conn.execute(
+            DomainRow.__table__.delete().where(DomainRow.__table__.c.id == domain_id)
+        )
+
+
+@pytest.fixture()
+async def project_read_permission(
+    database_engine: ExtendedAsyncSAEngine,
+    regular_user_fixture: UserFixtureData,
+    assignment_seed: AssignmentSeedData,
+) -> AsyncIterator[None]:
+    """Grant the regular user PROJECT:READ on the seeded project (self-scope)."""
+    role_id = uuid.uuid4()
+    async with database_engine.begin_session() as db_sess:
+        db_sess.add(
+            RoleRow(
+                id=role_id,
+                name=f"icb-role-{role_id.hex[:8]}",
+                description="idle checker assignment component test role",
+            )
+        )
+        await db_sess.flush()
+        db_sess.add(UserRoleRow(user_id=regular_user_fixture.user_uuid, role_id=role_id))
+        db_sess.add(
+            PermissionRow(
+                role_id=role_id,
+                scope_type=ScopeType.PROJECT,
+                scope_id=str(assignment_seed.project_id),
+                entity_type=EntityType.PROJECT,
+                operation=OperationType.READ,
+                permission=Permission.from_operation(OperationType.READ),
+            )
+        )
+        await db_sess.flush()
+    yield
+    async with database_engine.begin() as conn:
+        await conn.execute(
+            PermissionRow.__table__.delete().where(PermissionRow.__table__.c.role_id == role_id)
+        )
+        await conn.execute(
+            UserRoleRow.__table__.delete().where(UserRoleRow.__table__.c.role_id == role_id)
+        )
+        await conn.execute(RoleRow.__table__.delete().where(RoleRow.__table__.c.id == role_id))
+
+
+@pytest.fixture()
+async def project_assignment_manage_permission(
+    database_engine: ExtendedAsyncSAEngine,
+    regular_user_fixture: UserFixtureData,
+    assignment_seed: AssignmentSeedData,
+) -> AsyncIterator[None]:
+    """Grant the regular user UPDATE/PURGE on idle checker assignments of the seeded project.
+
+    Permissions are attached at the PROJECT scope with subject entity type
+    ``IDLE_CHECKER_ASSIGNMENT``, so they apply to assignments resolved to that project
+    via the scope chain — not to assignments of any other scope.
+    """
+    role_id = uuid.uuid4()
+    async with database_engine.begin_session() as db_sess:
+        db_sess.add(
+            RoleRow(
+                id=role_id,
+                name=f"icb-manage-role-{role_id.hex[:8]}",
+                description="idle checker assignment manage test role",
+            )
+        )
+        await db_sess.flush()
+        db_sess.add(UserRoleRow(user_id=regular_user_fixture.user_uuid, role_id=role_id))
+        for operation in (OperationType.UPDATE, OperationType.HARD_DELETE):
+            db_sess.add(
+                PermissionRow(
+                    role_id=role_id,
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=str(assignment_seed.project_id),
+                    entity_type=EntityType.IDLE_CHECKER_ASSIGNMENT,
+                    operation=operation,
+                    permission=Permission.from_operation(operation),
+                )
+            )
+        await db_sess.flush()
+    yield
+    async with database_engine.begin() as conn:
+        await conn.execute(
+            PermissionRow.__table__.delete().where(PermissionRow.__table__.c.role_id == role_id)
+        )
+        await conn.execute(
+            UserRoleRow.__table__.delete().where(UserRoleRow.__table__.c.role_id == role_id)
+        )
+        await conn.execute(RoleRow.__table__.delete().where(RoleRow.__table__.c.id == role_id))

--- a/tests/component/idle_checker_assignment/test_scoped_search_permissions.py
+++ b/tests/component/idle_checker_assignment/test_scoped_search_permissions.py
@@ -1,0 +1,209 @@
+"""Component tests for scoped idle-checker-assignment search RBAC.
+
+POST /v2/idle-checker-assignments/scoped/search runs through
+``BulkActionProcessor`` + ``BulkActionRBACValidator``: every scope item is
+RBAC-checked against the caller, items are OR'd, and one denied item fails
+the whole request.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ai.backend.client.v2.exceptions import PermissionDeniedError
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.dto.manager.v2.idle_checker_assignment.request import (
+    IdleCheckerAssignmentScopeDTO,
+    IdleCheckerScopeRefDTO,
+    ScopedSearchIdleCheckerAssignmentsInput,
+    UpdateIdleCheckerAssignmentInput,
+)
+from ai.backend.common.dto.manager.v2.idle_checker_assignment.types import IdleCheckerScopeTypeDTO
+from ai.backend.common.identifier.idle_checker import IdleCheckerAssignmentID
+
+from .conftest import AssignmentSeedData
+
+
+class TestScopedIdleCheckerAssignmentSearchPermissions:
+    async def test_superadmin_sees_assignments_in_any_scope(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        assignment_seed: AssignmentSeedData,
+    ) -> None:
+        """Superadmin bypasses RBAC and unions assignments across scope kinds."""
+        result = await admin_v2_registry.idle_checker_assignment.scoped_search(
+            ScopedSearchIdleCheckerAssignmentsInput(
+                scope=IdleCheckerAssignmentScopeDTO(
+                    items=[
+                        IdleCheckerScopeRefDTO(
+                            scope_type=IdleCheckerScopeTypeDTO.DOMAIN,
+                            scope_id=str(assignment_seed.domain_id),
+                        ),
+                        IdleCheckerScopeRefDTO(
+                            scope_type=IdleCheckerScopeTypeDTO.PROJECT,
+                            scope_id=str(assignment_seed.project_id),
+                        ),
+                    ]
+                )
+            )
+        )
+
+        assert {item.id for item in result.items} == {
+            assignment_seed.domain_assignment_id,
+            assignment_seed.project_assignment_id,
+        }
+
+    async def test_project_admin_sees_own_project_assignments(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        assignment_seed: AssignmentSeedData,
+        project_read_permission: None,
+    ) -> None:
+        """A user with PROJECT:READ on the project sees that project's assignments."""
+        result = await user_v2_registry.idle_checker_assignment.scoped_search(
+            ScopedSearchIdleCheckerAssignmentsInput(
+                scope=IdleCheckerAssignmentScopeDTO(
+                    items=[
+                        IdleCheckerScopeRefDTO(
+                            scope_type=IdleCheckerScopeTypeDTO.PROJECT,
+                            scope_id=str(assignment_seed.project_id),
+                        ),
+                    ]
+                )
+            )
+        )
+
+        assert [item.id for item in result.items] == [assignment_seed.project_assignment_id]
+
+    async def test_project_admin_denied_on_unauthorized_scope(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        assignment_seed: AssignmentSeedData,
+        project_read_permission: None,
+    ) -> None:
+        """One denied scope item fails the whole request, even with a permitted one."""
+        with pytest.raises(PermissionDeniedError):
+            await user_v2_registry.idle_checker_assignment.scoped_search(
+                ScopedSearchIdleCheckerAssignmentsInput(
+                    scope=IdleCheckerAssignmentScopeDTO(
+                        items=[
+                            IdleCheckerScopeRefDTO(
+                                scope_type=IdleCheckerScopeTypeDTO.PROJECT,
+                                scope_id=str(assignment_seed.project_id),
+                            ),
+                            IdleCheckerScopeRefDTO(
+                                scope_type=IdleCheckerScopeTypeDTO.DOMAIN,
+                                scope_id=str(assignment_seed.domain_id),
+                            ),
+                        ]
+                    )
+                )
+            )
+
+    async def test_regular_user_denied(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        assignment_seed: AssignmentSeedData,
+    ) -> None:
+        """A user without any scope permission is denied."""
+        with pytest.raises(PermissionDeniedError):
+            await user_v2_registry.idle_checker_assignment.scoped_search(
+                ScopedSearchIdleCheckerAssignmentsInput(
+                    scope=IdleCheckerAssignmentScopeDTO(
+                        items=[
+                            IdleCheckerScopeRefDTO(
+                                scope_type=IdleCheckerScopeTypeDTO.DOMAIN,
+                                scope_id=str(assignment_seed.domain_id),
+                            ),
+                        ]
+                    )
+                )
+            )
+
+    async def test_project_admin_denied_on_other_project(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        assignment_seed: AssignmentSeedData,
+        project_read_permission: None,
+    ) -> None:
+        """PROJECT:READ on one project grants nothing on another project."""
+        with pytest.raises(PermissionDeniedError):
+            await user_v2_registry.idle_checker_assignment.scoped_search(
+                ScopedSearchIdleCheckerAssignmentsInput(
+                    scope=IdleCheckerAssignmentScopeDTO(
+                        items=[
+                            IdleCheckerScopeRefDTO(
+                                scope_type=IdleCheckerScopeTypeDTO.PROJECT,
+                                scope_id=str(assignment_seed.other_project_id),
+                            ),
+                        ]
+                    )
+                )
+            )
+
+
+class TestIdleCheckerAssignmentMutationPermissions:
+    """update/purge on super-admin-created assignments, per caller scope permission."""
+
+    async def test_project_admin_updates_assignment_in_own_project(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        assignment_seed: AssignmentSeedData,
+        project_assignment_manage_permission: None,
+    ) -> None:
+        """A user with UPDATE at the project scope can update that project's assignment."""
+        result = await user_v2_registry.idle_checker_assignment.update(
+            assignment_seed.project_assignment_id,
+            UpdateIdleCheckerAssignmentInput(
+                id=IdleCheckerAssignmentID(assignment_seed.project_assignment_id),
+                enabled=False,
+            ),
+        )
+
+        assert result.idle_checker_assignment.id == assignment_seed.project_assignment_id
+        assert result.idle_checker_assignment.enabled is False
+
+    async def test_project_admin_purges_assignment_in_own_project(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        assignment_seed: AssignmentSeedData,
+        project_assignment_manage_permission: None,
+    ) -> None:
+        """A user with PURGE at the project scope can purge that project's assignment."""
+        result = await user_v2_registry.idle_checker_assignment.purge(
+            assignment_seed.project_assignment_id
+        )
+
+        assert result.id == assignment_seed.project_assignment_id
+
+    async def test_project_admin_cannot_update_assignment_in_other_project(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        assignment_seed: AssignmentSeedData,
+        project_assignment_manage_permission: None,
+    ) -> None:
+        """Manage permission on one project does not reach another project's assignment."""
+        with pytest.raises(PermissionDeniedError):
+            await user_v2_registry.idle_checker_assignment.update(
+                assignment_seed.other_project_assignment_id,
+                UpdateIdleCheckerAssignmentInput(
+                    id=IdleCheckerAssignmentID(assignment_seed.other_project_assignment_id),
+                    enabled=False,
+                ),
+            )
+
+    async def test_superadmin_updates_any_assignment(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        assignment_seed: AssignmentSeedData,
+    ) -> None:
+        """Superadmin bypasses RBAC for update on any scope's assignment."""
+        result = await admin_v2_registry.idle_checker_assignment.update(
+            assignment_seed.domain_assignment_id,
+            UpdateIdleCheckerAssignmentInput(
+                id=IdleCheckerAssignmentID(assignment_seed.domain_assignment_id),
+                enabled=False,
+            ),
+        )
+
+        assert result.idle_checker_assignment.enabled is False

--- a/tests/component/idle_checker_assignment/test_scoped_search_permissions.py
+++ b/tests/component/idle_checker_assignment/test_scoped_search_permissions.py
@@ -37,11 +37,11 @@ class TestScopedIdleCheckerAssignmentSearchPermissions:
                     items=[
                         IdleCheckerScopeRefDTO(
                             scope_type=IdleCheckerScopeTypeDTO.DOMAIN,
-                            scope_id=str(assignment_seed.domain_id),
+                            scope_id=assignment_seed.domain_id,
                         ),
                         IdleCheckerScopeRefDTO(
                             scope_type=IdleCheckerScopeTypeDTO.PROJECT,
-                            scope_id=str(assignment_seed.project_id),
+                            scope_id=assignment_seed.project_id,
                         ),
                     ]
                 )
@@ -66,7 +66,7 @@ class TestScopedIdleCheckerAssignmentSearchPermissions:
                     items=[
                         IdleCheckerScopeRefDTO(
                             scope_type=IdleCheckerScopeTypeDTO.PROJECT,
-                            scope_id=str(assignment_seed.project_id),
+                            scope_id=assignment_seed.project_id,
                         ),
                     ]
                 )
@@ -89,11 +89,11 @@ class TestScopedIdleCheckerAssignmentSearchPermissions:
                         items=[
                             IdleCheckerScopeRefDTO(
                                 scope_type=IdleCheckerScopeTypeDTO.PROJECT,
-                                scope_id=str(assignment_seed.project_id),
+                                scope_id=assignment_seed.project_id,
                             ),
                             IdleCheckerScopeRefDTO(
                                 scope_type=IdleCheckerScopeTypeDTO.DOMAIN,
-                                scope_id=str(assignment_seed.domain_id),
+                                scope_id=assignment_seed.domain_id,
                             ),
                         ]
                     )
@@ -113,7 +113,7 @@ class TestScopedIdleCheckerAssignmentSearchPermissions:
                         items=[
                             IdleCheckerScopeRefDTO(
                                 scope_type=IdleCheckerScopeTypeDTO.DOMAIN,
-                                scope_id=str(assignment_seed.domain_id),
+                                scope_id=assignment_seed.domain_id,
                             ),
                         ]
                     )
@@ -134,7 +134,7 @@ class TestScopedIdleCheckerAssignmentSearchPermissions:
                         items=[
                             IdleCheckerScopeRefDTO(
                                 scope_type=IdleCheckerScopeTypeDTO.PROJECT,
-                                scope_id=str(assignment_seed.other_project_id),
+                                scope_id=assignment_seed.other_project_id,
                             ),
                         ]
                     )


### PR DESCRIPTION
## Summary
- **Stacked PR 3/3** for idle checker assignments (base: #13214 service/API, bottom: #13212 repository)
- v2 SDK client (`V2IdleCheckerAssignmentClient`) and `./bai` CLI commands (`admin idle-checker-assignment create/search`, `idle-checker-assignment scoped-search/update/purge`), plus the bai-cli entity reference
- Component test suite (real server + real RBAC validators): superadmin bypass, project-scoped read isolation (own vs other project), project-admin update/purge of super-admin-created assignments in own project only, regular-user denial

## Test plan
- [x] Component tests (9 scenarios) pass against a real aiohttp server and Postgres
- [x] Live verification via `./bai` and gateway GQL against the local dev stack (admin create/search/filter, scoped search, update, purge, error contracts)
- [x] `pants fmt/fix/lint/check/test` pass on changed files
- [ ] CI green

Resolves BA-7057

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13209.org.readthedocs.build/en/13209/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13209.org.readthedocs.build/ko/13209/

<!-- readthedocs-preview sorna-ko end -->