### PR TITLE
chore(BA-7092): drop the unenforced preemptable_statuses declaration

### DIFF
--- a/changes/13268.misc.md
+++ b/changes/13268.misc.md
@@ -1,0 +1,1 @@
+Remove the unused `SessionStatus.preemptable_statuses()`, which declared a narrower preemption victim policy than the one the scheduler actually applies.

--- a/proposals/BEP-1055-preemption-scheduler-mechanics.md
+++ b/proposals/BEP-1055-preemption-scheduler-mechanics.md
@@ -13,6 +13,7 @@ Implemented-Version: 26.8.0
 
 - Epic **BA-3056**, this BEP **BA-6692** (blocks **BA-3058**, the implementation)
 - Amended by **BA-6926** — scope-local `job_priority` for preemption (sections 2.4, 3.a, 3.b)
+- Amended by **BA-7092** — as-built alignment: victim status set, the reservation-backed trigger, and the `RESERVED`/`RESCHEDULING` states (sections 2.2, 2.3, 3.a–3.c, Decision Summary, Open Questions)
 - Upstream spec (motivation): **[BEP-1014](BEP-1014-preemption-of-low-priority-sessions.md)** — referenced, not expanded
 - Prerequisites (done): BA-3057 (RG config), BA-4912 (`is_preemptible`). Out of scope: BA-4913 (Not Planned)
 
@@ -24,7 +25,7 @@ So far preemption has **only the data, config, and API surface**; there is **no 
 
 ## 2. Current State & Scope, by Area
 
-For each area, separate **✅ what already exists** from **➕ what to add**.
+For each area, separate **✅ what already exists** from **➕ what to add**. ✅ / ➕ are read against the state *before* this BEP; the rows describe what was actually built, and every ➕ item shipped in 26.8.0 unless its row says otherwise.
 
 ### 2.1 API (user and admin triggers)
 
@@ -35,7 +36,7 @@ For each area, separate **✅ what already exists** from **➕ what to add**.
 | ➕ | Expose `preemption.enabled` (preemption on/off toggle) and `preemption_min_runtime` (the anti-thrashing knob in section 3) in the RG config |
 | ➕ | On session creation, the user also sets `job_priority` — the session's **scope-local** preemption priority (used only for preemption; see 2.4). Distinct from the global scheduler `priority` |
 | ➕ | Keypair (user) resource policy gains `max_priority` — caps the `priority` a user may declare on session creation (2.4) |
-| ➕ | Remove admin `preemptible_priority` from the RG config — unused once victims are chosen by relative `job_priority` (3.b) |
+| ➕ | Retire admin `preemptible_priority` — unused once victims are chosen by relative `job_priority` (3.b). **As built the field is still accepted and returned by the RG config surface (REST/GQL/DB); no scheduler code reads it.** Removing it is a breaking API change — left as an Open Question |
 
 > Preemption is never invoked directly by a user; the scheduler decides it automatically, so **there is no new trigger API**.
 
