### PR TITLE
fix(BA-7094): return the resource group UUID as the v2 read API id

### DIFF
--- a/changes/13275.fix.md
+++ b/changes/13275.fix.md
@@ -1,0 +1,1 @@
+Return the resource group UUID instead of the name in the `id` field of the v2 resource group read APIs

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -5718,8 +5718,8 @@ type DeleteReservoirRegistryPayload
 type DeleteResourceGroupPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Name of the deleted resource group."""
-  id: String!
+  """UUID of the deleted resource group."""
+  id: UUID!
 }
 
 type DeleteResourcePreset

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -16927,7 +16927,9 @@ input ResourceConfigInput
   resourceOpts: ResourceOptsInput = null
 }
 
-"""Added in 26.1.0. Resource group with structured configuration"""
+"""
+Added in 26.1.0. Resource group with structured configuration. Since 26.8.0, the node id value is the resource group UUID instead of the name.
+"""
 type ResourceGroup implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
   @join__type(graph: STRAWBERRY)

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -3883,8 +3883,8 @@ type DeleteReservoirRegistryPayload {
 
 """Added in 26.4.2. Payload for resource group deletion."""
 type DeleteResourceGroupPayload {
-  """Name of the deleted resource group."""
-  id: String!
+  """UUID of the deleted resource group."""
+  id: UUID!
 }
 
 """Added in 26.4.2. Payload for resource preset deletion."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -11794,7 +11794,9 @@ input ResourceConfigInput {
   resourceOpts: ResourceOptsInput = null
 }
 
