### PR TITLE
feat(BA-7061): implement bulk action monitors (audit log/reporter/Prometheus)

### DIFF
--- a/changes/13256.feature.md
+++ b/changes/13256.feature.md
@@ -1,0 +1,1 @@
+Add bulk action monitors (audit log, reporter, Prometheus) and wire them through the DI composer

--- a/src/ai/backend/manager/actions/bulk/monitor/audit_log.py
+++ b/src/ai/backend/manager/actions/bulk/monitor/audit_log.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import override
+
+from ai.backend.common.contexts.request_id import current_request_id
+from ai.backend.common.contexts.user import current_user, triggered_user
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.bulk.base import BaseBulkAction
+from ai.backend.manager.actions.bulk.monitor.base import BulkActionMonitor
+from ai.backend.manager.actions.bulk.result import BulkActionProcessResult
+from ai.backend.manager.actions.types import BLANK_ID
+from ai.backend.manager.repositories.audit_log.creators import AuditLogCreatorSpec
+from ai.backend.manager.repositories.audit_log.repository import AuditLogRepository
+from ai.backend.manager.repositories.base import BulkCreator
+
+__all__ = ("BulkActionAuditLogMonitor",)
+
+
+class BulkActionAuditLogMonitor(BulkActionMonitor):
+    """Persists one audit-log row per target entity of a bulk action run.
+
+    Audit-log rows are tagged with a single ``(entity_type, entity_id)`` pair, so a
+    bulk run fans out into one row per target; the rows share the ``action_id``,
+    which ties them back to the same run. The rows are inserted in a single bulk
+    create rather than one round-trip per target.
+    """
+
+    _repository: AuditLogRepository
+
+    def __init__(self, repository: AuditLogRepository) -> None:
+        self._repository = repository
+
+    @override
+    async def prepare(self, action: BaseBulkAction, meta: BaseActionTriggerMeta) -> None:
+        pass
+
+    @override
+    async def done(self, action: BaseBulkAction, result: BulkActionProcessResult) -> None:
+        trigger = triggered_user()
+        acting = current_user()
+        meta = result.meta
+        request_id = current_request_id() or BLANK_ID
+        bulk_creator = BulkCreator(
+            specs=[
+                AuditLogCreatorSpec(
+                    action_id=meta.action_id,
+                    entity_type=action.entity_type(),
+                    operation=action.operation_type(),
+                    created_at=meta.started_at,
+                    description=meta.description,
+                    status=meta.status,
+                    entity_id=str(entity_id),
+                    request_id=request_id,
+                    triggered_by=str(trigger.user_id) if trigger else None,
+                    acted_as=acting.user_id if acting else None,
+                    duration=meta.duration,
+                )
+                for entity_id in meta.entity_ids
+            ]
+        )
+        await self._repository.bulk_create(bulk_creator)

--- a/src/ai/backend/manager/actions/bulk/monitor/prometheus.py
+++ b/src/ai/backend/manager/actions/bulk/monitor/prometheus.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import override
+
+from ai.backend.common.metrics.metric import ActionMetricObserver
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.bulk.base import BaseBulkAction
+from ai.backend.manager.actions.bulk.monitor.base import BulkActionMonitor
+from ai.backend.manager.actions.bulk.result import BulkActionProcessResult
+
+__all__ = ("BulkActionPrometheusMonitor",)
+
+
+class BulkActionPrometheusMonitor(BulkActionMonitor):
+    """Observes bulk action outcomes into the Prometheus action metrics.
+
+    One observation per run — the action metric is keyed by (entity_type,
+    operation, status), not by target, so a bulk run does not fan out.
+    """
+
+    _observer: ActionMetricObserver
+
+    def __init__(self) -> None:
+        self._observer = ActionMetricObserver.instance()
+
+    @override
+    async def prepare(self, action: BaseBulkAction, meta: BaseActionTriggerMeta) -> None:
+        return
+
+    @override
+    async def done(self, action: BaseBulkAction, result: BulkActionProcessResult) -> None:
+        self._observer.observe_action(
+            entity_type=action.entity_type(),
+            operation_type=action.operation_type(),
+            status=result.meta.status,
+            duration=result.meta.duration.total_seconds(),
+            error_code=result.meta.error_code,
+        )

