### PR TITLE
fix(BA-7084): Restore ["*"] fallback for unconstrained image accelerators

### DIFF
--- a/changes/13317.fix.md
+++ b/changes/13317.fix.md
@@ -1,0 +1,1 @@
+Fix v2 and v1 REST image APIs reporting no supported accelerators for images without an accelerator constraint, restoring the legacy `["*"]` (any accelerator) contract

--- a/src/ai/backend/manager/api/adapters/image/adapter.py
+++ b/src/ai/backend/manager/api/adapters/image/adapter.py
@@ -539,7 +539,7 @@ class ImageAdapter(BaseAdapter):
         ]
         accelerators = data.accelerators
         accelerator_list = (
-            [a.strip() for a in accelerators.split(",") if a.strip()] if accelerators else []
+            [a.strip() for a in accelerators.split(",") if a.strip()] if accelerators else ["*"]
         )
         resource_limits_gql = [
             ImageResourceLimitGQLInfo(

--- a/src/ai/backend/manager/api/rest/image/adapter.py
+++ b/src/ai/backend/manager/api/rest/image/adapter.py
@@ -55,7 +55,7 @@ class ImageAdapter(BaseFilterAdapter):
                 ImageResourceLimitDTO(key=rl.key, min=rl.min, max=self._convert_max(rl.max))
                 for rl in data.resource_limits
             ],
-            accelerators=data.accelerators,
+            accelerators=data.accelerators if data.accelerators else "*",
             config_digest=data.config_digest,
             is_local=data.is_local,
             created_at=data.created_at,


### PR DESCRIPTION
## Summary
- The v2 image adapter (shared by REST v2 `ImageNode` and GQL v2 `ImageV2GQL.requirements`) returned an empty `supported_accelerators` list for images without an accelerator constraint, while the legacy GQL API returns `["*"]` (the same bug was fixed in legacy once before, in BA-2358 / #5878). The UI reads the empty list as "no accelerator supported" and hides all accelerator options.
- Restore the `["*"]` fallback in the v2 adapter's `_data_to_dto`, matching the legacy contract ("no constraint" = "any accelerator") and the registry-scan write path, which stores a literal `"*"` for non-Backend.AI images with that exact meaning.
- Also align the v1 REST `convert_to_dto` path, which returned `None` for the same images while `convert_detailed_to_dto` already returned `"*"` — the same entity reported different values depending on the endpoint.

## Test plan
- [ ] `GET /v2/images` (search) returns `supported_accelerators: ["*"]` for an image whose `images.accelerators` column is NULL
- [ ] GQL v2 `requirements.supported_accelerators` returns `["*"]` for the same image
- [ ] v1 REST search/get returns `accelerators: "*"` for the same image, consistent with the detailed endpoint
- [ ] Constrained images (e.g. `cuda,rocm`) are unaffected on all paths

Resolves BA-7084

🤖 Generated with [Claude Code](https://claude.com/claude-code)