### PR TITLE
feat(BA-7065): add the app config fragment CLI v2

### DIFF
--- a/.claude/skills/bai-cli/SKILL.md
+++ b/.claude/skills/bai-cli/SKILL.md
@@ -107,7 +107,7 @@ Check options with `--help`.
 - **app-config**: user(get-domain, get-user, get-merged, delete-domain, delete-user)
 - **app-config-definition**: admin(create, get, search, purge)
 - **app-config-allow-list**: admin(create, get, search, update, purge)
-- **app-config-fragment**: user(get, bulk-upsert, purge, bulk-delete) · my(get, bulk-upsert) · admin(search)
+- **app-config-fragment**: user(get, update, purge, bulk-delete) · my(get, update) · admin(search)
 - **idle-checker**: admin(create, search, update, purge)
 - **export**: admin(list-reports, get-report, audit-logs, keypairs, projects, sessions, sessions-by-project, users, users-by-domain) · my(keypairs, sessions)
 

--- a/.claude/skills/bai-cli/SKILL.md
+++ b/.claude/skills/bai-cli/SKILL.md
@@ -107,7 +107,7 @@ Check options with `--help`.
 - **app-config**: user(get-domain, get-user, get-merged, delete-domain, delete-user)
 - **app-config-definition**: admin(create, get, search, purge)
 - **app-config-allow-list**: admin(create, get, search, update, purge)
-- **app-config-fragment**: user(get, update, purge, bulk-delete) · my(get, update) · admin(search)
+- **app-config-fragment**: user(get, update, purge, bulk-purge) · my(get, update) · admin(search)
 - **idle-checker**: admin(create, search, update, purge)
 - **export**: admin(list-reports, get-report, audit-logs, keypairs, projects, sessions, sessions-by-project, users, users-by-domain) · my(keypairs, sessions)
 

--- a/.claude/skills/bai-cli/SKILL.md
+++ b/.claude/skills/bai-cli/SKILL.md
@@ -107,6 +107,7 @@ Check options with `--help`.
 - **app-config**: user(get-domain, get-user, get-merged, delete-domain, delete-user)
 - **app-config-definition**: admin(create, get, search, purge)
 - **app-config-allow-list**: admin(create, get, search, update, purge)
+- **app-config-fragment**: user(get, bulk-upsert, purge, bulk-delete) · my(get, bulk-upsert) · admin(search)
 - **idle-checker**: admin(create, search, update, purge)
 - **export**: admin(list-reports, get-report, audit-logs, keypairs, projects, sessions, sessions-by-project, users, users-by-domain) · my(keypairs, sessions)
 

--- a/changes/13227.feature.md
+++ b/changes/13227.feature.md
@@ -1,1 +1,1 @@
-Add the app config fragment CLI v2: read and bulk-upsert fragments by config name at a scope or at the caller's own user scope, purge and bulk-delete by id, and the system-wide admin search.
+Add the app config fragment CLI v2: read and write fragments by config name at a scope or at the caller's own user scope, purge and bulk-delete by id, and the system-wide admin search.

--- a/changes/13227.feature.md
+++ b/changes/13227.feature.md
@@ -1,1 +1,1 @@
-Add the app config fragment CLI v2: read and write fragments by config name at a scope or at the caller's own user scope, purge and bulk-delete by id, and the system-wide admin search.
+Add the app config fragment CLI v2: read and write fragments by config name at a scope or at the caller's own user scope, purge and bulk-purge by id, and the system-wide admin search.

--- a/changes/13227.feature.md
+++ b/changes/13227.feature.md
@@ -1,1 +1,1 @@
-Add the app config fragment CLI v2: read fragments by config name and bulk-upsert them at a scope or at the caller's own user scope, get, purge and bulk-delete by id, and the system-wide admin search.
+Add the app config fragment CLI v2: read and bulk-upsert fragments by config name at a scope or at the caller's own user scope, purge and bulk-delete by id, and the system-wide admin search.

--- a/changes/13227.feature.md
+++ b/changes/13227.feature.md
@@ -1,0 +1,1 @@
+Add the app config fragment CLI v2: read fragments by config name and bulk-upsert them at a scope or at the caller's own user scope, get, purge and bulk-delete by id, and the system-wide admin search.

--- a/src/ai/backend/client/cli/v2/__init__.py
+++ b/src/ai/backend/client/cli/v2/__init__.py
@@ -51,6 +51,15 @@ v2.add_command(my)
 # Names are singular following the pattern: ./bai [admin] {entity} {operation}
 
 
