### PR TITLE
fix(BA-7093): give NoCompatibleAgentError an HTTP status (#13270)

### DIFF
--- a/changes/13270.fix.md
+++ b/changes/13270.fix.md
@@ -1,0 +1,1 @@
+Return `404` instead of `502` when no agent matches the request.

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/exceptions.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/exceptions.py
@@ -77,7 +77,7 @@ class NoAgentsInResourceGroupError(AgentSelectionError, web.HTTPServiceUnavailab
         )
 
 
-class NoCompatibleAgentError(AgentSelectionError):
+class NoCompatibleAgentError(AgentSelectionError, web.HTTPNotFound):
     """Raised inside an exclusion filter's recorder step when no candidates
     survive it.
 


### PR DESCRIPTION
This is an auto-generated backport PR of #13270 to the 26.8 release.