### PR TITLE
feat(BA-7064): add the app config fragment SDK v2

### DIFF
--- a/changes/13223.feature.md
+++ b/changes/13223.feature.md
@@ -1,0 +1,1 @@
+Add the app config fragment client SDK v2: read fragments by config name and bulk-upsert them at a scope or at the caller's own user scope, get, purge, bulk-purge, and the system-wide admin search.

--- a/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
+++ b/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
@@ -35,7 +35,7 @@ class V2AppConfigFragmentClient(BaseDomainClient):
     call is RBAC-gated at the scope it acts on.
     """
 
-    async def scoped_by_names(
+    async def scoped_get_app_config_fragments_by_names(
         self,
         request: ScopedAppConfigFragmentsByNamesInput,
     ) -> AppConfigFragmentsByNamesResponse:
@@ -51,7 +51,7 @@ class V2AppConfigFragmentClient(BaseDomainClient):
             response_model=AppConfigFragmentsByNamesResponse,
         )
 
-    async def scoped_bulk_upsert(
+    async def scoped_bulk_upsert_app_config_fragments(
         self,
         request: ScopedUpsertAppConfigFragmentsInput,
     ) -> UpsertAppConfigFragmentsPayload:
@@ -63,7 +63,7 @@ class V2AppConfigFragmentClient(BaseDomainClient):
             response_model=UpsertAppConfigFragmentsPayload,
         )
 
-    async def my_by_names(
+    async def my_get_app_config_fragments_by_names(
         self,
         request: MyAppConfigFragmentsByNamesInput,
     ) -> AppConfigFragmentsByNamesResponse:
@@ -75,7 +75,7 @@ class V2AppConfigFragmentClient(BaseDomainClient):
             response_model=AppConfigFragmentsByNamesResponse,
         )
 
-    async def my_bulk_upsert(
+    async def my_bulk_upsert_app_config_fragments(
         self,
         request: MyUpsertAppConfigFragmentsInput,
     ) -> UpsertAppConfigFragmentsPayload:

--- a/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
+++ b/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
@@ -1,0 +1,128 @@
+"""V2 SDK client for the app config fragment domain."""
+
+from __future__ import annotations
+
+from typing import Final
+from uuid import UUID
+
+from ai.backend.client.v2.base_domain import BaseDomainClient
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AdminSearchAppConfigFragmentInput,
+    BulkPurgeAppConfigFragmentInput,
+    MyAppConfigFragmentsByNamesInput,
+    MyUpsertAppConfigFragmentsInput,
+    ScopedAppConfigFragmentsByNamesInput,
+    ScopedUpsertAppConfigFragmentsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AppConfigFragmentNode,
+    AppConfigFragmentsByNamesResponse,
+    BulkPurgeAppConfigFragmentPayload,
+    PurgeAppConfigFragmentPayload,
+    SearchAppConfigFragmentPayload,
+    UpsertAppConfigFragmentsPayload,
+)
+
+_PATH: Final = "/v2/app-config-fragments"
+
+
+class V2AppConfigFragmentClient(BaseDomainClient):
+    """SDK client for app config fragment operations.
+
+    A fragment is addressed by ``(scope, config_name)``, so the write is an upsert and the
+    read takes config names: ``scoped_*`` names the scope in the request, ``my_*`` acts at
+    the caller's own user scope. Only the system-wide search is superadmin-only; every other
+    call is RBAC-gated at the scope it acts on.
+    """
+
+    async def scoped_by_names(
+        self,
+        request: ScopedAppConfigFragmentsByNamesInput,
+    ) -> AppConfigFragmentsByNamesResponse:
+        """Read one scope's fragments for the given config names.
+
+        The answer holds one entry per requested name, in the order they were given, and
+        ``None`` where the scope has no fragment for that name.
+        """
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/scoped/by-names",
+            request=request,
+            response_model=AppConfigFragmentsByNamesResponse,
+        )
+
+    async def scoped_bulk_upsert(
+        self,
+        request: ScopedUpsertAppConfigFragmentsInput,
+    ) -> UpsertAppConfigFragmentsPayload:
+        """Upsert many fragments at one scope, all-or-nothing."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/scoped/bulk-upsert",
+            request=request,
+            response_model=UpsertAppConfigFragmentsPayload,
+        )
+
+    async def my_by_names(
+        self,
+        request: MyAppConfigFragmentsByNamesInput,
+    ) -> AppConfigFragmentsByNamesResponse:
+        """Read the caller's own user-scope fragments for the given config names."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/my/by-names",
+            request=request,
+            response_model=AppConfigFragmentsByNamesResponse,
+        )
+
+    async def my_bulk_upsert(
+        self,
+        request: MyUpsertAppConfigFragmentsInput,
+    ) -> UpsertAppConfigFragmentsPayload:
+        """Upsert many fragments at the caller's own user scope, all-or-nothing."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/my/bulk-upsert",
+            request=request,
+            response_model=UpsertAppConfigFragmentsPayload,
+        )
+
+    async def get(self, app_config_fragment_id: UUID) -> AppConfigFragmentNode:
+        """Get a single fragment by id."""
+        return await self._client.typed_request(
+            "GET",
+            f"{_PATH}/{app_config_fragment_id}",
+            response_model=AppConfigFragmentNode,
+        )
+
+    async def purge(self, app_config_fragment_id: UUID) -> PurgeAppConfigFragmentPayload:
+        """Purge a single fragment by id."""
+        return await self._client.typed_request(
+            "DELETE",
+            f"{_PATH}/{app_config_fragment_id}",
+            response_model=PurgeAppConfigFragmentPayload,
+        )
+
+    async def bulk_purge(
+        self,
+        request: BulkPurgeAppConfigFragmentInput,
+    ) -> BulkPurgeAppConfigFragmentPayload:
+        """Purge many fragments by id, reporting per-item success and failure."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/bulk-delete",
+            request=request,
+            response_model=BulkPurgeAppConfigFragmentPayload,
+        )
+
+    async def admin_search(
+        self,
+        request: AdminSearchAppConfigFragmentInput,
+    ) -> SearchAppConfigFragmentPayload:
+        """Search fragments across every scope with filter/order/pagination (superadmin only)."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/admin/search",
+            request=request,
+            response_model=SearchAppConfigFragmentPayload,
+        )

