### PR TITLE
chore(BA-7125): split the changelog into per-version-branch files

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -36,7 +36,7 @@ Guides the Backend.AI release process: version bump, changelog generation, and R
 4. **Locate the changelog file**
    - The changelog is split per version branch: `CHANGELOG/{major}.{minor}.md`
      (`26.9.0rc1`, `26.9.0`, and `26.9.1` all live in `CHANGELOG/26.9.md`)
-   - The root `CHANGELOG.md` is the frozen archive of releases up to 26.8 — never write to it
+   - The root `CHANGELOG.md` archives the releases made before the split — never write to it
    - The file may not exist yet; the first release of the version branch creates it
 
 5. **For final releases, check for prior RC sections**
@@ -262,5 +262,5 @@ Agent: [Runs release.sh with WebUI version, full workflow]
 - `scripts/changelog_files.py` - Version to changelog path mapping
 - `pyproject.toml` - towncrier configuration (fragment types, template)
 - `changes/` - News fragment directory
-- `CHANGELOG/` - Per-version-branch changelogs; root `CHANGELOG.md` is the 26.8-and-earlier archive
+- `CHANGELOG/` - Per-version-branch changelogs; root `CHANGELOG.md` archives the pre-split releases
 - `/submit` - For regular PR submissions (not releases)

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -33,12 +33,18 @@ Guides the Backend.AI release process: version bump, changelog generation, and R
    - **Pre-release**: version contains `rc`, `alpha`, `beta`, or `dev` (e.g., `26.2.0rc1`)
    - **Final release**: clean semver (e.g., `26.2.0`)
 
-4. **For final releases, check for prior RC sections**
-   - Scan `CHANGELOG.md` for sections matching `## {major}.{minor}.{patch}rc\d+`
+4. **Locate the changelog file**
+   - The changelog is split per version branch: `CHANGELOG/{major}.{minor}.md`
+     (`26.9.0rc1`, `26.9.0`, and `26.9.1` all live in `CHANGELOG/26.9.md`)
+   - The root `CHANGELOG.md` is the frozen archive of releases up to 26.8 — never write to it
+   - The file may not exist yet; the first release of the version branch creates it
+
+5. **For final releases, check for prior RC sections**
+   - Scan `CHANGELOG/{major}.{minor}.md` for sections matching `## {major}.{minor}.{patch}rc\d+`
    - List found RC sections to user
    - These will be consolidated in Phase 3
 
-5. **Confirm with user before proceeding**
+6. **Confirm with user before proceeding**
    - Show: target version, release type, WebUI version (if any), RC sections to consolidate (if any)
    - Wait for user approval
 
