### PR TITLE
feat(BA-7063): expose network and utilization idle checker specs

### DIFF
--- a/changes/13230.feature.md
+++ b/changes/13230.feature.md
@@ -1,0 +1,1 @@
+Support network timeout and utilization specifications in idle checker CRUD APIs.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -8195,6 +8195,8 @@ enum IdleCheckerInputType
   @join__type(graph: STRAWBERRY)
 {
   SESSION_LIFETIME @join__enumValue(graph: STRAWBERRY)
+  NETWORK_TIMEOUT @join__enumValue(graph: STRAWBERRY)
+  UTILIZATION @join__enumValue(graph: STRAWBERRY)
 }
 
 """
@@ -8260,13 +8262,15 @@ input IdleCheckerScopeTypeFilter
 }
 
 """
-Added in 26.8.0. Contains the settings used by an idle checker implementation. This API version exposes session-lifetime settings only.
+Added in 26.8.0. Contains the settings used by an idle checker implementation.
 """
 type IdleCheckerSpec
   @join__type(graph: STRAWBERRY)
 {
   type: IdleCheckerType!
-  sessionLifetime: SessionLifetimeIdleCheckerSpec!
+  sessionLifetime: SessionLifetimeIdleCheckerSpec
+  network: NetworkTimeoutIdleCheckerSpec
+  utilization: UtilizationIdleCheckerSpec
 }
 
 """
@@ -8277,6 +8281,12 @@ input IdleCheckerSpecInput
 {
   """Session-lifetime checker settings."""
   sessionLifetime: SessionLifetimeIdleCheckerSpecInput
+
+  """Network-timeout checker settings."""
+  network: NetworkTimeoutIdleCheckerSpecInput
+
+  """Utilization checker settings."""
+  utilization: UtilizationIdleCheckerSpecInput
 }
 
 """
@@ -8286,6 +8296,8 @@ enum IdleCheckerType
   @join__type(graph: STRAWBERRY)
 {
   SESSION_LIFETIME @join__enumValue(graph: STRAWBERRY)
+  NETWORK_TIMEOUT @join__enumValue(graph: STRAWBERRY)
+  UTILIZATION @join__enumValue(graph: STRAWBERRY)
 }
 
 """
@@ -13040,6 +13052,23 @@ type NetworkNode implements Node
   options: JSONString @join__field(graph: GRAPHENE)
   created_at: DateTime @join__field(graph: GRAPHENE)
   updated_at: DateTime @join__field(graph: GRAPHENE)
+}
+
+"""
+Added in 26.8.0. Configures the maximum period without active network traffic.
+"""
+type NetworkTimeoutIdleCheckerSpec
+  @join__type(graph: STRAWBERRY)
+{
+  maxNetworkInactivitySeconds: Int!
+}
+
+"""Added in 26.8.0. Supplies settings for a network-timeout checker."""
+input NetworkTimeoutIdleCheckerSpecInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Maximum network inactivity period in seconds."""
+  maxNetworkInactivitySeconds: Int!
 }
 
 """
@@ -22830,6 +22859,46 @@ input UserWeightInputItem
   Priority weight multiplier. Higher weight = higher priority allocation ratio. Set to null to use resource group's default_weight.
   """
   weight: Decimal = null
+}
+
+"""
+Added in 26.8.0. Configures how long a session may remain underutilized.
+"""
+type UtilizationIdleCheckerSpec
+  @join__type(graph: STRAWBERRY)
+{
+  maxUnderutilizedDurationSeconds: Int!
+  threshold: UtilizationIdleCheckerThreshold!
+}
+
+"""Added in 26.8.0. Supplies settings for a utilization checker."""
+input UtilizationIdleCheckerSpecInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Maximum underutilized duration in seconds."""
+  maxUnderutilizedDurationSeconds: Int!
+
+  """Preset-backed utilization threshold."""
+  threshold: UtilizationIdleCheckerThresholdInput!
+}
+
+"""Added in 26.8.0. Defines a preset-backed utilization threshold."""
+type UtilizationIdleCheckerThreshold
+  @join__type(graph: STRAWBERRY)
+{
+  presetId: UUID!
+  threshold: Decimal!
+}
+
+"""Added in 26.8.0. Supplies a preset-backed utilization threshold."""
+input UtilizationIdleCheckerThresholdInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Prometheus query preset ID."""
+  presetId: UUID!
+
+  """Underutilization threshold."""
+  threshold: Decimal!
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -5595,6 +5595,8 @@ Added in 26.8.0. Lists checker implementations accepted by create and update ope
 """
 enum IdleCheckerInputType {
   SESSION_LIFETIME
+  NETWORK_TIMEOUT
+  UTILIZATION
 }
 
 """
@@ -5650,11 +5652,13 @@ input IdleCheckerScopeTypeFilter {
 }
 
 """
