### PR TITLE
chore: enable mypy truthy-bool error code

### DIFF
--- a/changes/13265.misc.md
+++ b/changes/13265.misc.md
@@ -1,0 +1,1 @@
+Enable mypy's `truthy-bool` error code, replacing always-true truthiness checks with explicit `is not None` comparisons and fixing latent bugs it uncovered (Redis client disconnect, vfolder-mount test cleanup, container-registry migration idempotency, auto-scaling rule deletion)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,7 +334,12 @@ namespace_packages = true
 explicit_package_bases = true
 python_executable = "dist/export/python/virtualenvs/python-default/3.13.7/bin/python"
 disable_error_code = ["typeddict-unknown-key", "import-untyped"]
-enable_error_code = ["possibly-undefined", "explicit-override", "truthy-iterable"]
+enable_error_code = [
+    "possibly-undefined",
+    "explicit-override",
+    "truthy-iterable",
+    "truthy-bool",
+]
 warn_unreachable = true
 
 # Disable errors in client CLI, web server, and tests

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1450,6 +1450,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
 
 
 class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
+    docker: Docker
     docker_info: Mapping[str, Any]
     monitor_docker_task: asyncio.Task[Any]
     agent_sockpath: Path
@@ -1621,7 +1622,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                 self.monitor_docker_task.cancel()
                 await self.monitor_docker_task
 
-        if self.docker:
+        if self.docker is not None:
             await self.docker.close()
 
     @override

--- a/src/ai/backend/agent/stage/kernel_lifecycle/docker/container_ssh.py
+++ b/src/ai/backend/agent/stage/kernel_lifecycle/docker/container_ssh.py
@@ -26,7 +26,7 @@ class AgentConfig:
 @dataclass
 class ContainerSSHSpec:
     work_dir: Path
-    ssh_keypair: ContainerSSHKeyPair
+    ssh_keypair: ContainerSSHKeyPair | None
     mounts: list[Mount]
 
     # Override UID/GID settings
@@ -60,7 +60,8 @@ class ContainerSSHProvisioner(Provisioner[ContainerSSHSpec, ContainerSSHResult])
 
     @override
     async def setup(self, spec: ContainerSSHSpec) -> ContainerSSHResult:
-        if not spec.ssh_keypair:
+        ssh_keypair = spec.ssh_keypair
+        if ssh_keypair is None:
             return ContainerSSHResult(ssh_dir=None)
 
         # Check if /home/work/.ssh is already mounted
@@ -72,12 +73,14 @@ class ContainerSSHProvisioner(Provisioner[ContainerSSHSpec, ContainerSSHResult])
 
         loop = asyncio.get_running_loop()
 
-        ssh_dir = await loop.run_in_executor(None, self._populate_ssh_config, spec)
+        ssh_dir = await loop.run_in_executor(None, self._populate_ssh_config, spec, ssh_keypair)
         return ContainerSSHResult(ssh_dir=ssh_dir)
 
-    def _populate_ssh_config(self, spec: ContainerSSHSpec) -> Path:
-        pubkey = spec.ssh_keypair.public_key.encode("ascii")
-        privkey = spec.ssh_keypair.private_key.encode("ascii")
+    def _populate_ssh_config(
+        self, spec: ContainerSSHSpec, ssh_keypair: ContainerSSHKeyPair
+    ) -> Path:
+        pubkey = ssh_keypair.public_key.encode("ascii")
+        privkey = ssh_keypair.private_key.encode("ascii")
         ssh_dir = spec.work_dir / ".ssh"
 
         # Create SSH directory

--- a/src/ai/backend/appproxy/coordinator/api/proxy.py
+++ b/src/ai/backend/appproxy/coordinator/api/proxy.py
@@ -25,7 +25,6 @@ from ai.backend.appproxy.common.types import (
 )
 from ai.backend.appproxy.common.utils import mime_match, pydantic_api_handler
 from ai.backend.appproxy.coordinator.api.types import ConfRequestModel
-from ai.backend.appproxy.coordinator.errors import CircuitCreationError
 from ai.backend.appproxy.coordinator.models import Circuit, Token, Worker, add_circuit
 from ai.backend.appproxy.coordinator.models.utils import execute_with_txn_retry
 from ai.backend.appproxy.coordinator.types import RootContext
@@ -193,9 +192,6 @@ async def proxy(
                 _update, root_ctx.db.begin_session, db_conn
             )
         log.debug("created new circuit {}", circuit.id)
-
-    if not circuit or not worker:
-        raise CircuitCreationError("Failed to create circuit and worker.")
 
     await root_ctx.circuit_manager.initialize_circuits([circuit])
     log.debug("Circuit is set (id:{})", str(circuit.id))

--- a/src/ai/backend/client/cli/admin/etcd.py
+++ b/src/ai/backend/client/cli/admin/etcd.py
@@ -1,5 +1,6 @@
 import json
 import sys
+from typing import Any, cast
 
 import click
 
@@ -32,12 +33,11 @@ def get(key: str, prefix: bool) -> None:
 
     with Session() as session:
         try:
-            data = session.EtcdConfig.get(key, prefix)
+            data = cast(dict[str, Any] | None, session.EtcdConfig.get(key, prefix))
         except Exception as e:
             print_error(e)
             sys.exit(ExitCode.FAILURE)
-        data = json.dumps(data, indent=2) if data else "null"
-        print_pretty(data)
+        print_pretty(json.dumps(data, indent=2) if data else "null")
 
 
 @etcd.command()

--- a/src/ai/backend/client/cli/admin/user.py
+++ b/src/ai/backend/client/cli/admin/user.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 import uuid
 from collections.abc import Iterable, Sequence
+from typing import Any, cast
 
 import click
 