-"""Added in 26.1.0. Resource group with structured configuration"""
+"""
+Added in 26.1.0. Resource group with structured configuration. Since 26.8.0, the node id value is the resource group UUID instead of the name.
+"""
 type ResourceGroup implements Node {
   """The Globally Unique ID of this object"""
   id: ID!

--- a/src/ai/backend/common/dto/manager/v2/resource_group/response.py
+++ b/src/ai/backend/common/dto/manager/v2/resource_group/response.py
@@ -22,7 +22,7 @@ from ai.backend.common.dto.manager.v2.resource_group.types import (
     SchedulerTypeDTO,
 )
 from ai.backend.common.dto.manager.v2.session_options import DefaultSessionOptionsInfo
-from ai.backend.common.identifier.resource_group import ResourceGroupName
+from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
 from ai.backend.common.types import PreemptionOrder
 
 __all__ = (
@@ -52,7 +52,7 @@ __all__ = (
 class ResourceGroupNode(BaseResponseModel):
     """Node model representing a resource group entity."""
 
-    id: UUID = Field(description="Resource group UUID.")
+    id: ResourceGroupID = Field(description="Resource group UUID.")
     name: str = Field(description="Unique name of the resource group.")
     domain_name: str = Field(description="Domain the resource group belongs to.")
     description: str | None = Field(
@@ -99,7 +99,7 @@ class UpdateResourceGroupPayload(BaseResponseModel):
 class DeleteResourceGroupPayload(BaseResponseModel):
     """Payload for resource group deletion mutation result."""
 
-    id: str = Field(description="Name of the deleted resource group.")
+    id: ResourceGroupID = Field(description="UUID of the deleted resource group.")
 
 
 class AdminSearchResourceGroupsPayload(BaseResponseModel):
@@ -181,7 +181,7 @@ class ResourceGroupSchedulerConfigInfo(BaseResponseModel):
 class ResourceGroupDetailNode(BaseResponseModel):
     """Detail node DTO for a resource group (GQL-layer representation)."""
 
-    id: str = Field(description="Resource group name used as the relay node ID.")
+    id: ResourceGroupID = Field(description="Resource group UUID used as the relay node ID.")
     name: str = Field(description="Unique name of the resource group.")
     status: ResourceGroupStatusInfo = Field(
         description="Status information including active and public flags."

--- a/src/ai/backend/manager/api/adapters/resource_group/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_group/adapter.py
@@ -61,7 +61,7 @@ from ai.backend.common.dto.manager.v2.resource_group.types import (
     ResourceGroupOrderField,
     SchedulerTypeDTO,
 )
-from ai.backend.common.identifier.resource_group import ResourceGroupName
+from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
 from ai.backend.common.types import PreemptionMode, PreemptionOrder, SlotQuantity
 from ai.backend.manager.api.adapter_options.deployment.options import (
     deployment_options_from_input,
@@ -215,8 +215,8 @@ class ResourceGroupAdapter(BaseAdapter):
     Bridges CreateResourceGroupInput / UpdateResourceGroupInput DTOs to
     ScalingGroup Processor actions and converts results back to Pydantic DTOs.
 
-    Note: ScalingGroupData uses ``name`` (str) as primary key.  Callers that
-        need an opaque identifier should use the ``name`` field instead.
+    Note: ScalingGroupData uses ``name`` (str) as primary key, while the
+        exposed ``id`` field carries the resource group UUID.
     """
 
     def __init__(
@@ -261,6 +261,27 @@ class ResourceGroupAdapter(BaseAdapter):
         return [
             self._data_to_detail_node(rg_map[name]) if name in rg_map else None for name in names
         ]
+
+    async def batch_load_by_ids(
+        self, ids: Sequence[ResourceGroupID]
+    ) -> list[ResourceGroupDetailNode | None]:
+        """Batch load resource groups by UUID for DataLoader use.
+
+        Returns ResourceGroupDetailNode items in the same order as the input ids list.
+        """
+        if not ids:
+            return []
+        querier = BatchQuerier(
+            pagination=OffsetPagination(limit=len(ids)),
+            conditions=[ScalingGroupConditions.by_ids(ids)],
+        )
+        action_result = (
+            await self._processors.scaling_group.search_scaling_groups.wait_for_complete(
+                SearchScalingGroupsAction(querier=querier)
+            )
+        )
+        rg_map = {sg.id: sg for sg in action_result.scaling_groups}
+        return [self._data_to_detail_node(rg_map[id_]) if id_ in rg_map else None for id_ in ids]
 
     async def search(self, input: AdminSearchResourceGroupsInput) -> ResourceGroupSearchPayload:
         """Search resource groups with filters, ordering, and pagination."""
@@ -775,7 +796,7 @@ class ResourceGroupAdapter(BaseAdapter):
     def _data_to_detail_node(data: ScalingGroupData) -> ResourceGroupDetailNode:
         """Convert ScalingGroupData to ResourceGroupDetailNode DTO for GQL layer."""
         return ResourceGroupDetailNode(
-            id=data.name,
+            id=data.id,
             name=data.name,
             status=ResourceGroupStatusInfo(
                 is_active=data.status.is_active,

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -13,6 +13,7 @@ from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.identifier.kernel_scheduling_history import KernelSchedulingHistoryID
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import AgentId, ImageID, KernelId, SessionId
 from ai.backend.manager.data.permission.id import ObjectId
 
@@ -237,6 +238,22 @@ class DataLoaders:
             )
 
             dtos = await adapter.batch_load_by_names(names)
+            return [RG.from_pydantic(dto) if dto is not None else None for dto in dtos]
+
+        return DataLoader(load_fn=load_fn)
+
+    @cached_property
+    def resource_group_by_id_loader(
+        self,
+    ) -> DataLoader[ResourceGroupID, ResourceGroupGQL | None]:
+        adapter = self._adapters.resource_group
+
+        async def load_fn(ids: list[ResourceGroupID]) -> list[ResourceGroupGQL | None]:
+            from ai.backend.manager.api.gql.resource_group.types import (  # pants: no-infer-dep
+                ResourceGroupGQL as RG,
+            )
+
+            dtos = await adapter.batch_load_by_ids(ids)
             return [RG.from_pydantic(dto) if dto is not None else None for dto in dtos]
 
         return DataLoader(load_fn=load_fn)

--- a/src/ai/backend/manager/api/gql/resource_group/types.py
+++ b/src/ai/backend/manager/api/gql/resource_group/types.py
@@ -325,7 +325,11 @@ class ResourceInfoGQL(PydanticOutputMixin[ResourceInfoNode]):
 @gql_node_type(
     BackendAIGQLMeta(
         added_version="26.1.0",
-        description="Resource group with structured configuration",
+        description=(
+            "Resource group with structured configuration."
+            " Since 26.8.0, the node id value is the resource group UUID"
+            " instead of the name."
+        ),
     ),
     name="ResourceGroup",
 )

--- a/src/ai/backend/manager/api/gql/resource_group/types.py
+++ b/src/ai/backend/manager/api/gql/resource_group/types.py
@@ -80,6 +80,7 @@ from ai.backend.common.dto.manager.v2.resource_group.response import (
 from ai.backend.common.dto.manager.v2.resource_group.response import (
     ReplaceResourceGroupDefaultSessionOptionsPayload as ReplaceResourceGroupDefaultSessionOptionsPayloadDTO,
 )
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.common.types import PreemptionOrder
 from ai.backend.manager.api.gql.base import OrderDirection, StringFilter
@@ -329,8 +330,12 @@ class ResourceInfoGQL(PydanticOutputMixin[ResourceInfoNode]):
     name="ResourceGroup",
 )
 class ResourceGroupGQL(PydanticNodeMixin[ResourceGroupDetailNode]):
-    id: NodeID[str] = gql_field(
-        description="Relay-style global node identifier for the resource group"
+    id: NodeID[UUID] = gql_field(
+        description=(
+            "Relay-style global node identifier for the resource group."
+            " Since 26.8.0, the underlying value is the resource group UUID"
+            " instead of the name."
+        )
     )
     name: str = gql_field(
         description="Unique name identifying the resource group. Used as primary key and referenced by agents, sessions, and resource presets."
@@ -386,7 +391,9 @@ class ResourceGroupGQL(PydanticNodeMixin[ResourceGroupDetailNode]):
         node_ids: Iterable[str],
         required: bool = False,
     ) -> Iterable[ResourceGroupGQL | None]:
-        return await info.context.data_loaders.resource_group_loader.load_many(node_ids)
+        return await info.context.data_loaders.resource_group_by_id_loader.load_many([
+            ResourceGroupID(UUID(nid)) for nid in node_ids
+        ])
 
     @gql_added_field(
         BackendAIGQLMeta(
@@ -653,7 +660,12 @@ class CreateResourceGroupPayloadGQL(PydanticOutputMixin[CreateResourceGroupPaylo
     name="DeleteResourceGroupPayload",
 )
 class DeleteResourceGroupPayloadGQL(PydanticOutputMixin[DeleteResourceGroupPayloadDTO]):
-    id: str = gql_field(description="ID of the deleted resource group.")
+    id: UUID = gql_field(
+        description=(
+            "UUID of the deleted resource group."
+            " Since 26.8.0, the value is the UUID instead of the name."
+        )
+    )
 
 
 # Allow / Disallow types

--- a/src/ai/backend/manager/models/scaling_group/conditions.py
+++ b/src/ai/backend/manager/models/scaling_group/conditions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import Collection
 
 import sqlalchemy as sa
@@ -182,17 +183,18 @@ class ScalingGroupConditions:
         return inner
 
     @staticmethod
-    def by_cursor_forward(cursor_name: str) -> QueryCondition:
+    def by_cursor_forward(cursor_id: str) -> QueryCondition:
         """Cursor condition for forward pagination (after cursor).
 
-        Uses subquery to get created_at of the cursor row and compare.
-        ScalingGroup uses name as primary key.
+        The cursor value is the resource group UUID; a subquery fetches the
+        cursor row's created_at to compare against.
         """
+        rg_id = ResourceGroupID(uuid.UUID(cursor_id))
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             subquery = (
                 sa.select(ScalingGroupRow.created_at)
-                .where(ScalingGroupRow.name == cursor_name)
+                .where(ScalingGroupRow.id == rg_id)
                 .scalar_subquery()
             )
             return ScalingGroupRow.created_at < subquery
@@ -200,17 +202,18 @@ class ScalingGroupConditions:
         return inner
 
     @staticmethod
-    def by_cursor_backward(cursor_name: str) -> QueryCondition:
+    def by_cursor_backward(cursor_id: str) -> QueryCondition:
         """Cursor condition for backward pagination (before cursor).
 
-        Uses subquery to get created_at of the cursor row and compare.
-        ScalingGroup uses name as primary key.
+        The cursor value is the resource group UUID; a subquery fetches the
+        cursor row's created_at to compare against.
         """
+        rg_id = ResourceGroupID(uuid.UUID(cursor_id))
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             subquery = (
                 sa.select(ScalingGroupRow.created_at)
-                .where(ScalingGroupRow.name == cursor_name)
+                .where(ScalingGroupRow.id == rg_id)
                 .scalar_subquery()
             )
             return ScalingGroupRow.created_at > subquery

--- a/tests/unit/common/dto/manager/v2/resource_group/test_response.py
+++ b/tests/unit/common/dto/manager/v2/resource_group/test_response.py
@@ -35,12 +35,13 @@ from ai.backend.common.dto.manager.v2.session_options.types import (
     AgentSelectionPolicyEnum,
     FailurePolicyEnum,
 )
+from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import PreemptionOrder
 
 
 def _make_resource_group_node(name: str = "test-group") -> ResourceGroupNode:
     return ResourceGroupNode(
-        id=uuid.uuid4(),
+        id=ResourceGroupID(uuid.uuid4()),
         name=name,
         domain_name="default",
         description="A test resource group",
@@ -56,7 +57,7 @@ def _make_resource_group_node(name: str = "test-group") -> ResourceGroupNode:
 
 def _make_resource_group_detail_node(name: str = "test-group") -> ResourceGroupDetailNode:
     return ResourceGroupDetailNode(
-        id=name,
+        id=ResourceGroupID(uuid.uuid4()),
         name=name,
         status=ResourceGroupStatusInfo(is_active=True, is_public=True),
         metadata=ResourceGroupMetadataInfo(
@@ -169,11 +170,12 @@ class TestDeleteResourceGroupPayload:
     """Tests for DeleteResourceGroupPayload model."""
 
     def test_valid_creation(self) -> None:
-        payload = DeleteResourceGroupPayload(id="test-group")
-        assert payload.id == "test-group"
+        rg_id = ResourceGroupID(uuid.uuid4())
+        payload = DeleteResourceGroupPayload(id=rg_id)
+        assert payload.id == rg_id
 
     def test_round_trip(self) -> None:
-        payload = DeleteResourceGroupPayload(id="test-group")
+        payload = DeleteResourceGroupPayload(id=ResourceGroupID(uuid.uuid4()))
         json_data = payload.model_dump_json()
         restored = DeleteResourceGroupPayload.model_validate_json(json_data)
         assert restored.id == payload.id

--- a/tests/unit/manager/api/gql/resource_group/test_resource_info.py
+++ b/tests/unit/manager/api/gql/resource_group/test_resource_info.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from datetime import UTC, datetime
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
@@ -238,7 +239,7 @@ class TestResourceGroupGQLResourceInfoResolver:
     def resource_group_gql(self) -> ResourceGroupGQL:
         """Create ResourceGroupGQL instance for testing."""
         return ResourceGroupGQL(
-            id="test-group",
+            id=uuid.uuid4(),
             name="test-group",
             status=ResourceGroupStatusGQL.from_pydantic(
                 ResourceGroupStatusInfo(is_active=True, is_public=True)

--- a/tests/unit/manager/models/scaling_group/test_conditions.py
+++ b/tests/unit/manager/models/scaling_group/test_conditions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import AsyncGenerator
 
 import pytest
@@ -81,32 +82,42 @@ class TestScalingGroupConditionsCursor:
 
     def test_by_cursor_forward_returns_callable(self) -> None:
         """Test that by_cursor_forward returns a callable QueryCondition."""
-        condition = ScalingGroupConditions.by_cursor_forward("test-name")
+        condition = ScalingGroupConditions.by_cursor_forward(str(uuid.uuid4()))
         assert callable(condition)
 
     def test_by_cursor_forward_returns_column_element(self) -> None:
         """Test that by_cursor_forward() returns a SQLAlchemy ColumnElement."""
-        condition = ScalingGroupConditions.by_cursor_forward("cursor-value")
+        condition = ScalingGroupConditions.by_cursor_forward(str(uuid.uuid4()))
         result = condition()
         # Result should be a SQLAlchemy expression
         assert isinstance(result, sa.sql.expression.ColumnElement)
 
+    def test_by_cursor_forward_rejects_non_uuid_cursor(self) -> None:
+        """Test that by_cursor_forward rejects a non-UUID cursor value."""
+        with pytest.raises(ValueError):
+            ScalingGroupConditions.by_cursor_forward("not-a-uuid")
+
     def test_by_cursor_backward_returns_callable(self) -> None:
         """Test that by_cursor_backward returns a callable QueryCondition."""
-        condition = ScalingGroupConditions.by_cursor_backward("test-name")
+        condition = ScalingGroupConditions.by_cursor_backward(str(uuid.uuid4()))
         assert callable(condition)
 
     def test_by_cursor_backward_returns_column_element(self) -> None:
         """Test that by_cursor_backward() returns a SQLAlchemy ColumnElement."""
-        condition = ScalingGroupConditions.by_cursor_backward("cursor-value")
+        condition = ScalingGroupConditions.by_cursor_backward(str(uuid.uuid4()))
         result = condition()
         # Result should be a SQLAlchemy expression
         assert isinstance(result, sa.sql.expression.ColumnElement)
 
+    def test_by_cursor_backward_rejects_non_uuid_cursor(self) -> None:
+        """Test that by_cursor_backward rejects a non-UUID cursor value."""
+        with pytest.raises(ValueError):
+            ScalingGroupConditions.by_cursor_backward("not-a-uuid")
+
     def test_by_cursor_forward_uses_closure(self) -> None:
         """Test that by_cursor_forward captures the value in closure."""
-        value1 = "value-a"
-        value2 = "value-b"
+        value1 = str(uuid.uuid4())
+        value2 = str(uuid.uuid4())
 
         condition1 = ScalingGroupConditions.by_cursor_forward(value1)
         condition2 = ScalingGroupConditions.by_cursor_forward(value2)
@@ -115,15 +126,13 @@ class TestScalingGroupConditionsCursor:
         result1 = condition1()
         result2 = condition2()
 
-        # Compiled SQL should show different values
-        assert str(result1.compile(compile_kwargs={"literal_binds": True})) != str(
-            result2.compile(compile_kwargs={"literal_binds": True})
-        )
+        # Bound parameters should show different values
+        assert result1.compile().params != result2.compile().params
 
     def test_by_cursor_backward_uses_closure(self) -> None:
         """Test that by_cursor_backward captures the value in closure."""
-        value1 = "value-a"
-        value2 = "value-b"
+        value1 = str(uuid.uuid4())
+        value2 = str(uuid.uuid4())
 
         condition1 = ScalingGroupConditions.by_cursor_backward(value1)
         condition2 = ScalingGroupConditions.by_cursor_backward(value2)
@@ -132,10 +141,8 @@ class TestScalingGroupConditionsCursor:
         result1 = condition1()
         result2 = condition2()
 
-        # Compiled SQL should show different values
-        assert str(result1.compile(compile_kwargs={"literal_binds": True})) != str(
-            result2.compile(compile_kwargs={"literal_binds": True})
-        )
+        # Bound parameters should show different values
+        assert result1.compile().params != result2.compile().params
 
 
 class TestScalingGroupOrdersCursor:


### PR DESCRIPTION
## Summary
- The v2 resource group read APIs (REST v2 get/search and the GraphQL `ResourceGroup` node) returned the resource group name string in the `id` field; they now return the UUID `id` column, typed as `ResourceGroupID` in the shared DTOs (`ResourceGroupDetailNode.id`, `DeleteResourceGroupPayload.id`).
- `ResourceGroupGQL.id` becomes `NodeID[UUID]` and relay node resolution goes through a new UUID-keyed `resource_group_by_id_loader` backed by `ResourceGroupAdapter.batch_load_by_ids`; the name-keyed loader remains for internal cross-entity references (RBAC included, which stays name-based).
- Connection cursors encode the node id, so the cursor pagination conditions now look up the cursor row by UUID; a malformed cursor surfaces as `InvalidCursor`.

## Test plan
- [x] DTO unit tests updated to UUID ids (`tests/unit/common/dto/manager/v2/resource_group/test_response.py`)
- [x] Cursor condition tests updated to UUID cursor values, including non-UUID rejection (`tests/unit/manager/models/scaling_group/test_conditions.py`)
- [x] GQL resolver test fixture updated (`tests/unit/manager/api/gql/resource_group/test_resource_info.py`)
- [x] `pants lint` / `pants check` / affected `pants test` pass (pre-push hook)

Resolves BA-7094

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13275.org.readthedocs.build/en/13275/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13275.org.readthedocs.build/ko/13275/

<!-- readthedocs-preview sorna-ko end -->