### PR TITLE
fix(BA-7073): store the resource group preemption config as a JSONB object

### DIFF
--- a/changes/13246.fix.md
+++ b/changes/13246.fix.md
@@ -1,0 +1,1 @@
+Fix the resource group preemption config being stored as a JSON string, which rolled back every write and left preemption impossible to enable.

--- a/src/ai/backend/manager/repositories/scaling_group/updaters.py
+++ b/src/ai/backend/manager/repositories/scaling_group/updaters.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, override
@@ -149,10 +148,13 @@ class ScalingGroupSchedulerConfigUpdaterSpec(UpdaterSpec[ScalingGroupRow]):
                 "mode": preemption.mode.value,
                 "preemption_min_runtime": preemption.preemption_min_runtime.total_seconds(),
             }
+            # Bind the mapping itself: a pre-serialized str would be JSON-encoded a
+            # second time by the JSONB bind processor and land as a JSON string,
+            # which then fails ScalingGroupOpts validation on read-back.
             to_update["scheduler_opts"] = func.jsonb_set(
                 sa.literal_column("scheduler_opts"),
                 pg_array(["preemption"]),
-                cast(json.dumps(preemption_dict), JSONB),
+                cast(preemption_dict, JSONB),
             )
         return to_update
 

--- a/src/ai/backend/manager/repositories/scaling_group/updaters.py
+++ b/src/ai/backend/manager/repositories/scaling_group/updaters.py
@@ -148,9 +148,6 @@ class ScalingGroupSchedulerConfigUpdaterSpec(UpdaterSpec[ScalingGroupRow]):
                 "mode": preemption.mode.value,
                 "preemption_min_runtime": preemption.preemption_min_runtime.total_seconds(),
             }
-            # Bind the mapping itself: a pre-serialized str would be JSON-encoded a
-            # second time by the JSONB bind processor and land as a JSON string,
-            # which then fails ScalingGroupOpts validation on read-back.
             to_update["scheduler_opts"] = func.jsonb_set(
                 sa.literal_column("scheduler_opts"),
                 pg_array(["preemption"]),

--- a/tests/unit/manager/repositories/scaling_group/test_updaters.py
+++ b/tests/unit/manager/repositories/scaling_group/test_updaters.py
@@ -21,7 +21,7 @@ def preemption_config() -> PreemptionConfig:
     )
 
 
-class TestSchedulerConfigUpdaterPreemption:
+class TestSchedulerConfigUpdater:
     def test_preemption_is_bound_as_a_mapping_not_a_json_string(
         self, preemption_config: PreemptionConfig
     ) -> None:
@@ -38,14 +38,3 @@ class TestSchedulerConfigUpdaterPreemption:
             "mode": "reschedule",
             "preemption_min_runtime": 30.0,
         }
-
-    def test_preemption_write_targets_only_its_own_key(
-        self, preemption_config: PreemptionConfig
-    ) -> None:
-        spec = ScalingGroupSchedulerConfigUpdaterSpec(
-            preemption_config=OptionalState.update(preemption_config)
-        )
-
-        _column, path, _new_value = spec.build_values()["scheduler_opts"].clauses
-
-        assert [element.value for element in path.clauses] == ["preemption"]

--- a/tests/unit/manager/repositories/scaling_group/test_updaters.py
+++ b/tests/unit/manager/repositories/scaling_group/test_updaters.py
@@ -1,0 +1,51 @@
+from datetime import timedelta
+
+import pytest
+
+from ai.backend.common.types import PreemptionMode, PreemptionOrder
+from ai.backend.manager.data.scaling_group.types import PreemptionConfig
+from ai.backend.manager.repositories.scaling_group.updaters import (
+    ScalingGroupSchedulerConfigUpdaterSpec,
+)
+from ai.backend.manager.types import OptionalState
+
+
+@pytest.fixture
+def preemption_config() -> PreemptionConfig:
+    return PreemptionConfig(
+        enabled=True,
+        preemptible_priority=3,
+        order=PreemptionOrder.NEWEST,
+        mode=PreemptionMode.RESCHEDULE,
+        preemption_min_runtime=timedelta(seconds=30),
+    )
+
+
+class TestSchedulerConfigUpdaterPreemption:
+    def test_preemption_is_bound_as_a_mapping_not_a_json_string(
+        self, preemption_config: PreemptionConfig
+    ) -> None:
+        spec = ScalingGroupSchedulerConfigUpdaterSpec(
+            preemption_config=OptionalState.update(preemption_config)
+        )
+
+        _column, _path, new_value = spec.build_values()["scheduler_opts"].clauses
+
+        assert new_value.clause.value == {
+            "enabled": True,
+            "preemptible_priority": 3,
+            "order": "newest",
+            "mode": "reschedule",
+            "preemption_min_runtime": 30.0,
+        }
+
+    def test_preemption_write_targets_only_its_own_key(
+        self, preemption_config: PreemptionConfig
+    ) -> None:
+        spec = ScalingGroupSchedulerConfigUpdaterSpec(
+            preemption_config=OptionalState.update(preemption_config)
+        )
+
+        _column, path, _new_value = spec.build_values()["scheduler_opts"].clauses
+
+        assert [element.value for element in path.clauses] == ["preemption"]


