### PR TITLE
feat(BA-7071): add the resource group config update CLI v2

### DIFF
--- a/.claude/skills/bai-cli/SKILL.md
+++ b/.claude/skills/bai-cli/SKILL.md
@@ -89,7 +89,7 @@ Check options with `--help`.
 
 ### Resource Management
 
-- **resource-group**: user(empty group) · admin(search, get, create, delete, resource-info, default-options, default-session-options, allow-domains, allowed-domains, allow-projects, allowed-projects, allow-for-domain, allowed-for-domain, allow-for-project, allowed-for-project)
+- **resource-group**: user(empty group) · admin(search, get, create, update, delete, resource-info, default-options, default-session-options, allow-domains, allowed-domains, allow-projects, allowed-projects, allow-for-domain, allowed-for-domain, allow-for-project, allowed-for-project)
 - **resource-allocation**: user(project-usage, resource-group-usage) · admin(domain-usage, effective) · my(effective, keypair-usage)
 - **resource-preset**: admin(search, get, create, update, delete, check-availability)
 - **resource-policy**: admin(sub keypair / project / user — each create, get, search, update, delete) · my(keypair, user)

--- a/changes/13242.feature.md
+++ b/changes/13242.feature.md
@@ -1,0 +1,1 @@
+Add `bai admin resource-group update` to change a resource group configuration, including the scheduler and preemption settings, from the CLI.

--- a/src/ai/backend/client/cli/v2/admin/resource_group.py
+++ b/src/ai/backend/client/cli/v2/admin/resource_group.py
@@ -8,10 +8,12 @@ import click
 
 from ai.backend.client.cli.v2.helpers import (
     create_v2_registry,
+    load_model,
     load_v2_config,
     parse_order_options,
     print_result,
 )
+from ai.backend.common.dto.manager.v2.resource_group.types import SchedulerTypeDTO
 
 
 @click.group(name="resource-group")
@@ -118,6 +120,99 @@ def create(name: str, domain_name: str, description: str | None) -> None:
                     name=name,
                     domain_name=domain_name,
                     description=description,
+                ),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@resource_group.command()
+@click.argument("name", type=str)
+@click.option(
+    "--is-active/--no-is-active",
+    "is_active",
+    default=None,
+    help="Whether the resource group accepts new sessions.",
+)
+@click.option(
+    "--is-public/--no-is-public",
+    "is_public",
+    default=None,
+    help="Whether the resource group is public.",
+)
+@click.option("--description", default=None, type=str, help="Human-readable description.")
+@click.option("--app-proxy-addr", default=None, type=str, help="App proxy address.")
+@click.option("--appproxy-api-token", default=None, type=str, help="App proxy API token.")
+@click.option(
+    "--use-host-network/--no-use-host-network",
+    "use_host_network",
+    default=None,
+    help="Whether sessions in this resource group use host network mode.",
+)
+@click.option(
+    "--scheduler-type",
+    default=None,
+    type=click.Choice([scheduler_type.value for scheduler_type in SchedulerTypeDTO]),
+    help="Scheduler used to admit sessions.",
+)
+@click.option(
+    "--preemption",
+    "preemption_spec",
+    default=None,
+    type=str,
+    help=(
+        "Preemption configuration as a JSON string or @file, matching how the other "
+        "scheduler options are supplied. Keys: enabled, preemptible_priority, order, "
+        "mode, preemption_min_runtime. Read the current block from `resource-group get`."
+    ),
+)
+def update(
+    name: str,
+    is_active: bool | None,
+    is_public: bool | None,
+    description: str | None,
+    app_proxy_addr: str | None,
+    appproxy_api_token: str | None,
+    use_host_network: bool | None,
+    scheduler_type: str | None,
+    preemption_spec: str | None,
+) -> None:
+    """Update a resource group's configuration (superadmin only).
+
+    Only the given options are changed. The server replaces the preemption block as a
+    whole rather than merging it, so a partial ``--preemption`` payload resets the keys
+    it omits to their defaults; read the current block from ``resource-group get``
+    first and send it back with the edits applied.
+    """
+    from ai.backend.common.dto.manager.v2.resource_group.request import (
+        PreemptionConfigInputDTO,
+        UpdateResourceGroupConfigInput,
+    )
+
+    preemption = (
+        load_model(preemption_spec, PreemptionConfigInputDTO)
+        if preemption_spec is not None
+        else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.resource_group.update_config(
+                name,
+                UpdateResourceGroupConfigInput(
+                    resource_group_name=name,
+                    is_active=is_active,
+                    is_public=is_public,
+                    description=description,
+                    app_proxy_addr=app_proxy_addr,
+                    appproxy_api_token=appproxy_api_token,
+                    use_host_network=use_host_network,
+                    scheduler_type=scheduler_type,
+                    preemption=preemption,
                 ),
             )
             print_result(result)


### PR DESCRIPTION
Resolves #13240 (BA-7071)

## Summary

- `PATCH /v2/resource-groups/{name}/config` and the SDK `update_config` already carried the whole `UpdateResourceGroupConfigInput`, but no `./bai` command reached them, so changing a resource group's scheduler configuration — in particular turning session preemption (BEP-1055) on — meant hand-writing an `adminUpdateResourceGroup` mutation.
- Add `./bai admin resource-group update`, covering every field of that input.

```
./bai admin resource-group update default --scheduler-type fifo \
    --preemption '{"enabled": true, "preemptible_priority": 5, "order": "oldest", "mode": "terminate", "preemption_min_runtime": 0}'
```

The flat fields (`is_active`, `is_public`, `description`, the app-proxy settings, `scheduler_type`) get one `--option` each, as CLI v2 `AGENTS.md` asks. The nested preemption block is taken as a JSON string or `@file` through the existing `load_model` helper, matching how the rest of the scheduler options are supplied everywhere else: the v1 CLI takes `--scheduler-opts` as JSON, gql_legacy types `scheduler_opts` as a bare `JSONString`, and the sibling `default-options` / `default-session-options` commands take `--config @file.json`. The server replaces the preemption block as a whole and so does the command, so the two agree without a hidden read-merge.

## Test plan

- [x] `pants fmt lint check` pass
- [x] `admin resource-group get default` returns the live preemption block from a running manager
- [x] Malformed `--preemption` JSON is rejected client-side by `load_model`
- [ ] End-to-end `update` run — blocked on #13246; the preemption write currently rolls back on the server, so the command cannot be exercised until that lands

> Depends on #13246 (BA-7073), which fixes the preemption block being stored as a JSON string. That bug was found while building this command; the two are independent changes and can merge in either order, but this command is only exercisable once the fix is in.
>
> `order` and `mode` are plain `str` on `PreemptionConfigInputDTO`, so a bad value is rejected by the server rather than by the CLI. Tightening them to enums on the DTO would fix that for every caller, not just this command — left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