@@ -47,11 +48,14 @@ For each area, separate **✅ what already exists** from **➕ what to add**.
 | ✅ | `ScalingGroupOpts.preemption = PreemptionConfig(preemptible_priority=5, order, mode)`, `PreemptionMode=terminate\|reschedule`, `PreemptionOrder=oldest\|newest` (BEP-1014's "suspend" is a typo). **No on/off field** |
 | ✅ | `SessionStatus`: PENDING, **DEPRIORITIZING** (on retry give-up, lowers its own priority by 10 and returns to PENDING), ..., TERMINATING, TERMINATED |
 | ➕ | New `PreemptionConfig.enabled: bool` — preemption on/off toggle, **default False (opt-in)** |
-| ➕ | New `SessionStatus.PREEMPTED` — the **single state** for a confirmed victim; after kernel cleanup it branches by mode to **PENDING (reschedule) or TERMINATED (terminate)** (3.(c)) |
+| ➕ | New `SessionStatus.PREEMPTED` — the **single state** for a confirmed victim; it branches by mode to **`TERMINATING` (terminate) or `RESCHEDULING` (reschedule)** (3.(c)) |
+| ➕ | New `SessionStatus.RESCHEDULING` (+ kernel counterpart) — a victim's kernels are torn down here before the session is re-enqueued as PENDING (3.(c)) |
+| ➕ | New `SessionStatus.RESERVED` / `KernelStatus.RESERVED` — the **initiator** holds its placement while its victims drain (3.(c)) |
+| ➕ | New `prereserved` bucket on the agent resource and allocation rows (with `prereserved_at`) — the initiator's hold before its kernels are admitted; counted as occupied by the capacity guard (3.(c)) |
 | ➕ | New `preemption_min_runtime` config field (RG opts) |
 | ➕ | New `SessionRow.job_priority` (default 10) — scope-local preemption priority, compared only within the same scope-owner (2.4, 3.b) |
 | ➕ | New keypair resource-policy field `max_priority` — per-user cap on the global `priority` (2.4) |
-| ➕ | Remove `PreemptionConfig.preemptible_priority` — the absolute RG threshold is unnecessary once victims are chosen by relative `job_priority` (3.b) |
+| ➕ | Retire `PreemptionConfig.preemptible_priority` — the absolute RG threshold is unnecessary once victims are chosen by relative `job_priority` (3.b). **Still stored and served; unread by the scheduler** (2.1) |
 
 ### 2.3 Sokovan (scheduler behavior)
 
@@ -61,9 +65,10 @@ For each area, separate **✅ what already exists** from **➕ what to add**.
 | ✅ | Provisioner: sequence (top-priority band) → validate → select agent → allocate. **Additive-only** — it never frees resources |
 | ✅ | Termination: `mark_sessions_terminating()` → next tick `TerminateSessionsLifecycleHandler` → `destroy_kernel` (**async**, finalized via agent events) |
 | ✅ | `is_preemptible` is used **only for deployment defaults (False) and RG default merging**, and is **never read for scheduling decisions (the core gap)** |
-| ➕ | Add running sessions (grouped by agent) to the snapshot (3.(a)) |
+| ➕ | Add the victim candidates (whole sessions, decomposed per agent) to the snapshot (3.(a)) |
 | ➕ | Preemption **planner** — candidate filter + victim selection (3.(b)) |
-| ➕ | **The (injected) controller marks victims PREEMPTED**, and a new preemption handler **branches by mode** (terminate/reschedule) + a multi-tick in-flight marker (3.(c)) |
+| ➕ | **The (injected) controller reserves the initiator and marks victims PREEMPTED**, and a new preemption handler **branches by mode** (terminate/reschedule) (3.(c)) |
+| ➕ | Two cycles that carry the reservation forward: `RELEASE_RESERVED` (admit prereserved kernels as capacity is restored) and `CHECK_RESERVED_PROGRESS` (promote a fully admitted session to SCHEDULED) (3.(c)) |
 
 > Because termination is async, the provisioner cannot terminate synchronously, so **preemption is inherently multi-tick**.
 
@@ -94,53 +99,65 @@ Preemption is decided by a **new axis, `job_priority`**, not the scheduler `prio
 
 ## 3. Implementation Design
 
-**Core flow:** pending placement fails → **planner selects victims** → **controller marks PREEMPTED and branches by mode** → (next tick) once resources free, normal allocation places the pending session.
+**Core flow:** pending placement fails → **planner selects victims** → **controller reserves the initiator's placement and marks the victims PREEMPTED, which branches by mode** → as the victims' resources come back the reservation is admitted and the initiator becomes SCHEDULED.
 
-### (a) Data layer — running sessions in the snapshot
+### (a) Data layer — victim candidates in the snapshot
 
-Since allocation is per-agent, load the running sessions' **preemption-relevant data grouped by agent** into the snapshot:
+Since allocation is per-agent, load the **victim candidates of the resource group grouped by scope-owner, each decomposed per agent** into the snapshot. Nothing is loaded when the group has preemption disabled.
 
-- `job_priority` (victim comparison key), `user_uuid` (scope-owner key for the same-owner filter; `group_id` added when project scope opens), is_preemptible, occupied slots, agent binding, created-at (for `order` and min-runtime), cluster_mode (for multi-node victim handling), session_type and private flag (candidate exclusion).
-- The repository fetches `RUNNING` sessions with per-agent occupied slots. (Exact types and field signatures are an implementation detail.)
+- The **candidate unit is a whole session** (a victim dies once and frees everywhere it holds), carrying `job_priority` (victim comparison key), execution start time (for `order` and min-runtime; absent when the session never ran), and the **per-agent amounts preemption would actually free**.
+- Reclaimable amount per (agent, slot) comes from the session's **live resource allocations** — the usage the agent has reported, falling back to the requested amount until it does. Allocations already released do not count.
+- **Every candidate condition of (b) is applied at load time**, so the selection layer only compares and orders; it never re-filters by status. Candidates are keyed by owner so the same-owner rule is a lookup rather than a scan.
 
 ### (b) Provisioner — preemption planner (read + propose)
 
-On allocation failure the provisioner calls the planner. The planner **only reads and proposes**; the controller initiates the actual eviction (the provisioner stays additive). Victim decisions are returned in `ScheduleResult`.
+When a requirement cannot be placed, the provisioner falls back to the planner. The planner **only reads and proposes**; the controller initiates the actual eviction (the provisioner stays additive). Victim decisions are returned in `ScheduleResult`, paired with the initiator that claimed them.
 
 **Victim candidate conditions** (all AND):
 
 | Condition | Note |
 |-----------|------|
-| `status == RUNNING` | Excludes PREEMPTED/TERMINATING so in-flight victims are not re-picked |
-| `is_preemptible` and not private/SFTP | Per-session opt-out + infrastructure sessions excluded |
+| The session **occupies resources and can still be terminated** — `SessionStatus.preemption_victim_statuses()` | **Not RUNNING-only.** A session being provisioned (SCHEDULED through CREATING) already holds an agent's slots, so it is a victim too. The set excludes TERMINATING (its resources free without preemption), PREEMPTED/RESCHEDULING (in-flight victims, so they are never re-picked) and RESERVED (that hold belongs to another preemption plan) |
+| The kernel is bound to an agent and its allocation is **not yet freed** | Only holds that preemption would actually release count |
+| `is_preemptible` and not private/SFTP | Per-session opt-out + infrastructure sessions excluded — as victim **and** as initiator (a private session never triggers preemption) |
 | `victim.user_uuid == pending.user_uuid` | **Same scope-owner (v1: user scope). `job_priority` is only comparable within one owner** |
-| `victim.job_priority < pending.job_priority` (strict) | **Preempt by scope-local `job_priority`, not the global `priority`. Equal `job_priority` is never preempted** |
+| `victim.job_priority < pending.job_priority` (strict) | **Preempt by scope-local `job_priority`, not the global `priority`. Equal `job_priority` is never preempted.** Loaded against the owner's **highest** pending `job_priority`; the exact per-pending comparison happens in the selection layer |
 | `now - started_at >= preemption_min_runtime` | Anti-thrashing. **Default 0 (disabled)** |
 
 **Victim selection** (per-agent):
-- On an agent where the pending session could fit, pick victims by **`job_priority` ascending, then the configured `order` strategy** — `oldest`/`newest` break ties by start time; `fewest-sessions`/`smallest-resources` choose deficit-aware against the pending session's shortfall. `preemption_order` is retained (only the `preemptible_priority` threshold is removed).
-- Preempt **only when fully satisfied**: `free(A) + sum(victim slots) >= requested` (no partial preemption, avoiding wasted kills and livelock).
-- **v1 trigger = single-node pending only.** Multi-node victims are allowed but **evicted atomically across all kernels** (no partial gang preemption). Multi-node (cross-agent) triggers are out of scope.
-- Keep a selected-victim set within a tick so one session is not double-counted for two pending sessions.
+- On an agent where the pending session could fit, pick victims by **`job_priority` ascending, then the configured `order` strategy** — `oldest`/`newest` break ties by start time; `fewest-sessions`/`smallest-resources` choose deficit-aware against the pending session's shortfall. `preemption_order` is retained (only the `preemptible_priority` threshold is retired).
+- Preempt **only when fully satisfied**. Feasibility is decided by **re-running the normal placement chain with every unclaimed victim provisionally credited back** to its agents; if no agent fits even then, the session is not placed and nothing is preempted (no partial preemption, avoiding wasted kills and livelock). Only after an agent is chosen are the victims collected — just enough to cover *that* agent's shortfall, so crediting all of them is a feasibility probe, not the eviction set.
+- A victim's whole allocation is credited on **every agent it touches** — a session dies once, so a multi-node victim is **evicted atomically across all its kernels** (no partial gang preemption).
+- **Multi-node initiators are supported**: a multi-node session is placed one requirement (kernel group) per agent, each requirement may fall back to preemption, and the victims of all its requirements are collected into one plan.
+- Victim proposals never leak into the state other sessions see: the probe is rolled back per requirement, and a **claimed-victim set spanning the pass** keeps one session from being counted for two initiators.
 
-### (c) Eviction — controller marks PREEMPTED, then branches by mode
+### (c) Eviction — the initiator reserves, the victims branch by mode
 
-The schedule pass (handler) **only judges and proposes**; it does not mutate victims directly (its target is PENDING, keeping side effects minimal). Given the victim decisions (`ScheduleResult`), **the injected `scheduling_controller` marks victims into the common `PREEMPTED` state** (plus event broadcast + requesting a schedule pass next tick) — the same controller-entry pattern user-requested termination uses via `mark_sessions_for_termination`.
+The schedule pass (handler) **only judges and proposes**; it does not mutate sessions directly (its target is PENDING, keeping side effects minimal). Given the plan (`ScheduleResult`), **the injected `scheduling_controller` writes both sides of it** — the same controller-entry pattern user-requested termination uses via `mark_sessions_for_termination`:
 
-Then **a new preemption lifecycle handler targeting `PREEMPTED` cleans up kernels and decides the destination by `preemption.mode`**:
+| Side | Written state | Meaning |
+|------|---------------|---------|
+| Initiator | `RESERVED` (kernels `RESERVED`, slots **prereserved** on the chosen agents) | The placement is already decided and held; the session is waiting only for its victims to drain |
+| Victims | `PREEMPTED` | Confirmed victims, plus an event broadcast and a request for the preemption cycle next tick |
 
-- **terminate**: hand off to the existing termination path → `TERMINATED`. Reason `PREEMPTED_BY_SCHEDULER`.
-- **reschedule**: **re-enqueue the same session as `PENDING`** (session id/config/priority/`job_priority` preserved, Slurm REQUEUE). Suited to batch jobs with checkpointing; **interactive sessions lose in-container state (accepted, documented).**
+**The reservation gates the eviction.** Victims are marked only for initiators whose reservation was actually written — the reservation batch is all-or-nothing against the agents' capacity guard, and a batch that rolls back leaves its sessions PENDING with no victim touched. Nothing is ever killed for a placement that did not take hold.
+
+Then **a preemption lifecycle handler targeting `PREEMPTED` picks the branch `preemption.mode` asks for** — both branches tear the kernels down under reason `PREEMPTED_BY_SCHEDULER`, and the follow-up belongs to the destination state's own handler:
+
+- **terminate**: hand off to the existing termination path → `TERMINATING` → `TERMINATED`.
+- **reschedule**: `RESCHEDULING`, whose handler re-sends the destruction request until every kernel is gone and then **re-enqueues the same session as `PENDING`** (session id/config/priority/`job_priority` preserved, Slurm REQUEUE). Suited to batch jobs with checkpointing; **interactive sessions lose in-container state (accepted, documented).**
 
 ```
-victim selected -> PREEMPTED (kernel cleanup)
-  ├ [terminate]  -> TERMINATED
-  └ [reschedule] -> PENDING   (priority preserved, re-competes)
+initiator -> RESERVED ---(victims freed, kernels admitted)--> SCHEDULED
+
+victim selected -> PREEMPTED
+  ├ [terminate]  -> TERMINATING  -> TERMINATED
+  └ [reschedule] -> RESCHEDULING -> PENDING   (priority preserved, re-competes)
 ```
 
-There is no separate `RESCHEDULING` state. `PREEMPTED` covers the kernel-cleanup phase, and **only the final destination (PENDING/TERMINATED) differs by mode.** This separates "the preemption decision" from "mode-specific execution."
+`PREEMPTED` is the **single decision state**: it says "this session is a confirmed victim" and nothing about how it dies. Each mode's teardown-and-destination work lives in its own handler, so the preemption decision stays separate from mode-specific execution.
 
-**Multi-tick:** a victim in PREEMPTED (or the following TERMINATING) leaves the candidate set, so it is not re-picked. To keep a still-waiting pending session from preempting *other* sessions, suppress re-triggering with an **in-flight marker** (until resources free or a timeout). Freed resources are not hard-reserved; the pass relies on the sequencer's top-priority-first ordering (soft).
+**Multi-tick.** A victim in PREEMPTED (or the following TERMINATING/RESCHEDULING) is outside the candidate set, so it is not re-picked. The **reservation is what keeps the initiator quiet**: a RESERVED session is no longer a pending candidate, so it cannot preempt anything further, and its prereserved hold counts as occupied capacity — no other session can consume the resources it is waiting for. Admission is **first reserved, first released**: each cycle the repository moves the prereserved holds of the longest-waiting reservations into place within each agent's restored capacity, and a session whose kernels are all admitted is promoted to SCHEDULED. When the operator opts into a phase timeout or retry limit, a reservation that waits too long is reset to PENDING, which releases its holds.
 
 ## Decision Summary
 
@@ -148,13 +165,15 @@ There is no separate `RESCHEDULING` state. `PREEMPTED` covers the kernel-cleanup
 |----------|---------|
 | Enable toggle | New RG `PreemptionConfig.enabled`, default False (opt-in). No preemption when off |
 | Trigger | Preempt when normal allocation fails AND preemption is on AND a fully-satisfying victim set exists |
-| Eviction path | Schedule pass only proposes; **the (injected) controller marks victims `PREEMPTED`**; a new preemption handler branches by mode |
-| State model | Single new state `PREEMPTED` → terminate: TERMINATED / reschedule: PENDING (REQUEUE, id/priority/`job_priority` preserved). No separate RESCHEDULING |
+| Eviction path | Schedule pass only proposes; **the (injected) controller reserves the initiator and marks victims `PREEMPTED`**; a preemption handler branches by mode |
+| State model | Decision state `PREEMPTED` → terminate: TERMINATING → TERMINATED / reschedule: RESCHEDULING → PENDING (REQUEUE, id/priority/`job_priority` preserved) |
+| Victim status set | Any session that **occupies resources and is still terminatable** — provisioning sessions (SCHEDULED…CREATING) included, not RUNNING-only. In-flight victims (PREEMPTED/RESCHEDULING), TERMINATING and other plans' RESERVED holds are excluded |
+| Freed resources | **Hard-reserved.** The initiator goes `RESERVED` with its slots prereserved at plan time; holds are admitted first-reserved-first as capacity returns, and released if the reservation is reset to PENDING. Supersedes the original soft "in-flight marker + top-priority-first ordering" design |
 | Preemption axis | Preempt by the new **`job_priority`** (scope-local), not the global scheduler `priority`; victims chosen by relative comparison within the same owner |
 | Priority scope | v1 = user scope only (`victim.user_uuid == pending.user_uuid`); project scope is future (needs a "project session") |
-| Config change | Drop RG `preemptible_priority` (absolute threshold unneeded); keep `preemption_order`, extended to `oldest\|newest\|fewest-sessions\|smallest-resources` (BA-6748) — the latter two select victims deficit-aware against the pending session |
+| Config change | Retire RG `preemptible_priority` (absolute threshold unneeded) — as built it survives on the config surface, unread by the scheduler; keep `preemption_order`, extended to `oldest\|newest\|fewest-sessions\|smallest-resources` (BA-6748) — the latter two select victims deficit-aware against the pending session |
 | Priority cap | Keypair resource policy `max_priority` caps the global `priority` a user may declare; `job_priority` needs no cap (self-scoped) |
-| Scope | v1 single-node trigger + atomic multi-node victim eviction, no partial preemption |
+| Scope | Single- and multi-node initiators (one requirement per agent, victims of all requirements in one plan) + atomic multi-node victim eviction, no partial preemption |
 | Anti-thrashing | Preempt only on full satisfaction, never preempt equal `job_priority`, `preemption_min_runtime` (default 0). Slurm's `PreemptExemptTime` is likewise no-exemption when unset (-1 equals 0) |
 | Pipeline | provisioner planner (read + propose) + controller initiates eviction |
 | Out of scope | Broad BA-4913 resource-policy priority validation (Not Planned). Only the keypair `max_priority` cap for the global `priority` is in scope (2.4) |
@@ -162,8 +181,8 @@ There is no separate `RESCHEDULING` state. `PREEMPTED` covers the kernel-cleanup
 ## Open Questions
 
 - Cross-tenant (cross-scope) preemption — v1's same-owner rule cannot evict *another* owner's session. Evicting a different tenant's low-priority work belongs to a separate **admin-managed cross-scope (project) axis**, gated on the "project session" concept, and must not be conflated with the user-declared `job_priority`.
-- Multi-node (cross-agent) trigger preemption — out of scope for v1, a follow-up BEP/Epic.
-- Strict reservation of freed resources (soft in v1) — decide the need in a follow-up.
+- **Should the victim set be narrowed?** Preempting a session that is still being provisioned wastes an in-flight image pull or container creation. Whether such a victim is ever actually evicted is **untested**, and the reservation guard makes it doubtful: the guard deliberately ignores the `used` bucket (a running victim's own usage, which the initiator is meant to overlap) but does count `reserved` — where a provisioning victim's slots still sit. The reservation would then roll back and the batch leaves every victim untouched. So the broad set may be inert in practice rather than harmful. Narrowing it (fully, or with a grace rule) is a **behavior change to victim selection** and needs its own decision; the RUNNING-only classifier that once declared the stricter policy was removed rather than wired in, because nothing enforced it (BA-7092).
+- Removing `preemptible_priority` from the RG config surface — a breaking API change, so the field still ships unread (2.1).
 
 ## References
 

--- a/proposals/BEP-1055-preemption-scheduler-mechanics.md
+++ b/proposals/BEP-1055-preemption-scheduler-mechanics.md
@@ -13,7 +13,6 @@ Implemented-Version: 26.8.0
 
 - Epic **BA-3056**, this BEP **BA-6692** (blocks **BA-3058**, the implementation)
 - Amended by **BA-6926** — scope-local `job_priority` for preemption (sections 2.4, 3.a, 3.b)
-- Amended by **BA-7092** — as-built alignment: victim status set, the reservation-backed trigger, and the `RESERVED`/`RESCHEDULING` states (sections 2.2, 2.3, 3.a–3.c, Decision Summary, Open Questions)
 - Upstream spec (motivation): **[BEP-1014](BEP-1014-preemption-of-low-priority-sessions.md)** — referenced, not expanded
 - Prerequisites (done): BA-3057 (RG config), BA-4912 (`is_preemptible`). Out of scope: BA-4913 (Not Planned)
 
@@ -25,7 +24,7 @@ So far preemption has **only the data, config, and API surface**; there is **no 
 
 ## 2. Current State & Scope, by Area
 
-For each area, separate **✅ what already exists** from **➕ what to add**. ✅ / ➕ are read against the state *before* this BEP; the rows describe what was actually built, and every ➕ item shipped in 26.8.0 unless its row says otherwise.
+For each area, separate **✅ what already exists** from **➕ what to add**.
 
 ### 2.1 API (user and admin triggers)
 
@@ -36,7 +35,7 @@ For each area, separate **✅ what already exists** from **➕ what to add**. �
 | ➕ | Expose `preemption.enabled` (preemption on/off toggle) and `preemption_min_runtime` (the anti-thrashing knob in section 3) in the RG config |
 | ➕ | On session creation, the user also sets `job_priority` — the session's **scope-local** preemption priority (used only for preemption; see 2.4). Distinct from the global scheduler `priority` |
 | ➕ | Keypair (user) resource policy gains `max_priority` — caps the `priority` a user may declare on session creation (2.4) |
-| ➕ | Retire admin `preemptible_priority` — unused once victims are chosen by relative `job_priority` (3.b). **As built the field is still accepted and returned by the RG config surface (REST/GQL/DB); no scheduler code reads it.** Removing it is a breaking API change — left as an Open Question |
+| ➕ | Remove admin `preemptible_priority` from the RG config — unused once victims are chosen by relative `job_priority` (3.b) |
 
 > Preemption is never invoked directly by a user; the scheduler decides it automatically, so **there is no new trigger API**.
 
@@ -48,14 +47,11 @@ For each area, separate **✅ what already exists** from **➕ what to add**. �
 | ✅ | `ScalingGroupOpts.preemption = PreemptionConfig(preemptible_priority=5, order, mode)`, `PreemptionMode=terminate\|reschedule`, `PreemptionOrder=oldest\|newest` (BEP-1014's "suspend" is a typo). **No on/off field** |
 | ✅ | `SessionStatus`: PENDING, **DEPRIORITIZING** (on retry give-up, lowers its own priority by 10 and returns to PENDING), ..., TERMINATING, TERMINATED |
 | ➕ | New `PreemptionConfig.enabled: bool` — preemption on/off toggle, **default False (opt-in)** |
-| ➕ | New `SessionStatus.PREEMPTED` — the **single state** for a confirmed victim; it branches by mode to **`TERMINATING` (terminate) or `RESCHEDULING` (reschedule)** (3.(c)) |
-| ➕ | New `SessionStatus.RESCHEDULING` (+ kernel counterpart) — a victim's kernels are torn down here before the session is re-enqueued as PENDING (3.(c)) |
-| ➕ | New `SessionStatus.RESERVED` / `KernelStatus.RESERVED` — the **initiator** holds its placement while its victims drain (3.(c)) |
-| ➕ | New `prereserved` bucket on the agent resource and allocation rows (with `prereserved_at`) — the initiator's hold before its kernels are admitted; counted as occupied by the capacity guard (3.(c)) |
+| ➕ | New `SessionStatus.PREEMPTED` — the **single state** for a confirmed victim; after kernel cleanup it branches by mode to **PENDING (reschedule) or TERMINATED (terminate)** (3.(c)) |
 | ➕ | New `preemption_min_runtime` config field (RG opts) |
 | ➕ | New `SessionRow.job_priority` (default 10) — scope-local preemption priority, compared only within the same scope-owner (2.4, 3.b) |
 | ➕ | New keypair resource-policy field `max_priority` — per-user cap on the global `priority` (2.4) |
-| ➕ | Retire `PreemptionConfig.preemptible_priority` — the absolute RG threshold is unnecessary once victims are chosen by relative `job_priority` (3.b). **Still stored and served; unread by the scheduler** (2.1) |
+| ➕ | Remove `PreemptionConfig.preemptible_priority` — the absolute RG threshold is unnecessary once victims are chosen by relative `job_priority` (3.b) |
 
 ### 2.3 Sokovan (scheduler behavior)
 
@@ -65,10 +61,9 @@ For each area, separate **✅ what already exists** from **➕ what to add**. �
 | ✅ | Provisioner: sequence (top-priority band) → validate → select agent → allocate. **Additive-only** — it never frees resources |
 | ✅ | Termination: `mark_sessions_terminating()` → next tick `TerminateSessionsLifecycleHandler` → `destroy_kernel` (**async**, finalized via agent events) |
 | ✅ | `is_preemptible` is used **only for deployment defaults (False) and RG default merging**, and is **never read for scheduling decisions (the core gap)** |
-| ➕ | Add the victim candidates (whole sessions, decomposed per agent) to the snapshot (3.(a)) |
+| ➕ | Add running sessions (grouped by agent) to the snapshot (3.(a)) |
 | ➕ | Preemption **planner** — candidate filter + victim selection (3.(b)) |
-| ➕ | **The (injected) controller reserves the initiator and marks victims PREEMPTED**, and a new preemption handler **branches by mode** (terminate/reschedule) (3.(c)) |
-| ➕ | Two cycles that carry the reservation forward: `RELEASE_RESERVED` (admit prereserved kernels as capacity is restored) and `CHECK_RESERVED_PROGRESS` (promote a fully admitted session to SCHEDULED) (3.(c)) |
+| ➕ | **The (injected) controller marks victims PREEMPTED**, and a new preemption handler **branches by mode** (terminate/reschedule) + a multi-tick in-flight marker (3.(c)) |
 
 > Because termination is async, the provisioner cannot terminate synchronously, so **preemption is inherently multi-tick**.
 
@@ -99,65 +94,53 @@ Preemption is decided by a **new axis, `job_priority`**, not the scheduler `prio
 
 ## 3. Implementation Design
 
-**Core flow:** pending placement fails → **planner selects victims** → **controller reserves the initiator's placement and marks the victims PREEMPTED, which branches by mode** → as the victims' resources come back the reservation is admitted and the initiator becomes SCHEDULED.
+**Core flow:** pending placement fails → **planner selects victims** → **controller marks PREEMPTED and branches by mode** → (next tick) once resources free, normal allocation places the pending session.
 
-### (a) Data layer — victim candidates in the snapshot
+### (a) Data layer — running sessions in the snapshot
 
-Since allocation is per-agent, load the **victim candidates of the resource group grouped by scope-owner, each decomposed per agent** into the snapshot. Nothing is loaded when the group has preemption disabled.
+Since allocation is per-agent, load the running sessions' **preemption-relevant data grouped by agent** into the snapshot:
 
-- The **candidate unit is a whole session** (a victim dies once and frees everywhere it holds), carrying `job_priority` (victim comparison key), execution start time (for `order` and min-runtime; absent when the session never ran), and the **per-agent amounts preemption would actually free**.
-- Reclaimable amount per (agent, slot) comes from the session's **live resource allocations** — the usage the agent has reported, falling back to the requested amount until it does. Allocations already released do not count.
-- **Every candidate condition of (b) is applied at load time**, so the selection layer only compares and orders; it never re-filters by status. Candidates are keyed by owner so the same-owner rule is a lookup rather than a scan.
+- `job_priority` (victim comparison key), `user_uuid` (scope-owner key for the same-owner filter; `group_id` added when project scope opens), is_preemptible, occupied slots, agent binding, created-at (for `order` and min-runtime), cluster_mode (for multi-node victim handling), session_type and private flag (candidate exclusion).
+- The repository fetches `RUNNING` sessions with per-agent occupied slots. (Exact types and field signatures are an implementation detail.)
 
 ### (b) Provisioner — preemption planner (read + propose)
 
-When a requirement cannot be placed, the provisioner falls back to the planner. The planner **only reads and proposes**; the controller initiates the actual eviction (the provisioner stays additive). Victim decisions are returned in `ScheduleResult`, paired with the initiator that claimed them.
+On allocation failure the provisioner calls the planner. The planner **only reads and proposes**; the controller initiates the actual eviction (the provisioner stays additive). Victim decisions are returned in `ScheduleResult`.
 
 **Victim candidate conditions** (all AND):
 
 | Condition | Note |
 |-----------|------|
-| The session **occupies resources and can still be terminated** — `SessionStatus.preemption_victim_statuses()` | **Not RUNNING-only.** A session being provisioned (SCHEDULED through CREATING) already holds an agent's slots, so it is a victim too. The set excludes TERMINATING (its resources free without preemption), PREEMPTED/RESCHEDULING (in-flight victims, so they are never re-picked) and RESERVED (that hold belongs to another preemption plan) |
-| The kernel is bound to an agent and its allocation is **not yet freed** | Only holds that preemption would actually release count |
-| `is_preemptible` and not private/SFTP | Per-session opt-out + infrastructure sessions excluded — as victim **and** as initiator (a private session never triggers preemption) |
+| `status == RUNNING` | Excludes PREEMPTED/TERMINATING so in-flight victims are not re-picked |
+| `is_preemptible` and not private/SFTP | Per-session opt-out + infrastructure sessions excluded |
 | `victim.user_uuid == pending.user_uuid` | **Same scope-owner (v1: user scope). `job_priority` is only comparable within one owner** |
-| `victim.job_priority < pending.job_priority` (strict) | **Preempt by scope-local `job_priority`, not the global `priority`. Equal `job_priority` is never preempted.** Loaded against the owner's **highest** pending `job_priority`; the exact per-pending comparison happens in the selection layer |
+| `victim.job_priority < pending.job_priority` (strict) | **Preempt by scope-local `job_priority`, not the global `priority`. Equal `job_priority` is never preempted** |
 | `now - started_at >= preemption_min_runtime` | Anti-thrashing. **Default 0 (disabled)** |
 
 **Victim selection** (per-agent):
-- On an agent where the pending session could fit, pick victims by **`job_priority` ascending, then the configured `order` strategy** — `oldest`/`newest` break ties by start time; `fewest-sessions`/`smallest-resources` choose deficit-aware against the pending session's shortfall. `preemption_order` is retained (only the `preemptible_priority` threshold is retired).
-- Preempt **only when fully satisfied**. Feasibility is decided by **re-running the normal placement chain with every unclaimed victim provisionally credited back** to its agents; if no agent fits even then, the session is not placed and nothing is preempted (no partial preemption, avoiding wasted kills and livelock). Only after an agent is chosen are the victims collected — just enough to cover *that* agent's shortfall, so crediting all of them is a feasibility probe, not the eviction set.
-- A victim's whole allocation is credited on **every agent it touches** — a session dies once, so a multi-node victim is **evicted atomically across all its kernels** (no partial gang preemption).
-- **Multi-node initiators are supported**: a multi-node session is placed one requirement (kernel group) per agent, each requirement may fall back to preemption, and the victims of all its requirements are collected into one plan.
-- Victim proposals never leak into the state other sessions see: the probe is rolled back per requirement, and a **claimed-victim set spanning the pass** keeps one session from being counted for two initiators.
+- On an agent where the pending session could fit, pick victims by **`job_priority` ascending, then the configured `order` strategy** — `oldest`/`newest` break ties by start time; `fewest-sessions`/`smallest-resources` choose deficit-aware against the pending session's shortfall. `preemption_order` is retained (only the `preemptible_priority` threshold is removed).
+- Preempt **only when fully satisfied**: `free(A) + sum(victim slots) >= requested` (no partial preemption, avoiding wasted kills and livelock).
+- **v1 trigger = single-node pending only.** Multi-node victims are allowed but **evicted atomically across all kernels** (no partial gang preemption). Multi-node (cross-agent) triggers are out of scope.
+- Keep a selected-victim set within a tick so one session is not double-counted for two pending sessions.
 
-### (c) Eviction — the initiator reserves, the victims branch by mode
+### (c) Eviction — controller marks PREEMPTED, then branches by mode
 
-The schedule pass (handler) **only judges and proposes**; it does not mutate sessions directly (its target is PENDING, keeping side effects minimal). Given the plan (`ScheduleResult`), **the injected `scheduling_controller` writes both sides of it** — the same controller-entry pattern user-requested termination uses via `mark_sessions_for_termination`:
+The schedule pass (handler) **only judges and proposes**; it does not mutate victims directly (its target is PENDING, keeping side effects minimal). Given the victim decisions (`ScheduleResult`), **the injected `scheduling_controller` marks victims into the common `PREEMPTED` state** (plus event broadcast + requesting a schedule pass next tick) — the same controller-entry pattern user-requested termination uses via `mark_sessions_for_termination`.
 
-| Side | Written state | Meaning |
-|------|---------------|---------|
-| Initiator | `RESERVED` (kernels `RESERVED`, slots **prereserved** on the chosen agents) | The placement is already decided and held; the session is waiting only for its victims to drain |
-| Victims | `PREEMPTED` | Confirmed victims, plus an event broadcast and a request for the preemption cycle next tick |
+Then **a new preemption lifecycle handler targeting `PREEMPTED` cleans up kernels and decides the destination by `preemption.mode`**:
 
-**The reservation gates the eviction.** Victims are marked only for initiators whose reservation was actually written — the reservation batch is all-or-nothing against the agents' capacity guard, and a batch that rolls back leaves its sessions PENDING with no victim touched. Nothing is ever killed for a placement that did not take hold.
-
-Then **a preemption lifecycle handler targeting `PREEMPTED` picks the branch `preemption.mode` asks for** — both branches tear the kernels down under reason `PREEMPTED_BY_SCHEDULER`, and the follow-up belongs to the destination state's own handler:
-
-- **terminate**: hand off to the existing termination path → `TERMINATING` → `TERMINATED`.
-- **reschedule**: `RESCHEDULING`, whose handler re-sends the destruction request until every kernel is gone and then **re-enqueues the same session as `PENDING`** (session id/config/priority/`job_priority` preserved, Slurm REQUEUE). Suited to batch jobs with checkpointing; **interactive sessions lose in-container state (accepted, documented).**
+- **terminate**: hand off to the existing termination path → `TERMINATED`. Reason `PREEMPTED_BY_SCHEDULER`.
+- **reschedule**: **re-enqueue the same session as `PENDING`** (session id/config/priority/`job_priority` preserved, Slurm REQUEUE). Suited to batch jobs with checkpointing; **interactive sessions lose in-container state (accepted, documented).**
 
 ```
-initiator -> RESERVED ---(victims freed, kernels admitted)--> SCHEDULED
-
-victim selected -> PREEMPTED
-  ├ [terminate]  -> TERMINATING  -> TERMINATED
-  └ [reschedule] -> RESCHEDULING -> PENDING   (priority preserved, re-competes)
+victim selected -> PREEMPTED (kernel cleanup)
+  ├ [terminate]  -> TERMINATED
+  └ [reschedule] -> PENDING   (priority preserved, re-competes)
 ```
 
-`PREEMPTED` is the **single decision state**: it says "this session is a confirmed victim" and nothing about how it dies. Each mode's teardown-and-destination work lives in its own handler, so the preemption decision stays separate from mode-specific execution.
+There is no separate `RESCHEDULING` state. `PREEMPTED` covers the kernel-cleanup phase, and **only the final destination (PENDING/TERMINATED) differs by mode.** This separates "the preemption decision" from "mode-specific execution."
 
-**Multi-tick.** A victim in PREEMPTED (or the following TERMINATING/RESCHEDULING) is outside the candidate set, so it is not re-picked. The **reservation is what keeps the initiator quiet**: a RESERVED session is no longer a pending candidate, so it cannot preempt anything further, and its prereserved hold counts as occupied capacity — no other session can consume the resources it is waiting for. Admission is **first reserved, first released**: each cycle the repository moves the prereserved holds of the longest-waiting reservations into place within each agent's restored capacity, and a session whose kernels are all admitted is promoted to SCHEDULED. When the operator opts into a phase timeout or retry limit, a reservation that waits too long is reset to PENDING, which releases its holds.
+**Multi-tick:** a victim in PREEMPTED (or the following TERMINATING) leaves the candidate set, so it is not re-picked. To keep a still-waiting pending session from preempting *other* sessions, suppress re-triggering with an **in-flight marker** (until resources free or a timeout). Freed resources are not hard-reserved; the pass relies on the sequencer's top-priority-first ordering (soft).
 
 ## Decision Summary
 
@@ -165,15 +148,13 @@ victim selected -> PREEMPTED
 |----------|---------|
 | Enable toggle | New RG `PreemptionConfig.enabled`, default False (opt-in). No preemption when off |
 | Trigger | Preempt when normal allocation fails AND preemption is on AND a fully-satisfying victim set exists |
-| Eviction path | Schedule pass only proposes; **the (injected) controller reserves the initiator and marks victims `PREEMPTED`**; a preemption handler branches by mode |
-| State model | Decision state `PREEMPTED` → terminate: TERMINATING → TERMINATED / reschedule: RESCHEDULING → PENDING (REQUEUE, id/priority/`job_priority` preserved) |
-| Victim status set | Any session that **occupies resources and is still terminatable** — provisioning sessions (SCHEDULED…CREATING) included, not RUNNING-only. In-flight victims (PREEMPTED/RESCHEDULING), TERMINATING and other plans' RESERVED holds are excluded |
-| Freed resources | **Hard-reserved.** The initiator goes `RESERVED` with its slots prereserved at plan time; holds are admitted first-reserved-first as capacity returns, and released if the reservation is reset to PENDING. Supersedes the original soft "in-flight marker + top-priority-first ordering" design |
+| Eviction path | Schedule pass only proposes; **the (injected) controller marks victims `PREEMPTED`**; a new preemption handler branches by mode |
+| State model | Single new state `PREEMPTED` → terminate: TERMINATED / reschedule: PENDING (REQUEUE, id/priority/`job_priority` preserved). No separate RESCHEDULING |
 | Preemption axis | Preempt by the new **`job_priority`** (scope-local), not the global scheduler `priority`; victims chosen by relative comparison within the same owner |
 | Priority scope | v1 = user scope only (`victim.user_uuid == pending.user_uuid`); project scope is future (needs a "project session") |
-| Config change | Retire RG `preemptible_priority` (absolute threshold unneeded) — as built it survives on the config surface, unread by the scheduler; keep `preemption_order`, extended to `oldest\|newest\|fewest-sessions\|smallest-resources` (BA-6748) — the latter two select victims deficit-aware against the pending session |
+| Config change | Drop RG `preemptible_priority` (absolute threshold unneeded); keep `preemption_order`, extended to `oldest\|newest\|fewest-sessions\|smallest-resources` (BA-6748) — the latter two select victims deficit-aware against the pending session |
 | Priority cap | Keypair resource policy `max_priority` caps the global `priority` a user may declare; `job_priority` needs no cap (self-scoped) |
-| Scope | Single- and multi-node initiators (one requirement per agent, victims of all requirements in one plan) + atomic multi-node victim eviction, no partial preemption |
+| Scope | v1 single-node trigger + atomic multi-node victim eviction, no partial preemption |
 | Anti-thrashing | Preempt only on full satisfaction, never preempt equal `job_priority`, `preemption_min_runtime` (default 0). Slurm's `PreemptExemptTime` is likewise no-exemption when unset (-1 equals 0) |
 | Pipeline | provisioner planner (read + propose) + controller initiates eviction |
 | Out of scope | Broad BA-4913 resource-policy priority validation (Not Planned). Only the keypair `max_priority` cap for the global `priority` is in scope (2.4) |
@@ -181,8 +162,8 @@ victim selected -> PREEMPTED
 ## Open Questions
 
 - Cross-tenant (cross-scope) preemption — v1's same-owner rule cannot evict *another* owner's session. Evicting a different tenant's low-priority work belongs to a separate **admin-managed cross-scope (project) axis**, gated on the "project session" concept, and must not be conflated with the user-declared `job_priority`.
-- **Should the victim set be narrowed?** Preempting a session that is still being provisioned wastes an in-flight image pull or container creation. Whether such a victim is ever actually evicted is **untested**, and the reservation guard makes it doubtful: the guard deliberately ignores the `used` bucket (a running victim's own usage, which the initiator is meant to overlap) but does count `reserved` — where a provisioning victim's slots still sit. The reservation would then roll back and the batch leaves every victim untouched. So the broad set may be inert in practice rather than harmful. Narrowing it (fully, or with a grace rule) is a **behavior change to victim selection** and needs its own decision; the RUNNING-only classifier that once declared the stricter policy was removed rather than wired in, because nothing enforced it (BA-7092).
-- Removing `preemptible_priority` from the RG config surface — a breaking API change, so the field still ships unread (2.1).
+- Multi-node (cross-agent) trigger preemption — out of scope for v1, a follow-up BEP/Epic.
+- Strict reservation of freed resources (soft in v1) — decide the need in a follow-up.
 
 ## References
 

--- a/src/ai/backend/manager/data/session/types.py
+++ b/src/ai/backend/manager/data/session/types.py
@@ -61,13 +61,14 @@ class SessionStatus(CIStrEnum):
     CANCELLED = "CANCELLED"
 
     @classmethod
-    def kernel_awaiting_statuses(cls) -> set[SessionStatus]:
-        return {
+    @lru_cache(maxsize=1)
+    def kernel_awaiting_statuses(cls) -> frozenset[SessionStatus]:
+        return frozenset((
             cls.PREPARING,
             cls.PULLING,
             cls.CREATING,
             cls.TERMINATING,
-        }
+        ))
 
     @classmethod
     @lru_cache(maxsize=1)

--- a/src/ai/backend/manager/data/session/types.py
+++ b/src/ai/backend/manager/data/session/types.py
@@ -120,17 +120,6 @@ class SessionStatus(CIStrEnum):
 
     @classmethod
     @lru_cache(maxsize=1)
-    def preemptable_statuses(cls) -> frozenset[SessionStatus]:
-        """Return statuses that can transition to PREEMPTED.
-
-        Only RUNNING sessions are eligible preemption victims (BEP-1055).
-        Sessions still being provisioned or already terminating are never
-        marked PREEMPTED, so those source statuses are rejected.
-        """
-        return frozenset((cls.RUNNING,))
-
-    @classmethod
-    @lru_cache(maxsize=1)
     def preemption_victim_statuses(cls) -> frozenset[SessionStatus]:
         """Return statuses eligible as preemption victim candidates (BEP-1055).
 

--- a/tests/unit/manager/data/session/test_session_status.py
+++ b/tests/unit/manager/data/session/test_session_status.py
@@ -11,21 +11,6 @@ class TestPreemptedStatus:
         assert SessionStatus("PREEMPTED") is SessionStatus.PREEMPTED
         assert SessionStatus.PREEMPTED.value == "PREEMPTED"
 
-    def test_only_running_can_transition_to_preempted(self) -> None:
-        """RUNNING -> PREEMPTED is allowed; every other source is rejected."""
-        assert SessionStatus.preemptable_statuses() == frozenset((SessionStatus.RUNNING,))
-        # Illegal sources are not eligible to be marked PREEMPTED.
-        for illegal_source in (
-            SessionStatus.PENDING,
-            SessionStatus.SCHEDULED,
-            SessionStatus.PREPARING,
-            SessionStatus.CREATING,
-            SessionStatus.TERMINATING,
-            SessionStatus.TERMINATED,
-            SessionStatus.PREEMPTED,
-        ):
-            assert illegal_source not in SessionStatus.preemptable_statuses()
-
     def test_preempted_can_transition_to_terminating(self) -> None:
         """PREEMPTED -> TERMINATING is allowed (terminate mode)."""
         assert SessionStatus.PREEMPTED in SessionStatus.terminatable_statuses()


### PR DESCRIPTION
`SessionStatus.preemptable_statuses()` declared a preemption victim policy that no production code consults:

> Return statuses that can transition to PREEMPTED. Only RUNNING sessions are eligible preemption victims (BEP-1055). Sessions still being provisioned or already terminating are never marked PREEMPTED, so those source statuses are rejected.

The policy actually in force is `preemption_victim_statuses()`, read by the candidate query in `repositories/scheduler/db_source/db_source.py`. It resolves to eight statuses — SCHEDULED, PREPARING, PULLING, PREPARED, CREATING, RUNNING, RESTARTING, RUNNING_DEGRADED — and carries its own reasoned docstring. The controller that writes PREEMPTED filters only terminal sessions, so it does not narrow the set either.

So two contradictory declarations sat side by side, and the unused one was the stricter. Its test asserted the narrower set under the name `test_only_running_can_transition_to_preempted` — reading as a guarantee that non-RUNNING sessions cannot be preempted, which nothing provided. That is false assurance rather than coverage, so both go.

**Behavior is unchanged.** The removed classmethod had no runtime reader (verified: no remaining references in `src/` or `tests/`), and its author confirms it was dead code rather than a policy that was lost.

## Also in this PR

Sweeping the same enum for other unread or inconsistent declarations turned up one: `SessionStatus.kernel_awaiting_statuses()` was the only classifier without `@lru_cache(maxsize=1)` and the only one returning a mutable `set`. It now matches its neighbours.

The two changes go together — caching a mutable set would hand every caller the same object, so one `.add()` on a returned value would leak into all later calls. A `frozenset` removes that hazard structurally.

## Open question, deliberately not settled here

If the RUNNING-only restriction was meant to be *enforced*, wiring it in is a behavior change to victim selection and deserves its own decision rather than being smuggled into a cleanup.

Whether a non-RUNNING victim can actually be marked PREEMPTED in practice is **untested**. A SCHEDULED victim holds its slots in the agent's `reserved` bucket, and the prereservation guard (`reserved + prereserved + requested <= capacity`) counts that bucket while deliberately ignoring `used`, so the reservation plausibly rolls back before any victim is marked. That is reasoning from the code, not an observation.

## How it was found

Reviewing the preemption path while running the BEP-1055 scenarios against a live manager. The declared victim policy and the queried victim policy did not match, and only one of them was reachable.

## Verification

- No references to `preemptable_statuses` remain anywhere in the tree
- `kernel_awaiting_statuses` has no caller at all, so the signature change breaks nothing
- `pants check` clean on `data/session/types.py`; `pants fmt` / `lint` clean on the changed targets
- Unit suite left to CI

## Related

- BA-7092
- BEP-1055 Preemption Scheduler Mechanics, section 3.b — victim candidate conditions
- BA-7078 — `is_preemptible` dropped at session creation, found in the same review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