+@v2.group(
+    cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.app_config_fragment:app_config_fragment",
+    name="app-config-fragment",
+)
+def app_config_fragment() -> None:
+    """App config fragment commands."""
+
+
 @v2.group(cls=LazyGroup, import_name="ai.backend.client.cli.v2.domain:domain")
 def domain() -> None:
     """Domain commands."""

--- a/src/ai/backend/client/cli/v2/admin/__init__.py
+++ b/src/ai/backend/client/cli/v2/admin/__init__.py
@@ -47,6 +47,15 @@ def agent() -> None:
 
 @admin.group(
     cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.admin.app_config_fragment:app_config_fragment",
+    name="app-config-fragment",
+)
+def app_config_fragment() -> None:
+    """Admin app config fragment commands."""
+
+
+@admin.group(
+    cls=LazyGroup,
     import_name="ai.backend.client.cli.v2.admin.app_config_allow_list:app_config_allow_list",
     name="app-config-allow-list",
 )

--- a/src/ai/backend/client/cli/v2/admin/app_config_fragment.py
+++ b/src/ai/backend/client/cli/v2/admin/app_config_fragment.py
@@ -1,0 +1,98 @@
+"""Admin CLI commands for app config fragments."""
+
+from __future__ import annotations
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    parse_order_options,
+    print_result,
+    run_async,
+)
+from ai.backend.common.data.app_config.types import AppConfigScopeType
+
+
+@click.group()
+def app_config_fragment() -> None:
+    """App config fragment admin commands (superadmin required)."""
+
+
+@app_config_fragment.command()
+@click.option("--limit", type=int, default=20, help="Maximum number of items to return.")
+@click.option("--offset", type=int, default=0, help="Number of items to skip.")
+@click.option(
+    "--config-name-contains",
+    default=None,
+    type=str,
+    help="Filter by config name (substring match).",
+)
+@click.option(
+    "--scope-type",
+    default=None,
+    type=click.Choice([scope_type.value for scope_type in AppConfigScopeType]),
+    help="Filter by scope type (exact match).",
+)
+@click.option(
+    "--order-by",
+    multiple=True,
+    help="Order by field:direction (e.g., config_name:asc, updated_at:desc).",
+)
+def search(
+    limit: int,
+    offset: int,
+    config_name_contains: str | None,
+    scope_type: str | None,
+    order_by: tuple[str, ...],
+) -> None:
+    """Search app config fragments across every scope."""
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        AdminSearchAppConfigFragmentInput,
+        AppConfigFragmentFilter,
+        AppConfigFragmentOrder,
+    )
+    from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
+        AppConfigFragmentOrderField,
+        AppConfigScopeTypeFilter,
+    )
+
+    filter_dto: AppConfigFragmentFilter | None = None
+    if config_name_contains is not None or scope_type is not None:
+        from ai.backend.common.dto.manager.query import StringFilter
+
+        filter_dto = AppConfigFragmentFilter(
+            config_name=(
+                StringFilter(contains=config_name_contains)
+                if config_name_contains is not None
+                else None
+            ),
+            scope_type=(
+                AppConfigScopeTypeFilter(equals=AppConfigScopeType(scope_type))
+                if scope_type is not None
+                else None
+            ),
+        )
+
+    orders = (
+        parse_order_options(order_by, AppConfigFragmentOrderField, AppConfigFragmentOrder)
+        if order_by
+        else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_fragment.admin_search(
+                AdminSearchAppConfigFragmentInput(
+                    filter=filter_dto,
+                    order=orders,
+                    limit=limit,
+                    offset=offset,
+                )
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)

--- a/src/ai/backend/client/cli/v2/app_config_fragment/__init__.py
+++ b/src/ai/backend/client/cli/v2/app_config_fragment/__init__.py
@@ -1,0 +1,3 @@
+from .commands import app_config_fragment as app_config_fragment
+
+__all__ = ("app_config_fragment",)

--- a/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
+++ b/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
@@ -105,7 +105,7 @@ def get(
     run_async(_run)
 
 
-@app_config_fragment.command(name="bulk-upsert")
+@app_config_fragment.command()
 @click.option(
     "--scope-type",
     required=True,
@@ -126,8 +126,12 @@ def get(
         "holding it."
     ),
 )
-def bulk_upsert(scope_type: str, scope_id: uuid.UUID | None, items: str) -> None:
-    """Upsert many fragments at one scope, all-or-nothing."""
+def update(scope_type: str, scope_id: uuid.UUID | None, items: str) -> None:
+    """Write the given configs' fragments at one scope, all-or-nothing.
+
+    Each item replaces the scope's fragment for its config name, or creates it when the
+    scope holds none. Every item lands or none does.
+    """
     from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
         AppConfigScopeRef,
         ScopedUpsertAppConfigFragmentsInput,

--- a/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
+++ b/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
@@ -123,7 +123,9 @@ def get(app_config_fragment_id: uuid.UUID) -> None:
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            result = await registry.app_config_fragment.get(app_config_fragment_id)
+            result = await registry.app_config_fragment.get(
+                AppConfigFragmentID(app_config_fragment_id)
+            )
             print_result(result)
         finally:
             await registry.close()
@@ -139,7 +141,9 @@ def purge(app_config_fragment_id: uuid.UUID) -> None:
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            result = await registry.app_config_fragment.purge(app_config_fragment_id)
+            result = await registry.app_config_fragment.purge(
+                AppConfigFragmentID(app_config_fragment_id)
+            )
             print_result(result)
         finally:
             await registry.close()

--- a/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
+++ b/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
@@ -1,0 +1,177 @@
+"""CLI commands for app config fragments (scoped reads, writes and purges)."""
+
+from __future__ import annotations
+
+import uuid
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_model,
+    load_v2_config,
+    print_result,
+    run_async,
+)
+from ai.backend.common.data.app_config.types import AppConfigScopeType
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AppConfigFragmentUpsertItem,
+)
+from ai.backend.common.identifier.app_config import AppConfigScopeID
+from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+
+
+@click.group()
+def app_config_fragment() -> None:
+    """App config fragment commands."""
+
+
+@app_config_fragment.command(name="by-names")
+@click.option(
+    "--scope-type",
+    required=True,
+    type=click.Choice([scope_type.value for scope_type in AppConfigScopeType]),
+    help="Scope the fragments are written at (public | domain | user).",
+)
+@click.option(
+    "--scope-id",
+    default=None,
+    type=click.UUID,
+    help="Domain id or user id; omit for the public scope.",
+)
+@click.argument("config_names", nargs=-1, required=True)
+def by_names(scope_type: str, scope_id: uuid.UUID | None, config_names: tuple[str, ...]) -> None:
+    """Read one scope's fragments for CONFIG_NAMES, answered in that order."""
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        AppConfigScopeRef,
+        ScopedAppConfigFragmentsByNamesInput,
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_fragment.scoped_get_app_config_fragments_by_names(
+                ScopedAppConfigFragmentsByNamesInput(
+                    scope=AppConfigScopeRef(
+                        scope_type=AppConfigScopeType(scope_type),
+                        scope_id=AppConfigScopeID(scope_id) if scope_id is not None else None,
+                    ),
+                    config_names=list(config_names),
+                )
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
+@app_config_fragment.command(name="bulk-upsert")
+@click.option(
+    "--scope-type",
+    required=True,
+    type=click.Choice([scope_type.value for scope_type in AppConfigScopeType]),
+    help="Scope the fragments are written at (public | domain | user).",
+)
+@click.option(
+    "--scope-id",
+    default=None,
+    type=click.UUID,
+    help="Domain id or user id; omit for the public scope.",
+)
+@click.option(
+    "--items",
+    required=True,
+    help=(
+        'JSON array of {"config_name": ..., "config": {...}} objects, or @path to a file '
+        "holding it."
+    ),
+)
+def bulk_upsert(scope_type: str, scope_id: uuid.UUID | None, items: str) -> None:
+    """Upsert many fragments at one scope, all-or-nothing."""
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        AppConfigScopeRef,
+        ScopedUpsertAppConfigFragmentsInput,
+    )
+
+    parsed_items = load_model(items, list[AppConfigFragmentUpsertItem])
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_fragment.scoped_bulk_upsert_app_config_fragments(
+                ScopedUpsertAppConfigFragmentsInput(
+                    scope=AppConfigScopeRef(
+                        scope_type=AppConfigScopeType(scope_type),
+                        scope_id=AppConfigScopeID(scope_id) if scope_id is not None else None,
+                    ),
+                    items=parsed_items,
+                )
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
+@app_config_fragment.command()
+@click.argument("app_config_fragment_id", type=click.UUID)
+def get(app_config_fragment_id: uuid.UUID) -> None:
+    """Get an app config fragment by id."""
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_fragment.get(app_config_fragment_id)
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
+@app_config_fragment.command()
+@click.argument("app_config_fragment_id", type=click.UUID)
+def purge(app_config_fragment_id: uuid.UUID) -> None:
+    """Purge an app config fragment by id."""
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_fragment.purge(app_config_fragment_id)
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
+@app_config_fragment.command(name="bulk-delete")
+@click.option(
+    "--id",
+    "ids",
+    required=True,
+    multiple=True,
+    type=click.UUID,
+    help="Fragment id to purge. Repeat for more.",
+)
+def bulk_delete(ids: tuple[uuid.UUID, ...]) -> None:
+    """Purge many fragments by id, reporting each item's outcome."""
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        BulkPurgeAppConfigFragmentInput,
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_fragment.bulk_purge(
+                BulkPurgeAppConfigFragmentInput(
+                    ids=[AppConfigFragmentID(fragment_id) for fragment_id in ids]
+                )
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)

--- a/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
+++ b/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
@@ -16,6 +16,7 @@ from ai.backend.client.cli.v2.helpers import (
 from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AppConfigFragmentUpsertItem,
+    AppConfigScopeRef,
 )
 from ai.backend.common.identifier.app_config import AppConfigScopeID
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
@@ -26,12 +27,35 @@ def app_config_fragment() -> None:
     """App config fragment commands."""
 
 
+def _resolve_scope(scope_type: str, scope_id: uuid.UUID | None) -> AppConfigScopeRef:
+    """The scope the request acts at, rejecting a scope-id that does not match its kind.
+
+    ``public`` is one global scope owning no id, while ``domain`` and ``user`` are each
+    identified by their owner. The server rejects a mismatch too, but only after the request
+    is on the wire, and as a validation error rather than a usage message.
+    """
+    resolved_type = AppConfigScopeType(scope_type)
+    match resolved_type:
+        case AppConfigScopeType.PUBLIC:
+            if scope_id is not None:
+                raise click.UsageError(
+                    "--scope-id must be omitted for the public scope, which has no owner."
+                )
+            return AppConfigScopeRef(scope_type=resolved_type, scope_id=None)
+        case AppConfigScopeType.DOMAIN | AppConfigScopeType.USER:
+            if scope_id is None:
+                raise click.UsageError(
+                    f"--scope-id is required for the {resolved_type.value} scope."
+                )
+            return AppConfigScopeRef(scope_type=resolved_type, scope_id=AppConfigScopeID(scope_id))
+
+
 @app_config_fragment.command()
 @click.option(
     "--scope-type",
-    default=None,
+    required=True,
     type=click.Choice([scope_type.value for scope_type in AppConfigScopeType]),
-    help="Scope whose fragments to read (public | domain | user). Required with CONFIG_NAMES.",
+    help="Scope whose fragments to read (public | domain | user).",
 )
 @click.option(
     "--scope-id",
@@ -39,66 +63,27 @@ def app_config_fragment() -> None:
     type=click.UUID,
     help="Domain id or user id; omit for the public scope.",
 )
-@click.option(
-    "--id",
-    "fragment_id",
-    default=None,
-    type=click.UUID,
-    help="Read a single fragment by its id instead of by config name.",
-)
-@click.argument("config_names", nargs=-1)
-def get(
-    scope_type: str | None,
-    scope_id: uuid.UUID | None,
-    fragment_id: uuid.UUID | None,
-    config_names: tuple[str, ...],
-) -> None:
+@click.argument("config_names", nargs=-1, required=True)
+def get(scope_type: str, scope_id: uuid.UUID | None, config_names: tuple[str, ...]) -> None:
     """Read one scope's fragments for CONFIG_NAMES, answered in that order.
 
     A name the scope holds no fragment for is answered as null, so the result lines up
-    position by position with CONFIG_NAMES. Pass --id to read a single fragment by id
-    instead; config names are how a caller normally addresses a fragment, ids come back
-    from a previous read or an admin search.
+    position by position with CONFIG_NAMES. Only fragments written at this scope are
+    answered — scopes do not inherit from one another.
     """
-    if fragment_id is not None:
-        if config_names or scope_type is not None or scope_id is not None:
-            raise click.UsageError(
-                "--id reads one fragment by id; it takes neither CONFIG_NAMES nor scope options."
-            )
-    else:
-        if not config_names:
-            raise click.UsageError(
-                "Pass CONFIG_NAMES to read by config name, or --id to read one fragment by id."
-            )
-        if scope_type is None:
-            raise click.UsageError("--scope-type is required when reading by config name.")
+    scope = _resolve_scope(scope_type, scope_id)
 
     async def _run() -> None:
         from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
-            AppConfigScopeRef,
             ScopedAppConfigFragmentsByNamesInput,
         )
 
         registry = await create_v2_registry(load_v2_config())
         try:
