### PR TITLE
fix(BA-7101): stop clearing GQL update fields that the client omitted (#13290)

### DIFF
--- a/changes/13290.fix.md
+++ b/changes/13290.fix.md
@@ -1,0 +1,1 @@
+Stop GraphQL update mutations from clearing fields that the client omitted; an omitted field now keeps its current value while an explicit null still clears it.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -18981,7 +18981,7 @@ input UpdateDomainInput
   name: String = null
 
   """New description."""
-  description: String = null
+  description: String
 
   """Updated active status."""
   isActive: Boolean = null
@@ -18990,7 +18990,7 @@ input UpdateDomainInput
   allowedDockerRegistries: [String!] = null
 
   """New external integration identifier."""
-  integrationName: String = null
+  integrationName: String
 }
 
 """Added in 25.14.0. """
@@ -19030,10 +19030,10 @@ input UpdateKeypairResourcePolicyInput
   maxConcurrentSessions: Int = null
 
   """Updated max pending sessions."""
-  maxPendingSessionCount: Int = null
+  maxPendingSessionCount: Int
 
   """Updated max pending session resource slots."""
-  maxPendingSessionResourceSlots: [ResourceSlotEntryInput!] = null
+  maxPendingSessionResourceSlots: [ResourceSlotEntryInput!]
 
   """Updated max concurrent SFTP sessions."""
   maxConcurrentSftpSessions: Int = null
@@ -19066,7 +19066,7 @@ input UpdateLoginClientTypeInput
   name: String = null
 
   """Updated description. Pass null to clear, omit to leave unchanged."""
-  description: String = null
+  description: String
 }
 
 """Added in 26.4.2. Payload for login client type update."""
@@ -19262,13 +19262,13 @@ input UpdateProjectInput
   name: String = null
 
   """New description."""
-  description: String = null
+  description: String
 
   """Updated active status."""
   isActive: Boolean = null
 
   """New external integration identifier."""
-  integrationName: String = null
+  integrationName: String
 
   """New resource policy name."""
   resourcePolicy: String = null
@@ -19573,7 +19573,7 @@ input UpdateUserResourcePolicyInput
   """
   Added in 26.4.2. Updated maximum number of concurrent authenticated login sessions per user. Set to null to clear (unlimited). Distinct from keypair_resource_policies.max_concurrent_sessions which caps compute sessions.
   """