-Added in 26.8.0. Contains the settings used by an idle checker implementation. This API version exposes session-lifetime settings only.
+Added in 26.8.0. Contains the settings used by an idle checker implementation.
 """
 type IdleCheckerSpec {
   type: IdleCheckerType!
-  sessionLifetime: SessionLifetimeIdleCheckerSpec!
+  sessionLifetime: SessionLifetimeIdleCheckerSpec
+  network: NetworkTimeoutIdleCheckerSpec
+  utilization: UtilizationIdleCheckerSpec
 }
 
 """
@@ -5663,6 +5667,12 @@ Added in 26.8.0. Supplies the implementation-specific settings for an idle check
 input IdleCheckerSpecInput @oneOf {
   """Session-lifetime checker settings."""
   sessionLifetime: SessionLifetimeIdleCheckerSpecInput
+
+  """Network-timeout checker settings."""
+  network: NetworkTimeoutIdleCheckerSpecInput
+
+  """Utilization checker settings."""
+  utilization: UtilizationIdleCheckerSpecInput
 }
 
 """
@@ -5670,6 +5680,8 @@ Added in 26.8.0. Identifies the implementation used to evaluate an idle conditio
 """
 enum IdleCheckerType {
   SESSION_LIFETIME
+  NETWORK_TIMEOUT
+  UTILIZATION
 }
 
 """
@@ -8751,6 +8763,19 @@ input MyUpsertAppConfigFragmentsInput {
 extend type NetworkNode implements Node @key(fields: "id") {
   """The Globally Unique ID of this object"""
   id: ID!
+}
+
+"""
+Added in 26.8.0. Configures the maximum period without active network traffic.
+"""
+type NetworkTimeoutIdleCheckerSpec {
+  maxNetworkInactivitySeconds: Int!
+}
+
+"""Added in 26.8.0. Supplies settings for a network-timeout checker."""
+input NetworkTimeoutIdleCheckerSpecInput {
+  """Maximum network inactivity period in seconds."""
+  maxNetworkInactivitySeconds: Int!
 }
 
 """An object with a Globally Unique ID"""
@@ -16375,6 +16400,38 @@ input UserWeightInputItem {
   Priority weight multiplier. Higher weight = higher priority allocation ratio. Set to null to use resource group's default_weight.
   """
   weight: Decimal = null
+}
+
+"""
+Added in 26.8.0. Configures how long a session may remain underutilized.
+"""
+type UtilizationIdleCheckerSpec {
+  maxUnderutilizedDurationSeconds: Int!
+  threshold: UtilizationIdleCheckerThreshold!
+}
+
+"""Added in 26.8.0. Supplies settings for a utilization checker."""
+input UtilizationIdleCheckerSpecInput {
+  """Maximum underutilized duration in seconds."""
+  maxUnderutilizedDurationSeconds: Int!
+
+  """Preset-backed utilization threshold."""
+  threshold: UtilizationIdleCheckerThresholdInput!
+}
+
+"""Added in 26.8.0. Defines a preset-backed utilization threshold."""
+type UtilizationIdleCheckerThreshold {
+  presetId: UUID!
+  threshold: Decimal!
+}
+
+"""Added in 26.8.0. Supplies a preset-backed utilization threshold."""
+input UtilizationIdleCheckerThresholdInput {
+  """Prometheus query preset ID."""
+  presetId: UUID!
+
+  """Underutilization threshold."""
+  threshold: Decimal!
 }
 
 """Added in 25.16.0. VFS Storage configuration."""

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -10281,7 +10281,9 @@
       },
       "IdleCheckerInputTypeDTO": {
         "enum": [
-          "session_lifetime"
+          "session_lifetime",
+          "network_timeout",
+          "utilization"
         ],
         "title": "IdleCheckerInputTypeDTO",
         "type": "string"
@@ -10299,9 +10301,45 @@
               }
             ],
             "default": null
+          },
+          "network": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NetworkTimeoutSpecInputDTO"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "utilization": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UtilizationSpecInputDTO"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
           }
         },
         "title": "IdleCheckerSpecInputDTO",
