### PR TITLE
fix(BA-7097): store the pending slot limit as a ResourceSlot (#13279)

### DIFF
--- a/changes/13279.fix.md
+++ b/changes/13279.fix.md
@@ -1,0 +1,1 @@
+Fix the 500 when updating a keypair resource policy's `max_pending_session_resource_slots`.

--- a/src/ai/backend/manager/api/adapters/resource_policy/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_policy/adapter.py
@@ -297,7 +297,7 @@ class ResourcePolicyAdapter(BaseAdapter):
                 else TriState.nullify()
                 if input.max_pending_session_resource_slots is None
                 else TriState.update(
-                    self._entries_to_resource_slot_dict(input.max_pending_session_resource_slots)
+                    self._entries_to_resource_slot(input.max_pending_session_resource_slots)
                 )
             ),
             max_concurrent_sftp_sessions=(

--- a/src/ai/backend/manager/api/gql_legacy/resource_policy.py
+++ b/src/ai/backend/manager/api/gql_legacy/resource_policy.py
@@ -393,8 +393,10 @@ class ModifyKeyPairResourcePolicyInput(graphene.InputObjectType):  # type: ignor
                 max_pending_session_count=TriState[int].from_graphql(
                     self.max_pending_session_count
                 ),
-                max_pending_session_resource_slots=TriState[dict[str, Any]].from_graphql(
-                    self.max_pending_session_resource_slots
+                max_pending_session_resource_slots=TriState[ResourceSlot].from_graphql(
+                    ResourceSlot.from_user_input(self.max_pending_session_resource_slots, None)
+                    if isinstance(self.max_pending_session_resource_slots, dict)
+                    else self.max_pending_session_resource_slots
                 ),
             ),
             pk_value=name,

--- a/src/ai/backend/manager/repositories/keypair_resource_policy/updaters.py
+++ b/src/ai/backend/manager/repositories/keypair_resource_policy/updaters.py
@@ -21,9 +21,7 @@ class KeyPairResourcePolicyUpdaterSpec(UpdaterSpec["KeyPairResourcePolicyRow"]):
     max_concurrent_sessions: OptionalState[int] = field(default_factory=OptionalState.nop)
     max_containers_per_session: OptionalState[int] = field(default_factory=OptionalState.nop)
     max_pending_session_count: TriState[int] = field(default_factory=TriState.nop)
-    max_pending_session_resource_slots: TriState[dict[str, Any]] = field(
-        default_factory=TriState.nop
-    )
+    max_pending_session_resource_slots: TriState[ResourceSlot] = field(default_factory=TriState.nop)
     max_quota_scope_size: OptionalState[int] = field(default_factory=OptionalState.nop)
     max_vfolder_count: OptionalState[int] = field(default_factory=OptionalState.nop)
     max_vfolder_size: OptionalState[int] = field(default_factory=OptionalState.nop)


### PR DESCRIPTION
This is an auto-generated backport PR of #13279 to the 26.8 release.