-            if fragment_id is not None:
-                print_result(
-                    await registry.app_config_fragment.get(AppConfigFragmentID(fragment_id))
-                )
-            else:
-                print_result(
-                    await registry.app_config_fragment.scoped_get_app_config_fragments_by_names(
-                        ScopedAppConfigFragmentsByNamesInput(
-                            scope=AppConfigScopeRef(
-                                scope_type=AppConfigScopeType(scope_type),
-                                scope_id=(
-                                    AppConfigScopeID(scope_id) if scope_id is not None else None
-                                ),
-                            ),
-                            config_names=list(config_names),
-                        )
-                    )
-                )
+            result = await registry.app_config_fragment.scoped_get_app_config_fragments_by_names(
+                ScopedAppConfigFragmentsByNamesInput(scope=scope, config_names=list(config_names))
+            )
+            print_result(result)
         finally:
             await registry.close()
 
@@ -133,23 +118,17 @@ def update(scope_type: str, scope_id: uuid.UUID | None, items: str) -> None:
     scope holds none. Every item lands or none does.
     """
     from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
-        AppConfigScopeRef,
         ScopedUpsertAppConfigFragmentsInput,
     )
 
+    scope = _resolve_scope(scope_type, scope_id)
     parsed_items = load_model(items, list[AppConfigFragmentUpsertItem])
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
             result = await registry.app_config_fragment.scoped_bulk_upsert_app_config_fragments(
-                ScopedUpsertAppConfigFragmentsInput(
-                    scope=AppConfigScopeRef(
-                        scope_type=AppConfigScopeType(scope_type),
-                        scope_id=AppConfigScopeID(scope_id) if scope_id is not None else None,
-                    ),
-                    items=parsed_items,
-                )
+                ScopedUpsertAppConfigFragmentsInput(scope=scope, items=parsed_items)
             )
             print_result(result)
         finally:
@@ -180,7 +159,7 @@ def purge(fragment_id: uuid.UUID) -> None:
     run_async(_run)
 
 
-@app_config_fragment.command(name="bulk-delete")
+@app_config_fragment.command(name="bulk-purge")
 @click.option(
     "--id",
     "ids",
@@ -189,7 +168,7 @@ def purge(fragment_id: uuid.UUID) -> None:
     type=click.UUID,
     help="Fragment id to purge. Repeat for more.",
 )
-def bulk_delete(ids: tuple[uuid.UUID, ...]) -> None:
+def bulk_purge(ids: tuple[uuid.UUID, ...]) -> None:
     """Purge many fragments by id, reporting each item's outcome."""
     from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
         BulkPurgeAppConfigFragmentInput,

