### PR TITLE
fix(BA-7077): expose RESERVED in the v2 kernel status enums (#13260)

### DIFF
--- a/changes/13260.fix.md
+++ b/changes/13260.fix.md
@@ -1,0 +1,1 @@
+Expose `RESERVED` in the v2 kernel status enums so kernels holding a preemption reservation can be selected by status filters.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -9413,6 +9413,7 @@ enum KernelV2Status
   @join__type(graph: STRAWBERRY)
 {
   PENDING @join__enumValue(graph: STRAWBERRY)
+  RESERVED @join__enumValue(graph: STRAWBERRY)
   SCHEDULED @join__enumValue(graph: STRAWBERRY)
   PREPARING @join__enumValue(graph: STRAWBERRY)
   PREPARED @join__enumValue(graph: STRAWBERRY)

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -6424,6 +6424,7 @@ type KernelV2SessionInfo {
 """Added in 26.2.0. Status of a kernel in its lifecycle."""
 enum KernelV2Status {
   PENDING
+  RESERVED
   SCHEDULED
   PREPARING
   PREPARED

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -29106,6 +29106,7 @@
         "description": "Kernel lifecycle status values for DTO filtering.",
         "enum": [
           "PENDING",
+          "RESERVED",
           "SCHEDULED",
           "PREPARING",
           "PREPARED",

--- a/src/ai/backend/common/dto/manager/v2/kernel/types.py
+++ b/src/ai/backend/common/dto/manager/v2/kernel/types.py
@@ -30,6 +30,7 @@ class KernelStatusEnum(StrEnum):
     """Kernel lifecycle status values for DTO filtering."""
 
     PENDING = "PENDING"
+    RESERVED = "RESERVED"
     SCHEDULED = "SCHEDULED"
     PREPARING = "PREPARING"
     PREPARED = "PREPARED"

--- a/src/ai/backend/manager/api/gql/kernel/types.py
+++ b/src/ai/backend/manager/api/gql/kernel/types.py
@@ -81,6 +81,7 @@ class KernelV2StatusGQL(StrEnum):
     """GraphQL enum for kernel status."""
 
     PENDING = "PENDING"
+    RESERVED = "RESERVED"
     SCHEDULED = "SCHEDULED"
     PREPARING = "PREPARING"
     PREPARED = "PREPARED"


### PR DESCRIPTION
This is an auto-generated backport PR of #13260 to the 26.8 release.

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13262.org.readthedocs.build/en/13262/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13262.org.readthedocs.build/ko/13262/

<!-- readthedocs-preview sorna-ko end -->