### PR TITLE
ci(BA-7131): sync a final release's changelog back to main

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,28 @@
+# GitHub Actions — Guardrails
+
+> A workflow and the script it calls sit side by side: `workflows/*.yml`, `scripts/*.sh`, `actions/*/action.yml`.
+> The script rules below hold for the repository's `scripts/` too, wherever a workflow calls into it.
+
+## Rules
+
+- **Write a script as a function: arguments in, printed value out.** State it was not given, it must not reach for — no CI variable, no ambient file, no "whatever revision happens to be checked out". A caller that has to arrange the surroundings before the script will answer correctly is the shape to avoid.
+- **A script reads no `GITHUB_*` variable.** `$GITHUB_ENV`, `$GITHUB_OUTPUT` and `::notice::` are the workflow's business: the script prints the value, the workflow turns it into whatever CI wants.
+- **Keep the deciding half free of effects.** Decide from the arguments, print the decision, and only then act. Anything with side effects takes `--dry-run`, and no script leaves the caller's HEAD, index or worktree moved.
+- **A workflow translates its event into arguments — nothing more.** Triggers, permissions, concurrency and wiring belong in the YAML. Once a `run:` grows past a line or two, it belongs in `scripts/<verb>-<object>.sh`.
+- **One job per outcome.** Split into separate jobs only where the runner, the permissions or a matrix genuinely differ.
+- **Do not re-implement a rule that a script already owns** — version parsing, changelog file names, the maintained-version registry. Call it.
+- **Never interpolate `${{ }}` into a shell command.** Hand it over through `env:` and quote the variable. A tag name, a branch name and a comment body are all written by someone else.
+- **Pin a third-party action to a commit SHA**, with a `# vN` comment beside it. `actions/*` may use a major tag.
+
+## Where a decision goes
+
+| In the workflow | In the script |
+|-----------------|---------------|
+| Which event runs it, and the filters on that event | What to do about it |
+| Permissions, `concurrency`, secrets, runner | Every branch, comparison and early exit |
+| Event context → arguments (`${{ github.ref_name }}` → `"$TAG"`) | Reading the repository, calling `git` / `gh` / `scripts/*` |
+| Turning a printed value into `$GITHUB_ENV` / `$GITHUB_OUTPUT` | Printing that value |
+
+A script whose decision cannot be reproduced by running it by hand is in the wrong shape.
+
+Worked examples: `scripts/sync-changelog-to-main.sh` (arguments, `--dry-run`, plain output) and `scripts/update-maintained-versions.sh` (arguments, in-place rewrite, `TODAY=` to pin the clock).

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/.github/scripts/sync-changelog-to-main.sh
+++ b/.github/scripts/sync-changelog-to-main.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# Open a pull request carrying the changelog file a final release wrote on its
+# version branch back to `main`.
+#
+#   sync-changelog-to-main.sh <version> [<commit>] [--dry-run]
+#
+#     <version>   the release to carry over, e.g. 26.8.0
+#     <commit>    the revision holding its changelog (default: <version>, the
+#                 release tag)
+#     --dry-run   report the decision; push nothing, open nothing
+#
+# The arguments and the repository decide everything -- no CI environment is
+# read, no particular revision has to be checked out, and the branch is built
+# with plumbing, so neither HEAD nor the worktree is touched. Run it against
+# your own checkout:
+#
+#   git fetch --tags && .github/scripts/sync-changelog-to-main.sh 26.8.0 --dry-run
+#
+# It exits 0 with the reason when there is nothing to carry over: a pre-release,
+# a release line older than the changelog split, or a file already on `main`.
+#
+# `gh` takes its credentials from GH_TOKEN under CI and from `gh auth login`
+# elsewhere. `bash -e` matches how GitHub runs a `run:` block.
+set -e
+
+usage() {
+  echo "Usage: $0 <version> [<commit>] [--dry-run]"
+  echo "  <version>   the release to carry the changelog of, e.g. 26.8.0"
+  echo "  <commit>    the revision holding it (default: <version>, the release tag)"
+  echo "  --dry-run   report the decision; push nothing, open nothing"
+}
+
+dry_run=0
+positional=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run) dry_run=1 ;;
+    -h|--help) usage; exit 0 ;;
+    -*) echo "Error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+    *) positional+=("$1") ;;
+  esac
+  shift
+done
+if [ "${#positional[@]}" -lt 1 ]; then
+  echo "Error: the release version is required" >&2
+  usage >&2
+  exit 2
+fi
+version="${positional[0]}"
+commit="${positional[1]:-$version}"
+branch="changelog-sync/$version"
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Every pre-release of a series writes into the same file as its final release,
+# so only the final one is worth carrying over. Asked of the script that already
+# owns the rule.
+if [ "$(python3 scripts/determine-release-type.py "$version")" = "true" ]; then
+  echo "$version is a pre-release; its changelog reaches main with the final release."
+  exit 0
+fi
+
+# Ask the mapping rule for the file name rather than assembling it here.
+path=$(python3 scripts/changelog_files.py "$version")
+
+if ! git cat-file -e "$commit:$path" 2> /dev/null; then
+  # A release line cut before the changelog was split has no such file. Say so
+  # and stop: a release must not fail over this.
+  echo "'$path' is absent at $commit; nothing to carry over to main."
+  exit 0
+fi
+
+# Keep a shallow clone shallow, and never shallow a full one.
+depth=()
+[ -e "$(git rev-parse --git-dir)/shallow" ] && depth=(--depth=1)
+git fetch "${depth[@]}" origin main
+base=$(git rev-parse FETCH_HEAD)
+
+if git diff --quiet "$base" "$commit" -- "$path"; then
+  echo "'$path' on main already matches $version."
+  exit 0
+fi
+
+# The `release:` prefix keeps this out of the news-fragment check, and the
+# `Backport:` trailer keeps the file from travelling back to the release
+# branches it came from.
+title="release: sync $path of $version to main"
+body="The $version release wrote \`$path\` on its own release branch. This copies that one file to \`main\`; nothing else from the release commit comes along.
+
+Backport: none"
+
+if [ "$dry_run" = 1 ]; then
+  echo "Would open '$title' from '$branch':"
+  git diff --stat "$base" "$commit" -- "$path"
+  exit 0
+fi
+
+# One file on top of main -- a copy, not a cherry-pick: the release commit also
+# carries version bumps and generated artifacts that must not reach `main`.
+# Assembled in a scratch index so that the caller's HEAD and worktree stay put.
+index=$(mktemp -u)
+tree=$(
+  export GIT_INDEX_FILE="$index"
+  git read-tree "$base"
+  git update-index --add --cacheinfo "100644,$(git rev-parse "$commit:$path"),$path"
+  git write-tree
+)
+rm -f "$index"
+new=$(
+  GIT_AUTHOR_NAME='github-actions[bot]' \
+  GIT_AUTHOR_EMAIL='41898282+github-actions[bot]@users.noreply.github.com' \
+  GIT_COMMITTER_NAME='github-actions[bot]' \
+  GIT_COMMITTER_EMAIL='41898282+github-actions[bot]@users.noreply.github.com' \
+  git commit-tree "$tree" -p "$base" -m "$title"
+)
+
+# One branch per release, force-pushed: a re-run of the same release revises its
+# pull request instead of opening a second one.
+git push --force origin "$new:refs/heads/$branch"
+
+existing=$(gh pr list --head "$branch" --base main --state open --json number --jq '.[0].number // ""')
+if [ -n "$existing" ]; then
+  echo "Revised the open pull request #$existing."
+  exit 0
+fi
+gh pr create --base main --head "$branch" --title "$title" --body "$body"