--- a/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
+++ b/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
@@ -26,12 +26,12 @@ def app_config_fragment() -> None:
     """App config fragment commands."""
 
 
-@app_config_fragment.command(name="by-names")
+@app_config_fragment.command()
 @click.option(
     "--scope-type",
-    required=True,
+    default=None,
     type=click.Choice([scope_type.value for scope_type in AppConfigScopeType]),
-    help="Scope the fragments are written at (public | domain | user).",
+    help="Scope whose fragments to read (public | domain | user). Required with CONFIG_NAMES.",
 )
 @click.option(
     "--scope-id",
@@ -39,27 +39,66 @@ def app_config_fragment() -> None:
     type=click.UUID,
     help="Domain id or user id; omit for the public scope.",
 )
-@click.argument("config_names", nargs=-1, required=True)
-def by_names(scope_type: str, scope_id: uuid.UUID | None, config_names: tuple[str, ...]) -> None:
-    """Read one scope's fragments for CONFIG_NAMES, answered in that order."""
-    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
-        AppConfigScopeRef,
-        ScopedAppConfigFragmentsByNamesInput,
-    )
+@click.option(
+    "--id",
+    "fragment_id",
+    default=None,
+    type=click.UUID,
+    help="Read a single fragment by its id instead of by config name.",
+)
+@click.argument("config_names", nargs=-1)
+def get(
+    scope_type: str | None,
+    scope_id: uuid.UUID | None,
+    fragment_id: uuid.UUID | None,
+    config_names: tuple[str, ...],
+) -> None:
+    """Read one scope's fragments for CONFIG_NAMES, answered in that order.
+
+    A name the scope holds no fragment for is answered as null, so the result lines up
+    position by position with CONFIG_NAMES. Pass --id to read a single fragment by id
+    instead; config names are how a caller normally addresses a fragment, ids come back
+    from a previous read or an admin search.
+    """
+    if fragment_id is not None:
+        if config_names or scope_type is not None or scope_id is not None:
+            raise click.UsageError(
+                "--id reads one fragment by id; it takes neither CONFIG_NAMES nor scope options."
+            )
+    else:
+        if not config_names:
+            raise click.UsageError(
+                "Pass CONFIG_NAMES to read by config name, or --id to read one fragment by id."
+            )
+        if scope_type is None:
+            raise click.UsageError("--scope-type is required when reading by config name.")
 
     async def _run() -> None:
