### PR TITLE
fix(BA-7095): expire sessions past their lifetime

### DIFF
--- a/changes/13274.fix.md
+++ b/changes/13274.fix.md
@@ -1,0 +1,1 @@
+Terminate sessions that exceed the `session_lifetime` idle checker's limit.

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/session_lifetime.py
@@ -53,7 +53,11 @@ class SessionLifetimeChecker(IdleChecker):
                         checker_id=assignment.definition.checker_id,
                         session_id=session.session_id,
                         expire_at=expires_at,
-                        status=IdleCheckPhase.IDLE,
+                        status=(
+                            IdleCheckPhase.IDLE_EXPIRED
+                            if context.current_time >= expires_at
+                            else IdleCheckPhase.IDLE
+                        ),
                         message=(
                             "Session lifetime check: "
                             f"max_lifetime_seconds={max_lifetime_seconds:f}, "

--- a/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
+++ b/tests/unit/manager/sokovan/idle_check/test_session_lifetime_checker.py
@@ -127,7 +127,7 @@ class TestSessionLifetimeChecker:
             "Session lifetime check: max_lifetime_seconds=30, running_seconds=29"
         )
 
-    async def test_session_at_deadline_is_idle_until_applied(
+    async def test_session_at_deadline_is_expired(
         self,
         checker: SessionLifetimeChecker,
         session_factory: SessionFactory,
@@ -146,12 +146,12 @@ class TestSessionLifetimeChecker:
         assert len(judgments) == 1
         assert judgments[0].session_id == session.session_id
         assert judgments[0].expire_at == _BASE_TIME + timedelta(seconds=30)
-        assert judgments[0].status is IdleCheckPhase.IDLE
+        assert judgments[0].status is IdleCheckPhase.IDLE_EXPIRED
         assert judgments[0].message == (
             "Session lifetime check: max_lifetime_seconds=30, running_seconds=30"
         )
 
-    async def test_session_after_deadline_is_idle_until_applied(
+    async def test_session_after_deadline_is_expired(
         self,
         checker: SessionLifetimeChecker,
         session_factory: SessionFactory,
@@ -168,7 +168,7 @@ class TestSessionLifetimeChecker:
         )
 
         assert judgments[0].expire_at == _BASE_TIME + timedelta(seconds=30)
-        assert judgments[0].status is IdleCheckPhase.IDLE
+        assert judgments[0].status is IdleCheckPhase.IDLE_EXPIRED
         assert judgments[0].message == (
             "Session lifetime check: max_lifetime_seconds=30, running_seconds=31.2"
         )
@@ -213,7 +213,7 @@ class TestSessionLifetimeChecker:
             long_lifetime.definition.checker_id,
         ]
         assert [judgment.status for judgment in judgments] == [
-            IdleCheckPhase.IDLE,
+            IdleCheckPhase.IDLE_EXPIRED,
             IdleCheckPhase.IDLE,
         ]
 
@@ -239,7 +239,7 @@ class TestSessionLifetimeChecker:
             active_session.session_id,
         ]
         assert [judgment.status for judgment in judgments] == [
-            IdleCheckPhase.IDLE,
+            IdleCheckPhase.IDLE_EXPIRED,
             IdleCheckPhase.IDLE,
         ]
 


### PR DESCRIPTION
The `session_lifetime` checker never collected a session. It computed the deadline and stored it as `expire_at`, but always reported `IdleCheckPhase.IDLE`. The expiry sweep only picks up rows whose `last_status` is `IDLE_EXPIRED`, so judgments accumulated and nothing was terminated.

`network_timeout` and `utilization` both raise the phase once the deadline passes; `session_lifetime` was the only checker that did not.

## Verified locally

A `session_lifetime` checker (`max_lifetime_seconds: 120`, grace 0) bound to a project, with interactive sessions left running:

| | before | after |
|---|---|---|
| `last_status` | `idle` | `idle_expired` |
| sessions | survived 10 min and 53 min against a 120 s limit | terminated within one tick |
| reason | — | `idle-timeout` on session and kernel |

A second checker targeting `batch` only did not judge the interactive sessions.

## Where the gap came from

BA-6966 moved deadline detection out of the sweep:

> Replace the `expired(now)` condition in `fetch_expired_idle_checks` with `last_status = IDLE_EXPIRED`. **Deadline-elapse detection is owned by the judgment stage (BA-6960); the sweep re-evaluates nothing.**
>
> Success criteria: … **a row past `expire_at` but still `IDLE` is NOT swept**

Before that, a checker reporting `IDLE` with a stored `expire_at` was enough — the sweep compared the time itself. After it, the checker has to raise the phase. `network_timeout` and `utilization` do; `session_lifetime` was not updated, so it produces exactly the row that success criterion describes.

## Why the tests changed

Four tests pinned the checker to reporting `IDLE` past its deadline, under names like `..._is_idle_until_applied` — accurate under the pre-BA-6966 design, where the sweep applied the deadline. They outlived the contract they described.

Two of the four read better now: their fixtures were already named `expired_session` and `active_session` while asserting `IDLE` for both.

## Note

The stored `expire_at` is not consulted the way `network_timeout` does it. A lifetime deadline derives from `starts_at` rather than being refreshed by activity, and the initial grace period is already applied by its own reconciler stage before a checker sees the session.

Found while running CHECKLIST_26.8 item 2 (Reconciler-based Idle Checker) against 26.8.0rc1.

## Related

- BA-7095

🤖 Generated with [Claude Code](https://claude.com/claude-code)
