### PR TITLE
feat(BA-7060): implement scope action monitors (audit log/reporter/Prometheus)

### DIFF
--- a/changes/13255.feature.md
+++ b/changes/13255.feature.md
@@ -1,0 +1,1 @@
+Add scope action monitors (audit log, reporter, Prometheus) and wire them through the DI composer

--- a/src/ai/backend/manager/actions/scope/monitor/audit_log.py
+++ b/src/ai/backend/manager/actions/scope/monitor/audit_log.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import override
+
+from ai.backend.common.contexts.request_id import current_request_id
+from ai.backend.common.contexts.user import current_user, triggered_user
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.scope.base import BaseScopeAction
+from ai.backend.manager.actions.scope.monitor.base import ScopeActionMonitor
+from ai.backend.manager.actions.scope.result import ScopeActionProcessResult
+from ai.backend.manager.actions.types import BLANK_ID
+from ai.backend.manager.repositories.audit_log.creators import AuditLogCreatorSpec
+from ai.backend.manager.repositories.audit_log.repository import AuditLogRepository
+from ai.backend.manager.repositories.base import Creator
+
+__all__ = ("ScopeActionAuditLogMonitor",)
+
+
+class ScopeActionAuditLogMonitor(ScopeActionMonitor):
+    """Persists one audit-log row per target scope of a scope action run.
+
+    A scope action has no single entity id; each row records the target scope's id
+    in the ``entity_id`` column, and the rows share the ``action_id``, which ties
+    them back to the same run.
+    """
+
+    _repository: AuditLogRepository
+
+    def __init__(self, repository: AuditLogRepository) -> None:
+        self._repository = repository
+
+    @override
+    async def prepare(self, action: BaseScopeAction, meta: BaseActionTriggerMeta) -> None:
+        pass
+
+    @override
+    async def done(self, action: BaseScopeAction, result: ScopeActionProcessResult) -> None:
+        trigger = triggered_user()
+        acting = current_user()
+        meta = result.meta
+        request_id = current_request_id() or BLANK_ID
+        for scope in meta.scope_targets:
+            creator = Creator(
+                spec=AuditLogCreatorSpec(
+                    action_id=meta.action_id,
+                    entity_type=action.entity_type(),
+                    operation=action.operation_type(),
+                    created_at=meta.started_at,
+                    description=meta.description,
+                    status=meta.status,
+                    entity_id=str(scope.scope_id),
+                    request_id=request_id,
+                    triggered_by=str(trigger.user_id) if trigger else None,
+                    acted_as=acting.user_id if acting else None,
+                    duration=meta.duration,
+                )
+            )
+            await self._repository.create(creator)

--- a/src/ai/backend/manager/actions/scope/monitor/prometheus.py
+++ b/src/ai/backend/manager/actions/scope/monitor/prometheus.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import override
+
+from ai.backend.common.metrics.metric import ActionMetricObserver
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.scope.base import BaseScopeAction
+from ai.backend.manager.actions.scope.monitor.base import ScopeActionMonitor
+from ai.backend.manager.actions.scope.result import ScopeActionProcessResult
+
+__all__ = ("ScopeActionPrometheusMonitor",)
+
+
+class ScopeActionPrometheusMonitor(ScopeActionMonitor):
+    """Observes scope action outcomes into the Prometheus action metrics.
+
+    One observation per run — the action metric is keyed by (entity_type,
+    operation, status), not by target scope, so a scope run does not fan out.
+    """
+
+    _observer: ActionMetricObserver
+
+    def __init__(self) -> None:
+        self._observer = ActionMetricObserver.instance()
+
+    @override
+    async def prepare(self, action: BaseScopeAction, meta: BaseActionTriggerMeta) -> None:
+        return
+
+    @override
+    async def done(self, action: BaseScopeAction, result: ScopeActionProcessResult) -> None:
+        self._observer.observe_action(
+            entity_type=action.entity_type(),
+            operation_type=action.operation_type(),
+            status=result.meta.status,
+            duration=result.meta.duration.total_seconds(),
+            error_code=result.meta.error_code,
+        )