+        from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+            AppConfigScopeRef,
+            ScopedAppConfigFragmentsByNamesInput,
+        )
+
         registry = await create_v2_registry(load_v2_config())
         try:
-            result = await registry.app_config_fragment.scoped_get_app_config_fragments_by_names(
-                ScopedAppConfigFragmentsByNamesInput(
-                    scope=AppConfigScopeRef(
-                        scope_type=AppConfigScopeType(scope_type),
-                        scope_id=AppConfigScopeID(scope_id) if scope_id is not None else None,
-                    ),
-                    config_names=list(config_names),
+            if fragment_id is not None:
+                print_result(
+                    await registry.app_config_fragment.get(AppConfigFragmentID(fragment_id))
                 )
-            )
-            print_result(result)
+            else:
+                print_result(
+                    await registry.app_config_fragment.scoped_get_app_config_fragments_by_names(
+                        ScopedAppConfigFragmentsByNamesInput(
+                            scope=AppConfigScopeRef(
+                                scope_type=AppConfigScopeType(scope_type),
+                                scope_id=(
+                                    AppConfigScopeID(scope_id) if scope_id is not None else None
+                                ),
+                            ),
+                            config_names=list(config_names),
+                        )
+                    )
+                )
         finally:
             await registry.close()
 
@@ -116,34 +155,20 @@ def bulk_upsert(scope_type: str, scope_id: uuid.UUID | None, items: str) -> None
 
 
 @app_config_fragment.command()
-@click.argument("app_config_fragment_id", type=click.UUID)
-def get(app_config_fragment_id: uuid.UUID) -> None:
-    """Get an app config fragment by id."""
-
-    async def _run() -> None:
-        registry = await create_v2_registry(load_v2_config())
-        try:
-            result = await registry.app_config_fragment.get(
-                AppConfigFragmentID(app_config_fragment_id)
-            )
-            print_result(result)
-        finally:
-            await registry.close()
-
-    run_async(_run)
-
-
-@app_config_fragment.command()
-@click.argument("app_config_fragment_id", type=click.UUID)
-def purge(app_config_fragment_id: uuid.UUID) -> None:
+@click.option(
+    "--id",
+    "fragment_id",
+    required=True,
+    type=click.UUID,
+    help="Id of the fragment to purge, as answered by a read or an admin search.",
+)
+def purge(fragment_id: uuid.UUID) -> None:
     """Purge an app config fragment by id."""
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            result = await registry.app_config_fragment.purge(
-                AppConfigFragmentID(app_config_fragment_id)
-            )
+            result = await registry.app_config_fragment.purge(AppConfigFragmentID(fragment_id))
             print_result(result)
         finally:
             await registry.close()

--- a/src/ai/backend/client/cli/v2/my/__init__.py
+++ b/src/ai/backend/client/cli/v2/my/__init__.py
@@ -16,6 +16,15 @@ def my() -> None:
     """Self-service commands for the current user."""
 
 
+@my.group(
+    cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.my.app_config_fragment:app_config_fragment",
+    name="app-config-fragment",
+)
+def app_config_fragment() -> None:
+    """My app config fragment commands."""
+
+
 @my.group(cls=LazyGroup, import_name="ai.backend.client.cli.v2.my.keypair:keypair")
 def keypair() -> None:
     """My keypair commands."""

--- a/src/ai/backend/client/cli/v2/my/app_config_fragment.py
+++ b/src/ai/backend/client/cli/v2/my/app_config_fragment.py
@@ -1,0 +1,72 @@
+"""Self-service CLI commands for the caller's own user-scope app config fragments."""
+
+from __future__ import annotations
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_model,
+    load_v2_config,
+    print_result,
+    run_async,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AppConfigFragmentUpsertItem,
+)
+
+
+@click.group()
+def app_config_fragment() -> None:
+    """My app config fragment commands."""
+
+
+@app_config_fragment.command(name="by-names")
+@click.argument("config_names", nargs=-1, required=True)
+def by_names(config_names: tuple[str, ...]) -> None:
+    """Read my user-scope fragments for CONFIG_NAMES, answered in that order."""
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        MyAppConfigFragmentsByNamesInput,
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_fragment.my_get_app_config_fragments_by_names(
+                MyAppConfigFragmentsByNamesInput(config_names=list(config_names))
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
+@app_config_fragment.command(name="bulk-upsert")
+@click.option(
+    "--items",
+    required=True,
+    help=(
+        'JSON array of {"config_name": ..., "config": {...}} objects, or @path to a file '
+        "holding it."
+    ),
+)
+def bulk_upsert(items: str) -> None:
+    """Upsert many fragments at my own user scope, all-or-nothing."""
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        MyUpsertAppConfigFragmentsInput,
+    )
+
+    parsed_items = load_model(items, list[AppConfigFragmentUpsertItem])
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_fragment.my_bulk_upsert_app_config_fragments(
+                MyUpsertAppConfigFragmentsInput(items=parsed_items)
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)