--- a/src/ai/backend/manager/actions/bulk/monitor/reporter.py
+++ b/src/ai/backend/manager/actions/bulk/monitor/reporter.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import override
+
+from ai.backend.common.contexts.request_id import current_request_id
+from ai.backend.common.contexts.user import current_user, triggered_user
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.bulk.base import BaseBulkAction
+from ai.backend.manager.actions.bulk.monitor.base import BulkActionMonitor
+from ai.backend.manager.actions.bulk.result import BulkActionProcessResult
+from ai.backend.manager.actions.types import BLANK_ID
+from ai.backend.manager.reporters.base import FinishedActionMessage, StartedActionMessage
+from ai.backend.manager.reporters.hub import ReporterHub
+
+__all__ = ("BulkActionReporterMonitor",)
+
+
+class BulkActionReporterMonitor(BulkActionMonitor):
+    """Reports the start and end of a bulk action run to the reporter hub.
+
+    A reporter message carries a single ``entity_id``, so a bulk run fans out into
+    one message per target entity; the messages share the ``action_id``, which ties
+    them back to the same run.
+    """
+
+    _reporter_hub: ReporterHub
+
+    def __init__(self, reporter_hub: ReporterHub) -> None:
+        self._reporter_hub = reporter_hub
+
+    @override
+    async def prepare(self, action: BaseBulkAction, meta: BaseActionTriggerMeta) -> None:
+        # triggered_by = the caller who triggered the request; acted_as = the effective
+        # (acting) subject. They differ only while a super admin is impersonating.
+        trigger = triggered_user()
+        acting = current_user()
+        request_id = current_request_id()
+        for entity_id in action.entity_ids():
+            message = StartedActionMessage(
+                action_id=meta.action_id,
+                action_type=action.spec().type(),
+                entity_id=entity_id,
+                entity_type=action.entity_type(),
+                request_id=request_id,
+                triggered_by=str(trigger.user_id) if trigger else None,
+                acted_as=acting.user_id if acting else None,
+                operation_type=action.operation_type(),
+                created_at=meta.started_at,
+            )
+            await self._reporter_hub.report_started(message)
+
+    @override
+    async def done(self, action: BaseBulkAction, result: BulkActionProcessResult) -> None:
+        trigger = triggered_user()
+        acting = current_user()
+        meta = result.meta
+        request_id = current_request_id() or BLANK_ID
+        for entity_id in meta.entity_ids:
+            message = FinishedActionMessage(
+                action_id=meta.action_id,
+                action_type=action.spec().type(),
+                entity_id=entity_id,
+                request_id=request_id,
+                triggered_by=str(trigger.user_id) if trigger else None,
+                acted_as=acting.user_id if acting else None,
+                entity_type=action.entity_type(),
+                operation_type=action.operation_type(),
+                status=meta.status,
+                description=meta.description,
+                created_at=meta.started_at,
+                ended_at=meta.ended_at,
+                duration=meta.duration,
+            )
+            await self._reporter_hub.report_finished(message)

--- a/src/ai/backend/manager/dependencies/processing/composer.py
+++ b/src/ai/backend/manager/dependencies/processing/composer.py
@@ -25,6 +25,9 @@ from ai.backend.common.message_queue.abc.queue import AbstractMessageQueue
 from ai.backend.common.plugin.event import EventDispatcherPluginContext
 from ai.backend.common.plugin.hook import HookPluginContext
 from ai.backend.common.plugin.monitor import ErrorPluginContext, StatsPluginContext
+from ai.backend.manager.actions.bulk.monitor.audit_log import BulkActionAuditLogMonitor
+from ai.backend.manager.actions.bulk.monitor.prometheus import BulkActionPrometheusMonitor
+from ai.backend.manager.actions.bulk.monitor.reporter import BulkActionReporterMonitor
 from ai.backend.manager.actions.bulk.validator.rbac import (
     VirtualScopeBulkActionRBACValidator,
 )
