### PR TITLE
fix(install): register local Harbor with a reachable host:port registry name

### DIFF
--- a/changes/13288.fix.md
+++ b/changes/13288.fix.md
@@ -1,0 +1,1 @@
+Fix the TUI installer to register the local Harbor container registry under its reachable `host:port` instead of the unresolvable `local-harbor` label, which docker parsed as a Docker Hub namespace and failed pushes with `insufficient_scope: authorization failed`

--- a/src/ai/backend/install/app.py
+++ b/src/ai/backend/install/app.py
@@ -466,9 +466,11 @@ class InstallReport(Static):
                 - Password: `{harbor.admin_password}`
 
                 The Harbor instance is also pre-registered as a Backend.AI
-                container registry named `local-harbor` (project `library`)
-                with the same admin credentials, so it appears in
-                `mgr image rescan` / the manager UI as soon as you start it.
+                container registry named `{harbor.hostname}:{harbor.http_port}`
+                (project `library`) with the same admin credentials, so it
+                appears in `mgr image rescan` / the manager UI as soon as you
+                start it. Push images to it with
+                `docker push {harbor.hostname}:{harbor.http_port}/library/<image>:<tag>`.
 
                 Note: Harbor may take 30-60 seconds to become fully ready
                 after `./dev harbor start`.

--- a/src/ai/backend/install/context.py
+++ b/src/ai/backend/install/context.py
@@ -1787,7 +1787,12 @@ class Context(metaclass=ABCMeta):
         idempotent.
         """
         harbor_url = f"http://{harbor.hostname}:{harbor.http_port}"
-        registry_name = "local-harbor"
+        # The registry name becomes the prefix of every image canonical
+        # (``{registry_name}/{image}:{tag}``) that docker pushes/pulls
+        # against, so it must be the actual reachable ``host:port`` — a bare
+        # label without a dot or colon would be parsed by docker as a Docker
+        # Hub namespace.
+        registry_name = f"{harbor.hostname}:{harbor.http_port}"
         project = "library"
         registry_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{harbor_url}/{project}"))
         fixture = {


### PR DESCRIPTION
## What this PR resolves

The TUI dev installer (#10963) pre-registers the local Harbor instance as a Backend.AI container registry named `local-harbor`. However, `registry_name` is not a display label — it becomes the prefix of every image canonical (`{registry_name}/{image}:{tag}`) that `docker push`/`docker pull` operate against.

Docker only treats the first path component of an image reference as a registry host when it contains a dot or a colon (or equals `localhost`). A bare `local-harbor` is parsed as a **Docker Hub namespace**, so pushing an image to the local Harbor fails with:

```
insufficient_scope: authorization failed, repository does not exist or may require authorization
```

(the push actually went to `docker.io/local-harbor/...`).

## Changes

- Register the local Harbor with `{hostname}:{port}` (e.g. `192.168.0.10:8084`) as the registry name — the same reachable address the installer already resolves for Harbor's own configuration (`_resolve_harbor_hostname()`).
- Update the installer report tab to show the actual registry name and a ready-to-copy `docker push` example.

The fixture row ID is derived from `uuid5(harbor_url + project)`, which is unchanged, so re-running the installer updates the existing row idempotently instead of duplicating it. Existing installations can be fixed by editing the registry name to the actual `host:port` in the manager UI (no automatic migration; this only affects dev installs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)