@@ -309,16 +310,19 @@ def add(
                     uuid.UUID(group_ref)
                     group_ids.append(group_ref)
                 except ValueError:
-                    data = session.Group.from_name(
-                        group_ref,
-                        domain_name=domain_name,
+                    matched_groups = cast(
+                        Sequence[dict[str, Any]],
+                        session.Group.from_name(
+                            group_ref,
+                            domain_name=domain_name,
+                        ),
                     )
-                    if not data:
+                    if not matched_groups:
                         # Either domain_name or group_ref may be invalid.
                         raise ValueError(
                             f"Cannot find the group {group_ref!r} in the domain {domain_name!r}"
                         ) from None
-                    group_ids.append(data[0]["id"])
+                    group_ids.append(matched_groups[0]["id"])
             data = session.User.create(
                 domain_name,
                 email,

--- a/src/ai/backend/client/cli/dotfile.py
+++ b/src/ai/backend/client/cli/dotfile.py
@@ -1,5 +1,7 @@
 import sys
+from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import cast
 
 import click
 from tabulate import tabulate
@@ -159,8 +161,11 @@ def list(owner_access_key: str | None, domain: str | None, group: str | None) ->
     ]
     with Session() as session:
         try:
-            resp = session.Dotfile.list_dotfiles(
-                owner_access_key=owner_access_key, domain=domain, group=group
+            resp = cast(
+                Sequence[Mapping[str, str]],
+                session.Dotfile.list_dotfiles(
+                    owner_access_key=owner_access_key, domain=domain, group=group
+                ),
             )
             if not resp:
                 print("There is no dotfiles created yet.")

--- a/src/ai/backend/client/cli/network.py
+++ b/src/ai/backend/client/cli/network.py
@@ -1,7 +1,7 @@
 import sys
 import uuid
-from collections.abc import Iterable
-from typing import Any
+from collections.abc import Iterable, Sequence
+from typing import Any, cast
 
 import click
 
@@ -43,11 +43,11 @@ def create(ctx: CLIContext, project: str, name: str, driver: str | None) -> None
         except ValueError:
             pass
         else:
-            if session.Group.detail(project):
+            if cast(dict[str, Any] | None, session.Group.detail(project)):
                 proj_id = project
 
         if not proj_id:
-            projects = session.Group.from_name(project)
+            projects = cast(Sequence[dict[str, Any]], session.Group.from_name(project))
             if not projects:
                 ctx.output.print_fail(f"Project '{project}' not found.")
                 sys.exit(ExitCode.FAILURE)

--- a/src/ai/backend/client/cli/scheduling_history.py
+++ b/src/ai/backend/client/cli/scheduling_history.py
@@ -152,7 +152,7 @@ def _render_flat_view(
             status_str = f" ({h.from_status or '?'} → {h.to_status or '?'})"
 
         # Format timestamp (convert UTC to local time)
-        created = _format_local_time(str(h.created_at) if h.created_at else None)
+        created = _format_local_time(str(h.created_at))
 
         print(
             f"{main_prefix} {result_indicator} {entity_label} | {phase_str}{status_str} @ {created}"
@@ -241,7 +241,7 @@ def _render_grouped_view(
                 status_str = f" ({h.from_status or '?'} → {h.to_status or '?'})"
 
             # Format timestamp (convert UTC to local time)
-            created = _format_local_time(str(h.created_at) if h.created_at else None)
+            created = _format_local_time(str(h.created_at))
 
             print(f"{history_prefix} {result_indicator} {phase_str}{status_str} @ {created}")
 

--- a/src/ai/backend/client/cli/session_template.py
+++ b/src/ai/backend/client/cli/session_template.py
@@ -1,5 +1,7 @@
 import sys
+from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import cast
 
 import click
 from tabulate import tabulate
@@ -133,7 +135,9 @@ def list(list_all: bool) -> None:
     ]
     with Session() as session:
         try:
-            resp = session.SessionTemplate.list_templates(list_all)
+            resp = cast(
+                Sequence[Mapping[str, str]], session.SessionTemplate.list_templates(list_all)
+            )
             if not resp:
                 print("There is no task templates created yet.")
                 return

--- a/src/ai/backend/common/api_handlers.py
+++ b/src/ai/backend/common/api_handlers.py
@@ -353,11 +353,6 @@ async def _parse_and_execute_handler(
 
         value = await extract_param_value(request=request, input_param_type=param.annotation)
 
-        if not value:
-            raise InvalidAPIParameters(
-                f"Type hint or Annotated must be added in API handler signature: {param.name}"
-            )
-
         handler_params.add(name, value)
 
     response = await handler(**handler_params.get_all())

--- a/src/ai/backend/common/redis_client.py
+++ b/src/ai/backend/common/redis_client.py
@@ -216,8 +216,8 @@ class RedisConnection(AbstractAsyncContextManager[RedisClient]):
     _socket_connect_timeout: float | None
     _keepalive_options: dict[int, int]
 
-    reader: asyncio.StreamReader | None
-    writer: asyncio.StreamWriter | None
+    _reader: asyncio.StreamReader | None
+    _writer: asyncio.StreamWriter | None
 
     def __init__(
         self,
@@ -230,8 +230,8 @@ class RedisConnection(AbstractAsyncContextManager[RedisClient]):
     ) -> None:
         self._redis_target = redis_target
         self._db = db
-        self.reader = None
-        self.writer = None
+        self._reader = None
+        self._writer = None
 
         self._socket_timeout = socket_timeout
         self._socket_connect_timeout = socket_connect_timeout
@@ -257,8 +257,8 @@ class RedisConnection(AbstractAsyncContextManager[RedisClient]):
             for opt, val in self._keepalive_options.items():
                 sock.setsockopt(socket.IPPROTO_TCP, opt, val)
 
-        self.writer = writer
-        self.reader = reader
+        self._writer = writer
+        self._reader = reader
 
         client = RedisClient(reader, writer)
 
@@ -284,9 +284,9 @@ class RedisConnection(AbstractAsyncContextManager[RedisClient]):
         return await self.connect()
 
     async def disconnect(self) -> None:
-        if self.writer is not None:
+        if self._writer is not None:
             try:
-                self.writer.close()
+                self._writer.close()
             except RuntimeError as e:
                 if str(e) == "Event loop is closed":
                     pass  # there's no more room we can do anything

--- a/src/ai/backend/common/redis_client.py
+++ b/src/ai/backend/common/redis_client.py
@@ -216,6 +216,9 @@ class RedisConnection(AbstractAsyncContextManager[RedisClient]):
     _socket_connect_timeout: float | None
     _keepalive_options: dict[int, int]
 
+    reader: asyncio.StreamReader | None
+    writer: asyncio.StreamWriter | None
+
     def __init__(
         self,
         redis_target: RedisTarget,
@@ -227,6 +230,8 @@ class RedisConnection(AbstractAsyncContextManager[RedisClient]):
     ) -> None:
         self._redis_target = redis_target
         self._db = db
+        self.reader = None
+        self.writer = None
 
         self._socket_timeout = socket_timeout
         self._socket_connect_timeout = socket_connect_timeout
@@ -279,7 +284,7 @@ class RedisConnection(AbstractAsyncContextManager[RedisClient]):
         return await self.connect()
 
     async def disconnect(self) -> None:
-        if self.writer:
+        if self.writer is not None:
             try:
                 self.writer.close()
             except RuntimeError as e:

--- a/src/ai/backend/install/context.py
+++ b/src/ai/backend/install/context.py
@@ -1110,8 +1110,6 @@ class Context(metaclass=ABCMeta):
                 if halfstack.redis_password:
                     redis_table["password"] = halfstack.redis_password
             else:
-                if not halfstack.redis_addr:
-                    raise RuntimeError("redis_addr must be configured")
                 redis_table = tomlkit.table()
                 redis_table["addr"] = (
                     f"{halfstack.redis_addr.face.host}:{halfstack.redis_addr.face.port}"

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -308,8 +308,7 @@ class BaseRunner(metaclass=ABCMeta):
             # allow remaining logs to be flushed.
             await asyncio.sleep(0.1)
             try:
-                if self.outsock:
-                    self.outsock.close()
+                self.outsock.close()
                 await self._shutdown_jupyter_kernel()
             finally:
                 self._log_task.cancel()

--- a/src/ai/backend/manager/api/rest/artifact/handler.py
+++ b/src/ai/backend/manager/api/rest/artifact/handler.py
@@ -203,7 +203,7 @@ class ArtifactHandler:
 
         # Process each artifact revision sequentially
         # TODO: Optimize with asyncio.gather() for parallel processing
-        force = body.parsed.options.force if body.parsed.options else False
+        force = body.parsed.options.force
         for artifact_revision_id in body.parsed.artifact_revision_ids:
             # When using VFolderStorage (vfolder_id provided), store at root path
             storage_prefix = "/" if body.parsed.vfolder_id else None

--- a/src/ai/backend/manager/api/wsproxy.py
+++ b/src/ai/backend/manager/api/wsproxy.py
@@ -235,7 +235,7 @@ class WebSocketProxy:
         while True:
             msg, tp = await self.upstream_buffer.get()
             try:
-                if self.up_conn and not self.up_conn.closed:
+                if not self.up_conn.closed:
                     if tp == aiohttp.WSMsgType.TEXT:
                         assert isinstance(msg, str)  # noqa: S101
                         await self.up_conn.send_str(msg)
@@ -258,5 +258,4 @@ class WebSocketProxy:
         if self.upstream_buffer_task:
             self.upstream_buffer_task.cancel()
             await self.upstream_buffer_task
-        if self.up_conn:
-            await self.up_conn.close()
+        await self.up_conn.close()

--- a/src/ai/backend/manager/dependencies/config/provider.py
+++ b/src/ai/backend/manager/dependencies/config/provider.py
@@ -64,10 +64,9 @@ class ConfigProviderDependency(
         # Create loader chain following server.py pattern
         loaders: list[Any] = []
 
-        # Add file loader if config path is provided
-        if setup_input.config_path:
-            toml_loader = TomlConfigLoader(setup_input.config_path, "manager")
-            loaders.append(toml_loader)
+        # Add file loader
+        toml_loader = TomlConfigLoader(setup_input.config_path, "manager")
+        loaders.append(toml_loader)
 
         # Add legacy etcd loader
         legacy_etcd_loader = LegacyEtcdLoader(setup_input.etcd)

--- a/src/ai/backend/manager/models/alembic/versions/1d42c726d8a3_migrate_container_registries_from_etcd_to_psql.py
+++ b/src/ai/backend/manager/models/alembic/versions/1d42c726d8a3_migrate_container_registries_from_etcd_to_psql.py
@@ -447,7 +447,9 @@ def mark_local_images_with_missing_registry_id() -> None:
     get_images_with_blank_registry_id = sa.select(images_table).where(
         images_table.c.registry_id.is_(None)
     )
-    images_with_missing_registry_id = db_connection.execute(get_images_with_blank_registry_id)
+    images_with_missing_registry_id = db_connection.execute(
+        get_images_with_blank_registry_id
+    ).fetchall()
 
     if not images_with_missing_registry_id:
         return

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -7,12 +7,13 @@ from collections import Counter, defaultdict
 from collections.abc import AsyncIterator, Collection, Mapping, Sequence
 from contextlib import asynccontextmanager as actxmgr
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime
 from decimal import Decimal
 from typing import Any, cast
 
 import sqlalchemy as sa
 from sqlalchemy.engine import CursorResult
+from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 from sqlalchemy.ext.asyncio import async_sessionmaker
@@ -2503,13 +2504,14 @@ class DeploymentDBSource:
         spec being deployed. No vfolder re-reads at runtime.
         """
         async with self._begin_readonly_session_read_committed() as db_sess:
-            endpoint = await EndpointRow.get(
-                db_sess,
-                endpoint_id,
-                load_revisions=True,
-            )
-            if not endpoint:
-                raise EndpointNotFound(str(endpoint_id))
+            try:
+                endpoint = await EndpointRow.get(
+                    db_sess,
+                    endpoint_id,
+                    load_revisions=True,
+                )
+            except NoResultFound as e:
+                raise EndpointNotFound(str(endpoint_id)) from e
             active_rev = endpoint._find_active_revision()
             if active_rev is None or active_rev.model_definition is None:
                 return None
@@ -3232,7 +3234,7 @@ class DeploymentDBSource:
                 id=row.id,
                 token=row.token,
                 expires_at=row.expires_at,
-                created_at=row.created_at or datetime.now(UTC),
+                created_at=row.created_at,
             )
 
     async def delete_access_token(

--- a/src/ai/backend/manager/repositories/model_serving/repository.py
+++ b/src/ai/backend/manager/repositories/model_serving/repository.py
@@ -641,9 +641,6 @@ class ModelServingRepository:
         async with self._db.begin_readonly_session_read_committed() as session:
             try:
                 rule = await EndpointAutoScalingRuleRow.get(session, rule_id, load_endpoint=True)
-                if not rule:
-                    return None
-
                 return rule.to_data()
             except ObjectNotFound:
                 return None
@@ -711,9 +708,6 @@ class ModelServingRepository:
             try:
                 # Validate lifecycle stage before update
                 rule = await EndpointAutoScalingRuleRow.get(session, rule_id, load_endpoint=True)
-                if not rule:
-                    return None
-
                 if rule.endpoint_row.lifecycle_stage in EndpointLifecycle.inactive_states():
                     return None
 
@@ -738,12 +732,9 @@ class ModelServingRepository:
         async with self._db.begin_session() as session:
             try:
                 rule = await EndpointAutoScalingRuleRow.get(session, rule_id, load_endpoint=True)
-                if not rule:
-                    return False
-
                 await session.delete(rule)
                 return True
-            except NoResultFound:
+            except ObjectNotFound:
                 return False
 
     @model_serving_repository_resilience.apply()

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -1923,7 +1923,7 @@ class ScheduleDBSource:
             if rg_row is None:
                 raise ScalingGroupNotFound(f"Resource group {resource_group_id} not found")
             resource_group = ResourceGroupEnqueueInfo(
-                defaults=rg_row.default_session_options or DefaultSessionOptions(),
+                defaults=rg_row.default_session_options,
                 network=ScalingGroupNetworkInfo(
                     use_host_network=rg_row.use_host_network,
                     wsproxy_addr=rg_row.wsproxy_addr,

--- a/src/ai/backend/manager/repositories/user/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/user/db_source/db_source.py
@@ -44,7 +44,6 @@ from ai.backend.manager.errors.user import (
     KeyPairNotFound,
     UserConflict,
     UserCreationBadRequest,
-    UserCreationFailure,
     UserModificationBadRequest,
     UserModificationFailure,
     UserNotFound,
@@ -218,9 +217,6 @@ class UserDBSource:
             )
             result = await execute_rbac_entity_creator(db_session, rbac_creator)
             row = result.row
-
-            if not row:
-                raise UserCreationFailure("Failed to create user")
             created_user = row.to_data()
 
             # Create default keypair with RBAC scope association
@@ -290,7 +286,6 @@ class UserDBSource:
         Raises:
             UserCreationBadRequest: If the domain does not exist.
             UserConflict: If email or username already exists.
-            UserCreationFailure: If user creation fails.
         """
         spec = cast(UserCreatorSpec, item.creator.spec)
 
@@ -321,9 +316,6 @@ class UserDBSource:
         )
         result = await execute_rbac_entity_creator(db_session, rbac_creator)
         row = result.row
-        if not row:
-            raise UserCreationFailure(f"Failed to create user {spec.email}")
-
         created_user = row.to_data()
 
         # Create default keypair with RBAC scope association

--- a/src/ai/backend/manager/services/artifact_revision/service.py
+++ b/src/ai/backend/manager/services/artifact_revision/service.py
@@ -301,17 +301,10 @@ class ArtifactRevisionService:
                         # We want the remote's "local" progress as our "remote" progress
                         remote_local = remote_resp.download_progress.local
 
-                        if remote_local:
-                            remote_download_progress = ArtifactRevisionDownloadProgress(
-                                progress=remote_local.progress,
-                                status=remote_local.status,
-                            )
-                        else:
-                            # Remote response exists but no local data
-                            remote_download_progress = ArtifactRevisionDownloadProgress(
-                                progress=None,
-                                status=remote_status,
-                            )
+                        remote_download_progress = ArtifactRevisionDownloadProgress(
+                            progress=remote_local.progress,
+                            status=remote_local.status,
+                        )
                     except Exception as e:
                         # If remote query fails, return remote status without progress
                         log.warning("Failed to get remote download progress {}", e)
@@ -418,9 +411,8 @@ class ArtifactRevisionService:
             volume_name: str | None = None
             if action.vfolder_id:
                 vfolder_data = await self._vfolder_repository.get_by_id(action.vfolder_id)
-                if vfolder_data:
-                    vfolder_id = VFolderID(vfolder_data.quota_scope_id, vfolder_data.id)
-                    _, volume_name = self._storage_manager.get_proxy_and_volume(vfolder_data.host)
+                vfolder_id = VFolderID(vfolder_data.quota_scope_id, vfolder_data.id)
+                _, volume_name = self._storage_manager.get_proxy_and_volume(vfolder_data.host)
 
             task_id: UUID
             match artifact.registry_type:

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -352,7 +352,7 @@ def _convert_route_info_to_replica_data(route: RouteInfo) -> ModelReplicaData:
     return ModelReplicaData(
         id=route.route_id,
         deployment_id=route.deployment_id,
-        revision_id=route.revision_id or route.deployment_id,
+        revision_id=route.revision_id,
         session_id=route.session_id,
         readiness_status=readiness,
         liveness_status=liveness,
@@ -1067,7 +1067,7 @@ class DeploymentService:
             id=token_row.id,
             token=token_row.token,
             expires_at=token_row.expires_at,
-            created_at=token_row.created_at or datetime.now(UTC),
+            created_at=token_row.created_at,
         )
         return CreateAccessTokenActionResult(data=data)
 

--- a/src/ai/backend/manager/services/permission_contoller/actions/create_role.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/create_role.py
@@ -38,4 +38,4 @@ class CreateRoleActionResult(BaseActionResult):
 
     @override
     def entity_id(self) -> str | None:
-        return str(self.data.id) if self.data else None
+        return str(self.data.id)

--- a/src/ai/backend/manager/services/permission_contoller/actions/permission.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/permission.py
@@ -43,7 +43,7 @@ class CreatePermissionActionResult(BaseActionResult):
 
     @override
     def entity_id(self) -> str | None:
-        return str(self.data.id) if self.data else None
+        return str(self.data.id)
 
 
 @dataclass

--- a/src/ai/backend/manager/services/permission_contoller/actions/update_permission.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/update_permission.py
@@ -29,4 +29,4 @@ class UpdatePermissionActionResult(BaseActionResult):
 
     @override
     def entity_id(self) -> str | None:
-        return str(self.data.id) if self.data else None
+        return str(self.data.id)

--- a/src/ai/backend/manager/services/permission_contoller/actions/update_role.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/update_role.py
@@ -29,4 +29,4 @@ class UpdateRoleActionResult(BaseActionResult):
 
     @override
     def entity_id(self) -> str | None:
-        return str(self.data.id) if self.data else None
+        return str(self.data.id)

--- a/src/ai/backend/manager/services/scaling_group/service.py
+++ b/src/ai/backend/manager/services/scaling_group/service.py
@@ -325,7 +325,7 @@ class ScalingGroupService:
         """
         # 1. Get existing scaling group (raises ScalingGroupNotFound if not found)
         existing_sg = await self._repository.get_scaling_group_by_name(action.resource_group)
-        existing_spec = existing_sg.fair_share_spec or FairShareScalingGroupSpec()
+        existing_spec = existing_sg.fair_share_spec
 
         # 2. Get ResourceInfo for capacity
         resource_info = await self._repository.get_resource_info(action.resource_group)

--- a/src/ai/backend/manager/services/vfolder/services/file.py
+++ b/src/ai/backend/manager/services/vfolder/services/file.py
@@ -76,8 +76,6 @@ class VFolderFileService:
         vfolder_data = await self._vfolder_repository.get_by_id_validated(
             action.vfolder_uuid, user.id, user.domain_name
         )
-        if not vfolder_data:
-            raise VFolderInvalidParameter("VFolder not found")
 
         # Check host permissions
         allowed_vfolder_types = (
@@ -126,8 +124,6 @@ class VFolderFileService:
         vfolder_data = await self._vfolder_repository.get_by_id_validated(
             action.vfolder_uuid, user.id, user.domain_name
         )
-        if not vfolder_data:
-            raise VFolderInvalidParameter("VFolder not found")
 
         # Check host permissions
         allowed_vfolder_types = (
@@ -248,8 +244,6 @@ class VFolderFileService:
         vfolder_data = await self._vfolder_repository.get_by_id_validated(
             action.vfolder_uuid, user.id, user.domain_name
         )
-        if not vfolder_data:
-            raise VFolderInvalidParameter("VFolder not found")
 
         # Check host permissions
         allowed_vfolder_types = (
@@ -292,9 +286,6 @@ class VFolderFileService:
             action.vfolder_uuid, user.id, user.domain_name
         )
 
-        if not vfolder_data:
-            raise VFolderInvalidParameter("The specified vfolder is not accessible.")
-
         proxy_name, volume_name = self._storage_manager.get_proxy_and_volume(
             vfolder_data.host, is_unmanaged(vfolder_data.unmanaged_path)
         )
@@ -324,9 +315,6 @@ class VFolderFileService:
         vfolder_data = await self._vfolder_repository.get_by_id_validated(
             action.vfolder_uuid, user.id, user.domain_name
         )
-
-        if not vfolder_data:
-            raise VFolderInvalidParameter("The specified vfolder is not accessible.")
 
         proxy_name, volume_name = self._storage_manager.get_proxy_and_volume(
             vfolder_data.host, is_unmanaged(vfolder_data.unmanaged_path)
@@ -365,8 +353,6 @@ class VFolderFileService:
         vfolder_data = await self._vfolder_repository.get_by_id_validated(
             action.vfolder_uuid, user.id, user.domain_name
         )
-        if not vfolder_data:
-            raise VFolderInvalidParameter("VFolder not found")
 
         proxy_name, volume_name = self._storage_manager.get_proxy_and_volume(
             vfolder_data.host, is_unmanaged(vfolder_data.unmanaged_path)
@@ -400,8 +386,6 @@ class VFolderFileService:
         vfolder_data = await self._vfolder_repository.get_by_id_validated(
             action.vfolder_uuid, user.id, user.domain_name
         )
-        if not vfolder_data:
-            raise VFolderInvalidParameter("VFolder not found")
 
         proxy_name, volume_name = self._storage_manager.get_proxy_and_volume(
             vfolder_data.host, is_unmanaged(vfolder_data.unmanaged_path)
@@ -466,8 +450,6 @@ class VFolderFileService:
         vfolder_data = await self._vfolder_repository.get_by_id_validated(
             action.vfolder_id, user.id, user.domain_name
         )
-        if not vfolder_data:
-            raise VFolderInvalidParameter("VFolder not found")
 
         proxy_name, volume_name = self._storage_manager.get_proxy_and_volume(
             vfolder_data.host, is_unmanaged(vfolder_data.unmanaged_path)
@@ -494,8 +476,6 @@ class VFolderFileService:
         vfolder_data = await self._vfolder_repository.get_by_id_validated(
             action.vfolder_id, user.id, user.domain_name
         )
-        if not vfolder_data:
-            raise VFolderInvalidParameter("VFolder not found")
 
         proxy_name, volume_name = self._storage_manager.get_proxy_and_volume(
             vfolder_data.host, is_unmanaged(vfolder_data.unmanaged_path)
@@ -521,8 +501,6 @@ class VFolderFileService:
         vfolder_data = await self._vfolder_repository.get_by_id_validated(
             action.vfolder_id, user.id, user.domain_name
         )
-        if not vfolder_data:
-            raise VFolderInvalidParameter("The specified vfolder is not accessible.")
 
         proxy_name, volume_name = self._storage_manager.get_proxy_and_volume(
             vfolder_data.host, is_unmanaged(vfolder_data.unmanaged_path)
@@ -551,8 +529,6 @@ class VFolderFileService:
         vfolder_data = await self._vfolder_repository.get_by_id_validated(
             action.vfolder_id, user.id, user.domain_name
         )
-        if not vfolder_data:
-            raise VFolderInvalidParameter("VFolder not found")
 
         # Host permission check — resolved from user_id
         await self._vfolder_repository.ensure_host_permission_allowed_by_user(

--- a/src/ai/backend/manager/services/vfolder/services/invite.py
+++ b/src/ai/backend/manager/services/vfolder/services/invite.py
@@ -68,8 +68,6 @@ class VFolderInviteService:
         vfolder_data = await self._vfolder_repository.get_by_id_validated(
             action.vfolder_uuid, action.user_uuid, user.domain_name
         )
-        if not vfolder_data:
-            raise VFolderNotFound()
 
         if vfolder_data.name.startswith("."):
             raise Forbidden("Cannot share private dot-prefixed vfolders.")
@@ -253,8 +251,6 @@ class VFolderInviteService:
         vfolder_data = await self._vfolder_repository.get_by_id_validated(
             action.vfolder_uuid, user.id, user.domain_name
         )
-        if not vfolder_data:
-            raise VFolderNotFound()
 
         if vfolder_data.ownership_type == VFolderOwnershipType.GROUP:
             raise VFolderInvalidParameter("Cannot leave a group vfolder.")

--- a/src/ai/backend/manager/services/vfolder/services/sharing.py
+++ b/src/ai/backend/manager/services/vfolder/services/sharing.py
@@ -38,8 +38,6 @@ class VFolderSharingService:
         vfolder_data = await self._vfolder_repository.get_by_id_validated(
             action.vfolder_uuid, user.id, user.domain_name
         )
-        if not vfolder_data:
-            raise VFolderNotFound()
         if vfolder_data.ownership_type != VFolderOwnershipType.GROUP:
             raise VFolderNotFound("Only project folders are directly sharable.")
 
@@ -68,8 +66,6 @@ class VFolderSharingService:
         vfolder_data = await self._vfolder_repository.get_by_id_validated(
             action.vfolder_uuid, user.id, user.domain_name
         )
-        if not vfolder_data:
-            raise VFolderNotFound()
         if vfolder_data.ownership_type != VFolderOwnershipType.GROUP:
             raise VFolderNotFound("Only project folders are directly unsharable.")
 

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -1705,8 +1705,6 @@ class VFolderService:
         vfolder_data = await self._vfolder_repository.get_by_id_validated(
             action.vfolder_id, user.id, user.domain_name
         )
-        if not vfolder_data:
-            raise VFolderNotFound("VFolder not found")
 
         # Host permission check — resolved from user_id
         await self._vfolder_repository.ensure_host_permission_allowed_by_user(
@@ -2017,5 +2015,5 @@ class VFolderService:
 
         return CloneVFolderV2ActionResult(
             new_vfolder_id=target_folder_id,
-            bgtask_id=str(_task_id) if _task_id else None,
+            bgtask_id=str(_task_id),
         )

--- a/src/ai/backend/storage/api/manager.py
+++ b/src/ai/backend/storage/api/manager.py
@@ -475,10 +475,6 @@ async def create_vfolder(request: web.Request) -> web.Response:
             except QuotaScopeNotFoundError:
                 if not ctx.local_config.storage_proxy.auto_quota_scope_creation:
                     raise
-                if not params["vfid"].quota_scope_id:
-                    raise InvalidAPIParameters(
-                        "quota_scope_id is required for auto quota scope creation"
-                    ) from None
                 if initial_max_size_for_quota_scope := (params["options"] or {}).get(
                     "initial_max_size_for_quota_scope"
                 ):

--- a/src/ai/backend/storage/services/artifacts/huggingface.py
+++ b/src/ai/backend/storage/services/artifacts/huggingface.py
@@ -45,7 +45,6 @@ from ai.backend.storage.data.storage.types import ImportStepContext, StorageTarg
 from ai.backend.storage.errors import (
     HuggingFaceAPIError,
     HuggingFaceModelNotFoundError,
-    ObjectStorageConfigInvalidError,
     RegistryNotFoundError,
     StorageStepRequiredStepNotProvided,
 )
@@ -292,7 +291,7 @@ class HuggingFaceFileDownloadStreamReader(StreamReader):
             self._download_complete = True
 
             # Cancel and wait for progress task
-            if self._progress_task:
+            if self._progress_task is not None:
                 self._progress_task.cancel()
                 try:
                     await self._progress_task
@@ -791,11 +790,6 @@ class HuggingFaceDownloadStep(ImportStep[None]):
 
     @override
     async def execute(self, context: ImportStepContext, input_data: None) -> DownloadStepResult:
-        if not context.storage_pool:
-            raise ObjectStorageConfigInvalidError(
-                "Storage pool not configured for import operations"
-            )
-
         registry_config = self._registry_configs.get(context.registry_name)
         if not registry_config:
             raise RegistryNotFoundError(f"Unknown registry: {context.registry_name}")

--- a/src/ai/backend/storage/services/artifacts/reservoir.py
+++ b/src/ai/backend/storage/services/artifacts/reservoir.py
@@ -222,7 +222,7 @@ class ReservoirVFSFileDownloader:
             self._download_complete = True
 
             # Cancel and wait for progress task
-            if self._progress_task:
+            if self._progress_task is not None:
                 self._progress_task.cancel()
                 try:
                     await self._progress_task
@@ -370,7 +370,7 @@ class ReservoirS3FileDownloadStreamReader(StreamReader):
             self._download_complete = True
 
             # Cancel and wait for progress task
-            if self._progress_task:
+            if self._progress_task is not None:
                 self._progress_task.cancel()
                 try:
                     await self._progress_task
@@ -962,7 +962,7 @@ class ReservoirDownloadStep(ImportStep[None]):
                 # Content-Type
                 object_meta = await src_s3_client.get_object_meta(key)
                 ctype = (
-                    (object_meta.content_type if object_meta else None)
+                    object_meta.content_type
                     or mimetypes.guess_type(key)[0]
                     or "application/octet-stream"
                 )

--- a/src/ai/backend/storage/storages/object_storage.py
+++ b/src/ai/backend/storage/storages/object_storage.py
@@ -96,7 +96,7 @@ class ObjectStorage(AbstractStorage):
             s3_client = self._get_s3_client()
             object_meta = await s3_client.get_object_meta(filepath)
             ctype = (
-                (object_meta.content_type if object_meta else None)
+                object_meta.content_type
                 or mimetypes.guess_type(filepath)[0]
                 or "application/octet-stream"
             )

--- a/src/ai/backend/storage/storages/vfs_storage.py
+++ b/src/ai/backend/storage/storages/vfs_storage.py
@@ -102,7 +102,7 @@ class VFSDirectoryDownloadServerStreamReader(StreamReader):
                     yield chunk
         finally:
             # Clean up temp file
-            if self._temp_file and self._temp_file.exists():
+            if self._temp_file is not None and self._temp_file.exists():
                 await aiofiles.os.remove(self._temp_file)
                 log.debug("Cleaned up temp file: {}", self._temp_file)
 

--- a/src/ai/backend/storage/volumes/xfs/__init__.py
+++ b/src/ai/backend/storage/volumes/xfs/__init__.py
@@ -175,7 +175,7 @@ class XFSProjectQuotaModel(BaseQuotaModel):
                 log.info(
                     "creating project quota (qs:{}, q:{})",
                     quota_scope_id,
-                    (options.limit_bytes if options else None),
+                    options.limit_bytes,
                 )
                 await aiofiles.os.makedirs(qspath)
                 await self.project_registry.read_project_info()

--- a/src/ai/backend/storage/watcher.py
+++ b/src/ai/backend/storage/watcher.py
@@ -451,10 +451,8 @@ class WatcherClient:
         if self.output_listening_task and not self.output_listening_task.done():
             self.output_listening_task.cancel()
             await self.output_listening_task
-        if self.input_sock:
-            self.input_sock.close()
-        if self.output_sock:
-            self.output_sock.close()
+        self.input_sock.close()
+        self.output_sock.close()
 
     async def _listen_output(self) -> None:
         while True:

--- a/src/ai/backend/test/templates/model_service/endpoint.py
+++ b/src/ai/backend/test/templates/model_service/endpoint.py
@@ -80,7 +80,7 @@ class _BaseEndpointTemplate(WrapperTestTemplate):
         if vfolder_func.id is None:
             raise RuntimeError("Model VFolder id is None.")
 
-        endpoint_id = None
+        endpoint_id: UUID | None = None
         try:
             response = await client_session.Service.create(
                 **self._build_service_params(),
@@ -124,7 +124,7 @@ class _BaseEndpointTemplate(WrapperTestTemplate):
             ):
                 yield
         finally:
-            if endpoint_id:
+            if endpoint_id is not None:
                 response = await client_session.Service(endpoint_id).delete()
                 assert response["success"], f"Model Service deletion failed!, response: {response}"
 

--- a/src/ai/backend/test/templates/session/dependent_session.py
+++ b/src/ai/backend/test/templates/session/dependent_session.py
@@ -96,7 +96,7 @@ class DependentSessionTemplate(WrapperTestTemplate):
         test_id = spec_meta.test_id
         client_session = ClientSessionContext.current()
         session_name = f"test_session_{test_id!s}"
-        session_id = None
+        session_id: UUID | None = None
         batch_session_meta = CreatedSessionMetaContext.current()
         try:
             session_id = await self._verify_session_creation(
@@ -110,5 +110,5 @@ class DependentSessionTemplate(WrapperTestTemplate):
             ):
                 yield
         finally:
-            if session_id:
+            if session_id is not None:
                 await self._verify_session_destruction(client_session, session_name)

--- a/src/ai/backend/test/templates/session/interactive_session.py
+++ b/src/ai/backend/test/templates/session/interactive_session.py
@@ -120,7 +120,7 @@ class _BaseInteractiveSessionTemplate(WrapperTestTemplate):
             ):
                 yield
         finally:
-            if session_id:
+            if session_id is not None:
                 await self._verify_session_destruction(client_session, session_name)
 
 

--- a/src/ai/backend/test/templates/session/session_template.py
+++ b/src/ai/backend/test/templates/session/session_template.py
@@ -230,7 +230,7 @@ class InteractiveSessionFromTemplateTemplate(WrapperTestTemplate):
         test_id = spec_meta.test_id
         client_session = ClientSessionContext.current()
         session_name = f"test_session_{test_id!s}"
-        session_id = None
+        session_id: UUID | None = None
         try:
             session_id = await self._verify_session_creation(client_session, session_name)
             with CreatedSessionMetaContext.with_current(
@@ -238,5 +238,5 @@ class InteractiveSessionFromTemplateTemplate(WrapperTestTemplate):
             ):
                 yield
         finally:
-            if session_id:
+            if session_id is not None:
                 await self._verify_session_destruction(client_session, session_name)

--- a/src/ai/backend/test/templates/session/vfolder_mounted_interactive_session.py
+++ b/src/ai/backend/test/templates/session/vfolder_mounted_interactive_session.py
@@ -96,7 +96,7 @@ class VFolderMountedInteractiveSessionTemplate(WrapperTestTemplate):
         test_id = spec_meta.test_id
         client_session = ClientSessionContext.current()
         session_name = f"test_session_{test_id!s}"
-        session_id = None
+        session_id: UUID | None = None
         vfolder_meta = CreatedVFolderMetaContext.current()
         try:
             session_id = await self._verify_session_creation(
@@ -109,5 +109,5 @@ class VFolderMountedInteractiveSessionTemplate(WrapperTestTemplate):
             ):
                 yield
         finally:
-            if session_id:
+            if session_id is not None:
                 await self._verify_session_destruction(client_session, session_name)

--- a/src/ai/backend/test/templates/user/user.py
+++ b/src/ai/backend/test/templates/user/user.py
@@ -101,7 +101,6 @@ class UserTemplate(WrapperTestTemplate):
         email = f"{username}@tester_email.com"
         description = f"Test user for {test_id}, used in tester package"
 
-        user_meta: CreatedUserMeta | None = None
         user_meta = await self._create_user_with_keypair(
             client_session,
             domain_ctx.name,
@@ -115,6 +114,5 @@ class UserTemplate(WrapperTestTemplate):
             with CreatedUserContext.with_current(user_meta):
                 yield
         finally:
-            if user_meta:
-                await client_session.User.delete(email)
-                await client_session.User.purge(email)
+            await client_session.User.delete(email)
+            await client_session.User.purge(email)

--- a/src/ai/backend/test/testcases/session/vfolder_mount.py
+++ b/src/ai/backend/test/testcases/session/vfolder_mount.py
@@ -27,6 +27,7 @@ class FileHandlingInMountedVFolderSuccess(TestCode):
         session_meta = CreatedSessionMetaContext.current()
         session_name = session_meta.name
 
+        file_upload_meta: _UploadFileMeta | None = None
         try:
             file_upload_meta = await self._create_dummy_file()
 
@@ -47,7 +48,7 @@ class FileHandlingInMountedVFolderSuccess(TestCode):
                 downloaded_file_path=f"{file_upload_meta.base_dir}/downloaded/{file_upload_meta.file_name}",
             )
         finally:
-            if file_upload_meta:
+            if file_upload_meta is not None:
                 await self._cleanup_dummy_file(file_upload_meta)
 
     def _verify_downloaded_file_identical(

--- a/tests/unit/agent/stage/kernel_lifecycle/docker/test_ssh_provisioners.py
+++ b/tests/unit/agent/stage/kernel_lifecycle/docker/test_ssh_provisioners.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -217,7 +216,7 @@ class TestContainerSSHProvisioner:
     def spec_no_keypair(self, tmp_path: Path, agent_config: AgentConfig) -> ContainerSSHSpec:
         return ContainerSSHSpec(
             work_dir=tmp_path,
-            ssh_keypair=cast(ContainerSSHKeyPair, None),
+            ssh_keypair=None,
             mounts=[],
             uid_override=None,
             gid_override=None,
@@ -283,7 +282,7 @@ class TestContainerSSHProvisioner:
         spec_default: ContainerSSHSpec,
     ) -> None:
         with patch(f"{_UTILS_OS}.geteuid", return_value=1000):
-            ssh_dir = provisioner._populate_ssh_config(spec_default)
+            ssh_dir = provisioner._populate_ssh_config(spec_default, ssh_keypair)
 
         assert ssh_dir == tmp_path / ".ssh"
         assert ssh_dir.is_dir()
@@ -304,6 +303,7 @@ class TestContainerSSHProvisioner:
     async def test_populate_ssh_config_skips_existing_id_rsa(
         self,
         tmp_path: Path,
+        ssh_keypair: ContainerSSHKeyPair,
         provisioner: ContainerSSHProvisioner,
         spec_default: ContainerSSHSpec,
     ) -> None:
@@ -313,12 +313,13 @@ class TestContainerSSHProvisioner:
         (ssh_dir / "id_rsa").write_bytes(existing_content)
 
         with patch(f"{_UTILS_OS}.geteuid", return_value=1000):
-            provisioner._populate_ssh_config(spec_default)
+            provisioner._populate_ssh_config(spec_default, ssh_keypair)
 
         assert (ssh_dir / "id_rsa").read_bytes() == existing_content
 
     async def test_populate_ssh_config_ownership(
         self,
+        ssh_keypair: ContainerSSHKeyPair,
         provisioner: ContainerSSHProvisioner,
         spec_with_ownership: ContainerSSHSpec,
     ) -> None:
@@ -326,7 +327,7 @@ class TestContainerSSHProvisioner:
             patch(f"{_UTILS_OS}.geteuid", return_value=0),
             patch(f"{_UTILS_OS}.chown") as mock_chown,
         ):
-            provisioner._populate_ssh_config(spec_with_ownership)
+            provisioner._populate_ssh_config(spec_with_ownership, ssh_keypair)
 
         assert mock_chown.call_count == 4
         for call in mock_chown.call_args_list:

--- a/tests/unit/manager/services/vfolder/test_vfolder_file_service.py
+++ b/tests/unit/manager/services/vfolder/test_vfolder_file_service.py
@@ -15,7 +15,7 @@ from ai.backend.common.types import (
     QuotaScopeID,
     QuotaScopeType,
 )
-from ai.backend.manager.errors.storage import VFolderInvalidParameter
+from ai.backend.manager.errors.storage import VFolderInvalidParameter, VFolderNotFound
 from ai.backend.manager.repositories.vfolder.repository import VfolderRepository
 from ai.backend.manager.services.vfolder.actions.file import (
     CreateDownloadSessionAction,
@@ -159,7 +159,7 @@ class TestCreateUploadSessionAction:
         assert "upload" in result.url
         assert result.vfolder_uuid == vfolder_uuid
 
-    async def test_inaccessible_vfolder_raises_invalid_parameter(
+    async def test_nonexistent_vfolder_raises_not_found(
         self,
         file_service: VFolderFileService,
         mock_vfolder_repository: MagicMock,
@@ -167,7 +167,7 @@ class TestCreateUploadSessionAction:
         vfolder_uuid: uuid.UUID,
         keypair_resource_policy: dict[str, str],
     ) -> None:
-        mock_vfolder_repository.get_by_id_validated = AsyncMock(return_value=None)
+        mock_vfolder_repository.get_by_id_validated = AsyncMock(side_effect=VFolderNotFound())
 
         action = CreateUploadSessionAction(
             keypair_resource_policy=keypair_resource_policy,
@@ -176,7 +176,7 @@ class TestCreateUploadSessionAction:
             path="data/file.bin",
             size="4096",
         )
-        with pytest.raises(VFolderInvalidParameter):
+        with pytest.raises(VFolderNotFound):
             await file_service.upload_file(action)
 
     async def test_no_upload_permission_raises_error(
@@ -458,14 +458,14 @@ class TestDeleteFilesAsyncAction:
         assert result.vfolder_uuid == vfolder_uuid
         assert result.task_id is not None
 
-    async def test_inaccessible_vfolder_raises_invalid_parameter(
+    async def test_nonexistent_vfolder_raises_not_found(
         self,
         file_service: VFolderFileService,
         mock_vfolder_repository: MagicMock,
         user_uuid: uuid.UUID,
         vfolder_uuid: uuid.UUID,
     ) -> None:
-        mock_vfolder_repository.get_by_id_validated = AsyncMock(return_value=None)
+        mock_vfolder_repository.get_by_id_validated = AsyncMock(side_effect=VFolderNotFound())
 
         action = DeleteFilesAsyncAction(
             user_uuid=user_uuid,
@@ -473,7 +473,7 @@ class TestDeleteFilesAsyncAction:
             files=["file.txt"],
             recursive=False,
         )
-        with pytest.raises(VFolderInvalidParameter):
+        with pytest.raises(VFolderNotFound):
             await file_service.delete_files_async(action)
 
 

--- a/tests/unit/manager/services/vfolder/test_vfolder_sharing_service.py
+++ b/tests/unit/manager/services/vfolder/test_vfolder_sharing_service.py
@@ -228,7 +228,7 @@ class TestShareVFolderAction:
         vfolder_uuid: uuid.UUID,
     ) -> None:
         mock_user_repo.get_user_by_uuid = AsyncMock(return_value=_make_user_data(user_uuid))
-        mock_vfolder_repo.get_by_id_validated = AsyncMock(return_value=None)
+        mock_vfolder_repo.get_by_id_validated = AsyncMock(side_effect=VFolderNotFound())
 
         action = ShareVFolderAction(
             user_uuid=user_uuid,


### PR DESCRIPTION
## Summary
- Enable the `truthy-bool` mypy error code in `pyproject.toml` and fix all 73 reported errors across 46 files.
- Most fixes either remove always-true dead checks on non-Optional values or convert intended None-checks to explicit `is not None` comparisons (adding `Optional` annotations where the value genuinely can be unset).
- The new error code surfaced four real runtime bugs, now fixed:
  - `common/redis_client.py`: `RedisConnection.disconnect()` raised `AttributeError` when called before/after a failed `connect()`; `reader`/`writer` are now declared Optional and guarded.
  - `test/testcases/session/vfolder_mount.py`: a failure in `_create_dummy_file()` caused `UnboundLocalError` in the `finally` block, masking the original exception.
  - Alembic `1d42c726d8a3`: the early-return checked a `CursorResult` (always truthy), so the migration created a local registry row and ran a no-op UPDATE even with nothing to migrate; it now checks fetched rows, which also improves idempotency on re-runs.
  - `manager/repositories/model_serving/repository.py`: `delete_auto_scaling_rule` caught SQLAlchemy's `NoResultFound` while the row loader raises `ObjectNotFound`, so a missing rule leaked a 404 instead of returning `False` per its contract.
- In `client/cli`, the flagged `Coroutine` truthiness checks are the known `@api_function` sync-Session typing limitation; they are handled with `cast(...)` following the existing precedent in `client/cli/image.py`.

## Test plan
- [x] `pants fmt` / `pants fix` / `pants lint` pass locally
- [x] CI typecheck (`pants check`) passes with the new error code enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)