### PR TITLE
fix(BA-7077): expose RESERVED in the v2 kernel status enums

### DIFF
--- a/changes/13260.fix.md
+++ b/changes/13260.fix.md
@@ -1,0 +1,1 @@
+Expose `RESERVED` in the v2 kernel status enums so kernels holding a preemption reservation can be selected by status filters.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -9413,6 +9413,7 @@ enum KernelV2Status
   @join__type(graph: STRAWBERRY)
 {
   PENDING @join__enumValue(graph: STRAWBERRY)
+  RESERVED @join__enumValue(graph: STRAWBERRY)
   SCHEDULED @join__enumValue(graph: STRAWBERRY)
   PREPARING @join__enumValue(graph: STRAWBERRY)
   PREPARED @join__enumValue(graph: STRAWBERRY)

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -6424,6 +6424,7 @@ type KernelV2SessionInfo {
 """Added in 26.2.0. Status of a kernel in its lifecycle."""
 enum KernelV2Status {
   PENDING
+  RESERVED
   SCHEDULED
   PREPARING
   PREPARED

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -29106,6 +29106,7 @@
         "description": "Kernel lifecycle status values for DTO filtering.",
         "enum": [
           "PENDING",
+          "RESERVED",
           "SCHEDULED",
           "PREPARING",
           "PREPARED",

--- a/src/ai/backend/common/dto/manager/v2/kernel/types.py
+++ b/src/ai/backend/common/dto/manager/v2/kernel/types.py
@@ -30,6 +30,7 @@ class KernelStatusEnum(StrEnum):
     """Kernel lifecycle status values for DTO filtering."""
 
     PENDING = "PENDING"
+    RESERVED = "RESERVED"
     SCHEDULED = "SCHEDULED"
     PREPARING = "PREPARING"
     PREPARED = "PREPARED"

--- a/src/ai/backend/manager/api/gql/kernel/types.py
+++ b/src/ai/backend/manager/api/gql/kernel/types.py
@@ -81,6 +81,7 @@ class KernelV2StatusGQL(StrEnum):
     """GraphQL enum for kernel status."""
 
     PENDING = "PENDING"
+    RESERVED = "RESERVED"
     SCHEDULED = "SCHEDULED"
     PREPARING = "PREPARING"
     PREPARED = "PREPARED"


### PR DESCRIPTION
Resolves #13259 (BA-7077)

## Summary

- A kernel holding a preemption reservation sits in `KernelStatus.RESERVED`, but neither `KernelStatusEnum` (v2 DTO filter) nor `KernelV2StatusGQL` carried the value, so those kernels could not be selected by status — not through the GraphQL `KernelV2StatusFilter`, and not through `./bai admin session kernel search --status RESERVED`.
- The kernel read DTO types `status` as a plain `str`, so serialization was unaffected. This is the filtering half of the gap #13235 (BA-7068) closed on the session side, where the missing value broke enum serialization outright.

Kernels do reach the status — the reservation write moves them `PENDING -> RESERVED`, `release-reserved-sessions` selects its work by `target_kernel_statuses = [KernelStatus.RESERVED]`, and `CHECK_RESERVED_PROGRESS` promotes the session to SCHEDULED only once no kernel is left in it.

## Test plan

- [x] `pants fmt lint check` pass
- [x] Confirmed the gap: internal `KernelStatus` carries 16 values, the two v2 enums carried 9, and `SessionStatusEnum` already exposes RESERVED
- [x] Confirmed kernels are written to RESERVED, not just filtered on it (`_reserve_single_session` sets `status=KernelStatus.RESERVED` under a `status == PENDING` idempotency gate)
- [ ] Filter a reserved kernel end-to-end once a preemption reservation can actually be produced — blocked on #13246, which fixes preemption config being unwritable

> The other values missing from the v2 kernel enums — `BUILDING`, `PULLING`, `RESIZING`, `RESTARTING`, `SUSPENDED`, `ERROR` — are left alone here; worth a follow-up.
>
> The GraphQL schema dump is regenerated and committed by the `update-api-schema` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