--- a/src/ai/backend/client/cli/v2/my/app_config_fragment.py
+++ b/src/ai/backend/client/cli/v2/my/app_config_fragment.py
@@ -46,7 +46,7 @@ def get(config_names: tuple[str, ...]) -> None:
     run_async(_run)
 
 
-@app_config_fragment.command(name="bulk-upsert")
+@app_config_fragment.command()
 @click.option(
     "--items",
     required=True,
@@ -55,8 +55,12 @@ def get(config_names: tuple[str, ...]) -> None:
         "holding it."
     ),
 )
-def bulk_upsert(items: str) -> None:
-    """Upsert many fragments at my own user scope, all-or-nothing."""
+def update(items: str) -> None:
+    """Write the given configs' fragments at my own user scope, all-or-nothing.
+
+    Each item replaces my fragment for its config name, or creates it when I hold none.
+    Every item lands or none does.
+    """
     from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
         MyUpsertAppConfigFragmentsInput,
     )

--- a/src/ai/backend/client/cli/v2/my/app_config_fragment.py
+++ b/src/ai/backend/client/cli/v2/my/app_config_fragment.py
@@ -21,10 +21,14 @@ def app_config_fragment() -> None:
     """My app config fragment commands."""
 
 
-@app_config_fragment.command(name="by-names")
+@app_config_fragment.command()
 @click.argument("config_names", nargs=-1, required=True)
