### PR TITLE
fix(BA-7105): mark role preset fixtures as deleted to disable auto-creation (#13304)

### DIFF
--- a/changes/13304.fix.md
+++ b/changes/13304.fix.md
@@ -1,0 +1,1 @@
+Disable preset-based role auto-creation by marking the role preset fixtures as soft-deleted

--- a/fixtures/manager/example-roles.json
+++ b/fixtures/manager/example-roles.json
@@ -7054,7 +7054,7 @@
             "name": "preset_domain_admin",
             "scope_type": "domain",
             "auto_assign": false,
-            "deleted": false,
+            "deleted": true,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00"
         },
@@ -7063,7 +7063,7 @@
             "name": "preset_project_admin",
             "scope_type": "project",
             "auto_assign": false,
-            "deleted": false,
+            "deleted": true,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00"
         },
@@ -7072,7 +7072,7 @@
             "name": "preset_project_member",
             "scope_type": "project",
             "auto_assign": true,
-            "deleted": false,
+            "deleted": true,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00"
         },
@@ -7081,7 +7081,7 @@
             "name": "preset_user",
             "scope_type": "user",
             "auto_assign": false,
-            "deleted": false,
+            "deleted": true,
             "created_at": "2025-09-12 09:51:58.265582+00",
             "updated_at": "2025-09-12 09:51:58.265582+00"
         }


### PR DESCRIPTION
This is an auto-generated backport PR of #13304 to the 26.8 release.