### PR TITLE
ci(BA-7130): tag the release and cut the version branch on an rc1 merge

### DIFF
--- a/.github/scripts/create-version-branch.sh
+++ b/.github/scripts/create-version-branch.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Tag the release an `X.Y.0rc1` release commit made, and cut the `X.Y` version
+# branch at that same commit.
+#
+#   create-version-branch.sh <commit>
+#
+#     <commit>    the release commit, e.g. the merge commit on `main`
+#
+# The commit decides everything: the subject `release.sh` left on it says which
+# release this is, so no CI environment is read and no particular revision has to
+# be checked out. Only refs are pushed, so neither HEAD nor the worktree is
+# touched, and the decision it acted on is printed.
+#
+# It exits 0 with the reason when the commit cuts no release line -- a later rc,
+# a final release, a patch release, or any other commit. It fails when the tag or
+# the branch is already there: a line is cut once, and neither ref is ever moved.
+#
+# `bash -e` matches how GitHub runs a `run:` block.
+set -e
+
+usage() {
+  echo "Usage: $0 <commit>"
+  echo "  <commit>    the release commit, e.g. the merge commit on \`main\`"
+}
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+  -*) echo "Error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+esac
+if [ "$#" -ne 1 ]; then
+  echo "Error: exactly one commit is required" >&2
+  usage >&2
+  exit 2
+fi
+commit=$(git rev-parse "$1")
+subject=$(git log -1 --format=%s "$commit")
+
+# `release.sh` commits `release: <target_version>` and the squash merge appends
+# ` (#N)`, so the subject already names the release -- nothing else has to
+# classify it. Only an `X.Y.0rc1` cuts a line, the same rule
+# `update-maintained-versions.sh` registers a line by; a later rc, a final
+# release or a patch release cuts nothing.
+if [[ ! "$subject" =~ ^release:\ (([0-9]+\.[0-9]+)\.0rc1)( \(#[0-9]+\))?$ ]]; then
+  echo "'$subject' cuts no release line; nothing to create."
+  exit 0
+fi
+tag="${BASH_REMATCH[1]}"
+branch="${BASH_REMATCH[2]}"
+
+for ref in "refs/tags/$tag" "refs/heads/$branch"; do
+  if git ls-remote --exit-code origin "$ref" > /dev/null 2>&1; then
+    echo "Error: '$ref' already exists; a release line is cut once and neither ref is moved." >&2
+    exit 1
+  fi
+done
+
+# One atomic push, without `--force` and with both refspecs naming the same
+# commit: the tag and the branch are created together at this very commit, or
+# neither of them is.
+git push --atomic origin \
+  "$commit:refs/tags/$tag" \
+  "$commit:refs/heads/$branch"
+echo "Created tag '$tag' and branch '$branch' at $commit."

--- a/.github/workflows/create-version-branch.yml
+++ b/.github/workflows/create-version-branch.yml
@@ -1,0 +1,36 @@
+name: create-version-branch
+
+# Cutting a release line and releasing its first rc are one action: merging
+# `release: X.Y.0rc1` into `main` is what tags the release and creates `X.Y`.
+
+on:
+  push:
+    branches:
+      - 'main'
+
+permissions:
+  contents: read
+
+concurrency:
+  # One group per commit: a re-run of the same push must not race the first run
+  # into the push of the refs.
+  group: ${{ github.workflow }}-${{ github.sha }}
+
+jobs:
+  cut:
+    # A cheap filter on the event; which release cuts a line is the script's call.
+    if: "startsWith(github.event.head_commit.message, 'release: ')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the release commit
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+          # Refs pushed with the workflow's own token trigger no workflow, and
+          # `ci.yml`'s `make-final-release` -- wheels, GitHub Release, PyPI --
+          # runs on the tag push.
+          token: ${{ secrets.OCTODOG }}
+      - name: Tag the release and cut the version branch
+        env:
+          COMMIT: ${{ github.sha }}
+        run: .github/scripts/create-version-branch.sh "$COMMIT"

--- a/changes/13356.misc.md
+++ b/changes/13356.misc.md
@@ -1,0 +1,1 @@
+Tag the release and cut the `X.Y` version branch from the `release: X.Y.0rc1` merge commit on `main`, so that the tag and the branch are always created together at one commit instead of by hand.

--- a/docs/dev/daily-workflows.rst
+++ b/docs/dev/daily-workflows.rst
@@ -833,7 +833,8 @@ Then, by hand:
   ``v`` prefix, lightweight) and push the tag.  **Pushing the tag is what
   publishes the release**: it triggers ``ci.yml``'s ``make-final-release``, which
   builds the wheels and SCIEs and uploads them to the GitHub Release and PyPI.
-  rc tags are published the same way.
+  Later rc tags are published the same way; the ``X.Y.0rc1`` that cuts a line is
+  the one exception -- a workflow tags it, as in `Making a new release branch`_.
 
 * When making a new major release, snapshot of prior release's final DB migration history
   should be dumped. This will later help to fill out missing gaps of DB revisions when
@@ -863,10 +864,14 @@ its first rc are one action.**
   ``NEXT_RELEASE_VERSION``, the regenerated schema dumps, ``CHANGELOG/X.Y.md``,
   and the registry entry for ``X.Y``.
 
-* Tag the merge commit ``X.Y.0rc1`` **and** create the branch ``X.Y`` at that same
-  commit.  The branch therefore starts with zero commits of its own, and
-  ``X.Y.0rc1`` is a common ancestor of both branches -- never tagged again from
-  the branch.
+* Nothing is tagged or branched by hand.  On the merge, the
+  ``create-version-branch.yml`` workflow reads the ``release: X.Y.0rc1`` subject
+  of the merge commit and creates the tag ``X.Y.0rc1`` **and** the branch ``X.Y``
+  at that same commit in one push.  The branch therefore starts with zero commits
+  of its own, and ``X.Y.0rc1`` is a common ancestor of both branches -- never
+  tagged again from the branch.  A tag or branch that is already there is never
+  moved: the workflow fails instead, and cutting the line again means deleting
+  them first.
 
 * Nothing else is done to ``main``.  It keeps developing the next version, and
   the release script has already pointed ``NEXT_RELEASE_VERSION`` at it.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,7 +4,7 @@ An index of the top-level scripts, grouped by **when they run** rather than by w
 they are about. Each row names its **caller**: a person, or the workflow / hook that
 runs it automatically.
 
-`.github/scripts/` holds the two scripts that only GitHub Actions and the release
+`.github/scripts/` holds the scripts that only GitHub Actions and the release
 script call; they are listed in the same tables.
 
 Subdirectories are summarized at the end. For the rules on keeping this index
@@ -69,6 +69,8 @@ current, see `AGENTS.md` in this directory.
 | `changelog_files.py` | Module, not a command: maps a version to its `CHANGELOG/<version>.md` | auto — imported by `run-towncrier.py`, `extract-release-changelog.py` |
 | `bump_next_release_version.py` | Advances `NEXT_RELEASE_VERSION` to the next sprint after a sprint release | auto — `release.sh` |
 | `.github/scripts/update-maintained-versions.sh` | Registers a newly cut line in `.github/maintained-versions.yml` and retires the due ones | auto — `release.sh` |
+| `.github/scripts/create-version-branch.sh` | Tags the `X.Y.0rc1` a release commit made and cuts the `X.Y` branch at that same commit | auto — `create-version-branch.yml` |
+| `.github/scripts/sync-changelog-to-main.sh` | Opens the pull request carrying a final release's `CHANGELOG/X.Y.md` back to `main` | auto — `changelog-sync.yml` |
 | `extract-release-changelog.py` | Extracts the tagged version's block for the GitHub release body | auto — `ci.yml` (release job) |
 | `determine-release-type.py` | Sets `IS_PRERELEASE` from the `VERSION` file | auto — `ci.yml` (release job) |
 | `build-wheels.sh` | Builds the platform-specific and generic wheels | auto — `ci.yml` (release job) |


### PR DESCRIPTION
## Summary

- Merging `release: X.Y.0rc1` into `main` now tags `X.Y.0rc1` **and** creates the `X.Y` version branch at that same commit. Both refspecs name the same commit in one non-forced `--atomic` push, so the tag and the branch cannot land on different commits, and neither ref is ever moved -- the workflow fails when one is already there instead of overwriting it.
- The signal is the commit subject `scripts/release.sh` already leaves, so nothing new classifies a release: only an `X.Y.0rc1` cuts a line, while a later rc, a final release and a patch release create nothing. The decision lives in `.github/scripts/create-version-branch.sh` (one commit in, the decision printed out) and the workflow only turns the push event into that argument.
- The tag is pushed with the same PAT the backport pull requests use, because a ref created with the workflow's own token triggers no workflow and `ci.yml`'s `make-final-release` -- wheels, GitHub Release, PyPI -- runs on the tag push.
- `docs/dev/daily-workflows.rst` no longer tells the releaser to tag and branch by hand when cutting a line; tagging a later rc, a final release or a patch release stays manual.

## Test plan

- [x] The decision per commit subject: `26.9.0rc1`, `26.10.0rc1`, `26.15.0rc1`, `27.1.0rc1` and `23.09.0rc1` cut a line; a later rc (`26.9.0rc2`), a final release (`26.9.0`), a patch release (`26.9.1`) and an ordinary commit cut nothing.
- [x] Refuses and pushes nothing when either ref exists, checked against this repository for the tag half (`26.8.0rc1`) and the branch half (`23.09`, whose branch exists without an rc1 tag).
- [x] The ref names it creates match every consumer filter: `ci.yml`'s branch and tag globs, `changelog-sync.yml`'s tag globs, and `update-api-schema.yml`'s base-ref pattern.
- [x] `shellcheck` and `actionlint -shellcheck` clean; `pants tailor --check update-build-files --check '::'` requires no BUILD change.
- [ ] On the next `X.Y.0rc1` merge: the tag and the branch point at the same commit, and the tag push starts `make-final-release`.

Resolves BA-7130


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13356.org.readthedocs.build/en/13356/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13356.org.readthedocs.build/ko/13356/

<!-- readthedocs-preview sorna-ko end -->