### PR TITLE
fix(BA-7084): Restore ["*"] fallback for unconstrained image accelerators (#13317)

### DIFF
--- a/changes/13317.fix.md
+++ b/changes/13317.fix.md
@@ -1,0 +1,1 @@
+Fix v2 and v1 REST image APIs reporting no supported accelerators for images without an accelerator constraint, restoring the legacy `["*"]` (any accelerator) contract

--- a/src/ai/backend/manager/api/adapters/image/adapter.py
+++ b/src/ai/backend/manager/api/adapters/image/adapter.py
@@ -539,7 +539,7 @@ class ImageAdapter(BaseAdapter):
         ]
         accelerators = data.accelerators
         accelerator_list = (
-            [a.strip() for a in accelerators.split(",") if a.strip()] if accelerators else []
+            [a.strip() for a in accelerators.split(",") if a.strip()] if accelerators else ["*"]
         )
         resource_limits_gql = [
             ImageResourceLimitGQLInfo(

--- a/src/ai/backend/manager/api/rest/image/adapter.py
+++ b/src/ai/backend/manager/api/rest/image/adapter.py
@@ -55,7 +55,7 @@ class ImageAdapter(BaseFilterAdapter):
                 ImageResourceLimitDTO(key=rl.key, min=rl.min, max=self._convert_max(rl.max))
                 for rl in data.resource_limits
             ],
-            accelerators=data.accelerators,
+            accelerators=data.accelerators if data.accelerators else "*",
             config_digest=data.config_digest,
             is_local=data.is_local,
             created_at=data.created_at,


### PR DESCRIPTION
This is an auto-generated backport PR of #13317 to the 26.8 release.