+        "type": "object"
+      },
+      "NetworkTimeoutSpecInputDTO": {
+        "properties": {
+          "max_network_inactivity_seconds": {
+            "minimum": 1,
+            "title": "Max Network Inactivity Seconds",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "max_network_inactivity_seconds"
+        ],
+        "title": "NetworkTimeoutSpecInputDTO",
         "type": "object"
       },
       "SessionLifetimeSpecInputDTO": {
@@ -10327,6 +10365,50 @@
         ],
         "title": "SessionTypes",
         "type": "string"
+      },
+      "UtilizationSpecInputDTO": {
+        "properties": {
+          "max_underutilized_duration_seconds": {
+            "minimum": 1,
+            "title": "Max Underutilized Duration Seconds",
+            "type": "integer"
+          },
+          "threshold": {
+            "$ref": "#/components/schemas/UtilizationThresholdInputDTO"
+          }
+        },
+        "required": [
+          "max_underutilized_duration_seconds",
+          "threshold"
+        ],
+        "title": "UtilizationSpecInputDTO",
+        "type": "object"
+      },
+      "UtilizationThresholdInputDTO": {
+        "properties": {
+          "preset_id": {
+            "format": "uuid",
+            "title": "Preset Id",
+            "type": "string"
+          },
+          "threshold": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Threshold"
+          }
+        },
+        "required": [
+          "preset_id",
+          "threshold"
+        ],
+        "title": "UtilizationThresholdInputDTO",
+        "type": "object"
       },
       "CreateIdleCheckerInput": {
         "properties": {
@@ -10534,7 +10616,9 @@
       },
       "IdleCheckerTypeDTO": {
         "enum": [
-          "session_lifetime"
+          "session_lifetime",
+          "network_timeout",
+          "utilization"
         ],
         "title": "IdleCheckerTypeDTO",
         "type": "string"

--- a/src/ai/backend/common/dto/manager/v2/idle_checker/request.py
+++ b/src/ai/backend/common/dto/manager/v2/idle_checker/request.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from decimal import Decimal
 from typing import Self
 
 from pydantic import ConfigDict, Field, model_validator
@@ -13,6 +14,7 @@ from ai.backend.common.dto.manager.v2.idle_checker.types import (
     IdleCheckerOrderField,
 )
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
+from ai.backend.common.identifier.prometheus_query_preset import PrometheusQueryPresetID
 from ai.backend.common.types import SessionTypes
 
 
@@ -20,14 +22,33 @@ class SessionLifetimeSpecInputDTO(BaseRequestModel):
     max_lifetime_seconds: int = Field(ge=1)
 
 
+class NetworkTimeoutSpecInputDTO(BaseRequestModel):
+    max_network_inactivity_seconds: int = Field(ge=1)
+
+
+class UtilizationThresholdInputDTO(BaseRequestModel):
+    preset_id: PrometheusQueryPresetID
+    threshold: Decimal
+
+
+class UtilizationSpecInputDTO(BaseRequestModel):
+    max_underutilized_duration_seconds: int = Field(ge=1)
+    threshold: UtilizationThresholdInputDTO
+
+
 class IdleCheckerSpecInputDTO(BaseRequestModel):
     model_config = ConfigDict(extra="forbid")
 
     session_lifetime: SessionLifetimeSpecInputDTO | None = Field(default=None)
+    network: NetworkTimeoutSpecInputDTO | None = Field(default=None)
+    utilization: UtilizationSpecInputDTO | None = Field(default=None)
 
     @model_validator(mode="after")
     def _validate_exactly_one_spec(self) -> Self:
-        if self.session_lifetime is None:
+        spec_count = sum(
+            spec is not None for spec in (self.session_lifetime, self.network, self.utilization)
+        )
+        if spec_count != 1:
             raise ValueError("Exactly one idle checker specification must be provided")
         return self
 
@@ -39,6 +60,17 @@ class CreateIdleCheckerInput(BaseRequestModel):
     target_session_types: list[SessionTypes] = Field(min_length=1)
     initial_grace_period_seconds: int = Field(default=0, ge=0)
     checker_spec: IdleCheckerSpecInputDTO
+
+    @model_validator(mode="after")
+    def _validate_checker_type_matches_spec(self) -> Self:
+        matches = {
+            IdleCheckerInputTypeDTO.SESSION_LIFETIME: self.checker_spec.session_lifetime,
+            IdleCheckerInputTypeDTO.NETWORK_TIMEOUT: self.checker_spec.network,
+            IdleCheckerInputTypeDTO.UTILIZATION: self.checker_spec.utilization,
+        }
+        if matches[self.checker_type] is None:
+            raise ValueError("checker_type must match the provided idle checker specification")
+        return self
 
 
 class UpdateIdleCheckerInput(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/idle_checker/response.py
+++ b/src/ai/backend/common/dto/manager/v2/idle_checker/response.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from datetime import datetime
+from decimal import Decimal
 
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.v2.idle_checker.types import IdleCheckerTypeDTO
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
+from ai.backend.common.identifier.prometheus_query_preset import PrometheusQueryPresetID
 from ai.backend.common.types import SessionTypes
 
 
@@ -14,9 +16,25 @@ class SessionLifetimeSpecInfo(BaseResponseModel):
     max_lifetime_seconds: int
 
 
+class NetworkTimeoutSpecInfo(BaseResponseModel):
+    max_network_inactivity_seconds: int
+
+
+class UtilizationThresholdInfo(BaseResponseModel):
+    preset_id: PrometheusQueryPresetID
+    threshold: Decimal
+
+
+class UtilizationSpecInfo(BaseResponseModel):
+    max_underutilized_duration_seconds: int
+    threshold: UtilizationThresholdInfo
+
+
 class IdleCheckerSpecInfo(BaseResponseModel):
     type: IdleCheckerTypeDTO
-    session_lifetime: SessionLifetimeSpecInfo
+    session_lifetime: SessionLifetimeSpecInfo | None = Field(default=None)
+    network: NetworkTimeoutSpecInfo | None = Field(default=None)
+    utilization: UtilizationSpecInfo | None = Field(default=None)
 
 
 class IdleCheckerNode(BaseResponseModel):

--- a/src/ai/backend/common/dto/manager/v2/idle_checker/types.py
+++ b/src/ai/backend/common/dto/manager/v2/idle_checker/types.py
@@ -9,10 +9,14 @@ from ai.backend.common.api_handlers import BaseRequestModel
 
 class IdleCheckerTypeDTO(StrEnum):
     SESSION_LIFETIME = "session_lifetime"
+    NETWORK_TIMEOUT = "network_timeout"
+    UTILIZATION = "utilization"
 
 
 class IdleCheckerInputTypeDTO(StrEnum):
     SESSION_LIFETIME = "session_lifetime"
+    NETWORK_TIMEOUT = "network_timeout"
+    UTILIZATION = "utilization"
 
 
 class CheckerTypeFilter(BaseRequestModel):

--- a/src/ai/backend/manager/api/adapters/idle_checker/adapter.py
+++ b/src/ai/backend/manager/api/adapters/idle_checker/adapter.py
@@ -10,7 +10,10 @@ from ai.backend.common.api_handlers import SENTINEL
 from ai.backend.common.data.idle_checker.types import (
     CheckerType,
     IdleCheckerSpec,
+    NetworkTimeoutSpec,
     SessionLifetimeSpec,
+    UtilizationSpec,
+    UtilizationThresholdEntry,
 )
 from ai.backend.common.dto.manager.v2.common import OrderDirection
 from ai.backend.common.dto.manager.v2.idle_checker.request import (
@@ -20,20 +23,22 @@ from ai.backend.common.dto.manager.v2.idle_checker.request import (
     IdleCheckerSpecInputDTO,
     PurgeIdleCheckerInput,
     SearchIdleCheckersInput,
-    SessionLifetimeSpecInputDTO,
     UpdateIdleCheckerInput,
+    UtilizationSpecInputDTO,
 )
 from ai.backend.common.dto.manager.v2.idle_checker.response import (
     CreateIdleCheckerPayload,
     IdleCheckerNode,
     IdleCheckerSpecInfo,
+    NetworkTimeoutSpecInfo,
     PurgeIdleCheckerPayload,
     SearchIdleCheckerPayload,
     SessionLifetimeSpecInfo,
     UpdateIdleCheckerPayload,
+    UtilizationSpecInfo,
+    UtilizationThresholdInfo,
 )
 from ai.backend.common.dto.manager.v2.idle_checker.types import (
-    IdleCheckerInputTypeDTO,
     IdleCheckerOrderField,
     IdleCheckerTypeDTO,
 )
@@ -90,7 +95,7 @@ class IdleCheckerAdapter(BaseAdapter):
                 description=input.description,
                 target_session_types=input.target_session_types,
                 initial_grace_period_seconds=input.initial_grace_period_seconds,
-                spec=self._build_spec(input.checker_type, input.checker_spec),
+                spec=self._build_spec(input.checker_spec),
             )
         )
         action_result = await self._processors.idle_checker.create.wait_for_complete(
@@ -183,7 +188,6 @@ class IdleCheckerAdapter(BaseAdapter):
 
     @staticmethod
     def _data_to_node(data: IdleCheckerData) -> IdleCheckerNode:
-        session_lifetime = cast(SessionLifetimeSpec, data.spec.session_lifetime)
         return IdleCheckerNode(
             id=data.id,
             name=data.name,
@@ -191,29 +195,73 @@ class IdleCheckerAdapter(BaseAdapter):
             checker_type=IdleCheckerTypeDTO(data.checker_type.value),
             target_session_types=data.target_session_types,
             initial_grace_period_seconds=data.initial_grace_period_seconds,
-            spec=IdleCheckerSpecInfo(
-                type=IdleCheckerTypeDTO(data.spec.type.value),
-                session_lifetime=SessionLifetimeSpecInfo(
-                    max_lifetime_seconds=session_lifetime.max_lifetime_seconds
-                ),
-            ),
+            spec=IdleCheckerAdapter._spec_to_info(data.spec),
             created_at=data.created_at,
             updated_at=data.updated_at,
         )
 
     @staticmethod
-    def _build_spec(
-        checker_type: IdleCheckerInputTypeDTO,
-        checker_spec: IdleCheckerSpecInputDTO,
-    ) -> IdleCheckerSpec:
-        session_lifetime = cast(
-            SessionLifetimeSpecInputDTO,
-            checker_spec.session_lifetime,
-        )
+    def _spec_to_info(spec: IdleCheckerSpec) -> IdleCheckerSpecInfo:
+        checker_type = IdleCheckerTypeDTO(spec.type.value)
+        match spec.type:
+            case CheckerType.SESSION_LIFETIME:
+                session_lifetime = cast(SessionLifetimeSpec, spec.session_lifetime)
+                return IdleCheckerSpecInfo(
+                    type=checker_type,
+                    session_lifetime=SessionLifetimeSpecInfo(
+                        max_lifetime_seconds=session_lifetime.max_lifetime_seconds
+                    ),
+                )
+            case CheckerType.NETWORK_TIMEOUT:
+                network = cast(NetworkTimeoutSpec, spec.network)
+                return IdleCheckerSpecInfo(
+                    type=checker_type,
+                    network=NetworkTimeoutSpecInfo(
+                        max_network_inactivity_seconds=network.max_network_inactivity_seconds
+                    ),
+                )
+            case CheckerType.UTILIZATION:
+                utilization = cast(UtilizationSpec, spec.utilization)
+                return IdleCheckerSpecInfo(
+                    type=checker_type,
+                    utilization=UtilizationSpecInfo(
+                        max_underutilized_duration_seconds=(
+                            utilization.max_underutilized_duration_seconds
+                        ),
+                        threshold=UtilizationThresholdInfo(
+                            preset_id=utilization.threshold.preset_id,
+                            threshold=utilization.threshold.threshold,
+                        ),
+                    ),
+                )
+
+    @staticmethod
+    def _build_spec(checker_spec: IdleCheckerSpecInputDTO) -> IdleCheckerSpec:
+        if checker_spec.session_lifetime is not None:
+            session_lifetime = checker_spec.session_lifetime
+            return IdleCheckerSpec(
+                type=CheckerType.SESSION_LIFETIME,
+                session_lifetime=SessionLifetimeSpec(
+                    max_lifetime_seconds=session_lifetime.max_lifetime_seconds
+                ),
+            )
+        if checker_spec.network is not None:
+            network = checker_spec.network
+            return IdleCheckerSpec(
+                type=CheckerType.NETWORK_TIMEOUT,
+                network=NetworkTimeoutSpec(
+                    max_network_inactivity_seconds=network.max_network_inactivity_seconds
+                ),
+            )
+        utilization = cast(UtilizationSpecInputDTO, checker_spec.utilization)
         return IdleCheckerSpec(
-            type=CheckerType(checker_type.value),
-            session_lifetime=SessionLifetimeSpec(
-                max_lifetime_seconds=session_lifetime.max_lifetime_seconds
+            type=CheckerType.UTILIZATION,
+            utilization=UtilizationSpec(
+                max_underutilized_duration_seconds=(utilization.max_underutilized_duration_seconds),
+                threshold=UtilizationThresholdEntry(
+                    preset_id=utilization.threshold.preset_id,
+                    threshold=utilization.threshold.threshold,
+                ),
             ),
         )
 
@@ -224,12 +272,7 @@ class IdleCheckerAdapter(BaseAdapter):
     ) -> OptionalState[IdleCheckerSpec]:
         if checker_spec is None:
             return OptionalState.nop()
-        return OptionalState.update(
-            cls._build_spec(
-                IdleCheckerInputTypeDTO.SESSION_LIFETIME,
-                checker_spec,
-            )
-        )
+        return OptionalState.update(cls._build_spec(checker_spec))
 
     def _convert_filter(self, filter_: IdleCheckerFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []

--- a/src/ai/backend/manager/api/gql/idle_checker/types.py
+++ b/src/ai/backend/manager/api/gql/idle_checker/types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from datetime import datetime
+from decimal import Decimal
 from enum import StrEnum
 from typing import Any, Self, cast, override
 from uuid import UUID
@@ -20,7 +21,10 @@ from ai.backend.common.dto.manager.v2.idle_checker.request import (
 )
 from ai.backend.common.dto.manager.v2.idle_checker.request import (
     IdleCheckerSpecInputDTO,
+    NetworkTimeoutSpecInputDTO,
     SessionLifetimeSpecInputDTO,
+    UtilizationSpecInputDTO,
+    UtilizationThresholdInputDTO,
 )
 from ai.backend.common.dto.manager.v2.idle_checker.request import (
     PurgeIdleCheckerInput as PurgeIdleCheckerInputDTO,
@@ -34,7 +38,10 @@ from ai.backend.common.dto.manager.v2.idle_checker.response import (
 from ai.backend.common.dto.manager.v2.idle_checker.response import (
     IdleCheckerNode,
     IdleCheckerSpecInfo,
+    NetworkTimeoutSpecInfo,
     SessionLifetimeSpecInfo,
+    UtilizationSpecInfo,
+    UtilizationThresholdInfo,
 )
 from ai.backend.common.dto.manager.v2.idle_checker.response import (
     PurgeIdleCheckerPayload as PurgeIdleCheckerPayloadDTO,
@@ -76,6 +83,8 @@ from ai.backend.manager.api.gql.utils import check_admin_only
 )
 class IdleCheckerTypeGQL(StrEnum):
     SESSION_LIFETIME = "session_lifetime"
+    NETWORK_TIMEOUT = "network_timeout"
+    UTILIZATION = "utilization"
 
 
 @gql_enum(
@@ -90,6 +99,8 @@ class IdleCheckerTypeGQL(StrEnum):
 )
 class IdleCheckerInputTypeGQL(StrEnum):
     SESSION_LIFETIME = "session_lifetime"
+    NETWORK_TIMEOUT = "network_timeout"
+    UTILIZATION = "utilization"
 
 
 @gql_pydantic_type(
@@ -110,18 +121,68 @@ class SessionLifetimeIdleCheckerSpecGQL(PydanticOutputMixin[SessionLifetimeSpecI
 @gql_pydantic_type(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
-        description=(
-            "Contains the settings used by an idle checker implementation. "
-            "This API version exposes session-lifetime settings only."
-        ),
+        description="Configures the maximum period without active network traffic.",
+    ),
+    model=NetworkTimeoutSpecInfo,
+    name="NetworkTimeoutIdleCheckerSpec",
+)
+class NetworkTimeoutIdleCheckerSpecGQL(PydanticOutputMixin[NetworkTimeoutSpecInfo]):
+    max_network_inactivity_seconds: int = gql_field(
+        description="Maximum network inactivity period in seconds."
+    )
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Defines a preset-backed utilization threshold.",
+    ),
+    model=UtilizationThresholdInfo,
+    name="UtilizationIdleCheckerThreshold",
+)
+class UtilizationIdleCheckerThresholdGQL(PydanticOutputMixin[UtilizationThresholdInfo]):
+    preset_id: UUID = gql_field(description="Prometheus query preset ID.")
+    threshold: Decimal = gql_field(description="Underutilization threshold.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Configures how long a session may remain underutilized.",
+    ),
+    model=UtilizationSpecInfo,
+    name="UtilizationIdleCheckerSpec",
+)
+class UtilizationIdleCheckerSpecGQL(PydanticOutputMixin[UtilizationSpecInfo]):
+    max_underutilized_duration_seconds: int = gql_field(
+        description="Maximum underutilized duration in seconds."
+    )
+    threshold: UtilizationIdleCheckerThresholdGQL = gql_field(
+        description="Preset-backed utilization threshold."
+    )
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Contains the settings used by an idle checker implementation.",
     ),
     model=IdleCheckerSpecInfo,
     name="IdleCheckerSpec",
 )
 class IdleCheckerSpecGQL(PydanticOutputMixin[IdleCheckerSpecInfo]):
     type: IdleCheckerTypeGQL = gql_field(description="Checker implementation type.")
-    session_lifetime: SessionLifetimeIdleCheckerSpecGQL = gql_field(
+    session_lifetime: SessionLifetimeIdleCheckerSpecGQL | None = gql_field(
         description="Settings that define the maximum lifetime of a session.",
+        default=None,
+    )
+    network: NetworkTimeoutIdleCheckerSpecGQL | None = gql_field(
+        description="Settings that define the maximum network inactivity period.",
+        default=None,
+    )
+    utilization: UtilizationIdleCheckerSpecGQL | None = gql_field(
+        description="Settings that define the maximum underutilized duration.",
+        default=None,
     )
 
 
@@ -204,6 +265,47 @@ class SessionLifetimeIdleCheckerSpecInputGQL(PydanticInputMixin[SessionLifetimeS
 @gql_pydantic_input(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
+        description="Supplies settings for a network-timeout checker.",
+    ),
+    name="NetworkTimeoutIdleCheckerSpecInput",
+)
+class NetworkTimeoutIdleCheckerSpecInputGQL(PydanticInputMixin[NetworkTimeoutSpecInputDTO]):
+    max_network_inactivity_seconds: int = gql_field(
+        description="Maximum network inactivity period in seconds."
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Supplies a preset-backed utilization threshold.",
+    ),
+    name="UtilizationIdleCheckerThresholdInput",
+)
+class UtilizationIdleCheckerThresholdInputGQL(PydanticInputMixin[UtilizationThresholdInputDTO]):
+    preset_id: UUID = gql_field(description="Prometheus query preset ID.")
+    threshold: Decimal = gql_field(description="Underutilization threshold.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Supplies settings for a utilization checker.",
+    ),
+    name="UtilizationIdleCheckerSpecInput",
+)
+class UtilizationIdleCheckerSpecInputGQL(PydanticInputMixin[UtilizationSpecInputDTO]):
+    max_underutilized_duration_seconds: int = gql_field(
+        description="Maximum underutilized duration in seconds."
+    )
+    threshold: UtilizationIdleCheckerThresholdInputGQL = gql_field(
+        description="Preset-backed utilization threshold."
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
         description=(
             "Supplies the implementation-specific settings for an idle checker. "
             "Exactly one checker-specific field must be provided."
@@ -215,6 +317,14 @@ class SessionLifetimeIdleCheckerSpecInputGQL(PydanticInputMixin[SessionLifetimeS
 class IdleCheckerSpecInputGQL(PydanticInputMixin[IdleCheckerSpecInputDTO]):
     session_lifetime: SessionLifetimeIdleCheckerSpecInputGQL | None = gql_field(
         description="Session-lifetime checker settings.",
+        default=UNSET,
+    )
+    network: NetworkTimeoutIdleCheckerSpecInputGQL | None = gql_field(
+        description="Network-timeout checker settings.",
+        default=UNSET,
+    )
+    utilization: UtilizationIdleCheckerSpecInputGQL | None = gql_field(
+        description="Utilization checker settings.",
         default=UNSET,
     )
 

--- a/tests/unit/common/dto/manager/v2/idle_checker/test_request.py
+++ b/tests/unit/common/dto/manager/v2/idle_checker/test_request.py
@@ -6,15 +6,23 @@ from pydantic import ValidationError
 from ai.backend.common.dto.manager.v2.idle_checker.request import (
     CreateIdleCheckerInput,
     IdleCheckerSpecInputDTO,
+    NetworkTimeoutSpecInputDTO,
     SessionLifetimeSpecInputDTO,
 )
 from ai.backend.common.dto.manager.v2.idle_checker.types import IdleCheckerInputTypeDTO
 from ai.backend.common.exception import BackendAISchemaValidationFailed
+from ai.backend.common.types import SessionTypes
 
 
 def _session_lifetime_spec() -> IdleCheckerSpecInputDTO:
     return IdleCheckerSpecInputDTO(
         session_lifetime=SessionLifetimeSpecInputDTO(max_lifetime_seconds=3600)
+    )
+
+
+def _network_spec() -> IdleCheckerSpecInputDTO:
+    return IdleCheckerSpecInputDTO(
+        network=NetworkTimeoutSpecInputDTO(max_network_inactivity_seconds=600)
     )
 
 
@@ -31,6 +39,22 @@ class TestCreateIdleCheckerInput:
     def test_rejects_missing_spec(self) -> None:
         with pytest.raises((BackendAISchemaValidationFailed, ValidationError)):
             IdleCheckerSpecInputDTO()
+
+    def test_rejects_multiple_specs(self) -> None:
+        with pytest.raises((BackendAISchemaValidationFailed, ValidationError)):
+            IdleCheckerSpecInputDTO(
+                session_lifetime=SessionLifetimeSpecInputDTO(max_lifetime_seconds=3600),
+                network=NetworkTimeoutSpecInputDTO(max_network_inactivity_seconds=600),
+            )
+
+    def test_rejects_checker_type_spec_mismatch(self) -> None:
+        with pytest.raises((BackendAISchemaValidationFailed, ValidationError)):
+            CreateIdleCheckerInput(
+                name="mismatched",
+                checker_type=IdleCheckerInputTypeDTO.SESSION_LIFETIME,
+                target_session_types=[SessionTypes.INTERACTIVE],
+                checker_spec=_network_spec(),
+            )
 
     def test_rejects_zero_max_lifetime(self) -> None:
         with pytest.raises((BackendAISchemaValidationFailed, ValidationError)):

--- a/tests/unit/manager/api/adapters/test_idle_checker_adapter.py
+++ b/tests/unit/manager/api/adapters/test_idle_checker_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -13,10 +14,13 @@ from ai.backend.common.data.idle_checker.types import (
 )
 from ai.backend.common.dto.manager.v2.idle_checker.request import (
     IdleCheckerSpecInputDTO,
+    NetworkTimeoutSpecInputDTO,
     SessionLifetimeSpecInputDTO,
+    UtilizationSpecInputDTO,
+    UtilizationThresholdInputDTO,
 )
-from ai.backend.common.dto.manager.v2.idle_checker.types import IdleCheckerInputTypeDTO
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
+from ai.backend.common.identifier.prometheus_query_preset import PrometheusQueryPresetID
 from ai.backend.common.types import SessionTypes
 from ai.backend.manager.api.adapters.idle_checker.adapter import IdleCheckerAdapter
 from ai.backend.manager.data.idle_checker.types import IdleCheckerData
@@ -82,14 +86,50 @@ class TestIdleCheckerAdapter:
         adapter: IdleCheckerAdapter,
         session_lifetime_spec_input: IdleCheckerSpecInputDTO,
     ) -> None:
-        spec = adapter._build_spec(
-            IdleCheckerInputTypeDTO.SESSION_LIFETIME,
-            session_lifetime_spec_input,
-        )
+        spec = adapter._build_spec(session_lifetime_spec_input)
 
         assert spec.type == CheckerType.SESSION_LIFETIME
         assert spec.session_lifetime is not None
         assert spec.session_lifetime.max_lifetime_seconds == 3600
+
+    def test_converts_network_spec(
+        self,
+        adapter: IdleCheckerAdapter,
+    ) -> None:
+        spec = adapter._build_spec(
+            IdleCheckerSpecInputDTO(
+                network=NetworkTimeoutSpecInputDTO(max_network_inactivity_seconds=600)
+            )
+        )
+        info = adapter._spec_to_info(spec)
+
+        assert spec.type == CheckerType.NETWORK_TIMEOUT
+        assert info.network is not None
+        assert info.network.max_network_inactivity_seconds == 600
+
+    def test_converts_utilization_spec(
+        self,
+        adapter: IdleCheckerAdapter,
+    ) -> None:
+        preset_id = PrometheusQueryPresetID(uuid4())
+        spec = adapter._build_spec(
+            IdleCheckerSpecInputDTO(
+                utilization=UtilizationSpecInputDTO(
+                    max_underutilized_duration_seconds=900,
+                    threshold=UtilizationThresholdInputDTO(
+                        preset_id=preset_id,
+                        threshold=Decimal("0.25"),
+                    ),
+                )
+            )
+        )
+        info = adapter._spec_to_info(spec)
+
+        assert spec.type == CheckerType.UTILIZATION
+        assert info.utilization is not None
+        assert info.utilization.max_underutilized_duration_seconds == 900
+        assert info.utilization.threshold.preset_id == preset_id
+        assert info.utilization.threshold.threshold == Decimal("0.25")
 
     async def test_batch_load_preserves_input_order_and_missing_entries(
         self,

--- a/tests/unit/manager/api/gql/idle_checker/test_types.py
+++ b/tests/unit/manager/api/gql/idle_checker/test_types.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
+from decimal import Decimal
+from uuid import uuid4
+
 from ai.backend.manager.api.gql.idle_checker.types import (
     IdleCheckerSpecInputGQL,
+    NetworkTimeoutIdleCheckerSpecInputGQL,
     SessionLifetimeIdleCheckerSpecInputGQL,
+    UtilizationIdleCheckerSpecInputGQL,
+    UtilizationIdleCheckerThresholdInputGQL,
 )
 
 
 class TestIdleCheckerInputs:
-    def test_one_of_spec_converts_to_dto(self) -> None:
+    def test_session_lifetime_spec_converts_to_dto(self) -> None:
         input_ = IdleCheckerSpecInputGQL(
             session_lifetime=SessionLifetimeIdleCheckerSpecInputGQL(max_lifetime_seconds=3600)
         )
@@ -16,3 +22,32 @@ class TestIdleCheckerInputs:
 
         assert dto.session_lifetime is not None
         assert dto.session_lifetime.max_lifetime_seconds == 3600
+
+    def test_network_spec_converts_to_dto(self) -> None:
+        input_ = IdleCheckerSpecInputGQL(
+            network=NetworkTimeoutIdleCheckerSpecInputGQL(max_network_inactivity_seconds=600)
+        )
+
+        dto = input_.to_pydantic()
+
+        assert dto.network is not None
+        assert dto.network.max_network_inactivity_seconds == 600
+
+    def test_utilization_spec_converts_to_dto(self) -> None:
+        preset_id = uuid4()
+        input_ = IdleCheckerSpecInputGQL(
+            utilization=UtilizationIdleCheckerSpecInputGQL(
+                max_underutilized_duration_seconds=900,
+                threshold=UtilizationIdleCheckerThresholdInputGQL(
+                    preset_id=preset_id,
+                    threshold=Decimal("0.25"),
+                ),
+            )
+        )
+
+        dto = input_.to_pydantic()
+
+        assert dto.utilization is not None
+        assert dto.utilization.max_underutilized_duration_seconds == 900
+        assert dto.utilization.threshold.preset_id == preset_id
+        assert dto.utilization.threshold.threshold == Decimal("0.25")


### PR DESCRIPTION
## Summary

- Extend idle checker CRUD DTOs and adapter conversion to support network timeout and utilization specifications.
- Expose typed GraphQL inputs and outputs for both checker types and regenerate the v2 and federated schemas.
- Validate one-of checker specs and require the create-time checker type to match the selected spec.

## Test plan

- [x] `pants fmt ::`
- [x] `pants fix ::`
- [x] `pants lint --changed-since=origin/main`
- [x] Pre-push lint, type check, and tests for `origin/main..HEAD`
- [x] Live REST create, search, update, and purge for network timeout and utilization checkers
- [x] Non-admin access returns 403

Resolves BA-7063


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13230.org.readthedocs.build/en/13230/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13230.org.readthedocs.build/ko/13230/

<!-- readthedocs-preview sorna-ko end -->