### PR TITLE
fix(BA-7103): keep a resource group description the update never mentioned

### DIFF
--- a/changes/13296.fix.md
+++ b/changes/13296.fix.md
@@ -1,0 +1,1 @@
+Stop wiping a resource group's description when the update request does not mention it.

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -20495,7 +20495,7 @@
               }
             ],
             "default": 1,
-            "description": "Updated description. Use SENTINEL to clear, null to keep existing value.",
+            "description": "Updated description. Omit to keep the existing value, null to clear.",
             "title": "Description"
           },
           "is_active": {

--- a/src/ai/backend/common/dto/manager/v2/AGENTS.md
+++ b/src/ai/backend/common/dto/manager/v2/AGENTS.md
@@ -39,8 +39,10 @@ Per domain: `v2/{domain}/types.py`, `request.py`, `response.py`, `__init__.py`
 
 - Use `Field()` constraints: `min_length`, `max_length`, `ge`, `le`, `pattern`.
 - Use `field_validator` for cross-field/format validation (e.g., stripping whitespace, verifying non-empty after strip).
-- nullable-clearable fields: SENTINEL pattern (sentinel value = "clear this field", None = "no change").
-- All optional update fields default to `None` to mean "no change".
+- nullable-clearable fields: SENTINEL pattern, typed `T | Sentinel | None` and defaulting to `SENTINEL`.
+  The three input states must stay distinct — `SENTINEL` (omitted) keeps the stored value, an explicit
+  `None` clears it, and a value sets it. The adapter maps them to `TriState.nop()` / `nullify()` / `update()`.
+- Update fields the adapter maps to `OptionalState` are not clearable; those default to `None`, which means "no change".
 
 ## Conversion
 

--- a/src/ai/backend/common/dto/manager/v2/resource_group/request.py
+++ b/src/ai/backend/common/dto/manager/v2/resource_group/request.py
@@ -93,7 +93,7 @@ class UpdateResourceGroupInput(BaseRequestModel):
     )
     description: str | Sentinel | None = Field(
         default=SENTINEL,
-        description=("Updated description. Use SENTINEL to clear, null to keep existing value."),
+        description=("Updated description. Omit to keep the existing value, null to clear."),
     )
     is_active: bool | None = Field(
         default=None,

--- a/src/ai/backend/manager/api/adapters/resource_group/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_group/adapter.py
@@ -432,12 +432,12 @@ class ResourceGroupAdapter(BaseAdapter):
         )
         metadata_spec = ScalingGroupMetadataUpdaterSpec(
             description=(
-                TriState.nullify()
+                TriState.nop()
                 if input.description is SENTINEL
                 else (
-                    TriState.update(str(input.description))
-                    if input.description is not None
-                    else TriState.nop()
+                    TriState.nullify()
+                    if input.description is None
+                    else TriState.update(input.description)
                 )
             ),
         )

--- a/tests/unit/common/dto/manager/v2/resource_group/test_request.py
+++ b/tests/unit/common/dto/manager/v2/resource_group/test_request.py
@@ -95,11 +95,11 @@ class TestUpdateResourceGroupInput:
         assert req.integration_name is SENTINEL
         assert req.resource_policy is SENTINEL
 
-    def test_sentinel_description_signals_clear(self) -> None:
+    def test_sentinel_description_means_no_change(self) -> None:
         req = UpdateResourceGroupInput(description=SENTINEL)
         assert req.description is SENTINEL
 
-    def test_none_description_means_no_change(self) -> None:
+    def test_none_description_signals_clear(self) -> None:
         req = UpdateResourceGroupInput(description=None)
         assert req.description is None
 


### PR DESCRIPTION
Updating a resource group clears its description unless the request resends it.

```
DB : scaling_groups.description = 'KEEP ME'
PATCH /v2/resource-groups/rg-second  {"is_active": true}
DB : scaling_groups.description = NULL
```

The request never mentions `description`, and there is no error.

## Cause

`update` was the only one of 61 sentinel branches in `api/adapters/` reading `SENTINEL` as "clear this column" rather than "the caller did not mention this field"; the other 60 map it to `TriState.nop()`. Every Sentinel-typed DTO field defaults to `SENTINEL`, so an omitted description meant a wiped one, and an explicit null — the one input that should clear it — was ignored.

```python
description=(
    TriState.nullify()
    if input.description is SENTINEL      # omitted -> cleared
    else (
        TriState.update(str(input.description))
        if input.description is not None
        else TriState.nop()               # explicit null -> kept
    )
),
```

## Verified locally

| request | before | after |
|---|---|---|
| `{"is_active": true}` | description wiped | unchanged |
| `{"description": "SET"}` | set | set |
| `{"description": null}` | ignored | cleared |
| omitted on every other field | unchanged | unchanged |

## Why the adapter drifted

The DTO field and `common/dto/manager/v2/AGENTS.md` both documented the inverted rule:

> nullable-clearable fields: SENTINEL pattern (sentinel value = "clear this field", None = "no change").

Both statements are false of the codebase: 60 of the 61 sentinel branches map `SENTINEL` to no-change, and all 79 Sentinel-typed DTO fields default to `SENTINEL` rather than to `None`. This adapter was the only code that followed the document. Correcting the code alone would leave the repository's only written rule pointing at the defect, so the document is fixed here to state what the other 60 branches do — and what #13290 codifies for the GraphQL input side.

## Not in scope

The same three states are still indistinguishable over the v2 CLI/SDK, because `client/v2/base_client.py` serializes requests with `exclude_none=True` and drops the explicit null before it is sent. That is a transport-layer defect on a different path; this PR is the server-side half and stands on its own via GraphQL and raw REST.

## Related

- BA-7103
- #13290 — `BA-7101`, the same three-state defect pointing the other way, on the GraphQL input side

🤖 Generated with [Claude Code](https://claude.com/claude-code)