-  maxConcurrentLogins: Int = null
+  maxConcurrentLogins: Int
 
   """Updated max quota scope size."""
   maxQuotaScopeSize: BinarySizeInput = null

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -13170,7 +13170,7 @@ input UpdateDomainInput {
   name: String = null
 
   """New description."""
-  description: String = null
+  description: String
 
   """Updated active status."""
   isActive: Boolean = null
@@ -13179,7 +13179,7 @@ input UpdateDomainInput {
   allowedDockerRegistries: [String!] = null
 
   """New external integration identifier."""
-  integrationName: String = null
+  integrationName: String
 }
 
 """Added in 25.14.0. """
@@ -13213,10 +13213,10 @@ input UpdateKeypairResourcePolicyInput {
   maxConcurrentSessions: Int = null
 
   """Updated max pending sessions."""
-  maxPendingSessionCount: Int = null
+  maxPendingSessionCount: Int
 
   """Updated max pending session resource slots."""
-  maxPendingSessionResourceSlots: [ResourceSlotEntryInput!] = null
+  maxPendingSessionResourceSlots: [ResourceSlotEntryInput!]
 
   """Updated max concurrent SFTP sessions."""
   maxConcurrentSftpSessions: Int = null
@@ -13245,7 +13245,7 @@ input UpdateLoginClientTypeInput {
   name: String = null
 
   """Updated description. Pass null to clear, omit to leave unchanged."""
-  description: String = null
+  description: String
 }
 
 """Added in 26.4.2. Payload for login client type update."""
@@ -13411,13 +13411,13 @@ input UpdateProjectInput {
   name: String = null
 
   """New description."""
-  description: String = null
+  description: String
 
   """Updated active status."""
   isActive: Boolean = null
 
   """New external integration identifier."""
-  integrationName: String = null
+  integrationName: String
 
   """New resource policy name."""
   resourcePolicy: String = null
@@ -13682,7 +13682,7 @@ input UpdateUserResourcePolicyInput {
   """
   Added in 26.4.2. Updated maximum number of concurrent authenticated login sessions per user. Set to null to clear (unlimited). Distinct from keypair_resource_policies.max_concurrent_sessions which caps compute sessions.
   """
-  maxConcurrentLogins: Int = null
+  maxConcurrentLogins: Int
 
   """Updated max quota scope size."""
   maxQuotaScopeSize: BinarySizeInput = null

--- a/src/ai/backend/manager/api/gql/domain_v2/types/mutations.py
+++ b/src/ai/backend/manager/api/gql/domain_v2/types/mutations.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from strawberry import UNSET
+
 from ai.backend.common.dto.manager.v2.domain.request import (
     CreateDomainInput as CreateDomainInputDTO,
 )
@@ -26,9 +28,6 @@ from ai.backend.manager.api.gql.decorators import (
 from ai.backend.manager.api.gql.domain_v2.types.node import DomainV2GQL
 from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin, PydanticOutputMixin
 
-UNSET = None
-
-
 # --- Inputs ---
 
 
@@ -43,13 +42,13 @@ class CreateDomainInputGQL(PydanticInputMixin[CreateDomainInputDTO]):
     """Input for creating a new domain."""
 
     name: str = gql_field(description="Domain name. Must be unique across the system.")
-    description: str | None = gql_field(default=UNSET, description="Optional description.")
+    description: str | None = gql_field(default=None, description="Optional description.")
     is_active: bool = gql_field(default=True, description="Whether the domain is active.")
     allowed_docker_registries: list[str] | None = gql_field(
-        default=UNSET, description="Allowed Docker registry URLs."
+        default=None, description="Allowed Docker registry URLs."
     )
     integration_name: str | None = gql_field(
-        default=UNSET, description="External integration identifier."
+        default=None, description="External integration identifier."
     )
 
 
@@ -63,11 +62,11 @@ class CreateDomainInputGQL(PydanticInputMixin[CreateDomainInputDTO]):
 class UpdateDomainInputGQL(PydanticInputMixin[UpdateDomainInputDTO]):
     """Input for updating domain information."""
 
-    name: str | None = gql_field(default=UNSET, description="New domain name.")
+    name: str | None = gql_field(default=None, description="New domain name.")
     description: str | None = gql_field(default=UNSET, description="New description.")
-    is_active: bool | None = gql_field(default=UNSET, description="Updated active status.")
+    is_active: bool | None = gql_field(default=None, description="Updated active status.")
     allowed_docker_registries: list[str] | None = gql_field(
-        default=UNSET, description="New allowed Docker registry URLs."
+        default=None, description="New allowed Docker registry URLs."
     )
     integration_name: str | None = gql_field(
         default=UNSET, description="New external integration identifier."

--- a/src/ai/backend/manager/api/gql/login_client_type/types.py
+++ b/src/ai/backend/manager/api/gql/login_client_type/types.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Any
 
+from strawberry import UNSET
 from strawberry.relay import Connection, Edge, NodeID
 
 from ai.backend.common.dto.manager.v2.login_client_type.request import (
@@ -191,7 +192,7 @@ class CreateLoginClientTypePayloadGQL(PydanticOutputMixin[CreateLoginClientTypeP
 class UpdateLoginClientTypeInputGQL(PydanticInputMixin[UpdateLoginClientTypeInputDTO]):
     name: str | None = gql_field(default=None, description="Updated name.")
     description: str | None = gql_field(
-        default=None,
+        default=UNSET,
         description="Updated description. Pass null to clear, omit to leave unchanged.",
     )
 

--- a/src/ai/backend/manager/api/gql/project_v2/types/mutations.py
+++ b/src/ai/backend/manager/api/gql/project_v2/types/mutations.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from uuid import UUID
 
+from strawberry import UNSET
+
 from ai.backend.common.dto.manager.v2.group.request import (
     CreateProjectInput as CreateProjectInputDTO,
 )
@@ -38,9 +40,6 @@ from ai.backend.manager.api.gql.project_v2.types.node import ProjectV2GQL
 from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin, PydanticOutputMixin
 from ai.backend.manager.api.gql.user.types.node import UserV2GQL
 
-UNSET = None
-
-
 # --- Inputs ---
 
 
@@ -56,12 +55,12 @@ class CreateProjectInputGQL(PydanticInputMixin[CreateProjectInputDTO]):
 
     name: str = gql_field(description="Project name. Must be unique within the domain.")
     domain_name: str = gql_field(description="Name of the domain this project belongs to.")
-    description: str | None = gql_field(default=UNSET, description="Optional description.")
+    description: str | None = gql_field(default=None, description="Optional description.")
     integration_name: str | None = gql_field(
-        default=UNSET, description="External integration identifier."
+        default=None, description="External integration identifier."
     )
     resource_policy: str | None = gql_field(
-        default=UNSET, description="Name of the resource policy to apply."
+        default=None, description="Name of the resource policy to apply."
     )
 
 
@@ -75,13 +74,13 @@ class CreateProjectInputGQL(PydanticInputMixin[CreateProjectInputDTO]):
 class UpdateProjectInputGQL(PydanticInputMixin[UpdateProjectInputDTO]):
     """Input for updating project information."""
 
-    name: str | None = gql_field(default=UNSET, description="New project name.")
+    name: str | None = gql_field(default=None, description="New project name.")
     description: str | None = gql_field(default=UNSET, description="New description.")
-    is_active: bool | None = gql_field(default=UNSET, description="Updated active status.")
+    is_active: bool | None = gql_field(default=None, description="Updated active status.")
     integration_name: str | None = gql_field(
         default=UNSET, description="New external integration identifier."
     )
-    resource_policy: str | None = gql_field(default=UNSET, description="New resource policy name.")
+    resource_policy: str | None = gql_field(default=None, description="New resource policy name.")
 
 
 # --- Payloads ---

--- a/src/ai/backend/manager/api/gql/resource_policy_v2/types/mutations.py
+++ b/src/ai/backend/manager/api/gql/resource_policy_v2/types/mutations.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from strawberry import UNSET
+
 from ai.backend.common.dto.manager.v2.resource_policy.request import (
     CreateKeypairResourcePolicyInput as CreateKeypairResourcePolicyInputDTO,
 )
@@ -67,9 +69,6 @@ from .node import (
     UserResourcePolicyV2GQL,
 )
 
-UNSET = None
-
-
 # ── Keypair Resource Policy Inputs ──
 
 
@@ -93,10 +92,10 @@ class CreateKeypairResourcePolicyInputGQL(PydanticInputMixin[CreateKeypairResour
     max_containers_per_session: int = gql_field(description="Maximum containers per session.")
     idle_timeout: int = gql_field(description="Idle timeout in seconds.")
     max_pending_session_count: int | None = gql_field(
-        default=UNSET, description="Maximum pending sessions. Null means unlimited."
+        default=None, description="Maximum pending sessions. Null means unlimited."
     )
     max_pending_session_resource_slots: list[ResourceSlotEntryInputGQL] | None = gql_field(
-        default=UNSET, description="Maximum pending session resource slots."
+        default=None, description="Maximum pending session resource slots."
     )
     max_concurrent_sftp_sessions: int = gql_field(
         default=1, description="Maximum concurrent SFTP sessions."
@@ -115,16 +114,16 @@ class CreateKeypairResourcePolicyInputGQL(PydanticInputMixin[CreateKeypairResour
 )
 class UpdateKeypairResourcePolicyInputGQL(PydanticInputMixin[UpdateKeypairResourcePolicyInputDTO]):
     default_for_unspecified: str | None = gql_field(
-        default=UNSET, description="Updated default for unspecified."
+        default=None, description="Updated default for unspecified."
     )
     total_resource_slots: list[ResourceSlotEntryInputGQL] | None = gql_field(
-        default=UNSET, description="Updated resource slot limits."
+        default=None, description="Updated resource slot limits."
     )
     max_session_lifetime: int | None = gql_field(
-        default=UNSET, description="Updated max session lifetime."
+        default=None, description="Updated max session lifetime."
     )
     max_concurrent_sessions: int | None = gql_field(
-        default=UNSET, description="Updated max concurrent sessions."
+        default=None, description="Updated max concurrent sessions."
     )
     max_pending_session_count: int | None = gql_field(
         default=UNSET, description="Updated max pending sessions."
@@ -133,14 +132,14 @@ class UpdateKeypairResourcePolicyInputGQL(PydanticInputMixin[UpdateKeypairResour
         default=UNSET, description="Updated max pending session resource slots."
     )
     max_concurrent_sftp_sessions: int | None = gql_field(
-        default=UNSET, description="Updated max concurrent SFTP sessions."
+        default=None, description="Updated max concurrent SFTP sessions."
     )
     max_containers_per_session: int | None = gql_field(
-        default=UNSET, description="Updated max containers per session."
+        default=None, description="Updated max containers per session."
     )
-    idle_timeout: int | None = gql_field(default=UNSET, description="Updated idle timeout.")
+    idle_timeout: int | None = gql_field(default=None, description="Updated idle timeout.")
     allowed_vfolder_hosts: list[VFolderHostPermissionEntryInputGQL] | None = gql_field(
-        default=UNSET, description="Updated vfolder host permissions."
+        default=None, description="Updated vfolder host permissions."
     )
 
 
@@ -167,7 +166,7 @@ class CreateUserResourcePolicyInputGQL(PydanticInputMixin[CreateUserResourcePoli
                 " which caps compute sessions."
             ),
         ),
-        default=UNSET,
+        default=None,
     )
     max_quota_scope_size: BinarySizeInputGQL = gql_field(
         description="Maximum quota scope size (e.g., '1g', '536870912').",
@@ -189,7 +188,7 @@ class CreateUserResourcePolicyInputGQL(PydanticInputMixin[CreateUserResourcePoli
 )
 class UpdateUserResourcePolicyInputGQL(PydanticInputMixin[UpdateUserResourcePolicyInputDTO]):
     max_vfolder_count: int | None = gql_field(
-        default=UNSET, description="Updated max vfolder count."
+        default=None, description="Updated max vfolder count."
     )
     max_concurrent_logins: int | None = gql_added_field(
         BackendAIGQLMeta(
@@ -204,13 +203,13 @@ class UpdateUserResourcePolicyInputGQL(PydanticInputMixin[UpdateUserResourcePoli
         default=UNSET,
     )
     max_quota_scope_size: BinarySizeInputGQL | None = gql_field(
-        default=UNSET, description="Updated max quota scope size."
+        default=None, description="Updated max quota scope size."
     )
     max_session_count_per_model_session: int | None = gql_field(
-        default=UNSET, description="Updated max sessions per model session."
+        default=None, description="Updated max sessions per model session."
     )
     max_customized_image_count: int | None = gql_field(
-        default=UNSET, description="Updated max customized image count."
+        default=None, description="Updated max customized image count."
     )
 
 
@@ -244,13 +243,13 @@ class CreateProjectResourcePolicyInputGQL(PydanticInputMixin[CreateProjectResour
 )
 class UpdateProjectResourcePolicyInputGQL(PydanticInputMixin[UpdateProjectResourcePolicyInputDTO]):
     max_vfolder_count: int | None = gql_field(
-        default=UNSET, description="Updated max vfolder count."
+        default=None, description="Updated max vfolder count."
     )
     max_quota_scope_size: BinarySizeInputGQL | None = gql_field(
-        default=UNSET, description="Updated max quota scope size."
+        default=None, description="Updated max quota scope size."
     )
     max_network_count: int | None = gql_field(
-        default=UNSET, description="Updated max network count."
+        default=None, description="Updated max network count."
     )
 
 


### PR DESCRIPTION
This is a manual backport PR of #13290 to the 26.4 release. The automatic backport failed because `max_priority` does not exist on this branch.

## Differences from the original

- `max_priority` (added by #13283, 26.8 only) is not part of this branch, so the field and its `tests/unit/manager/api/gql/resource_policy_v2/test_max_priority.py` are omitted.
- Everything else applies unchanged: **eight** fields lose their null schema default instead of nine.

| adapter | fields fixed here |
|---|---|
| `resource_policy` | `max_pending_session_count`, `max_pending_session_resource_slots`, `max_concurrent_logins` |
| `domain` | `description`, `integration_name` |
| `project` | `description`, `integration_name` |
| `login_client_type` | `description` |

## Verified

- The schema dumps were regenerated on this branch rather than merged by hand; the diff is exactly the eight fields above.
- `pants fmt / fix / lint / check --changed-since=origin/26.4 --changed-dependents=transitive` — 344 files, clean
- 3354 tests pass