--- a/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
+++ b/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
@@ -15,7 +15,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
 )
 from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
     AppConfigFragmentNode,
-    AppConfigFragmentsByNamesResponse,
+    AppConfigFragmentsByNamesPayload,
     BulkPurgeAppConfigFragmentPayload,
     PurgeAppConfigFragmentPayload,
     SearchAppConfigFragmentPayload,
@@ -38,7 +38,7 @@ class V2AppConfigFragmentClient(BaseDomainClient):
     async def scoped_get_app_config_fragments_by_names(
         self,
         request: ScopedAppConfigFragmentsByNamesInput,
-    ) -> AppConfigFragmentsByNamesResponse:
+    ) -> AppConfigFragmentsByNamesPayload:
         """Read one scope's fragments for the given config names.
 
         The answer holds one entry per requested name, in the order they were given, and
@@ -48,7 +48,7 @@ class V2AppConfigFragmentClient(BaseDomainClient):
             "POST",
             f"{_PATH}/scoped/by-names",
             request=request,
-            response_model=AppConfigFragmentsByNamesResponse,
+            response_model=AppConfigFragmentsByNamesPayload,
         )
 
     async def scoped_bulk_upsert_app_config_fragments(
@@ -66,13 +66,13 @@ class V2AppConfigFragmentClient(BaseDomainClient):
     async def my_get_app_config_fragments_by_names(
         self,
         request: MyAppConfigFragmentsByNamesInput,
-    ) -> AppConfigFragmentsByNamesResponse:
+    ) -> AppConfigFragmentsByNamesPayload:
         """Read the caller's own user-scope fragments for the given config names."""
         return await self._client.typed_request(
             "POST",
             f"{_PATH}/my/by-names",
             request=request,
-            response_model=AppConfigFragmentsByNamesResponse,
+            response_model=AppConfigFragmentsByNamesPayload,
         )
 
     async def my_bulk_upsert_app_config_fragments(

--- a/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
+++ b/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
@@ -35,7 +35,7 @@ class V2AppConfigFragmentClient(BaseDomainClient):
     call is RBAC-gated at the scope it acts on.
     """
 
-    # ------------------------------------------------------------------ Scoped
+    # --- Scoped ---
 
     async def scoped_get_app_config_fragments_by_names(
         self,
@@ -65,7 +65,7 @@ class V2AppConfigFragmentClient(BaseDomainClient):
             response_model=UpsertAppConfigFragmentsPayload,
         )
 
-    # ------------------------------------------------------------------ Self-service
+    # --- Self-service ---
 
     async def my_get_app_config_fragments_by_names(
         self,
@@ -91,7 +91,7 @@ class V2AppConfigFragmentClient(BaseDomainClient):
             response_model=UpsertAppConfigFragmentsPayload,
         )
 
-    # ------------------------------------------------------------------ By id
+    # --- By id ---
 
     async def get(self, app_config_fragment_id: AppConfigFragmentID) -> AppConfigFragmentNode:
         """Get a single fragment by id."""
@@ -123,7 +123,7 @@ class V2AppConfigFragmentClient(BaseDomainClient):
             response_model=BulkPurgeAppConfigFragmentPayload,
         )
 
-    # ------------------------------------------------------------------ Admin
+    # --- Admin ---
 
     async def admin_search(
         self,

--- a/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
+++ b/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
@@ -35,6 +35,8 @@ class V2AppConfigFragmentClient(BaseDomainClient):
     call is RBAC-gated at the scope it acts on.
     """
 
+    # ------------------------------------------------------------------ Scoped
+
     async def scoped_get_app_config_fragments_by_names(
         self,
         request: ScopedAppConfigFragmentsByNamesInput,
@@ -63,6 +65,8 @@ class V2AppConfigFragmentClient(BaseDomainClient):
             response_model=UpsertAppConfigFragmentsPayload,
         )
 
+    # ------------------------------------------------------------------ Self-service
+
     async def my_get_app_config_fragments_by_names(
         self,
         request: MyAppConfigFragmentsByNamesInput,
@@ -86,6 +90,8 @@ class V2AppConfigFragmentClient(BaseDomainClient):
             request=request,
             response_model=UpsertAppConfigFragmentsPayload,
         )
+
+    # ------------------------------------------------------------------ By id
 
     async def get(self, app_config_fragment_id: AppConfigFragmentID) -> AppConfigFragmentNode:
         """Get a single fragment by id."""
@@ -116,6 +122,8 @@ class V2AppConfigFragmentClient(BaseDomainClient):
             request=request,
             response_model=BulkPurgeAppConfigFragmentPayload,
         )