--- a/src/ai/backend/manager/actions/scope/monitor/reporter.py
+++ b/src/ai/backend/manager/actions/scope/monitor/reporter.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import override
+
+from ai.backend.common.contexts.request_id import current_request_id
+from ai.backend.common.contexts.user import current_user, triggered_user
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.scope.base import BaseScopeAction
+from ai.backend.manager.actions.scope.monitor.base import ScopeActionMonitor
+from ai.backend.manager.actions.scope.result import ScopeActionProcessResult
+from ai.backend.manager.actions.types import BLANK_ID
+from ai.backend.manager.reporters.base import FinishedActionMessage, StartedActionMessage
+from ai.backend.manager.reporters.hub import ReporterHub
+
+__all__ = ("ScopeActionReporterMonitor",)
+
+
+class ScopeActionReporterMonitor(ScopeActionMonitor):
+    """Reports the start and end of a scope action run to the reporter hub.
+
+    A reporter message carries a single ``entity_id``, so a scope run fans out into
+    one message per target scope with the scope's id recorded as ``entity_id``
+    (matching the audit-log rows); the messages share the ``action_id``, which ties
+    them back to the same run.
+    """
+
+    _reporter_hub: ReporterHub
+
+    def __init__(self, reporter_hub: ReporterHub) -> None:
+        self._reporter_hub = reporter_hub
+
+    @override
+    async def prepare(self, action: BaseScopeAction, meta: BaseActionTriggerMeta) -> None:
+        # triggered_by = the caller who triggered the request; acted_as = the effective
+        # (acting) subject. They differ only while a super admin is impersonating.
+        trigger = triggered_user()
+        acting = current_user()
+        request_id = current_request_id()
+        for scope in action.scope_targets():
+            message = StartedActionMessage(
+                action_id=meta.action_id,
+                action_type=action.spec().type(),
+                entity_id=scope.scope_id,
+                entity_type=action.entity_type(),
+                request_id=request_id,
+                triggered_by=str(trigger.user_id) if trigger else None,
+                acted_as=acting.user_id if acting else None,
+                operation_type=action.operation_type(),
+                created_at=meta.started_at,
+            )
+            await self._reporter_hub.report_started(message)
+
+    @override
+    async def done(self, action: BaseScopeAction, result: ScopeActionProcessResult) -> None:
+        trigger = triggered_user()
+        acting = current_user()
+        meta = result.meta
+        request_id = current_request_id() or BLANK_ID
+        for scope in meta.scope_targets:
+            message = FinishedActionMessage(
+                action_id=meta.action_id,
+                action_type=action.spec().type(),
+                entity_id=scope.scope_id,
+                request_id=request_id,
+                triggered_by=str(trigger.user_id) if trigger else None,
+                acted_as=acting.user_id if acting else None,
+                entity_type=action.entity_type(),
+                operation_type=action.operation_type(),
+                status=meta.status,
+                description=meta.description,
+                created_at=meta.started_at,
+                ended_at=meta.ended_at,
+                duration=meta.duration,
+            )
+            await self._reporter_hub.report_finished(message)

--- a/src/ai/backend/manager/dependencies/processing/composer.py
+++ b/src/ai/backend/manager/dependencies/processing/composer.py
@@ -32,6 +32,9 @@ from ai.backend.manager.actions.monitors import ActionMonitors
 from ai.backend.manager.actions.monitors.audit_log import AuditLogMonitor
 from ai.backend.manager.actions.monitors.prometheus import PrometheusMonitor
 from ai.backend.manager.actions.monitors.reporter import ReporterMonitor
+from ai.backend.manager.actions.scope.monitor.audit_log import ScopeActionAuditLogMonitor
+from ai.backend.manager.actions.scope.monitor.prometheus import ScopeActionPrometheusMonitor
+from ai.backend.manager.actions.scope.monitor.reporter import ScopeActionReporterMonitor
 from ai.backend.manager.actions.scope.validator.rbac import (
     VirtualScopeScopeActionRBACValidator,
 )
@@ -254,6 +257,11 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
                 SingleEntityActionReporterMonitor(reporter_hub),
                 SingleEntityActionPrometheusMonitor(),
                 SingleEntityActionAuditLogMonitor(audit_log_repository),
+            ],
+            scope=[
+                ScopeActionReporterMonitor(reporter_hub),
+                ScopeActionPrometheusMonitor(),
+                ScopeActionAuditLogMonitor(audit_log_repository),
             ],
         )
 


### PR DESCRIPTION
## Summary
- Add the monitor implementations bound to the pure-ABC `ScopeActionMonitor` base: `ScopeActionAuditLogMonitor` (one audit-log row per target scope, recording the scope's id as `entity_id`), `ScopeActionReporterMonitor` (one reporter message per target scope with the scope's id as `entity_id`, matching the audit-log rows), and `ScopeActionPrometheusMonitor` (one observation per run — the action metric is keyed by `(entity_type, operation, status)`). Per-scope records share the `action_id`, which ties them back to the same run.
- Introduce an `ActionMonitors` dataclass (mirroring `ActionValidators`) that groups the legacy monitor list with the per-type monitor lists, and wire the scope monitors through the DI composer and `create_processors`.
- Existing `BaseAction`-era processor packages keep receiving the legacy flat list unchanged. The `ActionMonitors` plumbing is intentionally identical to #13254 (BA-7059) and #13256 (BA-7061); whichever merges later only needs a trivial conflict resolution in the composer's per-type monitor lists.

## Test plan
- [x] CI type checks and tests pass

Resolves BA-7060

🤖 Generated with [Claude Code](https://claude.com/claude-code)