### PR TITLE
ci(BA-7132): enforce additive-only GraphQL schema policy on version branches

### DIFF
--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -99,6 +99,42 @@ jobs:
       - uses: actions/checkout@v6
       - uses: graphql-hive/graphql-inspector@v4.0.0
         with:
-          schema: '${{ github.base_ref }}:docs/manager/graphql-reference/schema.graphql'
+          schema: '${{ github.base_ref }}:docs/manager/graphql-reference/supergraph.graphql'
           rules: |
             gql-inspector-checker.js
+
+  # A version branch inherits NEXT_RELEASE_VERSION from the cut PR, where it already
+  # points at the *next* version -- one this branch never releases.  New references
+  # added here must therefore spell out the version this branch will actually ship.
+  version-branch-added-version:
+    if: ${{ github.base_ref != 'main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Reject NEXT_RELEASE_VERSION added on a version branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REF: ${{ github.base_ref }}
+          PR_FILES_API: repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files
+        run: |
+          if [[ ! "$BASE_REF" =~ ^[0-9]{2}\.[0-9]{1,2}$ ]]; then
+            echo "'$BASE_REF' is not a version branch (YY.S); nothing to check."
+            exit 0
+          fi
+          added=$(gh api --paginate "$PR_FILES_API" --jq '
+            .[] | select(.patch != null) | .filename as $file
+            | .patch | split("\n")[]
+            | select(startswith("+") and (startswith("+++") | not))
+            | select(test("NEXT_RELEASE_VERSION"))
+            | "\($file): \(.[1:])"
+          ')
+          if [ -z "$added" ]; then
+            echo "No newly added NEXT_RELEASE_VERSION reference."
+            exit 0
+          fi
+          echo "Newly added NEXT_RELEASE_VERSION references:"
+          echo "$added"
+          echo "::error::NEXT_RELEASE_VERSION must not be added on version branch ${BASE_REF}: it resolves to a version this branch never releases. Write the version this branch will ship instead (e.g. added_version=\"${BASE_REF}.<patch>\"). Pre-existing references are left alone."
+          exit 1

--- a/changes/13346.misc.md
+++ b/changes/13346.misc.md
@@ -1,0 +1,1 @@
+Check GraphQL breaking changes against the federated supergraph so v2 schema changes are covered, and reject `NEXT_RELEASE_VERSION` additions on release version branches.

--- a/proposals/BEP-1072-release-branching-and-backport.md
+++ b/proposals/BEP-1072-release-branching-and-backport.md
@@ -90,8 +90,10 @@ For each area, separate **✅ what already exists** from **➕ what to add**. Me
 | ✅ | The built WebUI bundle is committed into this repo (`src/ai/backend/web/static/`, 4718 files) and ships in the wheel via `resources(sources=["static/**/*"])` |
 | ✅ | `release.sh <version> [webui_version]` pins the bundle **inside the release commit** — every recent commit touching `static/` is a `release:` commit |
 | ✅ | WebUI builds against `docs/manager/graphql-reference/`, and every tag (rc included) already publishes `supergraph.graphql` as a GitHub Release asset |
-| ✅ | The schema does not move on a version branch in practice — 55 commits on `26.4` since its fork point, **0 touching `docs/manager/graphql-reference/`** |
-| ➕ | Make that a **rule**: from the rc1 tag onward the version branch does not change the GraphQL schema, enforced in CI |
+| ✅ | The schema moves less on a version branch, but it does move — 55 commits on `26.4` touched `docs/manager/graphql-reference/` 0 times, while **26.8 took 7 schema changes after rc1**: 6 additive, 1 breaking (`DeleteResourceGroupPayload.id` `String!`→`UUID!`, #13277) |
+| ✅ | The `graphql-inspector` job compares `schema.graphql` (graphene v1) only. All 7 changes were v2, so every one of them was outside its view and the breaking one merged |
+| ➕ | Make it a **rule**: from the rc1 tag onward a version branch may **add** to the schema but must not break it. Additive is allowed, breaking is blocked |
+| ➕ | Point `graphql-inspector` at `supergraph.graphql` (the v1+v2 superset) so the rule covers both subgraphs — this closes the same hole on `main` |
 | ➕ | Pin the bundle in an **independent PR**, not in the release commit — drop `webui_version` from `release.sh` |
 
 ## 3. Implementation Design
@@ -113,7 +115,7 @@ Row 1 is produced by a script (`cut-release-branch.sh`), not by hand: it runs `f
 
 There are two reasons to freeze in the cut PR rather than on the branch. `freeze_release_version.py` deletes imports and runs `pants fix/fmt`, so doing it on the branch diverges the two trees and increases later cherry-pick conflicts. And the `main` code at cut time first ships in `<version>.0`, so `added_version=<version>.0` is semantically correct.
 
-The NEXT bump happens in the same PR. The branch inherits `<next>.0`, but new GQL fields are `feat:` and therefore not automated backport targets, so this does not surface in practice. It is checked in review only when something is explicitly backported.
+The NEXT bump happens in the same PR, so the branch inherits `<next>.0` — a version it never releases. This does surface: 26.8 took 3 `feat:` commits after its rc1, and all three carry `added_version=26.9.0` while shipping in 26.8.x. The rule on a version branch is therefore the inverse of the one on `main`: write the literal version the branch will ship, never `NEXT_RELEASE_VERSION`. CI rejects newly added references on a version-branch PR and leaves pre-existing ones alone.
 
 The version changelog file is not pre-seeded as a stub; rc1's towncrier creates it, and it must already read as a complete release note at that point.
 
@@ -148,17 +150,19 @@ Why copying suffices: the version file is owned solely by that branch, and `main
 
 This PR does not touch `changes/`. **Each tree drains its own fragment pool with its own release** — the `main` pool is drained by the cut (rc1), the branch pool by that branch's releases. Fragments the branch consumed remain in the `main` pool and are consumed again into `<next>`'s notes at the next cut; the same fix appearing in two versions' notes is expected.
 
-### (d) WebUI bundle and the schema freeze contract
+### (d) WebUI bundle and the schema contract
 
 The bundle must ship inside the release artifact, so the two repos cannot be decoupled by packaging. They are decoupled in time instead: WebUI needs the schema **early** (at the cut) and this repo needs the bundle **late** (at the final release), and the rc period is exactly that gap.
 
 | Party | Commitment |
 |---|---|
-| backend.ai | Publish `supergraph.graphql` as a release asset at the rc1 tag, and **do not change the GraphQL schema on that version branch afterwards** |
+| backend.ai | Publish `supergraph.graphql` as a release asset at the rc1 tag, and make **no breaking change** to the schema on that version branch afterwards |
 | WebUI | Build against that asset and release its bundle |
 | backend.ai | Take the resulting bundle in an **independent PR**, not in the release commit |
 
-**The freeze is a rule, not an observation.** A version branch only takes `fix:` backports, which is why the schema has not moved in practice, but nothing prevents a fix from touching a GraphQL field. CI fails any change under `docs/manager/graphql-reference/` on a version-branch PR, with the existing `graphql-inspector` job as the breaking-change backstop. Only then can WebUI treat the rc1 asset as that version's final schema.
+**The contract is additive-only, not a full freeze.** A full freeze was the original intent, but the branch does take schema changes: 7 of them after 26.8 rc1, 6 additive and 1 breaking. Additive changes cost WebUI nothing — it simply does not use the new field — so blocking them would reject 6 harmless changes to catch 1 harmful one. What WebUI needs is the guarantee that everything in the rc1 asset stays: **the rc1 asset is the lower bound of the schema WebUI may depend on**, not that version's final schema.
+
+Enforcement is the existing `graphql-inspector` job, retargeted from `schema.graphql` to `supergraph.graphql`. The breaking change that merged into 26.8 (#13277) was v2-only and thus invisible to the job as configured; the supergraph is the superset of both subgraphs, so one input change covers v1 and v2 at once. Merge blocking stays as it is — the job's check run is a required status check, with the action's built-in `approved-breaking-change` label as the escape hatch. Registering that check as required on the version-branch rulesets is BA-7134.
 
 **Pinning the bundle is separate from releasing.** `release.sh` drops its `webui_version` argument; the bundle arrives as `chore: update webui to <x>` whenever WebUI ships, and a release commit simply carries whatever bundle the branch holds. If WebUI misses the rc window, `.0` still goes out on schedule with the current bundle and the update rides the next patch release — so a patch release may exist solely to advance the bundle, which is the one carve-out to "a patch release records only backported fixes" (3.(c)).
 
@@ -195,7 +199,7 @@ rc releases are published to PyPI like any other tag; `make-final-release` alrea
 |---|---|
 | **Version management in CI** | New `cut-release-branch.sh` (the whole cut PR procedure, absorbing freeze/bump out of `release.sh`), a workflow that tags and branches from `merge_commit_sha` on release-PR merge, align `VERSION` on `main` |
 | **Label-based backport + triage skill** | Introduce `maintained-versions.yml`, replace target decision in `backport.yml` (keep the matrix JSON shape → downstream jobs unchanged), remove `-X theirs`, draft PR on conflict, fix trailers, `backport:<version>` and `no-backport` labels, a Claude skill that lists `pending:backport` PRs and disposes of each one — resolve the conflict, or close it with the reason the fix does not apply to that version |
-| **WebUI decoupling** | Drop `webui_version` from `release.sh` so the bundle is pinned by its own PR, add a CI check that rejects `docs/manager/graphql-reference/` changes on version-branch PRs, and optionally warn when `static/version.json` lags the release version |
+| **WebUI decoupling** | Drop `webui_version` from `release.sh` so the bundle is pinned by its own PR, retarget `graphql-inspector` at `supergraph.graphql` and add a CI check that rejects newly added `NEXT_RELEASE_VERSION` references on version-branch PRs, and optionally warn when `static/version.json` lags the release version |
 | **Changelog split and script cleanup** | Per-version-branch files via a temporary towncrier config (written at the repo root so its relative `directory`/`template` paths resolve), towncrier skip guard, hardcoding and prerelease handling in `extract-release-changelog.py`, new `changelog-sync.yml`, 2 CI bugs (the edge-release regex `[0-9]{2}\.[0-9]{2}` never matches a `YY.S` branch, `X.Y.0rc1` in `check-backport-commits.py`), update `daily-workflows.rst` |
 
 ## 4. Decision Summary
@@ -207,7 +211,7 @@ rc releases are published to PyPI like any other tag; `make-final-release` alrea
 | Cut procedure | Done in **one PR**, generated by `cut-release-branch.sh` — `VERSION`, freeze, NEXT bump, regeneration, towncrier, version registration |
 | Script split | `cut-release-branch.sh` (on `main`, cut only) and `release.sh` (on a version branch, no freeze/bump) are separate; they share only the regeneration helpers |
 | `VERSION` | The version that tree **released last**. Only release commits update it, so it always matches the tag, there is no need to overwrite it at build time, and an rc claiming a final version on PyPI becomes structurally impossible |
-| `NEXT_RELEASE_VERSION` | Frozen and then bumped to the next target in the cut PR. The branch inherits `<next>.0`, but new fields are `feat:` and thus not automated backport targets |
+| `NEXT_RELEASE_VERSION` | Frozen and then bumped to the next target in the cut PR. The branch inherits `<next>.0`, which it never releases, so a version-branch PR writes the literal version it will ship — CI rejects newly added references there |
 | Backport targets | Milestone dropped. Prefix + labels + `maintained-versions.yml`. Grades and support periods are outside this BEP |
 | Backport scope | **Always backport to every target in the decided set**, never pre-filtered. A cherry-pick that cannot apply becomes a draft PR the skill resolves or closes with a recorded reason |
 | Backport failure | Not silently overwritten (`-X theirs` removed); left as a draft PR |
@@ -216,7 +220,8 @@ rc releases are published to PyPI like any other tag; `make-final-release` alrea
 | Fragment ownership | Each tree drains its own pool with its own release. No backward movement |
 | Reflection into `main` | **One version file copied** per final tag. Not a cherry-pick |
 | rc on PyPI | Published like any other tag. No workflow change needed |
-| Schema freeze | From the rc1 tag onward the version branch **does not change the GraphQL schema**, enforced in CI. The rc1 release asset is that version's final schema, and WebUI builds against it |
+| Schema policy | From the rc1 tag onward a version branch **may add to the GraphQL schema but must not break it**. The rc1 release asset is the **lower bound** of the schema WebUI may depend on, not that version's final schema |
+| Schema enforcement | The existing `graphql-inspector` job, retargeted from `schema.graphql` to `supergraph.graphql` so v1 and v2 are both covered — the 26.8 breaking change (#13277) was v2-only and slipped through. Merge blocking stays a required status check on that job |
 | WebUI bundle pin | Pinned by its own PR, never inside a release commit. A release carries whatever bundle the branch holds, so WebUI never blocks `.0`; a patch release may exist solely to advance the bundle |
 | Bundle ownership | Each tree owns its own bundle, like the fragment pool. Never cherry-picked between trees |
 

--- a/src/ai/backend/manager/api/gql/AGENTS.md
+++ b/src/ai/backend/manager/api/gql/AGENTS.md
@@ -33,6 +33,8 @@
   @gql_root_field(BackendAIGQLMeta(added_version=NEXT_RELEASE_VERSION, description="..."))
   async def my_foo(...): ...
   ```
+- On a **version branch** (`YY.S`) the rule is inverted: that branch inherits a `NEXT_RELEASE_VERSION` it never releases, so write the
+  literal version the branch will ship (`added_version="26.8.3"`). CI rejects newly added `NEXT_RELEASE_VERSION` references there.
 
 ## import
 


### PR DESCRIPTION
## Summary
- `graphql-inspector` now compares `supergraph.graphql` (the v1 graphene + v2
  strawberry superset) instead of `schema.graphql`. All 7 schema changes made on
  `26.8` after rc1 were v2-only, so the breaking one (#13277,
  `DeleteResourceGroupPayload.id` `String!`→`UUID!`) was outside the check's view
  and merged. This closes the same gap on `main`, not just on version branches.
- New `version-branch-added-version` job fails a PR targeting a `YY.S` branch when
  it *adds* a `NEXT_RELEASE_VERSION` reference. Such a branch inherits `<next>.0`
  from the cut PR — a version it never releases — and 3 `feat:` commits already
  shipped in 26.8.x carrying `added_version=26.9.0`. Pre-existing references are
  left alone, and PRs targeting `main` are unaffected.
- BEP-1072 corrected: the version-branch contract is "additive allowed, breaking
  blocked", not a full schema freeze, and the rc1 release asset is the lower bound
  of the schema WebUI may depend on rather than that version's final schema.

## Notes
- Merge blocking is unchanged: the action reports through a check run without
  failing the job, and registering that check as required on version-branch
  rulesets is tracked separately.
- This PR touches no schema file, so its own inspector diff is empty. Verified
  locally instead by running `@graphql-inspector/cli@4 diff --rule
  gql-inspector-checker.js` over the real supergraph.

## Test plan
- [ ] `graphql-inspector` check run passes on this PR (empty schema diff)
- [ ] Locally confirmed the retargeted job flags #13277's type change and an
      undocumented new field, while a version-tagged additive passes
- [ ] `version-branch-added-version` is skipped on this `main`-targeting PR

Resolves BA-7132

🤖 Generated with [Claude Code](https://claude.com/claude-code)
