### PR TITLE
fix(BA-7073): store the resource group preemption config as a JSONB object (#13246)

### DIFF
--- a/changes/13246.fix.md
+++ b/changes/13246.fix.md
@@ -1,0 +1,1 @@
+Fix the resource group preemption config being stored as a JSON string, which rolled back every write and left preemption impossible to enable.

--- a/src/ai/backend/manager/repositories/scaling_group/updaters.py
+++ b/src/ai/backend/manager/repositories/scaling_group/updaters.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, override
@@ -152,7 +151,7 @@ class ScalingGroupSchedulerConfigUpdaterSpec(UpdaterSpec[ScalingGroupRow]):
             to_update["scheduler_opts"] = func.jsonb_set(
                 sa.literal_column("scheduler_opts"),
                 pg_array(["preemption"]),
-                cast(json.dumps(preemption_dict), JSONB),
+                cast(preemption_dict, JSONB),
             )
         return to_update
 

--- a/tests/unit/manager/repositories/scaling_group/test_updaters.py
+++ b/tests/unit/manager/repositories/scaling_group/test_updaters.py
@@ -1,0 +1,40 @@
+from datetime import timedelta
+
+import pytest
+
+from ai.backend.common.types import PreemptionMode, PreemptionOrder
+from ai.backend.manager.data.scaling_group.types import PreemptionConfig
+from ai.backend.manager.repositories.scaling_group.updaters import (
+    ScalingGroupSchedulerConfigUpdaterSpec,
+)
+from ai.backend.manager.types import OptionalState
+
+
+@pytest.fixture
+def preemption_config() -> PreemptionConfig:
+    return PreemptionConfig(
+        enabled=True,
+        preemptible_priority=3,
+        order=PreemptionOrder.NEWEST,
+        mode=PreemptionMode.RESCHEDULE,
+        preemption_min_runtime=timedelta(seconds=30),
+    )
+
+
+class TestSchedulerConfigUpdater:
+    def test_preemption_is_bound_as_a_mapping_not_a_json_string(
+        self, preemption_config: PreemptionConfig
+    ) -> None:
+        spec = ScalingGroupSchedulerConfigUpdaterSpec(
+            preemption_config=OptionalState.update(preemption_config)
+        )
+
+        _column, _path, new_value = spec.build_values()["scheduler_opts"].clauses
+
+        assert new_value.clause.value == {
+            "enabled": True,
+            "preemptible_priority": 3,
+            "order": "newest",
+            "mode": "reschedule",
+            "preemption_min_runtime": 30.0,
+        }


### PR DESCRIPTION
This is an auto-generated backport PR of #13246 to the 26.8 release.