### PR TITLE
feat(BA-7061): implement bulk action monitors (audit log/reporter/Prometheus)

### DIFF
--- a/changes/13225.feature.md
+++ b/changes/13225.feature.md
@@ -1,0 +1,1 @@
+Add bulk action monitors (audit log, reporter, Prometheus) and wire them through the DI composer

--- a/src/ai/backend/manager/actions/bulk/monitor/audit_log.py
+++ b/src/ai/backend/manager/actions/bulk/monitor/audit_log.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import override
+
+from ai.backend.common.contexts.request_id import current_request_id
+from ai.backend.common.contexts.user import current_user, triggered_user
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.bulk.base import BaseBulkAction
+from ai.backend.manager.actions.bulk.monitor.base import BulkActionMonitor
+from ai.backend.manager.actions.bulk.result import BulkActionProcessResult
+from ai.backend.manager.actions.types import BLANK_ID
+from ai.backend.manager.repositories.audit_log.creators import AuditLogCreatorSpec
+from ai.backend.manager.repositories.audit_log.repository import AuditLogRepository
+from ai.backend.manager.repositories.base import Creator
+
+__all__ = ("BulkActionAuditLogMonitor",)
+
+
+class BulkActionAuditLogMonitor(BulkActionMonitor):
+    """Persists one audit-log row per target entity of a bulk action run.
+
+    Audit-log rows are tagged with a single ``(entity_type, entity_id)`` pair, so a
+    bulk run fans out into one row per target; the rows share the ``action_id``,
+    which ties them back to the same run.
+    """
+
+    _repository: AuditLogRepository
+
+    def __init__(self, repository: AuditLogRepository) -> None:
+        self._repository = repository
+
+    @override
+    async def prepare(self, action: BaseBulkAction, meta: BaseActionTriggerMeta) -> None:
+        pass
+
+    @override
+    async def done(self, action: BaseBulkAction, result: BulkActionProcessResult) -> None:
+        trigger = triggered_user()
+        acting = current_user()
+        meta = result.meta
+        request_id = current_request_id() or BLANK_ID
+        for entity_id in meta.entity_ids:
+            creator = Creator(
+                spec=AuditLogCreatorSpec(
+                    action_id=meta.action_id,
+                    entity_type=action.entity_type(),
+                    operation=action.operation_type(),
+                    created_at=meta.started_at,
+                    description=meta.description,
+                    status=meta.status,
+                    entity_id=str(entity_id),
+                    request_id=request_id,
+                    triggered_by=str(trigger.user_id) if trigger else None,
+                    acted_as=acting.user_id if acting else None,
+                    duration=meta.duration,
+                )
+            )
+            await self._repository.create(creator)

--- a/src/ai/backend/manager/actions/bulk/monitor/prometheus.py
+++ b/src/ai/backend/manager/actions/bulk/monitor/prometheus.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import override
+
+from ai.backend.common.metrics.metric import ActionMetricObserver
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.bulk.base import BaseBulkAction
+from ai.backend.manager.actions.bulk.monitor.base import BulkActionMonitor
+from ai.backend.manager.actions.bulk.result import BulkActionProcessResult
+
+__all__ = ("BulkActionPrometheusMonitor",)
+
+
+class BulkActionPrometheusMonitor(BulkActionMonitor):
+    """Observes bulk action outcomes into the Prometheus action metrics.
+
+    One observation per run — the action metric is keyed by (entity_type,
+    operation, status), not by target, so a bulk run does not fan out.
+    """
+
+    _observer: ActionMetricObserver
+
+    def __init__(self) -> None:
+        self._observer = ActionMetricObserver.instance()
+
+    @override
+    async def prepare(self, action: BaseBulkAction, meta: BaseActionTriggerMeta) -> None:
+        return
+
+    @override
+    async def done(self, action: BaseBulkAction, result: BulkActionProcessResult) -> None:
+        self._observer.observe_action(
+            entity_type=action.entity_type(),
+            operation_type=action.operation_type(),
+            status=result.meta.status,
+            duration=result.meta.duration.total_seconds(),
+            error_code=result.meta.error_code,
+        )