--- a/.github/workflows/changelog-sync.yml
+++ b/.github/workflows/changelog-sync.yml
@@ -1,0 +1,38 @@
+name: changelog-sync
+
+# A release branch keeps its own `CHANGELOG/<series>.md`, so a release cut there
+# never reaches `main`. This brings that one file back.
+
+on:
+  push:
+    tags:
+      - '[0-9][0-9].[0-9].*'
+      - '[0-9][0-9].[0-9][0-9].*'
+
+permissions:
+  contents: read
+
+concurrency:
+  # One group per tag: a re-run of the same tag must not race the first run into
+  # two pull requests.
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the tag
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+          # The pull request's checks only run when its branch is pushed by
+          # something other than the workflow's own token.
+          token: ${{ secrets.OCTODOG }}
+      - name: Sync the changelog to main
+        # The tag names the release; a tag name is never interpolated into the
+        # shell, only handed over as an argument.
+        env:
+          GH_TOKEN: ${{ secrets.OCTODOG }}
+          TAG: ${{ github.ref_name }}
+          COMMIT: ${{ github.sha }}
+        run: .github/scripts/sync-changelog-to-main.sh "$TAG" "$COMMIT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -859,9 +859,9 @@ jobs:
       run: |
         pip install -U 'twine~=6.0'
     - name: Extract the release changelog
-      run: |
-        python ./scripts/extract-release-changelog.py
-        python ./scripts/determine-release-type.py
+      run: python ./scripts/extract-release-changelog.py
+    - name: Determine the release type
+      run: echo "IS_PRERELEASE=$(python ./scripts/determine-release-type.py "$(cat VERSION)")" >> "$GITHUB_ENV"
     - name: Download wheels
       uses: actions/download-artifact@v6
       with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Applies to every generated artifact — docs, code comments, BEPs, PR descriptio
 
 **Core Documents (Read directly):**
 - `tests/AGENTS.md` — Testing guidelines and strategies
+- `.github/AGENTS.md` — CI workflows and the helper scripts they call, in `.github/scripts/` and `scripts/`
 - `BUILDING.md` — Build system, quality enforcement, BUILD policies
 - `src/ai/backend/manager/models/alembic/README.md` — Alembic migration backport strategy
 - `README.md` — Project overview and architecture

