### PR TITLE
fix(BA-7093): give NoCompatibleAgentError an HTTP status

### DIFF
--- a/changes/13270.fix.md
+++ b/changes/13270.fix.md
@@ -1,0 +1,1 @@
+Return `400` with the rejecting filter's reason when no agent can serve a request's designated agents or architecture, instead of failing the request with a `502`.

--- a/changes/13270.fix.md
+++ b/changes/13270.fix.md
@@ -1,1 +1,0 @@
-Return `400` with the rejecting filter's reason when no agent can serve a request's designated agents or architecture, instead of failing the request with a `502`.

--- a/changes/13270.fix.md
+++ b/changes/13270.fix.md
@@ -1,0 +1,1 @@
+Return `404` instead of `502` when no agent matches the request.

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/exceptions.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/exceptions.py
@@ -102,7 +102,7 @@ class NoCompatibleAgentError(AgentSelectionError, web.HTTPNotFound):
         return ErrorCode(
             domain=ErrorDomain.AGENT,
             operation=ErrorOperation.SCHEDULE,
-            error_detail=ErrorDetail.NOT_FOUND,
+            error_detail=ErrorDetail.UNAVAILABLE,
         )
 
 

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/exceptions.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/exceptions.py
@@ -77,16 +77,13 @@ class NoAgentsInResourceGroupError(AgentSelectionError, web.HTTPServiceUnavailab
         )
 
 
-class NoCompatibleAgentError(AgentSelectionError, web.HTTPBadRequest):
+class NoCompatibleAgentError(AgentSelectionError, web.HTTPNotFound):
     """Raised inside an exclusion filter's recorder step when no candidates
     survive it.
 
     An absolute failure: no state change (preemption included) can make the
     request placeable, so this propagates instead of becoming a
-    :class:`PlacementFailure`. What the filter rejected is a property of the
-    request — a designated agent that does not exist, an architecture no
-    agent serves — so the caller has to change the request, hence 400 rather
-    than the 503 its sibling returns when the group holds no agents at all.
+    :class:`PlacementFailure`.
     """
 
     error_type = "https://api.backend.ai/probs/no-compatible-agents"
@@ -105,7 +102,7 @@ class NoCompatibleAgentError(AgentSelectionError, web.HTTPBadRequest):
         return ErrorCode(
             domain=ErrorDomain.AGENT,
             operation=ErrorOperation.SCHEDULE,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
+            error_detail=ErrorDetail.NOT_FOUND,
         )
 
 

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/exceptions.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/exceptions.py
@@ -77,13 +77,16 @@ class NoAgentsInResourceGroupError(AgentSelectionError, web.HTTPServiceUnavailab
         )
 
 
-class NoCompatibleAgentError(AgentSelectionError):
+class NoCompatibleAgentError(AgentSelectionError, web.HTTPBadRequest):
     """Raised inside an exclusion filter's recorder step when no candidates
     survive it.
 
     An absolute failure: no state change (preemption included) can make the
     request placeable, so this propagates instead of becoming a
-    :class:`PlacementFailure`.
+    :class:`PlacementFailure`. What the filter rejected is a property of the
+    request — a designated agent that does not exist, an architecture no
+    agent serves — so the caller has to change the request, hence 400 rather
+    than the 503 its sibling returns when the group holds no agents at all.
     """
 
     error_type = "https://api.backend.ai/probs/no-compatible-agents"
@@ -102,7 +105,7 @@ class NoCompatibleAgentError(AgentSelectionError):
         return ErrorCode(
             domain=ErrorDomain.AGENT,
             operation=ErrorOperation.SCHEDULE,
-            error_detail=ErrorDetail.UNAVAILABLE,
+            error_detail=ErrorDetail.INVALID_PARAMETERS,
         )
 
 


### PR DESCRIPTION
`NoCompatibleAgentError` was the only exception in `selectors/exceptions.py` without an aiohttp status mixin, so it could not be rendered as a response. The request died mid-flight (`"POST /v2/sessions/compute-schedule HTTP/1.1" -1` in the access log) and the caller got a `502 Bad Gateway / "The proxy target server is inaccessible"` while the manager logged the real reason.

Its sibling absolute failure, `NoAgentsInResourceGroupError`, already mixes in `web.HTTPServiceUnavailable`. 404 matches how the rest of the API answers a body-referenced entity that resolves to nothing — an unknown `image_id` on session enqueue returns `404 / probs/object-not-found`.

## Before / after

Against a live manager:

```bash
./bai session compute-schedule \
  --resource-group-id <RG_UUID> --image-id <IMAGE_UUID> \
  -r cpu=1 -r mem=2147483648 \
  --designated-agent no-such-agent --agent-selection-policy strict
```


| | before | after |
|---|---|---|
| status | `502 Bad Gateway` | `404 Not Found` |
| type | `probs/bad-gateway` | `probs/no-compatible-agents` |
| title | The proxy target server is inaccessible. | No compatible agents for the request. |
| msg | — | `no agents passed the 'designated-strict' filter: none of the strictly designated agents [no-such-agent] is available` |

`error_code` stays `agent_schedule_unavailable`.

## No regression

- resource shortfall (`cpu=50`) — still `success: false` with `required_reduction: 40`, not an exception
- ordinary placement (`cpu=1`) — `success: true`
- existing designated agent — `success: true`

## For the reviewer

Every exclusion filter shares this exception, so the architecture filter now answers 404 too ("no agent serves the required architecture 'x86_64'"). A status per filter would mean moving it off the shared exception.

`designated-strict` does not distinguish an agent that does not exist from one that exists but is not a candidate (TERMINATED, `schedulable=false`, another resource group) — it intersects the request's agent IDs with the candidate list. Both produce this 404.

`NoAvailableAgentError` and `BatchAgentSelectionFailedError` in the same module also lack status mixins, but are normally converted to `PlacementFailure` values before reaching a handler, so they were left alone.

Found while running CHECKLIST_26.8 item 3 (Scheduler Dry-Run) against 26.8.0rc1.

## Related

- BA-7093

🤖 Generated with [Claude Code](https://claude.com/claude-code)
