### PR TITLE
ci(BA-7140): decide backport targets from arguments

### DIFF
--- a/.github/scripts/decide-backport-targets.sh
+++ b/.github/scripts/decide-backport-targets.sh
@@ -1,68 +1,142 @@
 #!/usr/bin/env bash
 #
 # Decide which release branches a pull request should be backported to, and
-# emit one `backport` job matrix entry per target as the `result` output.
+# print one `backport` job matrix entry per target -- a single line of JSON,
+# `[]` when nothing is to be backported.
 #
-# Driven by the `backport` workflow through the environment, from either of its
-# two triggers:
+#   decide-backport-targets.sh --event <name> --pr <number> [options]
 #
-#   EVENT_NAME=pull_request_target   a merged PR; the rules below decide
-#   EVENT_NAME=issue_comment         a `/backport <version> ...` comment, which
-#                                    names the targets outright
+#     --event <name>            pull_request_target, a merged pull request whose
+#                               metadata the rules below decide from, or
+#                               issue_comment, a `/backport <version> ...`
+#                               comment naming the targets outright
+#     --pr <number>             the pull request to back port
+#     --title <t>               its title, which the `fix:` rule reads
+#     --body <b>                its body, which carries the `Backport:` trailer
+#     --labels <csv>            its labels, carried onto the backport
+#     --base <ref>              the branch it was merged into
+#     --merge-commit <sha>      the commit to cherry-pick
+#     --comment-body <b>        the `/backport` comment, for --event issue_comment
+#     --author-association <a>  who wrote that comment, e.g. MEMBER
+#     --pr-author <login>       who the backport is assigned to
+#     --registry <path>         the maintained-version registry
+#                               (default: .github/maintained-versions.yml)
+#     --dry-run                 decide as usual, but report the pull request
+#                               comments instead of posting them
 #
-# Run it by hand to reproduce a decision -- with GITHUB_OUTPUT unset the result
-# goes to stdout:
+# The arguments decide everything -- no CI environment is read. Everything a
+# human reads goes to stderr, so stdout holds the matrix and nothing else. Run
+# it against your own checkout to reproduce a decision:
 #
-#   EVENT_NAME=pull_request_target PR_NUMBER=13346 PR_BASE=main \
-#   PR_TITLE='fix(BA-1234): ...' MERGE_COMMIT=<sha> \
-#   .github/scripts/decide-backport-targets.sh
+#   .github/scripts/decide-backport-targets.sh --event pull_request_target \
+#     --pr 13346 --base main --title 'fix(BA-1234): ...' \
+#     --merge-commit <sha> --dry-run
 #
-# `bash -e` matches how GitHub runs a `run:` block. `pipefail` is deliberately
-# left off: the trailer lookup below is a pipeline whose `grep` is expected to
-# find nothing on most pull requests. Bash 4 builtins are avoided so that the
-# script stays runnable on a stock macOS bash.
+# `gh` takes its credentials from GH_TOKEN under CI and from `gh auth login`
+# elsewhere. `bash -e` matches how GitHub runs a `run:` block. `pipefail` is
+# deliberately left off: the trailer lookup below is a pipeline whose `grep` is
+# expected to find nothing on most pull requests. Bash 4 builtins are avoided so
+# that the script stays runnable on a stock macOS bash.
 set -e
 
