### PR TITLE
fix(BA-7078): carry the resolved is_preemptible into the session row (#13264)

### DIFF
--- a/changes/13264.fix.md
+++ b/changes/13264.fix.md
@@ -1,0 +1,1 @@
+Store the requested `is_preemptible` value on session creation so that opting out of preemption takes effect.

--- a/src/ai/backend/manager/repositories/scheduler/creators.py
+++ b/src/ai/backend/manager/repositories/scheduler/creators.py
@@ -204,6 +204,7 @@ class SessionRowFromSpec(CreatorSpec[SessionRow]):
             cluster_size=spec.resource_spec.options.cluster_size,
             priority=spec.resource_spec.options.priority,
             job_priority=spec.resource_spec.options.job_priority,
+            is_preemptible=spec.resource_spec.options.is_preemptible,
             status=SessionStatus.PENDING,
             status_history={
                 SessionStatus.PENDING.name: self.enqueue_time.isoformat(),


### PR DESCRIPTION
This is an auto-generated backport PR of #13264 to the 26.8 release.