@@ -61,7 +67,7 @@ NEXT_DEV_VERSION={next_version} scripts/release.sh {target_version} [webui_versi
 2. Downloads WebUI release (if `webui_version` provided)
 3. Updates `VERSION` file
 4. Freezes `NEXT_RELEASE_VERSION` placeholders to the actual version (stable releases only; skipped for `rc`/`a`/`b`/`dev`/`post`)
-5. Runs towncrier to generate changelog entries
+5. Runs `scripts/run-towncrier.py {target_version}`, which consumes the `changes/` fragments into `CHANGELOG/{major}.{minor}.md` (skipped entirely when there are no fragments)
 6. Generates sample config files
 7. Generates API docs (OpenAPI, GraphQL schema)
 8. Runs quality checks: `pants tailor --check`, `pants check ::`
@@ -77,6 +83,7 @@ NEXT_DEV_VERSION={next_version} scripts/release.sh {target_version} [webui_versi
 **Error handling:**
 - If quality checks fail, report errors and stop
 - If towncrier fails, check `pyproject.toml` towncrier config and `changes/` directory
+- If no changelog block was produced, check whether `changes/` held any fragment — `run-towncrier.py` skips towncrier when there is none, by design
 - If config generation fails, check component CLI availability
 - On any failure, suggest user fix the issue and re-run the script manually
 
@@ -93,7 +100,7 @@ NEXT_DEV_VERSION={next_version} scripts/release.sh {target_version} [webui_versi
 This is the core value of the skill. When releasing a final version (e.g., `26.2.0`), all previous RC changelog sections (e.g., `26.2.0rc1`, `26.2.0rc2`) must be consolidated into the final version section.
 
 **Step 1: Collect RC entries**
-- Find all RC sections for the same major.minor.patch in `CHANGELOG.md`
+- Find all RC sections for the same major.minor.patch in `CHANGELOG/{major}.{minor}.md`
   - Pattern: `## {major}.{minor}.{patch}rc\d+ \(.*\)`
 - Extract all bullet items from each RC section, grouped by category (`### Features`, `### Improvements`, `### Fixes`, etc.)
 
@@ -103,8 +110,10 @@ This is the core value of the skill. When releasing a final version (e.g., `26.2
 - Group by category: Features, Improvements, Fixes, etc.
 
 **Step 3: Remove RC sections**
-- Delete the RC section blocks from `CHANGELOG.md`
-- Only the final version section should remain
+- Delete the RC section blocks from `CHANGELOG/{major}.{minor}.md`
+- Only the final version section should remain for this patch level; sections for
+  earlier patch releases of the same version branch (e.g. `## 26.9.0` when
+  releasing `26.9.1`) stay untouched below it
 
 **Step 4: Subsection grouping**
 - For each category (Features, Improvements, Fixes), group related items into `#### Subsection Title` blocks
@@ -172,7 +181,7 @@ Introduced StorageTarget abstraction for flexible storage configuration.
 
 **Step 6: Amend the release commit**
 ```bash
-git add CHANGELOG.md
+git add CHANGELOG/{major}.{minor}.md
 git commit --amend --no-edit
 ```
 
@@ -235,7 +244,7 @@ Agent: [Checks VERSION, runs release.sh, towncrier generates flat list, reports 
 ### Final release with RC consolidation
 ```
 User: /release 26.2.0
-Agent: [Checks VERSION, finds rc1/rc2 sections in CHANGELOG, runs release.sh,
+Agent: [Checks VERSION, finds rc1/rc2 sections in CHANGELOG/26.2.md, runs release.sh,
         consolidates RC entries + new entries, groups into subsections,
         presents for review, amends commit, reports summary]
 ```
@@ -249,6 +258,9 @@ Agent: [Runs release.sh with WebUI version, full workflow]
 ## Related
 
 - `scripts/release.sh` - The release automation script
+- `scripts/run-towncrier.py` - Runs towncrier against `CHANGELOG/{major}.{minor}.md`
+- `scripts/changelog_files.py` - Version to changelog path mapping
 - `pyproject.toml` - towncrier configuration (fragment types, template)
 - `changes/` - News fragment directory
+- `CHANGELOG/` - Per-version-branch changelogs; root `CHANGELOG.md` is the 26.8-and-earlier archive
 - `/submit` - For regular PR submissions (not releases)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -153,7 +153,8 @@ Once the PR number is assigned, proceed to the next step.
 After the PR is created and you have the **PR number**, write a changelog fragment.
 Backend.AI uses [Towncrier](https://towncrier.readthedocs.io/) to automatically generate release notes.
 
-**Important**: These fragments are used to generate [CHANGELOG.md](/CHANGELOG.md) for each release.
+**Important**: These fragments are used to generate the changelog of the version branch
+being released, under [`CHANGELOG/`](/CHANGELOG/).
 Write clearly and concisely about what you changed and its impact, as this will be read by users and other developers.
 
 **Create Fragment File**:

--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -24,6 +24,7 @@ jobs:
       always()
       && !contains(github.event.pull_request.labels.*.name, 'skip:changelog')
       && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
+      && !startsWith(github.event.pull_request.title, 'release:')
       && needs.assign-pr-number.result != 'failure'
     needs: [assign-pr-number]
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,7 @@ logs/
 
 # Release artifacts
 /CHANGELOG_RELEASE.md
+/.towncrier.generated.toml
 
 # macOS specific
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changes
 =======
 
+**This file is the archive of releases up to 26.8.** From 26.9 onward:
+
+| Looking for | Go to |
+|---|---|
+| The full changelog of a version branch | [`CHANGELOG/`](CHANGELOG/) — one file per version branch, holding every release of that branch (`26.9.0rc1`, `26.9.0`, `26.9.1`, ...) |
+| A single release, in date order | [Releases](https://github.com/lablup/backend.ai/releases) — published automatically for every tag |
+| Which version branches are still maintained | [`.github/maintained-versions.yml`](.github/maintained-versions.yml) |
+
 <!--
     You should *NOT* be adding new change log entries to this file, this
     file is managed by towncrier. You *may* edit previous change logs to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 Changes
 =======
 
-**This file is the archive of releases up to 26.8.** From 26.9 onward:
+**This file archives the releases made before the changelog was split.** From 26.9
+onward:
 
 | Looking for | Go to |
 |---|---|

--- a/changes/13345.misc.md
+++ b/changes/13345.misc.md
@@ -1,0 +1,1 @@
+Split the changelog into per-version-branch files under `CHANGELOG/`, so that releases from different version branches no longer collide on a single insertion point; the root `CHANGELOG.md` now archives the releases made before the split.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,10 @@ dynamic = ["version"]
 
 [tool.towncrier]
 package = "ai.backend.manager"  # reference point for getting __version__
+# Releases go to the per-version-branch file instead: scripts/run-towncrier.py
+# overrides this with CHANGELOG/<version>.md on every run. The value is kept
+# because towncrier picks the markdown template from this suffix, and because
+# dropping it would fall back to NEWS.rst.
 filename = "CHANGELOG.md"
 directory = "changes/"
 title_format = ""  # embedded inside the template

--- a/scripts/changelog_files.py
+++ b/scripts/changelog_files.py
@@ -1,0 +1,34 @@
+"""Mapping rule from a release version to the changelog file holding it.
+
+The changelog is split per version branch: every release of the ``26.9`` branch —
+``26.9.0rc1``, ``26.9.0``, ``26.9.1`` — writes into ``CHANGELOG/26.9.md``. Each
+release keeps its own heading block within that file; consolidating the
+pre-release blocks into the final one is a release-time editorial step.
+
+The root ``CHANGELOG.md`` is the frozen archive of releases up to 26.8.
+
+Shared by ``run-towncrier.py`` (which writes the block) and
+``extract-release-changelog.py`` (which reads it back).
+"""
+
+from __future__ import annotations
+
+import re
+
+# PEP 440 pre-release / post-release / development-release suffixes.
+_SUFFIX_RE = re.compile(
+    r"[._-]?(alpha|beta|preview|pre|rev|post|dev|rc|a|b|c|r)\d*$",
+    re.IGNORECASE,
+)
+_VERSION_RE = re.compile(r"^(\d+)\.(\d+)(?:\.\d+)*$")
+
+CHANGELOG_DIR = "CHANGELOG"
+
+
+def changelog_filename(version: str) -> str:
+    """Return the changelog path holding the given release version."""
+    base = _SUFFIX_RE.sub("", version.strip())
+    match = _VERSION_RE.match(base)
+    if match is None:
+        raise ValueError(f"Unrecognized release version: {version!r}")
+    return f"{CHANGELOG_DIR}/{match.group(1)}.{match.group(2)}.md"

--- a/scripts/changelog_files.py
+++ b/scripts/changelog_files.py
@@ -5,7 +5,7 @@ The changelog is split per version branch: every release of the ``26.9`` branch 
 release keeps its own heading block within that file; consolidating the
 pre-release blocks into the final one is a release-time editorial step.
 
-The root ``CHANGELOG.md`` is the frozen archive of releases up to 26.8.
+The root ``CHANGELOG.md`` archives the releases made before the split.
 
 Shared by ``run-towncrier.py`` (which writes the block) and
 ``extract-release-changelog.py`` (which reads it back).

--- a/scripts/extract-release-changelog.py
+++ b/scripts/extract-release-changelog.py
@@ -5,6 +5,13 @@ import subprocess
 import sys
 from pathlib import Path
 
+from changelog_files import changelog_filename
+
+DEFAULT_REPOSITORY = 'lablup/backend.ai'
+
+
+def get_repository():
+    return os.environ.get('GITHUB_REPOSITORY', DEFAULT_REPOSITORY)
 
 def get_tag():
     gh_ref_name = os.environ.get('GITHUB_REF_NAME')
@@ -16,7 +23,7 @@ def get_tag():
 
 def get_prev_tag():
     tag = get_tag()
-    subprocess.run(['git', 'clone', '--filter=blob:none', '--no-checkout', f'https://github.com/{os.environ["GITHUB_REPOSITORY"]}.git', '.git-tmp'])
+    subprocess.run(['git', 'clone', '--filter=blob:none', '--no-checkout', f'https://github.com/{get_repository()}.git', '.git-tmp'])
     p = subprocess.run(['git', 'describe', '--abbrev=0', '--tags', tag + '^'], capture_output=True, cwd='.git-tmp')
     prev_tag = p.stdout.decode().strip()
     return prev_tag
@@ -30,17 +37,19 @@ def main():
     args = parser.parse_args()
 
     prev_tag, tag = get_prev_tag(), get_tag()
-    commitlog_url = f"https://github.com/lablup/backend.ai/compare/{prev_tag}...{tag}"
-    changelog_url = f"https://github.com/lablup/backend.ai/blob/{tag}/CHANGELOG.md"
+    repository = get_repository()
+    version = Path('./VERSION').read_text().strip()
+    changelog_name = changelog_filename(version)
+    commitlog_url = f"https://github.com/{repository}/compare/{prev_tag}...{tag}"
+    changelog_url = f"https://github.com/{repository}/blob/{tag}/{changelog_name}"
 
     print(f"Making release notes for {tag} ...", file=sys.stderr)
 
-    input_path = Path('./CHANGELOG.md')
+    input_path = Path(f'./{changelog_name}')
     output_path = Path('./CHANGELOG_RELEASE.md')
     try:
-        version = Path('./VERSION').read_text().strip()
         input_text = input_path.read_text()
-        m = re.search(rf"(?:^|\n)## {re.escape(version)}(?:[^\n]*)?\n(.*?)(?:\n## |$)", input_text, re.S)
+        m = re.search(rf"(?:^|\n)## {re.escape(version)}(?![\w.])(?:[^\n]*)?\n(.*?)(?:\n## |$)", input_text, re.S)
         if m is not None:
             content = m.group(1).strip()
             content += (
@@ -58,7 +67,7 @@ def main():
             print("--------")
             print("Successfully extracted the latest changelog to CHANGELOG_RELEASE.md", file=sys.stderr)
         else:
-            print("::error ::Could not extract the latest changelog from CHANGELOG.md", file=sys.stderr)
+            print(f"::error ::Could not extract the {version} changelog from {changelog_name}", file=sys.stderr)
             sys.exit(1)
     except IOError as e:
         print(f"::error ::Could read or write from file: {e!r}", file=sys.stderr)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -45,8 +45,8 @@ else
     pants fmt ::
 fi
 
-# Update the changelog (--yes consumes news fragments without an interactive prompt)
-LOCKSET=towncrier/$(yq '.python.interpreter_constraints[0] | split("==") | .[1]' pants.toml) ./py -m towncrier --yes
+# Update the version-branch changelog (consumes news fragments without an interactive prompt)
+python3 scripts/run-towncrier.py "${TARGET_VERSION}"
 
 # Update sample config files (unmask secrets to show actual default values)
 ./backend.ai mgr config generate-sample --overwrite --unmask-secrets

--- a/scripts/run-towncrier.py
+++ b/scripts/run-towncrier.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Run towncrier against the version-specific changelog file.
+
+``pyproject.toml`` pins ``[tool.towncrier] filename`` to the frozen archive
+``CHANGELOG.md``. This script copies that section into a temporary config at the
+repository root with ``filename`` rewritten to the per-version-branch changelog
+(see ``changelog_files``), runs towncrier with it, and removes the temporary
+config afterwards.
+
+The temporary config must live at the repository root because towncrier resolves
+``directory`` and ``template`` relative to the config file's own directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from changelog_files import CHANGELOG_DIR, changelog_filename
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+PANTS_TOML_PATH = REPO_ROOT / "pants.toml"
+TEMP_CONFIG_PATH = REPO_ROOT / ".towncrier.generated.toml"
+INTERPRETER_RE = re.compile(r'CPython==([^"]+)')
+
+
+class UnsupportedConfigError(Exception):
+    """The ``[tool.towncrier]`` section has a shape this script cannot rewrite."""
+
+
+def load_towncrier_config() -> dict[str, Any]:
+    with PYPROJECT_PATH.open("rb") as f:
+        pyproject = tomllib.load(f)
+    try:
+        return pyproject["tool"]["towncrier"]
+    except KeyError:
+        raise UnsupportedConfigError(f"No [tool.towncrier] section in {PYPROJECT_PATH}") from None
+
+
+def format_value(value: Any) -> str:
+    # TOML basic strings share JSON's escaping rules.
+    if isinstance(value, str):
+        return json.dumps(value)
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return repr(value)
+    if isinstance(value, list):
+        return "[" + ", ".join(format_value(item) for item in value) + "]"
+    raise UnsupportedConfigError(f"Cannot serialize {value!r} back to TOML")
+
+
+def render_config(config: dict[str, Any]) -> str:
+    """Serialize the ``[tool.towncrier]`` section back to TOML.
+
+    Only the shape this project actually uses is supported: scalar (or list of
+    scalar) values plus the ``[[tool.towncrier.type]]`` array of tables. Anything
+    else is an error rather than a best-effort guess.
+    """
+    lines = ["[tool.towncrier]"]
+    for key, value in config.items():
+        if key == "type":
+            continue
+        lines.append(f"{key} = {format_value(value)}")
+    for entry in config.get("type", []):
+        if not isinstance(entry, dict):
+            raise UnsupportedConfigError(f"Unexpected [[tool.towncrier.type]] entry: {entry!r}")
+        lines.append("")
+        lines.append("[[tool.towncrier.type]]")
+        for key, value in entry.items():
+            lines.append(f"{key} = {format_value(value)}")
+    return "\n".join(lines) + "\n"
+
+
+def has_fragments(config: dict[str, Any]) -> bool:
+    """Tell whether ``changes/`` holds any file towncrier would consume.
+
+    Mirrors towncrier's own basename parsing: a fragment name is dot-separated
+    and carries a known type directory in any position but the first, which
+    excludes ``README.md`` and ``template.md``.
+    """
+    type_names = {entry["directory"] for entry in config.get("type", [])}
+    fragment_dir = REPO_ROOT / config["directory"]
+    if not fragment_dir.is_dir():
+        return False
+    for path in fragment_dir.iterdir():
+        if not path.is_file():
+            continue
+        if type_names.intersection(path.name.split(".")[1:]):
+            return True
+    return False
+
+
+def towncrier_lockset() -> str:
+    match = INTERPRETER_RE.search(PANTS_TOML_PATH.read_text())
+    if match is None:
+        raise UnsupportedConfigError(
+            f"Could not read the target CPython interpreter version from {PANTS_TOML_PATH}"
+        )
+    return f"towncrier/{match.group(1)}"
+
+
+def run_towncrier(version: str, config_path: Path) -> None:
+    env = {**os.environ, "LOCKSET": towncrier_lockset()}
+    # towncrier writes the newsfile but does not create its parent directory.
+    (REPO_ROOT / CHANGELOG_DIR).mkdir(exist_ok=True)
+    subprocess.run(
+        [
+            "./py",
+            "-m",
+            "towncrier",
+            "build",
+            "--yes",
+            "--config",
+            str(config_path),
+            "--version",
+            version,
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "version",
+        nargs="?",
+        help="Release version being prepared (defaults to the VERSION file)",
+    )
+    args = parser.parse_args()
+    version = args.version or (REPO_ROOT / "VERSION").read_text().strip()
+
+    try:
+        config = load_towncrier_config()
+        if not has_fragments(config):
+            print(
+                f"No news fragments in {config['directory']}; skipping towncrier.",
+                file=sys.stderr,
+            )
+            return 0
+        config["filename"] = changelog_filename(version)
+        TEMP_CONFIG_PATH.write_text(render_config(config))
+    except (UnsupportedConfigError, ValueError) as e:
+        print(f"::error ::{e}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Writing the {version} changelog block to {config['filename']} ...",
+        file=sys.stderr,
+    )
+    try:
+        run_towncrier(version, TEMP_CONFIG_PATH)
+    except subprocess.CalledProcessError as e:
+        print(f"::error ::towncrier failed with exit code {e.returncode}", file=sys.stderr)
+        return e.returncode
+    finally:
+        TEMP_CONFIG_PATH.unlink(missing_ok=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- towncrier now writes to `CHANGELOG/<version>.md`, one file per version branch holding every release of that branch, instead of a single `CHANGELOG.md` where every version inserted at the same point and two branches releasing meant a guaranteed conflict. The root `CHANGELOG.md` becomes the archive of the pre-split releases and points at the new layout.
- `run-towncrier.py` builds a temporary config at the repository root that copies `[tool.towncrier]` and overrides only `filename`, then removes it whether towncrier succeeds or fails. It skips towncrier entirely when `changes/` holds no fragment — previously an empty release heading block was produced and `extract-release-changelog.py` matched it, shipping empty release notes without failing.
- `extract-release-changelog.py` derives its input file from `VERSION` so the GitHub Release notes keep working, and reads the repository name from the environment instead of hardcoding it.
- Release PRs are exempted from the news fragment check. `towncrier.check` skips it only when its single configured `filename` is touched, which no longer happens once the changelog is split.

The `pyproject.toml` `filename` is kept because towncrier selects the markdown template from its suffix, and dropping it would fall back to `NEWS.rst`.

## Test plan

- [x] `26.9.0rc1` → `26.9.0rc2` → `26.9.0` → `26.9.1` in sequence produce four heading blocks in one `CHANGELOG/26.9.md`, newest first
- [x] Each of those tags extracts its own block through `extract-release-changelog.py`, run exactly as CI does (`python ./scripts/extract-release-changelog.py` from the repository root), with the notes linking to `CHANGELOG/26.9.md`
- [x] No fragments in `changes/` → towncrier is not run, exit 0, no file created
- [x] towncrier failure → exit code propagated and the temporary config removed
- [x] Missing changelog file → the existing failure behaviour is unchanged (`::error ::` + exit 1)
- [ ] CI: `timeline-check` and `make-final-release` paths

Resolves BA-7125