-event_name="${EVENT_NAME:-}"
-pr_number="${PR_NUMBER:-}"
-pr_title="${PR_TITLE:-}"
-pr_body="${PR_BODY:-}"
-pr_labels="${PR_LABELS:-}"
-pr_base="${PR_BASE:-}"
-merge_commit="${MERGE_COMMIT:-}"
-comment_body="${COMMENT_BODY:-}"
-author_association="${AUTHOR_ASSOCIATION:-}"
-pr_author_login="${PR_AUTHOR_LOGIN:-}"
-registry="${REGISTRY:-.github/maintained-versions.yml}"
-: "${GITHUB_OUTPUT:=/dev/stdout}"
+usage() {
+  echo "Usage: $0 --event <name> --pr <number> [options]"
+  echo "  --event <name>            pull_request_target or issue_comment"
+  echo "  --pr <number>             the pull request to back port"
+  echo "  --title <t>               its title"
+  echo "  --body <b>                its body, carrying the 'Backport:' trailer"
+  echo "  --labels <csv>            its labels"
+  echo "  --base <ref>              the branch it was merged into"
+  echo "  --merge-commit <sha>      the commit to cherry-pick"
+  echo "  --comment-body <b>        the '/backport' comment"
+  echo "  --author-association <a>  who wrote that comment"
+  echo "  --pr-author <login>       who the backport is assigned to"
+  echo "  --registry <path>         maintained-version registry"
+  echo "                            (default: .github/maintained-versions.yml)"
+  echo "  --dry-run                 report the pull request comments, post none"
+}
+
+event_name=""
+pr_number=""
+pr_title=""
+pr_body=""
+pr_labels=""
+pr_base=""
+merge_commit=""
+comment_body=""
+author_association=""
+pr_author_login=""
+registry=".github/maintained-versions.yml"
+dry_run=0
+
+while [ "$#" -gt 0 ]; do
+  # Every option but `--dry-run` takes a value; catching a missing one here
+  # keeps each branch below to a single assignment.
+  case "$1" in
+    --dry-run|-h|--help) ;;
+    *) [ "$#" -ge 2 ] || { echo "Error: $1 requires a value" >&2; usage >&2; exit 2; } ;;
+  esac
+  case "$1" in
+    --event) event_name="$2"; shift ;;
+    --pr) pr_number="$2"; shift ;;
+    --title) pr_title="$2"; shift ;;
+    --body) pr_body="$2"; shift ;;
+    --labels) pr_labels="$2"; shift ;;
+    --base) pr_base="$2"; shift ;;
+    --merge-commit) merge_commit="$2"; shift ;;
+    --comment-body) comment_body="$2"; shift ;;
+    --author-association) author_association="$2"; shift ;;
+    --pr-author) pr_author_login="$2"; shift ;;
+    --registry) registry="$2"; shift ;;
+    --dry-run) dry_run=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+if [ -z "$event_name" ] || [ -z "$pr_number" ]; then
+  echo "Error: --event and --pr are required" >&2
+  usage >&2
+  exit 2
+fi
 
 maintained=()   # versions the registry declares alive
 requested=()    # versions named by a `/backport` comment
 targets=()      # release branches to back port to
 
+# The one side effect this script has, and the only thing `--dry-run` withholds.
+comment_on_pr() {
+  if [ "$dry_run" -eq 1 ]; then
+    echo "dry run, would comment on #$pr_number: $1" >&2
+  else
+    gh pr comment "$pr_number" -b "$1"
+  fi
+}
+
 # Leave the reason on the pull request and stop -- for a human who asked.
 reply_and_exit() {
-  gh pr comment "$pr_number" -b "$1"
+  comment_on_pr "$1"
   exit 0
 }
 
 # Leave the reason on the pull request and fail -- for a request that cannot be
 # carried out, so that it is not mistaken for "nothing needed backporting".
 reply_and_fail() {
-  gh pr comment "$pr_number" -b "$1"
-  echo "::error::$1"
+  comment_on_pr "$1"
+  echo "$1" >&2
   exit 1
 }
 
-# Say why in the job log and stop -- for anything nobody asked for.
+# Say why and stop -- for anything nobody asked for.
 skip_and_exit() {
-  echo "::notice::$1"
+  echo "$1" >&2
   exit 0
 }
 
-# Write the step output and stop.
+# Print the matrix and stop.
 emit_and_exit() {
-  echo "result=$1" >> "$GITHUB_OUTPUT"
+  echo "$1"
   exit 0
 }
 
@@ -112,13 +186,13 @@ fi
 # Assign before the loop: a `yq` failure inside `< <(...)` would go unnoticed and
 # read as "no maintained versions", the silent skip this workflow exists to remove.
 if ! registry_versions=$(yq -e '.versions[].version' "$registry" 2>&1); then
-  echo "::error::'$registry' must hold a non-empty 'versions' list -- $registry_versions"
+  echo "'$registry' must hold a non-empty 'versions' list -- $registry_versions" >&2
   exit 1
 fi
 while IFS= read -r version; do
   maintained+=("$version")
 done <<< "$registry_versions"