-def by_names(config_names: tuple[str, ...]) -> None:
-    """Read my user-scope fragments for CONFIG_NAMES, answered in that order."""
+def get(config_names: tuple[str, ...]) -> None:
+    """Read my user-scope fragments for CONFIG_NAMES, answered in that order.
+
+    A name my scope holds no fragment for is answered as null, so the result lines up
+    position by position with CONFIG_NAMES.
+    """
     from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
         MyAppConfigFragmentsByNamesInput,
     )


### PR DESCRIPTION
## 📚 Stacked PRs

Part of the app config fragment client stack. **Merge in order (bottom-up):**

1. ✅ #13223 — `feat(BA-7064)`: add the app config fragment SDK v2
2. 👉 **#13227 — `feat(BA-7065)`: add the app config fragment CLI v2** ← you are here
3. #13375 — `feat(BA-7149)`: purge my own app config fragments by config name

Now based on `main`, which carries the SDK client.

Resolves #13229 (BA-7065)

## Summary

The CLI over the SDK client from #13223 — no REST calls of its own.

A fragment is addressed by `(scope, config_name)`, and that is what the CLI takes: config names are positional, the scope is named by options. Each command has exactly one addressing mode, so nothing is conditionally required. Ids appear only where they are the sole address — `purge` and `bulk-purge` — and always as `--id`, since an id is not something a caller knows up front.

