### PR TITLE
chore: enable mypy truthy-iterable error code

### DIFF
--- a/changes/13258.misc.md
+++ b/changes/13258.misc.md
@@ -1,0 +1,1 @@
+Enable mypy's `truthy-iterable` error code and annotate always-truthy `Iterable` parameters as `Collection`/`Sequence` for meaningful emptiness checks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,7 +334,7 @@ namespace_packages = true
 explicit_package_bases = true
 python_executable = "dist/export/python/virtualenvs/python-default/3.13.7/bin/python"
 disable_error_code = ["typeddict-unknown-key", "import-untyped"]
-enable_error_code = ["possibly-undefined", "explicit-override"]
+enable_error_code = ["possibly-undefined", "explicit-override", "truthy-iterable"]
 warn_unreachable = true
 
 # Disable errors in client CLI, web server, and tests

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -19,6 +19,7 @@ from collections.abc import (
     AsyncGenerator,
     Awaitable,
     Callable,
+    Collection,
     Coroutine,
     Generator,
     Iterable,
@@ -300,7 +301,7 @@ P = ParamSpec("P")
 KernelIdContainerPair = tuple[KernelId, Container]
 
 
-def update_additional_gids(environ: MutableMapping[str, str], gids: Iterable[int]) -> None:
+def update_additional_gids(environ: MutableMapping[str, str], gids: Collection[int]) -> None:
     if not gids:
         return
     if orig_additional_gids := environ.get("ADDITIONAL_GIDS"):

--- a/src/ai/backend/agent/alloc_map.py
+++ b/src/ai/backend/agent/alloc_map.py
@@ -8,7 +8,7 @@ import math
 import operator
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
-from collections.abc import Iterable, Mapping, MutableMapping, Sequence
+from collections.abc import Collection, Iterable, Mapping, MutableMapping, Sequence
 from decimal import ROUND_DOWN, Decimal
 from typing import (
     TYPE_CHECKING,
@@ -77,7 +77,7 @@ def round_down(from_dec: Decimal, with_dec: Decimal) -> Decimal:
 class AbstractAllocMap(metaclass=ABCMeta):
     device_slots: Mapping[DeviceId, DeviceSlotInfo]
     device_mask: frozenset[DeviceId]
-    exclusive_slot_types: Iterable[SlotName]
+    exclusive_slot_types: Collection[SlotName]
     allocations: MutableMapping[SlotName, MutableMapping[DeviceId, Decimal]]
 
     def __init__(
@@ -85,7 +85,7 @@ class AbstractAllocMap(metaclass=ABCMeta):
         *,
         device_slots: Mapping[DeviceId, DeviceSlotInfo] | None = None,
         device_mask: Iterable[DeviceId] | None = None,
-        exclusive_slot_types: Iterable[SlotName] | None = None,
+        exclusive_slot_types: Collection[SlotName] | None = None,
     ) -> None:
         self.exclusive_slot_types = exclusive_slot_types or {}
         self.device_slots = device_slots or {}

--- a/src/ai/backend/manager/models/endpoint/row.py
+++ b/src/ai/backend/manager/models/endpoint/row.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import uuid
 from collections.abc import (
+    Collection,
     Iterable,
     Sequence,
 )
@@ -1092,7 +1093,7 @@ class EndpointAutoScalingRuleRow(Base):  # type: ignore[misc]
     async def list(
         cls,
         session: AsyncSession,
-        endpoint_status_filter: Iterable[EndpointLifecycle] = frozenset([
+        endpoint_status_filter: Collection[EndpointLifecycle] = frozenset([
             EndpointLifecycle.CREATED
         ]),
     ) -> Sequence[Self]:

--- a/src/ai/backend/manager/models/group/row.py
+++ b/src/ai/backend/manager/models/group/row.py
@@ -486,7 +486,7 @@ async def resolve_groups(
     db_conn: SAConnection,
     domain_name: str,
     values: Iterable[uuid.UUID],
-) -> Iterable[uuid.UUID]: ...
+) -> Sequence[uuid.UUID]: ...
 
 
 @overload
@@ -494,14 +494,14 @@ async def resolve_groups(
     db_conn: SAConnection,
     domain_name: str,
     values: Iterable[str],
-) -> Iterable[uuid.UUID]: ...
+) -> Sequence[uuid.UUID]: ...
 
 
 async def resolve_groups(
     db_conn: SAConnection,
     domain_name: str,
     values: Iterable[uuid.UUID] | Iterable[str],
-) -> Iterable[uuid.UUID]:
+) -> Sequence[uuid.UUID]:
     listed_val = [*values]
     match listed_val:
         case [uuid.UUID(), *_]:

--- a/src/ai/backend/manager/models/scaling_group/row.py
+++ b/src/ai/backend/manager/models/scaling_group/row.py
@@ -532,7 +532,7 @@ async def query_allowed_sgroups(
     result = await db_conn.execute(query)
     from_domain = {row.scaling_group for row in result}
 
-    group_ids: Iterable[uuid.UUID] = []
+    group_ids: Sequence[uuid.UUID] = []
     match group:
         case uuid.UUID() | str():
             if group_id := await resolve_group_name_or_id(db_conn, domain_name, group):

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -4,7 +4,7 @@ import dataclasses
 import logging
 import uuid
 from collections import Counter, defaultdict
-from collections.abc import AsyncIterator, Iterable, Mapping, Sequence
+from collections.abc import AsyncIterator, Collection, Mapping, Sequence
 from contextlib import asynccontextmanager as actxmgr
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -2646,7 +2646,7 @@ class DeploymentDBSource:
                 preset_resource_slots=_project_preset_slots(preset_row, preset_slots),
             )
 
-    async def fetch_revision_required_slot_names(self) -> Iterable[SlotName]:
+    async def fetch_revision_required_slot_names(self) -> Collection[SlotName]:
         """Return the globally required resource slot names"""
         async with self._db.begin_readonly_session_read_committed() as session:
             stmt = sa.select(ResourceSlotTypeRow.slot_name).where(

--- a/src/ai/backend/manager/repositories/deployment/repository.py
+++ b/src/ai/backend/manager/repositories/deployment/repository.py
@@ -3,7 +3,7 @@
 import logging
 import uuid
 from collections import defaultdict
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Collection, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal, DecimalException
@@ -1249,7 +1249,7 @@ class DeploymentRepository:
         )
 
     @deployment_repository_resilience.apply()
-    async def fetch_revision_required_slot_names(self) -> Iterable[SlotName]:
+    async def fetch_revision_required_slot_names(self) -> Collection[SlotName]:
         """Globally required resource slot names for revision validation."""
         return await self._db_source.fetch_revision_required_slot_names()
 

--- a/src/ai/backend/manager/sokovan/deployment/validators/base.py
+++ b/src/ai/backend/manager/sokovan/deployment/validators/base.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Sequence
+from collections.abc import Collection, Iterable, Sequence
 from dataclasses import dataclass, field
 
 from ai.backend.common.types import SlotName
@@ -36,7 +36,7 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 class DeploymentRevisionValidationContext:
     """Read-only global state the validator chain consumes."""
 
-    required_slot_names: Iterable[SlotName] = field(default_factory=frozenset)
+    required_slot_names: Collection[SlotName] = field(default_factory=frozenset)
 
 
 class DeploymentRevisionValidatorRule(ABC):

--- a/src/ai/backend/manager/sokovan/deployment/validators/required_resource_slot_rule.py
+++ b/src/ai/backend/manager/sokovan/deployment/validators/required_resource_slot_rule.py
@@ -13,7 +13,7 @@ absent or non-positive:
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Collection
 from decimal import Decimal
 from typing import override
 
@@ -58,7 +58,7 @@ class RequiredResourceSlotRule(DeploymentRevisionValidatorRule):
     def _check_resource_slots(
         self,
         resource_slots: ResourceSlot,
-        required_slot_names: Iterable[SlotName],
+        required_slot_names: Collection[SlotName],
     ) -> None:
         if not required_slot_names:
             return


### PR DESCRIPTION
## Summary
- Enable mypy's `truthy-iterable` error code in `pyproject.toml` to catch always-true boolean checks on bare `Iterable` values.
- Re-annotate the flagged parameters and fields as `Collection`/`Sequence` so emptiness checks are type-safe: endpoint auto-scaling rule listing, allowed-sgroup group resolution, agent `exclusive_slot_types`/`update_additional_gids`, and the deployment required-resource-slot validation chain (db source → repository → validation context → rule).

## Test plan
- [x] `pants fmt` / `pants fix` / `pants lint --changed-since=origin/main` pass
- [x] CI type check (`pants check`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)