-echo "Maintained versions: ${maintained[*]}"
+echo "Maintained versions: ${maintained[*]}" >&2
 
 if [ ${#requested[@]} -gt 0 ]; then
   # `/backport` names the targets outright; the rules below do not apply.
@@ -134,7 +208,7 @@ if [ ${#requested[@]} -gt 0 ]; then
     reply_and_exit "No maintained version matches \`${unknown[*]}\`. The maintained versions are \`${maintained[*]}\` (see \`$registry\`)."
   fi
   if [ ${#unknown[@]} -gt 0 ]; then
-    echo "::warning::Ignoring '${unknown[*]}' requested on #$pr_number: not listed in $registry"
+    echo "Ignoring '${unknown[*]}' requested on #$pr_number: not listed in $registry" >&2
   fi
 else
   # A `Backport:` trailer names the targets outright, whatever the prefix would
@@ -148,7 +222,7 @@ else
       targets=("${maintained[@]}")
     fi
   elif [ ${#trailer_versions[@]} -eq 1 ] && [ "$(tr '[:upper:]' '[:lower:]' <<< "${trailer_versions[0]}")" = "none" ]; then
-    echo "The Backport: trailer of #$pr_number opts out; no backport target."
+    echo "The Backport: trailer of #$pr_number opts out; no backport target." >&2
   else
     unknown=()
     for version in "${trailer_versions[@]}"; do
@@ -173,7 +247,7 @@ if [ ${#targets[@]} -gt 0 ]; then
   done < <(printf '%s\n' "${targets[@]}" | sort -Vr -u)
   targets=("${sorted[@]}")
 fi
-echo "Backport targets of #$pr_number: ${targets[*]}"
+echo "Backport targets of #$pr_number: ${targets[*]}" >&2
 if [ ${#targets[@]} -eq 0 ]; then
   emit_and_exit "[]"
 fi
@@ -183,7 +257,7 @@ for branch in "${targets[@]}"; do
   if git ls-remote --exit-code --heads origin "$branch" > /dev/null 2>&1; then
     existing+=("$branch")
   else
-    echo "::warning::Skipping the '$branch' backport of #$pr_number: the release branch does not exist"
+    echo "Skipping the '$branch' backport of #$pr_number: the release branch does not exist" >&2
   fi
 done
 if [ ${#existing[@]} -eq 0 ]; then

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -46,7 +46,19 @@ jobs:
           COMMENT_BODY: ${{ github.event.comment.body }}
           AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
           PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
-        run: .github/scripts/decide-backport-targets.sh
+        run: |
+          result=$(.github/scripts/decide-backport-targets.sh \
+            --event "$EVENT_NAME" \
+            --pr "$PR_NUMBER" \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY" \
+            --labels "$PR_LABELS" \
+            --base "$PR_BASE" \
+            --merge-commit "$MERGE_COMMIT" \
+            --comment-body "$COMMENT_BODY" \
+            --author-association "$AUTHOR_ASSOCIATION" \
+            --pr-author "$PR_AUTHOR_LOGIN")
+          echo "result=$result" >> "$GITHUB_OUTPUT"
 
 
   backport:

--- a/changes/13358.misc.md
+++ b/changes/13358.misc.md
@@ -1,0 +1,1 @@
+Decide the backport targets with a script that takes arguments and prints the job matrix, so a decision can be reproduced by hand


### PR DESCRIPTION
## Summary

- `decide-backport-targets.sh` takes its inputs as options (`--event`, `--pr`, `--title`, `--body`, ...) instead of eleven environment variables, so a decision can be reproduced by hand.
- stdout is the matrix JSON alone (`[]` when nothing is to be backported); everything a human reads moves to stderr, without the `::error::`/`::notice::` markup. `--dry-run` reports the pull request comment instead of posting it.
- `backport.yml` passes the `env:`-carried event values as quoted arguments and turns the printed matrix into `$GITHUB_OUTPUT`.
- The decision logic -- the `Backport:` trailer, the `fix:` default, the `/backport` permission check, the unknown-version handling and the matrix shape -- is untouched.

## Test plan

- [x] 15 cases run against the pre-change script with `gh`/`git` stubs -- identical stdout JSON, exit code and side effects: `fix:` without a trailer, `Backport: none`, `Backport: 26.4 26.8`, an unknown version, a `feat:` pull request, a release-branch base, no merge commit, `/backport 26.4`, an unprivileged commenter, an unmerged pull request, `/backport` without a version, a mixed request, a missing release branch, and a multi-line body carrying backticks and `$(...)`
- [x] `--dry-run` posts no comment (stub log empty) and keeps the exit codes
- [x] stdout parses as JSON on its own (`... 2>/dev/null | python3 -m json.tool`)
- [x] `shellcheck` and `actionlint` clean

Resolves BA-7140

🤖 Generated with [Claude Code](https://claude.com/claude-code)