### PR TITLE
fix(BA-7105): mark role preset fixtures as deleted to disable auto-creation

### DIFF
--- a/changes/13304.fix.md
+++ b/changes/13304.fix.md
@@ -1,0 +1,1 @@
+Disable preset-based role auto-creation by marking the role preset fixtures as soft-deleted

--- a/fixtures/manager/example-roles.json
+++ b/fixtures/manager/example-roles.json
@@ -7054,7 +7054,7 @@
             "name": "preset_domain_admin",
             "scope_type": "domain",
             "auto_assign": false,
-            "deleted": false,
+            "deleted": true,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00"
         },
@@ -7063,7 +7063,7 @@
             "name": "preset_project_admin",
             "scope_type": "project",
             "auto_assign": false,
-            "deleted": false,
+            "deleted": true,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00"
         },
@@ -7072,7 +7072,7 @@
             "name": "preset_project_member",
             "scope_type": "project",
             "auto_assign": true,
-            "deleted": false,
+            "deleted": true,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00"
         },
@@ -7081,7 +7081,7 @@
             "name": "preset_user",
             "scope_type": "user",
             "auto_assign": false,
-            "deleted": false,
+            "deleted": true,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00"
         }


### PR DESCRIPTION
## Summary
- Set `"deleted": true` for all `role_presets` entries in `fixtures/manager/example-roles.json` (`preset_domain_admin`, `preset_project_admin`, `preset_project_member`, `preset_user`).
- `create_preset_roles` filters presets with `deleted == false`, so injecting them as soft-deleted prevents preset-based roles from being auto-generated at scope creation time, while keeping the preset data available for later activation.
- The web client does not support the role preset feature yet.

## Test plan
- [x] Apply the fixture to a fresh DB and verify that creating a user/project does not auto-generate preset-based roles.

Resolves BA-7105

🤖 Generated with [Claude Code](https://claude.com/claude-code)