--- a/changes/13355.misc.md
+++ b/changes/13355.misc.md
@@ -1,0 +1,1 @@
+Carry the changelog of a final release on a version branch back to `main` as a pull request

--- a/scripts/changelog_files.py
+++ b/scripts/changelog_files.py
@@ -8,12 +8,16 @@ pre-release blocks into the final one is a release-time editorial step.
 The root ``CHANGELOG.md`` archives the releases made before the split.
 
 Shared by ``run-towncrier.py`` (which writes the block) and
-``extract-release-changelog.py`` (which reads it back).
+``extract-release-changelog.py`` (which reads it back). Run it to ask the same
+question from a shell:
+
+    python scripts/changelog_files.py 26.8.0     # -> CHANGELOG/26.8.md
 """
 
 from __future__ import annotations
 
 import re
+import sys
 
 # PEP 440 pre-release / post-release / development-release suffixes.
 _SUFFIX_RE = re.compile(
@@ -32,3 +36,12 @@ def changelog_filename(version: str) -> str:
     if match is None:
         raise ValueError(f"Unrecognized release version: {version!r}")
     return f"{CHANGELOG_DIR}/{match.group(1)}.{match.group(2)}.md"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise SystemExit(f"Usage: {sys.argv[0]} <version>")
+    try:
+        print(changelog_filename(sys.argv[1]))
+    except ValueError as e:
+        raise SystemExit(str(e)) from None

--- a/scripts/determine-release-type.py
+++ b/scripts/determine-release-type.py
@@ -1,15 +1,20 @@
-import os
+"""Say whether a release version is a pre-release.
+
+Prints ``true`` or ``false``. Turning that into a CI variable is the caller's
+business:
+
+    answer=$(python scripts/determine-release-type.py "$(cat VERSION)")
+    echo "IS_PRERELEASE=$answer" >> "$GITHUB_ENV"
+"""
+
 import re
-from pathlib import Path
+import sys
 
 
 def main():
-    gh_env_file = Path(os.environ.get("GITHUB_ENV", "/dev/null"))
-    version = Path("./VERSION").read_text().strip()
+    version = sys.argv[1].strip()
     m = re.search(r"(rc\d+|a\d+|b\d+|dev\d+)$", version)
-    is_prerelease = "true" if m is not None else "false"
-    with open(gh_env_file, "a") as f:
-        f.write(f"IS_PRERELEASE={is_prerelease}\n")
+    print("true" if m is not None else "false")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
resolves [BA-7131](https://lablup.atlassian.net/browse/BA-7131)

A release cut on a version branch writes `CHANGELOG/<series>.md` on that branch, so `main` never learns what went into the series. On a final release tag, `changelog-sync` copies that one file over as a `release:` pull request.

A copy, not a cherry-pick: the release commit also carries version bumps and generated artifacts that must not reach `main`. The file is lifted out of the tag's tree and committed on top of `main` with plumbing, so nothing else can ride along.

Nothing about it can fail a release. A pre-release, a line older than the changelog split (`26.4`, `26.8` today), and a file already on `main` each stop with a reason and exit 0. A re-run of the same tag force-pushes the same branch, which revises the open pull request rather than opening a second one. The `release:` prefix exempts the generated PR from the news-fragment check and keeps it out of the backport decision; the `Backport: none` trailer says so explicitly.

### The two commits before it

`.github` had no `AGENTS.md`, so nothing said where a workflow ends and the script it calls begins. It says so now: a workflow translates its event into arguments, and a script answers from those arguments alone.

`determine-release-type.py` did not follow that — it took the version from the working directory's `VERSION` and reported through `$GITHUB_ENV`, so its answer could only be had by standing where CI stands. It now takes the version and prints the answer, and `ci.yml` does the one line of conversion. `changelog_files.py` gains the same shape as a command.

Three scripts that still break the rule are filed as BA-7138, BA-7139 and BA-7140 rather than fixed here.

### Verification

`actionlint` and `shellcheck` pass. The script was run against a throwaway origin holding a `26.8` branch with `26.8.0rc1`/`26.8.0` tags and a `26.4` branch in the old layout:

| Case | Result |
|---|---|
| `--dry-run` on the final tag | prints the pull request it would open; pushes nothing |
| final tag, no open pull request | one-file branch pushed, `gh pr create` called |
| after that run | `HEAD` unmoved, no tracked file changed |
| re-run with a pull request open | force-pushed, existing one revised, none created |
| `26.8.0rc1` | pre-release, exit 0 |
| `26.4.9` (old layout) | file absent, exit 0 |
| re-run after the pull request merged | already matches `main`, no branch, exit 0 |

**Checklist:** (if applicable)

- [x] Backport targets: `none` — the workflow belongs on `main` only.

[BA-7131]: https://lablup.atlassian.net/browse/BA-7131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