### PR TITLE
chore(BA-7133): freeze NEXT_RELEASE_VERSION by position, not by line

### DIFF
--- a/changes/13347.misc.md
+++ b/changes/13347.misc.md
@@ -1,0 +1,1 @@
+Freeze `NEXT_RELEASE_VERSION` by position at release time so that the `# Part of:` comment of each alembic migration keeps its bare version string instead of a quoted one.

--- a/scripts/freeze_release_version.py
+++ b/scripts/freeze_release_version.py
@@ -2,8 +2,13 @@
 """Freeze NEXT_RELEASE_VERSION references to the actual version string.
 
 At release time, all usages of the NEXT_RELEASE_VERSION constant are replaced
-with the actual version string literal. The constant definition in meta.py and
-its re-export in __init__.py remain untouched for the next development cycle.
+with the actual version. Which form the replacement takes depends on where the
+placeholder sits: a code reference becomes a quoted string literal, while a
+comment -- the ``# Part of:`` line of an alembic migration -- becomes a bare
+version string.
+
+The constant definition in meta.py and its re-export in __init__.py remain
+untouched for the next development cycle.
 
 After running this script, run ``pants fix ::`` and ``pants fmt ::`` to remove
 the now-unused NEXT_RELEASE_VERSION imports.
@@ -11,14 +16,64 @@ the now-unused NEXT_RELEASE_VERSION imports.
 
 from __future__ import annotations
 
+import io
 import re
 import sys
+import tokenize
 from pathlib import Path
+
+PLACEHOLDER = "NEXT_RELEASE_VERSION"
 
 EXCLUDE_PATHS = {
     Path("src/ai/backend/common/meta/meta.py"),
     Path("src/ai/backend/common/meta/__init__.py"),
 }
+
+# Standalone import line:
+#   from ai.backend.common.meta import NEXT_RELEASE_VERSION
+#   from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+IMPORT_LINE_PATTERN = re.compile(
+    rf"^from\s+ai\.backend\.common\.meta(?:\.meta)?\s+import\s+{PLACEHOLDER}\s*$"
+)
+
+
+def comment_columns(text: str) -> dict[int, int]:
+    """Map each 1-based line number to the column where its comment starts."""
+    columns: dict[int, int] = {}
+    for token in tokenize.generate_tokens(io.StringIO(text).readline):
+        if token.type == tokenize.COMMENT:
+            columns[token.start[0]] = token.start[1]
+    return columns
+
+
+def freeze_file(text: str, target_version: str) -> str:
+    columns = comment_columns(text)
+    new_lines: list[str] = []
+
+    for lineno, line in enumerate(text.splitlines(keepends=True), start=1):
+        stripped = line.strip()
+
+        if IMPORT_LINE_PATTERN.match(stripped):
+            continue
+
+        # Remove NEXT_RELEASE_VERSION item from multi-line imports:
+        #       NEXT_RELEASE_VERSION,
+        if stripped == f"{PLACEHOLDER},":
+            continue
+
+        split_at = columns.get(lineno, len(line))
+        code, comment = line[:split_at], line[split_at:]
+
+        # Replace {NEXT_RELEASE_VERSION} in f-strings with literal text
+        code = code.replace(f"{{{PLACEHOLDER}}}", target_version)
+        comment = comment.replace(f"{{{PLACEHOLDER}}}", target_version)
+
+        code = code.replace(PLACEHOLDER, f'"{target_version}"')
+        comment = comment.replace(PLACEHOLDER, target_version)
+
+        new_lines.append(code + comment)
+
+    return "".join(new_lines)
 
 
 def freeze_version(target_version: str) -> None:
@@ -27,38 +82,10 @@ def freeze_version(target_version: str) -> None:
             continue
 
         text = path.read_text()
-        if "NEXT_RELEASE_VERSION" not in text:
+        if PLACEHOLDER not in text:
             continue
 
-        lines = text.splitlines(keepends=True)
-        new_lines: list[str] = []
-
-        for line in lines:
-            stripped = line.strip()
-
-            # Remove standalone import line:
-            #   from ai.backend.common.meta import NEXT_RELEASE_VERSION
-            #   from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
-            if re.match(
-                r"^from\s+ai\.backend\.common\.meta(?:\.meta)?\s+import\s+NEXT_RELEASE_VERSION\s*$",
-                stripped,
-            ):
-                continue
-
-            # Remove NEXT_RELEASE_VERSION item from multi-line imports:
-            #       NEXT_RELEASE_VERSION,
-            if stripped == "NEXT_RELEASE_VERSION,":
-                continue
-
-            # Replace {NEXT_RELEASE_VERSION} in f-strings with literal text
-            line = line.replace("{NEXT_RELEASE_VERSION}", target_version)
-
-            # Replace remaining NEXT_RELEASE_VERSION with quoted string literal
-            line = line.replace("NEXT_RELEASE_VERSION", f'"{target_version}"')
-
-            new_lines.append(line)
-
-        path.write_text("".join(new_lines))
+        path.write_text(freeze_file(text, target_version))
 
 
 if __name__ == "__main__":

--- a/src/ai/backend/manager/models/alembic/versions/097389c0853b_add_fair_share_resource_group_id_columns.py
+++ b/src/ai/backend/manager/models/alembic/versions/097389c0853b_add_fair_share_resource_group_id_columns.py
@@ -18,7 +18,7 @@ from ai.backend.manager.models.base import GUID
 
 revision = "097389c0853b"
 down_revision = "c4e1a9b73f52"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/2ec0aa5a19cf_strip_materialized_nulls_from_stored_.py
+++ b/src/ai/backend/manager/models/alembic/versions/2ec0aa5a19cf_strip_materialized_nulls_from_stored_.py
@@ -30,7 +30,7 @@ revision = "2ec0aa5a19cf"
 down_revision = "b13d304bf1fd"
 branch_labels = None
 depends_on = None
-# Part of: "26.8.0"
+# Part of: 26.8.0
 
 
 def upgrade() -> None:

--- a/src/ai/backend/manager/models/alembic/versions/339ae21cb8ec_add_session_requested_starts_at.py
+++ b/src/ai/backend/manager/models/alembic/versions/339ae21cb8ec_add_session_requested_starts_at.py
@@ -23,7 +23,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "339ae21cb8ec"
 down_revision = "b3e8f1a24c76"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/39fadbbea696_add_initial_grace_period_to_idle_.py
+++ b/src/ai/backend/manager/models/alembic/versions/39fadbbea696_add_initial_grace_period_to_idle_.py
@@ -12,7 +12,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "39fadbbea696"
 down_revision = "b3e8f1a24c76"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/3f9a1c7b2e04_add_session_job_priority.py
+++ b/src/ai/backend/manager/models/alembic/versions/3f9a1c7b2e04_add_session_job_priority.py
@@ -14,7 +14,7 @@ from ai.backend.common.defs.session import JOB_PRIORITY_DEFAULT
 # revision identifiers, used by Alembic.
 revision = "3f9a1c7b2e04"
 down_revision = "4a39641d0fc2"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/45d3064b95c9_disable_auto_assign_for_admin_roles_followup.py
+++ b/src/ai/backend/manager/models/alembic/versions/45d3064b95c9_disable_auto_assign_for_admin_roles_followup.py
@@ -19,7 +19,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "45d3064b95c9"
 down_revision = "2ec0aa5a19cf"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/4a39641d0fc2_create_retention_policies_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/4a39641d0fc2_create_retention_policies_table.py
@@ -20,7 +20,7 @@ from ai.backend.manager.models.base import GUID
 # revision identifiers, used by Alembic.
 revision = "4a39641d0fc2"
 down_revision = "d004f760adc7"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/5405ee0d8eed_merge_heads_339ae21cb8ec_and_.py
+++ b/src/ai/backend/manager/models/alembic/versions/5405ee0d8eed_merge_heads_339ae21cb8ec_and_.py
@@ -9,7 +9,7 @@ Create Date: 2026-07-23 22:14:46.696886
 # revision identifiers, used by Alembic.
 revision = "5405ee0d8eed"
 down_revision = ("339ae21cb8ec", "39fadbbea696")
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/577c7a215934_merge_heads_b988f01b17a1_and_.py
+++ b/src/ai/backend/manager/models/alembic/versions/577c7a215934_merge_heads_b988f01b17a1_and_.py
@@ -9,7 +9,7 @@ Create Date: 2026-07-21 13:46:17.583476
 # revision identifiers, used by Alembic.
 revision = "577c7a215934"
 down_revision = ("b988f01b17a1", "a1c4e7b93f22")
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/5c92586bff94_create_session_idle_checks.py
+++ b/src/ai/backend/manager/models/alembic/versions/5c92586bff94_create_session_idle_checks.py
@@ -17,7 +17,7 @@ from ai.backend.manager.models.base import GUID
 # revision identifiers, used by Alembic.
 revision = "5c92586bff94"
 down_revision = "b3f1a9c2d7e4"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/66d0f891ed20_move_fragment_rank_to_app_config_allow_list.py
+++ b/src/ai/backend/manager/models/alembic/versions/66d0f891ed20_move_fragment_rank_to_app_config_allow_list.py
@@ -19,7 +19,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "66d0f891ed20"
 down_revision = "ba6615a4d2f1"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/710460cca1ed_add_kernel_usage_record_resource_group_id.py
+++ b/src/ai/backend/manager/models/alembic/versions/710460cca1ed_add_kernel_usage_record_resource_group_id.py
@@ -18,7 +18,7 @@ from ai.backend.manager.models.base import GUID
 
 revision = "710460cca1ed"
 down_revision = "097389c0853b"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/71cb16a7a9c5_derive_idle_checker_type_from_spec.py
+++ b/src/ai/backend/manager/models/alembic/versions/71cb16a7a9c5_derive_idle_checker_type_from_spec.py
@@ -12,7 +12,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "71cb16a7a9c5"
 down_revision = "8f3c1d5a2b47"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/7a9720934f55_add_usage_bucket_resource_group_id_columns.py
+++ b/src/ai/backend/manager/models/alembic/versions/7a9720934f55_add_usage_bucket_resource_group_id_columns.py
@@ -18,7 +18,7 @@ from ai.backend.manager.models.base import GUID
 
 revision = "7a9720934f55"
 down_revision = "710460cca1ed"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/7f2b9c4d1a83_add_agent_resource_group_id_column.py
+++ b/src/ai/backend/manager/models/alembic/versions/7f2b9c4d1a83_add_agent_resource_group_id_column.py
@@ -23,7 +23,7 @@ from ai.backend.manager.models.base import GUID
 # revision identifiers, used by Alembic.
 revision = "7f2b9c4d1a83"
 down_revision = "a560420476b6"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/890490020974_make_session_idle_check_expire_at_nullable.py
+++ b/src/ai/backend/manager/models/alembic/versions/890490020974_make_session_idle_check_expire_at_nullable.py
@@ -12,7 +12,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "890490020974"
 down_revision = "e7a41b29c8d3"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/8f3c1d5a2b47_add_session_groups_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/8f3c1d5a2b47_add_session_groups_table.py
@@ -30,7 +30,7 @@ from ai.backend.manager.models.base import GUID
 # revision identifiers, used by Alembic.
 revision = "8f3c1d5a2b47"
 down_revision = "890490020974"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/a0a28251f296_backfill_jsonb_null_default_model_.py
+++ b/src/ai/backend/manager/models/alembic/versions/a0a28251f296_backfill_jsonb_null_default_model_.py
@@ -24,7 +24,7 @@ revision = "a0a28251f296"
 down_revision = "e5b71c94d2a8"
 branch_labels = None
 depends_on = None
-# Part of: "26.8.0"
+# Part of: 26.8.0
 
 
 def upgrade() -> None:

--- a/src/ai/backend/manager/models/alembic/versions/a560420476b6_cascade_fragment_deletion_from_allow_list.py
+++ b/src/ai/backend/manager/models/alembic/versions/a560420476b6_cascade_fragment_deletion_from_allow_list.py
@@ -25,7 +25,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "a560420476b6"
 down_revision = "e9a1c77b42d0"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/aa27f1d5cd35_add_covering_indexes_for_virtual_scope_.py
+++ b/src/ai/backend/manager/models/alembic/versions/aa27f1d5cd35_add_covering_indexes_for_virtual_scope_.py
@@ -11,7 +11,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "aa27f1d5cd35"
 down_revision = "45d3064b95c9"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/b13d304bf1fd_change_audit_logs_acted_as_to_uuid.py
+++ b/src/ai/backend/manager/models/alembic/versions/b13d304bf1fd_change_audit_logs_acted_as_to_uuid.py
@@ -20,7 +20,7 @@ from sqlalchemy.dialects import postgresql
 # revision identifiers, used by Alembic.
 revision = "b13d304bf1fd"
 down_revision = "a3c1d8e5b294"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/b3d9f7a2c184_add_app_config_fragment_permissions_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/b3d9f7a2c184_add_app_config_fragment_permissions_to_rbac.py
@@ -23,7 +23,7 @@ from ai.backend.manager.models.rbac_models.migration.enums import (
 # revision identifiers, used by Alembic.
 revision = "b3d9f7a2c184"
 down_revision = "c4e1a9b73f52"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/b3e8f1a24c76_seed_retention_policies_disabled.py
+++ b/src/ai/backend/manager/models/alembic/versions/b3e8f1a24c76_seed_retention_policies_disabled.py
@@ -18,7 +18,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "b3e8f1a24c76"
 down_revision = "ea422739665b"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/b3f1a9c2d7e4_add_is_default_to_scaling_group.py
+++ b/src/ai/backend/manager/models/alembic/versions/b3f1a9c2d7e4_add_is_default_to_scaling_group.py
@@ -11,7 +11,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "b3f1a9c2d7e4"
 down_revision = "aa27f1d5cd35"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/b93d1c47af52_fragment_unique_nulls_not_distinct.py
+++ b/src/ai/backend/manager/models/alembic/versions/b93d1c47af52_fragment_unique_nulls_not_distinct.py
@@ -21,7 +21,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "b93d1c47af52"
 down_revision = "c4a91d7e05b2"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/b988f01b17a1_use_resource_group_id_for_fair_share_uniqueness.py
+++ b/src/ai/backend/manager/models/alembic/versions/b988f01b17a1_use_resource_group_id_for_fair_share_uniqueness.py
@@ -11,7 +11,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "b988f01b17a1"
 down_revision = "3f9a1c7b2e04"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/bd1bf0524350_recompute_inflated_fair_share_usage_buckets_from_kernel_records.py
+++ b/src/ai/backend/manager/models/alembic/versions/bd1bf0524350_recompute_inflated_fair_share_usage_buckets_from_kernel_records.py
@@ -30,7 +30,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "bd1bf0524350"
 down_revision = "daf20413acda"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/c05f9465a9cd_add_acted_as_to_audit_logs.py
+++ b/src/ai/backend/manager/models/alembic/versions/c05f9465a9cd_add_acted_as_to_audit_logs.py
@@ -19,7 +19,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "c05f9465a9cd"
 down_revision = "7f2b9c4d1a83"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/c4a91d7e05b2_recompute_inflated_fair_share_usage_buckets_from_kernel_records.py
+++ b/src/ai/backend/manager/models/alembic/versions/c4a91d7e05b2_recompute_inflated_fair_share_usage_buckets_from_kernel_records.py
@@ -26,7 +26,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "c4a91d7e05b2"
 down_revision = "71cb16a7a9c5"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/c4e1a7f9b26d_add_keypair_max_priority.py
+++ b/src/ai/backend/manager/models/alembic/versions/c4e1a7f9b26d_add_keypair_max_priority.py
@@ -14,7 +14,7 @@ from ai.backend.common.defs.session import SESSION_PRIORITY_MAX, SESSION_PRIORIT
 # revision identifiers, used by Alembic.
 revision = "c4e1a7f9b26d"
 down_revision = "5405ee0d8eed"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/c4e1a9b73f52_drop_dead_app_config_permissions.py
+++ b/src/ai/backend/manager/models/alembic/versions/c4e1a9b73f52_drop_dead_app_config_permissions.py
@@ -24,7 +24,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "c4e1a9b73f52"
 down_revision = "5c92586bff94"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/cd6332715576_add_reserved_at_to_resource_allocations.py
+++ b/src/ai/backend/manager/models/alembic/versions/cd6332715576_add_reserved_at_to_resource_allocations.py
@@ -18,7 +18,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "cd6332715576"
 down_revision = "c4e1a7f9b26d"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/d004f760adc7_merge_7a97_and_b3d9.py
+++ b/src/ai/backend/manager/models/alembic/versions/d004f760adc7_merge_7a97_and_b3d9.py
@@ -14,7 +14,7 @@ Create Date: 2026-07-19
 # revision identifiers, used by Alembic.
 revision = "d004f760adc7"
 down_revision = ("7a9720934f55", "b3d9f7a2c184")
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/daf20413acda_disable_auto_assign_for_admin_roles.py
+++ b/src/ai/backend/manager/models/alembic/versions/daf20413acda_disable_auto_assign_for_admin_roles.py
@@ -22,7 +22,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "daf20413acda"
 down_revision = "f2b9a4c7e103"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/e5b71c94d2a8_app_config_fragment_scope_id_to_uuid.py
+++ b/src/ai/backend/manager/models/alembic/versions/e5b71c94d2a8_app_config_fragment_scope_id_to_uuid.py
@@ -24,7 +24,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "e5b71c94d2a8"
 down_revision = "577c7a215934"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/e7a41b29c8d3_add_prereserved_to_agent_resources.py
+++ b/src/ai/backend/manager/models/alembic/versions/e7a41b29c8d3_add_prereserved_to_agent_resources.py
@@ -24,7 +24,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "e7a41b29c8d3"
 down_revision = "cd6332715576"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/e9a1c77b42d0_add_kernel_resource_group_id_column.py
+++ b/src/ai/backend/manager/models/alembic/versions/e9a1c77b42d0_add_kernel_resource_group_id_column.py
@@ -26,7 +26,7 @@ from ai.backend.manager.models.base import GUID
 # revision identifiers, used by Alembic.
 revision = "e9a1c77b42d0"
 down_revision = "66d0f891ed20"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/ea422739665b_make_session_idle_check_expire_at_non_nullable.py
+++ b/src/ai/backend/manager/models/alembic/versions/ea422739665b_make_session_idle_check_expire_at_non_nullable.py
@@ -12,7 +12,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "ea422739665b"
 down_revision = "a0a28251f296"
-# Part of: "26.8.0"
+# Part of: 26.8.0
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- The freeze script replaced every NEXT_RELEASE_VERSION occurrence with a quoted
  string literal, so each alembic migration's `# Part of: NEXT_RELEASE_VERSION`
  comment froze to `# Part of: "26.8.0"` and had to be undone by hand.
- Split each line at the comment column reported by `tokenize`: a code reference
  becomes a quoted string literal, a comment becomes a bare version string.
  Splitting on the COMMENT token rather than the first `#` keeps a `#` inside a
  string literal from being mistaken for the start of a comment.
- Unquote the 38 `# Part of:` comments the 26.9.0 bump left behind on main.

## Test plan
- [x] Ran the script with `26.8.0` over the tree preceding the 26.8.0 release
      commit (`e0fe1da5b^`); the result matches the released tree `e0fe1da5b`
      except for the version bump in `meta.py` and two leftover f-string
      prefixes that `pants fix` strips afterwards — the 38 alembic comments now
      come out right without hand-editing.
- [x] `git grep 'added_version="26\.'` → 1560 hits, `git grep '# Part of: 26\.'`
      → 117 hits, `git grep '# Part of: "'` → 0 hits.
- [x] `pants fmt ::`, `pants fix ::`, `pants lint --changed-since=origin/main`

Resolves BA-7133

🤖 Generated with [Claude Code](https://claude.com/claude-code)