--- a/src/ai/backend/manager/actions/bulk/monitor/reporter.py
+++ b/src/ai/backend/manager/actions/bulk/monitor/reporter.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import override
+
+from ai.backend.common.contexts.request_id import current_request_id
+from ai.backend.common.contexts.user import current_user, triggered_user
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.bulk.base import BaseBulkAction
+from ai.backend.manager.actions.bulk.monitor.base import BulkActionMonitor
+from ai.backend.manager.actions.bulk.result import BulkActionProcessResult
+from ai.backend.manager.actions.types import BLANK_ID
+from ai.backend.manager.reporters.base import FinishedActionMessage, StartedActionMessage
+from ai.backend.manager.reporters.hub import ReporterHub
+
+__all__ = ("BulkActionReporterMonitor",)
+
+
+class BulkActionReporterMonitor(BulkActionMonitor):
+    """Reports the start and end of a bulk action run to the reporter hub.
+
+    A reporter message is a per-run notification carrying a single ``entity_id``,
+    so a bulk run reports once with ``entity_id=None`` rather than fanning out per
+    target; the per-target trail is the audit-log monitor's job.
+    """
+
+    _reporter_hub: ReporterHub
+
+    def __init__(self, reporter_hub: ReporterHub) -> None:
+        self._reporter_hub = reporter_hub
+
+    @override
+    async def prepare(self, action: BaseBulkAction, meta: BaseActionTriggerMeta) -> None:
+        # triggered_by = the caller who triggered the request; acted_as = the effective
+        # (acting) subject. They differ only while a super admin is impersonating.
+        trigger = triggered_user()
+        acting = current_user()
+        message = StartedActionMessage(
+            action_id=meta.action_id,
+            action_type=action.spec().type(),
+            entity_id=None,
+            entity_type=action.entity_type(),
+            request_id=current_request_id(),
+            triggered_by=str(trigger.user_id) if trigger else None,
+            acted_as=acting.user_id if acting else None,
+            operation_type=action.operation_type(),
+            created_at=meta.started_at,
+        )
+        await self._reporter_hub.report_started(message)
+
+    @override
+    async def done(self, action: BaseBulkAction, result: BulkActionProcessResult) -> None:
+        trigger = triggered_user()
+        acting = current_user()
+        meta = result.meta
+        message = FinishedActionMessage(
+            action_id=meta.action_id,
+            action_type=action.spec().type(),
+            entity_id=None,
+            request_id=current_request_id() or BLANK_ID,
+            triggered_by=str(trigger.user_id) if trigger else None,
+            acted_as=acting.user_id if acting else None,
+            entity_type=action.entity_type(),
+            operation_type=action.operation_type(),
+            status=meta.status,
+            description=meta.description,
+            created_at=meta.started_at,
+            ended_at=meta.ended_at,
+            duration=meta.duration,
+        )
+        await self._reporter_hub.report_finished(message)

--- a/src/ai/backend/manager/actions/monitors/__init__.py
+++ b/src/ai/backend/manager/actions/monitors/__init__.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass, field
+
+from ai.backend.manager.actions.bulk.monitor.base import BulkActionMonitor
+from ai.backend.manager.actions.monitors.monitor import ActionMonitor
+from ai.backend.manager.actions.scope.monitor.base import ScopeActionMonitor
+from ai.backend.manager.actions.single_entity.monitor.base import SingleEntityActionMonitor
+
+__all__ = ("ActionMonitors",)
+
+
+@dataclass
+class ActionMonitors:
+    """Monitors grouped per action framework, mirroring :class:`ActionValidators`.
+
+    ``legacy`` feeds the ``BaseAction``-era processors; the per-type fields feed
+    the pure-ABC processors (``actions/{single_entity,bulk,scope}``).
+    """
+
+    legacy: list[ActionMonitor] = field(default_factory=list)
+    single_entity: list[SingleEntityActionMonitor] = field(default_factory=list)
+    bulk: list[BulkActionMonitor] = field(default_factory=list)
+    scope: list[ScopeActionMonitor] = field(default_factory=list)

--- a/src/ai/backend/manager/dependencies/processing/composer.py
+++ b/src/ai/backend/manager/dependencies/processing/composer.py
@@ -25,9 +25,13 @@ from ai.backend.common.message_queue.abc.queue import AbstractMessageQueue
 from ai.backend.common.plugin.event import EventDispatcherPluginContext
 from ai.backend.common.plugin.hook import HookPluginContext
 from ai.backend.common.plugin.monitor import ErrorPluginContext, StatsPluginContext
+from ai.backend.manager.actions.bulk.monitor.audit_log import BulkActionAuditLogMonitor
+from ai.backend.manager.actions.bulk.monitor.prometheus import BulkActionPrometheusMonitor
+from ai.backend.manager.actions.bulk.monitor.reporter import BulkActionReporterMonitor
 from ai.backend.manager.actions.bulk.validator.rbac import (
     VirtualScopeBulkActionRBACValidator,
 )
+from ai.backend.manager.actions.monitors import ActionMonitors
 from ai.backend.manager.actions.monitors.audit_log import AuditLogMonitor
 from ai.backend.manager.actions.monitors.prometheus import PrometheusMonitor
 from ai.backend.manager.actions.monitors.reporter import ReporterMonitor
@@ -236,7 +240,16 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
         reporter_hub = ReporterHub(ReporterHubArgs(reporters=action_reporters))
         reporter_monitor = ReporterMonitor(reporter_hub)
         prometheus_monitor = PrometheusMonitor()
