### PR TITLE
ci(BA-7138): pass the release version to extract-release-changelog.py

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -11,7 +11,7 @@
 - **A workflow translates its event into arguments — nothing more.** Triggers, permissions, concurrency and wiring belong in the YAML. Once a `run:` grows past a line or two, it belongs in `scripts/<verb>-<object>.sh`.
 - **One job per outcome.** Split into separate jobs only where the runner, the permissions or a matrix genuinely differ.
 - **Do not re-implement a rule that a script already owns** — version parsing, changelog file names, the maintained-version registry. Call it.
-- **Never interpolate `${{ }}` into a shell command.** Hand it over through `env:` and quote the variable. A tag name, a branch name and a comment body are all written by someone else.
+- **Never interpolate `${{ }}` into a shell command.** `env:` carries the value safely as far as the shell — from there hand it to the script as a quoted argument (`env: TAG: ${{ github.ref_name }}` → `run: scripts/foo.py "$TAG"`), so the script never learns the variable's name. A tag name, a branch name and a comment body are all written by someone else.
 - **Pin a third-party action to a commit SHA**, with a `# vN` comment beside it. `actions/*` may use a major tag.
 
 ## Where a decision goes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -859,7 +859,10 @@ jobs:
       run: |
         pip install -U 'twine~=6.0'
     - name: Extract the release changelog
-      run: python ./scripts/extract-release-changelog.py
+      env:
+        VERSION: ${{ github.ref_name }}
+        REPOSITORY: ${{ github.repository }}
+      run: python ./scripts/extract-release-changelog.py "$VERSION" --repository "$REPOSITORY"
     - name: Determine the release type
       run: echo "IS_PRERELEASE=$(python ./scripts/determine-release-type.py "$(cat VERSION)")" >> "$GITHUB_ENV"
     - name: Download wheels

--- a/changes/13357.misc.md
+++ b/changes/13357.misc.md
@@ -1,0 +1,1 @@
+Make `scripts/extract-release-changelog.py` take the release version as an argument instead of reading `GITHUB_REF_NAME`, `GITHUB_REPOSITORY` and `./VERSION`.

--- a/scripts/extract-release-changelog.py
+++ b/scripts/extract-release-changelog.py
@@ -1,5 +1,12 @@
+"""Extract one release's changelog block as the GitHub release body.
+
+Everything it needs comes from the arguments: the version names both the
+changelog heading to look for and the tag the links point at.
+
+    python scripts/extract-release-changelog.py 26.8.0 --draft
+"""
+
 import argparse
-import os
 import re
 import subprocess
 import sys
@@ -8,37 +15,43 @@ from pathlib import Path
 from changelog_files import changelog_filename
 
 DEFAULT_REPOSITORY = 'lablup/backend.ai'
+DEFAULT_OUTPUT = 'CHANGELOG_RELEASE.md'
 
 
-def get_repository():
-    return os.environ.get('GITHUB_REPOSITORY', DEFAULT_REPOSITORY)
+def release_tag(version):
+    """The tag naming a release, derived from its version."""
+    return version
 
-def get_tag():
-    gh_ref_name = os.environ.get('GITHUB_REF_NAME')
-    if gh_ref_name:
-        return gh_ref_name
-    p = subprocess.run(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], capture_output=True)
-    revision = p.stdout.decode().strip()
-    return revision
-
-def get_prev_tag():
-    tag = get_tag()
-    subprocess.run(['git', 'clone', '--filter=blob:none', '--no-checkout', f'https://github.com/{get_repository()}.git', '.git-tmp'])
+def get_prev_tag(tag, repository):
+    subprocess.run(['git', 'clone', '--filter=blob:none', '--no-checkout', f'https://github.com/{repository}.git', '.git-tmp'])
     p = subprocess.run(['git', 'describe', '--abbrev=0', '--tags', tag + '^'], capture_output=True, cwd='.git-tmp')
     prev_tag = p.stdout.decode().strip()
     return prev_tag
 
 def main():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        'version',
