### PR TITLE
fix(BA-7100): reject a half-specified revision resource config

### DIFF
--- a/changes/13287.fix.md
+++ b/changes/13287.fix.md
@@ -1,0 +1,1 @@
+Reject a deployment revision that specifies only one of `cluster_config` / `resource_config`, instead of silently discarding both.

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -199,6 +199,7 @@ from ai.backend.manager.data.deployment.types import (
 )
 from ai.backend.manager.data.deployment.upserter import DeploymentPolicyUpserter
 from ai.backend.manager.data.runtime_variant_preset.types import RuntimeVariantPresetValueData
+from ai.backend.manager.errors.api import InvalidAPIParameters
 from ai.backend.manager.errors.deployment import DeploymentRevisionNotFound
 from ai.backend.manager.errors.service import EndpointTokenNotFound
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
@@ -1227,6 +1228,12 @@ class DeploymentAdapter(BaseAdapter):
         image_id = input.image.id if input.image is not None else None
 
         resource_spec = None
+        if (input.cluster_config is None) != (input.resource_config is None):
+            missing = "cluster_config" if input.cluster_config is None else "resource_config"
+            raise InvalidAPIParameters(
+                f"{missing} is required alongside the one provided; "
+                "supply both to override the revision's resource spec, or neither to inherit it"
+            )
         if input.cluster_config is not None and input.resource_config is not None:
             resource_opts = (
                 {e.name: e.value for e in input.resource_config.resource_opts.entries}


### PR DESCRIPTION
`add_revision` built the `ResourceSpec` only when `cluster_config` and `resource_config` were both present:

```python
resource_spec = None
if input.cluster_config is not None and input.resource_config is not None:
    resource_spec = ResourceSpec(...)
```

Supplying one silently discarded the other, and the request then failed on the slots it had actually been given:

```
InvalidAPIParameters: resource_slots is missing required resource slot(s): ['cpu', 'mem'].
```

Both fields are optional on `AddRevisionInput` because a revision preset may supply them — unlike `CreateRevisionInput`, where both are required. That makes silent discard the wrong answer for a half-specified pair, so it is rejected instead, the way `deployment_controller` already rejects a missing `image_id`, `mounts`, or `model_definition`.

## Verified locally

| request | before | after |
|---|---|---|
| `resource_config` only | `resource_slots is missing required resource slot(s): ['cpu','mem']` | `cluster_config is required alongside the one provided…` |
| `cluster_config` only | silently ignored | `resource_config is required alongside the one provided…` |
| both | revision created | revision created |
| neither | inherits from the preset | unchanged |

## How it was found

Running CHECKLIST_26.8 item 12 (Model Serving / Deployment) against 26.8.0rc1. It took six attempts to add a revision, because each rejection named a different field than the one actually missing.

## Related

- BA-7100

🤖 Generated with [Claude Code](https://claude.com/claude-code)