+
+    # ------------------------------------------------------------------ Admin
 
     async def admin_search(
         self,

--- a/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
+++ b/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from typing import Final
-from uuid import UUID
 
 from ai.backend.client.v2.base_domain import BaseDomainClient
 from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
@@ -22,6 +21,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
     SearchAppConfigFragmentPayload,
     UpsertAppConfigFragmentsPayload,
 )
+from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
 
 _PATH: Final = "/v2/app-config-fragments"
 
@@ -87,7 +87,7 @@ class V2AppConfigFragmentClient(BaseDomainClient):
             response_model=UpsertAppConfigFragmentsPayload,
         )
 
-    async def get(self, app_config_fragment_id: UUID) -> AppConfigFragmentNode:
+    async def get(self, app_config_fragment_id: AppConfigFragmentID) -> AppConfigFragmentNode:
         """Get a single fragment by id."""
         return await self._client.typed_request(
             "GET",
@@ -95,7 +95,9 @@ class V2AppConfigFragmentClient(BaseDomainClient):
             response_model=AppConfigFragmentNode,
         )
 
-    async def purge(self, app_config_fragment_id: UUID) -> PurgeAppConfigFragmentPayload:
+    async def purge(
+        self, app_config_fragment_id: AppConfigFragmentID
+    ) -> PurgeAppConfigFragmentPayload:
         """Purge a single fragment by id."""
         return await self._client.typed_request(
             "DELETE",

--- a/src/ai/backend/client/v2/v2_registry.py
+++ b/src/ai/backend/client/v2/v2_registry.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from .domains_v2.agent import V2AgentClient
     from .domains_v2.app_config_allow_list import V2AppConfigAllowListClient
     from .domains_v2.app_config_definition import V2AppConfigDefinitionClient
+    from .domains_v2.app_config_fragment import V2AppConfigFragmentClient
     from .domains_v2.artifact import V2ArtifactClient
     from .domains_v2.artifact_registry import V2ArtifactRegistryClient
     from .domains_v2.audit_log import V2AuditLogClient
@@ -104,6 +105,12 @@ class V2ClientRegistry:
         from .domains_v2.app_config_definition import V2AppConfigDefinitionClient
 
         return V2AppConfigDefinitionClient(self._client)
+
+    @cached_property
+    def app_config_fragment(self) -> V2AppConfigFragmentClient:
+        from .domains_v2.app_config_fragment import V2AppConfigFragmentClient
+
+        return V2AppConfigFragmentClient(self._client)
 
     @cached_property
     def artifact(self) -> V2ArtifactClient:

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from pydantic import Field
 
-from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.api_handlers import BaseResponseModel, BaseRootResponseModel
 from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.identifier.app_config import AppConfigScopeID
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
@@ -15,6 +15,7 @@ from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
 __all__ = (
     "AppConfigFragmentBulkErrorInfo",
     "AppConfigFragmentNode",
+    "AppConfigFragmentsByNamesResponse",
     "BulkPurgeAppConfigFragmentPayload",
     "PurgeAppConfigFragmentPayload",
     "SearchAppConfigFragmentPayload",
@@ -34,6 +35,10 @@ class AppConfigFragmentNode(BaseResponseModel):
     config: dict[str, Any] = Field(description="The fragment's JSON config document.")
     created_at: datetime = Field(description="Creation timestamp (UTC).")
     updated_at: datetime = Field(description="Last update timestamp (UTC).")
+
+
+class AppConfigFragmentsByNamesResponse(BaseRootResponseModel[list[AppConfigFragmentNode | None]]):
+    """One entry per requested config name, null where the scope holds no fragment for it."""
 
 
 class UpsertAppConfigFragmentsPayload(BaseResponseModel):

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
@@ -15,7 +15,7 @@ from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
 __all__ = (
     "AppConfigFragmentBulkErrorInfo",
     "AppConfigFragmentNode",
-    "AppConfigFragmentsByNamesResponse",
+    "AppConfigFragmentsByNamesPayload",
     "BulkPurgeAppConfigFragmentPayload",
     "PurgeAppConfigFragmentPayload",
     "SearchAppConfigFragmentPayload",
@@ -37,7 +37,7 @@ class AppConfigFragmentNode(BaseResponseModel):
     updated_at: datetime = Field(description="Last update timestamp (UTC).")
 
 
-class AppConfigFragmentsByNamesResponse(BaseRootResponseModel[list[AppConfigFragmentNode | None]]):
+class AppConfigFragmentsByNamesPayload(BaseRootResponseModel[list[AppConfigFragmentNode | None]]):
     """One entry per requested config name, null where the scope holds no fragment for it."""
 
 

--- a/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
@@ -6,12 +6,7 @@ import logging
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Final
 
-from ai.backend.common.api_handlers import (
-    APIResponse,
-    BaseRootResponseModel,
-    BodyParam,
-    PathParam,
-)
+from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam
 from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AdminSearchAppConfigFragmentInput,
     BulkPurgeAppConfigFragmentInput,
@@ -20,7 +15,9 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     ScopedAppConfigFragmentsByNamesInput,
     ScopedUpsertAppConfigFragmentsInput,
 )
-from ai.backend.common.dto.manager.v2.app_config_fragment.response import AppConfigFragmentNode
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AppConfigFragmentsByNamesResponse,
+)
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.api.rest.v2.path_params import AppConfigFragmentIdPathParam
@@ -31,10 +28,6 @@ if TYPE_CHECKING:
     )
 
 log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