-        audit_log_monitor = AuditLogMonitor(setup_input.repositories.audit_log.repository)
+        audit_log_repository = setup_input.repositories.audit_log.repository
+        audit_log_monitor = AuditLogMonitor(audit_log_repository)
+        action_monitors = ActionMonitors(
+            legacy=[reporter_monitor, prometheus_monitor, audit_log_monitor],
+            bulk=[
+                BulkActionReporterMonitor(reporter_hub),
+                BulkActionPrometheusMonitor(),
+                BulkActionAuditLogMonitor(audit_log_repository),
+            ],
+        )
 
         ssh_key_validator = SSHKeyValidator()
 
@@ -299,7 +312,7 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
             ProcessorsDependency(),
             ProcessorsProviderInput(
                 service_args=service_args,
-                action_monitors=[reporter_monitor, prometheus_monitor, audit_log_monitor],
+                action_monitors=action_monitors,
                 event_hub=setup_input.event_hub,
                 event_fetcher=setup_input.event_fetcher,
                 validators=ActionValidators(

--- a/src/ai/backend/manager/dependencies/processing/processors.py
+++ b/src/ai/backend/manager/dependencies/processing/processors.py
@@ -8,7 +8,7 @@ from typing import override
 from ai.backend.common.dependencies import NonMonitorableDependencyProvider
 from ai.backend.common.events.fetcher import EventFetcher
 from ai.backend.common.events.hub.hub import EventHub
-from ai.backend.manager.actions.monitors.monitor import ActionMonitor
+from ai.backend.manager.actions.monitors import ActionMonitors
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.factory import create_processors
 from ai.backend.manager.services.processors import ProcessorArgs, Processors, ServiceArgs
@@ -19,7 +19,7 @@ class ProcessorsProviderInput:
     """Input required for Processors setup."""
 
     service_args: ServiceArgs
-    action_monitors: list[ActionMonitor]
+    action_monitors: ActionMonitors
     event_hub: EventHub
     event_fetcher: EventFetcher
     validators: ActionValidators

--- a/src/ai/backend/manager/services/factory.py
+++ b/src/ai/backend/manager/services/factory.py
@@ -1,5 +1,5 @@
 from ai.backend.manager.actions.action import RBAC_ACTION_REGISTRY
-from ai.backend.manager.actions.monitors.monitor import ActionMonitor
+from ai.backend.manager.actions.monitors import ActionMonitors
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.repositories.resource_allocation.repository import (
     ResourceAllocationRepository,
@@ -465,10 +465,13 @@ def create_services(args: ServiceArgs) -> Services:
 
 def create_processors(
     args: ProcessorArgs,
-    action_monitors: list[ActionMonitor],
+    monitors: ActionMonitors,
     validators: ActionValidators,
 ) -> Processors:
     services = create_services(args.service_args)
+    # Legacy BaseAction-era packages consume the flat monitor list; packages migrated
+    # to the pure-ABC frameworks pick the per-type monitors from `monitors` instead.
+    action_monitors = monitors.legacy
     return Processors(
         agent=AgentProcessors(services.agent, action_monitors, validators),
         app_config=AppConfigProcessors(services.app_config, action_monitors),

--- a/tests/unit/manager/dependencies/processing/test_processors.py
+++ b/tests/unit/manager/dependencies/processing/test_processors.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from ai.backend.manager.actions.monitors.monitor import ActionMonitor
+from ai.backend.manager.actions.monitors import ActionMonitors
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.dependencies.processing.processors import (
     ProcessorsDependency,
@@ -23,7 +23,7 @@ class TestProcessorsDependency:
         mock_create_processors.return_value = mock_processors
 
         mock_service_args = MagicMock()
-        mock_monitors: list[ActionMonitor] = [MagicMock(), MagicMock()]
+        mock_monitors = ActionMonitors(legacy=[MagicMock(), MagicMock()])
 
         dependency = ProcessorsDependency()
         processors_input = ProcessorsProviderInput(


### PR DESCRIPTION
## Summary
- Add the monitor implementations bound to the pure-ABC `BulkActionMonitor` base: `BulkActionAuditLogMonitor` (one audit-log row per target entity, sharing the `action_id`), `BulkActionReporterMonitor` (reports once per run with `entity_id=None` — reporter messages are per-run notifications, and the per-target trail belongs to the audit-log monitor), and `BulkActionPrometheusMonitor` (one observation per run — the action metric is keyed by `(entity_type, operation, status)`).
- Introduce an `ActionMonitors` dataclass (mirroring `ActionValidators`) that groups the legacy monitor list with the per-type monitor lists, and wire the bulk monitors through the DI composer and `create_processors`.
- Existing `BaseAction`-era processor packages keep receiving the legacy flat list unchanged. The `ActionMonitors` plumbing is intentionally identical to #13219 (BA-7059) and #13222 (BA-7060); whichever merges later only needs a trivial conflict resolution in the composer's per-type monitor lists.

## Test plan
- [x] CI type checks and tests pass

Resolves BA-7061

🤖 Generated with [Claude Code](https://claude.com/claude-code)