+        help="The release version, which also names its tag",
+    )
+    parser.add_argument(
+        '--repository', default=DEFAULT_REPOSITORY,
+        help=f"The owner/name the release links point at (default: {DEFAULT_REPOSITORY})",
+    )
+    parser.add_argument(
+        '--output', default=DEFAULT_OUTPUT,
+        help=f"Where to write the extracted notes (default: {DEFAULT_OUTPUT})",
+    )
     parser.add_argument(
         '--draft', action='store_true', default=False,
         help="Do not write to file but only print the expected output",
     )
     args = parser.parse_args()
 
-    prev_tag, tag = get_prev_tag(), get_tag()
-    repository = get_repository()
-    version = Path('./VERSION').read_text().strip()
+    version = args.version.strip()
+    repository = args.repository
+    tag = release_tag(version)
+    prev_tag = get_prev_tag(tag, repository)
     changelog_name = changelog_filename(version)
     commitlog_url = f"https://github.com/{repository}/compare/{prev_tag}...{tag}"
     changelog_url = f"https://github.com/{repository}/blob/{tag}/{changelog_name}"
@@ -46,7 +59,7 @@ def main():
     print(f"Making release notes for {tag} ...", file=sys.stderr)
 
     input_path = Path(f'./{changelog_name}')
-    output_path = Path('./CHANGELOG_RELEASE.md')
+    output_path = Path(args.output)
     try:
         input_text = input_path.read_text()
         m = re.search(rf"(?:^|\n)## {re.escape(version)}(?![\w.])(?:[^\n]*)?\n(.*?)(?:\n## |$)", input_text, re.S)
@@ -65,12 +78,12 @@ def main():
             print("--------")
             print(content)
             print("--------")
-            print("Successfully extracted the latest changelog to CHANGELOG_RELEASE.md", file=sys.stderr)
+            print(f"Successfully extracted the latest changelog to {output_path}", file=sys.stderr)
         else:
-            print(f"::error ::Could not extract the {version} changelog from {changelog_name}", file=sys.stderr)
+            print(f"Could not extract the {version} changelog from {changelog_name}", file=sys.stderr)
             sys.exit(1)
     except IOError as e:
-        print(f"::error ::Could read or write from file: {e!r}", file=sys.stderr)
+        print(f"Could read or write from file: {e!r}", file=sys.stderr)
         sys.exit(1)
 
 


### PR DESCRIPTION
## Summary

- `scripts/extract-release-changelog.py` now takes the release version as its one positional argument and derives the tag from it, replacing `GITHUB_REF_NAME` (which fell back to whatever branch happened to be checked out), `GITHUB_REPOSITORY` and `./VERSION`. `--repository` and `--output` keep their previous defaults, and errors print plain instead of `::error ::` markup.
- `ci.yml`'s `make-final-release` carries `github.ref_name` / `github.repository` through `env:` and hands them over as arguments — the workflow stays an adapter, per `.github/AGENTS.md`.
- Reworded the `env:` rule in `.github/AGENTS.md`: `env:` carries a value safely as far as the shell, and from there it goes on as a quoted argument. "Quote the variable" was reading as an invitation to use the variable inside the script.
- The `.git-tmp` clone that finds the previous tag stays put; hoisting `git describe` into the workflow would break the same rule from the other side.

## Test plan

`scripts/` has no BUILD file, so none of this is a pants target and CI does not check it. Verified by hand against a copy of the previous script:

- [x] `--draft` for 26.8.0: stdout byte-identical (68087 bytes), stderr identical
- [x] Non-draft run: written `CHANGELOG_RELEASE.md` byte-identical (68068 bytes)
- [x] `--output out/notes.md`: same content at the given path; unwritable path exits 1
- [x] Missing version block and missing changelog file: plain error, exit 1
- [x] No argument / unknown option: argparse usage, exit 2
- [x] `--repository someone/fork`: both links point at the given repository
- [x] `actionlint .github/workflows/ci.yml`: findings unchanged from before the edit

Resolves BA-7138

🤖 Generated with [Claude Code](https://claude.com/claude-code)