Command names follow the CLI's own vocabulary rather than the REST routes. `/by-names` is `get`, `/bulk-upsert` is `update` (the standard-six name, as `deployment policy update` already does over `upsert_policy`), and `/bulk-delete` is `bulk-purge` — every `bulk-*` command in the v2 CLI mirrors its entity's single-item operation, and this entity purges rather than deletes.

| Command | What it does | Auth |
|---|---|---|
| `./bai app-config-fragment get --scope-type <t> [--scope-id <uuid>] <config_name>...` | Read one scope's fragments for the named configs. Answers one entry per name, in the order given, `null` where the scope holds none. Only fragments written at that scope — scopes do not inherit. | auth + RBAC at that scope |
| `./bai app-config-fragment update --scope-type <t> [--scope-id <uuid>] --items <json\|@file>` | Write the given configs' fragments at one scope, all-or-nothing. Each item replaces that config name's fragment or creates it. `--items` takes `[{"config_name": ..., "config": {...}}]`. | auth + RBAC at that scope |
| `./bai app-config-fragment purge --id <uuid>` | Purge one fragment by id. | auth + RBAC |
| `./bai app-config-fragment bulk-purge --id <uuid>...` | Purge many by id, reporting each item's outcome. | auth + RBAC |
| `./bai my app-config-fragment get <config_name>...` | Same read at the caller's own user scope — no scope arguments. | auth |
| `./bai my app-config-fragment update --items <json\|@file>` | Same write at the caller's own user scope. | auth |
| `./bai admin app-config-fragment search [--config-name-contains ...] [--scope-type ...] [--order-by field:dir] [--limit/--offset]` | Search fragments across every scope, paginated. | superadmin |

```bash
# write two configs at my own user scope, then read them back
./bai my app-config-fragment update \
  --items '[{"config_name": "theme", "config": {"mode": "dark"}}, {"config_name": "menu", "config": {"pinned": ["sessions"]}}]'
./bai my app-config-fragment get theme menu

# a domain admin writing that domain's theme
./bai app-config-fragment update --scope-type domain --scope-id "$DOMAIN_ID" --items @theme.json

# superadmin sweep
./bai admin app-config-fragment search --scope-type user --order-by updated_at:desc --limit 20
```

`--scope-id` is required for `domain` and `user` and forbidden for `public`. Both scope-taking commands resolve that pair up front and answer a mismatch with a usage message, rather than letting `AppConfigScopeRef` reject it server-side once the request is already on the wire.

Placement follows `cli/v2/AGENTS.md`: scope-taking and id-addressed commands are user-facing, `my/` holds the self-service pair, the system-wide search is admin-only. The entity is registered in the `/bai-cli` skill's Entity-Command Reference.

## Test plan
- [x] `--help` on the three groups lists the commands above.
- [x] Scope validation on `get` and `update`: `--scope-type public` with `--scope-id`, and `domain` / `user` without one — each rejected with a usage error before any connection is opened.
- [x] `get` with no CONFIG_NAMES is rejected by click as a missing argument.
Verified live against a local manager (direct API mode), superadmin and a regular user:

- [x] `my update` writes two configs at the caller's own user scope; `my get` reads them back.
- [x] `get` answers position by position in the order asked, with `null` for a name the scope holds no fragment for (`get theme nosuch menu` → `theme, null, menu`), and the same result for the reversed argument order.
- [x] Scope isolation: `theme` written at `public`, `domain` and `user` yields three distinct rows, and each `get` answers only its own scope. `my get` matches `get --scope-type user --scope-id <me>`.
- [x] `update` replaces: rewriting a config name keeps the fragment id and `created_at` and bumps `updated_at`.
- [x] All-or-nothing: a batch pairing an allow-listed name with a non-allow-listed one is rejected 403 and leaves the allow-listed one untouched.
- [x] `admin search`: `--config-name-contains`, `--scope-type`, `--order-by config_name:desc`, and `--limit/--offset` (`has_previous_page`/`has_next_page` both true mid-page).
- [x] `purge --id` returns the purged id; `bulk-purge --id` with two real ids and one unknown reports the two under `items` and the unknown under `failed` with a not-found message.
- [x] Permission boundary as a regular user: `admin search` → 403, write at `public` → 403, write at another user's scope → 403, write at own scope via `my update` → OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