### PR DESCRIPTION
Resolves #13245 (BA-7073)

## Summary

- A resource group's preemption configuration could not be written at all. `ScalingGroupSchedulerConfigUpdaterSpec.build_values()` serialized the preemption mapping with `json.dumps()` and then bound the result as a JSONB parameter, so the bind processor encoded it a second time and the column held a JSON *string* instead of an object.
- `scheduler_opts` is validated as one `ScalingGroupOpts` document on every read, so the `SELECT` that `execute_updater` runs right after the `UPDATE` failed and the whole transaction rolled back. This reproduces through **both** the REST v2 and the GraphQL path, so preemption (BEP-1055) could not be enabled through any surface.

```
BackendAISchemaValidationFailed: 1 validation error for ScalingGroupOpts
preemption
  Input should be a valid dictionary or instance of PreemptionConfig
  [type=model_type, input_value='{"enabled": true, "preem...ion_min_runtime": 30.0}', input_type=str]
```

Bind the mapping itself and let the JSONB bind processor serialize it once.

## Reproducing on the pre-fix code

Run a manager from a checkout **without** this fix. Any preemption write triggers it — the failure is in the read-back, not in the values — and the target resource group must exist.

**GraphQL** (enum values are bare and uppercase):

```bash
./bai gql 'mutation {
  adminUpdateResourceGroup(input: {
    resourceGroupName: "default",
    preemption: {enabled: true, preemptiblePriority: 3, order: NEWEST,
                 mode: RESCHEDULE, preemptionMinRuntime: 30}
  }) { __typename }
}'
```

**REST v2** — `PATCH /v2/resource-groups/default/config` with an `UpdateResourceGroupConfigInput` body (enum values are lowercase strings here):

```json
{
  "resource_group_name": "default",
  "preemption": {"enabled": true, "preemptible_priority": 3, "order": "newest",
                 "mode": "reschedule", "preemption_min_runtime": 30}
}
```

GraphQL answers 200 with the failure in `errors[0].message` and `extensions.code = backendai_parsing_invalid-parameters`, leaving `data.adminUpdateResourceGroup` null; REST v2 answers 400 with the same text in `msg` / `traceback`. Either way the transaction rolls back, so nothing needs cleaning up — `./bai admin resource-group get default` still shows the old block. In Loki: `{service_name="manager"} |= "ScalingGroupOpts"`.

**Without a server**, run `tests/unit/manager/repositories/scaling_group/test_updaters.py` against the pre-fix code; the double-encoded value shows up in the assertion diff. At the DB level, `jsonb_set(..., cast(json.dumps(mapping), JSONB))` stores `jsonb_typeof = string` while `cast(mapping, JSONB)` stores `object`.

## Test plan

- [x] `pants fmt lint check` pass
- [x] Reproduced against a running manager via `PATCH /v2/resource-groups/{name}/config` and via the `adminUpdateResourceGroup` mutation — both returned the error above and left the resource group unchanged
- [x] JSONB bind behaviour verified against the halfstack Postgres on a temp table: `cast(json.dumps(mapping), JSONB)` yields `jsonb_typeof = string`, `cast(mapping, JSONB)` yields `object`
- [x] New unit coverage in `tests/unit/manager/repositories/scaling_group/test_updaters.py`: the preemption block reaches `jsonb_set` as a mapping rather than a pre-serialized string
- [x] Confirmed the test fails against the pre-fix code (double-encoded value shows up in the assertion diff), so it pins the regression rather than restating the fix
- [ ] End-to-end write with the fix applied, confirming the block reads back as a `PreemptionConfig` (needs a manager restarted from this branch)

> Found while adding the resource group config CLI in #13242, which needs this fix to be exercisable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
