### PR TITLE
fix(BA-7009): answer a by-names fragment read position by position

### DIFF
--- a/changes/13211.fix.md
+++ b/changes/13211.fix.md
@@ -1,0 +1,1 @@
+Answer the app config fragment by-names GraphQL queries position by position, holding a name with no fragment at the scope as a null instead of dropping it.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -15368,14 +15368,14 @@ type Query
   scopedIdleCheckerBindings(scope: IdleCheckerBindingScope!, filter: IdleCheckerBindingFilter = null, orderBy: [IdleCheckerBindingOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): IdleCheckerBindingConnection! @join__field(graph: STRAWBERRY)
 
   """
-  Added in 26.8.0. Read the fragments written at one scope for the given config names — the current values, to inspect before editing them. Answered in the order the names were given, leaving out a name with no fragment there. RBAC-authorized at that scope.
+  Added in 26.8.0. Read the fragments written at one scope for the given config names — the current values, to inspect before editing them. Answered position by position, null where the scope holds no fragment for that name. RBAC-authorized at that scope.
   """
-  scopedAppConfigFragmentsByNames(scope: AppConfigScopeRef!, configNames: [String!]!): [AppConfigFragment!]! @join__field(graph: STRAWBERRY)
+  scopedAppConfigFragmentsByNames(scope: AppConfigScopeRef!, configNames: [String!]!): [AppConfigFragment]! @join__field(graph: STRAWBERRY)
 
   """
-  Added in 26.8.0. Read the current user's own user-scope fragments for the given config names, in the order the names were given, leaving out a name with no fragment there.
+  Added in 26.8.0. Read the current user's own user-scope fragments for the given config names, position by position, null where the scope holds no fragment for that name.
   """
-  myAppConfigFragmentsByNames(configNames: [String!]!): [AppConfigFragment!]! @join__field(graph: STRAWBERRY)
+  myAppConfigFragmentsByNames(configNames: [String!]!): [AppConfigFragment]! @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Retrieve a specific artifact by its ID. Returns detailed information about the artifact including its metadata, registry information, and availability status.

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -10309,14 +10309,14 @@ type Query {
   scopedIdleCheckerBindings(scope: IdleCheckerBindingScope!, filter: IdleCheckerBindingFilter = null, orderBy: [IdleCheckerBindingOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): IdleCheckerBindingConnection!
 
   """
-  Added in 26.8.0. Read the fragments written at one scope for the given config names — the current values, to inspect before editing them. Answered in the order the names were given, leaving out a name with no fragment there. RBAC-authorized at that scope.
+  Added in 26.8.0. Read the fragments written at one scope for the given config names — the current values, to inspect before editing them. Answered position by position, null where the scope holds no fragment for that name. RBAC-authorized at that scope.
   """
-  scopedAppConfigFragmentsByNames(scope: AppConfigScopeRef!, configNames: [String!]!): [AppConfigFragment!]!
+  scopedAppConfigFragmentsByNames(scope: AppConfigScopeRef!, configNames: [String!]!): [AppConfigFragment]!
 
   """
-  Added in 26.8.0. Read the current user's own user-scope fragments for the given config names, in the order the names were given, leaving out a name with no fragment there.
+  Added in 26.8.0. Read the current user's own user-scope fragments for the given config names, position by position, null where the scope holds no fragment for that name.
   """
-  myAppConfigFragmentsByNames(configNames: [String!]!): [AppConfigFragment!]!
+  myAppConfigFragmentsByNames(configNames: [String!]!): [AppConfigFragment]!
 
   """
   Added in 25.14.0. Retrieve a specific artifact by its ID. Returns detailed information about the artifact including its metadata, registry information, and availability status.

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/request.py
@@ -66,8 +66,8 @@ class ScopedAppConfigFragmentsByNamesInput(BaseRequestModel):
     config_names: list[str] = Field(
         min_length=1,
         description=(
-            "Config names whose fragments to read. Answered in this order, a repeated name "
-            "repeated in the answer; a name with no fragment at the scope is left out."
+            "Config names whose fragments to read. Answered position by position, null "
+            "where the scope holds no fragment for that name."
         ),
     )
 
@@ -78,8 +78,8 @@ class MyAppConfigFragmentsByNamesInput(BaseRequestModel):
     config_names: list[str] = Field(
         min_length=1,
         description=(
-            "Config names whose fragments to read. Answered in this order, a repeated name "
-            "repeated in the answer; a name with no fragment at the scope is left out."
+            "Config names whose fragments to read. Answered position by position, null "
+            "where the scope holds no fragment for that name."
         ),
     )
 

--- a/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
@@ -279,7 +279,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
 
     async def scoped_app_config_fragments_by_names(
         self, input: ScopedAppConfigFragmentsByNamesInput
-    ) -> list[AppConfigFragmentNode]:
+    ) -> list[AppConfigFragmentNode | None]:
         """The fragments written at one scope for the given config names.
 
         RBAC-authorized at that scope, so a caller reads only a scope they may read. Meant for
@@ -294,7 +294,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
 
     async def my_app_config_fragments_by_names(
         self, input: MyAppConfigFragmentsByNamesInput
-    ) -> list[AppConfigFragmentNode]:
+    ) -> list[AppConfigFragmentNode | None]:
         """The current user's own ``user``-scope fragments for the given ``config_names``.
 
         Calls ``current_user()`` internally — the caller does not pass a scope.
@@ -311,7 +311,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
 
     async def _fragments_by_names(
         self, scope: AppConfigFragmentSearchScope, config_names: list[str]
-    ) -> list[AppConfigFragmentNode]:
+    ) -> list[AppConfigFragmentNode | None]:
         if not config_names:
             return []
         # A scope holds at most one fragment per config name, so the result is bounded by the
@@ -325,13 +325,14 @@ class AppConfigFragmentAdapter(BaseAdapter):
         action_result = await self._processors.app_config_fragment.scoped_search.wait_for_complete(
             ScopedSearchAppConfigFragmentAction(scope=scope, querier=querier)
         )
-        # Answer in the order the names were asked for; a name with no fragment at this scope
-        # is left out rather than held as a gap.
+        # Answer at the position each name was asked for, so a name with no fragment at this
+        # scope holds its place as a null.
         fragment_map = {fragment.config_name: fragment for fragment in action_result.data}
         return [
             self._fragment_to_node(fragment_map[config_name])
-            for config_name in config_names
             if config_name in fragment_map
+            else None
+            for config_name in config_names
         ]
 
     # --- admin fragment search ---

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver.py
@@ -145,8 +145,8 @@ async def my_upsert_app_config_fragments(
         added_version=NEXT_RELEASE_VERSION,
         description=(
             "Read the fragments written at one scope for the given config names — the current "
-            "values, to inspect before editing them. Answered in the order the names were "
-            "given, leaving out a name with no fragment there. RBAC-authorized at that scope."
+            "values, to inspect before editing them. Answered position by position, null "
+            "where the scope holds no fragment for that name. RBAC-authorized at that scope."
         ),
     )
 )  # type: ignore[misc]
@@ -154,27 +154,31 @@ async def scoped_app_config_fragments_by_names(
     info: Info[StrawberryGQLContext],
     scope: AppConfigScopeRefGQL,
     config_names: list[str],
-) -> list[AppConfigFragmentGQL]:
+) -> list[AppConfigFragmentGQL | None]:
     nodes = await info.context.adapters.app_config_fragment.scoped_app_config_fragments_by_names(
         ScopedAppConfigFragmentsByNamesInput(scope=scope.to_pydantic(), config_names=config_names)
     )
-    return [AppConfigFragmentGQL.from_pydantic(node) for node in nodes]
+    return [
+        AppConfigFragmentGQL.from_pydantic(node) if node is not None else None for node in nodes
+    ]
 
 
 @gql_root_field(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
         description=(
-            "Read the current user's own user-scope fragments for the given config names, in "
-            "the order the names were given, leaving out a name with no fragment there."
+            "Read the current user's own user-scope fragments for the given config names, "
+            "position by position, null where the scope holds no fragment for that name."
         ),
     )
 )  # type: ignore[misc]
 async def my_app_config_fragments_by_names(
     info: Info[StrawberryGQLContext],
     config_names: list[str],
-) -> list[AppConfigFragmentGQL]:
+) -> list[AppConfigFragmentGQL | None]:
     nodes = await info.context.adapters.app_config_fragment.my_app_config_fragments_by_names(
         MyAppConfigFragmentsByNamesInput(config_names=config_names)
     )
-    return [AppConfigFragmentGQL.from_pydantic(node) for node in nodes]
+    return [
+        AppConfigFragmentGQL.from_pydantic(node) if node is not None else None for node in nodes
+    ]


### PR DESCRIPTION
Resolves BA-7009

## Summary

`scopedAppConfigFragmentsByNames` / `myAppConfigFragmentsByNames` (merged in #13110) dropped a requested name from the answer when the scope held no fragment for it, so a caller could not tell which of its names came back empty and could not read the answer by position.

Each name now holds its place:

| Requested | At the scope | Answer |
|---|---|---|
| `["theme", "menu"]` | `theme` only | `[theme, null]` |
| `["theme", "theme"]` | `theme` | `[theme, theme]` |
| `["a", "b"]` | neither | `[null, null]` |

- Schema: `[AppConfigFragment!]!` → `[AppConfigFragment]!` (the list stays non-null; its items may be null).
- The adapter answers `list[AppConfigFragmentNode | None]`, mapping each requested name through the fragments found.
- A scope with no fragment for a name is the normal state before the first write, so it stays a null rather than a not-found.

## Note for review

`api/gql/AGENTS.md` says nullable list items are the Relay node loader's shape (`resolve_nodes`). This query is the other case the rule did not anticipate — a positional batch read where absence is expected and the caller needs to match answers to its own request. Happy to write the exception into that document if you agree with the shape.

## Test plan
- [ ] Read two names where only one has a fragment at the scope — the missing one answers null in place.
- [ ] Read a name twice — it answers twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13211.org.readthedocs.build/en/13211/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13211.org.readthedocs.build/ko/13211/

<!-- readthedocs-preview sorna-ko end -->