-
-
-class AppConfigFragmentsByNamesResponse(BaseRootResponseModel[list[AppConfigFragmentNode | None]]):
-    """One entry per requested config name, null where the scope holds no fragment for it."""
 
 
 class V2AppConfigFragmentHandler:

--- a/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
@@ -16,7 +16,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     ScopedUpsertAppConfigFragmentsInput,
 )
 from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
-    AppConfigFragmentsByNamesResponse,
+    AppConfigFragmentsByNamesPayload,
 )
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
 from ai.backend.logging import BraceStyleAdapter
@@ -77,7 +77,7 @@ class V2AppConfigFragmentHandler:
         """Read one scope's fragments for the given config names (auth, RBAC-authorized)."""
         nodes = await self._adapter.scoped_app_config_fragments_by_names(body.parsed)
         return APIResponse.build(
-            status_code=HTTPStatus.OK, response_model=AppConfigFragmentsByNamesResponse(nodes)
+            status_code=HTTPStatus.OK, response_model=AppConfigFragmentsByNamesPayload(nodes)
         )
 
     async def my_fragments_by_names(
@@ -87,7 +87,7 @@ class V2AppConfigFragmentHandler:
         """Read the caller's own user-scope fragments for the given config names (auth)."""
         nodes = await self._adapter.my_app_config_fragments_by_names(body.parsed)
         return APIResponse.build(
-            status_code=HTTPStatus.OK, response_model=AppConfigFragmentsByNamesResponse(nodes)
+            status_code=HTTPStatus.OK, response_model=AppConfigFragmentsByNamesPayload(nodes)
         )
 
     async def scoped_bulk_upsert(

--- a/tests/unit/client_v2/test_app_config_fragment.py
+++ b/tests/unit/client_v2/test_app_config_fragment.py
@@ -93,7 +93,7 @@ class TestScopedByNames:
             return_value=[node_payload, None],
         )
 
-        result = await client.scoped_by_names(
+        result = await client.scoped_get_app_config_fragments_by_names(
             ScopedAppConfigFragmentsByNamesInput(
                 scope=AppConfigScopeRef(
                     scope_type=AppConfigScopeType.USER,
@@ -125,7 +125,7 @@ class TestScopedBulkUpsert:
             return_value={"items": [node_payload]},
         )
 
-        result = await client.scoped_bulk_upsert(
+        result = await client.scoped_bulk_upsert_app_config_fragments(
             ScopedUpsertAppConfigFragmentsInput(
                 scope=AppConfigScopeRef(
                     scope_type=AppConfigScopeType.USER,
@@ -152,7 +152,9 @@ class TestMyByNames:
     ) -> None:
         mock_response.json = AsyncMock(return_value=[node_payload])
 
-        result = await client.my_by_names(MyAppConfigFragmentsByNamesInput(config_names=["theme"]))
+        result = await client.my_get_app_config_fragments_by_names(
+            MyAppConfigFragmentsByNamesInput(config_names=["theme"])
+        )
 
         call_args = mock_session.request.call_args
         assert call_args[0][0] == "POST"
@@ -173,7 +175,7 @@ class TestMyBulkUpsert:
             return_value={"items": [node_payload]},
         )
 
-        result = await client.my_bulk_upsert(
+        result = await client.my_bulk_upsert_app_config_fragments(
             MyUpsertAppConfigFragmentsInput(
                 items=[AppConfigFragmentUpsertItem(config_name="theme", config={"mode": "dark"})]
             )

--- a/tests/unit/client_v2/test_app_config_fragment.py
+++ b/tests/unit/client_v2/test_app_config_fragment.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from yarl import URL
+
+from ai.backend.client.v2.base_client import BackendAIAuthClient
+from ai.backend.client.v2.config import ClientConfig
+from ai.backend.client.v2.domains_v2.app_config_fragment import V2AppConfigFragmentClient
+from ai.backend.common.data.app_config.types import AppConfigScopeType
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AdminSearchAppConfigFragmentInput,
+    AppConfigFragmentUpsertItem,
+    AppConfigScopeRef,
+    BulkPurgeAppConfigFragmentInput,
+    MyAppConfigFragmentsByNamesInput,
+    MyUpsertAppConfigFragmentsInput,
+    ScopedAppConfigFragmentsByNamesInput,
+    ScopedUpsertAppConfigFragmentsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AppConfigFragmentNode,
+    AppConfigFragmentsByNamesResponse,
+    BulkPurgeAppConfigFragmentPayload,
+    PurgeAppConfigFragmentPayload,
+    SearchAppConfigFragmentPayload,
+    UpsertAppConfigFragmentsPayload,
+)
+from ai.backend.common.identifier.app_config import AppConfigScopeID
+from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+
+from .conftest import MockAuth
+
+_DEFAULT_CONFIG = ClientConfig(endpoint=URL("https://api.example.com"))
+_USER_SCOPE_ID = uuid4()
+
+
+@pytest.fixture
+def fragment_id() -> UUID:
+    return uuid4()
+
+
+@pytest.fixture
+def node_payload(fragment_id: UUID) -> dict[str, Any]:
+    """One fragment as the server sends it, for a ``theme`` fragment at a user scope."""
+    return {
+        "id": str(fragment_id),
+        "config_name": "theme",
+        "scope_type": "user",
+        "scope_id": str(_USER_SCOPE_ID),
+        "config": {"mode": "dark"},
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-02T00:00:00+00:00",
+    }
+
+
+@pytest.fixture
+def mock_response() -> AsyncMock:
+    """The HTTP response the mocked session hands back; each test sets its ``json``."""
+    response = AsyncMock()
+    response.status = 200
+    return response
+
+
+@pytest.fixture
+def mock_session(mock_response: AsyncMock) -> MagicMock:
+    request_ctx = AsyncMock()
+    request_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+    request_ctx.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.request = MagicMock(return_value=request_ctx)
+    return session
+
+
+@pytest.fixture
+def client(mock_session: MagicMock) -> V2AppConfigFragmentClient:
+    return V2AppConfigFragmentClient(BackendAIAuthClient(_DEFAULT_CONFIG, MockAuth(), mock_session))
+
+
+class TestScopedByNames:
+    async def test_answers_one_entry_per_requested_name(
+        self,
+        client: V2AppConfigFragmentClient,
+        mock_session: MagicMock,
+        mock_response: AsyncMock,
+        node_payload: dict[str, Any],
+    ) -> None:
+        """A name with no fragment at the scope holds its place as a null."""
+        mock_response.json = AsyncMock(
+            return_value=[node_payload, None],
+        )
+
+        result = await client.scoped_by_names(
+            ScopedAppConfigFragmentsByNamesInput(
+                scope=AppConfigScopeRef(
+                    scope_type=AppConfigScopeType.USER,
+                    scope_id=AppConfigScopeID(_USER_SCOPE_ID),
+                ),
+                config_names=["theme", "menu"],
+            )
+        )
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "POST"
+        assert str(call_args[0][1]).endswith("/v2/app-config-fragments/scoped/by-names")
+        assert isinstance(result, AppConfigFragmentsByNamesResponse)
+        assert [node.config_name if node is not None else None for node in result.root] == [
+            "theme",
+            None,
+        ]
+
+
+class TestScopedBulkUpsert:
+    async def test_happy_path(
+        self,
+        client: V2AppConfigFragmentClient,
+        mock_session: MagicMock,
+        mock_response: AsyncMock,
+        node_payload: dict[str, Any],
+    ) -> None:
+        mock_response.json = AsyncMock(
+            return_value={"items": [node_payload]},
+        )
+
+        result = await client.scoped_bulk_upsert(
+            ScopedUpsertAppConfigFragmentsInput(
+                scope=AppConfigScopeRef(
+                    scope_type=AppConfigScopeType.USER,
+                    scope_id=AppConfigScopeID(_USER_SCOPE_ID),
+                ),
+                items=[AppConfigFragmentUpsertItem(config_name="theme", config={"mode": "dark"})],
+            )
+        )
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "POST"
+        assert str(call_args[0][1]).endswith("/v2/app-config-fragments/scoped/bulk-upsert")
+        assert isinstance(result, UpsertAppConfigFragmentsPayload)
+        assert [item.config_name for item in result.items] == ["theme"]
+
+
+class TestMyByNames:
+    async def test_happy_path(
+        self,
+        client: V2AppConfigFragmentClient,
+        mock_session: MagicMock,
+        mock_response: AsyncMock,
+        node_payload: dict[str, Any],
+    ) -> None:
+        mock_response.json = AsyncMock(return_value=[node_payload])
+
+        result = await client.my_by_names(MyAppConfigFragmentsByNamesInput(config_names=["theme"]))
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "POST"
+        assert str(call_args[0][1]).endswith("/v2/app-config-fragments/my/by-names")
+        assert isinstance(result, AppConfigFragmentsByNamesResponse)
+        assert len(result.root) == 1
+
+
+class TestMyBulkUpsert:
+    async def test_happy_path(
+        self,
+        client: V2AppConfigFragmentClient,
+        mock_session: MagicMock,
+        mock_response: AsyncMock,
+        node_payload: dict[str, Any],
+    ) -> None:
+        mock_response.json = AsyncMock(
+            return_value={"items": [node_payload]},
+        )
+
+        result = await client.my_bulk_upsert(
+            MyUpsertAppConfigFragmentsInput(
+                items=[AppConfigFragmentUpsertItem(config_name="theme", config={"mode": "dark"})]
+            )
+        )
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "POST"
+        assert str(call_args[0][1]).endswith("/v2/app-config-fragments/my/bulk-upsert")
+        assert isinstance(result, UpsertAppConfigFragmentsPayload)
+
+
+class TestGet:
+    async def test_happy_path(
+        self,
+        client: V2AppConfigFragmentClient,
+        mock_session: MagicMock,
+        mock_response: AsyncMock,
+        node_payload: dict[str, Any],
+        fragment_id: UUID,
+    ) -> None:
+        mock_response.json = AsyncMock(return_value=node_payload)
+
+        result = await client.get(fragment_id)
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "GET"
+        assert str(call_args[0][1]).endswith(f"/v2/app-config-fragments/{fragment_id}")
+        assert isinstance(result, AppConfigFragmentNode)
+        assert result.config_name == "theme"
+
+
+class TestPurge:
+    async def test_happy_path(
+        self,
+        client: V2AppConfigFragmentClient,
+        mock_session: MagicMock,
+        mock_response: AsyncMock,
+        fragment_id: UUID,
+    ) -> None:
+        mock_response.json = AsyncMock(return_value={"id": str(fragment_id)})
+
+        result = await client.purge(fragment_id)
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "DELETE"
+        assert str(call_args[0][1]).endswith(f"/v2/app-config-fragments/{fragment_id}")
+        assert isinstance(result, PurgeAppConfigFragmentPayload)
+        assert result.id == AppConfigFragmentID(fragment_id)
+
+
+class TestBulkPurge:
+    async def test_reports_each_item(
+        self,
+        client: V2AppConfigFragmentClient,
+        mock_session: MagicMock,
+        mock_response: AsyncMock,
+        fragment_id: UUID,
+    ) -> None:
+        missing_id = uuid4()
+        mock_response.json = AsyncMock(
+            return_value={
+                "items": [str(fragment_id)],
+                "failed": [{"id": str(missing_id), "message": "not found"}],
+            },
+        )
+
+        result = await client.bulk_purge(
+            BulkPurgeAppConfigFragmentInput(
+                ids=[AppConfigFragmentID(fragment_id), AppConfigFragmentID(missing_id)]
+            )
+        )
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "POST"
+        assert str(call_args[0][1]).endswith("/v2/app-config-fragments/bulk-delete")
+        assert isinstance(result, BulkPurgeAppConfigFragmentPayload)
+        assert result.items == [AppConfigFragmentID(fragment_id)]
+        assert [item.id for item in result.failed] == [AppConfigFragmentID(missing_id)]
+
+
+class TestAdminSearch:
+    async def test_happy_path(
+        self,
+        client: V2AppConfigFragmentClient,
+        mock_session: MagicMock,
+        mock_response: AsyncMock,
+        node_payload: dict[str, Any],
+    ) -> None:
+        mock_response.json = AsyncMock(
+            return_value={
+                "items": [{**node_payload, "config_name": "menu"}],
+                "total_count": 1,
+                "has_next_page": False,
+                "has_previous_page": False,
+            },
+        )
+
+        result = await client.admin_search(AdminSearchAppConfigFragmentInput(limit=10))
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "POST"
+        assert str(call_args[0][1]).endswith("/v2/app-config-fragments/admin/search")
+        assert isinstance(result, SearchAppConfigFragmentPayload)
+        assert [item.config_name for item in result.items] == ["menu"]
+        assert result.total_count == 1

--- a/tests/unit/client_v2/test_app_config_fragment.py
+++ b/tests/unit/client_v2/test_app_config_fragment.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
 from yarl import URL
@@ -39,12 +39,12 @@ _USER_SCOPE_ID = uuid4()
 
 
 @pytest.fixture
-def fragment_id() -> UUID:
-    return uuid4()
+def fragment_id() -> AppConfigFragmentID:
+    return AppConfigFragmentID(uuid4())
 
 
 @pytest.fixture
-def node_payload(fragment_id: UUID) -> dict[str, Any]:
+def node_payload(fragment_id: AppConfigFragmentID) -> dict[str, Any]:
     """One fragment as the server sends it, for a ``theme`` fragment at a user scope."""
     return {
         "id": str(fragment_id),
@@ -194,7 +194,7 @@ class TestGet:
         mock_session: MagicMock,
         mock_response: AsyncMock,
         node_payload: dict[str, Any],
-        fragment_id: UUID,
+        fragment_id: AppConfigFragmentID,
     ) -> None:
         mock_response.json = AsyncMock(return_value=node_payload)
 
@@ -213,7 +213,7 @@ class TestPurge:
         client: V2AppConfigFragmentClient,
         mock_session: MagicMock,
         mock_response: AsyncMock,
-        fragment_id: UUID,
+        fragment_id: AppConfigFragmentID,
     ) -> None:
         mock_response.json = AsyncMock(return_value={"id": str(fragment_id)})
 
@@ -223,7 +223,7 @@ class TestPurge:
         assert call_args[0][0] == "DELETE"
         assert str(call_args[0][1]).endswith(f"/v2/app-config-fragments/{fragment_id}")
         assert isinstance(result, PurgeAppConfigFragmentPayload)
-        assert result.id == AppConfigFragmentID(fragment_id)
+        assert result.id == fragment_id
 
 
 class TestBulkPurge:
@@ -232,9 +232,9 @@ class TestBulkPurge:
         client: V2AppConfigFragmentClient,
         mock_session: MagicMock,
         mock_response: AsyncMock,
-        fragment_id: UUID,
+        fragment_id: AppConfigFragmentID,
     ) -> None:
-        missing_id = uuid4()
+        missing_id = AppConfigFragmentID(uuid4())
         mock_response.json = AsyncMock(
             return_value={
                 "items": [str(fragment_id)],
@@ -243,17 +243,15 @@ class TestBulkPurge:
         )
 
         result = await client.bulk_purge(
-            BulkPurgeAppConfigFragmentInput(
-                ids=[AppConfigFragmentID(fragment_id), AppConfigFragmentID(missing_id)]
-            )
+            BulkPurgeAppConfigFragmentInput(ids=[fragment_id, missing_id])
         )
 
         call_args = mock_session.request.call_args
         assert call_args[0][0] == "POST"
         assert str(call_args[0][1]).endswith("/v2/app-config-fragments/bulk-delete")
         assert isinstance(result, BulkPurgeAppConfigFragmentPayload)
-        assert result.items == [AppConfigFragmentID(fragment_id)]
-        assert [item.id for item in result.failed] == [AppConfigFragmentID(missing_id)]
+        assert result.items == [fragment_id]
+        assert [item.id for item in result.failed] == [missing_id]
 
 
 class TestAdminSearch:

--- a/tests/unit/client_v2/test_app_config_fragment.py
+++ b/tests/unit/client_v2/test_app_config_fragment.py
@@ -23,7 +23,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
 )
 from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
     AppConfigFragmentNode,
-    AppConfigFragmentsByNamesResponse,
+    AppConfigFragmentsByNamesPayload,
     BulkPurgeAppConfigFragmentPayload,
     PurgeAppConfigFragmentPayload,
     SearchAppConfigFragmentPayload,
@@ -106,7 +106,7 @@ class TestScopedByNames:
         call_args = mock_session.request.call_args
         assert call_args[0][0] == "POST"
         assert str(call_args[0][1]).endswith("/v2/app-config-fragments/scoped/by-names")
-        assert isinstance(result, AppConfigFragmentsByNamesResponse)
+        assert isinstance(result, AppConfigFragmentsByNamesPayload)
         assert [node.config_name if node is not None else None for node in result.root] == [
             "theme",
             None,
@@ -159,7 +159,7 @@ class TestMyByNames:
         call_args = mock_session.request.call_args
         assert call_args[0][0] == "POST"
         assert str(call_args[0][1]).endswith("/v2/app-config-fragments/my/by-names")
-        assert isinstance(result, AppConfigFragmentsByNamesResponse)
+        assert isinstance(result, AppConfigFragmentsByNamesPayload)
         assert len(result.root) == 1
 
 


### PR DESCRIPTION
## 📚 Stacked PRs

Part of the app config fragment client stack. **Merge in order (bottom-up):**

1. 👉 **#13223 — `feat(BA-7064)`: add the app config fragment SDK v2** ← you are here
2. #13227 — `feat(BA-7065)`: add the app config fragment CLI v2

Resolves BA-7064

## Summary

The app config fragment REST v2 surface shipped without a client. This adds the SDK v2 domain client; the CLI over it is #13227.

`client/v2/domains_v2/app_config_fragment.py`, registered on `V2ClientRegistry.app_config_fragment`:

| Method | Route | Notes |
|---|---|---|
| `scoped_get_app_config_fragments_by_names` | `POST /v2/app-config-fragments/scoped/by-names` | one entry per requested config name, in order, `None` where the scope holds none |
| `scoped_bulk_upsert_app_config_fragments` | `POST /v2/app-config-fragments/scoped/bulk-upsert` | all-or-nothing |
| `my_get_app_config_fragments_by_names` | `POST /v2/app-config-fragments/my/by-names` | caller's own user scope |
| `my_bulk_upsert_app_config_fragments` | `POST /v2/app-config-fragments/my/bulk-upsert` | caller's own user scope |
| `get` / `purge` | `GET` / `DELETE /v2/app-config-fragments/{id}` | |
| `bulk_purge` | `POST /v2/app-config-fragments/bulk-delete` | per-item success and failure |
| `admin_search` | `POST /v2/app-config-fragments/admin/search` | superadmin |

## Note for review

`AppConfigFragmentsByNamesResponse` — the root model for the by-names answer — moves from the REST handler into `common/dto/manager/v2/app_config_fragment/response.py`. The handler and the SDK now read the same definition, per the "v2 DTOs are the single source" rule; no wire format changes.

## Test plan
- [x] Unit tests cover all eight methods, including the null hole in a by-names answer.
- [x] `pants check` / `lint` clean; the OpenAPI dump is unchanged (no route changes).
- [ ] Live: exercised through the CLI in #13227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