@@ -257,6 +260,11 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
                 SingleEntityActionReporterMonitor(reporter_hub),
                 SingleEntityActionPrometheusMonitor(),
                 SingleEntityActionAuditLogMonitor(audit_log_repository),
+            ],
+            bulk=[
+                BulkActionReporterMonitor(reporter_hub),
+                BulkActionPrometheusMonitor(),
+                BulkActionAuditLogMonitor(audit_log_repository),
             ],
             scope=[
                 ScopeActionReporterMonitor(reporter_hub),

--- a/src/ai/backend/manager/repositories/audit_log/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/audit_log/db_source/db_source.py
@@ -15,8 +15,10 @@ from ai.backend.manager.models.audit_log import AuditLogRow
 from ai.backend.manager.models.scopes import SearchScope
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
+    BulkCreator,
     Creator,
     execute_batch_querier,
+    execute_bulk_creator,
     execute_creator,
 )
 
@@ -51,6 +53,13 @@ class AuditLogDBSource:
         async with self._db.begin_session() as db_sess:
             result = await execute_creator(db_sess, creator)
             return result.row.to_dataclass()
+
+    @audit_log_db_source_resilience.apply()
+    async def bulk_create(self, bulk_creator: BulkCreator[AuditLogRow]) -> list[AuditLogData]:
+        """Insert multiple audit-log rows in a single bulk operation."""
+        async with self._db.begin_session() as db_sess:
+            result = await execute_bulk_creator(db_sess, bulk_creator)
+            return [row.to_dataclass() for row in result.rows]
 
     @audit_log_db_source_resilience.apply()
     async def search(

--- a/src/ai/backend/manager/repositories/audit_log/repository.py
+++ b/src/ai/backend/manager/repositories/audit_log/repository.py
@@ -11,7 +11,7 @@ from ai.backend.common.resilience.resilience import Resilience
 from ai.backend.manager.data.audit_log.types import AuditLogData, AuditLogListResult
 from ai.backend.manager.models.audit_log import AuditLogRow
 from ai.backend.manager.models.scopes import SearchScope
-from ai.backend.manager.repositories.base import BatchQuerier, Creator
+from ai.backend.manager.repositories.base import BatchQuerier, BulkCreator, Creator
 
 from .db_source import AuditLogDBSource
 
@@ -46,6 +46,11 @@ class AuditLogRepository:
     @audit_log_repository_resilience.apply()
     async def create(self, creator: Creator[AuditLogRow]) -> AuditLogData:
         return await self._db_source.create(creator)
+
+    @audit_log_repository_resilience.apply()
+    async def bulk_create(self, bulk_creator: BulkCreator[AuditLogRow]) -> list[AuditLogData]:
+        """Insert multiple audit-log rows in a single bulk operation."""
+        return await self._db_source.bulk_create(bulk_creator)
 
     @audit_log_repository_resilience.apply()
     async def search(


### PR DESCRIPTION
## Summary
- Add the monitor implementations bound to the pure-ABC `BulkActionMonitor` base: `BulkActionAuditLogMonitor` (one audit-log row per target entity, inserted in a single bulk create), `BulkActionReporterMonitor` (one reporter message per target entity), and `BulkActionPrometheusMonitor` (one observation per run — the action metric is keyed by `(entity_type, operation, status)`). Per-entity records share the `action_id`, which ties them back to the same run.
- Add `AuditLogRepository.bulk_create` (backed by `BulkCreator`/`execute_bulk_creator`) so the audit-log fan-out is a single INSERT instead of one round-trip per target.
- Introduce an `ActionMonitors` dataclass (mirroring `ActionValidators`) that groups the legacy monitor list with the per-type monitor lists, and wire the bulk monitors through the DI composer and `create_processors`.
- Existing `BaseAction`-era processor packages keep receiving the legacy flat list unchanged. The `ActionMonitors` plumbing is intentionally identical to #13254 (BA-7059) and #13255 (BA-7060); whichever merges later only needs a trivial conflict resolution in the composer's per-type monitor lists.

## Test plan
- [x] CI type checks and tests pass

Resolves BA-7061

🤖 Generated with [Claude Code](https://claude.com/claude-code)